### PR TITLE
fix(social-leaderboard): keep Android hardware back inside follow-trading instead of closing the app

### DIFF
--- a/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.test.tsx
@@ -4,9 +4,25 @@ import renderWithProvider from '../../../../util/test/renderWithProvider';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import SocialTradersTabsView from './SocialTradersTabsView';
 import { SocialTradersTabsViewSelectorsIDs } from './SocialTradersTabsView.testIds';
+import Routes from '../../../../constants/navigation/Routes';
 
 const mockPlaySelection = jest.fn().mockResolvedValue(undefined);
 const mockTrack = jest.fn();
+const mockGoBack = jest.fn();
+const mockNavigate = jest.fn();
+const mockCanGoBack = jest.fn(() => true);
+
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({
+      goBack: mockGoBack,
+      navigate: mockNavigate,
+      canGoBack: mockCanGoBack,
+    }),
+  };
+});
 
 jest.mock('../analytics', () => {
   const actual = jest.requireActual('../analytics');
@@ -140,10 +156,35 @@ jest.mock('../FeedView/components/FeedSpotBuyAction', () => {
 describe('SocialTradersTabsView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCanGoBack.mockReturnValue(true);
     mockHasSpotItem = true;
     mockDeferBuyActionRef = false;
     mockAttachBuyActionRef = null;
     mockOnSpotAvailabilityChange = undefined;
+  });
+
+  it('calls goBack when the back button is pressed and a screen can be popped', () => {
+    mockCanGoBack.mockReturnValue(true);
+    renderWithProvider(<SocialTradersTabsView />);
+
+    fireEvent.press(
+      screen.getByTestId(SocialTradersTabsViewSelectorsIDs.BACK_BUTTON),
+    );
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalledWith(Routes.HOME_TABS);
+  });
+
+  it('navigates to Wallet Home when the back button is pressed at the stack root', () => {
+    mockCanGoBack.mockReturnValue(false);
+    renderWithProvider(<SocialTradersTabsView />);
+
+    fireEvent.press(
+      screen.getByTestId(SocialTradersTabsViewSelectorsIDs.BACK_BUTTON),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.HOME_TABS);
+    expect(mockGoBack).not.toHaveBeenCalled();
   });
 
   it('renders the header, tabs, and both pages', () => {

--- a/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.tsx
+++ b/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.tsx
@@ -41,6 +41,7 @@ import SocialTradersTabBar, {
   type SocialTradersTab,
 } from './SocialTradersTabBar';
 import { SocialTradersTabsViewSelectorsIDs } from './SocialTradersTabsView.testIds';
+import { useSocialLeaderboardBack } from '../hooks/useSocialLeaderboardBack';
 
 const LEADERBOARD_INDEX = 0;
 const FEED_INDEX = 1;
@@ -186,9 +187,7 @@ const SocialTradersTabsView: React.FC = () => {
     pagerRef.current?.setPage(activeIndex);
   }, [activeIndex]);
 
-  const handleBack = useCallback(() => {
-    navigation.goBack();
-  }, [navigation]);
+  const handleBack = useSocialLeaderboardBack();
 
   const handleNotificationPreferencesPress = useCallback(() => {
     if (isLoadingNotificationPreferences) {

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
@@ -77,6 +77,7 @@ jest.mock('@metamask/design-system-react-native', () => {
 
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
+const mockCanGoBack = jest.fn(() => true);
 const mockToggleFollow = jest.fn();
 const mockRefresh = jest.fn();
 const mockHasNotificationPreferences = jest.fn(() => true);
@@ -120,12 +121,18 @@ jest.mock('@react-navigation/native', () => {
   // Real React Navigation returns a stable `navigation` reference across
   // renders. Mirror that here (lazily, to respect const TDZ at mock-init time)
   // so hooks depending on `navigation` stay referentially stable.
-  let navigation: { goBack: jest.Mock; navigate: jest.Mock } | undefined;
+  let navigation:
+    | { goBack: jest.Mock; navigate: jest.Mock; canGoBack: jest.Mock }
+    | undefined;
   return {
     ...actual,
     useNavigation: () => {
       if (!navigation) {
-        navigation = { goBack: mockGoBack, navigate: mockNavigate };
+        navigation = {
+          goBack: mockGoBack,
+          navigate: mockNavigate,
+          canGoBack: mockCanGoBack,
+        };
       }
       return navigation;
     },
@@ -295,6 +302,7 @@ jest.mock('../analytics', () => {
 describe('TopTradersView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCanGoBack.mockReturnValue(true);
     resetTabResults();
     mockUseTopTradersHook.mockImplementation(
       (options?: UseTopTradersHookOptions) =>
@@ -363,10 +371,20 @@ describe('TopTradersView', () => {
     ).toHaveLength(1);
   });
 
-  it('calls goBack when the back button is pressed', () => {
+  it('calls goBack when the back button is pressed and a screen can be popped', () => {
+    mockCanGoBack.mockReturnValue(true);
     renderWithProvider(<TopTradersView />);
     fireEvent.press(screen.getByTestId(TopTradersViewSelectorsIDs.BACK_BUTTON));
     expect(mockGoBack).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalledWith(Routes.HOME_TABS);
+  });
+
+  it('navigates to Wallet Home when the back button is pressed at the stack root', () => {
+    mockCanGoBack.mockReturnValue(false);
+    renderWithProvider(<TopTradersView />);
+    fireEvent.press(screen.getByTestId(TopTradersViewSelectorsIDs.BACK_BUTTON));
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.HOME_TABS);
+    expect(mockGoBack).not.toHaveBeenCalled();
   });
 
   it('renders the notification button', () => {

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
@@ -58,6 +58,7 @@ import { useNotificationStoragePreferences } from '../../Settings/NotificationsS
 import { useNotificationPreferences } from '../NotificationPreferences/hooks';
 import { areTradingSignalsChannelsDisabled } from '../NotificationPreferences/hooks/tradingSignalsChannels';
 import { useOpenTradingSignalsSetup } from '../hooks/useOpenTradingSignalsSetup';
+import { useSocialLeaderboardBack } from '../hooks/useSocialLeaderboardBack';
 import {
   TraderRow,
   TraderRowSkeleton,
@@ -327,9 +328,7 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
     };
   });
 
-  const handleBack = useCallback(() => {
-    navigation.goBack();
-  }, [navigation]);
+  const handleBack = useSocialLeaderboardBack();
 
   // Auto-dismiss the notifications nudge after a fixed window so it never lingers
   // as permanent chrome. Cleared on manual close/unmount via the effect cleanup.

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
   within,
 } from '@testing-library/react-native';
+import { BackHandler } from 'react-native';
 import { playImpact, ImpactMoment } from '../../../../util/haptics';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
@@ -18,6 +19,7 @@ import Routes from '../../../../constants/navigation/Routes';
 
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
+const mockCanGoBack = jest.fn(() => true);
 const mockGetAssetImageUrl = jest.fn();
 const mockHandleFetch = handleFetch as jest.MockedFunction<typeof handleFetch>;
 const mockPriceChart = jest.fn();
@@ -283,6 +285,7 @@ jest.mock('@react-navigation/native', () => {
     useNavigation: () => ({
       goBack: mockGoBack,
       navigate: mockNavigate,
+      canGoBack: mockCanGoBack,
     }),
     useRoute: () => ({
       params: mockRouteParams,
@@ -304,6 +307,7 @@ jest.mock('../../../UI/Bridge/hooks/useAssetMetadata/utils', () => ({
 describe('TraderPositionView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCanGoBack.mockReturnValue(true);
     mockRefetchPosition.mockResolvedValue(undefined);
     mockRefreshProfile.mockResolvedValue(undefined);
     mockHandleFetch.mockResolvedValue({});
@@ -369,7 +373,8 @@ describe('TraderPositionView', () => {
     expect(screen.getByText('No trades yet')).toBeOnTheScreen();
   });
 
-  it('calls goBack when the back button is pressed', () => {
+  it('calls goBack when the back button is pressed and a screen can be popped', () => {
+    mockCanGoBack.mockReturnValue(true);
     renderWithProvider(<TraderPositionView />, { state: mockState });
 
     fireEvent.press(
@@ -378,6 +383,37 @@ describe('TraderPositionView', () => {
 
     expect(mockGoBack).toHaveBeenCalledTimes(1);
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates to Wallet Home when the back button is pressed at the stack root', () => {
+    // Cold-start push lands this screen as the stack root with nothing to pop.
+    mockCanGoBack.mockReturnValue(false);
+    renderWithProvider(<TraderPositionView />, { state: mockState });
+
+    fireEvent.press(
+      screen.getByTestId(TraderPositionViewSelectorsIDs.BACK_BUTTON),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.HOME_TABS);
+    expect(mockGoBack).not.toHaveBeenCalled();
+  });
+
+  it('consumes the Android hardware back event and routes to Wallet Home at the stack root', () => {
+    // Regression guard for "hardware back closes the app": the registered
+    // handler must return true (consume the event) instead of bubbling to the OS.
+    mockCanGoBack.mockReturnValue(false);
+    const addEventListenerSpy = jest.spyOn(BackHandler, 'addEventListener');
+    renderWithProvider(<TraderPositionView />, { state: mockState });
+
+    const hardwareBackHandler = addEventListenerSpy.mock.calls.find(
+      ([event]) => event === 'hardwareBackPress',
+    )?.[1] as (() => boolean) | undefined;
+
+    expect(hardwareBackHandler?.()).toBe(true);
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.HOME_TABS);
+    expect(mockGoBack).not.toHaveBeenCalled();
+
+    addEventListenerSpy.mockRestore();
   });
 
   it('navigates to the trader profile when the trader name is pressed', () => {

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
@@ -71,6 +71,7 @@ import {
 } from './useTraderPositionData';
 import { useTraderPosition } from './hooks/useTraderPosition';
 import { useTraderProfile } from '../TraderProfileView/hooks/useTraderProfile';
+import { useSocialLeaderboardBack } from '../hooks/useSocialLeaderboardBack';
 import {
   buildFollowTradingTokenContext,
   pickFollowTradingDismissedProperties,
@@ -196,13 +197,13 @@ const TraderPositionView = () => {
     }
   }, [refetchPosition, refreshProfile]);
 
-  // Plain goBack: returns to whatever the user was on before opening this
-  // screen — Profile (in-app row tap), Wallet Home (cold-start push), or the
-  // Notifications panel (in-app notification tap). The trader's name in the
-  // header is the affordance for navigating onward to Profile.
-  const handleBack = useCallback(() => {
-    navigation.goBack();
-  }, [navigation]);
+  // Resolves to whatever the user was on before opening this screen — Profile
+  // (in-app row tap) or the Notifications panel (in-app notification tap) — and
+  // falls back to Wallet Home when nothing is beneath (cold-start push, where
+  // this screen is the stack root). The hook also consumes Android hardware
+  // back so it never bubbles to the OS and closes the app. The trader's name in
+  // the header is the affordance for navigating onward to Profile.
+  const handleBack = useSocialLeaderboardBack();
 
   const handleTraderPress = useCallback(() => {
     navigation.navigate(Routes.SOCIAL_LEADERBOARD.PROFILE, {

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
@@ -17,6 +17,7 @@ import { MetaMetricsEvents } from '../../../../core/Analytics';
 
 const mockGoBack = jest.fn();
 const mockNavigate = jest.fn();
+const mockCanGoBack = jest.fn(() => true);
 const mockToggleFollow = jest.fn();
 const mockRefresh = jest.fn();
 const mockRefetchPositions = jest.fn();
@@ -215,7 +216,11 @@ jest.mock('@react-navigation/native', () => {
   const actual = jest.requireActual('@react-navigation/native');
   return {
     ...actual,
-    useNavigation: () => ({ goBack: mockGoBack, navigate: mockNavigate }),
+    useNavigation: () => ({
+      goBack: mockGoBack,
+      navigate: mockNavigate,
+      canGoBack: mockCanGoBack,
+    }),
     useRoute: () => ({ params: mockRouteParams }),
   };
 });
@@ -380,6 +385,7 @@ const channelsDisabledPreferences: SocialAIPreference = {
 describe('TraderProfileView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockCanGoBack.mockReturnValue(true);
     mockProfileResult = {
       profile: fixtureProfile,
       isLoading: false,
@@ -458,12 +464,24 @@ describe('TraderProfileView', () => {
     ).toHaveTextContent('+$20,610');
   });
 
-  it('calls goBack when the back button is pressed', () => {
+  it('calls goBack when the back button is pressed and a screen can be popped', () => {
+    mockCanGoBack.mockReturnValue(true);
     renderWithProvider(<TraderProfileView />);
     fireEvent.press(
       screen.getByTestId(TraderProfileViewSelectorsIDs.BACK_BUTTON),
     );
     expect(mockGoBack).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalledWith(Routes.HOME_TABS);
+  });
+
+  it('navigates to Wallet Home when the back button is pressed at the stack root', () => {
+    mockCanGoBack.mockReturnValue(false);
+    renderWithProvider(<TraderProfileView />);
+    fireEvent.press(
+      screen.getByTestId(TraderProfileViewSelectorsIDs.BACK_BUTTON),
+    );
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.HOME_TABS);
+    expect(mockGoBack).not.toHaveBeenCalled();
   });
 
   it('does not render a follower count', () => {

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
@@ -54,6 +54,7 @@ import TraderHeaderIdentity from '../components/TraderHeaderIdentity';
 import TraderMuteChip from '../components/TraderMuteChip';
 import { useOpenTradingSignalsSetup } from '../hooks/useOpenTradingSignalsSetup';
 import { useTraderMute } from '../hooks/useTraderMute';
+import { useSocialLeaderboardBack } from '../hooks/useSocialLeaderboardBack';
 import { HYPERLIQUID_CHAIN_NAME, isPerpPosition } from '../utils/perp';
 import { TraderProfileViewSelectorsIDs } from './TraderProfileView.testIds';
 import PositionRow from './components/PositionRow';
@@ -209,9 +210,7 @@ const TraderProfileView = () => {
   const [openSort, setOpenSort] = useState<OpenSortKey>('value');
   const [closedSort, setClosedSort] = useState<ClosedSortKey>('value');
 
-  const handleBack = useCallback(() => {
-    navigation.goBack();
-  }, [navigation]);
+  const handleBack = useSocialLeaderboardBack();
 
   const handleRefresh = useCallback(async () => {
     setIsRefreshing(true);

--- a/app/components/Views/SocialLeaderboard/hooks/useSocialLeaderboardBack.test.ts
+++ b/app/components/Views/SocialLeaderboard/hooks/useSocialLeaderboardBack.test.ts
@@ -1,0 +1,117 @@
+import { renderHook } from '@testing-library/react-native';
+import { BackHandler } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+import { useSocialLeaderboardBack } from './useSocialLeaderboardBack';
+import Routes from '../../../../constants/navigation/Routes';
+
+const mockGoBack = jest.fn();
+const mockNavigate = jest.fn();
+const mockCanGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    goBack: mockGoBack,
+    navigate: mockNavigate,
+    canGoBack: mockCanGoBack,
+  }),
+  useFocusEffect: jest.fn(),
+}));
+
+const mockUseFocusEffect = useFocusEffect as jest.MockedFunction<
+  typeof useFocusEffect
+>;
+
+// Captures the hardwareBackPress handler registered inside useFocusEffect so
+// the tests can invoke it directly and assert it consumes the event.
+let hardwareBackHandler: (() => boolean) | undefined;
+const mockRemove = jest.fn();
+let focusEffectCleanup: (() => void) | undefined;
+
+const runFocusEffect = () => {
+  const focusCallback = mockUseFocusEffect.mock.calls.at(-1)?.[0];
+  const cleanup = focusCallback?.();
+  focusEffectCleanup = typeof cleanup === 'function' ? cleanup : undefined;
+};
+
+describe('useSocialLeaderboardBack', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    hardwareBackHandler = undefined;
+    focusEffectCleanup = undefined;
+    mockCanGoBack.mockReturnValue(true);
+
+    jest
+      .spyOn(BackHandler, 'addEventListener')
+      .mockImplementation((_event, handler) => {
+        hardwareBackHandler = handler as () => boolean;
+        return { remove: mockRemove };
+      });
+
+    // Run the focus-effect callback synchronously so the hardware listener is
+    // registered, mirroring a focused screen.
+    mockUseFocusEffect.mockImplementation((callback) => {
+      const cleanup = callback();
+      focusEffectCleanup = typeof cleanup === 'function' ? cleanup : undefined;
+    });
+  });
+
+  it('goes back when there is a screen to pop', () => {
+    mockCanGoBack.mockReturnValue(true);
+
+    const { result } = renderHook(() => useSocialLeaderboardBack());
+    result.current();
+
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates to Wallet Home when nothing is beneath (stack root)', () => {
+    mockCanGoBack.mockReturnValue(false);
+
+    const { result } = renderHook(() => useSocialLeaderboardBack());
+    result.current();
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.HOME_TABS);
+    expect(mockGoBack).not.toHaveBeenCalled();
+  });
+
+  it('consumes the Android hardware back event and pops when possible', () => {
+    mockCanGoBack.mockReturnValue(true);
+
+    renderHook(() => useSocialLeaderboardBack());
+    runFocusEffect();
+
+    // Returning true is the load-bearing fix: it prevents the event bubbling to
+    // the OS, which would otherwise close the app at the stack root.
+    expect(hardwareBackHandler?.()).toBe(true);
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('consumes the Android hardware back event and routes to Wallet Home at the stack root', () => {
+    mockCanGoBack.mockReturnValue(false);
+
+    renderHook(() => useSocialLeaderboardBack());
+    runFocusEffect();
+
+    expect(hardwareBackHandler?.()).toBe(true);
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.HOME_TABS);
+    expect(mockGoBack).not.toHaveBeenCalled();
+  });
+
+  it('removes the hardware back listener when the screen loses focus', () => {
+    renderHook(() => useSocialLeaderboardBack());
+    runFocusEffect();
+
+    expect(BackHandler.addEventListener).toHaveBeenCalledWith(
+      'hardwareBackPress',
+      expect.any(Function),
+    );
+
+    focusEffectCleanup?.();
+
+    expect(mockRemove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/Views/SocialLeaderboard/hooks/useSocialLeaderboardBack.ts
+++ b/app/components/Views/SocialLeaderboard/hooks/useSocialLeaderboardBack.ts
@@ -1,0 +1,53 @@
+import { useCallback } from 'react';
+import { BackHandler } from 'react-native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import type { AppNavigationProp } from '../../../../core/NavigationService/types';
+import Routes from '../../../../constants/navigation/Routes';
+
+/**
+ * Centralizes back navigation for the follow-trading (SocialLeaderboard) flow so
+ * the app never exits from one of these screens.
+ *
+ * SocialLeaderboard screens are registered directly on the root native stack.
+ * On a cold-start notification/deeplink (e.g. handleSocialTraderPositionUrl ->
+ * SOCIAL_LEADERBOARD.POSITION) the feature screen can be the stack root with
+ * nothing beneath it. In that state a plain `goBack()` is a no-op for the header
+ * back button, and on Android the hardware back event falls through to the OS,
+ * which closes the app.
+ *
+ * `handleBack` resolves to the previous screen when one exists, otherwise to
+ * Wallet Home. A focus-scoped `hardwareBackPress` listener runs the same logic
+ * and returns `true` to consume the event so Android never exits the app. The
+ * listener is registered via `useFocusEffect` so only the focused screen owns
+ * hardware back — nested modals/bottom sheets presented on top keep handling
+ * their own back (mirrors the ActivityView cold-start-push precedent).
+ */
+export const useSocialLeaderboardBack = (): (() => void) => {
+  const navigation = useNavigation<AppNavigationProp>();
+
+  const handleBack = useCallback(() => {
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+    } else {
+      navigation.navigate(Routes.HOME_TABS);
+    }
+  }, [navigation]);
+
+  useFocusEffect(
+    useCallback(() => {
+      const subscription = BackHandler.addEventListener(
+        'hardwareBackPress',
+        () => {
+          handleBack();
+          return true;
+        },
+      );
+
+      return () => subscription.remove();
+    }, [handleBack]),
+  );
+
+  return handleBack;
+};
+
+export default useSocialLeaderboardBack;


### PR DESCRIPTION
## **Description**

On Android, pressing the hardware back button inside the follow-trading (SocialLeaderboard) flow could **close the app** instead of navigating back — this happens when a follow-trading screen is the root of the stack (e.g. entered via a cold-start notification/deeplink), because nothing consumed the `hardwareBackPress` event.

Adds a feature-scoped `useSocialLeaderboardBack` hook that centralizes header-back and Android hardware-back: it `goBack()` when possible, otherwise navigates to Wallet Home, and registers a **focus-scoped** `BackHandler` listener that **returns `true`** to consume the event (the load-bearing fix). Wired into all four follow-trading screens. Mirrors the existing `ActivityView` precedent.

Scoped entirely to the top-traders / follow-trading feature.

## **Changelog**

CHANGELOG entry: Fixed the Android hardware back button closing the app from the follow-trading screens; it now navigates back (or to Wallet Home).

## **Related issues**

Refs: N/A (internal follow-trading backlog)

## **Manual testing steps**

```gherkin
Feature: Android hardware back in follow-trading

  Scenario: back from a follow-trading screen opened as the stack root
    Given I opened a trader position from a notification (cold start)
    When I press the Android hardware back button
    Then the app navigates to Wallet Home
    And the app does NOT close

  Scenario: back with a screen beneath
    Given I navigated Leaderboard -> Profile -> Position
    When I press the Android hardware back button
    Then I go back to the previous follow-trading screen
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A — verified via unit tests; on-device capture deferred to review.

## **Reviewer notes**

Focus-scoped `useFocusEffect` listener so nested modals/bottom sheets (QuickBuy, trading-signals setup) still handle their own back. Could not run an Android build in this environment; behavior is inferred from code + the `ActivityView` precedent and covered by unit tests (hardware-back callback returns `true`; goBack vs navigate(HOME_TABS)).

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)