### PR TITLE
fix(social-leaderboard): skip QuickBuy quote fetch when a preset amount exceeds balance

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -708,6 +708,17 @@ export function useQuickBuyController(
     ],
   );
 
+  // When a buy pill exceeds balance the CTA routes to Ramp (Add funds) and no
+  // quote is ever used, so suppress the amount fed to the quotes hook. Passing
+  // undefined makes useQuickBuyQuotes short-circuit via its `!sourceTokenAmount`
+  // guard (resetQuotesIdle) — no bridge request and no blocking loading state,
+  // so the Add funds button is actionable immediately. The exported
+  // `sourceTokenAmount` is intentionally left untouched (still drives balance
+  // checks, the redux dispatch, and display).
+  const quotesSourceTokenAmount = isPresetAddFundsMode
+    ? undefined
+    : sourceTokenAmount;
+
   const {
     activeQuote,
     sortedQuotes,
@@ -725,7 +736,7 @@ export function useQuickBuyController(
   } = useQuickBuyQuotes({
     sourceToken,
     destToken,
-    sourceTokenAmount,
+    sourceTokenAmount: quotesSourceTokenAmount,
     analyticsContext: quotesAnalyticsContext,
     selectedQuoteRequestId,
     immediateFetchToken,
@@ -1685,7 +1696,10 @@ export function useQuickBuyController(
   }
 
   let confirmButtonState: 'idle' | 'loading' | 'success' = 'idle';
-  if (isConfirmLoading || isBlockingQuoteLoad) {
+  // In add-funds mode the CTA routes to Ramp and never needs a quote, so a rare
+  // mid-flight fetch (tapping an over-balance pill while a prior valid-amount
+  // fetch is still settling) must not spin the Add funds button.
+  if (!isPresetAddFundsMode && (isConfirmLoading || isBlockingQuoteLoad)) {
     confirmButtonState = 'loading';
   }
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -798,6 +798,107 @@ describe('useQuickBuyController', () => {
       expect(onClose).not.toHaveBeenCalled();
     });
 
+    it('skips quote fetching when a pill exceeds the available balance', () => {
+      // Balance 0.1 ETH @ 2000 => maxSpendFiat 200; the 250 pill exceeds it.
+      (useLatestBalance as jest.Mock).mockReturnValue({
+        displayBalance: '0.1',
+        atomicBalance: '100000000000000000',
+      });
+      const sourceWithRate = createSourceToken({ currencyExchangeRate: 2000 });
+      (usePayWithTokens as jest.Mock).mockReturnValue({
+        options: [sourceWithRate],
+      });
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      act(() => {
+        result.current.handleQuickAmountPress(250, 250);
+      });
+
+      // The amount handed to the quotes hook is suppressed (undefined), so no
+      // bridge request runs while the CTA routes to Ramp.
+      const calls = (useQuickBuyQuotes as jest.Mock).mock.calls;
+      expect(calls[calls.length - 1][0].sourceTokenAmount).toBeUndefined();
+      // Existing add-funds behaviour is preserved: actionable, labelled "Add funds".
+      expect(result.current.getButtonLabel()).toBe(
+        'social_leaderboard.quick_buy.add_funds',
+      );
+      expect(result.current.isConfirmDisabled).toBe(false);
+    });
+
+    it('keeps Add Funds actionable (not loading) even if quotes report loading', () => {
+      (useLatestBalance as jest.Mock).mockReturnValue({
+        displayBalance: '0.1',
+        atomicBalance: '100000000000000000',
+      });
+      const sourceWithRate = createSourceToken({ currencyExchangeRate: 2000 });
+      (usePayWithTokens as jest.Mock).mockReturnValue({
+        options: [sourceWithRate],
+      });
+      // Force a mid-flight fetch: even if a prior valid-amount request is still
+      // reporting loading, the add-funds CTA must not spin.
+      (useQuickBuyQuotes as jest.Mock).mockReturnValue({
+        activeQuote: undefined,
+        sortedQuotes: [],
+        destTokenAmount: undefined,
+        isQuoteLoading: true,
+        isNoQuotesAvailable: false,
+        quoteFetchError: null,
+        isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
+        quoteCount: 0,
+        quotesLastFetchedAt: null,
+        refreshCount: 0,
+        quoteRefreshRateMs: 30000,
+        maxRefreshCount: 5,
+        refetchQuotes: jest.fn(),
+      });
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      act(() => {
+        result.current.handleQuickAmountPress(250, 250);
+      });
+
+      // The quote layer still reports a blocking load, but preset add-funds mode
+      // decouples the CTA from it — the button stays idle and tappable.
+      expect(result.current.isBlockingQuoteLoad).toBe(true);
+      expect(result.current.confirmButtonState).toBe('idle');
+      expect(result.current.isConfirmDisabled).toBe(false);
+    });
+
+    it('still fetches quotes for a within-balance pill', () => {
+      // Balance 10 ETH @ 200 => maxSpendFiat 2000; the 50 pill is well within it.
+      (useLatestBalance as jest.Mock).mockReturnValue({
+        displayBalance: '10',
+        atomicBalance: '10000000000000000000',
+      });
+      const sourceWithRate = createSourceToken({ currencyExchangeRate: 200 });
+      (usePayWithTokens as jest.Mock).mockReturnValue({
+        options: [sourceWithRate],
+      });
+
+      const { result } = renderHook(() =>
+        useQuickBuyController(createTarget(), jest.fn()),
+      );
+
+      act(() => {
+        result.current.handleQuickAmountPress(50, 50);
+      });
+
+      // 50 / 200 = 0.25 ETH is passed through untouched — quotes still fetch.
+      const calls = (useQuickBuyQuotes as jest.Mock).mock.calls;
+      expect(calls[calls.length - 1][0].sourceTokenAmount).toBe('0.25');
+      expect(result.current.isPresetAddFundsMode).toBe(false);
+      expect(result.current.getButtonLabel()).toBe(
+        'social_leaderboard.trader_position.buy',
+      );
+    });
+
     it('exposes usdToCurrentCurrencyRate from native currency rates', () => {
       (selectCurrencyRates as unknown as jest.Mock).mockReturnValue({
         ETH: { conversionRate: 1000, usdConversionRate: 1200 },


### PR DESCRIPTION
## **Description**

On the QuickBuy sheet, tapping a quick-amount pill whose value **exceeds the spendable balance** (meaning the user must add funds) previously left the CTA spinning while a pointless bridge quote request ran, before the actionable **"Add funds"** button appeared.

This suppresses the amount fed to the quotes hook when in the preset add-funds state (so `useQuickBuyQuotes` short-circuits — no network request, no blocking loading state), and hardens the confirm-button state so a rare mid-flight fetch can never spin the Add funds button. The exported `sourceTokenAmount` (used by balance/display logic) is unchanged — only the value handed to the quotes hook is gated.

Scoped entirely to the top-traders / follow-trading feature.

## **Changelog**

CHANGELOG entry: Fixed a needless delay in QuickBuy: tapping an amount above your balance now shows “Add funds” immediately instead of fetching quotes first.

## **Related issues**

Refs: N/A (internal follow-trading backlog)

## **Manual testing steps**

```gherkin
Feature: QuickBuy skips quotes when funds are insufficient

  Scenario: user taps an amount above their balance
    Given I have the QuickBuy sheet open with a low balance
    When I tap a quick-amount pill whose value exceeds my balance
    Then the "Add funds" button appears immediately
    And no quote request is made
    And the button is not stuck in a loading state
```

## **Screenshots/Recordings**

### **Before**

**🔊 Sound on**

https://github.com/user-attachments/assets/10fd2bdc-bd50-4122-a6b1-06cc96a7ee39



### **After**
**🔊 Sound on**

https://github.com/user-attachments/assets/7b876620-ebb9-477f-a0fc-b8234e5e5f0a




## **Reviewer notes**

Two edits in `useQuickBuyController.ts`, both scoped to QuickBuy. No UI components, testIDs, analytics, or the chart A/B were touched.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Social Leaderboard QuickBuy controller logic and unit tests; no auth, payments, or shared bridge API changes beyond skipping fetch in a known UI state.
> 
> **Overview**
> **QuickBuy** no longer kicks off bridge quotes when the user taps a preset amount above their balance and the CTA is **Add funds** (Ramp). In that state, `useQuickBuyController` passes **`undefined`** into `useQuickBuyQuotes` instead of the real `sourceTokenAmount`, so the quotes hook short-circuits (`resetQuotesIdle`) and the button is not blocked on a useless fetch. Display, balance checks, and Redux still use the full `sourceTokenAmount`.
> 
> The confirm button also **stays idle** in add-funds mode even if a prior quote request is still loading, so **Add funds** does not spin. Within-balance pills still fetch quotes as before.
> 
> Tests cover skipped fetch, idle CTA under loading quotes, and unchanged quote behavior for in-balance amounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6a512cf1896567c9e3249fb5a47e560630d6652. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->