### PR TITLE
fix(social-leaderboard): reset trade-dot pulse per-marker so rapid taps don't leave dots enlarged

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -3818,7 +3818,7 @@ const state_state = {
     shapesByMarkerId: new Map(),
     markers: null,
     placementGeneration: 0,
-    pulseGeneration: 0,
+    pulseGenerations: new Map(),
 };
 function getShapeIds() {
     return state_state.shapeIds;
@@ -3829,6 +3829,8 @@ function pushShapeId(id) {
 function clearShapes() {
     state_state.shapeIds = [];
     state_state.shapesByMarkerId = new Map();
+    // Drop stale per-marker pulse counters so a rebuild starts clean.
+    state_state.pulseGenerations = new Map();
 }
 function getShapesByMarkerId() {
     return state_state.shapesByMarkerId;
@@ -3849,12 +3851,13 @@ function bumpPlacementGeneration() {
 function getPlacementGeneration() {
     return state_state.placementGeneration;
 }
-function bumpPulseGeneration() {
-    state_state.pulseGeneration += 1;
-    return state_state.pulseGeneration;
+function bumpPulseGeneration(markerId) {
+    const next = (state_state.pulseGenerations.get(markerId) ?? 0) + 1;
+    state_state.pulseGenerations.set(markerId, next);
+    return next;
 }
-function getPulseGeneration() {
-    return state_state.pulseGeneration;
+function getPulseGeneration(markerId) {
+    return state_state.pulseGenerations.get(markerId) ?? 0;
 }
 /** Test-only: reset every slice between test cases. */
 function __resetTradeMarkerStateForTests() {
@@ -3862,7 +3865,7 @@ function __resetTradeMarkerStateForTests() {
     state_state.shapesByMarkerId = new Map();
     state_state.markers = null;
     state_state.placementGeneration = 0;
-    state_state.pulseGeneration = 0;
+    state_state.pulseGenerations = new Map();
 }
 
 ;// CONCATENATED MODULE: ./app/components/UI/Charts/AdvancedChart/webview/src/overlays/tradeMarkers/index.ts
@@ -4165,9 +4168,11 @@ function __resetTradeMarkerRefreshForTests() {
 //
 // Ported from chartLogic.js \`handlePulseTradeMarker\` (~lines 2915-3001).
 // Decaying |sin| envelope over ~1.1s, two humps that shrink back to the
-// base size. A generation token cancels an in-flight pulse when a newer
-// pulse (or a full marker rebuild) starts, so we never leave a shape
-// stuck at the peak size.
+// base size. A per-marker generation token cancels an in-flight pulse only
+// when a newer pulse starts on the SAME marker (or a full marker rebuild
+// clears the counters), so rapid taps across different dots each pulse
+// independently and every dot's loop runs to completion and resets to the
+// base size — no dot is left stuck at the peak.
 
 
 
@@ -4224,7 +4229,7 @@ function handlePulseTradeMarker(payload) {
     const ringShape = getShape(chart, ringId);
     if (!fillShape && !ringShape)
         return;
-    const gen = bumpPulseGeneration();
+    const gen = bumpPulseGeneration(markerId);
     const startTs = Date.now();
     // Ring grows proportionally so the rim stays even.
     const ringRatio = TRADE_MARKER_RING_SIZE / TRADE_MARKER_SIZE;
@@ -4233,7 +4238,7 @@ function handlePulseTradeMarker(payload) {
         setSize(ringShape, fillSize * ringRatio);
     };
     const step = () => {
-        if (gen !== getPulseGeneration())
+        if (gen !== getPulseGeneration(markerId))
             return;
         if (!getWidget() || !isChartReady())
             return;

--- a/app/components/UI/Charts/AdvancedChart/webview/src/overlays/tradeMarkers/__tests__/animation.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/overlays/tradeMarkers/__tests__/animation.test.ts
@@ -3,6 +3,7 @@
  */
 import { handlePulseTradeMarker } from '../animation';
 import { __resetTradeMarkerStateForTests, getShapesByMarkerId } from '../state';
+import { TRADE_MARKER_SIZE } from '../index';
 import {
   __resetStateForTests,
   setChartReady,
@@ -112,6 +113,58 @@ describe('handlePulseTradeMarker', () => {
     jest.advanceTimersByTime(1500);
     // Property calls continued after the second pulse — first's loop was cancelled.
     expect(fillRec.properties.length).toBeGreaterThan(countAfterFirst);
+  });
+
+  it('resets an earlier dot to base size when a different dot is pulsed mid-pulse', () => {
+    // Two distinct markers: 'a' (fill + ring) and 'b' (fill only).
+    const { shape: fillA, record: fillARec } = makeShape('fill-a');
+    const { shape: ringA } = makeShape('ring-a');
+    const { shape: fillB, record: fillBRec } = makeShape('fill-b');
+    const { widget } = makeWidgetWithShapes({
+      'fill-a': fillA,
+      'ring-a': ringA,
+      'fill-b': fillB,
+    });
+    setWidget(widget);
+    setChartReady(true);
+    getShapesByMarkerId().set('a', { fill: 'fill-a', ring: 'ring-a' });
+    getShapesByMarkerId().set('b', { fill: 'fill-b', ring: null });
+
+    // Pulse 'a' and let it run partway so it is enlarged mid-envelope.
+    handlePulseTradeMarker({ id: 'a' });
+    jest.advanceTimersByTime(64);
+    const midSizeA = fillARec.properties[fillARec.properties.length - 1]
+      ?.size as number;
+    expect(midSizeA).toBeGreaterThan(TRADE_MARKER_SIZE);
+
+    // Pulse a DIFFERENT dot mid-pulse — must not freeze 'a' at its peak.
+    handlePulseTradeMarker({ id: 'b' });
+    jest.advanceTimersByTime(1500);
+
+    // Both dots' loops ran to completion and reset to the base size.
+    const finalSizeA = fillARec.properties[fillARec.properties.length - 1]
+      ?.size as number;
+    const finalSizeB = fillBRec.properties[fillBRec.properties.length - 1]
+      ?.size as number;
+    expect(finalSizeA).toBe(TRADE_MARKER_SIZE);
+    expect(finalSizeB).toBe(TRADE_MARKER_SIZE);
+  });
+
+  it('resets to base size after two quick pulses on the same dot', () => {
+    const { shape: fill, record: fillRec } = makeShape('fill-a');
+    const { widget } = makeWidgetWithShapes({ 'fill-a': fill });
+    setWidget(widget);
+    setChartReady(true);
+    getShapesByMarkerId().set('a', { fill: 'fill-a', ring: null });
+
+    handlePulseTradeMarker({ id: 'a' });
+    jest.advanceTimersByTime(64);
+    handlePulseTradeMarker({ id: 'a' }); // supersedes same dot
+    jest.advanceTimersByTime(1500);
+
+    const finalSize = fillRec.properties[fillRec.properties.length - 1]
+      ?.size as number;
+    expect(finalSize).toBe(TRADE_MARKER_SIZE);
   });
 
   it('no-ops when payload id is null', () => {

--- a/app/components/UI/Charts/AdvancedChart/webview/src/overlays/tradeMarkers/animation.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/overlays/tradeMarkers/animation.ts
@@ -2,9 +2,11 @@
 //
 // Ported from chartLogic.js `handlePulseTradeMarker` (~lines 2915-3001).
 // Decaying |sin| envelope over ~1.1s, two humps that shrink back to the
-// base size. A generation token cancels an in-flight pulse when a newer
-// pulse (or a full marker rebuild) starts, so we never leave a shape
-// stuck at the peak size.
+// base size. A per-marker generation token cancels an in-flight pulse only
+// when a newer pulse starts on the SAME marker (or a full marker rebuild
+// clears the counters), so rapid taps across different dots each pulse
+// independently and every dot's loop runs to completion and resets to the
+// base size — no dot is left stuck at the peak.
 
 import { reportErrorToRN } from '../../core/bridge';
 import { getWidget, isChartReady } from '../../core/state';
@@ -67,7 +69,7 @@ export function handlePulseTradeMarker(
   const ringShape = getShape(chart, ringId);
   if (!fillShape && !ringShape) return;
 
-  const gen = bumpPulseGeneration();
+  const gen = bumpPulseGeneration(markerId);
   const startTs = Date.now();
   // Ring grows proportionally so the rim stays even.
   const ringRatio = TRADE_MARKER_RING_SIZE / TRADE_MARKER_SIZE;
@@ -78,7 +80,7 @@ export function handlePulseTradeMarker(
   };
 
   const step = (): void => {
-    if (gen !== getPulseGeneration()) return;
+    if (gen !== getPulseGeneration(markerId)) return;
     if (!getWidget() || !isChartReady()) return;
     // Abort if the markers were rebuilt — record ids now point elsewhere.
     const current = getShapesByMarkerId().get(markerId);

--- a/app/components/UI/Charts/AdvancedChart/webview/src/overlays/tradeMarkers/state.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/overlays/tradeMarkers/state.ts
@@ -24,8 +24,12 @@ interface TradeMarkerState {
   markers: TradeMarker[] | null;
   /** Bumped on every placement round; stale createShape resolves discard on mismatch. */
   placementGeneration: number;
-  /** Bumped on every pulse; a newer pulse cancels the previous animation loop. */
-  pulseGeneration: number;
+  /**
+   * Per-marker pulse counter (marker.id → generation). A newer pulse cancels
+   * the previous animation loop for the SAME marker only, so pulses on other
+   * markers run to completion and reset themselves to base size.
+   */
+  pulseGenerations: Map<string, number>;
 }
 
 const state: TradeMarkerState = {
@@ -33,7 +37,7 @@ const state: TradeMarkerState = {
   shapesByMarkerId: new Map(),
   markers: null,
   placementGeneration: 0,
-  pulseGeneration: 0,
+  pulseGenerations: new Map(),
 };
 
 export function getShapeIds(): TVShapeId[] {
@@ -47,6 +51,8 @@ export function pushShapeId(id: TVShapeId): void {
 export function clearShapes(): void {
   state.shapeIds = [];
   state.shapesByMarkerId = new Map();
+  // Drop stale per-marker pulse counters so a rebuild starts clean.
+  state.pulseGenerations = new Map();
 }
 
 export function getShapesByMarkerId(): Map<string, MarkerShapePair> {
@@ -74,13 +80,14 @@ export function getPlacementGeneration(): number {
   return state.placementGeneration;
 }
 
-export function bumpPulseGeneration(): number {
-  state.pulseGeneration += 1;
-  return state.pulseGeneration;
+export function bumpPulseGeneration(markerId: string): number {
+  const next = (state.pulseGenerations.get(markerId) ?? 0) + 1;
+  state.pulseGenerations.set(markerId, next);
+  return next;
 }
 
-export function getPulseGeneration(): number {
-  return state.pulseGeneration;
+export function getPulseGeneration(markerId: string): number {
+  return state.pulseGenerations.get(markerId) ?? 0;
 }
 
 /** Test-only: reset every slice between test cases. */
@@ -89,5 +96,5 @@ export function __resetTradeMarkerStateForTests(): void {
   state.shapesByMarkerId = new Map();
   state.markers = null;
   state.placementGeneration = 0;
-  state.pulseGeneration = 0;
+  state.pulseGenerations = new Map();
 }


### PR DESCRIPTION
## **Description**

On the trader position chart, tapping trade dots in rapid succession left earlier dots stuck at their enlarged (pulsed) size. The pulse animation used a **single module-global generation counter**, so starting a pulse on any dot cancelled every other dot's in-flight animation loop **without** resetting the cancelled dot's size.

The fix makes the pulse generation **per-marker** (`Map<markerId, number>`), so a new pulse only supersedes the **same** dot's loop; every other dot's loop runs to completion and resets itself to base size. Rapidly-tapped dots now pulse independently and always shrink back.

Scoped entirely to the top-traders / follow-trading feature.

## **Changelog**

CHANGELOG entry: Fixed trade dots on the position chart staying enlarged when tapped in quick succession.

## **Related issues**

Refs: N/A (internal follow-trading backlog)

## **Manual testing steps**

```gherkin
Feature: Trade-dot pulse resets correctly

  Scenario: user taps several trade dots quickly
    Given I am viewing a trader's position chart with multiple trade dots
    When I tap several different dots in rapid succession
    Then each tapped dot pulses and shrinks back to its original size
    And no dot remains stuck enlarged
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A — verified via unit tests; on-device capture deferred to review.

## **Reviewer notes**

Regenerated the auto-generated `webview/chartLogicString.ts` bundle via `yarn build:advanced-chart-webview` (diff confined to the trade-marker region, ~17+/12-). Intended behavior change: tapped dots now pulse independently/simultaneously rather than only the last-tapped one animating. Token Details / Perps charts never call `pulseTradeMarker`, so no cross-feature regression. Not runtime-verified on a simulator — a quick manual smoke of rapid multi-dot tapping is worthwhile before merge.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)