### PR TITLE
fix(social-leaderboard): highlight the trade row on a single chart-marker tap

### DIFF
--- a/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
+++ b/app/components/UI/Charts/AdvancedChart/__tests__/AdvancedChart.test.tsx
@@ -1034,6 +1034,30 @@ describe('AdvancedChart', () => {
     });
   });
 
+  it('calls onTradeMarkerPress when WebView posts TRADE_MARKER_PRESSED', () => {
+    const onTradeMarkerPress = jest.fn();
+    const { getByTestId } = render(
+      <AdvancedChart
+        ohlcvData={MOCK_BARS}
+        onTradeMarkerPress={onTradeMarkerPress}
+      />,
+    );
+
+    const webView = getByTestId('mock-webview');
+    act(() => {
+      webView.props.onMessage({
+        nativeEvent: {
+          data: JSON.stringify({
+            type: 'TRADE_MARKER_PRESSED',
+            payload: { id: 'tx1' },
+          }),
+        },
+      });
+    });
+
+    expect(onTradeMarkerPress).toHaveBeenCalledWith('tx1');
+  });
+
   it('opens browser and fires analytics when WebView onOpenWindow fires', async () => {
     jest.mocked(Date.now).mockReturnValue(10000);
     const onChartTradingViewClicked = jest.fn();

--- a/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/chartLogicString.ts
@@ -4270,17 +4270,16 @@ function registerTradeMarkerPulseHandler() {
 }
 
 ;// CONCATENATED MODULE: ./app/components/UI/Charts/AdvancedChart/webview/src/overlays/tradeMarkers/markerHitTest.ts
-// Marker tap detection — turns a chart press into a TRADE_MARKER_PRESSED
-// message so the RN side can scroll the trades list to the pressed trade.
+// Marker tap detection — turns a chart tap into a TRADE_MARKER_PRESSED
+// message so the RN side can scroll the trades list to the tapped trade.
 //
-// Ported from chartLogic.js:
-//   findTradeMarkerIdNearPoint (~lines 3007-3072),
-//   crossHairMoved + mouse_up handlers (~lines 5692-5762).
-//
-// This owns its own crossHairMoved + mouse_up subscriptions rather than
-// piggy-backing on interaction/crosshair.ts, so overlays/tradeMarkers
-// stays self-contained and interaction/* has no knowledge of the
-// overlay's data.
+// Ported from chartLogic.js findTradeMarkerIdNearPoint (~lines 3007-3072) for
+// the pure hit-test. Tap capture is DOM-based: TradingView's crosshair only
+// fires on a long-press-and-hold on mobile, so a quick tap never produced a
+// point. We listen for real DOM taps on the chart document(s) instead and
+// hit-test the release point against the drawn markers. Listeners are
+// capture-phase + passive and NEVER call preventDefault, so chart pan / zoom
+// keep working untouched.
 
 
 
@@ -4288,9 +4287,22 @@ function registerTradeMarkerPulseHandler() {
 
 /** Pixel radius (Euclidean) for matching a tap to a marker. */
 const TAP_RADIUS_PX = 26;
-/** Max delay between last crosshair point and mouse_up to consider it a tap. */
-const TAP_MAX_AGE_MS = 700;
-let lastTapPoint = null;
+/** Max press duration (ms) still treated as a tap rather than a long-press. */
+const TAP_MAX_DURATION_MS = 350;
+/** Max finger travel (px) still treated as a tap rather than a drag / pan. */
+const TAP_MAX_MOVE_PX = 10;
+/**
+ * Window (ms) during which a repeat hit for the same id is dropped — absorbs
+ * the synthetic \`click\` a browser fires right after a touch \`touchend\`.
+ */
+const SAME_ID_DEDUPE_MS = 500;
+/** Finger-down position of the in-progress press, or null between presses. */
+let touchStart = null;
+/** Last emitted marker id + timestamp, for the synthetic-click dedupe. */
+let lastPressedId = null;
+let lastPressedAt = 0;
+/** Documents already wired with tap listeners (per-doc install guard). */
+const installedDocs = new Set();
 /**
  * Extract a normalized time range from a TradingView bar/visible range result.
  * Returns the range or null if the values are missing or non-normalizable.
@@ -4438,14 +4450,17 @@ function computeMarkerDistance(ctx, marker) {
     const dyPx = computeYDistance(ctx.chart, ctx.offsetY, snapped, marker.price);
     return { key: markerKey, dist: Math.hypot(dxPx, dyPx) };
 }
-function findTradeMarkerIdNearPoint(timeSec, offsetY) {
+/**
+ * Resolve the shared chart geometry (visible range, px-per-second, drawn
+ * shapes, cached markers) both hit-test entry points need. Returns null when
+ * the chart isn't ready or nothing is drawable.
+ */
+function resolveHitTestGeometry() {
     const markers = getMarkers();
     if (!markers?.length)
         return null;
     const widget = getWidget();
     if (!widget || !isChartReady())
-        return null;
-    if (!Number.isFinite(timeSec))
         return null;
     let chart;
     try {
@@ -4465,18 +4480,32 @@ function findTradeMarkerIdNearPoint(timeSec, offsetY) {
     const drawn = getShapesByMarkerId();
     if (!drawn.size)
         return null;
-    const ctx = {
+    return {
         chart,
         range,
         pxPerSec: plotW / (range.hi - range.lo),
         drawn,
         data: getOhlcvData(),
+        markers,
+    };
+}
+/**
+ * Nearest drawn marker id to (timeSec, offsetY), or null when none sits within
+ * TAP_RADIUS_PX.
+ */
+function findNearestMarkerId(geo, timeSec, offsetY) {
+    const ctx = {
+        chart: geo.chart,
+        range: geo.range,
+        pxPerSec: geo.pxPerSec,
+        drawn: geo.drawn,
+        data: geo.data,
         timeSec,
         offsetY,
     };
     let bestId = null;
     let bestDist = Infinity;
-    for (const marker of markers) {
+    for (const marker of geo.markers) {
         const result = computeMarkerDistance(ctx, marker);
         if (result && result.dist < bestDist) {
             bestDist = result.dist;
@@ -4486,48 +4515,190 @@ function findTradeMarkerIdNearPoint(timeSec, offsetY) {
     return bestDist <= TAP_RADIUS_PX ? bestId : null;
 }
 /**
- * Subscribes crossHairMoved (to capture the last tap point) and mouse_up
- * (to hit-test and emit TRADE_MARKER_PRESSED). The captured point is
- * consumed on release so a subsequent mouse_up without a fresh crosshair
- * update can't re-fire the same press.
+ * Nearest drawn trade-marker id to a tap expressed as (chart-time seconds,
+ * main-pane offsetY pixels), or null when none sits within TAP_RADIUS_PX.
  */
-function attachMarkerHitTest(widget, chart) {
+function findTradeMarkerIdNearPoint(timeSec, offsetY) {
+    if (!Number.isFinite(timeSec))
+        return null;
+    const geo = resolveHitTestGeometry();
+    if (!geo)
+        return null;
+    return findNearestMarkerId(geo, timeSec, offsetY);
+}
+/**
+ * Nearest drawn trade-marker id to a tap expressed as plot-relative pixels.
+ * Converts offsetX → chart-time via the visible range
+ * (timeSec = range.lo + offsetX / pxPerSec) then reuses the shared
+ * nearest-marker search.
+ */
+function findTradeMarkerIdNearPixel(offsetX, offsetY) {
+    if (!Number.isFinite(offsetX))
+        return null;
+    const geo = resolveHitTestGeometry();
+    if (!geo)
+        return null;
+    const timeSec = geo.range.lo + offsetX / geo.pxPerSec;
+    return findNearestMarkerId(geo, timeSec, offsetY);
+}
+/**
+ * Run \`fn\` for the host document and, when present, the TradingView
+ * same-origin iframe document. Mirrors widget/tvDomHelpers.eachChartDocument
+ * locally so overlays/* stay independent of widget/*.
+ */
+function eachChartTapDocument(fn) {
+    fn(document);
     try {
-        chart.crossHairMoved().subscribe(null, (params) => {
-            if (params?.price === undefined || params?.time === undefined) {
-                return;
-            }
-            lastTapPoint = {
-                timeSec: params.time,
-                offsetY: params.offsetY,
-                at: Date.now(),
-            };
-        });
+        const container = document.getElementById('tv_chart_container');
+        const iframe = container?.querySelector('iframe');
+        if (iframe?.contentDocument)
+            fn(iframe.contentDocument);
     }
-    catch (error) {
-        reportErrorToRN(error);
+    catch {
+        // iframe access can fail for detached / cross-origin frames.
     }
+}
+/**
+ * Resolve the plot element (outer \`.chart-markup-table\`, falling back to the
+ * chart container) whose top-left corner is the origin for pane-relative
+ * offsets. The right price scale + bottom time axis layout (see initChart)
+ * keeps the plot origin aligned with the container top-left, so
+ * clientX/Y − plotRect.left/top yields the plot-relative offset.
+ */
+function findPlotElement(doc) {
+    if (!doc)
+        return null;
+    const list = doc.querySelectorAll('.chart-markup-table');
+    for (const el of Array.from(list)) {
+        const className = el.className ? String(el.className) : '';
+        if (el.classList.contains('pane'))
+            continue;
+        if (className.includes('price-axis-container'))
+            continue;
+        if (className.includes('time-axis'))
+            continue;
+        return el;
+    }
+    if (list.length)
+        return list[0];
+    return doc.getElementById?.('tv_chart_container') ?? null;
+}
+/**
+ * Hit-test a tap at client coordinates and emit TRADE_MARKER_PRESSED on a hit.
+ * Drops a repeat of the same id inside SAME_ID_DEDUPE_MS to absorb the
+ * synthetic click a browser fires right after a touch tap.
+ */
+function handleTapAt(target, clientX, clientY) {
+    const doc = target?.ownerDocument ?? document;
+    const plot = findPlotElement(doc);
+    if (!plot)
+        return;
+    const rect = plot.getBoundingClientRect();
+    const id = findTradeMarkerIdNearPixel(clientX - rect.left, clientY - rect.top);
+    if (id == null)
+        return;
+    const now = Date.now();
+    if (id === lastPressedId && now - lastPressedAt < SAME_ID_DEDUPE_MS)
+        return;
+    lastPressedId = id;
+    lastPressedAt = now;
+    postToRN('TRADE_MARKER_PRESSED', { id });
+}
+function onTouchStart(ev) {
+    const touch = ev.touches?.[0];
+    if (!touch) {
+        touchStart = null;
+        return;
+    }
+    touchStart = { x: touch.clientX, y: touch.clientY, at: Date.now() };
+}
+function onTouchEnd(ev) {
+    const start = touchStart;
+    touchStart = null;
+    if (!start)
+        return;
+    const touch = ev.changedTouches?.[0];
+    if (!touch)
+        return;
+    // Reject long-press-and-hold and drag / pan gestures — only a quick,
+    // near-stationary release counts as a tap.
+    if (Date.now() - start.at > TAP_MAX_DURATION_MS)
+        return;
+    const dx = touch.clientX - start.x;
+    const dy = touch.clientY - start.y;
+    if (Math.hypot(dx, dy) > TAP_MAX_MOVE_PX)
+        return;
+    handleTapAt(ev.target, touch.clientX, touch.clientY);
+}
+function onClick(ev) {
+    const mouse = ev;
+    handleTapAt(ev.target, mouse.clientX, mouse.clientY);
+}
+/** Passive capture options — read-only, never blocks TV's own handlers. */
+const PASSIVE_CAPTURE = {
+    capture: true,
+    passive: true,
+};
+function installTapListeners(doc) {
+    if (!doc?.addEventListener || installedDocs.has(doc))
+        return;
     try {
-        widget.subscribe('mouse_up', () => {
-            const tap = lastTapPoint;
-            lastTapPoint = null;
-            if (!tap)
-                return;
-            if (Date.now() - tap.at > TAP_MAX_AGE_MS)
-                return;
-            const pressedId = findTradeMarkerIdNearPoint(tap.timeSec, tap.offsetY);
-            if (pressedId != null) {
-                postToRN('TRADE_MARKER_PRESSED', { id: pressedId });
-            }
-        });
+        doc.addEventListener('touchstart', onTouchStart, PASSIVE_CAPTURE);
+        doc.addEventListener('touchend', onTouchEnd, PASSIVE_CAPTURE);
+        // Mouse fallback (dev / web). Deduped against the synthetic post-touch
+        // click via handleTapAt's SAME_ID_DEDUPE_MS window.
+        doc.addEventListener('click', onClick, true);
+        installedDocs.add(doc);
     }
     catch (error) {
         reportErrorToRN(error);
     }
 }
-/** Test-only: forget any captured tap between test cases. */
+function applyTapDetectionOnce() {
+    eachChartTapDocument(installTapListeners);
+}
+/**
+ * Wire DOM tap detection so a single tap on a drawn marker emits
+ * TRADE_MARKER_PRESSED. Reapplies on the iframe \`load\` event and after
+ * 200 / 800 / 2000ms because TradingView mounts (and may swap) its iframe
+ * document asynchronously — mirrors externalLinkBridge's retry pattern.
+ * \`widget\` / \`chart\` are unused now that capture is DOM-based, but kept for
+ * signature stability with the crosshair-based predecessor and the caller.
+ */
+function attachMarkerHitTest(widget, chart) {
+    applyTapDetectionOnce();
+    try {
+        const container = document.getElementById('tv_chart_container');
+        const iframe = container?.querySelector('iframe');
+        if (iframe)
+            iframe.addEventListener('load', applyTapDetectionOnce);
+    }
+    catch {
+        // container / iframe may not exist yet on early calls.
+    }
+    setTimeout(applyTapDetectionOnce, 200);
+    setTimeout(applyTapDetectionOnce, 800);
+    setTimeout(applyTapDetectionOnce, 2000);
+}
+/**
+ * Test-only: forget in-flight tap state + dedupe memory and detach any
+ * installed listeners so the next attachMarkerHitTest re-installs exactly one.
+ */
 function __resetMarkerHitTestForTests() {
-    lastTapPoint = null;
+    touchStart = null;
+    lastPressedId = null;
+    lastPressedAt = 0;
+    for (const doc of installedDocs) {
+        try {
+            doc.removeEventListener('touchstart', onTouchStart, PASSIVE_CAPTURE);
+            doc.removeEventListener('touchend', onTouchEnd, PASSIVE_CAPTURE);
+            doc.removeEventListener('click', onClick, true);
+        }
+        catch {
+            // Document may already be gone during teardown.
+        }
+    }
+    installedDocs.clear();
 }
 
 ;// CONCATENATED MODULE: ./app/components/UI/Charts/AdvancedChart/webview/src/overlays/focusTime/index.ts

--- a/app/components/UI/Charts/AdvancedChart/webview/src/overlays/tradeMarkers/__tests__/markerHitTest.test.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/overlays/tradeMarkers/__tests__/markerHitTest.test.ts
@@ -4,6 +4,7 @@
 import {
   __resetMarkerHitTestForTests,
   attachMarkerHitTest,
+  findTradeMarkerIdNearPixel,
   findTradeMarkerIdNearPoint,
 } from '../markerHitTest';
 import {
@@ -313,8 +314,109 @@ describe('findTradeMarkerIdNearPoint — edge cases', () => {
   });
 });
 
-describe('attachMarkerHitTest', () => {
+describe('findTradeMarkerIdNearPixel', () => {
   beforeEach(() => {
+    __resetStateForTests();
+    __resetTradeMarkerStateForTests();
+    __resetMarkerHitTestForTests();
+    setOhlcvData(sampleBars);
+  });
+
+  it('returns null when no markers cached', () => {
+    setWidget(makeWidget(makeChart(300)));
+    setChartReady(true);
+    setMarkers([]);
+    expect(findTradeMarkerIdNearPixel(150, 0)).toBeNull();
+  });
+
+  it('returns marker id when offsetX maps to the marker plot-X', () => {
+    const chart = makeChart(300);
+    setWidget(makeWidget(chart));
+    setChartReady(true);
+    setMarkers([{ id: 'a', time: 2_000, intent: 'enter' }]);
+    getShapesByMarkerId().set('a', { fill: 'f', ring: 'r' });
+    // pxPerSec = 300 / (3-1) = 150. Marker snaps to time 2s.
+    // Plot-X = (2 - range.lo=1) * 150 = 150 → timeSec = 1 + 150/150 = 2.
+    expect(findTradeMarkerIdNearPixel(150, undefined)).toBe('a');
+  });
+
+  it('returns null when offsetX lands beyond the tap radius', () => {
+    const chart = makeChart(300);
+    setWidget(makeWidget(chart));
+    setChartReady(true);
+    setMarkers([{ id: 'a', time: 2_000, intent: 'enter' }]);
+    getShapesByMarkerId().set('a', { fill: 'f', ring: 'r' });
+    // offsetX = 0 → timeSec = 1 → dx = (2-1)*150 = 150px > 26 → null.
+    expect(findTradeMarkerIdNearPixel(0, undefined)).toBeNull();
+  });
+
+  it('returns null when offsetX is NaN', () => {
+    const chart = makeChart(300);
+    setWidget(makeWidget(chart));
+    setChartReady(true);
+    setMarkers([{ id: 'a', time: 2_000, intent: 'enter' }]);
+    getShapesByMarkerId().set('a', { fill: 'f', ring: 'r' });
+    expect(findTradeMarkerIdNearPixel(NaN, 0)).toBeNull();
+  });
+});
+
+interface SyntheticTouch {
+  clientX: number;
+  clientY: number;
+}
+
+/** Build a plot element with a stubbed bounding rect and mount it. */
+function mountPlot(rect: DOMRect): HTMLElement {
+  const el = document.createElement('div');
+  el.className = 'chart-markup-table';
+  el.getBoundingClientRect = () => rect;
+  document.body.appendChild(el);
+  return el;
+}
+
+function makeRect(width: number, height: number): DOMRect {
+  return {
+    left: 0,
+    top: 0,
+    right: width,
+    bottom: height,
+    width,
+    height,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  };
+}
+
+function dispatchTouch(
+  target: EventTarget,
+  type: 'touchstart' | 'touchend',
+  x: number,
+  y: number,
+): void {
+  const touch: SyntheticTouch = { clientX: x, clientY: y };
+  const ev = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(ev, {
+    touches: type === 'touchend' ? [] : [touch],
+    changedTouches: [touch],
+  });
+  target.dispatchEvent(ev);
+}
+
+function dispatchClick(target: EventTarget, x: number, y: number): void {
+  target.dispatchEvent(
+    new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      clientX: x,
+      clientY: y,
+    }),
+  );
+}
+
+describe('attachMarkerHitTest — DOM tap detection', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
     __resetStateForTests();
     __resetTradeMarkerStateForTests();
     __resetMarkerHitTestForTests();
@@ -323,7 +425,20 @@ describe('attachMarkerHitTest', () => {
       .ReactNativeWebView;
   });
 
-  it('posts TRADE_MARKER_PRESSED on a fresh tap landing on a marker', () => {
+  afterEach(() => {
+    __resetMarkerHitTestForTests();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  function setupChart(): {
+    bridge: MockBridge;
+    widget: TVChartingLibraryWidget;
+    chart: TVActiveChart;
+    plot: HTMLElement;
+  } {
     const bridge = installBridge();
     const chart = makeChart(300);
     const widget = makeWidget(chart);
@@ -331,120 +446,81 @@ describe('attachMarkerHitTest', () => {
     setChartReady(true);
     setMarkers([{ id: 'a', time: 2_000, intent: 'enter' }]);
     getShapesByMarkerId().set('a', { fill: 'f', ring: 'r' });
+    // pxPerSec = 300 / (3-1) = 150; marker plot-X = 150.
+    const plot = mountPlot(makeRect(300, 400));
+    return { bridge, widget, chart, plot };
+  }
 
+  it('posts TRADE_MARKER_PRESSED on a tap landing on a marker', () => {
+    const { bridge, widget, chart, plot } = setupChart();
     attachMarkerHitTest(widget, chart);
 
-    // Simulate the crosshair capturing a tap point at the marker's time.
-    const cb = (
-      globalThis as unknown as {
-        __crosshairCb: ((params: TVCrosshairParams) => void) | null;
-      }
-    ).__crosshairCb;
-    cb?.({ time: 2, price: 20, offsetY: undefined });
+    dispatchTouch(plot, 'touchstart', 150, 0);
+    dispatchTouch(plot, 'touchend', 150, 0);
 
-    // Release.
-    (widget as unknown as { __fire: (e: string) => void }).__fire('mouse_up');
     expect(bridge.postMessage).toHaveBeenCalledTimes(1);
-    const call = bridge.postMessage.mock.calls[0][0];
-    expect(JSON.parse(call)).toEqual({
+    expect(JSON.parse(bridge.postMessage.mock.calls[0][0])).toEqual({
       type: 'TRADE_MARKER_PRESSED',
       payload: { id: 'a' },
     });
   });
 
-  it('does not post when release lands off any marker', () => {
-    const bridge = installBridge();
-    const chart = makeChart(300);
-    const widget = makeWidget(chart);
-    setWidget(widget);
-    setChartReady(true);
-    setMarkers([{ id: 'a', time: 2_000, intent: 'enter' }]);
-    getShapesByMarkerId().set('a', { fill: 'f', ring: 'r' });
-
+  it('does not post when the tap lands off any marker', () => {
+    const { bridge, widget, chart, plot } = setupChart();
     attachMarkerHitTest(widget, chart);
 
-    const cb = (
-      globalThis as unknown as {
-        __crosshairCb: ((params: TVCrosshairParams) => void) | null;
-      }
-    ).__crosshairCb;
-    cb?.({ time: 1, price: 10, offsetY: undefined }); // ~150px away from marker
+    // offsetX = 0 → timeSec = 1 → ~150px from the marker.
+    dispatchTouch(plot, 'touchstart', 0, 0);
+    dispatchTouch(plot, 'touchend', 0, 0);
 
-    (widget as unknown as { __fire: (e: string) => void }).__fire('mouse_up');
     expect(bridge.postMessage).not.toHaveBeenCalled();
   });
 
-  it('consumes the tap point on release so a second mouse_up does not re-fire', () => {
-    const bridge = installBridge();
-    const chart = makeChart(300);
-    const widget = makeWidget(chart);
-    setWidget(widget);
-    setChartReady(true);
-    setMarkers([{ id: 'a', time: 2_000, intent: 'enter' }]);
-    getShapesByMarkerId().set('a', { fill: 'f', ring: 'r' });
-
+  it('does not post for a long-press beyond the tap duration', () => {
+    const { bridge, widget, chart, plot } = setupChart();
     attachMarkerHitTest(widget, chart);
-    const cb = (
-      globalThis as unknown as {
-        __crosshairCb: ((params: TVCrosshairParams) => void) | null;
-      }
-    ).__crosshairCb;
-    cb?.({ time: 2, price: 20, offsetY: undefined });
 
-    (widget as unknown as { __fire: (e: string) => void }).__fire('mouse_up');
-    (widget as unknown as { __fire: (e: string) => void }).__fire('mouse_up');
+    dispatchTouch(plot, 'touchstart', 150, 0);
+    jest.advanceTimersByTime(400); // > TAP_MAX_DURATION_MS (350)
+    dispatchTouch(plot, 'touchend', 150, 0);
+
+    expect(bridge.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not post for a drag beyond the movement slop', () => {
+    const { bridge, widget, chart, plot } = setupChart();
+    attachMarkerHitTest(widget, chart);
+
+    dispatchTouch(plot, 'touchstart', 150, 0);
+    dispatchTouch(plot, 'touchend', 150, 50); // moved 50px > 10px slop
+
+    expect(bridge.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('dedupes the synthetic click that follows a touch tap', () => {
+    const { bridge, widget, chart, plot } = setupChart();
+    attachMarkerHitTest(widget, chart);
+
+    dispatchTouch(plot, 'touchstart', 150, 0);
+    dispatchTouch(plot, 'touchend', 150, 0);
+    // Browser fires a synthetic click right after the touch tap.
+    dispatchClick(plot, 150, 0);
+
     expect(bridge.postMessage).toHaveBeenCalledTimes(1);
   });
 
-  it('ignores crosshair events with missing price or time', () => {
-    installBridge();
+  it('reports an error when installing listeners throws', () => {
+    const bridge = installBridge();
     const chart = makeChart(300);
     const widget = makeWidget(chart);
     setWidget(widget);
     setChartReady(true);
+    jest.spyOn(document, 'addEventListener').mockImplementation(() => {
+      throw new Error('addEventListener fail');
+    });
 
     attachMarkerHitTest(widget, chart);
-    const cb = (
-      globalThis as unknown as {
-        __crosshairCb: ((params: TVCrosshairParams) => void) | null;
-      }
-    ).__crosshairCb;
 
-    cb?.({ time: undefined, price: undefined } as unknown as TVCrosshairParams);
-    (widget as unknown as { __fire: (e: string) => void }).__fire('mouse_up');
-    // No marker pressed — tap point was never recorded
-  });
-
-  it('reports error when crossHairMoved subscription throws', () => {
-    const bridge = installBridge();
-    const chart = {
-      crossHairMoved: () => {
-        throw new Error('subscription fail');
-      },
-    } as unknown as TVActiveChart;
-    const widget = makeWidget(chart);
-    setWidget(widget);
-    setChartReady(true);
-
-    attachMarkerHitTest(widget, chart);
-    expect(bridge.postMessage).toHaveBeenCalledWith(
-      expect.stringContaining('"type":"ERROR"'),
-    );
-  });
-
-  it('reports error when widget.subscribe throws', () => {
-    const bridge = installBridge();
-    const chart = makeChart(300);
-    const widget = {
-      activeChart: () => chart,
-      subscribe: () => {
-        throw new Error('subscribe fail');
-      },
-    } as unknown as TVChartingLibraryWidget;
-    setWidget(widget);
-    setChartReady(true);
-
-    attachMarkerHitTest(widget, chart);
     expect(bridge.postMessage).toHaveBeenCalledWith(
       expect.stringContaining('"type":"ERROR"'),
     );

--- a/app/components/UI/Charts/AdvancedChart/webview/src/overlays/tradeMarkers/markerHitTest.ts
+++ b/app/components/UI/Charts/AdvancedChart/webview/src/overlays/tradeMarkers/markerHitTest.ts
@@ -1,14 +1,13 @@
-// Marker tap detection — turns a chart press into a TRADE_MARKER_PRESSED
-// message so the RN side can scroll the trades list to the pressed trade.
+// Marker tap detection — turns a chart tap into a TRADE_MARKER_PRESSED
+// message so the RN side can scroll the trades list to the tapped trade.
 //
-// Ported from chartLogic.js:
-//   findTradeMarkerIdNearPoint (~lines 3007-3072),
-//   crossHairMoved + mouse_up handlers (~lines 5692-5762).
-//
-// This owns its own crossHairMoved + mouse_up subscriptions rather than
-// piggy-backing on interaction/crosshair.ts, so overlays/tradeMarkers
-// stays self-contained and interaction/* has no knowledge of the
-// overlay's data.
+// Ported from chartLogic.js findTradeMarkerIdNearPoint (~lines 3007-3072) for
+// the pure hit-test. Tap capture is DOM-based: TradingView's crosshair only
+// fires on a long-press-and-hold on mobile, so a quick tap never produced a
+// point. We listen for real DOM taps on the chart document(s) instead and
+// hit-test the release point against the drawn markers. Listeners are
+// capture-phase + passive and NEVER call preventDefault, so chart pan / zoom
+// keep working untouched.
 
 import { postToRN, reportErrorToRN } from '../../core/bridge';
 import { getOhlcvData, getWidget, isChartReady } from '../../core/state';
@@ -17,7 +16,6 @@ import type {
   OHLCVBar,
   TVActiveChart,
   TVChartingLibraryWidget,
-  TVCrosshairParams,
 } from '../../core/types';
 import type { TradeMarker } from '../../messages/contract';
 import { getMarkers, getShapesByMarkerId } from './state';
@@ -25,16 +23,29 @@ import { snapMarkerToNearestBar } from './index';
 
 /** Pixel radius (Euclidean) for matching a tap to a marker. */
 const TAP_RADIUS_PX = 26;
-/** Max delay between last crosshair point and mouse_up to consider it a tap. */
-const TAP_MAX_AGE_MS = 700;
+/** Max press duration (ms) still treated as a tap rather than a long-press. */
+const TAP_MAX_DURATION_MS = 350;
+/** Max finger travel (px) still treated as a tap rather than a drag / pan. */
+const TAP_MAX_MOVE_PX = 10;
+/**
+ * Window (ms) during which a repeat hit for the same id is dropped — absorbs
+ * the synthetic `click` a browser fires right after a touch `touchend`.
+ */
+const SAME_ID_DEDUPE_MS = 500;
 
-interface LastTapPoint {
-  timeSec: number;
-  offsetY: number | undefined;
+interface TouchStartPoint {
+  x: number;
+  y: number;
   at: number;
 }
 
-let lastTapPoint: LastTapPoint | null = null;
+/** Finger-down position of the in-progress press, or null between presses. */
+let touchStart: TouchStartPoint | null = null;
+/** Last emitted marker id + timestamp, for the synthetic-click dedupe. */
+let lastPressedId: string | null = null;
+let lastPressedAt = 0;
+/** Documents already wired with tap listeners (per-doc install guard). */
+const installedDocs = new Set<Document>();
 
 interface VisibleTimeRangeSec {
   lo: number;
@@ -212,15 +223,25 @@ function computeMarkerDistance(
   return { key: markerKey, dist: Math.hypot(dxPx, dyPx) };
 }
 
-export function findTradeMarkerIdNearPoint(
-  timeSec: number,
-  offsetY: number | undefined,
-): string | null {
+interface HitTestGeometry {
+  chart: TVActiveChart;
+  range: VisibleTimeRangeSec;
+  pxPerSec: number;
+  drawn: Map<string, unknown>;
+  data: readonly OHLCVBar[];
+  markers: readonly TradeMarker[];
+}
+
+/**
+ * Resolve the shared chart geometry (visible range, px-per-second, drawn
+ * shapes, cached markers) both hit-test entry points need. Returns null when
+ * the chart isn't ready or nothing is drawable.
+ */
+function resolveHitTestGeometry(): HitTestGeometry | null {
   const markers = getMarkers();
   if (!markers?.length) return null;
   const widget = getWidget();
   if (!widget || !isChartReady()) return null;
-  if (!Number.isFinite(timeSec)) return null;
 
   let chart: TVActiveChart;
   try {
@@ -239,19 +260,38 @@ export function findTradeMarkerIdNearPoint(
   const drawn = getShapesByMarkerId();
   if (!drawn.size) return null;
 
-  const ctx: HitTestContext = {
+  return {
     chart,
     range,
     pxPerSec: plotW / (range.hi - range.lo),
     drawn,
     data: getOhlcvData(),
+    markers,
+  };
+}
+
+/**
+ * Nearest drawn marker id to (timeSec, offsetY), or null when none sits within
+ * TAP_RADIUS_PX.
+ */
+function findNearestMarkerId(
+  geo: HitTestGeometry,
+  timeSec: number,
+  offsetY: number | undefined,
+): string | null {
+  const ctx: HitTestContext = {
+    chart: geo.chart,
+    range: geo.range,
+    pxPerSec: geo.pxPerSec,
+    drawn: geo.drawn,
+    data: geo.data,
     timeSec,
     offsetY,
   };
 
   let bestId: string | null = null;
   let bestDist = Infinity;
-  for (const marker of markers) {
+  for (const marker of geo.markers) {
     const result = computeMarkerDistance(ctx, marker);
     if (result && result.dist < bestDist) {
       bestDist = result.dist;
@@ -262,46 +302,193 @@ export function findTradeMarkerIdNearPoint(
 }
 
 /**
- * Subscribes crossHairMoved (to capture the last tap point) and mouse_up
- * (to hit-test and emit TRADE_MARKER_PRESSED). The captured point is
- * consumed on release so a subsequent mouse_up without a fresh crosshair
- * update can't re-fire the same press.
+ * Nearest drawn trade-marker id to a tap expressed as (chart-time seconds,
+ * main-pane offsetY pixels), or null when none sits within TAP_RADIUS_PX.
  */
-export function attachMarkerHitTest(
-  widget: TVChartingLibraryWidget,
-  chart: TVActiveChart,
-): void {
+export function findTradeMarkerIdNearPoint(
+  timeSec: number,
+  offsetY: number | undefined,
+): string | null {
+  if (!Number.isFinite(timeSec)) return null;
+  const geo = resolveHitTestGeometry();
+  if (!geo) return null;
+  return findNearestMarkerId(geo, timeSec, offsetY);
+}
+
+/**
+ * Nearest drawn trade-marker id to a tap expressed as plot-relative pixels.
+ * Converts offsetX → chart-time via the visible range
+ * (timeSec = range.lo + offsetX / pxPerSec) then reuses the shared
+ * nearest-marker search.
+ */
+export function findTradeMarkerIdNearPixel(
+  offsetX: number,
+  offsetY: number | undefined,
+): string | null {
+  if (!Number.isFinite(offsetX)) return null;
+  const geo = resolveHitTestGeometry();
+  if (!geo) return null;
+  const timeSec = geo.range.lo + offsetX / geo.pxPerSec;
+  return findNearestMarkerId(geo, timeSec, offsetY);
+}
+
+/**
+ * Run `fn` for the host document and, when present, the TradingView
+ * same-origin iframe document. Mirrors widget/tvDomHelpers.eachChartDocument
+ * locally so overlays/* stay independent of widget/*.
+ */
+function eachChartTapDocument(fn: (doc: Document) => void): void {
+  fn(document);
   try {
-    chart.crossHairMoved().subscribe(null, (params: TVCrosshairParams) => {
-      if (params?.price === undefined || params?.time === undefined) {
-        return;
-      }
-      lastTapPoint = {
-        timeSec: params.time,
-        offsetY: params.offsetY,
-        at: Date.now(),
-      };
-    });
-  } catch (error) {
-    reportErrorToRN(error);
+    const container = document.getElementById('tv_chart_container');
+    const iframe = container?.querySelector('iframe');
+    if (iframe?.contentDocument) fn(iframe.contentDocument);
+  } catch {
+    // iframe access can fail for detached / cross-origin frames.
   }
+}
+
+/**
+ * Resolve the plot element (outer `.chart-markup-table`, falling back to the
+ * chart container) whose top-left corner is the origin for pane-relative
+ * offsets. The right price scale + bottom time axis layout (see initChart)
+ * keeps the plot origin aligned with the container top-left, so
+ * clientX/Y − plotRect.left/top yields the plot-relative offset.
+ */
+function findPlotElement(doc: Document | null | undefined): Element | null {
+  if (!doc) return null;
+  const list = doc.querySelectorAll('.chart-markup-table');
+  for (const el of Array.from(list)) {
+    const className = el.className ? String(el.className) : '';
+    if (el.classList.contains('pane')) continue;
+    if (className.includes('price-axis-container')) continue;
+    if (className.includes('time-axis')) continue;
+    return el;
+  }
+  if (list.length) return list[0];
+  return doc.getElementById?.('tv_chart_container') ?? null;
+}
+
+/**
+ * Hit-test a tap at client coordinates and emit TRADE_MARKER_PRESSED on a hit.
+ * Drops a repeat of the same id inside SAME_ID_DEDUPE_MS to absorb the
+ * synthetic click a browser fires right after a touch tap.
+ */
+function handleTapAt(
+  target: EventTarget | null,
+  clientX: number,
+  clientY: number,
+): void {
+  const doc = (target as Node | null)?.ownerDocument ?? document;
+  const plot = findPlotElement(doc);
+  if (!plot) return;
+  const rect = plot.getBoundingClientRect();
+  const id = findTradeMarkerIdNearPixel(
+    clientX - rect.left,
+    clientY - rect.top,
+  );
+  if (id == null) return;
+  const now = Date.now();
+  if (id === lastPressedId && now - lastPressedAt < SAME_ID_DEDUPE_MS) return;
+  lastPressedId = id;
+  lastPressedAt = now;
+  postToRN('TRADE_MARKER_PRESSED', { id });
+}
+
+function onTouchStart(ev: Event): void {
+  const touch = (ev as TouchEvent).touches?.[0];
+  if (!touch) {
+    touchStart = null;
+    return;
+  }
+  touchStart = { x: touch.clientX, y: touch.clientY, at: Date.now() };
+}
+
+function onTouchEnd(ev: Event): void {
+  const start = touchStart;
+  touchStart = null;
+  if (!start) return;
+  const touch = (ev as TouchEvent).changedTouches?.[0];
+  if (!touch) return;
+  // Reject long-press-and-hold and drag / pan gestures — only a quick,
+  // near-stationary release counts as a tap.
+  if (Date.now() - start.at > TAP_MAX_DURATION_MS) return;
+  const dx = touch.clientX - start.x;
+  const dy = touch.clientY - start.y;
+  if (Math.hypot(dx, dy) > TAP_MAX_MOVE_PX) return;
+  handleTapAt(ev.target, touch.clientX, touch.clientY);
+}
+
+function onClick(ev: Event): void {
+  const mouse = ev as MouseEvent;
+  handleTapAt(ev.target, mouse.clientX, mouse.clientY);
+}
+
+/** Passive capture options — read-only, never blocks TV's own handlers. */
+const PASSIVE_CAPTURE: AddEventListenerOptions = {
+  capture: true,
+  passive: true,
+};
+
+function installTapListeners(doc: Document): void {
+  if (!doc?.addEventListener || installedDocs.has(doc)) return;
   try {
-    widget.subscribe('mouse_up', () => {
-      const tap = lastTapPoint;
-      lastTapPoint = null;
-      if (!tap) return;
-      if (Date.now() - tap.at > TAP_MAX_AGE_MS) return;
-      const pressedId = findTradeMarkerIdNearPoint(tap.timeSec, tap.offsetY);
-      if (pressedId != null) {
-        postToRN('TRADE_MARKER_PRESSED', { id: pressedId });
-      }
-    });
+    doc.addEventListener('touchstart', onTouchStart, PASSIVE_CAPTURE);
+    doc.addEventListener('touchend', onTouchEnd, PASSIVE_CAPTURE);
+    // Mouse fallback (dev / web). Deduped against the synthetic post-touch
+    // click via handleTapAt's SAME_ID_DEDUPE_MS window.
+    doc.addEventListener('click', onClick, true);
+    installedDocs.add(doc);
   } catch (error) {
     reportErrorToRN(error);
   }
 }
 
-/** Test-only: forget any captured tap between test cases. */
+function applyTapDetectionOnce(): void {
+  eachChartTapDocument(installTapListeners);
+}
+
+/**
+ * Wire DOM tap detection so a single tap on a drawn marker emits
+ * TRADE_MARKER_PRESSED. Reapplies on the iframe `load` event and after
+ * 200 / 800 / 2000ms because TradingView mounts (and may swap) its iframe
+ * document asynchronously — mirrors externalLinkBridge's retry pattern.
+ * `widget` / `chart` are unused now that capture is DOM-based, but kept for
+ * signature stability with the crosshair-based predecessor and the caller.
+ */
+export function attachMarkerHitTest(
+  widget: TVChartingLibraryWidget,
+  chart: TVActiveChart,
+): void {
+  applyTapDetectionOnce();
+  try {
+    const container = document.getElementById('tv_chart_container');
+    const iframe = container?.querySelector('iframe');
+    if (iframe) iframe.addEventListener('load', applyTapDetectionOnce);
+  } catch {
+    // container / iframe may not exist yet on early calls.
+  }
+  setTimeout(applyTapDetectionOnce, 200);
+  setTimeout(applyTapDetectionOnce, 800);
+  setTimeout(applyTapDetectionOnce, 2000);
+}
+
+/**
+ * Test-only: forget in-flight tap state + dedupe memory and detach any
+ * installed listeners so the next attachMarkerHitTest re-installs exactly one.
+ */
 export function __resetMarkerHitTestForTests(): void {
-  lastTapPoint = null;
+  touchStart = null;
+  lastPressedId = null;
+  lastPressedAt = 0;
+  for (const doc of installedDocs) {
+    try {
+      doc.removeEventListener('touchstart', onTouchStart, PASSIVE_CAPTURE);
+      doc.removeEventListener('touchend', onTouchEnd, PASSIVE_CAPTURE);
+      doc.removeEventListener('click', onClick, true);
+    } catch {
+      // Document may already be gone during teardown.
+    }
+  }
+  installedDocs.clear();
 }


### PR DESCRIPTION
## **Description**

Tapping a trade **dot** on the trader position chart is meant to scroll the matching trade **row** into view and highlight it, but it only worked via a clunky **long press**. The RN-side scroll-into-view + highlight path was already correct; the bug was isolated to the WebView's press detection, which piggybacked on TradingView's crosshair (only active on a long-press-and-hold on mobile).

This replaces the crosshair coupling with **DOM-level tap detection** in the chart WebView: a real tap (short duration, little movement) is hit-tested against the drawn markers and posts `TRADE_MARKER_PRESSED`, which the existing RN handler already turns into scroll + highlight. No RN-side scroll/highlight changes were needed.

Scoped entirely to the top-traders / follow-trading feature.

## **Changelog**

CHANGELOG entry: Tapping a trade dot on the position chart now scrolls to and highlights the matching trade row (no more clunky long-press).

## **Related issues**

Refs: N/A (internal follow-trading backlog)

## **Manual testing steps**

```gherkin
Feature: Tap a chart dot to highlight its trade

  Scenario: user taps a trade dot
    Given I am viewing a trader's position with the trades list below the chart
    When I tap a trade dot on the chart
    Then the matching trade row scrolls into view
    And it is briefly highlighted
    And a normal tap (not a long press) is enough
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A — verified via unit tests; on-device capture deferred to review.

## **Reviewer notes**

Regenerated the auto-generated `webview/chartLogicString.ts` bundle via `yarn build:advanced-chart-webview` (diff confined to the marker-hit-test region). Touch listeners are passive and never `preventDefault`, so chart pan/zoom is unaffected. The shared AdvancedChart WebView is also used by Token Details / Perps, but they pass no trade markers so the tap path early-returns — no cross-feature change. Not runtime-verified on a simulator.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)