### PR TITLE
feat(social-leaderboard): persist trader profile position sort

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
@@ -1064,6 +1064,67 @@ describe('TraderProfileView', () => {
       expect(mockPlaySelection).toHaveBeenCalledTimes(2);
     });
 
+    it('reads the Open tab sort selection from redux state', () => {
+      renderWithProvider(<TraderProfileView />, {
+        state: {
+          socialLeaderboard: {
+            positionSort: { open: 'recent', closed: 'value' },
+          },
+        },
+      });
+
+      expect(screen.getByText('Recent')).toBeOnTheScreen();
+    });
+
+    it('reads the Closed tab sort selection from redux state', () => {
+      mockPositionsResult.closedPositions = fixtureClosedPositions;
+      renderWithProvider(<TraderProfileView />, {
+        state: {
+          socialLeaderboard: {
+            positionSort: { open: 'value', closed: 'pnl' },
+          },
+        },
+      });
+
+      fireEvent.press(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.TAB_CLOSED),
+      );
+
+      expect(screen.getByText('P&L %')).toBeOnTheScreen();
+    });
+
+    it('writes the Open tab sort selection to redux on tap', () => {
+      const { store } = renderWithProvider(<TraderProfileView />);
+
+      fireEvent.press(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.SORT_BUTTON),
+      );
+
+      expect(screen.getByText('P&L %')).toBeOnTheScreen();
+      expect(store.getState().socialLeaderboard.positionSort.open).toBe('pnl');
+    });
+
+    it('persists the sort selection across a remount', () => {
+      const { store, unmount } = renderWithProvider(<TraderProfileView />);
+
+      fireEvent.press(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.SORT_BUTTON),
+      );
+      fireEvent.press(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.SORT_BUTTON),
+      );
+      expect(screen.getByText('Recent')).toBeOnTheScreen();
+
+      const persisted = {
+        socialLeaderboard: store.getState().socialLeaderboard,
+      };
+      unmount();
+
+      renderWithProvider(<TraderProfileView />, { state: persisted });
+
+      expect(screen.getByText('Recent')).toBeOnTheScreen();
+    });
+
     it('hides the sort button when positions list is empty', () => {
       mockPositionsResult.openPositions = [];
       renderWithProvider(<TraderProfileView />);

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
@@ -31,7 +31,7 @@ import React, {
 import { RefreshControl, TouchableOpacity } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
 import Routes from '../../../../constants/navigation/Routes';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
@@ -76,6 +76,11 @@ import {
   type OpenSortKey,
   type SortKey,
 } from './utils/sortPositions';
+import { setPositionSort } from '../../../../reducers/socialLeaderboard';
+import {
+  selectClosedPositionSort,
+  selectOpenPositionSort,
+} from '../../../../reducers/socialLeaderboard/selectors';
 
 const POSITION_SKELETON_COUNT = 4;
 const POSITION_SKELETON_KEYS = Array.from(
@@ -205,9 +210,12 @@ const TraderProfileView = () => {
     useTraderMute(traderId);
   const { openSetupIfNeeded } = useOpenTradingSignalsSetup();
 
+  const dispatch = useDispatch();
   const [activeTab, setActiveTab] = useState<'open' | 'closed'>('open');
-  const [openSort, setOpenSort] = useState<OpenSortKey>('value');
-  const [closedSort, setClosedSort] = useState<ClosedSortKey>('value');
+  // Sort selection lives in Redux (persisted by default) so it survives leaving
+  // and returning to a profile and app restarts.
+  const openSort = useSelector(selectOpenPositionSort);
+  const closedSort = useSelector(selectClosedPositionSort);
 
   const handleBack = useCallback(() => {
     navigation.goBack();
@@ -333,17 +341,15 @@ const TraderProfileView = () => {
     // Fire-and-forget haptic; ignore rejection (unsupported platforms).
     playSelection().catch(() => undefined);
     if (activeTab === 'open') {
-      setOpenSort((current) => {
-        const idx = OPEN_SORT_CYCLE.indexOf(current);
-        return OPEN_SORT_CYCLE[(idx + 1) % OPEN_SORT_CYCLE.length];
-      });
+      const idx = OPEN_SORT_CYCLE.indexOf(openSort);
+      const sortKey = OPEN_SORT_CYCLE[(idx + 1) % OPEN_SORT_CYCLE.length];
+      dispatch(setPositionSort({ tab: 'open', sortKey }));
     } else {
-      setClosedSort((current) => {
-        const idx = CLOSED_SORT_CYCLE.indexOf(current);
-        return CLOSED_SORT_CYCLE[(idx + 1) % CLOSED_SORT_CYCLE.length];
-      });
+      const idx = CLOSED_SORT_CYCLE.indexOf(closedSort);
+      const sortKey = CLOSED_SORT_CYCLE[(idx + 1) % CLOSED_SORT_CYCLE.length];
+      dispatch(setPositionSort({ tab: 'closed', sortKey }));
     }
-  }, [activeTab]);
+  }, [activeTab, openSort, closedSort, dispatch]);
 
   const {
     scrollY: scrollYShared,

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/utils/sortPositions.ts
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/utils/sortPositions.ts
@@ -1,8 +1,18 @@
 import type { Position } from '@metamask/social-controllers';
 
-export type OpenSortKey = 'value' | 'pnl' | 'recent';
-export type ClosedSortKey = 'value' | 'pnl' | 'recent';
-export type SortKey = OpenSortKey | ClosedSortKey;
+// Sort key types live in the store layer so the reducer never imports from
+// app/components/Views (ADR-0020). Re-exported here to keep existing imports
+// (and the UI -> store direction) working.
+export type {
+  OpenSortKey,
+  ClosedSortKey,
+  SortKey,
+} from '../../../../../reducers/socialLeaderboard/types';
+import type {
+  OpenSortKey,
+  ClosedSortKey,
+  SortKey,
+} from '../../../../../reducers/socialLeaderboard/types';
 
 export const OPEN_SORT_CYCLE: readonly OpenSortKey[] = [
   'value',

--- a/app/reducers/index.ts
+++ b/app/reducers/index.ts
@@ -32,6 +32,8 @@ import cronjobControllerReducer from '../core/redux/slices/cronjobController';
 import networkConnectionBannerReducer, {
   NetworkConnectionBannerState,
 } from './networkConnectionBanner';
+import socialLeaderboardReducer from './socialLeaderboard';
+import { SocialLeaderboardState } from './socialLeaderboard/types';
 
 import bannersReducer, { BannersState } from './banners';
 import bridgeReducer from '../core/redux/slices/bridge';
@@ -137,6 +139,7 @@ export interface RootState {
   cronjobController: StateFromReducer<typeof cronjobControllerReducer>;
   rewards: RewardsState;
   networkConnectionBanner: NetworkConnectionBannerState;
+  socialLeaderboard: SocialLeaderboardState;
   attribution: StateFromReducer<typeof attributionReducer>;
   headlessOrderContexts: StateFromReducer<typeof headlessOrderContextsReducer>;
   terminalOrderAnalytics: StateFromReducer<
@@ -185,6 +188,7 @@ const baseReducers = {
   cronjobController: cronjobControllerReducer,
   rewards: rewardsReducer,
   networkConnectionBanner: networkConnectionBannerReducer,
+  socialLeaderboard: socialLeaderboardReducer,
 };
 
 if (isTestEnvironment) {

--- a/app/reducers/socialLeaderboard/index.test.ts
+++ b/app/reducers/socialLeaderboard/index.test.ts
@@ -1,0 +1,55 @@
+import reducer, { initialState, setPositionSort } from '.';
+import type { SocialLeaderboardState } from './types';
+
+describe('socialLeaderboard reducer', () => {
+  describe('default case', () => {
+    it('should return the initial state', () => {
+      expect(reducer(undefined, { type: '@@INIT' })).toStrictEqual(
+        initialState,
+      );
+    });
+
+    it('should return current state for unknown action types', () => {
+      const existingState: SocialLeaderboardState = {
+        positionSort: { open: 'pnl', closed: 'recent' },
+      };
+      const unknownAction = { type: 'UNKNOWN_ACTION_TYPE' } as const;
+
+      const result = reducer(existingState, unknownAction);
+
+      expect(result).toStrictEqual(existingState);
+    });
+  });
+
+  describe('setPositionSort', () => {
+    it('sets the open tab sort key without touching the closed tab', () => {
+      const result = reducer(
+        initialState,
+        setPositionSort({ tab: 'open', sortKey: 'recent' }),
+      );
+
+      expect(result.positionSort.open).toBe('recent');
+      expect(result.positionSort.closed).toBe('value');
+    });
+
+    it('sets the closed tab sort key without touching the open tab', () => {
+      const result = reducer(
+        initialState,
+        setPositionSort({ tab: 'closed', sortKey: 'pnl' }),
+      );
+
+      expect(result.positionSort.closed).toBe('pnl');
+      expect(result.positionSort.open).toBe('value');
+    });
+
+    it('does not mutate the original state', () => {
+      const result = reducer(
+        initialState,
+        setPositionSort({ tab: 'open', sortKey: 'pnl' }),
+      );
+
+      expect(result).not.toBe(initialState);
+      expect(initialState.positionSort.open).toBe('value');
+    });
+  });
+});

--- a/app/reducers/socialLeaderboard/index.ts
+++ b/app/reducers/socialLeaderboard/index.ts
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type {
+  SocialLeaderboardState,
+  OpenSortKey,
+  ClosedSortKey,
+} from './types';
+
+export const initialState: SocialLeaderboardState = {
+  positionSort: {
+    open: 'value',
+    closed: 'value',
+  },
+};
+
+const socialLeaderboardSlice = createSlice({
+  name: 'socialLeaderboard',
+  initialState,
+  reducers: {
+    setPositionSort: (
+      state,
+      action: PayloadAction<
+        | { tab: 'open'; sortKey: OpenSortKey }
+        | { tab: 'closed'; sortKey: ClosedSortKey }
+      >,
+    ) => {
+      state.positionSort[action.payload.tab] = action.payload.sortKey;
+    },
+  },
+});
+
+export const { setPositionSort } = socialLeaderboardSlice.actions;
+
+export default socialLeaderboardSlice.reducer;

--- a/app/reducers/socialLeaderboard/selectors.test.ts
+++ b/app/reducers/socialLeaderboard/selectors.test.ts
@@ -1,0 +1,18 @@
+import type { RootState } from '..';
+import { selectOpenPositionSort, selectClosedPositionSort } from './selectors';
+
+describe('socialLeaderboard selectors', () => {
+  const state = {
+    socialLeaderboard: {
+      positionSort: { open: 'pnl', closed: 'recent' },
+    },
+  } as RootState;
+
+  it('selectOpenPositionSort returns the open tab sort key', () => {
+    expect(selectOpenPositionSort(state)).toBe('pnl');
+  });
+
+  it('selectClosedPositionSort returns the closed tab sort key', () => {
+    expect(selectClosedPositionSort(state)).toBe('recent');
+  });
+});

--- a/app/reducers/socialLeaderboard/selectors.ts
+++ b/app/reducers/socialLeaderboard/selectors.ts
@@ -1,0 +1,8 @@
+import type { RootState } from '..';
+import type { OpenSortKey, ClosedSortKey } from './types';
+
+export const selectOpenPositionSort = (state: RootState): OpenSortKey =>
+  state.socialLeaderboard.positionSort.open;
+
+export const selectClosedPositionSort = (state: RootState): ClosedSortKey =>
+  state.socialLeaderboard.positionSort.closed;

--- a/app/reducers/socialLeaderboard/types.ts
+++ b/app/reducers/socialLeaderboard/types.ts
@@ -1,0 +1,26 @@
+/**
+ * Sort criteria for trader profile position lists.
+ *
+ * Defined here (in the store layer) rather than in the view so the reducer
+ * never imports from app/components/Views (ADR-0020 route-isolation). The
+ * view's sortPositions util re-exports these for its own use.
+ */
+export type PositionSortKey = 'value' | 'pnl' | 'recent';
+export type OpenSortKey = PositionSortKey;
+export type ClosedSortKey = PositionSortKey;
+export type SortKey = OpenSortKey | ClosedSortKey;
+
+/**
+ * Persisted UI state for the Social Leaderboard feature.
+ */
+export interface SocialLeaderboardState {
+  /**
+   * The active sort selection for each trader profile position tab. Kept in
+   * Redux (and persisted by default) so the choice survives leaving/returning
+   * to a profile and app restarts.
+   */
+  positionSort: {
+    open: OpenSortKey;
+    closed: ClosedSortKey;
+  };
+}

--- a/app/util/test/initial-root-state.ts
+++ b/app/util/test/initial-root-state.ts
@@ -19,6 +19,7 @@ import { initialState as initialSampleCounterState } from '../../features/Sample
 import { isTestEnvironment } from './utils';
 import { initialState as initialRewardsState } from '../../reducers/rewards';
 import { initialState as initialNetworkConnectionBannerState } from '../../reducers/networkConnectionBanner';
+import { initialState as initialSocialLeaderboardState } from '../../reducers/socialLeaderboard';
 // A cast is needed here because we use enums in some controllers, and TypeScript doesn't consider
 // the string value of an enum as satisfying an enum type.
 export const backgroundState: EngineState =
@@ -79,6 +80,7 @@ const initialRootState: RootState = {
   moneyBalance: initialMoneyBalanceState,
   rewards: initialRewardsState,
   networkConnectionBanner: initialNetworkConnectionBannerState,
+  socialLeaderboard: initialSocialLeaderboardState,
   attribution: {
     attribution: null,
   },


### PR DESCRIPTION
## **Description**

On a trader's profile, the position sort (e.g. "Recent") reset to the default every time you left and came back, because it was held in component-local state. This lifts the sort into a new Redux slice (`socialLeaderboard`) with selectors, so it survives navigation — and, via redux-persist, across app restarts.

Follows the repo's `createSlice` + colocated-selectors convention. The sort-key types were moved into the slice and re-exported from `sortPositions.ts` so the reducer never imports from `app/components/Views` (ADR-0020 route-isolation).

Scoped entirely to the top-traders / follow-trading feature.

## **Changelog**

CHANGELOG entry: The position sort on a trader’s profile is now remembered when you leave and return.

## **Related issues**

Refs: N/A (internal follow-trading backlog)

## **Manual testing steps**

```gherkin
Feature: Persisted position sort

  Scenario: sort survives leaving and returning
    Given I am on a trader's profile
    When I set the position sort to "Recent"
    And I navigate away and come back
    Then the sort is still "Recent"
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A — verified via unit tests; on-device capture deferred to review.

## **Reviewer notes**

**For product to confirm:** the sort preference is **global** (not per-trader) and **persists across app restarts** by default (new redux-persist key, blacklist model). This matches the recommended UX; if you want session-only, add `'socialLeaderboard'` to the persist blacklist. No migration needed (`autoMergeLevel2` falls back to initial state).

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)