### PR TITLE
feat: initialise new defi controller

### DIFF
--- a/app/constants/featureFlags.ts
+++ b/app/constants/featureFlags.ts
@@ -9,6 +9,7 @@ export enum FeatureFlagNames {
   otaUpdatesEnabled = 'otaUpdatesEnabled',
   fullPageAccountList = 'fullPageAccountList',
   assetsDefiPositionsEnabled = 'assetsDefiPositionsEnabled',
+  defiControllerV2 = 'defiControllerV2',
   tokenDetailsV2Buttons = 'tokenDetailsV2Buttons',
   tokenDetailsV2ButtonLayout = 'tokenDetailsV2ButtonLayout',
   complianceEnabled = 'complianceEnabled',
@@ -31,6 +32,7 @@ export const DEFAULT_FEATURE_FLAG_VALUES: Partial<
   Record<FeatureFlagNames, Json>
 > = {
   [FeatureFlagNames.assetsDefiPositionsEnabled]: true,
+  [FeatureFlagNames.defiControllerV2]: { enabled: false },
   [FeatureFlagNames.tokenDetailsV2Buttons]: false,
   [FeatureFlagNames.tokenDetailsV2ButtonLayout]: false,
   [FeatureFlagNames.tronClaimUnstakedTrxButtonEnabled]: false,

--- a/app/core/Engine/Engine.test.ts
+++ b/app/core/Engine/Engine.test.ts
@@ -169,6 +169,7 @@ describe('Engine', () => {
     expect(engine.context).toHaveProperty('EarnController');
     expect(engine.context).toHaveProperty('MultichainTransactionsController');
     expect(engine.context).toHaveProperty('DeFiPositionsController');
+    expect(engine.context).toHaveProperty('DeFiPositionsControllerV2');
     expect(engine.context).toHaveProperty('NetworkEnablementController');
     expect(engine.context).toHaveProperty('PerpsController');
     expect(engine.context).toHaveProperty('GatorPermissionsController');

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -124,6 +124,7 @@ import { bridgeStatusControllerInit } from './controllers/bridge-status-controll
 import { multichainNetworkControllerInit } from './controllers/multichain-network-controller/multichain-network-controller-init';
 import { currencyRateControllerInit } from './controllers/currency-rate-controller/currency-rate-controller-init';
 import { defiPositionsControllerInit } from './controllers/defi-positions-controller/defi-positions-controller-init';
+import { defiPositionsControllerV2Init } from './controllers/defi-positions-controller-v2/defi-positions-controller-v2-init';
 import { SignatureControllerInit } from './controllers/signature-controller';
 import { appMetadataControllerInit } from './controllers/app-metadata-controller';
 import { InternalAccount } from '@metamask/keyring-internal-api';
@@ -340,6 +341,7 @@ export class Engine {
         TokenSearchDiscoveryDataController:
           tokenSearchDiscoveryDataControllerInit,
         DeFiPositionsController: defiPositionsControllerInit,
+        DeFiPositionsControllerV2: defiPositionsControllerV2Init,
         BridgeController: bridgeControllerInit,
         BridgeStatusController: bridgeStatusControllerInit,
         NftController: nftControllerInit,
@@ -640,6 +642,8 @@ export class Engine {
         messengerClientsByName.MoneyAccountApiDataService,
       GeolocationController: geolocationController,
       DeFiPositionsController: messengerClientsByName.DeFiPositionsController,
+      DeFiPositionsControllerV2:
+        messengerClientsByName.DeFiPositionsControllerV2,
       SeedlessOnboardingController: seedlessOnboardingController,
       ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
       SamplePetnamesController: messengerClientsByName.SamplePetnamesController,
@@ -1470,6 +1474,7 @@ export default {
       ConnectivityController,
       CurrencyRateController,
       DeFiPositionsController,
+      DeFiPositionsControllerV2,
       DelegationController,
       EarnController,
       GasFeeController,
@@ -1544,6 +1549,7 @@ export default {
       ConnectivityController: ConnectivityController.state,
       CurrencyRateController: CurrencyRateController.state,
       DeFiPositionsController: DeFiPositionsController.state,
+      DeFiPositionsControllerV2: DeFiPositionsControllerV2.state,
       DelegationController: DelegationController.state,
       EarnController: EarnController.state,
       GasFeeController: GasFeeController.state,

--- a/app/core/Engine/constants.ts
+++ b/app/core/Engine/constants.ts
@@ -92,6 +92,7 @@ export const BACKGROUND_STATE_CHANGE_EVENT_NAMES = [
   'PerpsController:stateChange',
   'RewardsController:stateChange',
   'DeFiPositionsController:stateChange',
+  'DeFiPositionsControllerV2:stateChanged',
   'SeedlessOnboardingController:stateChange',
   ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
   'SamplePetnamesController:stateChange',

--- a/app/core/Engine/controllers/defi-positions-controller-v2/defi-positions-controller-v2-init.test.ts
+++ b/app/core/Engine/controllers/defi-positions-controller-v2/defi-positions-controller-v2-init.test.ts
@@ -1,0 +1,160 @@
+import { MessengerClientInitRequest } from '../../types';
+import { buildMessengerClientInitRequestMock } from '../../utils/test-utils';
+import { ExtendedMessenger } from '../../../ExtendedMessenger';
+import {
+  DeFiPositionsControllerV2InitMessenger,
+  getDeFiPositionsControllerV2Messenger,
+} from '../../messengers/defi-positions-controller-v2-messenger/defi-positions-controller-v2-messenger';
+import {
+  DeFiPositionsControllerV2,
+  DeFiPositionsControllerV2Messenger,
+} from '@metamask/assets-controllers';
+import { defiPositionsControllerV2Init } from './defi-positions-controller-v2-init';
+import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
+import { store } from '../../../../store';
+import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings';
+import { selectCompletedOnboarding } from '../../../../selectors/onboarding';
+import { selectDefiControllerV2Enabled } from '../../../../selectors/featureFlagController/defiControllerV2';
+
+jest.mock('@metamask/assets-controllers');
+jest.mock('@metamask/core-backend', () => ({
+  createApiPlatformClient: jest.fn().mockReturnValue({
+    accounts: {
+      fetchV6MultiAccountBalances: jest.fn(),
+    },
+  }),
+}));
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn().mockReturnValue('1.0.0'),
+}));
+jest.mock('../../../../store', () => ({
+  store: {
+    getState: jest.fn(),
+  },
+}));
+jest.mock('../../../../selectors/settings', () => ({
+  selectBasicFunctionalityEnabled: jest.fn(),
+}));
+jest.mock('../../../../selectors/onboarding', () => ({
+  selectCompletedOnboarding: jest.fn(),
+}));
+jest.mock(
+  '../../../../selectors/featureFlagController/defiControllerV2',
+  () => ({
+    selectDefiControllerV2Enabled: jest.fn(),
+  }),
+);
+
+function getInitRequestMock(
+  baseMessenger = new ExtendedMessenger<MockAnyNamespace>({
+    namespace: MOCK_ANY_NAMESPACE,
+  }),
+): jest.Mocked<
+  MessengerClientInitRequest<
+    DeFiPositionsControllerV2Messenger,
+    DeFiPositionsControllerV2InitMessenger
+  >
+> {
+  const mockInitMessenger = {
+    call: jest.fn().mockReturnValue({ selectedCurrency: 'usd' }),
+  } as unknown as DeFiPositionsControllerV2InitMessenger;
+
+  const requestMock = {
+    ...buildMessengerClientInitRequestMock(baseMessenger),
+    controllerMessenger: getDeFiPositionsControllerV2Messenger(baseMessenger),
+    initMessenger: mockInitMessenger,
+  };
+
+  return requestMock;
+}
+
+describe('DeFiPositionsControllerV2Init', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (store.getState as jest.Mock).mockReturnValue({});
+    (selectBasicFunctionalityEnabled as unknown as jest.Mock).mockReturnValue(
+      true,
+    );
+    (selectCompletedOnboarding as unknown as jest.Mock).mockReturnValue(true);
+    (selectDefiControllerV2Enabled as unknown as jest.Mock).mockReturnValue(
+      true,
+    );
+  });
+
+  it('returns controller instance with expected constructor args', () => {
+    const { controller } = defiPositionsControllerV2Init(getInitRequestMock());
+    expect(controller).toBeInstanceOf(DeFiPositionsControllerV2);
+
+    const controllerMock = jest.mocked(DeFiPositionsControllerV2);
+    expect(controllerMock).toHaveBeenCalledWith({
+      messenger: expect.any(Object),
+      apiClient: expect.any(Object),
+      isEnabled: expect.any(Function),
+      getVsCurrency: expect.any(Function),
+    });
+  });
+
+  describe('isEnabled', () => {
+    it.each([
+      {
+        basicFunctionality: true,
+        completedOnboarding: true,
+        flag: true,
+        expected: true,
+      },
+      {
+        basicFunctionality: false,
+        completedOnboarding: true,
+        flag: true,
+        expected: false,
+      },
+      {
+        basicFunctionality: true,
+        completedOnboarding: false,
+        flag: true,
+        expected: false,
+      },
+      {
+        basicFunctionality: true,
+        completedOnboarding: true,
+        flag: false,
+        expected: false,
+      },
+    ])(
+      'returns $expected when basicFunctionality=$basicFunctionality, completedOnboarding=$completedOnboarding, flag=$flag',
+      ({ basicFunctionality, completedOnboarding, flag, expected }) => {
+        (
+          selectBasicFunctionalityEnabled as unknown as jest.Mock
+        ).mockReturnValue(basicFunctionality);
+        (selectCompletedOnboarding as unknown as jest.Mock).mockReturnValue(
+          completedOnboarding,
+        );
+        (selectDefiControllerV2Enabled as unknown as jest.Mock).mockReturnValue(
+          flag,
+        );
+
+        defiPositionsControllerV2Init(getInitRequestMock());
+
+        const controllerMock = jest.mocked(DeFiPositionsControllerV2);
+        const isEnabled = controllerMock.mock.calls[0][0].isEnabled;
+
+        expect(isEnabled()).toBe(expected);
+      },
+    );
+  });
+
+  describe('getVsCurrency', () => {
+    it('returns selectedCurrency from AssetsController', () => {
+      const requestMock = getInitRequestMock();
+      defiPositionsControllerV2Init(requestMock);
+
+      const controllerMock = jest.mocked(DeFiPositionsControllerV2);
+      const getVsCurrency = controllerMock.mock.calls[0][0].getVsCurrency;
+
+      expect(getVsCurrency()).toBe('usd');
+      expect(requestMock.initMessenger.call).toHaveBeenCalledWith(
+        'AssetsController:getState',
+      );
+    });
+  });
+});

--- a/app/core/Engine/controllers/defi-positions-controller-v2/defi-positions-controller-v2-init.ts
+++ b/app/core/Engine/controllers/defi-positions-controller-v2/defi-positions-controller-v2-init.ts
@@ -1,0 +1,82 @@
+import {
+  DeFiPositionsControllerV2,
+  DeFiPositionsControllerV2Messenger,
+} from '@metamask/assets-controllers';
+import {
+  createApiPlatformClient,
+  type ApiPlatformClient,
+} from '@metamask/core-backend';
+import { getVersion } from 'react-native-device-info';
+import type { MessengerClientInitFunction } from '../../types';
+import { DeFiPositionsControllerV2InitMessenger } from '../../messengers/defi-positions-controller-v2-messenger/defi-positions-controller-v2-messenger';
+import { store } from '../../../../store';
+import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings';
+import { selectCompletedOnboarding } from '../../../../selectors/onboarding';
+import { selectDefiControllerV2Enabled } from '../../../../selectors/featureFlagController/defiControllerV2';
+
+/**
+ * Cached API client instance shared across init calls (matches AssetsController).
+ */
+let apiClient: ApiPlatformClient | null = null;
+
+/**
+ * Safely retrieves the bearer token for API authentication.
+ *
+ * @param initMessenger - The initialization messenger.
+ * @returns The bearer token or undefined if retrieval fails.
+ */
+async function safeGetBearerToken(
+  initMessenger: DeFiPositionsControllerV2InitMessenger,
+): Promise<string | undefined> {
+  try {
+    return await initMessenger.call('AuthenticationController:getBearerToken');
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Gets or creates the API platform client used to fetch DeFi positions.
+ *
+ * @param initMessenger - The initialization messenger.
+ * @returns The API platform client.
+ */
+function getApiClient(
+  initMessenger: DeFiPositionsControllerV2InitMessenger,
+): ApiPlatformClient {
+  if (!apiClient) {
+    apiClient = createApiPlatformClient({
+      clientProduct: 'metamask-mobile',
+      clientVersion: getVersion(),
+      getBearerToken: () => safeGetBearerToken(initMessenger),
+    });
+  }
+  return apiClient;
+}
+
+/**
+ * Initialize the DeFiPositionsControllerV2.
+ *
+ * @param request - The request object.
+ * @returns The DeFiPositionsControllerV2.
+ */
+export const defiPositionsControllerV2Init: MessengerClientInitFunction<
+  DeFiPositionsControllerV2,
+  DeFiPositionsControllerV2Messenger,
+  DeFiPositionsControllerV2InitMessenger
+> = (request) => {
+  const { initMessenger, controllerMessenger } = request;
+
+  const controller = new DeFiPositionsControllerV2({
+    messenger: controllerMessenger,
+    apiClient: getApiClient(initMessenger),
+    isEnabled: () =>
+      selectBasicFunctionalityEnabled(store.getState()) &&
+      selectCompletedOnboarding(store.getState()) &&
+      selectDefiControllerV2Enabled(store.getState()),
+    getVsCurrency: () =>
+      initMessenger.call('AssetsController:getState').selectedCurrency,
+  });
+
+  return { controller };
+};

--- a/app/core/Engine/controllers/defi-positions-controller/defi-positions-controller-init.test.ts
+++ b/app/core/Engine/controllers/defi-positions-controller/defi-positions-controller-init.test.ts
@@ -12,15 +12,27 @@ import {
 import { defiPositionsControllerInit } from './defi-positions-controller-init';
 import { AnalyticsEventBuilder } from '../../../../util/analytics/AnalyticsEventBuilder';
 import { MOCK_ANY_NAMESPACE, MockAnyNamespace } from '@metamask/messenger';
+import { store } from '../../../../store';
+import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings';
+import { selectDefiControllerV2Enabled } from '../../../../selectors/featureFlagController/defiControllerV2';
 
 jest.mock('@metamask/assets-controllers');
 jest.mock('../../../../util/analytics/AnalyticsEventBuilder');
 
-jest.mock('.../../../../store', () => ({
+jest.mock('../../../../store', () => ({
   store: {
     getState: jest.fn(),
   },
 }));
+jest.mock('../../../../selectors/settings', () => ({
+  selectBasicFunctionalityEnabled: jest.fn(),
+}));
+jest.mock(
+  '../../../../selectors/featureFlagController/defiControllerV2',
+  () => ({
+    selectDefiControllerV2Enabled: jest.fn(),
+  }),
+);
 
 function getInitRequestMock(
   baseMessenger = new ExtendedMessenger<MockAnyNamespace>({
@@ -48,6 +60,13 @@ function getInitRequestMock(
 describe('DeFiPositionsControllerInit', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (store.getState as jest.Mock).mockReturnValue({});
+    (selectBasicFunctionalityEnabled as unknown as jest.Mock).mockReturnValue(
+      true,
+    );
+    (selectDefiControllerV2Enabled as unknown as jest.Mock).mockReturnValue(
+      false,
+    );
     (AnalyticsEventBuilder.createEventBuilder as jest.Mock).mockReturnValue({
       addProperties: jest.fn().mockReturnThis(),
       build: jest.fn().mockReturnValue({
@@ -71,6 +90,48 @@ describe('DeFiPositionsControllerInit', () => {
       isEnabled: expect.any(Function),
       trackEvent: expect.any(Function),
     });
+  });
+
+  describe('isEnabled', () => {
+    it.each([
+      {
+        basicFunctionality: true,
+        v2Enabled: false,
+        expected: true,
+      },
+      {
+        basicFunctionality: true,
+        v2Enabled: true,
+        expected: false,
+      },
+      {
+        basicFunctionality: false,
+        v2Enabled: false,
+        expected: false,
+      },
+      {
+        basicFunctionality: false,
+        v2Enabled: true,
+        expected: false,
+      },
+    ])(
+      'returns $expected when basicFunctionality=$basicFunctionality, v2Enabled=$v2Enabled',
+      ({ basicFunctionality, v2Enabled, expected }) => {
+        (
+          selectBasicFunctionalityEnabled as unknown as jest.Mock
+        ).mockReturnValue(basicFunctionality);
+        (selectDefiControllerV2Enabled as unknown as jest.Mock).mockReturnValue(
+          v2Enabled,
+        );
+
+        defiPositionsControllerInit(getInitRequestMock());
+
+        const controllerMock = jest.mocked(DeFiPositionsController);
+        const isEnabled = controllerMock.mock.calls[0][0].isEnabled;
+
+        expect(isEnabled?.()).toBe(expected);
+      },
+    );
   });
 
   describe('trackEvent', () => {

--- a/app/core/Engine/controllers/defi-positions-controller/defi-positions-controller-init.ts
+++ b/app/core/Engine/controllers/defi-positions-controller/defi-positions-controller-init.ts
@@ -6,6 +6,7 @@ import type { MessengerClientInitFunction } from '../../types';
 import { DeFiPositionsControllerInitMessenger } from '../../messengers/defi-positions-controller-messenger/defi-positions-controller-messenger';
 import { store } from '../../../../store';
 import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings';
+import { selectDefiControllerV2Enabled } from '../../../../selectors/featureFlagController/defiControllerV2';
 import { AnalyticsEventBuilder } from '../../../../util/analytics/AnalyticsEventBuilder';
 import type { AnalyticsTrackingEvent as PackageAnalyticsTrackingEvent } from '@metamask/analytics-controller';
 import {
@@ -14,7 +15,10 @@ import {
 } from '../../../../constants/featureFlags';
 
 /**
- * Initialize the DeFiPositionsController.
+ * Initialize the DeFiPositionsController (V1).
+ *
+ * Enabled only when V2 is off: the two controllers are mutually exclusive via
+ * {@link selectDefiControllerV2Enabled}.
  *
  * @param request - The request object.
  * @returns The DeFiPositionsController.
@@ -41,7 +45,13 @@ export const defiPositionsControllerInit: MessengerClientInitFunction<
           ],
       );
 
-      return isBasicFunctionalityToggleEnabled && assetsDefiPositionsEnabled;
+      const isV2Enabled = selectDefiControllerV2Enabled(store.getState());
+
+      return (
+        isBasicFunctionalityToggleEnabled &&
+        assetsDefiPositionsEnabled &&
+        !isV2Enabled
+      );
     },
     trackEvent: (params: {
       event: string;

--- a/app/core/Engine/messengers/defi-positions-controller-v2-messenger/defi-positions-controller-v2-messenger.test.ts
+++ b/app/core/Engine/messengers/defi-positions-controller-v2-messenger/defi-positions-controller-v2-messenger.test.ts
@@ -1,0 +1,46 @@
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+  type MockAnyNamespace,
+  MOCK_ANY_NAMESPACE,
+} from '@metamask/messenger';
+import { DeFiPositionsControllerV2Messenger } from '@metamask/assets-controllers';
+import {
+  getDeFiPositionsControllerV2InitMessenger,
+  getDeFiPositionsControllerV2Messenger,
+  DeFiPositionsControllerV2InitMessenger,
+} from './defi-positions-controller-v2-messenger';
+
+type RootMessenger = Messenger<
+  MockAnyNamespace,
+  | MessengerActions<DeFiPositionsControllerV2Messenger>
+  | MessengerActions<DeFiPositionsControllerV2InitMessenger>,
+  | MessengerEvents<DeFiPositionsControllerV2Messenger>
+  | MessengerEvents<DeFiPositionsControllerV2InitMessenger>
+>;
+
+const getRootMessenger = (): RootMessenger =>
+  new Messenger<MockAnyNamespace, never, never>({
+    namespace: MOCK_ANY_NAMESPACE,
+  });
+
+describe('getDeFiPositionsControllerV2Messenger', () => {
+  it('returns a messenger', () => {
+    const rootMessenger = getRootMessenger();
+    const defiPositionsControllerV2Messenger =
+      getDeFiPositionsControllerV2Messenger(rootMessenger);
+
+    expect(defiPositionsControllerV2Messenger).toBeInstanceOf(Messenger);
+  });
+});
+
+describe('getDeFiPositionsControllerV2InitMessenger', () => {
+  it('returns a messenger', () => {
+    const rootMessenger = getRootMessenger();
+    const defiPositionsControllerV2InitMessenger =
+      getDeFiPositionsControllerV2InitMessenger(rootMessenger);
+
+    expect(defiPositionsControllerV2InitMessenger).toBeInstanceOf(Messenger);
+  });
+});

--- a/app/core/Engine/messengers/defi-positions-controller-v2-messenger/defi-positions-controller-v2-messenger.ts
+++ b/app/core/Engine/messengers/defi-positions-controller-v2-messenger/defi-positions-controller-v2-messenger.ts
@@ -1,0 +1,73 @@
+import { DeFiPositionsControllerV2Messenger } from '@metamask/assets-controllers';
+import {
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
+import { AuthenticationController } from '@metamask/profile-sync-controller';
+import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
+import { RootMessenger } from '../../types';
+import { AssetsControllerGetStateAction } from '@metamask/assets-controller';
+
+/**
+ * Get a restricted messenger for the DeFiPositionsControllerV2.
+ *
+ * @param rootMessenger - The messenger to restrict.
+ * @returns The restricted messenger.
+ */
+export function getDeFiPositionsControllerV2Messenger(
+  rootMessenger: RootMessenger,
+): DeFiPositionsControllerV2Messenger {
+  const messenger = new Messenger<
+    'DeFiPositionsControllerV2',
+    MessengerActions<DeFiPositionsControllerV2Messenger>,
+    MessengerEvents<DeFiPositionsControllerV2Messenger>,
+    RootMessenger
+  >({
+    namespace: 'DeFiPositionsControllerV2',
+    parent: rootMessenger,
+  });
+  rootMessenger.delegate({
+    actions: ['AccountTreeController:getAccountsFromSelectedAccountGroup'],
+    messenger,
+  });
+  return messenger;
+}
+
+type DeFiPositionsControllerV2InitMessengerActions =
+  | RemoteFeatureFlagControllerGetStateAction
+  | AssetsControllerGetStateAction
+  | AuthenticationController.AuthenticationControllerGetBearerTokenAction;
+
+export type DeFiPositionsControllerV2InitMessenger = ReturnType<
+  typeof getDeFiPositionsControllerV2InitMessenger
+>;
+
+/**
+ * Get a restricted messenger for DeFiPositionsControllerV2 initialization.
+ *
+ * @param rootMessenger - The messenger to restrict.
+ * @returns The restricted init messenger.
+ */
+export function getDeFiPositionsControllerV2InitMessenger(
+  rootMessenger: RootMessenger,
+) {
+  const messenger = new Messenger<
+    'DeFiPositionsControllerV2Init',
+    DeFiPositionsControllerV2InitMessengerActions,
+    never,
+    RootMessenger
+  >({
+    namespace: 'DeFiPositionsControllerV2Init',
+    parent: rootMessenger,
+  });
+  rootMessenger.delegate({
+    actions: [
+      'RemoteFeatureFlagController:getState',
+      'AssetsController:getState',
+      'AuthenticationController:getBearerToken',
+    ],
+    messenger,
+  });
+  return messenger;
+}

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -12,6 +12,10 @@ import {
   getDeFiPositionsControllerMessenger,
 } from './defi-positions-controller-messenger/defi-positions-controller-messenger';
 import {
+  getDeFiPositionsControllerV2InitMessenger,
+  getDeFiPositionsControllerV2Messenger,
+} from './defi-positions-controller-v2-messenger/defi-positions-controller-v2-messenger';
+import {
   getBackendWebSocketServiceMessenger,
   getBackendWebSocketServiceInitMessenger,
   getAccountActivityServiceMessenger,
@@ -238,6 +242,10 @@ export const MESSENGER_FACTORIES = {
   DeFiPositionsController: {
     getMessenger: getDeFiPositionsControllerMessenger,
     getInitMessenger: getDeFiPositionsControllerInitMessenger,
+  },
+  DeFiPositionsControllerV2: {
+    getMessenger: getDeFiPositionsControllerV2Messenger,
+    getInitMessenger: getDeFiPositionsControllerV2InitMessenger,
   },
   ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   AuthenticationController: {

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -42,6 +42,10 @@ import {
   DeFiPositionsControllerState,
   DeFiPositionsControllerEvents,
   DeFiPositionsControllerActions,
+  DeFiPositionsControllerV2,
+  DeFiPositionsControllerV2State,
+  DeFiPositionsControllerV2Events,
+  DeFiPositionsControllerV2Actions,
 
   ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   MultichainBalancesControllerState,
@@ -632,6 +636,7 @@ export type GlobalActions =
   | AppMetadataControllerActions
   | MultichainRoutingServiceActions
   | DeFiPositionsControllerActions
+  | DeFiPositionsControllerV2Actions
   | StorageServiceActions
   | DelegationControllerActions
   | SeedlessOnboardingControllerActions
@@ -729,6 +734,7 @@ export type GlobalEvents =
   | AppMetadataControllerEvents
   | SeedlessOnboardingControllerEvents
   | DeFiPositionsControllerEvents
+  | DeFiPositionsControllerV2Events
   | AccountTreeControllerEvents
   | DelegationControllerEvents
   | NftDetectionControllerEvents
@@ -824,6 +830,7 @@ export type MessengerClients = {
   TokenRatesController: TokenRatesController;
   TokensController: TokensController;
   DeFiPositionsController: DeFiPositionsController;
+  DeFiPositionsControllerV2: DeFiPositionsControllerV2;
   TransactionController: TransactionController;
   TransactionPayController: TransactionPayController;
   SmartTransactionsController: SmartTransactionsController;
@@ -925,6 +932,7 @@ export type EngineState = {
   GasFeeController: GasFeeState;
   TokensController: TokensControllerState;
   DeFiPositionsController: DeFiPositionsControllerState;
+  DeFiPositionsControllerV2: DeFiPositionsControllerV2State;
   ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   SnapController: PersistedSnapControllerState;
   SnapRegistryController: SnapRegistryControllerState;
@@ -1045,6 +1053,7 @@ export type MessengerClientsToInitialize =
   | 'AccountTreeController'
   | 'CurrencyRateController'
   | 'DeFiPositionsController'
+  | 'DeFiPositionsControllerV2'
   | 'GeolocationController'
   | 'GeolocationApiService'
   | 'MultichainNetworkController'

--- a/app/selectors/deFiPositionsSectionEnabled.test.ts
+++ b/app/selectors/deFiPositionsSectionEnabled.test.ts
@@ -1,16 +1,27 @@
 import { selectDeFiPositionsSectionEnabled } from './deFiPositionsSectionEnabled';
 
 describe('selectDeFiPositionsSectionEnabled', () => {
-  it('returns true only when remote flag and basic functionality are true', () => {
-    expect(selectDeFiPositionsSectionEnabled.resultFunc(true, true)).toBe(true);
-    expect(selectDeFiPositionsSectionEnabled.resultFunc(true, false)).toBe(
+  it('returns true when assets DeFi is enabled, V2 is disabled, and basic functionality is enabled', () => {
+    expect(
+      selectDeFiPositionsSectionEnabled.resultFunc(true, false, true),
+    ).toBe(true);
+  });
+
+  it('returns false when V2 is enabled', () => {
+    expect(selectDeFiPositionsSectionEnabled.resultFunc(true, true, true)).toBe(
       false,
     );
-    expect(selectDeFiPositionsSectionEnabled.resultFunc(false, true)).toBe(
-      false,
-    );
-    expect(selectDeFiPositionsSectionEnabled.resultFunc(false, false)).toBe(
-      false,
-    );
+  });
+
+  it('returns false when basic functionality is disabled', () => {
+    expect(
+      selectDeFiPositionsSectionEnabled.resultFunc(true, false, false),
+    ).toBe(false);
+  });
+
+  it('returns false when assets DeFi positions is disabled', () => {
+    expect(
+      selectDeFiPositionsSectionEnabled.resultFunc(false, false, true),
+    ).toBe(false);
   });
 });

--- a/app/selectors/deFiPositionsSectionEnabled.ts
+++ b/app/selectors/deFiPositionsSectionEnabled.ts
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 import { selectAssetsDefiPositionsEnabled } from './featureFlagController/assetsDefiPositions';
+import { selectDefiControllerV2Enabled } from './featureFlagController/defiControllerV2';
 import { selectBasicFunctionalityEnabled } from './settings';
 
 /**
@@ -11,7 +12,14 @@ import { selectBasicFunctionalityEnabled } from './settings';
  */
 export const selectDeFiPositionsSectionEnabled = createSelector(
   selectAssetsDefiPositionsEnabled,
+  selectDefiControllerV2Enabled,
   selectBasicFunctionalityEnabled,
-  (assetsDefiPositionsEnabled, basicFunctionalityEnabled) =>
-    assetsDefiPositionsEnabled && basicFunctionalityEnabled,
+  (
+    assetsDefiPositionsEnabled,
+    defiControllerV2Enabled,
+    basicFunctionalityEnabled,
+  ) =>
+    assetsDefiPositionsEnabled &&
+    basicFunctionalityEnabled &&
+    !defiControllerV2Enabled,
 );

--- a/app/selectors/deFiPositionsV2SectionEnabled.test.ts
+++ b/app/selectors/deFiPositionsV2SectionEnabled.test.ts
@@ -1,0 +1,21 @@
+import { selectDeFiPositionsV2SectionEnabled } from './deFiPositionsV2SectionEnabled';
+
+describe('selectDeFiPositionsV2SectionEnabled', () => {
+  it('returns true when both the V2 flag and basic functionality are enabled', () => {
+    expect(selectDeFiPositionsV2SectionEnabled.resultFunc(true, true)).toBe(
+      true,
+    );
+  });
+
+  it('returns false when the V2 flag is disabled', () => {
+    expect(selectDeFiPositionsV2SectionEnabled.resultFunc(false, true)).toBe(
+      false,
+    );
+  });
+
+  it('returns false when basic functionality is disabled', () => {
+    expect(selectDeFiPositionsV2SectionEnabled.resultFunc(true, false)).toBe(
+      false,
+    );
+  });
+});

--- a/app/selectors/deFiPositionsV2SectionEnabled.ts
+++ b/app/selectors/deFiPositionsV2SectionEnabled.ts
@@ -1,0 +1,19 @@
+import { createSelector } from 'reselect';
+import { selectDefiControllerV2Enabled } from './featureFlagController/defiControllerV2';
+import { selectBasicFunctionalityEnabled } from './settings';
+
+/**
+ * Whether the homepage / DeFi UI should use DeFi positions V2.
+ * True when V2 is on and basic functionality is enabled (mutually exclusive with
+ * the V1 path via {@link selectDefiControllerV2Enabled}).
+ * Onboarding is checked inside the V2 controller / fetch hook separately.
+ *
+ * Kept out of `featureFlagController/defiControllerV2` to avoid importing
+ * `settings` there (circular init risk, same pattern as V1).
+ */
+export const selectDeFiPositionsV2SectionEnabled = createSelector(
+  selectDefiControllerV2Enabled,
+  selectBasicFunctionalityEnabled,
+  (defiControllerV2Enabled, basicFunctionalityEnabled) =>
+    defiControllerV2Enabled && basicFunctionalityEnabled,
+);

--- a/app/selectors/featureFlagController/defiControllerV2/index.test.ts
+++ b/app/selectors/featureFlagController/defiControllerV2/index.test.ts
@@ -1,0 +1,43 @@
+import {
+  DEFAULT_FEATURE_FLAG_VALUES,
+  FeatureFlagNames,
+} from '../../../constants/featureFlags';
+import { selectDefiControllerV2Enabled } from '.';
+
+describe('selectDefiControllerV2Enabled', () => {
+  it('returns true when enabled is true', () => {
+    expect(
+      selectDefiControllerV2Enabled.resultFunc({
+        [FeatureFlagNames.defiControllerV2]: { enabled: true },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when enabled is false', () => {
+    expect(
+      selectDefiControllerV2Enabled.resultFunc({
+        [FeatureFlagNames.defiControllerV2]: { enabled: false },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns default when remote flag is not set', () => {
+    expect(selectDefiControllerV2Enabled.resultFunc({})).toBe(
+      Boolean(
+        (
+          DEFAULT_FEATURE_FLAG_VALUES[FeatureFlagNames.defiControllerV2] as {
+            enabled?: boolean;
+          }
+        )?.enabled,
+      ),
+    );
+  });
+
+  it('returns false when flag has invalid shape', () => {
+    expect(
+      selectDefiControllerV2Enabled.resultFunc({
+        [FeatureFlagNames.defiControllerV2]: { invalid: 'structure' },
+      }),
+    ).toBe(false);
+  });
+});

--- a/app/selectors/featureFlagController/defiControllerV2/index.ts
+++ b/app/selectors/featureFlagController/defiControllerV2/index.ts
@@ -1,0 +1,31 @@
+import { createSelector } from 'reselect';
+import { selectRemoteFeatureFlags } from '..';
+import {
+  DEFAULT_FEATURE_FLAG_VALUES,
+  FeatureFlagNames,
+} from '../../../constants/featureFlags';
+
+interface DefiControllerV2FeatureFlag {
+  enabled?: boolean;
+}
+
+/**
+ * Whether DeFi Positions Controller V2 is enabled.
+ * When true, V2 is used and the legacy V1 controller is disabled.
+ * When false, V1 is used and V2 is disabled.
+ *
+ * Remote flag key: `defiControllerV2`. Resolved shape is `{ enabled: boolean }`
+ * (version / threshold rollout is handled by RemoteFeatureFlagController).
+ */
+export const selectDefiControllerV2Enabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const featureFlag = (remoteFeatureFlags[
+      FeatureFlagNames.defiControllerV2
+    ] ?? DEFAULT_FEATURE_FLAG_VALUES[FeatureFlagNames.defiControllerV2]) as
+      | DefiControllerV2FeatureFlag
+      | undefined;
+
+    return Boolean(featureFlag?.enabled);
+  },
+);

--- a/app/util/logs/index.test.ts
+++ b/app/util/logs/index.test.ts
@@ -140,6 +140,7 @@ describe('logs :: generateStateLogs', () => {
           PhishingController: { whitelist: [] },
           AssetsContractController: { assets: [] },
           DeFiPositionsController: { positions: [] },
+          DeFiPositionsControllerV2: { positions: [] },
           PredictController: { predictions: [] },
           KeyringController: {
             vault: 'vault mock',
@@ -157,6 +158,7 @@ describe('logs :: generateStateLogs', () => {
     expect(logs.includes('NftDetectionController')).toBe(false);
     expect(logs.includes('PhishingController')).toBe(false);
     expect(logs.includes('DeFiPositionsController')).toBe(false);
+    expect(logs.includes('DeFiPositionsControllerV2')).toBe(false);
     expect(logs.includes('PredictController')).toBe(false);
     expect(logs.includes("vault: 'vault mock'")).toBe(false);
   });

--- a/app/util/logs/index.ts
+++ b/app/util/logs/index.ts
@@ -88,6 +88,7 @@ export const generateStateLogs = (state: any, loggedIn = true): string => {
   delete fullState.engine.backgroundState.PhishingController;
   delete fullState.engine.backgroundState.AssetsContractController;
   delete fullState.engine.backgroundState.DeFiPositionsController;
+  delete fullState.engine.backgroundState.DeFiPositionsControllerV2;
   delete fullState.engine.backgroundState.PredictController;
 
   // Strip cardHomeData to avoid leaking user PII (wallet addresses, holder names)

--- a/app/util/test/initial-background-state.json
+++ b/app/util/test/initial-background-state.json
@@ -808,6 +808,9 @@
     "allDeFiPositions": {},
     "allDeFiPositionsCount": {}
   },
+  "DeFiPositionsControllerV2": {
+    "allDeFiPositionsV2": {}
+  },
   "SamplePetnamesController": {
     "namesByChainIdAndAddress": {}
   },

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -238,6 +238,20 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  defiControllerV2: {
+    name: 'defiControllerV2',
+    type: FeatureFlagType.Remote,
+    inProd: false,
+    productionDefault: {
+      versions: {
+        '8.5.0': {
+          enabled: false,
+        },
+      },
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
   assetsEnableNotificationsByDefault: {
     name: 'assetsEnableNotificationsByDefault',
     type: FeatureFlagType.Remote,

--- a/tests/framework/fixtures/fixture-validation.ts
+++ b/tests/framework/fixtures/fixture-validation.ts
@@ -299,6 +299,7 @@ export function getMobileFixtureIgnoredKeys(): string[] {
     'engine.backgroundState.BridgeStatusController',
     'engine.backgroundState.ConnectivityController',
     'engine.backgroundState.DeFiPositionsController',
+    'engine.backgroundState.DeFiPositionsControllerV2',
     'engine.backgroundState.DelegationController',
     'engine.backgroundState.EarnController',
     'engine.backgroundState.GatorPermissionsController',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Sets up feature flag for DeFi positions v2 and initialises new DeFi controller.

The old controller remains the same, but is disabled when the new feature flag is enabled.
The new controller is only enabled when the new feature flag is enabled. The old feature flag has no impact.

There is a follow up PR with all the UI work needed to display the state from the new controller, and there is a task to remove the old flag and old controller when the new one becomes stable in prod.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3695

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

Should not display any changes, as it just initialises controller and the FF is off.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I've included tests if applicable
- [X] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [X] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Engine composition and mutually exclusive DeFi data paths behind a flag (default off); mis-flagging could disable positions or run the wrong controller, but rollout is controlled and well-tested at init/selector level.
> 
> **Overview**
> Introduces **`DeFiPositionsControllerV2`** into the mobile Engine alongside the existing DeFi positions controller, gated by a new remote feature flag **`defiControllerV2`** (default off).
> 
> **V2 init** wires the `@metamask/assets-controllers` controller with a cached **`createApiPlatformClient`** (bearer token via `AuthenticationController`, currency from `AssetsController`). It runs only when basic functionality, completed onboarding, and the V2 flag are all true.
> 
> **V1** `isEnabled` now also requires **`!selectDefiControllerV2Enabled`**, so only one controller fetches positions at a time. Homepage selectors split the same way: **`selectDeFiPositionsSectionEnabled`** turns off when V2 is on; **`selectDeFiPositionsV2SectionEnabled`** is the V2 UI gate.
> 
> Supporting changes register messengers, persist **`DeFiPositionsControllerV2`** state, subscribe to **`DeFiPositionsControllerV2:stateChanged`**, extend fixtures/logs/tests, and document the flag in the feature-flag registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f05ce2ec6775dba97a7439bdec09c3554aeeb269. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->