### PR TITLE
fix(ci): restore exec bit on hermesc and shell scripts in node_modules

### DIFF
--- a/.github/actions/restore-node-modules-permissions/action.yml
+++ b/.github/actions/restore-node-modules-permissions/action.yml
@@ -19,4 +19,11 @@ runs:
         find node_modules -type f -name "*.node" -exec chmod +x {} \; 2>/dev/null || true
         find node_modules -path "*/bin/*" -type f -exec chmod +x {} \; 2>/dev/null || true
         find node_modules -path "*/sdks/*" -type f -exec chmod +x {} \; 2>/dev/null || true
+        # Platform-suffixed binary dirs (linux64-bin, osx-bin, win64-bin) are not matched by
+        # "*/bin/*" since there is no exact "bin" path segment. hermes-compiler ships hermesc
+        # this way, and Metro spawns it directly during bundling.
+        find node_modules -path "*-bin/*" -type f -exec chmod +x {} \; 2>/dev/null || true
+        # Scripts spawned directly rather than through an interpreter (Xcode build phases,
+        # packager helpers) also need the bit back.
+        find node_modules -type f -name "*.sh" -exec chmod +x {} \; 2>/dev/null || true
         echo "✅ Permissions restored"


### PR DESCRIPTION
## **Description**

The EAS/OTA pipelines transport `node_modules` as a plain zip artifact, which strips Unix executable bits, so consumers call `restore-node-modules-permissions` to put them back. Its globs required an exact `bin` path segment (`*/bin/*`), which never matched the platform-suffixed directories `hermes-compiler` uses: `linux64-bin`, `osx-bin`, `win64-bin`.

Metro spawns `hermesc` directly during bundling, so OTA pushes fail with:

```
Error: spawn .../node_modules/hermes-compiler/hermesc/linux64-bin/hermesc EACCES
```

This became reachable when React Native `0.83.6` (#32281) moved `hermesc` out of the `react-native` package. Previously it lived at `react-native/sdks/hermesc/<os>-bin/hermesc`, which the existing `*/sdks/*` glob covered incidentally. `hermes-compiler`'s flat layout matches none of the four existing patterns.

This also covers `*.sh` scripts, which are spawned directly (Xcode build phases, packager helpers) and carry the same exposure. They aren't failing today only because native builds use the tarball/cache path, which preserves permissions.

Failing run: https://github.com/MetaMask/metamask-mobile/actions/runs/30454324689/job/90593099632

### Why this surfaced now

`release/8.3.1-ota` had identical inputs (RN `0.83.6`, `hermes-compiler` `0.14.1`, byte-identical CI files) but its OTA run failed earlier at **Fingerprint Mismatch Guard**, which skipped the bundling jobs entirely, so it never executed this path. `release/8.4.1-ota` is the first release to get past that guard since the upgrade.

### Scope reviewed

Only the zip-artifact path is affected. Reviewed all `node_modules` transport modes:

| Transport | Used by | Preserves exec bit | Affected |
| --- | --- | --- | --- |
| `actions/cache` | `build.yml` on `release/*` | Yes | No |
| zstd tarball via `tar` | `build.yml` other branches | Yes | No |
| plain zip artifact | EAS/OTA workflows | No | Yes |

Affected call sites are the three consumers of this action: `push-eas-update.yml` (PR deps and base-branch deps) and `eas-update-platform.yml`. All three pass `working-directory` correctly. `build.yml` is unaffected and correctly does not call this action.

I also enumerated every executable file in `node_modules` (2,343) to find remaining gaps. Excluding noise (packages shipping `.md`/`.json`/`.ts` as 755), the only spawnable ones still uncovered are `expo-image` xcframework binaries and `clipboardy/fallbacks/linux/xsel`, both reachable only from native builds on the permission-preserving tarball path. Left out to keep this change tight.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: node_modules executable permission restoration

  Scenario: OTA bundle after artifact download
    Given node_modules is downloaded as a zip artifact with stripped exec bits
    When restore-node-modules-permissions runs
    Then hermes-compiler/hermesc/<os>-bin/hermesc is executable
    And Metro bundling completes without EACCES
```

Verified in isolation that `hermesc` goes from `-rw-r--r--` to `-rwxr-xr-x` under the new patterns. End-to-end validation is the `8.4.1` Runway OTA RC run via the companion backport PR to `release/8.4.1-ota`.

N/A for automated tests: this only affects CI file permissions, which isn't covered by unit/e2e suites.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Follow-up (not in this PR)**

Glob-based restoration is inherently fragile: it broke silently because a dependency reorganized its folders, and every `find` ends in `|| true` so misses are invisible. Recommend a manifest-based approach (record exec bits at upload, replay at download) plus a hard assertion that `hermesc` is executable after restoration.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)