### PR TITLE
fix(ci): restore exec bit on hermesc and shell scripts in node_modules (8.4.1)

### DIFF
--- a/.github/actions/restore-node-modules-permissions/action.yml
+++ b/.github/actions/restore-node-modules-permissions/action.yml
@@ -19,4 +19,11 @@ runs:
         find node_modules -type f -name "*.node" -exec chmod +x {} \; 2>/dev/null || true
         find node_modules -path "*/bin/*" -type f -exec chmod +x {} \; 2>/dev/null || true
         find node_modules -path "*/sdks/*" -type f -exec chmod +x {} \; 2>/dev/null || true
+        # Platform-suffixed binary dirs (linux64-bin, osx-bin, win64-bin) are not matched by
+        # "*/bin/*" since there is no exact "bin" path segment. hermes-compiler ships hermesc
+        # this way, and Metro spawns it directly during bundling.
+        find node_modules -path "*-bin/*" -type f -exec chmod +x {} \; 2>/dev/null || true
+        # Scripts spawned directly rather than through an interpreter (Xcode build phases,
+        # packager helpers) also need the bit back.
+        find node_modules -type f -name "*.sh" -exec chmod +x {} \; 2>/dev/null || true
         echo "✅ Permissions restored"


### PR DESCRIPTION
## **Description**

Backport of #34004 to unblock the `8.4.1` OTA release.

**This backport is required separately** because CI composite actions resolve from the checked-out branch, not from `main`. `Runway OTA RC` is dispatched against `release/8.4.1-ota`, so it uses that branch's copy of `.github/actions/restore-node-modules-permissions` — meaning the `main` fix alone does not affect this release.

Failing run: https://github.com/MetaMask/metamask-mobile/actions/runs/30454324689/job/90593099632

```
Error: spawn .../node_modules/hermes-compiler/hermesc/linux64-bin/hermesc EACCES
```

Both `Push EAS Update (iOS)` and `Push EAS Update (Android)` fail at Metro bundling because `hermesc` lost its executable bit in the zip artifact round-trip and the permission-restore globs required an exact `bin` path segment, never matching `hermes-compiler`'s `linux64-bin` / `osx-bin` / `win64-bin` layout.

Full root-cause analysis, blast-radius review, and testing notes are in #34004.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: OTA push for 8.4.1

  Scenario: Runway OTA RC after backport
    Given this PR is merged into release/8.4.1-ota
    When Runway OTA RC is re-run for 8.4.1
    Then Push EAS Update (iOS) and (Android) bundle without EACCES
```

After merge, re-run **Runway OTA RC** for `8.4.1`.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Note for other release branches**

`release/8.4.0` and `release/8.5.0` carry the same combination (RN `0.83.6` plus the un-patched action) and will hit this on their next OTA push, so they likely want the same backport.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)