### PR TITLE
fix: quickbuy custom amounts menu

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyEditQuickAmountsScreen.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyEditQuickAmountsScreen.test.tsx
@@ -90,6 +90,19 @@ describe('QuickBuyEditQuickAmountsScreen', () => {
     ).toBeOnTheScreen();
   });
 
+  it('renders buy and sell amounts in a 2x2 grid', () => {
+    render(<QuickBuyEditQuickAmountsScreen />);
+
+    for (const index of [0, 1, 2, 3]) {
+      expect(
+        screen.getByTestId(`quick-buy-edit-buy-field-${index}`),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByTestId(`quick-buy-edit-sell-field-${index}`),
+      ).toBeOnTheScreen();
+    }
+  });
+
   it('switches focus without collapsing the keypad', () => {
     render(<QuickBuyEditQuickAmountsScreen />);
 

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyEditQuickAmountsScreen.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/QuickBuyEditQuickAmountsScreen.tsx
@@ -38,7 +38,7 @@ const QuickBuyEditQuickAmountsScreen: React.FC = () => {
     buyErrors,
     sellErrors,
     focusedField,
-    focusedValue,
+    keypadValue,
     isValid,
     handleFieldPress,
     handleKeypadChange,
@@ -122,7 +122,7 @@ const QuickBuyEditQuickAmountsScreen: React.FC = () => {
 
       <Box twClassName="px-4 pt-3 pb-4" testID="quick-buy-edit-amounts-keypad">
         <KeypadComponent
-          value={focusedValue}
+          value={keypadValue}
           onChange={handleKeypadChange}
           currency={keypadCurrency}
           decimals={keypadDecimals}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyEditAmountField.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyEditAmountField.test.ts
@@ -1,0 +1,43 @@
+import { getQuickBuyEditFieldErrorMessage } from './QuickBuyEditAmountField';
+
+jest.mock('../../../../../../../../locales/i18n', () => ({
+  strings: (key: string, params?: Record<string, string | number>) => {
+    if (!params) {
+      return key;
+    }
+    return `${key}:${JSON.stringify(params)}`;
+  },
+}));
+
+jest.mock('../../../../../../UI/Bridge/utils/currencyUtils', () => ({
+  formatCurrency: jest.fn(
+    (amount: number, currency: string) => `${currency}:${amount}`,
+  ),
+  getCurrencySymbol: jest.fn((currency: string) => currency),
+}));
+
+describe('getQuickBuyEditFieldErrorMessage', () => {
+  it('formats buy_below_max with the user currency', () => {
+    const message = getQuickBuyEditFieldErrorMessage('buy_below_max', {
+      currency: 'EUR',
+      usdToCurrentCurrencyRate: 0.9,
+    });
+
+    expect(message).toContain(
+      'social_leaderboard.quick_buy.edit_quick_amounts_buy_below_max',
+    );
+    expect(message).toContain('"max":"EUR:');
+    expect(message).not.toContain('$');
+  });
+
+  it('formats buy_above_zero with the user currency', () => {
+    const message = getQuickBuyEditFieldErrorMessage('buy_above_zero', {
+      currency: 'JPY',
+      usdToCurrentCurrencyRate: 150,
+    });
+
+    expect(message).toBe(
+      'social_leaderboard.quick_buy.edit_quick_amounts_buy_above_zero:{"min":"JPY:0"}',
+    );
+  });
+});

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyEditAmountField.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyEditAmountField.tsx
@@ -2,12 +2,15 @@ import {
   Box,
   Text,
   TextColor,
+  TextField,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React from 'react';
 import { Pressable } from 'react-native';
-import { getCurrencySymbol } from '../../../../../../UI/Bridge/utils/currencyUtils';
+import {
+  formatCurrency,
+  getCurrencySymbol,
+} from '../../../../../../UI/Bridge/utils/currencyUtils';
 import { strings } from '../../../../../../../../locales/i18n';
 import {
   getBuyAmountMaxValid,
@@ -15,8 +18,15 @@ import {
   type QuickBuyEditValidationContext,
 } from '../utils/validateQuickBuyEditAmounts';
 
+const ERROR_AMOUNT_CURRENCY_OPTIONS: Intl.NumberFormatOptions = {
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+};
+
 interface QuickBuyEditAmountFieldProps {
-  displayValue: string;
+  value: string;
+  kind: 'buy' | 'sell';
+  currency?: string;
   isError: boolean;
   isFocused?: boolean;
   testID?: string;
@@ -24,36 +34,48 @@ interface QuickBuyEditAmountFieldProps {
 }
 
 const QuickBuyEditAmountField: React.FC<QuickBuyEditAmountFieldProps> = ({
-  displayValue,
+  value,
+  kind,
+  currency,
   isError,
   isFocused = false,
   testID,
   onPress,
 }) => {
-  const tw = useTailwind();
+  const displayValue = value || '0';
+  const currencySymbol =
+    kind === 'buy' && currency ? getCurrencySymbol(currency) : null;
 
   return (
     <Box twClassName="min-w-0 flex-1">
       <Pressable accessibilityRole="button" onPress={onPress} testID={testID}>
-        <Box
-          style={tw.style(
-            'items-center justify-center rounded-xl border bg-muted px-4 py-3',
-            isError
-              ? 'border-error-default'
-              : isFocused
-                ? 'border-default'
-                : 'border-muted',
-          )}
-        >
-          <Text
-            variant={TextVariant.BodyMd}
-            color={TextColor.TextDefault}
-            twClassName="text-center"
-            numberOfLines={1}
-          >
-            {displayValue}
-          </Text>
-        </Box>
+        <TextField
+          value={displayValue}
+          isReadOnly
+          isError={isError}
+          pointerEvents="none"
+          startAccessory={
+            currencySymbol ? (
+              <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
+                {currencySymbol}
+              </Text>
+            ) : undefined
+          }
+          endAccessory={
+            kind === 'sell' ? (
+              <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
+                %
+              </Text>
+            ) : undefined
+          }
+          twClassName={
+            isFocused && !isError ? 'w-full border-default' : 'w-full'
+          }
+          inputProps={{
+            showSoftInputOnFocus: false,
+            caretHidden: true,
+          }}
+        />
       </Pressable>
     </Box>
   );
@@ -67,10 +89,15 @@ export function getQuickBuyEditFieldErrorMessage(
     return null;
   }
 
+  const currency = validationContext?.currency ?? 'USD';
+
   switch (error) {
     case 'buy_above_zero':
       return strings(
         'social_leaderboard.quick_buy.edit_quick_amounts_buy_above_zero',
+        {
+          min: formatCurrency(0, currency, ERROR_AMOUNT_CURRENCY_OPTIONS),
+        },
       );
     case 'buy_below_max': {
       const maxValid = validationContext
@@ -81,7 +108,13 @@ export function getQuickBuyEditFieldErrorMessage(
         : 9_999;
       return strings(
         'social_leaderboard.quick_buy.edit_quick_amounts_buy_below_max',
-        { max: maxValid.toLocaleString('en-US') },
+        {
+          max: formatCurrency(
+            maxValid,
+            currency,
+            ERROR_AMOUNT_CURRENCY_OPTIONS,
+          ),
+        },
       );
     }
     case 'sell_above_zero':
@@ -95,23 +128,6 @@ export function getQuickBuyEditFieldErrorMessage(
     default:
       return null;
   }
-}
-
-export function formatBuyEditDisplayValue(
-  value: string,
-  currency: string,
-): string {
-  if (!value) {
-    return `${getCurrencySymbol(currency)}0`;
-  }
-  return `${getCurrencySymbol(currency)}${value}`;
-}
-
-export function formatSellEditDisplayValue(value: string): string {
-  if (!value) {
-    return '0%';
-  }
-  return `${value}%`;
 }
 
 export default QuickBuyEditAmountField;

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyEditAmountRow.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyEditAmountRow.tsx
@@ -1,6 +1,8 @@
 import {
   Box,
   BoxFlexDirection,
+  FontWeight,
+  Label,
   Text,
   TextColor,
   TextVariant,
@@ -11,8 +13,6 @@ import type {
   QuickBuyEditValidationContext,
 } from '../utils/validateQuickBuyEditAmounts';
 import QuickBuyEditAmountField, {
-  formatBuyEditDisplayValue,
-  formatSellEditDisplayValue,
   getQuickBuyEditFieldErrorMessage,
 } from './QuickBuyEditAmountField';
 
@@ -31,6 +31,11 @@ interface QuickBuyEditAmountRowProps {
   validationContext: QuickBuyEditValidationContext;
   onFieldPress: (index: number) => void;
 }
+
+const FIELD_ROWS = [
+  [0, 1],
+  [2, 3],
+] as const;
 
 const QuickBuyEditAmountRow: React.FC<QuickBuyEditAmountRowProps> = ({
   label,
@@ -55,30 +60,30 @@ const QuickBuyEditAmountRow: React.FC<QuickBuyEditAmountRowProps> = ({
 
   return (
     <Box twClassName="gap-2 py-1">
-      <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
-        {label}
-      </Text>
-      <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-4">
-        {values.map((value, index) => {
-          const errorKey = errors[index];
-          const displayValue =
-            kind === 'buy'
-              ? formatBuyEditDisplayValue(value, currentCurrency)
-              : formatSellEditDisplayValue(value);
-
-          return (
-            <QuickBuyEditAmountField
-              key={`${kind}-${index}`}
-              displayValue={displayValue}
-              isError={errorKey !== null}
-              isFocused={
-                focusedField?.kind === kind && focusedField.index === index
-              }
-              testID={`quick-buy-edit-${kind}-field-${index}`}
-              onPress={() => onFieldPress(index)}
-            />
-          );
-        })}
+      <Label fontWeight={FontWeight.Medium}>{label}</Label>
+      <Box twClassName="gap-4">
+        {FIELD_ROWS.map((rowIndexes) => (
+          <Box
+            key={`${kind}-row-${rowIndexes[0]}`}
+            flexDirection={BoxFlexDirection.Row}
+            twClassName="gap-4"
+          >
+            {rowIndexes.map((index) => (
+              <QuickBuyEditAmountField
+                key={`${kind}-${index}`}
+                value={values[index] ?? ''}
+                kind={kind}
+                currency={kind === 'buy' ? currentCurrency : undefined}
+                isError={errors[index] !== null}
+                isFocused={
+                  focusedField?.kind === kind && focusedField.index === index
+                }
+                testID={`quick-buy-edit-${kind}-field-${index}`}
+                onPress={() => onFieldPress(index)}
+              />
+            ))}
+          </Box>
+        ))}
       </Box>
       {rowErrorMessage ? (
         <Text

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyEditAmountsForm.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyEditAmountsForm.test.ts
@@ -127,4 +127,45 @@ describe('useQuickBuyEditAmountsForm', () => {
     expect(result.current.buyValues[0]).toBe('12');
     expect(result.current.buyValues[1]).toBe('50');
   });
+
+  it('keeps the current amount on field press and replaces it on the first keypad digit', () => {
+    const buy: QuickBuyAmountTuple = [10, 50, 100, 250];
+    const sell: QuickBuySellPercentTuple = [25, 50, 75, 100];
+
+    const { result } = renderHook(() =>
+      useQuickBuyEditAmountsForm(buy, sell, true, usdValidationContext),
+    );
+
+    act(() => {
+      result.current.handleFieldPress('buy', 1);
+    });
+
+    expect(result.current.focusedField).toEqual({ kind: 'buy', index: 1 });
+    expect(result.current.buyValues).toEqual(['10', '50', '100', '250']);
+    expect(result.current.focusedValue).toBe('50');
+    expect(result.current.keypadValue).toBe('');
+
+    act(() => {
+      result.current.handleKeypadChange({
+        value: '7',
+        valueAsNumber: 7,
+        pressedKey: Keys.Digit7,
+      });
+    });
+
+    expect(result.current.buyValues).toEqual(['10', '7', '100', '250']);
+    expect(result.current.focusedValue).toBe('7');
+    expect(result.current.keypadValue).toBe('7');
+
+    act(() => {
+      result.current.handleKeypadChange({
+        value: '75',
+        valueAsNumber: 75,
+        pressedKey: Keys.Digit5,
+      });
+    });
+
+    expect(result.current.buyValues[1]).toBe('75');
+    expect(result.current.keypadValue).toBe('75');
+  });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyEditAmountsForm.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyEditAmountsForm.ts
@@ -51,6 +51,9 @@ export function useQuickBuyEditAmountsForm(
   const [focusedField, setFocusedField] = useState<
     Exclude<QuickBuyEditFocusedField, null>
   >(DEFAULT_FOCUSED_FIELD);
+  // After selecting a field, the next keypad digit replaces the amount
+  // instead of appending. The field keeps showing its current value until then.
+  const [replaceOnNextInput, setReplaceOnNextInput] = useState(true);
   const wasPreferencesLoadedRef = useRef(isPreferencesLoaded);
   const hasUserEditedRef = useRef(false);
 
@@ -91,9 +94,14 @@ export function useQuickBuyEditAmountsForm(
     [buyValues, focusedField, sellValues],
   );
 
+  // Seed the keypad with an empty value while replace mode is active so the
+  // first digit becomes the new amount instead of appending to the old one.
+  const keypadValue = replaceOnNextInput ? '' : focusedValue;
+
   const handleFieldPress = useCallback(
     (kind: 'buy' | 'sell', index: number) => {
       setFocusedField({ kind, index });
+      setReplaceOnNextInput(true);
     },
     [],
   );
@@ -122,6 +130,7 @@ export function useQuickBuyEditAmountsForm(
 
   const handleKeypadChange = useCallback(
     ({ value }: KeypadChangeData) => {
+      setReplaceOnNextInput(false);
       updateFocusedValue(value);
     },
     [updateFocusedValue],
@@ -145,6 +154,7 @@ export function useQuickBuyEditAmountsForm(
     sellErrors: validation.sellErrors as (QuickBuyEditFieldError | null)[],
     focusedField,
     focusedValue,
+    keypadValue,
     isValid: validation.isValid,
     handleFieldPress,
     handleKeypadChange,

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1281,12 +1281,12 @@
       "toast_complete_sell": "Sold {{amount}} of {{symbol}} for {{counter}}",
       "toast_failed_buy": "Couldn't buy {{symbol}}",
       "toast_failed_sell": "Couldn't sell {{symbol}}",
-      "edit_quick_amounts_title": "Edit quick amounts",
-      "edit_quick_amounts_set_buy": "Set Buy amounts",
-      "edit_quick_amounts_set_sell": "Set Sell amounts",
-      "edit_quick_amounts_confirm": "Confirm",
-      "edit_quick_amounts_buy_above_zero": "Buy amount should be above $0",
-      "edit_quick_amounts_buy_below_max": "Buy amount should be below ${{max}}",
+      "edit_quick_amounts_title": "Edit default amounts",
+      "edit_quick_amounts_set_buy": "To buy",
+      "edit_quick_amounts_set_sell": "To sell",
+      "edit_quick_amounts_confirm": "Save",
+      "edit_quick_amounts_buy_above_zero": "Buy amount should be above {{min}}",
+      "edit_quick_amounts_buy_below_max": "Buy amount should be below {{max}}",
       "edit_quick_amounts_sell_above_zero": "Sell amount should be above 0%",
       "edit_quick_amounts_sell_below_max": "Sell amount should be below 100%"
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Updates the Quick Buy **Edit default amounts** screen so custom buy/sell presets are usable across currencies and match the Swap Next design.

**Problem**
- Buy/sell presets were shown in a single 1×4 row. Longer currency symbols (e.g. `US$`) filled the narrow fields and truncated the amount, so users could not see or confidently edit values.
- Buy validation copy hard-coded a `$` symbol instead of the user’s selected currency.
- Focusing a field and typing appended to the existing amount, which made editing awkward.

**Solution**
- Switch buy and sell preset editors to a **2×2 grid**.
- Use design-system `TextField` / `Label`, with currency as `startAccessory` (via `getCurrencySymbol`) and `%` as `endAccessory` for sell amounts.
- Format buy validation messages with `formatCurrency` so min/max copy respects the selected currency.
- On field select, keep the current value visible; the **first keypad digit replaces** the amount, and later digits append normally.
- Align copy with design: “Edit default amounts”, “To buy”, “To sell”, “Save”.

Design reference: [Swap Next – Edit default amounts](https://www.figma.com/design/GO9uJiYlhdWRuXJe8dzZfR/Swap-Next?node-id=3254-9944)

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed Quick Buy custom amount editing so preset fields use a 2x2 layout and respect the user's selected currency

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: TSA-943

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Quick Buy edit default amounts

  Scenario: user edits buy and sell presets in a 2x2 layout
    Given the user is on Quick Buy amount screen with quick amount pills enabled
    And the user’s preferred currency is set (e.g. USD, EUR, or JPY)

    When the user opens Edit default amounts
    Then buy and sell amounts are shown in a 2x2 grid
    And buy fields show the correct currency symbol without truncating the amount
    And sell fields show percentage values with a % suffix

  Scenario: user replaces a preset with the first keypad digit
    Given the user is on Edit default amounts
    And a buy field shows an existing amount (e.g. 50)

    When the user taps that field
    Then the field stays selected and still shows 50
    When the user taps digit 7 on the keypad
    Then the field value becomes 7
    When the user taps digit 5
    Then the field value becomes 75

  Scenario: validation messages respect currency
    Given the user is on Edit default amounts with a non-USD currency selected

    When the user enters a buy amount above the allowed maximum
    Then the error message shows the max formatted in the user’s currency
    And it does not hard-code a $ symbol

  Scenario: user saves updated presets
    Given the user has entered valid buy and sell presets

    When the user taps Save
    Then the preferences are saved
    And the user returns to the Quick Buy amount screen
    And the quick amount pills reflect the new values
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — please attach before/after device screenshots of the Edit default amounts screen (1×4 cramped inputs vs 2×2 design-system fields) before marking ready for review.

### **Before**

<!-- [screenshots/recordings] -->
<img width="1179" height="1866" alt="image" src="https://github.com/user-attachments/assets/2e42eb36-d5ab-4701-86e4-e537d1eb46e3" />


### **After**

<!-- [screenshots/recordings] -->
<img width="469" height="952" alt="image" src="https://github.com/user-attachments/assets/f1e5df2b-1dda-4247-b20a-634257085ec8" />

https://github.com/user-attachments/assets/02871a5a-f648-4a77-964c-3e641182d38a



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and copy changes in Social Leaderboard Quick Buy preferences with unit tests; no auth, payments, or persistence logic changes beyond existing save flow.
> 
> **Overview**
> Improves the Quick Buy **Edit default amounts** flow so presets are easier to read and edit across currencies, aligned with Swap Next.
> 
> Buy and sell presets move from a single **1×4 row** to a **2×2 grid**, using design-system `Label` and read-only `TextField` with currency/`%` accessories instead of cramming symbols into the displayed value. **Buy validation** min/max copy now uses `formatCurrency` and i18n placeholders (`{{min}}` / `{{max}}`) instead of a hard-coded `$`.
> 
> **Keypad editing** changes: tapping a field keeps the current value visible while the keypad starts empty; the **first digit replaces** the amount, then further digits append. Screen strings are updated (“Edit default amounts”, “To buy”, “To sell”, “Save”). Tests cover the grid, replace-on-first-input, and localized error formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cc3f52c1a003e3f70b310ca68a4b0248f234b8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->