### PR TITLE
fix: restore Stellar/Arc bridge-controller patches cp-8.5.0

### DIFF
--- a/.yarn/patches/@metamask-bridge-controller-npm-77.6.0-2a4ded2811.patch
+++ b/.yarn/patches/@metamask-bridge-controller-npm-77.6.0-2a4ded2811.patch
@@ -1,46 +1,84 @@
-diff --git a/dist/bridge-controller.cjs b/dist/bridge-controller.cjs
-index f0442783267e65a7bd7d2d9def4937d74cbfb298..3975d9f864893054ee4c54b6d528e388d3a64734 100644
---- a/dist/bridge-controller.cjs
-+++ b/dist/bridge-controller.cjs
-@@ -333,8 +333,7 @@ class BridgeController extends (0, polling_controller_1.StaticIntervalPollingCon
-                 .flatMap((quoteRequest) => [
-                 (0, assets_1.getAssetIdsForToken)(quoteRequest.srcTokenAddress, quoteRequest.srcChainId),
-                 (0, assets_1.getAssetIdsForToken)(quoteRequest.destTokenAddress, quoteRequest.destChainId),
--            ].flat())
--                .filter((assetId) => !(0, selectors_1.selectIsAssetExchangeRateInState)(exchangeRateSources, assetId)));
-+            ].flat()));
-             const currency = __classPrivateFieldGet(this, _BridgeController_getUseAssetsControllerForRates, "f").call(this)
-                 ? this.messenger.call('AssetsController:getExchangeRatesForBridge')
-                     .currentCurrency
-@@ -344,7 +343,7 @@ class BridgeController extends (0, polling_controller_1.StaticIntervalPollingCon
-             }
-             const pricesByAssetId = await (0, fetch_1.fetchAssetPrices)({
-                 assetIds,
--                currencies: new Set([currency]),
-+                currencies: new Set([currency, "usd"]),
-                 clientId: __classPrivateFieldGet(this, _BridgeController_clientId, "f"),
-                 clientVersion: __classPrivateFieldGet(this, _BridgeController_clientVersion, "f"),
-                 fetchFn: __classPrivateFieldGet(this, _BridgeController_fetchFn, "f"),
-diff --git a/dist/bridge-controller.mjs b/dist/bridge-controller.mjs
-index c7e14bd1349fef6f374e3c01f71ed56abdf25f49..fc0d92a802eab5644a35f840ffe043580b2a05de 100644
---- a/dist/bridge-controller.mjs
-+++ b/dist/bridge-controller.mjs
-@@ -330,8 +330,7 @@ export class BridgeController extends StaticIntervalPollingController() {
-                 .flatMap((quoteRequest) => [
-                 getAssetIdsForToken(quoteRequest.srcTokenAddress, quoteRequest.srcChainId),
-                 getAssetIdsForToken(quoteRequest.destTokenAddress, quoteRequest.destChainId),
--            ].flat())
--                .filter((assetId) => !selectIsAssetExchangeRateInState(exchangeRateSources, assetId)));
-+            ].flat()));
-             const currency = __classPrivateFieldGet(this, _BridgeController_getUseAssetsControllerForRates, "f").call(this)
-                 ? this.messenger.call('AssetsController:getExchangeRatesForBridge')
-                     .currentCurrency
-@@ -341,7 +340,7 @@ export class BridgeController extends StaticIntervalPollingController() {
-             }
-             const pricesByAssetId = await fetchAssetPrices({
-                 assetIds,
--                currencies: new Set([currency]),
-+                currencies: new Set([currency, "usd"]),
-                 clientId: __classPrivateFieldGet(this, _BridgeController_clientId, "f"),
-                 clientVersion: __classPrivateFieldGet(this, _BridgeController_clientVersion, "f"),
-                 fetchFn: __classPrivateFieldGet(this, _BridgeController_fetchFn, "f"),
+diff --git a/dist/constants/bridge.cjs b/dist/constants/bridge.cjs
+index 4d169e95dc5df859b7cd14235231c8ebf054071e..a0498c1c40b5ddca28ffed5c8f84cacc2c6a6ad9 100644
+--- a/dist/constants/bridge.cjs
++++ b/dist/constants/bridge.cjs
+@@ -47,7 +47,6 @@ exports.DEFAULT_CHAIN_RANKING = [
+     { chainId: 'bip122:000000000019d6689c085ae165831e93', name: 'BTC' },
+     { chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp', name: 'Solana' },
+     { chainId: 'tron:728126428', name: 'Tron' },
+-    { chainId: 'stellar:pubnet', name: 'Stellar' },
+     { chainId: 'eip155:8453', name: 'Base' },
+     { chainId: 'eip155:42161', name: 'Arbitrum' },
+     { chainId: 'eip155:59144', name: 'Linea' },
+@@ -58,7 +57,6 @@ exports.DEFAULT_CHAIN_RANKING = [
+     { chainId: 'eip155:1329', name: 'Sei' },
+     { chainId: 'eip155:999', name: 'HyperEVM' },
+     { chainId: 'eip155:4326', name: 'MegaETH' },
+-    { chainId: 'eip155:5042', name: 'Arc' },
+     { chainId: 'eip155:4663', name: 'Robinhood Chain' },
+     { chainId: 'eip155:324', name: 'zkSync' },
+ ];
+diff --git a/dist/constants/bridge.d.cts b/dist/constants/bridge.d.cts
+index 681da522ddf1e2d06aebb8d6a770e3cd2cd441ce..a4c46054f2c5cd000f4c1cd883f038c1c82b2c4a 100644
+--- a/dist/constants/bridge.d.cts
++++ b/dist/constants/bridge.d.cts
+@@ -34,8 +34,6 @@ export declare const DEFAULT_CHAIN_RANKING: readonly [{
+     readonly chainId: "tron:728126428";
+     readonly name: "Tron";
+ }, {
+-    readonly chainId: "stellar:pubnet";
+-    readonly name: "Stellar";
+ }, {
+     readonly chainId: "eip155:8453";
+     readonly name: "Base";
+@@ -67,8 +65,6 @@ export declare const DEFAULT_CHAIN_RANKING: readonly [{
+     readonly chainId: "eip155:4326";
+     readonly name: "MegaETH";
+ }, {
+-    readonly chainId: "eip155:5042";
+-    readonly name: "Arc";
+ }, {
+     readonly chainId: "eip155:4663";
+     readonly name: "Robinhood Chain";
+diff --git a/dist/constants/bridge.d.mts b/dist/constants/bridge.d.mts
+index 81663828b77d36b5bfc015be95eb208de6d61d8e..f379917139aa1ade40f33dc306808f1a3ec09587 100644
+--- a/dist/constants/bridge.d.mts
++++ b/dist/constants/bridge.d.mts
+@@ -34,8 +34,6 @@ export declare const DEFAULT_CHAIN_RANKING: readonly [{
+     readonly chainId: "tron:728126428";
+     readonly name: "Tron";
+ }, {
+-    readonly chainId: "stellar:pubnet";
+-    readonly name: "Stellar";
+ }, {
+     readonly chainId: "eip155:8453";
+     readonly name: "Base";
+@@ -67,8 +65,6 @@ export declare const DEFAULT_CHAIN_RANKING: readonly [{
+     readonly chainId: "eip155:4326";
+     readonly name: "MegaETH";
+ }, {
+-    readonly chainId: "eip155:5042";
+-    readonly name: "Arc";
+ }, {
+     readonly chainId: "eip155:4663";
+     readonly name: "Robinhood Chain";
+diff --git a/dist/constants/bridge.mjs b/dist/constants/bridge.mjs
+index 01da97226b25daaeee44ff79572cb58e8cf1c788..bc286d5b6380fe623a167954e19a556a6325d02e 100644
+--- a/dist/constants/bridge.mjs
++++ b/dist/constants/bridge.mjs
+@@ -44,7 +44,6 @@ export const DEFAULT_CHAIN_RANKING = [
+     { chainId: 'bip122:000000000019d6689c085ae165831e93', name: 'BTC' },
+     { chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp', name: 'Solana' },
+     { chainId: 'tron:728126428', name: 'Tron' },
+-    { chainId: 'stellar:pubnet', name: 'Stellar' },
+     { chainId: 'eip155:8453', name: 'Base' },
+     { chainId: 'eip155:42161', name: 'Arbitrum' },
+     { chainId: 'eip155:59144', name: 'Linea' },
+@@ -55,7 +54,6 @@ export const DEFAULT_CHAIN_RANKING = [
+     { chainId: 'eip155:1329', name: 'Sei' },
+     { chainId: 'eip155:999', name: 'HyperEVM' },
+     { chainId: 'eip155:4326', name: 'MegaETH' },
+-    { chainId: 'eip155:5042', name: 'Arc' },
+     { chainId: 'eip155:4663', name: 'Robinhood Chain' },
+     { chainId: 'eip155:324', name: 'zkSync' },
+ ];

--- a/.yarn/patches/@metamask-bridge-controller-patch-997d5d00c5.patch
+++ b/.yarn/patches/@metamask-bridge-controller-patch-997d5d00c5.patch
@@ -1,0 +1,58 @@
+diff --git a/dist/bridge-controller.cjs b/dist/bridge-controller.cjs
+index f0442783267e65a7bd7d2d9def4937d74cbfb298..577f2e2c0269ebd5a63dba37b7c285883fa615e7 100644
+--- a/dist/bridge-controller.cjs
++++ b/dist/bridge-controller.cjs
+@@ -327,14 +327,12 @@ class BridgeController extends (0, polling_controller_1.StaticIntervalPollingCon
+          * @param quoteRequests - The quote requests to fetch the exchange rates for
+          */
+         _BridgeController_fetchAssetExchangeRates.set(this, async (quoteRequests) => {
+-            const exchangeRateSources = __classPrivateFieldGet(this, _BridgeController_getExchangeRateSources, "f").call(this);
+             // Get unique assetIds for all quote requests
+             const assetIds = new Set(quoteRequests
+                 .flatMap((quoteRequest) => [
+                 (0, assets_1.getAssetIdsForToken)(quoteRequest.srcTokenAddress, quoteRequest.srcChainId),
+                 (0, assets_1.getAssetIdsForToken)(quoteRequest.destTokenAddress, quoteRequest.destChainId),
+-            ].flat())
+-                .filter((assetId) => !(0, selectors_1.selectIsAssetExchangeRateInState)(exchangeRateSources, assetId)));
++            ].flat()));
+             const currency = __classPrivateFieldGet(this, _BridgeController_getUseAssetsControllerForRates, "f").call(this)
+                 ? this.messenger.call('AssetsController:getExchangeRatesForBridge')
+                     .currentCurrency
+@@ -344,7 +342,7 @@ class BridgeController extends (0, polling_controller_1.StaticIntervalPollingCon
+             }
+             const pricesByAssetId = await (0, fetch_1.fetchAssetPrices)({
+                 assetIds,
+-                currencies: new Set([currency]),
++                currencies: new Set([currency, "usd"]),
+                 clientId: __classPrivateFieldGet(this, _BridgeController_clientId, "f"),
+                 clientVersion: __classPrivateFieldGet(this, _BridgeController_clientVersion, "f"),
+                 fetchFn: __classPrivateFieldGet(this, _BridgeController_fetchFn, "f"),
+diff --git a/dist/bridge-controller.mjs b/dist/bridge-controller.mjs
+index c7e14bd1349fef6f374e3c01f71ed56abdf25f49..486790b574abd93d5096c2430813004530d397bd 100644
+--- a/dist/bridge-controller.mjs
++++ b/dist/bridge-controller.mjs
+@@ -324,14 +324,12 @@ export class BridgeController extends StaticIntervalPollingController() {
+          * @param quoteRequests - The quote requests to fetch the exchange rates for
+          */
+         _BridgeController_fetchAssetExchangeRates.set(this, async (quoteRequests) => {
+-            const exchangeRateSources = __classPrivateFieldGet(this, _BridgeController_getExchangeRateSources, "f").call(this);
+             // Get unique assetIds for all quote requests
+             const assetIds = new Set(quoteRequests
+                 .flatMap((quoteRequest) => [
+                 getAssetIdsForToken(quoteRequest.srcTokenAddress, quoteRequest.srcChainId),
+                 getAssetIdsForToken(quoteRequest.destTokenAddress, quoteRequest.destChainId),
+-            ].flat())
+-                .filter((assetId) => !selectIsAssetExchangeRateInState(exchangeRateSources, assetId)));
++            ].flat()));
+             const currency = __classPrivateFieldGet(this, _BridgeController_getUseAssetsControllerForRates, "f").call(this)
+                 ? this.messenger.call('AssetsController:getExchangeRatesForBridge')
+                     .currentCurrency
+@@ -341,7 +339,7 @@ export class BridgeController extends StaticIntervalPollingController() {
+             }
+             const pricesByAssetId = await fetchAssetPrices({
+                 assetIds,
+-                currencies: new Set([currency]),
++                currencies: new Set([currency, "usd"]),
+                 clientId: __classPrivateFieldGet(this, _BridgeController_clientId, "f"),
+                 clientVersion: __classPrivateFieldGet(this, _BridgeController_clientVersion, "f"),
+                 fetchFn: __classPrivateFieldGet(this, _BridgeController_fetchFn, "f"),

--- a/app/components/UI/Bridge/hooks/useBridgeExchangeRates/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeExchangeRates/index.ts
@@ -2,6 +2,8 @@ import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
 import { BridgeToken } from '../../types';
+import { selectTokenMarketData } from '../../../../../selectors/tokenRatesController';
+import { exchangeRateFromMarketData } from '../../utils/exchange-rates';
 import {
   setSourceTokenExchangeRate,
   setDestTokenExchangeRate,
@@ -25,6 +27,7 @@ export const useBridgeExchangeRates = ({
 }) => {
   const dispatch = useThunkDispatch();
   const currentCurrency = useSelector(selectCurrentCurrency);
+  const evmMarketData = useSelector(selectTokenMarketData);
 
   // If a currency override is provided, use it, otherwise use the current currency
   // Used in places like metrics, when we want to get a rate specifically in USD
@@ -33,13 +36,29 @@ export const useBridgeExchangeRates = ({
   // Fetch exchange rates for selected token if not found in marketData
   useEffect(() => {
     if (token?.chainId && token?.address) {
-      dispatch(
-        action({
-          chainId: token.chainId,
-          tokenAddress: token.address,
-          currency,
-        }),
+      const exchangeRateInNativeAsset = exchangeRateFromMarketData(
+        token.chainId,
+        token.address,
+        evmMarketData,
       );
+
+      if (!exchangeRateInNativeAsset && !token.currencyExchangeRate) {
+        dispatch(
+          action({
+            chainId: token.chainId,
+            tokenAddress: token.address,
+            currency,
+          }),
+        );
+      }
     }
-  }, [currency, dispatch, token?.chainId, token?.address, action]);
+  }, [
+    currency,
+    dispatch,
+    token?.chainId,
+    token?.address,
+    evmMarketData,
+    action,
+    token?.currencyExchangeRate,
+  ]);
 };

--- a/app/components/UI/Bridge/hooks/useBridgeExchangeRates/index.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeExchangeRates/index.ts
@@ -2,8 +2,6 @@ import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { selectCurrentCurrency } from '../../../../../selectors/currencyRateController';
 import { BridgeToken } from '../../types';
-import { selectTokenMarketData } from '../../../../../selectors/tokenRatesController';
-import { exchangeRateFromMarketData } from '../../utils/exchange-rates';
 import {
   setSourceTokenExchangeRate,
   setDestTokenExchangeRate,
@@ -27,7 +25,6 @@ export const useBridgeExchangeRates = ({
 }) => {
   const dispatch = useThunkDispatch();
   const currentCurrency = useSelector(selectCurrentCurrency);
-  const evmMarketData = useSelector(selectTokenMarketData);
 
   // If a currency override is provided, use it, otherwise use the current currency
   // Used in places like metrics, when we want to get a rate specifically in USD
@@ -36,29 +33,13 @@ export const useBridgeExchangeRates = ({
   // Fetch exchange rates for selected token if not found in marketData
   useEffect(() => {
     if (token?.chainId && token?.address) {
-      const exchangeRateInNativeAsset = exchangeRateFromMarketData(
-        token.chainId,
-        token.address,
-        evmMarketData,
+      dispatch(
+        action({
+          chainId: token.chainId,
+          tokenAddress: token.address,
+          currency,
+        }),
       );
-
-      if (!exchangeRateInNativeAsset && !token.currencyExchangeRate) {
-        dispatch(
-          action({
-            chainId: token.chainId,
-            tokenAddress: token.address,
-            currency,
-          }),
-        );
-      }
     }
-  }, [
-    currency,
-    dispatch,
-    token?.chainId,
-    token?.address,
-    evmMarketData,
-    action,
-    token?.currencyExchangeRate,
-  ]);
+  }, [currency, dispatch, token?.chainId, token?.address, action]);
 };

--- a/app/core/Engine/messengers/bridge-controller-messenger/index.ts
+++ b/app/core/Engine/messengers/bridge-controller-messenger/index.ts
@@ -30,6 +30,8 @@ export function getBridgeControllerMessenger(
       'SnapController:handleRequest',
       'NetworkController:getNetworkClientById',
       'NetworkController:findNetworkClientIdByChainId',
+      'TokenRatesController:getState',
+      'MultichainAssetsRatesController:getState',
       'CurrencyRateController:getState',
       'RemoteFeatureFlagController:getState',
       'AuthenticationController:getBearerToken',

--- a/package.json
+++ b/package.json
@@ -267,7 +267,7 @@
     "@metamask/base-controller": "^9.0.1",
     "@metamask/bitcoin-wallet-snap": "^1.14.2",
     "@metamask/bitcoin-wallet-standard": "^1.0.0",
-    "@metamask/bridge-controller": "patch:@metamask/bridge-controller@npm%3A77.6.0#~/.yarn/patches/@metamask-bridge-controller-npm-77.6.0-2a4ded2811.patch",
+    "@metamask/bridge-controller": "^77.6.0",
     "@metamask/bridge-status-controller": "^74.3.0",
     "@metamask/chain-agnostic-permission": "^1.5.0",
     "@metamask/chomp-api-service": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -235,8 +235,8 @@
     "expo-modules-autolinking@npm:3.0.24": "patch:expo-modules-autolinking@npm%3A3.0.24#~/.yarn/patches/expo-modules-autolinking-npm-3.0.24-67e807d080.patch",
     "@react-native/babel-preset@npm:0.83.6": "patch:@react-native/babel-preset@npm%3A0.83.6#~/.yarn/patches/@react-native-babel-preset-npm-0.83.6-90eed53ffb.patch",
     "@metamask/network-enablement-controller@npm:^5.4.1": "patch:@metamask/network-enablement-controller@npm%3A5.4.1#~/.yarn/patches/@metamask-network-enablement-controller-npm-5.4.1-020a82a308.patch",
-    "@metamask/bridge-controller@npm:^77.5.0": "patch:@metamask/bridge-controller@npm%3A77.6.0#~/.yarn/patches/@metamask-bridge-controller-npm-77.6.0-2a4ded2811.patch",
-    "@metamask/bridge-controller@npm:^77.6.0": "patch:@metamask/bridge-controller@npm%3A77.6.0#~/.yarn/patches/@metamask-bridge-controller-npm-77.6.0-2a4ded2811.patch"
+    "@metamask/bridge-controller@npm:^77.5.0": "patch:@metamask/bridge-controller@patch%3A@metamask/bridge-controller@npm%253A77.6.0%23~/.yarn/patches/@metamask-bridge-controller-npm-77.6.0-2a4ded2811.patch%3A%3Aversion=77.6.0&hash=e36d1e#~/.yarn/patches/@metamask-bridge-controller-patch-997d5d00c5.patch",
+    "@metamask/bridge-controller@npm:^77.6.0": "patch:@metamask/bridge-controller@patch%3A@metamask/bridge-controller@npm%253A77.6.0%23~/.yarn/patches/@metamask-bridge-controller-npm-77.6.0-2a4ded2811.patch%3A%3Aversion=77.6.0&hash=e36d1e#~/.yarn/patches/@metamask-bridge-controller-patch-997d5d00c5.patch"
   },
   "dependencies": {
     "@braze/react-native-sdk": "patch:@braze/react-native-sdk@npm%3A19.1.0#~/.yarn/patches/@braze-react-native-sdk-npm-19.1.0-076-reactmoduleinfo.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8209,7 +8209,7 @@ __metadata:
 
 "@metamask/bridge-controller@patch:@metamask/bridge-controller@npm%3A77.6.0#~/.yarn/patches/@metamask-bridge-controller-npm-77.6.0-2a4ded2811.patch":
   version: 77.6.0
-  resolution: "@metamask/bridge-controller@patch:@metamask/bridge-controller@npm%3A77.6.0#~/.yarn/patches/@metamask-bridge-controller-npm-77.6.0-2a4ded2811.patch::version=77.6.0&hash=d96d5c"
+  resolution: "@metamask/bridge-controller@patch:@metamask/bridge-controller@npm%3A77.6.0#~/.yarn/patches/@metamask-bridge-controller-npm-77.6.0-2a4ded2811.patch::version=77.6.0&hash=e36d1e"
   dependencies:
     "@ethersproject/address": "npm:^5.7.0"
     "@ethersproject/bignumber": "npm:^5.7.0"
@@ -8236,7 +8236,7 @@ __metadata:
     bignumber.js: "npm:^9.1.2"
     reselect: "npm:^5.1.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/e4fe9c80be42bfa5e5c59eb6e823f73c5f41342e57311d46f5d026e9a1c5b57fceb2653e93bc9b3e3beaf9587702f8b40e24be46b89ced01aa67757619814ec1
+  checksum: 10/d96e3460ac002f3128ec252ebd5d85cb7b33db83e4add69f7eabeb4b88981b1dd3e0fecb371f7d3b7af433c9c5f1e29c2ad9985e2c672372dd35b51f393ba2ad
   languageName: node
   linkType: hard
 
@@ -9128,14 +9128,14 @@ __metadata:
   linkType: hard
 
 "@metamask/keyring-api@npm:^23.1.0, @metamask/keyring-api@npm:^23.2.0, @metamask/keyring-api@npm:^23.3.0, @metamask/keyring-api@npm:^23.5.0":
-  version: 23.7.0
-  resolution: "@metamask/keyring-api@npm:23.7.0"
+  version: 23.5.0
+  resolution: "@metamask/keyring-api@npm:23.5.0"
   dependencies:
-    "@metamask/keyring-utils": "npm:^4.0.0"
-    "@metamask/superstruct": "npm:^3.4.1"
+    "@metamask/keyring-utils": "npm:^3.3.1"
+    "@metamask/superstruct": "npm:^3.3.0"
     "@metamask/utils": "npm:^11.11.0"
     bitcoin-address-validation: "npm:^2.2.3"
-  checksum: 10/3c1aea064e017be0b99202a4e59b7ed9e1965aeb732b04ad5cb252dfa6b443487284f8b4253986ca325d8b45fd7977cef93f470f95f0342d377551d4b93738c3
+  checksum: 10/2d8a4b378f5bad77284feb58bc7f3b64d541751527c693e43f7e4d860333bc55593e27fc5264fc908d719912b374f77dabec3f5e491bb49f72501fd2f5c43e68
   languageName: node
   linkType: hard
 
@@ -9245,18 +9245,6 @@ __metadata:
     "@metamask/utils": "npm:^11.11.0"
     bitcoin-address-validation: "npm:^2.2.3"
   checksum: 10/d0917b2f634d9eb2f563827739fca00c1675ee90674ec49b2b68afcb604aee843d6c5be5d79e9780fa22d29f71fc876f40b2d3d0ed4cab7f5948937ddd276691
-  languageName: node
-  linkType: hard
-
-"@metamask/keyring-utils@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@metamask/keyring-utils@npm:4.0.0"
-  dependencies:
-    "@ethereumjs/tx": "npm:^5.4.0"
-    "@metamask/superstruct": "npm:^3.4.1"
-    "@metamask/utils": "npm:^11.11.0"
-    bitcoin-address-validation: "npm:^2.2.3"
-  checksum: 10/a4299fafadd4a4f2f1a4475a7f4e6c4d268ccfa82e505cdd4cf4a1ff5cc6ca485edd7422650c498409db93d4fe32429db7bd02276ce6fee80aac5f6a64439578
   languageName: node
   linkType: hard
 
@@ -10558,10 +10546,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/superstruct@npm:^3.0.0, @metamask/superstruct@npm:^3.1.0, @metamask/superstruct@npm:^3.2.1, @metamask/superstruct@npm:^3.3.0, @metamask/superstruct@npm:^3.4.1":
-  version: 3.4.1
-  resolution: "@metamask/superstruct@npm:3.4.1"
-  checksum: 10/d37b5662dc9bbe0d99e06eb951167fa745829ae3abfa103423e9d8c05e8712f1451376f8479d484722e1e1c1d881732da1efddccaca8868b530a786264b903b5
+"@metamask/superstruct@npm:^3.0.0, @metamask/superstruct@npm:^3.1.0, @metamask/superstruct@npm:^3.2.1, @metamask/superstruct@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "@metamask/superstruct@npm:3.3.0"
+  checksum: 10/664d5e330484a86420bc004b1c7f8301e1501cce712f611fe657176b2979edbd7cc6f4c77c8b1610486a685ebbd0b72dacf4bd6cf143d6b52038069d2f4e84ab
   languageName: node
   linkType: hard
 
@@ -35900,7 +35888,7 @@ __metadata:
     "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/bitcoin-wallet-snap": "npm:^1.14.2"
     "@metamask/bitcoin-wallet-standard": "npm:^1.0.0"
-    "@metamask/bridge-controller": "patch:@metamask/bridge-controller@npm%3A77.6.0#~/.yarn/patches/@metamask-bridge-controller-npm-77.6.0-2a4ded2811.patch"
+    "@metamask/bridge-controller": "npm:^77.6.0"
     "@metamask/bridge-status-controller": "npm:^74.3.0"
     "@metamask/browser-passworder": "npm:^5.0.0"
     "@metamask/browser-playground": "npm:0.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8207,7 +8207,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@patch:@metamask/bridge-controller@npm%3A77.6.0#~/.yarn/patches/@metamask-bridge-controller-npm-77.6.0-2a4ded2811.patch":
+"@metamask/bridge-controller@patch:@metamask/bridge-controller@npm%3A77.6.0#~/.yarn/patches/@metamask-bridge-controller-npm-77.6.0-2a4ded2811.patch::version=77.6.0&hash=e36d1e":
   version: 77.6.0
   resolution: "@metamask/bridge-controller@patch:@metamask/bridge-controller@npm%3A77.6.0#~/.yarn/patches/@metamask-bridge-controller-npm-77.6.0-2a4ded2811.patch::version=77.6.0&hash=e36d1e"
   dependencies:
@@ -8237,6 +8237,39 @@ __metadata:
     reselect: "npm:^5.1.1"
     uuid: "npm:^8.3.2"
   checksum: 10/d96e3460ac002f3128ec252ebd5d85cb7b33db83e4add69f7eabeb4b88981b1dd3e0fecb371f7d3b7af433c9c5f1e29c2ad9985e2c672372dd35b51f393ba2ad
+  languageName: node
+  linkType: hard
+
+"@metamask/bridge-controller@patch:@metamask/bridge-controller@patch%3A@metamask/bridge-controller@npm%253A77.6.0%23~/.yarn/patches/@metamask-bridge-controller-npm-77.6.0-2a4ded2811.patch%3A%3Aversion=77.6.0&hash=e36d1e#~/.yarn/patches/@metamask-bridge-controller-patch-997d5d00c5.patch":
+  version: 77.6.0
+  resolution: "@metamask/bridge-controller@patch:@metamask/bridge-controller@patch%3A@metamask/bridge-controller@npm%253A77.6.0%23~/.yarn/patches/@metamask-bridge-controller-npm-77.6.0-2a4ded2811.patch%3A%3Aversion=77.6.0&hash=e36d1e#~/.yarn/patches/@metamask-bridge-controller-patch-997d5d00c5.patch::version=77.6.0&hash=e0d260"
+  dependencies:
+    "@ethersproject/address": "npm:^5.7.0"
+    "@ethersproject/bignumber": "npm:^5.7.0"
+    "@ethersproject/constants": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/accounts-controller": "npm:^39.0.5"
+    "@metamask/assets-controller": "npm:^11.0.0"
+    "@metamask/assets-controllers": "npm:^109.4.1"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/gas-fee-controller": "npm:^26.2.4"
+    "@metamask/keyring-api": "npm:^23.5.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/multichain-network-controller": "npm:^3.2.1"
+    "@metamask/network-controller": "npm:^34.0.0"
+    "@metamask/polling-controller": "npm:^16.0.8"
+    "@metamask/profile-sync-controller": "npm:^28.3.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/transaction-controller": "npm:^69.0.0"
+    "@metamask/utils": "npm:^11.11.0"
+    bignumber.js: "npm:^9.1.2"
+    reselect: "npm:^5.1.1"
+    uuid: "npm:^8.3.2"
+  checksum: 10/445f749e1611ab6cb0f295e7befae70704877052e0cdac85442b11a71788f3eb602434e2883fda41eafbf9e5f9edb4361de0bf0d377d0ad01970123f08bb0898
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Commit 296950a77c7c3ea11ae058b863b3e0225cbd5463 overwrote the existing bridge-controller patch. This PR reapplies the commit while preserving the old patch

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: restore Stellar/Arc bridge-controller patches

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A

## **Manual testing steps**

Test Arc/Stellar networks, test swap dest token amounts

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes patched bridge/swap quote pricing and default chain ranking for Stellar/Arc; incorrect patches could show wrong destination amounts or hide networks.
> 
> **Overview**
> Re-establishes **layered Yarn patches** on `@metamask/bridge-controller` after a prior change overwrote the single patch file. The base patch again **drops Stellar and Arc** from `DEFAULT_CHAIN_RANKING`; a second patch restores mobile-specific **quote pricing** behavior by always fetching prices for bridge quote assets (no skip when rates are already in state) and requesting **USD** alongside the user currency in `fetchAssetPrices`.
> 
> **BridgeController** messenger delegation now includes **`TokenRatesController:getState`** and **`MultichainAssetsRatesController:getState`**, matching what the patched controller expects for rates. `package.json` resolutions apply both patches in sequence and declare `@metamask/bridge-controller` as `^77.6.0` with lockfile updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d3df3c455907440fc39ccba0e158f9f2cd62083. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->