### PR TITLE
fix(predict): route funding Track to redesigned activity details and show Pay fees cp-8.6.0

### DIFF
--- a/app/components/UI/Predict/hooks/usePredictToastRegistrations.test.tsx
+++ b/app/components/UI/Predict/hooks/usePredictToastRegistrations.test.tsx
@@ -114,10 +114,20 @@ jest.mock('../../../../selectors/networkController', () => ({
 
 let mockBottomSheetEnabled = false;
 let mockProviderMounted = false;
+let mockTransactionsRedesignEnabled = false;
 
 jest.mock('../selectors/featureFlags', () => ({
   selectPredictBottomSheetEnabledFlag: jest.fn(() => mockBottomSheetEnabled),
 }));
+
+jest.mock(
+  '../../../../selectors/featureFlagController/activityRedesign',
+  () => ({
+    selectIsTransactionsRedesignEnabled: jest.fn(
+      () => mockTransactionsRedesignEnabled,
+    ),
+  }),
+);
 
 jest.mock('../contexts/PredictPreviewSheetContext', () => ({
   shouldSuppressLegacyOrderFailureToast: jest.fn(() => mockProviderMounted),
@@ -138,6 +148,7 @@ describe('usePredictToastRegistrations', () => {
 
     mockBottomSheetEnabled = false;
     mockProviderMounted = false;
+    mockTransactionsRedesignEnabled = false;
     mockWithdrawTransaction = { amount: 123.45 };
 
     mockDeposit.mockResolvedValue(undefined);
@@ -192,6 +203,37 @@ describe('usePredictToastRegistrations', () => {
       expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTION_DETAILS, {
         transactionId: 'tx-1',
       });
+    });
+
+    it('tracks to the redesigned details screen when the redesign is enabled', () => {
+      mockTransactionsRedesignEnabled = true;
+      jest
+        .mocked(selectTransactionMetadataById)
+        .mockReturnValue({ chainId: '0x89' } as unknown as ReturnType<
+          typeof selectTransactionMetadataById
+        >);
+      const handler = getHandler();
+
+      handler(
+        {
+          type: 'deposit',
+          status: 'approved',
+          transactionId: 'tx-1',
+          senderAddress: selectedAddress,
+        },
+        showToast,
+      );
+
+      showToast.mock.calls[0][0].closeButtonOptions.onPress();
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.ACTIVITY_DETAILS, {
+        chainId: 'eip155:137',
+        txIdentifier: 'tx-1',
+      });
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        Routes.TRANSACTION_DETAILS,
+        expect.anything(),
+      );
     });
 
     it('shows success toast on confirmed status', () => {

--- a/app/components/UI/Predict/hooks/usePredictToastRegistrations.tsx
+++ b/app/components/UI/Predict/hooks/usePredictToastRegistrations.tsx
@@ -4,6 +4,7 @@ import {
   Spinner,
 } from '@metamask/design-system-react-native';
 import { useNavigation } from '@react-navigation/native';
+import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
 import type { AppNavigationProp } from '../../../../core/NavigationService/types';
 import { useQueryClient } from '@tanstack/react-query';
 import React, { useCallback, useMemo } from 'react';
@@ -36,6 +37,7 @@ import {
 import { resolveWithdrawTokenInfo } from '../../../Views/confirmations/utils/withdraw-token-resolution';
 import { selectPredictBottomSheetEnabledFlag } from '../selectors/featureFlags';
 import { shouldSuppressLegacyOrderFailureToast } from '../contexts/PredictPreviewSheetContext';
+import { selectIsTransactionsRedesignEnabled } from '../../../../selectors/featureFlagController/activityRedesign';
 
 const showPendingToast = ({
   showToast,
@@ -147,6 +149,9 @@ export const usePredictToastRegistrations = (): ToastRegistration[] => {
   // Subscribe to account group changes so the hook re-renders when the user switches accounts
   useSelector(selectSelectedAccountGroupId);
   const bottomSheetEnabled = useSelector(selectPredictBottomSheetEnabledFlag);
+  const isTransactionsRedesignEnabled = useSelector(
+    selectIsTransactionsRedesignEnabled,
+  );
   const selectedAddress = getEvmAccountFromSelectedAccountGroup()?.address;
   const normalizedSelectedAddress = selectedAddress?.toLowerCase() ?? '';
   const handleTransactionStatusChanged = useCallback(
@@ -197,6 +202,10 @@ export const usePredictToastRegistrations = (): ToastRegistration[] => {
               navigateToTransactionDetails(navigation, {
                 transactionId,
                 initialTypeFilter: ActivityTypeFilter.Predictions,
+                isTransactionsRedesignEnabled,
+                ...(depositMeta?.chainId
+                  ? { chainId: toEvmCaipChainId(depositMeta.chainId) }
+                  : {}),
               });
             },
           });
@@ -412,6 +421,7 @@ export const usePredictToastRegistrations = (): ToastRegistration[] => {
       bottomSheetEnabled,
       claim,
       deposit,
+      isTransactionsRedesignEnabled,
       navigation,
       normalizedSelectedAddress,
       queryClient,

--- a/app/components/Views/ActivityDetails/ActivityDetails.testIds.ts
+++ b/app/components/Views/ActivityDetails/ActivityDetails.testIds.ts
@@ -14,6 +14,8 @@ export const ActivityDetailsSelectorsIDs = {
   TRANSACTION_ID_ROW: 'activity-details-transaction-id-row',
   TRANSACTION_ID_COPY: 'activity-details-transaction-id-copy',
   FEE_ROW: 'activity-details-fee-row',
+  NETWORK_FEE_ROW: 'activity-details-network-fee-row',
+  BRIDGE_FEE_ROW: 'activity-details-bridge-fee-row',
   TOTAL_ROW: 'activity-details-total-row',
   FOOTER: 'activity-details-footer',
   BLOCK_EXPLORER_BUTTON: 'activity-details-block-explorer-button',

--- a/app/components/Views/ActivityDetails/components/ActivityDetailsFeeValue.tsx
+++ b/app/components/Views/ActivityDetails/components/ActivityDetailsFeeValue.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, StyleSheet } from 'react-native';
+import { Image, StyleSheet, type ImageSourcePropType } from 'react-native';
 import {
   AvatarToken,
   AvatarTokenSize,
@@ -39,6 +39,74 @@ const styles = StyleSheet.create({
   },
 });
 
+/**
+ * A fee amount followed by its token and network badge (`$1.23 (◆)ETH`). Shows
+ * the amount alone when `symbol` is unknown.
+ */
+export function ActivityFeeTokenValue({
+  value,
+  symbol,
+  tokenImageSource,
+  networkImageSource,
+}: {
+  value: string;
+  symbol?: string;
+  tokenImageSource?: ReturnType<typeof getTokenImageSource>;
+  networkImageSource?: ImageSourcePropType;
+}) {
+  return (
+    <Box twClassName="flex-row items-center justify-end gap-2 shrink">
+      <Text
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Medium}
+        twClassName="shrink"
+        numberOfLines={1}
+        ellipsizeMode="tail"
+      >
+        {value}
+      </Text>
+      {symbol ? (
+        <Box twClassName="flex-row items-center gap-1 shrink">
+          <BadgeWrapper
+            position={BadgeWrapperPosition.BottomRight}
+            style={styles.tokenAvatarWrapper}
+            badge={
+              networkImageSource ? (
+                <Box
+                  twClassName="overflow-hidden border border-background-default bg-default"
+                  style={styles.networkBadge}
+                  testID="fee-network-badge"
+                >
+                  <Image
+                    source={networkImageSource}
+                    style={styles.networkBadgeImage}
+                  />
+                </Box>
+              ) : null
+            }
+          >
+            <AvatarToken
+              name={symbol}
+              src={tokenImageSource}
+              size={AvatarTokenSize.Xs}
+              testID="fee-token-avatar"
+            />
+          </BadgeWrapper>
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+            twClassName="ml-1 shrink"
+            numberOfLines={1}
+            ellipsizeMode="tail"
+          >
+            {symbol}
+          </Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
 export function ActivityDetailsFeeValue({
   fee,
   value,
@@ -70,58 +138,13 @@ export function ActivityDetailsFeeValue({
     symbol: fee.symbol,
     assetId: fee.assetId,
   };
-  const tokenImageSource = getTokenImageSource(token);
-  const networkImageSource = getNetworkImageSource({ chainId });
 
   return (
-    <Box twClassName="flex-row items-center justify-end gap-2 shrink">
-      <Text
-        variant={TextVariant.BodyMd}
-        fontWeight={FontWeight.Medium}
-        twClassName="shrink"
-        numberOfLines={1}
-        ellipsizeMode="tail"
-      >
-        {value}
-      </Text>
-      {fee.symbol ? (
-        <Box twClassName="flex-row items-center gap-1 shrink">
-          <BadgeWrapper
-            position={BadgeWrapperPosition.BottomRight}
-            style={styles.tokenAvatarWrapper}
-            badge={
-              networkImageSource ? (
-                <Box
-                  twClassName="overflow-hidden border border-background-default bg-default"
-                  style={styles.networkBadge}
-                  testID="fee-network-badge"
-                >
-                  <Image
-                    source={networkImageSource}
-                    style={styles.networkBadgeImage}
-                  />
-                </Box>
-              ) : null
-            }
-          >
-            <AvatarToken
-              name={fee.symbol}
-              src={tokenImageSource}
-              size={AvatarTokenSize.Xs}
-              testID="fee-token-avatar"
-            />
-          </BadgeWrapper>
-          <Text
-            variant={TextVariant.BodyMd}
-            fontWeight={FontWeight.Medium}
-            twClassName="ml-1 shrink"
-            numberOfLines={1}
-            ellipsizeMode="tail"
-          >
-            {fee.symbol}
-          </Text>
-        </Box>
-      ) : null}
-    </Box>
+    <ActivityFeeTokenValue
+      value={value}
+      symbol={fee.symbol}
+      tokenImageSource={getTokenImageSource(token)}
+      networkImageSource={getNetworkImageSource({ chainId })}
+    />
   );
 }

--- a/app/components/Views/ActivityDetails/components/ActivityDetailsPayFees.test.tsx
+++ b/app/components/Views/ActivityDetails/components/ActivityDetailsPayFees.test.tsx
@@ -1,0 +1,208 @@
+import React from 'react';
+import renderWithProvider from '../../../../util/test/renderWithProvider';
+import { backgroundState } from '../../../../util/test/initial-root-state';
+import type { ActivityListItem } from '../../../../util/activity-adapters';
+import {
+  ActivityDetailsPayFeesAndTotal,
+  hasActivityPayFiat,
+} from './ActivityDetailsPayFees';
+import { ActivityDetailsSelectorsIDs } from '../ActivityDetails.testIds';
+
+const { NETWORK_FEE_ROW, BRIDGE_FEE_ROW, TOTAL_ROW } =
+  ActivityDetailsSelectorsIDs;
+
+function payItem(
+  metamaskPay: Record<string, string> | undefined,
+): ActivityListItem {
+  return {
+    type: 'predictionsAddFunds',
+    chainId: 'eip155:137',
+    status: 'success',
+    timestamp: 1,
+    hash: '0xfund',
+    data: { token: { amount: '100000', decimals: 6, symbol: 'USDC' } },
+    raw: {
+      type: 'localTransaction',
+      data: {
+        primaryTransaction: { id: 'tx-1', chainId: '0x89', metamaskPay },
+        initialTransaction: { id: 'tx-1', chainId: '0x89' },
+        transactions: [],
+      },
+    },
+  } as unknown as ActivityListItem;
+}
+
+/** A provider-backed row — no local `TransactionMeta`, so no Pay metadata. */
+const providerItem = {
+  type: 'predictionPlaced',
+  chainId: 'eip155:137',
+  status: 'success',
+  timestamp: 1,
+  hash: 'predict-1',
+  data: {},
+  raw: { type: 'predictActivity', data: { id: 'predict-1' } },
+} as unknown as ActivityListItem;
+
+const USDC_MAINNET = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+const ACCOUNT = '0x0000000000000000000000000000000000000001';
+
+/** State where the payment token is a tracked ERC-20 on mainnet. */
+const stateWithPayToken = {
+  engine: {
+    backgroundState: {
+      ...backgroundState,
+      TokensController: {
+        ...backgroundState.TokensController,
+        allTokens: {
+          '0x1': {
+            [ACCOUNT]: [{ address: USDC_MAINNET, symbol: 'USDC', decimals: 6 }],
+          },
+        },
+      },
+    },
+  },
+};
+
+/** Non-USD display currency, to pin the deliberate USD formatting. */
+const eurState = {
+  engine: {
+    backgroundState: {
+      ...backgroundState,
+      CurrencyRateController: {
+        ...backgroundState.CurrencyRateController,
+        currentCurrency: 'eur',
+      },
+      // Read instead of `CurrencyRateController` once assets state unifies.
+      AssetsController: { selectedCurrency: 'eur' },
+    },
+  },
+};
+
+describe('ActivityDetailsPayFeesAndTotal', () => {
+  it('renders network fee, bridge fee and total', () => {
+    const { getByText, getByTestId } = renderWithProvider(
+      <ActivityDetailsPayFeesAndTotal
+        item={payItem({
+          networkFeeFiat: '0',
+          bridgeFeeFiat: '0.04',
+          totalFiat: '0.14',
+        })}
+      />,
+    );
+
+    expect(getByTestId(NETWORK_FEE_ROW)).toBeOnTheScreen();
+    expect(getByTestId(BRIDGE_FEE_ROW)).toBeOnTheScreen();
+    expect(getByTestId(TOTAL_ROW)).toBeOnTheScreen();
+    expect(getByText('Network fee')).toBeOnTheScreen();
+    // A sponsored network fee is recorded as zero and must still show.
+    expect(getByText('$0')).toBeOnTheScreen();
+    expect(getByText('$0.04')).toBeOnTheScreen();
+    expect(getByText('$0.14')).toBeOnTheScreen();
+  });
+
+  it('formats in USD even when the display currency is not USD', () => {
+    // Pay's values are USD amounts; reformatting them as EUR would relabel the
+    // same number as a different currency.
+    const { getByText, queryByText } = renderWithProvider(
+      <ActivityDetailsPayFeesAndTotal
+        item={payItem({ bridgeFeeFiat: '0.04', totalFiat: '0.14' })}
+      />,
+      { state: eurState },
+    );
+
+    expect(getByText('$0.04')).toBeOnTheScreen();
+    expect(queryByText('€0.04')).toBeNull();
+  });
+
+  it('denominates the network fee in the payment chain native asset and the bridge fee in the payment token', () => {
+    // Source-side both: gas in mainnet ETH, the provider's cut out of the USDC
+    // the user paid with.
+    const { getByText } = renderWithProvider(
+      <ActivityDetailsPayFeesAndTotal
+        item={payItem({
+          chainId: '0x1',
+          tokenAddress: USDC_MAINNET,
+          networkFeeFiat: '1.23',
+          bridgeFeeFiat: '0.09',
+          totalFiat: '1001.24',
+        })}
+      />,
+      { state: stateWithPayToken },
+    );
+
+    expect(getByText('ETH')).toBeOnTheScreen();
+    expect(getByText('USDC')).toBeOnTheScreen();
+  });
+
+  it('denominates both fees in the native asset when the user paid with it', () => {
+    const { getAllByText } = renderWithProvider(
+      <ActivityDetailsPayFeesAndTotal
+        item={payItem({
+          chainId: '0x1',
+          tokenAddress: '0x0000000000000000000000000000000000000000',
+          networkFeeFiat: '1.23',
+          bridgeFeeFiat: '0.09',
+        })}
+      />,
+    );
+
+    expect(getAllByText('ETH')).toHaveLength(2);
+  });
+
+  it('renders fees as fiat alone when the payment token is unknown', () => {
+    // An untracked payment token has no symbol, so no nameless avatar.
+    const { getByText, queryByText } = renderWithProvider(
+      <ActivityDetailsPayFeesAndTotal
+        item={payItem({
+          chainId: '0x1',
+          tokenAddress: USDC_MAINNET,
+          bridgeFeeFiat: '0.09',
+        })}
+      />,
+    );
+
+    expect(getByText('$0.09')).toBeOnTheScreen();
+    expect(queryByText('USDC')).toBeNull();
+  });
+
+  it('renders the total alone when Pay recorded no fees', () => {
+    const { getByTestId, queryByTestId } = renderWithProvider(
+      <ActivityDetailsPayFeesAndTotal item={payItem({ totalFiat: '0.14' })} />,
+    );
+
+    expect(getByTestId(TOTAL_ROW)).toBeOnTheScreen();
+    expect(queryByTestId(NETWORK_FEE_ROW)).toBeNull();
+    expect(queryByTestId(BRIDGE_FEE_ROW)).toBeNull();
+  });
+
+  it('renders nothing when the transaction has no Pay metadata', () => {
+    const { toJSON } = renderWithProvider(
+      <ActivityDetailsPayFeesAndTotal item={payItem(undefined)} />,
+    );
+
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders nothing for a row with no local transaction', () => {
+    const { toJSON } = renderWithProvider(
+      <ActivityDetailsPayFeesAndTotal item={providerItem} />,
+    );
+
+    expect(toJSON()).toBeNull();
+  });
+});
+
+describe('hasActivityPayFiat', () => {
+  it.each([
+    ['is true for a recorded zero fee', { networkFeeFiat: '0' }, true],
+    ['is true for a total with no fees', { totalFiat: '0.14' }, true],
+    ['is false for empty Pay metadata', {}, false],
+  ])('%s', (_name, metamaskPay, expected) => {
+    expect(hasActivityPayFiat(payItem(metamaskPay))).toBe(expected);
+  });
+
+  it('is false without Pay metadata or a local transaction', () => {
+    expect(hasActivityPayFiat(payItem(undefined))).toBe(false);
+    expect(hasActivityPayFiat(providerItem)).toBe(false);
+  });
+});

--- a/app/components/Views/ActivityDetails/components/ActivityDetailsPayFees.test.tsx
+++ b/app/components/Views/ActivityDetails/components/ActivityDetailsPayFees.test.tsx
@@ -73,7 +73,10 @@ const eurState = {
         currentCurrency: 'eur',
       },
       // Read instead of `CurrencyRateController` once assets state unifies.
-      AssetsController: { selectedCurrency: 'eur' },
+      AssetsController: {
+        ...backgroundState.AssetsController,
+        selectedCurrency: 'eur' as const,
+      },
     },
   },
 };

--- a/app/components/Views/ActivityDetails/components/ActivityDetailsPayFees.tsx
+++ b/app/components/Views/ActivityDetails/components/ActivityDetailsPayFees.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { BigNumber } from 'bignumber.js';
+import type { MetamaskPayMetadata } from '@metamask/transaction-controller';
+import { strings } from '../../../../../locales/i18n';
+import type { ActivityListItem } from '../../../../util/activity-adapters';
+import useFiatFormatter from '../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
+import {
+  ActivityDetailRow,
+  ActivityDetailSection,
+} from './ActivityDetailsLayout';
+import { ActivityDetailsSelectorsIDs } from '../ActivityDetails.testIds';
+
+/** Pay records its fiat values in USD, not the user's display currency. */
+const PAY_FIAT_CURRENCY = 'usd';
+
+/**
+ * MetaMask Pay's pre-aggregated fiat fees, read off the row's local transaction.
+ * Pay-routed rows carry no token-denominated `data.fees`, so this is their only
+ * fee source — the same one the legacy details screen reads.
+ */
+function getActivityPayMetadata(
+  item: ActivityListItem,
+): MetamaskPayMetadata | undefined {
+  return item.raw?.type === 'localTransaction'
+    ? item.raw.data.primaryTransaction?.metamaskPay
+    : undefined;
+}
+
+/**
+ * Whether {@link ActivityDetailsPayFeesAndTotal} renders anything, so templates
+ * can decide up front whether to add its divider.
+ */
+export function hasActivityPayFees(item: ActivityListItem): boolean {
+  const pay = getActivityPayMetadata(item);
+  return Boolean(pay?.networkFeeFiat || pay?.bridgeFeeFiat || pay?.totalFiat);
+}
+
+/**
+ * Network fee / bridge fee / total for a MetaMask Pay-routed transaction. Rows
+ * with no recorded value are omitted; a recorded zero still shows (`$0`).
+ */
+export function ActivityDetailsPayFeesAndTotal({
+  item,
+}: {
+  item: ActivityListItem;
+}) {
+  const formatFiat = useFiatFormatter({ currency: PAY_FIAT_CURRENCY });
+  const pay = getActivityPayMetadata(item);
+
+  if (!hasActivityPayFees(item)) {
+    return null;
+  }
+
+  const formatPayFiat = (value: string | undefined) =>
+    value ? formatFiat(new BigNumber(value)) : undefined;
+
+  return (
+    <ActivityDetailSection>
+      <ActivityDetailRow
+        label={strings('activity_details.network_fee')}
+        value={formatPayFiat(pay?.networkFeeFiat)}
+        testID={ActivityDetailsSelectorsIDs.FEE_ROW}
+      />
+      <ActivityDetailRow
+        label={strings('activity_details.bridge_fee')}
+        value={formatPayFiat(pay?.bridgeFeeFiat)}
+        testID={ActivityDetailsSelectorsIDs.FEE_ROW}
+      />
+      <ActivityDetailRow
+        label={strings('activity_details.total_amount')}
+        value={formatPayFiat(pay?.totalFiat)}
+        testID={ActivityDetailsSelectorsIDs.TOTAL_ROW}
+      />
+    </ActivityDetailSection>
+  );
+}

--- a/app/components/Views/ActivityDetails/components/ActivityDetailsPayFees.tsx
+++ b/app/components/Views/ActivityDetails/components/ActivityDetailsPayFees.tsx
@@ -1,17 +1,33 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { BigNumber } from 'bignumber.js';
+import type { Hex } from '@metamask/utils';
 import type { MetamaskPayMetadata } from '@metamask/transaction-controller';
 import { strings } from '../../../../../locales/i18n';
-import type { ActivityListItem } from '../../../../util/activity-adapters';
+import type { RootState } from '../../../../reducers';
+import { selectSingleTokenByAddressAndChainId } from '../../../../selectors/tokensController';
+import {
+  mobileActivityAdapterEnvironment,
+  type ActivityListItem,
+} from '../../../../util/activity-adapters';
+import { getNetworkImageSource } from '../../../../util/networks';
+import { getTokenImageSource } from '../../../UI/ActivityListItemRow/tokenIcon';
 import useFiatFormatter from '../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import {
   ActivityDetailRow,
   ActivityDetailSection,
 } from './ActivityDetailsLayout';
+import { ActivityFeeTokenValue } from './ActivityDetailsFeeValue';
 import { ActivityDetailsSelectorsIDs } from '../ActivityDetails.testIds';
 
 /** Pay records its fiat values in USD, not the user's display currency. */
 const PAY_FIAT_CURRENCY = 'usd';
+
+/** Symbol + asset id of the token a Pay fee is denominated in. */
+interface PayFeeToken {
+  symbol?: string;
+  assetId?: string;
+}
 
 /**
  * MetaMask Pay's pre-aggregated fiat fees, read off the row's local transaction.
@@ -28,11 +44,81 @@ function getActivityPayMetadata(
 
 /**
  * Whether {@link ActivityDetailsPayFeesAndTotal} renders anything, so templates
- * can decide up front whether to add its divider.
+ * can decide up front whether to add its divider. Fiat rather than fees: a row
+ * carrying only `totalFiat` still renders a section.
  */
-export function hasActivityPayFees(item: ActivityListItem): boolean {
+export function hasActivityPayFiat(item: ActivityListItem): boolean {
   const pay = getActivityPayMetadata(item);
   return Boolean(pay?.networkFeeFiat || pay?.bridgeFeeFiat || pay?.totalFiat);
+}
+
+/**
+ * Tokens the Pay fee rows are denominated in. Both fees are charged on the
+ * source side, so both come off the payment chain: network fee in its native
+ * asset (the fee is source-chain gas), bridge fee in the payment token. The
+ * quote records both as bare fiat, so these denominations are implied by how
+ * Pay charges them, not read back from it.
+ */
+function usePayFeeTokens(pay: MetamaskPayMetadata | undefined): {
+  networkFeeToken: PayFeeToken;
+  bridgeFeeToken: PayFeeToken;
+} {
+  const { chainId: payChainId, tokenAddress } = pay ?? {};
+  const importedPayToken = useSelector((state: RootState) =>
+    payChainId && tokenAddress
+      ? selectSingleTokenByAddressAndChainId(state, tokenAddress, payChainId)
+      : undefined,
+  );
+
+  const { getNativeAssetForChainId, nativeTokenAddress, equalsIgnoreCase } =
+    mobileActivityAdapterEnvironment;
+  const nativeAsset = payChainId
+    ? getNativeAssetForChainId(payChainId)
+    : undefined;
+  const networkFeeToken: PayFeeToken = {
+    symbol: nativeAsset?.symbol,
+    assetId: nativeAsset?.assetId,
+  };
+
+  if (!tokenAddress || equalsIgnoreCase(tokenAddress, nativeTokenAddress)) {
+    return { networkFeeToken, bridgeFeeToken: networkFeeToken };
+  }
+
+  return {
+    networkFeeToken,
+    bridgeFeeToken: {
+      symbol: importedPayToken?.symbol,
+      assetId: mobileActivityAdapterEnvironment.toAssetId(
+        tokenAddress,
+        payChainId,
+      ),
+    },
+  };
+}
+
+function PayFeeValue({
+  value,
+  token,
+  chainId,
+}: {
+  value: string;
+  token: PayFeeToken;
+  chainId: Hex | undefined;
+}) {
+  return (
+    <ActivityFeeTokenValue
+      value={value}
+      symbol={token.symbol}
+      tokenImageSource={getTokenImageSource({
+        direction: 'out',
+        symbol: token.symbol,
+        assetId: token.assetId,
+      })}
+      networkImageSource={
+        chainId ? getNetworkImageSource({ chainId }) : undefined
+      }
+    />
+  );
 }
 
 /**
@@ -46,25 +132,45 @@ export function ActivityDetailsPayFeesAndTotal({
 }) {
   const formatFiat = useFiatFormatter({ currency: PAY_FIAT_CURRENCY });
   const pay = getActivityPayMetadata(item);
+  const { networkFeeToken, bridgeFeeToken } = usePayFeeTokens(pay);
 
-  if (!hasActivityPayFees(item)) {
+  if (!hasActivityPayFiat(item)) {
     return null;
   }
 
   const formatPayFiat = (value: string | undefined) =>
     value ? formatFiat(new BigNumber(value)) : undefined;
 
+  const networkFee = formatPayFiat(pay?.networkFeeFiat);
+  const bridgeFee = formatPayFiat(pay?.bridgeFeeFiat);
+
   return (
     <ActivityDetailSection>
       <ActivityDetailRow
         label={strings('activity_details.network_fee')}
-        value={formatPayFiat(pay?.networkFeeFiat)}
-        testID={ActivityDetailsSelectorsIDs.FEE_ROW}
+        value={
+          networkFee ? (
+            <PayFeeValue
+              value={networkFee}
+              token={networkFeeToken}
+              chainId={pay?.chainId}
+            />
+          ) : undefined
+        }
+        testID={ActivityDetailsSelectorsIDs.NETWORK_FEE_ROW}
       />
       <ActivityDetailRow
         label={strings('activity_details.bridge_fee')}
-        value={formatPayFiat(pay?.bridgeFeeFiat)}
-        testID={ActivityDetailsSelectorsIDs.FEE_ROW}
+        value={
+          bridgeFee ? (
+            <PayFeeValue
+              value={bridgeFee}
+              token={bridgeFeeToken}
+              chainId={pay?.chainId}
+            />
+          ) : undefined
+        }
+        testID={ActivityDetailsSelectorsIDs.BRIDGE_FEE_ROW}
       />
       <ActivityDetailRow
         label={strings('activity_details.total_amount')}

--- a/app/components/Views/ActivityDetails/components/index.ts
+++ b/app/components/Views/ActivityDetails/components/index.ts
@@ -34,7 +34,7 @@ export {
 } from './ActivityDetailsFees';
 export {
   ActivityDetailsPayFeesAndTotal,
-  hasActivityPayFees,
+  hasActivityPayFiat,
 } from './ActivityDetailsPayFees';
 export {
   ActivityDetailsFooter,

--- a/app/components/Views/ActivityDetails/components/index.ts
+++ b/app/components/Views/ActivityDetails/components/index.ts
@@ -33,6 +33,10 @@ export {
   ActivityDetailsTotalRow,
 } from './ActivityDetailsFees';
 export {
+  ActivityDetailsPayFeesAndTotal,
+  hasActivityPayFees,
+} from './ActivityDetailsPayFees';
+export {
   ActivityDetailsFooter,
   ActivityDetailsBlockExplorerButton,
   ActivityDetailsBridgeExplorerButtons,

--- a/app/components/Views/ActivityDetails/templates/PredictDetails.test.tsx
+++ b/app/components/Views/ActivityDetails/templates/PredictDetails.test.tsx
@@ -249,4 +249,60 @@ describe('PredictDetails', () => {
     expect(getByText('Add funds')).toBeOnTheScreen();
     expect(getByText('Fund again')).toBeOnTheScreen();
   });
+
+  it('renders MetaMask Pay network fee, bridge fee and total for a funded account', () => {
+    const { getByText } = renderWithProvider(
+      <PredictDetails
+        item={addFundsItemWithPayMetadata({
+          networkFeeFiat: '0',
+          bridgeFeeFiat: '0.04',
+          totalFiat: '0.14',
+        })}
+      />,
+    );
+
+    expect(getByText('Network fee')).toBeOnTheScreen();
+    // A sponsored network fee is recorded as zero and must still show.
+    expect(getByText('$0')).toBeOnTheScreen();
+    expect(getByText('Bridge fee')).toBeOnTheScreen();
+    expect(getByText('$0.04')).toBeOnTheScreen();
+    expect(getByText('Total amount')).toBeOnTheScreen();
+    expect(getByText('$0.14')).toBeOnTheScreen();
+  });
+
+  it('omits the fee section when the funding transaction has no MetaMask Pay metadata', () => {
+    const { queryByText } = renderWithProvider(
+      <PredictDetails item={addFundsItemWithPayMetadata(undefined)} />,
+    );
+
+    expect(queryByText('Network fee')).toBeNull();
+    expect(queryByText('Total amount')).toBeNull();
+    // The step timeline still renders without a fee section above it.
+    expect(queryByText('Steps (2 completed)')).not.toBeNull();
+  });
 });
+
+function addFundsItemWithPayMetadata(
+  metamaskPay: Record<string, string> | undefined,
+): ActivityListItem {
+  return predictItem({
+    type: 'predictionsAddFunds',
+    hash: '0xfund',
+    data: {
+      token: {
+        amount: '100000',
+        decimals: 6,
+        symbol: 'USDC',
+        direction: 'in',
+      },
+    },
+    raw: {
+      type: 'localTransaction',
+      data: {
+        primaryTransaction: { id: 'tx-1', chainId: '0x89', metamaskPay },
+        initialTransaction: { id: 'tx-1', chainId: '0x89' },
+        transactions: [],
+      },
+    },
+  } as unknown as Partial<ActivityListItem>);
+}

--- a/app/components/Views/ActivityDetails/templates/PredictDetails/PredictFundsDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/PredictDetails/PredictFundsDetails.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { SectionDivider } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { selectSelectedAccountGroupEvmInternalAccount } from '../../../../../selectors/multichainAccounts/accountTreeController';
 import {
@@ -9,9 +10,11 @@ import {
   ActivityDetailsBlockExplorerButton,
   ActivityDetailsDoItAgainButton,
   ActivityDetailsNetworkValue,
+  ActivityDetailsPayFeesAndTotal,
   ActivityDetailsStepTimeline,
   ActivityDetailsTemplateFrame,
   formatActivityTokenAmount,
+  hasActivityPayFees,
 } from '../../components';
 import { ActivityDetailsSelectorsIDs } from '../../ActivityDetails.testIds';
 import { useActivityNetworkName } from '../../hooks/useActivityNetworkName';
@@ -79,6 +82,8 @@ export function PredictFundsDetails({
       ? getPredictFundsSteps(item.status, item.timestamp)
       : undefined;
   const completedCount = item.status === 'success' ? 2 : 1;
+  const showPayFees = isDeposit && hasActivityPayFees(item);
+  const showDetails = showPayFees || Boolean(steps);
 
   return (
     <ActivityDetailsTemplateFrame
@@ -91,18 +96,30 @@ export function PredictFundsDetails({
       }
       metadata={<PredictFundsMetadata item={item} />}
       details={
-        steps ? (
-          <ActivityDetailsStepTimeline
-            explorerTarget={
-              item.hash ? { chainId: item.chainId, hash: item.hash } : undefined
-            }
-            steps={steps}
-            title={getPredictFundsStepTitle(
-              item.status,
-              completedCount,
-              steps.length,
-            )}
-          />
+        showDetails ? (
+          <>
+            {showPayFees ? (
+              <ActivityDetailsPayFeesAndTotal item={item} />
+            ) : null}
+            {showPayFees && steps ? (
+              <SectionDivider marginVertical={3} />
+            ) : null}
+            {steps ? (
+              <ActivityDetailsStepTimeline
+                explorerTarget={
+                  item.hash
+                    ? { chainId: item.chainId, hash: item.hash }
+                    : undefined
+                }
+                steps={steps}
+                title={getPredictFundsStepTitle(
+                  item.status,
+                  completedCount,
+                  steps.length,
+                )}
+              />
+            ) : null}
+          </>
         ) : undefined
       }
       footer={

--- a/app/components/Views/ActivityDetails/templates/PredictDetails/PredictFundsDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/PredictDetails/PredictFundsDetails.tsx
@@ -14,7 +14,7 @@ import {
   ActivityDetailsStepTimeline,
   ActivityDetailsTemplateFrame,
   formatActivityTokenAmount,
-  hasActivityPayFees,
+  hasActivityPayFiat,
 } from '../../components';
 import { ActivityDetailsSelectorsIDs } from '../../ActivityDetails.testIds';
 import { useActivityNetworkName } from '../../hooks/useActivityNetworkName';
@@ -82,8 +82,8 @@ export function PredictFundsDetails({
       ? getPredictFundsSteps(item.status, item.timestamp)
       : undefined;
   const completedCount = item.status === 'success' ? 2 : 1;
-  const showPayFees = isDeposit && hasActivityPayFees(item);
-  const showDetails = showPayFees || Boolean(steps);
+  const showPaySection = isDeposit && hasActivityPayFiat(item);
+  const showDetails = showPaySection || Boolean(steps);
 
   return (
     <ActivityDetailsTemplateFrame
@@ -98,10 +98,10 @@ export function PredictFundsDetails({
       details={
         showDetails ? (
           <>
-            {showPayFees ? (
+            {showPaySection ? (
               <ActivityDetailsPayFeesAndTotal item={item} />
             ) : null}
-            {showPayFees && steps ? (
+            {showPaySection && steps ? (
               <SectionDivider marginVertical={3} />
             ) : null}
             {steps ? (

--- a/app/util/navigation/navigateToTransactionDetails.test.ts
+++ b/app/util/navigation/navigateToTransactionDetails.test.ts
@@ -67,6 +67,55 @@ describe('navigateToTransactionDetails', () => {
     );
   });
 
+  it('opens the redesigned details screen when the redesign is enabled', () => {
+    const navigation = createNavigation();
+
+    navigateToTransactionDetails(navigation, {
+      transactionId: 'tx-meta-id',
+      initialTypeFilter: ActivityTypeFilter.Predictions,
+      isTransactionsRedesignEnabled: true,
+      chainId: 'eip155:137',
+    });
+
+    expect(navigation.navigate).toHaveBeenNthCalledWith(
+      2,
+      Routes.ACTIVITY_DETAILS,
+      { chainId: 'eip155:137', txIdentifier: 'tx-meta-id' },
+    );
+    expect(navigation.navigate).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to the legacy details screen when the redesign is enabled without a chainId', () => {
+    const navigation = createNavigation();
+
+    navigateToTransactionDetails(navigation, {
+      transactionId: 'tx-meta-id',
+      isTransactionsRedesignEnabled: true,
+    });
+
+    expect(navigation.navigate).toHaveBeenNthCalledWith(
+      2,
+      Routes.TRANSACTION_DETAILS,
+      { transactionId: 'tx-meta-id' },
+    );
+  });
+
+  it('keeps the legacy details screen when the redesign is disabled', () => {
+    const navigation = createNavigation();
+
+    navigateToTransactionDetails(navigation, {
+      transactionId: 'tx-meta-id',
+      isTransactionsRedesignEnabled: false,
+      chainId: 'eip155:137',
+    });
+
+    expect(navigation.navigate).toHaveBeenNthCalledWith(
+      2,
+      Routes.TRANSACTION_DETAILS,
+      { transactionId: 'tx-meta-id' },
+    );
+  });
+
   it('opens only the activity list when no transactionId is given', () => {
     const navigation = createNavigation();
 

--- a/app/util/navigation/navigateToTransactionDetails.ts
+++ b/app/util/navigation/navigateToTransactionDetails.ts
@@ -1,9 +1,11 @@
 import type { NavigationProp, ParamListBase } from '@react-navigation/native';
+import type { CaipChainId } from '@metamask/utils';
 import Routes from '../../constants/navigation/Routes';
 import type {
   ActivityTypeFilter,
   PerpsActivityFilter,
 } from '../../components/Views/ActivityScreen/types';
+import type { ActivityDetailsParams } from '../../components/Views/ActivityDetails/ActivityDetails.types';
 
 interface NavigateToTransactionDetailsOptions {
   /** Transaction id/hash to open. When omitted, only the activity list opens. */
@@ -14,6 +16,19 @@ interface NavigateToTransactionDetailsOptions {
    */
   initialTypeFilter?: ActivityTypeFilter;
   initialPerpsFilter?: PerpsActivityFilter;
+  /**
+   * Whether the redesigned details screen is enabled
+   * (`selectIsTransactionsRedesignEnabled`). Callers read the flag themselves so
+   * this module stays store-free; passing it keeps toast entry points on the same
+   * destination the activity list already uses for the very same row.
+   */
+  isTransactionsRedesignEnabled?: boolean;
+  /**
+   * CAIP-2 chain id of `transactionId`. Required by the redesigned screen, which
+   * re-resolves the row per chain. Without it the legacy screen is used, since
+   * an unfiltered lookup could resolve a hash that collides across chains.
+   */
+  chainId?: CaipChainId;
 }
 
 /**
@@ -21,9 +36,16 @@ interface NavigateToTransactionDetailsOptions {
  * row), landing on the (optionally filtered) activity list first so "back"
  * returns there rather than to the caller.
  *
- * Both `TRANSACTIONS_VIEW` and `TRANSACTION_DETAILS` are reachable from the root
- * navigator, so the two navigations resolve immediately — no mount-order
- * `setTimeout` is needed (unlike the previous per-call-site workaround).
+ * With the redesign enabled (and a `chainId` to resolve the row on) this opens
+ * `ACTIVITY_DETAILS`, matching where the activity list sends the same row; it
+ * otherwise falls back to the confirmations team's `TRANSACTION_DETAILS`. The
+ * redesigned screen resolves local rows by `TransactionMeta.id`, which is what
+ * callers here hold, so it needs no out-of-band row hand-off.
+ *
+ * All of `TRANSACTIONS_VIEW`, `ACTIVITY_DETAILS` and `TRANSACTION_DETAILS` are
+ * reachable from the root navigator, so the two navigations resolve immediately
+ * — no mount-order `setTimeout` is needed (unlike the previous per-call-site
+ * workaround).
  */
 export function navigateToTransactionDetails(
   // Only `navigate` is needed; Pick avoids coupling to the caller's exact
@@ -33,6 +55,8 @@ export function navigateToTransactionDetails(
     transactionId,
     initialTypeFilter,
     initialPerpsFilter,
+    isTransactionsRedesignEnabled,
+    chainId,
   }: NavigateToTransactionDetailsOptions = {},
 ): void {
   if (initialTypeFilter) {
@@ -46,7 +70,16 @@ export function navigateToTransactionDetails(
   } else {
     navigation.navigate(Routes.TRANSACTIONS_VIEW);
   }
-  if (transactionId) {
-    navigation.navigate(Routes.TRANSACTION_DETAILS, { transactionId });
+  if (!transactionId) {
+    return;
   }
+  if (isTransactionsRedesignEnabled && chainId) {
+    const params: ActivityDetailsParams = {
+      chainId,
+      txIdentifier: transactionId,
+    };
+    navigation.navigate(Routes.ACTIVITY_DETAILS, params);
+    return;
+  }
+  navigation.navigate(Routes.TRANSACTION_DETAILS, { transactionId });
 }


### PR DESCRIPTION
## **Description**

Two defects on the Predict funding flow when the activity redesign is enabled.

**1. "Track" opened the legacy details screen.** The funding toast's Track button routed to `Routes.TRANSACTION_DETAILS` (the confirmations team's screen) unconditionally. The activity list already sends that same local row to the redesigned `Routes.ACTIVITY_DETAILS` when `selectIsTransactionsRedesignEnabled` is on, so the toast was the only entry point that disagreed — the same transaction rendered two different ways depending on how you reached it.

`navigateToTransactionDetails` now accepts `isTransactionsRedesignEnabled` + `chainId` and navigates to `ACTIVITY_DETAILS` when both are present. The flag is passed in by the caller rather than read from the store, so this util stays store-free (it lives in `app/util`, where importing the store risks an import cycle). Callers that don't pass the new options are unaffected, so the Perps toast keeps its current destination.

**2. The redesigned funding details had no fee rows.** MetaMask Pay records its already-aggregated fiat fees on the `TransactionMeta` (`metamaskPay.networkFeeFiat` / `bridgeFeeFiat` / `totalFiat`). The activity adapter's token-denominated `data.fees` is empty for these rows, so the shared `ActivityDetailsFeesAndTotal` had nothing to render.

A new `ActivityDetailsPayFees` section reads `metamaskPay` and renders Network fee / Bridge fee / Total using the redesign's own `ActivityDetailRow` primitives, formatted as USD via `useFiatFormatter({ currency: 'usd' })` — the same source and currency the legacy rows use, so the two screens can't disagree. A recorded zero still renders (a sponsored network fee shows `$0`); absent values omit their row.

**Scope:** deposits only. Withdrawals relabel these rows ("Provider fee" / "Received total" off `targetFiat`) and have no redesigned copy in the `activity_details` locale namespace yet — this matches the existing, deliberately deposit-only step timeline in the same template. Broader `mmPay` coverage (Perps and Money-account deposits/withdrawals) needs adapter work, since `local-transaction.ts` only special-cases the Predict types today; worth a follow-up ticket.

**Known limitation:** `metamaskPay` lives only on the local `TransactionMeta`, which `TransactionController#trimTransactionsForState` eventually trims. Once trimmed, the row resolves from the indexed API copy and the fee section renders nothing. It degrades to absent rather than wrong, and the legacy screen is worse in the same situation (blank body, since `useTransactionDetails` returns undefined). Pre-existing platform constraint, not introduced here.

## **Changelog**

CHANGELOG entry: Fixed the Predictions "Add funds" activity details to show network fee, bridge fee and total, and to open the redesigned details screen from the funding notification

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1215

## **Manual testing steps**

```gherkin
Feature: Predict funding activity details

  Scenario: user tracks a Predictions deposit from the funding toast
    Given the activity redesign feature flags are enabled
    And the user has added funds to their Predictions account

    When user taps "Track" on the "Adding funds" toast
    Then the redesigned activity details screen opens
    And the screen shows Network fee, Bridge fee and Total rows
    And tapping back returns to the Predictions-filtered activity list

  Scenario: user opens the same deposit from the activity list
    Given the activity redesign feature flags are enabled

    When user opens Wallet then Activity
    And user taps the "Add funds" Predictions row
    Then the same redesigned details screen opens with identical fee values

  Scenario: fee values match the legacy screen
    Given the activity redesign feature flags are disabled

    When user taps "Track" on the "Adding funds" toast
    Then the legacy details screen opens
    And its Network fee, Bridge fee and Total match the redesigned screen
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/22356882-4ca0-4176-8a47-50ff3d7b4cc4

### **Before**

https://github.com/user-attachments/assets/1ca0fc3e-7d5f-48b9-b272-0c37e243d6a4

### **After**

https://github.com/user-attachments/assets/22356882-4ca0-4176-8a47-50ff3d7b4cc4

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and navigation changes behind an existing feature flag, with legacy fallback when chain id is missing; fee display reads existing Pay metadata without changing payment logic.
> 
> **Overview**
> Aligns Predict funding **Track** navigation with the activity redesign and surfaces **MetaMask Pay** fee rows on the redesigned deposit details screen.
> 
> **Track navigation:** `navigateToTransactionDetails` now accepts `isTransactionsRedesignEnabled` and a CAIP-2 `chainId`. When both are set, it opens `ACTIVITY_DETAILS` instead of legacy `TRANSACTION_DETAILS`; without `chainId` it still falls back to legacy. Predict deposit toasts pass the redesign flag and chain id from transaction metadata (`toEvmCaipChainId`).
> 
> **Pay fees on redesigned details:** New `ActivityDetailsPayFees` reads `metamaskPay` from local transaction meta and renders network fee, bridge fee, and total in **USD** (even if the wallet display currency is not USD), with token/network badges via extracted `ActivityFeeTokenValue`. Deposit **Predict** funding template shows this section above the step timeline when Pay fiat metadata exists; zero fees still display (e.g. sponsored `$0`).
> 
> Tests cover navigation branches, Pay fee rendering edge cases, and Predict details integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92bc0dca1df9aa09f78cf4c066f5ad1e1826cf4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->