### PR TITLE
ci(appium): unify seedless smoke tag and raise seedless/wallet shards

### DIFF
--- a/.github/workflows/run-appium-smoke-tests-android.yml
+++ b/.github/workflows/run-appium-smoke-tests-android.yml
@@ -135,40 +135,15 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1]
+        split: [1, 2, 3, 4]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
       test-suite-name: appium-seedless-onboarding-android-smoke-${{ matrix.split }}
       platform: android
-      # Trailing colon required: bare SmokeSeedlessOnboarding also matches Extended titles.
-      test_suite_tag: 'SmokeSeedlessOnboarding:'
+      test_suite_tag: SmokeSeedlessOnboarding
       split_number: ${{ matrix.split }}
-      total_splits: 1
-      test-timeout-minutes: 25
-      build_type: ${{ inputs.build_type }}
-      metamask_environment: ${{ inputs.metamask_environment }}
-      runner_provider: ${{ inputs.runner_provider }}
-    secrets: inherit
-
-  appium-seedless-onboarding-extended-android-smoke:
-    if: >-
-      ${{
-        !cancelled() &&
-        (contains(fromJson(inputs.selected_tags), 'ALL') ||
-         contains(fromJson(inputs.selected_tags), 'SmokeSeedlessOnboardingExtended'))
-      }}
-    strategy:
-      matrix:
-        split: [1]
-      fail-fast: false
-    uses: ./.github/workflows/run-appium-e2e-workflow.yml
-    with:
-      test-suite-name: appium-seedless-onboarding-extended-android-smoke-${{ matrix.split }}
-      platform: android
-      test_suite_tag: SmokeSeedlessOnboardingExtended
-      split_number: ${{ matrix.split }}
-      total_splits: 1
+      total_splits: 4
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
@@ -232,7 +207,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2]
+        split: [1, 2, 3, 4]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -240,7 +215,7 @@ jobs:
       platform: android
       test_suite_tag: SmokeWalletPlatform
       split_number: ${{ matrix.split }}
-      total_splits: 2
+      total_splits: 4
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
       runner_provider: ${{ inputs.runner_provider }}

--- a/.github/workflows/run-appium-smoke-tests-ios.yml
+++ b/.github/workflows/run-appium-smoke-tests-ios.yml
@@ -115,40 +115,15 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1]
+        split: [1, 2, 3, 4]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
       test-suite-name: appium-seedless-onboarding-ios-smoke-${{ matrix.split }}
       platform: ios
-      # Trailing colon required: bare SmokeSeedlessOnboarding also matches Extended titles.
-      test_suite_tag: 'SmokeSeedlessOnboarding:'
+      test_suite_tag: SmokeSeedlessOnboarding
       split_number: ${{ matrix.split }}
-      total_splits: 1
-      test-timeout-minutes: 25
-      build_type: ${{ inputs.build_type || 'main' }}
-      metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
-      runner_provider: ${{ inputs.runner_provider || 'current' }}
-    secrets: inherit
-
-  appium-seedless-onboarding-extended-ios-smoke:
-    if: >-
-      ${{
-        !cancelled() &&
-        (contains(fromJson(inputs.selected_tags || '["ALL"]'), 'ALL') ||
-         contains(fromJson(inputs.selected_tags || '["ALL"]'), 'SmokeSeedlessOnboardingExtended'))
-      }}
-    strategy:
-      matrix:
-        split: [1]
-      fail-fast: false
-    uses: ./.github/workflows/run-appium-e2e-workflow.yml
-    with:
-      test-suite-name: appium-seedless-onboarding-extended-ios-smoke-${{ matrix.split }}
-      platform: ios
-      test_suite_tag: SmokeSeedlessOnboardingExtended
-      split_number: ${{ matrix.split }}
-      total_splits: 1
+      total_splits: 4
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
@@ -212,7 +187,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2]
+        split: [1, 2, 3, 4]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -220,7 +195,7 @@ jobs:
       platform: ios
       test_suite_tag: SmokeWalletPlatform
       split_number: ${{ matrix.split }}
-      total_splits: 2
+      total_splits: 4
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
       runner_provider: ${{ inputs.runner_provider || 'current' }}

--- a/tests/smoke-appium/seedless/google-login-add-srp.spec.ts
+++ b/tests/smoke-appium/seedless/google-login-add-srp.spec.ts
@@ -1,5 +1,5 @@
 import { test as appiumTest } from '../../framework/fixtures/playwright/index.js';
-import { SmokeSeedlessOnboardingExtended } from '../../tags.js';
+import { SmokeSeedlessOnboarding } from '../../tags.js';
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.js';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
 import Assertions from '../../framework/Assertions.js';
@@ -32,7 +32,7 @@ const googleNewUserWithFeatureFlagsMock = async (
 };
 
 appiumTest.describe(
-  SmokeSeedlessOnboardingExtended('Google Login - Add New SRP'),
+  SmokeSeedlessOnboarding('Google Login - Add New SRP'),
   () => {
     appiumTest(
       'creates wallet with Google login and adds a new SRP',

--- a/tests/smoke-appium/seedless/google-login-lock-unlock.spec.ts
+++ b/tests/smoke-appium/seedless/google-login-lock-unlock.spec.ts
@@ -1,5 +1,5 @@
 import { test as appiumTest } from '../../framework/fixtures/playwright/index.js';
-import { SmokeSeedlessOnboardingExtended } from '../../tags.js';
+import { SmokeSeedlessOnboarding } from '../../tags.js';
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.js';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
 import { PlatformDetector } from '../../framework/PlatformLocator.js';
@@ -13,7 +13,7 @@ import {
 } from './helpers/seedless-helpers.js';
 
 appiumTest.describe(
-  SmokeSeedlessOnboardingExtended('Google Login - Lock and Unlock'),
+  SmokeSeedlessOnboarding('Google Login - Lock and Unlock'),
   () => {
     appiumTest(
       'onboards with Google login, locks, and unlocks the app',

--- a/tests/smoke-appium/seedless/google-login-reset-wallet.spec.ts
+++ b/tests/smoke-appium/seedless/google-login-reset-wallet.spec.ts
@@ -1,5 +1,5 @@
 import { test as appiumTest } from '../../framework/fixtures/playwright/index.js';
-import { SmokeSeedlessOnboardingExtended } from '../../tags.js';
+import { SmokeSeedlessOnboarding } from '../../tags.js';
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.js';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
 import { PlatformDetector } from '../../framework/PlatformLocator.js';
@@ -12,7 +12,7 @@ import {
 } from './helpers/seedless-helpers.js';
 
 appiumTest.describe(
-  SmokeSeedlessOnboardingExtended('Google Login - Reset Wallet'),
+  SmokeSeedlessOnboarding('Google Login - Reset Wallet'),
   () => {
     appiumTest(
       'onboards with Google login, locks, and resets the wallet',

--- a/tests/smoke-appium/seedless/qr-sync-srp.spec.ts
+++ b/tests/smoke-appium/seedless/qr-sync-srp.spec.ts
@@ -1,6 +1,6 @@
 import type { Mockttp } from 'mockttp';
 import { test as appiumTest } from '../../framework/fixtures/playwright/index.js';
-import { SmokeSeedlessOnboardingExtended } from '../../tags.js';
+import { SmokeSeedlessOnboarding } from '../../tags.js';
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.js';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
 import { setupRemoteFeatureFlagsMock } from '../../api-mocking/helpers/remoteFeatureFlagsHelper.js';
@@ -31,7 +31,7 @@ const enableAddDeviceSyncFlag = async (mockServer: Mockttp) => {
 };
 
 appiumTest.describe(
-  SmokeSeedlessOnboardingExtended('QR sync SRP — mobile ↔ extension'),
+  SmokeSeedlessOnboarding('QR sync SRP — mobile ↔ extension'),
   () => {
     appiumTest(
       'new user: imports SRP from extension sync and lands on wallet home',

--- a/tests/smoke-appium/seedless/wallet-setup-completed-attribution.spec.ts
+++ b/tests/smoke-appium/seedless/wallet-setup-completed-attribution.spec.ts
@@ -1,5 +1,5 @@
 import { test as appiumTest } from '../../framework/fixtures/playwright/index.js';
-import { SmokeSeedlessOnboardingExtended } from '../../tags.js';
+import { SmokeSeedlessOnboarding } from '../../tags.js';
 import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.js';
 import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
 import { onboardingEvents } from '../../helpers/analytics/helpers.js';
@@ -32,7 +32,7 @@ function walletSetupCompletedOnlyExpectations(
 }
 
 appiumTest.describe(
-  SmokeSeedlessOnboardingExtended(
+  SmokeSeedlessOnboarding(
     'Wallet Setup Completed includes persisted attribution (Google + Apple)',
   ),
   () => {

--- a/tests/tags.js
+++ b/tests/tags.js
@@ -65,12 +65,7 @@ const smokeTags = {
   smokeSeedlessOnboarding: {
     tag: 'SmokeSeedlessOnboarding:',
     description:
-      'Tests core seedless onboarding with social login providers (Google and Apple). Covers new user wallet creation via Google and Apple OAuth, existing user detection with the Account Already Exists screen, SeedlessOnboardingController mock integration, OAuth token exchange, and the onboarding lifecycle including password creation, MetaMetrics opt-in, and wallet home arrival. When changes touch OAuth, SeedlessOnboardingController, social login UI, Account Already Exists, or the onboarding sheet, select this tag. For QR sync, add-SRP after seedless, attribution analytics, lock/unlock, or reset wallet, also select SmokeSeedlessOnboardingExtended. Related to SmokeWalletPlatform for wallet lifecycle and SmokeAccounts for account sync after social login.',
-  },
-  smokeSeedlessOnboardingExtended: {
-    tag: 'SmokeSeedlessOnboardingExtended:',
-    description:
-      'Tests extended seedless onboarding and post-onboard flows. Covers importing an additional SRP after Google seedless onboarding, Wallet Setup Completed attribution analytics for Google and Apple, QR sync SRP (new-user and existing-user mobile ↔ extension), and lock/unlock and reset-wallet after Google social login (may be skipped when flaky). Specs live in tests/smoke-appium/seedless/ under this tag. When changes touch Add Device / QR sync, post-seedless SRP import, onboarding attribution analytics, or seedless lock/reset, select this tag. Often pair with SmokeSeedlessOnboarding when OAuth onboarding UI also changes. Related to SmokeAccounts for multi-SRP after seedless and SmokeWalletPlatform for wallet lifecycle.',
+      'Tests seedless onboarding with social login providers (Google and Apple) and post-onboard flows. Covers new user wallet creation via Google and Apple OAuth, existing user detection with the Account Already Exists screen, SeedlessOnboardingController mock integration, OAuth token exchange, and the onboarding lifecycle including password creation, MetaMetrics opt-in, and wallet home arrival. Also covers importing an additional SRP after Google seedless onboarding, Wallet Setup Completed attribution analytics for Google and Apple, QR sync SRP (new-user and existing-user mobile ↔ extension), and lock/unlock and reset-wallet after Google social login (may be skipped when flaky). Specs live in tests/smoke-appium/seedless/. When changes touch OAuth, SeedlessOnboardingController, social login UI, Account Already Exists, the onboarding sheet, Add Device / QR sync, post-seedless SRP import, onboarding attribution analytics, or seedless lock/reset, select this tag. Related to SmokeWalletPlatform for wallet lifecycle and SmokeAccounts for account sync / multi-SRP after social login.',
   },
   smokeBrowser: {
     tag: 'SmokeBrowser:',
@@ -143,7 +138,6 @@ const {
   SmokeMultiChainAPI,
   SmokePredictions,
   SmokeSeedlessOnboarding,
-  SmokeSeedlessOnboardingExtended,
   SmokeBrowser,
   SmokeSnaps,
   SmokeMMConnect,
@@ -167,7 +161,6 @@ export {
   SmokeMultiChainAPI,
   SmokePredictions,
   SmokeSeedlessOnboarding,
-  SmokeSeedlessOnboardingExtended,
   SmokeBrowser,
   SmokeMMConnect,
   SampleFeature,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Merges Appium seedless onboarding into a single smoke group and raises shards for two suites that were pressing the job timeout:

1. **Seedless** — former `SmokeSeedlessOnboardingExtended` specs now use `SmokeSeedlessOnboarding`. The separate extended CI jobs are removed. One Appium suite runs with **4 shards** on Android and iOS.
2. **Wallet platform** — Appium shards raised from **2 → 4** on Android and iOS (iOS shard 1 was ~23m on the test-run step).

Core and extended seedless specs do not duplicate assertions; extended flows only reuse new-user onboarding as setup before asserting add-SRP, lock/unlock, reset, QR sync, or attribution.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: MetaMask/metamask-mobile#33898

## **Manual testing steps**

N/A — CI workflow and smoke-tag wiring only; no app runtime behavior change. Validation is via Appium smoke CI for `SmokeSeedlessOnboarding` and `SmokeWalletPlatform`.

## **Screenshots/Recordings**

N/A — no user-facing UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f45ee51-64e0-4391-91d7-54281bf2f153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f45ee51-64e0-4391-91d7-54281bf2f153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

