### PR TITLE
feat(wallet): hide the Money card while the onboarding checklist shows cp-8.6.0

### DIFF
--- a/app/components/Views/Wallet/Wallet.view.test.tsx
+++ b/app/components/Views/Wallet/Wallet.view.test.tsx
@@ -6,6 +6,9 @@ import {
 import { initialStateWallet } from '../../../../tests/component-view/presets/wallet';
 import { renderComponentViewScreen } from '../../../../tests/component-view/render';
 import { WalletViewSelectorsIDs } from './WalletView.testIds';
+import { MoneyBalanceCardTestIds } from '../../UI/Money/components/MoneyBalanceCard/MoneyBalanceCard.testIds';
+import { WalletHomeOnboardingStepsSelectors } from '../../UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.testIds';
+import { WALLET_HOME_ONBOARDING_VISIBLE_STEPS } from '../../UI/WalletHomeOnboardingSteps/walletHomeOnboardingStepsModel';
 import { describeForPlatforms } from '../../../../tests/component-view/platform';
 import { fireEvent } from '@testing-library/react-native';
 import Routes from '../../../constants/navigation/Routes';
@@ -236,6 +239,72 @@ describeForPlatforms('Wallet', () => {
       );
 
       expect(getByTestId(WalletViewSelectorsIDs.CARD_BUTTON)).toBeOnTheScreen();
+    });
+  });
+
+  describe('Money balance card', () => {
+    /** Money account enabled + geo-eligible, so only the checklist can hide the card. */
+    const renderMoneyAccountVisibleWallet = (
+      onboarding: Record<string, unknown>,
+    ) =>
+      renderWalletWithState((builder) =>
+        builder
+          .withRemoteFeatureFlags({
+            moneyEnableMoneyAccount: {
+              enabled: true,
+              minimumVersion: '0.0.0',
+            },
+            moneyAccountGeoBlockedCountries: { blockedRegions: ['GB'] },
+          })
+          .withOverrides({
+            ...walletStateOverrides,
+            engine: {
+              backgroundState: {
+                ...walletStateOverrides.engine.backgroundState,
+                GeolocationController: {
+                  location: 'US',
+                },
+              },
+            },
+            onboarding: {
+              completedOnboarding: true,
+              walletHomeOnboardingStepsEligible: true,
+              walletHomeOnboardingSkipInitialBalanceWait: true,
+              ...onboarding,
+            },
+          } as unknown as Record<string, unknown>),
+      );
+
+    it('hides the Money balance card while the onboarding checklist is showing', () => {
+      const { getByTestId, queryByTestId } = renderMoneyAccountVisibleWallet({
+        walletHomeOnboardingSteps: { suppressedReason: null, stepIndex: 0 },
+      });
+
+      expect(
+        queryByTestId(MoneyBalanceCardTestIds.LABEL),
+      ).not.toBeOnTheScreen();
+      expect(
+        getByTestId(WalletHomeOnboardingStepsSelectors.PROGRESS_LABEL),
+      ).toBeOnTheScreen();
+    });
+
+    it('shows the Money balance card after the user skips the last checklist step', () => {
+      const lastStepIndex = WALLET_HOME_ONBOARDING_VISIBLE_STEPS.length - 1;
+      const { getByTestId, queryByTestId } = renderMoneyAccountVisibleWallet({
+        walletHomeOnboardingSteps: {
+          suppressedReason: null,
+          stepIndex: lastStepIndex,
+        },
+      });
+
+      fireEvent.press(
+        getByTestId(WalletHomeOnboardingStepsSelectors.SKIP_BUTTON),
+      );
+
+      expect(
+        queryByTestId(WalletHomeOnboardingStepsSelectors.PROGRESS_LABEL),
+      ).not.toBeOnTheScreen();
+      expect(getByTestId(MoneyBalanceCardTestIds.LABEL)).toBeOnTheScreen();
     });
   });
 });

--- a/app/components/Views/Wallet/index.test.tsx
+++ b/app/components/Views/Wallet/index.test.tsx
@@ -1852,39 +1852,4 @@ describe('MoneyBalanceCard slot', () => {
 
     expect(queryByTestId('money-balance-card-mock')).not.toBeOnTheScreen();
   });
-
-  it('hides the MoneyBalanceCard while the onboarding checklist is showing', () => {
-    mockMoneyAccountEnabled = true;
-    jest
-      .mocked(useSelector)
-      .mockImplementation((callback: (state: unknown) => unknown) =>
-        callback(mockStateWalletHomePostOnboardingActive),
-      );
-
-    const { queryByTestId } = render(Wallet);
-
-    expect(queryByTestId('money-balance-card-mock')).not.toBeOnTheScreen();
-  });
-
-  it('restores the MoneyBalanceCard once the onboarding checklist is dismissed', () => {
-    mockMoneyAccountEnabled = true;
-    jest
-      .mocked(useSelector)
-      .mockImplementation((callback: (state: unknown) => unknown) =>
-        callback({
-          ...mockStateWalletHomePostOnboardingActive,
-          onboarding: {
-            ...mockStateWalletHomePostOnboardingActive.onboarding,
-            walletHomeOnboardingSteps: {
-              suppressedReason: 'user_dismissed',
-              stepIndex: 0,
-            },
-          },
-        }),
-      );
-
-    const { getByTestId } = render(Wallet);
-
-    expect(getByTestId('money-balance-card-mock')).toBeOnTheScreen();
-  });
 });

--- a/app/components/Views/Wallet/index.test.tsx
+++ b/app/components/Views/Wallet/index.test.tsx
@@ -1852,4 +1852,39 @@ describe('MoneyBalanceCard slot', () => {
 
     expect(queryByTestId('money-balance-card-mock')).not.toBeOnTheScreen();
   });
+
+  it('hides the MoneyBalanceCard while the onboarding checklist is showing', () => {
+    mockMoneyAccountEnabled = true;
+    jest
+      .mocked(useSelector)
+      .mockImplementation((callback: (state: unknown) => unknown) =>
+        callback(mockStateWalletHomePostOnboardingActive),
+      );
+
+    const { queryByTestId } = render(Wallet);
+
+    expect(queryByTestId('money-balance-card-mock')).not.toBeOnTheScreen();
+  });
+
+  it('restores the MoneyBalanceCard once the onboarding checklist is dismissed', () => {
+    mockMoneyAccountEnabled = true;
+    jest
+      .mocked(useSelector)
+      .mockImplementation((callback: (state: unknown) => unknown) =>
+        callback({
+          ...mockStateWalletHomePostOnboardingActive,
+          onboarding: {
+            ...mockStateWalletHomePostOnboardingActive.onboarding,
+            walletHomeOnboardingSteps: {
+              suppressedReason: 'user_dismissed',
+              stepIndex: 0,
+            },
+          },
+        }),
+      );
+
+    const { getByTestId } = render(Wallet);
+
+    expect(getByTestId('money-balance-card-mock')).toBeOnTheScreen();
+  });
 });

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -394,6 +394,8 @@ const Wallet = ({
   );
   const isMoneyAccountVisible =
     isMoneyAccountEnabled && isMoneyAccountGeoEligible;
+  const showMoneyBalanceCard =
+    isMoneyAccountVisible && !inWalletHomePostOnboardingFlow;
 
   /**
    * Provider configuration for the current selected network
@@ -1026,7 +1028,7 @@ const Wallet = ({
       {(!isMoneyAccountEnabled || isMoneyAccountGeoEligible) &&
         homeGrowthBannerContent}
       {homepageDiscoveryPills}
-      {isMoneyAccountVisible && <MoneyBalanceCard />}
+      {showMoneyBalanceCard && <MoneyBalanceCard />}
     </View>
   );
 


### PR DESCRIPTION
## **Description**

Newly onboarded users saw the wallet-home onboarding checklist and the Money card at the same time, giving them two competing primary CTAs. Per the ticket (approved by Johann), the Money card is now hidden while the checklist is on screen so the checklist owns the action.

The card is gated on the same selector the checklist tile already reads — `selectShouldShowWalletHomeOnboardingSteps`, surfaced in this view as the existing `inWalletHomePostOnboardingFlow` — so the two can't drift apart. That also satisfies the second acceptance criterion for free: dismissing or completing the checklist flips the selector, and the card reappears in the same render as the balance row that `AccountGroupBalance` swaps back in. No separate dismissal wiring was needed.

Deliberately scoped to the card. The header's activity button keeps using `isMoneyAccountVisible` and is unaffected — only the surface underneath the checklist was in conflict. `MoneyBalanceCard` has a single render site (`app/components/Views/Wallet/index.tsx`), so this is a one-line gate plus the derived flag.

Side benefit: `MoneyBalanceCard` fires a "component viewed" analytics event on mount, so it no longer reports views to users who never actually see the card.

## **Changelog**

CHANGELOG entry: Hid the Money card on the wallet home screen while the onboarding checklist is showing, so new users have a single clear next step

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-968

## **Manual testing steps**

```gherkin
Feature: Money card visibility during wallet-home onboarding

  Scenario: newly onboarded user sees only the checklist
    Given the Money account flag is on and the user is geo-eligible
    And the user has just completed onboarding so the wallet-home checklist is showing

    When user views the wallet home screen
    Then the onboarding checklist is visible
    And the Money card is not rendered below it

  Scenario: user dismisses the checklist
    Given the wallet-home onboarding checklist is showing

    When user dismisses the checklist
    Then the account balance is shown
    And the Money card appears below it

  Scenario: user completes the checklist
    Given the user is on the last checklist step

    When user completes the flow
    Then the balance and the Money card both appear after the exit animation

  Scenario: existing user is unaffected
    Given the user is not eligible for the wallet-home checklist
    And the Money account flag is on and the user is geo-eligible

    When user views the wallet home screen
    Then the Money card is visible as before
```

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/833ba151-9ad6-435d-9b56-efaf723f61e0

### **Before**

<img width="750px"  alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 20 45 37" src="https://github.com/user-attachments/assets/0c683e00-533b-4bbe-89d4-ec6250b8bdc9" />

### **After**

<img width="750px" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-29 at 20 48 36" src="https://github.com/user-attachments/assets/5556368f-a16e-4097-8c98-b27d4b820ea3" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI visibility change on wallet home with no auth, payments, or data-model changes; behavior is covered by new component-view tests.
> 
> **Overview**
> **Wallet home** no longer shows the **Money balance card** while the post-onboarding checklist is active, so new users aren’t offered two competing primary actions.
> 
> Rendering now uses a **`showMoneyBalanceCard`** flag: Money must be enabled and geo-eligible, and the user must **not** be in the wallet-home post-onboarding flow (`inWalletHomePostOnboardingFlow`, same signal as the checklist). Dismissing or finishing the checklist flips that flag and the card can mount again in the same render cycle as the normal balance UI.
> 
> **Component-view tests** cover the card hidden with the checklist visible, and visible again after skip on the last step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8d18774958d542e9bbd4a0f16f6b37b28cb6597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->