### PR TITLE
chore(core-platform): remove unreachable dead code

### DIFF
--- a/app/components/Snaps/SnapDialogApproval/SnapDialogApproval.test.tsx
+++ b/app/components/Snaps/SnapDialogApproval/SnapDialogApproval.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
-import SnapDialogApproval from './index';
+import SnapDialogApproval from './SnapDialogApproval';
 import Engine from '../../../core/Engine';
 import useApprovalRequest from '../../Views/confirmations/hooks/useApprovalRequest';
 import { DIALOG_APPROVAL_TYPES } from '@metamask/snaps-rpc-methods';

--- a/app/components/Snaps/SnapDialogApproval/index.ts
+++ b/app/components/Snaps/SnapDialogApproval/index.ts
@@ -1,3 +1,0 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
-export { default } from './SnapDialogApproval';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/UI/TemplateRenderer/SafeComponentList.ts
+++ b/app/components/UI/TemplateRenderer/SafeComponentList.ts
@@ -1,24 +1,13 @@
-import Button from '../../../component-library/components/Buttons/Button';
 import SheetHeader from '../../../component-library/components/Sheet/SheetHeader';
 import Text from '../../../component-library/components/Texts/Text';
 import Icon from '../../../component-library/components/Icons/Icon';
-import BottomSheetFooter from '../../../component-library/components/BottomSheets/BottomSheetFooter';
 import SmartTransactionStatus from '../../Views/transactions/SmartTransactionStatus/SmartTransactionStatus';
-import {
-  View,
-  Text as RNText,
-  ScrollView,
-  TouchableHighlight,
-} from 'react-native';
-import Checkbox from '../../../component-library/components/Checkbox/Checkbox';
+import { View, ScrollView, TouchableHighlight } from 'react-native';
 import { SnapUIImage } from '../../Snaps/SnapUIImage/SnapUIImage';
-import { SnapAvatar } from '../../Snaps/SnapAvatar/SnapAvatar';
-import AddressElement from '../../../components/Views/confirmations/legacy/components/AddressElement';
 import { Box } from '../Box/Box';
 import { SnapUICard } from '../../Snaps/SnapUICard/SnapUICard';
 import { SnapUILink } from '../../Snaps/SnapUILink/SnapUILink';
 import { SnapUIInput } from '../../Snaps/SnapUIInput/SnapUIInput';
-import { SnapIcon } from '../../Snaps/SnapIcon/SnapIcon';
 import { SnapUIFooterButton } from '../../Snaps/SnapUIFooterButton/SnapUIFooterButton';
 import { ConfirmInfoRowValueDouble } from '../../../component-library/components-temp/Snaps/ConfirmInfoRowValueDouble/ConfirmInfoRowValueDouble';
 import { SnapUIIcon } from '../../Snaps/SnapUIIcon/SnapUIIcon';
@@ -42,23 +31,17 @@ import { SnapUIDateTimePicker } from '../../Snaps/SnapUIDateTimePicker/SnapUIDat
 import { SnapUICollapsibleSection } from '../../Snaps/SnapUICollapsibleSection/SnapUICollapsibleSection';
 
 export const safeComponentList = {
-  BottomSheetFooter,
-  Button,
   Icon,
   SheetHeader,
   SmartTransactionStatus,
   Text,
   View,
-  Checkbox,
   SnapUIImage,
   SnapUICard,
-  SnapAvatar,
   SnapUILink,
-  AddressElement,
   Box,
   SnapUIInput,
   SnapUIAddressInput,
-  SnapIcon,
   SnapUIIcon,
   SnapUIFooterButton,
   ConfirmInfoRowValueDouble,
@@ -75,7 +58,6 @@ export const safeComponentList = {
   SnapUIInfoRow,
   SnapUIAccountSelector,
   SnapUIDateTimePicker,
-  RNText,
   ScrollView,
   SnapUITooltip,
   Skeleton,

--- a/app/components/Views/Snaps/KeyringSnapRemovalWarning/index.ts
+++ b/app/components/Views/Snaps/KeyringSnapRemovalWarning/index.ts
@@ -1,3 +1,0 @@
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-export { default as KeyringSnapRemovalWarning } from './KeyringSnapRemovalWarning';
-///: END:ONLY_INCLUDE_IF


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Removes unreachable `@MetaMask/core-platform` dead code found in a static import-graph audit: unused Snap re-export barrels and TemplateRenderer allowlist keys that nothing renders via `element:` templates.

**What changed:**
- Deleted unused barrels `SnapDialogApproval/index.ts` and `KeyringSnapRemovalWarning/index.ts` (production already imported the `.tsx` modules directly).
- Updated `SnapDialogApproval.test.tsx` to import `./SnapDialogApproval`.
- Trimmed unused `safeComponentList` entries: `AddressElement`, `BottomSheetFooter`, `Button`, `Checkbox`, `RNText`, `SnapAvatar`, and `SnapIcon` (those components remain available via their direct imports elsewhere).

No user-facing behavior change.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-978

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A for UI flows — no runtime behavior change. Verify with unit tests:

```bash
yarn jest app/components/Snaps/SnapDialogApproval/SnapDialogApproval.test.tsx app/components/Views/Snaps/KeyringSnapRemovalWarning/test/KeyringSnapRemovalWarning.test.tsx app/components/Views/confirmations/legacy/components/Approval/TemplateConfirmation/util.test.ts app/components/Views/confirmations/legacy/components/Approval/TemplateConfirmation/TemplateConfirmation.test.tsx --no-coverage --watchman=false
```

Optional smoke (snaps build): open Snap Settings and trigger a Snap dialog approval to confirm screens still mount.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — no UI changes

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only cleanup of unused exports and allowlist entries; production already used direct module paths and Snap UI component names.
> 
> **Overview**
> Removes **unreachable Snap-related dead code** identified by a static import-graph audit, with **no intended user-facing behavior change**.
> 
> **Barrel re-exports:** Deletes unused `index.ts` barrels for `SnapDialogApproval` and `KeyringSnapRemovalWarning` (call sites already import the `.tsx` modules). The `SnapDialogApproval` unit test now imports `./SnapDialogApproval` directly instead of the folder barrel.
> 
> **Template allowlist:** Trims `safeComponentList` in `SafeComponentList.ts` by dropping keys that are not used by `element:` template rendering (`Button`, `BottomSheetFooter`, `Checkbox`, `RNText`, `SnapAvatar`, `SnapIcon`, `AddressElement`). Snap UI continues to use dedicated components such as `SnapUIButton` and `SnapUIAvatar` via their direct imports elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a72daee40b4f78bf7ced6be9225790f00652d8ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->