### PR TITLE
fix(mm-pay): persist mm_pay_strategy for transactions failed on startup

### DIFF
--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.test.ts
@@ -1332,6 +1332,62 @@ describe('Metamask Pay Metrics', () => {
     });
   });
 
+  describe('failed on startup', () => {
+    beforeEach(() => {
+      request.transactionMeta.type = TransactionType.moneyAccountDeposit;
+      getStateMock.mockReturnValue({
+        engine: {
+          backgroundState: {
+            TokensController: { allTokens: {} },
+          },
+        },
+      } as never);
+    });
+
+    it.each([
+      'Transaction incomplete at startup',
+      'Transaction incomplete at startup with all required transactions confirmed',
+    ])(
+      'sets mm_pay_strategy to fiat when metamaskPay.fiat exists and error is "%s"',
+      (message) => {
+        request.transactionMeta.error = { name: 'Error', message };
+        request.transactionMeta.metamaskPay = {
+          fiat: { orderId: 'order-1', provider: 'transak-native' },
+        };
+
+        const result = getMetaMaskPayProperties(request) as TransactionMetrics;
+
+        expect(result.properties.mm_pay_strategy).toBe('fiat');
+      },
+    );
+
+    it('does not set mm_pay_strategy when metamaskPay has no fiat', () => {
+      request.transactionMeta.error = {
+        name: 'Error',
+        message: 'Transaction incomplete at startup',
+      };
+      request.transactionMeta.metamaskPay = { chainId: '0x1' };
+
+      const result = getMetaMaskPayProperties(request) as TransactionMetrics;
+
+      expect(result.properties.mm_pay_strategy).toBeUndefined();
+    });
+
+    it('does not set mm_pay_strategy for unrelated errors', () => {
+      request.transactionMeta.error = {
+        name: 'Error',
+        message: 'User rejected the transaction',
+      };
+      request.transactionMeta.metamaskPay = {
+        fiat: { orderId: 'order-1', provider: 'transak-native' },
+      };
+
+      const result = getMetaMaskPayProperties(request) as TransactionMetrics;
+
+      expect(result.properties.mm_pay_strategy).toBeUndefined();
+    });
+  });
+
   describe('mm_pay_time_to_complete_s', () => {
     afterEach(() => {
       jest.restoreAllMocks();

--- a/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
+++ b/app/core/Engine/controllers/transaction-controller/metrics_properties/metamask-pay.ts
@@ -82,6 +82,8 @@ export const getMetaMaskPayProperties: TransactionMetricsBuilder = ({
         transactionMeta,
         allTransactions,
       );
+
+      addFailedOnStartupMetrics(properties, transactionMeta);
     }
 
     return {
@@ -168,6 +170,30 @@ function addTimeToComplete(
 
   properties.mm_pay_time_to_complete_s =
     Math.round(Date.now() - submittedTime) / 1000;
+}
+
+// Error message set by @metamask/transaction-controller when it fails
+// approved/signed transactions that were still in-flight at the last app close.
+const STARTUP_INCOMPLETE_ERROR_PREFIX = 'Transaction incomplete at startup';
+
+/**
+ * Backfills mm_pay_* properties from the persisted transactionMeta.metamaskPay
+ * for transactions failed on startup, when the non-persisted
+ * TransactionPayController.transactionData is no longer available.
+ */
+function addFailedOnStartupMetrics(
+  properties: JsonMap,
+  transactionMeta: TransactionMeta,
+) {
+  const { error, metamaskPay } = transactionMeta;
+
+  if (!error?.message?.startsWith(STARTUP_INCOMPLETE_ERROR_PREFIX)) {
+    return;
+  }
+
+  if (metamaskPay?.fiat) {
+    properties.mm_pay_strategy = 'fiat';
+  }
 }
 
 /**


### PR DESCRIPTION
## **Description**

On app startup, `@metamask/transaction-controller` fails any `approved`/`signed` transactions that were still in-flight when the app was last closed, firing a `Transaction Finalized` event with `error == "Transaction incomplete at startup"`. At that point `TransactionPayController.transactionData` (which is `persist: false`) is gone, so `addPayTypeProperties` can only recover `mm_pay` / `mm_pay_chain_selected` / `mm_pay_token_selected` — every other MM Pay property is missing from the event.

This adds a small fallback, `addFailedOnStartupMetrics`, that runs only for these startup-incomplete transactions and backfills what can be reliably derived from the **persisted** `transactionMeta.metamaskPay`: it sets `mm_pay_strategy = 'fiat'` when `metamaskPay.fiat` exists.

Scope is intentionally minimal — only `mm_pay_strategy` is recovered. Other `transactionData`-derived properties (quotes, step totals, fee breakdowns) remain unavailable on startup because they are not persisted.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: MM Pay metrics for transactions failed on startup

  Scenario: fiat MM Pay transaction is finalized as incomplete on startup
    Given a fiat MM Pay transaction (e.g. moneyAccountDeposit) is left in an approved/signed state when the app is closed
    And its transactionMeta.metamaskPay.fiat is persisted

    When the app is restarted and the transaction is failed on startup
    Then the Transaction Finalized event includes error == "Transaction incomplete at startup"
    And the event includes mm_pay == true
    And the event includes mm_pay_strategy == "fiat"
```

## **Screenshots/Recordings**

### **Before**

N/A — analytics-only change.

### **After**

N/A — analytics-only change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only fallback gated on a specific error message and persisted fiat metadata; no transaction or payment logic changes.
> 
> **Overview**
> **Transaction Finalized** events for MM Pay flows that fail on app restart with *Transaction incomplete at startup* can no longer read `TransactionPayController.transactionData`, so analytics were missing **`mm_pay_strategy`** even when fiat metadata was still on the transaction.
> 
> This wires **`addFailedOnStartupMetrics`** into the existing MM Pay metrics path (alongside time-to-complete) so that, only for that startup-incomplete error prefix, **`mm_pay_strategy`** is set to **`fiat`** when persisted **`transactionMeta.metamaskPay.fiat`** is present. Other errors and non-fiat persisted metadata are unchanged; quote/fee fields that depend on non-persisted controller state are still not backfilled.
> 
> Tests cover both variants of the startup error message, the no-fiat case, and unrelated errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d825ca83dead30a02752e9fcd1ccf2693066a2bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->