### PR TITLE
fix: use unified import path and return to tokens full view

### DIFF
--- a/app/components/Views/AddAsset/Views/ConfirmAddTokenView/ConfirmAddAsset.test.tsx
+++ b/app/components/Views/AddAsset/Views/ConfirmAddTokenView/ConfirmAddAsset.test.tsx
@@ -152,7 +152,7 @@ describe('ConfirmAddAsset', () => {
     expect(mockGoBack).toHaveBeenCalledTimes(1);
   });
 
-  it('calls addTokenList and navigates to wallet when import button is pressed', async () => {
+  it('calls addTokenList and navigates to tokens full view when import button is pressed', async () => {
     const { getByTestId } = renderWithProvider(<ConfirmAddAsset />, {
       state: mockInitialState,
     });
@@ -163,12 +163,7 @@ describe('ConfirmAddAsset', () => {
     await userEvent.press(importButton);
 
     expect(mockAddTokenList).toHaveBeenCalledTimes(1);
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.HOME, {
-      screen: Routes.WALLET.TAB_STACK_FLOW,
-      params: {
-        screen: Routes.WALLET_VIEW,
-      },
-    });
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.TOKENS_FULL_VIEW);
   });
 
   it('shows loading feedback and prevents duplicate import presses', async () => {
@@ -203,12 +198,7 @@ describe('ConfirmAddAsset', () => {
     });
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.HOME, {
-        screen: Routes.WALLET.TAB_STACK_FLOW,
-        params: {
-          screen: Routes.WALLET_VIEW,
-        },
-      });
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.TOKENS_FULL_VIEW);
     });
   });
 
@@ -235,12 +225,9 @@ describe('ConfirmAddAsset', () => {
       getByTestId(TESTID_BOTTOMSHEETFOOTER_BUTTON_SUBSEQUENT),
     ).toBeEnabled();
     expect(getByTestId(TESTID_BOTTOMSHEETFOOTER_BUTTON)).toBeEnabled();
-    expect(mockNavigate).not.toHaveBeenCalledWith(Routes.WALLET.HOME, {
-      screen: Routes.WALLET.TAB_STACK_FLOW,
-      params: {
-        screen: Routes.WALLET_VIEW,
-      },
-    });
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      Routes.WALLET.TOKENS_FULL_VIEW,
+    );
   });
 
   it('renders without crashing when asset has no image', () => {

--- a/app/components/Views/AddAsset/Views/ConfirmAddTokenView/ConfirmAddAsset.tsx
+++ b/app/components/Views/AddAsset/Views/ConfirmAddTokenView/ConfirmAddAsset.tsx
@@ -39,15 +39,10 @@ const ConfirmAddAsset = () => {
   const [isImporting, setIsImporting] = useState(false);
 
   /**
-   * Go to wallet page
+   * Return to the View all tokens screen after a successful import.
    */
-  const goToWalletPage = useCallback(() => {
-    navigation.navigate(Routes.WALLET.HOME, {
-      screen: Routes.WALLET.TAB_STACK_FLOW,
-      params: {
-        screen: Routes.WALLET_VIEW,
-      },
-    });
+  const goToTokensFullView = useCallback(() => {
+    navigation.navigate(Routes.WALLET.TOKENS_FULL_VIEW);
   }, [navigation]);
 
   const handleImport = useCallback(async () => {
@@ -59,12 +54,12 @@ const ConfirmAddAsset = () => {
 
     try {
       await addTokenList();
-      goToWalletPage();
+      goToTokensFullView();
     } catch (error) {
       Logger.error(error as Error, 'ConfirmAddAsset: failed to import tokens');
       setIsImporting(false);
     }
-  }, [addTokenList, goToWalletPage, isImporting]);
+  }, [addTokenList, goToTokensFullView, isImporting]);
 
   return (
     <SafeAreaView

--- a/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.test.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.test.tsx
@@ -15,7 +15,6 @@ import {
 import { SupportedCaipChainId } from '@metamask/multichain-network-controller';
 import { CaipAssetType, Hex } from '@metamask/utils';
 import { toAssetId } from '../../../../UI/Bridge/hooks/useAssetMetadata/utils';
-import { selectIsAssetsUnifyStateEnabled } from '../../../../../selectors/featureFlagController/assetsUnifyState';
 import {
   convertTrendingAssetsToImporAssets,
   ImportAsset,
@@ -35,28 +34,8 @@ const mockAddCustomAsset = jest.fn();
 
 jest.mock('../../../../../core/Engine', () => ({
   context: {
-    TokensController: {
-      addTokens: jest.fn().mockResolvedValue(undefined),
-    },
-    MultichainAssetsController: {
-      addAssets: jest.fn().mockResolvedValue(undefined),
-    },
     AssetsController: {
       addCustomAsset: jest.fn(),
-    },
-    NetworkController: {
-      state: {
-        networkConfigurationsByChainId: {
-          '0x1': {
-            chainId: '0x1',
-            rpcEndpoints: [{ networkClientId: 'mainnet' }],
-            defaultRpcEndpointIndex: 0,
-          },
-        },
-      },
-    },
-    PreferencesController: {
-      setTokenNetworkFilter: jest.fn(),
     },
   },
 }));
@@ -64,13 +43,6 @@ jest.mock('../../../../../core/Engine', () => ({
 jest.mock('../../../../UI/Bridge/hooks/useAssetMetadata/utils', () => ({
   toAssetId: jest.fn(),
 }));
-
-jest.mock(
-  '../../../../../selectors/featureFlagController/assetsUnifyState',
-  () => ({
-    selectIsAssetsUnifyStateEnabled: jest.fn(),
-  }),
-);
 
 jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
   useAnalytics: jest.fn(() => ({
@@ -105,16 +77,6 @@ jest.mock('../../../../../selectors/multichainAccounts/accounts', () => ({
   ),
 }));
 
-jest.mock('../../../../../selectors/tokensController', () => ({
-  ...jest.requireActual('../../../../../selectors/tokensController'),
-  selectTokensByChainIdAndAddress: jest.fn(() => ({})),
-}));
-
-jest.mock('../../../../../selectors/multichain/multichain', () => ({
-  ...jest.requireActual('../../../../../selectors/multichain/multichain'),
-  selectMultichainAssets: jest.fn(() => ({})),
-}));
-
 jest.mock(
   '../../../../UI/Trending/hooks/useTrendingSearch/useTrendingSearch',
   () => ({
@@ -141,9 +103,6 @@ const mockIsNonEvmChainId = isNonEvmChainId as jest.MockedFunction<
 const mockUseTrendingSearch = jest.mocked(useTrendingSearch);
 const mockConvertTokens = jest.mocked(convertTrendingAssetsToImporAssets);
 const mockToAssetId = jest.mocked(toAssetId);
-const mockSelectIsAssetsUnifyStateEnabled = jest.mocked(
-  selectIsAssetsUnifyStateEnabled,
-);
 
 // --- Test data ---
 
@@ -240,8 +199,10 @@ describe('SearchTokenAutocomplete', () => {
     });
     mockBuild.mockReturnValue({ event: 'mock-event' });
     mockIsNonEvmChainId.mockReturnValue(false);
-    mockSelectInternalAccountByScope.mockReturnValue(null);
-    mockSelectIsAssetsUnifyStateEnabled.mockReturnValue(false);
+    mockSelectInternalAccountByScope.mockReturnValue({
+      id: 'evm-account-id',
+      address: '0xabc',
+    });
     mockToAssetId.mockReturnValue(
       'eip155:1/erc20:0x1234567890abcdef1234567890abcdef12345678' as CaipAssetType,
     );
@@ -255,12 +216,6 @@ describe('SearchTokenAutocomplete', () => {
       totalCount: undefined,
     } as ReturnType<typeof useTrendingSearch>);
     mockConvertTokens.mockReturnValue([]);
-    (Engine.context.TokensController.addTokens as jest.Mock).mockResolvedValue(
-      undefined,
-    );
-    (
-      Engine.context.MultichainAssetsController.addAssets as jest.Mock
-    ).mockResolvedValue(undefined);
     mockAddCustomAsset.mockResolvedValue(undefined);
     (Engine.context.AssetsController.addCustomAsset as jest.Mock) =
       mockAddCustomAsset;
@@ -424,78 +379,6 @@ describe('SearchTokenAutocomplete', () => {
     expect(mockTrackEvent).toHaveBeenCalled();
   });
 
-  it('addTokenList calls TokensController.addTokens for EVM chains', async () => {
-    setupWithTokenResults();
-
-    const utils = renderComponent();
-    selectTokenAndPressNext(utils);
-
-    const [, params] = mockNavigation.navigate.mock.calls[0];
-    await params.addTokenList();
-
-    expect(Engine.context.TokensController.addTokens).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({ address: mockImportAset.address }),
-      ]),
-      'mainnet',
-    );
-    expect(
-      Engine.context.MultichainAssetsController.addAssets,
-    ).not.toHaveBeenCalled();
-  });
-
-  it('addTokenList calls MultichainAssetsController.addAssets for non-EVM chains', async () => {
-    const solanaChainId =
-      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp' as SupportedCaipChainId;
-
-    const mockNonEvmToken = {
-      address: 'solana-address-123',
-      symbol: 'SOL',
-      name: 'Solana',
-      decimals: 9,
-      chainId: solanaChainId,
-      image: 'https://example.com/sol.png',
-      assetId: `${solanaChainId}/slip44:501`,
-    };
-
-    mockIsNonEvmChainId.mockReturnValue(true);
-    mockSelectInternalAccountByScope.mockReturnValue({
-      id: 'non-evm-account-id',
-      address: 'non-evm-address',
-    });
-
-    mockUseTrendingSearch.mockReturnValue({
-      data: [
-        {
-          ...mockTrendingResult,
-          assetId: `${solanaChainId}/slip44:501`,
-          symbol: 'SOL',
-          name: 'Solana',
-          decimals: 9,
-        },
-      ],
-      isLoading: false,
-      refetch: jest.fn(),
-      loadMore: jest.fn(),
-      isLoadingMore: false,
-      hasNextPage: false,
-      totalCount: undefined,
-    } as ReturnType<typeof useTrendingSearch>);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    mockConvertTokens.mockReturnValue([mockNonEvmToken as any]);
-
-    const utils = renderComponent({ selectedChainId: solanaChainId });
-    selectTokenAndPressNext(utils);
-
-    const [, params] = mockNavigation.navigate.mock.calls[0];
-    await params.addTokenList();
-
-    expect(
-      Engine.context.MultichainAssetsController.addAssets,
-    ).toHaveBeenCalledWith(['solana-address-123'], 'non-evm-account-id');
-    expect(Engine.context.TokensController.addTokens).not.toHaveBeenCalled();
-  });
-
   describe('addTokens - EVM chain', () => {
     it('disables the Next button when selectedChainId is null (no tokens to add)', () => {
       setupWithTokenResults();
@@ -508,43 +391,8 @@ describe('SearchTokenAutocomplete', () => {
       ).toBeDisabled();
     });
 
-    it('returns early when network config is not found for the chain', async () => {
+    it('calls AssetsController.addCustomAsset for each selected token', async () => {
       setupWithTokenResults();
-
-      const utils = renderComponent({ selectedChainId: '0x89' as Hex });
-      selectTokenAndPressNext(utils);
-
-      const [, params] = mockNavigation.navigate.mock.calls[0];
-      await params.addTokenList();
-
-      expect(Engine.context.TokensController.addTokens).not.toHaveBeenCalled();
-      // TOKEN_IMPORT_CLICKED fires from goToConfirmAddToken; TOKEN_ADDED must not fire
-      expect(mockCreateEventBuilder).not.toHaveBeenCalledWith(
-        MetaMetricsEvents.TOKEN_ADDED,
-      );
-    });
-
-    it('does not call AssetsController when isAssetsUnifyStateEnabled is false', async () => {
-      setupWithTokenResults();
-      mockSelectIsAssetsUnifyStateEnabled.mockReturnValue(false);
-
-      const utils = renderComponent();
-      selectTokenAndPressNext(utils);
-
-      const [, params] = mockNavigation.navigate.mock.calls[0];
-      await params.addTokenList();
-
-      expect(Engine.context.TokensController.addTokens).toHaveBeenCalled();
-      expect(mockAddCustomAsset).not.toHaveBeenCalled();
-    });
-
-    it('calls AssetsController.addCustomAsset for each token when isAssetsUnifyStateEnabled is true', async () => {
-      setupWithTokenResults();
-      mockSelectIsAssetsUnifyStateEnabled.mockReturnValue(true);
-      mockSelectInternalAccountByScope.mockReturnValue({
-        id: 'evm-account-id',
-        address: '0xabc',
-      });
       const expectedCaipAssetType =
         'eip155:1/erc20:0x1234567890abcdef1234567890abcdef12345678' as CaipAssetType;
       mockToAssetId.mockReturnValue(expectedCaipAssetType);
@@ -555,7 +403,6 @@ describe('SearchTokenAutocomplete', () => {
       const [, params] = mockNavigation.navigate.mock.calls[0];
       await params.addTokenList();
 
-      expect(Engine.context.TokensController.addTokens).toHaveBeenCalled();
       expect(mockAddCustomAsset).toHaveBeenCalledWith(
         'evm-account-id',
         expectedCaipAssetType,
@@ -586,11 +433,6 @@ describe('SearchTokenAutocomplete', () => {
         totalCount: undefined,
       } as ReturnType<typeof useTrendingSearch>);
 
-      mockSelectIsAssetsUnifyStateEnabled.mockReturnValue(true);
-      mockSelectInternalAccountByScope.mockReturnValue({
-        id: 'evm-account-id',
-        address: '0xabc',
-      });
       const caipAsset1 =
         'eip155:1/erc20:0x1234567890abcdef1234567890abcdef12345678' as CaipAssetType;
       const caipAsset2 =
@@ -628,9 +470,8 @@ describe('SearchTokenAutocomplete', () => {
       );
     });
 
-    it('logs warning and still tracks analytics when no EVM account found for AssetsController', async () => {
+    it('returns early without adding or TOKEN_ADDED when no account found', async () => {
       setupWithTokenResults();
-      mockSelectIsAssetsUnifyStateEnabled.mockReturnValue(true);
       mockSelectInternalAccountByScope.mockReturnValue(null);
 
       const utils = renderComponent();
@@ -640,16 +481,13 @@ describe('SearchTokenAutocomplete', () => {
       await params.addTokenList();
 
       expect(mockAddCustomAsset).not.toHaveBeenCalled();
-      expect(mockTrackEvent).toHaveBeenCalled();
+      expect(mockCreateEventBuilder).not.toHaveBeenCalledWith(
+        MetaMetricsEvents.TOKEN_ADDED,
+      );
     });
 
     it('logs error but still tracks analytics when addCustomAsset throws', async () => {
       setupWithTokenResults();
-      mockSelectIsAssetsUnifyStateEnabled.mockReturnValue(true);
-      mockSelectInternalAccountByScope.mockReturnValue({
-        id: 'evm-account-id',
-        address: '0xabc',
-      });
       mockAddCustomAsset.mockRejectedValue(new Error('contract error'));
 
       const utils = renderComponent();
@@ -664,11 +502,6 @@ describe('SearchTokenAutocomplete', () => {
 
     it('skips assets where toAssetId returns undefined', async () => {
       setupWithTokenResults();
-      mockSelectIsAssetsUnifyStateEnabled.mockReturnValue(true);
-      mockSelectInternalAccountByScope.mockReturnValue({
-        id: 'evm-account-id',
-        address: '0xabc',
-      });
       mockToAssetId.mockReturnValue(undefined);
 
       const utils = renderComponent();
@@ -727,7 +560,7 @@ describe('SearchTokenAutocomplete', () => {
       mockConvertTokens.mockReturnValue([mockNonEvmToken as any]);
     });
 
-    it('returns early and skips addAssets and analytics when no account found', async () => {
+    it('returns early without adding or TOKEN_ADDED when no account found', async () => {
       mockSelectInternalAccountByScope.mockReturnValue(null);
 
       const utils = renderComponent({ selectedChainId: solanaChainId });
@@ -736,41 +569,17 @@ describe('SearchTokenAutocomplete', () => {
       const [, params] = mockNavigation.navigate.mock.calls[0];
       await params.addTokenList();
 
-      expect(
-        Engine.context.MultichainAssetsController.addAssets,
-      ).not.toHaveBeenCalled();
-      // TOKEN_IMPORT_CLICKED fires from goToConfirmAddToken; TOKEN_ADDED must not fire
+      expect(mockAddCustomAsset).not.toHaveBeenCalled();
       expect(mockCreateEventBuilder).not.toHaveBeenCalledWith(
         MetaMetricsEvents.TOKEN_ADDED,
       );
     });
 
-    it('tracks analytics after successful non-EVM asset addition', async () => {
+    it('calls AssetsController.addCustomAsset and tracks analytics', async () => {
       mockSelectInternalAccountByScope.mockReturnValue({
         id: 'non-evm-account-id',
         address: 'non-evm-address',
       });
-
-      const utils = renderComponent({ selectedChainId: solanaChainId });
-      selectTokenAndPressNext(utils);
-
-      const [, params] = mockNavigation.navigate.mock.calls[0];
-      await params.addTokenList();
-
-      expect(
-        Engine.context.MultichainAssetsController.addAssets,
-      ).toHaveBeenCalled();
-      expect(mockTrackEvent).toHaveBeenCalledWith(
-        expect.objectContaining({ event: 'mock-event' }),
-      );
-    });
-
-    it('calls AssetsController.addCustomAsset for non-EVM chains', async () => {
-      mockSelectInternalAccountByScope.mockReturnValue({
-        id: 'non-evm-account-id',
-        address: 'non-evm-address',
-      });
-      mockSelectIsAssetsUnifyStateEnabled.mockReturnValue(true);
 
       const utils = renderComponent({ selectedChainId: solanaChainId });
       selectTokenAndPressNext(utils);
@@ -783,6 +592,80 @@ describe('SearchTokenAutocomplete', () => {
         solanaAddress,
         expect.objectContaining({ address: solanaAddress }),
       );
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ event: 'mock-event' }),
+      );
+    });
+  });
+
+  describe('already added tokens from AssetsController', () => {
+    const assetId =
+      'eip155:1/erc20:0x1234567890abcdef1234567890abcdef12345678' as CaipAssetType;
+
+    it('disables a token present in customAssets', () => {
+      setupWithTokenResults();
+
+      const stateWithCustomAsset = {
+        ...mockInitialState,
+        engine: {
+          backgroundState: {
+            ...mockInitialState.engine.backgroundState,
+            AssetsController: {
+              customAssets: {
+                'evm-account-id': [assetId],
+              },
+              assetsBalance: {},
+              assetPreferences: {},
+              assetsInfo: {},
+              assetsPrice: {},
+              selectedCurrency: 'usd',
+            },
+          },
+        },
+      };
+
+      const { getByTestId } = renderComponent({
+        state: stateWithCustomAsset as typeof mockInitialState,
+      });
+
+      expect(
+        getByTestId(ImportTokenViewSelectorsIDs.SEARCH_TOKEN_RESULT),
+      ).toBeDisabled();
+    });
+
+    it('keeps a hidden token selectable so it can be re-imported', () => {
+      setupWithTokenResults();
+
+      const stateWithHiddenAsset = {
+        ...mockInitialState,
+        engine: {
+          backgroundState: {
+            ...mockInitialState.engine.backgroundState,
+            AssetsController: {
+              customAssets: {},
+              assetsBalance: {
+                'evm-account-id': {
+                  [assetId]: { balance: '1' },
+                },
+              },
+              assetPreferences: {
+                [assetId]: { hidden: true },
+              },
+              assetsInfo: {},
+              assetsPrice: {},
+              selectedCurrency: 'usd',
+            },
+          },
+        },
+      };
+
+      const { getByTestId } = renderComponent({
+        state: stateWithHiddenAsset as typeof mockInitialState,
+      });
+
+      expect(
+        getByTestId(ImportTokenViewSelectorsIDs.SEARCH_TOKEN_RESULT),
+      ).not.toBeDisabled();
     });
   });
 

--- a/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.test.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.test.tsx
@@ -645,7 +645,7 @@ describe('SearchTokenAutocomplete', () => {
               customAssets: {},
               assetsBalance: {
                 'evm-account-id': {
-                  [assetId]: { balance: '1' },
+                  [assetId]: { amount: '1' },
                 },
               },
               assetPreferences: {

--- a/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
+++ b/app/components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { InteractionManager, LayoutAnimation, Platform } from 'react-native';
 import { strings } from '../../../../../../locales/i18n';
-import Engine from '../../../../../core/Engine';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 
 import Alert, { AlertType } from '../../../../Base/Alert';
@@ -14,7 +13,6 @@ import { selectNetworkName } from '../../../../../selectors/networkInfos';
 import { selectUseTokenDetection } from '../../../../../selectors/preferencesController';
 import { getDecimalChainId } from '../../../../../util/networks';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import Routes from '../../../../../constants/navigation/Routes';
 import SearchTokenResults from '../SearchTokenResults/SearchTokenResults';
 import {
   Button,
@@ -27,19 +25,15 @@ import {
 import { ImportTokenViewSelectorsIDs } from '../../ImportAssetView.testIds';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import Logger from '../../../../../util/Logger';
-import { CaipAssetType, Hex } from '@metamask/utils';
+import { CaipAssetType, Hex, parseCaipAssetType } from '@metamask/utils';
 import { SupportedCaipChainId } from '@metamask/multichain-network-controller';
 import { isNonEvmChainId } from '../../../../../core/Multichain/utils';
 import { selectSelectedInternalAccountByScope } from '../../../../../selectors/multichainAccounts/accounts';
 import {
-  selectTokensByChainIdAndAddress,
-  selectIgnoreTokens,
-} from '../../../../../selectors/tokensController';
-import {
-  selectMultichainAssets,
-  selectMultichainAssetsAllIgnoredAssets,
-} from '../../../../../selectors/multichain/multichain';
-import { RootState } from '../../../../../reducers';
+  getAssetPreferences,
+  getAssetsBalance,
+  getCustomAssets,
+} from '../../../../../selectors/assets/assets-controller';
 import { NATIVE_SWAPS_TOKEN_ADDRESS } from '../../../../../constants/bridge';
 import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import { useTrendingSearch } from '../../../../UI/Trending/hooks/useTrendingSearch/useTrendingSearch';
@@ -52,7 +46,6 @@ import {
   ImportAsset,
 } from '../../utils/utils';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
-import { selectIsAssetsUnifyStateEnabled } from '../../../../../selectors/featureFlagController/assetsUnifyState';
 import { toAssetId } from '../../../../UI/Bridge/hooks/useAssetMetadata/utils';
 import useAssetVisibility from '../../../../UI/TokenDetails/components/useAssetVisibility';
 import { filterExcludedImportAssets } from '../../../../../enablement/assets/networks-customization';
@@ -68,6 +61,36 @@ interface Props {
    * The selected network chain ID
    */
   selectedChainId: SupportedCaipChainId | Hex | null;
+}
+
+/**
+ * Address key used by SearchTokenResults for already-added checks.
+ * Non-EVM import assets use the CAIP-19 id as `address`; EVM uses the
+ * contract address extracted from the CAIP asset id.
+ */
+function addressKeyFromAssetId(
+  assetId: string,
+  isNonEvm: boolean,
+): string | undefined {
+  if (isNonEvm) {
+    return assetId.toLowerCase();
+  }
+  try {
+    return parseCaipAssetType(
+      assetId as CaipAssetType,
+    ).assetReference.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+function assetIdBelongsToChain(assetId: string, caipChainId: string): boolean {
+  try {
+    const { chain } = parseCaipAssetType(assetId as CaipAssetType);
+    return `${chain.namespace}:${chain.reference}` === caipChainId;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -116,82 +139,57 @@ const SearchTokenAutocomplete = ({ navigation, selectedChainId }: Props) => {
     selectSelectedInternalAccountByScope,
   );
 
-  const isAssetsUnifyStateEnabled = useSelector(
-    selectIsAssetsUnifyStateEnabled,
-  );
   const { handleAddCustomAsset } = useAssetVisibility();
 
-  // Get already added EVM tokens for the selected chain
-  const addedEvmTokens = useSelector((state: RootState) =>
-    selectedChainId && !isNonEvmChainId(selectedChainId)
-      ? selectTokensByChainIdAndAddress(state, selectedChainId as Hex)
-      : {},
-  );
+  const customAssets = useSelector(getCustomAssets);
+  const assetsBalance = useSelector(getAssetsBalance);
+  const assetPreferences = useSelector(getAssetPreferences);
 
-  // Ignored/hidden tokens for the active chain+account — these should remain
-  // importable even if they appear in allTokens.
-  const ignoredTokenAddresses = useSelector(selectIgnoreTokens);
-  const ignoredTokenSet = useMemo(
-    () =>
-      new Set((ignoredTokenAddresses ?? []).map((addr) => addr.toLowerCase())),
-    [ignoredTokenAddresses],
-  );
-
-  // Get already added non-EVM tokens
-  const multichainAssets = useSelector(selectMultichainAssets);
-
-  // Ignored/hidden non-EVM assets — keyed by accountId, value is array of CAIP asset IDs.
-  // These should remain importable even if they appear in accountsAssets.
-  const allIgnoredNonEvmAssets = useSelector(
-    selectMultichainAssetsAllIgnoredAssets,
-  );
-
-  // Create a Set of already added token addresses for quick lookup
+  // Create a Set of already added token addresses for quick lookup, sourced
+  // from AssetsController (custom + detected, excluding hidden).
   const alreadyAddedTokens = useMemo(() => {
     const addresses = new Set<string>();
 
     // Native tokens are always "added" since they're inherent to the chain
     addresses.add(NATIVE_SWAPS_TOKEN_ADDRESS.toLowerCase());
 
-    if (selectedChainId) {
-      if (isNonEvmChainId(selectedChainId)) {
-        // For non-EVM chains
-        const selectedNonEvmAccount = selectInternalAccountByScope(
-          selectedChainId as SupportedCaipChainId,
-        );
-        if (selectedNonEvmAccount?.id) {
-          const accountAssets =
-            multichainAssets?.[selectedNonEvmAccount.id] || [];
-          const ignoredNonEvmSet = new Set(
-            (allIgnoredNonEvmAssets[selectedNonEvmAccount.id] ?? []).map((a) =>
-              a.toLowerCase(),
-            ),
-          );
-          // Exclude ignored/hidden assets so the user can re-import them.
-          accountAssets.forEach((assetAddress: string) => {
-            if (!ignoredNonEvmSet.has(assetAddress.toLowerCase())) {
-              addresses.add(assetAddress.toLowerCase());
-            }
-          });
-        }
-      } else {
-        // For EVM chains — exclude tokens that are ignored/hidden so the user
-        // can re-import them from the search UI.
-        Object.keys(addedEvmTokens).forEach((address) => {
-          if (!ignoredTokenSet.has(address.toLowerCase())) {
-            addresses.add(address.toLowerCase());
-          }
-        });
-      }
+    if (!selectedChainId) {
+      return addresses;
     }
+
+    const caipChainId = formatChainIdToCaip(selectedChainId);
+    const account = selectInternalAccountByScope(
+      caipChainId as SupportedCaipChainId,
+    );
+    if (!account?.id) {
+      return addresses;
+    }
+
+    const isNonEvm = isNonEvmChainId(selectedChainId);
+    const presentAssetIds = new Set<string>([
+      ...(customAssets[account.id] ?? []),
+      ...Object.keys(assetsBalance[account.id] ?? {}),
+    ]);
+
+    presentAssetIds.forEach((assetId) => {
+      if (!assetIdBelongsToChain(assetId, caipChainId)) {
+        return;
+      }
+      if (assetPreferences[assetId]?.hidden === true) {
+        return;
+      }
+      const addressKey = addressKeyFromAssetId(assetId, isNonEvm);
+      if (addressKey) {
+        addresses.add(addressKey);
+      }
+    });
 
     return addresses;
   }, [
     selectedChainId,
-    addedEvmTokens,
-    ignoredTokenSet,
-    multichainAssets,
-    allIgnoredNonEvmAssets,
+    customAssets,
+    assetsBalance,
+    assetPreferences,
     selectInternalAccountByScope,
   ]);
 
@@ -255,118 +253,47 @@ const SearchTokenAutocomplete = ({ navigation, selectedChainId }: Props) => {
       return;
     }
 
-    const addresses = selectedAssets.map((asset) => asset.address);
+    const isNonEvm = isNonEvmChainId(selectedChainId);
+    const caipChainId = formatChainIdToCaip(selectedChainId);
+    const account = selectInternalAccountByScope(
+      caipChainId as SupportedCaipChainId,
+    );
 
-    if (isNonEvmChainId(selectedChainId)) {
-      const selectedNonEvmAccount = selectInternalAccountByScope(
-        selectedChainId as SupportedCaipChainId,
+    if (!account?.id) {
+      Logger.log(
+        'SearchTokenAutoComplete: No account found for selected chain',
       );
+      return;
+    }
 
-      if (!selectedNonEvmAccount) {
-        Logger.log(
-          'SearchTokenAutoComplete: No account ID found for non-EVM chain',
-        );
-        return;
-      }
-
-      const { MultichainAssetsController } = Engine.context;
-      await MultichainAssetsController.addAssets(
-        addresses as CaipAssetType[],
-        selectedNonEvmAccount.id,
-      );
-
-      if (isAssetsUnifyStateEnabled) {
-        try {
-          await Promise.all(
-            // Non-EVM asset addresses are themselves CAIP-19 asset IDs.
-            selectedAssets.map((asset) =>
-              handleAddCustomAsset(
-                asset.address as CaipAssetType,
-                {
-                  address: asset.address,
-                  symbol: asset.symbol,
-                  name: asset.name ?? '',
-                  decimals: asset.decimals ?? 0,
-                  chainId: asset.chainId,
-                },
-                selectedNonEvmAccount.id,
-              ),
-            ),
-          );
-        } catch (error) {
-          Logger.error(
-            error as Error,
-            'SearchTokenAutoComplete: addCustomAsset failed for non-EVM',
-          );
-        }
-      }
-    } else {
-      const caipChainId = formatChainIdToCaip(
-        selectedChainId as SupportedCaipChainId,
-      );
-
-      const networkConfig =
-        Engine.context.NetworkController.state
-          ?.networkConfigurationsByChainId?.[selectedChainId as Hex];
-
-      if (!networkConfig) {
-        return;
-      }
-
-      const networkClient =
-        networkConfig.rpcEndpoints?.[networkConfig.defaultRpcEndpointIndex]
-          ?.networkClientId;
-
-      if (!networkClient) {
-        return;
-      }
-
-      const { TokensController } = Engine.context;
-      await TokensController.addTokens(selectedAssets, networkClient);
-
-      if (isAssetsUnifyStateEnabled) {
-        const assetsWithIds = selectedAssets
-          .map((asset) => ({
-            asset,
-            assetId: toAssetId(asset.address, caipChainId),
-          }))
-          .filter(
-            (entry): entry is { asset: ImportAsset; assetId: CaipAssetType } =>
-              Boolean(entry.assetId),
-          );
-
-        // Resolve the account scoped to this EVM chain. The hook was
-        // initialised without an asset so its internal accountId falls back to
-        // the globally selected account, which may be a non-EVM account.
-        const evmAccount = selectInternalAccountByScope(
-          caipChainId as SupportedCaipChainId,
-        );
-
-        if (evmAccount?.id) {
-          try {
-            await Promise.all(
-              assetsWithIds.map(({ asset, assetId }) =>
-                handleAddCustomAsset(
-                  assetId,
-                  {
-                    address: asset.address,
-                    symbol: asset.symbol,
-                    name: asset.name ?? '',
-                    decimals: asset.decimals ?? 0,
-                    chainId: caipChainId,
-                  },
-                  evmAccount.id,
-                ),
-              ),
-            );
-          } catch (error) {
-            Logger.error(
-              error as Error,
-              'SearchTokenAutoComplete: addCustomAsset failed',
-            );
+    try {
+      await Promise.all(
+        selectedAssets.map(async (asset) => {
+          const assetId = isNonEvm
+            ? (asset.address as CaipAssetType)
+            : toAssetId(asset.address, caipChainId);
+          if (!assetId) {
+            return;
           }
-        }
-      }
+
+          await handleAddCustomAsset(
+            assetId,
+            {
+              address: asset.address,
+              symbol: asset.symbol,
+              name: asset.name ?? '',
+              decimals: asset.decimals ?? 0,
+              chainId: isNonEvm ? asset.chainId : caipChainId,
+            },
+            account.id,
+          );
+        }),
+      );
+    } catch (error) {
+      Logger.error(
+        error as Error,
+        'SearchTokenAutoComplete: addCustomAsset failed',
+      );
     }
 
     selectedAssets.forEach((asset) => {
@@ -390,21 +317,8 @@ const SearchTokenAutocomplete = ({ navigation, selectedChainId }: Props) => {
     selectInternalAccountByScope,
     selectedAssets,
     selectedChainId,
-    isAssetsUnifyStateEnabled,
     handleAddCustomAsset,
   ]);
-
-  /**
-   * Go to wallet page
-   */
-  const goToWalletPage = useCallback(() => {
-    navigation.navigate(Routes.WALLET.HOME, {
-      screen: Routes.WALLET.TAB_STACK_FLOW,
-      params: {
-        screen: Routes.WALLET_VIEW,
-      },
-    });
-  }, [navigation]);
 
   const addTokenList = useCallback(async () => {
     await addTokens();
@@ -412,7 +326,6 @@ const SearchTokenAutocomplete = ({ navigation, selectedChainId }: Props) => {
     setSelectedAssets([]);
 
     InteractionManager.runAfterInteractions(() => {
-      goToWalletPage();
       NotificationManager.showSimpleNotification({
         status: `import_success`,
         duration: 5000,
@@ -425,7 +338,7 @@ const SearchTokenAutocomplete = ({ navigation, selectedChainId }: Props) => {
             : strings('wallet.token_toast.token_imported_desc_1'),
       });
     });
-  }, [addTokens, selectedAssets, goToWalletPage]);
+  }, [addTokens, selectedAssets]);
 
   const networkName = useSelector(selectNetworkName);
 


### PR DESCRIPTION
Search token import now only writes to AssetsController, and ConfirmAddAsset navigates back to TokensFullView instead of the wallet home.

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: use unified import path and return to tokens full view- #34039

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the sole write path for search-based token imports and post-import navigation; regressions could leave tokens missing from the wallet or land users on the wrong screen if AssetsController behavior diverges from the removed controllers.
> 
> **Overview**
> Token search import now **always** adds tokens through `AssetsController` via `handleAddCustomAsset` for both EVM and non-EVM chains, removing the legacy `TokensController.addTokens` / `MultichainAssetsController.addAssets` paths and the `assetsUnifyState` feature-flag branch.
> 
> **Already-imported** detection in search is rebuilt on **AssetsController** state (`customAssets`, `assetsBalance`, `assetPreferences`): visible custom/detected assets disable selection, while **hidden** assets stay selectable for re-import.
> 
> After a successful import, **ConfirmAddAsset** navigates to `Routes.WALLET.TOKENS_FULL_VIEW` instead of wallet home; the inline search `addTokenList` flow no longer jumps to the wallet tab and only shows the success toast (confirm screen owns post-import navigation). Tests are aligned with the unified import path and new navigation targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57fe2445051060d0af6ad2903d65fe6a567bd365. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->