### PR TITLE
feat: show CDN fallback for gas fee token icons (CONF-1739)

### DIFF
--- a/app/components/Views/confirmations/components/gas/gas-fee-token-icon/gas-fee-token-icon.test.tsx
+++ b/app/components/Views/confirmations/components/gas/gas-fee-token-icon/gas-fee-token-icon.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Hex } from '@metamask/utils';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import useNetworkInfo from '../../../hooks/useNetworkInfo';
 import { NATIVE_TOKEN_ADDRESS } from '../../../constants/tokens';
@@ -8,6 +9,8 @@ import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { useTransactionBatchesMetadata } from '../../../hooks/transactions/useTransactionBatchesMetadata';
 import { merge } from 'lodash';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
+import { getAssetImageUrl } from '../../../../../UI/Bridge/hooks/useAssetMetadata/utils';
+import AvatarToken from '../../../../../../component-library/components/Avatars/Avatar/variants/AvatarToken';
 
 jest.mock('../../../hooks/transactions/useTransactionMetadataRequest');
 jest.mock('../../../hooks/transactions/useTransactionBatchesMetadata');
@@ -18,6 +21,13 @@ jest.mock('../../../hooks/tokens/useTokenWithBalance', () => ({
     .mockReturnValue({ asset: { logo: 'logo.png' } }),
 }));
 jest.mock('../../../hooks/transactions/useTransactionMetadataRequest');
+jest.mock('../../../../../UI/Bridge/hooks/useAssetMetadata/utils', () => ({
+  getAssetImageUrl: jest.fn(),
+}));
+jest.mock(
+  '../../../../../../component-library/components/Avatars/Avatar/variants/AvatarToken',
+  () => jest.fn(() => null),
+);
 
 describe('GasFeeTokenIcon', () => {
   const mockUseNetworkInfo = jest.mocked(useNetworkInfo);
@@ -28,8 +38,11 @@ describe('GasFeeTokenIcon', () => {
   const mockUseTransactionMetadataRequest = jest.mocked(
     useTransactionMetadataRequest,
   );
+  const mockGetAssetImageUrl = jest.mocked(getAssetImageUrl);
+  const mockAvatarToken = jest.mocked(AvatarToken);
 
   beforeEach(() => {
+    jest.clearAllMocks();
     mockUseNetworkInfo.mockReturnValue({
       networkImage: 10,
       networkNativeCurrency: 'ETH',
@@ -41,11 +54,17 @@ describe('GasFeeTokenIcon', () => {
     } as Partial<
       ReturnType<typeof useTransactionMetadataRequest>
     > as ReturnType<typeof useTransactionMetadataRequest>);
-    jest.clearAllMocks();
+    mockUseTokenWithBalance.mockReturnValue({
+      image: 'logo.png',
+      symbol: 'TOKEN',
+    } as ReturnType<typeof useTokenWithBalance>);
+    mockGetAssetImageUrl.mockReturnValue(
+      'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xtoken.png',
+    );
   });
 
   it('renders the token icon when tokenAddress is not the native', () => {
-    const tokenAddress = '0xTokenAddress';
+    const tokenAddress = '0xTokenAddress' as Hex;
 
     const { getByTestId } = renderWithProvider(
       <GasFeeTokenIcon tokenAddress={tokenAddress} />,
@@ -53,6 +72,37 @@ describe('GasFeeTokenIcon', () => {
     );
 
     expect(getByTestId('token-icon')).toBeOnTheScreen();
+  });
+
+  it('falls back to CDN token image when TokensController image is missing', () => {
+    const tokenAddress = '0xaca92e438df0b2401ff60da7e4337b687a2435da' as Hex;
+    const chainId = '0xe708' as Hex;
+    const cdnImageUrl =
+      'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/59144/erc20/0xaca92e438df0b2401ff60da7e4337b687a2435da.png';
+
+    mockUseTransactionMetadataRequest.mockReturnValue({
+      chainId,
+    } as Partial<
+      ReturnType<typeof useTransactionMetadataRequest>
+    > as ReturnType<typeof useTransactionMetadataRequest>);
+    mockUseTokenWithBalance.mockReturnValue({
+      image: undefined,
+      symbol: 'mUSD',
+    } as unknown as ReturnType<typeof useTokenWithBalance>);
+    mockGetAssetImageUrl.mockReturnValue(cdnImageUrl);
+
+    renderWithProvider(<GasFeeTokenIcon tokenAddress={tokenAddress} />, {
+      state: transferTransactionStateMock,
+    });
+
+    expect(mockGetAssetImageUrl).toHaveBeenCalledWith(tokenAddress, chainId);
+    expect(mockAvatarToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        imageSource: { uri: cdnImageUrl },
+        name: 'mUSD',
+      }),
+      undefined,
+    );
   });
 
   it('renders the native token icon when tokenAddress is the native', () => {

--- a/app/components/Views/confirmations/components/gas/gas-fee-token-icon/gas-fee-token-icon.tsx
+++ b/app/components/Views/confirmations/components/gas/gas-fee-token-icon/gas-fee-token-icon.tsx
@@ -17,6 +17,7 @@ import Badge, {
 import NetworkAssetLogo from '../../../../../UI/NetworkAssetLogo';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { useTransactionBatchesMetadata } from '../../../hooks/transactions/useTransactionBatchesMetadata';
+import { getAssetImageUrl } from '../../../../../UI/Bridge/hooks/useAssetMetadata/utils';
 
 export enum GasFeeTokenIconSize {
   Sm = 'sm',
@@ -52,6 +53,8 @@ export function GasFeeTokenIcon({
         <TokenIconWithNetworkBadge
           size={size}
           token={token}
+          tokenAddress={tokenAddress}
+          chainId={chainId as Hex}
           networkName={networkName}
           networkImage={networkImage}
           nativeCurrency={nativeCurrency}
@@ -78,17 +81,25 @@ export function GasFeeTokenIcon({
 function TokenIconWithNetworkBadge({
   size,
   token,
+  tokenAddress,
+  chainId,
   networkName,
   networkImage,
   nativeCurrency,
 }: {
   size: GasFeeTokenIconSize;
   token?: ReturnType<typeof useTokenWithBalance>;
+  tokenAddress: Hex;
+  chainId?: Hex;
   networkName?: string;
   networkImage?: object;
   nativeCurrency?: string;
 }) {
   const { styles } = useStyles(styleSheet, {});
+  const imageUri =
+    token?.image ||
+    (chainId ? getAssetImageUrl(tokenAddress, chainId) : undefined);
+
   return (
     <View>
       <BadgeWrapper
@@ -103,8 +114,8 @@ function TokenIconWithNetworkBadge({
         style={styles.badgeWrapper}
       >
         <AvatarToken
-          imageSource={token ? { uri: token?.image } : networkImage}
-          name={nativeCurrency}
+          imageSource={imageUri ? { uri: imageUri } : networkImage}
+          name={token?.symbol ?? nativeCurrency}
           size={size === GasFeeTokenIconSize.Md ? AvatarSize.Md : AvatarSize.Xs}
         />
       </BadgeWrapper>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

When paying gas with a token on Linea (e.g. mUSD), the network fee token dropdown could show a blank or letter fallback icon if TokensController had not hydrated `token.image` yet.

This change updates `GasFeeTokenIcon` to fall back to the CDN URL from `getAssetImageUrl`, matching confirmation `TokenIcon`. It also uses the token symbol for the avatar name when the image is missing.

## **Changelog**

CHANGELOG entry: Fixed missing token logos in the network fee token dropdown when paying with a token such as mUSD

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1739

## **Manual testing steps**

~~~gherkin
Feature: gas fee token icons

  Scenario: user sees mUSD logo in network fee token dropdown on Linea
    Given the user has mUSD on Linea
    And the user starts a send of any token on Linea

    When the user opens the network fee token dropdown
    Then mUSD shows its logo
~~~

## **Screenshots/Recordings**

N/A — pending manual verification on device/simulator.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.