### PR TITLE
fix(e2e): harden Appium Perps scroll and order readiness (MMQA-2141)

### DIFF
--- a/tests/flows/perps.flow.ts
+++ b/tests/flows/perps.flow.ts
@@ -291,6 +291,9 @@ export const openPosition = async (
   direction: PerpsPositionDirection,
 ): Promise<void> => {
   await navigateToPerpsOrderEntry(symbol, direction);
+  // Wait for order screen + fees row before tap
+  await waitForOrderScreenVisible();
+  await PerpsOrderView.waitForFeesReady();
   await PerpsOrderView.tapPlaceOrderButton();
   await dismissPerpsNotificationTooltipIfPresent();
   await PerpsMarketDetailsView.waitForScreenReady();

--- a/tests/framework/PlaywrightGestures.ts
+++ b/tests/framework/PlaywrightGestures.ts
@@ -385,9 +385,7 @@ export default class PlaywrightGestures {
       maxScrolls = 30,
     } = options || {};
     // Only guard scrollableElement here. The target may be off-screen / not yet
-    // in the hierarchy; WDIO scrolls until it becomes visible. The malformed
-    // getElementRect cascade comes from swipe() calling
-    // getElementRect(scrollableElement?.elementId) with undefined.
+    // in the hierarchy; WDIO scrolls until it becomes visible.
     if (scrollableElement) {
       await assertResolvedElementId(
         scrollableElement,

--- a/tests/framework/PlaywrightGestures.ts
+++ b/tests/framework/PlaywrightGestures.ts
@@ -6,6 +6,7 @@ import { boxedStep, getDriver } from './PlaywrightUtilities';
 import {
   createPlaywrightLogger,
   debugElementAction,
+  formatSelector,
 } from './playwrightLogger.ts';
 
 const logger = createPlaywrightLogger('PlaywrightGestures');
@@ -19,6 +20,42 @@ export interface ScrollOptions {
   duration?: number;
   /** WDIO native scrollIntoView limit; default is 10. */
   maxScrolls?: number;
+}
+
+/**
+ * Ensures a Appium element has a resolved `elementId` before any call that
+ * would invoke `getElementRect` (`scrollIntoView`, `getLocation`, `getSize`).
+ */
+export async function assertResolvedElementId(
+  elem: PlaywrightElement,
+  action: string,
+  role: 'target' | 'scrollableElement' = 'target',
+): Promise<string> {
+  const unwrapped = elem.unwrap();
+  let elementId: unknown;
+  try {
+    elementId = await unwrapped.elementId;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Cannot ${action}: failed to read ${role} elementId (${detail})`,
+    );
+  }
+
+  if (elementId === undefined || elementId === null || elementId === '') {
+    let selectorLabel = '';
+    try {
+      selectorLabel = formatSelector(await unwrapped.selector);
+    } catch {
+      // Selector may be unavailable for unresolved/stale elements.
+    }
+    const selectorPart = selectorLabel ? ` (selector: ${selectorLabel})` : '';
+    throw new Error(
+      `Cannot ${action}: ${role} has no valid Appium elementId${selectorPart}. Element was not found or is stale — refusing to call getElementRect.`,
+    );
+  }
+
+  return String(elementId);
 }
 
 /**
@@ -292,6 +329,7 @@ export default class PlaywrightGestures {
     elem: PlaywrightElement,
     duration = 1000,
   ): Promise<void> {
+    await assertResolvedElementId(elem, 'longPress', 'target');
     const location = await elem.unwrap().getLocation();
     const size = await elem.unwrap().getSize();
 
@@ -346,6 +384,17 @@ export default class PlaywrightGestures {
       duration,
       maxScrolls = 30,
     } = options || {};
+    // Only guard scrollableElement here. The target may be off-screen / not yet
+    // in the hierarchy; WDIO scrolls until it becomes visible. The malformed
+    // getElementRect cascade comes from swipe() calling
+    // getElementRect(scrollableElement?.elementId) with undefined.
+    if (scrollableElement) {
+      await assertResolvedElementId(
+        scrollableElement,
+        'scrollIntoView',
+        'scrollableElement',
+      );
+    }
     await debugElementAction(logger, 'Scrolling element into view', elem);
     await elem.unwrap().scrollIntoView({
       direction: scrollParams.direction,
@@ -377,6 +426,8 @@ export default class PlaywrightGestures {
     const drv = getDriver();
     if (!drv) return;
 
+    // Re-check before getLocation/getSize — element may have gone stale after scroll.
+    await assertResolvedElementId(elem, 'scrollIntoViewFullyVisible', 'target');
     const location = await elem.unwrap().getLocation();
     const size = await elem.unwrap().getSize();
     const windowSize = getWindowSize();

--- a/tests/framework/assertResolvedElementId.test.ts
+++ b/tests/framework/assertResolvedElementId.test.ts
@@ -1,0 +1,62 @@
+import { assertResolvedElementId } from './PlaywrightGestures.ts';
+import type { PlaywrightElement } from './PlaywrightAdapter.ts';
+
+describe('assertResolvedElementId', () => {
+  const mockElement = (opts: {
+    elementId?: unknown;
+    selector?: unknown;
+    elementIdError?: Error;
+  }): PlaywrightElement =>
+    ({
+      unwrap: () => ({
+        get elementId() {
+          if (opts.elementIdError) {
+            return Promise.reject(opts.elementIdError);
+          }
+          return Promise.resolve(opts.elementId);
+        },
+        get selector() {
+          return Promise.resolve(opts.selector);
+        },
+      }),
+    }) as unknown as PlaywrightElement;
+
+  it('returns elementId when present', async () => {
+    const elem = mockElement({ elementId: 'abc-123' });
+    await expect(
+      assertResolvedElementId(elem, 'scrollIntoView', 'target'),
+    ).resolves.toBe('abc-123');
+  });
+
+  it('throws a clear error when elementId is undefined', async () => {
+    const elem = mockElement({
+      elementId: undefined,
+      selector: '~wallet-scroll-view',
+    });
+    await expect(
+      assertResolvedElementId(elem, 'scrollIntoView', 'scrollableElement'),
+    ).rejects.toThrow(
+      /Cannot scrollIntoView: scrollableElement has no valid Appium elementId \(selector: ~wallet-scroll-view\).*refusing to call getElementRect/,
+    );
+  });
+
+  it('throws a clear error when elementId is empty string', async () => {
+    const elem = mockElement({ elementId: '' });
+    await expect(
+      assertResolvedElementId(elem, 'longPress', 'target'),
+    ).rejects.toThrow(
+      /Cannot longPress: target has no valid Appium elementId.*refusing to call getElementRect/,
+    );
+  });
+
+  it('throws when reading elementId fails', async () => {
+    const elem = mockElement({
+      elementIdError: new Error('stale element reference'),
+    });
+    await expect(
+      assertResolvedElementId(elem, 'scrollIntoView', 'target'),
+    ).rejects.toThrow(
+      /Cannot scrollIntoView: failed to read target elementId \(stale element reference\)/,
+    );
+  });
+});

--- a/tests/page-objects/Perps/PerpsOrderView.ts
+++ b/tests/page-objects/Perps/PerpsOrderView.ts
@@ -41,6 +41,29 @@ class PerpsOrderView {
   }
 
   /**
+   * Fees row value — only mounted after fee loading finishes
+   * Useful readiness signal before tapping Long/Short on Appium.
+   */
+  get feesValue(): EncapsulatedElementType {
+    return encapsulated({
+      detox: () =>
+        Matchers.getElementByID(PerpsOrderViewSelectorsIDs.FEES_VALUE),
+      appium: () =>
+        PlaywrightMatchers.getElementById(
+          PerpsOrderViewSelectorsIDs.FEES_VALUE,
+          { exact: true },
+        ),
+    });
+  }
+
+  async waitForFeesReady(timeout = 30_000): Promise<void> {
+    await Assertions.expectElementToBeVisible(this.feesValue, {
+      timeout,
+      description: 'Perps order fees value (fees finished loading)',
+    });
+  }
+
+  /**
    * Opens Auto close / TPSL from the order form. The row is labeled TP/SL in UI;
    * production uses STOP_LOSS_BUTTON testID on that touchable (see PerpsOrderView.tsx).
    */

--- a/tests/page-objects/wallet/WalletView.ts
+++ b/tests/page-objects/wallet/WalletView.ts
@@ -145,6 +145,10 @@ class WalletView {
     // Android: scrollIntoView inside the scroll view works reliably.
     // iOS: scrollIntoView gets stuck on the homepage; use bounded swipe loops instead.
     if (this.isAndroidAppium()) {
+      await Assertions.expectElementToBeVisible(this.walletScrollView, {
+        timeout: resolveE2EWaitTimeoutMs(10_000),
+        description: `wallet-scroll-view for ${description}`,
+      });
       const scrollView = await asPlaywrightElement(this.walletScrollView);
       const element = await asPlaywrightElement(target);
       await PlaywrightGestures.scrollIntoView(element, {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

CI SmokePerps Appium runs were timing out (~3.3m/attempt) with cascades of `NoSuchElementError` followed by `Malformed type for "elementId" parameter of command getElementRect`. WDIO `scrollIntoView` / `getLocation` / `getSize` call Appium `getElementRect` when `scrollableElement.elementId` is missing (e.g. `wallet-scroll-view` not ready).

This PR hardens the Appium Perps path:

1. **`assertResolvedElementId`** — refuse scroll/long-press rect calls when `elementId` is missing/stale, with a clear error (unit-tested).
2. **Wallet home** — wait for `wallet-scroll-view` displayed before Android `scrollIntoView`.
3. **Order entry** — wait for order screen + fees row (`perps-order-view-fees-value`) before tapping Long/Short so Android does not race disabled CTA while fees/validation settle.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-2141

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Appium SmokePerps Edit TP/SL

  Scenario: open long and edit stop loss without malformed getElementRect
    Given Appium smoke fixtures and Perps mocks are running
    And MetaMask main-e2e build is installed on iOS simulator or Android emulator

    When user runs perps-edit-tpsl-trigger.spec.ts
    Then the test reaches Perps order entry via wallet homepage scroll
    And no Malformed elementId getElementRect appears in Appium logs
    And Long/Short is tapped after fees are ready
    And the stop-loss edit flow completes successfully
```

Local commands used during validation:

```bash
# Android
ANDROID_APK_PATH=build/ci-main-e2e/app-prod-release.apk \
ANDROID_AVD_NAME=Pixel_5_Pro_API_34 \
ANDROID_DEVICE_UDID=emulator-5554 \
yarn appium-smoke:android --grep "Edit TP/SL" \
  tests/smoke-appium/perps/perps-edit-tpsl-trigger.spec.ts

# iOS
IOS_APP_PATH=build/ci-main-e2e/MetaMask.app \
IOS_SIMULATOR_UDID=<booted-udid> \
yarn appium-smoke:ios --grep "Edit TP/SL" \
  tests/smoke-appium/perps/perps-edit-tpsl-trigger.spec.ts
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — Appium framework / page-object changes only; validated via timed smoke runs and logs (no UI product change).

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)