### PR TITLE
feat: filter out wallet_activity foreground push notifications

### DIFF
--- a/app/core/Engine/controllers/notifications/push-utils.test.ts
+++ b/app/core/Engine/controllers/notifications/push-utils.test.ts
@@ -1,0 +1,142 @@
+import { type FirebaseMessagingTypes } from '@react-native-firebase/messaging';
+import FCMService from '../../../../util/notifications/services/FCMService';
+import NotificationsService from '../../../../util/notifications/services/NotificationService';
+import { PressActionId } from '../../../../util/notifications';
+import {
+  WALLET_ACTIVITY_NOTIFICATION_TYPE,
+  createSubscribeToPushNotifications,
+  shouldDisplayForegroundPushNotification,
+} from './push-utils';
+
+jest.mock('../../../../util/notifications/services/FCMService', () => ({
+  __esModule: true,
+  default: {
+    createRegToken: jest.fn(),
+    deleteRegToken: jest.fn(),
+    listenToPushNotificationsReceived: jest.fn(),
+    isPushNotificationsEnabled: jest.fn(),
+  },
+}));
+
+jest.mock(
+  '../../../../util/notifications/services/NotificationService',
+  () => ({
+    __esModule: true,
+    default: {
+      displayNotification: jest.fn(),
+    },
+  }),
+);
+
+const createRemoteMessage = (
+  overrides: {
+    title?: string;
+    body?: string;
+    data?: Record<string, string>;
+  } = {},
+): FirebaseMessagingTypes.RemoteMessage =>
+  ({
+    notification: {
+      title: overrides.title ?? 'You received ETH',
+      body: overrides.body ?? '0.05 ETH',
+    },
+    data: overrides.data,
+  }) as FirebaseMessagingTypes.RemoteMessage;
+
+describe('shouldDisplayForegroundPushNotification', () => {
+  it('returns false for wallet_activity notifications', () => {
+    const data = { notification_type: WALLET_ACTIVITY_NOTIFICATION_TYPE };
+
+    const result = shouldDisplayForegroundPushNotification(data);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true for non-wallet_activity notification types', () => {
+    const data = { notification_type: 'perps' };
+
+    const result = shouldDisplayForegroundPushNotification(data);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns true when notification_type is missing', () => {
+    const data = { notification_id: 'abc' };
+
+    const result = shouldDisplayForegroundPushNotification(data);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns true when data is undefined', () => {
+    const result = shouldDisplayForegroundPushNotification(undefined);
+
+    expect(result).toBe(true);
+  });
+});
+
+describe('createSubscribeToPushNotifications', () => {
+  const mockListen = jest.mocked(FCMService.listenToPushNotificationsReceived);
+  const mockDisplay = jest.mocked(NotificationsService.displayNotification);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListen.mockResolvedValue(jest.fn());
+    mockDisplay.mockResolvedValue(undefined);
+  });
+
+  const getForegroundHandler = async () => {
+    const subscribe = createSubscribeToPushNotifications();
+    await subscribe();
+    return mockListen.mock.calls[0][0];
+  };
+
+  it('does not display wallet_activity notifications in the foreground', async () => {
+    const handler = await getForegroundHandler();
+    const payload = createRemoteMessage({
+      data: {
+        notification_id: 'abc',
+        notification_type: WALLET_ACTIVITY_NOTIFICATION_TYPE,
+      },
+    });
+
+    await handler(payload);
+
+    expect(mockDisplay).not.toHaveBeenCalled();
+  });
+
+  it('displays non-wallet_activity notifications in the foreground', async () => {
+    const handler = await getForegroundHandler();
+    const payload = createRemoteMessage({
+      data: {
+        notification_id: 'platform-1',
+        notification_type: 'platform',
+      },
+    });
+
+    await handler(payload);
+
+    expect(mockDisplay).toHaveBeenCalledWith({
+      pressActionId: PressActionId.OPEN_NOTIFICATIONS_VIEW,
+      id: 'platform-1',
+      title: 'You received ETH',
+      body: '0.05 ETH',
+      data: {
+        notification_id: 'platform-1',
+        notification_type: 'platform',
+      },
+    });
+  });
+
+  it('does not display notifications without a title', async () => {
+    const handler = await getForegroundHandler();
+    const payload = {
+      notification: { body: '0.05 ETH' },
+      data: { notification_type: 'platform' },
+    } as unknown as FirebaseMessagingTypes.RemoteMessage;
+
+    await handler(payload);
+
+    expect(mockDisplay).not.toHaveBeenCalled();
+  });
+});

--- a/app/core/Engine/controllers/notifications/push-utils.ts
+++ b/app/core/Engine/controllers/notifications/push-utils.ts
@@ -6,6 +6,23 @@ import { toFcmDataStringRecord } from '../../../../util/notifications/utils/fcm-
 export const createRegToken = FCMService.createRegToken;
 export const deleteRegToken = FCMService.deleteRegToken;
 
+/**
+ * FCM `notification_type` for on-chain wallet activity (send/receive/etc).
+ * Suppressed in the foreground so transaction toasts remain the primary
+ * in-app surface; background/closed push still delivers via the OS.
+ */
+export const WALLET_ACTIVITY_NOTIFICATION_TYPE = 'wallet_activity';
+
+/**
+ * Whether a foreground FCM payload should show a system banner.
+ * Background/killed delivery never reaches this path.
+ */
+export function shouldDisplayForegroundPushNotification(
+  data: Record<string, string> | undefined,
+): boolean {
+  return data?.notification_type !== WALLET_ACTIVITY_NOTIFICATION_TYPE;
+}
+
 export const createSubscribeToPushNotifications = () => async () =>
   FCMService.listenToPushNotificationsReceived(async (rawPayload) => {
     const title = rawPayload.notification?.title;
@@ -14,6 +31,9 @@ export const createSubscribeToPushNotifications = () => async () =>
       return;
     }
     const data = toFcmDataStringRecord(rawPayload.data);
+    if (!shouldDisplayForegroundPushNotification(data)) {
+      return;
+    }
     await NotificationsService.displayNotification({
       pressActionId: PressActionId.OPEN_NOTIFICATIONS_VIEW,
       id: data?.notification_id,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

When a user completes a Money Account (or other wallet) transaction while the app is open, FCM can deliver a `wallet_activity` push at the same time as the in-app transaction toast. Both surfaces communicate the same event, which duplicates messaging and can stack UI—especially once transaction toasts move to the top of the screen.

This PR suppresses foreground display of `wallet_activity` push banners in `push-utils.ts` (FCM `onMessage` → Notifee). That path only runs while the app is in the foreground, so:

- In-app transaction toasts remain the primary surface for transaction progress
- Background / killed-state push delivery is unchanged (still handled by the OS from the FCM notification payload)
- Other foreground notification types (e.g. platform) continue to display normally

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed wallet activity push notifications overlapping with transaction toasts while the app is open

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/GE-357

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Suppress wallet_activity push banners while the app is in the foreground

  Scenario: Money Account transaction while the app is open
    Given the user has Money Account enabled and push notifications allowed
    And the MetaMask app is in the foreground
    When the user completes a Money Account deposit, withdraw, or send
    Then the in-app transaction toast is shown for progress and completion
    And no wallet_activity system notification banner is displayed

  Scenario: Wallet activity push while the app is backgrounded
    Given the user has push notifications allowed
    And the MetaMask app is in the background or closed
    When a wallet_activity push notification is received
    Then the OS still delivers the push notification normally

  Scenario: Non-wallet_activity push while the app is open
    Given the MetaMask app is in the foreground
    When a non-wallet_activity push notification is received (e.g. platform)
    Then the system notification banner is still displayed
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — Change is the absence of a foreground system banner alongside existing transaction toasts. Before/after recordings can be attached after manual QA with a foreground `wallet_activity` FCM payload.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.