### PR TITLE
test: DO NOT MERGE — validate slim E2E yarn cache (#34051)

### DIFF
--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -325,12 +325,22 @@ runs:
       if: ${{ inputs.runner_provider != 'namespace' && inputs.runner_provider != 'bitrise' }}
       uses: actions/cache@v4
       with:
+        # Exclude Gradle/CMake build intermediates that Android native builds
+        # write inside node_modules (~5 GB uncompressed, ~900 MB compressed).
+        # They inflated the Android cache to ~1.5 GB vs ~600 MB for iOS and
+        # added ~1 min of download time to every Android E2E job restore.
+        # Gradle reuse is handled by the dedicated Gradle caches instead.
         path: |
           node_modules
+          !node_modules/**/android/build
+          !node_modules/**/android/.cxx
           .yarn/install-state.gz
-        key: ${{ inputs.cache-prefix }}-yarn-v2-${{ inputs.platform }}-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+        # v3: bump to drop existing entries that already contain the build
+        # intermediates — a cache hit is never re-saved, so without the bump
+        # the fat archives would keep being served forever.
+        key: ${{ inputs.cache-prefix }}-yarn-v3-${{ inputs.platform }}-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
         restore-keys: |
-          ${{ inputs.cache-prefix }}-yarn-v2-${{ inputs.platform }}-${{ runner.os }}-
+          ${{ inputs.cache-prefix }}-yarn-v3-${{ inputs.platform }}-${{ runner.os }}-
       continue-on-error: true
 
     - name: Install JavaScript dependencies with retry

--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -325,17 +325,17 @@ runs:
       if: ${{ inputs.runner_provider != 'namespace' && inputs.runner_provider != 'bitrise' }}
       uses: actions/cache@v4
       with:
-        # Exclude Gradle/CMake build intermediates that Android native builds
-        # write inside node_modules (~5 GB uncompressed, ~900 MB compressed).
-        # They inflated the Android cache to ~1.5 GB vs ~600 MB for iOS and
-        # added ~1 min of download time to every Android E2E job restore.
-        # Gradle reuse is handled by the dedicated Gradle caches instead.
+        # NOTE: actions/cache archives directories recursively and does NOT
+        # honour `!` exclusion patterns for directory contents (resolvePaths
+        # runs with implicitDescendants: false). Gradle/CMake intermediates
+        # that Android native builds write inside node_modules (~4-5 GB
+        # uncompressed) are instead deleted by the "Clean native build
+        # intermediates from node_modules" step in build-android-e2e.yml
+        # before the post-job save runs.
         path: |
           node_modules
-          !node_modules/**/android/build
-          !node_modules/**/android/.cxx
           .yarn/install-state.gz
-        # v3: bump to drop existing entries that already contain the build
+        # v3: bump to drop existing entries polluted with those build
         # intermediates — a cache hit is never re-saved, so without the bump
         # the fat archives would keep being served forever.
         key: ${{ inputs.cache-prefix }}-yarn-v3-${{ inputs.platform }}-${{ runner.os }}-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -584,6 +584,20 @@ jobs:
           printf '%s\n' "${EXPECTED}" > "${CACHE_DIR}/.e2e-apk-cache-marker"
           echo "Namespace APK cache marker + APKs written to ${CACHE_DIR}."
 
+      # DO-NOT-MERGE: debug step to identify what inflates the yarn cache
+      - name: Debug node_modules size breakdown
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          echo "=== total ==="
+          du -sm node_modules || true
+          echo "=== top 25 packages ==="
+          du -sm node_modules/* node_modules/@*/* 2>/dev/null | sort -rn | head -25 || true
+          echo "=== android build/cxx dirs (should be excluded from cache) ==="
+          find node_modules -type d \( -name build -o -name .cxx \) -path '*/android/*' -prune 2>/dev/null | head -40 || true
+          echo "=== biggest dirs at depth 3 (incl hidden) ==="
+          du -sm node_modules/*/* node_modules/*/.[!.]* 2>/dev/null | sort -rn | head -30 || true
+
       - name: Repack APK with JS updates using @expo/repack-app
         if: ${{ steps.gate.outputs.needs-native-build != 'true' && inputs.reuse-main-builds-only != true }}
         run: |

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -1,5 +1,7 @@
 # Pure Android E2E build workflow - just builds APKs and uploads artifacts
 # No testing, no unnecessary setup - optimized for speed and efficiency
+# DO-NOT-MERGE: no-op change to trigger the E2E pipeline for validating
+# the slim yarn cache in PR #34051.
 
 name: Build Android E2E APKs
 

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -729,3 +729,23 @@ jobs:
           path: ${{ steps.determine-target-paths.outputs.test-apk-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}-androidTest.apk
           retention-days: 7
           if-no-files-found: error
+
+      # Gradle builds every RN library module inside node_modules
+      # (node_modules/<pkg>/android/build) and CMake writes to
+      # node_modules/<pkg>/android/.cxx — ~4-5 GB of intermediates that used
+      # to balloon the post-job yarn cache save (setup-e2e-env) from ~600 MB
+      # to ~1.5 GB, adding ~1 min of cache download to every Android E2E job.
+      # Main steps all run before post-job steps, so deleting the
+      # intermediates here (after the APKs have been uploaded — they live in
+      # android/app/build, not node_modules) means the post-job save archives
+      # a clean tree. Gradle build reuse is handled by the dedicated Gradle
+      # caches, which are correctly keyed on Gradle config files.
+      - name: Clean native build intermediates from node_modules
+        if: ${{ steps.gate.outputs.needs-native-build == 'true' }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          before=$(du -sm node_modules | cut -f1)
+          find node_modules -type d \( -name build -o -name .cxx \) -path '*/android/*' -prune -exec rm -rf {} + 2>/dev/null || true
+          after=$(du -sm node_modules | cut -f1)
+          echo "node_modules: ${before} MB -> ${after} MB (removed $((before - after)) MB of Gradle/CMake intermediates)"


### PR DESCRIPTION
Throwaway validation PR for #34051 — **do not merge**.

Stacked on `ci/slim-android-e2e-yarn-cache` plus a no-op comment in `build-android-e2e.yml` so the file filter triggers the E2E pipeline (the composite-action change alone doesn't — `.github/actions/setup-e2e-env/action.yml` is not in `e2e_relevant_workflows`).

Expected on the Android E2E build job:
- `Restore Yarn cache`: **miss** on `e2e-yarn-v3-android-Linux-…` (new key)
- Post-job cache save: **~600 MB** archive instead of the current ~1.5 GB `v2` entry
- Subsequent runs restore the slim cache in ~35-45s instead of ~93s

Will be closed without merging once validated.

Made with [Cursor](https://cursor.com)