### PR TITLE
fix(e2e): stabilize iOS multi-srp account list open after import toast

### DIFF
--- a/tests/flows/wallet.flow.ts
+++ b/tests/flows/wallet.flow.ts
@@ -751,7 +751,9 @@ export const loginToAppPlaywright = async (
 
   const dismissPostLoginModals = async (): Promise<void> => {
     await PlaywrightUtilities.wait(500);
-    await dismissPushNotificationExistingUserSheet();
+    // Push "Never miss a move" sheet is not shown for fixture/e2e logins —
+    // probing it burns ~5s per login. Call dismissPushNotificationExistingUserSheet
+    // explicitly from onboarding flows that can show it.
     await dismissExperienceEnhancerModal();
   };
 

--- a/tests/flows/wallet.flow.ts
+++ b/tests/flows/wallet.flow.ts
@@ -681,54 +681,61 @@ export const loginToApp = async (password?: string): Promise<void> => {
  * Dismisses the push notification opt-in sheet for existing users, if it appears.
  * This sheet may appear after login and block navigation. It is safe to call
  * even when the sheet is not present — the function will silently no-op.
+ *
+ * @param options.appearTimeout - How long to wait for the sheet to show before
+ *   treating it as absent. Keep this short on fixture login (~1.5s); onboarding
+ *   flows that expect the sheet can pass a longer value.
  */
-export const dismissPushNotificationExistingUserSheet =
-  async (): Promise<void> => {
+export const dismissPushNotificationExistingUserSheet = async (
+  options: { appearTimeout?: number } = {},
+): Promise<void> => {
+  const appearTimeout = options.appearTimeout ?? 5_000;
+
+  try {
+    const sheetTitle = await asPlaywrightElement(
+      encapsulated({
+        detox: () =>
+          Matchers.getElementByID(ExistingUserSheetSelectorsIDs.TITLE),
+        appium: () =>
+          PlaywrightMatchers.getElementByText('Never miss a move', true),
+      }),
+    );
+    await PlaywrightAssertions.expectElementToBeVisible(sheetTitle, {
+      timeout: appearTimeout,
+      description: 'Push notification existing user sheet',
+    });
+
     try {
-      const sheetTitle = await asPlaywrightElement(
+      const notNowById = await asPlaywrightElement(
         encapsulated({
           detox: () =>
-            Matchers.getElementByID(ExistingUserSheetSelectorsIDs.TITLE),
+            Matchers.getElementByID(
+              ExistingUserSheetSelectorsIDs.BUTTON_NOT_NOW,
+            ),
           appium: () =>
-            PlaywrightMatchers.getElementByText('Never miss a move', true),
+            PlaywrightMatchers.getElementById(
+              ExistingUserSheetSelectorsIDs.BUTTON_NOT_NOW,
+              { exact: true },
+            ),
         }),
       );
-      await PlaywrightAssertions.expectElementToBeVisible(sheetTitle, {
-        timeout: 5_000,
-        description: 'Push notification existing user sheet',
-      });
-
-      try {
-        const notNowById = await asPlaywrightElement(
-          encapsulated({
-            detox: () =>
-              Matchers.getElementByID(
-                ExistingUserSheetSelectorsIDs.BUTTON_NOT_NOW,
-              ),
-            appium: () =>
-              PlaywrightMatchers.getElementById(
-                ExistingUserSheetSelectorsIDs.BUTTON_NOT_NOW,
-                { exact: true },
-              ),
-          }),
-        );
-        await PlaywrightGestures.waitAndTap(notNowById, { timeout: 5_000 });
-      } catch {
-        const notNowByText = await asPlaywrightElement(
-          PlaywrightMatchers.getElementByText('Not now', true),
-        );
-        await PlaywrightGestures.waitAndTap(notNowByText, { timeout: 5_000 });
-      }
-
-      await PlaywrightAssertions.expectElementToNotBeVisible(sheetTitle, {
-        timeout: 10_000,
-        description: 'Push notification existing user sheet should close',
-      });
-      logger.debug('Dismissed push notification existing user sheet');
+      await PlaywrightGestures.waitAndTap(notNowById, { timeout: 5_000 });
     } catch {
-      // Sheet not present — no-op
+      const notNowByText = await asPlaywrightElement(
+        PlaywrightMatchers.getElementByText('Not now', true),
+      );
+      await PlaywrightGestures.waitAndTap(notNowByText, { timeout: 5_000 });
     }
-  };
+
+    await PlaywrightAssertions.expectElementToNotBeVisible(sheetTitle, {
+      timeout: 10_000,
+      description: 'Push notification existing user sheet should close',
+    });
+    logger.debug('Dismissed push notification existing user sheet');
+  } catch {
+    // Sheet not present — no-op
+  }
+};
 
 /**
  * Dismisses the marketing consent (Experience Enhancer) modal if it appears
@@ -751,9 +758,9 @@ export const loginToAppPlaywright = async (
 
   const dismissPostLoginModals = async (): Promise<void> => {
     await PlaywrightUtilities.wait(500);
-    // Push "Never miss a move" sheet is not shown for fixture/e2e logins —
-    // probing it burns ~5s per login. Call dismissPushNotificationExistingUserSheet
-    // explicitly from onboarding flows that can show it.
+    // Short appear timeout: sheet is often absent on fixture login, but when
+    // present (e.g. seedless existing-user) it blocks account-picker taps.
+    await dismissPushNotificationExistingUserSheet({ appearTimeout: 1_500 });
     await dismissExperienceEnhancerModal();
   };
 

--- a/tests/flows/wallet.flow.ts
+++ b/tests/flows/wallet.flow.ts
@@ -681,61 +681,54 @@ export const loginToApp = async (password?: string): Promise<void> => {
  * Dismisses the push notification opt-in sheet for existing users, if it appears.
  * This sheet may appear after login and block navigation. It is safe to call
  * even when the sheet is not present — the function will silently no-op.
- * Fixture login should pass a short `appearTimeout` (~1.5s); onboarding callers
- * that expect the sheet can use the default.
- *
- * @param options.appearTimeout - Max wait for the sheet before treating it as absent.
  */
-export const dismissPushNotificationExistingUserSheet = async (
-  options: { appearTimeout?: number } = {},
-): Promise<void> => {
-  const appearTimeout = options.appearTimeout ?? 5_000;
-
-  try {
-    const sheetTitle = await asPlaywrightElement(
-      encapsulated({
-        detox: () =>
-          Matchers.getElementByID(ExistingUserSheetSelectorsIDs.TITLE),
-        appium: () =>
-          PlaywrightMatchers.getElementByText('Never miss a move', true),
-      }),
-    );
-    await PlaywrightAssertions.expectElementToBeVisible(sheetTitle, {
-      timeout: appearTimeout,
-      description: 'Push notification existing user sheet',
-    });
-
+export const dismissPushNotificationExistingUserSheet =
+  async (): Promise<void> => {
     try {
-      const notNowById = await asPlaywrightElement(
+      const sheetTitle = await asPlaywrightElement(
         encapsulated({
           detox: () =>
-            Matchers.getElementByID(
-              ExistingUserSheetSelectorsIDs.BUTTON_NOT_NOW,
-            ),
+            Matchers.getElementByID(ExistingUserSheetSelectorsIDs.TITLE),
           appium: () =>
-            PlaywrightMatchers.getElementById(
-              ExistingUserSheetSelectorsIDs.BUTTON_NOT_NOW,
-              { exact: true },
-            ),
+            PlaywrightMatchers.getElementByText('Never miss a move', true),
         }),
       );
-      await PlaywrightGestures.waitAndTap(notNowById, { timeout: 5_000 });
-    } catch {
-      const notNowByText = await asPlaywrightElement(
-        PlaywrightMatchers.getElementByText('Not now', true),
-      );
-      await PlaywrightGestures.waitAndTap(notNowByText, { timeout: 5_000 });
-    }
+      await PlaywrightAssertions.expectElementToBeVisible(sheetTitle, {
+        timeout: 5_000,
+        description: 'Push notification existing user sheet',
+      });
 
-    await PlaywrightAssertions.expectElementToNotBeVisible(sheetTitle, {
-      timeout: 10_000,
-      description: 'Push notification existing user sheet should close',
-    });
-    logger.debug('Dismissed push notification existing user sheet');
-  } catch {
-    // Sheet not present — no-op
-  }
-};
+      try {
+        const notNowById = await asPlaywrightElement(
+          encapsulated({
+            detox: () =>
+              Matchers.getElementByID(
+                ExistingUserSheetSelectorsIDs.BUTTON_NOT_NOW,
+              ),
+            appium: () =>
+              PlaywrightMatchers.getElementById(
+                ExistingUserSheetSelectorsIDs.BUTTON_NOT_NOW,
+                { exact: true },
+              ),
+          }),
+        );
+        await PlaywrightGestures.waitAndTap(notNowById, { timeout: 5_000 });
+      } catch {
+        const notNowByText = await asPlaywrightElement(
+          PlaywrightMatchers.getElementByText('Not now', true),
+        );
+        await PlaywrightGestures.waitAndTap(notNowByText, { timeout: 5_000 });
+      }
+
+      await PlaywrightAssertions.expectElementToNotBeVisible(sheetTitle, {
+        timeout: 10_000,
+        description: 'Push notification existing user sheet should close',
+      });
+      logger.debug('Dismissed push notification existing user sheet');
+    } catch {
+      // Sheet not present — no-op
+    }
+  };
 
 /**
  * Dismisses the marketing consent (Experience Enhancer) modal if it appears
@@ -758,9 +751,7 @@ export const loginToAppPlaywright = async (
 
   const dismissPostLoginModals = async (): Promise<void> => {
     await PlaywrightUtilities.wait(500);
-    // Short appear timeout: sheet is often absent on fixture login, but when
-    // present (e.g. seedless existing-user) it blocks account-picker taps.
-    await dismissPushNotificationExistingUserSheet({ appearTimeout: 1_500 });
+    await dismissPushNotificationExistingUserSheet();
     await dismissExperienceEnhancerModal();
   };
 

--- a/tests/flows/wallet.flow.ts
+++ b/tests/flows/wallet.flow.ts
@@ -681,10 +681,10 @@ export const loginToApp = async (password?: string): Promise<void> => {
  * Dismisses the push notification opt-in sheet for existing users, if it appears.
  * This sheet may appear after login and block navigation. It is safe to call
  * even when the sheet is not present — the function will silently no-op.
+ * Fixture login should pass a short `appearTimeout` (~1.5s); onboarding callers
+ * that expect the sheet can use the default.
  *
- * @param options.appearTimeout - How long to wait for the sheet to show before
- *   treating it as absent. Keep this short on fixture login (~1.5s); onboarding
- *   flows that expect the sheet can pass a longer value.
+ * @param options.appearTimeout - Max wait for the sheet before treating it as absent.
  */
 export const dismissPushNotificationExistingUserSheet = async (
   options: { appearTimeout?: number } = {},

--- a/tests/page-objects/wallet/AccountListBottomSheet.ts
+++ b/tests/page-objects/wallet/AccountListBottomSheet.ts
@@ -307,6 +307,10 @@ class AccountListBottomSheet {
    * Appium: poll until the account list sheet is open.
    * Retries lookup + visibility — needed after rename/back navigation when the
    * sheet is animating in and text/testID queries can briefly miss.
+   *
+   * iOS: exact "Accounts" title (not contains), any displayed match, then
+   * fall back to a visible `create-account` child — mirrors wallet-home
+   * readiness where XCTest can report wrappers as displayed=false.
    */
   async waitForAccountListVisible(timeout = 15_000): Promise<void> {
     if (!FrameworkDetector.isAppium()) {
@@ -316,17 +320,19 @@ class AccountListBottomSheet {
 
     await Utilities.executeWithRetry(
       async () => {
+        if (PlatformDetector.isIOS()) {
+          if (await this.isIosAccountListOpen()) {
+            return;
+          }
+          throw new Error('Account list sheet is not visible yet');
+        }
+
         let el: PlaywrightElement;
         try {
-          el = PlatformDetector.isIOS()
-            ? await PlaywrightMatchers.getElementByText(
-                AccountListBottomSheetSelectorsText.ACCOUNTS_LIST_TITLE,
-                true,
-              )
-            : await PlaywrightMatchers.getElementById(
-                AccountListBottomSheetSelectorsIDs.ACCOUNT_LIST_ID,
-                { exact: true },
-              );
+          el = await PlaywrightMatchers.getElementById(
+            AccountListBottomSheetSelectorsIDs.ACCOUNT_LIST_ID,
+            { exact: true },
+          );
         } catch {
           throw new Error('Account list sheet element not found');
         }
@@ -342,6 +348,38 @@ class AccountListBottomSheet {
         description: 'Account list sheet visible',
       },
     );
+  }
+
+  /**
+   * iOS Appium readiness for the account list sheet.
+   * Prefers a displayed exact "Accounts" title; falls back to `create-account`
+   * when the title exists in the tree but reports displayed=false.
+   */
+  private async isIosAccountListOpen(): Promise<boolean> {
+    const title = AccountListBottomSheetSelectorsText.ACCOUNTS_LIST_TITLE;
+    const escaped = title.replace(/'/g, "\\'");
+    const xpath = `//*[@name='${escaped}' or @label='${escaped}' or @text='${escaped}']`;
+
+    try {
+      const matches = await PlaywrightMatchers.getAllElementsByXPath(xpath);
+      for (const el of matches) {
+        if (await el.isVisible().catch(() => false)) {
+          return true;
+        }
+      }
+    } catch {
+      // Title query failed — try child indicator.
+    }
+
+    try {
+      const createAccount = await PlaywrightMatchers.getElementById(
+        AccountListBottomSheetSelectorsIDs.CREATE_ACCOUNT,
+        { exact: true },
+      );
+      return await createAccount.isVisible().catch(() => false);
+    } catch {
+      return false;
+    }
   }
 
   async tapAddAccountButtonV2(options?: {

--- a/tests/page-objects/wallet/ToastModal.ts
+++ b/tests/page-objects/wallet/ToastModal.ts
@@ -5,7 +5,7 @@ import {
 import Assertions from '../../framework/Assertions';
 import Gestures from '../../framework/Gestures';
 import Matchers from '../../framework/Matchers';
-import { PlaywrightAssertions } from '../../framework';
+import { PlaywrightAssertions, PlaywrightGestures } from '../../framework';
 import PlaywrightMatchers from '../../framework/PlaywrightMatchers';
 import { sleep } from '../../framework/Utilities';
 import {
@@ -19,6 +19,7 @@ import { PlaywrightElement } from '../../framework/PlaywrightAdapter';
 const DEFAULT_TOAST_DISMISS_TIMEOUT_MS = 15_000;
 const DEFAULT_TOAST_APPEAR_TIMEOUT_MS = 5_000;
 const TOAST_POLL_INTERVAL_MS = 250;
+const FORCE_DISMISS_SETTLE_TIMEOUT_MS = 5_000;
 
 class ToastModal {
   get container(): EncapsulatedElementType {
@@ -51,8 +52,10 @@ class ToastModal {
 
   /**
    * If a toast is visible, waits for it to disappear. Otherwise returns
-   * immediately. Never fails the test when no toast is shown or dismiss is slow.
-   * Used before tapping header back controls that top toasts can cover.
+   * immediately. When auto-dismiss is slow on Appium, force-dismisses via
+   * swipe-up (product supports pan dismiss) so the toast cannot keep covering
+   * the account picker / header controls. Still best-effort — never fails the
+   * test if the toast is absent or resists dismiss.
    */
   async waitForToastToDismiss(
     options: {
@@ -76,7 +79,15 @@ class ToastModal {
             timeout: dismissTimeout,
           });
         } catch {
-          // Toast still visible — continue without failing the test.
+          try {
+            await this.tapToastCloseButton();
+            await Assertions.expectElementToNotBeVisible(this.container, {
+              description: 'Toast dismissed after close tap',
+              timeout: FORCE_DISMISS_SETTLE_TIMEOUT_MS,
+            });
+          } catch {
+            // Toast still visible — continue without failing the test.
+          }
         }
       },
       appium: async () => {
@@ -91,10 +102,53 @@ class ToastModal {
             timeout: dismissTimeout,
           });
         } catch {
-          // Toast still visible — continue without failing the test.
+          await this.forceDismissAppiumToast(toast);
+          const refreshed = await asPlaywrightElement(this.containerElement);
+          try {
+            await PlaywrightAssertions.expectElementToNotBeVisible(refreshed, {
+              description: 'Toast dismissed after force dismiss',
+              timeout: FORCE_DISMISS_SETTLE_TIMEOUT_MS,
+            });
+          } catch {
+            // Toast still visible — callers should reopen/retry critical taps.
+          }
         }
       },
     });
+  }
+
+  /**
+   * Best-effort Appium dismiss: swipe up from the toast center (matches the
+   * product pan-to-dismiss gesture), then fall back to tapping the toast.
+   */
+  private async forceDismissAppiumToast(
+    toast: PlaywrightElement,
+  ): Promise<void> {
+    try {
+      const native = toast.unwrap();
+      const location = await native.getLocation();
+      const size = await native.getSize();
+      const centerX = Math.floor(location.x + size.width / 2);
+      const fromY = Math.floor(location.y + size.height * 0.6);
+      const toY = Math.max(0, Math.floor(location.y - size.height));
+
+      await PlaywrightGestures.swipe({
+        scrollParams: { direction: 'up' },
+        duration: 200,
+        percent: 0.9,
+        from: { x: centerX, y: fromY },
+        to: { x: centerX, y: toY },
+      });
+      return;
+    } catch {
+      // Fall through to tap.
+    }
+
+    try {
+      await toast.unwrap().click();
+    } catch {
+      // Best-effort only.
+    }
   }
 
   private async pollAppiumToastVisible(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Hardens the remaining Appium flake around iOS multi-SRP account list open after import toast, on top of the multi-srp / exact-title changes already on main (#34008).

### Changes (unique to this PR)
1. **`ToastModal.waitForToastToDismiss`** — if the toast does not auto-dismiss in time on Appium, force-dismiss via swipe-up (product pan dismiss); Detox tries close tap.
2. **`AccountListBottomSheet.waitForAccountListVisible`** — iOS readiness checks any displayed exact `"Accounts"` title match, then falls back to a visible `create-account` child (same idea as wallet-home XCTest displayed=false quirks).

`multi-srp.spec.ts` already uses `ensureAccountListOpenPlaywright()` + longer toast appear timeout on main — left as-is.

`"Never miss a move"` dismiss left identical to main.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: flaky `appium-accounts-ios-smoke` multi-srp (`Account list sheet is not visible yet`)

## **Manual testing steps**

N/A — Appium smoke / POM-only change.

```bash
CI=true IOS_APP_PATH=build/ci-main-e2e/MetaMask.app \
  yarn appium-smoke:ios --grep "Account syncing - Multiple SRPs"
```

## **Screenshots/Recordings**

N/A — test infrastructure only.

### **Before**

N/A

### **After**

N/A — pending green Appium accounts CI.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A — test-only POM change
- [x] I've tested with a power user scenario
  - N/A
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A — test-only change

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd05f416-097a-48e8-9480-1f362ff4847d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd05f416-097a-48e8-9480-1f362ff4847d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

