### PR TITLE
fix(bridge): require sendbundle for batch sell stx flags

### DIFF
--- a/app/components/UI/Bridge/hooks/useBatchSellQuoteData/index.ts
+++ b/app/components/UI/Bridge/hooks/useBatchSellQuoteData/index.ts
@@ -32,6 +32,7 @@ import type { BridgeToken } from '../../types';
 import { hasValidBatchSellSourceAmounts } from '../useBatchSellQuoteRequest';
 import { getQuoteRefreshRate, isQuoteExpired } from '../../utils/quoteUtils';
 import { getMaybeHexChainId } from '../../../../../util/bridge';
+import { useIsSendBundleSupported } from '../useIsSendBundleSupported';
 
 const UNKNOWN_DESTINATION_TOKEN_SYMBOL = 'UNKNOWN';
 const QUOTE_DETAILS_PLACEHOLDER_AMOUNT = '--';
@@ -228,9 +229,13 @@ export function useBatchSellQuoteData({
   const bridgeFeatureFlags = useSelector(selectBridgeFeatureFlags);
   const currentCurrency = useSelector(selectCurrentCurrency);
   const batchSellChainId = getMaybeHexChainId(sourceTokens[0]?.chainId);
-  const isSmartTransaction = useSelector((state: RootState) =>
+  const shouldUseSmartTransaction = useSelector((state: RootState) =>
     selectShouldUseSmartTransaction(state, batchSellChainId),
   );
+  const isSendBundleSupportedForChain =
+    useIsSendBundleSupported(batchSellChainId);
+  const isSmartTransaction =
+    shouldUseSmartTransaction && Boolean(isSendBundleSupportedForChain);
   const priceImpactWarningThreshold =
     bridgeFeatureFlags?.priceImpactThreshold?.warning ??
     AppConstants.BRIDGE.PRICE_IMPACT_WARNING_THRESHOLD;

--- a/app/components/UI/Bridge/hooks/useBatchSellQuoteData/useBatchSellQuoteData.test.ts
+++ b/app/components/UI/Bridge/hooks/useBatchSellQuoteData/useBatchSellQuoteData.test.ts
@@ -19,6 +19,15 @@ import * as bridgeSlice from '../../../../../core/redux/slices/bridge';
 // eslint-disable-next-line import-x/no-namespace -- jest.spyOn must patch the module namespace the hook imports
 import * as bridgeUtils from '../../../../../util/bridge';
 
+let mockIsSendBundleSupported = false;
+
+jest.mock('../useIsSendBundleSupported', () => ({
+  useIsSendBundleSupported: jest.fn(() => mockIsSendBundleSupported),
+}));
+
+const { useIsSendBundleSupported: mockUseIsSendBundleSupported } =
+  jest.requireMock('../useIsSendBundleSupported');
+
 jest.mock('../useBatchSellQuoteRequest', () => ({
   getBatchSellAtomicSourceAmount: jest.fn(
     (_token: BridgeToken, sourceAmount?: string) =>
@@ -226,6 +235,7 @@ describe('useBatchSellQuoteData', () => {
   let selectBatchSellSourceTokenAmountsSpy = jest.SpyInstance;
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsSendBundleSupported = false;
     jest
       .spyOn(bridgeUtils, 'getMaybeHexChainId')
       .mockImplementation(mockGetMaybeHexChainId);
@@ -553,6 +563,7 @@ describe('useBatchSellQuoteData', () => {
 
   it('passes isSmartTransaction=false to updateBatchSellTrades when STX is disabled', () => {
     selectShouldUseSmartTransactionSpy.mockReturnValue(false);
+    mockIsSendBundleSupported = true;
 
     renderHook(() => useBatchSellQuoteData());
 
@@ -561,8 +572,20 @@ describe('useBatchSellQuoteData', () => {
     ).toHaveBeenCalledWith(expect.any(Array), false);
   });
 
-  it('passes isSmartTransaction=true to updateBatchSellTrades when STX is enabled', () => {
+  it('passes isSmartTransaction=false to updateBatchSellTrades when sendBundle is not supported', () => {
     selectShouldUseSmartTransactionSpy.mockReturnValue(true);
+    mockIsSendBundleSupported = false;
+
+    renderHook(() => useBatchSellQuoteData());
+
+    expect(
+      Engine.context.BridgeController.updateBatchSellTrades,
+    ).toHaveBeenCalledWith(expect.any(Array), false);
+  });
+
+  it('passes isSmartTransaction=true to updateBatchSellTrades when STX and sendBundle are enabled', () => {
+    selectShouldUseSmartTransactionSpy.mockReturnValue(true);
+    mockIsSendBundleSupported = true;
 
     renderHook(() => useBatchSellQuoteData());
 
@@ -932,7 +955,7 @@ describe('useBatchSellQuoteData', () => {
     );
   });
 
-  it('passes the normalized source chain ID to selectShouldUseSmartTransaction', () => {
+  it('passes the normalized source chain ID to selectShouldUseSmartTransaction and useIsSendBundleSupported', () => {
     selectBatchSellSourceTokensSpy.mockReturnValue([
       { ...ethToken, chainId: '0x1' as Hex },
     ]);
@@ -944,9 +967,10 @@ describe('useBatchSellQuoteData', () => {
       expect.anything(),
       '0x1',
     );
+    expect(mockUseIsSendBundleSupported).toHaveBeenCalledWith('0x1');
   });
 
-  it('passes undefined chain ID to selectShouldUseSmartTransaction when there are no source tokens', () => {
+  it('passes undefined chain ID to selectShouldUseSmartTransaction and useIsSendBundleSupported when there are no source tokens', () => {
     selectBatchSellSourceTokensSpy.mockReturnValue([]);
 
     renderHook(() => useBatchSellQuoteData());
@@ -956,6 +980,7 @@ describe('useBatchSellQuoteData', () => {
       expect.anything(),
       undefined,
     );
+    expect(mockUseIsSendBundleSupported).toHaveBeenCalledWith(undefined);
   });
 
   it('marks the quote set unavailable when no rows have quotes', () => {

--- a/app/components/UI/Bridge/hooks/useBatchSellQuoteRequest/index.ts
+++ b/app/components/UI/Bridge/hooks/useBatchSellQuoteRequest/index.ts
@@ -23,6 +23,7 @@ import { getBatchSellSlippage } from '../../components/SlippageModal/utils';
 import { getSecurityWarnings } from '../../utils/tokenSecurityUtils';
 import { RootState } from '../../../../../reducers';
 import { getMaybeHexChainId } from '../../../../../util/bridge';
+import { useIsSendBundleSupported } from '../useIsSendBundleSupported';
 
 export const BATCH_SELL_QUOTE_DEBOUNCE_MS = 300;
 
@@ -202,9 +203,13 @@ export function useBatchSellQuoteRequest() {
   const batchSellSlippages = useSelector(selectBatchSellSlippages);
   const walletAddress = useSelector(selectBatchSellSourceWalletAddress);
   const batchSellChainId = getMaybeHexChainId(sourceTokens[0]?.chainId);
-  const smartTransactionsEnabled = useSelector((state: RootState) =>
+  const shouldUseSmartTransaction = useSelector((state: RootState) =>
     selectShouldUseSmartTransaction(state, batchSellChainId),
   );
+  const isSendBundleSupportedForChain =
+    useIsSendBundleSupported(batchSellChainId);
+  const smartTransactionsEnabled =
+    shouldUseSmartTransaction && Boolean(isSendBundleSupportedForChain);
 
   const quoteRequestData = useMemo(
     () =>

--- a/app/components/UI/Bridge/hooks/useBatchSellQuoteRequest/useBatchSellQuoteRequest.test.ts
+++ b/app/components/UI/Bridge/hooks/useBatchSellQuoteRequest/useBatchSellQuoteRequest.test.ts
@@ -19,6 +19,7 @@ import {
 let mockWalletAddress: string | undefined =
   '0x1234567890123456789012345678901234567890';
 let mockShouldUseSmartTransaction = false;
+let mockIsSendBundleSupported = false;
 
 jest.mock('../../../../../core/Engine', () => ({
   __esModule: true,
@@ -40,8 +41,14 @@ jest.mock('../../../../../selectors/smartTransactionsController', () => ({
   selectShouldUseSmartTransaction: jest.fn(() => mockShouldUseSmartTransaction),
 }));
 
+jest.mock('../useIsSendBundleSupported', () => ({
+  useIsSendBundleSupported: jest.fn(() => mockIsSendBundleSupported),
+}));
+
 const { selectShouldUseSmartTransaction: mockSelectShouldUseSmartTransaction } =
   jest.requireMock('../../../../../selectors/smartTransactionsController');
+const { useIsSendBundleSupported: mockUseIsSendBundleSupported } =
+  jest.requireMock('../useIsSendBundleSupported');
 
 const ethToken: BridgeToken = {
   address: '0x1111111111111111111111111111111111111111',
@@ -91,6 +98,7 @@ describe('useBatchSellQuoteRequest', () => {
     jest.useFakeTimers();
     mockWalletAddress = '0x1234567890123456789012345678901234567890';
     mockShouldUseSmartTransaction = false;
+    mockIsSendBundleSupported = false;
   });
 
   afterEach(() => {
@@ -447,8 +455,9 @@ describe('useBatchSellQuoteRequest', () => {
     );
   });
 
-  it('passes stx_enabled: true in context when smart transactions are enabled', async () => {
+  it('passes stx_enabled: true in context when STX and sendBundle are enabled', async () => {
     mockShouldUseSmartTransaction = true;
+    mockIsSendBundleSupported = true;
 
     const testState = createBridgeTestState({
       bridgeReducerOverrides: {
@@ -480,8 +489,9 @@ describe('useBatchSellQuoteRequest', () => {
     );
   });
 
-  it('passes stx_enabled: false in context when smart transactions are disabled', async () => {
+  it('passes stx_enabled: false in context when STX is disabled', async () => {
     mockShouldUseSmartTransaction = false;
+    mockIsSendBundleSupported = true;
 
     const testState = createBridgeTestState({
       bridgeReducerOverrides: {
@@ -513,7 +523,41 @@ describe('useBatchSellQuoteRequest', () => {
     );
   });
 
-  it('passes the normalized source chain ID to selectShouldUseSmartTransaction', () => {
+  it('passes stx_enabled: false in context when sendBundle is not supported', async () => {
+    mockShouldUseSmartTransaction = true;
+    mockIsSendBundleSupported = false;
+
+    const testState = createBridgeTestState({
+      bridgeReducerOverrides: {
+        batchSellSourceTokens: [ethToken],
+        batchSellSourceTokenAmounts: {
+          [ethAssetId]: '0.749',
+        },
+        batchSellDestToken: usdcToken,
+        batchSellSlippages: {},
+      },
+    });
+
+    const { result } = renderHookWithProvider(
+      () => useBatchSellQuoteRequest(),
+      {
+        state: testState,
+      },
+    );
+
+    result.current.updateBatchSellQuoteParams();
+    await flushQuoteRequestDebounce();
+
+    expect(
+      getBridgeControllerMock().updateBridgeQuoteRequestParams.mock.calls[0][1],
+    ).toEqual(
+      expect.objectContaining({
+        stx_enabled: false,
+      }),
+    );
+  });
+
+  it('passes the normalized source chain ID to selectShouldUseSmartTransaction and useIsSendBundleSupported', () => {
     const caipSourceToken: BridgeToken = {
       ...ethToken,
       chainId: 'eip155:1' as unknown as Hex,
@@ -534,9 +578,10 @@ describe('useBatchSellQuoteRequest', () => {
       expect.anything(),
       '0x1',
     );
+    expect(mockUseIsSendBundleSupported).toHaveBeenCalledWith('0x1');
   });
 
-  it('passes undefined chain ID to selectShouldUseSmartTransaction when there are no source tokens', () => {
+  it('passes undefined chain ID to selectShouldUseSmartTransaction and useIsSendBundleSupported when there are no source tokens', () => {
     const testState = createBridgeTestState({
       bridgeReducerOverrides: {
         batchSellSourceTokens: [],
@@ -552,5 +597,6 @@ describe('useBatchSellQuoteRequest', () => {
       expect.anything(),
       undefined,
     );
+    expect(mockUseIsSendBundleSupported).toHaveBeenCalledWith(undefined);
   });
 });

--- a/app/components/UI/Bridge/hooks/useSubmitBatchSellTx/index.ts
+++ b/app/components/UI/Bridge/hooks/useSubmitBatchSellTx/index.ts
@@ -15,13 +15,18 @@ import { RootState } from '../../../../../reducers';
 import { selectBatchSellSourceWalletAddress } from '../../../../../selectors/bridge';
 import { selectShouldUseSmartTransaction } from '../../../../../selectors/smartTransactionsController';
 import { getMaybeHexChainId } from '../../../../../util/bridge';
+import { useIsSendBundleSupported } from '../useIsSendBundleSupported';
 
 export function useSubmitBatchSellTx() {
   const sourceTokens = useSelector(selectBatchSellSourceTokens);
   const batchSellChainId = getMaybeHexChainId(sourceTokens[0]?.chainId);
-  const smartTransactionsEnabled = useSelector((state: RootState) =>
+  const shouldUseSmartTransaction = useSelector((state: RootState) =>
     selectShouldUseSmartTransaction(state, batchSellChainId),
   );
+  const isSendBundleSupportedForChain =
+    useIsSendBundleSupported(batchSellChainId);
+  const smartTransactionsEnabled =
+    shouldUseSmartTransaction && Boolean(isSendBundleSupportedForChain);
   const walletAddress = useSelector(selectBatchSellSourceWalletAddress);
   const destToken = useSelector(selectBatchSellDestToken);
 

--- a/app/components/UI/Bridge/hooks/useSubmitBatchSellTx/useSubmitBatchSellTx.test.tsx
+++ b/app/components/UI/Bridge/hooks/useSubmitBatchSellTx/useSubmitBatchSellTx.test.tsx
@@ -51,8 +51,14 @@ jest.mock('../../../../../selectors/smartTransactionsController', () => ({
   selectShouldUseSmartTransaction: jest.fn(() => true),
 }));
 
+jest.mock('../useIsSendBundleSupported', () => ({
+  useIsSendBundleSupported: jest.fn(() => true),
+}));
+
 const { selectShouldUseSmartTransaction: mockSelectShouldUseSmartTransaction } =
   jest.requireMock('../../../../../selectors/smartTransactionsController');
+const { useIsSendBundleSupported: mockUseIsSendBundleSupported } =
+  jest.requireMock('../useIsSendBundleSupported');
 
 const mockSourceTokens = [
   {
@@ -171,7 +177,7 @@ describe('useSubmitBatchSellTx', () => {
     ).rejects.toThrow('Batch Sell wallet address is not set');
   });
 
-  it('passes the normalized source chain ID to selectShouldUseSmartTransaction', () => {
+  it('passes the normalized source chain ID to selectShouldUseSmartTransaction and useIsSendBundleSupported', () => {
     renderHook(() => useSubmitBatchSellTx(), {
       wrapper: createWrapper(),
     });
@@ -180,5 +186,6 @@ describe('useSubmitBatchSellTx', () => {
       expect.anything(),
       '0x1',
     );
+    expect(mockUseIsSendBundleSupported).toHaveBeenCalledWith('0x1');
   });
 });


### PR DESCRIPTION
## **Description**

Batch sell was setting STX-related flags from chain-scoped smart transaction state alone. That could send `stx_enabled` / `isStxEnabled: true` even when Sentinel reports `sendBundle` is unavailable on the batch-sell source chain, causing incorrect gasless/STX-backed quote behavior.

This change aligns batch sell with bridge/swap gating by requiring both `selectShouldUseSmartTransaction(sourceChain)` and `useIsSendBundleSupported(sourceChain)` before enabling STX across quote requests, trades simulation, and submission.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: SWAPS-4869

## **Manual testing steps**

N/A — logic-only change with no user-facing UI updates; behavior is covered by updated unit tests for quote request, trades simulation, and submission hooks.

## **Screenshots/Recordings**

N/A — non-user-facing internal flag gating change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.