### PR TITLE
fix: remove Android duplicated push notification icon [GE-392]

### DIFF
--- a/app/util/notifications/services/NotificationService.test.ts
+++ b/app/util/notifications/services/NotificationService.test.ts
@@ -543,7 +543,13 @@ describe('NotificationService - displayNotification', () => {
         title: notification.title,
         body: notification.body,
         data: { dataStr: JSON.stringify(notification.data) },
+        android: expect.objectContaining({
+          smallIcon: 'ic_notification_small',
+        }),
       }),
     );
+    const displayCall =
+      mocks.mockNotifeeDisplayNotification.mock.calls[0][0];
+    expect(displayCall.android).not.toHaveProperty('largeIcon');
   });
 });

--- a/app/util/notifications/services/NotificationService.test.ts
+++ b/app/util/notifications/services/NotificationService.test.ts
@@ -548,8 +548,7 @@ describe('NotificationService - displayNotification', () => {
         }),
       }),
     );
-    const displayCall =
-      mocks.mockNotifeeDisplayNotification.mock.calls[0][0];
+    const displayCall = mocks.mockNotifeeDisplayNotification.mock.calls[0][0];
     expect(displayCall.android).not.toHaveProperty('largeIcon');
   });
 });

--- a/app/util/notifications/services/NotificationService.ts
+++ b/app/util/notifications/services/NotificationService.ts
@@ -286,8 +286,8 @@ class NotificationsService {
         // Notifee can only store and handle data strings
         data: { dataStr: JSON.stringify(data) },
         android: {
+          // Omit largeIcon — same fox as smallIcon caused a duplicate on Android.
           smallIcon: 'ic_notification_small',
-          largeIcon: 'ic_notification',
           channelId: channelId ?? ChannelId.DEFAULT_NOTIFICATION_CHANNEL_ID,
           pressAction: {
             id: pressActionId,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

On Android, foreground push notifications displayed via Notifee showed the MetaMask fox icon twice: once on the left (`smallIcon` / black circular background) and once on the right (`largeIcon` / white rounded square).

This became visible after [#32100](https://github.com/MetaMask/metamask-mobile/pull/32100) started displaying foreground pushes through `NotificationsService.displayNotification`. Background/system FCM delivery only uses the default small icon from the Android manifest, so those notifications never showed the duplicate.

**Solution:** Remove `largeIcon: 'ic_notification'` from the Notifee Android config so foreground notifications match background delivery and show a single fox icon on the left.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed Android push notifications showing the MetaMask fox icon twice

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/GE-392

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

1. Build and run the Android app with push notifications enabled.
2. Keep the app in the foreground.
3. Trigger a push notification (e.g. marketing/platform push, or any payload that shows a system banner while foregrounded).
4. Verify the notification tray / heads-up banner shows a **single** MetaMask fox icon on the left (no second fox on the right).
5. Background or kill the app and send another push.
6. Verify background/system delivery still shows a single fox icon as before.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

Android push notification shows the MetaMask fox twice: left (black circular background) and right (white rounded square). Attach device screenshot before marking ready for review.

![Screenshot_20260730-145319.png](https://github.com/user-attachments/assets/9d577ad7-d15c-4f8c-b945-3b522d4f72dc)


### **After**

Android push notification shows a single MetaMask fox icon on the left only. Attach device screenshot before marking ready for review.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized Android notification UI change with no impact on auth, data, or push handling logic beyond icon presentation.
> 
> **Overview**
> Fixes **duplicate MetaMask fox icons** on Android when foreground pushes are shown through Notifee.
> 
> `NotificationService.displayNotification` no longer sets **`largeIcon: 'ic_notification'`** on the Android payload—only **`smallIcon: 'ic_notification_small'`** remains, with a short comment that the same asset on both slots caused the duplicate. Foreground banners should now align with background FCM delivery (single icon on the left).
> 
> Tests for **`displayNotification`** now expect the Android config to include **`smallIcon`** and explicitly assert **`largeIcon`** is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 350bf1dd55d5f46f85ddae88b6ad0244e5534345. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->