### PR TITLE
feat(ci): reuse fingerprint + JS repack for performance BS builds (MMQA-2147)

### DIFF
--- a/.github/workflows/build-android-upload-to-browserstack.yml
+++ b/.github/workflows/build-android-upload-to-browserstack.yml
@@ -2,9 +2,18 @@
 # Build 1: With ADDITIONAL_SRP_1 and PREDEFINED_PASSWORD (pre-imported wallet) — e2e-bs-with-srp
 # Build 2: With E2E_MOCK_OAUTH (seedless onboarding) — e2e-bs-without-srp
 #
-# When source_fingerprint is provided, tries to reuse android-apk-main-e2e-bs-* (or
-# variant) artifacts from a prior workflow run with the same @expo/fingerprint hash,
-# then re-uploads those APKs to BrowserStack — same reuse model as build-android-e2e.yml.
+# Fingerprint reuse (test-only / main_branch_only):
+#   When source_fingerprint is set AND main_branch_only is true, try to reuse
+#   android-apk-main-e2e-bs-* (or variant) artifacts from a prior workflow run with
+#   the same @expo/fingerprint hash, then re-upload those APKs to BrowserStack.
+#   This mirrors build-android-e2e.yml's reuse-main-builds-only path, which also
+#   skips @expo/repack-app because only test files changed (app JS is unchanged).
+#
+#   As-is reuse is intentionally NOT used for general fingerprint hits: @expo/fingerprint
+#   ignores JS-only changes, and this workflow does not repack the JS bundle into the
+#   reused APKs. Reusing on a JS-only app change would run performance tests against a
+#   stale binary. Until an E2E-style repack path exists for both BS profiles, non-test-only
+#   runs always take the fresh dual-build path.
 
 name: Build Android Dual Versions and Upload to BrowserStack
 
@@ -32,17 +41,18 @@ on:
         required: false
         type: string
         description: >-
-          @expo/fingerprint hash from native-build-fingerprint. When set, skip
-          fresh dual builds if matching BrowserStack performance APKs exist on a
-          prior ci.yml or run-performance-e2e.yml run.
+          @expo/fingerprint hash from native-build-fingerprint. Used with
+          main_branch_only to reuse BrowserStack performance APKs on test-only
+          PRs (app JS unchanged). Ignored for as-is reuse when main_branch_only
+          is false — see workflow header comment about stale JS / missing repack.
         default: ''
       main_branch_only:
         required: false
         type: boolean
         description: >-
-          When true, fingerprint reuse only searches the base branch (main).
-          Used for test-only PRs as a fallback when BrowserStack custom_id reuse
-          did not resolve apps.
+          When true (test-only PRs), allow as-is fingerprint reuse of prior
+          main-e2e-bs-* APKs. When false, always compile fresh dual builds so
+          JS-only app changes are not tested against a stale binary.
         default: false
     outputs:
       with-srp-browserstack-url:
@@ -115,9 +125,13 @@ jobs:
     name: Resolve fingerprint-reusable BrowserStack APKs
     runs-on: ubuntu-latest
     needs: [check-builds-needed]
+    # As-is APK reuse is safe only when app JS did not change (test-only PRs).
+    # @expo/fingerprint ignores JS-only changes and this workflow does not run
+    # @expo/repack-app, so general fingerprint hits must not reuse prior APKs.
     if: >-
       needs.check-builds-needed.outputs.builds-needed == 'true' &&
-      inputs.source_fingerprint
+      inputs.source_fingerprint &&
+      inputs.main_branch_only
     outputs:
       found: ${{ steps.finalize.outputs.found }}
       run-id: ${{ steps.finalize.outputs.run-id }}

--- a/.github/workflows/build-android-upload-to-browserstack.yml
+++ b/.github/workflows/build-android-upload-to-browserstack.yml
@@ -2,18 +2,12 @@
 # Build 1: With ADDITIONAL_SRP_1 and PREDEFINED_PASSWORD (pre-imported wallet) — e2e-bs-with-srp
 # Build 2: With E2E_MOCK_OAUTH (seedless onboarding) — e2e-bs-without-srp
 #
-# Fingerprint reuse (test-only / main_branch_only):
-#   When source_fingerprint is set AND main_branch_only is true, try to reuse
-#   android-apk-main-e2e-bs-* (or variant) artifacts from a prior workflow run with
-#   the same @expo/fingerprint hash, then re-upload those APKs to BrowserStack.
-#   This mirrors build-android-e2e.yml's reuse-main-builds-only path, which also
-#   skips @expo/repack-app because only test files changed (app JS is unchanged).
-#
-#   As-is reuse is intentionally NOT used for general fingerprint hits: @expo/fingerprint
-#   ignores JS-only changes, and this workflow does not repack the JS bundle into the
-#   reused APKs. Reusing on a JS-only app change would run performance tests against a
-#   stale binary. Until an E2E-style repack path exists for both BS profiles, non-test-only
-#   runs always take the fresh dual-build path.
+# Fingerprint reuse (same procedure as build-android-e2e.yml):
+#   1. Look up prior android-apk-main-e2e-bs-* (or variant) artifacts by @expo/fingerprint.
+#   2. On miss → fresh dual Gradle builds (unchanged).
+#   3. On hit + main_branch_only (test-only) → re-upload APKs as-is (app JS unchanged).
+#   4. On hit + app changes → skip Gradle, @expo/repack-app both profiles with current JS,
+#      then upload (avoids stale JS; fingerprint ignores JS-only changes).
 
 name: Build Android Dual Versions and Upload to BrowserStack
 
@@ -41,18 +35,16 @@ on:
         required: false
         type: string
         description: >-
-          @expo/fingerprint hash from native-build-fingerprint. Used with
-          main_branch_only to reuse BrowserStack performance APKs on test-only
-          PRs (app JS unchanged). Ignored for as-is reuse when main_branch_only
-          is false — see workflow header comment about stale JS / missing repack.
+          @expo/fingerprint hash from native-build-fingerprint. When set, try to
+          reuse prior BrowserStack performance APKs (repack JS unless test-only).
         default: ''
       main_branch_only:
         required: false
         type: boolean
         description: >-
-          When true (test-only PRs), allow as-is fingerprint reuse of prior
-          main-e2e-bs-* APKs. When false, always compile fresh dual builds so
-          JS-only app changes are not tested against a stale binary.
+          When true (test-only PRs), search mainly on main and skip JS repack
+          (app JS unchanged). When false, fingerprint hit still reuses native
+          APKs but repacks the JS bundle like E2E.
         default: false
     outputs:
       with-srp-browserstack-url:
@@ -94,6 +86,7 @@ jobs:
       builds-needed: ${{ steps.check-builds.outputs.builds-needed }}
       with-srp-build-name: ${{ steps.names.outputs.with-srp-build-name }}
       without-srp-build-name: ${{ steps.names.outputs.without-srp-build-name }}
+      github-environment: ${{ steps.names.outputs.github-environment }}
 
     steps:
       - name: Check if builds are needed
@@ -113,25 +106,24 @@ jobs:
           if [ "${{ inputs.build_variant }}" = "exp" ]; then
             echo "with-srp-build-name=main-exp-with-srp" >> "$GITHUB_OUTPUT"
             echo "without-srp-build-name=main-exp-without-srp" >> "$GITHUB_OUTPUT"
+            echo "github-environment=build-exp" >> "$GITHUB_OUTPUT"
           elif [ "${{ inputs.build_variant }}" = "rc" ]; then
             echo "with-srp-build-name=main-rc-with-srp" >> "$GITHUB_OUTPUT"
             echo "without-srp-build-name=main-rc-without-srp" >> "$GITHUB_OUTPUT"
+            echo "github-environment=build-rc" >> "$GITHUB_OUTPUT"
           else
             echo "with-srp-build-name=main-e2e-bs-with-srp" >> "$GITHUB_OUTPUT"
             echo "without-srp-build-name=main-e2e-bs-without-srp" >> "$GITHUB_OUTPUT"
+            echo "github-environment=build-e2e" >> "$GITHUB_OUTPUT"
           fi
 
   resolve-fingerprint-reuse:
     name: Resolve fingerprint-reusable BrowserStack APKs
     runs-on: ubuntu-latest
     needs: [check-builds-needed]
-    # As-is APK reuse is safe only when app JS did not change (test-only PRs).
-    # @expo/fingerprint ignores JS-only changes and this workflow does not run
-    # @expo/repack-app, so general fingerprint hits must not reuse prior APKs.
     if: >-
       needs.check-builds-needed.outputs.builds-needed == 'true' &&
-      inputs.source_fingerprint &&
-      inputs.main_branch_only
+      inputs.source_fingerprint
     outputs:
       found: ${{ steps.finalize.outputs.found }}
       run-id: ${{ steps.finalize.outputs.run-id }}
@@ -275,7 +267,23 @@ jobs:
 
   upload-to-browserstack:
     name: Upload APKs to BrowserStack
-    runs-on: ubuntu-latest
+    # Repack needs Android SDK/apksigner (Cirrus). Light as-is/fresh upload can stay on ubuntu.
+    runs-on: >-
+      ${{
+        needs.resolve-fingerprint-reuse.outputs.found == 'true' &&
+        inputs.main_branch_only != true &&
+        fromJSON('["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg"]') ||
+        fromJSON('["ubuntu-latest"]')
+      }}
+    # Only the JS-repack path needs build-e2e/rc/exp secrets (ADDITIONAL_SRP_1, etc.).
+    # Fresh/as-is upload only needs repo-level BrowserStack credentials.
+    environment: >-
+      ${{
+        needs.resolve-fingerprint-reuse.outputs.found == 'true' &&
+        inputs.main_branch_only != true &&
+        needs.check-builds-needed.outputs.github-environment ||
+        ''
+      }}
     needs:
       [
         check-builds-needed,
@@ -303,6 +311,35 @@ jobs:
       without-srp-version: ${{ steps.browserstack-upload.outputs.without-srp-version }}
 
     steps:
+      - name: Checkout (repack path)
+        if: >-
+          needs.resolve-fingerprint-reuse.outputs.found == 'true' &&
+          inputs.main_branch_only != true
+        uses: actions/checkout@v6
+
+      - name: Setup E2E environment for APK repack
+        if: >-
+          needs.resolve-fingerprint-reuse.outputs.found == 'true' &&
+          inputs.main_branch_only != true
+        uses: ./.github/actions/setup-e2e-env
+        with:
+          platform: android
+          setup-simulator: 'false'
+          configure-keystores: 'true'
+          install-foundry: 'false'
+          runner_provider: current
+
+      - name: Setup project dependencies (lightweight, repack path)
+        if: >-
+          needs.resolve-fingerprint-reuse.outputs.found == 'true' &&
+          inputs.main_branch_only != true
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: yarn setup:github-ci --no-build-ios --no-build-android
+
       - name: Download reused with-SRP APK
         if: needs.resolve-fingerprint-reuse.outputs.found == 'true'
         uses: actions/download-artifact@v4
@@ -337,6 +374,89 @@ jobs:
           name: android-apk-${{ needs.check-builds-needed.outputs.without-srp-build-name }}
           path: artifacts/without-srp
 
+      - name: Repack reused APKs with current JS (E2E-style)
+        if: >-
+          needs.resolve-fingerprint-reuse.outputs.found == 'true' &&
+          inputs.main_branch_only != true
+        env:
+          WITH_SRP_BUILD_NAME: ${{ needs.check-builds-needed.outputs.with-srp-build-name }}
+          WITHOUT_SRP_BUILD_NAME: ${{ needs.check-builds-needed.outputs.without-srp-build-name }}
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+          CI: 'true'
+          GITHUB_CI: 'true'
+          PLATFORM: android
+          NODE_OPTIONS: '--max-old-space-size=8192'
+          METRO_MAX_WORKERS: '6'
+        run: |
+          set -euo pipefail
+
+          # Apply builds.yml env + secrets into THIS shell so metro (child of yarn
+          # build:repack) inherits them. set-secrets-from-config only writes GITHUB_ENV
+          # for later steps, which is too late for a same-step metro invoke.
+          export_build_env() {
+            local build_name="$1"
+            eval "$(node scripts/apply-build-config.js "$build_name" --export)"
+            export CONFIG_SECRETS
+            CONFIG_SECRETS="$(node -e "
+              const yaml = require('js-yaml');
+              const fs = require('fs');
+              const build = yaml.load(fs.readFileSync('builds.yml', 'utf8')).builds[process.argv[1]];
+              process.stdout.write(JSON.stringify(build.secrets || {}));
+            " "$build_name")"
+            eval "$(node -e "
+              const mapping = JSON.parse(process.env.CONFIG_SECRETS || '{}');
+              const all = JSON.parse(process.env.ALL_SECRETS || '{}');
+              for (const [envVar, secretName] of Object.entries(mapping)) {
+                const value = all[secretName];
+                if (value != null && value !== '') {
+                  process.stdout.write('export ' + envVar + '=' + JSON.stringify(String(value)) + '\n');
+                } else {
+                  console.error('Warning: secret ' + secretName + ' missing for ' + envVar);
+                }
+              }
+            ")"
+          }
+
+          repack_profile() {
+            local build_name="$1"
+            local src_dir="$2"
+            local out_dir="$3"
+            local label="$4"
+
+            local src_apk
+            src_apk="$(find "$src_dir" -name '*.apk' -type f | head -1)"
+            if [ -z "$src_apk" ]; then
+              echo "❌ No APK found in $src_dir for $label"
+              exit 1
+            fi
+
+            echo "=== Repacking $label from $src_apk using builds.yml profile $build_name ==="
+            mkdir -p "$out_dir" android/app/build/outputs/apk/prod/release "android/app/build/repack-working-$label" sourcemaps/android
+
+            export_build_env "$build_name"
+
+            export REPACK_SOURCE_APK="$src_apk"
+            export REPACK_OUTPUT_APK="android/app/build/outputs/apk/prod/release/app-prod-release-repack-$label.apk"
+            export REPACK_FINAL_APK="$out_dir/app-prod-release.apk"
+            export REPACK_WORKING_DIR="android/app/build/repack-working-$label"
+            export REPACK_SOURCEMAP_PATH="sourcemaps/android/index.android.bundle.$label.map"
+
+            yarn build:repack:android
+            echo "✅ Repacked $label → $REPACK_FINAL_APK ($(du -h "$REPACK_FINAL_APK" | cut -f1))"
+          }
+
+          # with-SRP first (ADDITIONAL_SRP_1 + PREDEFINED_PASSWORD inlined into JS via metro)
+          repack_profile "$WITH_SRP_BUILD_NAME" artifacts/with-srp artifacts/with-srp-repacked with-srp
+
+          # without-SRP: drop with-SRP bake-ins so they are not left in process.env
+          unset ADDITIONAL_SRP_1 PREDEFINED_PASSWORD || true
+          repack_profile "$WITHOUT_SRP_BUILD_NAME" artifacts/without-srp artifacts/without-srp-repacked without-srp
+
+          # Replace staged dirs so the upload step always reads artifacts/{with,without}-srp
+          rm -rf artifacts/with-srp artifacts/without-srp
+          mv artifacts/with-srp-repacked artifacts/with-srp
+          mv artifacts/without-srp-repacked artifacts/without-srp
+
       - name: Upload APKs to BrowserStack
         id: browserstack-upload
         env:
@@ -344,6 +464,7 @@ jobs:
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           FINGERPRINT_REUSED: ${{ needs.resolve-fingerprint-reuse.outputs.found }}
           REUSED_SOURCE_SHA: ${{ needs.resolve-fingerprint-reuse.outputs.source-sha }}
+          MAIN_BRANCH_ONLY: ${{ inputs.main_branch_only }}
           FRESH_WITH_SRP_VERSION: ${{ needs.build-with-srp.outputs.semantic_version }}
           FRESH_WITHOUT_SRP_VERSION: ${{ needs.build-without-srp.outputs.semantic_version }}
         run: |
@@ -352,9 +473,6 @@ jobs:
 
           BRANCH_NAME="${{ inputs.branch_name || github.ref_name }}"
           BRANCH_SLUG="$(printf '%s' "$BRANCH_NAME" | sed 's/[^A-Za-z0-9._-]/_/g' | cut -c1-40)"
-          # Stable per-branch custom_id (no run_id). BrowserStack overwrites the
-          # previous app for the same custom_id, so resolve can look up
-          # recent_apps/MetaMask-Android-*-main exactly.
           WITH_SRP_CUSTOM_ID="MetaMask-Android-With-SRP-${BRANCH_SLUG}"
           WITHOUT_SRP_CUSTOM_ID="MetaMask-Android-Without-SRP-${BRANCH_SLUG}"
           echo "BrowserStack custom_id branch slug: $BRANCH_SLUG"
@@ -362,16 +480,21 @@ jobs:
           echo "Without-SRP custom_id: $WITHOUT_SRP_CUSTOM_ID"
 
           if [ "$FINGERPRINT_REUSED" = "true" ]; then
-            WITH_SRP_VERSION="fingerprint-reuse-${REUSED_SOURCE_SHA:0:7}"
-            WITHOUT_SRP_VERSION="fingerprint-reuse-${REUSED_SOURCE_SHA:0:7}"
-            echo "APK source: fingerprint reuse (sha=${REUSED_SOURCE_SHA})"
+            if [ "$MAIN_BRANCH_ONLY" = "true" ]; then
+              WITH_SRP_VERSION="fingerprint-reuse-as-is-${REUSED_SOURCE_SHA:0:7}"
+              WITHOUT_SRP_VERSION="fingerprint-reuse-as-is-${REUSED_SOURCE_SHA:0:7}"
+              echo "APK source: fingerprint reuse as-is (test-only, sha=${REUSED_SOURCE_SHA})"
+            else
+              WITH_SRP_VERSION="fingerprint-reuse-repack-${REUSED_SOURCE_SHA:0:7}"
+              WITHOUT_SRP_VERSION="fingerprint-reuse-repack-${REUSED_SOURCE_SHA:0:7}"
+              echo "APK source: fingerprint reuse + JS repack (sha=${REUSED_SOURCE_SHA})"
+            fi
           else
             WITH_SRP_VERSION="${FRESH_WITH_SRP_VERSION}"
             WITHOUT_SRP_VERSION="${FRESH_WITHOUT_SRP_VERSION}"
             echo "APK source: fresh dual build"
           fi
 
-          # Initialize outputs
           {
             echo "with-srp-apk-uploaded=false"
             echo "without-srp-apk-uploaded=false"
@@ -382,11 +505,9 @@ jobs:
           WITH_SRP_ERROR=""
           WITHOUT_SRP_ERROR=""
 
-          # Find the APK files
           WITH_SRP_APK=$(find artifacts/with-srp -name "*.apk" | head -1)
           WITHOUT_SRP_APK=$(find artifacts/without-srp -name "*.apk" | head -1)
 
-          # Upload with-SRP APK
           if [ -n "$WITH_SRP_APK" ]; then
             echo "Uploading with-SRP APK: $WITH_SRP_APK"
             echo "File size: $(du -h "$WITH_SRP_APK" | cut -f1)"
@@ -419,7 +540,6 @@ jobs:
             echo "❌ With-SRP: $WITH_SRP_ERROR"
           fi
 
-          # Upload without-SRP APK
           if [ -n "$WITHOUT_SRP_APK" ]; then
             echo "Uploading without-SRP APK: $WITHOUT_SRP_APK"
             echo "File size: $(du -h "$WITHOUT_SRP_APK" | cut -f1)"
@@ -452,7 +572,6 @@ jobs:
             echo "❌ Without-SRP: $WITHOUT_SRP_ERROR"
           fi
 
-          # Summary
           echo ""
           echo "=== BrowserStack Upload Summary ==="
           if [ -n "$WITH_SRP_APP_URL" ]; then
@@ -466,7 +585,6 @@ jobs:
             echo "❌ Without-SRP: FAILED — ${WITHOUT_SRP_ERROR:-unknown error}"
           fi
 
-          # Fail only if BOTH uploads failed
           if [ -z "$WITH_SRP_APP_URL" ] && [ -z "$WITHOUT_SRP_APP_URL" ]; then
             echo ""
             echo "❌ Both APK uploads failed. Failing step."

--- a/.github/workflows/build-android-upload-to-browserstack.yml
+++ b/.github/workflows/build-android-upload-to-browserstack.yml
@@ -1,6 +1,10 @@
 # This workflow creates two Android Builds and uploads to BrowserStack using GitHub Actions.
 # Build 1: With ADDITIONAL_SRP_1 and PREDEFINED_PASSWORD (pre-imported wallet) — e2e-bs-with-srp
 # Build 2: With E2E_MOCK_OAUTH (seedless onboarding) — e2e-bs-without-srp
+#
+# When source_fingerprint is provided, tries to reuse android-apk-main-e2e-bs-* (or
+# variant) artifacts from a prior workflow run with the same @expo/fingerprint hash,
+# then re-uploads those APKs to BrowserStack — same reuse model as build-android-e2e.yml.
 
 name: Build Android Dual Versions and Upload to BrowserStack
 
@@ -24,6 +28,22 @@ on:
         type: string
         description: 'Build variant (e2e = e2e environment, exp = experimental)'
         default: 'exp'
+      source_fingerprint:
+        required: false
+        type: string
+        description: >-
+          @expo/fingerprint hash from native-build-fingerprint. When set, skip
+          fresh dual builds if matching BrowserStack performance APKs exist on a
+          prior ci.yml or run-performance-e2e.yml run.
+        default: ''
+      main_branch_only:
+        required: false
+        type: boolean
+        description: >-
+          When true, fingerprint reuse only searches the base branch (main).
+          Used for test-only PRs as a fallback when BrowserStack custom_id reuse
+          did not resolve apps.
+        default: false
     outputs:
       with-srp-browserstack-url:
         description: 'BrowserStack URL for with-SRP version'
@@ -53,6 +73,8 @@ on:
 permissions:
   contents: write
   id-token: write
+  actions: read
+  statuses: read
 
 jobs:
   check-builds-needed:
@@ -60,6 +82,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       builds-needed: ${{ steps.check-builds.outputs.builds-needed }}
+      with-srp-build-name: ${{ steps.names.outputs.with-srp-build-name }}
+      without-srp-build-name: ${{ steps.names.outputs.without-srp-build-name }}
 
     steps:
       - name: Check if builds are needed
@@ -73,24 +97,164 @@ jobs:
             echo "Android builds needed - no BS URLs provided"
           fi
 
+      - name: Resolve build artifact names
+        id: names
+        run: |
+          if [ "${{ inputs.build_variant }}" = "exp" ]; then
+            echo "with-srp-build-name=main-exp-with-srp" >> "$GITHUB_OUTPUT"
+            echo "without-srp-build-name=main-exp-without-srp" >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.build_variant }}" = "rc" ]; then
+            echo "with-srp-build-name=main-rc-with-srp" >> "$GITHUB_OUTPUT"
+            echo "without-srp-build-name=main-rc-without-srp" >> "$GITHUB_OUTPUT"
+          else
+            echo "with-srp-build-name=main-e2e-bs-with-srp" >> "$GITHUB_OUTPUT"
+            echo "without-srp-build-name=main-e2e-bs-without-srp" >> "$GITHUB_OUTPUT"
+          fi
+
+  resolve-fingerprint-reuse:
+    name: Resolve fingerprint-reusable BrowserStack APKs
+    runs-on: ubuntu-latest
+    needs: [check-builds-needed]
+    if: >-
+      needs.check-builds-needed.outputs.builds-needed == 'true' &&
+      inputs.source_fingerprint
+    outputs:
+      found: ${{ steps.finalize.outputs.found }}
+      run-id: ${{ steps.finalize.outputs.run-id }}
+      source-sha: ${{ steps.finalize.outputs.source-sha }}
+      source-branch: ${{ steps.finalize.outputs.source-branch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github/actions/find-reusable-build
+          sparse-checkout-cone-mode: false
+
+      - name: Find reusable performance APKs on ci.yml
+        id: find-ci
+        uses: ./.github/actions/find-reusable-build
+        with:
+          fingerprint: ${{ inputs.source_fingerprint }}
+          artifact-names: ${{ format('["android-apk-{0}","android-apk-{1}"]', needs.check-builds-needed.outputs.with-srp-build-name, needs.check-builds-needed.outputs.without-srp-build-name) }}
+          github-token: ${{ github.token }}
+          workflow-file: ci.yml
+          main-branch-only: ${{ inputs.main_branch_only }}
+          max-candidates-per-branch: ${{ inputs.main_branch_only && '30' || '10' }}
+
+      - name: Find reusable performance APKs on run-performance-e2e.yml
+        id: find-perf
+        if: ${{ steps.find-ci.outputs.found != 'true' }}
+        uses: ./.github/actions/find-reusable-build
+        with:
+          fingerprint: ${{ inputs.source_fingerprint }}
+          artifact-names: ${{ format('["android-apk-{0}","android-apk-{1}"]', needs.check-builds-needed.outputs.with-srp-build-name, needs.check-builds-needed.outputs.without-srp-build-name) }}
+          github-token: ${{ github.token }}
+          workflow-file: run-performance-e2e.yml
+          main-branch-only: ${{ inputs.main_branch_only }}
+          max-candidates-per-branch: ${{ inputs.main_branch_only && '30' || '10' }}
+
+      - name: Find reusable performance APKs on run-performance-e2e-release.yml
+        id: find-release
+        if: ${{ steps.find-ci.outputs.found != 'true' && steps.find-perf.outputs.found != 'true' }}
+        uses: ./.github/actions/find-reusable-build
+        with:
+          fingerprint: ${{ inputs.source_fingerprint }}
+          artifact-names: ${{ format('["android-apk-{0}","android-apk-{1}"]', needs.check-builds-needed.outputs.with-srp-build-name, needs.check-builds-needed.outputs.without-srp-build-name) }}
+          github-token: ${{ github.token }}
+          workflow-file: run-performance-e2e-release.yml
+          main-branch-only: ${{ inputs.main_branch_only }}
+          max-candidates-per-branch: ${{ inputs.main_branch_only && '30' || '10' }}
+
+      - name: Find reusable performance APKs on run-performance-e2e-experimental.yml
+        id: find-exp
+        if: ${{ steps.find-ci.outputs.found != 'true' && steps.find-perf.outputs.found != 'true' && steps.find-release.outputs.found != 'true' }}
+        uses: ./.github/actions/find-reusable-build
+        with:
+          fingerprint: ${{ inputs.source_fingerprint }}
+          artifact-names: ${{ format('["android-apk-{0}","android-apk-{1}"]', needs.check-builds-needed.outputs.with-srp-build-name, needs.check-builds-needed.outputs.without-srp-build-name) }}
+          github-token: ${{ github.token }}
+          workflow-file: run-performance-e2e-experimental.yml
+          main-branch-only: ${{ inputs.main_branch_only }}
+          max-candidates-per-branch: ${{ inputs.main_branch_only && '30' || '10' }}
+
+      - name: Finalize fingerprint reuse decision
+        id: finalize
+        run: |
+          if [ "${{ steps.find-ci.outputs.found }}" = "true" ]; then
+            {
+              echo "found=true"
+              echo "run-id=${{ steps.find-ci.outputs.run-id }}"
+              echo "source-sha=${{ steps.find-ci.outputs.source-sha }}"
+              echo "source-branch=${{ steps.find-ci.outputs.source-branch }}"
+            } >> "$GITHUB_OUTPUT"
+            echo "Reusing performance APKs from ci.yml run ${{ steps.find-ci.outputs.run-id }}"
+          elif [ "${{ steps.find-perf.outputs.found }}" = "true" ]; then
+            {
+              echo "found=true"
+              echo "run-id=${{ steps.find-perf.outputs.run-id }}"
+              echo "source-sha=${{ steps.find-perf.outputs.source-sha }}"
+              echo "source-branch=${{ steps.find-perf.outputs.source-branch }}"
+            } >> "$GITHUB_OUTPUT"
+            echo "Reusing performance APKs from run-performance-e2e.yml run ${{ steps.find-perf.outputs.run-id }}"
+          elif [ "${{ steps.find-release.outputs.found }}" = "true" ]; then
+            {
+              echo "found=true"
+              echo "run-id=${{ steps.find-release.outputs.run-id }}"
+              echo "source-sha=${{ steps.find-release.outputs.source-sha }}"
+              echo "source-branch=${{ steps.find-release.outputs.source-branch }}"
+            } >> "$GITHUB_OUTPUT"
+            echo "Reusing performance APKs from run-performance-e2e-release.yml run ${{ steps.find-release.outputs.run-id }}"
+          elif [ "${{ steps.find-exp.outputs.found }}" = "true" ]; then
+            {
+              echo "found=true"
+              echo "run-id=${{ steps.find-exp.outputs.run-id }}"
+              echo "source-sha=${{ steps.find-exp.outputs.source-sha }}"
+              echo "source-branch=${{ steps.find-exp.outputs.source-branch }}"
+            } >> "$GITHUB_OUTPUT"
+            echo "Reusing performance APKs from run-performance-e2e-experimental.yml run ${{ steps.find-exp.outputs.run-id }}"
+          else
+            {
+              echo "found=false"
+              echo "run-id="
+              echo "source-sha="
+              echo "source-branch="
+            } >> "$GITHUB_OUTPUT"
+            echo "No fingerprint-matching BrowserStack performance APKs found; will build fresh."
+          fi
+
   build-with-srp:
     name: Build Android with-SRP
-    needs: [check-builds-needed]
-    if: needs.check-builds-needed.outputs.builds-needed == 'true'
+    needs: [check-builds-needed, resolve-fingerprint-reuse]
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.check-builds-needed.outputs.builds-needed == 'true' &&
+      (
+        needs.resolve-fingerprint-reuse.result == 'skipped' ||
+        needs.resolve-fingerprint-reuse.outputs.found != 'true'
+      )
     uses: ./.github/workflows/build.yml
     with:
-      build_name: ${{ inputs.build_variant == 'exp' && 'main-exp-with-srp' || inputs.build_variant == 'rc' && 'main-rc-with-srp' || 'main-e2e-bs-with-srp' }}
+      build_name: ${{ needs.check-builds-needed.outputs.with-srp-build-name }}
       platform: android
       source_branch: ${{ inputs.branch_name || github.ref_name }}
     secrets: inherit
 
   build-without-srp:
     name: Build Android without-SRP
-    needs: [check-builds-needed]
-    if: needs.check-builds-needed.outputs.builds-needed == 'true'
+    needs: [check-builds-needed, resolve-fingerprint-reuse]
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.check-builds-needed.outputs.builds-needed == 'true' &&
+      (
+        needs.resolve-fingerprint-reuse.result == 'skipped' ||
+        needs.resolve-fingerprint-reuse.outputs.found != 'true'
+      )
     uses: ./.github/workflows/build.yml
     with:
-      build_name: ${{ inputs.build_variant == 'exp' && 'main-exp-without-srp' || inputs.build_variant == 'rc' && 'main-rc-without-srp' || 'main-e2e-bs-without-srp' }}
+      build_name: ${{ needs.check-builds-needed.outputs.without-srp-build-name }}
       platform: android
       source_branch: ${{ inputs.branch_name || github.ref_name }}
     secrets: inherit
@@ -98,8 +262,24 @@ jobs:
   upload-to-browserstack:
     name: Upload APKs to BrowserStack
     runs-on: ubuntu-latest
-    needs: [check-builds-needed, build-with-srp, build-without-srp]
-    if: needs.check-builds-needed.outputs.builds-needed == 'true' && needs.build-with-srp.result == 'success' && needs.build-without-srp.result == 'success'
+    needs:
+      [
+        check-builds-needed,
+        resolve-fingerprint-reuse,
+        build-with-srp,
+        build-without-srp,
+      ]
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.check-builds-needed.outputs.builds-needed == 'true' &&
+      (
+        needs.resolve-fingerprint-reuse.outputs.found == 'true' ||
+        (
+          needs.build-with-srp.result == 'success' &&
+          needs.build-without-srp.result == 'success'
+        )
+      )
     outputs:
       with-srp-browserstack-url: ${{ steps.browserstack-upload.outputs.with-srp-browserstack-url }}
       without-srp-browserstack-url: ${{ steps.browserstack-upload.outputs.without-srp-browserstack-url }}
@@ -109,16 +289,38 @@ jobs:
       without-srp-version: ${{ steps.browserstack-upload.outputs.without-srp-version }}
 
     steps:
-      - name: Download with-SRP APK
+      - name: Download reused with-SRP APK
+        if: needs.resolve-fingerprint-reuse.outputs.found == 'true'
         uses: actions/download-artifact@v4
         with:
-          name: android-apk-${{ inputs.build_variant == 'exp' && 'main-exp-with-srp' || inputs.build_variant == 'rc' && 'main-rc-with-srp' || 'main-e2e-bs-with-srp' }}
+          name: android-apk-${{ needs.check-builds-needed.outputs.with-srp-build-name }}
+          path: artifacts/with-srp
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.resolve-fingerprint-reuse.outputs.run-id }}
+
+      - name: Download reused without-SRP APK
+        if: needs.resolve-fingerprint-reuse.outputs.found == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: android-apk-${{ needs.check-builds-needed.outputs.without-srp-build-name }}
+          path: artifacts/without-srp
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.resolve-fingerprint-reuse.outputs.run-id }}
+
+      - name: Download with-SRP APK from current build
+        if: needs.resolve-fingerprint-reuse.outputs.found != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: android-apk-${{ needs.check-builds-needed.outputs.with-srp-build-name }}
           path: artifacts/with-srp
 
-      - name: Download without-SRP APK
+      - name: Download without-SRP APK from current build
+        if: needs.resolve-fingerprint-reuse.outputs.found != 'true'
         uses: actions/download-artifact@v4
         with:
-          name: android-apk-${{ inputs.build_variant == 'exp' && 'main-exp-without-srp' || inputs.build_variant == 'rc' && 'main-rc-without-srp' || 'main-e2e-bs-without-srp' }}
+          name: android-apk-${{ needs.check-builds-needed.outputs.without-srp-build-name }}
           path: artifacts/without-srp
 
       - name: Upload APKs to BrowserStack
@@ -126,6 +328,10 @@ jobs:
         env:
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          FINGERPRINT_REUSED: ${{ needs.resolve-fingerprint-reuse.outputs.found }}
+          REUSED_SOURCE_SHA: ${{ needs.resolve-fingerprint-reuse.outputs.source-sha }}
+          FRESH_WITH_SRP_VERSION: ${{ needs.build-with-srp.outputs.semantic_version }}
+          FRESH_WITHOUT_SRP_VERSION: ${{ needs.build-without-srp.outputs.semantic_version }}
         run: |
           set +e  # Don't exit on error — attempt both uploads independently
           echo "Uploading APKs to BrowserStack..."
@@ -140,6 +346,16 @@ jobs:
           echo "BrowserStack custom_id branch slug: $BRANCH_SLUG"
           echo "With-SRP custom_id: $WITH_SRP_CUSTOM_ID"
           echo "Without-SRP custom_id: $WITHOUT_SRP_CUSTOM_ID"
+
+          if [ "$FINGERPRINT_REUSED" = "true" ]; then
+            WITH_SRP_VERSION="fingerprint-reuse-${REUSED_SOURCE_SHA:0:7}"
+            WITHOUT_SRP_VERSION="fingerprint-reuse-${REUSED_SOURCE_SHA:0:7}"
+            echo "APK source: fingerprint reuse (sha=${REUSED_SOURCE_SHA})"
+          else
+            WITH_SRP_VERSION="${FRESH_WITH_SRP_VERSION}"
+            WITHOUT_SRP_VERSION="${FRESH_WITHOUT_SRP_VERSION}"
+            echo "APK source: fresh dual build"
+          fi
 
           # Initialize outputs
           {
@@ -176,7 +392,7 @@ jobs:
               {
                 echo "with-srp-browserstack-url=$WITH_SRP_APP_URL"
                 echo "with-srp-app-id=$WITH_SRP_APP_ID"
-                echo "with-srp-version=${{ needs.build-with-srp.outputs.semantic_version }}"
+                echo "with-srp-version=$WITH_SRP_VERSION"
                 echo "with-srp-apk-uploaded=true"
               } >> "$GITHUB_OUTPUT"
             else
@@ -209,7 +425,7 @@ jobs:
               {
                 echo "without-srp-browserstack-url=$WITHOUT_SRP_APP_URL"
                 echo "without-srp-app-id=$WITHOUT_SRP_APP_ID"
-                echo "without-srp-version=${{ needs.build-without-srp.outputs.semantic_version }}"
+                echo "without-srp-version=$WITHOUT_SRP_VERSION"
                 echo "without-srp-apk-uploaded=true"
               } >> "$GITHUB_OUTPUT"
             else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1233,7 +1233,7 @@ jobs:
           )
         )
       }}
-    needs: [get_requirements, smart-e2e-selection]
+    needs: [get_requirements, smart-e2e-selection, native-build-fingerprint]
     uses: ./.github/workflows/run-performance-e2e.yml
     with:
       performance_tags: ${{ needs.get_requirements.outputs.run_performance != 'true' && needs.smart-e2e-selection.outputs.ai_performance_test_tags || '' }}
@@ -1242,12 +1242,14 @@ jobs:
       branch_name: ${{ github.head_ref }}
       pr_number: ${{ github.event.pull_request.number }}
       reuse_main_builds: ${{ needs.get_requirements.outputs.native_build_needed == 'false' }}
+      source_fingerprint: ${{ needs.native-build-fingerprint.outputs.fingerprint }}
     secrets: inherit
     permissions:
       contents: write
       id-token: write
       actions: write
       pull-requests: write
+      statuses: write
 
   build-android-apks:
     name: 'Build Android APKs'

--- a/.github/workflows/run-performance-e2e-experimental.yml
+++ b/.github/workflows/run-performance-e2e-experimental.yml
@@ -24,6 +24,8 @@ permissions:
   contents: write
   id-token: write
   actions: write
+  pull-requests: write
+  statuses: write
 
 concurrency:
   group: performance-e2e-experimental-${{ github.ref }}-${{ github.event_name }}

--- a/.github/workflows/run-performance-e2e-release.yml
+++ b/.github/workflows/run-performance-e2e-release.yml
@@ -22,6 +22,8 @@ permissions:
   contents: write
   id-token: write
   actions: write
+  pull-requests: write
+  statuses: write
 
 jobs:
   check-release-trigger:

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -53,6 +53,14 @@ on:
         required: false
         type: boolean
         default: false
+      source_fingerprint:
+        description: >-
+          Optional @expo/fingerprint hash. When omitted, the workflow computes and
+          posts build-source-hash so Android BrowserStack dual builds can be reused
+          across runs with matching native sources.
+        required: false
+        type: string
+        default: ''
   workflow_call:
     inputs:
       description:
@@ -112,12 +120,21 @@ on:
         required: false
         type: boolean
         default: false
+      source_fingerprint:
+        description: >-
+          @expo/fingerprint hash from the caller (ci.yml native-build-fingerprint).
+          When empty, this workflow computes and posts build-source-hash for
+          Android BrowserStack APK reuse.
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: write
   id-token: write
   actions: write
   pull-requests: write
+  statuses: write
 
 concurrency:
   # Include build_variant so e2e, experimental (exp), and release/direct (rc) don't share the same
@@ -172,6 +189,66 @@ jobs:
 
           echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
           echo "Branch: $BRANCH_NAME"
+
+  ensure-fingerprint:
+    name: Ensure native build fingerprint
+    runs-on: ubuntu-latest
+    outputs:
+      fingerprint: ${{ steps.resolve.outputs.fingerprint }}
+    steps:
+      - name: Use caller-provided fingerprint
+        id: provided
+        if: ${{ inputs.source_fingerprint }}
+        env:
+          SOURCE_FINGERPRINT: ${{ inputs.source_fingerprint }}
+        run: |
+          echo "fingerprint=$SOURCE_FINGERPRINT" >> "$GITHUB_OUTPUT"
+          echo "Using caller-provided fingerprint: $SOURCE_FINGERPRINT"
+
+      - name: Checkout
+        if: ${{ !inputs.source_fingerprint }}
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        if: ${{ !inputs.source_fingerprint }}
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install Yarn dependencies with retry
+        if: ${{ !inputs.source_fingerprint }}
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: yarn install --immutable
+
+      - name: Compute and post build-source-hash
+        id: computed
+        if: ${{ !inputs.source_fingerprint }}
+        uses: ./.github/actions/post-build-source-hash
+        with:
+          github-token: ${{ github.token }}
+          post-status: 'true'
+          target-sha: ${{ github.sha }}
+
+      - name: Resolve fingerprint output
+        id: resolve
+        env:
+          PROVIDED: ${{ steps.provided.outputs.fingerprint }}
+          COMPUTED: ${{ steps.computed.outputs.fingerprint }}
+        run: |
+          if [ -n "$PROVIDED" ]; then
+            echo "fingerprint=$PROVIDED" >> "$GITHUB_OUTPUT"
+          elif [ -n "$COMPUTED" ]; then
+            echo "fingerprint=$COMPUTED" >> "$GITHUB_OUTPUT"
+          else
+            echo "❌ No fingerprint available" >&2
+            exit 1
+          fi
+          echo "Resolved fingerprint: $(grep fingerprint= "$GITHUB_OUTPUT" | tail -1)"
 
   read-device-matrix:
     name: Read Device Matrix
@@ -319,12 +396,13 @@ jobs:
   trigger-android-dual-versions:
     name: Trigger Android Dual Versions and Extract BrowserStack URLs
     uses: ./.github/workflows/build-android-upload-to-browserstack.yml
-    needs: [determine-branch-name, resolve-main-browserstack-urls]
+    needs: [determine-branch-name, resolve-main-browserstack-urls, ensure-fingerprint]
     # Build/upload when not reusing main, or when main reuse lookup found nothing.
     if: >-
       always() &&
       !cancelled() &&
       (needs.resolve-main-browserstack-urls.result == 'skipped' || needs.resolve-main-browserstack-urls.result == 'success') &&
+      needs.ensure-fingerprint.result == 'success' &&
       (!inputs.browserstack_app_url_android_onboarding && !inputs.browserstack_app_url_android_imported_wallet) &&
       (
         !inputs.reuse_main_builds ||
@@ -333,6 +411,8 @@ jobs:
     with:
       branch_name: ${{ needs.determine-branch-name.outputs.branch_name }}
       build_variant: ${{ inputs.build_variant || 'e2e' }}
+      source_fingerprint: ${{ needs.ensure-fingerprint.outputs.fingerprint }}
+      main_branch_only: ${{ inputs.reuse_main_builds }}
     secrets: inherit
 
   trigger-ios-dual-versions:

--- a/scripts/repack.js
+++ b/scripts/repack.js
@@ -64,19 +64,33 @@ function getKeystoreConfig() {
 
 /**
  * Repack Android APK
- * Currently supports 'flask' and 'main' build types
+ * Currently supports 'flask' and 'main' build types.
+ *
+ * Optional path overrides (used by performance BrowserStack fingerprint reuse):
+ *   REPACK_SOURCE_APK, REPACK_OUTPUT_APK, REPACK_WORKING_DIR, REPACK_SOURCEMAP_PATH
  */
 async function repackAndroid() {
   const startTime = Date.now();
-  const sourceApk = 'android/app/build/outputs/apk/prod/release/app-prod-release.apk';
-  const repackedApk = 'android/app/build/outputs/apk/prod/release/app-prod-release-repack.apk';
-  const finalApk = 'android/app/build/outputs/apk/prod/release/app-prod-release.apk';
-  const sourcemapPath = 'sourcemaps/android/index.android.bundle.map';
-  const workingDir = 'android/app/build/repack-working-main';
+  const sourceApk =
+    process.env.REPACK_SOURCE_APK ||
+    'android/app/build/outputs/apk/prod/release/app-prod-release.apk';
+  const repackedApk =
+    process.env.REPACK_OUTPUT_APK ||
+    'android/app/build/outputs/apk/prod/release/app-prod-release-repack.apk';
+  const finalApk =
+    process.env.REPACK_FINAL_APK ||
+    'android/app/build/outputs/apk/prod/release/app-prod-release.apk';
+  const sourcemapPath =
+    process.env.REPACK_SOURCEMAP_PATH ||
+    'sourcemaps/android/index.android.bundle.map';
+  const workingDir =
+    process.env.REPACK_WORKING_DIR || 'android/app/build/repack-working-main';
 
   try {
     logger.info('🚀 Starting Android E2E APK repack process...');
     logger.info(`Source APK: ${sourceApk}`);
+    logger.info(`Output APK: ${finalApk}`);
+    logger.info(`Working dir: ${workingDir}`);
 
     // Verify source APK exists
     if (!fs.existsSync(sourceApk)) {

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -587,10 +587,13 @@ E2E_PERFORMANCE_BUILD_VARIANT=rc
 # (GitHub environment build-e2e). E2E_PERFORMANCE_BUILD_VARIANT=rc is set separately
 # in performance-test-runner for the flags API. Release workflows use build_variant=rc.
 #
-# Android BrowserStack dual builds (main-e2e-bs-*) can be reused across CI runs that share
-# the same @expo/fingerprint (native-build-fingerprint / build-source-hash), via
-# find-reusable-build in build-android-upload-to-browserstack.yml. This is separate from
-# Appium smoke main-e2e APKs and from reuse_main_builds (BrowserStack custom_id on main).
+# Android BrowserStack dual builds (main-e2e-bs-*) can be reused as-is across
+# test-only CI runs that share the same @expo/fingerprint (native-build-fingerprint /
+# build-source-hash), via find-reusable-build in build-android-upload-to-browserstack.yml
+# when main_branch_only/reuse_main_builds is set. This mirrors E2E's no-repack path:
+# fingerprint ignores JS-only changes, and performance does not yet repack the bundle,
+# so non-test-only runs always compile fresh dual builds. Separate from Appium smoke
+# main-e2e APKs and from reuse_main_builds BrowserStack custom_id resolution on main.
 ```
 
 ### Sentry Performance Instrumentation (Optional)

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -587,13 +587,15 @@ E2E_PERFORMANCE_BUILD_VARIANT=rc
 # (GitHub environment build-e2e). E2E_PERFORMANCE_BUILD_VARIANT=rc is set separately
 # in performance-test-runner for the flags API. Release workflows use build_variant=rc.
 #
-# Android BrowserStack dual builds (main-e2e-bs-*) can be reused as-is across
-# test-only CI runs that share the same @expo/fingerprint (native-build-fingerprint /
-# build-source-hash), via find-reusable-build in build-android-upload-to-browserstack.yml
-# when main_branch_only/reuse_main_builds is set. This mirrors E2E's no-repack path:
-# fingerprint ignores JS-only changes, and performance does not yet repack the bundle,
-# so non-test-only runs always compile fresh dual builds. Separate from Appium smoke
-# main-e2e APKs and from reuse_main_builds BrowserStack custom_id resolution on main.
+# Android BrowserStack dual builds (main-e2e-bs-*) follow the same fingerprint
+# procedure as Detox E2E (build-android-e2e.yml), via find-reusable-build in
+# build-android-upload-to-browserstack.yml:
+#   - miss → fresh dual Gradle builds
+#   - hit + test-only (main_branch_only/reuse_main_builds) → re-upload APKs as-is
+#   - hit + app changes → skip Gradle, @expo/repack-app both profiles with current JS,
+#     then upload (fingerprint ignores JS-only changes, so repack avoids stale JS)
+# Separate from Appium smoke main-e2e APKs and from reuse_main_builds BrowserStack
+# custom_id resolution on main (test-only fast path that skips the dual-build job).
 ```
 
 ### Sentry Performance Instrumentation (Optional)

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -586,6 +586,11 @@ E2E_PERFORMANCE_BUILD_VARIANT=rc
 # CI note: scheduled/feature-branch performance workflows use build_variant=e2e
 # (GitHub environment build-e2e). E2E_PERFORMANCE_BUILD_VARIANT=rc is set separately
 # in performance-test-runner for the flags API. Release workflows use build_variant=rc.
+#
+# Android BrowserStack dual builds (main-e2e-bs-*) can be reused across CI runs that share
+# the same @expo/fingerprint (native-build-fingerprint / build-source-hash), via
+# find-reusable-build in build-android-upload-to-browserstack.yml. This is separate from
+# Appium smoke main-e2e APKs and from reuse_main_builds (BrowserStack custom_id on main).
 ```
 
 ### Sentry Performance Instrumentation (Optional)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

Performance Android BrowserStack dual builds (`main-e2e-bs-with-srp` / `main-e2e-bs-without-srp`) previously always compiled fresh on app-change PRs, even when native sources matched a prior run's `@expo/fingerprint`.

This aligns the performance dual-upload path with Detox E2E (`build-android-e2e.yml`):

1. Look up prior `android-apk-main-e2e-bs-*` artifacts by fingerprint (`find-reusable-build` across `ci.yml` / `run-performance-e2e*.yml`).
2. **Miss** → fresh dual Gradle builds (unchanged).
3. **Hit + test-only** (`main_branch_only` / `reuse_main_builds`) → re-upload APKs as-is (app JS unchanged; same as E2E's no-repack path).
4. **Hit + app changes** → skip Gradle, `@expo/repack-app` both profiles with current JS (env from `builds.yml`, including `IS_PERFORMANCE_TEST` / SRP bake-ins), then upload to BrowserStack.

`scripts/repack.js` gains optional path overrides (`REPACK_SOURCE_APK`, etc.) so both profiles can be repacked without colliding.

Does **not** reuse Appium smoke `main-e2e` APKs (different ABI/flags/profile). Test-only PRs still prefer BrowserStack `custom_id` reuse on main when available; fingerprint is the fallback / app-change savings path.

Companion / supersedes the earlier draft on `MMQA-2147-use-fingerprint-performance-builds` ([#34049](https://github.com/MetaMask/metamask-mobile/pull/34049)) with the full E2E-parity repack path.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MMQA-2147](https://consensyssoftware.atlassian.net/browse/MMQA-2147)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Android performance BrowserStack fingerprint reuse + repack

  Scenario: test-only fingerprint hit reuses BS APKs as-is
    Given a PR with only test file changes (reuse_main_builds / main_branch_only true)
    And BrowserStack custom_id reuse did not resolve apps
    And a prior run uploaded android-apk-main-e2e-bs-with-srp and android-apk-main-e2e-bs-without-srp for the same fingerprint
    When the Build Android Dual Versions workflow runs
    Then resolve-fingerprint-reuse reports found=true
    And build-with-srp and build-without-srp are skipped
    And Upload APKs to BrowserStack re-uploads the reused APKs without repack

  Scenario: app-change fingerprint hit skips Gradle and repacks JS
    Given a PR that changes app JS with the same native fingerprint as a prior BS dual build
    And reuse_main_builds is false
    When the Build Android Dual Versions workflow runs
    Then resolve-fingerprint-reuse reports found=true
    And build-with-srp and build-without-srp are skipped
    And Upload APKs to BrowserStack runs on Cirrus, repacks both profiles, then uploads
    And upload summary shows fingerprint-reuse-repack-<sha>

  Scenario: fingerprint miss still builds fresh
    Given no prior matching android-apk-main-e2e-bs-* artifacts for this fingerprint
    When the Build Android Dual Versions workflow runs
    Then both with-SRP and without-SRP Android builds run fresh
    And APKs are uploaded to BrowserStack as before

  Scenario: test-only PR still prefers BrowserStack custom_id reuse
    Given a PR with only test file changes and main BrowserStack apps resolve
    When run-performance-e2e runs
    Then trigger-android-dual-versions is skipped
    And tests use the resolved main BrowserStack app URLs
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — CI workflow-only change; no app UI. Verification evidence is GitHub Actions job logs for `resolve-fingerprint-reuse` / skipped build jobs / repack step / BrowserStack upload summary.

### **Before**

N/A — app-change performance runs always compiled both Android BS variants from scratch.

### **After**

N/A — on fingerprint hit with app JS changes, dual Gradle jobs are skipped and both APKs are repacked then re-uploaded (confirm in Actions logs). Test-only hits still upload as-is.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83c6732f-f2f5-4168-92f3-c43d2033a60d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83c6732f-f2f5-4168-92f3-c43d2033a60d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[MMQA-2147]: https://consensyssoftware.atlassian.net/browse/MMQA-2147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ