### PR TITLE
feat(rewards): align MAS stats with the net-new-deposits qualification rule

### DIFF
--- a/app/components/UI/Rewards/Views/MoneyAccountSweepstakesCampaignDetailsView.test.tsx
+++ b/app/components/UI/Rewards/Views/MoneyAccountSweepstakesCampaignDetailsView.test.tsx
@@ -238,18 +238,18 @@ const mockUseGetMoneyAccountSweepstakesStatsMe =
   >;
 
 const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
-  currentBalanceTitle: 'Current balance',
-  currentBalanceDescription: 'Current balance description',
-  eligibleBalanceTitle: 'Eligible balance',
-  eligibleBalanceDescription: 'Eligible balance description',
+  eligibleBalanceTitle: 'Qualifying deposits',
+  eligibleBalanceDescription:
+    "Net new deposits in your Money Account since you joined. Reach $100 and don't drop below it before midnight UTC to earn today's entry. Balance from before joining doesn't count.",
   entriesTitle: 'Entries',
-  entriesDescription: 'Entries description',
+  entriesDescription:
+    'One entry for each UTC day your qualifying deposits stayed at $100 or above. Max 7 per week.',
   entriesCountValue: '{count} / 7',
   drawScheduleTitle: 'Draw schedule',
   addFundsTitle: 'Add funds',
-  addFundsNoBalanceTitle: "You don't have any balance yet",
+  addFundsNoBalanceTitle: 'No balance to deposit into Money Account',
   addFundsNoBalanceDescription:
-    'Deposit crypto or mUSD in your wallet before moving them to Money Account',
+    'Deposit crypto or mUSD in your wallet before transferring them to Money Account.',
   weekTitle: 'Week {number}',
   completeLabel: 'Complete',
   activeLabel: 'Active',
@@ -261,7 +261,7 @@ const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
   formulaLabel: 'Formula',
   drawFormulaLabel: 'Weighted raffle (Efraimidis–Spirakis)',
   drawFormulaDescription:
-    'Each day you held at least $100 in your Money Account earned you an entry.',
+    "Each day your qualifying deposits stayed at $100 or above earned an entry (counted from the day you joined). After the week ended, we locked everyone's entries and published a commitment (the Merkle root) before the random seed existed. The seed is a future block hash nobody can predict. We then run a weighted raffle: more entries improve your odds but don't guarantee a win. Anyone can re-check the commitment, seed, and formula to verify the ranking.",
   seedBlockLabel: 'Seed block number',
   seedBlockHashLabel: 'Seed block hash',
   drawProofEntriesLabel: 'Entries',
@@ -276,7 +276,9 @@ const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
     'Money Account already binds to another Rewards profile.',
   onTrackDescription: "You are on track to earn today's entry.",
   notYetQualifiedDescription:
-    "Maintain a balance of $100 or more in your Money Account to earn tomorrow's entry.",
+    "Deposit the shortfall to reach $100 and hold through midnight UTC for today's entry.",
+  lostTodayDescription:
+    "Today's entry is forfeit after dipping below $100. Get back to $100+ to earn again tomorrow.",
 };
 
 const details: MoneyAccountSweepstakesCampaignDetails = {

--- a/app/components/UI/Rewards/Views/MoneyAccountSweepstakesCampaignDetailsView.test.tsx
+++ b/app/components/UI/Rewards/Views/MoneyAccountSweepstakesCampaignDetailsView.test.tsx
@@ -275,7 +275,7 @@ const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
   bindingConflictDescription:
     'Money Account already binds to another Rewards profile.',
   onTrackDescription: "You are on track to earn today's entry.",
-  belowThresholdDescription:
+  notYetQualifiedDescription:
     "Maintain a balance of $100 or more in your Money Account to earn tomorrow's entry.",
 };
 
@@ -305,7 +305,8 @@ const statsWithBalance: MoneyAccountSweepstakesStatsMeDto = {
   entryCount: 2,
   currentBalanceUsd: 250,
   yieldEarnedUsd: 1.5,
-  todayMinUsd: 100,
+  qualifyingDepositsUsd: 100,
+  qualifyingThresholdUsd: 100,
   todayStatus: 'on_track',
   daysRemaining: 5,
 };

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignCTA.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignCTA.test.tsx
@@ -164,7 +164,7 @@ const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
   bindingConflictDescription:
     'Money Account already binds to another Rewards profile.',
   onTrackDescription: "You are on track to earn today's entry.",
-  belowThresholdDescription:
+  notYetQualifiedDescription:
     "Maintain a balance of $100 or more in your Money Account to earn tomorrow's entry.",
 };
 

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignCTA.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignCTA.test.tsx
@@ -127,18 +127,18 @@ jest.mock('../../../../../../../locales/i18n', () => ({
 }));
 
 const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
-  currentBalanceTitle: 'Current balance',
-  currentBalanceDescription: 'Current balance description',
-  eligibleBalanceTitle: 'Eligible balance',
-  eligibleBalanceDescription: 'Eligible balance description',
+  eligibleBalanceTitle: 'Qualifying deposits',
+  eligibleBalanceDescription:
+    "Net new deposits in your Money Account since you joined. Reach $100 and don't drop below it before midnight UTC to earn today's entry. Balance from before joining doesn't count.",
   entriesTitle: 'Entries',
-  entriesDescription: 'Entries description',
+  entriesDescription:
+    'One entry for each UTC day your qualifying deposits stayed at $100 or above. Max 7 per week.',
   entriesCountValue: '{count} / 7',
   drawScheduleTitle: 'Draw schedule',
   addFundsTitle: 'Add funds',
-  addFundsNoBalanceTitle: "You don't have any balance yet",
+  addFundsNoBalanceTitle: 'No balance to deposit into Money Account',
   addFundsNoBalanceDescription:
-    'Deposit crypto or mUSD in your wallet before moving them to Money Account',
+    'Deposit crypto or mUSD in your wallet before transferring them to Money Account.',
   weekTitle: 'Week {number}',
   completeLabel: 'Complete',
   activeLabel: 'Active',
@@ -150,7 +150,7 @@ const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
   formulaLabel: 'Formula',
   drawFormulaLabel: 'Weighted raffle (Efraimidis–Spirakis)',
   drawFormulaDescription:
-    'Each day you held at least $100 in your Money Account earned you an entry.',
+    "Each day your qualifying deposits stayed at $100 or above earned an entry (counted from the day you joined). After the week ended, we locked everyone's entries and published a commitment (the Merkle root) before the random seed existed. The seed is a future block hash nobody can predict. We then run a weighted raffle: more entries improve your odds but don't guarantee a win. Anyone can re-check the commitment, seed, and formula to verify the ranking.",
   seedBlockLabel: 'Seed block number',
   seedBlockHashLabel: 'Seed block hash',
   drawProofEntriesLabel: 'Entries',
@@ -165,7 +165,9 @@ const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
     'Money Account already binds to another Rewards profile.',
   onTrackDescription: "You are on track to earn today's entry.",
   notYetQualifiedDescription:
-    "Maintain a balance of $100 or more in your Money Account to earn tomorrow's entry.",
+    "Deposit the shortfall to reach $100 and hold through midnight UTC for today's entry.",
+  lostTodayDescription:
+    "Today's entry is forfeit after dipping below $100. Get back to $100+ to earn again tomorrow.",
 };
 
 function buildCampaign(overrides: Partial<CampaignDto> = {}): CampaignDto {
@@ -282,8 +284,8 @@ describe('MoneyAccountSweepstakesCampaignCTA', () => {
     });
 
     expect(mockEntriesClosed).toHaveBeenCalledWith(
-      "You don't have any balance yet",
-      'Deposit crypto or mUSD in your wallet before moving them to Money Account',
+      'No balance to deposit into Money Account',
+      'Deposit crypto or mUSD in your wallet before transferring them to Money Account.',
     );
     expect(mockShowToast).toHaveBeenCalledTimes(1);
   });

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesDrawProofModal.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesDrawProofModal.test.tsx
@@ -95,18 +95,18 @@ jest.mock('../../../../../../../locales/i18n', () => ({
 const TEST_IDS = MONEY_ACCOUNT_SWEEPSTAKES_DRAW_PROOF_MODAL_TEST_IDS;
 
 const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
-  currentBalanceTitle: 'Current balance',
-  currentBalanceDescription: 'Current balance description',
-  eligibleBalanceTitle: 'Eligible balance',
-  eligibleBalanceDescription: 'Eligible balance description',
+  eligibleBalanceTitle: 'Qualifying deposits',
+  eligibleBalanceDescription:
+    "Net new deposits in your Money Account since you joined. Reach $100 and don't drop below it before midnight UTC to earn today's entry. Balance from before joining doesn't count.",
   entriesTitle: 'Entries',
-  entriesDescription: 'Entries description',
+  entriesDescription:
+    'One entry for each UTC day your qualifying deposits stayed at $100 or above. Max 7 per week.',
   entriesCountValue: '{count} / 7',
   drawScheduleTitle: 'Draw schedule',
   addFundsTitle: 'Add funds',
-  addFundsNoBalanceTitle: "You don't have any balance yet",
+  addFundsNoBalanceTitle: 'No balance to deposit into Money Account',
   addFundsNoBalanceDescription:
-    'Deposit crypto or mUSD in your wallet before moving them to Money Account',
+    'Deposit crypto or mUSD in your wallet before transferring them to Money Account.',
   weekTitle: 'Week {number}',
   completeLabel: 'Complete',
   activeLabel: 'Active',
@@ -118,7 +118,7 @@ const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
   formulaLabel: 'Formula',
   drawFormulaLabel: 'Weighted raffle (Efraimidis–Spirakis)',
   drawFormulaDescription:
-    'Each day you held at least $100 earned you an entry.',
+    "Each day your qualifying deposits stayed at $100 or above earned an entry (counted from the day you joined). After the week ended, we locked everyone's entries and published a commitment (the Merkle root) before the random seed existed. The seed is a future block hash nobody can predict. We then run a weighted raffle: more entries improve your odds but don't guarantee a win. Anyone can re-check the commitment, seed, and formula to verify the ranking.",
   seedBlockLabel: 'Seed block number',
   seedBlockHashLabel: 'Seed block hash',
   drawProofEntriesLabel: 'Entries',
@@ -133,7 +133,9 @@ const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
     'Money Account already binds to another Rewards profile.',
   onTrackDescription: "You are on track to earn today's entry.",
   notYetQualifiedDescription:
-    "Maintain a balance of $100 or more in your Money Account to earn tomorrow's entry.",
+    "Deposit the shortfall to reach $100 and hold through midnight UTC for today's entry.",
+  lostTodayDescription:
+    "Today's entry is forfeit after dipping below $100. Get back to $100+ to earn again tomorrow.",
 };
 
 const MERKLE_ROOT =
@@ -265,7 +267,7 @@ describe('MoneyAccountSweepstakesDrawProofModal', () => {
     fireEvent.press(getByTestId(TEST_IDS.FORMULA_TOGGLE));
 
     expect(getByTestId(TEST_IDS.FORMULA_DESCRIPTION)).toHaveTextContent(
-      'Each day you held at least $100 earned you an entry.',
+      "Each day your qualifying deposits stayed at $100 or above earned an entry (counted from the day you joined). After the week ended, we locked everyone's entries and published a commitment (the Merkle root) before the random seed existed. The seed is a future block hash nobody can predict. We then run a weighted raffle: more entries improve your odds but don't guarantee a win. Anyone can re-check the commitment, seed, and formula to verify the ranking.",
     );
 
     fireEvent.press(getByTestId(TEST_IDS.FORMULA_TOGGLE));

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesDrawProofModal.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesDrawProofModal.test.tsx
@@ -132,7 +132,7 @@ const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
   bindingConflictDescription:
     'Money Account already binds to another Rewards profile.',
   onTrackDescription: "You are on track to earn today's entry.",
-  belowThresholdDescription:
+  notYetQualifiedDescription:
     "Maintain a balance of $100 or more in your Money Account to earn tomorrow's entry.",
 };
 

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesDrawScheduleSection.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesDrawScheduleSection.test.tsx
@@ -123,7 +123,7 @@ const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
   bindingConflictDescription:
     'Money Account already binds to another Rewards profile.',
   onTrackDescription: "You are on track to earn today's entry.",
-  belowThresholdDescription:
+  notYetQualifiedDescription:
     "Maintain a balance of $100 or more in your Money Account to earn tomorrow's entry.",
 };
 

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesDrawScheduleSection.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesDrawScheduleSection.test.tsx
@@ -86,18 +86,18 @@ jest.mock('../CampaignTile.utils', () => {
 });
 
 const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
-  currentBalanceTitle: 'Current balance',
-  currentBalanceDescription: 'Current balance description',
-  eligibleBalanceTitle: 'Eligible balance',
-  eligibleBalanceDescription: 'Eligible balance description',
+  eligibleBalanceTitle: 'Qualifying deposits',
+  eligibleBalanceDescription:
+    "Net new deposits in your Money Account since you joined. Reach $100 and don't drop below it before midnight UTC to earn today's entry. Balance from before joining doesn't count.",
   entriesTitle: 'Entries',
-  entriesDescription: 'Entries description',
+  entriesDescription:
+    'One entry for each UTC day your qualifying deposits stayed at $100 or above. Max 7 per week.',
   entriesCountValue: '{count} / 7',
   drawScheduleTitle: 'Draw schedule',
   addFundsTitle: 'Add funds',
-  addFundsNoBalanceTitle: "You don't have any balance yet",
+  addFundsNoBalanceTitle: 'No balance to deposit into Money Account',
   addFundsNoBalanceDescription:
-    'Deposit crypto or mUSD in your wallet before moving them to Money Account',
+    'Deposit crypto or mUSD in your wallet before transferring them to Money Account.',
   weekTitle: 'Week {number}',
   completeLabel: 'Complete',
   activeLabel: 'Active',
@@ -109,7 +109,7 @@ const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
   formulaLabel: 'Formula',
   drawFormulaLabel: 'Weighted raffle (Efraimidis–Spirakis)',
   drawFormulaDescription:
-    'Each day you held at least $100 in your Money Account earned you an entry.',
+    "Each day your qualifying deposits stayed at $100 or above earned an entry (counted from the day you joined). After the week ended, we locked everyone's entries and published a commitment (the Merkle root) before the random seed existed. The seed is a future block hash nobody can predict. We then run a weighted raffle: more entries improve your odds but don't guarantee a win. Anyone can re-check the commitment, seed, and formula to verify the ranking.",
   seedBlockLabel: 'Seed block number',
   seedBlockHashLabel: 'Seed block hash',
   drawProofEntriesLabel: 'Entries',
@@ -124,7 +124,9 @@ const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
     'Money Account already binds to another Rewards profile.',
   onTrackDescription: "You are on track to earn today's entry.",
   notYetQualifiedDescription:
-    "Maintain a balance of $100 or more in your Money Account to earn tomorrow's entry.",
+    "Deposit the shortfall to reach $100 and hold through midnight UTC for today's entry.",
+  lostTodayDescription:
+    "Today's entry is forfeit after dipping below $100. Get back to $100+ to earn again tomorrow.",
 };
 
 const drawProof: MoneyAccountSweepstakesDrawProofDto = {

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesStatsSummary.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesStatsSummary.test.tsx
@@ -59,18 +59,18 @@ jest.mock('../../../utils/formatUtils', () => ({
 const TEST_IDS = MONEY_ACCOUNT_SWEEPSTAKES_STATS_SUMMARY_TEST_IDS;
 
 const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
-  currentBalanceTitle: 'Current balance',
-  currentBalanceDescription: 'Current balance description',
-  eligibleBalanceTitle: 'Eligible balance',
-  eligibleBalanceDescription: 'Eligible balance description',
+  eligibleBalanceTitle: 'Qualifying deposits',
+  eligibleBalanceDescription:
+    "Net new deposits in your Money Account since you joined. Reach $100 and don't drop below it before midnight UTC to earn today's entry. Balance from before joining doesn't count.",
   entriesTitle: 'Entries',
-  entriesDescription: 'Entries description',
+  entriesDescription:
+    'One entry for each UTC day your qualifying deposits stayed at $100 or above. Max 7 per week.',
   entriesCountValue: '{count} / 7',
   drawScheduleTitle: 'Draw schedule',
   addFundsTitle: 'Add funds',
-  addFundsNoBalanceTitle: "You don't have any balance yet",
+  addFundsNoBalanceTitle: 'No balance to deposit into Money Account',
   addFundsNoBalanceDescription:
-    'Deposit crypto or mUSD in your wallet before moving them to Money Account',
+    'Deposit crypto or mUSD in your wallet before transferring them to Money Account.',
   weekTitle: 'Week {number}',
   completeLabel: 'Complete',
   activeLabel: 'Active',
@@ -82,7 +82,7 @@ const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
   formulaLabel: 'Formula',
   drawFormulaLabel: 'Weighted raffle (Efraimidis–Spirakis)',
   drawFormulaDescription:
-    'Each day you held at least $100 in your Money Account earned you an entry.',
+    "Each day your qualifying deposits stayed at $100 or above earned an entry (counted from the day you joined). After the week ended, we locked everyone's entries and published a commitment (the Merkle root) before the random seed existed. The seed is a future block hash nobody can predict. We then run a weighted raffle: more entries improve your odds but don't guarantee a win. Anyone can re-check the commitment, seed, and formula to verify the ranking.",
   seedBlockLabel: 'Seed block number',
   seedBlockHashLabel: 'Seed block hash',
   drawProofEntriesLabel: 'Entries',
@@ -97,7 +97,9 @@ const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
     'Money Account already binds to another Rewards profile.',
   onTrackDescription: "You are on track to earn today's entry.",
   notYetQualifiedDescription:
-    "Maintain a balance of $100 or more in your Money Account to earn tomorrow's entry.",
+    "Deposit the shortfall to reach $100 and hold through midnight UTC for today's entry.",
+  lostTodayDescription:
+    "Today's entry is forfeit after dipping below $100. Get back to $100+ to earn again tomorrow.",
 };
 
 const stats: MoneyAccountSweepstakesStatsMeDto = {
@@ -125,7 +127,7 @@ describe('MoneyAccountSweepstakesStatsSummary', () => {
     );
 
     expect(getByTestId(TEST_IDS.CONTAINER)).toBeOnTheScreen();
-    expect(getByText('Eligible balance')).toBeOnTheScreen();
+    expect(getByText('Qualifying deposits')).toBeOnTheScreen();
     expect(getByText('Entries')).toBeOnTheScreen();
     // Shown against the threshold, not alone: the qualifying figure is net new
     // deposits and is normally lower than the account balance, so a bare number
@@ -145,10 +147,10 @@ describe('MoneyAccountSweepstakesStatsSummary', () => {
       />,
     );
 
-    const labels = getAllByText(/^(Eligible balance|Entries)$/);
+    const labels = getAllByText(/^(Qualifying deposits|Entries)$/);
 
     expect(labels.map(({ props }) => props.children)).toEqual([
-      'Eligible balance',
+      'Qualifying deposits',
       'Entries',
     ]);
   });
@@ -257,7 +259,8 @@ describe('MoneyAccountSweepstakesStatsSummary', () => {
       Routes.MODAL.REWARDS_INFO_SHEET_MODAL,
       {
         title: 'Entries',
-        description: 'Entries description',
+        description:
+          'One entry for each UTC day your qualifying deposits stayed at $100 or above. Max 7 per week.',
       },
     );
   });
@@ -276,9 +279,9 @@ describe('MoneyAccountSweepstakesStatsSummary', () => {
     expect(mockNavigate).toHaveBeenCalledWith(
       Routes.MODAL.REWARDS_INFO_SHEET_MODAL,
       {
-        title: 'Eligible balance',
+        title: 'Qualifying deposits',
         description:
-          "Eligible balance description You are on track to earn today's entry.",
+          "Net new deposits in your Money Account since you joined. Reach $100 and don't drop below it before midnight UTC to earn today's entry. Balance from before joining doesn't count. You are on track to earn today's entry.",
       },
     );
   });
@@ -297,9 +300,9 @@ describe('MoneyAccountSweepstakesStatsSummary', () => {
     expect(mockNavigate).toHaveBeenCalledWith(
       Routes.MODAL.REWARDS_INFO_SHEET_MODAL,
       {
-        title: 'Eligible balance',
+        title: 'Qualifying deposits',
         description:
-          "Eligible balance description Maintain a balance of $100 or more in your Money Account to earn tomorrow's entry.",
+          "Net new deposits in your Money Account since you joined. Reach $100 and don't drop below it before midnight UTC to earn today's entry. Balance from before joining doesn't count. Deposit the shortfall to reach $100 and hold through midnight UTC for today's entry.",
       },
     );
   });

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesStatsSummary.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesStatsSummary.test.tsx
@@ -96,7 +96,7 @@ const localizedText: MoneyAccountSweepstakesLocalizedTextDto = {
   bindingConflictDescription:
     'Money Account already binds to another Rewards profile.',
   onTrackDescription: "You are on track to earn today's entry.",
-  belowThresholdDescription:
+  notYetQualifiedDescription:
     "Maintain a balance of $100 or more in your Money Account to earn tomorrow's entry.",
 };
 
@@ -104,7 +104,8 @@ const stats: MoneyAccountSweepstakesStatsMeDto = {
   entryCount: 3,
   currentBalanceUsd: 1250.5,
   yieldEarnedUsd: 12.34,
-  todayMinUsd: 1000,
+  qualifyingDepositsUsd: 1000,
+  qualifyingThresholdUsd: 100,
   todayStatus: 'on_track',
   daysRemaining: 4,
 };
@@ -126,8 +127,11 @@ describe('MoneyAccountSweepstakesStatsSummary', () => {
     expect(getByTestId(TEST_IDS.CONTAINER)).toBeOnTheScreen();
     expect(getByText('Eligible balance')).toBeOnTheScreen();
     expect(getByText('Entries')).toBeOnTheScreen();
+    // Shown against the threshold, not alone: the qualifying figure is net new
+    // deposits and is normally lower than the account balance, so a bare number
+    // is not legible on its own.
     expect(getByTestId(TEST_IDS.ELIGIBLE_BALANCE).props.children).toBe(
-      '$1000.00',
+      '$1000.00 / $100.00',
     );
     expect(getByTestId(TEST_IDS.ENTRIES).props.children).toBe('3 / 7');
   });
@@ -163,10 +167,10 @@ describe('MoneyAccountSweepstakesStatsSummary', () => {
     ).toBe('Check');
   });
 
-  it('shows Danger icon when todayStatus is below_threshold', () => {
+  it('shows Danger icon only when todayStatus is lost_today', () => {
     const { getByTestId } = render(
       <MoneyAccountSweepstakesStatsSummary
-        stats={{ ...stats, todayStatus: 'below_threshold' }}
+        stats={{ ...stats, todayStatus: 'lost_today' }}
         localizedText={localizedText}
         isLoading={false}
       />,
@@ -175,6 +179,22 @@ describe('MoneyAccountSweepstakesStatsSummary', () => {
     expect(
       getByTestId(TEST_IDS.ELIGIBLE_STATUS_ICON).props.accessibilityLabel,
     ).toBe('Danger');
+  });
+
+  it('does not warn when todayStatus is not_yet_qualified, which is still winnable', () => {
+    // The previous single below_threshold status forced these two to look
+    // identical; only lost_today is unrecoverable, so only it warns.
+    const { getByTestId } = render(
+      <MoneyAccountSweepstakesStatsSummary
+        stats={{ ...stats, todayStatus: 'not_yet_qualified' }}
+        localizedText={localizedText}
+        isLoading={false}
+      />,
+    );
+
+    expect(
+      getByTestId(TEST_IDS.ELIGIBLE_STATUS_ICON).props.accessibilityLabel,
+    ).not.toBe('Danger');
   });
 
   it('renders dashes when stats are unavailable', () => {
@@ -214,8 +234,11 @@ describe('MoneyAccountSweepstakesStatsSummary', () => {
     );
 
     expect(getByTestId(TEST_IDS.ENTRIES).props.children).toBe('3 / 7');
+    // Shown against the threshold, not alone: the qualifying figure is net new
+    // deposits and is normally lower than the account balance, so a bare number
+    // is not legible on its own.
     expect(getByTestId(TEST_IDS.ELIGIBLE_BALANCE).props.children).toBe(
-      '$1000.00',
+      '$1000.00 / $100.00',
     );
   });
 
@@ -260,10 +283,10 @@ describe('MoneyAccountSweepstakesStatsSummary', () => {
     );
   });
 
-  it('opens eligible balance info with below_threshold status description', () => {
+  it('opens eligible balance info with the not_yet_qualified description', () => {
     const { getAllByTestId } = render(
       <MoneyAccountSweepstakesStatsSummary
-        stats={{ ...stats, todayStatus: 'below_threshold' }}
+        stats={{ ...stats, todayStatus: 'not_yet_qualified' }}
         localizedText={localizedText}
         isLoading={false}
       />,

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesStatsSummary.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesStatsSummary.tsx
@@ -43,10 +43,12 @@ function getEligibleStatusDescription(
   switch (todayStatus) {
     case 'on_track':
       return `${base} ${localizedText.onTrackDescription}`;
-    case 'below_threshold':
-      // Covers both "never reached threshold" and "dipped below" — the API
-      // collapses those cases because both are unrecoverable for today.
-      return `${base} ${localizedText.belowThresholdDescription}`;
+    case 'not_yet_qualified':
+      // Still winnable today: depositing the shortfall earns today's entry.
+      return `${base} ${localizedText.notYetQualifiedDescription}`;
+    case 'lost_today':
+      // Reached the threshold and fell below it — today is forfeit.
+      return `${base} ${localizedText.lostTodayDescription}`;
     default:
       return base;
   }
@@ -69,7 +71,18 @@ const MoneyAccountSweepstakesStatsSummary: React.FC<
 
   const showSkeleton = isLoading && !stats;
 
-  const eligibleBalanceDisplay = stats ? formatUsd(stats.todayMinUsd) : '—';
+  // The qualifying figure is net new deposits since joining, not the account
+  // balance — it is normally LOWER than the balance, so it is shown against the
+  // threshold rather than alone, and the shortfall is spelled out.
+  // Deposits net of outflows, never re-valued at the current rate — accrued
+  // yield does not count toward the threshold. Outflows ARE valued when they
+  // happen, so they carry the yield earned on the position; withdrawing a
+  // fully-accrued position can leave the total a few cents below zero. Clamped
+  // so the tile never shows a negative figure.
+  const qualifyingUsd = stats ? Math.max(0, stats.qualifyingDepositsUsd) : 0;
+  const qualifyingDisplay = stats
+    ? `${formatUsd(qualifyingUsd)} / ${formatUsd(stats.qualifyingThresholdUsd)}`
+    : '—';
   const entriesDisplay = stats
     ? localizedText.entriesCountValue.replace(
         ENTRIES_COUNT_PLACEHOLDER,
@@ -78,7 +91,11 @@ const MoneyAccountSweepstakesStatsSummary: React.FC<
     : '—';
 
   const todayStatus = stats?.todayStatus;
-  const isWarningStatus = todayStatus === 'below_threshold';
+  // `not_yet_qualified` is recoverable today, `lost_today` is not — only the
+  // latter is a warning. Treating them alike is what the previous single
+  // `below_threshold` status forced.
+  const isWarningStatus = todayStatus === 'lost_today';
+  const isRecoverable = todayStatus === 'not_yet_qualified';
   const eligibleValueColor = isWarningStatus
     ? TextColor.WarningDefault
     : TextColor.TextDefault;
@@ -99,6 +116,18 @@ const MoneyAccountSweepstakesStatsSummary: React.FC<
         />
       );
     }
+    if (isRecoverable) {
+      return (
+        <Icon
+          name={IconName.Add}
+          size={IconSize.Md}
+          color={IconColor.IconAlternative}
+          testID={
+            MONEY_ACCOUNT_SWEEPSTAKES_STATS_SUMMARY_TEST_IDS.ELIGIBLE_STATUS_ICON
+          }
+        />
+      );
+    }
     if (isWarningStatus) {
       return (
         <Icon
@@ -112,7 +141,7 @@ const MoneyAccountSweepstakesStatsSummary: React.FC<
       );
     }
     return null;
-  }, [todayStatus, isWarningStatus]);
+  }, [todayStatus, isWarningStatus, isRecoverable]);
 
   const infoSuffix = (title: string, description: string) => (
     <ButtonIcon
@@ -131,7 +160,7 @@ const MoneyAccountSweepstakesStatsSummary: React.FC<
       <Box flexDirection={BoxFlexDirection.Row}>
         <StatCell
           label={localizedText.eligibleBalanceTitle}
-          value={eligibleBalanceDisplay}
+          value={qualifyingDisplay}
           isLoading={showSkeleton}
           valueColor={eligibleValueColor}
           testID={

--- a/app/components/UI/Rewards/hooks/useGetMoneyAccountSweepstakesStatsMe.test.ts
+++ b/app/components/UI/Rewards/hooks/useGetMoneyAccountSweepstakesStatsMe.test.ts
@@ -36,7 +36,8 @@ const MOCK_STATS: MoneyAccountSweepstakesStatsMeDto = {
   entryCount: 3,
   currentBalanceUsd: 1250.5,
   yieldEarnedUsd: 12.34,
-  todayMinUsd: 1000,
+  qualifyingDepositsUsd: 1000,
+  qualifyingThresholdUsd: 100,
   todayStatus: 'on_track',
   daysRemaining: 4,
 };

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -5710,8 +5710,9 @@ export class RewardsController extends BaseController<
         entryCount: 0,
         currentBalanceUsd: 0,
         yieldEarnedUsd: 0,
-        todayMinUsd: null,
-        todayStatus: 'below_threshold',
+        qualifyingDepositsUsd: 0,
+        qualifyingThresholdUsd: 0,
+        todayStatus: 'not_yet_qualified',
         daysRemaining: 0,
       };
     }
@@ -5732,7 +5733,8 @@ export class RewardsController extends BaseController<
             entryCount: cached.entryCount,
             currentBalanceUsd: cached.currentBalanceUsd,
             yieldEarnedUsd: cached.yieldEarnedUsd,
-            todayMinUsd: cached.todayMinUsd,
+            qualifyingDepositsUsd: cached.qualifyingDepositsUsd,
+            qualifyingThresholdUsd: cached.qualifyingThresholdUsd,
             todayStatus: cached.todayStatus,
             daysRemaining: cached.daysRemaining,
           },

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -1213,10 +1213,9 @@ export type PredictThePitchCampaignDetails = CampaignDetails;
 
 // Backend resolveMoneyAccountSweepstakesLocalizedText guarantees every key is
 // populated, so the UI can rely on these strings without a local fallback.
+// Keep in lockstep with Contentful + backend DEFAULT_MONEY_ACCOUNT_SWEEPSTAKES_LOCALIZED_TEXT.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type MoneyAccountSweepstakesLocalizedTextDto = {
-  currentBalanceTitle: string;
-  currentBalanceDescription: string;
   eligibleBalanceTitle: string;
   eligibleBalanceDescription: string;
   entriesTitle: string;

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -1249,7 +1249,8 @@ export type MoneyAccountSweepstakesLocalizedTextDto = {
   bindingConflictTitle: string;
   bindingConflictDescription: string;
   onTrackDescription: string;
-  belowThresholdDescription: string;
+  notYetQualifiedDescription: string;
+  lostTodayDescription: string;
 };
 
 export interface MoneyAccountSweepstakesCampaignDetails
@@ -1474,13 +1475,17 @@ export type PredictThePitchPrizePoolState = {
 
 // ─── Money Account Sweepstakes Campaign ───────────────────────────────────
 
-export type MoneyAccountSweepstakesTodayStatus = 'on_track' | 'below_threshold';
+export type MoneyAccountSweepstakesTodayStatus =
+  | 'on_track'
+  | 'not_yet_qualified'
+  | 'lost_today';
 
 export interface MoneyAccountSweepstakesStatsMeDto {
   entryCount: number;
   currentBalanceUsd: number;
   yieldEarnedUsd: number;
-  todayMinUsd: number | null;
+  qualifyingDepositsUsd: number;
+  qualifyingThresholdUsd: number;
   todayStatus: MoneyAccountSweepstakesTodayStatus;
   daysRemaining: number;
 }
@@ -1557,7 +1562,8 @@ export type MoneyAccountSweepstakesStatsMeState = {
   entryCount: number;
   currentBalanceUsd: number;
   yieldEarnedUsd: number;
-  todayMinUsd: number | null;
+  qualifyingDepositsUsd: number;
+  qualifyingThresholdUsd: number;
   todayStatus: MoneyAccountSweepstakesTodayStatus;
   daysRemaining: number;
   lastFetched: number;


### PR DESCRIPTION
## **Description**

Client side of [va-mmcx-rewards#748](https://github.com/consensys-vertical-apps/va-mmcx-rewards/pull/748), which changes what qualifies a sweepstakes day: **net new deposits since the participant joined**, rather than an intra-day balance minimum. Targets `feat/money-account-sweepstakes` (#33887), so review that first.

**Draft** — the backend PR and its spec ([va-mmcx-rewards#747](https://github.com/consensys-vertical-apps/va-mmcx-rewards/pull/747)) are still awaiting product sign-off. If the rule changes, this changes with it.

- `todayMinUsd` → `qualifyingDepositsUsd`, plus a new `qualifyingThresholdUsd` carrying the campaign's threshold so progress can be rendered. The threshold is per-campaign Contentful config, so it can't be hardcoded client-side — it did not previously reach the client at all, which is why the API now returns it.
- `todayStatus` splits `below_threshold` back into `not_yet_qualified` and `lost_today`. These are **not** interchangeable: the first is still winnable today by depositing the shortfall, the second is forfeit. Only `lost_today` warns; `not_yet_qualified` gets a neutral add affordance. Reverses the collapse in #34024.
- The tile shows the qualifying figure **against the threshold** (`$50 / $100`) rather than a bare number. The qualifying figure counts only deposits, never accrued yield, so it is normally **lower** than the account balance — someone holding $100 who deposited $50 since joining is legitimately at $50, and a lone figure gave them no way to understand that.
- The figure is clamped at zero for display. An outflow is valued when it happens and so carries the yield earned on the position, which can leave the total a few cents below zero after a full withdrawal.
- Copy keys follow the API: `belowThresholdDescription` → `notYetQualifiedDescription` + `lostTodayDescription`, and `currentBalanceTitle` / `currentBalanceDescription` are gone. Those two described the account balance, which no longer decides a day and is rendered nowhere, so the DTO stops requiring strings the API no longer sends.
- The localized-text fixtures now hold the strings the API actually returns, with the threshold already substituted. The backend resolves `{threshold}` from campaign config before responding, so a fixture carrying the raw token was asserting on copy no client can receive.

**Known remaining gap, left for design:** "Current balance" is still absent from the tiles, so the total balance appears nowhere on screen. Showing it as context beside the qualifying figure is the piece that makes the two numbers coherent, and it needs a design call rather than a guess.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/consensys-vertical-apps/va-mmcx-rewards/pull/748

## **Manual testing steps**

Not performed — this is a draft against an unmerged base, and the API fields it consumes are not deployed to any environment yet. Verification so far is type-level and unit-level only:

1. `npx tsc --noEmit -p tsconfig.json` — clean.
2. `npx jest app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes app/components/UI/Rewards/hooks/useGetMoneyAccountSweepstakesStatsMe.test.ts app/components/UI/Rewards/Views/MoneyAccountSweepstakesCampaignDetailsView.test.tsx` — 7 suites, 54 tests passing.
3. `npx jest app/core/Engine/controllers/rewards-controller` — 9 suites, 888 tests passing.

Once #748 is on DEV: open the campaign, confirm the tile reads `qualifying / threshold`, that a participant below the threshold shows the neutral state rather than a warning, and that a participant who dipped after crossing shows the warning.

## **Screenshots/Recordings**

### **Before**

N/A — not captured. Draft against an unmerged base with undeployed API fields, so the screen cannot render real data yet.

### **After**

N/A — see above. To be added before this leaves draft.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the rewards campaign stats contract and user-facing qualification messaging; scope is limited to MAS with unit tests, but behavior depends on an unmerged backend API.
> 
> **Overview**
> Aligns the Money Account Sweepstakes client with the backend rule that **net new deposits since join** (not intra-day balance minimum) determine daily entries.
> 
> **Stats API & types:** Replaces `todayMinUsd` with `qualifyingDepositsUsd` and `qualifyingThresholdUsd`. Splits `todayStatus` from `below_threshold` into `not_yet_qualified` (still winnable today) and `lost_today` (forfeit). Drops unused `currentBalance*` localized strings and swaps `belowThresholdDescription` for `notYetQualifiedDescription` / `lostTodayDescription`. `RewardsController` disabled-feature defaults and cache mapping follow the new shape.
> 
> **Stats tile (`MoneyAccountSweepstakesStatsSummary`):** Shows progress as **`$qualifying / $threshold`** with qualifying amount clamped at zero. Warning styling and danger icon apply only to `lost_today`; `not_yet_qualified` uses a neutral add icon. Info-sheet copy picks the status-specific description.
> 
> **Tests:** MAS fixtures and expectations updated for the new copy and fields (including CTA “no balance” toast strings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16d79de752e5499716257a39bc9764e1af8a29ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->