### PR TITLE
fix: Unable to navigate on Android after completing a hardware wallet transaction

### DIFF
--- a/app/components/UI/HardwareWallet/Swaps/hwSwapSuccess.test.ts
+++ b/app/components/UI/HardwareWallet/Swaps/hwSwapSuccess.test.ts
@@ -59,4 +59,68 @@ describe('completeHwSwapSuccess', () => {
     expect(mockDispatch).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
   });
+
+  describe('send flow root-stack pop', () => {
+    // The send origin registers HardwareWalletsSwaps on the root stack, so the
+    // screen must be popped before targeting activity — otherwise React
+    // Navigation resolves activity in a child navigator and cascades focus back
+    // up, popping the root stack in the same frame. Android's native stack does
+    // not survive that and leaves a blank, unusable screen.
+    it('pops the signing screen before navigating to activity', () => {
+      const mockGoBack = jest.fn();
+
+      completeHwSwapSuccess({
+        dispatch: mockDispatch,
+        navigation: {
+          navigate: mockNavigate,
+          canGoBack: () => true,
+          goBack: mockGoBack,
+        },
+        toastRef: undefined,
+        isSendFlow: true,
+      });
+
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
+      // Order matters: settle the root stack, then navigate.
+      expect(mockGoBack.mock.invocationCallOrder[0]).toBeLessThan(
+        mockNavigate.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('does not pop when there is nothing to go back to', () => {
+      const mockGoBack = jest.fn();
+
+      completeHwSwapSuccess({
+        dispatch: mockDispatch,
+        navigation: {
+          navigate: mockNavigate,
+          canGoBack: () => false,
+          goBack: mockGoBack,
+        },
+        toastRef: undefined,
+        isSendFlow: true,
+      });
+
+      expect(mockGoBack).not.toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
+    });
+
+    it('leaves bridge untouched — single navigate, no pop', () => {
+      const mockGoBack = jest.fn();
+
+      completeHwSwapSuccess({
+        dispatch: mockDispatch,
+        navigation: {
+          navigate: mockNavigate,
+          canGoBack: () => true,
+          goBack: mockGoBack,
+        },
+        toastRef: undefined,
+      });
+
+      expect(mockGoBack).not.toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTIONS_VIEW);
+    });
+  });
 });

--- a/app/components/UI/HardwareWallet/Swaps/hwSwapSuccess.ts
+++ b/app/components/UI/HardwareWallet/Swaps/hwSwapSuccess.ts
@@ -7,10 +7,49 @@ import { ToastVariants } from '../../../../component-library/components/Toast';
 import { IconName as ToastIconName } from '../../../../component-library/components/Icons/Icon';
 import type { ToastRef } from '../../../../component-library/components/Toast/Toast.types';
 
+/** The navigation surface this module needs (Pick-style, to avoid coupling to
+ * the caller's exact NavigationProp variant). */
+export interface HwFlowNavigation {
+  navigate: (route: string) => void;
+  canGoBack?: () => boolean;
+  goBack?: () => void;
+}
+
+/**
+ * Navigates to the activity view at the end of a hardware-wallet signing flow.
+ *
+ * The send origin registers `HardwareWalletsSwaps` on the ROOT stack
+ * (`Nav/App/App.tsx`), but `TRANSACTIONS_VIEW` only exists deeper in the tree
+ * (inside `MainNavigator` / the tab navigator). Dispatching the activity
+ * navigation while this screen is still mounted therefore makes React
+ * Navigation resolve the action in a child navigator and then cascade focus
+ * back UP, which pops the root stack and remounts the activity tab
+ * (`UnmountOnBlur`) in the same frame. iOS absorbs that; Android's native stack
+ * does not, and the user is left on a blank, unusable screen.
+ *
+ * Leaving the signing screen first settles the root stack, so the follow-up
+ * navigation no longer has to pop it as part of the focus cascade.
+ *
+ * Bridge is unaffected: it registers the screen inside `BridgeScreenStack`
+ * (a `MainNavigator` child), so it keeps its original single `navigate`.
+ */
+export function navigateToActivityFromHwFlow(
+  navigation: HwFlowNavigation,
+  isSendFlow?: boolean,
+): void {
+  if (isSendFlow && navigation.canGoBack?.()) {
+    navigation.goBack?.();
+  }
+  navigation.navigate(Routes.TRANSACTIONS_VIEW);
+}
+
 export interface CompleteHwSwapSuccessParams {
   dispatch: (action: ReturnType<typeof resetHardwareWalletsSwaps>) => void;
-  navigation: { navigate: (route: string) => void };
+  navigation: HwFlowNavigation;
   toastRef: RefObject<ToastRef | null> | undefined;
+  /** True for the send origin, which needs the root-stack pop described in
+   * {@link navigateToActivityFromHwFlow}. Bridge omits it. */
+  isSendFlow?: boolean;
 }
 
 /**
@@ -25,6 +64,7 @@ export function completeHwSwapSuccess({
   dispatch,
   navigation,
   toastRef,
+  isSendFlow,
 }: CompleteHwSwapSuccessParams): void {
   toastRef?.current?.showToast({
     variant: ToastVariants.Icon,
@@ -37,5 +77,5 @@ export function completeHwSwapSuccess({
     ],
   });
   dispatch(resetHardwareWalletsSwaps());
-  navigation.navigate(Routes.TRANSACTIONS_VIEW);
+  navigateToActivityFromHwFlow(navigation, isSendFlow);
 }

--- a/app/components/UI/HardwareWallet/Swaps/useHwSwapLifecycle.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHwSwapLifecycle.ts
@@ -11,14 +11,16 @@ import { useNavigation, useIsFocused } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../core/NavigationService/types';
 import { navigateWithDetails } from '../../../../util/navigation/navUtils';
 
-import Routes from '../../../../constants/navigation/Routes';
 import {
   resetHardwareWalletsSwaps,
   selectHardwareWalletsSwaps,
   updateHardwareWalletsSwaps,
 } from '../../../../core/redux/slices/bridge';
 import { ToastContext } from '../../../../component-library/components/Toast';
-import { completeHwSwapSuccess } from './hwSwapSuccess';
+import {
+  completeHwSwapSuccess,
+  navigateToActivityFromHwFlow,
+} from './hwSwapSuccess';
 import {
   HardwareWalletsSwapsStatus,
   HardwareWalletsSwapsEventType,
@@ -165,8 +167,13 @@ export function useHwSwapLifecycle({
   const completeSignedFlow = useCallback(() => {
     if (hasAutoNavigatedRef.current) return;
     hasAutoNavigatedRef.current = true;
-    completeHwSwapSuccess({ dispatch, navigation, toastRef });
-  }, [dispatch, navigation, toastRef]);
+    completeHwSwapSuccess({
+      dispatch,
+      navigation,
+      toastRef,
+      isSendFlow: strategy.isSendFlow,
+    });
+  }, [dispatch, navigation, toastRef, strategy.isSendFlow]);
 
   const reconcileStuckFlowProgress = useCallback(() => {
     const current = progressRef.current;
@@ -350,8 +357,9 @@ export function useHwSwapLifecycle({
   const handleDone = useCallback(() => {
     clearCachedSubmission();
     dispatch(resetHardwareWalletsSwaps());
-    navigation.navigate(Routes.TRANSACTIONS_VIEW);
-  }, [dispatch, navigation, clearCachedSubmission]);
+    // Same root-stack hazard as the auto-navigate path above.
+    navigateToActivityFromHwFlow(navigation, strategy.isSendFlow);
+  }, [dispatch, navigation, clearCachedSubmission, strategy.isSendFlow]);
 
   return {
     isRetrying,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->


Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
## Problem

  After completing a send with a Ledger, Android users land on a blank,
  unusable screen. iOS is fine.

  ## Root cause

  `HardwareWalletsSwaps` (the HW signing progress screen) is registered on the
  **root** navigation stack for the send flow, but `TRANSACTIONS_VIEW` only
  exists deeper in the tree, inside `MainNavigator` / the tab navigator.

  On success we called `navigation.navigate(Routes.TRANSACTIONS_VIEW)` while the
  signing screen was still mounted. Because the root stack doesn't own that
  route, React Navigation:

  1. bubbles the action *down* into a child navigator, which handles it, then
  2. cascades focus back *up*, popping the root stack, while
  3. `UnmountOnBlur` remounts the Activity tab

  ...all in the same frame. That's several native view mutations across three
  navigators at once. iOS absorbs it; Android's native stack does not, and the
  user is left with a detached view hierarchy — a screen with literally nothing
  rendered in it.


2. What is the improvement/solution?
  ## Fix

  Leave the signing screen *before* targeting Activity, so the root stack is
  already settled and the follow-up navigation has nothing left to pop:

  ```ts
  if (isSendFlow && navigation.canGoBack?.()) {
    navigation.goBack?.();
  }
  navigation.navigate(Routes.TRANSACTIONS_VIEW);
```

  Applied in hwSwapSuccess.ts (auto-navigate on signing complete) and
  useHwSwapLifecycle.handleDone (header X / Done button — same defect, different
  entry point).

  Gated on isSendFlow, so bridge/swaps behaviour is byte-identical — bridge
  registers the screen inside BridgeScreenStack (a MainNavigator child) and was
  never exposed to this.

  3 files, +120/−8. No navigator restructuring, no shared-helper changes.

  Alternatives considered

  1. Move the route registration into the Send stack. Register
  HARDWARE_WALLETS_SWAPS inside send.tsx and drop the root App.tsx
  registration. getParent() would then resolve to MainNavigator, letting the HW
  path reuse navigateToActivityAfterConfirmation verbatim — the exact same code
  path as every other account type, and it fixes the back-navigation issue too.

  This is the architecturally correct fix and where we should end up. Rejected
  for the hotfix: it's a structural navigation change affecting both Ledger and QR
  send, and it needs real device testing across both.

  2. Root-level navigation.reset(...). One atomic transition, no cascade at
  all, and wipes all history so back can't reach the stale send. Rejected because it
  remounts MainNavigator — re-rendering the wallet and resetting tab state after
  every HW send. Heavier than the bug warrants. This is the escalation path if the
  chosen fix doesn't hold on device.

  3. Harden navigateToActivityAfterConfirmation's fallback. Its stack-clearing
  StackActions.replace only runs when Money-account is enabled; otherwise it
  degrades to a bare navigate. Fixing that would resolve back-navigation for HW
  and non-HW sends — but it touches every confirmation flow (send, staking,
  lending, Earn). Too wide for a cherry-pick.

  Why this one: smallest diff with a direct causal link to the Android failure,
  zero blast radius outside the HW send path, and it leaves the better structural
  fix available as a follow-up.


  Known remaining gap (follow-up ticket)

  Back-navigation after a send is only partly fixed. With Money-account off,
  focus propagation now pops the Send route, so back won't reach the consumed
  confirmation. With Money-account on, MainNavigator pushes Activity above
  Send rather than replacing it, so back can still land on the stale send. That
  needs alternative 1 or 3 above.


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:  Fix issue where user was unable to navigate after successfully completing a send transaction with a hardware wallet. 

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-2101

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/d87282b3-a8f6-473d-9b01-4ceb23558c34



### **After**


https://github.com/user-attachments/assets/9e5d2405-bfc6-4101-b481-7dd64a8e261d



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
