### PR TITLE
fix: report the real network name in Blockaid false-positive reports

### DIFF
--- a/app/components/Views/confirmations/components/blockaid-alert-content/blockaid-alert-content.test.tsx
+++ b/app/components/Views/confirmations/components/blockaid-alert-content/blockaid-alert-content.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+import { fireEvent, waitFor, act } from '@testing-library/react-native';
 import BlockaidAlertContent from './blockaid-alert-content';
 // TODO: Remove legacy import
 import {
@@ -7,13 +7,35 @@ import {
   Reason,
 } from '../../components/blockaid-banner/BlockaidBanner.types';
 import { deflate } from 'react-native-gzip';
-import { BLOCKAID_SUPPORTED_NETWORK_NAMES } from '../../../../../util/networks';
+import type { Hex } from '@metamask/utils';
 import { ResultType as BlockaidResultType } from '../../constants/signatures';
 import { strings } from '../../../../../../locales/i18n';
+import renderWithProvider, {
+  DeepPartial,
+} from '../../../../../util/test/renderWithProvider';
+import { RootState } from '../../../../../reducers';
 
 jest.mock('react-native-gzip', () => ({
   deflate: jest.fn().mockResolvedValue('compressedData'),
 }));
+
+const networkStateWith = (
+  chainId: Hex,
+  name: string,
+): DeepPartial<RootState> => ({
+  engine: {
+    backgroundState: {
+      NetworkController: {
+        networkConfigurationsByChainId: {
+          [chainId]: { chainId, name },
+        },
+      },
+    },
+  },
+});
+
+const MAINNET_CHAIN_ID: Hex = '0x1';
+const MAINNET_STATE = networkStateWith(MAINNET_CHAIN_ID, 'Ethereum');
 
 describe('BlockaidAlertContent', () => {
   const DETAILS_ACCORDION_TITLE = 'See details';
@@ -31,7 +53,7 @@ describe('BlockaidAlertContent', () => {
     features: ALERT_DETAILS_MOCK,
     block: BLOCK_NUMBER_MOCK,
     req: REQUEST_MOCK,
-    chainId: '1',
+    chainId: MAINNET_CHAIN_ID,
   };
 
   const mockOnContactUsClicked = jest.fn();
@@ -41,12 +63,13 @@ describe('BlockaidAlertContent', () => {
   });
 
   it('renders correctly with given props', () => {
-    const { getByText } = render(
+    const { getByText } = renderWithProvider(
       <BlockaidAlertContent
         alertDetails={ALERT_DETAILS_MOCK}
         securityAlertResponse={mockSecurityAlertResponse}
         onContactUsClicked={mockOnContactUsClicked}
       />,
+      { state: MAINNET_STATE },
     );
 
     expect(getByText(DETAILS_ACCORDION_TITLE)).toBeDefined();
@@ -56,12 +79,13 @@ describe('BlockaidAlertContent', () => {
   });
 
   it('toggles accordion details on press', () => {
-    const { getByText, queryByText } = render(
+    const { getByText, queryByText } = renderWithProvider(
       <BlockaidAlertContent
         alertDetails={ALERT_DETAILS_MOCK}
         securityAlertResponse={mockSecurityAlertResponse}
         onContactUsClicked={mockOnContactUsClicked}
       />,
+      { state: MAINNET_STATE },
     );
 
     const accordionTitle = getByText(DETAILS_ACCORDION_TITLE);
@@ -79,12 +103,13 @@ describe('BlockaidAlertContent', () => {
   });
 
   it('generates the correct report URL', async () => {
-    render(
+    renderWithProvider(
       <BlockaidAlertContent
         alertDetails={ALERT_DETAILS_MOCK}
         securityAlertResponse={mockSecurityAlertResponse}
         onContactUsClicked={mockOnContactUsClicked}
       />,
+      { state: MAINNET_STATE },
     );
 
     await waitFor(() => {
@@ -94,7 +119,7 @@ describe('BlockaidAlertContent', () => {
           jsonRpcMethod: REQUEST_MOCK.method,
           jsonRpcParams: '["param1","param2"]',
           blockNumber: BLOCK_NUMBER_MOCK,
-          chain: BLOCKAID_SUPPORTED_NETWORK_NAMES['1'],
+          chain: 'Ethereum',
           classification: Reason.other,
           resultType: BlockaidResultType.Malicious,
           reproduce: '["Detail 1","Detail 2"]',
@@ -104,12 +129,13 @@ describe('BlockaidAlertContent', () => {
   });
 
   it('calls onContactUsClicked when report link is clicked', async () => {
-    const { getByText } = render(
+    const { getByText } = renderWithProvider(
       <BlockaidAlertContent
         alertDetails={ALERT_DETAILS_MOCK}
         securityAlertResponse={mockSecurityAlertResponse}
         onContactUsClicked={mockOnContactUsClicked}
       />,
+      { state: MAINNET_STATE },
     );
 
     const accordionTitle = getByText(DETAILS_ACCORDION_TITLE);
@@ -131,12 +157,13 @@ describe('BlockaidAlertContent', () => {
       req: null,
     } as unknown as SecurityAlertResponse;
 
-    render(
+    renderWithProvider(
       <BlockaidAlertContent
         alertDetails={ALERT_DETAILS_MOCK}
         securityAlertResponse={mockSecurityAlertResponseWithoutReq}
         onContactUsClicked={mockOnContactUsClicked}
       />,
+      { state: MAINNET_STATE },
     );
 
     await waitFor(() => {
@@ -148,16 +175,61 @@ describe('BlockaidAlertContent', () => {
       chainId: null,
     } as unknown as SecurityAlertResponse;
 
-    render(
+    renderWithProvider(
       <BlockaidAlertContent
         alertDetails={ALERT_DETAILS_MOCK}
         securityAlertResponse={mockSecurityAlertResponseWithoutChainId}
         onContactUsClicked={mockOnContactUsClicked}
       />,
+      { state: MAINNET_STATE },
     );
 
     await waitFor(() => {
       expect(deflate).not.toHaveBeenCalled();
+    });
+  });
+
+  it('reports the network name for a chain absent from the legacy Blockaid network map', async () => {
+    const ROBINHOOD_CHAIN_ID: Hex = '0x1237';
+
+    renderWithProvider(
+      <BlockaidAlertContent
+        alertDetails={ALERT_DETAILS_MOCK}
+        securityAlertResponse={{
+          ...mockSecurityAlertResponse,
+          chainId: ROBINHOOD_CHAIN_ID,
+        }}
+        onContactUsClicked={mockOnContactUsClicked}
+      />,
+      {
+        state: networkStateWith(ROBINHOOD_CHAIN_ID, 'Robinhood Chain'),
+      },
+    );
+
+    await waitFor(() => {
+      expect(deflate).toHaveBeenCalledWith(
+        expect.stringContaining('"chain":"Robinhood Chain"'),
+      );
+    });
+  });
+
+  it('omits the chain when the network is not configured', async () => {
+    renderWithProvider(
+      <BlockaidAlertContent
+        alertDetails={ALERT_DETAILS_MOCK}
+        securityAlertResponse={{
+          ...mockSecurityAlertResponse,
+          chainId: '0xdead',
+        }}
+        onContactUsClicked={mockOnContactUsClicked}
+      />,
+      { state: MAINNET_STATE },
+    );
+
+    await waitFor(() => {
+      expect(deflate).toHaveBeenCalledWith(
+        expect.not.stringContaining('"chain"'),
+      );
     });
   });
 
@@ -167,12 +239,13 @@ describe('BlockaidAlertContent', () => {
       reason: 'unknown_reason' as Reason,
     };
 
-    const { getByText } = render(
+    const { getByText } = renderWithProvider(
       <BlockaidAlertContent
         alertDetails={ALERT_DETAILS_MOCK}
         securityAlertResponse={mockSecurityAlertResponseWithUnknownReason}
         onContactUsClicked={mockOnContactUsClicked}
       />,
+      { state: MAINNET_STATE },
     );
 
     expect(

--- a/app/components/Views/confirmations/components/blockaid-alert-content/blockaid-alert-content.tsx
+++ b/app/components/Views/confirmations/components/blockaid-alert-content/blockaid-alert-content.tsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { View } from 'react-native';
+import { useSelector } from 'react-redux';
 import { deflate } from 'react-native-gzip';
+import type { Hex } from '@metamask/utils';
 import { strings } from '../../../../../../locales/i18n';
 import AppConstants from '../../../../../core/AppConstants';
-import { BLOCKAID_SUPPORTED_NETWORK_NAMES } from '../../../../../util/networks';
+import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
 import { WALLET_CONNECT_ORIGIN } from '../../../../../util/walletconnect';
 import {
   FALSE_POSITIVE_REPORT_BASE_URL,
@@ -46,6 +48,9 @@ const BlockaidAlertContent: React.FC<BlockaidAlertContentProps> = ({
   const [isExpanded, setIsExpanded] = useState(false);
   const [reportUrl, setReportUrl] = useState<string>('');
   const { styles } = useStyles(styleSheet, {});
+  const networkConfigurations = useSelector(
+    selectEvmNetworkConfigurationsByChainId,
+  );
 
   const onToggleShowDetails = () => {
     setIsExpanded(!isExpanded);
@@ -71,7 +76,7 @@ const BlockaidAlertContent: React.FC<BlockaidAlertContentProps> = ({
       jsonRpcMethod: req.method,
       jsonRpcParams: JSON.stringify(req.params),
       blockNumber: block,
-      chain: BLOCKAID_SUPPORTED_NETWORK_NAMES[chainId],
+      chain: networkConfigurations?.[chainId as Hex]?.name,
       classification: reason,
       resultType: result_type,
       reproduce: JSON.stringify(features),
@@ -83,7 +88,7 @@ const BlockaidAlertContent: React.FC<BlockaidAlertContentProps> = ({
         setReportUrl(getReportUrl(compressed));
       }
     })();
-  }, [securityAlertResponse, isExpanded]);
+  }, [securityAlertResponse, isExpanded, networkConfigurations]);
 
   return (
     <>

--- a/app/components/Views/confirmations/components/blockaid-banner/BlockaidBanner.test.tsx
+++ b/app/components/Views/confirmations/components/blockaid-banner/BlockaidBanner.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-import { fireEvent } from '@testing-library/react-native';
+import { fireEvent, waitFor } from '@testing-library/react-native';
+import { deflate } from 'react-native-gzip';
+import type { Hex } from '@metamask/utils';
 
 import { TESTID_ACCORDION_CONTENT } from '../../../../../component-library/components/Accordions/Accordion/Accordion.constants';
 import { TESTID_ACCORDIONHEADER } from '../../../../../component-library/components/Accordions/Accordion/foundation/AccordionHeader/AccordionHeader.constants';
@@ -17,17 +19,33 @@ jest.mock('../../../../../util/blockaid', () => ({
 
 jest.mock('react-native-gzip', () => ({
   // TODO: Replace "any" with type
+  // TODO: Replace "any" with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  deflate: (val: any) => val,
+  deflate: jest.fn((val: any) => val),
 }));
 
-const mockState: DeepPartial<RootState> = {
+const MAINNET_CHAIN_ID: Hex = '0x1';
+
+const stateWithNetwork = (
+  chainId: Hex,
+  name: string,
+): DeepPartial<RootState> => ({
   engine: {
     backgroundState: {
       PreferencesController: { securityAlertsEnabled: true },
+      NetworkController: {
+        networkConfigurationsByChainId: {
+          [chainId]: { chainId, name },
+        },
+      },
     },
   },
-};
+});
+
+const mockState: DeepPartial<RootState> = stateWithNetwork(
+  MAINNET_CHAIN_ID,
+  'Ethereum',
+);
 
 const mockFeatures = [
   'We found attack vectors in this request',
@@ -198,6 +216,28 @@ describe('BlockaidBanner', () => {
 
     expect(wrapper.queryByTestId(TESTID_ACCORDIONHEADER)).toBeNull();
     expect(wrapper.queryByTestId(TESTID_ACCORDION_CONTENT)).toBeNull();
+  });
+
+  it('reports the network name for a chain absent from the legacy Blockaid network map', async () => {
+    const ROBINHOOD_CHAIN_ID: Hex = '0x1237';
+
+    renderWithProvider(
+      <BlockaidBanner
+        securityAlertResponse={{
+          ...securityAlertResponse,
+          result_type: ResultType.Warning,
+          reason: Reason.approvalFarming,
+          chainId: ROBINHOOD_CHAIN_ID,
+        }}
+      />,
+      { state: stateWithNetwork(ROBINHOOD_CHAIN_ID, 'Robinhood Chain') },
+    );
+
+    await waitFor(() => {
+      expect(deflate).toHaveBeenCalledWith(
+        expect.stringContaining('"chain":"Robinhood Chain"'),
+      );
+    });
   });
 
   it('should render normal banner alert if resultType is failed', () => {

--- a/app/components/Views/confirmations/components/blockaid-banner/BlockaidBanner.tsx
+++ b/app/components/Views/confirmations/components/blockaid-banner/BlockaidBanner.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { ActivityIndicator } from 'react-native';
 import { View } from 'react-native-animatable';
+import { useSelector } from 'react-redux';
 import { captureException } from '@sentry/react-native';
 import { deflate } from 'react-native-gzip';
+import type { Hex } from '@metamask/utils';
 
 import { strings } from '../../../../../../locales/i18n';
 import { AccordionHeaderHorizontalAlignment } from '../../../../../component-library/components/Accordions/Accordion';
@@ -28,7 +30,7 @@ import {
   FALSE_POSITIVE_REPORT_BASE_URL,
   UTM_SOURCE,
 } from '../../../../../constants/urls';
-import { BLOCKAID_SUPPORTED_NETWORK_NAMES } from '../../../../../util/networks';
+import { selectEvmNetworkConfigurationsByChainId } from '../../../../../selectors/networkController';
 import { WALLET_CONNECT_ORIGIN } from '../../../../../util/walletconnect';
 import AppConstants from '../../../../../core/AppConstants';
 import { ConfirmationTopSheetSelectorsIDs } from '../../ConfirmationView.testIds';
@@ -59,6 +61,9 @@ const BlockaidBanner = (bannerProps: BlockaidBannerProps) => {
   } = bannerProps;
   const { styles, theme } = useStyles(styleSheet, { style });
   const [reportUrl, setReportUrl] = useState<string>('');
+  const networkConfigurations = useSelector(
+    selectEvmNetworkConfigurationsByChainId,
+  );
 
   useEffect(() => {
     if (!securityAlertResponse) {
@@ -80,7 +85,7 @@ const BlockaidBanner = (bannerProps: BlockaidBannerProps) => {
       jsonRpcMethod: req.method,
       jsonRpcParams: JSON.stringify(req.params),
       blockNumber: block,
-      chain: BLOCKAID_SUPPORTED_NETWORK_NAMES[chainId],
+      chain: networkConfigurations?.[chainId as Hex]?.name,
       classification: reason,
       resultType: result_type,
       reproduce: JSON.stringify(features),
@@ -90,7 +95,7 @@ const BlockaidBanner = (bannerProps: BlockaidBannerProps) => {
       const compressed = await deflate(JSON.stringify(reportData));
       setReportUrl(getReportUrl(compressed));
     })();
-  }, [securityAlertResponse]);
+  }, [securityAlertResponse, networkConfigurations]);
 
   if (!securityAlertResponse) {
     return null;

--- a/app/util/networks/index.js
+++ b/app/util/networks/index.js
@@ -193,23 +193,6 @@ export const NetworkList = {
 
 const NetworkListKeys = Object.keys(NetworkList);
 
-export const BLOCKAID_SUPPORTED_NETWORK_NAMES = {
-  [NETWORKS_CHAIN_ID.MAINNET]: 'Ethereum Mainnet',
-  [NETWORKS_CHAIN_ID.BSC]: 'Binance Smart Chain',
-  [NETWORKS_CHAIN_ID.BASE]: 'Base',
-  [NETWORKS_CHAIN_ID.OPTIMISM]: 'Optimism',
-  [NETWORKS_CHAIN_ID.POLYGON]: 'Polygon',
-  [NETWORKS_CHAIN_ID.ARBITRUM]: 'Arbitrum',
-  [NETWORKS_CHAIN_ID.LINEA_MAINNET]: 'Linea',
-  [NETWORKS_CHAIN_ID.SEPOLIA]: 'Sepolia',
-  [NETWORKS_CHAIN_ID.OPBNB]: 'opBNB',
-  [NETWORKS_CHAIN_ID.ZKSYNC_ERA]: 'zkSync Era Mainnet',
-  [NETWORKS_CHAIN_ID.SCROLL]: 'Scroll',
-  [NETWORKS_CHAIN_ID.BERACHAIN]: 'Berachain',
-  [NETWORKS_CHAIN_ID.METACHAIN_ONE]: 'Metachain One Mainnet',
-  [NETWORKS_CHAIN_ID.SEI]: 'Sei Mainnet',
-};
-
 export default NetworkList;
 
 export const getAllNetworks = () =>


### PR DESCRIPTION
## Description

The `chain` field of the Blockaid false-positive report payload was resolved from `BLOCKAID_SUPPORTED_NETWORK_NAMES` — a hardcoded 14-entry chainId → name map in `app/util/networks/index.js`. Its last network addition was Sei in June 2025 ([#14661](https://github.com/MetaMask/metamask-mobile/pull/14661)); the last batch added for security-alerts coverage was July 2024 ([#10139](https://github.com/MetaMask/metamask-mobile/pull/10139)).

Mobile screens every chain `@metamask/phishing-controller` supports — `TrustSignalsMiddleware` passes the raw chainId straight to `scanAddress`, with no client-side allowlist — so the map had drifted badly behind. **35 screened EVM chains resolved to `undefined`**, including Robinhood Chain (`0x1237`) and Arc (`0x13b2`), plus Avalanche, Gnosis, Unichain, Monad, Berachain-Bartio, Mantle, Plasma, Katana, Plume and others.

Because `JSON.stringify` omits `undefined` values, `chain` was **dropped from the payload entirely** rather than sent as `undefined`. Reports reaching the portal from those chains carried no chain attribution at all, which makes a verdict hard to reproduce — the same contract address exists on many EVM chains. The 14 chains that did work are the highest-volume ones, so the feedback loop looked healthy in aggregate while being blind on the long tail, which is exactly where new-network false positives concentrate.

Two entries pointed the other way: opBNB (`0xcc`) and Metachain One (`0x1b6e6`) are absent from the controller's chain map, so they are never screened — the map claimed coverage that does not exist.

**No effect on screening or user protection.** Screening already fires correctly on all of these chains. This only fixes the outbound report.

## Approach

Resolve the name from NetworkController configuration via `selectEvmNetworkConfigurationsByChainId` and delete the map. This covers every configured network including custom ones, always reflects what the user sees in the app, and cannot drift again.

It also **converges mobile onto the values the extension already sends** the same portal — extension reads `NETWORK_TO_NAME_MAP`, whose `*_DISPLAY_NAME` constants match NetworkController's names exactly. Three values change, all toward extension parity:

| chainId | before | after (and what extension already sends) |
|---|---|---|
| `0x1` | Ethereum Mainnet | **Ethereum** |
| `0x38` | Binance Smart Chain | **BNB Chain** |
| `0xa` | Optimism | **OP** |

If the portal parses `chain` as an enum rather than displaying it, flag it — but given extension has been sending these exact strings, that seems unlikely.

## Testing

The only test covering this payload was vacuous: it asserted `chain: BLOCKAID_SUPPORTED_NETWORK_NAMES['1']` — the map compared against itself, keyed by a **decimal** chainId that is not in the map and never occurs in production (NetworkController always supplies hex). Both sides evaluated to `undefined`, so it passed against any map contents, including an empty one. `BlockaidBanner`'s copy of the payload had no assertion at all.

- `generates the correct report URL` now uses a hex chainId and asserts the literal `"Ethereum"` — proving no regression for mainnet and that the assertion is no longer self-referential.
- New: `reports the network name for a chain absent from the legacy Blockaid network map` (Robinhood `0x1237`), in both `blockaid-alert-content` and `BlockaidBanner`. Verified failing before the fix — the received payload had no `chain` key.
- New: `omits the chain when the network is not configured`.
- Migrated `blockaid-alert-content` tests to `renderWithProvider` (the component now reads Redux); `BlockaidBanner` already used it.

```
Test Suites: 7 passed, 7 total
Tests:       164 passed, 164 total
```

`yarn eslint` on the changed files: 0 errors (7 pre-existing `Text`/`BannerAlert` deprecation warnings on untouched lines). `yarn lint:tsc`: no errors in any changed file.

## Context

Ticket: [PSAFE-577](https://consensyssoftware.atlassian.net/browse/PSAFE-577).

Found while auditing [PSAFE-561](https://consensyssoftware.atlassian.net/browse/PSAFE-561) (add Robinhood/Arc to trust signals screening on mobile). That ticket turned out to be already satisfied — mobile has no chain allowlist, and [core #9506](https://github.com/MetaMask/core/pull/9506) shipped `robinhood`/`arc` in phishing-controller `17.3.0`. This map was the one real mobile-side gap the audit turned up. It is a reporting-fidelity bug, not the screening gap PSAFE-561 describes, so it is filed on its own rather than under that ticket.

## Pre-merge checklist

- [x] Tests pass
- [x] No screening behaviour changed
- [ ] Confirm with the Blockaid portal owners that `chain` is a display string, not a parsed enum

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PSAFE-561]: https://consensyssoftware.atlassian.net/browse/PSAFE-561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reporting-only change with no screening or transaction logic; minor string changes for a few well-known chains on the portal payload.
> 
> **Overview**
> **Blockaid false-positive report payloads** now set `chain` from **NetworkController** (`selectEvmNetworkConfigurationsByChainId`) instead of the removed **`BLOCKAID_SUPPORTED_NETWORK_NAMES`** map in `app/util/networks/index.js`.
> 
> That fixes missing `chain` on many screened EVM networks (undefined map entries were dropped by `JSON.stringify`) and aligns labels with what users see—e.g. mainnet reports **Ethereum** rather than **Ethereum Mainnet**. Screening and alert UI are unchanged; only outbound report metadata is affected.
> 
> **`BlockaidAlertContent`** and **`BlockaidBanner`** read Redux for network config and include `networkConfigurations` in the report `useEffect` deps. Tests use **`renderWithProvider`** with mocked **`NetworkController`** state, assert literal **`"Ethereum"`** for mainnet, and add cases for Robinhood Chain (`0x1237`) and unconfigured chains (no `chain` key).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbfbb14a31aea69b4526173150a031001b55f08a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



[PSAFE-577]: https://consensyssoftware.atlassian.net/browse/PSAFE-577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ