### PR TITLE
chore: skip expo-dev artifact download when Actions digest matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ yarn install:ios:dev --skipInstall
 yarn install:android:dev --skipInstall
 ```
 
+Re-runs skip the download when the GitHub Actions artifact digest matches a local cache under `build/gh-expo-dev-build/`. Force a fresh download with `--force-download`:
+
+```bash
+yarn install:ios:dev --force-download
+yarn install:android:dev --force-download
+```
+
 Artifacts land under `build/` (`MetaMask.app` on iOS, `metamask-dev.apk` on Android). The workflow run id is saved to `build/expo-dev-build-run-id.txt`.
 
 **Manual download from GitHub Actions:**

--- a/scripts/install-android-dev-app.sh
+++ b/scripts/install-android-dev-app.sh
@@ -9,6 +9,9 @@ set -euo pipefail
 #   Step 1 (Resolve):  Run with --skipInstall and watch the resolved run id / artifact size.
 #   Step 2 (Download): Inspect build/gh-expo-dev-build/android/*.apk and build/metamask-dev.apk.
 #   Step 3 (Install):  Run with --skip-download to install build/metamask-dev.apk on a booted emulator.
+#   Digest cache:      Re-runs skip download when the Actions artifact digest matches
+#                      build/gh-expo-dev-build/<artifact-name>.digest. Use --force-download
+#                      to re-download even when digests match.
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -45,6 +48,7 @@ RUN_ID=""
 UNINSTALL=false
 SKIP_DOWNLOAD=false
 SKIP_INSTALL=false
+FORCE_DOWNLOAD=false
 DOWNLOAD_SUCCESS=false
 
 cleanup() {
@@ -74,14 +78,19 @@ while [[ $# -gt 0 ]]; do
       SKIP_DOWNLOAD=true
       shift
       ;;
+    --force-download)
+      FORCE_DOWNLOAD=true
+      shift
+      ;;
     --skipInstall)
       SKIP_INSTALL=true
       shift
       ;;
     *)
       echo -e "${RED}Unknown option: $1${NC}"
-      echo "Usage: $0 [--branch main] [--run RUN_ID] [--skip-download] [--skipInstall] [--uninstall]"
+      echo "Usage: $0 [--branch main] [--run RUN_ID] [--skip-download] [--force-download] [--skipInstall] [--uninstall]"
       echo "Targets ADB_SERIAL or ANDROID_DEVICE from .js.env; falls back to first connected device."
+      echo "  --force-download  Re-download even when the local Actions artifact digest matches."
       exit 1
       ;;
   esac
@@ -94,8 +103,15 @@ download_latest_app() {
   require_gh
 
   local resolved_run_id
+  local remote_digest
   resolved_run_id="$(resolve_expo_dev_run "$ANDROID_APK_ARTIFACT_NAME" "$BRANCH" "$RUN_ID")"
   echo "$resolved_run_id" > "$BUILD_DIR/expo-dev-build-run-id.txt"
+
+  if should_skip_artifact_download "$resolved_run_id" "$ANDROID_APK_ARTIFACT_NAME" "$STABLE_APK_PATH" "$FORCE_DOWNLOAD"; then
+    return 0
+  fi
+
+  remote_digest="$(fetch_artifact_digest "$resolved_run_id" "$ANDROID_APK_ARTIFACT_NAME")"
 
   echo -e "${BLUE}━━━ Step 2: Downloading ${ANDROID_APK_ARTIFACT_NAME} ━━━${NC}"
   rm -rf "$DOWNLOAD_DIR"
@@ -121,6 +137,7 @@ download_latest_app() {
   echo -e "${BLUE}━━━ Step 3: Copying to stable path ━━━${NC}"
   cp -f "$downloaded_apk" "$STABLE_APK_PATH"
   echo -e "${GREEN}✓ Copied to ${STABLE_APK_PATH}${NC}"
+  write_cached_artifact_digest "$ANDROID_APK_ARTIFACT_NAME" "$remote_digest"
   DOWNLOAD_SUCCESS=true
 }
 

--- a/scripts/install-ios-dev-app.sh
+++ b/scripts/install-ios-dev-app.sh
@@ -25,6 +25,9 @@ set -euo pipefail
 #   Step 1 (Resolve):  Run with --skipInstall and watch the resolved run id / artifact size.
 #   Step 2 (Download): Inspect build/gh-expo-dev-build/ios/* and build/MetaMask.{app,ipa}.
 #   Step 3 (Install):  Run with --skip-download to install without re-downloading.
+#   Digest cache:      Re-runs skip download when the Actions artifact digest matches
+#                      build/gh-expo-dev-build/<artifact-name>.digest. Use --force-download
+#                      to re-download even when digests match.
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -63,6 +66,7 @@ RUN_ID=""
 UNINSTALL=false
 SKIP_DOWNLOAD=false
 SKIP_INSTALL=false
+FORCE_DOWNLOAD=false
 DEVICE_MODE=false
 ZIP_PATH=""
 DOWNLOAD_SUCCESS=false
@@ -83,7 +87,10 @@ safe_rm_dir() {
 
 cleanup() {
   if [[ "$DOWNLOAD_SUCCESS" == true ]]; then
+    # Remove the downloaded zip/ipa and the empty download dir. Digests live as
+    # siblings under build/gh-expo-dev-build/*.digest and must not be deleted.
     safe_rm "$ZIP_PATH"
+    safe_rm_dir "$DOWNLOAD_DIR"
   fi
 }
 trap cleanup EXIT
@@ -108,6 +115,10 @@ while [[ $# -gt 0 ]]; do
       SKIP_DOWNLOAD=true
       shift
       ;;
+    --force-download)
+      FORCE_DOWNLOAD=true
+      shift
+      ;;
     --skipInstall)
       SKIP_INSTALL=true
       shift
@@ -118,10 +129,11 @@ while [[ $# -gt 0 ]]; do
       ;;
     *)
       echo -e "${RED}Unknown option: $1${NC}"
-      echo "Usage: $0 [--branch main] [--run RUN_ID] [--device] [--skip-download] [--skipInstall] [--uninstall]"
+      echo "Usage: $0 [--branch main] [--run RUN_ID] [--device] [--skip-download] [--force-download] [--skipInstall] [--uninstall]"
       echo "  (default) Targets IOS_SIMULATOR from .js.env (boots if needed); falls back to booted simulator."
       echo "  --device  Targets IOS_DEVICE from .js.env (name or UDID); falls back to single connected iPhone."
       echo "            Auto-connects to Metro after install. Add --skip-download to just reconnect."
+      echo "  --force-download  Re-download even when the local Actions artifact digest matches."
       exit 1
       ;;
   esac
@@ -134,8 +146,16 @@ download_latest_app_simulator() {
   require_gh
 
   local resolved_run_id
+  local target_app="$BUILD_DIR/$APP_NAME"
+  local remote_digest
   resolved_run_id="$(resolve_expo_dev_run "$IOS_SIMULATOR_ARTIFACT_NAME" "$BRANCH" "$RUN_ID")"
   echo "$resolved_run_id" > "$BUILD_DIR/expo-dev-build-run-id.txt"
+
+  if should_skip_artifact_download "$resolved_run_id" "$IOS_SIMULATOR_ARTIFACT_NAME" "$target_app" "$FORCE_DOWNLOAD"; then
+    return 0
+  fi
+
+  remote_digest="$(fetch_artifact_digest "$resolved_run_id" "$IOS_SIMULATOR_ARTIFACT_NAME")"
 
   echo -e "${BLUE}━━━ Step 2: Downloading ${IOS_SIMULATOR_ARTIFACT_NAME} ━━━${NC}"
   rm -rf "$DOWNLOAD_DIR"
@@ -176,13 +196,13 @@ download_latest_app_simulator() {
     exit 1
   fi
 
-  local target_app="$BUILD_DIR/$APP_NAME"
   if [[ "$extracted_app" != "$target_app" ]]; then
     safe_rm_dir "$target_app"
     mv "$extracted_app" "$target_app"
   fi
 
   echo -e "${GREEN}✓ Extracted to ${target_app}${NC}"
+  write_cached_artifact_digest "$IOS_SIMULATOR_ARTIFACT_NAME" "$remote_digest"
   DOWNLOAD_SUCCESS=true
 }
 
@@ -193,8 +213,16 @@ download_latest_app_device() {
   require_gh
 
   local resolved_run_id
+  local target_ipa="$BUILD_DIR/$IPA_NAME"
+  local remote_digest
   resolved_run_id="$(resolve_expo_dev_run "$IOS_DEVICE_IPA_ARTIFACT_NAME" "$BRANCH" "$RUN_ID")"
   echo "$resolved_run_id" > "$BUILD_DIR/expo-dev-build-run-id.txt"
+
+  if should_skip_artifact_download "$resolved_run_id" "$IOS_DEVICE_IPA_ARTIFACT_NAME" "$target_ipa" "$FORCE_DOWNLOAD"; then
+    return 0
+  fi
+
+  remote_digest="$(fetch_artifact_digest "$resolved_run_id" "$IOS_DEVICE_IPA_ARTIFACT_NAME")"
 
   echo -e "${BLUE}━━━ Step 2: Downloading ${IOS_DEVICE_IPA_ARTIFACT_NAME} ━━━${NC}"
   rm -rf "$DOWNLOAD_DIR"
@@ -218,10 +246,10 @@ download_latest_app_device() {
   echo -e "${GREEN}✓ Downloaded: ${downloaded_ipa}${NC}"
 
   echo -e "${BLUE}━━━ Step 3: Staging .ipa ━━━${NC}"
-  local target_ipa="$BUILD_DIR/$IPA_NAME"
   rm -f "$target_ipa"
   cp "$downloaded_ipa" "$target_ipa"
   echo -e "${GREEN}✓ Staged to ${target_ipa}${NC}"
+  write_cached_artifact_digest "$IOS_DEVICE_IPA_ARTIFACT_NAME" "$remote_digest"
   DOWNLOAD_SUCCESS=true
 }
 

--- a/scripts/lib/download-gha-expo-dev-build.sh
+++ b/scripts/lib/download-gha-expo-dev-build.sh
@@ -124,18 +124,19 @@ print_artifact_summary() {
   local artifact_meta
   local expired
   local artifact_size_bytes
+  local artifact_digest
   local artifact_size_mb
 
   artifact_meta="$(gh api "repos/${GITHUB_REPO}/actions/runs/${run_id}/artifacts" \
     --paginate \
-    --jq ".artifacts[] | select(.name==\"${artifact_name}\") | \"\(.expired)|\(.size_in_bytes)\"" 2>/dev/null | head -1 || true)"
+    --jq ".artifacts[] | select(.name==\"${artifact_name}\") | \"\(.expired)|\(.size_in_bytes)|\(.digest // \"\")\"" 2>/dev/null | head -1 || true)"
 
   if [[ -z "$artifact_meta" ]]; then
     echo -e "${RED}❌ Artifact '${artifact_name}' not found in run ${run_id}${NC}" >&2
     return 1
   fi
 
-  IFS='|' read -r expired artifact_size_bytes <<< "$artifact_meta"
+  IFS='|' read -r expired artifact_size_bytes artifact_digest <<< "$artifact_meta"
 
   if [[ "$expired" == "true" ]]; then
     echo -e "${RED}❌ Artifact '${artifact_name}' has expired for run ${run_id}${NC}" >&2
@@ -145,7 +146,81 @@ print_artifact_summary() {
 
   artifact_size_mb=$((artifact_size_bytes / 1024 / 1024))
   echo -e "${GREEN}✓ Artifact '${artifact_name}' size: ${artifact_size_mb}MB${NC}"
+  if [[ -n "$artifact_digest" ]]; then
+    echo -e "${GREEN}✓ Artifact digest: ${artifact_digest}${NC}"
+  fi
   echo -e "${BLUE}🔗 https://github.com/${GITHUB_REPO}/actions/runs/${run_id}${NC}"
+}
+
+# Sidecar stores the GitHub Actions archive digest (sha256:...), not a hash of the
+# extracted .apk/.app/.ipa — those do not match the API digest.
+artifact_digest_cache_path() {
+  local artifact_name="$1"
+  echo "${BUILD_DIR}/gh-expo-dev-build/${artifact_name}.digest"
+}
+
+fetch_artifact_digest() {
+  local run_id="$1"
+  local artifact_name="$2"
+  gh api "repos/${GITHUB_REPO}/actions/runs/${run_id}/artifacts" \
+    --paginate \
+    --jq ".artifacts[] | select(.expired == false and .name == \"${artifact_name}\") | .digest // empty" \
+    2>/dev/null | head -1 || true
+}
+
+read_cached_artifact_digest() {
+  local artifact_name="$1"
+  local cache_path
+  cache_path="$(artifact_digest_cache_path "$artifact_name")"
+  if [[ -f "$cache_path" ]]; then
+    tr -d '[:space:]' < "$cache_path"
+  fi
+}
+
+write_cached_artifact_digest() {
+  local artifact_name="$1"
+  local digest="$2"
+  local cache_path
+  cache_path="$(artifact_digest_cache_path "$artifact_name")"
+
+  if [[ -z "$digest" ]]; then
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$cache_path")"
+  printf '%s\n' "$digest" > "$cache_path"
+}
+
+# Returns 0 when download can be skipped (digest match + local installable present).
+should_skip_artifact_download() {
+  local run_id="$1"
+  local artifact_name="$2"
+  local stable_path="$3"
+  local force_download="$4"
+  local remote_digest
+  local cached_digest
+
+  if [[ "$force_download" == true ]]; then
+    return 1
+  fi
+
+  if [[ ! -e "$stable_path" ]]; then
+    return 1
+  fi
+
+  remote_digest="$(fetch_artifact_digest "$run_id" "$artifact_name")"
+  if [[ -z "$remote_digest" ]]; then
+    return 1
+  fi
+
+  cached_digest="$(read_cached_artifact_digest "$artifact_name")"
+  if [[ -z "$cached_digest" || "$cached_digest" != "$remote_digest" ]]; then
+    return 1
+  fi
+
+  echo -e "${GREEN}✓ Skipping download (digest match): ${remote_digest}${NC}" >&2
+  echo -e "${GREEN}✓ Using local: ${stable_path}${NC}" >&2
+  return 0
 }
 
 download_artifact_from_run() {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

`yarn install:ios:dev`, `yarn install:ios:dev:device`, and `yarn install:android:dev` always re-downloaded the large Expo Dev Build GitHub Actions artifacts (~100–170MB+), even when the engineer already had the same build locally. That made common workflows (reinstall after wipe, reconnect device to Metro, `--skipInstall` checks) unnecessarily slow.

This PR adds **digest-based download skipping** using the Actions artifact `digest` field (`sha256:…`) returned by the GitHub API:

1. Resolve the workflow run / artifact as before (cheap API calls).
2. Compare the remote digest to a local sidecar at `build/gh-expo-dev-build/<artifact-name>.digest`.
3. If digests match **and** the stable installable still exists (`build/MetaMask.app`, `build/MetaMask.ipa`, or `build/metamask-dev.apk`), **skip** `gh run download`.
4. After a successful download, write/update the sidecar.
5. `--force-download` always re-downloads and overwrites the local installable + sidecar, even when digests match.

**Why a sidecar (not hashing the local binary):** GitHub’s digest is the SHA-256 of the **uploaded Actions archive**, not of the extracted `.apk` / `.app` / `.ipa`. After download we discard the archive, so hashing the staged binary cannot match the API digest.

Shared logic lives in `scripts/lib/download-gha-expo-dev-build.sh`. iOS cleanup now also removes `build/gh-expo-dev-build/ios/` after a successful download so an empty download dir is not left next to the `.digest` file. Existing `--skip-download` / `--skipInstall` behavior is unchanged.

README documents the cache behavior and `--force-download`.

<details>
<summary>Example terminal sequences (digest missing / mismatch / match)</summary>

### 1) Digest not present locally (first download or sidecar missing)

Typical first run, or after deleting `build/gh-expo-dev-build/*.digest` / the staged app:

```text
━━━ Step 1: Resolving expo-dev-build run ━━━
Looking up latest successful run on 'main' for expo-dev-build.yml...
✓ Latest run with artifact: 30561104091
Run #30561104091 | … | 693a23a | … | https://github.com/MetaMask/metamask-mobile/actions/runs/30561104091
✓ Artifact 'android-apk-main-dev-expo' size: 161MB
✓ Artifact digest: sha256:760e51ff6ebcb0cfe06f25dd4cc20268a54085f796e50d335169b7bcd018383b
🔗 https://github.com/MetaMask/metamask-mobile/actions/runs/30561104091
━━━ Step 2: Downloading android-apk-main-dev-expo ━━━
✓ Downloaded: …/build/gh-expo-dev-build/android/….apk
━━━ Step 3: Copying to stable path ━━━
✓ Copied to …/build/metamask-dev.apk
```

After success, the sidecar is written (e.g. `build/gh-expo-dev-build/android-apk-main-dev-expo.digest`).

### 2) Digest does not match (newer CI artifact / different run)

Local sidecar still has the old digest; remote digest from the resolved run differs → full download again:

```text
━━━ Step 1: Resolving expo-dev-build run ━━━
Looking up latest successful run on 'main' for expo-dev-build.yml...
✓ Latest run with artifact: 30570000000
…
✓ Artifact 'ios-app-main-dev-expo' size: 92MB
✓ Artifact digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
🔗 https://github.com/MetaMask/metamask-mobile/actions/runs/30570000000
━━━ Step 2: Downloading ios-app-main-dev-expo ━━━
✓ Downloaded: …/build/gh-expo-dev-build/ios/….zip
━━━ Step 3: Extracting .app bundle ━━━
✓ Extracted to …/build/MetaMask.app
```

Same path if the stable installable is missing even when the sidecar matches.

### 3) Digest matches (skip download)

Re-run with the same Actions artifact still on disk:

```text
━━━ Step 1: Resolving expo-dev-build run ━━━
Looking up latest successful run on 'main' for expo-dev-build.yml...
✓ Latest run with artifact: 30561104091
…
✓ Artifact 'android-apk-main-dev-expo' size: 161MB
✓ Artifact digest: sha256:760e51ff6ebcb0cfe06f25dd4cc20268a54085f796e50d335169b7bcd018383b
🔗 https://github.com/MetaMask/metamask-mobile/actions/runs/30561104091
✓ Skipping download (digest match): sha256:760e51ff6ebcb0cfe06f25dd4cc20268a54085f796e50d335169b7bcd018383b
✓ Using local: …/build/metamask-dev.apk
```

Then install proceeds as usual (unless `--skipInstall`). To force a re-download despite a match:

```bash
yarn install:android:dev --force-download
yarn install:ios:dev --force-download
yarn install:ios:dev:device --force-download
```

</details>

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A (developer tooling improvement for expo-dev install scripts; builds on the GHA artifact install flow documented under “Download and install the development build”)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Digest-based skip for expo-dev install scripts

  Background:
    Given gh is authenticated with access to MetaMask/metamask-mobile
    And the developer is at the repository root

  Scenario: First download writes digest sidecar (digest not present)
    Given build/gh-expo-dev-build has no matching *.digest sidecar
    When the developer runs "yarn install:android:dev --skipInstall"
    Then the script resolves a successful expo-dev-build run
    And it downloads the android-apk-main-dev-expo artifact
    And it stages build/metamask-dev.apk
    And it writes build/gh-expo-dev-build/android-apk-main-dev-expo.digest

  Scenario: Matching digest skips download
    Given build/metamask-dev.apk exists
    And build/gh-expo-dev-build/android-apk-main-dev-expo.digest matches the remote Actions digest
    When the developer runs "yarn install:android:dev --skipInstall"
    Then the script prints "Skipping download (digest match)"
    And it does not call "gh run download"
    And it keeps using build/metamask-dev.apk

  Scenario: Mismatched digest re-downloads
    Given build/metamask-dev.apk exists
    And the local *.digest sidecar does not match the remote Actions digest
    When the developer runs "yarn install:android:dev --skipInstall"
    Then the script downloads the artifact again
    And it updates the local sidecar to the new digest

  Scenario: --force-download ignores matching digest
    Given digests match and the local installable exists
    When the developer runs "yarn install:android:dev --force-download --skipInstall"
    Then the script re-downloads and overwrites the local APK and sidecar

  Scenario: iOS simulator path also skips and cleans download dir
    Given build/MetaMask.app exists with a matching ios-app-main-dev-expo.digest
    When the developer runs "yarn install:ios:dev --skipInstall"
    Then download is skipped when digests match
    And after a forced re-download, build/gh-expo-dev-build/ios/ is removed and only the *.digest remains under gh-expo-dev-build
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — CLI / developer-scripting change only (no app UI). Previously every `install:ios:dev` / `install:android:dev` re-ran `gh run download` for ~100MB+ artifacts.

### **After**

N/A — no app UI. See the foldable “Example terminal sequences” section in **Description** for before/after CLI output (download vs skip).

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only shell scripts and README; no app runtime, auth, or production build paths affected.
> 
> **Overview**
> **Expo dev install scripts** (`yarn install:ios:dev`, `install:ios:dev:device`, `install:android:dev`) now avoid re-downloading large GitHub Actions artifacts when the remote artifact digest matches a local sidecar and the staged installable still exists.
> 
> Shared logic in `scripts/lib/download-gha-expo-dev-build.sh` compares the GitHub API `digest` (`sha256:…`) to files under `build/gh-expo-dev-build/<artifact-name>.digest`, skips `gh run download` when they match (and `build/MetaMask.app`, `MetaMask.ipa`, or `metamask-dev.apk` is present), and writes the sidecar after a successful download. **`--force-download`** bypasses the cache.
> 
> iOS cleanup after download now removes the transient `build/gh-expo-dev-build/ios/` tree while keeping `*.digest` siblings. README documents cache behavior and `--force-download`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c10fec05056ff7eae3c6a8905ecd7cf4cd0427b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->