### PR TITLE
chore: remove always-on code fences (snaps, keyring-snaps, multi-srp, bitcoin, solana, tron)

### DIFF
--- a/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.constants.ts
+++ b/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.constants.ts
@@ -1,4 +1,2 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_INSTALL_FLOW = 'snap-install-flow';
 export const SNAP_INSTALL_OK = 'snap-install-ok';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.styles.ts
+++ b/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.styles.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../util/theme/models';
 import Device from '../../../util/device';
@@ -63,4 +62,3 @@ const styleSheet = (params: { theme: Theme }) => {
 };
 
 export default styleSheet;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.tsx
+++ b/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useEffect, useState } from 'react';
 import ApprovalModal from '../ApprovalModal';
 import useApprovalRequest, {
@@ -118,8 +117,6 @@ const InstallSnapApproval = () => {
       setInstallState(SnapInstallState.SnapInstallError);
     }
   };
-  ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
 
   if (!approvalRequest || installState === undefined) return null;
 
@@ -170,8 +167,6 @@ const InstallSnapApproval = () => {
             error={installError}
           />
         );
-      ///: END:ONLY_INCLUDE_IF
-      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       default:
         return null;
     }
@@ -191,4 +186,3 @@ const InstallSnapApproval = () => {
 };
 
 export default InstallSnapApproval;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.types.ts
+++ b/app/components/Approvals/InstallSnapApproval/InstallSnapApproval.types.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 interface InstallSnapFlowProps {
   // TODO: Replace "any" with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -19,4 +18,3 @@ export enum SnapInstallState {
 }
 
 export type { InstallSnapFlowProps };
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/InstallSnapConnectionRequest.constants.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/InstallSnapConnectionRequest.constants.ts
@@ -1,6 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_INSTALL_CONNECTION_REQUEST =
   'snap-install-connection-request';
 export const SNAP_INSTALL_CANCEL = 'snap-install-cancel';
 export const SNAP_INSTALL_CONNECT = 'snap-install-connect';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/InstallSnapConnectionRequest.tsx
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/InstallSnapConnectionRequest.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useMemo } from 'react';
 import { View } from 'react-native';
 import { InstallSnapFlowProps } from '../../InstallSnapApproval.types';
@@ -103,4 +102,3 @@ const InstallSnapConnectionRequest = ({
 };
 
 export default React.memo(InstallSnapConnectionRequest);
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/index.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapConnectionRequest/index.ts
@@ -1,6 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
 import InstallSnapConnectionRequest from './InstallSnapConnectionRequest';
 
 export { InstallSnapConnectionRequest };
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapError/InstallSnapError.constants.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapError/InstallSnapError.constants.ts
@@ -1,4 +1,2 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 const SNAP_INSTALL_ERROR = 'snap-install-error';
 export default SNAP_INSTALL_ERROR;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapError/InstallSnapError.tsx
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapError/InstallSnapError.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useMemo } from 'react';
 import { View } from 'react-native';
 import styleSheet from '../../InstallSnapApproval.styles';
@@ -87,4 +86,3 @@ const InstallSnapError = ({
 };
 
 export default React.memo(InstallSnapError);
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapError/index.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapError/index.ts
@@ -1,4 +1,2 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
 export { default as InstallSnapError } from './InstallSnapError';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/InstallSnapPermissionsRequest.constants.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/InstallSnapPermissionsRequest.constants.ts
@@ -1,7 +1,5 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_INSTALL_CANCEL = 'snap-install-cancel';
 export const SNAP_INSTALL_PERMISSIONS_REQUEST_APPROVE =
   'snap-install-connection-permissions-request-approve';
 export const SNAP_INSTALL_PERMISSIONS_REQUEST =
   'snap-install-connection-permissions-request';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/InstallSnapPermissionsRequest.tsx
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/InstallSnapPermissionsRequest.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useMemo } from 'react';
 import { ScrollView, View } from 'react-native';
 import styleSheet from '../../InstallSnapApproval.styles';
@@ -94,4 +93,3 @@ const InstallSnapPermissionsRequest = ({
 };
 
 export default React.memo(InstallSnapPermissionsRequest);
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/index.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapPermissionsRequest/index.ts
@@ -1,4 +1,2 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
 export { default as InstallSnapPermissionsRequest } from './InstallSnapPermissionsRequest';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapSuccess/InstallSnapSuccess.constants.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapSuccess/InstallSnapSuccess.constants.ts
@@ -1,4 +1,2 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 const SNAP_INSTALL_SUCCESS = 'snap-install-success';
 export default SNAP_INSTALL_SUCCESS;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapSuccess/InstallSnapSuccess.tsx
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapSuccess/InstallSnapSuccess.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { View } from 'react-native';
 import styleSheet from '../../InstallSnapApproval.styles';
@@ -80,4 +79,3 @@ const InstallSnapSuccess = ({
 };
 
 export default React.memo(InstallSnapSuccess);
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/InstallSnapSuccess/index.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/InstallSnapSuccess/index.ts
@@ -1,4 +1,2 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
 export { default as InstallSnapSuccess } from './InstallSnapSuccess';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/components/index.ts
+++ b/app/components/Approvals/InstallSnapApproval/components/index.ts
@@ -1,7 +1,5 @@
 /* eslint-disable import-x/prefer-default-export */
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export { InstallSnapPermissionsRequest } from './InstallSnapPermissionsRequest';
 export { InstallSnapError } from './InstallSnapError';
 export { InstallSnapSuccess } from './InstallSnapSuccess';
 export { InstallSnapConnectionRequest } from './InstallSnapConnectionRequest';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/InstallSnapApproval/index.ts
+++ b/app/components/Approvals/InstallSnapApproval/index.ts
@@ -1,3 +1,1 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export { default } from './InstallSnapApproval';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/SnapAccountCustomNameApproval/SnapAccountCustomNameApproval.constants.ts
+++ b/app/components/Approvals/SnapAccountCustomNameApproval/SnapAccountCustomNameApproval.constants.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 export const SNAP_ACCOUNT_CUSTOM_NAME_APPROVAL =
   'snap-account-custom-name-approval';
 export const SNAP_ACCOUNT_CUSTOM_NAME_CANCEL_BUTTON =
@@ -7,4 +6,3 @@ export const SNAP_ACCOUNT_CUSTOM_NAME_ADD_ACCOUNT_BUTTON =
   'snap-account-custom-name-approval-add-account-button';
 export const SNAP_ACCOUNT_CUSTOM_NAME_INPUT =
   'snap-account-custom-name-approval-input';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/SnapAccountCustomNameApproval/SnapAccountCustomNameApproval.styles.ts
+++ b/app/components/Approvals/SnapAccountCustomNameApproval/SnapAccountCustomNameApproval.styles.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../util/theme/models';
 import Device from '../../../util/device';
@@ -43,4 +42,3 @@ const styleSheet = (params: { theme: Theme }) => {
 };
 
 export default styleSheet;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/SnapAccountCustomNameApproval/SnapAccountCustomNameApproval.tsx
+++ b/app/components/Approvals/SnapAccountCustomNameApproval/SnapAccountCustomNameApproval.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import React, { useEffect, useState } from 'react';
 import { TextInput, View } from 'react-native';
 import ApprovalModal from '../ApprovalModal';
@@ -123,4 +122,3 @@ const SnapAccountCustomNameApproval = () => {
 };
 
 export default SnapAccountCustomNameApproval;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Approvals/SnapAccountCustomNameApproval/index.ts
+++ b/app/components/Approvals/SnapAccountCustomNameApproval/index.ts
@@ -1,3 +1,1 @@
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 export { default } from './SnapAccountCustomNameApproval';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -88,14 +88,12 @@ import DepositOrderDetails from '../../UI/Ramp/Views/OrderDetails/DepositOrderDe
 import ProcessingInfoModal from '../../UI/Ramp/Views/Modals/ProcessingInfoModal/ProcessingInfoModal';
 import SendTransaction from '../../UI/Ramp/Aggregator/Views/SendTransaction';
 import TabBar from '../../../component-library/components/Navigation/TabBar';
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { SnapsSettingsList } from '../../Views/Snaps/SnapsSettingsList';
 import {
   SnapSettings,
   ALLOWED_CAPABILITIES as SNAPS_SETTINGS_ROUTE_ALLOWED_CAPABILITIES,
 } from '../../Views/Snaps/SnapSettings';
 import { CAN_INSTALL_THIRD_PARTY_SNAPS } from '../../../constants/snaps';
-///: END:ONLY_INCLUDE_IF
 import Routes from '../../../constants/navigation/Routes';
 import {
   clearNativeStackNavigatorOptions,
@@ -409,7 +407,6 @@ const ExploreHome = () => {
   );
 };
 
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 const SnapSettingsWithMessenger = withMessenger(SnapSettings, {
   capabilities: SNAPS_SETTINGS_ROUTE_ALLOWED_CAPABILITIES,
 });
@@ -434,7 +431,6 @@ const SnapsSettingsStack = () => {
     </NativeStack.Navigator>
   );
 };
-///: END:ONLY_INCLUDE_IF
 
 const SettingsFlow = () => {
   const { colors } = useTheme();
@@ -557,18 +553,12 @@ const SettingsFlow = () => {
         name={Routes.SETTINGS.REGION_SELECTOR}
         component={RegionSelector}
       />
-      {
-        ///: BEGIN:ONLY_INCLUDE_IF(snaps)
-      }
       {CAN_INSTALL_THIRD_PARTY_SNAPS && (
         <NativeStack.Screen
           name={Routes.SNAPS.SNAPS_SETTINGS_LIST}
           component={SnapsSettingsStack}
         />
       )}
-      {
-        ///: END:ONLY_INCLUDE_IF
-      }
     </NativeStack.Navigator>
   );
 };

--- a/app/components/Nav/Main/RootRPCMethodsUI.js
+++ b/app/components/Nav/Main/RootRPCMethodsUI.js
@@ -11,13 +11,9 @@ import FlowLoaderModal from '../../Approvals/FlowLoaderModal';
 import TemplateConfirmationModal from '../../Approvals/TemplateConfirmationModal';
 import { ConfirmRoot } from '../../../components/Views/confirmations/components/confirm';
 
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import InstallSnapApproval from '../../Approvals/InstallSnapApproval';
 import SnapDialogApproval from '../../Snaps/SnapDialogApproval/SnapDialogApproval';
-///: END:ONLY_INCLUDE_IF
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import SnapAccountCustomNameApproval from '../../Approvals/SnapAccountCustomNameApproval';
-///: END:ONLY_INCLUDE_IF
 
 const RootRPCMethodsUI = (props) => {
   useEffect(
@@ -38,21 +34,9 @@ const RootRPCMethodsUI = (props) => {
       <PermissionApproval navigation={props.navigation} />
       <FlowLoaderModal />
       <TemplateConfirmationModal />
-      {
-        ///: BEGIN:ONLY_INCLUDE_IF(snaps)
-      }
       <InstallSnapApproval />
       <SnapDialogApproval />
-      {
-        ///: END:ONLY_INCLUDE_IF
-      }
-      {
-        ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-      }
       <SnapAccountCustomNameApproval />
-      {
-        ///: END:ONLY_INCLUDE_IF
-      }
     </React.Fragment>
   );
 };

--- a/app/components/Snaps/SnapAvatar/SnapAvatar.styles.ts
+++ b/app/components/Snaps/SnapAvatar/SnapAvatar.styles.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../util/theme/models';
 
@@ -36,4 +35,3 @@ const styleSheet = (params: { theme: Theme }) => {
 };
 
 export default styleSheet;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Snaps/SnapAvatar/SnapAvatar.tsx
+++ b/app/components/Snaps/SnapAvatar/SnapAvatar.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/prop-types */
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { useSelector } from 'react-redux';
 import AvatarFavicon from '../../../component-library/components/Avatars/Avatar/variants/AvatarFavicon';
@@ -75,4 +74,3 @@ export const SnapAvatar: React.FunctionComponent<SnapAvatarProps> = ({
     </BadgeWrapper>
   );
 };
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Snaps/SnapDialogApproval/SnapDialogApproval.tsx
+++ b/app/components/Snaps/SnapDialogApproval/SnapDialogApproval.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useEffect, useState } from 'react';
 import { View } from 'react-native';
 import { useStyles } from '../../hooks/useStyles';
@@ -159,4 +158,3 @@ const SnapDialogApproval = () => {
 };
 
 export default SnapDialogApproval;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Snaps/SnapDialogApproval/index.ts
+++ b/app/components/Snaps/SnapDialogApproval/index.ts
@@ -1,3 +1,1 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export { default } from './SnapDialogApproval';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Snaps/SnapUIImage/SnapUIImage.tsx
+++ b/app/components/Snaps/SnapUIImage/SnapUIImage.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { isValidUrl } from '@metamask/snaps-utils';
 import React from 'react';
 import { StyleProp, View, ViewStyle, ImageStyle } from 'react-native';
@@ -124,4 +123,3 @@ export const SnapUIImage: React.FC<SnapUIImageProps> = ({
     </View>
   );
 };
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Snaps/SnapUILink/SnapUILink.tsx
+++ b/app/components/Snaps/SnapUILink/SnapUILink.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import {
   Text,
@@ -69,5 +68,3 @@ export const SnapUILink: React.FC<SnapUILinkProps> = ({
     </Component>
   );
 };
-
-///: END:ONLY_INCLUDE_IF

--- a/app/components/UI/AssetOverview/Balance/Balance.tsx
+++ b/app/components/UI/AssetOverview/Balance/Balance.tsx
@@ -141,10 +141,8 @@ const Balance = ({
     if (isEvmNetworkSelected) {
       return evmPricePercentChange1d;
     }
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     return allMultichainAssetsRates[asset?.address as CaipAssetType]?.marketData
       ?.pricePercentChange?.P1D;
-    ///: END:ONLY_INCLUDE_IF(keyring-snaps)
   };
 
   // Calculate percentage change and color for secondary balance

--- a/app/components/UI/AssetOverview/TokenDetails/TokenDetails.tsx
+++ b/app/components/UI/AssetOverview/TokenDetails/TokenDetails.tsx
@@ -1,7 +1,5 @@
 import {
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   CaipAssetId,
-  ///: END:ONLY_INCLUDE_IF
   Hex,
   isCaipAssetType,
   parseCaipAssetType,
@@ -28,9 +26,7 @@ import {
   selectTokenDisplayData,
 } from '../../../../selectors/tokenSearchDiscoveryDataController';
 import { selectTokenMarketData } from '../../../../selectors/tokenRatesController';
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { selectMultichainAssetsRates } from '../../../../selectors/multichain';
-///: END:ONLY_INCLUDE_IF
 import { MarketDataDetails } from '@metamask/assets-controllers';
 import { formatMarketDetails } from '../utils/marketDetails';
 import { getTokenDetails } from '../utils/getTokenDetails';
@@ -85,14 +81,12 @@ const TokenDetails: React.FC<TokenDetailsProps> = ({
     selectTokenDisplayData(state, asset.chainId as Hex, asset.address as Hex),
   );
 
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   const allMultichainAssetsRates = useSelector(selectMultichainAssetsRates);
 
   const multichainAssetRates =
     allMultichainAssetsRates[asset.address as CaipAssetId];
 
   const nonEvmMarketData = multichainAssetRates?.marketData;
-  ///: END:ONLY_INCLUDE_IF
 
   const evmMarketData = useSelector((state: RootState) =>
     !isNonEvmAsset && tokenContractAddress

--- a/app/components/UI/Bridge/components/QuoteSelectorView/QuoteList.tsx
+++ b/app/components/UI/Bridge/components/QuoteSelectorView/QuoteList.tsx
@@ -8,9 +8,7 @@ import {
   selectCurrentCurrency,
 } from '../../../../../selectors/currencyRateController';
 import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { selectMultichainAssetsRates } from '../../../../../selectors/multichain';
-///: END:ONLY_INCLUDE_IF(keyring-snaps)
 import { getDisplayCurrencyValue } from '../../utils/exchange-rates';
 
 interface Props {
@@ -27,9 +25,7 @@ export const QuoteList = ({ data }: Props) => {
   const currentCurrency = useSelector(selectCurrentCurrency);
 
   let nonEvmMultichainAssetRates = {};
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   nonEvmMultichainAssetRates = useSelector(selectMultichainAssetsRates);
-  ///: END:ONLY_INCLUDE_IF(keyring-snaps)
 
   return data.map(({ provider, ...quote }) => (
     <QuoteRowView

--- a/app/components/UI/Bridge/hooks/useDisplayCurrencyValue/index.ts
+++ b/app/components/UI/Bridge/hooks/useDisplayCurrencyValue/index.ts
@@ -7,9 +7,7 @@ import {
   selectCurrentCurrency,
 } from '../../../../../selectors/currencyRateController';
 import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { selectMultichainAssetsRates } from '../../../../../selectors/multichain';
-///: END:ONLY_INCLUDE_IF(keyring-snaps)
 
 export const useDisplayCurrencyValue = (
   amount?: string,
@@ -23,9 +21,7 @@ export const useDisplayCurrencyValue = (
   const currentCurrency = useSelector(selectCurrentCurrency);
 
   let nonEvmMultichainAssetRates = {};
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   nonEvmMultichainAssetRates = useSelector(selectMultichainAssetsRates);
-  ///: END:ONLY_INCLUDE_IF(keyring-snaps)
 
   const currencyValue = getDisplayCurrencyValue({
     token,

--- a/app/components/UI/Bridge/hooks/useSwitchTokens/index.ts
+++ b/app/components/UI/Bridge/hooks/useSwitchTokens/index.ts
@@ -25,12 +25,7 @@ export const useSwitchTokens = () => {
     domainIsConnectedDapp,
     networkName: selectedNetworkName,
   } = useNetworkInfo();
-  const {
-    onSetRpcTarget,
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-    onNonEvmNetworkChange,
-    ///: END:ONLY_INCLUDE_IF
-  } = useSwitchNetworks({
+  const { onSetRpcTarget, onNonEvmNetworkChange } = useSwitchNetworks({
     domainIsConnectedDapp,
     selectedChainId: selectedEvmChainId,
     selectedNetworkName,

--- a/app/components/UI/Bridge/hooks/useTokenFiatRate/index.ts
+++ b/app/components/UI/Bridge/hooks/useTokenFiatRate/index.ts
@@ -4,9 +4,7 @@ import { calcTokenFiatRate } from '../../utils/exchange-rates';
 import { selectTokenMarketData } from '../../../../../selectors/tokenRatesController';
 import { selectCurrencyRates } from '../../../../../selectors/currencyRateController';
 import { selectNetworkConfigurations } from '../../../../../selectors/networkController';
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { selectMultichainAssetsRates } from '../../../../../selectors/multichain';
-///: END:ONLY_INCLUDE_IF(keyring-snaps)
 
 export const useTokenFiatRate = (token?: BridgeToken) => {
   const evmMultiChainMarketData = useSelector(selectTokenMarketData);
@@ -16,9 +14,7 @@ export const useTokenFiatRate = (token?: BridgeToken) => {
   );
 
   let nonEvmMultichainAssetRates = {};
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   nonEvmMultichainAssetRates = useSelector(selectMultichainAssetsRates);
-  ///: END:ONLY_INCLUDE_IF(keyring-snaps)
 
   return calcTokenFiatRate({
     token,

--- a/app/components/UI/Earn/Views/EarnInputView/EarnInputView.tsx
+++ b/app/components/UI/Earn/Views/EarnInputView/EarnInputView.tsx
@@ -27,9 +27,7 @@ import Button, {
   ButtonWidthTypes,
 } from '../../../../../component-library/components/Buttons/Button';
 import { TextVariant } from '../../../../../component-library/components/Texts/Text';
-///: BEGIN:ONLY_INCLUDE_IF(tron)
 import ResourceToggle from '../../components/Tron/ResourceToggle';
-///: END:ONLY_INCLUDE_IF
 import Routes from '../../../../../constants/navigation/Routes';
 import Engine from '../../../../../core/Engine';
 import { RootState } from '../../../../../reducers';
@@ -82,13 +80,11 @@ import { trace, TraceName } from '../../../../../util/trace';
 import { useEndTraceOnMount } from '../../../../hooks/useEndTraceOnMount';
 import { EVM_SCOPE } from '../../constants/networks';
 
-///: BEGIN:ONLY_INCLUDE_IF(tron)
 import useTronStake from '../../hooks/useTronStake';
 import useTronStakeApy from '../../hooks/useTronStakeApy';
 import TronStakePreview from '../../components/Tron/StakePreview/TronStakePreview';
 import { ComputeFeeResult } from '../../utils/tron-staking-snap';
 import { handleTronStakingNavigationResult } from '../../utils/tron';
-///: END:ONLY_INCLUDE_IF
 
 const EarnInputView = () => {
   // navigation hooks
@@ -131,7 +127,6 @@ const EarnInputView = () => {
   const { attemptDepositTransaction } = usePoolStakedDeposit();
   const { getEarnToken } = useEarnTokens();
 
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   const {
     isTronNative,
     isTronEnabled,
@@ -144,13 +139,10 @@ const EarnInputView = () => {
     tronAccountId,
   } = useTronStake({ token });
   useTronStakeApy();
-  ///: END:ONLY_INCLUDE_IF
 
   // Flag to conditionally show Tron-specific UI (false in non-Tron builds)
   let showTronStakingUI = false;
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   showTronStakingUI = isTronEnabled;
-  ///: END:ONLY_INCLUDE_IF
 
   const earnToken = getEarnToken(token);
 
@@ -244,7 +236,6 @@ const EarnInputView = () => {
 
   // Debounced fee computation that reacts to amount/resourceType changes from any input method.
   // resourceType is captured implicitly via tronValidateStakeAmount's dependency on it.
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   useEffect(() => {
     if (!isTronEnabled || !isNonZeroAmount) return undefined;
 
@@ -255,7 +246,6 @@ const EarnInputView = () => {
 
     return () => clearTimeout(timer);
   }, [amountToken, isTronEnabled, isNonZeroAmount, tronValidateStakeAmount]);
-  ///: END:ONLY_INCLUDE_IF
 
   const navigateToLearnMoreModal = useCallback(() => {
     const tokenExperience = earnToken?.experience?.type;
@@ -263,7 +253,6 @@ const EarnInputView = () => {
     if (tokenExperience === EARN_EXPERIENCES.POOLED_STAKING) {
       trace({ name: TraceName.EarnFaq, data: { experience: tokenExperience } });
 
-      ///: BEGIN:ONLY_INCLUDE_IF(tron)
       // Navigate to TRX staking learn more modal
       if (isTronNative) {
         navigation.navigate('StakeModals', {
@@ -271,7 +260,6 @@ const EarnInputView = () => {
         });
         return;
       }
-      ///: END:ONLY_INCLUDE_IF
 
       navigation.navigate('StakeModals', {
         screen: Routes.STAKING.MODALS.LEARN_MORE,
@@ -286,13 +274,7 @@ const EarnInputView = () => {
         params: { asset: earnToken },
       });
     }
-  }, [
-    earnToken,
-    navigation,
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
-    isTronNative,
-    ///: END:ONLY_INCLUDE_IF
-  ]);
+  }, [earnToken, navigation, isTronNative]);
 
   const handleQuickAmountPressWithTracking = useCallback(
     ({ value }: { value: number }) => {
@@ -662,7 +644,6 @@ const EarnInputView = () => {
   ]);
 
   const handleEarnPress = useCallback(async () => {
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     if (isTronEnabled) {
       const result = await tronConfirmStake?.(amountToken);
       handleTronStakingNavigationResult(
@@ -673,7 +654,6 @@ const EarnInputView = () => {
       );
       return;
     }
-    ///: END:ONLY_INCLUDE_IF
 
     // Stablecoin Lending Flow
     if (
@@ -690,12 +670,10 @@ const EarnInputView = () => {
     earnToken?.experience?.type,
     isStablecoinLendingEnabled,
     amountToken,
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     isTronEnabled,
     navigation,
     tronConfirmStake,
     tronAccountId,
-    ///: END:ONLY_INCLUDE_IF
     handlePooledStakingFlow,
     handleLendingFlow,
   ]);
@@ -815,12 +793,10 @@ const EarnInputView = () => {
   );
 
   const getButtonLabel = () => {
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     // Tron staking has a simpler flow - just show "Stake"
     if (isTronEnabled) {
       return strings('stake.stake');
     }
-    ///: END:ONLY_INCLUDE_IF
 
     if (!isNonZeroAmount) {
       return strings('stake.enter_amount');
@@ -978,10 +954,8 @@ const EarnInputView = () => {
     (isTronNative ? isTronStakeValidating : isLoadingEarnGasFee) ||
     isSubmittingStakeDepositTransaction;
 
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   const shouldShowTronReviewButton =
     isTronEnabled && isTronNative && isPreviewVisible && isNonZeroAmount;
-  ///: END:ONLY_INCLUDE_IF
 
   const renderReviewButton = (isDisabled: boolean) => (
     <View style={styles.reviewButtonContainer}>
@@ -1010,13 +984,9 @@ const EarnInputView = () => {
         }
         includesTopInset
       />
-      {
-        ///: BEGIN:ONLY_INCLUDE_IF(tron)
-        isTronEnabled && (
-          <ResourceToggle value={resourceType} onChange={setResourceType} />
-        )
-        ///: END:ONLY_INCLUDE_IF
-      }
+      {isTronEnabled && (
+        <ResourceToggle value={resourceType} onChange={setResourceType} />
+      )}
       <ScrollView
         style={styles.scrollView}
         contentContainerStyle={styles.scrollViewContent}
@@ -1050,19 +1020,12 @@ const EarnInputView = () => {
             ) : null)}
         </View>
       </ScrollView>
-      {
-        ///: BEGIN:ONLY_INCLUDE_IF(tron)
-        isTronEnabled &&
-          isTronNative &&
-          isPreviewVisible &&
-          isNonZeroAmount && (
-            <TronStakePreview
-              stakeAmount={amountToken}
-              fee={tronPreview?.fee as ComputeFeeResult}
-            />
-          )
-        ///: END:ONLY_INCLUDE_IF
-      }
+      {isTronEnabled && isTronNative && isPreviewVisible && isNonZeroAmount && (
+        <TronStakePreview
+          stakeAmount={amountToken}
+          fee={tronPreview?.fee as ComputeFeeResult}
+        />
+      )}
       {!isPreviewVisible && (
         <>
           <QuickAmounts
@@ -1080,11 +1043,7 @@ const EarnInputView = () => {
           />
         </>
       )}
-      {
-        ///: BEGIN:ONLY_INCLUDE_IF(tron)
-        shouldShowTronReviewButton && renderReviewButton(isReviewButtonDisabled)
-        ///: END:ONLY_INCLUDE_IF
-      }
+      {shouldShowTronReviewButton && renderReviewButton(isReviewButtonDisabled)}
       {!isTronEnabled && renderReviewButton(isReviewButtonDisabled)}
     </ScreenLayout>
   );

--- a/app/components/UI/Earn/Views/EarnWithdrawInputView/EarnWithdrawInputView.tsx
+++ b/app/components/UI/Earn/Views/EarnWithdrawInputView/EarnWithdrawInputView.tsx
@@ -70,14 +70,12 @@ import { trace, TraceName } from '../../../../../util/trace';
 import useEndTraceOnMount from '../../../../hooks/useEndTraceOnMount';
 import { EVM_SCOPE } from '../../constants/networks';
 import { formatChainIdForAnalytics } from '../../utils';
-///: BEGIN:ONLY_INCLUDE_IF(tron)
 import useTronUnstake from '../../hooks/useTronUnstake';
 import useTronStakeApy from '../../hooks/useTronStakeApy';
 import ResourceToggle from '../../components/Tron/ResourceToggle';
 import { handleTronStakingNavigationResult } from '../../utils/tron';
 import TronStakePreview from '../../components/Tron/StakePreview/TronStakePreview';
 import { ComputeFeeResult } from '../../utils/tron-staking-snap';
-///: END:ONLY_INCLUDE_IF
 
 export const EARN_WITHDRAW_INPUT_VIEW_BACK_BUTTON_TEST_ID =
   'earn-withdraw-input-header-back-button';
@@ -106,7 +104,6 @@ const EarnWithdrawInputView = () => {
 
   const earnTokenFromMap = getEarnToken(token);
 
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   const {
     isTronEnabled,
     resourceType,
@@ -119,31 +116,21 @@ const EarnWithdrawInputView = () => {
     tronAccountId,
   } = useTronUnstake({ token });
   const { apyPercent: tronApyPercent } = useTronStakeApy();
-  ///: END:ONLY_INCLUDE_IF
 
   // Flag to conditionally show Tron-specific UI
   let showTronUnstakingUI = false;
   let isTronValidating = false;
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   showTronUnstakingUI = isTronEnabled;
   isTronValidating = isTronUnstakeValidating;
-  ///: END:ONLY_INCLUDE_IF
 
   // Receipt token represents the staked position (stETH, aUSDC, sTRX)
   // For Tron, tronWithdrawalToken acts as the receipt token with staked balance
   const receiptTokenToUse: EarnTokenDetails | undefined = React.useMemo(() => {
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     if (tronWithdrawalToken) {
       return tronWithdrawalToken;
     }
-    ///: END:ONLY_INCLUDE_IF
     return receiptToken as EarnTokenDetails | undefined;
-  }, [
-    receiptToken,
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
-    tronWithdrawalToken,
-    ///: END:ONLY_INCLUDE_IF
-  ]);
+  }, [receiptToken, tronWithdrawalToken]);
 
   const withdrawalToken: EarnTokenDetails | undefined = useMemo(() => {
     if (
@@ -247,7 +234,6 @@ const EarnWithdrawInputView = () => {
 
   // Debounced fee computation that reacts to amount/resourceType changes from any input method.
   // resourceType is captured implicitly via tronValidateUnstakeAmount's dependency on it.
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   useEffect(() => {
     if (!isTronEnabled || !isNonZeroAmount) return undefined;
 
@@ -258,7 +244,6 @@ const EarnWithdrawInputView = () => {
 
     return () => clearTimeout(timer);
   }, [amountToken, isTronEnabled, isNonZeroAmount, tronValidateUnstakeAmount]);
-  ///: END:ONLY_INCLUDE_IF
 
   const [maxRiskAwareWithdrawalAmount, setMaxRiskAwareWithdrawalAmount] =
     useState<string | undefined>(undefined);
@@ -614,7 +599,6 @@ const EarnWithdrawInputView = () => {
   // TODO: think about if we could rely on receiptToken experience instead here
   // should we be able to, consider the implications of not being able to
   const handleWithdrawPress = useCallback(async () => {
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     if (isTronEnabled) {
       const result = await tronConfirmUnstake?.(amountToken);
       handleTronStakingNavigationResult(
@@ -625,7 +609,6 @@ const EarnWithdrawInputView = () => {
       );
       return;
     }
-    ///: END:ONLY_INCLUDE_IF
     if (
       withdrawalToken?.experience?.type === EARN_EXPERIENCES.STABLECOIN_LENDING
     ) {
@@ -636,13 +619,11 @@ const EarnWithdrawInputView = () => {
       return handleUnstakeWithdrawalFlow();
     }
   }, [
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     isTronEnabled,
     tronConfirmUnstake,
     amountToken,
     navigation,
     tronAccountId,
-    ///: END:ONLY_INCLUDE_IF
     withdrawalToken?.experience?.type,
     handleLendingWithdrawalFlow,
     handleUnstakeWithdrawalFlow,
@@ -713,12 +694,10 @@ const EarnWithdrawInputView = () => {
       return strings('earn.amount_exceeds_safe_withdrawal_limit');
     }
 
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     // Tron unstaking confirms directly without a review screen
     if (showTronUnstakingUI) {
       return strings('stake.unstake');
     }
-    ///: END:ONLY_INCLUDE_IF
 
     return strings('stake.review');
   }, [
@@ -726,9 +705,7 @@ const EarnWithdrawInputView = () => {
     isOverMaximum.isOverMaximumToken,
     isOverMaximum.isOverMaximumEth,
     isWithdrawingMoreThanAvailableForLendingToken,
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     showTronUnstakingUI,
-    ///: END:ONLY_INCLUDE_IF
     withdrawalToken?.ticker,
     withdrawalToken?.symbol,
   ]);
@@ -862,7 +839,6 @@ const EarnWithdrawInputView = () => {
     [handleKeypadChange],
   );
 
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   const shouldShowTronWithdrawButton =
     isTronEnabled && isPreviewVisible && isNonZeroAmount;
 
@@ -872,7 +848,6 @@ const EarnWithdrawInputView = () => {
     isOverMaximum.isOverMaximumEth ||
     isSubmittingStakeWithdrawalTransaction ||
     isTronUnstakeValidating;
-  ///: END:ONLY_INCLUDE_IF
 
   const isWithdrawButtonDisabled =
     (showTronUnstakingUI
@@ -907,13 +882,9 @@ const EarnWithdrawInputView = () => {
         style={headerSubtitle ? styles.headerWithSubtitle : undefined}
       />
       <ScreenLayout style={styles.container}>
-        {
-          ///: BEGIN:ONLY_INCLUDE_IF(tron)
-          isTronEnabled && (
-            <ResourceToggle value={resourceType} onChange={setResourceType} />
-          )
-          ///: END:ONLY_INCLUDE_IF
-        }
+        {isTronEnabled && (
+          <ResourceToggle value={resourceType} onChange={setResourceType} />
+        )}
         <ScrollView
           style={styles.scrollView}
           contentContainerStyle={styles.scrollViewContent}
@@ -947,17 +918,13 @@ const EarnWithdrawInputView = () => {
             </View>
           )}
         </ScrollView>
-        {
-          ///: BEGIN:ONLY_INCLUDE_IF(tron)
-          isTronEnabled && isPreviewVisible && isNonZeroAmount && (
-            <TronStakePreview
-              stakeAmount={amountToken}
-              fee={tronPreview?.fee as ComputeFeeResult}
-              mode="unstake"
-            />
-          )
-          ///: END:ONLY_INCLUDE_IF
-        }
+        {isTronEnabled && isPreviewVisible && isNonZeroAmount && (
+          <TronStakePreview
+            stakeAmount={amountToken}
+            fee={tronPreview?.fee as ComputeFeeResult}
+            mode="unstake"
+          />
+        )}
         {!isPreviewVisible && (
           <>
             <QuickAmounts
@@ -976,25 +943,21 @@ const EarnWithdrawInputView = () => {
             />
           </>
         )}
-        {
-          ///: BEGIN:ONLY_INCLUDE_IF(tron)
-          shouldShowTronWithdrawButton && (
-            <View style={styles.reviewButtonContainer}>
-              <Button
-                testID="review-button"
-                label={buttonLabel}
-                size={ButtonSize.Lg}
-                labelTextVariant={TextVariant.BodyMDMedium}
-                variant={ButtonVariants.Primary}
-                loading={isSubmittingStakeWithdrawalTransaction}
-                isDisabled={isTronWithdrawButtonDisabled}
-                width={ButtonWidthTypes.Full}
-                onPress={handleWithdrawPress}
-              />
-            </View>
-          )
-          ///: END:ONLY_INCLUDE_IF
-        }
+        {shouldShowTronWithdrawButton && (
+          <View style={styles.reviewButtonContainer}>
+            <Button
+              testID="review-button"
+              label={buttonLabel}
+              size={ButtonSize.Lg}
+              labelTextVariant={TextVariant.BodyMDMedium}
+              variant={ButtonVariants.Primary}
+              loading={isSubmittingStakeWithdrawalTransaction}
+              isDisabled={isTronWithdrawButtonDisabled}
+              width={ButtonWidthTypes.Full}
+              onPress={handleWithdrawPress}
+            />
+          </View>
+        )}
         {!isTronEnabled && (
           <View style={styles.reviewButtonContainer}>
             <Button

--- a/app/components/UI/Earn/components/EarnBalance/index.tsx
+++ b/app/components/UI/Earn/components/EarnBalance/index.tsx
@@ -7,9 +7,7 @@ import StakingBalance from '../../../Stake/components/StakingBalance/StakingBala
 import { TokenI } from '../../../Tokens/types';
 import EarnLendingBalance from '../EarnLendingBalance';
 import { selectIsStakeableToken } from '../../../Stake/selectors/stakeableTokens';
-///: BEGIN:ONLY_INCLUDE_IF(tron)
 import { selectTrxStakingEnabled } from '../../../../../selectors/featureFlagController/trxStakingEnabled';
-///: END:ONLY_INCLUDE_IF
 import { useMusdConversionTokens } from '../../hooks/useMusdConversionTokens';
 import { useMusdConversionEligibility } from '../../hooks/useMusdConversionEligibility';
 import { selectIsMusdConversionFlowEnabledFlag } from '../../selectors/featureFlags';
@@ -36,14 +34,12 @@ const EarnBalance = ({ asset }: EarnBalanceProps) => {
   const { isConversionToken } = useMusdConversionTokens();
   const { isEligible: isGeoEligible } = useMusdConversionEligibility();
 
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   const isTrxStakingEnabled = useSelector(selectTrxStakingEnabled);
   const isTron = asset?.chainId?.startsWith('tron:');
 
   if (isTron && isTrxStakingEnabled) {
     return null;
   }
-  ///: END:ONLY_INCLUDE_IF
 
   const isConvertibleStablecoin =
     isMusdConversionFlowEnabled && isConversionToken(asset) && isGeoEligible;

--- a/app/components/UI/Navbar/index.js
+++ b/app/components/UI/Navbar/index.js
@@ -1285,10 +1285,8 @@ export function getStakingNavbar(
   themeColors,
   navBarOptions,
   metricsOptions,
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   earnToken = null,
   aprOverride = null,
-  ///: END:ONLY_INCLUDE_IF
 ) {
   const {
     hasBackButton = true,
@@ -1361,40 +1359,34 @@ export function getStakingNavbar(
     }
   }
 
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   const parsedOverride = aprOverride ? parseFloat(aprOverride) : 0;
   const apr =
     parsedOverride > 0
       ? aprOverride
       : `${parseFloat(earnToken?.experience?.apr ?? '0').toFixed(1)}%`;
-  ///: END:ONLY_INCLUDE_IF
 
   return {
     headerTitle: () => (
       <View style={innerStyles.headerTitle}>
         <MorphText variant={TextVariant.HeadingMD}>{title}</MorphText>
-        {
-          ///: BEGIN:ONLY_INCLUDE_IF(tron)
-          earnToken && (
-            <View style={innerStyles.headerTitleBalanceAndAPR}>
-              <MorphText
-                variant={TextVariant.BodySMMedium}
-                color={TextColor.Alternative}
-                numberOfLines={1}
-                ellipsizeMode="tail"
-              >
-                {earnToken.balanceFormatted}
-              </MorphText>
-              <MorphText
-                variant={TextVariant.BodySMMedium}
-                color={TextColor.Success}
-              >
-                {`${apr} ${strings('earn.apr')}`}
-              </MorphText>
-            </View>
-          )
-          ///: END:ONLY_INCLUDE_IF
-        }
+        {earnToken && (
+          <View style={innerStyles.headerTitleBalanceAndAPR}>
+            <MorphText
+              variant={TextVariant.BodySMMedium}
+              color={TextColor.Alternative}
+              numberOfLines={1}
+              ellipsizeMode="tail"
+            >
+              {earnToken.balanceFormatted}
+            </MorphText>
+            <MorphText
+              variant={TextVariant.BodySMMedium}
+              color={TextColor.Success}
+            >
+              {`${apr} ${strings('earn.apr')}`}
+            </MorphText>
+          </View>
+        )}
       </View>
     ),
     headerStyle: innerStyles.headerStyle,

--- a/app/components/UI/Ramp/Aggregator/hooks/useBalance.ts
+++ b/app/components/UI/Ramp/Aggregator/hooks/useBalance.ts
@@ -20,10 +20,8 @@ import {
 import { CaipChainId, Hex } from '@metamask/utils';
 import { toHex } from '@metamask/controller-utils';
 import { getEvmHexChainId } from '../utils';
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { selectMultichainBalances } from '../../../../../selectors/multichain';
 import { selectSelectedInternalAccountByScope } from '../../../../../selectors/multichainAccounts/accounts';
-///: END:ONLY_INCLUDE_IF
 
 const defaultReturn = {
   balance: null,
@@ -40,9 +38,7 @@ interface Asset {
 
 export default function useBalance(asset?: Asset) {
   const accountsByChainId = useSelector(selectAccountsByChainId);
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   const multiChainTokenBalance = useSelector(selectMultichainBalances);
-  ///: END:ONLY_INCLUDE_IF
   const selectedAddress = useSelector(
     selectSelectedInternalAccountFormattedAddress,
   );
@@ -74,7 +70,6 @@ export default function useBalance(asset?: Asset) {
 
   let balance, balanceFiat, balanceBN;
 
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   if (asset.assetId) {
     const selectedAccount = selectInternalAccountByScope(
       asset.chainId as CaipChainId,
@@ -93,7 +88,6 @@ export default function useBalance(asset?: Asset) {
     }`.trim();
   }
 
-  ///: END:ONLY_INCLUDE_IF
   if (!balance && asset.address === NATIVE_ADDRESS && asset.chainId) {
     const hexChainId = toHex(asset.chainId);
     // Chain id should exist in accountsByChainId in AccountTrackerController at this point in time

--- a/app/components/UI/Stake/components/StakeButton/index.tsx
+++ b/app/components/UI/Stake/components/StakeButton/index.tsx
@@ -33,12 +33,10 @@ import { StakeSDKProvider } from '../../sdk/stakeSdkProvider';
 import { Hex } from '@metamask/utils';
 import { trace, TraceName } from '../../../../../util/trace';
 import { earnSelectors } from '../../../../../selectors/earnController/earn';
-///: BEGIN:ONLY_INCLUDE_IF(tron)
 import { selectTrxStakingEnabled } from '../../../../../selectors/featureFlagController/trxStakingEnabled';
 import { isTronChainId } from '../../../../../core/Multichain/utils';
 import useTronStakeApy from '../../../Earn/hooks/useTronStakeApy';
 import useStakingEligibility from '../../hooks/useStakingEligibility';
-///: END:ONLY_INCLUDE_IF
 import BigNumber from 'bignumber.js';
 import { MINIMUM_BALANCE_FOR_EARN_CTA } from '../../../Earn/constants/token';
 import useEarnToken from '../../../Earn/hooks/useEarnToken';
@@ -62,12 +60,10 @@ const StakeButtonContent = ({ earnToken }: StakeButtonContentProps) => {
     selectStablecoinLendingEnabledFlag,
   );
 
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   const isTrxStakingEnabled = useSelector(selectTrxStakingEnabled);
   const isTronNative =
     earnToken?.isNative && isTronChainId(earnToken.chainId as Hex);
   const { apyPercent: tronApyPercent } = useTronStakeApy();
-  ///: END:ONLY_INCLUDE_IF
   const network = useSelector((state: RootState) =>
     selectNetworkConfigurationByChainId(state, earnToken?.chainId as Hex),
   );
@@ -80,7 +76,6 @@ const StakeButtonContent = ({ earnToken }: StakeButtonContentProps) => {
     !isPooledStakingEnabled && !isStablecoinLendingEnabled;
 
   const handleStakeRedirect = async () => {
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     if (isTronNative && isTrxStakingEnabled) {
       // Track analytics before eligibility check to preserve behavior
       trackEvent(
@@ -105,7 +100,6 @@ const StakeButtonContent = ({ earnToken }: StakeButtonContentProps) => {
       });
       return;
     }
-    ///: END:ONLY_INCLUDE_IF
 
     if (!isStakingSupportedChain) {
       await Engine.context.MultichainNetworkController.setActiveNetwork(
@@ -166,11 +160,9 @@ const StakeButtonContent = ({ earnToken }: StakeButtonContentProps) => {
         ? strings('stake.stake')
         : strings('stake.earn');
 
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     if (isTronNative && isTrxStakingEnabled && tronApyPercent) {
       return `${ctaLabel} ${tronApyPercent}`;
     }
-    ///: END:ONLY_INCLUDE_IF
 
     const aprNumber = Number(earnToken?.experience?.apr);
     const aprText =

--- a/app/components/UI/Stake/routes/index.tsx
+++ b/app/components/UI/Stake/routes/index.tsx
@@ -9,9 +9,7 @@ import MaxInputModal from '../../Earn/components/MaxInputModal';
 import GasImpactModal from '../components/GasImpactModal';
 import StakeEarningsHistoryView from '../Views/StakeEarningsHistoryView/StakeEarningsHistoryView';
 import PoolStakingLearnMoreModal from '../components/PoolStakingLearnMoreModal';
-///: BEGIN:ONLY_INCLUDE_IF(tron)
 import TronStakingLearnMoreModal from '../../Earn/components/Tron/TronStakingLearnMoreModal';
-///: END:ONLY_INCLUDE_IF
 import EarnTokenList from '../../Earn/components/EarnTokenList';
 import EarnInputView from '../../Earn/Views/EarnInputView/EarnInputView';
 import EarnWithdrawInputView from '../../Earn/Views/EarnWithdrawInputView/EarnWithdrawInputView';
@@ -88,17 +86,11 @@ const StakeModalStack = () => (
         component={PoolStakingLearnMoreModal}
         options={{ headerShown: false }}
       />
-      {
-        ///: BEGIN:ONLY_INCLUDE_IF(tron)
-      }
       <ModalStack.Screen
         name={Routes.STAKING.MODALS.TRX_LEARN_MORE}
         component={TronStakingLearnMoreModal}
         options={{ headerShown: false }}
       />
-      {
-        ///: END:ONLY_INCLUDE_IF
-      }
       <ModalStack.Screen
         name={Routes.STAKING.MODALS.MAX_INPUT}
         component={MaxInputModal}

--- a/app/components/UI/TokenDetails/Views/TokenDetails.tsx
+++ b/app/components/UI/TokenDetails/Views/TokenDetails.tsx
@@ -330,11 +330,9 @@ const TokenDetails: React.FC<{
     fiatBalance,
     balanceFiatUsd,
     tokenFormattedBalance,
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     stakedTrxAsset,
     inLockPeriodBalance,
     readyForWithdrawalBalance,
-    ///: END:ONLY_INCLUDE_IF
   } = useTokenBalance(token, { calculateUsdBalance: true });
 
   const hasBalanceValue = Boolean(balance) && balance !== '0';
@@ -490,11 +488,9 @@ const TokenDetails: React.FC<{
         onExitAction={onCtaClicked}
         isPricePositive={chartPricePositive}
         onPerpsMarketResolved={onPerpsMarketResolved}
-        ///: BEGIN:ONLY_INCLUDE_IF(tron)
         stakedTrxAsset={stakedTrxAsset}
         inLockPeriodBalance={inLockPeriodBalance}
         readyForWithdrawalBalance={readyForWithdrawalBalance}
-        ///: END:ONLY_INCLUDE_IF
       />
       {(txLoading || hasTransactions) && (
         <ActivityHeader

--- a/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
+++ b/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
@@ -86,11 +86,9 @@ import {
 } from '@metamask/design-system-react-native';
 import { TextColor as ComponentLibraryTextColor } from '../../../../component-library/components/Texts/Text';
 import { SecurityBanner } from './SecurityBanner';
-///: BEGIN:ONLY_INCLUDE_IF(tron)
 import TronEnergyBandwidthDetail from '../../AssetOverview/TronEnergyBandwidthDetail/TronEnergyBandwidthDetail';
 import TronAssetOverviewSection from './TronAssetOverviewSection';
 import { isTronNativeToken } from '../utils/isTronNativeToken';
-///: END:ONLY_INCLUDE_IF
 import MarketClosedActionButton from '../../AssetOverview/MarketClosedActionButton';
 import { IconName as ComponentLibraryIconName } from '../../../../component-library/components/Icons/Icon';
 import { useRWAToken } from '../../Bridge/hooks/useRWAToken';
@@ -663,11 +661,7 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
               )}
             </View>
           ) : null}
-          {
-            ///: BEGIN:ONLY_INCLUDE_IF(tron)
-            tronNativeToken && <TronEnergyBandwidthDetail />
-            ///: END:ONLY_INCLUDE_IF
-          }
+          {tronNativeToken && <TronEnergyBandwidthDetail />}
           {balance != null && (
             <>
               <Balance
@@ -690,18 +684,14 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
               location={MONEY_HUB_EVENTS_CONSTANTS.EVENT_LOCATIONS.ASSET_DETAIL}
             />
           )}
-          {
-            ///: BEGIN:ONLY_INCLUDE_IF(tron)
-            tronNativeToken && (
-              <TronAssetOverviewSection
-                token={tronNativeToken}
-                stakedTrxAsset={stakedTrxAsset}
-                inLockPeriodBalance={inLockPeriodBalance}
-                readyForWithdrawalBalance={readyForWithdrawalBalance}
-              />
-            )
-            ///: END:ONLY_INCLUDE_IF
-          }
+          {tronNativeToken && (
+            <TronAssetOverviewSection
+              token={tronNativeToken}
+              stakedTrxAsset={stakedTrxAsset}
+              inLockPeriodBalance={inLockPeriodBalance}
+              readyForWithdrawalBalance={readyForWithdrawalBalance}
+            />
+          )}
           {showPerpsSection && perpsPosition && (
             <View style={styles.perpsPositionCardContainer}>
               <Text variant={TextVariant.HeadingMd} twClassName="mb-2 px-4">

--- a/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenAtomicActions.ts
@@ -354,9 +354,7 @@ export const useHandleOnSend = ({ token }: { token: TokenActionInput }) => {
   const { trackEvent, createEventBuilder } = useAnalytics();
   const { navigateToSendPage } = useSendNavigation();
 
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   const { sendNonEvmAsset } = useSendNonEvmAsset({ asset: token });
-  ///: END:ONLY_INCLUDE_IF
 
   return useCallback(async () => {
     trackEvent(

--- a/app/components/UI/TokenDetails/hooks/useTokenBalance.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenBalance.ts
@@ -4,32 +4,26 @@ import { RootState } from '../../../../reducers';
 import { TokenI } from '../../Tokens/types';
 import {
   selectAsset,
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   selectTronSpecialAssetsBySelectedAccountGroup,
-  ///: END:ONLY_INCLUDE_IF
 } from '../../../../selectors/assets/assets-list';
 import { toFormattedAddress } from '../../../../util/address';
 import {
   selectCurrencyRateForChainId,
   selectUSDConversionRateByChainId,
 } from '../../../../selectors/currencyRateController';
-///: BEGIN:ONLY_INCLUDE_IF(tron)
 import I18n from '../../../../../locales/i18n';
 import { formatWithThreshold } from '../../../../util/assets';
 import { createStakedTrxAsset } from '../../AssetOverview/utils/createStakedTrxAsset';
 import { isTronNativeToken } from '../utils/isTronNativeToken';
-///: END:ONLY_INCLUDE_IF
 
 export interface UseTokenBalanceResult {
   balance: string | undefined;
   fiatBalance: string | undefined;
   tokenFormattedBalance: string | undefined;
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   isTronNative: boolean;
   stakedTrxAsset: TokenI | undefined;
   inLockPeriodBalance: string | undefined;
   readyForWithdrawalBalance: string | undefined;
-  ///: END:ONLY_INCLUDE_IF
 }
 
 export interface UseTokenBalanceWithUsdResult extends UseTokenBalanceResult {
@@ -68,7 +62,6 @@ export function useTokenBalance(
       : undefined,
   );
 
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   const {
     stakedTrxForEnergy,
     stakedTrxForBandwidth,
@@ -112,7 +105,6 @@ export function useTokenBalance(
           maximumFractionDigits: 5,
         }) || undefined
       : undefined;
-  ///: END:ONLY_INCLUDE_IF
 
   const balance = processedAsset?.balance;
 
@@ -122,12 +114,10 @@ export function useTokenBalance(
     tokenFormattedBalance: balance
       ? `${balance} ${processedAsset.symbol}`
       : undefined,
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     isTronNative,
     stakedTrxAsset,
     inLockPeriodBalance,
     readyForWithdrawalBalance,
-    ///: END:ONLY_INCLUDE_IF
   };
 
   if (!options?.calculateUsdBalance) {

--- a/app/components/UI/TokenDetails/hooks/useTokenTransactions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenTransactions.ts
@@ -38,13 +38,11 @@ import {
 } from '../../../../selectors/currencyRateController';
 import { TokenI } from '../../Tokens/types';
 import { RootState } from '../../../../reducers';
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { selectNonEvmTransactionsForSelectedAccountGroup } from '../../../../selectors/multichain';
 import {
   AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,
   SupportedCaipChainId,
 } from '@metamask/multichain-network-controller';
-///: END:ONLY_INCLUDE_IF
 
 /**
  * Transaction type alias for this hook.
@@ -151,11 +149,9 @@ export const useTokenTransactions = (
     [selectedAddressForAsset],
   );
 
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   const nonEvmTransactionsData = useSelector(
     selectNonEvmTransactionsForSelectedAccountGroup,
   );
-  ///: END:ONLY_INCLUDE_IF
 
   // Get all transactions (EVM or non-EVM)
   const allTransactions = useMemo(() => {
@@ -167,7 +163,6 @@ export const useTokenTransactions = (
         )
       : evmTransactions;
 
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     if (asset.chainId && isNonEvmChainId(asset.chainId)) {
       const txs =
         nonEvmTransactionsData?.transactions?.filter(
@@ -264,7 +259,6 @@ export const useTokenTransactions = (
         (a, b) => (b?.time ?? 0) - (a?.time ?? 0),
       );
     }
-    ///: END:ONLY_INCLUDE_IF
 
     return transactions;
   }, [
@@ -275,9 +269,7 @@ export const useTokenTransactions = (
     asset.symbol,
     asset.isNative,
     asset.isETH,
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     nonEvmTransactionsData,
-    ///: END:ONLY_INCLUDE_IF
   ]);
 
   // Wrapper for shared mUSD claim detection utility

--- a/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.tsx
+++ b/app/components/UI/Tokens/TokenList/TokenListItem/TokenListItem.tsx
@@ -183,9 +183,7 @@ export const TokenListItem = React.memo(
     const tokenMarketData = useSelector(selectTokenMarketData);
     const currencyRates = useSelector(selectCurrencyRates);
 
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     const multichainAssetsRates = useSelector(selectMultichainAssetsRates);
-    ///: END:ONLY_INCLUDE_IF
 
     const asset = useSelector((state: RootState) =>
       selectAsset(state, {
@@ -273,14 +271,12 @@ export const TokenListItem = React.memo(
         return undefined;
       }
 
-      ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
       // Non-EVM: use MultichainAssetsRatesController (rate is already in fiat)
       const multichainRate =
         multichainAssetsRates?.[asset.address as CaipAssetType]?.rate;
       if (multichainRate !== undefined) {
         return multichainRate;
       }
-      ///: END:ONLY_INCLUDE_IF
 
       // EVM: convert token price from native currency to fiat
       if (!nativeCurrency) {
@@ -323,9 +319,7 @@ export const TokenListItem = React.memo(
       currencyRates,
       nativeCurrency,
       showFiatOnTestnets,
-      ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
       multichainAssetsRates,
-      ///: END:ONLY_INCLUDE_IF
     ]);
 
     const handleTokenListItemCtaPress = useCallback(async () => {

--- a/app/components/UI/Tokens/hooks/useTokenPricePercentageChange.ts
+++ b/app/components/UI/Tokens/hooks/useTokenPricePercentageChange.ts
@@ -20,9 +20,7 @@ export const useTokenPricePercentageChange = (
 ): number | undefined => {
   const multiChainMarketData = useSelector(selectTokenMarketData);
 
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   const allMultichainAssetsRates = useSelector(selectMultichainAssetsRates);
-  ///: END:ONLY_INCLUDE_IF(keyring-snaps)
 
   const tokenPercentageChange = asset?.address
     ? multiChainMarketData?.[asset?.chainId as Hex]?.[asset.address as Hex]

--- a/app/components/UI/Trending/utils/trendingNetworksList.ts
+++ b/app/components/UI/Trending/utils/trendingNetworksList.ts
@@ -1,8 +1,4 @@
-import {
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
-  TrxScope,
-  ///: END:ONLY_INCLUDE_IF
-} from '@metamask/keyring-api';
+import { TrxScope } from '@metamask/keyring-api';
 import type { CaipChainId } from '@metamask/utils';
 import { ProcessedNetwork } from '../../../hooks/useNetworksByNamespace/useNetworksByNamespace';
 import { getNetworkImageSource } from '../../../../util/networks';
@@ -24,7 +20,6 @@ export const TRENDING_NETWORKS_LIST: ProcessedNetwork[] = [
       chainId: NetworkToCaipChainId.ETHEREUM,
     }),
   },
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   {
     id: NetworkToCaipChainId.SOLANA,
     name: 'Solana',
@@ -34,7 +29,6 @@ export const TRENDING_NETWORKS_LIST: ProcessedNetwork[] = [
       chainId: NetworkToCaipChainId.SOLANA,
     }),
   },
-  ///: END:ONLY_INCLUDE_IF
   {
     id: NetworkToCaipChainId.BNB,
     name: 'BNB Chain',
@@ -51,7 +45,6 @@ export const TRENDING_NETWORKS_LIST: ProcessedNetwork[] = [
       chainId: NetworkToCaipChainId.BASE,
     }),
   },
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   {
     id: TrxScope.Mainnet,
     name: 'Tron',
@@ -59,7 +52,6 @@ export const TRENDING_NETWORKS_LIST: ProcessedNetwork[] = [
     isSelected: false,
     imageSource: getNetworkImageSource({ chainId: TrxScope.Mainnet }),
   },
-  ///: END:ONLY_INCLUDE_IF
   {
     id: NetworkToCaipChainId.ARBITRUM,
     name: 'Arbitrum',

--- a/app/components/Views/AccountActions/AccountActions.tsx
+++ b/app/components/Views/AccountActions/AccountActions.tsx
@@ -35,9 +35,7 @@ import { useAnalytics } from '../../../components/hooks/useAnalytics/useAnalytic
 import {
   isHardwareAccount,
   isHDOrFirstPartySnapAccount,
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   isSnapAccount,
-  ///: END:ONLY_INCLUDE_IF
 } from '../../../util/address';
 import { removeAccountsFromPermissions } from '../../../core/Permissions';
 import ExtendedKeyringTypes, {
@@ -240,8 +238,6 @@ const AccountActions = () => {
     }
   }, [controllers.KeyringController]);
 
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-
   /**
    * Remove the snap account from the keyring
    */
@@ -287,7 +283,6 @@ const AccountActions = () => {
       ],
     );
   }, [removeSnapAccount]);
-  ///: END:ONLY_INCLUDE_IF
 
   /**
    * Forget the device if there are no more accounts in the keyring
@@ -446,18 +441,14 @@ const AccountActions = () => {
             }
           />
         )}
-        {
-          ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-          selectedAddress && isSnapAccount(selectedAddress) && (
-            <AccountAction
-              actionTitle={strings('accounts.remove_snap_account')}
-              iconName={IconName.Close}
-              onPress={showRemoveSnapAccountAlert}
-              testID={AccountActionsBottomSheetSelectorsIDs.REMOVE_SNAP_ACCOUNT}
-            />
-          )
-          ///: END:ONLY_INCLUDE_IF
-        }
+        {selectedAddress && isSnapAccount(selectedAddress) && (
+          <AccountAction
+            actionTitle={strings('accounts.remove_snap_account')}
+            iconName={IconName.Close}
+            onPress={showRemoveSnapAccountAlert}
+            testID={AccountActionsBottomSheetSelectorsIDs.REMOVE_SNAP_ACCOUNT}
+          />
+        )}
         {networkSupporting7702Present &&
           !isHardwareAccount(selectedAddress) && (
             <AccountAction

--- a/app/components/Views/Browser/index.js
+++ b/app/components/Views/Browser/index.js
@@ -51,10 +51,8 @@ import styleSheet from './styles';
 import Routes from '../../../constants/navigation/Routes';
 import { MAX_BROWSER_TABS, MAX_MOUNTED_TABS } from './constants';
 import { getMountedTabIds } from './utils';
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import DiscoveryTab from '../DiscoveryTab/DiscoveryTab';
-///: END:ONLY_INCLUDE_IF
 
 /**
  * Component that wraps all the browser

--- a/app/components/Views/NetworkSelector/NetworkSelector.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelector.tsx
@@ -76,9 +76,7 @@ import ReusableModal, { ReusableModalRef } from '../../UI/ReusableModal';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   selectIsEvmNetworkSelected,
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   selectNonEvmNetworkConfigurationsByChainId,
-  ///: END:ONLY_INCLUDE_IF
   selectSelectedNonEvmNetworkChainId,
 } from '../../../selectors/multichainNetworkController';
 import { isNonEvmChainId } from '../../../core/Multichain/utils';
@@ -128,11 +126,9 @@ const NetworkSelector = ({ route }: NetworkSelectorProps) => {
     selectEvmNetworkConfigurationsByChainId,
   );
 
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   const nonEvmNetworkConfigurations = useSelector(
     selectNonEvmNetworkConfigurationsByChainId,
   );
-  ///: END:ONLY_INCLUDE_IF
 
   const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
   const selectedNonEvmChainId = useSelector(selectSelectedNonEvmNetworkChainId);
@@ -324,21 +320,16 @@ const NetworkSelector = ({ route }: NetworkSelectorProps) => {
     return chainId === selectedChainId;
   };
 
-  const {
-    onSetRpcTarget,
-    onNetworkChange,
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-    onNonEvmNetworkChange,
-    ///: END:ONLY_INCLUDE_IF
-  } = useSwitchNetworks({
-    domainIsConnectedDapp,
-    origin,
-    selectedChainId,
-    selectedNetworkName,
-    dismissModal: () => sheetRef.current?.dismissModal(),
-    closeRpcModal,
-    parentSpan,
-  });
+  const { onSetRpcTarget, onNetworkChange, onNonEvmNetworkChange } =
+    useSwitchNetworks({
+      domainIsConnectedDapp,
+      origin,
+      selectedChainId,
+      selectedNetworkName,
+      dismissModal: () => sheetRef.current?.dismissModal(),
+      closeRpcModal,
+      parentSpan,
+    });
 
   useEffect(() => {
     endTrace({ name: TraceName.NetworkSwitch });
@@ -442,9 +433,7 @@ const NetworkSelector = ({ route }: NetworkSelectorProps) => {
         >
           <NetworkSelectorList
             networkConfigurations={networkConfigurations}
-            ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
             nonEvmNetworkConfigurations={nonEvmNetworkConfigurations}
-            ///: END:ONLY_INCLUDE_IF
             searchString={searchString}
             showTestNetworks={showTestNetworks}
             isSendFlow={isSendFlow}
@@ -461,9 +450,7 @@ const NetworkSelector = ({ route }: NetworkSelectorProps) => {
             isNetworkSelected={isNetworkSelected}
             onSetRpcTarget={onSetRpcTarget}
             onNetworkChange={onNetworkChange}
-            ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
             onNonEvmNetworkChange={onNonEvmNetworkChange}
-            ///: END:ONLY_INCLUDE_IF
             openModal={openModal}
             openRpcModal={openRpcModal}
             onCancel={onCancel}

--- a/app/components/Views/NetworkSelector/NetworkSelectorList/NetworkSelectorList.tsx
+++ b/app/components/Views/NetworkSelector/NetworkSelectorList/NetworkSelectorList.tsx
@@ -69,9 +69,7 @@ const getItemType = (item: NetworkSelectorListItem) => item.type;
 
 const NetworkSelectorList = ({
   networkConfigurations,
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   nonEvmNetworkConfigurations,
-  ///: END:ONLY_INCLUDE_IF
   searchString,
   showTestNetworks,
   isSendFlow,
@@ -88,9 +86,7 @@ const NetworkSelectorList = ({
   isNetworkSelected,
   onSetRpcTarget,
   onNetworkChange,
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   onNonEvmNetworkChange,
-  ///: END:ONLY_INCLUDE_IF
   openModal,
   openRpcModal,
   onCancel,
@@ -402,7 +398,6 @@ const NetworkSelectorList = ({
     );
   };
 
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   const renderNonEvmNetwork = (network: NonEvmNetworkListConfiguration) => (
     <Cell
       variant={CellVariant.Select}
@@ -418,7 +413,6 @@ const NetworkSelectorList = ({
       style={styles.networkCell}
     />
   );
-  ///: END:ONLY_INCLUDE_IF
 
   const renderAdditionalNetworks = () => {
     const filteredNetworks =
@@ -495,7 +489,6 @@ const NetworkSelectorList = ({
       });
     });
 
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     if (!isSendFlow) {
       Object.values(nonEvmNetworkConfigurations)
         .filter((network) => !network.isTestnet)
@@ -507,7 +500,6 @@ const NetworkSelectorList = ({
           });
         });
     }
-    ///: END:ONLY_INCLUDE_IF
 
     if (!isSendFlow && isRedesignEnabled && searchString.length === 0) {
       items.push({
@@ -545,7 +537,6 @@ const NetworkSelectorList = ({
         });
       });
 
-      ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
       Object.values(nonEvmNetworkConfigurations)
         .filter((network) => network.isTestnet)
         .forEach((networkConfiguration) => {
@@ -555,7 +546,6 @@ const NetworkSelectorList = ({
             networkConfiguration,
           });
         });
-      ///: END:ONLY_INCLUDE_IF
     }
 
     return items;
@@ -563,9 +553,7 @@ const NetworkSelectorList = ({
     isRedesignEnabled,
     isSendFlow,
     networkConfigurations,
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     nonEvmNetworkConfigurations,
-    ///: END:ONLY_INCLUDE_IF
     isNoSearchResults,
     searchString,
     showTestNetworks,

--- a/app/components/Views/NetworkSelector/NetworkSelectorList/NetworkSelectorList.types.ts
+++ b/app/components/Views/NetworkSelector/NetworkSelectorList/NetworkSelectorList.types.ts
@@ -37,12 +37,10 @@ export type NetworkSelectorListItem =
 
 export interface NetworkSelectorListProps {
   networkConfigurations: Record<Hex, NetworkConfiguration>;
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   nonEvmNetworkConfigurations: Record<
     CaipChainId,
     NonEvmNetworkListConfiguration
   >;
-  ///: END:ONLY_INCLUDE_IF
   searchString: string;
   showTestNetworks: boolean;
   isSendFlow: boolean;
@@ -59,9 +57,7 @@ export interface NetworkSelectorListProps {
   isNetworkSelected: (chainId: Hex | CaipChainId) => boolean;
   onSetRpcTarget: (networkConfiguration: NetworkConfiguration) => Promise<void>;
   onNetworkChange: (networkType: InfuraNetworkType) => Promise<void>;
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   onNonEvmNetworkChange: (chainId: CaipChainId) => Promise<void>;
-  ///: END:ONLY_INCLUDE_IF
   openModal: (
     chainId: Hex,
     displayEdit: boolean,

--- a/app/components/Views/NetworkSelector/useSwitchNetworks.ts
+++ b/app/components/Views/NetworkSelector/useSwitchNetworks.ts
@@ -7,12 +7,7 @@ import {
   InfuraNetworkType,
   BUILT_IN_NETWORKS,
 } from '@metamask/controller-utils';
-import {
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-  CaipChainId,
-  ///: END:ONLY_INCLUDE_IF
-  Hex,
-} from '@metamask/utils';
+import { CaipChainId, Hex } from '@metamask/utils';
 import { POPULAR_NETWORK_CHAIN_IDS } from '../../../constants/popular-networks';
 import {
   selectEvmNetworkConfigurationsByChainId,
@@ -42,9 +37,7 @@ interface UseSwitchNetworksProps {
 interface UseSwitchNetworksReturn {
   onSetRpcTarget: (networkConfiguration: NetworkConfiguration) => Promise<void>;
   onNetworkChange: (type: InfuraNetworkType) => Promise<void>;
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   onNonEvmNetworkChange: (chainId: CaipChainId) => Promise<void>;
-  ///: END:ONLY_INCLUDE_IF
 }
 
 /**
@@ -228,8 +221,6 @@ export function useSwitchNetworks({
     ],
   );
 
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-
   const onNonEvmNetworkChange = useCallback(
     async (chainId: CaipChainId) => {
       await Engine.context.MultichainNetworkController.setActiveNetwork(
@@ -239,13 +230,10 @@ export function useSwitchNetworks({
     },
     [dismissModal],
   );
-  ///: END:ONLY_INCLUDE_IF
 
   return {
     onSetRpcTarget,
     onNetworkChange,
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     onNonEvmNetworkChange,
-    ///: END:ONLY_INCLUDE_IF
   };
 }

--- a/app/components/Views/QRScanner/index.test.tsx
+++ b/app/components/Views/QRScanner/index.test.tsx
@@ -1479,7 +1479,6 @@ describe('QrScanner', () => {
       });
     });
 
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     describe('Solana Address Scanning', () => {
       beforeEach(() => {
         const solanaModule = jest.requireMock('@solana/addresses');
@@ -1734,7 +1733,6 @@ describe('QrScanner', () => {
         });
       });
     });
-    ///: END:ONLY_INCLUDE_IF
 
     describe('Callback-based origin handling', () => {
       beforeEach(() => {

--- a/app/components/Views/QRScanner/index.tsx
+++ b/app/components/Views/QRScanner/index.tsx
@@ -601,7 +601,6 @@ const QRScanner = ({
             return;
           }
 
-          ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
           // Handle non-EVM addresses when keyring-snaps is enabled (Solana, Bitcoin)
           if (
             predefinedRecipient &&
@@ -625,7 +624,6 @@ const QRScanner = ({
             });
             return;
           }
-          ///: END:ONLY_INCLUDE_IF
 
           // If non-EVM and keyring-snaps is disabled, show error
           if (

--- a/app/components/Views/Root/index.tsx
+++ b/app/components/Views/Root/index.tsx
@@ -20,9 +20,7 @@ import ControllersGate from '../../Nav/ControllersGate';
 import { isTestEnvironment } from '../../../util/test/utils';
 import { FeatureFlagOverrideProvider } from '../../../contexts/FeatureFlagOverrideContext';
 import { ScreenOrientationService } from '../../../core/ScreenOrientation';
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { SnapsExecutionWebView } from '../../../lib/snaps';
-///: END:ONLY_INCLUDE_IF
 import { ReducedMotionConfig, ReduceMotion } from 'react-native-reanimated';
 import { QueryClientProvider } from '@tanstack/react-query';
 import reactQueryService from '../../../core/ReactQueryService';
@@ -103,10 +101,8 @@ const Root = ({ foxCode }: RootProps) => {
             <PersistGate persistor={persistor}>
               <ErrorBoundary view="Root">
                 {
-                  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
                   // NOTE: This must be mounted before Engine initialization since Engine interacts with SnapsExecutionWebView
                   <SnapsExecutionWebView />
-                  ///: END:ONLY_INCLUDE_IF
                 }
                 <QueryClientProvider client={reactQueryService.queryClient}>
                   <FeatureFlagOverrideProvider>

--- a/app/components/Views/Settings/index.tsx
+++ b/app/components/Views/Settings/index.tsx
@@ -12,12 +12,10 @@ import { useTheme } from '../../../util/theme';
 import Routes from '../../../constants/navigation/Routes';
 import { Colors } from '../../../util/theme/models';
 import { SettingsViewSelectorsIDs } from './SettingsView.testIds';
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { createSnapsSettingsListNavDetails } from '../Snaps/SnapsSettingsList/SnapsSettingsList';
 import { navigateWithDetails } from '../../../util/navigation/navUtils';
 import { CAN_INSTALL_THIRD_PARTY_SNAPS } from '../../../constants/snaps';
-///: END:ONLY_INCLUDE_IF
 import { useAnalytics } from '../../../components/hooks/useAnalytics/useAnalytics';
 import { isNotificationsFeatureEnabled } from '../../../util/notifications';
 import { isTestEnvironment } from '../../../util/test/utils';
@@ -108,11 +106,9 @@ const Settings = () => {
     navigation.navigate(Routes.FEATURE_FLAG_OVERRIDE);
   };
 
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   const onPressSnaps = () => {
     navigateWithDetails(navigation, createSnapsSettingsListNavDetails());
   };
-  ///: END:ONLY_INCLUDE_IF
 
   const oauthFlow = useSelector(selectSeedlessOnboardingLoginFlow);
   return (
@@ -165,9 +161,6 @@ const Settings = () => {
             testID={SettingsViewSelectorsIDs.NOTIFICATIONS}
           />
         )}
-        {
-          ///: BEGIN:ONLY_INCLUDE_IF(snaps)
-        }
         {CAN_INSTALL_THIRD_PARTY_SNAPS && (
           <SettingsDrawer
             title={strings('app_settings.snaps.title')}
@@ -176,9 +169,6 @@ const Settings = () => {
             testID={SettingsViewSelectorsIDs.SNAPS}
           />
         )}
-        {
-          ///: END:ONLY_INCLUDE_IF
-        }
         <SettingsDrawer
           title={strings('app_settings.fiat_on_ramp.title')}
           description={strings('app_settings.fiat_on_ramp.description')}

--- a/app/components/Views/Snaps/KeyringSnapRemovalWarning/KeyringSnapRemovalWarning.constants.ts
+++ b/app/components/Views/Snaps/KeyringSnapRemovalWarning/KeyringSnapRemovalWarning.constants.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 export const KEYRING_SNAP_REMOVAL_WARNING = 'keyring-snap-removal-warning';
 export const KEYRING_SNAP_REMOVAL_WARNING_CONTINUE =
   'keyring-snap-removal-warning-continue';
@@ -6,4 +5,3 @@ export const KEYRING_SNAP_REMOVAL_WARNING_CANCEL =
   'keyring-snap-removal-warning-cancel';
 export const KEYRING_SNAP_REMOVAL_WARNING_TEXT_INPUT =
   'keyring-snap-removal-warning-text-input';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/KeyringSnapRemovalWarning/KeyringSnapRemovalWarning.styles.ts
+++ b/app/components/Views/Snaps/KeyringSnapRemovalWarning/KeyringSnapRemovalWarning.styles.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../util/theme/models';
 
@@ -40,4 +39,3 @@ const styleSheet = (params: { theme: Theme }) => {
 };
 
 export default styleSheet;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/KeyringSnapRemovalWarning/KeyringSnapRemovalWarning.tsx
+++ b/app/components/Views/Snaps/KeyringSnapRemovalWarning/KeyringSnapRemovalWarning.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import React, {
   useEffect,
   useRef,
@@ -223,4 +222,3 @@ export default function KeyringSnapRemovalWarning({
     </BottomSheet>
   );
 }
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/KeyringSnapRemovalWarning/index.ts
+++ b/app/components/Views/Snaps/KeyringSnapRemovalWarning/index.ts
@@ -1,3 +1,1 @@
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 export { default as KeyringSnapRemovalWarning } from './KeyringSnapRemovalWarning';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.constants.ts
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.constants.ts
@@ -1,6 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_SETTINGS_HEADER = 'snap-settings-header';
 export const SNAP_SETTINGS_BACK_BUTTON = 'snap-settings-back-button';
 export const SNAP_SETTINGS_REMOVE_BUTTON = 'snap-settings-remove-button';
 export const SNAP_SETTINGS_SCROLLVIEW = 'snap-settings-scrollview';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.styles.ts
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.styles.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 
 const styleSheet = () =>
@@ -21,4 +20,3 @@ const styleSheet = () =>
   });
 
 export default styleSheet;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapSettings/SnapSettings.tsx
+++ b/app/components/Views/Snaps/SnapSettings/SnapSettings.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps,keyring-snaps)
 import React, { useCallback, useEffect, useState } from 'react';
 import { View, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -223,4 +222,3 @@ const SnapSettings = () => {
 };
 
 export default React.memo(SnapSettings);
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapSettings/index.ts
+++ b/app/components/Views/Snaps/SnapSettings/index.ts
@@ -1,5 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
 export { default as SnapSettings } from './SnapSettings';
 export { ALLOWED_CAPABILITIES } from './messenger';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.constants.ts
+++ b/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.constants.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { TextColor } from '@metamask/design-system-react-native';
 
 export const SNAPS_SETTINGS_LIST_HEADER = 'snaps-settings-list-header';
@@ -9,4 +8,3 @@ export const SNAPS_SETTINGS_LIST_BACK_BUTTON =
 export const SNAPS_HEADER_TITLE_PROPS = {
   color: TextColor.PrimaryDefault,
 } as const;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.styles.ts
+++ b/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.styles.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../util/theme/models';
 
@@ -37,4 +36,3 @@ const styleSheet = (params: { theme: Theme }) => {
 };
 
 export default styleSheet;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.test.tsx
+++ b/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.test.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
 import { Snap, Status } from '@metamask/snaps-utils';
@@ -128,4 +127,3 @@ describe('SnapsSettingsList', () => {
     expect(getByText(exampleSnap.manifest.proposedName)).toBeOnTheScreen();
   });
 });
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.tsx
+++ b/app/components/Views/Snaps/SnapsSettingsList/SnapsSettingsList.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useCallback } from 'react';
 import { ScrollView } from 'react-native';
 import { useSelector } from 'react-redux';
@@ -56,4 +55,3 @@ const SnapsSettingsList = () => {
 };
 
 export default React.memo(SnapsSettingsList);
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/SnapsSettingsList/index.ts
+++ b/app/components/Views/Snaps/SnapsSettingsList/index.ts
@@ -1,4 +1,2 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
 export { default as SnapsSettingsList } from './SnapsSettingsList';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/KeyringAccountListItem/KeyringAccountListItem.constants.ts
+++ b/app/components/Views/Snaps/components/KeyringAccountListItem/KeyringAccountListItem.constants.ts
@@ -1,5 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 export const KEYRING_ACCOUNT_LIST_ITEM = 'keyring-account-list-item';
 export const KEYRING_ACCOUNT_LIST_ITEM_BUTTON =
   'keyring-account-list-item-button';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/KeyringAccountListItem/KeyringAccountListItem.styles.ts
+++ b/app/components/Views/Snaps/components/KeyringAccountListItem/KeyringAccountListItem.styles.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../../util/theme/models';
 
@@ -33,4 +32,3 @@ const styleSheet = (params: { theme: Theme }) => {
 };
 
 export default styleSheet;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/KeyringAccountListItem/KeyringAccountListItem.tsx
+++ b/app/components/Views/Snaps/components/KeyringAccountListItem/KeyringAccountListItem.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import React, { useCallback } from 'react';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
@@ -85,4 +84,3 @@ const KeyringAccountListItem = ({
 };
 
 export default React.memo(KeyringAccountListItem);
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/KeyringAccountListItem/index.ts
+++ b/app/components/Views/Snaps/components/KeyringAccountListItem/index.ts
@@ -1,3 +1,1 @@
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 export { default as KeyringAccountListItem } from './KeyringAccountListItem';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDescription/SnapDescription.constants.ts
+++ b/app/components/Views/Snaps/components/SnapDescription/SnapDescription.constants.ts
@@ -1,4 +1,2 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_DESCRIPTION_TITLE = 'snap-description-title';
 export const SNAP_DESCRIPTION = 'snap-description';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDescription/SnapDescription.styles.tsx
+++ b/app/components/Views/Snaps/components/SnapDescription/SnapDescription.styles.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../../util/theme/models';
 
@@ -43,4 +42,3 @@ const styleSheet = (params: { theme: Theme }) => {
 };
 
 export default styleSheet;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDescription/SnapDescription.tsx
+++ b/app/components/Views/Snaps/components/SnapDescription/SnapDescription.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { View } from 'react-native';
 import Text, {
@@ -55,4 +54,3 @@ const SnapDescription = ({
 };
 
 export default React.memo(SnapDescription);
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDescription/index.ts
+++ b/app/components/Views/Snaps/components/SnapDescription/index.ts
@@ -1,4 +1,2 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
 export { default as SnapDescription } from './SnapDescription';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDetails/SnapDetails.constants.ts
+++ b/app/components/Views/Snaps/components/SnapDetails/SnapDetails.constants.ts
@@ -1,6 +1,4 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_DETAILS_CELL = 'snap-details-cell';
 export const SNAP_DETAILS_SWITCH = 'snap-details-switch';
 export const SNAP_DETAILS_INSTALL_ORIGIN = 'snap-details-install-origin';
 export const SNAP_DETAILS_INSTALL_DATE = 'snap-details-install-date';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDetails/SnapDetails.styles.ts
+++ b/app/components/Views/Snaps/components/SnapDetails/SnapDetails.styles.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../../util/theme/models';
 
@@ -42,4 +41,3 @@ const styleSheet = (params: { theme: Theme }) => {
 };
 
 export default styleSheet;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDetails/SnapDetails.tsx
+++ b/app/components/Views/Snaps/components/SnapDetails/SnapDetails.tsx
@@ -1,6 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck - Snaps team directory
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useCallback, useMemo, useState } from 'react';
 import { View, Switch } from 'react-native';
 
@@ -114,4 +113,3 @@ const SnapDetails = ({ snap }: SnapDetailsProps) => {
 };
 
 export default React.memo(SnapDetails);
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapDetails/index.ts
+++ b/app/components/Views/Snaps/components/SnapDetails/index.ts
@@ -1,4 +1,2 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
 export { default as SnapDetails } from './SnapDetails';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapElement/SnapElement.constants.ts
+++ b/app/components/Views/Snaps/components/SnapElement/SnapElement.constants.ts
@@ -1,4 +1,2 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 const SNAP_ElEMENT = 'snap-element';
 export default SNAP_ElEMENT;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapElement/SnapElement.styles.ts
+++ b/app/components/Views/Snaps/components/SnapElement/SnapElement.styles.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 
 const styleSheet = () =>
@@ -9,4 +8,3 @@ const styleSheet = () =>
     arrowContainer: { justifyContent: 'center', flex: 1 },
   });
 export default styleSheet;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapElement/SnapElement.tsx
+++ b/app/components/Views/Snaps/components/SnapElement/SnapElement.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { View } from 'react-native';
 import Cell, {
@@ -47,4 +46,3 @@ const SnapElement = (snap: Snap) => {
 };
 
 export default SnapElement;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapElement/index.ts
+++ b/app/components/Views/Snaps/components/SnapElement/index.ts
@@ -1,4 +1,2 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
 export { default as SnapElement } from './SnapElement';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapPermissionCell/SnapPermissionCell.constants.ts
+++ b/app/components/Views/Snaps/components/SnapPermissionCell/SnapPermissionCell.constants.ts
@@ -1,5 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_PERMISSIONS_DATE = 'snap-permissions-date';
 export const SNAP_PERMISSION_CELL = 'snap-permission-cell';
 export const SNAP_PERMISSIONS_TITLE = 'snap-permissions-title';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapPermissionCell/SnapPermissionCell.styles.ts
+++ b/app/components/Views/Snaps/components/SnapPermissionCell/SnapPermissionCell.styles.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../../util/theme/models';
 
@@ -40,4 +39,3 @@ const styleSheet = (params: { theme: Theme }) => {
   });
 };
 export default styleSheet;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapPermissionCell/SnapPermissionCell.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissionCell/SnapPermissionCell.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useMemo } from 'react';
 import { View } from 'react-native';
 import { useStyles } from '../../../../hooks/useStyles';
@@ -72,4 +71,3 @@ const SnapPermissionCell = ({ title, date }: SnapPermissionCellProps) => {
 };
 
 export default React.memo(SnapPermissionCell);
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapPermissionCell/index.ts
+++ b/app/components/Views/Snaps/components/SnapPermissionCell/index.ts
@@ -1,4 +1,2 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
 export { default as SnapPermissionCell } from './SnapPermissionCell';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.contants.ts
+++ b/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.contants.ts
@@ -1,4 +1,2 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 const SNAP_PERMISSIONS = 'snap-permissions';
 export default SNAP_PERMISSIONS;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.styles.ts
+++ b/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.styles.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 
 /**
@@ -15,4 +14,3 @@ const styleSheet = () =>
     },
   });
 export default styleSheet;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
+++ b/app/components/Views/Snaps/components/SnapPermissions/SnapPermissions.tsx
@@ -1,6 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck - Snaps team directory
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { useCallback, useMemo } from 'react';
 import { View } from 'react-native';
 import slip44 from '@metamask/slip44';
@@ -303,4 +302,3 @@ const SnapPermissions = ({
 };
 
 export default React.memo(SnapPermissions);
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapPermissions/index.ts
+++ b/app/components/Views/Snaps/components/SnapPermissions/index.ts
@@ -1,4 +1,2 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
 export { default as SnapPermissions } from './SnapPermissions';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.constants.ts
+++ b/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.constants.ts
@@ -1,4 +1,2 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export const SNAP_VERSION_BADGE = 'snap-version-badge';
 export const SNAP_VERSION_BADGE_VALUE = 'snap-version-badge-value';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.styles.ts
+++ b/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.styles.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../../../util/theme/models';
 
@@ -29,4 +28,3 @@ const styleSheet = (params: { theme: Theme }) => {
 };
 
 export default styleSheet;
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.tsx
+++ b/app/components/Views/Snaps/components/SnapVersionTag/SnapVersionTag.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React from 'react';
 import { View } from 'react-native';
 import Text, {
@@ -45,4 +44,3 @@ const SnapVersionTag: React.FC<SnapVersionTagProps> = ({
 };
 
 export default React.memo(SnapVersionTag);
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/Snaps/components/SnapVersionTag/index.ts
+++ b/app/components/Views/Snaps/components/SnapVersionTag/index.ts
@@ -1,4 +1,2 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable import-x/prefer-default-export */
 export { default as SnapVersionBadge } from './SnapVersionTag';
-///: END:ONLY_INCLUDE_IF

--- a/app/components/Views/TransactionsView/index.js
+++ b/app/components/Views/TransactionsView/index.js
@@ -37,10 +37,8 @@ import {
   selectEnabledNetworksByNamespace,
   selectEVMEnabledNetworks,
 } from '../../../selectors/networkEnablementController';
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { selectNonEvmTransactions } from '../../../selectors/multichain';
 import { isEvmAccountType } from '@metamask/keyring-api';
-///: END:ONLY_INCLUDE_IF
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import useCurrencyRatePolling from '../../hooks/AssetPolling/useCurrencyRatePolling';
 import useTokenRatesPolling from '../../hooks/AssetPolling/useTokenRatesPolling';
@@ -274,7 +272,6 @@ const mapStateToProps = (state) => {
   const selectedInternalAccount = selectSelectedInternalAccount(state);
   const evmTransactions = selectSortedTransactions(state);
 
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   let allTransactions = evmTransactions;
   if (
     selectedInternalAccount &&
@@ -287,7 +284,6 @@ const mapStateToProps = (state) => {
       (a, b) => (b?.time ?? 0) - (a?.time ?? 0),
     );
   }
-  ///: END:ONLY_INCLUDE_IF
 
   return {
     conversionRate: selectConversionRate(state),

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -151,9 +151,7 @@ import {
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import AssetDetailsActions from '../AssetDetails/AssetDetailsActions';
 import AppConstants from '../../../core/AppConstants';
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { useSendNonEvmAsset } from '../../hooks/useSendNonEvmAsset';
-///: END:ONLY_INCLUDE_IF
 import { suppressWalletHomeOnboardingSteps } from '../../../actions/onboarding';
 import { useWalletHomeOnboardingChecklistTradePress } from '../../UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingChecklistTradePress';
 import {
@@ -421,14 +419,12 @@ const Wallet = ({
   }, [navigation]);
 
   // Hook for handling non-EVM asset sending
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   const { sendNonEvmAsset } = useSendNonEvmAsset({
     asset: {
       chainId: chainId as string,
       address: undefined,
     },
   });
-  ///: END:ONLY_INCLUDE_IF
 
   const displayBuyButton = true;
   const displaySwapsButton = AppConstants.SWAPS.ACTIVE;
@@ -500,7 +496,6 @@ const Wallet = ({
         location: ActionLocation.HOME,
       });
 
-      ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
       // Try non-EVM first, if handled, return early
       const wasHandledAsNonEvm = await sendNonEvmAsset(
         InitSendLocation.HomePage,
@@ -508,45 +503,30 @@ const Wallet = ({
       if (wasHandledAsNonEvm) {
         return;
       }
-      ///: END:ONLY_INCLUDE_IF
 
       navigateToSendPage({ location: InitSendLocation.HomePage });
     } catch (error) {
       console.error('Error initiating send flow:', error);
       navigateToSendPage({ location: InitSendLocation.HomePage });
     }
-  }, [
-    trackEvent,
-    createEventBuilder,
-    navigateToSendPage,
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-    sendNonEvmAsset,
-    ///: END:ONLY_INCLUDE_IF
-  ]);
+  }, [trackEvent, createEventBuilder, navigateToSendPage, sendNonEvmAsset]);
 
   /** Navigation-only send for AB treatment buttons (they own ACTION_BUTTON_CLICKED). */
   const onSendWithoutTracking = useCallback(async () => {
     try {
-      ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
       const wasHandledAsNonEvm = await sendNonEvmAsset(
         InitSendLocation.HomePage,
       );
       if (wasHandledAsNonEvm) {
         return;
       }
-      ///: END:ONLY_INCLUDE_IF
 
       navigateToSendPage({ location: InitSendLocation.HomePage });
     } catch (error) {
       console.error('Error initiating send flow:', error);
       navigateToSendPage({ location: InitSendLocation.HomePage });
     }
-  }, [
-    navigateToSendPage,
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-    sendNonEvmAsset,
-    ///: END:ONLY_INCLUDE_IF
-  ]);
+  }, [navigateToSendPage, sendNonEvmAsset]);
 
   const isDataCollectionForMarketingEnabled = useSelector(
     (state: RootState) => state.security.dataCollectionForMarketing,

--- a/app/components/Views/confirmations/hooks/send/useAccounts.ts
+++ b/app/components/Views/confirmations/hooks/send/useAccounts.ts
@@ -11,9 +11,7 @@ import { selectInternalAccountsById } from '../../../../../selectors/accountsCon
 import {
   isBtcAccount,
   isSolanaAccount,
-  /// BEGIN:ONLY_INCLUDE_IF(tron)
   isTronAccount,
-  /// END:ONLY_INCLUDE_IF
   isStellarAccount,
 } from '../../../../../core/Multichain/utils';
 import { type RecipientType } from '../../components/UI/recipient';
@@ -27,12 +25,8 @@ export const useAccounts = (): RecipientType[] => {
   const {
     isEvmSendType,
     isSolanaSendType,
-    /// BEGIN:ONLY_INCLUDE_IF(bitcoin)
     isBitcoinSendType,
-    /// END:ONLY_INCLUDE_IF
-    /// BEGIN:ONLY_INCLUDE_IF(tron)
     isTronSendType,
-    /// END:ONLY_INCLUDE_IF
     isStellarSendType,
   } = useSendType();
 
@@ -52,16 +46,12 @@ export const useAccounts = (): RecipientType[] => {
       if (isSolanaSendType) {
         return isSolanaAccount(account);
       }
-      /// BEGIN:ONLY_INCLUDE_IF(bitcoin)
       if (isBitcoinSendType) {
         return isBtcAccount(account);
       }
-      /// END:ONLY_INCLUDE_IF
-      /// BEGIN:ONLY_INCLUDE_IF(tron)
       if (isTronSendType) {
         return isTronAccount(account);
       }
-      /// END:ONLY_INCLUDE_IF
       if (isStellarSendType) {
         return isStellarAccount(account);
       }
@@ -71,12 +61,8 @@ export const useAccounts = (): RecipientType[] => {
       internalAccountsById,
       isEvmSendType,
       isSolanaSendType,
-      /// BEGIN:ONLY_INCLUDE_IF(bitcoin)
       isBitcoinSendType,
-      /// END:ONLY_INCLUDE_IF
-      /// BEGIN:ONLY_INCLUDE_IF(tron)
       isTronSendType,
-      /// END:ONLY_INCLUDE_IF
       isStellarSendType,
       from,
     ],

--- a/app/components/Views/confirmations/hooks/send/useSendType.ts
+++ b/app/components/Views/confirmations/hooks/send/useSendType.ts
@@ -1,8 +1,6 @@
 import { isAddress as isEvmAddress } from 'ethers/lib/utils';
 import {
-  /// BEGIN:ONLY_INCLUDE_IF(bitcoin)
   isBitcoinChainId,
-  /// END:ONLY_INCLUDE_IF
   isSolanaChainId,
   isStellarChainId,
 } from '@metamask/bridge-controller';
@@ -11,9 +9,7 @@ import { useCallback, useMemo } from 'react';
 import { useSendContext } from '../../context/send-context';
 import {
   isNonEvmChainId,
-  /// BEGIN:ONLY_INCLUDE_IF(tron)
   isTronChainId,
-  /// END:ONLY_INCLUDE_IF
 } from '../../../../../core/Multichain/utils';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { PredefinedRecipient } from '../../utils/send';
@@ -63,19 +59,15 @@ export const useSendType = () => {
     [createChainTypeCheck, isPredefinedSolana],
   );
 
-  /// BEGIN:ONLY_INCLUDE_IF(bitcoin)
   const isBitcoinSendType = useMemo(
     () => createChainTypeCheck(isPredefinedBitcoin, isBitcoinChainId),
     [createChainTypeCheck, isPredefinedBitcoin],
   );
-  /// END:ONLY_INCLUDE_IF
 
-  /// BEGIN:ONLY_INCLUDE_IF(tron)
   const isTronSendType = useMemo(
     () => createChainTypeCheck(isPredefinedTron, isTronChainId),
     [createChainTypeCheck, isPredefinedTron],
   );
-  /// END:ONLY_INCLUDE_IF
 
   const isStellarSendType = useMemo(
     () => createChainTypeCheck(isPredefinedStellar, isStellarChainId),
@@ -94,14 +86,10 @@ export const useSendType = () => {
       isNonEvmSendType,
       isSolanaSendType,
       isPredefinedSolana,
-      /// BEGIN:ONLY_INCLUDE_IF(bitcoin)
       isBitcoinSendType,
       isPredefinedBitcoin,
-      /// END:ONLY_INCLUDE_IF
-      /// BEGIN:ONLY_INCLUDE_IF(tron)
       isTronSendType,
       isPredefinedTron,
-      /// END:ONLY_INCLUDE_IF
       isStellarSendType,
       isPredefinedStellar,
     }),
@@ -112,14 +100,10 @@ export const useSendType = () => {
       assetIsNative,
       isSolanaSendType,
       isPredefinedSolana,
-      /// BEGIN:ONLY_INCLUDE_IF(bitcoin)
       isBitcoinSendType,
       isPredefinedBitcoin,
-      /// END:ONLY_INCLUDE_IF
-      /// BEGIN:ONLY_INCLUDE_IF(tron)
       isTronSendType,
       isPredefinedTron,
-      /// END:ONLY_INCLUDE_IF
       isStellarSendType,
       isPredefinedStellar,
     ],

--- a/app/components/hooks/useMultichainBalances/useSelectedAccountMultichainBalances.ts
+++ b/app/components/hooks/useMultichainBalances/useSelectedAccountMultichainBalances.ts
@@ -12,14 +12,12 @@ import { useGetTotalFiatBalanceCrossChains } from '../useGetTotalFiatBalanceCros
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import useIsOriginalNativeTokenSymbol from '../useIsOriginalNativeTokenSymbol/useIsOriginalNativeTokenSymbol';
 import { UseSelectedAccountMultichainBalancesHook } from './useMultichainBalances.types';
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import {
   selectMultichainShouldShowFiat,
   selectMultichainBalances,
   selectMultichainAssets,
   selectMultichainAssetsRates,
 } from '../../../selectors/multichain';
-///: END:ONLY_INCLUDE_IF
 import { useMemo } from 'react';
 import {
   getAccountBalanceData,
@@ -62,12 +60,10 @@ const useSelectedAccountMultichainBalances =
       type,
     );
 
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     const shouldShowFiat = useSelector(selectMultichainShouldShowFiat);
     const multichainBalances = useSelector(selectMultichainBalances);
     const multichainAssets = useSelector(selectMultichainAssets);
     const multichainAssetsRates = useSelector(selectMultichainAssetsRates);
-    ///: END:ONLY_INCLUDE_IF
 
     const selectedAccountMultichainBalance = useMemo(() => {
       if (selectedInternalAccount && isOriginalNativeEvmTokenSymbol !== null) {
@@ -76,12 +72,10 @@ const useSelectedAccountMultichainBalances =
           currentCurrency,
           totalFiatBalancesCrossEvmChain,
           isOriginalNativeEvmTokenSymbol,
-          ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
           multichainBalances,
           multichainAssets,
           multichainAssetsRates,
           shouldShowFiat,
-          ///: END:ONLY_INCLUDE_IF
         );
         return {
           displayBalance: accountBalanceData.displayBalance,
@@ -108,12 +102,10 @@ const useSelectedAccountMultichainBalances =
       currentCurrency,
       isOriginalNativeEvmTokenSymbol,
       totalFiatBalancesCrossEvmChain,
-      ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
       multichainAssets,
       multichainAssetsRates,
       multichainBalances,
       shouldShowFiat,
-      ///: END:ONLY_INCLUDE_IF
     ]);
     return {
       selectedAccountMultichainBalance,

--- a/app/components/hooks/useMultichainBalances/utils.ts
+++ b/app/components/hooks/useMultichainBalances/utils.ts
@@ -1,6 +1,5 @@
 /* eslint-disable arrow-body-style */
 import { InternalAccount } from '@metamask/keyring-internal-api';
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import {
   getMultichainNetworkAggregatedBalance,
   MultichainNetworkAggregatedBalance,
@@ -11,7 +10,6 @@ import {
   MultichainAssetsRatesControllerState,
   MultichainBalancesControllerState,
 } from '@metamask/assets-controllers';
-///: END:ONLY_INCLUDE_IF
 import { formatWithThreshold } from '../../../util/assets';
 import I18n from '../../../../locales/i18n';
 import Engine from '../../../core/Engine';
@@ -53,7 +51,6 @@ const getEvmBalance = (
   };
 };
 
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 const getMultiChainFiatBalance = (
   balance: number | undefined,
   currency: string,
@@ -82,7 +79,6 @@ const getNonEvmDisplayBalance = (
     currentCurrency,
   );
 };
-///: END:ONLY_INCLUDE_IF
 
 export const getShouldShowAggregatedPercentage = (
   chainId: SupportedCaipChainId,
@@ -107,19 +103,16 @@ export const getAccountBalanceData = (
   currentCurrency: string,
   totalFiatBalancesCrossEvmChain: TotalFiatBalancesCrossChains,
   isOriginalNativeEvmTokenSymbol: boolean,
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   multichainBalances: MultichainBalancesControllerState['balances'],
   multichainAssets: MultichainAssetsControllerState['accountsAssets'],
   multichainAssetsRates: MultichainAssetsRatesControllerState['conversionRates'],
   shouldShowFiat: boolean,
-  ///: END:ONLY_INCLUDE_IF
 ): {
   displayBalance: string;
   totalFiatBalance: number | undefined;
   totalNativeTokenBalance: string | undefined;
   nativeTokenUnit: string;
 } => {
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   if (!isEvmAccountType(account.type)) {
     const nonEvmAccountBalance = getMultichainNetworkAggregatedBalance(
       account,
@@ -139,7 +132,6 @@ export const getAccountBalanceData = (
       nativeTokenUnit: nonEvmAccountBalance.totalNativeTokenBalance?.unit || '',
     };
   }
-  ///: END:ONLY_INCLUDE_IF
   const evmAccountBalance = getEvmBalance(
     account,
     isOriginalNativeEvmTokenSymbol,

--- a/app/components/hooks/useNetworkSelection/useNetworkSelection.ts
+++ b/app/components/hooks/useNetworkSelection/useNetworkSelection.ts
@@ -17,9 +17,7 @@ import { useNetworkEnablement } from '../useNetworkEnablement/useNetworkEnableme
 import { ProcessedNetwork } from '../useNetworksByNamespace/useNetworksByNamespace';
 import { POPULAR_NETWORK_CHAIN_IDS } from '../../../constants/popular-networks';
 import Engine from '../../../core/Engine';
-///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
 import { selectInternalAccounts } from '../../../selectors/accountsController';
-///: END:ONLY_INCLUDE_IF
 
 interface UseNetworkSelectionOptions {
   /**
@@ -69,9 +67,7 @@ export const useNetworkSelection = ({
     selectEvmNetworkConfigurationsByChainId,
   );
 
-  ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
   const internalAccounts = useSelector(selectInternalAccounts);
-  ///: END:ONLY_INCLUDE_IF
 
   const popularNetworkChainIds = useMemo(
     () =>
@@ -97,7 +93,6 @@ export const useNetworkSelection = ({
     [currentEnabledNetworks, popularNetworkChainIds],
   );
 
-  ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
   const bitcoinInternalAccounts = useMemo(
     () =>
       internalAccounts.filter((account) =>
@@ -105,12 +100,10 @@ export const useNetworkSelection = ({
       ),
     [internalAccounts],
   );
-  ///: END:ONLY_INCLUDE_IF
 
   /** Selects a custom network exclusively (disables other custom networks) */
   const selectCustomNetwork = useCallback(
     async (chainId: CaipChainId, onComplete?: () => void) => {
-      ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
       const bitcoAccountInScope = bitcoinInternalAccounts.find((account) =>
         account.scopes.includes(chainId),
       );
@@ -118,20 +111,13 @@ export const useNetworkSelection = ({
       if (chainId.includes(KnownCaipNamespace.Bip122) && bitcoAccountInScope) {
         Engine.setSelectedAddress(bitcoAccountInScope.address);
       }
-      ///: END:ONLY_INCLUDE_IF
 
       // Enable the network in NetworkEnablementController
       await enableNetwork(chainId);
 
       onComplete?.();
     },
-    [
-      enableNetwork,
-
-      ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
-      bitcoinInternalAccounts,
-      ///: END:ONLY_INCLUDE_IF(bitcoin)
-    ],
+    [enableNetwork, bitcoinInternalAccounts],
   );
 
   const selectAllPopularNetworks = useCallback(

--- a/app/components/hooks/useNetworksToUse/useNetworksToUse.ts
+++ b/app/components/hooks/useNetworksToUse/useNetworksToUse.ts
@@ -6,15 +6,7 @@ import {
   NetworkType,
   ProcessedNetwork,
 } from '../useNetworksByNamespace/useNetworksByNamespace';
-import {
-  ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
-  BtcScope,
-  ///: END:ONLY_INCLUDE_IF
-  SolScope,
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
-  TrxScope,
-  ///: END:ONLY_INCLUDE_IF
-} from '@metamask/keyring-api';
+import { BtcScope, SolScope, TrxScope } from '@metamask/keyring-api';
 import { EVM_SCOPE } from '../../UI/Earn/constants/networks';
 import { selectSelectedInternalAccountByScope } from '../../../selectors/multichainAccounts/accounts';
 import { InternalAccount } from '@metamask/keyring-internal-api';
@@ -29,29 +21,17 @@ interface UseNetworksToUseReturn {
   networksToUse: ProcessedNetwork[];
   evmNetworks: ProcessedNetwork[];
   solanaNetworks: ProcessedNetwork[];
-  ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
   bitcoinNetworks: ProcessedNetwork[];
-  ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   tronNetworks: ProcessedNetwork[];
-  ///: END:ONLY_INCLUDE_IF
   selectedEvmAccount: InternalAccount | null;
   selectedSolanaAccount: InternalAccount | null;
-  ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
   selectedBitcoinAccount: InternalAccount | null;
-  ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   selectedTronAccount: InternalAccount | null;
-  ///: END:ONLY_INCLUDE_IF
   areAllNetworksSelectedCombined: boolean;
   areAllEvmNetworksSelected: boolean;
   areAllSolanaNetworksSelected: boolean;
-  ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
   areAllBitcoinNetworksSelected: boolean;
-  ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   areAllTronNetworksSelected: boolean;
-  ///: END:ONLY_INCLUDE_IF
 }
 
 /**
@@ -73,15 +53,11 @@ export const useNetworksToUse = ({
   const selectedSolanaAccount =
     useSelector(selectSelectedInternalAccountByScope)(SolScope.Mainnet) || null;
 
-  ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
   const selectedBitcoinAccount =
     useSelector(selectSelectedInternalAccountByScope)(BtcScope.Mainnet) || null;
-  ///: END:ONLY_INCLUDE_IF
 
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   const selectedTronAccount =
     useSelector(selectSelectedInternalAccountByScope)(TrxScope.Mainnet) || null;
-  ///: END:ONLY_INCLUDE_IF
 
   const {
     networks: evmNetworks = [],
@@ -99,7 +75,6 @@ export const useNetworksToUse = ({
     namespace: KnownCaipNamespace.Solana,
   });
 
-  ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
   const {
     networks: bitcoinNetworks = [],
     areAllNetworksSelected: areAllBitcoinNetworksSelected = false,
@@ -107,9 +82,7 @@ export const useNetworksToUse = ({
     networkType,
     namespace: KnownCaipNamespace.Bip122,
   });
-  ///: END:ONLY_INCLUDE_IF
 
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   const {
     networks: tronNetworks = [],
     areAllNetworksSelected: areAllTronNetworksSelected = false,
@@ -117,29 +90,20 @@ export const useNetworksToUse = ({
     networkType,
     namespace: KnownCaipNamespace.Tron,
   });
-  ///: END:ONLY_INCLUDE_IF
 
   // Helper functions to make network selection logic more readable
   const hasSelectedAccounts = useMemo(
     () => ({
       evm: !!selectedEvmAccount,
       solana: !!selectedSolanaAccount,
-      ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
       bitcoin: !!selectedBitcoinAccount,
-      ///: END:ONLY_INCLUDE_IF
-      ///: BEGIN:ONLY_INCLUDE_IF(tron)
       tron: !!selectedTronAccount,
-      ///: END:ONLY_INCLUDE_IF
     }),
     [
       selectedEvmAccount,
       selectedSolanaAccount,
-      ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
       selectedBitcoinAccount,
-      ///: END:ONLY_INCLUDE_IF
-      ///: BEGIN:ONLY_INCLUDE_IF(tron)
       selectedTronAccount,
-      ///: END:ONLY_INCLUDE_IF
     ],
   );
 
@@ -155,24 +119,16 @@ export const useNetworksToUse = ({
     const anySelectedAccount = [
       hasSelectedAccounts.evm,
       hasSelectedAccounts.solana,
-      ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
       hasSelectedAccounts.bitcoin,
-      ///: END:ONLY_INCLUDE_IF
-      ///: BEGIN:ONLY_INCLUDE_IF(tron)
       hasSelectedAccounts.tron,
-      ///: END:ONLY_INCLUDE_IF
     ].some(Boolean);
 
     if (anySelectedAccount) {
       return combineAvailableNetworks([
         hasSelectedAccounts.evm ? evmNetworks : [],
         hasSelectedAccounts.solana ? solanaNetworks : [],
-        ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
         hasSelectedAccounts.bitcoin ? bitcoinNetworks : [],
-        ///: END:ONLY_INCLUDE_IF
-        ///: BEGIN:ONLY_INCLUDE_IF(tron)
         hasSelectedAccounts.tron ? tronNetworks : [],
-        ///: END:ONLY_INCLUDE_IF
       ]);
     }
 
@@ -181,22 +137,14 @@ export const useNetworksToUse = ({
   }, [
     hasSelectedAccounts.evm,
     hasSelectedAccounts.solana,
-    ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
     hasSelectedAccounts.bitcoin,
-    ///: END:ONLY_INCLUDE_IF
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     hasSelectedAccounts.tron,
-    ///: END:ONLY_INCLUDE_IF
     networks,
     combineAvailableNetworks,
     evmNetworks,
     solanaNetworks,
-    ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
     bitcoinNetworks,
-    ///: END:ONLY_INCLUDE_IF
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     tronNetworks,
-    ///: END:ONLY_INCLUDE_IF
   ]);
 
   const areAllNetworksSelectedCombined = useMemo(() => {
@@ -211,17 +159,13 @@ export const useNetworksToUse = ({
       accountSelectionFlags.push(areAllSolanaNetworksSelected);
     }
 
-    ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
     if (hasSelectedAccounts.bitcoin) {
       accountSelectionFlags.push(areAllBitcoinNetworksSelected);
     }
-    ///: END:ONLY_INCLUDE_IF
 
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     if (hasSelectedAccounts.tron) {
       accountSelectionFlags.push(areAllTronNetworksSelected);
     }
-    ///: END:ONLY_INCLUDE_IF
 
     // If any accounts are selected, all their networks must be selected
     // If no accounts are selected, fallback to original areAllNetworksSelected
@@ -233,40 +177,24 @@ export const useNetworksToUse = ({
     hasSelectedAccounts,
     areAllEvmNetworksSelected,
     areAllSolanaNetworksSelected,
-    ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
     areAllBitcoinNetworksSelected,
-    ///: END:ONLY_INCLUDE_IF
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     areAllTronNetworksSelected,
-    ///: END:ONLY_INCLUDE_IF
   ]);
 
   return {
     networksToUse,
     evmNetworks,
     solanaNetworks,
-    ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
     bitcoinNetworks,
-    ///: END:ONLY_INCLUDE_IF
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     tronNetworks,
-    ///: END:ONLY_INCLUDE_IF
     selectedEvmAccount,
     selectedSolanaAccount,
-    ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
     selectedBitcoinAccount,
-    ///: END:ONLY_INCLUDE_IF
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     selectedTronAccount,
-    ///: END:ONLY_INCLUDE_IF
     areAllNetworksSelectedCombined,
     areAllEvmNetworksSelected,
     areAllSolanaNetworksSelected,
-    ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
     areAllBitcoinNetworksSelected,
-    ///: END:ONLY_INCLUDE_IF
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     areAllTronNetworksSelected,
-    ///: END:ONLY_INCLUDE_IF
   };
 };

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -515,12 +515,10 @@ const Routes = {
     PRIVATE_KEY_LIST: 'MultichainPrivateKeyList',
     ACCOUNT_CELL_ACTIONS: 'MultichainAccountActions',
   },
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   SNAPS: {
     SNAPS_SETTINGS_LIST: 'SnapsSettingsList',
     SNAP_SETTINGS: 'SnapSettings',
   },
-  ///: END:ONLY_INCLUDE_IF
   FOX_LOADER: 'FoxLoader',
   SEEDPHRASE_MODAL: 'SeedphraseModal',
   SET_PASSWORD_FLOW: {

--- a/app/constants/popular-networks.ts
+++ b/app/constants/popular-networks.ts
@@ -1,10 +1,4 @@
-import {
-  BtcScope,
-  SolScope,
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
-  TrxScope,
-  ///: END:ONLY_INCLUDE_IF
-} from '@metamask/keyring-api';
+import { BtcScope, SolScope, TrxScope } from '@metamask/keyring-api';
 import { PopularList } from '../util/networks/customNetworks';
 import { NETWORKS_CHAIN_ID } from './network';
 
@@ -14,9 +8,7 @@ export const POPULAR_NETWORK_CHAIN_IDS = new Set([
   NETWORKS_CHAIN_ID.LINEA_MAINNET,
   SolScope.Mainnet,
   BtcScope.Mainnet,
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   TrxScope.Mainnet,
-  ///: END:ONLY_INCLUDE_IF
 ]);
 
 export const POPULAR_NETWORK_CHAIN_IDS_CAIP = new Set([
@@ -25,7 +17,5 @@ export const POPULAR_NETWORK_CHAIN_IDS_CAIP = new Set([
   NETWORKS_CHAIN_ID.LINEA_MAINNET,
   SolScope.Mainnet,
   BtcScope.Mainnet,
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   TrxScope.Mainnet,
-  ///: END:ONLY_INCLUDE_IF
 ]);

--- a/app/core/BackgroundBridge/BackgroundBridge.js
+++ b/app/core/BackgroundBridge/BackgroundBridge.js
@@ -25,10 +25,8 @@ import RemotePort from './RemotePort';
 import WalletConnectPort from './WalletConnectPort';
 import Port from './Port';
 import { store } from '../../store';
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { rpcErrors } from '@metamask/rpc-errors';
 import snapMethodMiddlewareBuilder from '../Snaps/SnapsMethodMiddleware';
-///: END:ONLY_INCLUDE_IF
 import {
   PermissionDoesNotExistError,
   SubjectType,
@@ -89,10 +87,8 @@ import { getAuthorizedScopes } from '../../selectors/permissions';
 import {
   SolAccountType,
   SolScope,
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   TrxScope,
   TrxAccountType,
-  ///: END:ONLY_INCLUDE_IF
 } from '@metamask/keyring-api';
 import { parseCaipAccountId } from '@metamask/utils';
 import { toFormattedAddress, areAddressesEqual } from '../../util/address';
@@ -163,9 +159,7 @@ export class BackgroundBridge extends EventEmitter {
     this.multichainMiddlewareManager = null;
 
     this.lastSelectedSolanaAccountAddress = null;
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     this.lastSelectedTronAccountAddress = null;
-    ///: END:ONLY_INCLUDE_IF
 
     const networkClientId = Engine.controllerMessenger.call(
       'SelectedNetworkController:getNetworkClientIdForDomain',
@@ -541,7 +535,6 @@ export class BackgroundBridge extends EventEmitter {
         `${AccountTreeController.name}:selectedAccountGroupChange`,
         this.handleSolanaAccountChangedFromSelectedAccountGroupChanges,
       );
-      ///: BEGIN:ONLY_INCLUDE_IF(tron)
       controllerMessenger.tryUnsubscribe(
         `${PermissionController.name}:stateChange`,
         this.handleTronAccountChangedFromScopeChanges,
@@ -554,7 +547,6 @@ export class BackgroundBridge extends EventEmitter {
         `${AccountTreeController.name}:selectedAccountGroupChange`,
         this.handleTronAccountChangedFromSelectedAccountGroupChanges,
       );
-      ///: END:ONLY_INCLUDE_IF
 
       controllerMessenger.tryUnsubscribe(
         `${AccountTreeController.name}:selectedAccountGroupChange`,
@@ -604,9 +596,7 @@ export class BackgroundBridge extends EventEmitter {
     // messages before attempting to establish the connection meaning that it will
     // have listeners ready for this Solana and Tron accountChanged event below.
     this.notifySolanaAccountChangedForCurrentAccount();
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     this.notifyTronAccountChangedForCurrentAccount();
-    ///: END:ONLY_INCLUDE_IF
 
     const filterStream = createDupeReqFilterStream();
 
@@ -658,7 +648,6 @@ export class BackgroundBridge extends EventEmitter {
     // Sentry tracing middleware
     engine.push(createTracingMiddleware());
 
-    ///: BEGIN:ONLY_INCLUDE_IF(snaps)
     // These Snaps RPC methods are disabled in WalletConnect and SDK for now
     if (this.isMMSDK || this.isWalletConnect) {
       engine.push((req, _res, next, end) => {
@@ -670,9 +659,7 @@ export class BackgroundBridge extends EventEmitter {
         return next();
       });
     }
-    ///: END:ONLY_INCLUDE_IF
 
-    ///: BEGIN:ONLY_INCLUDE_IF(snaps)
     // The Snaps middleware is disabled in WalletConnect and SDK for now.
     if (!this.isMMSDK && !this.isWalletConnect) {
       engine.push(
@@ -684,7 +671,6 @@ export class BackgroundBridge extends EventEmitter {
         ),
       );
     }
-    ///: END:ONLY_INCLUDE_IF
 
     // Origin throttling middleware for spam filtering
     engine.push(createOriginThrottlingMiddleware(this.navigation));
@@ -956,7 +942,6 @@ export class BackgroundBridge extends EventEmitter {
     } catch {
       // noop
     }
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     try {
       this.lastSelectedTronAccountAddress =
         AccountsController.getSelectedMultichainAccount(
@@ -965,7 +950,6 @@ export class BackgroundBridge extends EventEmitter {
     } catch {
       // noop
     }
-    ///: END:ONLY_INCLUDE_IF
 
     // wallet_sessionChanged and eth_subscription setup/teardown
     controllerMessenger.subscribe(
@@ -992,7 +976,6 @@ export class BackgroundBridge extends EventEmitter {
       this.handleSolanaAccountChangedFromSelectedAccountGroupChanges,
     );
 
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     // wallet_notify for Tron accountChanged when permission changes
     controllerMessenger.subscribe(
       `${PermissionController.name}:stateChange`,
@@ -1010,7 +993,6 @@ export class BackgroundBridge extends EventEmitter {
       `${AccountTreeController.name}:selectedAccountGroupChange`,
       this.handleTronAccountChangedFromSelectedAccountGroupChanges,
     );
-    ///: END:ONLY_INCLUDE_IF
 
     // wallet_sessionChanged when selected account group changes (account ordering update)
     controllerMessenger.subscribe(
@@ -1244,7 +1226,6 @@ export class BackgroundBridge extends EventEmitter {
     return solanaAccount;
   }
 
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   handleTronAccountChangedFromScopeChanges = (currentValue, previousValue) => {
     const previousTronAccountChangedNotificationsEnabled = Boolean(
       previousValue?.sessionProperties?.[
@@ -1369,7 +1350,6 @@ export class BackgroundBridge extends EventEmitter {
     );
     return tronAccount;
   }
-  ///: END:ONLY_INCLUDE_IF
 
   sendNotificationEip1193(payload) {
     DevLogger.log(`BackgroundBridge::sendNotificationEip1193: `, payload);
@@ -1584,7 +1564,6 @@ export class BackgroundBridge extends EventEmitter {
     }
   }
 
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   /**
    * For origins with a Tron scope permitted, sends a wallet_notify -> metamask_accountChanged
    * event to fire for the Tron scope with the currently selected Tron account if any are
@@ -1651,7 +1630,6 @@ export class BackgroundBridge extends EventEmitter {
       }
     }
   }
-  ///: END:ONLY_INCLUDE_IF
 
   _notifyMultichainAccountChange(value, scope) {
     this.sendNotificationMultichain({

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -1,11 +1,9 @@
 /* eslint-disable @typescript-eslint/no-shadow */
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import {
   AppState,
   AppStateStatus,
   NativeEventSubscription,
 } from 'react-native';
-///: END:ONLY_INCLUDE_IF
 import {
   CodefiTokenPricesServiceV2,
   TokenListService,
@@ -23,9 +21,7 @@ import {
   type CaveatSpecificationConstraint,
   PermissionController,
   type PermissionSpecificationConstraint,
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   SubjectMetadataController,
-  ///: END:ONLY_INCLUDE_IF
 } from '@metamask/permission-controller';
 import { isTestNet } from '../../util/networks';
 import { deprecatedGetNetworkId } from '../../util/networks/engineNetworkUtils';
@@ -50,10 +46,8 @@ import Logger from '../../util/Logger';
 import { isZero } from '../../util/lodash';
 import { initializeRpcProviderDomains } from '../../util/rpc-domain-utils';
 
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { notificationServicesControllerInit } from './controllers/notifications/notification-services-controller-init';
 import { notificationServicesPushControllerInit } from './controllers/notifications/notification-services-push-controller-init';
-///: END:ONLY_INCLUDE_IF
 import {
   backendWebSocketServiceInit,
   accountActivityServiceInit,
@@ -72,12 +66,7 @@ import {
 } from '../../core/redux/slices/inpageProvider';
 import type { SmartTransactionsController } from '@metamask/smart-transactions-controller';
 import { zeroAddress } from 'ethereumjs-util';
-import {
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-  toHex,
-  ///: END:ONLY_INCLUDE_IF
-} from '@metamask/controller-utils';
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+import { toHex } from '@metamask/controller-utils';
 import { removeAccountsFromPermissions } from '../Permissions';
 import { multichainBalancesControllerInit } from './controllers/multichain-balances-controller/multichain-balances-controller-init';
 import { multichainAssetsControllerInit } from './controllers/multichain-assets-controller/multichain-assets-controller-init';
@@ -86,8 +75,6 @@ import { multichainTransactionsControllerInit } from './controllers/multichain-t
 import { multichainAccountServiceInit } from './controllers/multichain-account-service/multichain-account-service-init';
 import { snapAccountServiceInit } from './controllers/snap-account-service/snap-account-service-init';
 import { SnapKeyring } from '@metamask/eth-snap-keyring';
-///: END:ONLY_INCLUDE_IF
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import {
   cronjobControllerInit,
   executionServiceInit,
@@ -96,7 +83,6 @@ import {
   snapRegistryControllerInit,
 } from './controllers/snaps';
 import { RestrictedMethods } from '../Permissions/constants';
-///: END:ONLY_INCLUDE_IF
 import {
   RootExtendedMessenger,
   EngineState,
@@ -137,9 +123,7 @@ import type { GatorPermissionsController } from '@metamask/gator-permissions-con
 import { DelegationControllerInit } from './controllers/delegation/delegation-controller-init';
 import { selectedNetworkControllerInit } from './controllers/selected-network-controller-init';
 import { permissionControllerInit } from './controllers/permission-controller-init';
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { subjectMetadataControllerInit } from './controllers/subject-metadata-controller-init';
-///: END:ONLY_INCLUDE_IF
 import { PreferencesController } from '@metamask/preferences-controller';
 import { preferencesControllerInit } from './controllers/preferences-controller-init';
 import { TransactionPayControllerInit } from './controllers/transaction-pay-controller';
@@ -241,7 +225,6 @@ export class Engine {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   lastIncomingTxBlockInfo: any;
 
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   /**
    * The app state event listener.
    * This is used to handle app state changes in snaps lifecycle hooks.
@@ -249,7 +232,6 @@ export class Engine {
   appStateListener: NativeEventSubscription;
 
   subjectMetadataController: SubjectMetadataController;
-  ///: END:ONLY_INCLUDE_IF
 
   /**
    * The app state WebSocket manager.
@@ -307,9 +289,7 @@ export class Engine {
     const initRequest = {
       getState: () => store.getState(),
       getGlobalChainId: () => currentChainId,
-      ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
       removeAccount: this.removeAccount.bind(this),
-      ///: END:ONLY_INCLUDE_IF
       analyticsId,
       codefiTokenApiV2,
       tokenListService,
@@ -320,9 +300,7 @@ export class Engine {
         LoggingController: loggingControllerInit,
         PreferencesController: preferencesControllerInit,
         PermissionController: permissionControllerInit,
-        ///: BEGIN:ONLY_INCLUDE_IF(snaps)
         SubjectMetadataController: subjectMetadataControllerInit,
-        ///: END:ONLY_INCLUDE_IF
         AccountTreeController: accountTreeControllerInit,
         AppMetadataController: appMetadataControllerInit,
         AssetsContractController: assetsContractControllerInit,
@@ -355,7 +333,6 @@ export class Engine {
         BridgeStatusController: bridgeStatusControllerInit,
         NftController: nftControllerInit,
         NftDetectionController: nftDetectionControllerInit,
-        ///: BEGIN:ONLY_INCLUDE_IF(snaps)
         ExecutionService: executionServiceInit,
         CronjobController: cronjobControllerInit,
         SnapRegistryController: snapRegistryControllerInit,
@@ -367,11 +344,9 @@ export class Engine {
         WebSocketService: WebSocketServiceInit,
         AuthenticationController: authenticationControllerInit,
         UserStorageController: userStorageControllerInit,
-        ///: END:ONLY_INCLUDE_IF
         BackendWebSocketService: backendWebSocketServiceInit,
         AccountActivityService: accountActivityServiceInit,
         OHLCVService: ohlcvServiceInit,
-        ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
         SnapAccountService: snapAccountServiceInit,
         MultichainAssetsController: multichainAssetsControllerInit,
         MultichainAssetsRatesController: multichainAssetsRatesControllerInit,
@@ -379,7 +354,6 @@ export class Engine {
         MultichainRoutingService: multichainRoutingServiceInit,
         MultichainTransactionsController: multichainTransactionsControllerInit,
         MultichainAccountService: multichainAccountServiceInit,
-        ///: END:ONLY_INCLUDE_IF
         SamplePetnamesController: samplePetnamesControllerInit,
         PerpsController: perpsControllerInit,
         // AssetsController must be initialized before ClientController so it
@@ -507,7 +481,6 @@ export class Engine {
       messengerClientsByName.NftDetectionController;
     const networkController = this.#wallet.getInstance('NetworkController');
 
-    ///: BEGIN:ONLY_INCLUDE_IF(snaps)
     const cronjobController = messengerClientsByName.CronjobController;
     const executionService = messengerClientsByName.ExecutionService;
     const snapController = messengerClientsByName.SnapController;
@@ -525,7 +498,6 @@ export class Engine {
     const authenticationController =
       messengerClientsByName.AuthenticationController;
     const userStorageController = messengerClientsByName.UserStorageController;
-    ///: END:ONLY_INCLUDE_IF
 
     // Initialize BackendWebSocketService lifecycle management
     const backendWebSocketService =
@@ -537,7 +509,6 @@ export class Engine {
       messengerClientsByName.AccountActivityService;
     const ohlcvService = messengerClientsByName.OHLCVService;
 
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     const multichainAssetsController =
       messengerClientsByName.MultichainAssetsController;
     const multichainAssetsRatesController =
@@ -549,7 +520,6 @@ export class Engine {
     const multichainAccountService =
       messengerClientsByName.MultichainAccountService;
     const snapAccountService = messengerClientsByName.SnapAccountService;
-    ///: END:ONLY_INCLUDE_IF
 
     const networkEnablementController =
       messengerClientsByName.NetworkEnablementController;
@@ -571,12 +541,10 @@ export class Engine {
       captureException(error);
     });
 
-    ///: BEGIN:ONLY_INCLUDE_IF(snaps)
     snapController.init();
     cronjobController.init();
     // Notification Setup
     notificationServicesController.init();
-    ///: END:ONLY_INCLUDE_IF
 
     this.context = {
       AnalyticsController: analyticsController,
@@ -612,7 +580,6 @@ export class Engine {
       SelectedNetworkController: selectedNetworkController,
       SignatureController: signatureController,
       LoggingController: loggingController,
-      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       CronjobController: cronjobController,
       ExecutionService: executionService,
       SnapController: snapController,
@@ -624,19 +591,16 @@ export class Engine {
       WebSocketService: webSocketService,
       NotificationServicesController: notificationServicesController,
       NotificationServicesPushController: notificationServicesPushController,
-      ///: END:ONLY_INCLUDE_IF
       BackendWebSocketService: backendWebSocketService,
       AccountActivityService: accountActivityService,
       OHLCVService: ohlcvService,
       AccountsController: accountsController,
-      ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
       MultichainBalancesController: multichainBalancesController,
       MultichainAssetsController: multichainAssetsController,
       MultichainAssetsRatesController: multichainAssetsRatesController,
       MultichainTransactionsController: multichainTransactionsController,
       MultichainAccountService: multichainAccountService,
       SnapAccountService: snapAccountService,
-      ///: END:ONLY_INCLUDE_IF
       TokenSearchDiscoveryDataController: tokenSearchDiscoveryDataController,
       MultichainNetworkController: multichainNetworkController,
       BridgeController: bridgeController,
@@ -725,7 +689,6 @@ export class Engine {
       },
     );
 
-    ///: BEGIN:ONLY_INCLUDE_IF(snaps)
     this.controllerMessenger.subscribe(
       `${snapController.name}:snapTerminated`,
       (truncatedSnap) => {
@@ -865,7 +828,6 @@ export class Engine {
         }
       },
     );
-    ///: END:ONLY_INCLUDE_IF
 
     this.configureControllersOnNetworkChange();
     this.handleVaultBackup();
@@ -1220,7 +1182,6 @@ export class Engine {
     };
   };
 
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   /**
    * Removes an account from state / storage.
    *
@@ -1233,7 +1194,6 @@ export class Engine {
     // Remove account from the keyring
     await this.keyringController.removeAccount(addressHex);
   };
-  ///: END:ONLY_INCLUDE_IF
 
   /**
    * Returns true or false whether the user has funds or not
@@ -1285,18 +1245,14 @@ export class Engine {
       TokenRatesController,
       PermissionController,
       // SelectedNetworkController,
-      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       SnapController,
-      ///: END:ONLY_INCLUDE_IF
       LoggingController,
       MoneyAccountController,
     } = this.context;
 
     // Remove all permissions.
     PermissionController?.clearState?.();
-    ///: BEGIN:ONLY_INCLUDE_IF(snaps)
     await SnapController.clearState();
-    ///: END:ONLY_INCLUDE_IF
 
     // Clear selected network
     // TODO implement this method on SelectedNetworkController
@@ -1328,9 +1284,7 @@ export class Engine {
   removeAllListeners() {
     this.controllerMessenger.clearSubscriptions();
 
-    ///: BEGIN:ONLY_INCLUDE_IF(snaps)
     this.appStateListener?.remove();
-    ///: END:ONLY_INCLUDE_IF
 
     // Cleanup AppStateWebSocketManager
     this.appStateWebSocketManager.cleanup();
@@ -1509,7 +1463,6 @@ export default {
       ClientController,
       SocialController,
       ComplianceController,
-      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       AuthenticationController,
       CronjobController,
       NotificationServicesController,
@@ -1519,13 +1472,10 @@ export default {
       SnapRegistryController,
       SubjectMetadataController,
       UserStorageController,
-      ///: END:ONLY_INCLUDE_IF
-      ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
       MultichainAssetsController,
       MultichainAssetsRatesController,
       MultichainBalancesController,
       MultichainTransactionsController,
-      ///: END:ONLY_INCLUDE_IF
       ProfileMetricsController,
       MoneyAccountController,
       MoneyAccountUpgradeController,
@@ -1588,7 +1538,6 @@ export default {
       CardController: CardController.state,
       ClientController: ClientController.state,
       ComplianceController: ComplianceController.state,
-      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       AuthenticationController: AuthenticationController.state,
       CronjobController: CronjobController.state,
       NotificationServicesController: NotificationServicesController.state,
@@ -1599,13 +1548,10 @@ export default {
       SnapRegistryController: SnapRegistryController.state,
       SubjectMetadataController: SubjectMetadataController.state,
       UserStorageController: UserStorageController.state,
-      ///: END:ONLY_INCLUDE_IF
-      ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
       MultichainAssetsController: MultichainAssetsController.state,
       MultichainAssetsRatesController: MultichainAssetsRatesController.state,
       MultichainBalancesController: MultichainBalancesController.state,
       MultichainTransactionsController: MultichainTransactionsController.state,
-      ///: END:ONLY_INCLUDE_IF
       ProfileMetricsController: ProfileMetricsController.state,
       MoneyAccountController: MoneyAccountController.state,
       MoneyAccountUpgradeController: MoneyAccountUpgradeController.state,
@@ -1671,10 +1617,8 @@ export default {
   // TODO: Use the KeyringController to find the appropriate QR keyring bridge instead of using a global.
   getQrKeyringScanner: () => qrKeyringBridge,
 
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   removeAccount: async (address: string) => {
     assertEngineExists(instance);
     return await instance.removeAccount(address);
   },
-  ///: END:ONLY_INCLUDE_IF
 };

--- a/app/core/Engine/constants.ts
+++ b/app/core/Engine/constants.ts
@@ -66,7 +66,6 @@ export const BACKGROUND_STATE_CHANGE_EVENT_NAMES = [
   'TransactionController:stateChange',
   'TransactionPayController:stateChange',
   'MultichainNetworkController:stateChange',
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   'SnapController:stateChange',
   'SnapRegistryController:stateChange',
   'SubjectMetadataController:stateChange',
@@ -76,14 +75,11 @@ export const BACKGROUND_STATE_CHANGE_EVENT_NAMES = [
   'NotificationServicesPushController:stateChange',
   'SnapInterfaceController:stateChange',
   'CronjobController:stateChange',
-  ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   'MultichainBalancesController:stateChange',
   'MultichainAssetsRatesController:stateChange',
   // TODO: Export this from the assets controller
   'MultichainAssetsController:stateChange',
   'MultichainTransactionsController:stateChange',
-  ///: END:ONLY_INCLUDE_IF
   'BridgeController:stateChange',
   'BridgeStatusController:stateChange',
   'EarnController:stateChange',

--- a/app/core/Engine/controllers/multichain-account-service/multichain-account-service-init.ts
+++ b/app/core/Engine/controllers/multichain-account-service/multichain-account-service-init.ts
@@ -43,12 +43,8 @@ export const multichainAccountServiceInit: MessengerClientInitFunction<
     messenger: controllerMessenger,
     providerConfigs: {
       [SOL_ACCOUNT_PROVIDER_NAME]: snapAccountProviderConfig,
-      /// BEGIN:ONLY_INCLUDE_IF(bitcoin)
       [BTC_ACCOUNT_PROVIDER_NAME]: snapAccountProviderConfig,
-      /// END:ONLY_INCLUDE_IF
-      /// BEGIN:ONLY_INCLUDE_IF(tron)
       [TRX_ACCOUNT_PROVIDER_NAME]: snapAccountProviderConfig,
-      /// END:ONLY_INCLUDE_IF
     },
   });
 

--- a/app/core/Engine/controllers/permission-controller-init.ts
+++ b/app/core/Engine/controllers/permission-controller-init.ts
@@ -11,9 +11,7 @@ import {
   getPermissionSpecifications,
   unrestrictedMethods,
 } from '../../Permissions/specifications';
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { getSnapPermissionSpecifications } from '../../Snaps/permissions/specifications';
-///: END:ONLY_INCLUDE_IF
 import { CaipChainId } from '@metamask/utils';
 
 /**
@@ -55,9 +53,7 @@ export const permissionControllerInit: MessengerClientInitFunction<
     }),
     permissionSpecifications: {
       ...getPermissionSpecifications(),
-      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       ...getSnapPermissionSpecifications(initMessenger),
-      ///: END:ONLY_INCLUDE_IF
     },
     unrestrictedMethods,
   });

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -17,7 +17,6 @@ import {
   getAccountActivityServiceMessenger,
   getOHLCVServiceMessenger,
 } from './core-backend';
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import {
   getCronjobControllerMessenger,
   getExecutionServiceMessenger,
@@ -27,14 +26,11 @@ import {
   getSnapRegistryControllerMessenger,
   getWebSocketServiceMessenger,
 } from './snaps';
-///: END:ONLY_INCLUDE_IF
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { getMultichainAssetsRatesControllerMessenger } from './multichain-assets-rates-controller-messenger/multichain-assets-rates-controller-messenger';
 import { getMultichainAssetsControllerMessenger } from './multichain-assets-controller-messenger/multichain-assets-controller-messenger';
 import { getMultichainBalancesControllerMessenger } from './multichain-balances-controller-messenger/multichain-balances-controller-messenger';
 import { getMultichainTransactionsControllerMessenger } from './multichain-transactions-controller-messenger/multichain-transactions-controller-messenger';
 import { getSnapAccountServiceMessenger } from './snap-account-service-messenger/snap-account-service-messenger';
-///: END:ONLY_INCLUDE_IF
 import { getNotificationServicesControllerMessenger } from './notifications/notification-services-controller-messenger';
 import { getNotificationServicesPushControllerMessenger } from './notifications/notification-services-push-controller-messenger';
 import { getSignatureControllerMessenger } from './signature-controller-messenger';
@@ -238,7 +234,6 @@ export const MESSENGER_FACTORIES = {
     getMessenger: getDeFiPositionsControllerMessenger,
     getInitMessenger: getDeFiPositionsControllerInitMessenger,
   },
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   AuthenticationController: {
     getMessenger: getAuthenticationControllerMessenger,
     getInitMessenger: noop,
@@ -283,8 +278,6 @@ export const MESSENGER_FACTORIES = {
     getMessenger: getWebSocketServiceMessenger,
     getInitMessenger: noop,
   },
-  ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   MultichainAssetsController: {
     getMessenger: getMultichainAssetsControllerMessenger,
     getInitMessenger: noop,
@@ -313,7 +306,6 @@ export const MESSENGER_FACTORIES = {
     getMessenger: getSnapAccountServiceMessenger,
     getInitMessenger: noop,
   },
-  ///: END:ONLY_INCLUDE_IF
   PermissionController: {
     getMessenger: getPermissionControllerMessenger,
     getInitMessenger: getPermissionControllerInitMessenger,

--- a/app/core/Engine/messengers/permission-controller-messenger.ts
+++ b/app/core/Engine/messengers/permission-controller-messenger.ts
@@ -52,11 +52,9 @@ export function getPermissionControllerMessenger(
       'ApprovalController:hasRequest',
       'ApprovalController:acceptRequest',
       'ApprovalController:rejectRequest',
-      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       'SnapController:getPermittedSnaps',
       'SnapController:installSnaps',
       'SubjectMetadataController:getSubjectMetadata',
-      ///: END:ONLY_INCLUDE_IF
     ],
     events: [],
     messenger,

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -44,8 +44,6 @@ import {
   DeFiPositionsControllerState,
   DeFiPositionsControllerEvents,
   DeFiPositionsControllerActions,
-
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   MultichainBalancesControllerState,
   MultichainBalancesController,
   MultichainBalancesControllerEvents,
@@ -65,7 +63,6 @@ import {
   CodefiTokenPricesServiceV2,
   TokenDetectionControllerEvents,
   TokenDetectionControllerActions,
-  ///: END:ONLY_INCLUDE_IF
 } from '@metamask/assets-controllers';
 import {
   AssetsController,
@@ -73,7 +70,6 @@ import {
   AssetsControllerEvents,
   AssetsControllerState,
 } from '@metamask/assets-controller';
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import {
   MultichainTransactionsController,
   MultichainTransactionsControllerState,
@@ -82,7 +78,6 @@ import {
   MultichainTransactionsControllerEvents,
   MultichainTransactionsControllerActions,
 } from './messengers/multichain-transactions-controller-messenger/types';
-///: END:ONLY_INCLUDE_IF
 import {
   AddressBookController,
   AddressBookControllerActions,
@@ -177,14 +172,11 @@ import {
   PermissionControllerActions,
   PermissionControllerEvents,
   PermissionControllerState,
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   SubjectMetadataController,
   SubjectMetadataControllerActions,
   SubjectMetadataControllerEvents,
   SubjectMetadataControllerState,
-  ///: END:ONLY_INCLUDE_IF
 } from '@metamask/permission-controller';
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import {
   SnapController,
   ExecutionService,
@@ -210,7 +202,6 @@ import {
   ExecutionServiceActions,
   ExecutionServiceEvents,
 } from '@metamask/snaps-controllers';
-///: END:ONLY_INCLUDE_IF
 import {
   LoggingController,
   LoggingControllerActions,
@@ -235,7 +226,6 @@ import {
   type SmartTransactionsControllerEvents,
   SmartTransactionsControllerState,
 } from '@metamask/smart-transactions-controller';
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import {
   AuthenticationController,
   UserStorageController,
@@ -253,7 +243,6 @@ import type {
   NotificationServicesPushControllerState,
 } from '@metamask/notification-services-controller/push-services';
 
-///: END:ONLY_INCLUDE_IF
 import {
   BackendWebSocketService,
   BackendWebSocketServiceActions,
@@ -543,7 +532,6 @@ type OptionalControllers = Pick<
 type PermissionsByRpcMethod = ReturnType<typeof getPermissionSpecifications>;
 type Permissions = PermissionsByRpcMethod[keyof PermissionsByRpcMethod];
 
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 // TODO: Abstract this into controller utils for SnapsController
 type SnapsGlobalActions =
   | SnapControllerActions
@@ -556,7 +544,6 @@ type SnapsGlobalEvents =
   | SnapRegistryControllerEvents
   | SubjectMetadataControllerEvents
   | PhishingControllerEvents;
-///: END:ONLY_INCLUDE_IF
 
 export type GlobalActions =
   | SamplePetnamesControllerActions
@@ -576,7 +563,6 @@ export type GlobalActions =
   | SignatureControllerActions
   | LoggingControllerActions
   | AnalyticsControllerActions
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   | SnapsGlobalActions
   | SnapInterfaceControllerActions
   | AuthenticationController.Actions
@@ -586,18 +572,15 @@ export type GlobalActions =
   | CronjobControllerActions
   | WebSocketServiceActions
   | ExecutionServiceActions
-  ///: END:ONLY_INCLUDE_IF
   | BackendWebSocketServiceActions
   | AccountActivityServiceActions
   | OHLCVServiceActions
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   | MultichainBalancesControllerActions
   | MultichainAssetsControllerActions
   | MultichainAssetsRatesControllerActions
   | MultichainTransactionsControllerActions
   | MultichainAccountServiceActions
   | SnapAccountServiceActions
-  ///: END:ONLY_INCLUDE_IF
   | AccountsControllerActions
   | AccountTreeControllerActions
   | PreferencesControllerActions
@@ -671,7 +654,6 @@ export type GlobalEvents =
   | NetworkControllerEvents
   | NetworkEnablementControllerEvents
   | PermissionControllerEvents
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   | SnapsGlobalEvents
   | SnapInterfaceControllerEvents
   | AuthenticationController.Events
@@ -680,18 +662,15 @@ export type GlobalEvents =
   | NotificationServicesPushControllerEvents
   | CronjobControllerEvents
   | ExecutionServiceEvents
-  ///: END:ONLY_INCLUDE_IF
   | BackendWebSocketServiceEvents
   | AccountActivityServiceEvents
   | OHLCVServiceEvents
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   | MultichainBalancesControllerEvents
   | MultichainAssetsControllerEvents
   | MultichainAssetsRatesControllerEvents
   | MultichainTransactionsControllerEvents
   | MultichainAccountServiceEvents
   | SnapAccountServiceEvents
-  ///: END:ONLY_INCLUDE_IF
   | SignatureControllerEvents
   | LoggingControllerEvents
   | AnalyticsControllerEvents
@@ -826,7 +805,6 @@ export type MessengerClients = {
   SmartTransactionsController: SmartTransactionsController;
   SignatureController: SignatureController;
   StorageService: StorageService;
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   ExecutionService: ExecutionService;
   SnapController: SnapController;
   SnapRegistryController: SnapRegistryController;
@@ -838,11 +816,9 @@ export type MessengerClients = {
   SnapInterfaceController: SnapInterfaceController;
   CronjobController: CronjobController;
   WebSocketService: WebSocketService;
-  ///: END:ONLY_INCLUDE_IF
   BackendWebSocketService: BackendWebSocketService;
   AccountActivityService: AccountActivityService;
   OHLCVService: OHLCVService;
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   MultichainBalancesController: MultichainBalancesController;
   MultichainAssetsRatesController: MultichainAssetsRatesController;
   MultichainAssetsController: MultichainAssetsController;
@@ -850,7 +826,6 @@ export type MessengerClients = {
   MultichainTransactionsController: MultichainTransactionsController;
   MultichainAccountService: MultichainAccountService;
   SnapAccountService: SnapAccountService;
-  ///: END:ONLY_INCLUDE_IF
   TokenSearchDiscoveryDataController: TokenSearchDiscoveryDataController;
   MultichainNetworkController: MultichainNetworkController;
   BridgeController: BridgeController;
@@ -922,7 +897,6 @@ export type EngineState = {
   GasFeeController: GasFeeState;
   TokensController: TokensControllerState;
   DeFiPositionsController: DeFiPositionsControllerState;
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   SnapController: PersistedSnapControllerState;
   SnapRegistryController: SnapRegistryControllerState;
   SubjectMetadataController: SubjectMetadataControllerState;
@@ -932,7 +906,6 @@ export type EngineState = {
   NotificationServicesPushController: NotificationServicesPushControllerState;
   SnapInterfaceController: SnapInterfaceControllerState;
   CronjobController: CronjobControllerState;
-  ///: END:ONLY_INCLUDE_IF
   PermissionController: PermissionControllerState<Permissions>;
   ApprovalController: ApprovalControllerState;
   LoggingController: LoggingControllerState;
@@ -941,12 +914,10 @@ export type EngineState = {
   AccountTreeController: AccountTreeControllerState;
   SelectedNetworkController: SelectedNetworkControllerState;
   SignatureController: SignatureControllerState;
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   MultichainBalancesController: MultichainBalancesControllerState;
   MultichainAssetsController: MultichainAssetsControllerState;
   MultichainAssetsRatesController: MultichainAssetsRatesControllerState;
   MultichainTransactionsController: MultichainTransactionsControllerState;
-  ///: END:ONLY_INCLUDE_IF
   TokenSearchDiscoveryDataController: TokenSearchDiscoveryDataControllerState;
   MultichainNetworkController: MultichainNetworkControllerState;
   BridgeController: BridgeControllerState;
@@ -1005,7 +976,6 @@ export type MessengerClientsToInitialize =
   | 'ConfigRegistryController'
   | 'ConfigRegistryApiService'
   | 'SentinelApiService'
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   | 'AuthenticationController'
   | 'CronjobController'
   | 'ExecutionService'
@@ -1018,11 +988,9 @@ export type MessengerClientsToInitialize =
   | 'AppMetadataController'
   | 'SubjectMetadataController'
   | 'UserStorageController'
-  ///: END:ONLY_INCLUDE_IF
   | 'BackendWebSocketService'
   | 'AccountActivityService'
   | 'OHLCVService'
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   | 'MultichainAssetsController'
   | 'MultichainAssetsRatesController'
   | 'MultichainBalancesController'
@@ -1030,7 +998,6 @@ export type MessengerClientsToInitialize =
   | 'MultichainTransactionsController'
   | 'MultichainAccountService'
   | 'SnapAccountService'
-  ///: END:ONLY_INCLUDE_IF
   | 'EarnController'
   | 'MoneyAccountController'
   | 'MoneyAccountBalanceService'
@@ -1166,14 +1133,12 @@ export type MessengerClientInitRequest<
    */
   analyticsId: string;
 
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   /**
    * Remove an account from all controllers that manage accounts.
    *
    * @param address - The address of the account to remove.
    */
   removeAccount(address: string): Promise<void>;
-  ///: END:ONLY_INCLUDE_IF
 
   /**
    * The initial state of the keyring controller, if applicable.
@@ -1230,9 +1195,7 @@ export interface InitMessengerClientsFunctionRequest {
   analyticsId: string;
   codefiTokenApiV2: CodefiTokenPricesServiceV2;
   tokenListService: TokenListService;
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   removeAccount: (address: string) => Promise<void>;
-  ///: END:ONLY_INCLUDE_IF
   persistedState: MessengerClientPersistedState;
 }
 

--- a/app/core/Engine/wallet-init/keyrings.ts
+++ b/app/core/Engine/wallet-init/keyrings.ts
@@ -119,7 +119,6 @@ export function getKeyringBuilders(
   moneyKeyringBuilder.type = MoneyKeyring.type;
   keyrings.push(moneyKeyringBuilder);
 
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   const snapKeyringMessenger = getLegacySnapKeyringBuilderMessenger(messenger);
   // @ts-expect-error: `addAccounts` is missing in `SnapKeyring` type.
   keyrings.push(legacySnapKeyringBuilder(snapKeyringMessenger));
@@ -130,7 +129,6 @@ export function getKeyringBuilders(
   // via `unwrap()` for the v2 builder, so both entries share the same
   // underlying object — enabling both `withKeyring` and `withKeyringV2`.
   keyrings.push(snapKeyringV2AdaptedAsV1Builder(snapKeyringMessenger));
-  ///: END:ONLY_INCLUDE_IF
 
   return keyrings;
 }
@@ -197,13 +195,11 @@ export function getKeyringV2Builders(): KeyringControllerOptions['keyringV2Build
     buildHardwareKeyringV2Builder(LedgerKeyringV2, LedgerKeyring.type),
     buildHardwareKeyringV2Builder(QrKeyringV2, QrKeyring.type),
     buildMoneyKeyringV2Builder(MoneyKeyringV2, MoneyKeyring.type),
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     // The v2 Snap keyring is registered via `KeyringV1Adapter`, which owns the
     // inner `SnapKeyring` (v2) instance and exposes a v1-compatible facade for
     // KeyringController vault management. The same inner instance is retrieved
     // via `unwrap()` for the v2 builder, so both entries share the same
     // underlying object — enabling both `withKeyring` and `withKeyringV2`.
     snapKeyringV2Builder(),
-    ///: END:ONLY_INCLUDE_IF
   ];
 }

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -1088,11 +1088,9 @@ export type RootStackParamList = {
   MultichainPrivateKeyList: PrivateKeyListParams | undefined;
   SmartAccountDetails: SmartAccountParams | undefined;
 
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   // Snaps routes
   SnapsSettingsList: undefined;
   SnapSettings: SnapSettingsParams | undefined;
-  ///: END:ONLY_INCLUDE_IF
 
   // Misc routes
   FoxLoader: FoxLoaderParams | undefined;

--- a/app/core/Permissions/constants.ts
+++ b/app/core/Permissions/constants.ts
@@ -5,7 +5,6 @@ export const CaveatTypes = Object.freeze({
 
 export const RestrictedMethods = Object.freeze({
   eth_accounts: 'eth_accounts',
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   // Snap Specific Restricted Methods
   snap_notify: 'snap_notify',
   snap_dialog: 'snap_dialog',
@@ -15,5 +14,4 @@ export const RestrictedMethods = Object.freeze({
   snap_getBip44Entropy: 'snap_getBip44Entropy',
   snap_getEntropy: 'snap_getEntropy',
   wallet_snap: 'wallet_snap',
-  ///: END:ONLY_INCLUDE_IF
 });

--- a/app/core/Permissions/specifications.js
+++ b/app/core/Permissions/specifications.js
@@ -1,9 +1,7 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import {
   caveatSpecifications as snapsCaveatsSpecifications,
   endowmentCaveatSpecifications as snapsEndowmentCaveatSpecifications,
 } from '@metamask/snaps-rpc-methods';
-///: END:ONLY_INCLUDE_IF
 import { RestrictedMethods } from './constants';
 import {
   caip25CaveatBuilder,
@@ -68,10 +66,8 @@ export const getCaveatSpecifications = ({
     isNonEvmScopeSupported,
     getNonEvmAccountAddresses,
   }),
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   ...snapsCaveatsSpecifications,
   ...snapsEndowmentCaveatSpecifications,
-  ///: END:ONLY_INCLUDE_IF
 });
 
 /**
@@ -163,7 +159,6 @@ export const unrestrictedMethods = Object.freeze([
   'wallet_sendCalls',
   'wallet_getCallsStatus',
   'wallet_getCapabilities',
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   'wallet_getAllSnaps',
   'wallet_getSnaps',
   'wallet_requestSnaps',
@@ -192,5 +187,4 @@ export const unrestrictedMethods = Object.freeze([
   'snap_closeWebSocket',
   'snap_getWebSockets',
   'snap_messengerCall',
-  ///: END:ONLY_INCLUDE_IF
 ]);

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -55,14 +55,12 @@ const Engine = ImportedEngine as any;
 
 let appVersion = '';
 
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 export const SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES = {
   confirmAccountCreation: 'snap_manageAccounts:confirmAccountCreation',
   confirmAccountRemoval: 'snap_manageAccounts:confirmAccountRemoval',
   showSnapAccountRedirect: 'snap_manageAccounts:showSnapAccountRedirect',
   showNameSnapAccount: 'snap_manageAccounts:showNameSnapAccount',
 };
-///: END:ONLY_INCLUDE_IF
 
 export enum ApprovalTypes {
   CONNECT_ACCOUNTS = 'CONNECT_ACCOUNTS',
@@ -77,11 +75,9 @@ export enum ApprovalTypes {
   RESULT_ERROR = 'result_error',
   RESULT_SUCCESS = 'result_success',
   SMART_TRANSACTION_STATUS = 'smart_transaction_status',
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   INSTALL_SNAP = 'wallet_installSnap',
   UPDATE_SNAP = 'wallet_updateSnap',
   SNAP_DIALOG = 'snap_dialog',
-  ///: END:ONLY_INCLUDE_IF
 }
 
 export interface RPCMethodsMiddleParameters {

--- a/app/core/SnapKeyring/BitcoinWalletSnap.ts
+++ b/app/core/SnapKeyring/BitcoinWalletSnap.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
 import { SnapId } from '@metamask/snaps-sdk';
 import { Sender } from '@metamask/keyring-snap-client';
 import { HandlerType } from '@metamask/snaps-utils';
@@ -23,4 +22,3 @@ export class BitcoinWalletSnapSender implements Sender {
       request,
     })) as Json;
 }
-///: END:ONLY_INCLUDE_IF

--- a/app/core/SnapKeyring/SolanaWalletSnap.ts
+++ b/app/core/SnapKeyring/SolanaWalletSnap.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { SnapId } from '@metamask/snaps-sdk';
 import { Sender } from '@metamask/keyring-snap-client';
 import { HandlerType } from '@metamask/snaps-utils';
@@ -23,4 +22,3 @@ export class SolanaWalletSnapSender implements Sender {
       request,
     })) as Json;
 }
-///: END:ONLY_INCLUDE_IF

--- a/app/core/SnapKeyring/TronWalletSnap.ts
+++ b/app/core/SnapKeyring/TronWalletSnap.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(tron)
 import { SnapId } from '@metamask/snaps-sdk';
 import { Sender } from '@metamask/keyring-snap-client';
 import { HandlerType } from '@metamask/snaps-utils';
@@ -23,4 +22,3 @@ export class TronWalletSnapSender implements Sender {
       request,
     })) as Json;
 }
-///: END:ONLY_INCLUDE_IF

--- a/app/core/SnapKeyring/keyringSnapsPermissions.ts
+++ b/app/core/SnapKeyring/keyringSnapsPermissions.ts
@@ -6,12 +6,10 @@ import { KeyringRpcMethod } from '@metamask/keyring-api';
  */
 const PORTFOLIO_ORIGINS: string[] = [
   'https://portfolio.metamask.io',
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
   'https://dev.portfolio.metamask.io',
   'https://stage.portfolio.metamask.io',
   'https://ramps-dev.portfolio.metamask.io',
   'https://portfolio-builds.metafi-dev.codefi.network',
-  ///: END:ONLY_INCLUDE_IF
 ];
 
 /**

--- a/app/core/SnapKeyring/types.ts
+++ b/app/core/SnapKeyring/types.ts
@@ -52,17 +52,11 @@ export type SnapKeyringBuilderMessenger = Messenger<
 >;
 
 export enum WalletClientType {
-  ///: BEGIN:ONLY_INCLUDE_IF(solana)
   Solana = 'solana',
-  ///: END:ONLY_INCLUDE_IF
 
-  ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
   Bitcoin = 'bitcoin',
-  ///: END:ONLY_INCLUDE_IF
 
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   Tron = 'tron',
-  ///: END:ONLY_INCLUDE_IF
 
   Stellar = 'stellar',
 }

--- a/app/core/SnapKeyring/utils/getAccountsBySnapId.ts
+++ b/app/core/SnapKeyring/utils/getAccountsBySnapId.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { isSnapKeyring } from '@metamask/eth-snap-keyring/v2';
 import { SnapId } from '@metamask/snaps-sdk';
 import Engine from '../../../core/Engine';
@@ -31,4 +30,3 @@ export const getAccountsBySnapId = async (
     return [];
   }
 };
-///: END:ONLY_INCLUDE_IF

--- a/app/core/SnapKeyring/utils/snaps.ts
+++ b/app/core/SnapKeyring/utils/snaps.ts
@@ -2,9 +2,7 @@ import { SnapId } from '@metamask/snaps-sdk';
 import PREINSTALLED_SNAPS from '../../../lib/snaps/preinstalled-snaps';
 import { BITCOIN_WALLET_SNAP_ID } from '../BitcoinWalletSnap';
 import { SOLANA_WALLET_SNAP_ID } from '../SolanaWalletSnap';
-///: BEGIN:ONLY_INCLUDE_IF(tron)
 import { TRON_WALLET_SNAP_ID } from '../TronWalletSnap';
-///: END:ONLY_INCLUDE_IF
 import { STELLAR_WALLET_SNAP_ID } from '../StellarWalletSnap';
 import {
   getLocalizedSnapManifest,
@@ -50,9 +48,7 @@ export function isSnapPreinstalled(snapId: SnapId) {
 const ALLOW_LISTED_SNAPS = [
   BITCOIN_WALLET_SNAP_ID,
   SOLANA_WALLET_SNAP_ID,
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   TRON_WALLET_SNAP_ID,
-  ///: END:ONLY_INCLUDE_IF
   STELLAR_WALLET_SNAP_ID,
 ];
 

--- a/app/core/Snaps/SnapsMethodMiddleware.ts
+++ b/app/core/Snaps/SnapsMethodMiddleware.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import {
   createSnapsMethodMiddleware,
   type PermittedRpcMethodHooks,
@@ -73,4 +72,3 @@ const snapMethodMiddlewareBuilder = (
   );
 
 export default snapMethodMiddlewareBuilder;
-///: END:ONLY_INCLUDE_IF

--- a/app/core/Snaps/index.ts
+++ b/app/core/Snaps/index.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import SnapBridge from './SnapBridge';
 import {
   ExcludedSnapPermissions,
@@ -15,4 +14,3 @@ export {
   detectSnapLocation,
 };
 export type { DetectSnapLocationOptions };
-///: END:ONLY_INCLUDE_IF

--- a/app/core/Snaps/location/index.ts
+++ b/app/core/Snaps/location/index.ts
@@ -1,3 +1,1 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export * from './location';
-///: END:ONLY_INCLUDE_IF

--- a/app/core/Snaps/location/location.ts
+++ b/app/core/Snaps/location/location.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { NpmLocation } from './npm';
 import {
   HttpLocation,
@@ -44,4 +43,3 @@ export function detectSnapLocation(
       );
   }
 }
-///: END:ONLY_INCLUDE_IF

--- a/app/core/Snaps/location/npm.ts
+++ b/app/core/Snaps/location/npm.ts
@@ -1,5 +1,4 @@
 /* eslint-disable import-x/prefer-default-export */
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { VirtualFile } from '@metamask/snaps-utils';
 import { assert, getErrorMessage } from '@metamask/utils';
 import { NativeModules } from 'react-native';
@@ -123,4 +122,3 @@ export class NpmLocation extends BaseNpmLocation {
     }
   }
 }
-///: END:ONLY_INCLUDE_IF

--- a/app/core/Snaps/permissions/permissions.ts
+++ b/app/core/Snaps/permissions/permissions.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 // TODO: Figure out which permissions should be disabled at this point
 export const ExcludedSnapPermissions = Object.freeze({
   eth_accounts:
@@ -19,4 +18,3 @@ export const EndowmentPermissions = Object.freeze({
   'endowment:name-lookup': 'endowment:name-lookup',
   'endowment:keyring': 'endowment:keyring',
 } as const);
-///: END:ONLY_INCLUDE_IF

--- a/app/core/Snaps/permissions/specifications.ts
+++ b/app/core/Snaps/permissions/specifications.ts
@@ -73,7 +73,6 @@ export const getSnapPermissionSpecifications = (
   ...buildSnapRestrictedMethodSpecifications(
     Object.keys(ExcludedSnapPermissions),
     {
-      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       getUnlockPromise: async () => {
         if (messenger.call('KeyringController:getState').isUnlocked) {
           return;
@@ -122,8 +121,6 @@ export const getSnapPermissionSpecifications = (
           showTestnets: showTestNetworks,
         };
       },
-      ///: END:ONLY_INCLUDE_IF
-      ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
       getSnapKeyring: async () => ({
         // We only need a subset of the Snap keyring's functionality, and this message handling is now
         // owned by the Snap account service.
@@ -135,7 +132,6 @@ export const getSnapPermissionSpecifications = (
           );
         },
       }),
-      ///: END:ONLY_INCLUDE_IF
     },
     messenger as RestrictedMethodMessenger,
   ),

--- a/app/core/WalletConnect/multichain/registry.ts
+++ b/app/core/WalletConnect/multichain/registry.ts
@@ -10,9 +10,7 @@ import type { KnownCaipNamespace } from '@metamask/utils';
 
 import type { AnyChainAdapter } from './types';
 
-///: BEGIN:ONLY_INCLUDE_IF(tron)
 import { tronAdapter } from './tron';
-///: END:ONLY_INCLUDE_IF
 
 // Keyed by raw namespace string so lookups accept whatever a dapp proposal
 // sent, which we don't trust upfront.
@@ -46,6 +44,4 @@ export function getAllRegisteredNamespaces(): KnownCaipNamespace[] {
   return Array.from(adapters.keys()) as KnownCaipNamespace[];
 }
 
-///: BEGIN:ONLY_INCLUDE_IF(tron)
 registerAdapter(tronAdapter);
-///: END:ONLY_INCLUDE_IF

--- a/app/images/image-icons.js
+++ b/app/images/image-icons.js
@@ -18,11 +18,9 @@ import KAIA_MAINNET from './kaia.png';
 import FOX_LOGO from '../../app/images/branding/tiny-logo.png';
 import BTC from './bitcoin-logo.png';
 import CHZ from './chiliz.png';
-///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
 import BTC_TESTNET from './bitcoin-testnet-logo.png';
 import BTC_MUTINYNET from './bitcoin-mutinynet-logo.png';
 import BTC_SIGNET from './bitcoin-signet-logo.svg';
-///: END:ONLY_INCLUDE_IF
 import BASE from './base.png';
 import MEGAETH_TESTNET from './megaeth-testnet-logo.png';
 import HL from './HL_symbol_mint_green.png';
@@ -66,9 +64,7 @@ import TEMPO_NATIVE from './tempo-native.png';
 import ARC_NATIVE from './arc-native-token-logo.png';
 import ROBINHOOD from './robinhood.png';
 import GNOSIS_NATIVE from './gnosis-native-token-logo.png';
-/// BEGIN:ONLY_INCLUDE_IF(tron)
 import TRON from './tron-logo.png';
-/// END:ONLY_INCLUDE_IF
 import STELLAR from './xlm.png';
 
 export default {
@@ -94,18 +90,14 @@ export default {
   SOLANA_DEVNET,
   FOX_LOGO,
   BTC,
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   TRON,
   TRX: TRON,
   sTRX: TRON,
-  ///: END:ONLY_INCLUDE_IF
   STELLAR,
   XLM: STELLAR,
-  ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
   'BTC-TESTNET': BTC_TESTNET,
   'BTC-MUTINYNET': BTC_MUTINYNET,
   'BTC-SIGNET': BTC_SIGNET,
-  ///: END:ONLY_INCLUDE_IF
   BASE,
   'MEGAETH-TESTNET': MEGAETH_TESTNET,
   'MEGAETH-TESTNET-V2': MEGAETH_TESTNET,

--- a/app/lib/snaps/SnapsExecutionWebView.tsx
+++ b/app/lib/snaps/SnapsExecutionWebView.tsx
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import React, { Component } from 'react';
 import { View } from 'react-native';
 import { WebViewMessageEvent, WebView } from '@metamask/react-native-webview';
@@ -145,4 +144,3 @@ export class SnapsExecutionWebView extends Component {
     );
   }
 }
-///: END:ONLY_INCLUDE_IF

--- a/app/lib/snaps/index.ts
+++ b/app/lib/snaps/index.ts
@@ -1,3 +1,1 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 export * from './SnapsExecutionWebView';
-///: END:ONLY_INCLUDE_IF

--- a/app/lib/snaps/preinstalled-snaps.ts
+++ b/app/lib/snaps/preinstalled-snaps.ts
@@ -1,37 +1,21 @@
 import type { PreinstalledSnap } from '@metamask/snaps-controllers';
 import MessageSigningSnap from '@metamask/message-signing-snap/dist/preinstalled-snap.json';
 import ENSResolverSnap from '@metamask/ens-resolver-snap/dist/preinstalled-snap.json';
-///: BEGIN:ONLY_INCLUDE_IF(solana)
 import SolanaWalletSnap from '@metamask/solana-wallet-snap/dist/preinstalled-snap.json';
-///: END:ONLY_INCLUDE_IF
-///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
 import BitcoinWalletSnap from '@metamask/bitcoin-wallet-snap/dist/preinstalled-snap.json';
-///: END:ONLY_INCLUDE_IF
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import PreinstalledExampleSnap from '@metamask/preinstalled-example-snap/dist/preinstalled-snap.json';
 import { isTestEnvironment } from '../../util/test/utils';
-///: END:ONLY_INCLUDE_IF
-///: BEGIN:ONLY_INCLUDE_IF(tron)
 import TronWalletSnap from '@metamask/tron-wallet-snap/dist/preinstalled-snap.json';
-///: END:ONLY_INCLUDE_IF
 
 const PREINSTALLED_SNAPS: readonly PreinstalledSnap[] = Object.freeze([
   ENSResolverSnap as unknown as PreinstalledSnap,
   MessageSigningSnap as unknown as PreinstalledSnap,
-  ///: BEGIN:ONLY_INCLUDE_IF(solana)
   SolanaWalletSnap as unknown as PreinstalledSnap,
-  ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
   BitcoinWalletSnap as unknown as PreinstalledSnap,
-  ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   ...(isTestEnvironment
     ? [PreinstalledExampleSnap as unknown as PreinstalledSnap]
     : []),
-  ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
   TronWalletSnap as unknown as PreinstalledSnap,
-  ///: END:ONLY_INCLUDE_IF
 ]);
 
 export default PREINSTALLED_SNAPS;

--- a/app/lib/snaps/styles.ts
+++ b/app/lib/snaps/styles.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /* eslint-disable react-native/no-color-literals */
 import { StyleSheet } from 'react-native';
 
@@ -9,4 +8,3 @@ export const createStyles = () =>
       width: 0,
     },
   });
-///: END:ONLY_INCLUDE_IF

--- a/app/selectors/accountsController.ts
+++ b/app/selectors/accountsController.ts
@@ -247,8 +247,6 @@ export const selectHasCreatedSolanaMainnetAccount = createSelector(
   (accounts) => accounts.some((account) => isSolanaAccount(account)),
 );
 
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-
 /**
  * A selector that returns the solana account address
  * @param state - Root redux state
@@ -263,8 +261,6 @@ export const selectSolanaAccount = createSelector(
   selectInternalAccounts,
   (accounts) => accounts.find((account) => isSolanaAccount(account)),
 );
-
-///: END:ONLY_INCLUDE_IF
 
 /**
  * A memoized selector that returns all internal accounts that are valid for a given scope.

--- a/app/selectors/multichain/multichain.ts
+++ b/app/selectors/multichain/multichain.ts
@@ -1,4 +1,3 @@
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 /* eslint-disable arrow-body-style */
 import { RootState } from '../../reducers';
 import {
@@ -750,5 +749,3 @@ export const selectAccountsWithNativeBalanceByChainId = createDeepEqualSelector(
     }, {});
   },
 );
-
-///: END:ONLY_INCLUDE_IF

--- a/app/selectors/multichainNetworkController/index.ts
+++ b/app/selectors/multichainNetworkController/index.ts
@@ -9,21 +9,12 @@ import {
 } from '@metamask/multichain-network-controller';
 import { toHex } from '@metamask/controller-utils';
 import { CaipChainId, Json } from '@metamask/utils';
-import {
-  BtcScope,
-  SolScope,
-  EthScope,
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
-  TrxScope,
-  ///: END:ONLY_INCLUDE_IF
-} from '@metamask/keyring-api';
+import { BtcScope, SolScope, EthScope, TrxScope } from '@metamask/keyring-api';
 import { RootState } from '../../reducers';
 import imageIcons from '../../images/image-icons';
 import { createDeepEqualSelector } from '../util';
 import { selectIsSolanaTestnetEnabled } from '../featureFlagController/solanaTestnet';
-///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
 import { selectIsBitcoinTestnetEnabled } from '../featureFlagController/bitcoinTestnet';
-///: END:ONLY_INCLUDE_IF
 
 export const selectMultichainNetworkControllerState = (state: RootState) =>
   state.engine.backgroundState?.MultichainNetworkController ??
@@ -52,21 +43,15 @@ export const selectNonEvmNetworkConfigurationsByChainId = createSelector(
   [
     selectMultichainNetworkControllerState,
     selectIsSolanaTestnetEnabled,
-    ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
     selectIsBitcoinTestnetEnabled,
-    ///: END:ONLY_INCLUDE_IF
   ],
   (
     multichainNetworkControllerState: MultichainNetworkControllerState,
     isSolanaTestnetEnabled: Json,
-    ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
     isBitcoinTestnetEnabled: Json,
-    ///: END:ONLY_INCLUDE_IF
   ) => {
     const isSolanaTestnetEnabledBoolean = Boolean(isSolanaTestnetEnabled);
-    ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
     const isBitcoinTestnetEnabledBoolean = Boolean(isBitcoinTestnetEnabled);
-    ///: END:ONLY_INCLUDE_IF
     const extendedNonEvmData: Record<
       CaipChainId,
       {
@@ -121,7 +106,6 @@ export const selectNonEvmNetworkConfigurationsByChainId = createSelector(
         ticker: MULTICHAIN_NETWORK_TICKER[BtcScope.Regtest],
         isTestnet: true,
       },
-      ///: BEGIN:ONLY_INCLUDE_IF(tron)
       [TrxScope.Mainnet]: {
         decimals: MULTICHAIN_NETWORK_DECIMAL_PLACES[TrxScope.Mainnet],
         imageSource: imageIcons.TRON,
@@ -140,7 +124,6 @@ export const selectNonEvmNetworkConfigurationsByChainId = createSelector(
         ticker: MULTICHAIN_NETWORK_TICKER[TrxScope.Shasta],
         isTestnet: true,
       },
-      ///: END:ONLY_INCLUDE_IF(tron)
     };
 
     const networks: Record<CaipChainId, MultichainNetworkConfiguration> =
@@ -148,20 +131,16 @@ export const selectNonEvmNetworkConfigurationsByChainId = createSelector(
       {};
 
     const NON_EVM_CAIP_CHAIN_IDS: CaipChainId[] = [
-      ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
       BtcScope.Mainnet,
       ...(isBitcoinTestnetEnabledBoolean
         ? [BtcScope.Testnet, BtcScope.Signet]
         : []),
-      ///: END:ONLY_INCLUDE_IF
       SolScope.Mainnet,
       ...(isSolanaTestnetEnabledBoolean ? [SolScope.Devnet] : []),
-      ///: BEGIN:ONLY_INCLUDE_IF(tron)
       TrxScope.Mainnet,
       // TODO: Uncomment these when we have a FF to enable them
       // TrxScope.Nile,
       // TrxScope.Shasta,
-      ///: END:ONLY_INCLUDE_IF
     ];
 
     const nonEvmNetworks: Record<CaipChainId, MultichainNetworkConfiguration> =
@@ -275,7 +254,6 @@ export const getActiveNetworksByScopes = createDeepEqualSelector(
       ];
     }
 
-    ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
     if (account.scopes.includes(BtcScope.Mainnet)) {
       return [
         {
@@ -311,9 +289,7 @@ export const getActiveNetworksByScopes = createDeepEqualSelector(
         },
       ];
     }
-    ///: END:ONLY_INCLUDE_IF(bitcoin)
 
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     if (account.scopes.includes(TrxScope.Mainnet)) {
       return [
         {
@@ -335,7 +311,6 @@ export const getActiveNetworksByScopes = createDeepEqualSelector(
         },
       ];
     }
-    ///: END:ONLY_INCLUDE_IF
 
     return [];
   },

--- a/app/selectors/types.ts
+++ b/app/selectors/types.ts
@@ -17,9 +17,7 @@ import { GasFeeController } from '@metamask/gas-fee-controller';
 import { ApprovalControllerState } from '@metamask/approval-controller';
 import { AccountsControllerState } from '@metamask/accounts-controller';
 import { AccountTreeControllerState } from '@metamask/account-tree-controller';
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 import { SnapController } from '@metamask/snaps-controllers';
-///: END:ONLY_INCLUDE_IF
 
 export interface EngineState {
   engine: {
@@ -36,9 +34,7 @@ export interface EngineState {
       TokenBalancesController: TokenBalancesControllerState;
       TokenRatesController: TokenRatesControllerState;
       TransactionController: TransactionControllerState;
-      ///: BEGIN:ONLY_INCLUDE_IF(snaps)
       SnapController: SnapController;
-      ///: END:ONLY_INCLUDE_IF
       GasFeeController: GasFeeController;
       TokensController: TokensControllerState;
       ApprovalController: ApprovalControllerState;

--- a/app/store/sagas/index.ts
+++ b/app/store/sagas/index.ts
@@ -443,7 +443,6 @@ export function* initializeSDKServicesSaga() {
   }
 }
 
-///: BEGIN:ONLY_INCLUDE_IF(snaps)
 /**
  * Handles updating the Snaps registry when the user has booted the app and is onboarded
  */
@@ -472,7 +471,6 @@ export function* handleSnapsRegistry() {
     }
   }
 }
-///: END:ONLY_INCLUDE_IF
 
 /**
  * Handles initializing app services on start up
@@ -526,7 +524,5 @@ export function* rootSaga() {
   yield fork(watchMarketingAttributionOnClearOnboarding);
 
   yield fork(promptIosGoogleWarningSheetSaga);
-  ///: BEGIN:ONLY_INCLUDE_IF(snaps)
   yield fork(handleSnapsRegistry);
-  ///: END:ONLY_INCLUDE_IF
 }

--- a/app/util/address/index.ts
+++ b/app/util/address/index.ts
@@ -435,7 +435,6 @@ export function getLabelTextByInternalAccount(
       return strings('accounts.qr_hardware');
     case ExtendedKeyringTypes.simple:
       return strings('accounts.imported');
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     case KeyringTypes.snap: {
       // TODO: We should return multiple labels if one day we allow 3rd party Snaps (since they might have 2 pills:
       // 1. For the SRP (if they provide `options.entropySource`)
@@ -453,7 +452,6 @@ export function getLabelTextByInternalAccount(
         return strings('accounts.snap_account_tag');
       }
     }
-    ///: END:ONLY_INCLUDE_IF
   }
   return null;
 }

--- a/app/util/networks/customNetworks.tsx
+++ b/app/util/networks/customNetworks.tsx
@@ -2,16 +2,7 @@ import { CaipChainId, Hex } from '@metamask/utils';
 import { toHex } from '@metamask/controller-utils';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { Network } from '../../components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.types';
-import {
-  ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
-  BtcScope,
-  SolScope,
-  ///: END:ONLY_INCLUDE_IF
-  ///: BEGIN:ONLY_INCLUDE_IF(tron)
-  TrxScope,
-  ///: END:ONLY_INCLUDE_IF
-  XlmScope,
-} from '@metamask/keyring-api';
+import { BtcScope, SolScope, TrxScope, XlmScope } from '@metamask/keyring-api';
 
 /* eslint-disable @typescript-eslint/no-require-imports, import-x/no-commonjs */
 const InfuraKey = process.env.MM_INFURA_PROJECT_ID;
@@ -257,14 +248,12 @@ export const getNonEvmNetworkImageSourceByChainId = (chainId: CaipChainId) => {
       return require('../../images/bitcoin-testnet-logo.png');
     case BtcScope.Signet:
       return require('../../images/bitcoin-signet-logo.svg');
-    ///: BEGIN:ONLY_INCLUDE_IF(tron)
     case TrxScope.Mainnet:
       return require('../../images/tron.png');
     case TrxScope.Nile:
       return require('../../images/tron.png');
     case TrxScope.Shasta:
       return require('../../images/tron.png');
-    ///: END:ONLY_INCLUDE_IF(tron)
     case XlmScope.Pubnet:
       return require('../../images/xlm.png');
     default:

--- a/app/util/permissions/index.ts
+++ b/app/util/permissions/index.ts
@@ -9,9 +9,7 @@ import { providerErrors } from '@metamask/rpc-errors';
 import { ApprovalRequest } from '@metamask/approval-controller';
 import { ApprovalType } from '@metamask/controller-utils';
 import { DIALOG_APPROVAL_TYPES } from '@metamask/snaps-rpc-methods';
-///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
 import { SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES } from '../../core/RPCMethods/RPCMethodMiddleware';
-///: END:ONLY_INCLUDE_IF
 
 const approvalLog = createProjectLogger('approval-utils');
 
@@ -53,14 +51,12 @@ const rejectApproval = ({
       deleteInterface?.(interfaceId);
       break;
 
-    ///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
     case SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.confirmAccountCreation:
     case SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.confirmAccountRemoval:
     case SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.showSnapAccountRedirect:
       approvalLog('Rejecting snap account confirmation', { id, origin, type });
       ApprovalController.acceptRequest(id, false);
       break;
-    ///: END:ONLY_INCLUDE_IF
 
     default:
       approvalLog('Rejecting pending approval', { id, origin, type });


### PR DESCRIPTION
## Summary

Part 3 of 4 in the code-fencing removal series (stacked on #34098).

Mechanically strips `///: BEGIN:ONLY_INCLUDE_IF(...)` / `///: END:ONLY_INCLUDE_IF` markers for feature flags that are enabled in **every** shipping build type (main, beta, flask): `snaps`, `keyring-snaps`, `multi-srp`, `bitcoin`, `solana`, and `tron`. These features are never actually excluded at build time, so the fences were dead weight processed by Metro's transformer on every build with no behavioral effect.

- 153 files touched, purely mechanical: only the marker comment lines (and a handful of now-empty JSX expression containers, e.g. `{ ///: BEGIN... }`) are removed. The enclosed code is left completely untouched.
- **No functional changes.**

Stacked as PR 3 of 4:
1. flask/beta runtime checks (#34097)
2. sample-feature runtime gates (#34098)
3. **This PR** - remove always-on fences
4. Strip fencing tooling (metro.transform.js, build-utils) + add CI guard

## Test plan

- [x] `yarn lint` (0 errors)
- [x] `yarn lint:tsc` (0 errors)
- [x] Targeted unit tests across all touched modules (Engine, Snaps, Permissions, MainNavigator, multichain, etc. — ~575 tests) pass
- [x] Prettier-formatted all touched files after mechanical removal; diffed to confirm changes are purely cosmetic where reformatting occurred
- [x] No fence markers remain matching `snaps|keyring-snaps|multi-srp|bitcoin|solana|tron` (verified via the guard script added in PR 4)

Made with [Cursor](https://cursor.com)