### PR TITLE
fix(perps): polish Pro trading layout and available balance

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProMarketLayout.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProMarketLayout.styles.ts
@@ -1,0 +1,27 @@
+import { StyleSheet } from 'react-native';
+
+/** Matches `px-2` (8px) — same inset as `PerpsProPositionsPanel` rows. */
+export const PRO_SCREEN_HORIZONTAL_INSET = 8;
+export const PRO_TRADING_AREA_BOTTOM_INSET = 16;
+export const PRO_ORDER_BOOK_COLUMN_WIDTH = 132;
+export const PRO_ORDER_BOOK_SEPARATOR_INSET = 16;
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    paddingBottom: PRO_TRADING_AREA_BOTTOM_INSET,
+    paddingHorizontal: PRO_SCREEN_HORIZONTAL_INSET,
+  },
+  orderFormColumn: {
+    flex: 1,
+    alignSelf: 'flex-start',
+  },
+  orderBookColumn: {
+    width: PRO_ORDER_BOOK_COLUMN_WIDTH,
+    alignSelf: 'flex-start',
+    paddingLeft: PRO_ORDER_BOOK_SEPARATOR_INSET,
+  },
+});
+
+export default styles;

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProMarketLayout.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProMarketLayout.test.tsx
@@ -32,27 +32,34 @@ describe('PerpsProMarketLayout', () => {
     expect(rightColumn).toHaveStyle({ width: 132 });
   });
 
-  it('uses the Figma trading-area dimensions', () => {
+  it('uses content-driven column heights without a fixed trading-area min height', () => {
     const { getByTestId } = renderLayout();
 
     expect(getByTestId(PerpsProMarketViewSelectorsIDs.LAYOUT)).toHaveStyle({
-      minHeight: 682,
+      paddingBottom: 16,
+      paddingHorizontal: 8,
     });
+    expect(getByTestId(PerpsProMarketViewSelectorsIDs.LEFT_COLUMN)).toHaveStyle(
+      {
+        alignSelf: 'flex-start',
+      },
+    );
     expect(
-      getByTestId(PerpsProMarketViewSelectorsIDs.VERTICAL_DIVIDER),
-    ).toHaveStyle({ width: 24 });
+      getByTestId(PerpsProMarketViewSelectorsIDs.RIGHT_COLUMN),
+    ).toHaveStyle({
+      width: 132,
+      alignSelf: 'flex-start',
+      paddingLeft: 16,
+    });
   });
 
-  it('hides the order book column and divider when collapsed', () => {
+  it('hides the order book column when collapsed', () => {
     const { getByTestId, queryByTestId } = renderLayout({
       isOrderBookCollapsed: true,
     });
 
     expect(
       queryByTestId(PerpsProMarketViewSelectorsIDs.RIGHT_COLUMN),
-    ).not.toBeOnTheScreen();
-    expect(
-      queryByTestId(PerpsProMarketViewSelectorsIDs.VERTICAL_DIVIDER),
     ).not.toBeOnTheScreen();
     expect(getByTestId('mock-order-form')).toBeOnTheScreen();
   });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProMarketLayout.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProMarketLayout.tsx
@@ -1,13 +1,13 @@
-import { Box, BoxFlexDirection } from '@metamask/design-system-react-native';
 import { AnimationDuration } from '@metamask/design-tokens';
 import React, { type ReactNode } from 'react';
-import { StyleSheet } from 'react-native';
+import { View } from 'react-native';
 import Animated, {
   FadeIn,
   FadeOut,
   LinearTransition,
 } from 'react-native-reanimated';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
+import styles from './PerpsProMarketLayout.styles';
 
 interface PerpsProMarketLayoutProps {
   orderForm: ReactNode;
@@ -25,60 +25,17 @@ interface PerpsProMarketLayoutProps {
   isOrderBookCollapsed?: boolean;
 }
 
-const PRO_TRADING_AREA_MIN_HEIGHT = 682;
-const PRO_DIVIDER_COLUMN_WIDTH = 24;
-const PRO_ORDER_BOOK_COLUMN_WIDTH = 132;
-
-const styles = StyleSheet.create({
-  container: {
-    minHeight: PRO_TRADING_AREA_MIN_HEIGHT,
-  },
-  dividerColumn: {
-    width: PRO_DIVIDER_COLUMN_WIDTH,
-  },
-  dividerLine: {
-    width: 1,
-  },
-  orderFormColumn: {
-    flex: 1,
-  },
-  orderBookColumn: {
-    width: PRO_ORDER_BOOK_COLUMN_WIDTH,
-  },
-  orderBookGroup: {
-    flexDirection: 'row',
-  },
-});
-
 /**
  * Two-column trading area for the Pro-mode market screen.
  *
- * Matches the current Figma layout: the order form fills the left column and
- * the order book occupies the fixed-width right column. Configurable panel
- * positioning is deferred until the rearrangeable-layout feature consumes the
- * controller preferences.
- *
- * The 16px screen-edge inset is applied once here (`px-4` on the row), not
- * by either column individually — Figma's own two-column section is inset
- * this way, with both inner columns at `px-0`. Applying it per-column would
- * double the gap next to the divider (column padding + divider width).
- *
- * When the book is collapsed, `{orderBook}` is not rendered so the panel
- * unmounts and live order-book sockets disconnect. That remount-on-expand
- * path intentionally drops session-only book preferences (currency, metric,
- * view mode); persisted grouping survives via `usePerpsOrderBookGrouping`.
+ * Uses an 8px (`px-2`) screen-edge inset aligned with the positions panel.
  */
 const PerpsProMarketLayout = ({
   orderForm,
   orderBook,
   isOrderBookCollapsed = false,
 }: PerpsProMarketLayoutProps) => (
-  <Box
-    testID={PerpsProMarketViewSelectorsIDs.LAYOUT}
-    flexDirection={BoxFlexDirection.Row}
-    twClassName="px-2"
-    style={styles.container}
-  >
+  <View testID={PerpsProMarketViewSelectorsIDs.LAYOUT} style={styles.container}>
     <Animated.View
       testID={PerpsProMarketViewSelectorsIDs.LEFT_COLUMN}
       style={styles.orderFormColumn}
@@ -86,35 +43,17 @@ const PerpsProMarketLayout = ({
     >
       {orderForm}
     </Animated.View>
-    {/* Omit the column while collapsed: unmount disconnects subscriptions.
-        The fade in/out is purely visual — Reanimated still lets React unmount
-        the column immediately, it just keeps the last frame on screen for the
-        exit animation's duration. */}
     {!isOrderBookCollapsed ? (
       <Animated.View
-        style={styles.orderBookGroup}
+        testID={PerpsProMarketViewSelectorsIDs.RIGHT_COLUMN}
+        style={styles.orderBookColumn}
         entering={FadeIn.duration(AnimationDuration.Fast)}
         exiting={FadeOut.duration(AnimationDuration.Fast)}
       >
-        <Box
-          testID={PerpsProMarketViewSelectorsIDs.VERTICAL_DIVIDER}
-          twClassName="items-center"
-          style={styles.dividerColumn}
-        >
-          <Box
-            twClassName="flex-1 bg-border-muted"
-            style={styles.dividerLine}
-          />
-        </Box>
-        <Box
-          testID={PerpsProMarketViewSelectorsIDs.RIGHT_COLUMN}
-          style={styles.orderBookColumn}
-        >
-          {orderBook}
-        </Box>
+        {orderBook}
       </Animated.View>
     ) : null}
-  </Box>
+  </View>
 );
 
 export default PerpsProMarketLayout;

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.tsx
@@ -549,11 +549,12 @@ const PerpsProOrderBookPanel = ({
     <Box
       testID={testID}
       flexDirection={BoxFlexDirection.Column}
-      twClassName="flex-1 py-2"
+      collapsable={false}
+      twClassName="w-full py-2"
     >
       {/* Header: flush with the ladder rows below (no inset — Figma's column
           is px-0; the screen/divider edges come from PerpsProMarketLayout's
-          outer px-4), settings sit flush on the right */}
+          outer px-2), settings sit flush on the right */}
       <Box
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
@@ -636,7 +637,7 @@ const PerpsProOrderBookPanel = ({
           flexDirection={BoxFlexDirection.Column}
           alignItems={BoxAlignItems.Center}
           justifyContent={BoxJustifyContent.Center}
-          twClassName="flex-1 gap-3 px-2"
+          twClassName="gap-3 px-2 py-8"
           testID={hasConnectionError ? `${testID}-connection-error` : undefined}
         >
           <Text

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -90,6 +90,18 @@ describe('PerpsProOrderForm', () => {
       expect(screen.getByTestId(ids.ADD_FUNDS_BUTTON)).toBeOnTheScreen();
     });
 
+    it('announces the available balance and the add funds action to screen readers', () => {
+      renderForm({
+        availableBalance: '$250 available',
+        onAddFundsPress: jest.fn(),
+      });
+
+      const addFundsButton = screen.getByTestId(ids.ADD_FUNDS_BUTTON);
+
+      expect(addFundsButton).toHaveAccessibleName('$250 available');
+      expect(addFundsButton.props.accessibilityHint).toBe('Add funds');
+    });
+
     it('calls onAddFundsPress when the available balance text is pressed', () => {
       const onAddFundsPress = jest.fn();
       renderForm({ availableBalance: '$250 available', onAddFundsPress });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -78,6 +78,27 @@ describe('PerpsProOrderForm', () => {
       expect(screen.queryByTestId(ids.LIMIT_PRICE_INPUT)).not.toBeOnTheScreen();
     });
 
+    it('shows available balance with add funds action below the size input', () => {
+      renderForm({
+        availableBalance: '$250 available',
+        onAddFundsPress: jest.fn(),
+      });
+
+      expect(screen.getByTestId(ids.AVAILABLE_BALANCE)).toHaveTextContent(
+        '$250 available',
+      );
+      expect(screen.getByTestId(ids.ADD_FUNDS_BUTTON)).toBeOnTheScreen();
+    });
+
+    it('calls onAddFundsPress when the available balance text is pressed', () => {
+      const onAddFundsPress = jest.fn();
+      renderForm({ availableBalance: '$250 available', onAddFundsPress });
+
+      fireEvent.press(screen.getByTestId(ids.AVAILABLE_BALANCE));
+
+      expect(onAddFundsPress).toHaveBeenCalledTimes(1);
+    });
+
     it('connects each iOS numeric input to its own keyboard accessory', () => {
       renderForm({ orderType: 'limit' });
 
@@ -195,6 +216,22 @@ describe('PerpsProOrderForm', () => {
       fireEvent.press(screen.getByTestId(ids.PLACE_ORDER_BUTTON));
 
       expect(onPlaceOrderPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onSlippagePress when the slippage value is pressed', () => {
+      const onSlippagePress = jest.fn();
+      renderForm({
+        summary: {
+          margin: '--',
+          liquidationPrice: '--',
+          slippage: '0.50% / 1%',
+          onSlippagePress,
+        },
+      });
+
+      fireEvent.press(screen.getByTestId(ids.SUMMARY_SLIPPAGE_BUTTON));
+
+      expect(onSlippagePress).toHaveBeenCalledTimes(1);
     });
 
     it('disables Place Order when requested', () => {
@@ -318,6 +355,14 @@ describe('PerpsProOrderForm', () => {
 
       expect(screen.getByTestId(ids.SUMMARY_MARGIN)).toHaveStyle({
         height: 20,
+      });
+    });
+
+    it('uses no horizontal padding on summary rows so they align with the form', () => {
+      renderForm();
+
+      expect(screen.getByTestId(ids.SUMMARY_MARGIN)).toHaveStyle({
+        paddingHorizontal: 0,
       });
     });
   });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -192,6 +192,71 @@ const Notices = ({ notices }: { notices: PerpsProOrderNotice[] }) =>
     </Box>
   ) : null;
 
+const summaryRowClassName = 'h-5 px-0';
+const summaryRowStyle = { paddingHorizontal: 0 } as const;
+
+interface SlippageValueProps {
+  value: string;
+  onPress?: () => void;
+}
+
+const SlippageValue = ({ value, onPress }: SlippageValueProps) => (
+  <Pressable
+    accessibilityRole="button"
+    accessibilityState={{ disabled: !onPress }}
+    disabled={!onPress}
+    onPress={onPress}
+    testID={ids.SUMMARY_SLIPPAGE_BUTTON}
+  >
+    <Box twClassName="min-w-0 flex-1 flex-row items-center justify-end gap-1">
+      <Text
+        variant={TextVariant.BodyXs}
+        fontWeight={FontWeight.Medium}
+        numberOfLines={1}
+        ellipsizeMode="tail"
+      >
+        {value}
+      </Text>
+      <Icon
+        name={IconName.Edit}
+        size={IconSize.Sm}
+        color={IconColor.IconDefault}
+      />
+    </Box>
+  </Pressable>
+);
+
+interface AvailableBalanceRowProps {
+  value: string;
+  onPress?: () => void;
+}
+
+const AvailableBalanceRow = ({ value, onPress }: AvailableBalanceRowProps) => (
+  <Pressable
+    accessibilityRole="button"
+    accessibilityState={{ disabled: !onPress }}
+    accessibilityLabel={strings('perps.add_funds')}
+    disabled={!onPress}
+    onPress={onPress}
+    testID={ids.ADD_FUNDS_BUTTON}
+  >
+    <Box twClassName="flex-row items-center gap-1">
+      <Text
+        variant={TextVariant.BodySm}
+        color={TextColor.TextAlternative}
+        testID={ids.AVAILABLE_BALANCE}
+      >
+        {value}
+      </Text>
+      <Icon
+        name={IconName.AddCircle}
+        size={IconSize.Sm}
+        color={IconColor.IconAlternative}
+      />
+    </Box>
+  </Pressable>
+);
+
 const OrderSummary = ({
   margin,
   liquidationPrice,
@@ -202,13 +267,14 @@ const OrderSummary = ({
   onSlippagePress,
   onFeesInfoPress,
 }: PerpsProOrderSummaryProps) => (
-  <Box twClassName="gap-1" testID={ids.SUMMARY}>
+  <Box twClassName="w-full gap-1 overflow-hidden" testID={ids.SUMMARY}>
     <KeyValueRow
       keyLabel={strings('perps.order.margin')}
       value={margin}
       keyTextProps={summaryKeyTextProps}
       valueTextProps={summaryValueTextProps}
-      twClassName="h-5"
+      twClassName={summaryRowClassName}
+      style={summaryRowStyle}
       testID={ids.SUMMARY_MARGIN}
     />
     <KeyValueRow
@@ -216,21 +282,18 @@ const OrderSummary = ({
       value={liquidationPrice}
       keyTextProps={summaryKeyTextProps}
       valueTextProps={summaryValueTextProps}
-      twClassName="h-5"
+      twClassName={summaryRowClassName}
+      style={summaryRowStyle}
       testID={ids.SUMMARY_LIQUIDATION}
     />
     {slippage !== undefined ? (
       <KeyValueRow
         keyLabel={strings('perps.slippage.slippage')}
-        value={slippage}
-        valueEndButtonIconProps={buttonIcon(
-          IconName.Edit,
-          ids.SUMMARY_SLIPPAGE_BUTTON,
-          onSlippagePress,
-        )}
+        value={<SlippageValue value={slippage} onPress={onSlippagePress} />}
         keyTextProps={summaryKeyTextProps}
         valueTextProps={summaryValueTextProps}
-        twClassName="h-5"
+        twClassName={summaryRowClassName}
+        style={summaryRowStyle}
         testID={ids.SUMMARY_SLIPPAGE}
       />
     ) : null}
@@ -252,7 +315,8 @@ const OrderSummary = ({
       )}
       keyTextProps={summaryKeyTextProps}
       valueTextProps={summaryValueTextProps}
-      twClassName="h-5"
+      twClassName={summaryRowClassName}
+      style={summaryRowStyle}
       testID={ids.SUMMARY_FEES}
     />
   </Box>
@@ -295,9 +359,10 @@ const PerpsProOrderForm = ({
   return (
     <>
       <Box twClassName="gap-4" testID={ids.CONTAINER}>
-        {/* Screen-edge inset comes from PerpsProMarketLayout's outer px-4
-            (wraps form + divider + book), not this Box — keeps the summary
-            rows below flush with everything above instead of edge-to-edge. */}
+        {/* Screen-edge inset comes from PerpsProMarketLayout's outer padding
+            (wraps form + divider + book), not this Box. Summary rows use
+            KeyValueRow which ships with px-4 by default — override to px-0 so
+            margin/liquidation/slippage/fees align with the form above. */}
         <Box twClassName="gap-4">
           <Box
             flexDirection={BoxFlexDirection.Row}
@@ -448,24 +513,10 @@ const PerpsProOrderForm = ({
                 />
               }
             />
-            <Box twClassName="flex-row items-center gap-1">
-              <Text
-                variant={TextVariant.BodySm}
-                color={TextColor.TextAlternative}
-                testID={ids.AVAILABLE_BALANCE}
-              >
-                {availableBalance}
-              </Text>
-              <ButtonIcon
-                iconName={IconName.AddCircle}
-                size={ButtonIconSize.Xs}
-                iconProps={{ color: IconColor.IconAlternative }}
-                isDisabled={!onAddFundsPress}
-                onPress={onAddFundsPress}
-                testID={ids.ADD_FUNDS_BUTTON}
-                accessibilityLabel={strings('perps.add_funds')}
-              />
-            </Box>
+            <AvailableBalanceRow
+              value={availableBalance}
+              onPress={onAddFundsPress}
+            />
           </Box>
           <ReduceOnlyRow
             label={strings('perps.order.reduce_only')}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -235,7 +235,8 @@ const AvailableBalanceRow = ({ value, onPress }: AvailableBalanceRowProps) => (
   <Pressable
     accessibilityRole="button"
     accessibilityState={{ disabled: !onPress }}
-    accessibilityLabel={strings('perps.add_funds')}
+    accessibilityLabel={value}
+    accessibilityHint={onPress ? strings('perps.add_funds') : undefined}
     disabled={!onPress}
     onPress={onPress}
     testID={ids.ADD_FUNDS_BUTTON}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
@@ -139,8 +139,10 @@ jest.mock('../../../../hooks/stream', () => ({
   usePerpsTopOfBook: () => ({ bestBid: '89999', bestAsk: '90001' }),
 }));
 
+let mockIsInitialized = true;
+
 jest.mock('../../../../hooks/usePerpsConnection', () => ({
-  usePerpsConnection: () => ({ isInitialized: true }),
+  usePerpsConnection: () => ({ isInitialized: mockIsInitialized }),
 }));
 
 jest.mock('../../../../hooks/usePerpsEstimatedSlippage', () => ({
@@ -206,7 +208,24 @@ describe('usePerpsProOrderForm', () => {
     mockExistingPosition = null;
     mockIsAtCap = false;
     mockEstimatedSlippageBps = 50;
+    mockIsInitialized = true;
     mockUpdatePositionTPSL.mockResolvedValue({ success: true });
+  });
+
+  describe('availableBalance', () => {
+    it('formats spendable balance as "$amount available" when connected', () => {
+      const { result } = renderProForm();
+
+      expect(result.current.availableBalance).toMatch(/^\$500 available$/);
+    });
+
+    it('shows the unavailable placeholder before Perps is initialized', () => {
+      mockIsInitialized = false;
+
+      const { result } = renderProForm();
+
+      expect(result.current.availableBalance).toBe('-- available');
+    });
   });
 
   describe('summary', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
@@ -741,9 +741,17 @@ export const usePerpsProOrderForm = ({
         )
       : 0;
 
-  const availableBalance = formatPerpsFiat(spendableBalance, {
-    ranges: PRICE_RANGES_MINIMAL_VIEW,
-  });
+  const availableBalance = useMemo(() => {
+    if (!isInitialized) {
+      return strings('perps.pro_order_form.available_balance_unavailable');
+    }
+
+    return strings('perps.pro_order_form.available_balance', {
+      amount: formatPerpsFiat(spendableBalance, {
+        ranges: PRICE_RANGES_MINIMAL_VIEW,
+      }),
+    });
+  }, [isInitialized, spendableBalance]);
 
   const notices = useMemo<PerpsProOrderNotice[]>(() => {
     const list: PerpsProOrderNotice[] = [];

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.styles.ts
@@ -1,0 +1,19 @@
+import { StyleSheet } from 'react-native';
+import type { Theme } from '../../../../../../util/theme/models';
+import { PRO_ORDER_BOOK_SEPARATOR_INSET } from './PerpsProMarketLayout.styles';
+
+export { PRO_ORDER_BOOK_SEPARATOR_INSET };
+
+export const createStyles = ({ theme }: { theme: Theme }) =>
+  StyleSheet.create({
+    panel: {
+      width: '100%',
+      alignSelf: 'flex-start',
+      paddingTop: 16,
+    },
+    panelWithBookSeparator: {
+      paddingRight: PRO_ORDER_BOOK_SEPARATOR_INSET,
+      borderRightWidth: 1,
+      borderRightColor: theme.colors.border.muted,
+    },
+  });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.test.tsx
@@ -34,7 +34,7 @@ const DEFAULT_MOCK_HOOK_RESULT = {
   onSizeChange: jest.fn(),
   balancePercentage: 20,
   onBalancePercentageChange: jest.fn(),
-  availableBalance: '$500.00',
+  availableBalance: '$500 available',
   onAddFundsPress: jest.fn(),
   reduceOnly: false,
   onReduceOnlyChange: jest.fn(),
@@ -156,7 +156,9 @@ jest.mock('../../../components/PerpsBottomSheetTooltip', () => {
 
 const market = { symbol: 'BTC', name: 'Bitcoin' } as PerpsMarketData;
 
-const renderPanel = () => render(<PerpsProOrderFormPanel market={market} />);
+const renderPanel = (
+  props: Partial<React.ComponentProps<typeof PerpsProOrderFormPanel>> = {},
+) => render(<PerpsProOrderFormPanel market={market} {...props} />);
 
 describe('PerpsProOrderFormPanel', () => {
   beforeEach(() => {
@@ -177,6 +179,27 @@ describe('PerpsProOrderFormPanel', () => {
     expect(
       screen.getByTestId(PerpsProOrderFormSelectorsIDs.CONTAINER),
     ).toBeOnTheScreen();
+  });
+
+  it('renders the book separator on the form when the order book is visible', () => {
+    renderPanel({ isOrderBookCollapsed: false });
+
+    expect(
+      screen.getByTestId(PerpsProMarketViewSelectorsIDs.ORDER_FORM_PANEL),
+    ).toHaveStyle({
+      borderRightWidth: 1,
+      paddingRight: 16,
+    });
+  });
+
+  it('omits the book separator when the order book is collapsed', () => {
+    renderPanel({ isOrderBookCollapsed: true });
+
+    expect(
+      screen.getByTestId(PerpsProMarketViewSelectorsIDs.ORDER_FORM_PANEL),
+    ).not.toHaveStyle({
+      borderRightWidth: 1,
+    });
   });
 
   it('wires direction changes to the hook', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.tsx
@@ -4,6 +4,7 @@ import type { PerpsMarketData } from '@metamask/perps-controller';
 import React from 'react';
 import { Modal, View } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
+import { useStyles } from '../../../../../../component-library/hooks';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
 import PerpsBottomSheetTooltip from '../../../components/PerpsBottomSheetTooltip';
 import PerpsLeverageBottomSheet from '../../../components/PerpsLeverageBottomSheet';
@@ -11,6 +12,7 @@ import PerpsOrderTypeBottomSheetView from '../../../components/PerpsOrderTypeBot
 import PerpsSlippageBottomSheet from '../../../components/PerpsSlippageBottomSheet';
 import { PerpsOrderProvider } from '../../../contexts/PerpsOrderContext';
 import PerpsProOrderForm from './PerpsProOrderForm/PerpsProOrderForm';
+import { createStyles } from './PerpsProOrderFormPanel.styles';
 import { usePerpsProOrderForm } from './PerpsProOrderForm/usePerpsProOrderForm';
 
 export interface PerpsProOrderFormPanelProps {
@@ -72,10 +74,16 @@ const PerpsProOrderFormContent = ({
     feeDiscountPercentage,
   } = usePerpsProOrderForm({ market });
 
+  const { styles } = useStyles(createStyles, {});
+
   return (
     <Box
       testID={PerpsProMarketViewSelectorsIDs.ORDER_FORM_PANEL}
-      twClassName="flex-1 py-4"
+      collapsable={false}
+      style={[
+        styles.panel,
+        !isOrderBookCollapsed && styles.panelWithBookSeparator,
+      ]}
     >
       <PerpsProOrderForm
         direction={direction}

--- a/locales/languages/de.json
+++ b/locales/languages/de.json
@@ -1513,6 +1513,7 @@
       "size_usd": "Größe USD",
       "size_percentage": "Ordergröße in Prozent",
       "toggle_size_unit": "Wechsel der Nenngröße",
+      "available_balance": "{{amount}} verfügbar",
       "available_balance_unavailable": "-- verfügbar",
       "est_liquidation": "Gesch. Liquidation",
       "tpsl": "TP / SL",

--- a/locales/languages/el.json
+++ b/locales/languages/el.json
@@ -1513,6 +1513,7 @@
       "size_usd": "Μέγεθος (USD)",
       "size_percentage": "Ποσοστό μεγέθους εντολής",
       "toggle_size_unit": "Αλλαγή μονάδας μεγέθους",
+      "available_balance": "{{amount}} διαθέσιμο",
       "available_balance_unavailable": "-- διαθέσιμο",
       "est_liquidation": "Εκτ. ρευστοποίηση",
       "tpsl": "ΛΚ/ΠΖ",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1527,6 +1527,7 @@
       "size_usd": "Size USD",
       "size_percentage": "Order size percentage",
       "toggle_size_unit": "Switch size denomination",
+      "available_balance": "{{amount}} available",
       "available_balance_unavailable": "-- available",
       "est_liquidation": "Est Liquidation",
       "tpsl": "TP / SL",

--- a/locales/languages/es.json
+++ b/locales/languages/es.json
@@ -1513,6 +1513,7 @@
       "size_usd": "Monto en USD",
       "size_percentage": "Porcentaje del monto de la orden",
       "toggle_size_unit": "Cambiar unidad del monto",
+      "available_balance": "{{amount}} disponible",
       "available_balance_unavailable": "-- disponible",
       "est_liquidation": "Liquidación est.",
       "tpsl": "TG/LP",

--- a/locales/languages/fr.json
+++ b/locales/languages/fr.json
@@ -1513,6 +1513,7 @@
       "size_usd": "Taille en USD",
       "size_percentage": "Pourcentage de la taille de l’ordre",
       "toggle_size_unit": "Changer la dénomination de la taille",
+      "available_balance": "{{amount}} disponible",
       "available_balance_unavailable": "-- disponible ",
       "est_liquidation": "Liquidation estimée",
       "tpsl": "TP/SL",

--- a/locales/languages/hi.json
+++ b/locales/languages/hi.json
@@ -1513,6 +1513,7 @@
       "size_usd": "साइज़ USD",
       "size_percentage": "ऑर्डर साइज़ का प्रतिशत",
       "toggle_size_unit": "साइज़ डिनॉमिनेशन बदलें",
+      "available_balance": "{{amount}} उपलब्ध",
       "available_balance_unavailable": "-- उपलब्ध",
       "est_liquidation": "अनुमानित लिक्विडेशन",
       "tpsl": "TP / SL",

--- a/locales/languages/id.json
+++ b/locales/languages/id.json
@@ -1513,6 +1513,7 @@
       "size_usd": "Ukuran USD",
       "size_percentage": "Persentase ukuran order",
       "toggle_size_unit": "Ubah ukuran denominasi",
+      "available_balance": "{{amount}} tersedia",
       "available_balance_unavailable": "-- tersedia",
       "est_liquidation": "Estimasi Likuidasi",
       "tpsl": "TP/SL",

--- a/locales/languages/ja.json
+++ b/locales/languages/ja.json
@@ -1513,6 +1513,7 @@
       "size_usd": "サイズのUSD換算額",
       "size_percentage": "注文サイズの割合",
       "toggle_size_unit": "サイズ単位の切り替え",
+      "available_balance": "{{amount}} 使用可能",
       "available_balance_unavailable": "-- 使用可能",
       "est_liquidation": "推定清算価格",
       "tpsl": "TP / SL",

--- a/locales/languages/ko.json
+++ b/locales/languages/ko.json
@@ -1513,6 +1513,7 @@
       "size_usd": "규모(USD)",
       "size_percentage": "주문 규모 비율",
       "toggle_size_unit": "규모 표시 단위 전환",
+      "available_balance": "{{amount}} 사용 가능",
       "available_balance_unavailable": "-- 사용 가능",
       "est_liquidation": "예상 강제 청산가",
       "tpsl": "익절/손절",

--- a/locales/languages/pt.json
+++ b/locales/languages/pt.json
@@ -1513,6 +1513,7 @@
       "size_usd": "Tamanho em USD",
       "size_percentage": "Porcentagem do tamanho da ordem",
       "toggle_size_unit": "Alterar unidade do tamanho",
+      "available_balance": "{{amount}} disponível",
       "available_balance_unavailable": "-- disponível",
       "est_liquidation": "Liquidação est.",
       "tpsl": "TP / SL",

--- a/locales/languages/ru.json
+++ b/locales/languages/ru.json
@@ -1513,6 +1513,7 @@
       "size_usd": "Размер в USD",
       "size_percentage": "Процент размера ордера",
       "toggle_size_unit": "Переключить номинал размера",
+      "available_balance": "{{amount}} доступно",
       "available_balance_unavailable": "-- доступно",
       "est_liquidation": "Ожид. ликвидация",
       "tpsl": "ТП/СЛ",

--- a/locales/languages/tl.json
+++ b/locales/languages/tl.json
@@ -1513,6 +1513,7 @@
       "size_usd": "Laki USD",
       "size_percentage": "Porsiyento ng laki ng order",
       "toggle_size_unit": "Palitan ang laki ng denominasyon",
+      "available_balance": "{{amount}} available",
       "available_balance_unavailable": "-- available",
       "est_liquidation": "Tinatayang Liquidation",
       "tpsl": "TP / SL",

--- a/locales/languages/tr.json
+++ b/locales/languages/tr.json
@@ -1513,6 +1513,7 @@
       "size_usd": "USD cinsinden Büyüklüğü",
       "size_percentage": "Emir büyüklüğü yüzdesi",
       "toggle_size_unit": "Büyüklük birimini değiştir",
+      "available_balance": "{{amount}} kullanılabilir",
       "available_balance_unavailable": "-- kullanılabilir",
       "est_liquidation": "Tahmini Likidasyon",
       "tpsl": "KA / ZD",

--- a/locales/languages/vi.json
+++ b/locales/languages/vi.json
@@ -1513,6 +1513,7 @@
       "size_usd": "Kích thước theo USD",
       "size_percentage": "Tỷ lệ kích thước lệnh",
       "toggle_size_unit": "Chuyển đổi đơn vị kích thước",
+      "available_balance": "{{amount}} khả dụng",
       "available_balance_unavailable": "-- khả dụng",
       "est_liquidation": "Giá thanh lý ước tính",
       "tpsl": "Chốt lời/Cắt lỗ",

--- a/locales/languages/zh.json
+++ b/locales/languages/zh.json
@@ -1513,6 +1513,7 @@
       "size_usd": "规模（USD）",
       "size_percentage": "订单规模百分比",
       "toggle_size_unit": "切换规模单位",
+      "available_balance": "{{amount}} 可用",
       "available_balance_unavailable": "-- 可用",
       "est_liquidation": "预估清算",
       "tpsl": "止盈/止损",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Polishes the Perps Pro market trading area so form/order-book spacing matches the Positions panel, and surfaces available balance under the size input.

1. **Reason:** Screen-edge padding on the Pro form/book row drifted from the Positions section (`px-2`), and traders lacked a clear available-balance affordance next to size.
2. **Solution:** Use an 8px (`px-2`) horizontal inset on the trading layout; move form/book styles into dedicated `.styles.ts` files with the separator on the form panel; show a tappable `$XX available` row that opens add funds.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Improved Perps Pro order form layout alignment and added available balance under size

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps Pro trading layout and available balance

  Scenario: trading area aligns with Positions panel
    Given the user opens a Perps market in Pro mode with the order book visible
    Then the left edge of the order form aligns with the Positions tab content
    And the right edge of the order book aligns with Positions content
    And a vertical separator appears between the form and order book with 16px inset on each side

  Scenario: available balance opens add funds
    Given the user is on the Pro order form with an initialized Perps balance
    When the user taps the available balance row under Size
    Then the add-funds / deposit flow opens
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and presentation changes in Perps Pro with tests updated; add-funds still uses existing callbacks, not new payment logic.
> 
> **Overview**
> Aligns the **Perps Pro** trading row with the Positions panel and improves the order form UX.
> 
> **Layout:** `PerpsProMarketLayout` drops the fixed 682px min height and the standalone vertical divider column in favor of content-driven heights, **8px** horizontal inset (`PRO_SCREEN_HORIZONTAL_INSET`), and styles moved into `PerpsProMarketLayout.styles.ts`. The form/book separator is now a **right border + 16px padding** on `PerpsProOrderFormPanel` when the order book is visible (`PerpsProOrderFormPanel.styles.ts`). The order book panel uses full width instead of `flex-1`.
> 
> **Order form:** Available balance under size is a single tappable row (`AvailableBalanceRow`) that opens add funds, with screen-reader label/hint. Slippage uses a dedicated pressable with edit icon. Summary `KeyValueRow`s override default horizontal padding so margin/liquidation/slippage/fees line up with the form. `usePerpsProOrderForm` formats balance as localized `"{{amount}} available"` and shows `"-- available"` until Perps is initialized.
> 
> **i18n:** New `perps.pro_order_form.available_balance` / `available_balance_unavailable` across locale files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be0fa55d8f2a7662f12bc395f13697c9d5ec3689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->