### PR TITLE
feat: integrate money account utils

### DIFF
--- a/app/components/UI/Earn/constants/musd.ts
+++ b/app/components/UI/Earn/constants/musd.ts
@@ -1,9 +1,5 @@
 /**
  * mUSD Conversion Constants for Earn namespace
- *
- * Shared constants and guards live in `@metamask/money-account-utils` and are
- * re-exported here so existing import paths keep working. Client-specific
- * presentation (icon asset) and configuration stay local.
  */
 
 import { MUSD_TOKEN as MUSD_TOKEN_BASE } from '@metamask/money-account-utils';

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.pendingTransaction.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.pendingTransaction.test.tsx
@@ -99,11 +99,12 @@ jest.mock('@metamask/design-system-react-native', () => {
 
 // Keep the real `useMoneyAccountDeposit` + `useConfirmNavigation`; stub only the
 // heavy deposit-building internals so `initiateDeposit` reaches navigation.
-jest.mock('../../utils/moneyAccountTransactions', () => ({
-  buildMoneyAccountDepositBatch: jest.fn().mockResolvedValue({
-    approveTx: { to: '0xapprove', data: '0x', value: '0x0' },
-    depositTx: { to: '0xdeposit', data: '0x', value: '0x0' },
-  }),
+jest.mock('@metamask/money-account-utils', () => ({
+  ...jest.requireActual('@metamask/money-account-utils'),
+  buildMoneyAccountDepositPlaceholderBatch: jest.fn(() => ({
+    approveTx: { to: '0xapprove', value: '0x0' },
+    depositTx: { to: '0xdeposit', value: '0x0' },
+  })),
   getMoneyAccountDepositAssetAddress: jest.fn(() => '0xasset'),
   getMoneyAccountDepositAssetId: jest.fn(
     () => 'eip155:143/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA',

--- a/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.pendingTransaction.test.tsx
+++ b/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.pendingTransaction.test.tsx
@@ -100,10 +100,10 @@ jest.mock('@metamask/design-system-react-native', () => {
 // navigation.
 jest.mock('@metamask/money-account-utils', () => ({
   ...jest.requireActual('@metamask/money-account-utils'),
-  buildMoneyAccountWithdrawBatch: jest.fn().mockResolvedValue({
-    withdrawTx: { to: '0xwithdraw', data: '0x', value: '0x0' },
-    transferTx: { to: '0xtransfer', data: '0x', value: '0x0' },
-  }),
+  buildMoneyAccountWithdrawPlaceholderBatch: jest.fn(() => ({
+    withdrawTx: { to: '0xwithdraw', value: '0x0' },
+    transferTx: { to: '0xtransfer', value: '0x0' },
+  })),
   getMoneyAccountDepositAssetAddress: jest.fn(() => '0xasset'),
 }));
 

--- a/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.pendingTransaction.test.tsx
+++ b/app/components/UI/Money/components/MoneyTransferSheet/MoneyTransferSheet.pendingTransaction.test.tsx
@@ -98,7 +98,8 @@ jest.mock('@metamask/design-system-react-native', () => {
 // Keep the real `useMoneyAccountWithdrawal` + `useConfirmNavigation`; stub only
 // the heavy withdrawal-building internals so `initiateWithdrawal` reaches
 // navigation.
-jest.mock('../../utils/moneyAccountTransactions', () => ({
+jest.mock('@metamask/money-account-utils', () => ({
+  ...jest.requireActual('@metamask/money-account-utils'),
   buildMoneyAccountWithdrawBatch: jest.fn().mockResolvedValue({
     withdrawTx: { to: '0xwithdraw', data: '0x', value: '0x0' },
     transferTx: { to: '0xtransfer', data: '0x', value: '0x0' },

--- a/app/components/UI/Money/hooks/useMoneyAccount.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccount.test.ts
@@ -18,7 +18,7 @@ import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountCon
 import { selectEvmAddress } from '../../../../selectors/accountsController';
 import {
   buildMoneyAccountDepositPlaceholderBatch,
-  buildMoneyAccountWithdrawBatch,
+  buildMoneyAccountWithdrawPlaceholderBatch,
 } from '@metamask/money-account-utils';
 import {
   getMoneyAccountDepositIntent,
@@ -74,7 +74,7 @@ jest.mock('../../../../core/Engine', () => ({
 jest.mock('@metamask/money-account-utils', () => ({
   ...jest.requireActual('@metamask/money-account-utils'),
   buildMoneyAccountDepositPlaceholderBatch: jest.fn(),
-  buildMoneyAccountWithdrawBatch: jest.fn(),
+  buildMoneyAccountWithdrawPlaceholderBatch: jest.fn(),
   // The mock vault chain here is Arbitrum, which has no mUSD deployment, so the
   // real resolver would throw. The address itself is not under test.
   getMoneyAccountDepositAssetAddress: jest.fn(
@@ -136,8 +136,8 @@ const mockBuildDepositBatch =
     typeof buildMoneyAccountDepositPlaceholderBatch
   >;
 const mockBuildWithdrawBatch =
-  buildMoneyAccountWithdrawBatch as jest.MockedFunction<
-    typeof buildMoneyAccountWithdrawBatch
+  buildMoneyAccountWithdrawPlaceholderBatch as jest.MockedFunction<
+    typeof buildMoneyAccountWithdrawPlaceholderBatch
   >;
 const mockFindNetworkClientIdByChainId = Engine.context.NetworkController
   .findNetworkClientIdByChainId as jest.MockedFunction<
@@ -621,19 +621,18 @@ describe('useMoneyAccountWithdrawal', () => {
     setupSelectors();
     mockGetProviderByChainId.mockReturnValue(MOCK_PROVIDER);
     mockFindNetworkClientIdByChainId.mockReturnValue('arbitrum-one');
-    mockBuildWithdrawBatch.mockResolvedValue({
+    // The placeholder batch is synchronous and carries no calldata.
+    mockBuildWithdrawBatch.mockReturnValue({
       withdrawTx: {
         params: {
           to: '0xteller' as Hex,
-          data: '0xwithdraw' as Hex,
           value: '0x0' as Hex,
         },
         type: 'moneyAccountWithdraw' as never,
       },
       transferTx: {
         params: {
-          to: '0xusdc' as Hex,
-          data: '0xtransfer' as Hex,
+          to: '0xmusd' as Hex,
           value: '0x0' as Hex,
         },
         type: 'tokenMethodTransfer' as never,
@@ -693,19 +692,12 @@ describe('useMoneyAccountWithdrawal', () => {
       await result.current.initiateWithdrawal();
     });
 
-    // Hook calls the builder with a placeholder amount of 0n; MM Pay rewrites
-    // the calldata via `updateMoneyAccountWithdrawTokenAmount` once the user
-    // picks an amount on the confirmation screen.
-    expect(mockBuildWithdrawBatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        amount: BigInt(0),
-        chainId: MOCK_VAULT_CONFIG.chainId,
-        tellerAddress: MOCK_VAULT_CONFIG.tellerAddress,
-        accountantAddress: MOCK_VAULT_CONFIG.accountantAddress,
-        moneyAccountAddress: MOCK_MONEY_ACCOUNT.address,
-        recipient: MOCK_RECIPIENT,
-      }),
-    );
+    // MM Pay writes the calldata via `updateMoneyAccountWithdrawTokenAmount`
+    // once the user picks an amount, so the hook only resolves the call targets.
+    expect(mockBuildWithdrawBatch).toHaveBeenCalledWith({
+      chainId: MOCK_VAULT_CONFIG.chainId,
+      tellerAddress: MOCK_VAULT_CONFIG.tellerAddress,
+    });
 
     expect(getNavigateToConfirmation()).toHaveBeenCalledWith({
       loader: ConfirmationLoader.AdvancedCustomAmount,
@@ -796,7 +788,9 @@ describe('useMoneyAccountWithdrawal', () => {
 
   it('backs out and shows a failure toast when withdrawal batch building fails', async () => {
     const buildError = new Error('withdrawal batch build failed');
-    mockBuildWithdrawBatch.mockRejectedValue(buildError);
+    mockBuildWithdrawBatch.mockImplementation(() => {
+      throw buildError;
+    });
 
     const { result } = renderHook(() => useMoneyAccountWithdrawal());
 

--- a/app/components/UI/Money/hooks/useMoneyAccount.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccount.test.ts
@@ -17,9 +17,9 @@ import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlag
 import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
 import { selectEvmAddress } from '../../../../selectors/accountsController';
 import {
-  buildMoneyAccountDepositBatch,
+  buildMoneyAccountDepositPlaceholderBatch,
   buildMoneyAccountWithdrawBatch,
-} from '../utils/moneyAccountTransactions';
+} from '@metamask/money-account-utils';
 import {
   getMoneyAccountDepositIntent,
   clearMoneyAccountDepositIntent,
@@ -71,7 +71,16 @@ jest.mock('../../../../core/Engine', () => ({
     },
   },
 }));
-jest.mock('../utils/moneyAccountTransactions');
+jest.mock('@metamask/money-account-utils', () => ({
+  ...jest.requireActual('@metamask/money-account-utils'),
+  buildMoneyAccountDepositPlaceholderBatch: jest.fn(),
+  buildMoneyAccountWithdrawBatch: jest.fn(),
+  // The mock vault chain here is Arbitrum, which has no mUSD deployment, so the
+  // real resolver would throw. The address itself is not under test.
+  getMoneyAccountDepositAssetAddress: jest.fn(
+    () => '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+  ),
+}));
 jest.mock(
   '../../../Views/confirmations/components/confirm/confirm-component',
   () => ({
@@ -123,8 +132,8 @@ const mockAddTransactionBatch = addTransactionBatch as jest.MockedFunction<
   typeof addTransactionBatch
 >;
 const mockBuildDepositBatch =
-  buildMoneyAccountDepositBatch as jest.MockedFunction<
-    typeof buildMoneyAccountDepositBatch
+  buildMoneyAccountDepositPlaceholderBatch as jest.MockedFunction<
+    typeof buildMoneyAccountDepositPlaceholderBatch
   >;
 const mockBuildWithdrawBatch =
   buildMoneyAccountWithdrawBatch as jest.MockedFunction<
@@ -222,11 +231,11 @@ describe('useMoneyAccountDeposit', () => {
     setupSelectors();
     mockGetProviderByChainId.mockReturnValue(MOCK_PROVIDER);
     mockFindNetworkClientIdByChainId.mockReturnValue('arbitrum-one');
-    mockBuildDepositBatch.mockResolvedValue({
+    // The placeholder batch is synchronous and carries no calldata.
+    mockBuildDepositBatch.mockReturnValue({
       approveTx: {
         params: {
           to: '0xtoken' as Hex,
-          data: '0xapprove' as Hex,
           value: '0x0' as Hex,
         },
         type: 'tokenMethodApprove' as never,
@@ -234,7 +243,6 @@ describe('useMoneyAccountDeposit', () => {
       depositTx: {
         params: {
           to: '0xteller' as Hex,
-          data: '0xdeposit' as Hex,
           value: '0x0' as Hex,
         },
         type: 'moneyAccountDeposit' as never,
@@ -285,14 +293,10 @@ describe('useMoneyAccountDeposit', () => {
       await result.current.initiateDeposit();
     });
 
-    expect(mockBuildDepositBatch).toHaveBeenCalledWith(
-      expect.objectContaining({
-        amount: BigInt(0),
-        chainId: MOCK_VAULT_CONFIG.chainId,
-        boringVault: MOCK_VAULT_CONFIG.boringVault,
-        initialiseWithoutData: true,
-      }),
-    );
+    expect(mockBuildDepositBatch).toHaveBeenCalledWith({
+      chainId: MOCK_VAULT_CONFIG.chainId,
+      tellerAddress: MOCK_VAULT_CONFIG.tellerAddress,
+    });
 
     expect(getNavigateToConfirmation()).toHaveBeenCalledWith({
       loader: ConfirmationLoader.AdvancedCustomAmount,
@@ -483,7 +487,9 @@ describe('useMoneyAccountDeposit', () => {
   it('backs out and shows a failure toast when deposit batch building fails', async () => {
     const buildError = new Error('deposit batch build failed');
     const onDepositSetupFailure = jest.fn();
-    mockBuildDepositBatch.mockRejectedValue(buildError);
+    mockBuildDepositBatch.mockImplementation(() => {
+      throw buildError;
+    });
 
     const { result } = renderHook(() => useMoneyAccountDeposit());
 

--- a/app/components/UI/Money/hooks/useMoneyAccount.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccount.ts
@@ -11,10 +11,10 @@ import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlag
 import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
 import { selectEvmAddress } from '../../../../selectors/accountsController';
 import {
-  buildMoneyAccountDepositBatch,
+  buildMoneyAccountDepositPlaceholderBatch,
   buildMoneyAccountWithdrawBatch,
   getMoneyAccountDepositAssetAddress,
-} from '../utils/moneyAccountTransactions';
+} from '@metamask/money-account-utils';
 import { getProviderByChainId } from '../../../../util/notifications/methods/common';
 import Logger from '../../../../util/Logger';
 import { showDevErrorAlert } from '../utils/devErrorAlert';
@@ -112,17 +112,12 @@ export function useMoneyAccountDeposit() {
         }
         const moneyAccountAddress = primaryMoneyAccount.address;
 
-        const {
-          chainId,
-          boringVault,
-          tellerAddress,
-          accountantAddress,
-          lensAddress,
-        } = vaultConfig;
+        const { chainId, tellerAddress } = vaultConfig;
 
         const chainIdHex = chainId as Hex;
-        const provider = getProviderByChainId(chainIdHex);
-        if (!provider) {
+        // The placeholder batch needs no vault reads, but an unreachable chain
+        // should still fail before we navigate to a confirmation.
+        if (!getProviderByChainId(chainIdHex)) {
           throw new Error(
             `${LOG_TAG} No provider available for chain ${chainId}`,
           );
@@ -130,11 +125,7 @@ export function useMoneyAccountDeposit() {
 
         return {
           chainIdHex,
-          boringVault,
           tellerAddress,
-          accountantAddress,
-          lensAddress,
-          provider,
           moneyAccountAddress,
           networkClientId: resolveNetworkClientId(chainIdHex),
           isGasFeeSponsored: isMonadMainnetChainId(chainIdHex),
@@ -182,16 +173,13 @@ export function useMoneyAccountDeposit() {
         // Allows confirmation skeleton to render immediately before setup work for immediate navigation.
         await waitForNextFrame();
 
-        const { approveTx, depositTx } = await buildMoneyAccountDepositBatch({
-          amount: BigInt(0),
-          chainId: depositSetup.chainIdHex,
-          boringVault: depositSetup.boringVault,
-          tellerAddress: depositSetup.tellerAddress,
-          accountantAddress: depositSetup.accountantAddress,
-          lensAddress: depositSetup.lensAddress,
-          provider: depositSetup.provider,
-          initialiseWithoutData: true,
-        });
+        // Placeholder batch — MM Pay re-encodes both calls via
+        // `updateMoneyAccountDepositTokenAmount` once the user picks an amount.
+        const { approveTx, depositTx } =
+          buildMoneyAccountDepositPlaceholderBatch({
+            chainId: depositSetup.chainIdHex,
+            tellerAddress: depositSetup.tellerAddress as Hex,
+          });
 
         // We only set the transaction from the money account perspective.
         // MM Pay selects the user's account and moves funds to the money account,

--- a/app/components/UI/Money/hooks/useMoneyAccount.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccount.ts
@@ -12,7 +12,7 @@ import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountCon
 import { selectEvmAddress } from '../../../../selectors/accountsController';
 import {
   buildMoneyAccountDepositPlaceholderBatch,
-  buildMoneyAccountWithdrawBatch,
+  buildMoneyAccountWithdrawPlaceholderBatch,
   getMoneyAccountDepositAssetAddress,
 } from '@metamask/money-account-utils';
 import { getProviderByChainId } from '../../../../util/notifications/methods/common';
@@ -253,10 +253,11 @@ export function useMoneyAccountWithdrawal() {
       throw new Error(`${LOG_TAG} Missing recipient EVM address`);
     }
 
-    const { chainId, tellerAddress, accountantAddress } = vaultConfig;
+    const { chainId, tellerAddress } = vaultConfig;
 
-    const provider = getProviderByChainId(chainId);
-    if (!provider) {
+    // The placeholder batch needs no vault reads, but an unreachable chain
+    // should still fail before we navigate to a confirmation.
+    if (!getProviderByChainId(chainId)) {
       throw new Error(`${LOG_TAG} No provider available for chain ${chainId}`);
     }
 
@@ -273,17 +274,10 @@ export function useMoneyAccountWithdrawal() {
       // Allows confirmation skeleton to render immediately before setup work for immediate navigation.
       await waitForNextFrame();
 
-      // Placeholder amount — MM Pay re-encodes both calls via
+      // Placeholder batch — MM Pay re-encodes both calls via
       // `updateMoneyAccountWithdrawTokenAmount` once the user picks an amount.
-      const { withdrawTx, transferTx } = await buildMoneyAccountWithdrawBatch({
-        amount: BigInt(0),
-        chainId,
-        tellerAddress,
-        accountantAddress,
-        moneyAccountAddress: primaryMoneyAccount.address as Hex,
-        recipient: recipient as Hex,
-        provider,
-      });
+      const { withdrawTx, transferTx } =
+        buildMoneyAccountWithdrawPlaceholderBatch({ chainId, tellerAddress });
 
       await addTransactionBatch({
         disableHook: true,

--- a/app/components/UI/Money/hooks/useMoneyAccount.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccount.ts
@@ -114,21 +114,20 @@ export function useMoneyAccountDeposit() {
 
         const { chainId, tellerAddress } = vaultConfig;
 
-        const chainIdHex = chainId as Hex;
         // The placeholder batch needs no vault reads, but an unreachable chain
         // should still fail before we navigate to a confirmation.
-        if (!getProviderByChainId(chainIdHex)) {
+        if (!getProviderByChainId(chainId)) {
           throw new Error(
             `${LOG_TAG} No provider available for chain ${chainId}`,
           );
         }
 
         return {
-          chainIdHex,
+          chainId,
           tellerAddress,
           moneyAccountAddress,
-          networkClientId: resolveNetworkClientId(chainIdHex),
-          isGasFeeSponsored: isMonadMainnetChainId(chainIdHex),
+          networkClientId: resolveNetworkClientId(chainId),
+          isGasFeeSponsored: isMonadMainnetChainId(chainId),
         };
       };
 
@@ -177,8 +176,8 @@ export function useMoneyAccountDeposit() {
         // `updateMoneyAccountDepositTokenAmount` once the user picks an amount.
         const { approveTx, depositTx } =
           buildMoneyAccountDepositPlaceholderBatch({
-            chainId: depositSetup.chainIdHex,
-            tellerAddress: depositSetup.tellerAddress as Hex,
+            chainId: depositSetup.chainId,
+            tellerAddress: depositSetup.tellerAddress,
           });
 
         // We only set the transaction from the money account perspective.
@@ -196,9 +195,7 @@ export function useMoneyAccountDeposit() {
           origin: ORIGIN_METAMASK,
           requiredAssets: [
             {
-              address: getMoneyAccountDepositAssetAddress(
-                depositSetup.chainIdHex,
-              ),
+              address: getMoneyAccountDepositAssetAddress(depositSetup.chainId),
               amount: '0x0' as Hex,
               standard: 'erc20',
             },
@@ -258,14 +255,13 @@ export function useMoneyAccountWithdrawal() {
 
     const { chainId, tellerAddress, accountantAddress } = vaultConfig;
 
-    const chainIdHex = chainId as Hex;
-    const provider = getProviderByChainId(chainIdHex);
+    const provider = getProviderByChainId(chainId);
     if (!provider) {
       throw new Error(`${LOG_TAG} No provider available for chain ${chainId}`);
     }
 
-    const networkClientId = resolveNetworkClientId(chainIdHex);
-    const isGasFeeSponsored = isMonadMainnetChainId(chainIdHex);
+    const networkClientId = resolveNetworkClientId(chainId);
+    const isGasFeeSponsored = isMonadMainnetChainId(chainId);
 
     // Show the confirmation skeleton while the withdrawal batch is created.
     navigateToConfirmation({
@@ -281,9 +277,9 @@ export function useMoneyAccountWithdrawal() {
       // `updateMoneyAccountWithdrawTokenAmount` once the user picks an amount.
       const { withdrawTx, transferTx } = await buildMoneyAccountWithdrawBatch({
         amount: BigInt(0),
-        chainId: chainIdHex,
-        tellerAddress: tellerAddress as Hex,
-        accountantAddress: accountantAddress as Hex,
+        chainId,
+        tellerAddress,
+        accountantAddress,
         moneyAccountAddress: primaryMoneyAccount.address as Hex,
         recipient: recipient as Hex,
         provider,

--- a/app/components/UI/Money/hooks/useMoneyAccountDepositAssetId.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountDepositAssetId.test.ts
@@ -48,4 +48,15 @@ describe('useMoneyAccountDepositAssetId', () => {
 
     expect(result.current).toBe(MUSD_TOKEN_ASSET_ID_BY_CHAIN[CHAIN_IDS.MONAD]);
   });
+
+  it('falls back to the Monad asset id when the vault chain has no mUSD deployment', () => {
+    // The shared resolver returns `undefined` here; the Monad default is client
+    // policy applied in this hook. Without it the deposit entry-point gate would
+    // compare against an undefined asset id.
+    withVaultConfig({ chainId: CHAIN_IDS.ARBITRUM });
+
+    const { result } = renderHook(() => useMoneyAccountDepositAssetId());
+
+    expect(result.current).toBe(MUSD_TOKEN_ASSET_ID_BY_CHAIN[CHAIN_IDS.MONAD]);
+  });
 });

--- a/app/components/UI/Money/hooks/useMoneyAccountDepositAssetId.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountDepositAssetId.ts
@@ -1,8 +1,12 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import type { CaipAssetType, Hex } from '@metamask/utils';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import {
+  getMoneyAccountDepositAssetId,
+  MUSD_TOKEN_ASSET_ID_BY_CHAIN,
+} from '@metamask/money-account-utils';
 import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlagController/moneyAccount';
-import { getMoneyAccountDepositAssetId } from '../utils/moneyAccountTransactions';
 
 /**
  * Resolves the CAIP-19 asset id of the Money Account deposit asset (mUSD) from
@@ -10,7 +14,9 @@ import { getMoneyAccountDepositAssetId } from '../utils/moneyAccountTransactions
  * exact asset the deposit targets.
  *
  * Money Account is Monad-only today, so this falls back to the Monad mUSD asset
- * id when no vault config is available (see `getMoneyAccountDepositAssetId`).
+ * id when no vault config is available or the configured chain has no mUSD
+ * deployment. The shared resolver returns `undefined` in those cases; the
+ * Monad default is a client policy, applied here.
  * The result is memoized on the vault chain id.
  * @returns The CAIP-19 asset id of the deposit asset for the active vault chain.
  */
@@ -18,7 +24,9 @@ export function useMoneyAccountDepositAssetId(): CaipAssetType {
   const vaultConfig = useSelector(selectMoneyAccountVaultConfig);
 
   return useMemo(
-    () => getMoneyAccountDepositAssetId(vaultConfig?.chainId as Hex),
+    () =>
+      getMoneyAccountDepositAssetId(vaultConfig?.chainId as Hex) ??
+      MUSD_TOKEN_ASSET_ID_BY_CHAIN[CHAIN_IDS.MONAD],
     [vaultConfig?.chainId],
   );
 }

--- a/app/components/UI/Money/hooks/useMoneyAccountDepositAssetId.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountDepositAssetId.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import type { CaipAssetType, Hex } from '@metamask/utils';
+import type { CaipAssetType } from '@metamask/utils';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import {
   getMoneyAccountDepositAssetId,
@@ -25,7 +25,7 @@ export function useMoneyAccountDepositAssetId(): CaipAssetType {
 
   return useMemo(
     () =>
-      getMoneyAccountDepositAssetId(vaultConfig?.chainId as Hex) ??
+      getMoneyAccountDepositAssetId(vaultConfig?.chainId) ??
       MUSD_TOKEN_ASSET_ID_BY_CHAIN[CHAIN_IDS.MONAD],
     [vaultConfig?.chainId],
   );

--- a/app/components/UI/Money/hooks/useMoneyTransactionStatus.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionStatus.ts
@@ -22,7 +22,7 @@ import {
   TOAST_TRACKING_CLEANUP_DELAY_MS,
 } from '../../Earn/constants/musd';
 import { moneyFormatUsd } from '../utils/moneyFormatFiat';
-import { TELLER_ABI } from '../utils/moneyAccountTransactions';
+import { TELLER_ABI } from '@metamask/money-account-utils';
 import {
   isMoneyAccountTx,
   isMoneyDepositTx,

--- a/app/components/UI/Money/utils/moneyAccountTransactions.contract.test.ts
+++ b/app/components/UI/Money/utils/moneyAccountTransactions.contract.test.ts
@@ -1,0 +1,362 @@
+import { Interface, defaultAbiCoder } from '@ethersproject/abi';
+import { TransactionType } from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+import {
+  MUSD_DECIMALS,
+  MUSD_TOKEN_ADDRESS_BY_CHAIN,
+  TELLER_ABI,
+  applySlippage,
+  buildMoneyAccountDepositBatch,
+  buildMoneyAccountDepositPlaceholderBatch,
+  buildMoneyAccountWithdrawBatch,
+  getMoneyAccountDepositAssetAddress,
+  getSharesForWithdrawal,
+} from '@metamask/money-account-utils';
+
+/**
+ * Contract tests for `@metamask/money-account-utils`.
+ *
+ * Every other Money suite mocks this package, so nothing in mobile CI executes
+ * the real encoding path — a library regression (floor instead of ceiling
+ * division, a wrong `minimumAssets`, a changed argument order) would ship with
+ * a green suite. These tests deliberately do NOT mock the package: they drive
+ * the real builders through a stub provider and decode the resulting calldata,
+ * so mobile CI fails if the vault call shapes or the rounding ever change.
+ *
+ * They are the mobile-side half of the coverage that moved into the library
+ * when the builders were extracted.
+ */
+
+const CHAIN_ID = '0x8f' as Hex;
+const MUSD_ADDRESS = MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_ID];
+const BORING_VAULT = '0xb4563bcd3b7764ccbf497f515585f70b6c3ea5ae' as Hex;
+const TELLER = '0x2d49ea58a4c70b62c8b56de971310d9e999c8117' as Hex;
+const ACCOUNTANT = '0x7382c5b8b51b8c4f127b3123c1039581baa5a06b' as Hex;
+const LENS = '0xa816ecd922de94c6879ad23b9a884db257f20947' as Hex;
+const MONEY_ACCOUNT = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as Hex;
+const RECIPIENT = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Hex;
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+const ONE_SHARE = 1_000_000n;
+
+const tellerInterface = new Interface(TELLER_ABI);
+const erc20Interface = new Interface([
+  'function approve(address spender, uint256 amount)',
+  'function transfer(address to, uint256 amount)',
+]);
+
+/**
+ * A minimal ethers v5 provider that answers every `eth_call` with a single
+ * ABI-encoded uint256. Both vault reads the builders make (`previewDeposit` on
+ * the lens, `getRate` on the accountant) return one uint256, so this is enough
+ * to exercise the real contract wrappers without a network.
+ * @param value - The uint256 the stubbed call returns.
+ * @returns The stub provider and the underlying `call` mock.
+ */
+function stubProvider(value: bigint) {
+  const call = jest
+    .fn()
+    .mockResolvedValue(defaultAbiCoder.encode(['uint256'], [value]));
+  // `_isProvider` is how ethers v5 recognises a Provider.
+  return { provider: { _isProvider: true, call } as never, call };
+}
+
+/**
+ * Mirrors the teller's `mulDivDown(shares * rate / ONE_SHARE)` so the tests can
+ * assert the invariant the ceiling division exists to protect.
+ * @param shares - Vault shares being redeemed.
+ * @param rate - The vault rate.
+ * @returns The assets the teller would return.
+ */
+function assetsOutFor(shares: bigint, rate: bigint): bigint {
+  return (shares * rate) / ONE_SHARE;
+}
+
+describe('money-account-utils contract', () => {
+  it('agrees with the client on mUSD decimals', () => {
+    // The wrappers convert human amounts with this constant before handing them
+    // to the builders; a drift here misprices every deposit and withdrawal.
+    expect(MUSD_DECIMALS).toBe(6);
+  });
+
+  it('resolves the deposit asset for the Money Account chain', () => {
+    expect(getMoneyAccountDepositAssetAddress(CHAIN_ID)).toBe(MUSD_ADDRESS);
+  });
+
+  it('throws for a chain mUSD is not deployed on', () => {
+    // Arbitrum — reachable if the remote vault config ever names a chain
+    // without an mUSD deployment.
+    expect(() => getMoneyAccountDepositAssetAddress('0xa4b1')).toThrow(
+      'mUSD not deployed on chain 0xa4b1',
+    );
+  });
+
+  describe('deposit batch', () => {
+    const AMOUNT = 10_500_000n;
+    const SHARES = 10_400_000n;
+
+    it('encodes approve on mUSD and deposit on the teller', async () => {
+      const { provider } = stubProvider(SHARES);
+
+      const { approveTx, depositTx } = await buildMoneyAccountDepositBatch({
+        amount: AMOUNT,
+        chainId: CHAIN_ID,
+        boringVault: BORING_VAULT,
+        tellerAddress: TELLER,
+        accountantAddress: ACCOUNTANT,
+        lensAddress: LENS,
+        provider,
+      });
+
+      expect(approveTx.type).toBe(TransactionType.tokenMethodApprove);
+      expect(approveTx.params.to).toBe(MUSD_ADDRESS);
+      expect(approveTx.params.value).toBe('0x0');
+      const approveArgs = erc20Interface.decodeFunctionData(
+        'approve',
+        approveTx.params.data,
+      );
+      expect(approveArgs[0].toLowerCase()).toBe(BORING_VAULT);
+      expect(approveArgs[1].toString()).toBe(AMOUNT.toString());
+
+      expect(depositTx.type).toBe(TransactionType.moneyAccountDeposit);
+      expect(depositTx.params.to).toBe(TELLER);
+      expect(depositTx.params.value).toBe('0x0');
+      const depositArgs = tellerInterface.decodeFunctionData(
+        'deposit',
+        depositTx.params.data,
+      );
+      expect(depositArgs[0].toLowerCase()).toBe(MUSD_ADDRESS);
+      expect(depositArgs[1].toString()).toBe(AMOUNT.toString());
+      // minimumMint is the previewed shares less the 0.2% slippage tolerance.
+      expect(depositArgs[2].toString()).toBe(applySlippage(SHARES).toString());
+      expect(depositArgs[3]).toBe(ZERO_ADDRESS);
+    });
+
+    it('previews the deposit against the lens before encoding', async () => {
+      const { provider, call } = stubProvider(SHARES);
+
+      await buildMoneyAccountDepositBatch({
+        amount: AMOUNT,
+        chainId: CHAIN_ID,
+        boringVault: BORING_VAULT,
+        tellerAddress: TELLER,
+        accountantAddress: ACCOUNTANT,
+        lensAddress: LENS,
+        provider,
+      });
+
+      expect(call).toHaveBeenCalledTimes(1);
+      const [{ to, data }] = call.mock.calls[0];
+      expect(to.toLowerCase()).toBe(LENS);
+      const previewArgs = new Interface([
+        'function previewDeposit(address depositAsset, uint256 depositAmount, address boringVault, address accountant) view returns (uint256 shares)',
+      ]).decodeFunctionData('previewDeposit', data);
+      expect(previewArgs[0].toLowerCase()).toBe(MUSD_ADDRESS);
+      expect(previewArgs[1].toString()).toBe(AMOUNT.toString());
+      expect(previewArgs[2].toLowerCase()).toBe(BORING_VAULT);
+      expect(previewArgs[3].toLowerCase()).toBe(ACCOUNTANT);
+    });
+
+    it('applies a 0.2% slippage tolerance to the previewed shares', () => {
+      expect(applySlippage(1_000_000n)).toBe(998_000n);
+      expect(applySlippage(0n)).toBe(0n);
+      // Truncates rather than rounding, so minimumMint is never optimistic.
+      expect(applySlippage(1_001n)).toBe(998n);
+    });
+
+    it('skips the vault read for a zero-amount batch', async () => {
+      const { provider, call } = stubProvider(SHARES);
+
+      const { depositTx } = await buildMoneyAccountDepositBatch({
+        amount: 0n,
+        chainId: CHAIN_ID,
+        boringVault: BORING_VAULT,
+        tellerAddress: TELLER,
+        accountantAddress: ACCOUNTANT,
+        lensAddress: LENS,
+        provider,
+      });
+
+      expect(call).not.toHaveBeenCalled();
+      const depositArgs = tellerInterface.decodeFunctionData(
+        'deposit',
+        depositTx.params.data,
+      );
+      expect(depositArgs[2].toString()).toBe('0');
+    });
+  });
+
+  describe('deposit placeholder batch', () => {
+    it('resolves targets and types without calldata or a provider', () => {
+      const { approveTx, depositTx } = buildMoneyAccountDepositPlaceholderBatch(
+        {
+          chainId: CHAIN_ID,
+          tellerAddress: TELLER,
+        },
+      );
+
+      expect(approveTx).toStrictEqual({
+        params: { to: MUSD_ADDRESS, value: '0x0' },
+        type: TransactionType.tokenMethodApprove,
+      });
+      expect(depositTx).toStrictEqual({
+        params: { to: TELLER, value: '0x0' },
+        type: TransactionType.moneyAccountDeposit,
+      });
+    });
+  });
+
+  describe('withdraw batch', () => {
+    const AMOUNT = 1_000_000n;
+    const RATE = 1_000_000n;
+
+    it('encodes withdraw on the teller and transfer on mUSD', async () => {
+      const { provider } = stubProvider(RATE);
+
+      const { withdrawTx, transferTx } = await buildMoneyAccountWithdrawBatch({
+        amount: AMOUNT,
+        chainId: CHAIN_ID,
+        tellerAddress: TELLER,
+        accountantAddress: ACCOUNTANT,
+        moneyAccountAddress: MONEY_ACCOUNT,
+        recipient: RECIPIENT,
+        provider,
+      });
+
+      expect(withdrawTx.type).toBe(TransactionType.moneyAccountWithdraw);
+      expect(withdrawTx.params.to).toBe(TELLER);
+      expect(withdrawTx.params.value).toBe('0x0');
+      const withdrawArgs = tellerInterface.decodeFunctionData(
+        'withdraw',
+        withdrawTx.params.data,
+      );
+      expect(withdrawArgs[0].toLowerCase()).toBe(MUSD_ADDRESS);
+      expect(withdrawArgs[1].toString()).toBe(AMOUNT.toString());
+      // 1-unit tolerance against the teller's mulDivDown truncation.
+      expect(withdrawArgs[2].toString()).toBe((AMOUNT - 1n).toString());
+      // The vault redeems to the money account, not straight to the user.
+      expect(withdrawArgs[3].toLowerCase()).toBe(MONEY_ACCOUNT);
+
+      // The second leg targets the token contract and pays the user the exact
+      // amount they asked for — not the share amount, not the tolerance.
+      expect(transferTx.type).toBe(TransactionType.tokenMethodTransfer);
+      expect(transferTx.params.to).toBe(MUSD_ADDRESS);
+      expect(transferTx.params.value).toBe('0x0');
+      const transferArgs = erc20Interface.decodeFunctionData(
+        'transfer',
+        transferTx.params.data,
+      );
+      expect(transferArgs[0].toLowerCase()).toBe(RECIPIENT);
+      expect(transferArgs[1].toString()).toBe(AMOUNT.toString());
+    });
+
+    it('reads the rate from the accountant', async () => {
+      const { provider, call } = stubProvider(RATE);
+
+      await buildMoneyAccountWithdrawBatch({
+        amount: AMOUNT,
+        chainId: CHAIN_ID,
+        tellerAddress: TELLER,
+        accountantAddress: ACCOUNTANT,
+        moneyAccountAddress: MONEY_ACCOUNT,
+        recipient: RECIPIENT,
+        provider,
+      });
+
+      expect(call).toHaveBeenCalledTimes(1);
+      const [{ to }] = call.mock.calls[0];
+      expect(to.toLowerCase()).toBe(ACCOUNTANT);
+    });
+
+    it('skips the rate read and zeroes the bounds for a placeholder batch', async () => {
+      const { provider, call } = stubProvider(RATE);
+
+      const { withdrawTx, transferTx } = await buildMoneyAccountWithdrawBatch({
+        amount: 0n,
+        chainId: CHAIN_ID,
+        tellerAddress: TELLER,
+        accountantAddress: ACCOUNTANT,
+        moneyAccountAddress: MONEY_ACCOUNT,
+        recipient: RECIPIENT,
+        provider,
+      });
+
+      expect(call).not.toHaveBeenCalled();
+      const withdrawArgs = tellerInterface.decodeFunctionData(
+        'withdraw',
+        withdrawTx.params.data,
+      );
+      expect(withdrawArgs[1].toString()).toBe('0');
+      expect(withdrawArgs[2].toString()).toBe('0');
+      const transferArgs = erc20Interface.decodeFunctionData(
+        'transfer',
+        transferTx.params.data,
+      );
+      expect(transferArgs[1].toString()).toBe('0');
+    });
+
+    it('converts the amount to shares by ceiling division', async () => {
+      // rate > 1:1, so shares < amount and the division has a remainder.
+      const rate = 1_000_094n;
+      const { provider } = stubProvider(rate);
+
+      const { withdrawTx } = await buildMoneyAccountWithdrawBatch({
+        amount: 1_960_000n,
+        chainId: CHAIN_ID,
+        tellerAddress: TELLER,
+        accountantAddress: ACCOUNTANT,
+        moneyAccountAddress: MONEY_ACCOUNT,
+        recipient: RECIPIENT,
+        provider,
+      });
+
+      const withdrawArgs = tellerInterface.decodeFunctionData(
+        'withdraw',
+        withdrawTx.params.data,
+      );
+      const shares = getSharesForWithdrawal(1_960_000n, rate);
+      expect(withdrawArgs[0].toString()).toBeDefined();
+      expect(withdrawArgs[1].toString()).toBe(shares.toString());
+      // Floor division would give one share less, which is the regression the
+      // ceiling exists to prevent.
+      expect(shares).toBe((1_960_000n * ONE_SHARE) / rate + 1n);
+    });
+  });
+
+  describe('getSharesForWithdrawal', () => {
+    it('reproduces the reported $1.96 at rate ~1,000,094 scenario', () => {
+      const amount = 1_960_000n;
+      const rate = 1_000_094n;
+
+      const shares = getSharesForWithdrawal(amount, rate);
+
+      // Asserted against `amount`, not `minimumAssets` (amount - 1): floor
+      // division lands exactly on amount - 1 for this case, so the weaker
+      // bound passes by luck and misses the regression entirely.
+      expect(assetsOutFor(shares, rate)).toBeGreaterThanOrEqual(amount);
+    });
+
+    it('is exact when the division has no remainder', () => {
+      expect(getSharesForWithdrawal(1_000_000n, 1_000_000n)).toBe(1_000_000n);
+      expect(getSharesForWithdrawal(2_000_000n, 2_000_000n)).toBe(1_000_000n);
+    });
+
+    it('returns 0 for a zero amount', () => {
+      expect(getSharesForWithdrawal(0n, 1_000_094n)).toBe(0n);
+    });
+
+    it('keeps assetsOut >= amount across a sweep of rates', () => {
+      const amounts = [1n, 999n, 1_000_000n, 1_960_000n, 123_456_789n];
+
+      // Ceiling division makes `assetsOut >= amount` a hard guarantee, which is
+      // what the teller's 1-unit `minimumAssets` tolerance sits on top of.
+      // Floor division breaks this for any rate that leaves a remainder.
+      for (let rate = 999_000n; rate <= 1_001_000n; rate += 7n) {
+        for (const amount of amounts) {
+          const shares = getSharesForWithdrawal(amount, rate);
+          expect(assetsOutFor(shares, rate)).toBeGreaterThanOrEqual(amount);
+        }
+      }
+    });
+  });
+});

--- a/app/components/UI/Money/utils/moneyAccountTransactions.contract.test.ts
+++ b/app/components/UI/Money/utils/moneyAccountTransactions.contract.test.ts
@@ -9,6 +9,7 @@ import {
   buildMoneyAccountDepositBatch,
   buildMoneyAccountDepositPlaceholderBatch,
   buildMoneyAccountWithdrawBatch,
+  buildMoneyAccountWithdrawPlaceholderBatch,
   getMoneyAccountDepositAssetAddress,
   getSharesForWithdrawal,
 } from '@metamask/money-account-utils';
@@ -164,30 +165,29 @@ describe('money-account-utils contract', () => {
       expect(applySlippage(1_001n)).toBe(998n);
     });
 
-    it('skips the vault read for a zero-amount batch', async () => {
+    it('rejects a zero amount rather than encoding a deposit that mints nothing', async () => {
       const { provider, call } = stubProvider(SHARES);
 
-      const { depositTx } = await buildMoneyAccountDepositBatch({
-        amount: 0n,
-        chainId: CHAIN_ID,
-        boringVault: BORING_VAULT,
-        tellerAddress: TELLER,
-        accountantAddress: ACCOUNTANT,
-        lensAddress: LENS,
-        provider,
-      });
+      await expect(
+        buildMoneyAccountDepositBatch({
+          amount: 0n,
+          chainId: CHAIN_ID,
+          boringVault: BORING_VAULT,
+          tellerAddress: TELLER,
+          accountantAddress: ACCOUNTANT,
+          lensAddress: LENS,
+          provider,
+        }),
+      ).rejects.toThrow(
+        'use buildMoneyAccountDepositPlaceholderBatch for placeholder batches',
+      );
 
       expect(call).not.toHaveBeenCalled();
-      const depositArgs = tellerInterface.decodeFunctionData(
-        'deposit',
-        depositTx.params.data,
-      );
-      expect(depositArgs[2].toString()).toBe('0');
     });
   });
 
-  describe('deposit placeholder batch', () => {
-    it('resolves targets and types without calldata or a provider', () => {
+  describe('placeholder batches', () => {
+    it('resolves deposit targets and types without calldata or a provider', () => {
       const { approveTx, depositTx } = buildMoneyAccountDepositPlaceholderBatch(
         {
           chainId: CHAIN_ID,
@@ -202,6 +202,23 @@ describe('money-account-utils contract', () => {
       expect(depositTx).toStrictEqual({
         params: { to: TELLER, value: '0x0' },
         type: TransactionType.moneyAccountDeposit,
+      });
+    });
+
+    it('resolves withdraw targets and types without calldata or a provider', () => {
+      const { withdrawTx, transferTx } =
+        buildMoneyAccountWithdrawPlaceholderBatch({
+          chainId: CHAIN_ID,
+          tellerAddress: TELLER,
+        });
+
+      expect(withdrawTx).toStrictEqual({
+        params: { to: TELLER, value: '0x0' },
+        type: TransactionType.moneyAccountWithdraw,
+      });
+      expect(transferTx).toStrictEqual({
+        params: { to: MUSD_ADDRESS, value: '0x0' },
+        type: TransactionType.tokenMethodTransfer,
       });
     });
   });
@@ -268,31 +285,24 @@ describe('money-account-utils contract', () => {
       expect(to.toLowerCase()).toBe(ACCOUNTANT);
     });
 
-    it('skips the rate read and zeroes the bounds for a placeholder batch', async () => {
+    it('rejects a zero amount rather than encoding a zero-share redemption', async () => {
       const { provider, call } = stubProvider(RATE);
 
-      const { withdrawTx, transferTx } = await buildMoneyAccountWithdrawBatch({
-        amount: 0n,
-        chainId: CHAIN_ID,
-        tellerAddress: TELLER,
-        accountantAddress: ACCOUNTANT,
-        moneyAccountAddress: MONEY_ACCOUNT,
-        recipient: RECIPIENT,
-        provider,
-      });
+      await expect(
+        buildMoneyAccountWithdrawBatch({
+          amount: 0n,
+          chainId: CHAIN_ID,
+          tellerAddress: TELLER,
+          accountantAddress: ACCOUNTANT,
+          moneyAccountAddress: MONEY_ACCOUNT,
+          recipient: RECIPIENT,
+          provider,
+        }),
+      ).rejects.toThrow(
+        'use buildMoneyAccountWithdrawPlaceholderBatch for placeholder batches',
+      );
 
       expect(call).not.toHaveBeenCalled();
-      const withdrawArgs = tellerInterface.decodeFunctionData(
-        'withdraw',
-        withdrawTx.params.data,
-      );
-      expect(withdrawArgs[1].toString()).toBe('0');
-      expect(withdrawArgs[2].toString()).toBe('0');
-      const transferArgs = erc20Interface.decodeFunctionData(
-        'transfer',
-        transferTx.params.data,
-      );
-      expect(transferArgs[1].toString()).toBe('0');
     });
 
     it('converts the amount to shares by ceiling division', async () => {

--- a/app/components/UI/Money/utils/moneyAccountTransactions.test.ts
+++ b/app/components/UI/Money/utils/moneyAccountTransactions.test.ts
@@ -1,23 +1,14 @@
-import { ethers } from 'ethers';
-import {
-  TransactionMeta,
-  TransactionType,
-} from '@metamask/transaction-controller';
+import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import {
-  MUSD_TOKEN_ADDRESS_BY_CHAIN,
-  MUSD_TOKEN_ASSET_ID_BY_CHAIN,
-} from '../../Earn/constants/musd';
-import {
-  applySlippage,
-  getSharesForWithdrawal,
   buildMoneyAccountDepositBatch,
   buildMoneyAccountWithdrawBatch,
+} from '@metamask/money-account-utils';
+import {
   updateMoneyAccountDepositTokenAmount,
   updateMoneyAccountWithdrawTokenAmount,
   getMoneyAccountDepositTransactionsData,
   getMoneyAccountWithdrawTransactionsData,
-  getMoneyAccountDepositAssetId,
 } from './moneyAccountTransactions';
 import ReduxService from '../../../../core/redux/ReduxService';
 import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
@@ -28,22 +19,17 @@ import {
   selectMoneyAccountVaultConfig,
 } from '../../../../selectors/featureFlagController/moneyAccount';
 
-jest.mock('../../Earn/constants/musd', () => ({
-  MUSD_TOKEN_ADDRESS_BY_CHAIN: {} as Record<string, Hex>,
-  MUSD_DECIMALS: 6,
-  MUSD_TOKEN_ASSET_ID_BY_CHAIN: {
-    // Monad (0x8f) mUSD CAIP-19 asset id.
-    '0x8f': 'eip155:143/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
-    // Mainnet (0x1) mUSD CAIP-19 asset id.
-    '0x1': 'eip155:1/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
-  } as Record<string, string>,
+// The pure builders now live in `@metamask/money-account-utils` and are tested
+// there; these tests cover only the Redux-coupled wrappers, so the package
+// boundary is mocked.
+jest.mock('@metamask/money-account-utils', () => ({
+  ...jest.requireActual('@metamask/money-account-utils'),
+  buildMoneyAccountDepositBatch: jest.fn(),
+  buildMoneyAccountWithdrawBatch: jest.fn(),
 }));
 
-jest.mock('../../../../core/AppConstants', () => ({
-  __esModule: true,
-  default: {
-    ZERO_ADDRESS: '0x0000000000000000000000000000000000000000',
-  },
+jest.mock('../../Earn/constants/musd', () => ({
+  MUSD_DECIMALS: 6,
 }));
 
 jest.mock('../../../../core/redux/ReduxService', () => ({
@@ -67,38 +53,13 @@ jest.mock('../../../../selectors/accountsController', () => ({
 jest.mock('../../../../util/notifications/methods/common', () => ({
   getProviderByChainId: jest.fn(),
 }));
-jest.mock('../../../../util/notifications/methods/common');
-jest.mock('../../../../core/redux');
-jest.mock('../../../../selectors/featureFlagController/moneyAccount');
 
-const mockPreviewDeposit = jest.fn();
-const mockGetRate = jest.fn();
-
-jest.mock('ethers', () => {
-  const actualEthers = jest.requireActual('ethers');
-  return {
-    ...actualEthers,
-    ethers: {
-      ...actualEthers.ethers,
-      Contract: jest.fn().mockImplementation((_address, abi) => {
-        const abiStr = JSON.stringify(abi);
-        if (abiStr.includes('previewDeposit')) {
-          return { previewDeposit: mockPreviewDeposit };
-        }
-        if (abiStr.includes('getRate')) {
-          return { getRate: mockGetRate };
-        }
-        return {};
-      }),
-      utils: actualEthers.ethers.utils,
-    },
-  };
-});
-
+const mockBuildDepositBatch = jest.mocked(buildMoneyAccountDepositBatch);
+const mockBuildWithdrawBatch = jest.mocked(buildMoneyAccountWithdrawBatch);
 const mockGetProviderByChainId = jest.mocked(getProviderByChainId);
-const mockSelectMoneyAccountVaultConfig = jest.mocked(
-  selectMoneyAccountVaultConfig,
-);
+const mockSelectVaultConfig = jest.mocked(selectMoneyAccountVaultConfig);
+const mockSelectPrimaryMoneyAccount = jest.mocked(selectPrimaryMoneyAccount);
+const mockSelectEvmAddress = jest.mocked(selectEvmAddress);
 
 const MOCK_CHAIN_ID = '0x8f' as Hex;
 const MOCK_MUSD_ADDRESS = '0xaca92e438df0b2401ff60da7e4337b687a2435da' as Hex;
@@ -106,7 +67,11 @@ const MOCK_BORING_VAULT = '0xB5F07d769dD60fE54c97dd53101181073DDf21b2' as Hex;
 const MOCK_TELLER = '0x86821F179eaD9F0b3C79b2f8deF0227eEBFDc9f9' as Hex;
 const MOCK_ACCOUNTANT = '0x800ebc3B74F67EaC27C9CCE4E4FF28b17CdCA173' as Hex;
 const MOCK_LENS = '0x846a7832022350434B5cC006d07cc9c782469660' as Hex;
-const MOCK_PROVIDER = {} as ethers.providers.Provider;
+const MOCK_MONEY_ACCOUNT = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as Hex;
+const MOCK_EVM_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Hex;
+const MOCK_RECIPIENT_OVERRIDE =
+  '0x1111111111111111111111111111111111111111' as Hex;
+const MOCK_PROVIDER = {} as never;
 
 const MOCK_VAULT_CONFIG: MoneyAccountVaultConfig = {
   chainId: MOCK_CHAIN_ID,
@@ -116,869 +81,325 @@ const MOCK_VAULT_CONFIG: MoneyAccountVaultConfig = {
   lensAddress: MOCK_LENS,
 };
 
+const MOCK_TRANSACTION_META = {
+  chainId: MOCK_CHAIN_ID,
+} as TransactionMeta;
+
+const DEPOSIT_BATCH = {
+  approveTx: {
+    params: {
+      to: MOCK_MUSD_ADDRESS,
+      data: '0xapprove' as Hex,
+      value: '0x0' as Hex,
+    },
+    type: 'tokenMethodApprove' as never,
+  },
+  depositTx: {
+    params: {
+      to: MOCK_TELLER,
+      data: '0xdeposit' as Hex,
+      value: '0x0' as Hex,
+    },
+    type: 'moneyAccountDeposit' as never,
+  },
+};
+
+const WITHDRAW_BATCH = {
+  withdrawTx: {
+    params: {
+      to: MOCK_TELLER,
+      data: '0xwithdraw' as Hex,
+      value: '0x0' as Hex,
+    },
+    type: 'moneyAccountWithdraw' as never,
+  },
+  transferTx: {
+    params: {
+      to: MOCK_MUSD_ADDRESS,
+      data: '0xtransfer' as Hex,
+      value: '0x0' as Hex,
+    },
+    type: 'tokenMethodTransfer' as never,
+  },
+};
+
 describe('moneyAccountTransactions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (MUSD_TOKEN_ADDRESS_BY_CHAIN as Record<string, Hex>)[MOCK_CHAIN_ID] =
-      MOCK_MUSD_ADDRESS;
-  });
-
-  describe('applySlippage', () => {
-    it('applies 0.2% slippage to a round value', () => {
-      const result = applySlippage(BigInt(1000));
-      expect(result).toBe(BigInt(998));
-    });
-
-    it('applies 0.2% slippage with integer truncation', () => {
-      const result = applySlippage(BigInt(1));
-      expect(result).toBe(BigInt(0));
-    });
-
-    it('applies 0.2% slippage to a large value', () => {
-      const amount = BigInt('1000000000000000000');
-      const expected = (amount * BigInt(998)) / BigInt(1000);
-      expect(applySlippage(amount)).toBe(expected);
-    });
-
-    it('returns 0 for 0 input', () => {
-      expect(applySlippage(BigInt(0))).toBe(BigInt(0));
-    });
-  });
-
-  describe('getSharesForWithdrawal', () => {
-    const SHARE_SCALAR = BigInt(1_000_000);
-
-    it('converts amount to shares at 1:1 rate (exact division)', () => {
-      const amount = BigInt(1_000_000);
-      const rate = BigInt(1_000_000);
-      // 1_000_000 * 1_000_000 / 1_000_000 = exact, ceiling = floor
-      expect(getSharesForWithdrawal(amount, rate)).toBe(BigInt(1_000_000));
-    });
-
-    it('scales down when rate is higher than 1:1 (exact division)', () => {
-      const amount = BigInt(1_000_000);
-      const rate = BigInt(2_000_000);
-      // 1_000_000 * 1_000_000 / 2_000_000 = exact 500_000
-      expect(getSharesForWithdrawal(amount, rate)).toBe(BigInt(500_000));
-    });
-
-    it('scales up when rate is lower than 1:1 (exact division)', () => {
-      const amount = BigInt(2_000_000);
-      const rate = BigInt(1_000_000);
-      expect(getSharesForWithdrawal(amount, rate)).toBe(BigInt(2_000_000));
-    });
-
-    it('uses ceiling division — rounds up when remainder exists', () => {
-      // 1_000_000 * 1_000_000 = 1_000_000_000_000
-      // floor(1_000_000_000_000 / 3_000_000) = 333_333
-      // ceil should be 333_334
-      const amount = BigInt(1_000_000);
-      const rate = BigInt(3_000_000);
-      const floorResult = (amount * SHARE_SCALAR) / rate;
-      expect(floorResult).toBe(BigInt(333_333));
-      expect(getSharesForWithdrawal(amount, rate)).toBe(BigInt(333_334));
-    });
-
-    it('reproduces the exact reported scenario — $1.96 at rate ~1,000,094', () => {
-      // This was the failing case: floor division gave 1,959,815 shares,
-      // contract mulDivDown produced 1,959,999 assetsOut < 1,960,000 minimumAssets
-      const amount = BigInt(1_960_000); // $1.96 in 6 decimals
-      const rate = BigInt(1_000_094);
-
-      const floorShares = (amount * SHARE_SCALAR) / rate;
-      expect(floorShares).toBe(BigInt(1_959_815)); // old buggy value
-
-      const ceilShares = getSharesForWithdrawal(amount, rate);
-      expect(ceilShares).toBe(BigInt(1_959_816)); // fixed: one more share
-
-      // Verify: contract mulDivDown(ceilShares * rate / SCALAR) >= amount
-      const assetsOut = (ceilShares * rate) / SHARE_SCALAR;
-      expect(assetsOut).toBeGreaterThanOrEqual(amount);
-    });
-
-    it('reproduces the reported $1.00 scenario — was passing by luck', () => {
-      const amount = BigInt(1_000_000);
-      const rate = BigInt(1_000_094);
-
-      const floorShares = (amount * SHARE_SCALAR) / rate;
-      const ceilShares = getSharesForWithdrawal(amount, rate);
-
-      // With ceiling, we get at least as many shares as floor
-      expect(ceilShares).toBeGreaterThanOrEqual(floorShares);
-
-      // Contract-side check still passes
-      const assetsOut = (ceilShares * rate) / SHARE_SCALAR;
-      expect(assetsOut).toBeGreaterThanOrEqual(amount);
-    });
-
-    it('handles large amounts with ceiling division', () => {
-      const amount = BigInt('1000000000000'); // $1M in 6 decimals
-      const rate = BigInt('1500000');
-      const result = getSharesForWithdrawal(amount, rate);
-      const floorResult = (amount * SHARE_SCALAR) / rate;
-      // Ceiling >= floor always
-      expect(result).toBeGreaterThanOrEqual(floorResult);
-      // And at most 1 more than floor
-      expect(result - floorResult).toBeLessThanOrEqual(1n);
-    });
-
-    it('ceiling division equals floor when division is exact', () => {
-      // 2_000_000 * 1_000_000 / 500_000 = 4_000_000_000 (exact)
-      const amount = BigInt(2_000_000);
-      const rate = BigInt(500_000);
-      const floorResult = (amount * SHARE_SCALAR) / rate;
-      expect(getSharesForWithdrawal(amount, rate)).toBe(floorResult);
-    });
-
-    it('returns 0 for zero amount', () => {
-      expect(getSharesForWithdrawal(0n, BigInt(1_000_000))).toBe(0n);
-    });
-
-    it('guarantees assetsOut >= amount for many rate values', () => {
-      // Fuzz-like: sweep a range of rates near 1:1
-      const amount = BigInt(1_960_000);
-      for (let r = 999_900; r <= 1_000_200; r++) {
-        const rate = BigInt(r);
-        const shares = getSharesForWithdrawal(amount, rate);
-        // Simulate contract mulDivDown
-        const assetsOut = (shares * rate) / SHARE_SCALAR;
-        expect(assetsOut).toBeGreaterThanOrEqual(amount);
-      }
-    });
-  });
-
-  describe('getMoneyAccountDepositAssetId', () => {
-    it('returns the mapped asset id for a known chain', () => {
-      expect(getMoneyAccountDepositAssetId('0x8f' as Hex)).toBe(
-        MUSD_TOKEN_ASSET_ID_BY_CHAIN['0x8f'],
-      );
-      expect(getMoneyAccountDepositAssetId('0x1' as Hex)).toBe(
-        MUSD_TOKEN_ASSET_ID_BY_CHAIN['0x1'],
-      );
-    });
-
-    it('falls back to the Monad asset id for an unknown chain', () => {
-      expect(getMoneyAccountDepositAssetId('0xdead' as Hex)).toBe(
-        MUSD_TOKEN_ASSET_ID_BY_CHAIN['0x8f'],
-      );
-    });
-
-    it('falls back to the Monad asset id when chainId is undefined', () => {
-      expect(getMoneyAccountDepositAssetId(undefined)).toBe(
-        MUSD_TOKEN_ASSET_ID_BY_CHAIN['0x8f'],
-      );
-    });
-  });
-
-  describe('buildMoneyAccountDepositBatch', () => {
-    it('returns approve and deposit transactions with correct types', async () => {
-      mockPreviewDeposit.mockResolvedValue(ethers.BigNumber.from('1000000'));
-
-      const result = await buildMoneyAccountDepositBatch({
-        amount: BigInt(1_000_000),
-        chainId: MOCK_CHAIN_ID,
-        boringVault: MOCK_BORING_VAULT,
-        tellerAddress: MOCK_TELLER,
-        accountantAddress: MOCK_ACCOUNTANT,
-        lensAddress: MOCK_LENS,
-        provider: MOCK_PROVIDER,
-      });
-
-      expect(result.approveTx.type).toBe(TransactionType.tokenMethodApprove);
-      expect(result.approveTx.params.value).toBe('0x0');
-
-      expect(result.depositTx.type).toBe(TransactionType.moneyAccountDeposit);
-      expect(result.depositTx.params.to).toBe(MOCK_TELLER);
-      expect(result.depositTx.params.value).toBe('0x0');
-    });
-
-    it('encodes approve data targeting the boring vault', async () => {
-      mockPreviewDeposit.mockResolvedValue(ethers.BigNumber.from('1000000'));
-
-      const result = await buildMoneyAccountDepositBatch({
-        amount: BigInt(500_000),
-        chainId: MOCK_CHAIN_ID,
-        boringVault: MOCK_BORING_VAULT,
-        tellerAddress: MOCK_TELLER,
-        accountantAddress: MOCK_ACCOUNTANT,
-        lensAddress: MOCK_LENS,
-        provider: MOCK_PROVIDER,
-      });
-
-      expect(result.approveTx.params.data).toBeDefined();
-      expect(typeof result.approveTx.params.data).toBe('string');
-      expect(result.approveTx.params.data?.startsWith('0x')).toBe(true);
-    });
-
-    it('calls previewDeposit with correct arguments', async () => {
-      mockPreviewDeposit.mockResolvedValue(ethers.BigNumber.from('500000'));
-
-      await buildMoneyAccountDepositBatch({
-        amount: BigInt(1_000_000),
-        chainId: MOCK_CHAIN_ID,
-        boringVault: MOCK_BORING_VAULT,
-        tellerAddress: MOCK_TELLER,
-        accountantAddress: MOCK_ACCOUNTANT,
-        lensAddress: MOCK_LENS,
-        provider: MOCK_PROVIDER,
-      });
-
-      expect(mockPreviewDeposit).toHaveBeenCalledWith(
-        expect.any(String),
-        '1000000',
-        MOCK_BORING_VAULT,
-        MOCK_ACCOUNTANT,
-      );
-    });
-
-    it('returns undefined data fields when initialiseWithoutData is true', async () => {
-      const result = await buildMoneyAccountDepositBatch({
-        amount: BigInt(0),
-        chainId: MOCK_CHAIN_ID,
-        boringVault: MOCK_BORING_VAULT,
-        tellerAddress: MOCK_TELLER,
-        accountantAddress: MOCK_ACCOUNTANT,
-        lensAddress: MOCK_LENS,
-        provider: MOCK_PROVIDER,
-        initialiseWithoutData: true,
-      });
-
-      expect(result.approveTx.params.data).toBeUndefined();
-      expect(result.depositTx.params.data).toBeUndefined();
-      expect(result.approveTx.type).toBe(TransactionType.tokenMethodApprove);
-      expect(result.depositTx.type).toBe(TransactionType.moneyAccountDeposit);
-      expect(result.approveTx.params.to).toBe(MOCK_MUSD_ADDRESS);
-      expect(result.depositTx.params.to).toBe(MOCK_TELLER);
-    });
-
-    it('skips calldata encoding but still resolves minimumMint for non-zero amounts when initialiseWithoutData is true', async () => {
-      mockPreviewDeposit.mockResolvedValue(ethers.BigNumber.from('1000000'));
-
-      const result = await buildMoneyAccountDepositBatch({
-        amount: BigInt(1_000_000),
-        chainId: MOCK_CHAIN_ID,
-        boringVault: MOCK_BORING_VAULT,
-        tellerAddress: MOCK_TELLER,
-        accountantAddress: MOCK_ACCOUNTANT,
-        lensAddress: MOCK_LENS,
-        provider: MOCK_PROVIDER,
-        initialiseWithoutData: true,
-      });
-
-      expect(result.approveTx.params.data).toBeUndefined();
-      expect(result.depositTx.params.data).toBeUndefined();
-    });
-
-    it('builds calldata normally when initialiseWithoutData is false', async () => {
-      mockPreviewDeposit.mockResolvedValue(ethers.BigNumber.from('1000000'));
-
-      const result = await buildMoneyAccountDepositBatch({
-        amount: BigInt(1_000_000),
-        chainId: MOCK_CHAIN_ID,
-        boringVault: MOCK_BORING_VAULT,
-        tellerAddress: MOCK_TELLER,
-        accountantAddress: MOCK_ACCOUNTANT,
-        lensAddress: MOCK_LENS,
-        provider: MOCK_PROVIDER,
-        initialiseWithoutData: false,
-      });
-
-      expect(result.approveTx.params.data).toBeDefined();
-      expect(result.approveTx.params.data?.startsWith('0x')).toBe(true);
-      expect(result.depositTx.params.data).toBeDefined();
-      expect(result.depositTx.params.data?.startsWith('0x')).toBe(true);
-    });
+    mockSelectVaultConfig.mockReturnValue(MOCK_VAULT_CONFIG);
+    mockSelectPrimaryMoneyAccount.mockReturnValue({
+      address: MOCK_MONEY_ACCOUNT,
+    } as never);
+    mockSelectEvmAddress.mockReturnValue(MOCK_EVM_ADDRESS);
+    mockGetProviderByChainId.mockReturnValue(MOCK_PROVIDER);
+    mockBuildDepositBatch.mockResolvedValue(DEPOSIT_BATCH);
+    mockBuildWithdrawBatch.mockResolvedValue(WITHDRAW_BATCH);
+    (ReduxService.store.getState as jest.Mock).mockReturnValue({});
   });
 
   describe('updateMoneyAccountDepositTokenAmount', () => {
-    const mockTransactionMeta = {
-      id: 'tx-1',
-      chainId: MOCK_VAULT_CONFIG.chainId as Hex,
-    } as unknown as TransactionMeta;
-
-    beforeEach(() => {
-      // Default: vault config present, provider present
-      mockGetProviderByChainId.mockReturnValue(MOCK_PROVIDER as never);
-      mockSelectMoneyAccountVaultConfig.mockReturnValue(MOCK_VAULT_CONFIG);
-      (
-        jest.mocked(ReduxService) as unknown as {
-          store: { getState: jest.Mock };
-        }
-      ).store = { getState: jest.fn().mockReturnValue({}) };
-    });
-
-    it('returns indexed approve and deposit calls for a valid amount', async () => {
-      mockPreviewDeposit.mockResolvedValue(ethers.BigNumber.from('1000000'));
-
+    it('returns indexed approve and deposit calls', async () => {
       const result = await updateMoneyAccountDepositTokenAmount(
-        mockTransactionMeta,
-        '1.0',
+        MOCK_TRANSACTION_META,
+        '10.5',
       );
 
-      expect(result).toHaveLength(2);
-      expect(result[0].nestedTransactionIndex).toBe(0);
-      expect(result[0].transactionData).toMatch(/^0x/);
-      expect(result[1].nestedTransactionIndex).toBe(1);
-      expect(result[1].transactionData).toMatch(/^0x/);
+      expect(result).toStrictEqual([
+        { nestedTransactionIndex: 0, transactionData: '0xapprove' },
+        { nestedTransactionIndex: 1, transactionData: '0xdeposit' },
+      ]);
     });
 
-    it('calls previewDeposit with the converted amount', async () => {
-      mockPreviewDeposit.mockResolvedValue(ethers.BigNumber.from('1000000'));
+    it('forwards the vault config and the converted amount to the builder', async () => {
+      await updateMoneyAccountDepositTokenAmount(MOCK_TRANSACTION_META, '10.5');
 
-      await updateMoneyAccountDepositTokenAmount(mockTransactionMeta, '1.0');
+      expect(mockBuildDepositBatch).toHaveBeenCalledWith({
+        amount: BigInt(10_500_000),
+        chainId: MOCK_CHAIN_ID,
+        boringVault: MOCK_BORING_VAULT,
+        tellerAddress: MOCK_TELLER,
+        accountantAddress: MOCK_ACCOUNTANT,
+        lensAddress: MOCK_LENS,
+        provider: MOCK_PROVIDER,
+      });
+    });
 
-      // 1.0 USDC with 6 decimals = 1_000_000
-      expect(mockPreviewDeposit).toHaveBeenCalledWith(
-        expect.any(String),
-        '1000000',
-        MOCK_VAULT_CONFIG.boringVault,
-        MOCK_VAULT_CONFIG.accountantAddress,
+    it('rounds the amount up to the next base unit', async () => {
+      await updateMoneyAccountDepositTokenAmount(
+        MOCK_TRANSACTION_META,
+        '1.0000005',
+      );
+
+      expect(mockBuildDepositBatch).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: BigInt(1_000_001) }),
       );
     });
 
     it('returns [] when vault config is missing', async () => {
-      mockSelectMoneyAccountVaultConfig.mockReturnValue(undefined);
+      mockSelectVaultConfig.mockReturnValue(undefined);
 
-      const result = await updateMoneyAccountDepositTokenAmount(
-        mockTransactionMeta,
-        '1.0',
-      );
-
-      expect(result).toEqual([]);
-      expect(mockGetProviderByChainId).not.toHaveBeenCalled();
-      expect(mockPreviewDeposit).not.toHaveBeenCalled();
+      expect(
+        await updateMoneyAccountDepositTokenAmount(
+          MOCK_TRANSACTION_META,
+          '10.5',
+        ),
+      ).toStrictEqual([]);
+      expect(mockBuildDepositBatch).not.toHaveBeenCalled();
     });
 
-    it('returns [] when provider is missing', async () => {
+    it('returns [] when no provider is available for the chain', async () => {
       mockGetProviderByChainId.mockReturnValue(undefined as never);
 
-      const result = await updateMoneyAccountDepositTokenAmount(
-        mockTransactionMeta,
-        '1.0',
-      );
-
-      expect(result).toEqual([]);
-      expect(mockPreviewDeposit).not.toHaveBeenCalled();
+      expect(
+        await updateMoneyAccountDepositTokenAmount(
+          MOCK_TRANSACTION_META,
+          '10.5',
+        ),
+      ).toStrictEqual([]);
+      expect(mockBuildDepositBatch).not.toHaveBeenCalled();
     });
 
-    it('rejects when previewDeposit fails so the dispatcher can log the error', async () => {
-      const rpcError = new Error('RPC connection refused');
-      mockPreviewDeposit.mockRejectedValue(rpcError);
+    it('propagates builder errors so the dispatcher can log them', async () => {
+      mockBuildDepositBatch.mockRejectedValue(new Error('RPC down'));
 
       await expect(
-        updateMoneyAccountDepositTokenAmount(mockTransactionMeta, '1.0'),
-      ).rejects.toThrow('RPC connection refused');
+        updateMoneyAccountDepositTokenAmount(MOCK_TRANSACTION_META, '10.5'),
+      ).rejects.toThrow('RPC down');
     });
   });
 
   describe('updateMoneyAccountWithdrawTokenAmount', () => {
-    const mockGetState = jest.mocked(ReduxService).store.getState as jest.Mock;
-    const mockSelectVaultConfig = jest.mocked(selectMoneyAccountVaultConfig);
-    const mockSelectPrimaryMoneyAccount = jest.mocked(
-      selectPrimaryMoneyAccount,
-    );
-    const mockSelectEvmAddress = jest.mocked(selectEvmAddress);
-    const mockGetProviderByChainId = jest.mocked(getProviderByChainId);
-
-    const MOCK_VAULT_CONFIG = {
-      chainId: MOCK_CHAIN_ID,
-      boringVault: MOCK_BORING_VAULT,
-      tellerAddress: MOCK_TELLER,
-      accountantAddress: MOCK_ACCOUNTANT,
-      lensAddress: MOCK_LENS,
-    };
-    const MOCK_MONEY_ACCOUNT_ADDRESS =
-      '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as Hex;
-    const MOCK_RECIPIENT = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Hex;
-
-    const MOCK_TX_META = {
-      id: 'tx-1',
-      chainId: MOCK_CHAIN_ID,
-    } as unknown as TransactionMeta;
-
-    beforeEach(() => {
-      mockGetState.mockReturnValue({});
-      mockSelectVaultConfig.mockReturnValue(MOCK_VAULT_CONFIG);
-      mockSelectPrimaryMoneyAccount.mockReturnValue({
-        address: MOCK_MONEY_ACCOUNT_ADDRESS,
-      } as ReturnType<typeof selectPrimaryMoneyAccount>);
-      mockSelectEvmAddress.mockReturnValue(MOCK_RECIPIENT);
-      mockGetProviderByChainId.mockReturnValue(
-        MOCK_PROVIDER as ReturnType<typeof getProviderByChainId>,
-      );
-      mockGetRate.mockResolvedValue(ethers.BigNumber.from('1000000'));
-    });
-
-    it('returns two UpdateTransactionPayAmountCall entries with nestedTransactionIndex 0 and 1', async () => {
+    it('returns indexed withdraw and transfer calls', async () => {
       const result = await updateMoneyAccountWithdrawTokenAmount(
-        MOCK_TX_META,
-        '1',
+        MOCK_TRANSACTION_META,
+        '10.5',
       );
 
-      expect(result).toHaveLength(2);
-      expect(result[0].nestedTransactionIndex).toBe(0);
-      expect(result[1].nestedTransactionIndex).toBe(1);
+      expect(result).toStrictEqual([
+        { nestedTransactionIndex: 0, transactionData: '0xwithdraw' },
+        { nestedTransactionIndex: 1, transactionData: '0xtransfer' },
+      ]);
     });
 
-    it('returns calldata hex strings for both nested transactions', async () => {
-      const result = await updateMoneyAccountWithdrawTokenAmount(
-        MOCK_TX_META,
-        '1',
+    it('forwards the vault config, money account and recipient to the builder', async () => {
+      await updateMoneyAccountWithdrawTokenAmount(
+        MOCK_TRANSACTION_META,
+        '10.5',
       );
 
-      expect(result[0].transactionData).toBeDefined();
-      expect(result[0].transactionData.startsWith('0x')).toBe(true);
-
-      expect(result[1].transactionData).toBeDefined();
-      expect(result[1].transactionData.startsWith('0x')).toBe(true);
+      expect(mockBuildWithdrawBatch).toHaveBeenCalledWith({
+        amount: BigInt(10_500_000),
+        chainId: MOCK_CHAIN_ID,
+        tellerAddress: MOCK_TELLER,
+        accountantAddress: MOCK_ACCOUNTANT,
+        moneyAccountAddress: MOCK_MONEY_ACCOUNT,
+        recipient: MOCK_EVM_ADDRESS,
+        provider: MOCK_PROVIDER,
+      });
     });
 
-    it('returns empty array when vaultConfig is missing', async () => {
+    it('uses recipientOverride when provided', async () => {
+      await updateMoneyAccountWithdrawTokenAmount(
+        MOCK_TRANSACTION_META,
+        '10.5',
+        MOCK_RECIPIENT_OVERRIDE,
+      );
+
+      expect(mockBuildWithdrawBatch).toHaveBeenCalledWith(
+        expect.objectContaining({ recipient: MOCK_RECIPIENT_OVERRIDE }),
+      );
+    });
+
+    it('returns [] when vault config is missing', async () => {
       mockSelectVaultConfig.mockReturnValue(undefined);
 
-      const result = await updateMoneyAccountWithdrawTokenAmount(
-        MOCK_TX_META,
-        '1',
-      );
-
-      expect(result).toEqual([]);
+      expect(
+        await updateMoneyAccountWithdrawTokenAmount(
+          MOCK_TRANSACTION_META,
+          '10.5',
+        ),
+      ).toStrictEqual([]);
     });
 
-    it('returns empty array when primaryMoneyAccount is missing', async () => {
-      mockSelectPrimaryMoneyAccount.mockReturnValue(undefined);
+    it('returns [] when the primary money account is missing', async () => {
+      mockSelectPrimaryMoneyAccount.mockReturnValue(undefined as never);
 
-      const result = await updateMoneyAccountWithdrawTokenAmount(
-        MOCK_TX_META,
-        '1',
-      );
-
-      expect(result).toEqual([]);
+      expect(
+        await updateMoneyAccountWithdrawTokenAmount(
+          MOCK_TRANSACTION_META,
+          '10.5',
+        ),
+      ).toStrictEqual([]);
     });
 
-    it('returns empty array when recipient (selectEvmAddress) is missing', async () => {
-      mockSelectEvmAddress.mockReturnValue(undefined);
+    it('returns [] when there is no recipient', async () => {
+      mockSelectEvmAddress.mockReturnValue(undefined as never);
 
-      const result = await updateMoneyAccountWithdrawTokenAmount(
-        MOCK_TX_META,
-        '1',
-      );
-
-      expect(result).toEqual([]);
+      expect(
+        await updateMoneyAccountWithdrawTokenAmount(
+          MOCK_TRANSACTION_META,
+          '10.5',
+        ),
+      ).toStrictEqual([]);
     });
 
-    it('returns empty array when provider is not available for the chain', async () => {
-      mockGetProviderByChainId.mockReturnValue(
-        undefined as unknown as ReturnType<typeof getProviderByChainId>,
-      );
+    it('returns [] when no provider is available for the chain', async () => {
+      mockGetProviderByChainId.mockReturnValue(undefined as never);
 
-      const result = await updateMoneyAccountWithdrawTokenAmount(
-        MOCK_TX_META,
-        '1',
-      );
-
-      expect(result).toEqual([]);
-    });
-
-    it('uses recipientOverride as recipient when provided', async () => {
-      const overrideAddress =
-        '0x1111111111111111111111111111111111111111' as Hex;
-
-      const result = await updateMoneyAccountWithdrawTokenAmount(
-        MOCK_TX_META,
-        '1',
-        overrideAddress,
-      );
-
-      expect(result).toHaveLength(2);
-      const encodedOverride = overrideAddress
-        .toLowerCase()
-        .replace('0x', '')
-        .padStart(64, '0');
-      expect(result[1].transactionData.toLowerCase()).toContain(
-        encodedOverride,
-      );
-    });
-
-    it('falls back to selectEvmAddress when recipientOverride is undefined', async () => {
-      const result = await updateMoneyAccountWithdrawTokenAmount(
-        MOCK_TX_META,
-        '1',
-      );
-
-      expect(result).toHaveLength(2);
-      const encodedRecipient = MOCK_RECIPIENT.toLowerCase()
-        .replace('0x', '')
-        .padStart(64, '0');
-      expect(result[1].transactionData.toLowerCase()).toContain(
-        encodedRecipient,
-      );
-    });
-  });
-
-  describe('buildMoneyAccountWithdrawBatch', () => {
-    const MOCK_MONEY_ACCOUNT_ADDRESS =
-      '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as Hex;
-    const MOCK_RECIPIENT_ADDRESS =
-      '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Hex;
-
-    it('returns withdrawTx and transferTx with correct transaction types', async () => {
-      mockGetRate.mockResolvedValue(ethers.BigNumber.from('1000000'));
-
-      const result = await buildMoneyAccountWithdrawBatch({
-        amount: BigInt(1_000_000),
-        chainId: MOCK_CHAIN_ID,
-        tellerAddress: MOCK_TELLER,
-        accountantAddress: MOCK_ACCOUNTANT,
-        moneyAccountAddress: MOCK_MONEY_ACCOUNT_ADDRESS,
-        recipient: MOCK_RECIPIENT_ADDRESS,
-        provider: MOCK_PROVIDER,
-      });
-
-      expect(result.withdrawTx.type).toBe(TransactionType.moneyAccountWithdraw);
-      expect(result.withdrawTx.params.to).toBe(MOCK_TELLER);
-      expect(result.withdrawTx.params.value).toBe('0x0');
-
-      expect(result.transferTx.type).toBe(TransactionType.tokenMethodTransfer);
-      expect(result.transferTx.params.value).toBe('0x0');
-    });
-
-    it('transferTx targets the USDC contract address', async () => {
-      mockGetRate.mockResolvedValue(ethers.BigNumber.from('1000000'));
-
-      const result = await buildMoneyAccountWithdrawBatch({
-        amount: BigInt(1_000_000),
-        chainId: MOCK_CHAIN_ID,
-        tellerAddress: MOCK_TELLER,
-        accountantAddress: MOCK_ACCOUNTANT,
-        moneyAccountAddress: MOCK_MONEY_ACCOUNT_ADDRESS,
-        recipient: MOCK_RECIPIENT_ADDRESS,
-        provider: MOCK_PROVIDER,
-      });
-
-      // transferTx.to is the ERC-20 token contract (USDC), not the recipient
-      expect(result.transferTx.params.to).not.toBe(MOCK_RECIPIENT_ADDRESS);
-      expect(result.transferTx.params.to.startsWith('0x')).toBe(true);
-    });
-
-    it('encodes both withdraw and transfer data as hex strings', async () => {
-      mockGetRate.mockResolvedValue(ethers.BigNumber.from('1000000'));
-
-      const result = await buildMoneyAccountWithdrawBatch({
-        amount: BigInt(1_000_000),
-        chainId: MOCK_CHAIN_ID,
-        tellerAddress: MOCK_TELLER,
-        accountantAddress: MOCK_ACCOUNTANT,
-        moneyAccountAddress: MOCK_MONEY_ACCOUNT_ADDRESS,
-        recipient: MOCK_RECIPIENT_ADDRESS,
-        provider: MOCK_PROVIDER,
-      });
-
-      expect(result.withdrawTx.params.data).toBeDefined();
-      expect(result.withdrawTx.params.data?.startsWith('0x')).toBe(true);
-
-      expect(result.transferTx.params.data).toBeDefined();
-      expect(result.transferTx.params.data?.startsWith('0x')).toBe(true);
-    });
-
-    it('calls getRate on the accountant contract', async () => {
-      mockGetRate.mockResolvedValue(ethers.BigNumber.from('2000000'));
-
-      await buildMoneyAccountWithdrawBatch({
-        amount: BigInt(1_000_000),
-        chainId: MOCK_CHAIN_ID,
-        tellerAddress: MOCK_TELLER,
-        accountantAddress: MOCK_ACCOUNTANT,
-        moneyAccountAddress: MOCK_MONEY_ACCOUNT_ADDRESS,
-        recipient: MOCK_RECIPIENT_ADDRESS,
-        provider: MOCK_PROVIDER,
-      });
-
-      expect(mockGetRate).toHaveBeenCalledTimes(1);
-    });
-
-    it('skips getRate when amount is 0 (placeholder batch)', async () => {
-      const result = await buildMoneyAccountWithdrawBatch({
-        amount: BigInt(0),
-        chainId: MOCK_CHAIN_ID,
-        tellerAddress: MOCK_TELLER,
-        accountantAddress: MOCK_ACCOUNTANT,
-        moneyAccountAddress: MOCK_MONEY_ACCOUNT_ADDRESS,
-        recipient: MOCK_RECIPIENT_ADDRESS,
-        provider: MOCK_PROVIDER,
-      });
-
-      expect(mockGetRate).not.toHaveBeenCalled();
-      expect(result.withdrawTx.params.data?.startsWith('0x')).toBe(true);
-      expect(result.transferTx.params.data?.startsWith('0x')).toBe(true);
-    });
-
-    it('encodes the recipient address in the transfer calldata', async () => {
-      mockGetRate.mockResolvedValue(ethers.BigNumber.from('1000000'));
-
-      const result = await buildMoneyAccountWithdrawBatch({
-        amount: BigInt(1_000_000),
-        chainId: MOCK_CHAIN_ID,
-        tellerAddress: MOCK_TELLER,
-        accountantAddress: MOCK_ACCOUNTANT,
-        moneyAccountAddress: MOCK_MONEY_ACCOUNT_ADDRESS,
-        recipient: MOCK_RECIPIENT_ADDRESS,
-        provider: MOCK_PROVIDER,
-      });
-
-      // The recipient address (lowercased, without 0x prefix) should appear in the calldata
-      expect(result.transferTx.params.data?.toLowerCase()).toContain(
-        MOCK_RECIPIENT_ADDRESS.toLowerCase().slice(2),
-      );
-    });
-
-    it('encodes minimumAssets as amount - 1 for defense-in-depth', async () => {
-      mockGetRate.mockResolvedValue(ethers.BigNumber.from('1000000'));
-
-      const amount = BigInt(1_960_000);
-      const result = await buildMoneyAccountWithdrawBatch({
-        amount,
-        chainId: MOCK_CHAIN_ID,
-        tellerAddress: MOCK_TELLER,
-        accountantAddress: MOCK_ACCOUNTANT,
-        moneyAccountAddress: MOCK_MONEY_ACCOUNT_ADDRESS,
-        recipient: MOCK_RECIPIENT_ADDRESS,
-        provider: MOCK_PROVIDER,
-      });
-
-      // Decode withdraw calldata to verify minimumAssets = amount - 1
-      const iface = new ethers.utils.Interface([
-        'function withdraw(address withdrawAsset, uint256 shareAmount, uint256 minimumAssets, address to) returns (uint256 assetsOut)',
-      ]);
-      const withdrawData = result.withdrawTx.params.data;
-      if (!withdrawData) throw new Error('Expected withdraw data');
-      const decoded = iface.decodeFunctionData('withdraw', withdrawData);
-      const encodedMinimumAssets = BigInt(decoded.minimumAssets.toString());
-      expect(encodedMinimumAssets).toBe(amount - 1n);
-    });
-
-    it('encodes minimumAssets as 0 when amount is 0 (placeholder batch)', async () => {
-      const result = await buildMoneyAccountWithdrawBatch({
-        amount: BigInt(0),
-        chainId: MOCK_CHAIN_ID,
-        tellerAddress: MOCK_TELLER,
-        accountantAddress: MOCK_ACCOUNTANT,
-        moneyAccountAddress: MOCK_MONEY_ACCOUNT_ADDRESS,
-        recipient: MOCK_RECIPIENT_ADDRESS,
-        provider: MOCK_PROVIDER,
-      });
-
-      const iface = new ethers.utils.Interface([
-        'function withdraw(address withdrawAsset, uint256 shareAmount, uint256 minimumAssets, address to) returns (uint256 assetsOut)',
-      ]);
-      const withdrawData = result.withdrawTx.params.data;
-      if (!withdrawData) throw new Error('Expected withdraw data');
-      const decoded = iface.decodeFunctionData('withdraw', withdrawData);
-      expect(BigInt(decoded.minimumAssets.toString())).toBe(0n);
-    });
-
-    it('uses ceiling division for shareAmount in withdraw calldata', async () => {
-      // Use a rate that produces a remainder to verify ceiling division
-      mockGetRate.mockResolvedValue(ethers.BigNumber.from('1000094'));
-
-      const amount = BigInt(1_960_000);
-      const result = await buildMoneyAccountWithdrawBatch({
-        amount,
-        chainId: MOCK_CHAIN_ID,
-        tellerAddress: MOCK_TELLER,
-        accountantAddress: MOCK_ACCOUNTANT,
-        moneyAccountAddress: MOCK_MONEY_ACCOUNT_ADDRESS,
-        recipient: MOCK_RECIPIENT_ADDRESS,
-        provider: MOCK_PROVIDER,
-      });
-
-      const iface = new ethers.utils.Interface([
-        'function withdraw(address withdrawAsset, uint256 shareAmount, uint256 minimumAssets, address to) returns (uint256 assetsOut)',
-      ]);
-      const withdrawData = result.withdrawTx.params.data;
-      if (!withdrawData) throw new Error('Expected withdraw data');
-      const decoded = iface.decodeFunctionData('withdraw', withdrawData);
-      const shareAmount = BigInt(decoded.shareAmount.toString());
-
-      // With ceiling division: (1_960_000 * 1_000_000 + 1_000_094 - 1) / 1_000_094 = 1_959_816
-      // Old floor division would give 1_959_815
-      expect(shareAmount).toBe(BigInt(1_959_816));
+      expect(
+        await updateMoneyAccountWithdrawTokenAmount(
+          MOCK_TRANSACTION_META,
+          '10.5',
+        ),
+      ).toStrictEqual([]);
+      expect(mockBuildWithdrawBatch).not.toHaveBeenCalled();
     });
   });
 
   describe('getMoneyAccountDepositTransactionsData', () => {
-    beforeEach(() => {
-      mockGetProviderByChainId.mockReturnValue(MOCK_PROVIDER as never);
-      mockSelectMoneyAccountVaultConfig.mockReturnValue(MOCK_VAULT_CONFIG);
-      (
-        jest.mocked(ReduxService) as unknown as {
-          store: { getState: jest.Mock };
-        }
-      ).store = { getState: jest.fn().mockReturnValue({}) };
-    });
-
-    it('returns two transaction param objects for a valid amount', async () => {
-      mockPreviewDeposit.mockResolvedValue(ethers.BigNumber.from('1000000'));
-
+    it('returns the approve and deposit params', async () => {
       const result = await getMoneyAccountDepositTransactionsData(
         MOCK_CHAIN_ID,
-        '1.0',
+        '10.5',
       );
 
-      expect(result).toHaveLength(2);
-      expect(result[0]).toMatchObject({
-        to: expect.any(String),
-        data: expect.stringMatching(/^0x/),
-        value: '0x0',
-      });
-      expect(result[1]).toMatchObject({
-        to: expect.any(String),
-        data: expect.stringMatching(/^0x/),
-        value: '0x0',
-      });
+      expect(result).toStrictEqual([
+        DEPOSIT_BATCH.approveTx.params,
+        DEPOSIT_BATCH.depositTx.params,
+      ]);
     });
 
-    it('returns [] when vault config is missing', async () => {
-      mockSelectMoneyAccountVaultConfig.mockReturnValue(undefined);
+    it('forwards the converted amount to the builder', async () => {
+      await getMoneyAccountDepositTransactionsData(MOCK_CHAIN_ID, '10.5');
 
-      const result = await getMoneyAccountDepositTransactionsData(
-        MOCK_CHAIN_ID,
-        '1.0',
-      );
-
-      expect(result).toEqual([]);
-      expect(mockPreviewDeposit).not.toHaveBeenCalled();
-    });
-
-    it('returns [] when provider is missing', async () => {
-      mockGetProviderByChainId.mockReturnValue(undefined as never);
-
-      const result = await getMoneyAccountDepositTransactionsData(
-        MOCK_CHAIN_ID,
-        '1.0',
-      );
-
-      expect(result).toEqual([]);
-      expect(mockPreviewDeposit).not.toHaveBeenCalled();
-    });
-
-    it('calls previewDeposit with the converted token amount', async () => {
-      mockPreviewDeposit.mockResolvedValue(ethers.BigNumber.from('1000000'));
-
-      await getMoneyAccountDepositTransactionsData(MOCK_CHAIN_ID, '1.0');
-
-      // 1.0 with 6 decimals = 1_000_000
-      expect(mockPreviewDeposit).toHaveBeenCalledWith(
-        expect.any(String),
-        '1000000',
-        MOCK_VAULT_CONFIG.boringVault,
-        MOCK_VAULT_CONFIG.accountantAddress,
-      );
-    });
-
-    it('propagates RPC errors', async () => {
-      mockPreviewDeposit.mockRejectedValue(new Error('RPC timeout'));
-
-      await expect(
-        getMoneyAccountDepositTransactionsData(MOCK_CHAIN_ID, '1.0'),
-      ).rejects.toThrow('RPC timeout');
-    });
-  });
-
-  describe('getMoneyAccountWithdrawTransactionsData', () => {
-    const mockGetState = jest.mocked(ReduxService).store.getState as jest.Mock;
-    const mockSelectVaultConfig = jest.mocked(selectMoneyAccountVaultConfig);
-    const mockSelectPrimaryMoneyAccount = jest.mocked(
-      selectPrimaryMoneyAccount,
-    );
-    const mockGetProvider = jest.mocked(getProviderByChainId);
-
-    const MOCK_MONEY_ACCOUNT_ADDRESS =
-      '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as Hex;
-    const MOCK_RECIPIENT = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Hex;
-
-    beforeEach(() => {
-      mockGetState.mockReturnValue({});
-      mockSelectVaultConfig.mockReturnValue(MOCK_VAULT_CONFIG);
-      mockSelectPrimaryMoneyAccount.mockReturnValue({
-        address: MOCK_MONEY_ACCOUNT_ADDRESS,
-      } as ReturnType<typeof selectPrimaryMoneyAccount>);
-      mockGetProvider.mockReturnValue(
-        MOCK_PROVIDER as ReturnType<typeof getProviderByChainId>,
-      );
-      mockGetRate.mockResolvedValue(ethers.BigNumber.from('1000000'));
-    });
-
-    it('returns two transaction param objects for a valid amount', async () => {
-      const result = await getMoneyAccountWithdrawTransactionsData(
-        MOCK_CHAIN_ID,
-        '1.0',
-        MOCK_RECIPIENT,
-      );
-
-      expect(result).toHaveLength(2);
-      expect(result[0]).toMatchObject({
-        to: expect.any(String),
-        data: expect.stringMatching(/^0x/),
-        value: '0x0',
-      });
-      expect(result[1]).toMatchObject({
-        to: expect.any(String),
-        data: expect.stringMatching(/^0x/),
-        value: '0x0',
-      });
-    });
-
-    it('encodes the recipient address in the transfer calldata', async () => {
-      const result = await getMoneyAccountWithdrawTransactionsData(
-        MOCK_CHAIN_ID,
-        '1.0',
-        MOCK_RECIPIENT,
-      );
-
-      expect(result[1].data?.toLowerCase()).toContain(
-        MOCK_RECIPIENT.toLowerCase().slice(2),
+      expect(mockBuildDepositBatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amount: BigInt(10_500_000),
+          chainId: MOCK_CHAIN_ID,
+        }),
       );
     });
 
     it('returns [] when vault config is missing', async () => {
       mockSelectVaultConfig.mockReturnValue(undefined);
 
-      const result = await getMoneyAccountWithdrawTransactionsData(
-        MOCK_CHAIN_ID,
-        '1.0',
-        MOCK_RECIPIENT,
-      );
-
-      expect(result).toEqual([]);
-      expect(mockGetRate).not.toHaveBeenCalled();
+      expect(
+        await getMoneyAccountDepositTransactionsData(MOCK_CHAIN_ID, '10.5'),
+      ).toStrictEqual([]);
     });
 
-    it('returns [] when primary money account is missing', async () => {
-      mockSelectPrimaryMoneyAccount.mockReturnValue(undefined);
+    it('returns [] when no provider is available for the chain', async () => {
+      mockGetProviderByChainId.mockReturnValue(undefined as never);
 
-      const result = await getMoneyAccountWithdrawTransactionsData(
-        MOCK_CHAIN_ID,
-        '1.0',
-        MOCK_RECIPIENT,
-      );
-
-      expect(result).toEqual([]);
-      expect(mockGetRate).not.toHaveBeenCalled();
+      expect(
+        await getMoneyAccountDepositTransactionsData(MOCK_CHAIN_ID, '10.5'),
+      ).toStrictEqual([]);
     });
 
-    it('returns [] when provider is missing', async () => {
-      mockGetProvider.mockReturnValue(
-        undefined as unknown as ReturnType<typeof getProviderByChainId>,
-      );
+    it('propagates builder errors', async () => {
+      mockBuildDepositBatch.mockRejectedValue(new Error('RPC down'));
 
+      await expect(
+        getMoneyAccountDepositTransactionsData(MOCK_CHAIN_ID, '10.5'),
+      ).rejects.toThrow('RPC down');
+    });
+  });
+
+  describe('getMoneyAccountWithdrawTransactionsData', () => {
+    it('returns the withdraw and transfer params', async () => {
       const result = await getMoneyAccountWithdrawTransactionsData(
         MOCK_CHAIN_ID,
-        '1.0',
-        MOCK_RECIPIENT,
+        '10.5',
       );
 
-      expect(result).toEqual([]);
-      expect(mockGetRate).not.toHaveBeenCalled();
+      expect(result).toStrictEqual([
+        WITHDRAW_BATCH.withdrawTx.params,
+        WITHDRAW_BATCH.transferTx.params,
+      ]);
+    });
+
+    it('uses recipientOverride when provided', async () => {
+      await getMoneyAccountWithdrawTransactionsData(
+        MOCK_CHAIN_ID,
+        '10.5',
+        MOCK_RECIPIENT_OVERRIDE,
+      );
+
+      expect(mockBuildWithdrawBatch).toHaveBeenCalledWith(
+        expect.objectContaining({ recipient: MOCK_RECIPIENT_OVERRIDE }),
+      );
+    });
+
+    it('falls back to the selected EVM address when no override is given', async () => {
+      await getMoneyAccountWithdrawTransactionsData(MOCK_CHAIN_ID, '10.5');
+
+      expect(mockBuildWithdrawBatch).toHaveBeenCalledWith(
+        expect.objectContaining({ recipient: MOCK_EVM_ADDRESS }),
+      );
+    });
+
+    it('returns [] when vault config is missing', async () => {
+      mockSelectVaultConfig.mockReturnValue(undefined);
+
+      expect(
+        await getMoneyAccountWithdrawTransactionsData(MOCK_CHAIN_ID, '10.5'),
+      ).toStrictEqual([]);
+    });
+
+    it('returns [] when the primary money account is missing', async () => {
+      mockSelectPrimaryMoneyAccount.mockReturnValue(undefined as never);
+
+      expect(
+        await getMoneyAccountWithdrawTransactionsData(MOCK_CHAIN_ID, '10.5'),
+      ).toStrictEqual([]);
+    });
+
+    it('returns [] when no provider is available for the chain', async () => {
+      mockGetProviderByChainId.mockReturnValue(undefined as never);
+
+      expect(
+        await getMoneyAccountWithdrawTransactionsData(MOCK_CHAIN_ID, '10.5'),
+      ).toStrictEqual([]);
     });
   });
 });

--- a/app/components/UI/Money/utils/moneyAccountTransactions.test.ts
+++ b/app/components/UI/Money/utils/moneyAccountTransactions.test.ts
@@ -164,14 +164,14 @@ describe('moneyAccountTransactions', () => {
       });
     });
 
-    it('rounds the amount up to the next base unit', async () => {
+    it('rounds the amount down to the previous base unit', async () => {
       await updateMoneyAccountDepositTokenAmount(
         MOCK_TRANSACTION_META,
         '1.0000005',
       );
 
       expect(mockBuildDepositBatch).toHaveBeenCalledWith(
-        expect.objectContaining({ amount: BigInt(1_000_001) }),
+        expect.objectContaining({ amount: BigInt(1_000_000) }),
       );
     });
 
@@ -223,15 +223,14 @@ describe('moneyAccountTransactions', () => {
       },
     );
 
-    it('still encodes a sub-base-unit amount, which rounds up to 1', async () => {
-      await updateMoneyAccountDepositTokenAmount(
-        MOCK_TRANSACTION_META,
-        '0.0000001',
-      );
-
-      expect(mockBuildDepositBatch).toHaveBeenCalledWith(
-        expect.objectContaining({ amount: BigInt(1) }),
-      );
+    it('no-ops for a sub-base-unit amount, which rounds down to 0', async () => {
+      expect(
+        await updateMoneyAccountDepositTokenAmount(
+          MOCK_TRANSACTION_META,
+          '0.0000001',
+        ),
+      ).toStrictEqual([]);
+      expect(mockBuildDepositBatch).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Money/utils/moneyAccountTransactions.test.ts
+++ b/app/components/UI/Money/utils/moneyAccountTransactions.test.ts
@@ -206,6 +206,33 @@ describe('moneyAccountTransactions', () => {
         updateMoneyAccountDepositTokenAmount(MOCK_TRANSACTION_META, '10.5'),
       ).rejects.toThrow('RPC down');
     });
+
+    it.each(['0', '0.00'])(
+      'no-ops without calling the builder for the zero amount %p',
+      async (amountHuman) => {
+        // Pay pushes every amount change, including a cleared field. The builder
+        // rejects zero rather than encode a deposit that mints nothing, so there
+        // must be nothing left to re-encode by the time we call it.
+        expect(
+          await updateMoneyAccountDepositTokenAmount(
+            MOCK_TRANSACTION_META,
+            amountHuman,
+          ),
+        ).toStrictEqual([]);
+        expect(mockBuildDepositBatch).not.toHaveBeenCalled();
+      },
+    );
+
+    it('still encodes a sub-base-unit amount, which rounds up to 1', async () => {
+      await updateMoneyAccountDepositTokenAmount(
+        MOCK_TRANSACTION_META,
+        '0.0000001',
+      );
+
+      expect(mockBuildDepositBatch).toHaveBeenCalledWith(
+        expect.objectContaining({ amount: BigInt(1) }),
+      );
+    });
   });
 
   describe('updateMoneyAccountWithdrawTokenAmount', () => {
@@ -294,6 +321,14 @@ describe('moneyAccountTransactions', () => {
       ).toStrictEqual([]);
       expect(mockBuildWithdrawBatch).not.toHaveBeenCalled();
     });
+
+    it('no-ops without calling the builder for a zero amount', async () => {
+      // The builder rejects zero rather than encode a zero-share redemption.
+      expect(
+        await updateMoneyAccountWithdrawTokenAmount(MOCK_TRANSACTION_META, '0'),
+      ).toStrictEqual([]);
+      expect(mockBuildWithdrawBatch).not.toHaveBeenCalled();
+    });
   });
 
   describe('getMoneyAccountDepositTransactionsData', () => {
@@ -342,6 +377,13 @@ describe('moneyAccountTransactions', () => {
       await expect(
         getMoneyAccountDepositTransactionsData(MOCK_CHAIN_ID, '10.5'),
       ).rejects.toThrow('RPC down');
+    });
+
+    it('returns [] without calling the builder for a zero amount', async () => {
+      expect(
+        await getMoneyAccountDepositTransactionsData(MOCK_CHAIN_ID, '0'),
+      ).toStrictEqual([]);
+      expect(mockBuildDepositBatch).not.toHaveBeenCalled();
     });
   });
 
@@ -400,6 +442,22 @@ describe('moneyAccountTransactions', () => {
       expect(
         await getMoneyAccountWithdrawTransactionsData(MOCK_CHAIN_ID, '10.5'),
       ).toStrictEqual([]);
+    });
+
+    it('returns [] when there is no recipient', async () => {
+      mockSelectEvmAddress.mockReturnValue(undefined as never);
+
+      expect(
+        await getMoneyAccountWithdrawTransactionsData(MOCK_CHAIN_ID, '10.5'),
+      ).toStrictEqual([]);
+      expect(mockBuildWithdrawBatch).not.toHaveBeenCalled();
+    });
+
+    it('returns [] without calling the builder for a zero amount', async () => {
+      expect(
+        await getMoneyAccountWithdrawTransactionsData(MOCK_CHAIN_ID, '0'),
+      ).toStrictEqual([]);
+      expect(mockBuildWithdrawBatch).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Money/utils/moneyAccountTransactions.ts
+++ b/app/components/UI/Money/utils/moneyAccountTransactions.ts
@@ -31,6 +31,21 @@ function toMusdBaseUnits(amountHuman: string): bigint {
 }
 
 /**
+ * Converts a human-readable amount to mUSD base units, treating zero as absent.
+ *
+ * The amount arrives from Pay whenever the confirmation's amount changes, which
+ * includes the user clearing the field. There is nothing to re-encode for a zero
+ * amount, and the vault builders reject it rather than encode a call that cannot
+ * succeed, so callers no-op instead.
+ * @param amountHuman - Human-readable amount.
+ * @returns The amount in mUSD base units, or `undefined` if it is zero.
+ */
+function toNonZeroMusdBaseUnits(amountHuman: string): bigint | undefined {
+  const amount = toMusdBaseUnits(amountHuman);
+  return amount === 0n ? undefined : amount;
+}
+
+/**
  * Returns the per-nested-call data updates required when the user changes
  * the deposit amount on a Money Account deposit confirmation.
  *
@@ -50,6 +65,9 @@ export async function updateMoneyAccountDepositTokenAmount(
     ReduxService.store.getState() as RootState,
   );
   if (!vaultConfig) return [];
+
+  const amount = toNonZeroMusdBaseUnits(amountHuman);
+  if (amount === undefined) return [];
 
   const chainIdHex = transactionMeta.chainId as Hex;
   const provider = getProviderByChainId(chainIdHex);
@@ -97,12 +115,15 @@ export async function updateMoneyAccountWithdrawTokenAmount(
   const recipient = recipientOverride ?? selectEvmAddress(state);
   if (!vaultConfig || !primaryMoneyAccount?.address || !recipient) return [];
 
+  const amount = toNonZeroMusdBaseUnits(amountHuman);
+  if (amount === undefined) return [];
+
   const chainIdHex = transactionMeta.chainId as Hex;
   const provider = getProviderByChainId(chainIdHex);
   if (!provider) return [];
 
   const { withdrawTx, transferTx } = await buildMoneyAccountWithdrawBatch({
-    amount: toMusdBaseUnits(amountHuman),
+    amount,
     chainId: chainIdHex,
     tellerAddress: vaultConfig.tellerAddress,
     accountantAddress: vaultConfig.accountantAddress,
@@ -133,11 +154,14 @@ export async function getMoneyAccountDepositTransactionsData(
   );
   if (!vaultConfig) return [];
 
+  const amount = toNonZeroMusdBaseUnits(amountHuman);
+  if (amount === undefined) return [];
+
   const provider = getProviderByChainId(chainId);
   if (!provider) return [];
 
   const { approveTx, depositTx } = await buildMoneyAccountDepositBatch({
-    amount: toMusdBaseUnits(amountHuman),
+    amount,
     chainId,
     boringVault: vaultConfig.boringVault,
     tellerAddress: vaultConfig.tellerAddress,
@@ -169,11 +193,14 @@ export async function getMoneyAccountWithdrawTransactionsData(
   const recipient = recipientOverride ?? selectEvmAddress(state);
   if (!vaultConfig || !primaryMoneyAccount?.address || !recipient) return [];
 
+  const amount = toNonZeroMusdBaseUnits(amountHuman);
+  if (amount === undefined) return [];
+
   const provider = getProviderByChainId(chainId);
   if (!provider) return [];
 
   const { withdrawTx, transferTx } = await buildMoneyAccountWithdrawBatch({
-    amount: toMusdBaseUnits(amountHuman),
+    amount,
     chainId,
     tellerAddress: vaultConfig.tellerAddress,
     accountantAddress: vaultConfig.accountantAddress,

--- a/app/components/UI/Money/utils/moneyAccountTransactions.ts
+++ b/app/components/UI/Money/utils/moneyAccountTransactions.ts
@@ -1,18 +1,13 @@
-import { ethers } from 'ethers';
 import BigNumber from 'bignumber.js';
+import { TransactionMeta } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
 import {
-  CHAIN_IDS,
-  TransactionMeta,
-  TransactionType,
-} from '@metamask/transaction-controller';
-import { CaipAssetType, Hex } from '@metamask/utils';
+  buildMoneyAccountDepositBatch,
+  buildMoneyAccountWithdrawBatch,
+  type MoneyAccountTxParams,
+} from '@metamask/money-account-utils';
 import { UpdateTransactionPayAmountCall } from '../../../Views/confirmations/types/transactions';
-import {
-  MUSD_DECIMALS,
-  MUSD_TOKEN_ADDRESS_BY_CHAIN,
-  MUSD_TOKEN_ASSET_ID_BY_CHAIN,
-} from '../../Earn/constants/musd';
-import AppConstants from '../../../../core/AppConstants';
+import { MUSD_DECIMALS } from '../../Earn/constants/musd';
 import ReduxService from '../../../../core/redux/ReduxService';
 import { RootState } from '../../../../reducers';
 import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlagController/moneyAccount';
@@ -21,213 +16,18 @@ import { selectEvmAddress } from '../../../../selectors/accountsController';
 import { getProviderByChainId } from '../../../../util/notifications/methods/common';
 import { calcTokenValue } from '../../../../util/transactions';
 
-const LENS_ABI = [
-  'function previewDeposit(address depositAsset, uint256 depositAmount, address boringVault, address accountant) view returns (uint256 shares)',
-];
-
-export const TELLER_ABI = [
-  'function deposit(address depositAsset, uint256 depositAmount, uint256 minimumMint, address referralAddress) payable returns (uint256 shares)',
-  'function withdraw(address withdrawAsset, uint256 shareAmount, uint256 minimumAssets, address to) returns (uint256 assetsOut)',
-];
-
-const ACCOUNTANT_ABI = ['function getRate() view returns (uint256 rate)'];
-
-const ERC20_ABI = [
-  'function approve(address spender, uint256 amount)',
-  'function transfer(address to, uint256 amount)',
-];
-
-// -- Shared constants ------------------------------------------------------
-
-const SLIPPAGE_NUMERATOR = BigInt(998);
-const SLIPPAGE_DENOMINATOR = BigInt(1000);
-
 /**
- * Applies a 0.2% slippage tolerance to a bigint value.
- * If this sanity-check causes a revert, no funds are lost — retry with a fresh quote.
+ * Converts a human-readable amount (e.g. "10.5") to mUSD base units, rounding
+ * up so the user is never short of the amount they asked for.
+ * @param amountHuman - Human-readable amount.
+ * @returns The amount in mUSD base units.
  */
-export function applySlippage(value: bigint): bigint {
-  return (value * SLIPPAGE_NUMERATOR) / SLIPPAGE_DENOMINATOR;
-}
-
-// -- Shared types ----------------------------------------------------------
-
-export interface MoneyAccountTxParams {
-  params: {
-    to: Hex;
-    data?: Hex;
-    value: Hex;
-  };
-  type: TransactionType;
-}
-
-/**
- * Result shape for Money Account transaction batch builders. The string keys
- * (e.g. `approveTx`, `withdrawTx`) name each call so callers don't depend on
- * positional ordering in `addTransactionBatch.transactions[]`.
- */
-type MoneyAccountBatchResult<TxKey extends string> = Record<
-  TxKey,
-  MoneyAccountTxParams
->;
-
-// -- Deposit helpers -------------------------------------------------------
-
-async function getExpectedDepositShares({
-  lensAddress,
-  boringVault,
-  accountantAddress,
-  musdAddress,
-  amount,
-  provider,
-}: {
-  lensAddress: string;
-  boringVault: string;
-  accountantAddress: string;
-  musdAddress: string;
-  amount: bigint;
-  provider: ethers.providers.Provider;
-}): Promise<bigint> {
-  const lensContract = new ethers.Contract(lensAddress, LENS_ABI, provider);
-  const shares = await lensContract.previewDeposit(
-    musdAddress,
-    amount.toString(),
-    boringVault,
-    accountantAddress,
+function toMusdBaseUnits(amountHuman: string): bigint {
+  return BigInt(
+    calcTokenValue(amountHuman, MUSD_DECIMALS)
+      .decimalPlaces(0, BigNumber.ROUND_UP)
+      .toFixed(0),
   );
-  return BigInt(shares.toString());
-}
-
-function buildApproveData(boringVault: string, amount: bigint): Hex {
-  const iface = new ethers.utils.Interface(ERC20_ABI);
-  return iface.encodeFunctionData('approve', [
-    boringVault,
-    amount.toString(),
-  ]) as Hex;
-}
-
-function buildErc20TransferData(to: string, amount: bigint): Hex {
-  const iface = new ethers.utils.Interface(ERC20_ABI);
-  return iface.encodeFunctionData('transfer', [to, amount.toString()]) as Hex;
-}
-
-function buildDepositData(
-  musdAddress: string,
-  amount: bigint,
-  minimumMint: bigint,
-): Hex {
-  const iface = new ethers.utils.Interface(TELLER_ABI);
-  return iface.encodeFunctionData('deposit', [
-    musdAddress,
-    amount.toString(),
-    minimumMint.toString(),
-    AppConstants.ZERO_ADDRESS,
-  ]) as Hex;
-}
-
-/**
- * Single source of truth for the deposit asset so both calldata encoding
- * (`buildMoneyAccountDepositBatch`) and Pay's `requiredAssets` agree.
- * @param _chainId - The chain ID to get the deposit asset address for.
- * @returns The deposit asset address for the given chain ID.
- */
-export function getMoneyAccountDepositAssetAddress(chainId: Hex): Hex {
-  const musdAddress = MUSD_TOKEN_ADDRESS_BY_CHAIN[chainId];
-  if (!musdAddress) {
-    throw new Error(`mUSD not deployed on chain ${chainId}`);
-  }
-  return musdAddress;
-}
-
-/**
- * Resolves the CAIP-19 asset id of the Money Account deposit asset (mUSD) for a
- * given chain. Pure mapping over `MUSD_TOKEN_ASSET_ID_BY_CHAIN`.
- *
- * Money Account is Monad-only today, so an unknown or undefined `chainId` falls
- * back to the Monad mUSD asset id rather than throwing — the entry-point gate
- * that consumes this should still resolve against the asset the deposit flow
- * actually targets.
- * @param chainId - The chain ID to get the deposit asset id for.
- * @returns The CAIP-19 asset id of the deposit asset for the given chain ID.
- */
-export function getMoneyAccountDepositAssetId(chainId?: Hex): CaipAssetType {
-  return (MUSD_TOKEN_ASSET_ID_BY_CHAIN[chainId as Hex] ??
-    MUSD_TOKEN_ASSET_ID_BY_CHAIN[CHAIN_IDS.MONAD]) as CaipAssetType;
-}
-
-export type MoneyAccountDepositBatchResult = MoneyAccountBatchResult<
-  'approveTx' | 'depositTx'
->;
-
-/**
- * Builds the approve + deposit transaction pair for a Money Account deposit.
- *
- * 1. Calls `previewDeposit` on the lens contract to get expected vault shares.
- * 2. Applies a 0.2% slippage tolerance to derive `minimumMint`.
- * 3. Encodes ERC-20 `approve(boringVault, amount)` on the mUSD token.
- * 4. Encodes `deposit(mUSD, amount, minimumMint, 0x0)` on the teller contract.
- */
-export async function buildMoneyAccountDepositBatch({
-  amount,
-  chainId,
-  boringVault,
-  tellerAddress,
-  accountantAddress,
-  lensAddress,
-  provider,
-  initialiseWithoutData = false,
-}: {
-  amount: bigint;
-  chainId: Hex;
-  boringVault: string;
-  tellerAddress: string;
-  accountantAddress: string;
-  lensAddress: string;
-  provider: ethers.providers.Provider;
-  initialiseWithoutData?: boolean;
-}): Promise<MoneyAccountDepositBatchResult> {
-  const musdAddress = getMoneyAccountDepositAssetAddress(chainId);
-
-  // Skip the RPC call for zero-amount placeholder batches (e.g. initial deposit submission).
-  const minimumMint =
-    amount === 0n
-      ? 0n
-      : applySlippage(
-          await getExpectedDepositShares({
-            lensAddress,
-            boringVault,
-            accountantAddress,
-            musdAddress,
-            amount,
-            provider,
-          }),
-        );
-
-  const approveData = initialiseWithoutData
-    ? undefined
-    : buildApproveData(boringVault, amount);
-  const depositData = initialiseWithoutData
-    ? undefined
-    : buildDepositData(musdAddress, amount, minimumMint);
-
-  return {
-    approveTx: {
-      params: {
-        to: musdAddress,
-        data: approveData,
-        value: '0x0' as Hex,
-      },
-      type: TransactionType.tokenMethodApprove,
-    },
-    depositTx: {
-      params: {
-        to: tellerAddress as Hex,
-        data: depositData,
-        value: '0x0' as Hex,
-      },
-      type: TransactionType.moneyAccountDeposit,
-    },
-  };
 }
 
 /**
@@ -266,20 +66,16 @@ export async function updateMoneyAccountDepositTokenAmount(
   const { approveTx, depositTx } = await buildMoneyAccountDepositBatch({
     amount,
     chainId: chainIdHex,
-    boringVault: vaultConfig.boringVault,
-    tellerAddress: vaultConfig.tellerAddress,
-    accountantAddress: vaultConfig.accountantAddress,
-    lensAddress: vaultConfig.lensAddress,
+    boringVault: vaultConfig.boringVault as Hex,
+    tellerAddress: vaultConfig.tellerAddress as Hex,
+    accountantAddress: vaultConfig.accountantAddress as Hex,
+    lensAddress: vaultConfig.lensAddress as Hex,
     provider,
   });
 
-  const approveData = approveTx.params.data;
-  const depositData = depositTx.params.data;
-  if (!approveData || !depositData) return [];
-
   return [
-    { nestedTransactionIndex: 0, transactionData: approveData },
-    { nestedTransactionIndex: 1, transactionData: depositData },
+    { nestedTransactionIndex: 0, transactionData: approveTx.params.data },
+    { nestedTransactionIndex: 1, transactionData: depositTx.params.data },
   ];
 }
 
@@ -305,14 +101,8 @@ export async function updateMoneyAccountWithdrawTokenAmount(
   const provider = getProviderByChainId(chainIdHex);
   if (!provider) return [];
 
-  const amount = BigInt(
-    calcTokenValue(amountHuman, MUSD_DECIMALS)
-      .decimalPlaces(0, BigNumber.ROUND_UP)
-      .toFixed(0),
-  );
-
   const { withdrawTx, transferTx } = await buildMoneyAccountWithdrawBatch({
-    amount,
+    amount: toMusdBaseUnits(amountHuman),
     chainId: chainIdHex,
     tellerAddress: vaultConfig.tellerAddress as Hex,
     accountantAddress: vaultConfig.accountantAddress as Hex,
@@ -321,13 +111,9 @@ export async function updateMoneyAccountWithdrawTokenAmount(
     provider,
   });
 
-  const withdrawData = withdrawTx.params.data;
-  const transferData = transferTx.params.data;
-  if (!withdrawData || !transferData) return [];
-
   return [
-    { nestedTransactionIndex: 0, transactionData: withdrawData },
-    { nestedTransactionIndex: 1, transactionData: transferData },
+    { nestedTransactionIndex: 0, transactionData: withdrawTx.params.data },
+    { nestedTransactionIndex: 1, transactionData: transferTx.params.data },
   ];
 }
 
@@ -350,19 +136,13 @@ export async function getMoneyAccountDepositTransactionsData(
   const provider = getProviderByChainId(chainId);
   if (!provider) return [];
 
-  const amount = BigInt(
-    calcTokenValue(amountHuman, MUSD_DECIMALS)
-      .decimalPlaces(0, BigNumber.ROUND_UP)
-      .toFixed(0),
-  );
-
   const { approveTx, depositTx } = await buildMoneyAccountDepositBatch({
-    amount,
+    amount: toMusdBaseUnits(amountHuman),
     chainId,
-    boringVault: vaultConfig.boringVault,
-    tellerAddress: vaultConfig.tellerAddress,
-    accountantAddress: vaultConfig.accountantAddress,
-    lensAddress: vaultConfig.lensAddress,
+    boringVault: vaultConfig.boringVault as Hex,
+    tellerAddress: vaultConfig.tellerAddress as Hex,
+    accountantAddress: vaultConfig.accountantAddress as Hex,
+    lensAddress: vaultConfig.lensAddress as Hex,
     provider,
   });
 
@@ -374,7 +154,7 @@ export async function getMoneyAccountDepositTransactionsData(
  *
  * @param chainId - Chain ID in hex
  * @param amountHuman - Human-readable withdrawal amount (e.g. "10.5")
- * @param recipientOverride - Optional EVM address to receive the withdrawn USDC.
+ * @param recipientOverride - Optional EVM address to receive the withdrawn mUSD.
  * When omitted, defaults to the currently selected EVM account.
  * @returns `[withdrawTx.params, transferTx.params]`, or `[]` if vault config or provider is unavailable
  */
@@ -392,14 +172,8 @@ export async function getMoneyAccountWithdrawTransactionsData(
   const provider = getProviderByChainId(chainId);
   if (!provider) return [];
 
-  const amount = BigInt(
-    calcTokenValue(amountHuman, MUSD_DECIMALS)
-      .decimalPlaces(0, BigNumber.ROUND_UP)
-      .toFixed(0),
-  );
-
   const { withdrawTx, transferTx } = await buildMoneyAccountWithdrawBatch({
-    amount,
+    amount: toMusdBaseUnits(amountHuman),
     chainId,
     tellerAddress: vaultConfig.tellerAddress as Hex,
     accountantAddress: vaultConfig.accountantAddress as Hex,
@@ -409,134 +183,4 @@ export async function getMoneyAccountWithdrawTransactionsData(
   });
 
   return [withdrawTx.params, transferTx.params];
-}
-
-// -- Withdrawal helpers ----------------------------------------------------
-
-async function getVaultRate({
-  accountantAddress,
-  provider,
-}: {
-  accountantAddress: string;
-  provider: ethers.providers.Provider;
-}): Promise<bigint> {
-  const accountant = new ethers.Contract(
-    accountantAddress,
-    ACCOUNTANT_ABI,
-    provider,
-  );
-  const rate = await accountant.getRate();
-  return BigInt(rate.toString());
-}
-
-const SHARE_DECIMALS_SCALAR = BigInt(1_000_000);
-
-/**
- * Converts a USD asset amount (6 decimals) to vault shares given a pre-fetched rate.
- * Pure arithmetic — no I/O, safe to call directly inside workflows.
- *
- * Uses ceiling division so the contract's `mulDivDown(shares × rate / ONE_SHARE)`
- * always produces `assetsOut >= minimumAssets`. Floor division caused a double-
- * truncation bug where `assetsOut` could land 1 unit below `minimumAssets`,
- * reverting with `MinimumAssetsNotMet`.
- */
-export function getSharesForWithdrawal(amount: bigint, rate: bigint): bigint {
-  return (amount * SHARE_DECIMALS_SCALAR + rate - 1n) / rate;
-}
-
-function buildWithdrawData(
-  musdAddress: string,
-  shareAmount: bigint,
-  minimumAssets: bigint,
-  toAddress: string,
-): Hex {
-  const iface = new ethers.utils.Interface(TELLER_ABI);
-  return iface.encodeFunctionData('withdraw', [
-    musdAddress,
-    shareAmount.toString(),
-    minimumAssets.toString(),
-    toAddress,
-  ]) as Hex;
-}
-
-export type MoneyAccountWithdrawBatchResult = MoneyAccountBatchResult<
-  'withdrawTx' | 'transferTx'
->;
-
-/**
- * Builds the two-transaction withdrawal batch for a Money Account withdrawal.
- *
- * 1. Calls `getRate` on the accountant contract to get the current vault rate.
- * 2. Converts the asset amount to vault shares.
- * 3. Encodes `withdraw(mUSD, shareAmount, minimumAssets, moneyAccountAddress)` on the teller contract — USDC lands on the money account.
- * 4. Encodes `transfer(recipient, amount)` on the USDC contract — moves the exact requested USDC from the money account to the user's selected EVM account.
- *
- * When `amount === 0n` the rate fetch is skipped: the caller is encoding a
- * placeholder batch that MM Pay will re-encode via
- * `updateMoneyAccountWithdrawTokenAmount` once the user picks an amount.
- */
-export async function buildMoneyAccountWithdrawBatch({
-  amount,
-  chainId,
-  tellerAddress,
-  accountantAddress,
-  moneyAccountAddress,
-  recipient,
-  provider,
-}: {
-  amount: bigint;
-  chainId: Hex;
-  tellerAddress: Hex;
-  accountantAddress: Hex;
-  /** Address of the money account — vault sends USDC here first. */
-  moneyAccountAddress: Hex;
-  /** Address of the user's selected EVM account — receives the USDC transfer. */
-  recipient: Hex;
-  provider: ethers.providers.Provider;
-}): Promise<MoneyAccountWithdrawBatchResult> {
-  const musdAddress = getMoneyAccountDepositAssetAddress(chainId);
-
-  const shareAmount =
-    amount === BigInt(0)
-      ? BigInt(0)
-      : getSharesForWithdrawal(
-          amount,
-          await getVaultRate({ accountantAddress, provider }),
-        );
-  // Allow 1-unit slippage on minimumAssets as defense-in-depth against
-  // rounding: the contract's mulDivDown can truncate assetsOut by up to
-  // 1 unit relative to the requested amount. This tolerance is safe
-  // because ceiling division in getSharesForWithdrawal already guarantees
-  // assetsOut >= amount; the 1-unit slack here is a second line of
-  // defense, not a standalone fix. The subsequent ERC-20 transfer uses
-  // the original `amount`, so the tolerance does not affect how much the
-  // user receives — it only prevents a spurious revert from the teller's
-  // MinimumAssetsNotMet check.
-  const minimumAssets = amount > 0n ? amount - 1n : 0n;
-  const withdrawData = buildWithdrawData(
-    musdAddress,
-    shareAmount,
-    minimumAssets,
-    moneyAccountAddress,
-  );
-  const transferData = buildErc20TransferData(recipient, amount);
-
-  return {
-    withdrawTx: {
-      params: {
-        to: tellerAddress,
-        data: withdrawData,
-        value: '0x0' as Hex,
-      },
-      type: TransactionType.moneyAccountWithdraw,
-    },
-    transferTx: {
-      params: {
-        to: musdAddress,
-        data: transferData,
-        value: '0x0' as Hex,
-      },
-      type: TransactionType.tokenMethodTransfer,
-    },
-  };
 }

--- a/app/components/UI/Money/utils/moneyAccountTransactions.ts
+++ b/app/components/UI/Money/utils/moneyAccountTransactions.ts
@@ -17,15 +17,19 @@ import { getProviderByChainId } from '../../../../util/notifications/methods/com
 import { calcTokenValue } from '../../../../util/transactions';
 
 /**
- * Converts a human-readable amount (e.g. "10.5") to mUSD base units, rounding
- * up so the user is never short of the amount they asked for.
+ * Converts a human-readable amount (e.g. "10.5") to mUSD base units.
  * @param amountHuman - Human-readable amount.
+ * @param rounding - Rounding mode; defaults to `ROUND_UP` so the user is
+ * never short of the amount they asked for.
  * @returns The amount in mUSD base units.
  */
-function toMusdBaseUnits(amountHuman: string): bigint {
+function toMusdBaseUnits(
+  amountHuman: string,
+  rounding: BigNumber.RoundingMode = BigNumber.ROUND_UP,
+): bigint {
   return BigInt(
     calcTokenValue(amountHuman, MUSD_DECIMALS)
-      .decimalPlaces(0, BigNumber.ROUND_UP)
+      .decimalPlaces(0, rounding)
       .toFixed(0),
   );
 }
@@ -38,10 +42,14 @@ function toMusdBaseUnits(amountHuman: string): bigint {
  * amount, and the vault builders reject it rather than encode a call that cannot
  * succeed, so callers no-op instead.
  * @param amountHuman - Human-readable amount.
+ * @param rounding - Rounding mode passed through to {@link toMusdBaseUnits}.
  * @returns The amount in mUSD base units, or `undefined` if it is zero.
  */
-function toNonZeroMusdBaseUnits(amountHuman: string): bigint | undefined {
-  const amount = toMusdBaseUnits(amountHuman);
+function toNonZeroMusdBaseUnits(
+  amountHuman: string,
+  rounding?: BigNumber.RoundingMode,
+): bigint | undefined {
+  const amount = toMusdBaseUnits(amountHuman, rounding);
   return amount === 0n ? undefined : amount;
 }
 
@@ -66,20 +74,14 @@ export async function updateMoneyAccountDepositTokenAmount(
   );
   if (!vaultConfig) return [];
 
-  const amount = toNonZeroMusdBaseUnits(amountHuman);
+  // ROUND_DOWN so Max / near-Max from an 18-decimal pay token never encodes
+  // more mUSD than the source balance can fund (ROUND_UP was pushing past it).
+  const amount = toNonZeroMusdBaseUnits(amountHuman, BigNumber.ROUND_DOWN);
   if (amount === undefined) return [];
 
   const chainIdHex = transactionMeta.chainId as Hex;
   const provider = getProviderByChainId(chainIdHex);
   if (!provider) return [];
-
-  // ROUND_DOWN so Max / near-Max from an 18-decimal pay token never encodes
-  // more mUSD than the source balance can fund (ROUND_UP was pushing past it).
-  const amount = BigInt(
-    calcTokenValue(amountHuman, MUSD_DECIMALS)
-      .decimalPlaces(0, BigNumber.ROUND_DOWN)
-      .toFixed(0),
-  );
 
   const { approveTx, depositTx } = await buildMoneyAccountDepositBatch({
     amount,

--- a/app/components/UI/Money/utils/moneyAccountTransactions.ts
+++ b/app/components/UI/Money/utils/moneyAccountTransactions.ts
@@ -66,10 +66,10 @@ export async function updateMoneyAccountDepositTokenAmount(
   const { approveTx, depositTx } = await buildMoneyAccountDepositBatch({
     amount,
     chainId: chainIdHex,
-    boringVault: vaultConfig.boringVault as Hex,
-    tellerAddress: vaultConfig.tellerAddress as Hex,
-    accountantAddress: vaultConfig.accountantAddress as Hex,
-    lensAddress: vaultConfig.lensAddress as Hex,
+    boringVault: vaultConfig.boringVault,
+    tellerAddress: vaultConfig.tellerAddress,
+    accountantAddress: vaultConfig.accountantAddress,
+    lensAddress: vaultConfig.lensAddress,
     provider,
   });
 
@@ -104,8 +104,8 @@ export async function updateMoneyAccountWithdrawTokenAmount(
   const { withdrawTx, transferTx } = await buildMoneyAccountWithdrawBatch({
     amount: toMusdBaseUnits(amountHuman),
     chainId: chainIdHex,
-    tellerAddress: vaultConfig.tellerAddress as Hex,
-    accountantAddress: vaultConfig.accountantAddress as Hex,
+    tellerAddress: vaultConfig.tellerAddress,
+    accountantAddress: vaultConfig.accountantAddress,
     moneyAccountAddress: primaryMoneyAccount.address as Hex,
     recipient: recipient as Hex,
     provider,
@@ -139,10 +139,10 @@ export async function getMoneyAccountDepositTransactionsData(
   const { approveTx, depositTx } = await buildMoneyAccountDepositBatch({
     amount: toMusdBaseUnits(amountHuman),
     chainId,
-    boringVault: vaultConfig.boringVault as Hex,
-    tellerAddress: vaultConfig.tellerAddress as Hex,
-    accountantAddress: vaultConfig.accountantAddress as Hex,
-    lensAddress: vaultConfig.lensAddress as Hex,
+    boringVault: vaultConfig.boringVault,
+    tellerAddress: vaultConfig.tellerAddress,
+    accountantAddress: vaultConfig.accountantAddress,
+    lensAddress: vaultConfig.lensAddress,
     provider,
   });
 
@@ -167,7 +167,7 @@ export async function getMoneyAccountWithdrawTransactionsData(
   const vaultConfig = selectMoneyAccountVaultConfig(state);
   const primaryMoneyAccount = selectPrimaryMoneyAccount(state);
   const recipient = recipientOverride ?? selectEvmAddress(state);
-  if (!vaultConfig || !primaryMoneyAccount?.address) return [];
+  if (!vaultConfig || !primaryMoneyAccount?.address || !recipient) return [];
 
   const provider = getProviderByChainId(chainId);
   if (!provider) return [];
@@ -175,8 +175,8 @@ export async function getMoneyAccountWithdrawTransactionsData(
   const { withdrawTx, transferTx } = await buildMoneyAccountWithdrawBatch({
     amount: toMusdBaseUnits(amountHuman),
     chainId,
-    tellerAddress: vaultConfig.tellerAddress as Hex,
-    accountantAddress: vaultConfig.accountantAddress as Hex,
+    tellerAddress: vaultConfig.tellerAddress,
+    accountantAddress: vaultConfig.accountantAddress,
     moneyAccountAddress: primaryMoneyAccount.address as Hex,
     recipient: recipient as Hex,
     provider,

--- a/app/core/Engine/controllers/money-account-upgrade-controller-init.ts
+++ b/app/core/Engine/controllers/money-account-upgrade-controller-init.ts
@@ -135,13 +135,13 @@ export const moneyAccountUpgradeControllerInit: MessengerClientInitFunction<
   };
 
   const bootstrap = async (vaultConfig: MoneyAccountVaultConfig) => {
-    const chainId = vaultConfig.chainId as Hex;
+    const chainId = vaultConfig.chainId;
 
     await ensureChainConfigured(chainId);
 
     await controller.init({
       chainId,
-      boringVaultAddress: vaultConfig.boringVault as Hex,
+      boringVaultAddress: vaultConfig.boringVault,
     });
   };
 

--- a/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.test.ts
@@ -112,6 +112,18 @@ describe('getAmountData', () => {
     });
   });
 
+  it('returns empty updates for a zero amount without calling the builder', async () => {
+    // Pay pushes every amount change, including a cleared field. The builder
+    // rejects zero rather than encode a deposit that mints nothing.
+    const result = await getAmountData({
+      amount: '0',
+      transaction: buildTransaction(),
+    });
+
+    expect(result).toStrictEqual({ updates: [] });
+    expect(buildDepositBatchMock).not.toHaveBeenCalled();
+  });
+
   it('returns empty updates when transaction type is not moneyAccountDeposit', async () => {
     const result = await getAmountData({
       amount: '5000000',

--- a/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.test.ts
@@ -5,7 +5,10 @@ import {
 import type { Hex } from '@metamask/utils';
 import { buildMoneyAccountDepositBatch } from '@metamask/money-account-utils';
 import ReduxService from '../../../../core/redux/ReduxService';
-import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlagController/moneyAccount';
+import {
+  type MoneyAccountVaultConfig,
+  selectMoneyAccountVaultConfig,
+} from '../../../../selectors/featureFlagController/moneyAccount';
 import { getProviderByChainId } from '../../../../util/notifications/methods/common';
 import { getAmountData } from './amount-data-callback';
 
@@ -20,12 +23,12 @@ jest.mock('../../../../core/redux/ReduxService', () => ({
 jest.mock('../../../../selectors/featureFlagController/moneyAccount');
 jest.mock('../../../../util/notifications/methods/common');
 
-const VAULT_CONFIG = {
+const VAULT_CONFIG: MoneyAccountVaultConfig = {
   chainId: '0x8f',
-  boringVault: '0xBoringVault',
-  tellerAddress: '0xTeller',
-  accountantAddress: '0xAccountant',
-  lensAddress: '0xLens',
+  boringVault: '0xb4563bcd3b7764ccbf497f515585f70b6c3ea5ae',
+  tellerAddress: '0x2d49ea58a4c70b62c8b56de971310d9e999c8117',
+  accountantAddress: '0x7382c5b8b51b8c4f127b3123c1039581baa5a06b',
+  lensAddress: '0xa816ecd922de94c6879ad23b9a884db257f20947',
 };
 
 const APPROVE_DATA = '0xapprove-calldata' as Hex;

--- a/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.test.ts
@@ -3,13 +3,16 @@ import {
   type TransactionMeta,
 } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
-import { buildMoneyAccountDepositBatch } from '../../../../components/UI/Money/utils/moneyAccountTransactions';
+import { buildMoneyAccountDepositBatch } from '@metamask/money-account-utils';
 import ReduxService from '../../../../core/redux/ReduxService';
 import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlagController/moneyAccount';
 import { getProviderByChainId } from '../../../../util/notifications/methods/common';
 import { getAmountData } from './amount-data-callback';
 
-jest.mock('../../../../components/UI/Money/utils/moneyAccountTransactions');
+jest.mock('@metamask/money-account-utils', () => ({
+  ...jest.requireActual('@metamask/money-account-utils'),
+  buildMoneyAccountDepositBatch: jest.fn(),
+}));
 jest.mock('../../../../core/redux/ReduxService', () => ({
   __esModule: true,
   default: { store: { getState: jest.fn().mockReturnValue({}) } },

--- a/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.ts
@@ -57,6 +57,13 @@ export async function getAmountData(
 
   const rawAmount = BigInt(amount);
 
+  // Pay pushes every amount change, including the field being cleared. There is
+  // nothing to re-encode for a zero amount, and the deposit builder rejects it
+  // rather than encode a deposit that mints nothing.
+  if (rawAmount === 0n) {
+    return { updates: [] };
+  }
+
   try {
     let buildResult;
 

--- a/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.ts
@@ -3,7 +3,7 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
-import { buildMoneyAccountDepositBatch } from '../../../../components/UI/Money/utils/moneyAccountTransactions';
+import { buildMoneyAccountDepositBatch } from '@metamask/money-account-utils';
 import ReduxService from '../../../../core/redux/ReduxService';
 import { RootState } from '../../../../reducers';
 import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlagController/moneyAccount';
@@ -64,10 +64,10 @@ export async function getAmountData(
       buildResult = await buildMoneyAccountDepositBatch({
         amount: rawAmount,
         chainId: chainIdHex,
-        boringVault: vaultConfig.boringVault,
-        tellerAddress: vaultConfig.tellerAddress,
-        accountantAddress: vaultConfig.accountantAddress,
-        lensAddress: vaultConfig.lensAddress,
+        boringVault: vaultConfig.boringVault as Hex,
+        tellerAddress: vaultConfig.tellerAddress as Hex,
+        accountantAddress: vaultConfig.accountantAddress as Hex,
+        lensAddress: vaultConfig.lensAddress as Hex,
         provider,
       });
     } catch (error) {

--- a/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/amount-data-callback.ts
@@ -64,10 +64,10 @@ export async function getAmountData(
       buildResult = await buildMoneyAccountDepositBatch({
         amount: rawAmount,
         chainId: chainIdHex,
-        boringVault: vaultConfig.boringVault as Hex,
-        tellerAddress: vaultConfig.tellerAddress as Hex,
-        accountantAddress: vaultConfig.accountantAddress as Hex,
-        lensAddress: vaultConfig.lensAddress as Hex,
+        boringVault: vaultConfig.boringVault,
+        tellerAddress: vaultConfig.tellerAddress,
+        accountantAddress: vaultConfig.accountantAddress,
+        lensAddress: vaultConfig.lensAddress,
         provider,
       });
     } catch (error) {

--- a/app/core/Engine/controllers/transaction-pay-controller/money-account-amount-update.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/money-account-amount-update.test.ts
@@ -7,7 +7,7 @@ import { createDeferredPromise, type Hex } from '@metamask/utils';
 import {
   buildMoneyAccountDepositBatch,
   getMoneyAccountDepositAssetAddress,
-} from '../../../../components/UI/Money/utils/moneyAccountTransactions';
+} from '@metamask/money-account-utils';
 import ReduxService from '../../../../core/redux/ReduxService';
 import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlagController/moneyAccount';
 import { getProviderByChainId } from '../../../../util/notifications/methods/common';
@@ -18,7 +18,11 @@ jest.mock('@metamask/transaction-controller', () => ({
   ...jest.requireActual('@metamask/transaction-controller'),
   updateEIP7702BatchData: jest.fn(),
 }));
-jest.mock('../../../../components/UI/Money/utils/moneyAccountTransactions');
+jest.mock('@metamask/money-account-utils', () => ({
+  ...jest.requireActual('@metamask/money-account-utils'),
+  buildMoneyAccountDepositBatch: jest.fn(),
+  getMoneyAccountDepositAssetAddress: jest.fn(),
+}));
 jest.mock('../../../../core/redux/ReduxService', () => ({
   __esModule: true,
   default: { store: { getState: jest.fn().mockReturnValue({}) } },

--- a/app/core/Engine/controllers/transaction-pay-controller/money-account-amount-update.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/money-account-amount-update.test.ts
@@ -130,6 +130,17 @@ describe('updateMoneyAccountDepositAmount', () => {
     });
   });
 
+  it('commits nothing for a zero amount and does not call the builder', async () => {
+    // Pay pushes every amount change, including a cleared field. The builder
+    // rejects zero rather than encode a deposit that mints nothing.
+    await expect(
+      updateMoneyAccountDepositAmount(currentTransaction, '0'),
+    ).resolves.toBe(false);
+
+    expect(buildDepositBatchMock).not.toHaveBeenCalled();
+    expect(updateTransactionMetadataMock).not.toHaveBeenCalled();
+  });
+
   it('prepares and commits one coherent update without re-simulation', async () => {
     currentTransaction.txParams.gas = '0x5208';
     currentTransaction.simulationData = { tokenBalanceChanges: [] };

--- a/app/core/Engine/controllers/transaction-pay-controller/money-account-amount-update.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/money-account-amount-update.test.ts
@@ -9,7 +9,10 @@ import {
   getMoneyAccountDepositAssetAddress,
 } from '@metamask/money-account-utils';
 import ReduxService from '../../../../core/redux/ReduxService';
-import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlagController/moneyAccount';
+import {
+  type MoneyAccountVaultConfig,
+  selectMoneyAccountVaultConfig,
+} from '../../../../selectors/featureFlagController/moneyAccount';
 import { getProviderByChainId } from '../../../../util/notifications/methods/common';
 import Engine from '../../index';
 import { updateMoneyAccountDepositAmount } from './money-account-amount-update';
@@ -48,12 +51,12 @@ const SECOND_ASSET_ADDRESS =
 const APPROVE_DATA = '0x1234' as Hex;
 const DEPOSIT_DATA = '0x5678' as Hex;
 const BATCH_DATA = '0x9abc' as Hex;
-const VAULT_CONFIG = {
+const VAULT_CONFIG: MoneyAccountVaultConfig = {
   chainId: CHAIN_ID,
-  boringVault: '0xBoringVault',
-  tellerAddress: '0xTeller',
-  accountantAddress: '0xAccountant',
-  lensAddress: '0xLens',
+  boringVault: '0xb4563bcd3b7764ccbf497f515585f70b6c3ea5ae',
+  tellerAddress: '0x2d49ea58a4c70b62c8b56de971310d9e999c8117',
+  accountantAddress: '0x7382c5b8b51b8c4f127b3123c1039581baa5a06b',
+  lensAddress: '0xa816ecd922de94c6879ad23b9a884db257f20947',
 };
 
 const selectVaultConfigMock = jest.mocked(selectMoneyAccountVaultConfig);

--- a/app/core/Engine/controllers/transaction-pay-controller/money-account-amount-update.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/money-account-amount-update.ts
@@ -9,7 +9,7 @@ import type { Hex } from '@metamask/utils';
 import {
   buildMoneyAccountDepositBatch,
   getMoneyAccountDepositAssetAddress,
-} from '../../../../components/UI/Money/utils/moneyAccountTransactions';
+} from '@metamask/money-account-utils';
 import { MUSD_DECIMALS } from '../../../../components/UI/Earn/constants/musd';
 import ReduxService from '../../../../core/redux/ReduxService';
 import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlagController/moneyAccount';
@@ -97,10 +97,10 @@ async function updateMoneyAccountDepositAmountInternal(
   const buildResult = await buildMoneyAccountDepositBatch({
     amount: BigInt(amountRaw),
     chainId,
-    boringVault: vaultConfig.boringVault,
-    tellerAddress: vaultConfig.tellerAddress,
-    accountantAddress: vaultConfig.accountantAddress,
-    lensAddress: vaultConfig.lensAddress,
+    boringVault: vaultConfig.boringVault as Hex,
+    tellerAddress: vaultConfig.tellerAddress as Hex,
+    accountantAddress: vaultConfig.accountantAddress as Hex,
+    lensAddress: vaultConfig.lensAddress as Hex,
     provider,
   });
 

--- a/app/core/Engine/controllers/transaction-pay-controller/money-account-amount-update.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/money-account-amount-update.ts
@@ -93,6 +93,14 @@ async function updateMoneyAccountDepositAmountInternal(
   const amountRaw = calcTokenValue(amountHuman, MUSD_DECIMALS)
     .decimalPlaces(0, BigNumber.ROUND_DOWN)
     .toFixed(0);
+
+  // Pay pushes every amount change, including the field being cleared. There is
+  // nothing to commit for a zero amount, and the deposit builder rejects it
+  // rather than encode a deposit that mints nothing.
+  if (BigInt(amountRaw) === 0n) {
+    return false;
+  }
+
   const depositAssetAddress = getMoneyAccountDepositAssetAddress(chainId);
   const buildResult = await buildMoneyAccountDepositBatch({
     amount: BigInt(amountRaw),

--- a/app/core/Engine/controllers/transaction-pay-controller/money-account-amount-update.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/money-account-amount-update.ts
@@ -97,10 +97,10 @@ async function updateMoneyAccountDepositAmountInternal(
   const buildResult = await buildMoneyAccountDepositBatch({
     amount: BigInt(amountRaw),
     chainId,
-    boringVault: vaultConfig.boringVault as Hex,
-    tellerAddress: vaultConfig.tellerAddress as Hex,
-    accountantAddress: vaultConfig.accountantAddress as Hex,
-    lensAddress: vaultConfig.lensAddress as Hex,
+    boringVault: vaultConfig.boringVault,
+    tellerAddress: vaultConfig.tellerAddress,
+    accountantAddress: vaultConfig.accountantAddress,
+    lensAddress: vaultConfig.lensAddress,
     provider,
   });
 

--- a/app/core/Engine/controllers/transaction-pay-controller/paymentoverride-callback.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/paymentoverride-callback.test.ts
@@ -12,7 +12,7 @@ import type { Hex } from '@metamask/utils';
 import {
   buildMoneyAccountDepositBatch,
   buildMoneyAccountWithdrawBatch,
-} from '../../../../components/UI/Money/utils/moneyAccountTransactions';
+} from '@metamask/money-account-utils';
 import ReduxService from '../../../../core/redux/ReduxService';
 import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlagController/moneyAccount';
 import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
@@ -21,7 +21,11 @@ import { calcTokenValue } from '../../../../util/transactions';
 import { getDelegationTransaction } from '../../../../util/transactions/delegation';
 import { getPaymentOverrideData } from './paymentoverride-callback';
 
-jest.mock('../../../../components/UI/Money/utils/moneyAccountTransactions');
+jest.mock('@metamask/money-account-utils', () => ({
+  ...jest.requireActual('@metamask/money-account-utils'),
+  buildMoneyAccountDepositBatch: jest.fn(),
+  buildMoneyAccountWithdrawBatch: jest.fn(),
+}));
 jest.mock('../../../../components/UI/Earn/constants/musd', () => ({
   MUSD_DECIMALS: 18,
 }));

--- a/app/core/Engine/controllers/transaction-pay-controller/paymentoverride-callback.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/paymentoverride-callback.test.ts
@@ -61,11 +61,11 @@ const MOCK_AUTHORIZATION_LIST = [
 ];
 
 const MOCK_VAULT_CONFIG = {
-  tellerAddress: '0xTeller',
-  accountantAddress: '0xAccountant',
-  boringVault: '0xBoringVault',
-  lensAddress: '0xLens',
-};
+  tellerAddress: '0x2d49ea58a4c70b62c8b56de971310d9e999c8117',
+  accountantAddress: '0x7382c5b8b51b8c4f127b3123c1039581baa5a06b',
+  boringVault: '0xb4563bcd3b7764ccbf497f515585f70b6c3ea5ae',
+  lensAddress: '0xa816ecd922de94c6879ad23b9a884db257f20947',
+} as const;
 
 const MOCK_PROVIDER = {} as never;
 

--- a/app/core/Engine/controllers/transaction-pay-controller/paymentoverride-callback.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/paymentoverride-callback.ts
@@ -55,6 +55,9 @@ async function getMoneyAccountWithdrawPaymentOverrideData<
       .decimalPlaces(0, BigNumber.ROUND_DOWN)
       .toFixed(0),
   );
+  // No override to build before there is an amount to move, and the withdraw
+  // builder rejects zero rather than encode a zero-share redemption.
+  if (amount === 0n) return [];
 
   const { withdrawTx, transferTx } = await buildMoneyAccountWithdrawBatch({
     amount,
@@ -142,6 +145,9 @@ async function getMoneyAccountDepositPaymentOverrideData<
       .decimalPlaces(0, BigNumber.ROUND_DOWN)
       .toFixed(0),
   );
+  // No override to build before there is an amount to move, and the deposit
+  // builder rejects zero rather than encode a deposit that mints nothing.
+  if (amount === 0n) return { calls: [] };
 
   const { approveTx, depositTx } = await buildMoneyAccountDepositBatch({
     amount,

--- a/app/core/Engine/controllers/transaction-pay-controller/paymentoverride-callback.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/paymentoverride-callback.ts
@@ -59,8 +59,8 @@ async function getMoneyAccountWithdrawPaymentOverrideData<
   const { withdrawTx, transferTx } = await buildMoneyAccountWithdrawBatch({
     amount,
     chainId,
-    tellerAddress: vaultConfig.tellerAddress as Hex,
-    accountantAddress: vaultConfig.accountantAddress as Hex,
+    tellerAddress: vaultConfig.tellerAddress,
+    accountantAddress: vaultConfig.accountantAddress,
     moneyAccountAddress,
     recipient,
     provider,
@@ -146,10 +146,10 @@ async function getMoneyAccountDepositPaymentOverrideData<
   const { approveTx, depositTx } = await buildMoneyAccountDepositBatch({
     amount,
     chainId,
-    boringVault: vaultConfig.boringVault as Hex,
-    tellerAddress: vaultConfig.tellerAddress as Hex,
-    accountantAddress: vaultConfig.accountantAddress as Hex,
-    lensAddress: vaultConfig.lensAddress as Hex,
+    boringVault: vaultConfig.boringVault,
+    tellerAddress: vaultConfig.tellerAddress,
+    accountantAddress: vaultConfig.accountantAddress,
+    lensAddress: vaultConfig.lensAddress,
     provider,
   });
 

--- a/app/core/Engine/controllers/transaction-pay-controller/paymentoverride-callback.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/paymentoverride-callback.ts
@@ -15,7 +15,7 @@ import BigNumber from 'bignumber.js';
 import {
   buildMoneyAccountDepositBatch,
   buildMoneyAccountWithdrawBatch,
-} from '../../../../components/UI/Money/utils/moneyAccountTransactions';
+} from '@metamask/money-account-utils';
 import { MUSD_DECIMALS } from '../../../../components/UI/Earn/constants/musd';
 import Engine from '../../../../core/Engine';
 import ReduxService from '../../../../core/redux/ReduxService';
@@ -146,10 +146,10 @@ async function getMoneyAccountDepositPaymentOverrideData<
   const { approveTx, depositTx } = await buildMoneyAccountDepositBatch({
     amount,
     chainId,
-    boringVault: vaultConfig.boringVault,
-    tellerAddress: vaultConfig.tellerAddress,
-    accountantAddress: vaultConfig.accountantAddress,
-    lensAddress: vaultConfig.lensAddress,
+    boringVault: vaultConfig.boringVault as Hex,
+    tellerAddress: vaultConfig.tellerAddress as Hex,
+    accountantAddress: vaultConfig.accountantAddress as Hex,
+    lensAddress: vaultConfig.lensAddress as Hex,
     provider,
   });
 

--- a/app/selectors/featureFlagController/moneyAccount/index.test.ts
+++ b/app/selectors/featureFlagController/moneyAccount/index.test.ts
@@ -7,6 +7,7 @@ import {
   MONEY_ACCOUNT_DEPOSIT_QUOTE_PIPELINE_FLAG_KEY,
   MONEY_ENABLE_ONBOARDING_STEPPER_ANIMATION_FLAG_KEY,
   DEV_VAULT_CONFIG,
+  parseMoneyAccountVaultConfig,
 } from './index';
 
 jest.mock('react-native-device-info', () => ({
@@ -221,6 +222,15 @@ describe('Money Account feature flag selectors', () => {
   describe('selectMoneyAccountVaultConfig', () => {
     const originalDevEnabled = process.env.MM_MONEY_DEPOSIT_CONFIG_DEV_ENABLED;
 
+    // Addresses are validated, so fixtures must be real ones.
+    const REMOTE_CONFIG = {
+      chainId: '0x8f',
+      boringVault: '0xb4563bcd3b7764ccbf497f515585f70b6c3ea5ae',
+      tellerAddress: '0x2d49ea58a4c70b62c8b56de971310d9e999c8117',
+      accountantAddress: '0x7382c5b8b51b8c4f127b3123c1039581baa5a06b',
+      lensAddress: '0xa816ecd922de94c6879ad23b9a884db257f20947',
+    };
+
     afterEach(() => {
       if (originalDevEnabled === undefined) {
         delete process.env.MM_MONEY_DEPOSIT_CONFIG_DEV_ENABLED;
@@ -230,19 +240,109 @@ describe('Money Account feature flag selectors', () => {
     });
 
     it('returns remote config when present', () => {
-      const remoteConfig = {
-        chainId: '0x1',
-        boringVault: '0xvault',
-        tellerAddress: '0xteller',
-        accountantAddress: '0xaccountant',
-        lensAddress: '0xlens',
+      const result = selectMoneyAccountVaultConfig.resultFunc({
+        moneyAccountVaultConfig: REMOTE_CONFIG,
+      });
+
+      expect(result).toEqual(REMOTE_CONFIG);
+    });
+
+    it('accepts checksummed addresses unchanged', () => {
+      const checksummed = {
+        ...REMOTE_CONFIG,
+        boringVault: '0xb4563bcD3B7764CCBf497f515585f70B6C3EA5Ae',
       };
 
       const result = selectMoneyAccountVaultConfig.resultFunc({
-        moneyAccountVaultConfig: remoteConfig,
+        moneyAccountVaultConfig: checksummed,
       });
 
-      expect(result).toEqual(remoteConfig);
+      expect(result).toEqual(checksummed);
+    });
+
+    it('returns undefined when the remote config is malformed', () => {
+      delete process.env.MM_MONEY_DEPOSIT_CONFIG_DEV_ENABLED;
+
+      const result = selectMoneyAccountVaultConfig.resultFunc({
+        moneyAccountVaultConfig: { ...REMOTE_CONFIG, tellerAddress: '0xnope' },
+      });
+
+      expect(result).toBeUndefined();
+    });
+
+    it('falls back to the dev config when the remote config is malformed', () => {
+      process.env.MM_MONEY_DEPOSIT_CONFIG_DEV_ENABLED = 'true';
+
+      const result = selectMoneyAccountVaultConfig.resultFunc({
+        moneyAccountVaultConfig: { ...REMOTE_CONFIG, tellerAddress: '0xnope' },
+      });
+
+      expect(result).toEqual(DEV_VAULT_CONFIG);
+    });
+
+    it('prefers remote config over dev fallback', () => {
+      process.env.MM_MONEY_DEPOSIT_CONFIG_DEV_ENABLED = 'true';
+
+      const result = selectMoneyAccountVaultConfig.resultFunc({
+        moneyAccountVaultConfig: REMOTE_CONFIG,
+      });
+
+      expect(result).toEqual(REMOTE_CONFIG);
+    });
+  });
+
+  describe('parseMoneyAccountVaultConfig', () => {
+    const RAW_CONFIG = {
+      chainId: '0x8f',
+      boringVault: '0xb4563bcd3b7764ccbf497f515585f70b6c3ea5ae',
+      tellerAddress: '0x2d49ea58a4c70b62c8b56de971310d9e999c8117',
+      accountantAddress: '0x7382c5b8b51b8c4f127b3123c1039581baa5a06b',
+      lensAddress: '0xa816ecd922de94c6879ad23b9a884db257f20947',
+    };
+
+    it('parses a well-formed config', () => {
+      expect(parseMoneyAccountVaultConfig(RAW_CONFIG)).toStrictEqual(
+        RAW_CONFIG,
+      );
+    });
+
+    it('parses the dev config it ships', () => {
+      expect(parseMoneyAccountVaultConfig(DEV_VAULT_CONFIG)).toStrictEqual(
+        DEV_VAULT_CONFIG,
+      );
+    });
+
+    it('ignores unknown extra keys', () => {
+      expect(
+        parseMoneyAccountVaultConfig({ ...RAW_CONFIG, somethingElse: true }),
+      ).toStrictEqual(RAW_CONFIG);
+    });
+
+    it.each([
+      ['chainId is not hex', { chainId: '143' }],
+      ['chainId is missing', { chainId: undefined }],
+      ['chainId is not a string', { chainId: 143 }],
+      ['an address is not hex', { tellerAddress: 'teller' }],
+      ['an address is truncated', { lensAddress: '0xdeadbeef' }],
+      [
+        'an address has a bad checksum',
+        { boringVault: '0xB4563BCD3b7764CCBf497f515585f70B6C3EA5Ae' },
+      ],
+      ['an address is missing', { accountantAddress: undefined }],
+      ['an address is not a string', { boringVault: 12345 }],
+    ])('returns undefined when %s', (_case, override) => {
+      expect(
+        parseMoneyAccountVaultConfig({ ...RAW_CONFIG, ...override }),
+      ).toBeUndefined();
+    });
+
+    it.each([
+      ['undefined', undefined],
+      ['null', null],
+      ['a string', 'not-an-object'],
+      ['a number', 42],
+    ])('returns undefined when the flag is %s', (_case, raw) => {
+      expect(parseMoneyAccountVaultConfig(raw)).toBeUndefined();
     });
 
     it('returns dev fallback when remote config is absent and dev flag is enabled', () => {
@@ -273,24 +373,6 @@ describe('Money Account feature flag selectors', () => {
       });
 
       expect(result).toBeUndefined();
-    });
-
-    it('prefers remote config over dev fallback', () => {
-      process.env.MM_MONEY_DEPOSIT_CONFIG_DEV_ENABLED = 'true';
-
-      const remoteConfig = {
-        chainId: '0x89',
-        boringVault: '0xremoteVault',
-        tellerAddress: '0xremoteTeller',
-        accountantAddress: '0xremoteAccountant',
-        lensAddress: '0xremoteLens',
-      };
-
-      const result = selectMoneyAccountVaultConfig.resultFunc({
-        moneyAccountVaultConfig: remoteConfig,
-      });
-
-      expect(result).toEqual(remoteConfig);
     });
   });
 });

--- a/app/selectors/featureFlagController/moneyAccount/index.ts
+++ b/app/selectors/featureFlagController/moneyAccount/index.ts
@@ -1,4 +1,9 @@
 import { createSelector } from 'reselect';
+import {
+  isStrictHexString,
+  isValidHexAddress,
+  type Hex,
+} from '@metamask/utils';
 import { selectRemoteFeatureFlags } from '..';
 import { validatedVersionGatedFeatureFlag } from '../../../util/remoteFeatureFlag';
 
@@ -55,11 +60,11 @@ export const selectMoneyOnboardingStepperAnimationEnabled = createSelector(
 );
 
 export interface MoneyAccountVaultConfig {
-  chainId: string;
-  boringVault: string;
-  tellerAddress: string;
-  accountantAddress: string;
-  lensAddress: string;
+  chainId: Hex;
+  boringVault: Hex;
+  tellerAddress: Hex;
+  accountantAddress: Hex;
+  lensAddress: Hex;
 }
 
 export const DEV_VAULT_CONFIG: MoneyAccountVaultConfig = {
@@ -70,13 +75,63 @@ export const DEV_VAULT_CONFIG: MoneyAccountVaultConfig = {
   lensAddress: '0xA816ECd922de94c6879AD23B9A884dB257F20947',
 };
 
+const VAULT_CONFIG_ADDRESS_KEYS = [
+  'boringVault',
+  'tellerAddress',
+  'accountantAddress',
+  'lensAddress',
+] as const;
+
+/**
+ * Parses the raw `moneyAccountVaultConfig` remote feature flag into a config
+ * whose chain id and addresses are known-good `Hex`.
+ *
+ * These addresses become the `spender` of an ERC-20 `approve` and the target of
+ * the vault calls, so they are validated once here rather than asserted with
+ * `as Hex` at every call site. A malformed flag yields `undefined`, which the
+ * existing `if (!vaultConfig)` guards already treat as "Money is unavailable" —
+ * the deposit and withdraw entry points stay hidden instead of failing partway
+ * through a confirmation.
+ * @param raw - The raw remote feature flag value.
+ * @returns The parsed vault config, or `undefined` if any field is missing or
+ * malformed.
+ */
+export const parseMoneyAccountVaultConfig = (
+  raw: unknown,
+): MoneyAccountVaultConfig | undefined => {
+  if (typeof raw !== 'object' || raw === null) {
+    return undefined;
+  }
+
+  const candidate = raw as Record<string, unknown>;
+  const { chainId } = candidate;
+  if (!isStrictHexString(chainId)) {
+    return undefined;
+  }
+
+  const addresses = {} as Record<
+    (typeof VAULT_CONFIG_ADDRESS_KEYS)[number],
+    Hex
+  >;
+  for (const key of VAULT_CONFIG_ADDRESS_KEYS) {
+    const value = candidate[key];
+    // `isValidHexAddress` accepts all-lowercase or a valid ERC-55 checksum,
+    // matching what ethers will accept when it encodes the calldata.
+    if (!isStrictHexString(value) || !isValidHexAddress(value)) {
+      return undefined;
+    }
+    addresses[key] = value;
+  }
+
+  return { chainId, ...addresses };
+};
+
 export const getMoneyAccountVaultConfig = (
   remoteFeatureFlags: Record<string, unknown> | undefined,
 ): MoneyAccountVaultConfig | undefined => {
-  const remoteConfig =
-    remoteFeatureFlags?.moneyAccountVaultConfig as unknown as
-      | MoneyAccountVaultConfig
-      | undefined;
+  const remoteConfig = parseMoneyAccountVaultConfig(
+    remoteFeatureFlags?.moneyAccountVaultConfig,
+  );
   if (remoteConfig) {
     return remoteConfig;
   }

--- a/package.json
+++ b/package.json
@@ -185,7 +185,6 @@
     ]
   },
   "resolutions": {
-    "@metamask/money-account-utils": "npm:@metamask-previews/money-account-utils@1.0.0-preview-7aa2077d5",
     "@metamask/network-controller": "34.0.0",
     "@metamask/seedless-onboarding-controller": "10.1.1",
     "@react-native-community/viewpager": "patch:@react-native-community/viewpager@npm%3A3.3.0#~/.yarn/patches/@react-native-community-viewpager-npm-3.3.0.patch",
@@ -322,7 +321,7 @@
     "@metamask/money-account-balance-service": "^2.4.0",
     "@metamask/money-account-controller": "^0.2.0",
     "@metamask/money-account-upgrade-controller": "^3.0.0",
-    "@metamask/money-account-utils": "^1.0.0",
+    "@metamask/money-account-utils": "^1.1.0",
     "@metamask/multichain-account-service": "^13.0.0",
     "@metamask/multichain-api-client": "^0.11.0",
     "@metamask/multichain-api-middleware": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     ]
   },
   "resolutions": {
-    "@metamask/money-account-utils": "npm:@metamask-previews/money-account-utils@1.0.0-preview-a42e8d0d2",
+    "@metamask/money-account-utils": "npm:@metamask-previews/money-account-utils@1.0.0-preview-7aa2077d5",
     "@metamask/network-controller": "34.0.0",
     "@metamask/seedless-onboarding-controller": "10.1.1",
     "@react-native-community/viewpager": "patch:@react-native-community/viewpager@npm%3A3.3.0#~/.yarn/patches/@react-native-community-viewpager-npm-3.3.0.patch",

--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
     ]
   },
   "resolutions": {
+    "@metamask/money-account-utils": "npm:@metamask-previews/money-account-utils@1.0.0-preview-a42e8d0d2",
     "@metamask/network-controller": "34.0.0",
     "@metamask/seedless-onboarding-controller": "10.1.1",
     "@react-native-community/viewpager": "patch:@react-native-community/viewpager@npm%3A3.3.0#~/.yarn/patches/@react-native-community-viewpager-npm-3.3.0.patch",

--- a/package.json
+++ b/package.json
@@ -250,7 +250,6 @@
     "@lavamoat/react-native-lockdown": "^0.0.2",
     "@ledgerhq/hw-app-eth": "^6.42.0",
     "@ledgerhq/react-native-hw-transport-ble": "^6.37.0",
-    "@metamask-previews/money-account-utils": "0.0.0-preview-9eed894c0",
     "@metamask/abi-utils": "^3.0.0",
     "@metamask/account-api": "^1.0.4",
     "@metamask/account-tree-controller": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -250,6 +250,7 @@
     "@lavamoat/react-native-lockdown": "^0.0.2",
     "@ledgerhq/hw-app-eth": "^6.42.0",
     "@ledgerhq/react-native-hw-transport-ble": "^6.37.0",
+    "@metamask-previews/money-account-utils": "0.0.0-preview-9eed894c0",
     "@metamask/abi-utils": "^3.0.0",
     "@metamask/account-api": "^1.0.4",
     "@metamask/account-tree-controller": "^7.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9250,16 +9250,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/money-account-utils@npm:@metamask-previews/money-account-utils@1.0.0-preview-7aa2077d5":
-  version: 1.0.0-preview-7aa2077d5
-  resolution: "@metamask-previews/money-account-utils@npm:1.0.0-preview-7aa2077d5"
+"@metamask/money-account-utils@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@metamask/money-account-utils@npm:1.1.0"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/abstract-provider": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
-    "@metamask/transaction-controller": "npm:^69.3.0"
+    "@metamask/transaction-controller": "npm:^69.4.0"
     "@metamask/utils": "npm:^11.11.0"
-  checksum: 10/679309862773a322301c69b49c037307695068b79fc4fe4fe95177b71146fdf125a11c9f0cff7be038130b406caa6cf710c8ea345c11e75aabf2260656b3d7f0
+  checksum: 10/1117c232b37d6551af0b2e68b3f7ced9ec5d9b7bc025089bf54feeb15d627fcc474c9b65e5cf47b9c000cad19773cc9ea0ee5410aaa035ef250820d54b7efdd5
   languageName: node
   linkType: hard
 
@@ -35929,7 +35929,7 @@ __metadata:
     "@metamask/money-account-balance-service": "npm:^2.4.0"
     "@metamask/money-account-controller": "npm:^0.2.0"
     "@metamask/money-account-upgrade-controller": "npm:^3.0.0"
-    "@metamask/money-account-utils": "npm:^1.0.0"
+    "@metamask/money-account-utils": "npm:^1.1.0"
     "@metamask/multichain-account-service": "npm:^13.0.0"
     "@metamask/multichain-api-client": "npm:^0.11.0"
     "@metamask/multichain-api-middleware": "npm:^4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7478,6 +7478,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask-previews/money-account-utils@npm:0.0.0-preview-9eed894c0":
+  version: 0.0.0-preview-9eed894c0
+  resolution: "@metamask-previews/money-account-utils@npm:0.0.0-preview-9eed894c0"
+  dependencies:
+    "@metamask/transaction-controller": "npm:^68.2.2"
+    "@metamask/utils": "npm:^11.11.0"
+  checksum: 10/a6f9e819d5a3ff89082e52d03ba0bcd5207a0d3353b899b4e446e25337b18b7c0ee5e274c03b16396b359c59ea269bbf0d97f424e32ec0e715d1d2a4724d689a
+  languageName: node
+  linkType: hard
+
 "@metamask/7715-permission-types@npm:^0.5.0":
   version: 0.5.0
   resolution: "@metamask/7715-permission-types@npm:0.5.0"
@@ -35844,6 +35854,7 @@ __metadata:
     "@lavamoat/react-native-lockdown": "npm:^0.0.2"
     "@ledgerhq/hw-app-eth": "npm:^6.42.0"
     "@ledgerhq/react-native-hw-transport-ble": "npm:^6.37.0"
+    "@metamask-previews/money-account-utils": "npm:0.0.0-preview-9eed894c0"
     "@metamask/abi-utils": "npm:^3.0.0"
     "@metamask/account-api": "npm:^1.0.4"
     "@metamask/account-tree-controller": "npm:^7.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7478,16 +7478,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask-previews/money-account-utils@npm:0.0.0-preview-9eed894c0":
-  version: 0.0.0-preview-9eed894c0
-  resolution: "@metamask-previews/money-account-utils@npm:0.0.0-preview-9eed894c0"
-  dependencies:
-    "@metamask/transaction-controller": "npm:^68.2.2"
-    "@metamask/utils": "npm:^11.11.0"
-  checksum: 10/a6f9e819d5a3ff89082e52d03ba0bcd5207a0d3353b899b4e446e25337b18b7c0ee5e274c03b16396b359c59ea269bbf0d97f424e32ec0e715d1d2a4724d689a
-  languageName: node
-  linkType: hard
-
 "@metamask/7715-permission-types@npm:^0.5.0":
   version: 0.5.0
   resolution: "@metamask/7715-permission-types@npm:0.5.0"
@@ -35854,7 +35844,6 @@ __metadata:
     "@lavamoat/react-native-lockdown": "npm:^0.0.2"
     "@ledgerhq/hw-app-eth": "npm:^6.42.0"
     "@ledgerhq/react-native-hw-transport-ble": "npm:^6.37.0"
-    "@metamask-previews/money-account-utils": "npm:0.0.0-preview-9eed894c0"
     "@metamask/abi-utils": "npm:^3.0.0"
     "@metamask/account-api": "npm:^1.0.4"
     "@metamask/account-tree-controller": "npm:^7.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9250,13 +9250,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/money-account-utils@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@metamask/money-account-utils@npm:1.0.0"
+"@metamask/money-account-utils@npm:@metamask-previews/money-account-utils@1.0.0-preview-a42e8d0d2":
+  version: 1.0.0-preview-a42e8d0d2
+  resolution: "@metamask-previews/money-account-utils@npm:1.0.0-preview-a42e8d0d2"
   dependencies:
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/abstract-provider": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
     "@metamask/transaction-controller": "npm:^69.3.0"
     "@metamask/utils": "npm:^11.11.0"
-  checksum: 10/bb85219266b451115260263b291c0408ec60060ee1b54f52c48f9220c6077fe492e25347754c1c392ef5d4ecd9b5ddf65de4c1d3bf93966e15d275f2c3364265
+  checksum: 10/5858ec4f36284b86479613a0382eb4b70a7901ef961652ec0bea36ff7c33618b522c86f26f369982ac6b75ed255d115bd0324526f961fb4396460a89f63c0651
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9250,16 +9250,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/money-account-utils@npm:@metamask-previews/money-account-utils@1.0.0-preview-a42e8d0d2":
-  version: 1.0.0-preview-a42e8d0d2
-  resolution: "@metamask-previews/money-account-utils@npm:1.0.0-preview-a42e8d0d2"
+"@metamask/money-account-utils@npm:@metamask-previews/money-account-utils@1.0.0-preview-7aa2077d5":
+  version: 1.0.0-preview-7aa2077d5
+  resolution: "@metamask-previews/money-account-utils@npm:1.0.0-preview-7aa2077d5"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/abstract-provider": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
     "@metamask/transaction-controller": "npm:^69.3.0"
     "@metamask/utils": "npm:^11.11.0"
-  checksum: 10/5858ec4f36284b86479613a0382eb4b70a7901ef961652ec0bea36ff7c33618b522c86f26f369982ac6b75ed255d115bd0324526f961fb4396460a89f63c0651
+  checksum: 10/679309862773a322301c69b49c037307695068b79fc4fe4fe95177b71146fdf125a11c9f0cff7be038130b406caa6cf710c8ea345c11e75aabf2260656b3d7f0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
This PR integrates the latest version of money account utils. This new version moves a lot of code that was previously in this codebase into core - and so we are now replacing that moved code with the packaged version.
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:  use updated money utils package

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: MUSD-1238

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**
<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Money deposit/withdraw confirmation and on-chain calldata paths; mitigated by contract tests and stricter vault config validation, but regressions in encoding or placeholders could still break funding flows.
> 
> **Overview**
> Bumps **`@metamask/money-account-utils`** to **^1.1.0** and moves vault deposit/withdraw encoding (builders, ABIs, mUSD helpers) out of **`moneyAccountTransactions.ts`** into the package. Mobile keeps Redux/Pay wrappers that call the real builders when the user sets an amount.
> 
> **Deposit/withdraw entry** now submits **placeholder batches** (`buildMoneyAccountDepositPlaceholderBatch` / `buildMoneyAccountWithdrawPlaceholderBatch`) with only chain + teller—no provider or lens/accountant reads up front. MM Pay still re-encodes calldata after amount selection.
> 
> **Remote vault config** is parsed once via **`parseMoneyAccountVaultConfig`** (strict hex chain id + valid addresses); bad flags yield `undefined` so Money stays hidden instead of failing mid-flow. **`useMoneyAccountDepositAssetId`** uses the package resolver and **falls back to Monad** when config is missing or the chain has no mUSD deployment.
> 
> **Zero amounts** short-circuit across Pay callbacks and amount updaters so cleared fields do not hit builders that reject `0n`. Adds **`moneyAccountTransactions.contract.test.ts`** to decode real package calldata in CI (other suites mock the package).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67283e27621a39a7ddee62802420508b02e64f07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->