### PR TITLE
fix(e2e): capped Appium poll RTT subtraction without zeroing timers

### DIFF
--- a/tests/framework/PlaywrightAssertions.ts
+++ b/tests/framework/PlaywrightAssertions.ts
@@ -6,7 +6,10 @@ import PlaywrightGestures from './PlaywrightGestures.ts';
 import { PlatformDetector } from './PlatformLocator.ts';
 import {
   addOverhead,
+  addOverheadSleep,
   isOverheadTrackingActive,
+  nextMeasuringPollIntervalMs,
+  recordFailedPollCommand,
   recordOverheadProbe,
   recordSuccessPollCommand,
   withImplicitWait,
@@ -30,9 +33,13 @@ export interface TextDisplayedOptions extends AssertionOptions {
  *
  * ## How overhead compensation works
  *
- * While `TimerHelper.measure()` is active we subtract only the post-detect
- * probe (`isExisting` after the element is visible). That is pure Appium RTT.
- * Resolution / confirm waits stay in app time so cold start is not under-reported.
+ * While `TimerHelper.measure()` is active we subtract:
+ * - the post-detect probe (`isExisting` after visible) — pure Appium RTT
+ * - failed/success poll command time, each capped at that probe RTT
+ *
+ * Poll sleeps and uncapped portions of poll commands (e.g. implicit wait)
+ * stay in app time so cold start is not under-reported, and timers cannot
+ * collapse to 0ms after a real wait.
  */
 export default class PlaywrightAssertions {
   private static getTimeout(options: AssertionOptions): number {
@@ -48,22 +55,31 @@ export default class PlaywrightAssertions {
    * Appium providers do not pay 2× `setTimeout` RTT every probe — that
    * overhead was inflating performance timers.
    *
-   * When measuring, only the successful confirm (+ probe) counts as infra.
-   * A shorter poll interval reduces detection lag without zeroing app time.
+   * While measuring, the poll interval adapts to the last command duration
+   * (never faster than cloud RTT, never slower than a normal wait).
    */
   private static readonly FINAL_WAIT_RESERVE_MS = 2_000;
   /** Fast implicit wait for poll probes — avoids 3.5s find penalty per attempt. */
   private static readonly POLL_IMPLICIT_WAIT_MS = 300;
   private static readonly POLL_INTERVAL_MS = 300;
-  private static readonly POLL_INTERVAL_WHILE_MEASURING_MS = 50;
+
+  private static async pollSleep(ms: number): Promise<void> {
+    if (ms <= 0) {
+      return;
+    }
+    if (isOverheadTrackingActive()) {
+      addOverheadSleep(ms);
+    }
+    await sleep(ms);
+  }
 
   private static async pollUntilVisible(
     el: PlaywrightElement,
     timeout: number,
   ): Promise<void> {
     const tracking = isOverheadTrackingActive();
-    const interval = tracking
-      ? this.POLL_INTERVAL_WHILE_MEASURING_MS
+    let interval = tracking
+      ? nextMeasuringPollIntervalMs(0)
       : this.POLL_INTERVAL_MS;
     const start = Date.now();
 
@@ -76,6 +92,7 @@ export default class PlaywrightAssertions {
             break;
           }
           const t0 = Date.now();
+          let lastCommandMs = 0;
           try {
             const exists = await el.unwrap().isExisting();
             if (exists) {
@@ -88,10 +105,20 @@ export default class PlaywrightAssertions {
                 return true;
               }
             }
+            lastCommandMs = Date.now() - t0;
+            if (tracking) {
+              recordFailedPollCommand(lastCommandMs);
+            }
           } catch {
-            // element not ready yet
+            lastCommandMs = Date.now() - t0;
+            if (tracking) {
+              recordFailedPollCommand(lastCommandMs);
+            }
           }
-          await sleep(Math.min(interval, remaining));
+          if (tracking) {
+            interval = nextMeasuringPollIntervalMs(lastCommandMs);
+          }
+          await this.pollSleep(Math.min(interval, remaining));
         }
         return false;
       },
@@ -210,11 +237,18 @@ export default class PlaywrightAssertions {
 
     const timeout = this.getTimeout(options);
     const tracking = isOverheadTrackingActive();
-    const interval = tracking ? 50 : 300;
+    let interval = tracking
+      ? nextMeasuringPollIntervalMs(0)
+      : this.POLL_INTERVAL_MS;
     const start = Date.now();
     while (Date.now() - start < timeout) {
+      const remaining = timeout - (Date.now() - start);
+      if (remaining <= 0) {
+        break;
+      }
+      const t0 = Date.now();
+      let lastCommandMs = 0;
       try {
-        const t0 = Date.now();
         const text = await el.textContent();
         if (text === expected) {
           if (tracking) {
@@ -223,10 +257,20 @@ export default class PlaywrightAssertions {
           }
           return;
         }
+        lastCommandMs = Date.now() - t0;
+        if (tracking) {
+          recordFailedPollCommand(lastCommandMs);
+        }
       } catch {
-        // element not ready yet
+        lastCommandMs = Date.now() - t0;
+        if (tracking) {
+          recordFailedPollCommand(lastCommandMs);
+        }
       }
-      await sleep(interval);
+      if (tracking) {
+        interval = nextMeasuringPollIntervalMs(lastCommandMs);
+      }
+      await this.pollSleep(Math.min(interval, remaining));
     }
     throw new Error(`Expected element text "${expected}" within ${timeout}ms`);
   }

--- a/tests/framework/PlaywrightUtilities.ts
+++ b/tests/framework/PlaywrightUtilities.ts
@@ -265,8 +265,10 @@ export function boxedStep<This, Args extends unknown[], Return>(
  * infrastructure latency — on cloud device farms this can dominate the timer.
  *
  * Conservative model while `TimerHelper.measure()` is active (click stays outside):
- * - Probe only: post-detect `isExisting` (pure RTT we add after the UI is up).
- * - Resolution / success confirms are not subtracted — they often include app load and under-reported on-device time when capped as infra.
+ * - Post-detect probe (`isExisting` after visible) — pure Appium/network RTT.
+ * - Failed + success poll command durations, each capped at the probe RTT so
+ *   implicit-wait / app-load time inside those commands stays in app time.
+ * - Poll sleeps and element-resolution (`directMs`) stay in app time.
  *
  * When no `measure()` is active all functions are no-ops.
  */
@@ -277,6 +279,19 @@ export interface OverheadAccumulatorState {
   successPollMs: number | null;
   probeMs: number | null;
 }
+
+export interface OverheadTrackingResult {
+  infraMs: number;
+  sleepMs: number;
+}
+
+/** Minimum poll gap while measuring — still allows snappy local detection. */
+export const MEASURING_POLL_INTERVAL_MIN_MS = 50;
+/**
+ * Upper bound matches the non-measuring poll interval so adaptive backing-off
+ * never becomes slower than a normal wait.
+ */
+export const MEASURING_POLL_INTERVAL_MAX_MS = 300;
 
 let _tracking = false;
 let _directMs = 0;
@@ -296,12 +311,12 @@ function resetOverheadState(): void {
 /**
  * Computes infra ms to subtract from wall-clock.
  *
- * Only the post-detect probe is subtracted. That call is pure Appium/network
- * overhead we add after the screen is already visible.
+ * Uses the post-detect probe as the RTT cap. Each failed/success poll may
+ * contribute at most that cap (not its full duration), so implicit-wait time
+ * inside `isExisting` is not mistaken for network overhead.
  *
- * Resolution and success-confirm durations often include real app load (cold
- * start findElement / waitForDisplayed). Subtracting them (even capped to RTT)
- * under-reports app time vs on-device video.
+ * `directMs` / `sleepMs` are intentionally excluded — resolution and sleeps
+ * are treated as app time.
  *
  * Exported for unit tests.
  */
@@ -311,7 +326,59 @@ export function computeAppiumInfraOverheadMs(
   if (state.probeMs == null || state.probeMs <= 0) {
     return 0;
   }
-  return state.probeMs;
+
+  const rttCap = state.probeMs;
+  let infraMs = rttCap;
+
+  for (const durationMs of state.failedPollDurationsMs) {
+    if (durationMs > 0) {
+      infraMs += Math.min(durationMs, rttCap);
+    }
+  }
+
+  if (state.successPollMs != null && state.successPollMs > 0) {
+    // Success path may include isExisting + isVisible (~2 commands). Cap at
+    // one probe RTT so we under-subtract rather than invent near-zero app time.
+    infraMs += Math.min(state.successPollMs, rttCap);
+  }
+
+  return infraMs;
+}
+
+/**
+ * Caps infra subtraction so reported app time cannot collapse to 0ms when the
+ * wall-clock wait had real content (poll sleeps, or any positive duration).
+ *
+ * Exported for unit tests.
+ */
+export function clampInfraSubtractionMs(
+  wallClockMs: number,
+  infraMs: number,
+  sleepMs: number,
+): number {
+  if (wallClockMs <= 0) {
+    return 0;
+  }
+  const appFloorMs = Math.max(sleepMs, 1);
+  return Math.min(Math.max(0, infraMs), Math.max(0, wallClockMs - appFloorMs));
+}
+
+/**
+ * Adaptive poll gap while measuring: never poll faster than the last command
+ * took (cloud RTT), and never slower than a normal non-measuring wait.
+ *
+ * Exported for unit tests.
+ */
+export function nextMeasuringPollIntervalMs(
+  lastCommandDurationMs: number,
+): number {
+  if (!Number.isFinite(lastCommandDurationMs) || lastCommandDurationMs <= 0) {
+    return MEASURING_POLL_INTERVAL_MIN_MS;
+  }
+  return Math.min(
+    MEASURING_POLL_INTERVAL_MAX_MS,
+    Math.max(MEASURING_POLL_INTERVAL_MIN_MS, Math.ceil(lastCommandDurationMs)),
+  );
 }
 
 export function startOverheadTracking(): void {
@@ -351,17 +418,18 @@ export function recordOverheadProbe(durationMs: number): void {
   }
 }
 
-export function stopOverheadTracking(): number {
+export function stopOverheadTracking(): OverheadTrackingResult {
   _tracking = false;
-  const result = computeAppiumInfraOverheadMs({
+  const infraMs = computeAppiumInfraOverheadMs({
     directMs: _directMs,
     sleepMs: _sleepMs,
     failedPollDurationsMs: _failedPollDurationsMs,
     successPollMs: _successPollMs,
     probeMs: _probeMs,
   });
+  const sleepMs = _sleepMs;
   resetOverheadState();
-  return result;
+  return { infraMs, sleepMs };
 }
 
 export function isOverheadTrackingActive(): boolean {

--- a/tests/framework/TimerHelper.ts
+++ b/tests/framework/TimerHelper.ts
@@ -1,5 +1,6 @@
 import TimerStore from './TimerStore';
 import {
+  clampInfraSubtractionMs,
   startOverheadTracking,
   stopOverheadTracking,
 } from './PlaywrightUtilities';
@@ -124,7 +125,7 @@ class TimerHelper {
 
   /**
    * Measures the execution time of an async action and subtracts Appium
-   * infrastructure overhead (findElement / isExisting / probes) on both
+   * infrastructure overhead (poll RTTs capped to the post-detect probe) on both
    * Android and iOS. See {@link measureWithOverhead}.
    *
    * Use {@link measureRaw} if you need wall-clock without overhead subtraction.
@@ -139,6 +140,9 @@ class TimerHelper {
   /**
    * Measurement path that subtracts Appium overhead from the recorded duration.
    *
+   * Infra is capped so poll sleeps (and at least 1ms) remain in app time —
+   * timers must not collapse to 0ms after a real wait.
+   *
    * @param action - Async function to measure
    * @returns This TimerHelper instance for chaining
    */
@@ -151,9 +155,8 @@ class TimerHelper {
       this.stop();
     }
     const wallClockMs = this.getDuration() ?? 0;
-    const rawInfraMs = stopOverheadTracking();
-    // Never subtract more than wall-clock (avoids false 0ms from over-counting).
-    const infraMs = Math.min(rawInfraMs, wallClockMs);
+    const { infraMs: rawInfraMs, sleepMs } = stopOverheadTracking();
+    const infraMs = clampInfraSubtractionMs(wallClockMs, rawInfraMs, sleepMs);
     if (infraMs > 0) {
       this.subtractOverhead(infraMs);
     }

--- a/tests/framework/computeAppiumInfraOverheadMs.test.ts
+++ b/tests/framework/computeAppiumInfraOverheadMs.test.ts
@@ -1,7 +1,13 @@
-import { computeAppiumInfraOverheadMs } from './PlaywrightUtilities';
+import {
+  clampInfraSubtractionMs,
+  computeAppiumInfraOverheadMs,
+  nextMeasuringPollIntervalMs,
+} from './PlaywrightUtilities';
 
 describe('computeAppiumInfraOverheadMs', () => {
-  it('subtracts only the probe RTT', () => {
+  it('subtracts probe plus failed/success polls capped at probe RTT', () => {
+    // Failed polls often include implicit-wait time (~300ms+). Cap each at
+    // probe RTT so we only remove network/infra, not app wait inside the command.
     expect(
       computeAppiumInfraOverheadMs({
         directMs: 8000,
@@ -10,7 +16,31 @@ describe('computeAppiumInfraOverheadMs', () => {
         successPollMs: 2000,
         probeMs: 204,
       }),
-    ).toBe(204);
+    ).toBe(204 + 204 + 204 + 204);
+  });
+
+  it('does not subtract directMs or sleepMs', () => {
+    expect(
+      computeAppiumInfraOverheadMs({
+        directMs: 8000,
+        sleepMs: 900,
+        failedPollDurationsMs: [],
+        successPollMs: null,
+        probeMs: 150,
+      }),
+    ).toBe(150);
+  });
+
+  it('caps a fast failed poll at its own duration when below probe RTT', () => {
+    expect(
+      computeAppiumInfraOverheadMs({
+        directMs: 0,
+        sleepMs: 0,
+        failedPollDurationsMs: [80, 90],
+        successPollMs: 100,
+        probeMs: 200,
+      }),
+    ).toBe(200 + 80 + 90 + 100);
   });
 
   it('subtracts nothing without a probe', () => {
@@ -18,10 +48,43 @@ describe('computeAppiumInfraOverheadMs', () => {
       computeAppiumInfraOverheadMs({
         directMs: 8000,
         sleepMs: 0,
-        failedPollDurationsMs: [],
+        failedPollDurationsMs: [700],
         successPollMs: 500,
         probeMs: null,
       }),
     ).toBe(0);
+  });
+});
+
+describe('clampInfraSubtractionMs', () => {
+  it('preserves poll sleep time so long waits cannot collapse to 0ms', () => {
+    expect(clampInfraSubtractionMs(5_000, 4_800, 900)).toBe(4_100);
+  });
+
+  it('keeps a 1ms app floor when wall-clock is positive but sleep is 0', () => {
+    expect(clampInfraSubtractionMs(400, 400, 0)).toBe(399);
+  });
+
+  it('returns 0 infra when wall-clock is 0', () => {
+    expect(clampInfraSubtractionMs(0, 200, 0)).toBe(0);
+  });
+});
+
+describe('nextMeasuringPollIntervalMs', () => {
+  it('does not poll faster than the last command RTT', () => {
+    expect(nextMeasuringPollIntervalMs(200)).toBe(200);
+  });
+
+  it('respects the minimum interval for instant commands', () => {
+    expect(nextMeasuringPollIntervalMs(10)).toBe(50);
+  });
+
+  it('caps at the non-measuring poll interval', () => {
+    expect(nextMeasuringPollIntervalMs(800)).toBe(300);
+  });
+
+  it('falls back to the minimum when last duration is unknown', () => {
+    expect(nextMeasuringPollIntervalMs(0)).toBe(50);
+    expect(nextMeasuringPollIntervalMs(Number.NaN)).toBe(50);
   });
 });

--- a/tests/performance/onboarding/fresh-srp-wallet-creation.spec.ts
+++ b/tests/performance/onboarding/fresh-srp-wallet-creation.spec.ts
@@ -135,8 +135,8 @@ const waitForPostOnboardingDestination = async (
   let visibleCandidate: (typeof candidates)[number] | undefined;
 
   // Probe concrete elements instead of getPageSource(): full hierarchy dumps
-  // are multi-second Appium RTTs on BrowserStack/TestMu and were not fully
-  // subtracted from TimerHelper (only the final probe is).
+  // are multi-second Appium RTTs on BrowserStack/TestMu and are not tracked as
+  // capped poll overhead the way expectElementToBeVisible is.
   await withImplicitWait(DESTINATION_PROBE_IMPLICIT_WAIT_MS, async () => {
     await appDriver.waitUntil(
       async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

Performance `TimerHelper.measure()` previously subtracted only the post-detect Appium probe RTT. On high-RTT clouds (BrowserStack and TestMu), failed poll commands still inflated reported app time because their network cost stayed in the timer.

This change makes measured app time closer to real UI wait for **all** providers:

1. **Capped poll overhead** — subtract failed + success poll command durations, each capped at the post-detect probe RTT (so implicit-wait / app-load inside those commands is not removed).
2. **Adaptive poll interval** — while measuring, do not poll faster than the last command took (capped between 50–300ms).
3. **Anti-zero floor** — clamp infra subtraction so poll sleeps (and at least 1ms) remain in app time; timers cannot collapse to 0ms after a real wait.

No provider-specific logic. Same tests / same config; both BS and TestMu benefit when RTT is non-trivial.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: MMQA-2042 TestMu vs BrowserStack performance PoC

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: TimerHelper Appium overhead compensation

  Scenario: unit coverage for capped infra and floor
    Given the computeAppiumInfraOverheadMs / clampInfraSubtractionMs / nextMeasuringPollIntervalMs unit tests
    When yarn jest tests/framework/computeAppiumInfraOverheadMs.test.ts
    Then all tests pass

  Scenario: optional cloud sanity (N/A for merge if unit-only)
    Given a performance smoke run on BrowserStack or TestMu
    When a measured wait has multiple failed polls
    Then timer logs show wall-clock > app, infra > probe-only, and app is never 0ms after a multi-second wait
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — measurement framework / unit-tested change; no UI.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a75116c-34e8-4488-896c-267d304e469b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a75116c-34e8-4488-896c-267d304e469b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

