### PR TITLE
feat(ci): add @metamaskbot create-testflight-build-{exp,rc} PR command

### DIFF
--- a/.github/workflows/build-and-upload-to-testflight.yml
+++ b/.github/workflows/build-and-upload-to-testflight.yml
@@ -28,6 +28,11 @@ on:
         required: false
         type: string
         default: current
+      pr_number:
+        description: 'If set, post the TestFlight upload summary as a comment on this PR'
+        required: false
+        type: string
+        default: ''
   workflow_dispatch:
     inputs:
       source_branch:
@@ -66,6 +71,11 @@ on:
           - current
           - namespace
         default: current
+      pr_number:
+        description: 'If set, post the TestFlight upload summary as a comment on this PR'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -100,4 +110,5 @@ jobs:
       build_number: ${{ needs.build.outputs.ios_version_code }}
       distribute_external: ${{ inputs.distribute_external }}
       runner_provider: ${{ inputs.runner_provider }}
+      pr_number: ${{ inputs.pr_number }}
     secrets: inherit

--- a/.github/workflows/create-testflight-build.yml
+++ b/.github/workflows/create-testflight-build.yml
@@ -1,0 +1,147 @@
+# Bot command to build the current PR's branch and upload it to TestFlight.
+#
+# Usage (comment on a pull request):
+#   @metamaskbot create-testflight-build-exp   -> builds the PR branch on the `exp` track
+#   @metamaskbot create-testflight-build-rc     -> builds the PR branch on the `rc` track
+#
+# All other build parameters (TestFlight group, external distribution, runner
+# provider) use the defaults of build-and-upload-to-testflight.yml.
+#
+# NOTE: issue_comment always runs from the default branch (main). To build the
+# PR's version of the workflow/code, this handler dispatches a workflow_dispatch
+# event on the PR branch, then exits. The dispatched run posts the version and
+# build number back to the PR when the upload finishes (via the pr_number input).
+
+name: Create TestFlight build (bot command)
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  dispatch:
+    name: Dispatch TestFlight build to PR branch
+    if: >-
+      ${{
+        github.event.issue.pull_request &&
+        (
+          startsWith(github.event.comment.body, '@metamaskbot create-testflight-build-exp') ||
+          startsWith(github.event.comment.body, '@metamaskbot create-testflight-build-rc')
+        )
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check the commenter has write access
+        id: perm
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+          PERM=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq '.permission' 2>/dev/null || echo 'none')
+          echo "permission=${PERM}"
+          if [ "$PERM" = "write" ] || [ "$PERM" = "admin" ]; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Reject unauthorized commenter
+        if: steps.perm.outputs.authorized != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          ACTOR: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" \
+            --body "@${ACTOR} TestFlight build commands require **write** access to this repository."
+          echo "::error::User ${ACTOR} is not authorized to trigger TestFlight builds"
+          exit 1
+
+      - name: React to the comment
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content='+1'
+
+      - name: Determine build track
+        id: track
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+          # The job-level `if` guarantees the comment starts with one of these.
+          if [ "${COMMENT_BODY#@metamaskbot create-testflight-build-rc}" != "$COMMENT_BODY" ]; then
+            echo "environment=rc" >> "$GITHUB_OUTPUT"
+          elif [ "${COMMENT_BODY#@metamaskbot create-testflight-build-exp}" != "$COMMENT_BODY" ]; then
+            echo "environment=exp" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Unrecognized TestFlight build command"
+            exit 1
+          fi
+
+      - name: Get PR details
+        id: pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          IS_FORK=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" --json isCrossRepository --jq '.isCrossRepository')
+          BRANCH=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" --json headRefName --jq '.headRefName')
+          {
+            echo "is_fork=${IS_FORK}"
+            echo "branch=${BRANCH}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Reject fork pull requests
+        if: steps.pr.outputs.is_fork == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" \
+            --body "⚠️ TestFlight builds can't run for pull requests from forks — the branch isn't available in this repository and signing secrets aren't exposed to fork workflows."
+          echo "::error::Cannot build fork pull requests"
+          exit 1
+
+      - name: Dispatch build-and-upload-to-testflight on the PR branch
+        if: steps.pr.outputs.is_fork == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          BRANCH: ${{ steps.pr.outputs.branch }}
+          ENVIRONMENT: ${{ steps.track.outputs.environment }}
+        run: |
+          set -euo pipefail
+          gh workflow run build-and-upload-to-testflight.yml \
+            --repo "${REPO}" \
+            --ref "${BRANCH}" \
+            -f "source_branch=${BRANCH}" \
+            -f "environment=${ENVIRONMENT}" \
+            -f "pr_number=${PR_NUMBER}"
+
+          ACTIONS_URL="${SERVER_URL}/${REPO}/actions/workflows/build-and-upload-to-testflight.yml"
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" \
+            --body "🚀 **TestFlight \`${ENVIRONMENT}\` build started** for branch \`${BRANCH}\`. [View workflow runs](${ACTIONS_URL}). The version and build number will be posted here once the upload finishes."

--- a/.github/workflows/create-testflight-build.yml
+++ b/.github/workflows/create-testflight-build.yml
@@ -7,10 +7,12 @@
 # All other build parameters (TestFlight group, external distribution, runner
 # provider) use the defaults of build-and-upload-to-testflight.yml.
 #
-# NOTE: issue_comment always runs from the default branch (main). To build the
-# PR's version of the workflow/code, this handler dispatches a workflow_dispatch
-# event on the PR branch, then exits. The dispatched run posts the version and
-# build number back to the PR when the upload finishes (via the pr_number input).
+# NOTE: issue_comment always runs from the default branch (main). This handler
+# dispatches build-and-upload-to-testflight.yml as a workflow_dispatch on `main`
+# (so the pipeline definition is always the stable main version), while passing
+# source_branch=<PR branch> so the PR's *code* is what gets built. The dispatched
+# run posts the version and build number back to the PR when the upload finishes
+# (via the pr_number input).
 
 name: Create TestFlight build (bot command)
 
@@ -135,9 +137,11 @@ jobs:
           ENVIRONMENT: ${{ steps.track.outputs.environment }}
         run: |
           set -euo pipefail
+          # Dispatch on `main` so the pipeline definition is always the stable
+          # main version; source_branch makes build.yml check out the PR's code.
           gh workflow run build-and-upload-to-testflight.yml \
             --repo "${REPO}" \
-            --ref "${BRANCH}" \
+            --ref main \
             -f "source_branch=${BRANCH}" \
             -f "environment=${ENVIRONMENT}" \
             -f "pr_number=${PR_NUMBER}"

--- a/.github/workflows/upload-to-testflight.yml
+++ b/.github/workflows/upload-to-testflight.yml
@@ -45,6 +45,11 @@ on:
         required: false
         type: string
         default: current
+      pr_number:
+        description: 'If set, post the upload summary as a comment on this PR when done'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -170,3 +175,44 @@ jobs:
         run: |
           rm -f ios/AuthKey.p8
           echo "🧹 Cleaned up API key file"
+
+  comment-on-pr:
+    name: Comment upload summary on PR
+    needs: [upload-ios-testflight]
+    # Only when a PR number was supplied (i.e. triggered via the bot command).
+    if: ${{ inputs.pr_number != '' }}
+    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Post TestFlight upload summary to the PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          SOURCE_BRANCH: ${{ inputs.source_branch }}
+          BUILD_NAME: ${{ inputs.build_name }}
+          BUILD_COMMIT_SHA: ${{ inputs.build_commit_sha }}
+          BUILD_VERSION: ${{ inputs.build_version }}
+          BUILD_NUMBER: ${{ inputs.build_number }}
+          TESTFLIGHT_GROUP: ${{ inputs.testflight_group }}
+        run: |
+          set -euo pipefail
+          # Values are passed via env (not expression interpolation in the script
+          # body) so branch names etc. cannot break out of the shell.
+          {
+            echo "### 📲 TestFlight build uploaded"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| **Track / environment** | \`${ENVIRONMENT}\` |"
+            echo "| **Source branch** | \`${SOURCE_BRANCH}\` |"
+            echo "| **Build version** | \`${BUILD_VERSION}\` |"
+            echo "| **Build number** | \`${BUILD_NUMBER}\` |"
+            echo "| **Build commit SHA** | \`${BUILD_COMMIT_SHA}\` |"
+            echo "| **Build name** | \`${BUILD_NAME}\` |"
+            echo "| **TestFlight group** | ${TESTFLIGHT_GROUP} |"
+          } > testflight-pr-comment.md
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body-file testflight-pr-comment.md


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Adds a `@metamaskbot` PR command so an engineer with **write access** can build the PR's own branch and upload it to TestFlight straight from a PR comment, without opening the Actions tab and wiring up inputs by hand.

**What is the reason for the change?** Today, producing a TestFlight build for a PR means manually dispatching `build-and-upload-to-testflight.yml` and filling in the branch/track by hand. This makes on-demand PR builds a one-line comment.

**What is the improvement/solution?** Two new commands you can post on any PR:

```
@metamaskbot create-testflight-build-exp   # builds the PR branch on the `exp` track
@metamaskbot create-testflight-build-rc     # builds the PR branch on the `rc` track
```

All other build parameters (TestFlight group, external distribution, runner provider) keep the existing defaults of `build-and-upload-to-testflight.yml`. When the upload finishes, the run posts the **build version and build number** (plus track, commit SHA, and group) back to the PR as a comment.

How it works:
- **New `create-testflight-build.yml`** (the command handler) fires on `issue_comment` and: verifies the **commenter** has `write`/`admin` access (rejects others with a comment); reacts 👍; derives the track; resolves the PR head branch; rejects fork PRs; then dispatches `build-and-upload-to-testflight.yml` as a `workflow_dispatch` **on `main`** with `source_branch=<PR branch>`, `environment`, and `pr_number`, and comments a "build started" link.
- **`build-and-upload-to-testflight.yml`** — new optional `pr_number` input (both triggers, default `''`), threaded into the upload job. Backward-compatible.
- **`upload-to-testflight.yml`** — new optional `pr_number` input + a `comment-on-pr` job that posts the upload summary to the PR when `pr_number` is set.

**Why a dispatch, and why on `main`?** `issue_comment` workflows always run from `main`'s workflow files, so the handler can't build the PR directly — it validates and then dispatches. It dispatches with `--ref main` so the build pipeline is always the stable main version and the `pr_number` input is read from `main` (PR branches never need to rebase to use the command); `source_branch=<PR branch>` makes `build.yml` check out the PR's code. The pattern (comment handler → dispatch) mirrors the existing `app-profiling-check.yml`. Consequence: the comment command is only usable once this is merged to `main`; before then the build/upload/comment path can be tested via a manual `workflow_dispatch`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

<!-- Internal CI/tooling change; not end-user-facing. -->

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A (internal CI tooling request)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

The comment-triggered dispatcher can only run once merged to `main` (issue_comment handlers always run from the default branch). The build → upload → PR-comment path can be verified now via a manual dispatch on this branch:

```gherkin
Feature: TestFlight build from a PR comment

  Scenario: engineer with write access triggers a build via manual dispatch (pre-merge)
    Given the branch feat/testflight-bot-command
    When they run:
      gh workflow run build-and-upload-to-testflight.yml \
        --repo MetaMask/metamask-mobile \
        --ref feat/testflight-bot-command \
        -f source_branch=feat/testflight-bot-command \
        -f environment=exp \
        -f pr_number=34136 \
        -f distribute_external=false
    Then a TestFlight build is produced for the PR branch on the exp track
    And a comment with the build version and build number is posted on this PR

  Scenario: bot command (post-merge)
    Given this change is on main and a PR branch includes the pr_number input
    When an engineer with write access comments "@metamaskbot create-testflight-build-rc"
    Then the comment is reacted to with 👍
    And a build is dispatched on the PR branch on the rc track
    And the version/build number are posted back to the PR when the upload finishes

  Scenario: unauthorized commenter
    Given a user without write access
    When they comment "@metamaskbot create-testflight-build-exp"
    Then the command is rejected with an explanatory comment and no build runs
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — CI workflow changes only; no UI.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

<!-- Performance checks N/A: this PR only changes GitHub Actions workflow YAML. -->

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Triggers signed iOS TestFlight uploads from PR comments; mitigated by write-access checks and fork rejection, but still expands who can start costly release-pipeline runs.
> 
> **Overview**
> Adds a **PR comment bot** so collaborators with write access can kick off a TestFlight build of the PR’s head branch on **`exp`** or **`rc`** without manually dispatching Actions.
> 
> A new **`create-testflight-build.yml`** handler listens for `@metamaskbot create-testflight-build-exp` / `create-testflight-build-rc`, checks permissions, blocks fork PRs, dispatches **`build-and-upload-to-testflight.yml`** on **`main`** with `source_branch` set to the PR branch and `pr_number` set, and posts a “build started” comment.
> 
> The TestFlight pipeline gains an optional **`pr_number`** input (wired through **`build-and-upload-to-testflight.yml`** into **`upload-to-testflight.yml`**). When set, a new **`comment-on-pr`** job posts an upload summary table (track, version, build number, SHA, group) on the PR after upload completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b927f2d71408775ef12122a8908e211ea61b18d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->