### PR TITLE
Fix release performance workflow permissions

### DIFF
--- a/.github/workflows/run-performance-e2e-release.yml
+++ b/.github/workflows/run-performance-e2e-release.yml
@@ -23,6 +23,7 @@ permissions:
   id-token: write
   actions: write
   pull-requests: write
+  statuses: write
 
 jobs:
   check-release-trigger:

--- a/.github/workflows/run-performance-e2e-release.yml
+++ b/.github/workflows/run-performance-e2e-release.yml
@@ -22,6 +22,7 @@ permissions:
   contents: write
   id-token: write
   actions: write
+  pull-requests: write
 
 jobs:
   check-release-trigger:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- backport the release-workflow permission update already present on `main`
- grant `pull-requests: write` and `statuses: write` so the reusable performance E2E workflow can be called successfully

## Background
This synchronizes the release branch with commit `7e6129a3051` from PR #34049.

## Testing
- `git diff --check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6ad81df-55cf-46bc-a05a-acc2b802bb7c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6ad81df-55cf-46bc-a05a-acc2b802bb7c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

