### PR TITLE
Backport performance BrowserStack workflow changes to release

### DIFF
--- a/.github/workflows/build-android-upload-to-browserstack.yml
+++ b/.github/workflows/build-android-upload-to-browserstack.yml
@@ -1,6 +1,17 @@
 # This workflow creates two Android Builds and uploads to BrowserStack using GitHub Actions.
 # Build 1: With ADDITIONAL_SRP_1 and PREDEFINED_PASSWORD (pre-imported wallet) — e2e-bs-with-srp
 # Build 2: With E2E_MOCK_OAUTH (seedless onboarding) — e2e-bs-without-srp
+#
+# Fingerprint reuse (same procedure as build-android-e2e.yml):
+#   1. Look up prior android-apk-main-e2e-bs-* (or variant) artifacts by @expo/fingerprint.
+#   2. Download + validate both APKs before committing to reuse (continue-on-error).
+#      On download/validation failure → found=false and fall back to fresh dual Gradle builds.
+#      On success → stage as fingerprint-reuse-android-apk-* (collision-safe), set found=true,
+#      then best-effort publish android-apk-* for future lookup (only after reuse is committed,
+#      so a partial publish cannot break Gradle fallback).
+#   3. On validated hit + main_branch_only (test-only) → re-upload APKs as-is (app JS unchanged).
+#   4. On validated hit + app changes → skip Gradle, @expo/repack-app both profiles with
+#      current JS, then upload (fingerprint ignores JS-only changes).
 
 name: Build Android Dual Versions and Upload to BrowserStack
 
@@ -24,6 +35,21 @@ on:
         type: string
         description: 'Build variant (e2e = e2e environment, exp = experimental)'
         default: 'exp'
+      source_fingerprint:
+        required: false
+        type: string
+        description: >-
+          @expo/fingerprint hash from native-build-fingerprint. When set, try to
+          reuse prior BrowserStack performance APKs (repack JS unless test-only).
+        default: ''
+      main_branch_only:
+        required: false
+        type: boolean
+        description: >-
+          When true (test-only PRs), search mainly on main and skip JS repack
+          (app JS unchanged). When false, fingerprint hit still reuses native
+          APKs but repacks the JS bundle like E2E.
+        default: false
     outputs:
       with-srp-browserstack-url:
         description: 'BrowserStack URL for with-SRP version'
@@ -53,6 +79,8 @@ on:
 permissions:
   contents: write
   id-token: write
+  actions: read
+  statuses: read
 
 jobs:
   check-builds-needed:
@@ -60,6 +88,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       builds-needed: ${{ steps.check-builds.outputs.builds-needed }}
+      with-srp-build-name: ${{ steps.names.outputs.with-srp-build-name }}
+      without-srp-build-name: ${{ steps.names.outputs.without-srp-build-name }}
+      github-environment: ${{ steps.names.outputs.github-environment }}
 
     steps:
       - name: Check if builds are needed
@@ -73,33 +104,387 @@ jobs:
             echo "Android builds needed - no BS URLs provided"
           fi
 
-  build-with-srp:
-    name: Build Android with-SRP
+      - name: Resolve build artifact names
+        id: names
+        run: |
+          if [ "${{ inputs.build_variant }}" = "exp" ]; then
+            {
+              echo "with-srp-build-name=main-exp-with-srp"
+              echo "without-srp-build-name=main-exp-without-srp"
+              echo "github-environment=build-exp"
+            } >> "$GITHUB_OUTPUT"
+          elif [ "${{ inputs.build_variant }}" = "rc" ]; then
+            {
+              echo "with-srp-build-name=main-rc-with-srp"
+              echo "without-srp-build-name=main-rc-without-srp"
+              echo "github-environment=build-rc"
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "with-srp-build-name=main-e2e-bs-with-srp"
+              echo "without-srp-build-name=main-e2e-bs-without-srp"
+              echo "github-environment=build-e2e"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+  resolve-fingerprint-reuse:
+    name: Resolve fingerprint-reusable BrowserStack APKs
+    runs-on: ubuntu-latest
     needs: [check-builds-needed]
-    if: needs.check-builds-needed.outputs.builds-needed == 'true'
+    if: >-
+      needs.check-builds-needed.outputs.builds-needed == 'true' &&
+      inputs.source_fingerprint
+    outputs:
+      found: ${{ steps.finalize.outputs.found }}
+      run-id: ${{ steps.finalize.outputs.run-id }}
+      source-sha: ${{ steps.finalize.outputs.source-sha }}
+      source-branch: ${{ steps.finalize.outputs.source-branch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github/actions/find-reusable-build
+          sparse-checkout-cone-mode: false
+
+      - name: Find reusable performance APKs on ci.yml
+        id: find-ci
+        uses: ./.github/actions/find-reusable-build
+        with:
+          fingerprint: ${{ inputs.source_fingerprint }}
+          artifact-names: ${{ format('["android-apk-{0}","android-apk-{1}"]', needs.check-builds-needed.outputs.with-srp-build-name, needs.check-builds-needed.outputs.without-srp-build-name) }}
+          github-token: ${{ github.token }}
+          workflow-file: ci.yml
+          main-branch-only: ${{ inputs.main_branch_only }}
+          max-candidates-per-branch: ${{ inputs.main_branch_only && '30' || '10' }}
+
+      - name: Find reusable performance APKs on run-performance-e2e.yml
+        id: find-perf
+        if: ${{ steps.find-ci.outputs.found != 'true' }}
+        uses: ./.github/actions/find-reusable-build
+        with:
+          fingerprint: ${{ inputs.source_fingerprint }}
+          artifact-names: ${{ format('["android-apk-{0}","android-apk-{1}"]', needs.check-builds-needed.outputs.with-srp-build-name, needs.check-builds-needed.outputs.without-srp-build-name) }}
+          github-token: ${{ github.token }}
+          workflow-file: run-performance-e2e.yml
+          main-branch-only: ${{ inputs.main_branch_only }}
+          max-candidates-per-branch: ${{ inputs.main_branch_only && '30' || '10' }}
+
+      - name: Find reusable performance APKs on run-performance-e2e-release.yml
+        id: find-release
+        if: ${{ steps.find-ci.outputs.found != 'true' && steps.find-perf.outputs.found != 'true' }}
+        uses: ./.github/actions/find-reusable-build
+        with:
+          fingerprint: ${{ inputs.source_fingerprint }}
+          artifact-names: ${{ format('["android-apk-{0}","android-apk-{1}"]', needs.check-builds-needed.outputs.with-srp-build-name, needs.check-builds-needed.outputs.without-srp-build-name) }}
+          github-token: ${{ github.token }}
+          workflow-file: run-performance-e2e-release.yml
+          main-branch-only: ${{ inputs.main_branch_only }}
+          max-candidates-per-branch: ${{ inputs.main_branch_only && '30' || '10' }}
+
+      - name: Find reusable performance APKs on run-performance-e2e-experimental.yml
+        id: find-exp
+        if: ${{ steps.find-ci.outputs.found != 'true' && steps.find-perf.outputs.found != 'true' && steps.find-release.outputs.found != 'true' }}
+        uses: ./.github/actions/find-reusable-build
+        with:
+          fingerprint: ${{ inputs.source_fingerprint }}
+          artifact-names: ${{ format('["android-apk-{0}","android-apk-{1}"]', needs.check-builds-needed.outputs.with-srp-build-name, needs.check-builds-needed.outputs.without-srp-build-name) }}
+          github-token: ${{ github.token }}
+          workflow-file: run-performance-e2e-experimental.yml
+          main-branch-only: ${{ inputs.main_branch_only }}
+          max-candidates-per-branch: ${{ inputs.main_branch_only && '30' || '10' }}
+
+      # Select a candidate run only. found=true is deferred until both APK downloads
+      # succeed (mirrors build-android-e2e.yml gate: never skip native build on lookup alone).
+      - name: Select fingerprint reuse candidate
+        id: candidate
+        run: |
+          if [ "${{ steps.find-ci.outputs.found }}" = "true" ]; then
+            {
+              echo "found=true"
+              echo "run-id=${{ steps.find-ci.outputs.run-id }}"
+              echo "source-sha=${{ steps.find-ci.outputs.source-sha }}"
+              echo "source-branch=${{ steps.find-ci.outputs.source-branch }}"
+              echo "source-workflow=ci.yml"
+            } >> "$GITHUB_OUTPUT"
+            echo "Candidate: ci.yml run ${{ steps.find-ci.outputs.run-id }}"
+          elif [ "${{ steps.find-perf.outputs.found }}" = "true" ]; then
+            {
+              echo "found=true"
+              echo "run-id=${{ steps.find-perf.outputs.run-id }}"
+              echo "source-sha=${{ steps.find-perf.outputs.source-sha }}"
+              echo "source-branch=${{ steps.find-perf.outputs.source-branch }}"
+              echo "source-workflow=run-performance-e2e.yml"
+            } >> "$GITHUB_OUTPUT"
+            echo "Candidate: run-performance-e2e.yml run ${{ steps.find-perf.outputs.run-id }}"
+          elif [ "${{ steps.find-release.outputs.found }}" = "true" ]; then
+            {
+              echo "found=true"
+              echo "run-id=${{ steps.find-release.outputs.run-id }}"
+              echo "source-sha=${{ steps.find-release.outputs.source-sha }}"
+              echo "source-branch=${{ steps.find-release.outputs.source-branch }}"
+              echo "source-workflow=run-performance-e2e-release.yml"
+            } >> "$GITHUB_OUTPUT"
+            echo "Candidate: run-performance-e2e-release.yml run ${{ steps.find-release.outputs.run-id }}"
+          elif [ "${{ steps.find-exp.outputs.found }}" = "true" ]; then
+            {
+              echo "found=true"
+              echo "run-id=${{ steps.find-exp.outputs.run-id }}"
+              echo "source-sha=${{ steps.find-exp.outputs.source-sha }}"
+              echo "source-branch=${{ steps.find-exp.outputs.source-branch }}"
+              echo "source-workflow=run-performance-e2e-experimental.yml"
+            } >> "$GITHUB_OUTPUT"
+            echo "Candidate: run-performance-e2e-experimental.yml run ${{ steps.find-exp.outputs.run-id }}"
+          else
+            {
+              echo "found=false"
+              echo "run-id="
+              echo "source-sha="
+              echo "source-branch="
+              echo "source-workflow="
+            } >> "$GITHUB_OUTPUT"
+            echo "No fingerprint-matching BrowserStack performance APK candidate found."
+          fi
+
+      - name: Download candidate with-SRP APK
+        id: download-with-srp
+        if: steps.candidate.outputs.found == 'true'
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: android-apk-${{ needs.check-builds-needed.outputs.with-srp-build-name }}
+          path: artifacts/with-srp
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.candidate.outputs.run-id }}
+
+      - name: Download candidate without-SRP APK
+        id: download-without-srp
+        if: steps.candidate.outputs.found == 'true'
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: android-apk-${{ needs.check-builds-needed.outputs.without-srp-build-name }}
+          path: artifacts/without-srp
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.candidate.outputs.run-id }}
+
+      - name: Validate downloaded candidate APKs
+        id: validate-downloads
+        env:
+          CANDIDATE_FOUND: ${{ steps.candidate.outputs.found }}
+          CANDIDATE_RUN_ID: ${{ steps.candidate.outputs.run-id }}
+          CANDIDATE_SOURCE_WORKFLOW: ${{ steps.candidate.outputs.source-workflow }}
+          DOWNLOAD_WITH_SRP: ${{ steps.download-with-srp.outcome }}
+          DOWNLOAD_WITHOUT_SRP: ${{ steps.download-without-srp.outcome }}
+        run: |
+          set -euo pipefail
+
+          if [ "$CANDIDATE_FOUND" != "true" ]; then
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            echo "No fingerprint-matching BrowserStack performance APKs found; will build fresh."
+            exit 0
+          fi
+
+          with_srp_apk="$(find artifacts/with-srp -name '*.apk' -type f 2>/dev/null | head -1 || true)"
+          without_srp_apk="$(find artifacts/without-srp -name '*.apk' -type f 2>/dev/null | head -1 || true)"
+
+          if [ "$DOWNLOAD_WITH_SRP" = "success" ] \
+            && [ "$DOWNLOAD_WITHOUT_SRP" = "success" ] \
+            && [ -n "$with_srp_apk" ] \
+            && [ -n "$without_srp_apk" ]; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
+            echo "Validated downloaded performance APKs from $CANDIDATE_SOURCE_WORKFLOW run $CANDIDATE_RUN_ID"
+            echo "  with-SRP: $with_srp_apk ($(du -h "$with_srp_apk" | cut -f1))"
+            echo "  without-SRP: $without_srp_apk ($(du -h "$without_srp_apk" | cut -f1))"
+          else
+            echo "valid=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Reusable run $CANDIDATE_RUN_ID was found but artifact download/validation failed (with-srp=$DOWNLOAD_WITH_SRP, without-srp=$DOWNLOAD_WITHOUT_SRP); falling back to fresh dual Gradle builds."
+          fi
+
+      # Re-stage on this run so upload does not re-download from the prior run
+      # (artifacts can expire between lookup and the later upload job).
+      #
+      # Two artifact name families:
+      #   1) fingerprint-reuse-android-apk-* — collision-safe staging used to decide
+      #      reuse. If staging fails we fall back to Gradle; these names never clash
+      #      with build.yml's android-apk-*.
+      #   2) android-apk-* — published only AFTER found=true is committed, so a
+      #      partial publish can never collide with a fresh-build fallback. Needed
+      #      so reuse-only runs remain find-reusable-build sources (~10-run window).
+      - name: Re-stage with-SRP APK on current run
+        id: restage-with-srp
+        if: steps.validate-downloads.outputs.valid == 'true'
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: fingerprint-reuse-android-apk-${{ needs.check-builds-needed.outputs.with-srp-build-name }}
+          path: artifacts/with-srp
+          retention-days: 1
+          if-no-files-found: error
+          # Artifacts persist across run attempts; without overwrite a full re-run
+          # after a hit would fail staging and cascade into android-apk-* conflicts.
+          overwrite: true
+
+      - name: Re-stage without-SRP APK on current run
+        id: restage-without-srp
+        if: steps.validate-downloads.outputs.valid == 'true'
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: fingerprint-reuse-android-apk-${{ needs.check-builds-needed.outputs.without-srp-build-name }}
+          path: artifacts/without-srp
+          retention-days: 1
+          if-no-files-found: error
+          overwrite: true
+
+      # Commit reuse only from collision-safe staging. Never require android-apk-*
+      # publish here — a partial android-apk-* upload before found=false would
+      # break the Gradle fallback via upload-artifact v4 name conflicts.
+      - name: Finalize fingerprint reuse decision
+        id: finalize
+        env:
+          DOWNLOADS_VALID: ${{ steps.validate-downloads.outputs.valid }}
+          RESTAGE_WITH_SRP: ${{ steps.restage-with-srp.outcome }}
+          RESTAGE_WITHOUT_SRP: ${{ steps.restage-without-srp.outcome }}
+          CANDIDATE_RUN_ID: ${{ steps.candidate.outputs.run-id }}
+          CANDIDATE_SOURCE_SHA: ${{ steps.candidate.outputs.source-sha }}
+          CANDIDATE_SOURCE_BRANCH: ${{ steps.candidate.outputs.source-branch }}
+        run: |
+          set -euo pipefail
+
+          if [ "$DOWNLOADS_VALID" = "true" ] \
+            && [ "$RESTAGE_WITH_SRP" = "success" ] \
+            && [ "$RESTAGE_WITHOUT_SRP" = "success" ]; then
+            {
+              echo "found=true"
+              echo "run-id=$CANDIDATE_RUN_ID"
+              echo "source-sha=$CANDIDATE_SOURCE_SHA"
+              echo "source-branch=$CANDIDATE_SOURCE_BRANCH"
+            } >> "$GITHUB_OUTPUT"
+            echo "Fingerprint reuse committed: staging artifacts are on this run (Gradle skipped)."
+          else
+            {
+              echo "found=false"
+              echo "run-id="
+              echo "source-sha="
+              echo "source-branch="
+            } >> "$GITHUB_OUTPUT"
+            if [ "$DOWNLOADS_VALID" = "true" ]; then
+              echo "::warning::Candidate APKs downloaded but staging failed (with-srp=$RESTAGE_WITH_SRP, without-srp=$RESTAGE_WITHOUT_SRP); falling back to fresh dual Gradle builds."
+            fi
+          fi
+
+      # Best-effort lookup-chain publish. Runs only after reuse is committed
+      # (builds already skipped), so partial failure cannot collide with Gradle.
+      - name: Publish with-SRP APK for future fingerprint lookup
+        id: publish-lookup-with-srp
+        if: steps.finalize.outputs.found == 'true'
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk-${{ needs.check-builds-needed.outputs.with-srp-build-name }}
+          path: artifacts/with-srp
+          if-no-files-found: error
+          overwrite: true
+
+      - name: Publish without-SRP APK for future fingerprint lookup
+        id: publish-lookup-without-srp
+        if: steps.finalize.outputs.found == 'true'
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk-${{ needs.check-builds-needed.outputs.without-srp-build-name }}
+          path: artifacts/without-srp
+          if-no-files-found: error
+          overwrite: true
+
+      - name: Warn if lookup-chain publish was incomplete
+        if: steps.finalize.outputs.found == 'true'
+        env:
+          PUBLISH_LOOKUP_WITH_SRP: ${{ steps.publish-lookup-with-srp.outcome }}
+          PUBLISH_LOOKUP_WITHOUT_SRP: ${{ steps.publish-lookup-without-srp.outcome }}
+        run: |
+          if [ "$PUBLISH_LOOKUP_WITH_SRP" != "success" ] || [ "$PUBLISH_LOOKUP_WITHOUT_SRP" != "success" ]; then
+            echo "::warning::Reuse will proceed for this run, but android-apk-* lookup publish was incomplete (with-srp=$PUBLISH_LOOKUP_WITH_SRP, without-srp=$PUBLISH_LOOKUP_WITHOUT_SRP). This run may not be a future fingerprint source."
+          else
+            echo "Lookup-chain artifacts published (android-apk-*)."
+          fi
+
+  build-with-srp:
+    name: Performance Build Android (with-SRP)
+    needs: [check-builds-needed, resolve-fingerprint-reuse]
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.check-builds-needed.outputs.builds-needed == 'true' &&
+      (
+        needs.resolve-fingerprint-reuse.result == 'skipped' ||
+        needs.resolve-fingerprint-reuse.outputs.found != 'true'
+      )
     uses: ./.github/workflows/build.yml
     with:
-      build_name: ${{ inputs.build_variant == 'exp' && 'main-exp-with-srp' || inputs.build_variant == 'rc' && 'main-rc-with-srp' || 'main-e2e-bs-with-srp' }}
+      build_name: ${{ needs.check-builds-needed.outputs.with-srp-build-name }}
       platform: android
       source_branch: ${{ inputs.branch_name || github.ref_name }}
     secrets: inherit
 
   build-without-srp:
-    name: Build Android without-SRP
-    needs: [check-builds-needed]
-    if: needs.check-builds-needed.outputs.builds-needed == 'true'
+    name: Performance Build Android (without-SRP)
+    needs: [check-builds-needed, resolve-fingerprint-reuse]
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.check-builds-needed.outputs.builds-needed == 'true' &&
+      (
+        needs.resolve-fingerprint-reuse.result == 'skipped' ||
+        needs.resolve-fingerprint-reuse.outputs.found != 'true'
+      )
     uses: ./.github/workflows/build.yml
     with:
-      build_name: ${{ inputs.build_variant == 'exp' && 'main-exp-without-srp' || inputs.build_variant == 'rc' && 'main-rc-without-srp' || 'main-e2e-bs-without-srp' }}
+      build_name: ${{ needs.check-builds-needed.outputs.without-srp-build-name }}
       platform: android
       source_branch: ${{ inputs.branch_name || github.ref_name }}
     secrets: inherit
 
   upload-to-browserstack:
     name: Upload APKs to BrowserStack
-    runs-on: ubuntu-latest
-    needs: [check-builds-needed, build-with-srp, build-without-srp]
-    if: needs.check-builds-needed.outputs.builds-needed == 'true' && needs.build-with-srp.result == 'success' && needs.build-without-srp.result == 'success'
+    # Repack needs Android SDK/apksigner (Cirrus). Light as-is/fresh upload can stay on ubuntu.
+    runs-on: >-
+      ${{
+        needs.resolve-fingerprint-reuse.outputs.found == 'true' &&
+        inputs.main_branch_only != true &&
+        fromJSON('["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg"]') ||
+        fromJSON('["ubuntu-latest"]')
+      }}
+    # Only the JS-repack path needs build-e2e/rc/exp secrets (ADDITIONAL_SRP_1, etc.).
+    # Fresh/as-is upload only needs repo-level BrowserStack credentials.
+    environment: >-
+      ${{
+        needs.resolve-fingerprint-reuse.outputs.found == 'true' &&
+        inputs.main_branch_only != true &&
+        needs.check-builds-needed.outputs.github-environment ||
+        ''
+      }}
+    needs:
+      [
+        check-builds-needed,
+        resolve-fingerprint-reuse,
+        build-with-srp,
+        build-without-srp,
+      ]
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.check-builds-needed.outputs.builds-needed == 'true' &&
+      (
+        needs.resolve-fingerprint-reuse.outputs.found == 'true' ||
+        (
+          needs.build-with-srp.result == 'success' &&
+          needs.build-without-srp.result == 'success'
+        )
+      )
     outputs:
       with-srp-browserstack-url: ${{ steps.browserstack-upload.outputs.with-srp-browserstack-url }}
       without-srp-browserstack-url: ${{ steps.browserstack-upload.outputs.without-srp-browserstack-url }}
@@ -109,39 +494,195 @@ jobs:
       without-srp-version: ${{ steps.browserstack-upload.outputs.without-srp-version }}
 
     steps:
-      - name: Download with-SRP APK
+      - name: Checkout (repack path)
+        if: >-
+          needs.resolve-fingerprint-reuse.outputs.found == 'true' &&
+          inputs.main_branch_only != true
+        uses: actions/checkout@v6
+
+      - name: Setup E2E environment for APK repack
+        if: >-
+          needs.resolve-fingerprint-reuse.outputs.found == 'true' &&
+          inputs.main_branch_only != true
+        uses: ./.github/actions/setup-e2e-env
+        with:
+          platform: android
+          setup-simulator: 'false'
+          configure-keystores: 'true'
+          install-foundry: 'false'
+          runner_provider: current
+
+      - name: Setup project dependencies (lightweight, repack path)
+        if: >-
+          needs.resolve-fingerprint-reuse.outputs.found == 'true' &&
+          inputs.main_branch_only != true
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: yarn setup:github-ci --no-build-ios --no-build-android
+
+      - name: Download reused with-SRP APK
+        if: needs.resolve-fingerprint-reuse.outputs.found == 'true'
         uses: actions/download-artifact@v4
         with:
-          name: android-apk-${{ inputs.build_variant == 'exp' && 'main-exp-with-srp' || inputs.build_variant == 'rc' && 'main-rc-with-srp' || 'main-e2e-bs-with-srp' }}
+          name: fingerprint-reuse-android-apk-${{ needs.check-builds-needed.outputs.with-srp-build-name }}
           path: artifacts/with-srp
 
-      - name: Download without-SRP APK
+      - name: Download reused without-SRP APK
+        if: needs.resolve-fingerprint-reuse.outputs.found == 'true'
         uses: actions/download-artifact@v4
         with:
-          name: android-apk-${{ inputs.build_variant == 'exp' && 'main-exp-without-srp' || inputs.build_variant == 'rc' && 'main-rc-without-srp' || 'main-e2e-bs-without-srp' }}
+          name: fingerprint-reuse-android-apk-${{ needs.check-builds-needed.outputs.without-srp-build-name }}
           path: artifacts/without-srp
+
+      - name: Download fresh with-SRP APK
+        if: needs.resolve-fingerprint-reuse.outputs.found != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: android-apk-${{ needs.check-builds-needed.outputs.with-srp-build-name }}
+          path: artifacts/with-srp
+
+      - name: Download fresh without-SRP APK
+        if: needs.resolve-fingerprint-reuse.outputs.found != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: android-apk-${{ needs.check-builds-needed.outputs.without-srp-build-name }}
+          path: artifacts/without-srp
+
+      - name: Repack reused APKs with current JS (E2E-style)
+        if: >-
+          needs.resolve-fingerprint-reuse.outputs.found == 'true' &&
+          inputs.main_branch_only != true
+        env:
+          WITH_SRP_BUILD_NAME: ${{ needs.check-builds-needed.outputs.with-srp-build-name }}
+          WITHOUT_SRP_BUILD_NAME: ${{ needs.check-builds-needed.outputs.without-srp-build-name }}
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+          CI: 'true'
+          GITHUB_CI: 'true'
+          PLATFORM: android
+          NODE_OPTIONS: '--max-old-space-size=8192'
+          METRO_MAX_WORKERS: '6'
+        run: |
+          set -euo pipefail
+
+          # Apply builds.yml env + secrets into THIS shell so metro (child of yarn
+          # build:repack) inherits them. set-secrets-from-config only writes GITHUB_ENV
+          # for later steps, which is too late for a same-step metro invoke.
+          #
+          # Secret values are emitted single-quoted (with embedded quotes escaped) so
+          # bash never expands $, backticks, or $() inside them during eval.
+          cat > /tmp/export-profile-secrets.js <<'EXPORT_SECRETS_JS'
+          // Script lives in /tmp, so plain require() would resolve from /tmp and
+          // miss the repo's node_modules. Anchor resolution to the workspace cwd.
+          const { createRequire } = require('module');
+          const requireFromCwd = createRequire(process.cwd() + '/');
+          const yaml = requireFromCwd('js-yaml');
+          const fs = require('fs');
+          const buildName = process.argv[2];
+          const build = yaml.load(fs.readFileSync('builds.yml', 'utf8')).builds[buildName];
+          const mapping = (build && build.secrets) || {};
+          const all = JSON.parse(process.env.ALL_SECRETS || '{}');
+          const shellQuote = (s) => "'" + String(s).replace(/'/g, "'\\''") + "'";
+          for (const [envVar, secretName] of Object.entries(mapping)) {
+            if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(envVar)) {
+              console.error('Skipping invalid env var name: ' + envVar);
+              continue;
+            }
+            const value = all[secretName];
+            if (value != null && value !== '') {
+              process.stdout.write('export ' + envVar + '=' + shellQuote(value) + '\n');
+            } else {
+              console.error('Warning: secret ' + secretName + ' missing for ' + envVar);
+            }
+          }
+          EXPORT_SECRETS_JS
+
+          export_build_env() {
+            local build_name="$1"
+            eval "$(node scripts/apply-build-config.js "$build_name" --export)"
+            eval "$(node /tmp/export-profile-secrets.js "$build_name")"
+          }
+
+          repack_profile() {
+            local build_name="$1"
+            local src_dir="$2"
+            local out_dir="$3"
+            local label="$4"
+
+            local src_apk
+            src_apk="$(find "$src_dir" -name '*.apk' -type f | head -1)"
+            if [ -z "$src_apk" ]; then
+              echo "❌ No APK found in $src_dir for $label"
+              exit 1
+            fi
+
+            echo "=== Repacking $label from $src_apk using builds.yml profile $build_name ==="
+            mkdir -p "$out_dir" android/app/build/outputs/apk/prod/release "android/app/build/repack-working-$label" sourcemaps/android
+
+            export_build_env "$build_name"
+
+            export REPACK_SOURCE_APK="$src_apk"
+            export REPACK_OUTPUT_APK="android/app/build/outputs/apk/prod/release/app-prod-release-repack-$label.apk"
+            export REPACK_FINAL_APK="$out_dir/app-prod-release.apk"
+            export REPACK_WORKING_DIR="android/app/build/repack-working-$label"
+            export REPACK_SOURCEMAP_PATH="sourcemaps/android/index.android.bundle.$label.map"
+
+            yarn build:repack:android
+            echo "✅ Repacked $label → $REPACK_FINAL_APK ($(du -h "$REPACK_FINAL_APK" | cut -f1))"
+          }
+
+          # with-SRP first (ADDITIONAL_SRP_1 + PREDEFINED_PASSWORD inlined into JS via metro)
+          repack_profile "$WITH_SRP_BUILD_NAME" artifacts/with-srp artifacts/with-srp-repacked with-srp
+
+          # without-SRP: drop with-SRP bake-ins so they are not left in process.env
+          unset ADDITIONAL_SRP_1 PREDEFINED_PASSWORD || true
+          repack_profile "$WITHOUT_SRP_BUILD_NAME" artifacts/without-srp artifacts/without-srp-repacked without-srp
+
+          # Replace staged dirs so the upload step always reads artifacts/{with,without}-srp
+          rm -rf artifacts/with-srp artifacts/without-srp
+          mv artifacts/with-srp-repacked artifacts/with-srp
+          mv artifacts/without-srp-repacked artifacts/without-srp
 
       - name: Upload APKs to BrowserStack
         id: browserstack-upload
         env:
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          FINGERPRINT_REUSED: ${{ needs.resolve-fingerprint-reuse.outputs.found }}
+          REUSED_SOURCE_SHA: ${{ needs.resolve-fingerprint-reuse.outputs.source-sha }}
+          MAIN_BRANCH_ONLY: ${{ inputs.main_branch_only }}
+          FRESH_WITH_SRP_VERSION: ${{ needs.build-with-srp.outputs.semantic_version }}
+          FRESH_WITHOUT_SRP_VERSION: ${{ needs.build-without-srp.outputs.semantic_version }}
         run: |
           set +e  # Don't exit on error — attempt both uploads independently
           echo "Uploading APKs to BrowserStack..."
 
           BRANCH_NAME="${{ inputs.branch_name || github.ref_name }}"
           BRANCH_SLUG="$(printf '%s' "$BRANCH_NAME" | sed 's/[^A-Za-z0-9._-]/_/g' | cut -c1-40)"
-          # Stable per-branch custom_id (no run_id). BrowserStack overwrites the
-          # previous app for the same custom_id, so resolve can look up
-          # recent_apps/MetaMask-Android-*-main exactly.
           WITH_SRP_CUSTOM_ID="MetaMask-Android-With-SRP-${BRANCH_SLUG}"
           WITHOUT_SRP_CUSTOM_ID="MetaMask-Android-Without-SRP-${BRANCH_SLUG}"
           echo "BrowserStack custom_id branch slug: $BRANCH_SLUG"
           echo "With-SRP custom_id: $WITH_SRP_CUSTOM_ID"
           echo "Without-SRP custom_id: $WITHOUT_SRP_CUSTOM_ID"
 
-          # Initialize outputs
+          if [ "$FINGERPRINT_REUSED" = "true" ]; then
+            if [ "$MAIN_BRANCH_ONLY" = "true" ]; then
+              WITH_SRP_VERSION="fingerprint-reuse-as-is-${REUSED_SOURCE_SHA:0:7}"
+              WITHOUT_SRP_VERSION="fingerprint-reuse-as-is-${REUSED_SOURCE_SHA:0:7}"
+              echo "APK source: fingerprint reuse as-is (test-only, sha=${REUSED_SOURCE_SHA})"
+            else
+              WITH_SRP_VERSION="fingerprint-reuse-repack-${REUSED_SOURCE_SHA:0:7}"
+              WITHOUT_SRP_VERSION="fingerprint-reuse-repack-${REUSED_SOURCE_SHA:0:7}"
+              echo "APK source: fingerprint reuse + JS repack (sha=${REUSED_SOURCE_SHA})"
+            fi
+          else
+            WITH_SRP_VERSION="${FRESH_WITH_SRP_VERSION}"
+            WITHOUT_SRP_VERSION="${FRESH_WITHOUT_SRP_VERSION}"
+            echo "APK source: fresh dual build"
+          fi
+
           {
             echo "with-srp-apk-uploaded=false"
             echo "without-srp-apk-uploaded=false"
@@ -152,11 +693,9 @@ jobs:
           WITH_SRP_ERROR=""
           WITHOUT_SRP_ERROR=""
 
-          # Find the APK files
           WITH_SRP_APK=$(find artifacts/with-srp -name "*.apk" | head -1)
           WITHOUT_SRP_APK=$(find artifacts/without-srp -name "*.apk" | head -1)
 
-          # Upload with-SRP APK
           if [ -n "$WITH_SRP_APK" ]; then
             echo "Uploading with-SRP APK: $WITH_SRP_APK"
             echo "File size: $(du -h "$WITH_SRP_APK" | cut -f1)"
@@ -176,7 +715,7 @@ jobs:
               {
                 echo "with-srp-browserstack-url=$WITH_SRP_APP_URL"
                 echo "with-srp-app-id=$WITH_SRP_APP_ID"
-                echo "with-srp-version=${{ needs.build-with-srp.outputs.semantic_version }}"
+                echo "with-srp-version=$WITH_SRP_VERSION"
                 echo "with-srp-apk-uploaded=true"
               } >> "$GITHUB_OUTPUT"
             else
@@ -189,7 +728,6 @@ jobs:
             echo "❌ With-SRP: $WITH_SRP_ERROR"
           fi
 
-          # Upload without-SRP APK
           if [ -n "$WITHOUT_SRP_APK" ]; then
             echo "Uploading without-SRP APK: $WITHOUT_SRP_APK"
             echo "File size: $(du -h "$WITHOUT_SRP_APK" | cut -f1)"
@@ -209,7 +747,7 @@ jobs:
               {
                 echo "without-srp-browserstack-url=$WITHOUT_SRP_APP_URL"
                 echo "without-srp-app-id=$WITHOUT_SRP_APP_ID"
-                echo "without-srp-version=${{ needs.build-without-srp.outputs.semantic_version }}"
+                echo "without-srp-version=$WITHOUT_SRP_VERSION"
                 echo "without-srp-apk-uploaded=true"
               } >> "$GITHUB_OUTPUT"
             else
@@ -222,7 +760,6 @@ jobs:
             echo "❌ Without-SRP: $WITHOUT_SRP_ERROR"
           fi
 
-          # Summary
           echo ""
           echo "=== BrowserStack Upload Summary ==="
           if [ -n "$WITH_SRP_APP_URL" ]; then
@@ -236,7 +773,6 @@ jobs:
             echo "❌ Without-SRP: FAILED — ${WITHOUT_SRP_ERROR:-unknown error}"
           fi
 
-          # Fail only if BOTH uploads failed
           if [ -z "$WITH_SRP_APP_URL" ] && [ -z "$WITHOUT_SRP_APP_URL" ]; then
             echo ""
             echo "❌ Both APK uploads failed. Failing step."

--- a/.github/workflows/build-ios-upload-to-browserstack.yml
+++ b/.github/workflows/build-ios-upload-to-browserstack.yml
@@ -93,7 +93,7 @@ jobs:
           fi
 
   trigger-ios-with-srp-build:
-    name: Trigger iOS with-SRP Build
+    name: Performance Build iOS (with-SRP)
     needs: [check-builds-needed]
     if: needs.check-builds-needed.outputs.builds-needed == 'true'
     uses: ./.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
     secrets: inherit
 
   trigger-ios-without-srp-build:
-    name: Trigger iOS without-SRP Build
+    name: Performance Build iOS (without-SRP)
     needs: [check-builds-needed]
     if: needs.check-builds-needed.outputs.builds-needed == 'true'
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1233,7 +1233,7 @@ jobs:
           )
         )
       }}
-    needs: [get_requirements, smart-e2e-selection]
+    needs: [get_requirements, smart-e2e-selection, native-build-fingerprint]
     uses: ./.github/workflows/run-performance-e2e.yml
     with:
       performance_tags: ${{ needs.get_requirements.outputs.run_performance != 'true' && needs.smart-e2e-selection.outputs.ai_performance_test_tags || '' }}
@@ -1242,12 +1242,14 @@ jobs:
       branch_name: ${{ github.head_ref }}
       pr_number: ${{ github.event.pull_request.number }}
       reuse_main_builds: ${{ needs.get_requirements.outputs.native_build_needed == 'false' }}
+      source_fingerprint: ${{ needs.native-build-fingerprint.outputs.fingerprint }}
     secrets: inherit
     permissions:
       contents: write
       id-token: write
       actions: write
       pull-requests: write
+      statuses: write
 
   build-android-apks:
     name: 'Build Android APKs'

--- a/.github/workflows/run-performance-e2e-experimental.yml
+++ b/.github/workflows/run-performance-e2e-experimental.yml
@@ -24,6 +24,8 @@ permissions:
   contents: write
   id-token: write
   actions: write
+  pull-requests: write
+  statuses: write
 
 concurrency:
   group: performance-e2e-experimental-${{ github.ref }}-${{ github.event_name }}

--- a/.github/workflows/run-performance-e2e-release.yml
+++ b/.github/workflows/run-performance-e2e-release.yml
@@ -22,6 +22,8 @@ permissions:
   contents: write
   id-token: write
   actions: write
+  pull-requests: write
+  statuses: write
 
 jobs:
   check-release-trigger:

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -53,6 +53,14 @@ on:
         required: false
         type: boolean
         default: false
+      source_fingerprint:
+        description: >-
+          Optional @expo/fingerprint hash. When omitted, the workflow computes and
+          posts build-source-hash so Android BrowserStack dual builds can be reused
+          across runs with matching native sources.
+        required: false
+        type: string
+        default: ''
   workflow_call:
     inputs:
       description:
@@ -112,12 +120,21 @@ on:
         required: false
         type: boolean
         default: false
+      source_fingerprint:
+        description: >-
+          @expo/fingerprint hash from the caller (ci.yml native-build-fingerprint).
+          When empty, this workflow computes and posts build-source-hash for
+          Android BrowserStack APK reuse.
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: write
   id-token: write
   actions: write
   pull-requests: write
+  statuses: write
 
 concurrency:
   # Include build_variant so e2e, experimental (exp), and release/direct (rc) don't share the same
@@ -172,6 +189,71 @@ jobs:
 
           echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
           echo "Branch: $BRANCH_NAME"
+
+  # Same contract as ci.yml native-build-fingerprint → build-android-e2e:
+  # fingerprint must resolve for this job to succeed. Empty fingerprint disables
+  # reuse inside build-android-upload-to-browserstack (resolve job is skipped) but
+  # the dual Gradle path still runs. Download-miss fallback lives in that workflow,
+  # matching build-android-e2e.yml's continue-on-error + native-build gate.
+  ensure-fingerprint:
+    name: Ensure native build fingerprint
+    runs-on: ubuntu-latest
+    outputs:
+      fingerprint: ${{ steps.resolve.outputs.fingerprint }}
+    steps:
+      - name: Use caller-provided fingerprint
+        id: provided
+        if: ${{ inputs.source_fingerprint }}
+        env:
+          SOURCE_FINGERPRINT: ${{ inputs.source_fingerprint }}
+        run: |
+          echo "fingerprint=$SOURCE_FINGERPRINT" >> "$GITHUB_OUTPUT"
+          echo "Using caller-provided fingerprint: $SOURCE_FINGERPRINT"
+
+      - name: Checkout
+        if: ${{ !inputs.source_fingerprint }}
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        if: ${{ !inputs.source_fingerprint }}
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install Yarn dependencies with retry
+        if: ${{ !inputs.source_fingerprint }}
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: yarn install --immutable
+
+      - name: Compute and post build-source-hash
+        id: computed
+        if: ${{ !inputs.source_fingerprint }}
+        uses: ./.github/actions/post-build-source-hash
+        with:
+          github-token: ${{ github.token }}
+          post-status: 'true'
+          target-sha: ${{ github.sha }}
+
+      - name: Resolve fingerprint output
+        id: resolve
+        env:
+          PROVIDED: ${{ steps.provided.outputs.fingerprint }}
+          COMPUTED: ${{ steps.computed.outputs.fingerprint }}
+        run: |
+          if [ -n "$PROVIDED" ]; then
+            echo "fingerprint=$PROVIDED" >> "$GITHUB_OUTPUT"
+          elif [ -n "$COMPUTED" ]; then
+            echo "fingerprint=$COMPUTED" >> "$GITHUB_OUTPUT"
+          else
+            echo "❌ No fingerprint available" >&2
+            exit 1
+          fi
+          echo "Resolved fingerprint: $(grep fingerprint= "$GITHUB_OUTPUT" | tail -1)"
 
   read-device-matrix:
     name: Read Device Matrix
@@ -319,12 +401,15 @@ jobs:
   trigger-android-dual-versions:
     name: Trigger Android Dual Versions and Extract BrowserStack URLs
     uses: ./.github/workflows/build-android-upload-to-browserstack.yml
-    needs: [determine-branch-name, resolve-main-browserstack-urls]
+    needs: [determine-branch-name, resolve-main-browserstack-urls, ensure-fingerprint]
     # Build/upload when not reusing main, or when main reuse lookup found nothing.
+    # Fingerprint job must succeed (same as ci.yml native-build-fingerprint → E2E).
+    # Download-miss → fresh dual Gradle fallback is inside build-android-upload-to-browserstack.
     if: >-
       always() &&
       !cancelled() &&
       (needs.resolve-main-browserstack-urls.result == 'skipped' || needs.resolve-main-browserstack-urls.result == 'success') &&
+      needs.ensure-fingerprint.result == 'success' &&
       (!inputs.browserstack_app_url_android_onboarding && !inputs.browserstack_app_url_android_imported_wallet) &&
       (
         !inputs.reuse_main_builds ||
@@ -333,6 +418,8 @@ jobs:
     with:
       branch_name: ${{ needs.determine-branch-name.outputs.branch_name }}
       build_variant: ${{ inputs.build_variant || 'e2e' }}
+      source_fingerprint: ${{ needs.ensure-fingerprint.outputs.fingerprint }}
+      main_branch_only: ${{ inputs.reuse_main_builds }}
     secrets: inherit
 
   trigger-ios-dual-versions:
@@ -351,7 +438,7 @@ jobs:
   # =============================================================================
 
   run-android-onboarding-tests:
-    name: Run Android Onboarding Tests
+    name: Performance Test Android (Onboarding)
     uses: ./.github/workflows/performance-test-runner.yml
     needs:
       [
@@ -392,7 +479,7 @@ jobs:
     secrets: inherit
 
   run-ios-onboarding-tests:
-    name: Run iOS Onboarding Tests
+    name: Performance Test iOS (Onboarding)
     uses: ./.github/workflows/performance-test-runner.yml
     needs:
       [
@@ -432,7 +519,7 @@ jobs:
           echo "Proceeding with imported wallet tests..."
 
   run-android-imported-wallet-tests:
-    name: Run Android Imported Wallet Tests
+    name: Performance Test Android (Imported Wallet)
     uses: ./.github/workflows/performance-test-runner.yml
     needs:
       [
@@ -474,7 +561,7 @@ jobs:
     secrets: inherit
 
   run-ios-imported-wallet-tests:
-    name: Run iOS Imported Wallet Tests
+    name: Performance Test iOS (Imported Wallet)
     uses: ./.github/workflows/performance-test-runner.yml
     needs:
       [

--- a/scripts/repack.js
+++ b/scripts/repack.js
@@ -64,19 +64,33 @@ function getKeystoreConfig() {
 
 /**
  * Repack Android APK
- * Currently supports 'flask' and 'main' build types
+ * Currently supports 'flask' and 'main' build types.
+ *
+ * Optional path overrides (used by performance BrowserStack fingerprint reuse):
+ *   REPACK_SOURCE_APK, REPACK_OUTPUT_APK, REPACK_WORKING_DIR, REPACK_SOURCEMAP_PATH
  */
 async function repackAndroid() {
   const startTime = Date.now();
-  const sourceApk = 'android/app/build/outputs/apk/prod/release/app-prod-release.apk';
-  const repackedApk = 'android/app/build/outputs/apk/prod/release/app-prod-release-repack.apk';
-  const finalApk = 'android/app/build/outputs/apk/prod/release/app-prod-release.apk';
-  const sourcemapPath = 'sourcemaps/android/index.android.bundle.map';
-  const workingDir = 'android/app/build/repack-working-main';
+  const sourceApk =
+    process.env.REPACK_SOURCE_APK ||
+    'android/app/build/outputs/apk/prod/release/app-prod-release.apk';
+  const repackedApk =
+    process.env.REPACK_OUTPUT_APK ||
+    'android/app/build/outputs/apk/prod/release/app-prod-release-repack.apk';
+  const finalApk =
+    process.env.REPACK_FINAL_APK ||
+    'android/app/build/outputs/apk/prod/release/app-prod-release.apk';
+  const sourcemapPath =
+    process.env.REPACK_SOURCEMAP_PATH ||
+    'sourcemaps/android/index.android.bundle.map';
+  const workingDir =
+    process.env.REPACK_WORKING_DIR || 'android/app/build/repack-working-main';
 
   try {
     logger.info('🚀 Starting Android E2E APK repack process...');
     logger.info(`Source APK: ${sourceApk}`);
+    logger.info(`Output APK: ${finalApk}`);
+    logger.info(`Working dir: ${workingDir}`);
 
     // Verify source APK exists
     if (!fs.existsSync(sourceApk)) {

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -586,6 +586,16 @@ E2E_PERFORMANCE_BUILD_VARIANT=rc
 # CI note: scheduled/feature-branch performance workflows use build_variant=e2e
 # (GitHub environment build-e2e). E2E_PERFORMANCE_BUILD_VARIANT=rc is set separately
 # in performance-test-runner for the flags API. Release workflows use build_variant=rc.
+#
+# Android BrowserStack dual builds (main-e2e-bs-*) follow the same fingerprint
+# procedure as Detox E2E (build-android-e2e.yml), via find-reusable-build in
+# build-android-upload-to-browserstack.yml:
+#   - miss → fresh dual Gradle builds
+#   - hit + test-only (main_branch_only/reuse_main_builds) → re-upload APKs as-is
+#   - hit + app changes → skip Gradle, @expo/repack-app both profiles with current JS,
+#     then upload (fingerprint ignores JS-only changes, so repack avoids stale JS)
+# Separate from Appium smoke main-e2e APKs and from reuse_main_builds BrowserStack
+# custom_id resolution on main (test-only fast path that skips the dual-build job).
 ```
 
 ### Sentry Performance Instrumentation (Optional)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- cherry-pick PR #34049 onto `release/8.6.0`
- synchronize BrowserStack performance build workflows and required permissions
- include the release workflow `pull-requests: write` and `statuses: write` permissions

## Testing
- `git diff HEAD^ --check`
- cherry-pick applied without conflicts
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6ad81df-55cf-46bc-a05a-acc2b802bb7c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6ad81df-55cf-46bc-a05a-acc2b802bb7c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

