### PR TITLE
fix: Monad send native reduced amount ux glitch

### DIFF
--- a/app/components/Views/confirmations/hooks/useMaxValueRefresher.test.ts
+++ b/app/components/Views/confirmations/hooks/useMaxValueRefresher.test.ts
@@ -127,5 +127,43 @@ describe('useMaxValueRefresher', () => {
 
       expect(mockUpdateEditableParams).not.toHaveBeenCalled();
     });
+
+    it('gas estimation has failed', () => {
+      mockUseMaxValueMode.mockReturnValue({
+        maxValueMode: true,
+      });
+
+      const transferConfirmationStateWithSimulationFails = merge(
+        {},
+        transferConfirmationState,
+        {
+          engine: {
+            backgroundState: {
+              TransactionController: {
+                transactions: [
+                  {
+                    simulationFails: {
+                      reason: 'execution reverted',
+                      debug: {},
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      );
+
+      mockUseSelector.mockImplementation(
+        (fn: (state: DeepPartial<RootState>) => unknown) =>
+          fn(transferConfirmationStateWithSimulationFails),
+      );
+
+      renderHookWithProvider(() => useMaxValueRefresher(), {
+        state: transferConfirmationStateWithSimulationFails,
+      });
+
+      expect(mockUpdateEditableParams).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/components/Views/confirmations/hooks/useMaxValueRefresher.ts
+++ b/app/components/Views/confirmations/hooks/useMaxValueRefresher.ts
@@ -20,7 +20,7 @@ export function useMaxValueRefresher() {
   const [valueJustUpdated, setValueJustUpdated] = useState(false);
   const { setIsTransactionValueUpdating } = useConfirmationContext();
   const transactionMetadata = useTransactionMetadataRequest();
-  const { chainId, id, txParams, type } =
+  const { chainId, id, simulationFails, txParams, type } =
     transactionMetadata as TransactionMeta;
   const { maxFeeNativeHex } = useFeeCalculations(
     transactionMetadata as TransactionMeta,
@@ -28,7 +28,11 @@ export function useMaxValueRefresher() {
   const { balanceWeiInHex } = useAccountNativeBalance(chainId, txParams.from);
 
   useEffect(() => {
-    if (!maxValueMode || type !== TransactionType.simpleSend) {
+    if (
+      !maxValueMode ||
+      type !== TransactionType.simpleSend ||
+      simulationFails
+    ) {
       // Not compatible with transaction value refresh logic
       return;
     }
@@ -55,6 +59,7 @@ export function useMaxValueRefresher() {
     maxValueMode,
     maxFeeNativeHex,
     setIsTransactionValueUpdating,
+    simulationFails,
     txParams,
     type,
   ]);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When sending "Max MON" (native token) on Monad, the tx will show failure - going under the 10 MON minimum reserve - which is expected. The issue is that when this happens, the `amount` sent shown in the tx preview changes. This is because the predicted failure causes more gas consumption predicted, making the sent MON amount decrease by a seemingly-random amount.

Solution: Skip the step that refreshes the amount when done on the basis of a failing/reverting tx.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: send MAX native reduced amount ux glitch

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-extension/issues/44994 (twin issue for Mobile)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

Fix:
1. Go on Monad network.
2. Select "send" for MON.
3. Click the "max" button and don't edit the amount after that.
4. Click "next" to reach tx confirmation.
5. Check that send amount is consistent with was was pre-filled when clicking the "max" button. Check that the blocking alert is about a 10 MON minimum reserve (expected behavior).

Non-Reg:
1. Perform the same test for another Network.
2. Validate that even when editing the gas during tx confirmation, the "send max" behavior is preserve (sent amount refreshed based on <balance>-<gasEstimate>).

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/45b101a3-ebea-4a54-a053-73bb46027f1d" />

<!-- [screenshots/recordings] -->

### **After**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/77018ece-c417-4989-b322-31d4c6263b07" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow guard in send-max confirmation logic with a focused unit test; no auth, security, or data-handling changes.
> 
> **Overview**
> Fixes a confirmation UX glitch where **send max** native transfers (e.g. Monad MON) showed a **different send amount** on the review screen after simulation predicted a revert (such as violating a minimum reserve).
> 
> `useMaxValueRefresher` now **bails out** when transaction metadata includes `simulationFails`, so it no longer recomputes `value` as balance minus fee while gas estimates are inflated by a failing simulation. `simulationFails` is included in the effect dependencies, and a unit test asserts `updateEditableParams` is not called in that case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcbff006e9e47ef6c90ebb7d8a60639d90c793da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->