### PR TITLE
fix(ci): use cherry-pick version from PR title for release labels 

### DIFF
--- a/.github/scripts/add-release-label-to-pr-and-linked-issues.ts
+++ b/.github/scripts/add-release-label-to-pr-and-linked-issues.ts
@@ -8,6 +8,13 @@ import { Labelable, addLabelToLabelable } from './shared/labelable';
 import { retrievePullRequest } from './shared/pull-request';
 import { isValidVersionFormat } from './shared/utils';
 
+// Extracts version from cherry-pick PR titles (e.g., "cp-8.3.0" -> "8.3.0")
+function extractCherryPickVersion(title: string): string | null {
+  const cherryPickPattern = /cp-(\d+\.\d+\.\d+)/i;
+  const match = title.match(cherryPickPattern);
+  return match ? match[1] : null;
+}
+
 main().catch((error: Error): void => {
   console.error(error);
   process.exit(1);
@@ -42,12 +49,30 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // Release label indicates the next release version number
+  // Use cherry-pick version from PR title if present, otherwise use next release version
+  const pullRequestTitle = context.payload.pull_request?.title || '';
+  const cherryPickVersion = extractCherryPickVersion(pullRequestTitle);
+
+  let releaseVersionNumber: string;
+  if (cherryPickVersion) {
+    if (!isValidVersionFormat(cherryPickVersion)) {
+      core.setFailed(
+        `Cherry-pick version (${cherryPickVersion}) extracted from PR title is not a valid version format. The expected format is "x.y.z", where "x", "y" and "z" are numbers.`,
+      );
+      process.exit(1);
+    }
+    core.info(`Cherry-pick detected, using release version ${cherryPickVersion}`);
+    releaseVersionNumber = cherryPickVersion;
+  } else {
+    releaseVersionNumber = nextReleaseVersionNumber;
+  }
+
+  // Release label indicates the release version number
   // Example release label: "release-6.5.0"
   const releaseLabel: Label = {
-    name: `release-${nextReleaseVersionNumber}`,
+    name: `release-${releaseVersionNumber}`,
     color: 'EDEDED',
-    description: `Issue or pull request that will be included in release ${nextReleaseVersionNumber}`,
+    description: `Issue or pull request that will be included in release ${releaseVersionNumber}`,
   };
 
   // Initialise octokit, required to call Github GraphQL API

--- a/.github/scripts/add-release-label-to-pr-and-linked-issues.ts
+++ b/.github/scripts/add-release-label-to-pr-and-linked-issues.ts
@@ -50,6 +50,7 @@ async function main(): Promise<void> {
   }
 
   // Use cherry-pick version from PR title if present, otherwise use next release version
+  // CodeQL: user-controlled input is intentional; worst case is mislabeling, caught during release validation
   const pullRequestTitle = context.payload.pull_request?.title || '';
   const cherryPickVersion = extractCherryPickVersion(pullRequestTitle);
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
 Fixes https://consensyssoftware.atlassian.net/browse/MCRM-104 - metamask-ci bot is incorrectly applying release labels to PRs, leading to incorrect inclusion/exclusion in the current Release Validation Tracker.
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
 1. Added extractCherryPickVersion() function (lines 11-16) - extracts version from cp-X.Y.Z pattern in PR title            
 2. Added logic (lines 52-68) to use cherry-pick version when detected, with validation                                     
 3. Updated releaseLabel to use releaseVersionNumber instead of hardcoded nextReleaseVersionNumber  -->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
[MCRM-104](https://consensyssoftware.atlassian.net/browse/MCRM-104)
## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin

N/A
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
N/A
<!-- [screenshots/recordings] -->

### **After**
N/A
<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is limited to GitHub release-label automation with existing semver validation; impact is label accuracy on PRs/issues, not runtime app behavior.
> 
> **Overview**
> Fixes release labeling for cherry-pick PRs by deriving the target version from the PR title instead of always using `NEXT_SEMVER_VERSION`.
> 
> The **add-release-label** workflow script now parses titles matching `cp-X.Y.Z` via `extractCherryPickVersion()`, validates the extracted semver, and applies `release-{version}` to the PR and linked issues; non–cherry-pick PRs behave as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e861345fee1e986096ab1fe7e1f48514b04abfcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



[MCRM-104]: https://consensyssoftware.atlassian.net/browse/MCRM-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ