### PR TITLE
test(e2e): stop forcing native context in Appium Assertions

### DIFF
--- a/tests/framework/Assertions.ts
+++ b/tests/framework/Assertions.ts
@@ -10,7 +10,6 @@ import {
 import { Json } from '@metamask/utils';
 import { FrameworkDetector } from './FrameworkDetector.ts';
 import PlaywrightAssertions from './PlaywrightAssertions.ts';
-import PlaywrightContextHelpers from './PlaywrightContextHelpers.ts';
 
 /**
  * Assertions with auto-retry and better error messages
@@ -30,11 +29,6 @@ export default class Assertions {
     options: AssertionOptions = {},
   ): Promise<void> {
     if (FrameworkDetector.isAppium()) {
-      // Switch context BEFORE resolving the matcher so its findElement is
-      // minted against UiAutomator2, not the webview automator. Passing a
-      // thunk defers the find until after the switch, avoiding a cross-engine
-      // request-shape error on the confirmation screen post webview sign.
-      await PlaywrightContextHelpers.switchToNativeContext();
       const resolved = typeof elem === 'function' ? elem() : elem;
       return PlaywrightAssertions.expectElementToBeVisible(
         asPlaywrightElement(resolved as EncapsulatedElementType),
@@ -85,7 +79,6 @@ export default class Assertions {
     options: AssertionOptions = {},
   ): Promise<void> {
     if (FrameworkDetector.isAppium()) {
-      await PlaywrightContextHelpers.switchToNativeContext();
       const resolved = typeof elem === 'function' ? elem() : elem;
       return PlaywrightAssertions.expectElementToNotBeVisible(
         asPlaywrightElement(resolved as EncapsulatedElementType),
@@ -230,7 +223,6 @@ export default class Assertions {
     options: AssertionOptions = {},
   ): Promise<void> {
     if (FrameworkDetector.isAppium()) {
-      await PlaywrightContextHelpers.switchToNativeContext();
       return PlaywrightAssertions.expectElementToHaveLabel(
         asPlaywrightElement(elem),
         label,

--- a/tests/framework/PlaywrightWebMatchers.ts
+++ b/tests/framework/PlaywrightWebMatchers.ts
@@ -37,6 +37,11 @@ export default class PlaywrightWebMatchers {
     return this.findElementByWebID(innerID);
   }
 
+  /**
+   * Run `action` in the page's WEBVIEW context, then always restore NATIVE_APP.
+   * Native assertions after WebView interaction rely on this restore — do not
+   * compensate inside Assertions.
+   */
   static async withWebViewAction(
     pageUrl: string,
     action: () => Promise<void>,

--- a/tests/smoke-appium/confirmations/signatures/signatures-typed.spec.ts
+++ b/tests/smoke-appium/confirmations/signatures/signatures-typed.spec.ts
@@ -34,9 +34,7 @@ const SIGNATURE_LIST = [
       }),
     requestType: () => RequestTypes.TypedSignRequest,
     additionAssertions: async () => {
-      await Assertions.expectElementToBeVisible(
-        () => RowComponents.NetworkAndOrigin,
-      );
+      await Assertions.expectElementToBeVisible(RowComponents.NetworkAndOrigin);
     },
   },
   {
@@ -47,7 +45,7 @@ const SIGNATURE_LIST = [
       }),
     requestType: () => RequestTypes.TypedSignRequest,
     additionAssertions: async () => {
-      await Assertions.expectElementToBeVisible(() => RowComponents.OriginInfo);
+      await Assertions.expectElementToBeVisible(RowComponents.OriginInfo);
     },
   },
   {
@@ -58,7 +56,7 @@ const SIGNATURE_LIST = [
       }),
     requestType: () => RequestTypes.TypedSignRequest,
     additionAssertions: async () => {
-      await Assertions.expectElementToBeVisible(() => RowComponents.OriginInfo);
+      await Assertions.expectElementToBeVisible(RowComponents.OriginInfo);
     },
   },
 ];
@@ -129,20 +127,18 @@ appiumTest.describe(SmokeConfirmations('Typed Signature Requests'), () => {
 
             // cancel request
             await testDappBtn();
-            await Assertions.expectElementToBeVisible(requestType);
+            await Assertions.expectElementToBeVisible(requestType());
             await FooterActions.tapCancelButton();
-            await Assertions.expectElementToNotBeVisible(requestType);
+            await Assertions.expectElementToNotBeVisible(requestType());
 
             await testDappBtn();
-            await Assertions.expectElementToBeVisible(requestType);
+            await Assertions.expectElementToBeVisible(requestType());
 
             // check different sections are visible
             await Assertions.expectElementToBeVisible(
-              () => RowComponents.AccountNetwork,
+              RowComponents.AccountNetwork,
             );
-            await Assertions.expectElementToBeVisible(
-              () => RowComponents.Message,
-            );
+            await Assertions.expectElementToBeVisible(RowComponents.Message);
 
             // any signature specific additional assertions
             if (additionAssertions) {
@@ -151,7 +147,7 @@ appiumTest.describe(SmokeConfirmations('Typed Signature Requests'), () => {
 
             // confirm request
             await FooterActions.tapConfirmButton();
-            await Assertions.expectElementToNotBeVisible(requestType);
+            await Assertions.expectElementToNotBeVisible(requestType());
           },
         );
       },

--- a/tests/smoke-appium/confirmations/signatures/signatures.spec.ts
+++ b/tests/smoke-appium/confirmations/signatures/signatures.spec.ts
@@ -34,9 +34,7 @@ const SIGNATURE_LIST = [
       }),
     requestType: () => RequestTypes.PersonalSignRequest,
     additionAssertions: async () => {
-      await Assertions.expectElementToBeVisible(
-        () => RowComponents.NetworkAndOrigin,
-      );
+      await Assertions.expectElementToBeVisible(RowComponents.NetworkAndOrigin);
     },
   },
   {
@@ -48,7 +46,7 @@ const SIGNATURE_LIST = [
     requestType: () => RequestTypes.PersonalSignRequest,
     additionAssertions: async () => {
       await Assertions.expectElementToBeVisible(
-        () => RowComponents.SiweSigningAccountInfo,
+        RowComponents.SiweSigningAccountInfo,
       );
     },
   },
@@ -120,20 +118,18 @@ appiumTest.describe(SmokeConfirmations('Signature Requests'), () => {
 
             // cancel request
             await testDappBtn();
-            await Assertions.expectElementToBeVisible(requestType);
+            await Assertions.expectElementToBeVisible(requestType());
             await FooterActions.tapCancelButton();
-            await Assertions.expectElementToNotBeVisible(requestType);
+            await Assertions.expectElementToNotBeVisible(requestType());
 
             await testDappBtn();
-            await Assertions.expectElementToBeVisible(requestType);
+            await Assertions.expectElementToBeVisible(requestType());
 
             // check different sections are visible
             await Assertions.expectElementToBeVisible(
-              () => RowComponents.AccountNetwork,
+              RowComponents.AccountNetwork,
             );
-            await Assertions.expectElementToBeVisible(
-              () => RowComponents.Message,
-            );
+            await Assertions.expectElementToBeVisible(RowComponents.Message);
 
             // any signature specific additional assertions
             if (additionAssertions) {
@@ -142,7 +138,7 @@ appiumTest.describe(SmokeConfirmations('Signature Requests'), () => {
 
             // confirm request
             await FooterActions.tapConfirmButton();
-            await Assertions.expectElementToNotBeVisible(requestType);
+            await Assertions.expectElementToNotBeVisible(requestType());
           },
         );
       },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Removes the blanket `switchToNativeContext()` from Appium `Assertions.expectElementToBeVisible` / `NotBeVisible` / `HaveLabel`.

**Why:** Forcing native context inside a generic visibility assert is an anti-pattern. Assertions should not own Appium context — callers assert both native and WebView elements, and a global switch breaks that contract. Context restore belongs at the WebView interaction boundary (`withWebViewAction` already restores `NATIVE_APP` in `finally`).

Also drops the call-site thunk workarounds that only existed to paper over that switch.

**Origin:** The switch was introduced in #32804 (networks Appium migration). #33528 later added thunks for signature confirmations on top of it.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #33528
Refs: #32804

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — test-framework only. Coverage via Appium `SmokeConfirmations` signature specs.

```bash
yarn appium-smoke:android --grep "Signature Requests"
yarn appium-smoke:ios --grep "Signature Requests"
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — test-only change; no user-facing UI.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
