### PR TITLE
test(appium): session reuse + soft reload and smoke shard rebalance

### DIFF
--- a/.e2e.env.example
+++ b/.e2e.env.example
@@ -28,6 +28,11 @@ export PREBUILT_ANDROID_TEST_APK_PATH='build/MetaMask-Test.apk'
 # export SKIP_APP_REINSTALL=true
 export SKIP_APP_REINSTALL=false
 
+# Playwright Appium: reuse one WebDriver session per worker (emulator/simulator).
+# Default is on when unset. Set false to force per-test deleteSession (rollback).
+# BrowserStack ignores this and never reuses sessions.
+# export APPIUM_SESSION_REUSE=false
+
 export TEST_SRP_1=
 export TEST_SRP_2=
 export TEST_SRP_3=

--- a/.github/workflows/run-appium-smoke-tests-android.yml
+++ b/.github/workflows/run-appium-smoke-tests-android.yml
@@ -65,7 +65,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2, 3, 4]
+        split: [1, 2]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -73,7 +73,8 @@ jobs:
       platform: android
       test_suite_tag: SmokeAccounts
       split_number: ${{ matrix.split }}
-      total_splits: 4
+      total_splits: 2
+      test-timeout-minutes: 25
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
       runner_provider: ${{ inputs.runner_provider }}
@@ -88,7 +89,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2]
+        split: [1]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -96,7 +97,8 @@ jobs:
       platform: android
       test_suite_tag: SmokePerps
       split_number: ${{ matrix.split }}
-      total_splits: 2
+      total_splits: 1
+      test-timeout-minutes: 25
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
       runner_provider: ${{ inputs.runner_provider }}
@@ -111,7 +113,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2, 3]
+        split: [1, 2]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -119,7 +121,7 @@ jobs:
       platform: android
       test_suite_tag: SmokePredictions
       split_number: ${{ matrix.split }}
-      total_splits: 3
+      total_splits: 2
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
@@ -135,7 +137,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2, 3, 4]
+        split: [1, 2]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -143,7 +145,7 @@ jobs:
       platform: android
       test_suite_tag: SmokeSeedlessOnboarding
       split_number: ${{ matrix.split }}
-      total_splits: 4
+      total_splits: 2
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
@@ -160,7 +162,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2, 3, 4, 5, 6, 7, 8]
+        split: [1, 2, 3]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -168,10 +170,9 @@ jobs:
       platform: android
       test_suite_tag: SmokeSnaps
       split_number: ${{ matrix.split }}
-      total_splits: 8
-      # Temporary: full login+install per test makes Android snaps shards slow.
-      # Drop back toward 25 once Appium has reloadReactNative (no full login each test).
-      test-timeout-minutes: 40
+      total_splits: 3
+      # Session reuse + soft reload: denser shards; drop toward 25 after one green main.
+      test-timeout-minutes: 30
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
       runner_provider: ${{ inputs.runner_provider }}
@@ -209,7 +210,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2, 3, 4]
+        split: [1, 2]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -217,7 +218,8 @@ jobs:
       platform: android
       test_suite_tag: SmokeWalletPlatform
       split_number: ${{ matrix.split }}
-      total_splits: 4
+      total_splits: 2
+      test-timeout-minutes: 25
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
       runner_provider: ${{ inputs.runner_provider }}
@@ -232,7 +234,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2]
+        split: [1]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -240,8 +242,8 @@ jobs:
       platform: android
       test_suite_tag: SmokeSwap
       split_number: ${{ matrix.split }}
-      total_splits: 2
-      test-timeout-minutes: 25
+      total_splits: 1
+      test-timeout-minutes: 30
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
       runner_provider: ${{ inputs.runner_provider }}
@@ -256,7 +258,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2]
+        split: [1]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -264,7 +266,7 @@ jobs:
       platform: android
       test_suite_tag: SmokeStake
       split_number: ${{ matrix.split }}
-      total_splits: 2
+      total_splits: 1
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
@@ -362,7 +364,7 @@ jobs:
       test_suite_tag: SmokeConfirmations
       split_number: ${{ matrix.split }}
       total_splits: 2
-      test-timeout-minutes: 60
+      test-timeout-minutes: 35
       build_type: ${{ inputs.build_type }}
       metamask_environment: ${{ inputs.metamask_environment }}
       runner_provider: ${{ inputs.runner_provider }}

--- a/.github/workflows/run-appium-smoke-tests-ios.yml
+++ b/.github/workflows/run-appium-smoke-tests-ios.yml
@@ -44,7 +44,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2, 3, 4]
+        split: [1, 2]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -52,7 +52,7 @@ jobs:
       platform: ios
       test_suite_tag: SmokeAccounts
       split_number: ${{ matrix.split }}
-      total_splits: 4
+      total_splits: 2
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
@@ -68,7 +68,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2]
+        split: [1]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -76,7 +76,8 @@ jobs:
       platform: ios
       test_suite_tag: SmokePerps
       split_number: ${{ matrix.split }}
-      total_splits: 2
+      total_splits: 1
+      test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
       runner_provider: ${{ inputs.runner_provider || 'current' }}
@@ -91,7 +92,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2, 3]
+        split: [1, 2]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -99,7 +100,7 @@ jobs:
       platform: ios
       test_suite_tag: SmokePredictions
       split_number: ${{ matrix.split }}
-      total_splits: 3
+      total_splits: 2
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
@@ -115,7 +116,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2, 3, 4]
+        split: [1, 2]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -123,7 +124,7 @@ jobs:
       platform: ios
       test_suite_tag: SmokeSeedlessOnboarding
       split_number: ${{ matrix.split }}
-      total_splits: 4
+      total_splits: 2
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
@@ -140,7 +141,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2, 3, 4, 5, 6, 7, 8]
+        split: [1, 2, 3]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -148,8 +149,9 @@ jobs:
       platform: ios
       test_suite_tag: SmokeSnaps
       split_number: ${{ matrix.split }}
-      total_splits: 8
-      test-timeout-minutes: 25
+      total_splits: 3
+      # Session reuse + denser shards; headroom vs former 25m single-shard load.
+      test-timeout-minutes: 30
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
       runner_provider: ${{ inputs.runner_provider || 'current' }}
@@ -187,7 +189,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2, 3, 4]
+        split: [1, 2]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -195,7 +197,8 @@ jobs:
       platform: ios
       test_suite_tag: SmokeWalletPlatform
       split_number: ${{ matrix.split }}
-      total_splits: 4
+      total_splits: 2
+      test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
       runner_provider: ${{ inputs.runner_provider || 'current' }}
@@ -234,7 +237,7 @@ jobs:
       }}
     strategy:
       matrix:
-        split: [1, 2]
+        split: [1]
       fail-fast: false
     uses: ./.github/workflows/run-appium-e2e-workflow.yml
     with:
@@ -242,7 +245,7 @@ jobs:
       platform: ios
       test_suite_tag: SmokeStake
       split_number: ${{ matrix.split }}
-      total_splits: 2
+      total_splits: 1
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
@@ -315,7 +318,7 @@ jobs:
       test_suite_tag: SmokeConfirmations
       split_number: ${{ matrix.split }}
       total_splits: 2
-      test-timeout-minutes: 60
+      test-timeout-minutes: 35
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
       runner_provider: ${{ inputs.runner_provider || 'current' }}

--- a/babel.config.js
+++ b/babel.config.js
@@ -119,7 +119,14 @@ module.exports = {
     [
       'transform-inline-environment-variables',
       {
-        exclude: ['JEST_WORKER_ID', 'EXPO_OS', 'EXPO_SERVER', 'EXPO_BASE_URL'],
+        exclude: [
+          'JEST_WORKER_ID',
+          'EXPO_OS',
+          'EXPO_SERVER',
+          'EXPO_BASE_URL',
+          // Must remain runtime-readable for emergency Appium session-reuse rollback.
+          'APPIUM_SESSION_REUSE',
+        ],
       },
     ],
     dynamicImportToRequire,

--- a/babel.config.tests.js
+++ b/babel.config.tests.js
@@ -77,6 +77,8 @@ const newOverrides = [
       'tests/framework/playwrightLogger.ts',
       'tests/framework/PlaywrightUtilities.ts',
       'tests/framework/fixtures/FixtureHelper.ts',
+      'tests/framework/fixtures/playwright/sessionReuse.ts',
+      'tests/framework/fixtures/playwright/sessionReuse.test.ts',
       'tests/framework/services/providers/emulator/reinstallLocalBuildFromPath.ts',
       'tests/framework/services/appium/ScreenRecording.ts',
       'tests/framework/services/appium/AppiumServer.ts',

--- a/docs/testing/appium-smoke-testing.md
+++ b/docs/testing/appium-smoke-testing.md
@@ -178,6 +178,24 @@ Ensure the emulator is running before starting tests.
 
 Both use `tests/playwright.smoke-appium.config.ts`. Pass standard Playwright flags: `--grep`, file paths, `--debug`, etc.
 
+## Session reuse and soft reload
+
+Local emulator/simulator Appium smoke **reuses one WebDriver session per Playwright worker** by default, and resets the app between tests via soft reload (`clearAppData` → `NATIVE_APP` context → relaunch → wait for `/state.json`).
+
+| Concern                               | Behavior                                                                                     |
+| ------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Session create                        | Once per worker (happy path). Logs `Reusing WebDriver session sessionId=...` on later tests. |
+| Between tests (`restartDevice: true`) | Soft reload — does **not** create a new Appium session.                                      |
+| Unhealthy session                     | Test-scoped `driver` fixture recreates once (`sessionRecreated=true` annotation).            |
+| BrowserStack                          | Session reuse stays **off** (legacy per-test sessions).                                      |
+| Rollback                              | `APPIUM_SESSION_REUSE=false` restores per-test session delete.                               |
+
+Helpers:
+
+- `isAppiumSessionReuseEnabled` — `tests/framework/fixtures/playwright/sessionReuse.ts`
+- `softReloadAppForFixtures` — `tests/framework/services/appium/softReloadApp.ts`
+- Worker fixtures — `deviceProvider` + `sharedSession` in `tests/framework/fixtures/playwright/`
+
 ## Reports and artifacts
 
 | Output                        | Path                                  |

--- a/tests/docs/PLAYWRIGHT_LOCAL_EMULATOR.md
+++ b/tests/docs/PLAYWRIGHT_LOCAL_EMULATOR.md
@@ -31,6 +31,14 @@ We keep Appium’s reset flags **mild** in [`EmulatorConfigBuilder`](../framewor
 
 > **Note:** `noReset: true` for the **Appium session** still means the driver is not asked to wipe app data on its own. After `globalSetup`’s explicit uninstall+install, the app is freshly installed for that run.
 
+## Session reuse (local emulator)
+
+Playwright Appium runs on emulator/simulator **reuse one WDIO session per worker** by default (`APPIUM_SESSION_REUSE`). Between tests, `withFixtures({ restartDevice: true })` soft-reloads the app (clear data + launch + fixture bootstrap) without `deleteSession`.
+
+- **Disable reuse:** `APPIUM_SESSION_REUSE=false`
+- **BrowserStack:** reuse is always off
+- Details: [appium-smoke-testing.md](../../docs/testing/appium-smoke-testing.md#session-reuse-and-soft-reload)
+
 ## Android device targeting
 
 For Android, the adb serial is resolved from `use.device.name` (AVD name) or `use.device.udid` — see [`resolveAndroidAdbUdid`](../framework/services/providers/emulator/android/resolveAndroidAdbUdid.ts) and the `EmulatorConfig` JSDoc in [`types.ts`](../framework/types.ts).
@@ -61,3 +69,5 @@ Get available Simulators:
 - [`reinstallLocalBuildFromPath`](../framework/services/providers/emulator/reinstallLocalBuildFromPath.ts) — `adb` / `simctl` install helpers.
 - `EmulatorProvider.globalSetup` — path check, then reinstall when `buildPath` is set; or `isAppInstalled()` when unset.
 - `EmulatorProvider.getDriver` / `EmulatorConfigBuilder.build` — capabilities including `appium:app` when `buildPath` is set.
+- Worker session reuse — [`sessionReuse.ts`](../framework/fixtures/playwright/sessionReuse.ts), [`driver.fixture.ts`](../framework/fixtures/playwright/driver.fixture.ts).
+- Soft reload — [`softReloadApp.ts`](../framework/services/appium/softReloadApp.ts).

--- a/tests/framework/fixtures/FixtureHelper.ts
+++ b/tests/framework/fixtures/FixtureHelper.ts
@@ -15,7 +15,7 @@ import {
   startMultiInstanceResourceWithRetry,
   cleanupAllAndroidPortForwarding,
 } from './FixtureUtils';
-import Utilities, { sleep } from '../Utilities';
+import Utilities from '../Utilities';
 import {
   dismissAndroidSystemOverlaysPlaywright,
   dismissDevScreens,
@@ -46,13 +46,13 @@ import {
   FALLBACK_MOCKSERVER_PORT,
   FALLBACK_FIXTURE_SERVER_PORT,
   FALLBACK_COMMAND_QUEUE_SERVER_PORT,
-  resolveE2EFixtureBootstrapTimeoutMs,
   shouldHandleMetroDevLauncherLocally,
 } from '../Constants';
 import ContractAddressRegistry from '../../../app/util/test/contract-address-registry';
 import FixtureBuilder from './FixtureBuilder';
 import { createLogger } from '../logger';
 import { mockNotificationServices } from '../../smoke-appium/notifications/utils/mocks';
+import { softReloadAppForFixtures } from '../services/appium/softReloadApp';
 import {
   runAnalyticsExpectations,
   shouldRunAnalyticsExpectations,
@@ -70,7 +70,6 @@ import {
   resetAccountActivityMockState,
 } from '../../websocket/account-activity-mocks';
 import { FrameworkDetector } from '../FrameworkDetector';
-import PlaywrightUtilities from '../PlaywrightUtilities';
 import { DeviceCommandHandler } from '../services/device-commands';
 
 const logger = createLogger({
@@ -690,42 +689,14 @@ export async function withFixtures(
           ...(launchArgs || {}),
         };
 
-        if (deviceCommands) {
-          await deviceCommands.clearAppData();
-        }
-
-        // Cold Metro bundles can take 60–160s locally; pre-warm runs in launchApp but
-        // device-side load + E2E bootstrap still need headroom after deep link.
-        const appStateRequest = fixtureServer.waitForNextStateRequest(
-          resolveE2EFixtureBootstrapTimeoutMs(),
-        );
-        try {
-          await PlaywrightUtilities.launchApp(currentDeviceDetails, {
-            launchArgs: testArgs,
-          });
-          if (shouldHandleMetroDevLauncherLocally()) {
-            didAttemptPlaywrightDevelopmentServerPickerDismissal = true;
-            await Promise.all([
-              appStateRequest,
-              (async () => {
-                for (;;) {
-                  await dismissDevelopmentServerPickerPlaywright();
-                  const bootstrapped = await Promise.race([
-                    appStateRequest.then(() => true),
-                    sleep(1500).then(() => false),
-                  ]);
-                  if (bootstrapped) {
-                    return;
-                  }
-                }
-              })(),
-            ]);
-          } else {
-            await appStateRequest;
-          }
-        } catch (error) {
-          appStateRequest.catch(() => undefined);
-          throw error;
+        const softReloadResult = await softReloadAppForFixtures({
+          currentDeviceDetails,
+          deviceCommands,
+          launchArgs: testArgs,
+          fixtureServer,
+        });
+        if (softReloadResult.attemptedMetroDevLauncherDismissal) {
+          didAttemptPlaywrightDevelopmentServerPickerDismissal = true;
         }
       } else {
         throw new Error(`Unsupported test runner: ${framework}`);

--- a/tests/framework/fixtures/playwright/deviceProvider.fixture.ts
+++ b/tests/framework/fixtures/playwright/deviceProvider.fixture.ts
@@ -1,10 +1,10 @@
-import type { FullProject, WorkerInfo } from '@playwright/test';
+import type { Fixtures, FullProject, WorkerInfo } from '@playwright/test';
 import { createServiceProvider, type ServiceProvider } from '../../services';
 import type { WebDriverConfig } from '../../types.ts';
 import { createPlaywrightLogger } from '../../playwrightLogger.ts';
 import { FrameworkDetector } from '../../FrameworkDetector.ts';
 import UnifiedGestures from '../../UnifiedGestures.ts';
-import type { SharedAppiumSession } from './types.ts';
+import type { SharedAppiumSession, WorkerLevelFixtures } from './types.ts';
 
 const logger = createPlaywrightLogger('deviceProvider');
 
@@ -14,7 +14,11 @@ const logger = createPlaywrightLogger('deviceProvider');
  * this fixture only creates the provider once and tears down session+server
  * at worker end.
  */
-export const workerDeviceProviderFixture = {
+export const workerDeviceProviderFixture: Fixtures<
+  // No test-scoped fixtures declared here.
+  object,
+  WorkerLevelFixtures
+> = {
   deviceProvider: [
     async (
       {}, // eslint-disable-line no-empty-pattern
@@ -35,7 +39,7 @@ export const workerDeviceProviderFixture = {
         `Worker device provider "${providerName}" fixture ended (sessionId=${deviceProvider.sessionId ?? 'none'})`,
       );
     },
-    { scope: 'worker' as const },
+    { scope: 'worker' },
   ],
 
   sharedSession: [
@@ -83,6 +87,6 @@ export const workerDeviceProviderFixture = {
         logger.error('Worker cleanupProvider failed:', error);
       }
     },
-    { scope: 'worker' as const },
+    { scope: 'worker' },
   ],
 };

--- a/tests/framework/fixtures/playwright/deviceProvider.fixture.ts
+++ b/tests/framework/fixtures/playwright/deviceProvider.fixture.ts
@@ -1,29 +1,88 @@
-import type { FullProject, TestInfo } from '@playwright/test';
+import type { FullProject, WorkerInfo } from '@playwright/test';
 import { createServiceProvider, type ServiceProvider } from '../../services';
 import type { WebDriverConfig } from '../../types.ts';
 import { createPlaywrightLogger } from '../../playwrightLogger.ts';
+import { FrameworkDetector } from '../../FrameworkDetector.ts';
+import UnifiedGestures from '../../UnifiedGestures.ts';
+import type { SharedAppiumSession } from './types.ts';
 
 const logger = createPlaywrightLogger('deviceProvider');
 
-export const deviceProviderFixture = {
-  deviceProvider: async (
-    {}, // eslint-disable-line no-empty-pattern
-    use: (deviceProvider: ServiceProvider) => Promise<void>,
-    testInfo: TestInfo,
-  ) => {
-    const project = testInfo.project as FullProject<WebDriverConfig>;
-    const providerName = project.use.device?.provider ?? 'unknown';
+/**
+ * Worker-scoped provider + mutable session holder.
+ * Session create/delete for reuse lives in the test-scoped `driver` fixture;
+ * this fixture only creates the provider once and tears down session+server
+ * at worker end.
+ */
+export const workerDeviceProviderFixture = {
+  deviceProvider: [
+    async (
+      {}, // eslint-disable-line no-empty-pattern
+      use: (deviceProvider: ServiceProvider) => Promise<void>,
+      workerInfo: WorkerInfo,
+    ) => {
+      const project = workerInfo.project as FullProject<WebDriverConfig>;
+      const providerName = project.use.device?.provider ?? 'unknown';
 
-    logger.info(
-      `Creating device provider "${providerName}" for project "${project.name}"`,
-    );
+      logger.info(
+        `Creating worker-scoped device provider "${providerName}" for project "${project.name}"`,
+      );
 
-    const deviceProvider = createServiceProvider(project);
+      const deviceProvider = createServiceProvider(project);
+      await use(deviceProvider);
 
-    await use(deviceProvider);
+      logger.info(
+        `Worker device provider "${providerName}" fixture ended (sessionId=${deviceProvider.sessionId ?? 'none'})`,
+      );
+    },
+    { scope: 'worker' as const },
+  ],
 
-    logger.info(
-      `Device provider "${providerName}" teardown complete (sessionId=${deviceProvider.sessionId ?? 'none'})`,
-    );
-  },
+  sharedSession: [
+    async (
+      { deviceProvider }: { deviceProvider: ServiceProvider },
+      use: (sharedSession: SharedAppiumSession) => Promise<void>,
+    ) => {
+      const sharedSession: SharedAppiumSession = {};
+      await use(sharedSession);
+
+      logger.info(
+        'Worker sharedSession teardown: cleanupSession then cleanupProvider',
+      );
+
+      try {
+        if (sharedSession.drv) {
+          await deviceProvider.cleanupSession?.(sharedSession.drv);
+        } else {
+          await deviceProvider.cleanupSession?.();
+        }
+      } catch (error) {
+        logger.error('Worker cleanupSession failed:', error);
+      } finally {
+        sharedSession.drv = undefined;
+      }
+
+      try {
+        delete globalThis.driver;
+        FrameworkDetector.reset();
+        UnifiedGestures.resetStrategy();
+      } catch (error) {
+        logger.error(
+          'Failed to clear global driver on worker teardown:',
+          error,
+        );
+      }
+
+      try {
+        if (deviceProvider.cleanupProvider) {
+          await deviceProvider.cleanupProvider();
+        } else {
+          await deviceProvider.cleanup?.();
+        }
+      } catch (error) {
+        logger.error('Worker cleanupProvider failed:', error);
+      }
+    },
+    { scope: 'worker' as const },
+  ],
 };

--- a/tests/framework/fixtures/playwright/driver.fixture.ts
+++ b/tests/framework/fixtures/playwright/driver.fixture.ts
@@ -195,6 +195,9 @@ export const driverFixture = {
       if (!reuseEnabled) {
         try {
           if (drv) {
+            // Always pass drv so providers (including BrowserStack via
+            // BaseServiceProvider) actually deleteSession — a no-arg /
+            // missing cleanupSession must not leave cloud sessions open.
             if (deviceProvider.cleanupSession) {
               await deviceProvider.cleanupSession(drv);
             } else {

--- a/tests/framework/fixtures/playwright/driver.fixture.ts
+++ b/tests/framework/fixtures/playwright/driver.fixture.ts
@@ -2,64 +2,115 @@ import type { FullProject, TestInfo } from '@playwright/test';
 import type { WebDriverConfig } from '../../types.ts';
 import { DEFAULT_IMPLICIT_WAIT_MS } from '../../Constants.ts';
 import { setDeviceInfo } from '../../DeviceInfoCache.ts';
-import type { TestLevelFixtures } from './types.ts';
+import type { SharedAppiumSession, WorkerLevelFixtures } from './types.ts';
 import {
   isVideoRecordingOnFailureEnabled,
   startFailureRecording,
   stopFailureRecordingAndAttach,
 } from '../../services/appium/ScreenRecording.ts';
+import { isSessionAlive } from '../../services/appium/sessionHealth.ts';
 import { createPlaywrightLogger } from '../../playwrightLogger.ts';
 import { FrameworkDetector, TestFramework } from '../../FrameworkDetector.ts';
 import UnifiedGestures from '../../UnifiedGestures.ts';
+import type { ServiceProvider } from '../../services';
+import { isAppiumSessionReuseEnabled } from './sessionReuse.ts';
 
 const logger = createPlaywrightLogger('driver');
 
+async function configureImplicitWait(
+  drv: WebdriverIO.Browser,
+  implicitMs: number,
+): Promise<void> {
+  // Wrapped in retry because BrowserStack sessions can transiently reject
+  // the setTimeout command before the session is fully initialised.
+  const maxRetries = 5;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      await drv.setTimeout({ implicit: implicitMs });
+      return;
+    } catch (err) {
+      if (attempt === maxRetries) throw err;
+      const backoff = Math.min(2 ** attempt * 1000, 15000);
+      logger.warn(
+        `driver.setTimeout failed (attempt ${attempt}/${maxRetries}), retrying in ${backoff}ms`,
+      );
+      await new Promise((r) => setTimeout(r, backoff));
+    }
+  }
+}
+
+async function createSession(
+  deviceProvider: ServiceProvider,
+  sharedSession: SharedAppiumSession,
+): Promise<WebdriverIO.Browser> {
+  const drv = await deviceProvider.getDriver();
+  sharedSession.drv = drv;
+  return drv;
+}
+
 export const driverFixture = {
   driver: async (
-    { deviceProvider }: Pick<TestLevelFixtures, 'deviceProvider'>,
-    use: (driver: WebdriverIO.Browser) => Promise<void>,
+    {
+      deviceProvider,
+      sharedSession,
+    }: Pick<WorkerLevelFixtures, 'deviceProvider' | 'sharedSession'>,
+    use: (drv: WebdriverIO.Browser) => Promise<void>,
     testInfo: TestInfo,
   ) => {
-    let driver: WebdriverIO.Browser | undefined;
+    let drv: WebdriverIO.Browser | undefined;
     let recordingBackend: Awaited<ReturnType<typeof startFailureRecording>>;
     const project = testInfo.project as FullProject<WebDriverConfig>;
     const platform = project.use.platform;
+    const reuseEnabled = isAppiumSessionReuseEnabled(project.use);
     const recordVideoOnFailure = isVideoRecordingOnFailureEnabled(
       project.use.device?.provider,
     );
 
+    let sessionReused = false;
+    let sessionRecreated = false;
+
     try {
-      logger.info(
-        `Starting WebDriver session for "${testInfo.title}" (project: ${project.name})`,
-      );
-
-      driver = await deviceProvider.getDriver();
-
-      // Wrapped in retry because BrowserStack sessions can transiently reject
-      // the setTimeout command before the session is fully initialised.
-      const implicitMs = project.use.expectTimeout ?? DEFAULT_IMPLICIT_WAIT_MS;
-      const maxRetries = 5;
-      for (let attempt = 1; attempt <= maxRetries; attempt++) {
-        try {
-          await driver.setTimeout({ implicit: implicitMs });
-          break;
-        } catch (err) {
-          if (attempt === maxRetries) throw err;
-          const backoff = Math.min(2 ** attempt * 1000, 15000);
-          logger.warn(
-            `driver.setTimeout failed (attempt ${attempt}/${maxRetries}), retrying in ${backoff}ms`,
+      if (reuseEnabled && sharedSession.drv) {
+        const alive = await isSessionAlive(sharedSession.drv);
+        if (alive) {
+          drv = sharedSession.drv;
+          sessionReused = true;
+          logger.info(
+            `Reusing WebDriver session sessionId=${deviceProvider.sessionId ?? sharedSession.drv.sessionId ?? 'unknown'} for "${testInfo.title}"`,
           );
-          await new Promise((r) => setTimeout(r, backoff));
+        } else {
+          logger.warn(
+            `Shared WebDriver session is unhealthy; recreating for "${testInfo.title}"`,
+          );
+          try {
+            await deviceProvider.cleanupSession?.(sharedSession.drv);
+          } catch (error) {
+            logger.error(
+              'Failed to cleanup unhealthy session before recreate:',
+              error,
+            );
+          }
+          sharedSession.drv = undefined;
+          sessionRecreated = true;
+          drv = await createSession(deviceProvider, sharedSession);
         }
+      } else {
+        logger.info(
+          `${reuseEnabled ? 'Starting' : 'Starting (reuse off)'} WebDriver session for "${testInfo.title}" (project: ${project.name})`,
+        );
+        drv = await createSession(deviceProvider, sharedSession);
       }
 
-      globalThis.driver = driver;
+      const implicitMs = project.use.expectTimeout ?? DEFAULT_IMPLICIT_WAIT_MS;
+      await configureImplicitWait(drv, implicitMs);
+
+      globalThis.driver = drv;
       FrameworkDetector.reset();
       FrameworkDetector.setFramework(TestFramework.APPIUM);
       UnifiedGestures.resetStrategy();
 
-      const platformName = (await driver.capabilities)?.platformName;
-      const windowSize = await driver.getWindowSize();
+      const platformName = (await drv.capabilities)?.platformName;
+      const windowSize = await drv.getWindowSize();
       setDeviceInfo(
         (platformName?.toLowerCase() === 'android' ? 'android' : 'ios') as
           | 'android'
@@ -73,7 +124,8 @@ export const driverFixture = {
         `WebDriver session ready: sessionId=${deviceProvider.sessionId ?? 'unknown'}, ` +
           `platform=${platformName ?? 'unknown'}, ` +
           `screen=${windowSize.width}x${windowSize.height}, ` +
-          `implicitWait=${implicitMs}ms, provider=${deviceProviderName ?? 'unknown'}` +
+          `implicitWait=${implicitMs}ms, provider=${deviceProviderName ?? 'unknown'}, ` +
+          `sessionReused=${sessionReused}, sessionRecreated=${sessionRecreated}` +
           (deviceProvider.sessionCreationDurationMs !== undefined
             ? `, sessionCreation=${deviceProvider.sessionCreationDurationMs}ms`
             : ''),
@@ -88,6 +140,14 @@ export const driverFixture = {
           type: 'sessionId',
           description: deviceProvider.sessionId || 'no-session',
         },
+        {
+          type: 'sessionReused',
+          description: String(sessionReused),
+        },
+        {
+          type: 'sessionRecreated',
+          description: String(sessionRecreated),
+        },
       );
 
       try {
@@ -97,22 +157,22 @@ export const driverFixture = {
       }
 
       if (recordVideoOnFailure) {
-        recordingBackend = await startFailureRecording(driver, platform);
+        recordingBackend = await startFailureRecording(drv, platform);
       }
 
-      await use(driver);
+      await use(drv);
     } finally {
       const testStatus = testInfo.status;
       const testError = testInfo.error?.message;
 
       logger.info(
-        `Tearing down WebDriver session for "${testInfo.title}" (status: ${testStatus ?? 'unknown'})`,
+        `Tearing down driver fixture for "${testInfo.title}" (status: ${testStatus ?? 'unknown'}, reuse=${reuseEnabled})`,
       );
 
       try {
-        if (driver) {
+        if (drv) {
           await stopFailureRecordingAndAttach(
-            driver,
+            drv,
             testInfo,
             recordingBackend,
             platform,
@@ -132,27 +192,31 @@ export const driverFixture = {
         logger.error('Failed to sync test details:', error);
       }
 
-      try {
-        if (driver) {
-          await driver.deleteSession();
-          logger.info('WebDriver session deleted');
+      if (!reuseEnabled) {
+        try {
+          if (drv) {
+            if (deviceProvider.cleanupSession) {
+              await deviceProvider.cleanupSession(drv);
+            } else {
+              await drv.deleteSession();
+              logger.info('WebDriver session deleted');
+            }
+          }
+        } catch (error) {
+          logger.error('Failed to delete WebDriver session:', error);
+        } finally {
+          sharedSession.drv = undefined;
         }
-      } catch (error) {
-        logger.error('Failed to delete WebDriver session:', error);
-      }
 
-      try {
-        delete globalThis.driver;
-        FrameworkDetector.reset();
-        UnifiedGestures.resetStrategy();
-      } catch (error) {
-        logger.error('Failed to clean up global driver:', error);
-      }
-
-      try {
-        await deviceProvider.cleanup?.();
-      } catch (error) {
-        logger.error('Provider cleanup failed:', error);
+        try {
+          delete globalThis.driver;
+          FrameworkDetector.reset();
+          UnifiedGestures.resetStrategy();
+        } catch (error) {
+          logger.error('Failed to clean up global driver:', error);
+        }
+        // Appium server stop is deferred to worker sharedSession teardown
+        // (cleanupProvider) so local runs do not depend on SKIP_APPIUM_STOP.
       }
     }
   },

--- a/tests/framework/fixtures/playwright/index.ts
+++ b/tests/framework/fixtures/playwright/index.ts
@@ -1,21 +1,26 @@
 import '../../nodeNativeUtilsShim.cjs';
 import { test as base } from '@playwright/test';
-import type { TestLevelFixtures } from './types.ts';
+import type { TestLevelFixtures, WorkerLevelFixtures } from './types.ts';
 import { currentDeviceDetailsFixture } from './currentDeviceDetails.fixture.ts';
-import { deviceProviderFixture } from './deviceProvider.fixture.ts';
+import { workerDeviceProviderFixture } from './deviceProvider.fixture.ts';
 import { driverFixture } from './driver.fixture.ts';
 import { performanceTrackerFixture } from './performanceTracker.fixture.ts';
 
-export type { CurrentDeviceDetails, TestLevelFixtures } from './types.ts';
+export type {
+  CurrentDeviceDetails,
+  SharedAppiumSession,
+  TestLevelFixtures,
+  WorkerLevelFixtures,
+} from './types.ts';
 
 declare global {
   // eslint-disable-next-line no-var
   var driver: WebdriverIO.Browser | undefined;
 }
 
-export const test = base.extend<TestLevelFixtures>({
+export const test = base.extend<TestLevelFixtures, WorkerLevelFixtures>({
+  ...workerDeviceProviderFixture,
   ...currentDeviceDetailsFixture,
-  ...deviceProviderFixture,
   ...driverFixture,
   ...performanceTrackerFixture,
 });

--- a/tests/framework/fixtures/playwright/performanceTracker.fixture.ts
+++ b/tests/framework/fixtures/playwright/performanceTracker.fixture.ts
@@ -12,7 +12,7 @@ import {
 } from '../../quality-gates';
 import { getTeamInfoFromTags } from '../../utils/teams';
 import { publishPerformanceScenarioToSentry } from '../../../reporters/providers/sentry/PerformanceSentryPublisher';
-import type { TestLevelFixtures } from './types.ts';
+import type { TestLevelFixtures, WorkerLevelFixtures } from './types.ts';
 import { createPlaywrightLogger } from '../../playwrightLogger.ts';
 
 const logger = createPlaywrightLogger('performanceTracker');
@@ -25,7 +25,7 @@ function getSessionIdFromAnnotations(
 
 export const performanceTrackerFixture = {
   performanceTracker: async (
-    { deviceProvider }: Pick<TestLevelFixtures, 'deviceProvider'>,
+    { deviceProvider }: Pick<WorkerLevelFixtures, 'deviceProvider'>,
     use: (performanceTracker: PerformanceTracker) => Promise<void>,
     testInfo: TestInfo,
   ) => {

--- a/tests/framework/fixtures/playwright/sessionReuse.test.ts
+++ b/tests/framework/fixtures/playwright/sessionReuse.test.ts
@@ -1,5 +1,5 @@
 import { isAppiumSessionReuseEnabled } from './sessionReuse.ts';
-import { ProviderName, type WebDriverConfig } from '../../types.ts';
+import { ProviderName } from '../../types.ts';
 
 describe('isAppiumSessionReuseEnabled', () => {
   // Bracket access — babel transform-inline-environment-variables must not
@@ -25,7 +25,7 @@ describe('isAppiumSessionReuseEnabled', () => {
 
     const result = isAppiumSessionReuseEnabled({
       device: { provider: ProviderName.BROWSERSTACK, name: 'Pixel' },
-    } as Pick<WebDriverConfig, 'device'>);
+    });
 
     expect(result).toBe(false);
   });
@@ -36,7 +36,7 @@ describe('isAppiumSessionReuseEnabled', () => {
 
     const result = isAppiumSessionReuseEnabled({
       device: { provider: ProviderName.EMULATOR, name: 'Pixel' },
-    } as Pick<WebDriverConfig, 'device'>);
+    });
 
     expect(result).toBe(false);
   });
@@ -47,7 +47,7 @@ describe('isAppiumSessionReuseEnabled', () => {
 
     const result = isAppiumSessionReuseEnabled({
       device: { provider: ProviderName.EMULATOR, name: 'Pixel' },
-    } as Pick<WebDriverConfig, 'device'>);
+    });
 
     expect(result).toBe(true);
   });
@@ -58,7 +58,7 @@ describe('isAppiumSessionReuseEnabled', () => {
 
     const result = isAppiumSessionReuseEnabled({
       device: { provider: ProviderName.SIMULATOR, name: 'iPhone' },
-    } as Pick<WebDriverConfig, 'device'>);
+    });
 
     expect(result).toBe(true);
   });

--- a/tests/framework/fixtures/playwright/sessionReuse.test.ts
+++ b/tests/framework/fixtures/playwright/sessionReuse.test.ts
@@ -1,0 +1,65 @@
+import { isAppiumSessionReuseEnabled } from './sessionReuse.ts';
+import { ProviderName, type WebDriverConfig } from '../../types.ts';
+
+describe('isAppiumSessionReuseEnabled', () => {
+  // Bracket access — babel transform-inline-environment-variables must not
+  // bake these reads/writes or afterEach cleanup becomes `delete undefined`.
+  // eslint-disable-next-line dot-notation
+  const envKey = 'APPIUM_SESSION_REUSE';
+  // eslint-disable-next-line dot-notation
+  const previous = process.env[envKey];
+
+  afterEach(() => {
+    if (previous === undefined) {
+      // eslint-disable-next-line dot-notation
+      delete process.env[envKey];
+    } else {
+      // eslint-disable-next-line dot-notation
+      process.env[envKey] = previous;
+    }
+  });
+
+  it('returns false for BrowserStack regardless of env', () => {
+    // eslint-disable-next-line dot-notation
+    process.env[envKey] = 'true';
+
+    const result = isAppiumSessionReuseEnabled({
+      device: { provider: ProviderName.BROWSERSTACK, name: 'Pixel' },
+    } as Pick<WebDriverConfig, 'device'>);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when APPIUM_SESSION_REUSE is false', () => {
+    // eslint-disable-next-line dot-notation
+    process.env[envKey] = 'false';
+
+    const result = isAppiumSessionReuseEnabled({
+      device: { provider: ProviderName.EMULATOR, name: 'Pixel' },
+    } as Pick<WebDriverConfig, 'device'>);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true by default for emulator when env is unset', () => {
+    // eslint-disable-next-line dot-notation
+    delete process.env[envKey];
+
+    const result = isAppiumSessionReuseEnabled({
+      device: { provider: ProviderName.EMULATOR, name: 'Pixel' },
+    } as Pick<WebDriverConfig, 'device'>);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns true when APPIUM_SESSION_REUSE is true', () => {
+    // eslint-disable-next-line dot-notation
+    process.env[envKey] = 'true';
+
+    const result = isAppiumSessionReuseEnabled({
+      device: { provider: ProviderName.SIMULATOR, name: 'iPhone' },
+    } as Pick<WebDriverConfig, 'device'>);
+
+    expect(result).toBe(true);
+  });
+});

--- a/tests/framework/fixtures/playwright/sessionReuse.ts
+++ b/tests/framework/fixtures/playwright/sessionReuse.ts
@@ -9,9 +9,11 @@ import { ProviderName, type WebDriverConfig } from '../../types.ts';
  * - APPIUM_SESSION_REUSE=true|1: force on
  * - default: true for emulator/simulator
  */
-export function isAppiumSessionReuseEnabled(
-  projectUse: Pick<WebDriverConfig, 'device'>,
-): boolean {
+export function isAppiumSessionReuseEnabled(projectUse: {
+  // Playwright `project.use` makes config fields optional even when WebDriverConfig
+  // declares them required.
+  device?: WebDriverConfig['device'];
+}): boolean {
   if (projectUse.device?.provider === ProviderName.BROWSERSTACK) {
     return false;
   }

--- a/tests/framework/fixtures/playwright/sessionReuse.ts
+++ b/tests/framework/fixtures/playwright/sessionReuse.ts
@@ -1,0 +1,31 @@
+import { ProviderName, type WebDriverConfig } from '../../types.ts';
+
+/**
+ * Whether Appium WebDriver sessions should be reused across Playwright tests
+ * in the same worker.
+ *
+ * - BrowserStack: always false (out of scope)
+ * - APPIUM_SESSION_REUSE=false|0: force off (rollback)
+ * - APPIUM_SESSION_REUSE=true|1: force on
+ * - default: true for emulator/simulator
+ */
+export function isAppiumSessionReuseEnabled(
+  projectUse: Pick<WebDriverConfig, 'device'>,
+): boolean {
+  if (projectUse.device?.provider === ProviderName.BROWSERSTACK) {
+    return false;
+  }
+
+  // Bracket access avoids babel transform-inline-environment-variables so
+  // APPIUM_SESSION_REUSE can be toggled at runtime (local + tests).
+  // eslint-disable-next-line dot-notation
+  const flag = process.env['APPIUM_SESSION_REUSE']?.trim().toLowerCase();
+  if (flag === 'false' || flag === '0') {
+    return false;
+  }
+  if (flag === 'true' || flag === '1') {
+    return true;
+  }
+
+  return true;
+}

--- a/tests/framework/fixtures/playwright/types.ts
+++ b/tests/framework/fixtures/playwright/types.ts
@@ -16,18 +16,32 @@ export interface CurrentDeviceDetails {
   isBrowserstack: boolean;
 }
 
+/**
+ * Mutable holder for the worker-scoped Appium/WDIO session.
+ * The test-scoped `driver` fixture reads/writes `drv`.
+ */
+export interface SharedAppiumSession {
+  drv?: WebdriverIO.Browser;
+}
+
+export interface WorkerLevelFixtures {
+  /**
+   * Worker-scoped device provider (one instance per Playwright worker/shard).
+   */
+  deviceProvider: ServiceProvider;
+
+  /**
+   * Worker-scoped session holder for reuse across tests.
+   */
+  sharedSession: SharedAppiumSession;
+}
+
 export interface TestLevelFixtures {
   /**
    * Platform detector to be used for the test.
    * This detects the platform of the device being tested.
    */
   currentDeviceDetails: CurrentDeviceDetails;
-
-  /**
-   * Device provider to be used for the test.
-   * This creates and manages the device lifecycle for the test
-   */
-  deviceProvider: ServiceProvider;
 
   /**
    * The device instance that will be used for running the test.

--- a/tests/framework/services/appium/index.ts
+++ b/tests/framework/services/appium/index.ts
@@ -13,3 +13,4 @@ export {
   startFailureRecording,
   stopFailureRecordingAndAttach,
 } from './ScreenRecording.ts';
+export { isSessionAlive, switchToNativeContext } from './sessionHealth.ts';

--- a/tests/framework/services/appium/index.ts
+++ b/tests/framework/services/appium/index.ts
@@ -14,3 +14,10 @@ export {
   stopFailureRecordingAndAttach,
 } from './ScreenRecording.ts';
 export { isSessionAlive, switchToNativeContext } from './sessionHealth.ts';
+export {
+  softReloadAppForFixtures,
+  type SoftReloadAppForFixturesOptions,
+  type SoftReloadAppForFixturesResult,
+  type SoftReloadDeviceCommands,
+  type SoftReloadFixtureServer,
+} from './softReloadApp.ts';

--- a/tests/framework/services/appium/sessionHealth.test.ts
+++ b/tests/framework/services/appium/sessionHealth.test.ts
@@ -1,0 +1,59 @@
+import { isSessionAlive, switchToNativeContext } from './sessionHealth.ts';
+
+describe('isSessionAlive', () => {
+  it('returns false when drv is undefined', async () => {
+    const result = await isSessionAlive(undefined);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true when getWindowSize resolves', async () => {
+    const drv = {
+      getWindowSize: jest.fn().mockResolvedValue({ width: 390, height: 844 }),
+    } as unknown as WebdriverIO.Browser;
+
+    const result = await isSessionAlive(drv);
+
+    expect(result).toBe(true);
+    expect(drv.getWindowSize).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false when getWindowSize rejects', async () => {
+    const drv = {
+      getWindowSize: jest.fn().mockRejectedValue(new Error('invalid session')),
+    } as unknown as WebdriverIO.Browser;
+
+    const result = await isSessionAlive(drv);
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('switchToNativeContext', () => {
+  it('returns false when drv is undefined', async () => {
+    const result = await switchToNativeContext(undefined);
+
+    expect(result).toBe(false);
+  });
+
+  it('switches to NATIVE_APP and returns true', async () => {
+    const drv = {
+      switchContext: jest.fn().mockResolvedValue(undefined),
+    } as unknown as WebdriverIO.Browser;
+
+    const result = await switchToNativeContext(drv);
+
+    expect(result).toBe(true);
+    expect(drv.switchContext).toHaveBeenCalledWith('NATIVE_APP');
+  });
+
+  it('returns false when switchContext rejects', async () => {
+    const drv = {
+      switchContext: jest.fn().mockRejectedValue(new Error('no contexts')),
+    } as unknown as WebdriverIO.Browser;
+
+    const result = await switchToNativeContext(drv);
+
+    expect(result).toBe(false);
+  });
+});

--- a/tests/framework/services/appium/sessionHealth.ts
+++ b/tests/framework/services/appium/sessionHealth.ts
@@ -1,0 +1,38 @@
+/**
+ * Cheap liveness check for a reused Appium/WDIO session.
+ * Prefer getWindowSize over getSession — it exercises the session without
+ * depending on provider-specific session APIs.
+ */
+export async function isSessionAlive(
+  drv: WebdriverIO.Browser | undefined,
+): Promise<boolean> {
+  if (!drv) {
+    return false;
+  }
+
+  try {
+    await drv.getWindowSize();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Best-effort reset to the native app context after WebView / browser work.
+ * Soft reload must not leave a stale WEBVIEW context on a reused session.
+ */
+export async function switchToNativeContext(
+  drv: WebdriverIO.Browser | undefined,
+): Promise<boolean> {
+  if (!drv || typeof drv.switchContext !== 'function') {
+    return false;
+  }
+
+  try {
+    await drv.switchContext('NATIVE_APP');
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/framework/services/appium/softReloadApp.test.ts
+++ b/tests/framework/services/appium/softReloadApp.test.ts
@@ -1,0 +1,151 @@
+import {
+  softReloadAppForFixtures,
+  type SoftReloadDeviceCommands,
+  type SoftReloadFixtureServer,
+} from './softReloadApp.ts';
+import type { CurrentDeviceDetails } from '../../fixtures/playwright';
+import PlaywrightUtilities from '../../PlaywrightUtilities.ts';
+import { shouldHandleMetroDevLauncherLocally } from '../../Constants.ts';
+import { switchToNativeContext } from './sessionHealth.ts';
+import { dismissDevelopmentServerPickerPlaywright } from '../../../flows/general.flow';
+
+jest.mock('../../PlaywrightUtilities.ts', () => ({
+  __esModule: true,
+  default: {
+    launchApp: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('../../Constants.ts', () => ({
+  ...jest.requireActual('../../Constants.ts'),
+  resolveE2EFixtureBootstrapTimeoutMs: jest.fn(() => 5_000),
+  shouldHandleMetroDevLauncherLocally: jest.fn(() => false),
+}));
+
+jest.mock('./sessionHealth.ts', () => ({
+  switchToNativeContext: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('../../../flows/general.flow', () => ({
+  dismissDevelopmentServerPickerPlaywright: jest
+    .fn()
+    .mockResolvedValue(undefined),
+}));
+
+const launchAppMock = PlaywrightUtilities.launchApp as jest.MockedFunction<
+  typeof PlaywrightUtilities.launchApp
+>;
+const switchToNativeContextMock = switchToNativeContext as jest.MockedFunction<
+  typeof switchToNativeContext
+>;
+const shouldHandleMetroMock =
+  shouldHandleMetroDevLauncherLocally as jest.MockedFunction<
+    typeof shouldHandleMetroDevLauncherLocally
+  >;
+const dismissMetroMock =
+  dismissDevelopmentServerPickerPlaywright as jest.MockedFunction<
+    typeof dismissDevelopmentServerPickerPlaywright
+  >;
+
+describe('softReloadAppForFixtures', () => {
+  const currentDeviceDetails: CurrentDeviceDetails = {
+    platform: 'android',
+    deviceName: 'Pixel_5',
+    udid: 'emulator-5554',
+    packageName: 'io.metamask',
+    launchableActivity: 'io.metamask.MainActivity',
+    isBrowserstack: false,
+  };
+
+  let fixtureServer: SoftReloadFixtureServer;
+  let deviceCommands: SoftReloadDeviceCommands;
+  let waitForNextStateRequest: jest.Mock;
+  let clearAppData: jest.Mock;
+
+  beforeEach(() => {
+    waitForNextStateRequest = jest.fn().mockResolvedValue(undefined);
+    clearAppData = jest.fn().mockResolvedValue(undefined);
+    fixtureServer = { waitForNextStateRequest };
+    deviceCommands = { clearAppData };
+    shouldHandleMetroMock.mockReturnValue(false);
+    switchToNativeContextMock.mockResolvedValue(true);
+    launchAppMock.mockResolvedValue(undefined);
+    dismissMetroMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('clears app data, resets NATIVE_APP context, launches, and waits for bootstrap', async () => {
+    const drv = { sessionId: 's1' } as unknown as WebdriverIO.Browser;
+    const launchArgs = { fixtureServerPort: '1234' };
+
+    const result = await softReloadAppForFixtures({
+      currentDeviceDetails,
+      deviceCommands,
+      launchArgs,
+      fixtureServer,
+      drv,
+    });
+
+    expect(clearAppData).toHaveBeenCalledTimes(1);
+    expect(switchToNativeContextMock).toHaveBeenCalledWith(drv);
+    expect(waitForNextStateRequest).toHaveBeenCalledWith(5_000);
+    expect(launchAppMock).toHaveBeenCalledWith(currentDeviceDetails, {
+      launchArgs,
+    });
+    expect(result.attemptedMetroDevLauncherDismissal).toBe(false);
+    expect(result.clearAppDataMs).toBeGreaterThanOrEqual(0);
+    expect(result.contextResetMs).toBeGreaterThanOrEqual(0);
+    expect(result.launchAppMs).toBeGreaterThanOrEqual(0);
+    expect(result.fixtureBootstrapMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('skips clearAppData when deviceCommands is omitted', async () => {
+    await softReloadAppForFixtures({
+      currentDeviceDetails,
+      launchArgs: {},
+      fixtureServer,
+      drv: {} as WebdriverIO.Browser,
+    });
+
+    expect(clearAppData).not.toHaveBeenCalled();
+    expect(launchAppMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers bootstrap waiter before launching the app', async () => {
+    const callOrder: string[] = [];
+    waitForNextStateRequest.mockImplementation(async () => {
+      callOrder.push('wait');
+    });
+    launchAppMock.mockImplementation(async () => {
+      callOrder.push('launch');
+    });
+
+    await softReloadAppForFixtures({
+      currentDeviceDetails,
+      deviceCommands,
+      launchArgs: {},
+      fixtureServer,
+      drv: {} as WebdriverIO.Browser,
+    });
+
+    expect(callOrder.indexOf('wait')).toBeLessThan(callOrder.indexOf('launch'));
+  });
+
+  it('runs metro dismissal loop when local Metro launch handling is enabled', async () => {
+    shouldHandleMetroMock.mockReturnValue(true);
+
+    const result = await softReloadAppForFixtures({
+      currentDeviceDetails,
+      deviceCommands,
+      launchArgs: {},
+      fixtureServer,
+      drv: {} as WebdriverIO.Browser,
+    });
+
+    expect(result.attemptedMetroDevLauncherDismissal).toBe(true);
+    expect(dismissMetroMock).toHaveBeenCalled();
+  });
+});

--- a/tests/framework/services/appium/softReloadApp.ts
+++ b/tests/framework/services/appium/softReloadApp.ts
@@ -1,0 +1,153 @@
+import type { CurrentDeviceDetails } from '../../fixtures/playwright';
+import type { LaunchArgs } from '../../types.ts';
+import {
+  resolveE2EFixtureBootstrapTimeoutMs,
+  shouldHandleMetroDevLauncherLocally,
+} from '../../Constants.ts';
+import PlaywrightUtilities from '../../PlaywrightUtilities.ts';
+import { createPlaywrightLogger } from '../../playwrightLogger.ts';
+import { dismissDevelopmentServerPickerPlaywright } from '../../../flows/general.flow';
+import { switchToNativeContext } from './sessionHealth.ts';
+
+const logger = createPlaywrightLogger('softReloadApp');
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    // Allow Jest / process exit when this timer loses a Promise.race.
+    if (typeof timer.unref === 'function') {
+      timer.unref();
+    }
+  });
+
+/**
+ * Minimal fixture-server surface needed for soft reload bootstrap wait.
+ */
+export interface SoftReloadFixtureServer {
+  waitForNextStateRequest(timeoutMs?: number): Promise<void>;
+}
+
+/**
+ * Minimal device-command surface for clearing app data before relaunch.
+ */
+export interface SoftReloadDeviceCommands {
+  clearAppData(): Promise<void>;
+}
+
+export interface SoftReloadAppForFixturesOptions {
+  currentDeviceDetails: CurrentDeviceDetails;
+  deviceCommands?: SoftReloadDeviceCommands;
+  launchArgs: Partial<LaunchArgs>;
+  fixtureServer: SoftReloadFixtureServer;
+  /**
+   * Override bootstrap timeout. Defaults to resolveE2EFixtureBootstrapTimeoutMs().
+   */
+  bootstrapTimeoutMs?: number;
+  /**
+   * WDIO browser used for NATIVE_APP context reset. Defaults to globalThis.driver.
+   */
+  drv?: WebdriverIO.Browser;
+}
+
+export interface SoftReloadAppForFixturesResult {
+  clearAppDataMs: number;
+  contextResetMs: number;
+  launchAppMs: number;
+  fixtureBootstrapMs: number;
+  /** True when the Metro/dev-launcher picker dismissal loop ran during bootstrap. */
+  attemptedMetroDevLauncherDismissal: boolean;
+}
+
+async function measureMs(fn: () => Promise<void>): Promise<number> {
+  const start = Date.now();
+  await fn();
+  return Date.now() - start;
+}
+
+/**
+ * Soft-reload the app on an existing Appium session for fixture re-bootstrap.
+ *
+ * Extract of the Appium `restartDevice: true` path:
+ * clearAppData → NATIVE_APP context reset → launchApp → wait for /state.json.
+ */
+export async function softReloadAppForFixtures(
+  options: SoftReloadAppForFixturesOptions,
+): Promise<SoftReloadAppForFixturesResult> {
+  const {
+    currentDeviceDetails,
+    deviceCommands,
+    launchArgs,
+    fixtureServer,
+    bootstrapTimeoutMs = resolveE2EFixtureBootstrapTimeoutMs(),
+    drv = globalThis.driver,
+  } = options;
+
+  let clearAppDataMs = 0;
+  if (deviceCommands) {
+    clearAppDataMs = await measureMs(() => deviceCommands.clearAppData());
+  }
+
+  const contextResetMs = await measureMs(async () => {
+    const switched = await switchToNativeContext(drv);
+    if (!switched) {
+      logger.debug('NATIVE_APP context reset skipped or failed (best-effort)');
+    }
+  });
+
+  // Register waiter before launch so we do not miss a fast /state.json request.
+  const appStateRequest =
+    fixtureServer.waitForNextStateRequest(bootstrapTimeoutMs);
+
+  let attemptedMetroDevLauncherDismissal = false;
+  let launchAppMs = 0;
+  let fixtureBootstrapMs = 0;
+
+  try {
+    launchAppMs = await measureMs(() =>
+      PlaywrightUtilities.launchApp(currentDeviceDetails, { launchArgs }),
+    );
+
+    const bootstrapStart = Date.now();
+    if (shouldHandleMetroDevLauncherLocally()) {
+      attemptedMetroDevLauncherDismissal = true;
+      await Promise.all([
+        appStateRequest,
+        (async () => {
+          for (;;) {
+            await dismissDevelopmentServerPickerPlaywright();
+            const bootstrapped = await Promise.race([
+              appStateRequest.then(() => true),
+              sleep(1500).then(() => false),
+            ]);
+            if (bootstrapped) {
+              return;
+            }
+          }
+        })(),
+      ]);
+    } else {
+      await appStateRequest;
+    }
+    fixtureBootstrapMs = Date.now() - bootstrapStart;
+  } catch (error) {
+    appStateRequest.catch(() => undefined);
+    throw error;
+  }
+
+  logger.info(
+    `Soft reload complete: clearAppData=${clearAppDataMs}ms, ` +
+      `contextReset=${contextResetMs}ms, launchApp=${launchAppMs}ms, ` +
+      `fixtureBootstrap=${fixtureBootstrapMs}ms` +
+      (attemptedMetroDevLauncherDismissal
+        ? ', metroDevLauncherDismissal=true'
+        : ''),
+  );
+
+  return {
+    clearAppDataMs,
+    contextResetMs,
+    launchAppMs,
+    fixtureBootstrapMs,
+    attemptedMetroDevLauncherDismissal,
+  };
+}

--- a/tests/framework/services/common/base/BaseServiceProvider.cleanupSession.test.ts
+++ b/tests/framework/services/common/base/BaseServiceProvider.cleanupSession.test.ts
@@ -1,0 +1,50 @@
+import type { Browser } from 'webdriverio';
+import { BaseServiceProvider } from './BaseServiceProvider.ts';
+import type { ProjectConfig } from '../types.ts';
+import { Platform, ProviderName } from '../../../types.ts';
+
+class TestServiceProvider extends BaseServiceProvider {
+  async getDriver(): Promise<Browser> {
+    throw new Error('not used');
+  }
+}
+
+function createProject(): ProjectConfig {
+  return {
+    use: {
+      platform: Platform.ANDROID,
+      device: {
+        provider: ProviderName.BROWSERSTACK,
+        name: 'Pixel_5',
+      },
+    },
+  } as ProjectConfig;
+}
+
+describe('BaseServiceProvider.cleanupSession', () => {
+  it('deletes the WebDriver session when drv is provided', async () => {
+    const provider = new TestServiceProvider(createProject(), 'TestProvider');
+    provider.sessionId = 'bs-session-1';
+    const deleteSession = jest.fn().mockResolvedValue(undefined);
+    const drv = {
+      sessionId: 'bs-session-1',
+      deleteSession,
+    } as unknown as Browser;
+
+    await provider.cleanupSession(drv);
+
+    expect(deleteSession).toHaveBeenCalledTimes(1);
+    expect(provider.sessionId).toBeUndefined();
+  });
+
+  it('clears sessionId without deleting when drv is omitted', async () => {
+    const provider = new TestServiceProvider(createProject(), 'TestProvider');
+    provider.sessionId = 'bs-session-2';
+    const deleteSession = jest.fn();
+
+    await provider.cleanupSession();
+
+    expect(deleteSession).not.toHaveBeenCalled();
+    expect(provider.sessionId).toBeUndefined();
+  });
+});

--- a/tests/framework/services/common/base/BaseServiceProvider.ts
+++ b/tests/framework/services/common/base/BaseServiceProvider.ts
@@ -31,7 +31,24 @@ export abstract class BaseServiceProvider implements ServiceProvider {
   }
 
   /**
-   * Optional cleanup - override in subclasses if needed
+   * Optional session cleanup - override in subclasses if needed
+   */
+  async cleanupSession?(drv?: Browser): Promise<void> {
+    this.logger.debug(
+      `Session cleanup for ${this.constructor.name}` +
+        (drv ? ` (driver sessionId=${drv.sessionId})` : ''),
+    );
+  }
+
+  /**
+   * Optional provider cleanup - override in subclasses if needed
+   */
+  async cleanupProvider?(): Promise<void> {
+    this.logger.debug(`Provider cleanup for ${this.constructor.name}`);
+  }
+
+  /**
+   * Legacy cleanup — prefer cleanupSession + cleanupProvider.
    */
   async cleanup?(): Promise<void> {
     this.logger.debug(`Cleanup for ${this.constructor.name}`);

--- a/tests/framework/services/common/base/BaseServiceProvider.ts
+++ b/tests/framework/services/common/base/BaseServiceProvider.ts
@@ -31,13 +31,31 @@ export abstract class BaseServiceProvider implements ServiceProvider {
   }
 
   /**
-   * Optional session cleanup - override in subclasses if needed
+   * Deletes the WebDriver session when a browser is provided.
+   * Providers that cache a browser (e.g. EmulatorProvider) should override
+   * this so they can also clear their local reference.
    */
   async cleanupSession?(drv?: Browser): Promise<void> {
+    if (!drv) {
+      this.sessionId = undefined;
+      this.logger.debug(
+        `Session cleanup for ${this.constructor.name}: no active session`,
+      );
+      return;
+    }
+
     this.logger.debug(
-      `Session cleanup for ${this.constructor.name}` +
-        (drv ? ` (driver sessionId=${drv.sessionId})` : ''),
+      `Deleting WebDriver session ${drv.sessionId ?? this.sessionId ?? 'unknown'} (${this.constructor.name})`,
     );
+    try {
+      await drv.deleteSession();
+      this.logger.info('WebDriver session deleted');
+    } catch (error) {
+      this.logger.error('Failed to delete WebDriver session:', error);
+      throw error;
+    } finally {
+      this.sessionId = undefined;
+    }
   }
 
   /**

--- a/tests/framework/services/common/base/BaseServiceProvider.ts
+++ b/tests/framework/services/common/base/BaseServiceProvider.ts
@@ -35,7 +35,7 @@ export abstract class BaseServiceProvider implements ServiceProvider {
    * Providers that cache a browser (e.g. EmulatorProvider) should override
    * this so they can also clear their local reference.
    */
-  async cleanupSession?(drv?: Browser): Promise<void> {
+  async cleanupSession(drv?: Browser): Promise<void> {
     if (!drv) {
       this.sessionId = undefined;
       this.logger.debug(

--- a/tests/framework/services/common/interfaces/ServiceProvider.ts
+++ b/tests/framework/services/common/interfaces/ServiceProvider.ts
@@ -12,7 +12,7 @@ export interface ServiceProvider {
 
   /**
    * Time in milliseconds from session creation request to session ready.
-   * Only populated by providers that involve remote session allocation (e.g. BrowserStack).
+   * Populated by Emulator and BrowserStack providers after getDriver().
    */
   sessionCreationDurationMs?: number;
 
@@ -36,7 +36,20 @@ export interface ServiceProvider {
   }): Promise<void>;
 
   /**
-   * Cleanup resources (optional)
+   * Deletes the active WebDriver session and clears session metadata.
+   * Does not stop the Appium server.
+   */
+  cleanupSession?(drv?: Browser): Promise<void>;
+
+  /**
+   * Releases provider-level resources (e.g. stop local Appium server).
+   * Does not delete the WebDriver session.
+   */
+  cleanupProvider?(): Promise<void>;
+
+  /**
+   * Legacy cleanup — prefer `cleanupSession` then `cleanupProvider`.
+   * EmulatorProvider maps this to `cleanupProvider` only (historical behavior).
    */
   cleanup?(): Promise<void>;
 

--- a/tests/framework/services/providers/emulator/EmulatorProvider.cleanup.test.ts
+++ b/tests/framework/services/providers/emulator/EmulatorProvider.cleanup.test.ts
@@ -5,7 +5,7 @@ import { Platform, ProviderName } from '../../../types.ts';
 import { EmulatorProvider } from './EmulatorProvider.ts';
 
 jest.mock('../../appium', () => ({
-  ...jest.requireActual('../../appium'),
+  startAppiumServer: jest.fn().mockResolvedValue(undefined),
   stopAppiumServer: jest.fn().mockResolvedValue(undefined),
 }));
 

--- a/tests/framework/services/providers/emulator/EmulatorProvider.cleanup.test.ts
+++ b/tests/framework/services/providers/emulator/EmulatorProvider.cleanup.test.ts
@@ -1,0 +1,92 @@
+import type { Browser } from 'webdriverio';
+import { stopAppiumServer } from '../../appium';
+import type { ProjectConfig } from '../../common/types.ts';
+import { Platform, ProviderName } from '../../../types.ts';
+import { EmulatorProvider } from './EmulatorProvider.ts';
+
+jest.mock('../../appium', () => ({
+  ...jest.requireActual('../../appium'),
+  stopAppiumServer: jest.fn().mockResolvedValue(undefined),
+}));
+
+const stopAppiumServerMock = stopAppiumServer as jest.MockedFunction<
+  typeof stopAppiumServer
+>;
+
+function createProject(): ProjectConfig {
+  return {
+    use: {
+      platform: Platform.ANDROID,
+      device: {
+        provider: ProviderName.EMULATOR,
+        name: 'Pixel_5',
+        udid: 'emulator-5554',
+      },
+      app: {
+        packageName: 'io.metamask',
+      },
+    },
+  } as ProjectConfig;
+}
+
+describe('EmulatorProvider cleanup split', () => {
+  beforeEach(() => {
+    stopAppiumServerMock.mockClear();
+    stopAppiumServerMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('cleanupSession deletes the WebDriver session without stopping Appium', async () => {
+    const provider = new EmulatorProvider(createProject());
+    const deleteSession = jest.fn().mockResolvedValue(undefined);
+    const browser = {
+      sessionId: 'session-1',
+      deleteSession,
+    } as unknown as Browser;
+    // Seed the private browser used when no drv arg is passed.
+    (provider as unknown as { browser?: Browser }).browser = browser;
+    provider.sessionId = 'session-1';
+
+    await provider.cleanupSession();
+
+    expect(deleteSession).toHaveBeenCalledTimes(1);
+    expect(stopAppiumServerMock).not.toHaveBeenCalled();
+    expect(provider.sessionId).toBeUndefined();
+  });
+
+  it('cleanupProvider stops Appium without deleting the session', async () => {
+    const provider = new EmulatorProvider(createProject());
+    const deleteSession = jest.fn().mockResolvedValue(undefined);
+    const browser = {
+      sessionId: 'session-2',
+      deleteSession,
+    } as unknown as Browser;
+    (provider as unknown as { browser?: Browser }).browser = browser;
+    provider.sessionId = 'session-2';
+
+    await provider.cleanupProvider();
+
+    expect(stopAppiumServerMock).toHaveBeenCalledTimes(1);
+    expect(deleteSession).not.toHaveBeenCalled();
+    expect(provider.sessionId).toBe('session-2');
+  });
+
+  it('legacy cleanup only stops Appium (cleanupProvider)', async () => {
+    const provider = new EmulatorProvider(createProject());
+    const deleteSession = jest.fn().mockResolvedValue(undefined);
+    (provider as unknown as { browser?: Browser }).browser = {
+      sessionId: 'session-3',
+      deleteSession,
+    } as unknown as Browser;
+    provider.sessionId = 'session-3';
+
+    await provider.cleanup();
+
+    expect(stopAppiumServerMock).toHaveBeenCalledTimes(1);
+    expect(deleteSession).not.toHaveBeenCalled();
+    expect(provider.sessionId).toBe('session-3');
+  });
+});

--- a/tests/framework/services/providers/emulator/EmulatorProvider.ts
+++ b/tests/framework/services/providers/emulator/EmulatorProvider.ts
@@ -26,6 +26,9 @@ import {
  * Service provider for local emulator/simulator testing
  */
 export class EmulatorProvider extends BaseServiceProvider {
+  /** Active WDIO browser for cleanupSession when no drv arg is passed. */
+  private browser?: Browser;
+
   constructor(project: ProjectConfig) {
     super(project, 'EmulatorProvider');
   }
@@ -299,20 +302,50 @@ export class EmulatorProvider extends BaseServiceProvider {
     const configBuilder = new EmulatorConfigBuilder(this.project);
     const config = configBuilder.build();
 
+    const sessionCreationStart = Date.now();
     const browser = await remote(config);
+    this.sessionCreationDurationMs = Date.now() - sessionCreationStart;
+    this.browser = browser;
     this.sessionId = browser.sessionId;
 
     this.logger.info(
-      `Driver created for emulator with session: ${this.sessionId}`,
+      `Driver created for emulator with session: ${this.sessionId} ` +
+        `(session creation took ${this.sessionCreationDurationMs}ms)`,
     );
     return browser;
   }
 
   /**
-   * Cleanup - stop the Appium server
+   * Delete the WebDriver session. Does not stop the Appium server.
    */
-  async cleanup(): Promise<void> {
-    this.logger.debug('Cleaning up emulator provider');
+  async cleanupSession(drv?: Browser): Promise<void> {
+    const session = drv ?? this.browser;
+    if (!session) {
+      this.sessionId = undefined;
+      this.browser = undefined;
+      return;
+    }
+
+    this.logger.debug(
+      `Deleting WebDriver session ${session.sessionId ?? this.sessionId ?? 'unknown'}`,
+    );
+    try {
+      await session.deleteSession();
+      this.logger.info('WebDriver session deleted');
+    } catch (error) {
+      this.logger.error('Failed to delete WebDriver session:', error);
+      throw error;
+    } finally {
+      this.browser = undefined;
+      this.sessionId = undefined;
+    }
+  }
+
+  /**
+   * Stop the Appium server. Does not delete the WebDriver session.
+   */
+  async cleanupProvider(): Promise<void> {
+    this.logger.debug('Cleaning up emulator provider (Appium server)');
     try {
       await stopAppiumServer();
       this.logger.info('Appium server stopped successfully');
@@ -320,5 +353,13 @@ export class EmulatorProvider extends BaseServiceProvider {
       this.logger.error('Failed to stop Appium server:', error);
       throw error;
     }
+  }
+
+  /**
+   * Legacy cleanup — stops Appium only (historical EmulatorProvider behavior).
+   * Callers that also need session teardown should call cleanupSession first.
+   */
+  async cleanup(): Promise<void> {
+    await this.cleanupProvider();
   }
 }


### PR DESCRIPTION
## **Description**

Appium smoke was paying for a full WebDriver create/delete on every Playwright test. This PR reuses one session per worker, soft-reloads the app between tests (`clearAppData` → `NATIVE_APP` → launch → fixture bootstrap), and rebalances CI shards/timeouts so reuse can amortize across denser shards.

- Worker-scoped `deviceProvider` + shared session; test `driver` inherits and recreates if unhealthy
- Soft reload helper wired through Appium `restartDevice: true`
- `APPIUM_SESSION_REUSE` (default on for emulator/simulator; off for BrowserStack; `false` for rollback)
- CI shard consolidation (e.g. Snaps 8→3, Accounts 4→2) and timeout trims

### CI impact (vs main)

Measured on full Appium smoke vs main merge-base (69 → 40 shards):

- **~23% fewer Appium machine-minutes** (~687m → ~526m per run)
- **Fewer concurrent runners** (69 → 40 shards), so capacity frees up sooner and other PRs spend less time waiting in the queue
- Session reuse confirmed in CI (~83% `sessionReused=true`, 0 unhealthy recreates); BrowserStack / performance path stays reuse-off by design

Individual shard wall time can be longer where packs are denser (expected with consolidation); the win is total compute + runner availability.

### CI evidence

Two full green CI runs on this branch:

1. [`30707019727`](https://github.com/MetaMask/metamask-mobile/actions/runs/30707019727) — Appium smoke **40/40** green; also ran **Performance Tests (PR)** (Android onboarding + imported-wallet jobs succeeded), confirming the shared Playwright fixture path stays healthy with reuse-off on BrowserStack
2. [`30736123224`](https://github.com/MetaMask/metamask-mobile/actions/runs/30736123224) — Appium smoke **40/40** green again after merge from `main` (performance skipped by job selection)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Closes: [MMQA-2156](https://consensyssoftware.atlassian.net/browse/MMQA-2156) (parent epic [MMQA-2149](https://consensyssoftware.atlassian.net/browse/MMQA-2149) — Mobile CI North Star Metrics)

## **Manual testing steps**

N/A — test-infra only. Covered by unit tests for session health, soft reload, cleanup split, and reuse flag; validate via Appium smoke CI (session reuse logs + shard durations).

## **Screenshots/Recordings**

N/A — no user-facing UI changes

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

[MMQA-2156]: https://consensyssoftware.atlassian.net/browse/MMQA-2156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ