### PR TITLE
fix(perps): [Bug]: Perps - Error when selecting imported account `ApiRequestError: Multi-sig required`

### DIFF
--- a/.yarn/patches/@metamask-perps-controller-npm-10.0.0-31df3e0573.patch
+++ b/.yarn/patches/@metamask-perps-controller-npm-10.0.0-31df3e0573.patch
@@ -1,0 +1,104 @@
+diff --git a/dist/providers/HyperLiquidProvider.mjs b/dist/providers/HyperLiquidProvider.mjs
+index ce6e65981441ee060a118abd1b6e0bc5588f4842..62877680d32bca58bb70972727a77137c89c0bce 100644
+--- a/dist/providers/HyperLiquidProvider.mjs
++++ b/dist/providers/HyperLiquidProvider.mjs
+@@ -25,7 +25,7 @@ import { TradingReadinessCache, PerpsSigningCache } from "../services/TradingRea
+ import { PerpsAnalyticsEvent } from "../types/index.mjs";
+ import { HL_ABSTRACTION_WIRE, HL_UNIFIED_ACCOUNT_MODE, hyperLiquidModeFoldsSpot } from "../types/hyperliquid-types.mjs";
+ import { addSpotBalanceToAccountState, aggregateAccountStates } from "../utils/accountUtils.mjs";
+-import { ensureError, isHyperLiquidUserNotFoundError, isKeyringLockedError } from "../utils/errorUtils.mjs";
++import { ensureError, isHyperLiquidMultiSigRequiredError, isHyperLiquidUserNotFoundError, isKeyringLockedError } from "../utils/errorUtils.mjs";
+ import { shouldDeferUnifiedAccountSetup } from "../utils/hyperLiquidAbstraction.mjs";
+ import { adaptAccountStateFromSDK, adaptHyperLiquidLedgerUpdateToUserHistoryItem, adaptMarketFromSDK, adaptOrderFromSDK, adaptPositionFromSDK, buildAssetMapping, formatHyperLiquidPrice, formatHyperLiquidSize, parseAssetName } from "../utils/hyperLiquidAdapter.mjs";
+ import { createErrorResult, getMaxOrderValue, getSupportedPaths, validateAssetSupport, validateBalance, validateCoinExists, validateDepositParams, validateOrderParams, validateWithdrawalParams } from "../utils/hyperLiquidValidation.mjs";
+@@ -3983,6 +3983,22 @@ async function _HyperLiquidProvider_ensureUnifiedAccountEnabled(options) {
+         currentMode = await infoClient.userAbstraction({
+             user: userAddress,
+         });
++        const multiSigSigners = await infoClient.userToMultiSigSigners({
++            user: userAddress,
++        });
++        if (multiSigSigners !== null) {
++            __classPrivateFieldGet(this, _HyperLiquidProvider_deps, "f").debugLogger.log('HyperLiquidProvider: Multi-sig Hyperliquid account, skipping unified account migration', { user: userAddress, network });
++            __classPrivateFieldGet(this, _HyperLiquidProvider_deps, "f").metrics.trackPerpsEvent(PerpsAnalyticsEvent.AccountSetup, {
++                [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.NOT_APPLICABLE,
++                [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: 'multi_sig_account',
++            });
++            TradingReadinessCache.set(network, userAddress, {
++                attempted: true,
++                enabled: false,
++            });
++            completeInFlight();
++            return;
++        }
+         if (currentMode === 'unifiedAccount' ||
+             currentMode === 'portfolioMargin') {
+             // portfolioMargin is a superset of unifiedAccount — it already supports
+@@ -4100,6 +4116,22 @@ async function _HyperLiquidProvider_ensureUnifiedAccountEnabled(options) {
+             completeInFlight();
+             return;
+         }
++        if (isHyperLiquidMultiSigRequiredError(error)) {
++            __classPrivateFieldGet(this, _HyperLiquidProvider_deps, "f").debugLogger.log('[ensureUnifiedAccountEnabled] Multi-sig Hyperliquid account, skipping unified account migration', { user: userAddress, network, currentMode });
++            __classPrivateFieldGet(this, _HyperLiquidProvider_deps, "f").metrics.trackPerpsEvent(PerpsAnalyticsEvent.AccountSetup, {
++                ...(currentMode && {
++                    [PERPS_EVENT_PROPERTY.PREVIOUS_ABSTRACTION_MODE]: currentMode,
++                }),
++                [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.NOT_APPLICABLE,
++                [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: 'multi_sig_account',
++            });
++            TradingReadinessCache.set(network, userAddress, {
++                attempted: true,
++                enabled: false,
++            });
++            completeInFlight();
++            return;
++        }
+         // Cache failure ONLY for the user-prompted path
+         // (`dexAbstraction → unifiedAccount` via `userSetAbstraction`). The
+         // rationale for caching is "don't re-prompt a user who already saw the
+diff --git a/dist/utils/errorUtils.cjs b/dist/utils/errorUtils.cjs
+index 324bc88d2912809fc7a7977800b5e553c0eec593..e1dd0014f881304cdecdd90b1b6a7a9d17cba71c 100644
+--- a/dist/utils/errorUtils.cjs
++++ b/dist/utils/errorUtils.cjs
+@@ -85,4 +85,17 @@ function isHyperLiquidUserNotFoundError(error) {
+     return (lower.includes('user or api wallet') && lower.includes('does not exist'));
+ }
+ exports.isHyperLiquidUserNotFoundError = isHyperLiquidUserNotFoundError;
++/**
++ * Hyperliquid rejects single-wallet exchange writes when the account has been
++ * converted to multi-sig. MetaMask currently supports only single-signer
++ * wallets for agent/user exchange actions.
++ *
++ * @param error - The caught error.
++ * @returns True if the error indicates multi-sig signing is required.
++ */
++function isHyperLiquidMultiSigRequiredError(error) {
++    const lower = ensureError(error).message.toLowerCase();
++    return lower.includes('multi-sig required') || lower.includes('multisig required');
++}
++exports.isHyperLiquidMultiSigRequiredError = isHyperLiquidMultiSigRequiredError;
+ //# sourceMappingURL=errorUtils.cjs.map
+\ No newline at end of file
+diff --git a/dist/utils/errorUtils.mjs b/dist/utils/errorUtils.mjs
+index f8e18790a628809e0519805a32da7a9e8d97d460..4a7ed135a6848b2034e62d7575e6ee7770a1d536 100644
+--- a/dist/utils/errorUtils.mjs
++++ b/dist/utils/errorUtils.mjs
+@@ -78,4 +78,16 @@ export function isHyperLiquidUserNotFoundError(error) {
+     const lower = ensureError(error).message.toLowerCase();
+     return (lower.includes('user or api wallet') && lower.includes('does not exist'));
+ }
++/**
++ * Hyperliquid rejects single-wallet exchange writes when the account has been
++ * converted to multi-sig. MetaMask currently supports only single-signer
++ * wallets for agent/user exchange actions.
++ *
++ * @param error - The caught error.
++ * @returns True if the error indicates multi-sig signing is required.
++ */
++export function isHyperLiquidMultiSigRequiredError(error) {
++    const lower = ensureError(error).message.toLowerCase();
++    return lower.includes('multi-sig required') || lower.includes('multisig required');
++}
+ //# sourceMappingURL=errorUtils.mjs.map
+\ No newline at end of file

--- a/.yarn/patches/@metamask-perps-controller-npm-10.0.0-31df3e0573.patch
+++ b/.yarn/patches/@metamask-perps-controller-npm-10.0.0-31df3e0573.patch
@@ -80,6 +80,44 @@ index 324bc88d2912809fc7a7977800b5e553c0eec593..e1dd0014f881304cdecdd90b1b6a7a9d
 +exports.isHyperLiquidMultiSigRequiredError = isHyperLiquidMultiSigRequiredError;
  //# sourceMappingURL=errorUtils.cjs.map
 \ No newline at end of file
+diff --git a/dist/utils/errorUtils.d.cts b/dist/utils/errorUtils.d.cts
+index ea6fff32f6e5a0306219cb5dbfbecc2c86cfd40b..fcc8e3db55eed0d5c3f51bcf324ccffb8035ac5b 100644
+--- a/dist/utils/errorUtils.d.cts
++++ b/dist/utils/errorUtils.d.cts
+@@ -35,4 +35,13 @@ export declare function ensureError(error: unknown, context?: string): Error;
+  * @returns True if the error matches the Hyperliquid "user not on chain yet" rejection.
+  */
+ export declare function isHyperLiquidUserNotFoundError(error: unknown): boolean;
++/**
++ * Hyperliquid rejects single-wallet exchange writes when the account has been
++ * converted to multi-sig. MetaMask currently supports only single-signer
++ * wallets for agent/user exchange actions.
++ *
++ * @param error - The caught error.
++ * @returns True if the error indicates multi-sig signing is required.
++ */
++export declare function isHyperLiquidMultiSigRequiredError(error: unknown): boolean;
+ //# sourceMappingURL=errorUtils.d.cts.map
+\ No newline at end of file
+diff --git a/dist/utils/errorUtils.d.mts b/dist/utils/errorUtils.d.mts
+index 227a443e74bb0c849796fe98ff7bec0f515313d1..a80998ac9709f88da2a2cf2f421d1d7c7702e2fe 100644
+--- a/dist/utils/errorUtils.d.mts
++++ b/dist/utils/errorUtils.d.mts
+@@ -35,4 +35,13 @@ export declare function ensureError(error: unknown, context?: string): Error;
+  * @returns True if the error matches the Hyperliquid "user not on chain yet" rejection.
+  */
+ export declare function isHyperLiquidUserNotFoundError(error: unknown): boolean;
++/**
++ * Hyperliquid rejects single-wallet exchange writes when the account has been
++ * converted to multi-sig. MetaMask currently supports only single-signer
++ * wallets for agent/user exchange actions.
++ *
++ * @param error - The caught error.
++ * @returns True if the error indicates multi-sig signing is required.
++ */
++export declare function isHyperLiquidMultiSigRequiredError(error: unknown): boolean;
+ //# sourceMappingURL=errorUtils.d.mts.map
+\ No newline at end of file
 diff --git a/dist/utils/errorUtils.mjs b/dist/utils/errorUtils.mjs
 index f8e18790a628809e0519805a32da7a9e8d97d460..4a7ed135a6848b2034e62d7575e6ee7770a1d536 100644
 --- a/dist/utils/errorUtils.mjs

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -957,13 +957,6 @@ class PerpsConnectionManagerClass {
           error,
           'PerpsConnectionManager.connect',
         );
-        if (
-          errorInstance.message.toLowerCase().includes('multi-sig required')
-        ) {
-          DevLogger.log(
-            '[PR-TAT-3214] BUG_MARKER: ApiRequestError Multi-sig required during Perps connection for imported account',
-          );
-        }
         if (!suppressError) {
           this.setError(errorInstance);
         }

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -957,6 +957,13 @@ class PerpsConnectionManagerClass {
           error,
           'PerpsConnectionManager.connect',
         );
+        if (
+          errorInstance.message.toLowerCase().includes('multi-sig required')
+        ) {
+          DevLogger.log(
+            '[PR-TAT-3214] BUG_MARKER: ApiRequestError Multi-sig required during Perps connection for imported account',
+          );
+        }
         if (!suppressError) {
           this.setError(errorInstance);
         }

--- a/app/components/UI/Perps/utils/hyperLiquidMultiSigError.test.ts
+++ b/app/components/UI/Perps/utils/hyperLiquidMultiSigError.test.ts
@@ -1,0 +1,17 @@
+import { isHyperLiquidMultiSigRequiredError } from '@metamask/perps-controller/utils/errorUtils';
+
+describe('isHyperLiquidMultiSigRequiredError', () => {
+  it('detects ApiRequestError multi-sig required messages', () => {
+    expect(
+      isHyperLiquidMultiSigRequiredError(
+        new Error('ApiRequestError: Multi-sig required'),
+      ),
+    ).toBe(true);
+  });
+
+  it('ignores unrelated connection errors', () => {
+    expect(isHyperLiquidMultiSigRequiredError(new Error('Network error'))).toBe(
+      false,
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -328,7 +328,7 @@
     "@metamask/network-enablement-controller": "patch:@metamask/network-enablement-controller@npm%3A5.4.1#~/.yarn/patches/@metamask-network-enablement-controller-npm-5.4.1-020a82a308.patch",
     "@metamask/notification-services-controller": "^26.0.0",
     "@metamask/permission-controller": "^13.1.1",
-    "@metamask/perps-controller": "^10.0.0",
+    "@metamask/perps-controller": "patch:@metamask/perps-controller@npm%3A10.0.0#~/.yarn/patches/@metamask-perps-controller-npm-10.0.0-31df3e0573.patch",
     "@metamask/phishing-controller": "^17.3.0",
     "@metamask/post-message-stream": "^10.0.0",
     "@metamask/preferences-controller": "^23.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9697,7 +9697,7 @@ __metadata:
 
 "@metamask/perps-controller@patch:@metamask/perps-controller@npm%3A10.0.0#~/.yarn/patches/@metamask-perps-controller-npm-10.0.0-31df3e0573.patch":
   version: 10.0.0
-  resolution: "@metamask/perps-controller@patch:@metamask/perps-controller@npm%3A10.0.0#~/.yarn/patches/@metamask-perps-controller-npm-10.0.0-31df3e0573.patch::version=10.0.0&hash=021943"
+  resolution: "@metamask/perps-controller@patch:@metamask/perps-controller@npm%3A10.0.0#~/.yarn/patches/@metamask-perps-controller-npm-10.0.0-31df3e0573.patch::version=10.0.0&hash=015d18"
   dependencies:
     "@metamask/abi-utils": "npm:^2.0.3"
     "@metamask/base-controller": "npm:^9.1.0"
@@ -9713,7 +9713,7 @@ __metadata:
   dependenciesMeta:
     "@myx-trade/sdk":
       optional: true
-  checksum: 10/7ed218aafea67a13bfd8c17e294e1ce4357f574c0748e15a85fd4630f480993c1187e44c517bf73009406e5373026d8a043265512a3b64832cab8ad3f0c933fa
+  checksum: 10/1face93c8672974ac515ff0fd97aee88d3a5dba2a155fe64651006e25aaf0510c8036ec5537e2abd26becbfbc3b4dd49aa887090e0cc296792390f63a19b640c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9673,7 +9673,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/perps-controller@npm:^10.0.0":
+"@metamask/perps-controller@npm:10.0.0":
   version: 10.0.0
   resolution: "@metamask/perps-controller@npm:10.0.0"
   dependencies:
@@ -9692,6 +9692,28 @@ __metadata:
     "@myx-trade/sdk":
       optional: true
   checksum: 10/b67cc2265ff05320ceebaeba56a8e6941d0d35982b9ee70e4f86c6812bed39ba8c38c21c74b8a697ddde23483625e6f170d172d9b28f157fd5f663f426068caa
+  languageName: node
+  linkType: hard
+
+"@metamask/perps-controller@patch:@metamask/perps-controller@npm%3A10.0.0#~/.yarn/patches/@metamask-perps-controller-npm-10.0.0-31df3e0573.patch":
+  version: 10.0.0
+  resolution: "@metamask/perps-controller@patch:@metamask/perps-controller@npm%3A10.0.0#~/.yarn/patches/@metamask-perps-controller-npm-10.0.0-31df3e0573.patch::version=10.0.0&hash=021943"
+  dependencies:
+    "@metamask/abi-utils": "npm:^2.0.3"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.11.0"
+    "@myx-trade/sdk": "npm:^0.1.265"
+    "@nktkas/hyperliquid": "npm:^0.33.1"
+    bignumber.js: "npm:^9.1.2"
+    reselect: "npm:^5.1.1"
+    uuid: "npm:^8.3.2"
+  dependenciesMeta:
+    "@myx-trade/sdk":
+      optional: true
+  checksum: 10/7ed218aafea67a13bfd8c17e294e1ce4357f574c0748e15a85fd4630f480993c1187e44c517bf73009406e5373026d8a043265512a3b64832cab8ad3f0c933fa
   languageName: node
   linkType: hard
 
@@ -35910,7 +35932,7 @@ __metadata:
     "@metamask/notification-services-controller": "npm:^26.0.0"
     "@metamask/object-multiplex": "npm:^1.1.0"
     "@metamask/permission-controller": "npm:^13.1.1"
-    "@metamask/perps-controller": "npm:^10.0.0"
+    "@metamask/perps-controller": "patch:@metamask/perps-controller@npm%3A10.0.0#~/.yarn/patches/@metamask-perps-controller-npm-10.0.0-31df3e0573.patch"
     "@metamask/phishing-controller": "npm:^17.3.0"
     "@metamask/post-message-stream": "npm:^10.0.0"
     "@metamask/preferences-controller": "npm:^23.0.0"


### PR DESCRIPTION
## **Description**

Skip Hyperliquid unified-account migration when the selected wallet is a multi-sig HL account, so Perps init no longer surfaces `ApiRequestError: Multi-sig required` for imported private-key accounts.

## **Changelog**

CHANGELOG entry: Fixed Perps showing a multi-sig error when switching to an imported account whose Hyperliquid address requires multi-sig signing.

## **Related issues**

Fixes: [TAT-3214](https://consensyssoftware.atlassian.net/browse/TAT-3214)

## **Manual testing steps**

```gherkin
Feature: Perps imported account connection

  Scenario: imported account opens Perps without multi-sig error
    Given an unlocked wallet with imported private-key account Trading selected
    When user opens the Perps tab
    Then Perps loads without ApiRequestError Multi-sig required
```

## **Screenshots/Recordings**

Imported Trading account opens Perps without connection error.

<table>
<tr><td colspan="2"><strong>Perps loads for imported private-key account</strong></td></tr>
<tr>
<td align="center" valign="top" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/34170/before-evidence-ac1-perps-market-list.png?sha=3cd96b7bb2bb1de1" alt="before" width="320" /></td>
<td align="center" valign="top" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/34170/after-ac1-perps-market-list.png?sha=ce19463251112611" alt="after" width="320" /></td>
</tr>
</table>

## **Validation Recipe**

<details>
<summary>recipe.json</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "TAT-3214 imported account opens Perps without multi-sig error",
  "workflow": {
    "entry": "setup-unlock",
    "nodes": {
      "setup-unlock": {
        "action": "metamask.wallet.ensure_unlocked",
        "intent": "Ensure the wallet is unlocked",
        "next": "setup-select-imported"
      },
      "setup-select-imported": {
        "action": "metamask.wallet.select_account",
        "intent": "Switch to the imported private-key Trading account",
        "address": "0x316BDE155acd07609872a56Bc32CcfB0B13201fA",
        "next": "ac1-navigate-perps"
      },
      "ac1-navigate-perps": {
        "action": "ui.navigate",
        "intent": "Show the Perps home surface",
        "page": "perps",
        "next": "ac1-wait-ready"
      },
      "ac1-wait-ready": {
        "action": "ui.wait_for",
        "intent": "Confirm the user can browse perpetuals",
        "test_id": "perps-market-list",
        "timeout_ms": 20000,
        "next": "ac1-assert-no-multisig-log"
      },
      "ac1-assert-no-multisig-log": {
        "action": "command",
        "intent": "Verify no multi-sig connection failure was logged during init",

        "next": "ac1-capture-proof"
      },
      "ac1-capture-proof": {
        "action": "ui.screenshot",
        "intent": "Record what the trader sees after opening derivatives",

        "label": "AC1: Perps market list loads for imported account",
        "next": "done"
      },
      "done": {
        "action": "end",
        "status": "pass"
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
flowchart TD
  A[Unlock wallet] --> B[Select imported Trading account]
  B --> C[Navigate to Perps]
  C --> D[Wait for market list]
  D --> E[Assert no multi-sig in metro log]
  E --> F[Screenshot evidence]
```

</details>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TAT-3214]: https://consensyssoftware.atlassian.net/browse/TAT-3214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Perps account-setup behavior via a vendored controller patch; incorrect detection could skip migration for some users or leave multi-sig accounts partially enabled.
> 
> **Overview**
> Fixes Perps failing on imported accounts whose Hyperliquid address is multi-sig by **patching `@metamask/perps-controller`** so unified-account setup is skipped instead of attempting single-signer exchange writes that trigger `ApiRequestError: Multi-sig required`.
> 
> The patch adds **`isHyperLiquidMultiSigRequiredError`** and, in **`ensureUnifiedAccountEnabled`**, checks **`userToMultiSigSigners`** up front and treats multi-sig API errors as a no-op: logs, records account-setup analytics as not applicable (`multi_sig_account`), and caches trading readiness as attempted with unified account disabled.
> 
> Mobile wires the dependency through a **Yarn patch** (`package.json` / `yarn.lock`) and adds a small unit test for the new error classifier under Perps utils.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cc521477c553fdbb2fea113f3138c4eea210a11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->