### PR TITLE
fix(stellar): Stellar preparation - mask XLM spendable balance when privacy mode is on

### DIFF
--- a/app/components/UI/SpendableBalance/SpendableBalanceSection.test.tsx
+++ b/app/components/UI/SpendableBalance/SpendableBalanceSection.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
 
 import {
   SpendableBalanceSection,
@@ -20,6 +21,13 @@ jest.mock('../../../../locales/i18n', () => ({
   },
 }));
 
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+
+const mockUseSelector = jest.mocked(useSelector);
+
 describe('SpendableBalanceSection', () => {
   const defaultProps = {
     minimumReserveBalance: '2.5',
@@ -28,6 +36,10 @@ describe('SpendableBalanceSection', () => {
     symbol: 'XLM',
     fiatValue: '$105.00',
   };
+
+  beforeEach(() => {
+    mockUseSelector.mockReturnValue(false);
+  });
 
   it('renders total, spendable, reserved, and fiat balances', () => {
     const { getByTestId, getByText } = render(
@@ -62,12 +74,29 @@ describe('SpendableBalanceSection', () => {
     );
   });
 
-  it('renders labels for total, fiat, spendable, and reserved rows', () => {
-    const { getByText } = render(<SpendableBalanceSection {...defaultProps} />);
+  it('masks balances when privacy mode is enabled', () => {
+    mockUseSelector.mockReturnValue(true);
 
-    expect(getByText('Total balance')).toBeOnTheScreen();
-    expect(getByText('Value')).toBeOnTheScreen();
-    expect(getByText('Spendable')).toBeOnTheScreen();
-    expect(getByText('Reserved (locked)')).toBeOnTheScreen();
+    const { getByTestId, queryByText } = render(
+      <SpendableBalanceSection {...defaultProps} />,
+    );
+
+    const maskedBalance = '•••••••••';
+    expect(getByTestId(SpendableBalanceSectionTestIds.TOTAL)).toHaveTextContent(
+      maskedBalance,
+    );
+    expect(
+      getByTestId(SpendableBalanceSectionTestIds.SPENDABLE),
+    ).toHaveTextContent(maskedBalance);
+    expect(
+      getByTestId(SpendableBalanceSectionTestIds.RESERVED),
+    ).toHaveTextContent(maskedBalance);
+    expect(getByTestId(SpendableBalanceSectionTestIds.FIAT)).toHaveTextContent(
+      maskedBalance,
+    );
+    expect(queryByText('250 XLM')).toBeNull();
+    expect(queryByText('247.5 XLM')).toBeNull();
+    expect(queryByText('2.5 XLM')).toBeNull();
+    expect(queryByText('$105.00')).toBeNull();
   });
 });

--- a/app/components/UI/SpendableBalance/SpendableBalanceSection.tsx
+++ b/app/components/UI/SpendableBalance/SpendableBalanceSection.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
-import { Box, BoxFlexDirection } from '@metamask/design-system-react-native';
-// design-system-react-native TextVariant is not aligned with the mobile
-// component-library TextVariant, so use the local Text component.
-import Text, {
+import { useSelector } from 'react-redux';
+import {
+  Box,
+  BoxFlexDirection,
+  FontWeight,
+  SensitiveText,
+  SensitiveTextLength,
+  Text,
   TextColor,
   TextVariant,
-} from '../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
+
 import { strings } from '../../../../locales/i18n';
+import { selectPrivacyMode } from '../../../selectors/preferencesController';
 
 export const SpendableBalanceSectionTestIds = {
   CONTAINER: 'spendable-balance-section',
@@ -44,6 +50,7 @@ export const SpendableBalanceSection = ({
   const totalDisplay = `${totalBalance} ${symbol}`;
   const spendableDisplay = `${spendableBalance} ${symbol}`;
   const reservedDisplay = `${minimumReserveBalance} ${symbol}`;
+  const privacyMode = useSelector(selectPrivacyMode);
 
   return (
     <Box
@@ -51,69 +58,82 @@ export const SpendableBalanceSection = ({
       flexDirection={BoxFlexDirection.Column}
       twClassName="px-4 py-4 gap-3"
     >
-      <Text variant={TextVariant.HeadingMD}>
+      <Text variant={TextVariant.HeadingMd}>
         {strings('asset_overview.your_balance')}
       </Text>
       <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-3">
         <Box flexDirection={BoxFlexDirection.Column} twClassName="flex-1 gap-1">
           <Text
-            variant={TextVariant.BodySMMedium}
-            color={TextColor.Alternative}
+            variant={TextVariant.BodySm}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextAlternative}
           >
             {strings('asset_spendable_balance.total_balance')}
           </Text>
-          <Text
-            variant={TextVariant.BodyMDMedium}
+          <SensitiveText
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
             testID={SpendableBalanceSectionTestIds.TOTAL}
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Medium}
           >
             {totalDisplay}
-          </Text>
+          </SensitiveText>
         </Box>
         <Box flexDirection={BoxFlexDirection.Column} twClassName="flex-1 gap-1">
           <Text
-            variant={TextVariant.BodySMMedium}
-            color={TextColor.Alternative}
+            variant={TextVariant.BodySm}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextAlternative}
           >
             {strings('asset_spendable_balance.fiat_value')}
           </Text>
-          <Text
-            variant={TextVariant.BodyMD}
+          <SensitiveText
+            variant={TextVariant.BodyMd}
             testID={SpendableBalanceSectionTestIds.FIAT}
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Medium}
           >
             {fiatValue ?? '—'}
-          </Text>
+          </SensitiveText>
         </Box>
       </Box>
       <Box flexDirection={BoxFlexDirection.Row} twClassName="gap-3">
         <Box flexDirection={BoxFlexDirection.Column} twClassName="flex-1 gap-1">
           <Text
-            variant={TextVariant.BodySMMedium}
-            color={TextColor.Alternative}
+            variant={TextVariant.BodySm}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextAlternative}
           >
             {strings('asset_spendable_balance.spendable')}
           </Text>
-          <Text
-            variant={TextVariant.BodyMD}
-            color={TextColor.Success}
+          <SensitiveText
+            variant={TextVariant.BodyMd}
+            color={TextColor.SuccessDefault}
             testID={SpendableBalanceSectionTestIds.SPENDABLE}
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Medium}
           >
             {spendableDisplay}
-          </Text>
+          </SensitiveText>
         </Box>
         <Box flexDirection={BoxFlexDirection.Column} twClassName="flex-1 gap-1">
           <Text
-            variant={TextVariant.BodySMMedium}
-            color={TextColor.Alternative}
+            variant={TextVariant.BodySm}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextAlternative}
           >
             {strings('asset_spendable_balance.base_reserved')}
           </Text>
-          <Text
-            variant={TextVariant.BodyMD}
-            color={TextColor.Success}
+          <SensitiveText
+            variant={TextVariant.BodyMd}
+            color={TextColor.SuccessDefault}
             testID={SpendableBalanceSectionTestIds.RESERVED}
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Medium}
           >
             {reservedDisplay}
-          </Text>
+          </SensitiveText>
         </Box>
       </Box>
     </Box>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -10727,19 +10727,5 @@
     "empty_add_tokens_cta": "Add {{count}} token",
     "empty_add_tokens_cta_plural": "Add {{count}} tokens",
     "search_placeholder": "Search for any asset to add"
-  },
-  "asset_spendable_balance": {
-    "spendable": "Spendable",
-    "base_reserved": "Reserved (locked)",
-    "fiat_value": "Value",
-    "total_balance": "Total balance"
-  },
-  "asset_activation": {
-    "activate": "Activate",
-    "activate_description": "Activate {{symbol}} on {{chainName}} to get started.",
-    "inactive": "Inactive",
-    "activate_error": "Something went wrong while adding this trustline. Try again.",
-    "deactivate_error": "Something went wrong while removing this trustline. Try again.",
-    "deactivate_error_non_zero_balance_stellar": "You still have {{balance}} {{symbol}} in this wallet. You must send or swap it all before deactivating this asset on Stellar."
   }
 }

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -10727,5 +10727,19 @@
     "empty_add_tokens_cta": "Add {{count}} token",
     "empty_add_tokens_cta_plural": "Add {{count}} tokens",
     "search_placeholder": "Search for any asset to add"
+  },
+  "asset_spendable_balance": {
+    "spendable": "Spendable",
+    "base_reserved": "Reserved (locked)",
+    "fiat_value": "Value",
+    "total_balance": "Total balance"
+  },
+  "asset_activation": {
+    "activate": "Activate",
+    "activate_description": "Activate {{symbol}} on {{chainName}} to get started.",
+    "inactive": "Inactive",
+    "activate_error": "Something went wrong while adding this trustline. Try again.",
+    "deactivate_error": "Something went wrong while removing this trustline. Try again.",
+    "deactivate_error_non_zero_balance_stellar": "You still have {{balance}} {{symbol}} in this wallet. You must send or swap it all before deactivating this asset on Stellar."
   }
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

## **Stellar is not activate, so we cant actual test it, the video was recording in the Stellar Dev Branch**

Spendable balance (XLM) now respects privacy mode: total, fiat, spendable, and reserved amounts use design-system SensitiveText driven by selectPrivacyMode, so values show as bullets instead of real numbers when hiding balances is enabled.
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:  Fixed XLM Spendable amount with sensitive text wrapper when privacy mode is on

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
## **Stellar is not activate, so we cant actual test it, the video was recording in the Stellar Dev Branch**
<!-- [screenshots/recordings] -->
https://www.loom.com/share/4bb127991c564ee4a35d85b1321713a0
## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI change reusing an established privacy pattern; no auth, data, or payment logic touched.
> 
> **Overview**
> **Spendable balance (XLM)** now respects **privacy mode**: total, fiat, spendable, and reserved amounts use design-system `SensitiveText` driven by `selectPrivacyMode`, so values show as bullets instead of real numbers when hiding balances is enabled.
> 
> The section also moves balance UI from component-library `Text` to `@metamask/design-system-react-native` (including updated `TextVariant` / `TextColor` names). Tests mock `useSelector` and assert masking when privacy mode is on, replacing a label-only assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9106ea2629a15c230e7d0b99de645331daf24773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->