### PR TITLE
fix: update Agent CLI QR login copy

### DIFF
--- a/app/component-library/components-temp/BaseNotification/index.test.tsx
+++ b/app/component-library/components-temp/BaseNotification/index.test.tsx
@@ -142,6 +142,17 @@ describe('BaseNotification', () => {
     },
   );
 
+  it('does not fall back when an empty description is provided', () => {
+    const { queryByText } = renderWithProvider(
+      <BaseNotification
+        status="success"
+        data={{ title: 'Agent CLI successfully linked', description: '' }}
+      />,
+    );
+
+    expect(queryByText(getDescription('success', {}))).toBeNull();
+  });
+
   it('does not crash when data is undefined', () => {
     const { getByTestId } = renderWithProvider(
       <BaseNotification status="success" />,

--- a/app/component-library/components-temp/BaseNotification/index.tsx
+++ b/app/component-library/components-temp/BaseNotification/index.tsx
@@ -199,9 +199,8 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
   const dismissDurationMs = dismissDuration ?? NOTIFICATION_VISIBILITY_DURATION;
 
   const hasCloseIconButton = autoDismiss;
-  const resolvedDescription = !description
-    ? getDescription(status, safeData)
-    : description;
+  const resolvedDescription =
+    description === null ? getDescription(status, safeData) : description;
   const hasDescription = resolvedDescription.length > 0;
   const shouldTopAlign =
     (titleLineCount !== null && titleLineCount > 1 && hasDescription) ||

--- a/app/component-library/components-temp/BaseNotification/index.tsx
+++ b/app/component-library/components-temp/BaseNotification/index.tsx
@@ -199,8 +199,7 @@ const BaseNotification: React.FC<BaseNotificationProps> = ({
   const dismissDurationMs = dismissDuration ?? NOTIFICATION_VISIBILITY_DURATION;
 
   const hasCloseIconButton = autoDismiss;
-  const resolvedDescription =
-    description === null ? getDescription(status, safeData) : description;
+  const resolvedDescription = description ?? getDescription(status, safeData);
   const hasDescription = resolvedDescription.length > 0;
   const shouldTopAlign =
     (titleLineCount !== null && titleLineCount > 1 && hasDescription) ||

--- a/app/components/Views/SDK/SDKConnectV2OtpModal/SDKConnectV2OtpModal.test.tsx
+++ b/app/components/Views/SDK/SDKConnectV2OtpModal/SDKConnectV2OtpModal.test.tsx
@@ -109,11 +109,10 @@ jest.mock('../../../../../locales/i18n', () => ({
       'sdk_connect_v2.show_otp.modal_title': 'Link MetaMask Agent CLI',
       'sdk_connect_v2.show_otp.modal_description':
         'Pair MetaMask Mobile with your MetaMask Agent CLI.',
-      'sdk_connect_v2.show_otp.code_label': 'ENTER THIS CODE IN THE CLI',
+      'sdk_connect_v2.show_otp.code_label': 'ENTER CODE IN TERMINAL',
       'sdk_connect_v2.show_otp.expires_in': `Expires in ${params?.time}`,
       'sdk_connect_v2.show_otp.expired': 'Code expired',
-      'sdk_connect_v2.show_otp.security_notice':
-        "Securing the connection first. You'll authorize CLI access in the next step",
+      'sdk_connect_v2.show_otp.security_notice': 'Securing the connection',
     };
     return translations[key] ?? key;
   },
@@ -144,6 +143,8 @@ describe('SDKConnectV2OtpModal', () => {
       getByTestId(SDKConnectV2OtpModalSelectors.CONTAINER),
     ).toBeOnTheScreen();
     expect(getByText('Link MetaMask Agent CLI')).toBeOnTheScreen();
+    expect(getByText('ENTER CODE IN TERMINAL')).toBeOnTheScreen();
+    expect(getByText('Securing the connection')).toBeOnTheScreen();
     expect(
       getByTestId(SDKConnectV2OtpModalSelectors.OTP_CODE),
     ).toHaveTextContent('4892–AKJ7');

--- a/app/core/AgenticCli/AgenticCliMwpConnectionService.test.ts
+++ b/app/core/AgenticCli/AgenticCliMwpConnectionService.test.ts
@@ -292,7 +292,12 @@ describe('AgenticCliMwpConnectionService', () => {
 
     expect(mockHostApp.showConnectionLoading).toHaveBeenCalledTimes(1);
     expect(mockHostApp.showConnectionLoading).toHaveBeenCalledWith(
-      expect.objectContaining({ id: mockConnectionInfo.id }),
+      expect.objectContaining({
+        id: mockConnectionInfo.id,
+        metadata: expect.objectContaining({
+          dapp: expect.objectContaining({ name: 'Agent CLI' }),
+        }),
+      }),
       { autodismissMs: AGENTIC_CLI_CONNECTION_LOADING_AUTODISMISS_MS },
     );
     expect(mockHostApp.hideConnectionLoading).toHaveBeenCalledTimes(1);

--- a/app/core/AgenticCli/AgenticCliMwpConnectionService.ts
+++ b/app/core/AgenticCli/AgenticCliMwpConnectionService.ts
@@ -27,6 +27,8 @@ import {
   waitForKeyringUnlock,
 } from './AgenticCliQrLoginService';
 
+const AGENTIC_CLI_DISPLAY_NAME = 'Agent CLI';
+
 export interface AgenticCliMwpConnectionDeps {
   relayURL: string;
   keymanager: IKeyManager;
@@ -123,7 +125,15 @@ export async function handleAgenticCliConnectDeeplink(
 
     connInfo = {
       id: connReq.sessionRequest.id,
-      metadata: connReq.metadata,
+      metadata: {
+        ...connReq.metadata,
+        dapp: {
+          ...connReq.metadata.dapp,
+          // The Agent CLI is a known first-party flow, so do not surface the
+          // self-reported "MM CLI" name in product UI.
+          name: AGENTIC_CLI_DISPLAY_NAME,
+        },
+      },
       expiresAt: Date.now() + DEFAULT_SESSION_TTL,
     };
 

--- a/app/core/AgenticCli/AgenticCliQrLoginService.test.ts
+++ b/app/core/AgenticCli/AgenticCliQrLoginService.test.ts
@@ -237,6 +237,7 @@ describe('AgenticCliQrLoginService', () => {
       id: '11111111-2222-3333-4444-555555555555-cli-link-success',
       autodismiss: 3000,
       title: 'sdk_connect_v2.show_cli_link_success.title',
+      description: '',
       status: 'success',
     });
     expect(store.dispatch).toHaveBeenCalledTimes(1);

--- a/app/core/AgenticCli/AgenticCliQrLoginService.test.ts
+++ b/app/core/AgenticCli/AgenticCliQrLoginService.test.ts
@@ -238,7 +238,6 @@ describe('AgenticCliQrLoginService', () => {
       autodismiss: 3000,
       title: 'sdk_connect_v2.show_cli_link_success.title',
       status: 'success',
-      description: 'sdk_connect_v2.show_cli_link_success.description',
     });
     expect(store.dispatch).toHaveBeenCalledTimes(1);
     expect(mockMaybePromptPushPermissionAfterCliLogin).toHaveBeenCalledTimes(1);

--- a/app/core/AgenticCli/AgenticCliQrLoginService.ts
+++ b/app/core/AgenticCli/AgenticCliQrLoginService.ts
@@ -147,9 +147,6 @@ export async function handleAgenticCliQrLogin({
         autodismiss: 3000,
         title: strings('sdk_connect_v2.show_cli_link_success.title'),
         status: 'success',
-        description: strings(
-          'sdk_connect_v2.show_cli_link_success.description',
-        ),
       }),
     );
 

--- a/app/core/AgenticCli/AgenticCliQrLoginService.ts
+++ b/app/core/AgenticCli/AgenticCliQrLoginService.ts
@@ -146,6 +146,7 @@ export async function handleAgenticCliQrLogin({
         id: `${conn.id}-cli-link-success`,
         autodismiss: 3000,
         title: strings('sdk_connect_v2.show_cli_link_success.title'),
+        description: '',
         status: 'success',
       }),
     );

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -10386,7 +10386,7 @@
       "description": "Return to the app to continue."
     },
     "show_cli_link_success": {
-      "title": "MetaMask Agent CLI link successful",
+      "title": "Agent CLI successfully linked",
       "description": "Return to the CLI to continue."
     },
     "push_nudge": {
@@ -10402,10 +10402,10 @@
       "description": "Enter {{otp}} in {{dappName}} to finish connecting. This code expires in {{seconds}} seconds.",
       "modal_title": "Link MetaMask Agent CLI",
       "modal_description": "Pair MetaMask Mobile with your MetaMask Agent CLI.",
-      "code_label": "ENTER THIS CODE IN THE CLI",
+      "code_label": "ENTER CODE IN TERMINAL",
       "expires_in": "Expires in {{time}}",
       "expired": "Code expired",
-      "security_notice": "Securing the connection first. You'll authorize CLI access in the next step"
+      "security_notice": "Securing the connection"
     },
     "show_not_found": {
       "title": "Connection Not Found",


### PR DESCRIPTION
# fix: update Agent CLI QR login copy

## **Description**

Updates the Agent CLI QR pairing flow to use the approved Agent CLI copy, label the loading toast consistently, and display a title-only success toast without the unrelated transaction subtitle.

## **Changelog**

CHANGELOG entry: Updated Agent CLI pairing copy.

## **Related issues**

Refs: MMAI-1001

## **Manual testing steps**

```gherkin
Feature: Agent CLI QR pairing

  Scenario: Pairing succeeds
    Given MetaMask Mobile is ready to pair with Agent CLI
    When the user scans a valid Agent CLI QR code and completes pairing
    Then the OTP screen uses the updated copy
    And the loading toast identifies Agent CLI
    And the success toast shows "Agent CLI successfully linked" without a subtitle
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

<img width="300" alt="Agent CLI QR pairing" src="https://github.com/user-attachments/assets/f2913f33-b0ae-4712-b38e-32448a5c5442" />
<img width="300" alt="Agent CLI OTP" src="https://github.com/user-attachments/assets/b6c160b5-3ce3-43b4-be06-2b4165079d53" />
<img width="300" alt="Agent CLI pairing success" src="https://github.com/user-attachments/assets/2dbf6ff8-957f-4752-9901-9f0a21f41977" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and notification-display tweaks in a first-party CLI flow; behavior change is limited to empty-description handling in BaseNotification, which is covered by a new unit test.
> 
> **Overview**
> Updates **Agent CLI QR pairing** strings: OTP modal uses **"ENTER CODE IN TERMINAL"** and a shorter **"Securing the connection"** notice; the link-success title is **"Agent CLI successfully linked"**.
> 
> The success toast now passes an **empty `description`** so users do not see the generic success subtitle. **`BaseNotification`** resolves description with **`??`** instead of treating `''` as missing, so an intentional empty description is not replaced by **`getDescription`**.
> 
> During MWP connect, connection metadata **`dapp.name`** is forced to **"Agent CLI"** (not self-reported **"MM CLI"**) so the loading toast label matches product copy. Tests cover the new strings, metadata, and empty-description behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65a85f5ae697a1926bc5124ad99eae1a8b0290a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->