### PR TITLE
fix(ci): scope TestFlight PR-comment permission to avoid breaking reusable-workflow callers

### DIFF
--- a/.github/workflows/build-and-upload-to-testflight.yml
+++ b/.github/workflows/build-and-upload-to-testflight.yml
@@ -110,5 +110,48 @@ jobs:
       build_number: ${{ needs.build.outputs.ios_version_code }}
       distribute_external: ${{ inputs.distribute_external }}
       runner_provider: ${{ inputs.runner_provider }}
-      pr_number: ${{ inputs.pr_number }}
     secrets: inherit
+
+  # Post the version and build number back to the PR when triggered via the
+  # @metamaskbot bot command (pr_number set). This lives here rather than in the
+  # shared upload-to-testflight.yml so that pull-requests: write is only required
+  # of this workflow's callers, not of every caller of upload-to-testflight.yml.
+  comment-on-pr:
+    name: Comment upload summary on PR
+    needs: [build, upload-ios-testflight]
+    if: ${{ inputs.pr_number != '' }}
+    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Post TestFlight upload summary to the PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          SOURCE_BRANCH: ${{ inputs.source_branch }}
+          BUILD_NAME: main-${{ inputs.environment }}
+          BUILD_COMMIT_SHA: ${{ needs.build.outputs.built_commit_sha }}
+          BUILD_VERSION: ${{ needs.build.outputs.semantic_version }}
+          BUILD_NUMBER: ${{ needs.build.outputs.ios_version_code }}
+          TESTFLIGHT_GROUP: ${{ inputs.testflight_group || 'MetaMask BETA & Release Candidates' }}
+        run: |
+          set -euo pipefail
+          # Values are passed via env (not expression interpolation in the script
+          # body) so branch names etc. cannot break out of the shell.
+          {
+            echo "### 📲 TestFlight build uploaded"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| **Track / environment** | \`${ENVIRONMENT}\` |"
+            echo "| **Source branch** | \`${SOURCE_BRANCH}\` |"
+            echo "| **Build version** | \`${BUILD_VERSION}\` |"
+            echo "| **Build number** | \`${BUILD_NUMBER}\` |"
+            echo "| **Build commit SHA** | \`${BUILD_COMMIT_SHA}\` |"
+            echo "| **Build name** | \`${BUILD_NAME}\` |"
+            echo "| **TestFlight group** | ${TESTFLIGHT_GROUP} |"
+          } > testflight-pr-comment.md
+          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body-file testflight-pr-comment.md

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -15,6 +15,12 @@ on:
 permissions:
   contents: read
   id-token: write
+  # build-and-upload-to-testflight.yml contains a comment-on-pr job that declares
+  # pull-requests: write. GitHub validates a reusable workflow's nested-job
+  # permissions against the caller statically, before `if` is evaluated, so this
+  # must be granted here even though nightly never sets pr_number (the job is
+  # always skipped at runtime).
+  pull-requests: write
 
 jobs:
   ios-exp:

--- a/.github/workflows/upload-to-testflight.yml
+++ b/.github/workflows/upload-to-testflight.yml
@@ -45,11 +45,6 @@ on:
         required: false
         type: string
         default: current
-      pr_number:
-        description: 'If set, post the upload summary as a comment on this PR when done'
-        required: false
-        type: string
-        default: ''
 
 permissions:
   contents: read
@@ -175,44 +170,3 @@ jobs:
         run: |
           rm -f ios/AuthKey.p8
           echo "🧹 Cleaned up API key file"
-
-  comment-on-pr:
-    name: Comment upload summary on PR
-    needs: [upload-ios-testflight]
-    # Only when a PR number was supplied (i.e. triggered via the bot command).
-    if: ${{ inputs.pr_number != '' }}
-    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Post TestFlight upload summary to the PR
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ inputs.pr_number }}
-          ENVIRONMENT: ${{ inputs.environment }}
-          SOURCE_BRANCH: ${{ inputs.source_branch }}
-          BUILD_NAME: ${{ inputs.build_name }}
-          BUILD_COMMIT_SHA: ${{ inputs.build_commit_sha }}
-          BUILD_VERSION: ${{ inputs.build_version }}
-          BUILD_NUMBER: ${{ inputs.build_number }}
-          TESTFLIGHT_GROUP: ${{ inputs.testflight_group }}
-        run: |
-          set -euo pipefail
-          # Values are passed via env (not expression interpolation in the script
-          # body) so branch names etc. cannot break out of the shell.
-          {
-            echo "### 📲 TestFlight build uploaded"
-            echo ""
-            echo "| Field | Value |"
-            echo "| --- | --- |"
-            echo "| **Track / environment** | \`${ENVIRONMENT}\` |"
-            echo "| **Source branch** | \`${SOURCE_BRANCH}\` |"
-            echo "| **Build version** | \`${BUILD_VERSION}\` |"
-            echo "| **Build number** | \`${BUILD_NUMBER}\` |"
-            echo "| **Build commit SHA** | \`${BUILD_COMMIT_SHA}\` |"
-            echo "| **Build name** | \`${BUILD_NAME}\` |"
-            echo "| **TestFlight group** | ${TESTFLIGHT_GROUP} |"
-          } > testflight-pr-comment.md
-          gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body-file testflight-pr-comment.md


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Follow-up fix for #34136, which introduced a **High-severity CI regression**.

That PR added a `comment-on-pr` job to the shared `upload-to-testflight.yml` reusable workflow, declaring `pull-requests: write`. GitHub validates a reusable workflow's nested-job permissions against the **caller** *statically, at "Set up job" time — before `if` conditions are evaluated*. So every caller that doesn't grant `pull-requests: write` fails to start, even though the comment job is skipped whenever `pr_number` is unset.

**Impact (already on `main`):** the next run of these would fail at "Set up job":
- Direct callers of `upload-to-testflight.yml`: `post-release-cut-testflight.yml`, `auto-rc-ota-build-core.yml`, `runway-production-builds.yml`, `runway-rc-builds.yml`
- Transitively via `build-and-upload-to-testflight.yml`: `nightly-build.yml`

**Fix — contain the permission to the smallest possible surface.** Move the PR-comment job out of the shared upload workflow and into `build-and-upload-to-testflight.yml` (which already has the build version/number in scope via `needs.build.outputs.*`). This means `pull-requests: write` is only required of *that* workflow's callers, not of every caller of `upload-to-testflight.yml`:

- **`upload-to-testflight.yml`** — reverted: removed the `pr_number` input and the `comment-on-pr` job. Restores the 4 direct callers.
- **`build-and-upload-to-testflight.yml`** — kept the `pr_number` input; stopped forwarding it to the upload job; added the `comment-on-pr` job here with **job-level** `pull-requests: write`. The bot path (`workflow_dispatch`) gets this scope from the repo default; behavior is unchanged.
- **`nightly-build.yml`** — granted `pull-requests: write` at the workflow level. It never sets `pr_number` (so the nested comment job is always skipped at runtime), but static validation still requires the caller to allow it.

No functional change to the `@metamaskbot create-testflight-build-{exp,rc}` command — the version/build-number comment still lands on the PR; it's just emitted one workflow level up.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

<!-- Internal CI/tooling fix; not end-user-facing. -->

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://github.com/MetaMask/metamask-mobile/pull/34136

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: reusable TestFlight workflows start under least-privilege callers

  Scenario: a caller that grants no pull-requests permission still starts
    Given upload-to-testflight.yml no longer declares a pull-requests: write job
    When post-release-cut-testflight.yml / runway-*-builds.yml / auto-rc-ota-build-core.yml runs
    Then the run passes "Set up job" instead of failing on nested-job permissions

  Scenario: nightly build starts and skips the comment job
    Given nightly-build.yml now grants pull-requests: write
    When the nightly build runs (no pr_number)
    Then the run starts and the comment-on-pr job is skipped

  Scenario: bot command still comments the version + build number
    When an authorized user comments "@metamaskbot create-testflight-build-rc" on a PR
    Then build-and-upload-to-testflight.yml runs with pr_number set
    And its comment-on-pr job posts the build version and build number to the PR
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — CI workflow changes only; no UI.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

<!-- Performance checks N/A: this PR only changes GitHub Actions workflow YAML. -->

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> GitHub Actions permission scoping only; no app runtime or release upload logic changes, with bot PR comments preserved on the build-and-upload path.
> 
> **Overview**
> **Fixes a CI regression** where `pull-requests: write` on a nested job inside the shared `upload-to-testflight.yml` caused GitHub to fail other callers at "Set up job" before runtime `if` checks could skip the comment job.
> 
> The **PR comment job** and **`pr_number` input** are **removed** from `upload-to-testflight.yml`, restoring least-privilege for direct upload callers (Runway, post-release-cut, auto-rc-ota, etc.). The same **`comment-on-pr` job** is **added** to `build-and-upload-to-testflight.yml` (with job-level `pull-requests: write` and build outputs from `needs.build`), and the upload step **no longer forwards** `pr_number`. **`nightly-build.yml`** now grants **`pull-requests: write`** at workflow scope so static validation passes when it calls `build-and-upload-to-testflight.yml`, even though nightly never sets `pr_number`.
> 
> **@metamaskbot** TestFlight flows are unchanged: the version/build table still posts on the PR when `pr_number` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 309e6e3347554132a7a336e4be289c68743431e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->