### PR TITLE
fix(performance): keep CI build variant independent from flags

### DIFF
--- a/tests/reporters/providers/sentry/PerformanceSentryPublisher.test.ts
+++ b/tests/reporters/providers/sentry/PerformanceSentryPublisher.test.ts
@@ -607,6 +607,33 @@ describe('PerformanceSentryPublisher', () => {
     expect(payload.spans[0].data.github_ref).toBe('release/7.58.0');
   });
 
+  it('does not use the feature-flags variant as the CI build variant', async () => {
+    process.env.E2E_PERFORMANCE_SENTRY_DSN =
+      'https://publicKey@o123.ingest.sentry.io/4567';
+    process.env.E2E_PERFORMANCE_BUILD_VARIANT = 'rc';
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+    } as Response);
+
+    await publishPerformanceScenarioToSentry({
+      metrics: createMetrics(),
+      testTitle: 'Import wallet flow',
+      projectName: 'browserstack-android',
+      tags: [],
+      status: 'passed',
+    });
+
+    const [, requestInit] = fetchMock.mock.calls[0] ?? [];
+    const body = requestInit?.body as string;
+    const [, , payloadLine] = body.split('\n');
+    const payload = JSON.parse(payloadLine);
+
+    expect(payload.tags.build_variant).toBe('rc');
+    expect(payload.tags.ci_build_variant).toBe('unknown');
+    expect(payload.spans[0].data.ci_build_variant).toBe('unknown');
+  });
+
   it('derives release_version from release/* github ref when env is unset', async () => {
     process.env.E2E_PERFORMANCE_SENTRY_DSN =
       'https://publicKey@o123.ingest.sentry.io/4567';

--- a/tests/reporters/providers/sentry/PerformanceSentryPublisher.ts
+++ b/tests/reporters/providers/sentry/PerformanceSentryPublisher.ts
@@ -400,8 +400,7 @@ export async function publishPerformanceScenarioToSentry(
     getEnvValue(ENV_SENTRY_BUILD_VARIANT),
   );
   const ciBuildVariant = normalizeCiBuildVariant(
-    getEnvValue(ENV_SENTRY_CI_BUILD_VARIANT) ||
-      getEnvValue(ENV_SENTRY_BUILD_VARIANT),
+    getEnvValue(ENV_SENTRY_CI_BUILD_VARIANT),
   );
   const releaseVersion = resolveReleaseVersion();
   const githubRef = getEnvValue(ENV_GITHUB_REF_NAME) ?? null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- stop falling back from `E2E_PERFORMANCE_CI_BUILD_VARIANT` to the feature-flags build variant
- add regression coverage preventing non-RC CI runs from being tagged as RC

## Testing
- `yarn jest tests/reporters/providers/sentry/PerformanceSentryPublisher.test.ts --runInBand`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0dc5dc0e-fb9e-4be3-90af-cb03730e7d80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0dc5dc0e-fb9e-4be3-90af-cb03730e7d80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

