### PR TITLE
fix: apply top safe-area inset to Add Device back button on iOS

### DIFF
--- a/app/components/Views/AddDeviceToWallet/index.test.tsx
+++ b/app/components/Views/AddDeviceToWallet/index.test.tsx
@@ -79,6 +79,28 @@ jest.mock('../QRTabSwitcher', () => ({
   QRTabSwitcherScreens: { Scanner: 'Scanner' },
 }));
 
+jest.mock(
+  '../../../component-library/components-temp/HeaderCompactStandard',
+  () => {
+    const ActualReact = jest.requireActual('react');
+    const { Pressable } = jest.requireActual('react-native');
+
+    return {
+      __esModule: true,
+      default: jest.fn(
+        ({ onBack }: { onBack?: () => void; includesTopInset?: boolean }) =>
+          ActualReact.createElement(Pressable, {
+            testID: 'button-icon',
+            onPress: onBack,
+            accessibilityRole: 'button',
+          }),
+      ),
+    };
+  },
+);
+
+import HeaderCompactStandard from '../../../component-library/components-temp/HeaderCompactStandard';
+
 const renderComponent = (
   qrSyncState: Partial<typeof defaultQrSyncControllerState> = {},
   completedOnboarding = false,
@@ -106,6 +128,15 @@ describe('AddDeviceToWallet', () => {
   });
 
   describe('initial render', () => {
+    it('applies top safe-area inset to the header so the back button is tappable on iOS', () => {
+      renderComponent();
+
+      expect(HeaderCompactStandard).toHaveBeenCalledWith(
+        expect.objectContaining({ includesTopInset: true }),
+        undefined,
+      );
+    });
+
     it('renders the page heading', () => {
       const { getByText } = renderComponent();
 

--- a/app/components/Views/AddDeviceToWallet/index.tsx
+++ b/app/components/Views/AddDeviceToWallet/index.tsx
@@ -150,10 +150,11 @@ const AddDeviceToWallet = () => {
 
   return (
     <SafeAreaView
+      edges={['bottom', 'left', 'right']}
       style={tw.style('flex-1 bg-default')}
       testID={AddDeviceToWalletTestIds.SCREEN}
     >
-      <HeaderCompactStandard onBack={handleBack} />
+      <HeaderCompactStandard onBack={handleBack} includesTopInset />
       <Box twClassName="flex-1 gap-5 px-4 py-4">
         <Image
           source={addDeviceToWalletImage}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
* Fixes the Add Device instructions screen back control sitting under the iOS status bar so taps do nothing.
* Jira: https://consensyssoftware.atlassian.net/browse/TO-991
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the Add Device back button sitting under the iOS status bar so it can be tapped again

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/34139

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Add Device instructions back navigation (iOS)

  Background:
    Given the addDeviceSync feature flag is enabled
    And the user is logged into a wallet on iOS

  Scenario: back button is below the status bar and returns to Add wallet
    Given the user opens Accounts menu
    When the user taps Add wallet
    And the user taps Import accounts from MetaMask extension
    Then the Add this device to wallet screen is shown
    And the back chevron is below the status bar (not overlapping the clock)
    When the user taps the back chevron
    Then the Add wallet screen is shown again
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/eb32cd42-a3e4-4418-8652-545c89360fab


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small layout change on one onboarding screen with a focused unit test; no auth, data, or navigation logic changes beyond safe-area edges.
> 
> **Overview**
> Fixes the **Add this device to wallet** instructions screen on iOS where the back chevron sat under the status bar and could not be tapped.
> 
> The screen’s `SafeAreaView` now excludes the **top** edge (`edges={['bottom', 'left', 'right']}`) so the status-bar inset is not double-applied, and `HeaderCompactStandard` is rendered with **`includesTopInset`** so the header (and back control) sit below the status bar. A unit test asserts `HeaderCompactStandard` receives `includesTopInset: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a70a1bd7097d8e5dd01c7ebfdab2ec30c9b1517. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->