### PR TITLE
fix(ci): pass test-source-prefix for Appium Playwright health report (MMQA-2013)

### DIFF
--- a/.github/workflows/flaky-test-report.yml
+++ b/.github/workflows/flaky-test-report.yml
@@ -48,7 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate Playwright test health report
-        uses: MetaMask/github-tools/.github/actions/playwright-test-health-report@4a2ddd75e9a8182261f0f07fbfc332cc856c89a0
+        # Bumped for MMQA-2013 / MetaMask/github-tools#274 (test-source-prefix support).
+        uses: MetaMask/github-tools/.github/actions/playwright-test-health-report@c733aff51645dfc04cfe4ec6a3627941d402dbb0
         with:
           repository: ${{ github.event.repository.name }}
           workflow-ids: ci.yml
@@ -57,3 +58,5 @@ jobs:
           lookback-days: ${{ github.event_name == 'workflow_dispatch' && inputs.lookback_days || '1' }}
           top-n: '10'
           report-title: Playwright Test Health Report (Mobile Appium)
+          # Appium smoke testDir is tests/smoke-appium; Playwright paths are testDir-relative.
+          test-source-prefix: tests/smoke-appium

--- a/.github/workflows/flaky-test-report.yml
+++ b/.github/workflows/flaky-test-report.yml
@@ -48,8 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate Playwright test health report
-        # Bumped for MMQA-2013 / MetaMask/github-tools#274 (test-source-prefix support).
-        uses: MetaMask/github-tools/.github/actions/playwright-test-health-report@c733aff51645dfc04cfe4ec6a3627941d402dbb0
+        # MetaMask/github-tools#274 (MMQA-2013) — test-source-prefix + path normalization.
+        uses: MetaMask/github-tools/.github/actions/playwright-test-health-report@a4a179a9ad2d02f6acb3c781e1b22a38bbc8dbca
         with:
           repository: ${{ github.event.repository.name }}
           workflow-ids: ci.yml

--- a/.github/workflows/flaky-test-report.yml
+++ b/.github/workflows/flaky-test-report.yml
@@ -48,7 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate Playwright test health report
-        # MetaMask/github-tools#274 (MMQA-2013) — test-source-prefix + path normalization.
         uses: MetaMask/github-tools/.github/actions/playwright-test-health-report@a4a179a9ad2d02f6acb3c781e1b22a38bbc8dbca
         with:
           repository: ${{ github.event.repository.name }}
@@ -58,5 +57,4 @@ jobs:
           lookback-days: ${{ github.event_name == 'workflow_dispatch' && inputs.lookback_days || '1' }}
           top-n: '10'
           report-title: Playwright Test Health Report (Mobile Appium)
-          # Appium smoke testDir is tests/smoke-appium; Playwright paths are testDir-relative.
           test-source-prefix: tests/smoke-appium


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Complements [MetaMask/github-tools#274](https://github.com/MetaMask/github-tools/pull/274) (**merged**) for [MMQA-2013](https://consensyssoftware.atlassian.net/browse/MMQA-2013).

Slack links from the Playwright Appium test health report were 404ing because Playwright reports paths relative to `testDir` (`tests/smoke-appium`), e.g. `accounts/foo.spec.ts`, while GitHub blob URLs need the repo-relative path.

This PR:
1. Pins `playwright-test-health-report` to the **merged** github-tools `main` commit (`a4a179a`) that adds path normalization and the `test-source-prefix` input
2. Passes `test-source-prefix: tests/smoke-appium` from `.github/workflows/flaky-test-report.yml`

### Validation

Manual `workflow_dispatch` on this branch succeeded:
https://github.com/MetaMask/metamask-mobile/actions/runs/30814511794

That run used `test-source-prefix: tests/smoke-appium` against the pre-merge github-tools commit; pin was then retargeted to the merged `main` SHA (`a4a179a`).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: MMQA-2013
Refs: https://github.com/MetaMask/github-tools/pull/274

## **Manual testing steps**

```gherkin
Feature: Appium Playwright health report Slack links

  Scenario: workflow dispatch generates report with valid blob URLs
    Given MetaMask/github-tools#274 is merged on main
    And secrets for the Playwright health Slack webhook are configured

    When a maintainer runs workflow_dispatch on "Flaky test report" with job=appium
    Then the Slack report spec links resolve to files under tests/smoke-appium/
    And absolute CI paths under tests/ also resolve without 404s
```

Validated via workflow_dispatch: https://github.com/MetaMask/metamask-mobile/actions/runs/30814511794 (success).

## **Screenshots/Recordings**

N/A — CI workflow / Slack link formatting only; no app UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5930e9be-91ea-4be3-928a-706d928cebd2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5930e9be-91ea-4be3-928a-706d928cebd2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[MMQA-2013]: https://consensyssoftware.atlassian.net/browse/MMQA-2013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ