### PR TITLE
fix(perf): prefer fresh BrowserStack APK URLs

### DIFF
--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -471,8 +471,10 @@ jobs:
       sentry_target: ${{ inputs.sentry_target || 'test' }}
       build_variant: ${{ inputs.build_variant || 'e2e' }}
       device_matrix: ${{ needs.read-device-matrix.outputs.android_matrix }}
-      browserstack_app_url: ${{ needs.resolve-main-browserstack-urls.outputs.without-srp-browserstack-url || needs.trigger-android-dual-versions.outputs.without-srp-browserstack-url || inputs.browserstack_app_url_android_onboarding }}
-      app_version: ${{ needs.resolve-main-browserstack-urls.outputs.without-srp-version || needs.trigger-android-dual-versions.outputs.without-srp-version || 'Manual-Input' }}
+      # Prefer an explicitly supplied or freshly uploaded app. Reused main
+      # URLs are only a fallback so onboarding cannot receive a stale variant.
+      browserstack_app_url: ${{ inputs.browserstack_app_url_android_onboarding || needs.trigger-android-dual-versions.outputs.without-srp-browserstack-url || needs.resolve-main-browserstack-urls.outputs.without-srp-browserstack-url }}
+      app_version: ${{ needs.trigger-android-dual-versions.outputs.without-srp-version || needs.resolve-main-browserstack-urls.outputs.without-srp-version || 'Manual-Input' }}
       branch_name: ${{ needs.determine-branch-name.outputs.branch_name }}
       browserstack_build_name: ${{ needs.set-build-names.outputs.android_build_name }}
       grep_tags: ${{ needs.compute-test-selection.outputs.grep_pattern }}
@@ -553,8 +555,8 @@ jobs:
       sentry_target: ${{ inputs.sentry_target || 'test' }}
       build_variant: ${{ inputs.build_variant || 'e2e' }}
       device_matrix: ${{ needs.read-device-matrix.outputs.android_matrix }}
-      browserstack_app_url: ${{ needs.resolve-main-browserstack-urls.outputs.with-srp-browserstack-url || needs.trigger-android-dual-versions.outputs.with-srp-browserstack-url || inputs.browserstack_app_url_android_imported_wallet }}
-      app_version: ${{ needs.resolve-main-browserstack-urls.outputs.with-srp-version || needs.trigger-android-dual-versions.outputs.with-srp-version || 'Manual-Input' }}
+      browserstack_app_url: ${{ inputs.browserstack_app_url_android_imported_wallet || needs.trigger-android-dual-versions.outputs.with-srp-browserstack-url || needs.resolve-main-browserstack-urls.outputs.with-srp-browserstack-url }}
+      app_version: ${{ needs.trigger-android-dual-versions.outputs.with-srp-version || needs.resolve-main-browserstack-urls.outputs.with-srp-version || 'Manual-Input' }}
       branch_name: ${{ needs.determine-branch-name.outputs.branch_name }}
       browserstack_build_name: ${{ needs.set-build-names.outputs.android_build_name }}
       grep_tags: ${{ needs.compute-test-selection.outputs.grep_pattern }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

Fixes provider APK selection in the performance E2E workflow. When fresh Android APKs are built and uploaded, the workflow previously preferred a reused `main` BrowserStack URL over the fresh URL from the current build. This could cause onboarding to run with a stale with-SRP/without-SRP variant.

The workflow now applies this precedence for Android performance tests:

1. Explicitly supplied app URL.
2. Fresh app URL produced by the current Android build/upload job.
3. Reused `main` app URL as fallback.

Onboarding therefore consumes the fresh without-SRP APK, while imported-wallet tests consume the fresh with-SRP APK.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: MMQA-2042

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Select the correct Android performance APK

  Scenario: onboarding uses the fresh without-SRP APK
    Given the performance workflow creates fresh with-SRP and without-SRP Android APKs
    When the Android onboarding job starts
    Then it receives the fresh without-SRP BrowserStack app URL

  Scenario: imported-wallet uses the fresh with-SRP APK
    Given the performance workflow creates fresh with-SRP and without-SRP Android APKs
    When the Android imported-wallet job starts
    Then it receives the fresh with-SRP BrowserStack app URL

  Scenario: fallback to main app URLs
    Given no fresh app URL is available
    When the performance workflow starts a provider job
    Then it uses the reusable main-branch app URL
```

Validation performed:
- Parsed `.github/workflows/run-performance-e2e.yml` successfully.
- Ran `git diff --check`.
- Verified the precedence against the run logs where fresh uploads were `bs://f3a3a73d5c7dc6ba288ee5c8a64c170c95ec3b2a` (with-SRP) and `bs://7c64eb464611faff309cea37313a089dab818be2` (without-SRP), while onboarding incorrectly consumed a reused main URL.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — CI workflow-only change; no UI is modified.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - This change affects CI APK selection; validation is documented above.
- [ ] I've tested with a power user scenario
  - N/A — no application behavior changes.
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A — no production code changes.

## **Pre-merge reviewer checklist**

<!-- mms-check: type=checklist required=true -->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a75116c-34e8-4488-896c-267d304e469b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a75116c-34e8-4488-896c-267d304e469b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

