### PR TITLE
test: assert Whats New Link Clicked feature and action props

### DIFF
--- a/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.test.tsx
+++ b/app/components/UI/Perps/components/PerpsGTMModal/PerpsGTMModal.test.tsx
@@ -8,6 +8,12 @@ import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { PERPS_GTM_MODAL_SHOWN } from '../../../../../constants/storage';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
+import { PerpsGTMModalSelectorsIDs } from '../../Perps.testIds';
+import {
+  PERPS_GTM_MODAL_DECLINE,
+  PERPS_GTM_MODAL_ENGAGE,
+  PERPS_GTM_WHATS_NEW_MODAL,
+} from '../../constants/perpsConfig';
 
 jest.mock('../../../../../util/theme', () => {
   const { mockTheme } = jest.requireActual('../../../../../util/theme');
@@ -25,6 +31,14 @@ jest.mock('../../../../../store/storage-wrapper', () => ({
   setItem: jest.fn(),
 }));
 
+jest.mock('../../../../../util/metrics', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    platform: 'ios',
+    deviceModel: 'iPhone 14',
+  })),
+}));
+
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
@@ -38,9 +52,11 @@ jest.mock('@react-navigation/native', () => {
 });
 
 const mockTrackEvent = jest.fn();
+const mockAddProperties = jest.fn().mockReturnThis();
+const mockBuild = jest.fn().mockReturnValue({});
 const mockCreateEventBuilder = jest.fn().mockReturnValue({
-  addProperties: jest.fn().mockReturnThis(),
-  build: jest.fn().mockReturnValue({}),
+  addProperties: mockAddProperties,
+  build: mockBuild,
 });
 jest.mock('../../../../../components/hooks/useAnalytics/useAnalytics');
 
@@ -53,6 +69,12 @@ const initialState = {
 describe('PerpsGTMModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAddProperties.mockReturnThis();
+    mockBuild.mockReturnValue({});
+    mockCreateEventBuilder.mockReturnValue({
+      addProperties: mockAddProperties,
+      build: mockBuild,
+    });
     (StorageWrapper.getItem as jest.Mock).mockResolvedValue('false');
     jest.mocked(useAnalytics).mockReturnValue({
       trackEvent: mockTrackEvent,
@@ -60,7 +82,7 @@ describe('PerpsGTMModal', () => {
     } as unknown as ReturnType<typeof useAnalytics>);
   });
 
-  it('renders correctly with all main elements', async () => {
+  it('renders all main elements', async () => {
     const { getByText, getByTestId } = renderWithProvider(<PerpsGTMModal />, {
       state: initialState,
     });
@@ -70,39 +92,49 @@ describe('PerpsGTMModal', () => {
       expect(getByText('perps.gtm_content.title_description')).toBeTruthy();
       expect(getByText('perps.gtm_content.try_now')).toBeTruthy();
       expect(getByText('perps.gtm_content.not_now')).toBeTruthy();
-      expect(getByTestId('perps-gtm-modal')).toBeTruthy();
+      expect(
+        getByTestId(PerpsGTMModalSelectorsIDs.PERPS_GTM_MODAL),
+      ).toBeTruthy();
     });
   });
 
-  it('handles close button press correctly', async () => {
-    const { getByText } = renderWithProvider(<PerpsGTMModal />, {
+  it('tracks Whats New Link Clicked with decline action when not now is pressed', async () => {
+    const { getByTestId } = renderWithProvider(<PerpsGTMModal />, {
       state: initialState,
     });
 
     await waitFor(() => {
-      const notNowButton = getByText('perps.gtm_content.not_now');
-      fireEvent.press(notNowButton);
+      fireEvent.press(
+        getByTestId(PerpsGTMModalSelectorsIDs.PERPS_NOT_NOW_BUTTON),
+      );
     });
 
     expect(StorageWrapper.setItem).toHaveBeenCalledWith(
       PERPS_GTM_MODAL_SHOWN,
       'true',
     );
-    expect(mockTrackEvent).toHaveBeenCalled();
     expect(mockCreateEventBuilder).toHaveBeenCalledWith(
       MetaMetricsEvents.WHATS_NEW_LINK_CLICKED,
     );
+    expect(mockAddProperties).toHaveBeenCalledWith({
+      platform: 'ios',
+      deviceModel: 'iPhone 14',
+      feature: PERPS_GTM_WHATS_NEW_MODAL,
+      action: PERPS_GTM_MODAL_DECLINE,
+    });
+    expect(mockTrackEvent).toHaveBeenCalled();
     expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.HOME);
   });
 
-  it('handles try now button press correctly', async () => {
-    const { getByText } = renderWithProvider(<PerpsGTMModal />, {
+  it('tracks Whats New Link Clicked with engage action when try now is pressed', async () => {
+    const { getByTestId } = renderWithProvider(<PerpsGTMModal />, {
       state: initialState,
     });
 
     await waitFor(() => {
-      const tryNowButton = getByText('perps.gtm_content.try_now');
-      fireEvent.press(tryNowButton);
+      fireEvent.press(
+        getByTestId(PerpsGTMModalSelectorsIDs.PERPS_TRY_NOW_BUTTON),
+      );
     });
 
     expect(StorageWrapper.setItem).toHaveBeenCalledWith(
@@ -110,22 +142,30 @@ describe('PerpsGTMModal', () => {
       'true',
       { emitEvent: false },
     );
-    expect(mockTrackEvent).toHaveBeenCalled();
     expect(mockCreateEventBuilder).toHaveBeenCalledWith(
       MetaMetricsEvents.WHATS_NEW_LINK_CLICKED,
     );
+    expect(mockAddProperties).toHaveBeenCalledWith({
+      platform: 'ios',
+      deviceModel: 'iPhone 14',
+      feature: PERPS_GTM_WHATS_NEW_MODAL,
+      action: PERPS_GTM_MODAL_ENGAGE,
+    });
+    expect(mockTrackEvent).toHaveBeenCalled();
     expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.TUTORIAL, {
       isFromGTMModal: true,
     });
   });
 
-  it('renders image correctly', async () => {
+  it('renders image', async () => {
     const { getByTestId } = renderWithProvider(<PerpsGTMModal />, {
       state: initialState,
     });
 
     await waitFor(() => {
-      expect(getByTestId('perps-gtm-modal')).toBeTruthy();
+      expect(
+        getByTestId(PerpsGTMModalSelectorsIDs.PERPS_GTM_MODAL),
+      ).toBeTruthy();
     });
   });
 });

--- a/app/components/UI/Predict/components/PredictGTMModal/PredictGTMModal.test.tsx
+++ b/app/components/UI/Predict/components/PredictGTMModal/PredictGTMModal.test.tsx
@@ -9,6 +9,12 @@ import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 import { useAnalytics } from '../../../../../components/hooks/useAnalytics/useAnalytics';
 import { createMockUseAnalyticsHook } from '../../../../../util/test/analyticsMock';
+import {
+  PREDICT_GTM_MODAL_DECLINE,
+  PREDICT_GTM_MODAL_ENGAGE,
+  PREDICT_GTM_WHATS_NEW_MODAL,
+} from '../../constants/eventNames';
+import { PREDICT_GTM_MODAL_TEST_IDS } from './PredictGTMModal.testIds';
 
 jest.mock('../../../../../util/theme', () => {
   const { mockTheme } = jest.requireActual('../../../../../util/theme');
@@ -39,9 +45,11 @@ jest.mock('@react-navigation/native', () => {
 });
 
 const mockTrackEvent = jest.fn();
+const mockAddProperties = jest.fn().mockReturnThis();
+const mockBuild = jest.fn().mockReturnValue({});
 const mockCreateEventBuilder = jest.fn().mockReturnValue({
-  addProperties: jest.fn().mockReturnThis(),
-  build: jest.fn().mockReturnValue({}),
+  addProperties: mockAddProperties,
+  build: mockBuild,
 });
 jest.mock('../../../../../components/hooks/useAnalytics/useAnalytics');
 
@@ -62,6 +70,12 @@ const initialState = {
 describe('PredictGTMModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAddProperties.mockReturnThis();
+    mockBuild.mockReturnValue({});
+    mockCreateEventBuilder.mockReturnValue({
+      addProperties: mockAddProperties,
+      build: mockBuild,
+    });
     jest.mocked(useAnalytics).mockReturnValue(
       createMockUseAnalyticsHook({
         trackEvent: mockTrackEvent,
@@ -71,7 +85,7 @@ describe('PredictGTMModal', () => {
     jest.mocked(StorageWrapper.getItem).mockResolvedValue('false');
   });
 
-  it('renders correctly with all main elements', async () => {
+  it('renders all main elements', async () => {
     const { getByText, getByTestId } = renderWithProvider(<PredictGTMModal />, {
       state: initialState,
     });
@@ -81,39 +95,45 @@ describe('PredictGTMModal', () => {
       expect(getByText('predict.gtm_content.title_description')).toBeTruthy();
       expect(getByText('predict.gtm_content.get_started')).toBeTruthy();
       expect(getByText('predict.gtm_content.not_now')).toBeTruthy();
-      expect(getByTestId('predict-gtm-modal-container')).toBeTruthy();
+      expect(getByTestId(PREDICT_GTM_MODAL_TEST_IDS.CONTAINER)).toBeTruthy();
     });
   });
 
-  it('handles close button press correctly', async () => {
-    const { getByText } = renderWithProvider(<PredictGTMModal />, {
+  it('tracks Whats New Link Clicked with decline action when not now is pressed', async () => {
+    const { getByTestId } = renderWithProvider(<PredictGTMModal />, {
       state: initialState,
     });
 
     await waitFor(() => {
-      const notNowButton = getByText('predict.gtm_content.not_now');
-      fireEvent.press(notNowButton);
+      fireEvent.press(getByTestId(PREDICT_GTM_MODAL_TEST_IDS.NOT_NOW_BUTTON));
     });
 
     expect(StorageWrapper.setItem).toHaveBeenCalledWith(
       PREDICT_GTM_MODAL_SHOWN,
       'true',
     );
-    expect(mockTrackEvent).toHaveBeenCalled();
     expect(mockCreateEventBuilder).toHaveBeenCalledWith(
       MetaMetricsEvents.WHATS_NEW_LINK_CLICKED,
     );
+    expect(mockAddProperties).toHaveBeenCalledWith({
+      platform: 'ios',
+      deviceModel: 'iPhone 14',
+      feature: PREDICT_GTM_WHATS_NEW_MODAL,
+      action: PREDICT_GTM_MODAL_DECLINE,
+    });
+    expect(mockTrackEvent).toHaveBeenCalled();
     expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.HOME);
   });
 
-  it('handles get started button press correctly', async () => {
-    const { getByText } = renderWithProvider(<PredictGTMModal />, {
+  it('tracks Whats New Link Clicked with engage action when get started is pressed', async () => {
+    const { getByTestId } = renderWithProvider(<PredictGTMModal />, {
       state: initialState,
     });
 
     await waitFor(() => {
-      const getStartedButton = getByText('predict.gtm_content.get_started');
-      fireEvent.press(getStartedButton);
+      fireEvent.press(
+        getByTestId(PREDICT_GTM_MODAL_TEST_IDS.GET_STARTED_BUTTON),
+      );
     });
 
     expect(StorageWrapper.setItem).toHaveBeenCalledWith(
@@ -121,10 +141,16 @@ describe('PredictGTMModal', () => {
       'true',
       { emitEvent: false },
     );
-    expect(mockTrackEvent).toHaveBeenCalled();
     expect(mockCreateEventBuilder).toHaveBeenCalledWith(
       MetaMetricsEvents.WHATS_NEW_LINK_CLICKED,
     );
+    expect(mockAddProperties).toHaveBeenCalledWith({
+      platform: 'ios',
+      deviceModel: 'iPhone 14',
+      feature: PREDICT_GTM_WHATS_NEW_MODAL,
+      action: PREDICT_GTM_MODAL_ENGAGE,
+    });
+    expect(mockTrackEvent).toHaveBeenCalled();
     expect(mockNavigate).toHaveBeenCalledWith(Routes.WALLET.HOME);
     expect(mockNavigate).toHaveBeenCalledWith(Routes.PREDICT.ROOT, {
       screen: Routes.PREDICT.MARKET_LIST,
@@ -134,13 +160,13 @@ describe('PredictGTMModal', () => {
     });
   });
 
-  it('renders image correctly', async () => {
+  it('renders image', async () => {
     const { getByTestId } = renderWithProvider(<PredictGTMModal />, {
       state: initialState,
     });
 
     await waitFor(() => {
-      expect(getByTestId('predict-gtm-modal-container')).toBeTruthy();
+      expect(getByTestId(PREDICT_GTM_MODAL_TEST_IDS.CONTAINER)).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Included unit tests so WHATS_NEW_LINK_CLICKED asserts feature and action (engage / decline)

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
https://consensyssoftware.atlassian.net/browse/MMQA-2170

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
CI should pass
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production or analytics implementation edits.
> 
> **Overview**
> **Tightens unit tests** for the Perps and Predict GTM “what’s new” modals so `WHATS_NEW_LINK_CLICKED` analytics are verified with the full payload, not just that tracking fired.
> 
> For **Not now** / **Try now** (Perps) and **Not now** / **Get started** (Predict), tests now assert `addProperties` receives `platform`, `deviceModel`, `feature`, and `action` (`decline` vs `engage`) using shared config constants. Analytics mocks expose `mockAddProperties` / `mockBuild`, and Perps adds a `util/metrics` mock for device metadata.
> 
> Interactions use **test IDs** (`PerpsGTMModalSelectorsIDs`, `PREDICT_GTM_MODAL_TEST_IDS`) instead of pressing by label text; test names were updated to describe the analytics behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a80a43a13c79b83fa7007fad63aac28b3bdd3c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->