### PR TITLE
feat(rewards): add /rewards?campaign=money deeplink for Money Account Sweepstakes

### DIFF
--- a/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.test.tsx
@@ -266,12 +266,32 @@ jest.mock('../hooks/useMoneyAccountSweepstakesOutcomeToast', () => ({
   useMoneyAccountSweepstakesOutcomeToast: jest.fn(),
 }));
 
+jest.mock('../hooks/useRewardCampaigns', () => ({
+  useRewardCampaigns: jest.fn(),
+}));
+
+jest.mock('../hooks/useMoneyAccountSweepstakesSeries', () => ({
+  useMoneyAccountSweepstakesSeries: jest.fn(),
+}));
+
+jest.mock('../hooks/useMoneyAccountSweepstakesParticipation', () => ({
+  useMoneyAccountSweepstakesParticipation: jest.fn(),
+}));
+
 // Import mocked hooks
 import { useRewardOptinSummary } from '../hooks/useRewardOptinSummary';
 import { useRewardDashboardModals } from '../hooks/useRewardDashboardModals';
 import { useBulkLinkState } from '../hooks/useBulkLinkState';
 import { useMoneyAccountSweepstakesOutcomeToast } from '../hooks/useMoneyAccountSweepstakesOutcomeToast';
+import { useRewardCampaigns } from '../hooks/useRewardCampaigns';
+import { useMoneyAccountSweepstakesSeries } from '../hooks/useMoneyAccountSweepstakesSeries';
+import { useMoneyAccountSweepstakesParticipation } from '../hooks/useMoneyAccountSweepstakesParticipation';
 import { AccountGroupType, AccountWalletType } from '@metamask/account-api';
+import {
+  CampaignType,
+  type CampaignDto,
+} from '../../../../core/Engine/controllers/rewards-controller/types';
+import type { MoneyAccountSweepstakesSeries } from '../utils/moneyAccountSweepstakesSeries';
 
 const mockUseRewardOptinSummary = useRewardOptinSummary as jest.MockedFunction<
   typeof useRewardOptinSummary
@@ -298,6 +318,25 @@ const mockUseMoneyAccountSweepstakesOutcomeToast =
   useMoneyAccountSweepstakesOutcomeToast as jest.MockedFunction<
     typeof useMoneyAccountSweepstakesOutcomeToast
   >;
+const mockUseRewardCampaigns = useRewardCampaigns as jest.MockedFunction<
+  typeof useRewardCampaigns
+>;
+const mockUseMoneyAccountSweepstakesSeries =
+  useMoneyAccountSweepstakesSeries as jest.MockedFunction<
+    typeof useMoneyAccountSweepstakesSeries
+  >;
+const mockUseMoneyAccountSweepstakesParticipation =
+  useMoneyAccountSweepstakesParticipation as jest.MockedFunction<
+    typeof useMoneyAccountSweepstakesParticipation
+  >;
+const emptyMoneyAccountSeries: MoneyAccountSweepstakesSeries = {
+  campaigns: [],
+  first: null,
+  last: null,
+  activeCampaign: null,
+  displayCampaign: null,
+  seriesStatus: null,
+};
 
 describe('RewardsDashboard', () => {
   const mockShowUnlinkedAccountsModal = jest.fn();
@@ -422,6 +461,23 @@ describe('RewardsDashboard', () => {
       defaultHookValues.useRewardDashboardModals,
     );
     mockUseBulkLinkState.mockReturnValue(defaultHookValues.useBulkLinkState);
+    mockUseRewardCampaigns.mockReturnValue({
+      campaigns: [],
+      categorizedCampaigns: { active: [], upcoming: [], previous: [] },
+      isLoading: false,
+      hasError: false,
+      hasLoaded: true,
+      fetchCampaigns: jest.fn(),
+    });
+    mockUseMoneyAccountSweepstakesSeries.mockReturnValue(
+      emptyMoneyAccountSeries,
+    );
+    mockUseMoneyAccountSweepstakesParticipation.mockReturnValue({
+      optedInAny: false,
+      optedInByCampaignId: {},
+      isLoading: false,
+      refetch: jest.fn(),
+    });
 
     // Setup default modal hook behavior - return false for all modal types by default
     mockHasShownModal.mockReturnValue(false);
@@ -785,6 +841,60 @@ describe('RewardsDashboard', () => {
       return render(<RewardsDashboard />);
     };
 
+    const activeMoneyCampaign: CampaignDto = {
+      id: 'week-2',
+      type: CampaignType.MONEY_ACCOUNT_SWEEPSTAKES,
+      name: 'Money Account Sweepstakes',
+      startDate: '2026-07-08T00:00:00.000Z',
+      endDate: '2026-07-15T00:00:00.000Z',
+      termsAndConditions: null,
+      excludedRegions: [],
+      details: {
+        howItWorks: {
+          title: 'How it works',
+          description: 'Enter the weekly draw',
+          steps: [],
+          tour: [
+            {
+              title: 'Step 1',
+              description: 'Description 1',
+              image: null,
+              actions: null,
+            },
+          ],
+        },
+      },
+      featured: false,
+      showUpcomingDate: false,
+    };
+
+    const activeMoneySeries: MoneyAccountSweepstakesSeries = {
+      campaigns: [activeMoneyCampaign],
+      first: activeMoneyCampaign,
+      last: activeMoneyCampaign,
+      activeCampaign: activeMoneyCampaign,
+      displayCampaign: activeMoneyCampaign,
+      seriesStatus: 'active',
+    };
+
+    const previousMoneySeries: MoneyAccountSweepstakesSeries = {
+      campaigns: [activeMoneyCampaign],
+      first: activeMoneyCampaign,
+      last: activeMoneyCampaign,
+      activeCampaign: null,
+      displayCampaign: activeMoneyCampaign,
+      seriesStatus: 'previous',
+    };
+
+    const upcomingMoneySeries: MoneyAccountSweepstakesSeries = {
+      campaigns: [activeMoneyCampaign],
+      first: activeMoneyCampaign,
+      last: activeMoneyCampaign,
+      activeCampaign: null,
+      displayCampaign: activeMoneyCampaign,
+      seriesStatus: 'upcoming',
+    };
+
     it.each([
       ['page', 'campaigns', Routes.REWARDS_CAMPAIGNS_VIEW],
       ['campaign', 'ondo', Routes.REWARDS_ONDO_CAMPAIGN_DETAILS_VIEW],
@@ -835,6 +945,154 @@ describe('RewardsDashboard', () => {
       // Unrecognized intents are preserved (not cleared) so they can be retried
       // rather than silently dropped.
       renderWithPendingDeeplink({ page: 'totally-unknown' });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalledWith(setPendingDeeplink(null));
+    });
+
+    it('waits for campaigns to load before handling campaign=money', () => {
+      mockUseRewardCampaigns.mockReturnValue({
+        campaigns: [],
+        categorizedCampaigns: { active: [], upcoming: [], previous: [] },
+        isLoading: true,
+        hasError: false,
+        hasLoaded: false,
+        fetchCampaigns: jest.fn(),
+      });
+
+      renderWithPendingDeeplink({ campaign: 'money' });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalledWith(setPendingDeeplink(null));
+    });
+
+    it('keeps pending campaign=money when campaigns failed with an empty series', () => {
+      // campaignsHasLoaded is true on error too — do not treat empty series as
+      // a final "stay on dashboard" result or a later retry can never recover.
+      mockUseRewardCampaigns.mockReturnValue({
+        campaigns: [],
+        categorizedCampaigns: { active: [], upcoming: [], previous: [] },
+        isLoading: false,
+        hasError: true,
+        hasLoaded: true,
+        fetchCampaigns: jest.fn(),
+      });
+
+      renderWithPendingDeeplink({ campaign: 'money' });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalledWith(setPendingDeeplink(null));
+    });
+
+    it('keeps pending campaign=money while a campaigns retry is in flight with an empty series', () => {
+      // Retry clears the error flag before settling, so an empty series during
+      // loading must also keep the deeplink.
+      mockUseRewardCampaigns.mockReturnValue({
+        campaigns: [],
+        categorizedCampaigns: { active: [], upcoming: [], previous: [] },
+        isLoading: true,
+        hasError: false,
+        hasLoaded: true,
+        fetchCampaigns: jest.fn(),
+      });
+
+      renderWithPendingDeeplink({ campaign: 'money' });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalledWith(setPendingDeeplink(null));
+    });
+
+    it('still routes campaign=money when a campaigns refresh failed but series data already exists', () => {
+      mockUseRewardCampaigns.mockReturnValue({
+        campaigns: [activeMoneyCampaign],
+        categorizedCampaigns: {
+          active: [activeMoneyCampaign],
+          upcoming: [],
+          previous: [],
+        },
+        isLoading: false,
+        hasError: true,
+        hasLoaded: true,
+        fetchCampaigns: jest.fn(),
+      });
+      mockUseMoneyAccountSweepstakesSeries.mockReturnValue(previousMoneySeries);
+
+      renderWithPendingDeeplink({ campaign: 'money' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_FLOW, {
+        screen: Routes.REWARDS_MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_DETAILS_VIEW,
+        params: { campaignId: 'week-2' },
+      });
+      expect(mockDispatch).toHaveBeenCalledWith(setPendingDeeplink(null));
+    });
+
+    it('stays on dashboard and clears pending deeplink for upcoming money series', () => {
+      mockUseMoneyAccountSweepstakesSeries.mockReturnValue(upcomingMoneySeries);
+
+      renderWithPendingDeeplink({ campaign: 'money' });
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(mockDispatch).toHaveBeenCalledWith(setPendingDeeplink(null));
+    });
+
+    it('routes campaign=money to details for previous series', () => {
+      mockUseMoneyAccountSweepstakesSeries.mockReturnValue(previousMoneySeries);
+
+      renderWithPendingDeeplink({ campaign: 'money' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_FLOW, {
+        screen: Routes.REWARDS_MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_DETAILS_VIEW,
+        params: { campaignId: 'week-2' },
+      });
+      expect(mockDispatch).toHaveBeenCalledWith(setPendingDeeplink(null));
+    });
+
+    it('routes campaign=money to tour when active, not opted in, and tour exists', () => {
+      mockUseMoneyAccountSweepstakesSeries.mockReturnValue(activeMoneySeries);
+      mockUseMoneyAccountSweepstakesParticipation.mockReturnValue({
+        optedInAny: false,
+        optedInByCampaignId: { 'week-2': false },
+        isLoading: false,
+        refetch: jest.fn(),
+      });
+
+      renderWithPendingDeeplink({ campaign: 'money' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_FLOW, {
+        screen: Routes.REWARDS_CAMPAIGN_TOUR_STEP,
+        params: { campaignId: 'week-2' },
+      });
+      expect(mockDispatch).toHaveBeenCalledWith(setPendingDeeplink(null));
+    });
+
+    it('routes campaign=money to details when already opted in', () => {
+      mockUseMoneyAccountSweepstakesSeries.mockReturnValue(activeMoneySeries);
+      mockUseMoneyAccountSweepstakesParticipation.mockReturnValue({
+        optedInAny: true,
+        optedInByCampaignId: { 'week-2': true },
+        isLoading: false,
+        refetch: jest.fn(),
+      });
+
+      renderWithPendingDeeplink({ campaign: 'money' });
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_FLOW, {
+        screen: Routes.REWARDS_MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_DETAILS_VIEW,
+        params: { campaignId: 'week-2' },
+      });
+      expect(mockDispatch).toHaveBeenCalledWith(setPendingDeeplink(null));
+    });
+
+    it('waits for participation statuses before handling active campaign=money', () => {
+      mockUseMoneyAccountSweepstakesSeries.mockReturnValue(activeMoneySeries);
+      mockUseMoneyAccountSweepstakesParticipation.mockReturnValue({
+        optedInAny: false,
+        optedInByCampaignId: {},
+        isLoading: true,
+        refetch: jest.fn(),
+      });
+
+      renderWithPendingDeeplink({ campaign: 'money' });
 
       expect(mockNavigate).not.toHaveBeenCalled();
       expect(mockDispatch).not.toHaveBeenCalledWith(setPendingDeeplink(null));

--- a/app/components/UI/Rewards/Views/RewardsDashboard.tsx
+++ b/app/components/UI/Rewards/Views/RewardsDashboard.tsx
@@ -45,6 +45,10 @@ import useTrackRewardsPageView from '../hooks/useTrackRewardsPageView';
 import { selectSelectedAccountGroup } from '../../../../selectors/multichainAccounts/accountTreeController';
 import { useGeoRewardsMetadata } from '../hooks/useGeoRewardsMetadata';
 import { useReferralDetails } from '../hooks/useReferralDetails';
+import { useRewardCampaigns } from '../hooks/useRewardCampaigns';
+import { useMoneyAccountSweepstakesSeries } from '../hooks/useMoneyAccountSweepstakesSeries';
+import { useMoneyAccountSweepstakesParticipation } from '../hooks/useMoneyAccountSweepstakesParticipation';
+import { resolveMoneyAccountSweepstakesEntryRoute } from '../utils/moneyAccountSweepstakesSeries';
 import { navigateToRewardsRoute } from '../utils';
 import CampaignsPreview from '../components/Campaigns/CampaignsPreview';
 import EarnRewardsPreview from '../components/EarnRewards/EarnRewardsPreview';
@@ -78,6 +82,18 @@ const RewardsDashboard: React.FC = () => {
   const activeTab = useSelector(selectActiveTab);
   const { trackEvent, createEventBuilder } = useAnalytics();
   const hasTrackedDashboardViewed = useRef(false);
+
+  const isMoneyCampaignDeeplink = pendingDeeplink?.campaign === 'money';
+  const {
+    hasLoaded: campaignsHasLoaded,
+    hasError: campaignsHasError,
+    isLoading: isCampaignsLoading,
+  } = useRewardCampaigns();
+  const moneyAccountSeries = useMoneyAccountSweepstakesSeries();
+  const {
+    optedInAny: moneyAccountOptedInAny,
+    isLoading: isMoneyAccountParticipationLoading,
+  } = useMoneyAccountSweepstakesParticipation(isMoneyCampaignDeeplink);
 
   useTrackRewardsPageView({ page_type: 'home' });
   useOndoOutcomeToast();
@@ -127,6 +143,44 @@ const RewardsDashboard: React.FC = () => {
         navigation,
         Routes.REWARDS_PREDICT_THE_PITCH_CAMPAIGN_DETAILS_VIEW,
       );
+    } else if (pendingDeeplink.campaign === 'money') {
+      // Only an active series can route to the tour, so that is the one case
+      // where the decision has to wait on opt-in status.
+      const waitingForParticipation =
+        moneyAccountSeries.seriesStatus === 'active' &&
+        isMoneyAccountParticipationLoading;
+      // Failed and in-flight fetches also flip campaignsHasLoaded, so an empty
+      // series is only trustworthy once a successful fetch has settled.
+      const waitingForCampaigns =
+        !campaignsHasLoaded ||
+        (moneyAccountSeries.campaigns.length === 0 &&
+          (campaignsHasError || isCampaignsLoading));
+
+      if (waitingForCampaigns || waitingForParticipation) {
+        handled = false;
+      } else {
+        const entry = resolveMoneyAccountSweepstakesEntryRoute({
+          series: moneyAccountSeries,
+          optedInAny: moneyAccountOptedInAny,
+        });
+
+        if (entry.kind === 'tour') {
+          navigateToRewardsRoute(
+            navigation,
+            Routes.REWARDS_CAMPAIGN_TOUR_STEP,
+            {
+              campaignId: entry.campaignId,
+            },
+          );
+        } else if (entry.kind === 'details') {
+          navigateToRewardsRoute(
+            navigation,
+            Routes.REWARDS_MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_DETAILS_VIEW,
+            { campaignId: entry.campaignId },
+          );
+        }
+        // entry.kind === 'dashboard': stay on dashboard (upcoming / empty)
+      }
     } else if (pendingDeeplink.page === 'musd') {
       navigateToRewardsRoute(navigation, Routes.REWARDS_MUSD_CALCULATOR_VIEW);
     } else if (pendingDeeplink.page === 'benefits') {
@@ -141,7 +195,17 @@ const RewardsDashboard: React.FC = () => {
     if (handled) {
       dispatch(setPendingDeeplink(null));
     }
-  }, [navigation, dispatch, pendingDeeplink]);
+  }, [
+    navigation,
+    dispatch,
+    pendingDeeplink,
+    campaignsHasLoaded,
+    campaignsHasError,
+    isCampaignsLoading,
+    moneyAccountSeries,
+    moneyAccountOptedInAny,
+    isMoneyAccountParticipationLoading,
+  ]);
 
   const hideUnlinkedAccountsBanner = useSelector(
     selectHideUnlinkedAccountsBanner,

--- a/app/components/UI/Rewards/hooks/useMoneyAccountSweepstakesParticipation.test.ts
+++ b/app/components/UI/Rewards/hooks/useMoneyAccountSweepstakesParticipation.test.ts
@@ -215,6 +215,67 @@ describe('useMoneyAccountSweepstakesParticipation', () => {
     expect(result.current.optedInAny).toBe(false);
   });
 
+  it('reports loading until the first status fetch settles', async () => {
+    const resolvers: ((value: unknown) => void)[] = [];
+    mockCall.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }) as never,
+    );
+
+    const { result } = renderHook(() =>
+      useMoneyAccountSweepstakesParticipation(),
+    );
+
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      resolvers.forEach((resolve) =>
+        resolve({ optedIn: false, participantCount: 0 }),
+      );
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+  });
+
+  it('stops reporting loading when the fetch fails', async () => {
+    mockCall.mockRejectedValue(new Error('network down') as never);
+
+    const { result } = renderHook(() =>
+      useMoneyAccountSweepstakesParticipation(),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.optedInAny).toBe(false);
+  });
+
+  it('is not loading when a stored opt-in already proves participation', async () => {
+    setupHooks({
+      statuses: {
+        [`${SUBSCRIPTION_ID}:week-2`]: { optedIn: true },
+      },
+    });
+    mockCall.mockImplementation(() => new Promise(() => undefined) as never);
+
+    const { result } = renderHook(() =>
+      useMoneyAccountSweepstakesParticipation(),
+    );
+
+    expect(result.current.optedInAny).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('is not loading when no fetch is warranted', async () => {
+    setupHooks({ campaigns: [] });
+
+    const { result } = renderHook(() =>
+      useMoneyAccountSweepstakesParticipation(),
+    );
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
   it('refetches when a campaign opt-in event fires', async () => {
     await renderParticipation();
     mockCall.mockClear();

--- a/app/components/UI/Rewards/hooks/useMoneyAccountSweepstakesParticipation.ts
+++ b/app/components/UI/Rewards/hooks/useMoneyAccountSweepstakesParticipation.ts
@@ -25,16 +25,18 @@ export function useMoneyAccountSweepstakesParticipation(
   const series = useMoneyAccountSweepstakesSeries();
   const subscriptionId = useSelector(selectRewardsSubscriptionId);
   const statuses = useSelector(selectCampaignParticipantStatuses);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isFetching, setIsFetching] = useState(false);
+  const [settledKey, setSettledKey] = useState<string | null>(null);
 
   const campaignIdsKey = series.campaigns.map((c) => c.id).join(',');
+  const fetchKey = `${subscriptionId ?? ''}|${campaignIdsKey}`;
 
   const refetch = useCallback(async (): Promise<void> => {
     if (!enabled || !subscriptionId || series.campaigns.length === 0) {
       return;
     }
 
-    setIsLoading(true);
+    setIsFetching(true);
     try {
       await Promise.all(
         series.campaigns.map(async (campaign) => {
@@ -52,12 +54,18 @@ export function useMoneyAccountSweepstakesParticipation(
           );
         }),
       );
+    } catch {
+      // Keep the last known statuses; callers get the settled flag below rather
+      // than a rejection they would have to handle at every call site.
     } finally {
-      setIsLoading(false);
+      // Mark the attempt settled even when it failed, so consumers are not
+      // left waiting forever on a status that will never arrive.
+      setSettledKey(fetchKey);
+      setIsFetching(false);
     }
     // campaignIdsKey captures series.campaigns identity without unstable array ref
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, subscriptionId, campaignIdsKey, dispatch]);
+  }, [enabled, subscriptionId, campaignIdsKey, fetchKey, dispatch]);
 
   useEffect(() => {
     refetch();
@@ -85,6 +93,18 @@ export function useMoneyAccountSweepstakesParticipation(
     () => Object.values(optedInByCampaignId).some(Boolean),
     [optedInByCampaignId],
   );
+
+  // An opt-in anywhere in the series is enough to know the user participates, so
+  // it settles the answer even if other weeks are still unresolved. Otherwise a
+  // warranted fetch that has not settled yet counts as loading, so callers never
+  // read the initial "not opted in" default as a real answer.
+  const isLoading =
+    !optedInAny &&
+    (isFetching ||
+      (enabled &&
+        Boolean(subscriptionId) &&
+        series.campaigns.length > 0 &&
+        settledKey !== fetchKey));
 
   return {
     optedInAny,

--- a/app/components/UI/Rewards/utils/moneyAccountSweepstakesSeries.test.ts
+++ b/app/components/UI/Rewards/utils/moneyAccountSweepstakesSeries.test.ts
@@ -6,6 +6,7 @@ import {
   buildMoneyAccountSweepstakesTileCampaign,
   getMoneyAccountSweepstakesSeries,
   getMoneyAccountSweepstakesWeekNumber,
+  resolveMoneyAccountSweepstakesEntryRoute,
 } from './moneyAccountSweepstakesSeries';
 
 const buildCampaign = (
@@ -25,6 +26,17 @@ const buildCampaign = (
     featured: false,
     showUpcomingDate: false,
     ...overrides,
+  }) as CampaignDto;
+
+const withTour = (campaign: CampaignDto): CampaignDto =>
+  ({
+    ...campaign,
+    details: {
+      ...(campaign.details ?? {}),
+      howItWorks: {
+        tour: [{ title: 'Step 1', description: 'Description 1' }],
+      },
+    },
   }) as CampaignDto;
 
 describe('moneyAccountSweepstakesSeries', () => {
@@ -107,5 +119,82 @@ describe('moneyAccountSweepstakesSeries', () => {
     expect(
       getMoneyAccountSweepstakesWeekNumber(series.campaigns, 'missing'),
     ).toBe(0);
+  });
+
+  describe('resolveMoneyAccountSweepstakesEntryRoute', () => {
+    it('returns dashboard when there are no sweepstakes campaigns', () => {
+      const series = getMoneyAccountSweepstakesSeries([]);
+      expect(
+        resolveMoneyAccountSweepstakesEntryRoute({
+          series,
+          optedInAny: false,
+        }),
+      ).toEqual({ kind: 'dashboard' });
+    });
+
+    it('returns dashboard when the series is upcoming', () => {
+      const series = getMoneyAccountSweepstakesSeries(
+        [week1, week2, week3],
+        new Date('2026-06-30T12:00:00.000Z'),
+      );
+      expect(
+        resolveMoneyAccountSweepstakesEntryRoute({
+          series,
+          optedInAny: false,
+        }),
+      ).toEqual({ kind: 'dashboard' });
+    });
+
+    it('returns details for the last campaign when the series is previous', () => {
+      const series = getMoneyAccountSweepstakesSeries(
+        [week1, week2, week3],
+        new Date('2026-07-23T12:00:00.000Z'),
+      );
+      expect(
+        resolveMoneyAccountSweepstakesEntryRoute({
+          series,
+          optedInAny: false,
+        }),
+      ).toEqual({ kind: 'details', campaignId: 'week-3' });
+    });
+
+    it('returns tour for the active campaign when eligible', () => {
+      const series = getMoneyAccountSweepstakesSeries(
+        [week1, withTour(week2), week3],
+        new Date('2026-07-10T12:00:00.000Z'),
+      );
+      expect(
+        resolveMoneyAccountSweepstakesEntryRoute({
+          series,
+          optedInAny: false,
+        }),
+      ).toEqual({ kind: 'tour', campaignId: 'week-2' });
+    });
+
+    it('returns details for the active campaign when already opted in', () => {
+      const series = getMoneyAccountSweepstakesSeries(
+        [week1, withTour(week2), week3],
+        new Date('2026-07-10T12:00:00.000Z'),
+      );
+      expect(
+        resolveMoneyAccountSweepstakesEntryRoute({
+          series,
+          optedInAny: true,
+        }),
+      ).toEqual({ kind: 'details', campaignId: 'week-2' });
+    });
+
+    it('returns details for the active campaign when there is no tour', () => {
+      const series = getMoneyAccountSweepstakesSeries(
+        [week1, week2, week3],
+        new Date('2026-07-10T12:00:00.000Z'),
+      );
+      expect(
+        resolveMoneyAccountSweepstakesEntryRoute({
+          series,
+          optedInAny: false,
+        }),
+      ).toEqual({ kind: 'details', campaignId: 'week-2' });
+    });
   });
 });

--- a/app/components/UI/Rewards/utils/moneyAccountSweepstakesSeries.ts
+++ b/app/components/UI/Rewards/utils/moneyAccountSweepstakesSeries.ts
@@ -121,3 +121,52 @@ export function mapSeriesStatusToCampaignStatus(
   }
   return seriesStatus;
 }
+
+export type MoneyAccountSweepstakesEntryRoute =
+  | { kind: 'dashboard' }
+  | { kind: 'tour'; campaignId: string }
+  | { kind: 'details'; campaignId: string };
+
+/**
+ * Resolve where a Money Account Sweepstakes entry point (deeplink / tile) should land.
+ *
+ * - upcoming / empty → stay on dashboard
+ * - previous → details for the last campaign in the series
+ * - active → tour when eligible, otherwise details for the current active campaign
+ */
+export function resolveMoneyAccountSweepstakesEntryRoute({
+  series,
+  optedInAny,
+}: {
+  series: MoneyAccountSweepstakesSeries;
+  optedInAny: boolean;
+}): MoneyAccountSweepstakesEntryRoute {
+  if (!series.seriesStatus || series.campaigns.length === 0) {
+    return { kind: 'dashboard' };
+  }
+
+  if (series.seriesStatus === 'upcoming') {
+    return { kind: 'dashboard' };
+  }
+
+  if (series.seriesStatus === 'previous') {
+    const campaignId = series.last?.id ?? series.displayCampaign?.id;
+    if (!campaignId) {
+      return { kind: 'dashboard' };
+    }
+    return { kind: 'details', campaignId };
+  }
+
+  const activeCampaign = series.activeCampaign;
+  if (!activeCampaign) {
+    return { kind: 'dashboard' };
+  }
+
+  const hasTour = (activeCampaign.details?.howItWorks?.tour?.length ?? 0) > 0;
+
+  if (hasTour && !optedInAny) {
+    return { kind: 'tour', campaignId: activeCampaign.id };
+  }
+
+  return { kind: 'details', campaignId: activeCampaign.id };
+}

--- a/app/core/DeeplinkManager/handlers/legacy/__tests__/handleRewardsUrl.test.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/__tests__/handleRewardsUrl.test.ts
@@ -164,6 +164,16 @@ describe('handleRewardsUrl', () => {
       expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
     });
 
+    it('dispatches pending deeplink and navigates to rewards view with campaign=money param', async () => {
+      await handleRewardsUrl({ rewardsPath: '?campaign=money' });
+
+      expect(setPendingDeeplink).toHaveBeenCalledWith({
+        page: undefined,
+        campaign: 'money',
+      });
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.REWARDS_VIEW);
+    });
+
     it('dispatches pending deeplink and navigates to rewards view with page=musd param', async () => {
       await handleRewardsUrl({ rewardsPath: '?page=musd' });
 

--- a/app/core/DeeplinkManager/handlers/legacy/handleRewardsUrl.ts
+++ b/app/core/DeeplinkManager/handlers/legacy/handleRewardsUrl.ts
@@ -20,7 +20,7 @@ interface HandleRewardsUrlParams {
 interface RewardsNavigationParams {
   referral?: string;
   page?: 'campaigns' | 'musd' | 'benefits';
-  campaign?: 'ondo' | 'season1' | 'perps-comp' | 'predict-the-pitch';
+  campaign?: 'ondo' | 'season1' | 'perps-comp' | 'predict-the-pitch' | 'money';
 }
 
 /**
@@ -45,9 +45,13 @@ const parseRewardsNavigationParams = (
     page: (['campaigns', 'musd', 'benefits'].includes(pageParam ?? '')
       ? pageParam
       : undefined) as RewardsNavigationParams['page'],
-    campaign: (['ondo', 'season1', 'perps-comp', 'predict-the-pitch'].includes(
-      campaignParam ?? '',
-    )
+    campaign: ([
+      'ondo',
+      'season1',
+      'perps-comp',
+      'predict-the-pitch',
+      'money',
+    ].includes(campaignParam ?? '')
       ? campaignParam
       : undefined) as RewardsNavigationParams['campaign'],
   };
@@ -67,6 +71,7 @@ const parseRewardsNavigationParams = (
  * - https://link.metamask.io/rewards?campaign=ondo
  * - https://link.metamask.io/rewards?campaign=season1
  * - https://link.metamask.io/rewards?campaign=predict-the-pitch
+ * - https://link.metamask.io/rewards?campaign=money
  */
 const prepareRewardsDeeplink = (rewardsPath: string) => {
   // Parse navigation parameters from URL

--- a/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController-method-action-types.ts
@@ -485,9 +485,10 @@ export type RewardsControllerOptInToCampaignAction = {
 
 /**
  * Opt a subscription into multiple campaigns in one batch.
- * POSTs each opt-in sequentially, then invalidates once per campaign and
- * publishes a single `campaignOptedIn` so UI listeners do not refetch after
- * every intermediate opt-in (important for series campaigns).
+ * POSTs each opt-in sequentially (up to 3 attempts per campaign on throw or
+ * non-opted-in response), continues after exhausted failures, then invalidates
+ * once per campaign and publishes a single `campaignOptedIn` so UI listeners
+ * do not refetch after every intermediate opt-in (important for series campaigns).
  * Participant-status cache entries are re-seeded from the POST responses so
  * post-event status fetches hit cache instead of the network.
  * @param campaignIds - Campaign IDs to opt into, in call order.

--- a/app/reducers/rewards/index.ts
+++ b/app/reducers/rewards/index.ts
@@ -320,7 +320,7 @@ export interface RewardsState {
  */
 export interface PendingDeeplink {
   page?: 'campaigns' | 'musd' | 'benefits';
-  campaign?: 'ondo' | 'season1' | 'perps-comp' | 'predict-the-pitch';
+  campaign?: 'ondo' | 'season1' | 'perps-comp' | 'predict-the-pitch' | 'money';
 }
 
 export const initialState: RewardsState = {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->
https://consensyssoftware.atlassian.net/browse/RWDS-1486
Adds `/rewards?campaign=money` as the Money Account Sweepstakes campaign deeplink, stacked on #33887.

The link stores `{ campaign: 'money' }` in Redux `pendingDeeplink`, then `RewardsDashboard` waits for campaigns (and, for an active series, participation) before resolving the destination:

- **upcoming / empty** → stay on Rewards dashboard
- **active** → campaign tour when eligible (tour exists, not opted into any week in the series); otherwise details for the **current active** week
- **previous** → details for the last campaign in the series

Also tightens `useMoneyAccountSweepstakesParticipation` so `isLoading` covers the pre-fetch window, while any series opt-in (`optedInAny`) immediately settles participation as known — so tour-vs-details does not race a false “not opted in”.

Depends on: https://github.com/MetaMask/metamask-mobile/pull/33887

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Added a Rewards deeplink to open the Money Account Sweepstakes campaign

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: rewards-money-account-sweepstakes

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money Account Sweepstakes campaign deeplink

  Scenario: active series, not opted in, tour available
    Given the user is enrolled in Rewards
    And a MONEY_ACCOUNT_SWEEPSTAKES series is active with tour steps
    And the user is not opted into any week in the series

    When the user opens https://link.metamask.io/rewards?campaign=money
    Then Rewards opens the campaign tour for the current active week

  Scenario: active series, already opted in
    Given the user is opted into at least one week in the active series

    When the user opens /rewards?campaign=money
    Then Rewards opens Money Account Sweepstakes campaign details for the active week

  Scenario: series upcoming
    Given the Money Account Sweepstakes series has not started

    When the user opens /rewards?campaign=money
    Then the user lands on the Rewards dashboard (no tour/details push)

  Scenario: series previous
    Given the Money Account Sweepstakes series has ended

    When the user opens /rewards?campaign=money
    Then Rewards opens campaign details for the last week in the series
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — deeplink routing only; UI screens come from #33887

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)