### PR TITLE
fix: fail fast in set-secrets-from-config.js when ALL_SECRETS is missing

### DIFF
--- a/scripts/set-secrets-from-config.js
+++ b/scripts/set-secrets-from-config.js
@@ -15,8 +15,19 @@
 
 const fs = require('fs');
 
+// No fallback: an unresolved toJSON(secrets) expands to an empty string, and
+// defaulting it to {} would skip every secret while still exiting 0 — producing
+// a signed binary with no Infura ID, Sentry DSN, or RPC failover URLs.
+if (!process.env.ALL_SECRETS) {
+  // GitHub Actions annotation so the error surfaces on the run summary.
+  console.error(
+    '::error title=Secret injection failed::ALL_SECRETS is not defined. Expected toJSON(secrets).',
+  );
+  process.exit(1);
+}
+
 const secretsMapping = JSON.parse(process.env.CONFIG_SECRETS || '{}');
-const allSecrets = JSON.parse(process.env.ALL_SECRETS || '{}');
+const allSecrets = JSON.parse(process.env.ALL_SECRETS);
 const githubEnvPath = process.env.GITHUB_ENV;
 
 function appendToGithubEnv(name, value) {


### PR DESCRIPTION
## Summary
- `set-secrets-from-config.js` silently defaulted `ALL_SECRETS` (`toJSON(secrets)`) to `{}` when unset, so an unresolved workflow expression would skip injecting every secret and still exit 0 — producing a signed build with no Infura ID, Sentry DSN, or RPC failover URLs baked in.
- Now fails fast with a clear `::error::` annotation when `ALL_SECRETS` is unset/empty, instead of silently continuing.

## Test plan
- [ ] CI passes

Made with [Cursor](https://cursor.com)