### PR TITLE
chore(stellar): Stellar preparation - Add Stellar account feature flag and update test

### DIFF
--- a/app/components/UI/Bridge/_mocks_/initialState.ts
+++ b/app/components/UI/Bridge/_mocks_/initialState.ts
@@ -9,6 +9,8 @@ import {
   BtcAccountType,
   TrxScope,
   TrxAccountType,
+  XlmScope,
+  XlmAccountType,
 } from '@metamask/keyring-api';
 import { AccountWalletType, AccountGroupType } from '@metamask/account-api';
 import { ethers } from 'ethers';
@@ -56,6 +58,11 @@ export const btcNativeTokenAddress =
 export const trxAccountId = 'trxAccountId';
 export const trxAccountAddress = 'TN3W4Bb1JVHPiWJVm7d9q9qHGXSdoMrMrE';
 export const trxNativeTokenAddress = 'tron:728126428/slip44:195' as CaipAssetId;
+
+export const xlmAccountId = 'xlmAccountId';
+export const xlmAccountAddress =
+  'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NYMPL5AFHTDXUDT7JOZZYNQLEI';
+export const xlmNativeTokenAddress = 'stellar:pubnet/slip44:148' as CaipAssetId;
 
 export const initialState = {
   engine: {
@@ -105,6 +112,11 @@ export const initialState = {
                 isGaslessSwapEnabled: false,
               },
               [TrxScope.Mainnet]: {
+                isActiveSrc: true,
+                isActiveDest: true,
+                isGaslessSwapEnabled: false,
+              },
+              [XlmScope.Pubnet]: {
                 isActiveSrc: true,
                 isActiveDest: true,
                 isGaslessSwapEnabled: false,
@@ -275,6 +287,9 @@ export const initialState = {
           tron: {
             [TrxScope.Mainnet]: true,
           },
+          stellar: {
+            [XlmScope.Pubnet]: true,
+          },
         },
       },
       MultichainNetworkController: {
@@ -299,6 +314,12 @@ export const initialState = {
             chainId: TrxScope.Mainnet,
             name: 'Tron',
             nativeCurrency: 'tron:728126428/slip44:195' as const,
+            isEvm: false as const,
+          },
+          [XlmScope.Pubnet]: {
+            chainId: XlmScope.Pubnet,
+            name: 'Stellar',
+            nativeCurrency: 'stellar:pubnet/slip44:148' as const,
             isEvm: false as const,
           },
         },
@@ -327,6 +348,12 @@ export const initialState = {
               unit: 'TRX',
             },
           },
+          [xlmAccountId]: {
+            [xlmNativeTokenAddress]: {
+              amount: '250',
+              unit: 'XLM',
+            },
+          },
         },
       },
       MultichainAssetsController: {
@@ -334,6 +361,7 @@ export const initialState = {
           [solanaAccountId]: [solanaNativeTokenAddress, solanaToken2Address],
           [btcAccountId]: [btcNativeTokenAddress],
           [trxAccountId]: [trxNativeTokenAddress],
+          [xlmAccountId]: [xlmNativeTokenAddress],
         },
         assetsMetadata: {
           [btcNativeTokenAddress]: {
@@ -410,6 +438,20 @@ export const initialState = {
               },
             ],
           },
+          [xlmNativeTokenAddress]: {
+            name: 'Stellar',
+            symbol: 'XLM',
+            iconUrl:
+              'https://static.cx.metamask.io/api/v2/tokenIcons/assets/stellar/pubnet/slip44/148.png',
+            fungible: true as const,
+            units: [
+              {
+                name: 'Stellar',
+                symbol: 'XLM',
+                decimals: 7,
+              },
+            ],
+          },
         },
       },
       MultichainAssetsRatesController: {
@@ -428,6 +470,10 @@ export const initialState = {
           },
           [trxNativeTokenAddress]: {
             rate: '0.10', // 1 TRX = 0.10 USD
+            conversionTime: 0,
+          },
+          [xlmNativeTokenAddress]: {
+            rate: '0.12', // 1 XLM = 0.12 USD
             conversionTime: 0,
           },
         },
@@ -472,6 +518,16 @@ export const initialState = {
               name: 'Account 4',
               type: TrxAccountType.Eoa,
               scopes: [TrxScope.Mainnet],
+              metadata: {
+                lastSelected: 0,
+              },
+            },
+            [xlmAccountId]: {
+              id: xlmAccountId,
+              address: xlmAccountAddress,
+              name: 'Account 5',
+              type: XlmAccountType.Account,
+              scopes: [XlmScope.Pubnet],
               metadata: {
                 lastSelected: 0,
               },

--- a/app/components/UI/Bridge/constants/default-swap-dest-tokens.ts
+++ b/app/components/UI/Bridge/constants/default-swap-dest-tokens.ts
@@ -3,6 +3,7 @@ import {
   CaipChainId,
   SolScope,
   TrxScope,
+  XlmScope,
 } from '@metamask/keyring-api';
 import { BridgeToken } from '../types';
 import { CaipAssetType, Hex } from '@metamask/utils';
@@ -226,6 +227,18 @@ export const DefaultSwapDestTokens: Partial<
       chainId: TrxScope.Mainnet,
     },
   },
+  [XlmScope.Pubnet]: {
+    '*': {
+      address:
+        'stellar:pubnet/asset:USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+      symbol: 'USDC',
+      name: 'USD Coin',
+      decimals: 7,
+      image:
+        'https://static.cx.metamask.io/api/v2/tokenIcons/assets/stellar/pubnet/asset/USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN.png',
+      chainId: XlmScope.Pubnet,
+    },
+  },
 };
 
 export const Bip44TokensForDefaultPairs: Record<CaipAssetType, BridgeToken> = {
@@ -294,4 +307,24 @@ export const Bip44TokensForDefaultPairs: Record<CaipAssetType, BridgeToken> = {
     chainId: TrxScope.Mainnet,
     name: 'Tether USD',
   },
+  'stellar:pubnet/slip44:148': {
+    address: 'stellar:pubnet/slip44:148',
+    symbol: 'XLM',
+    decimals: 7,
+    image:
+      'https://static.cx.metamask.io/api/v2/tokenIcons/assets/stellar/pubnet/slip44/148.png',
+    chainId: XlmScope.Pubnet,
+    name: 'Stellar',
+  },
+  'stellar:pubnet/asset:USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN':
+    {
+      address:
+        'stellar:pubnet/asset:USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+      symbol: 'USDC',
+      decimals: 7,
+      image:
+        'https://static.cx.metamask.io/api/v2/tokenIcons/assets/stellar/pubnet/asset/USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN.png',
+      chainId: XlmScope.Pubnet,
+      name: 'USD Coin',
+    },
 };

--- a/app/components/UI/Bridge/hooks/useIsNetworkFeeUnavailable/index.test.ts
+++ b/app/components/UI/Bridge/hooks/useIsNetworkFeeUnavailable/index.test.ts
@@ -67,7 +67,7 @@ describe('isQuoteNetworkFeeUnavailable', () => {
     expect(isQuoteNetworkFeeUnavailable(createQuote())).toBe(false);
   });
 
-  it('returns false for a non-BTC/non-Tron quote with zero network fee', () => {
+  it('returns false for a non-BTC/non-Tron/non-Stellar quote with zero network fee', () => {
     expect(
       isQuoteNetworkFeeUnavailable(
         createQuote({
@@ -142,6 +142,70 @@ describe('isQuoteNetworkFeeUnavailable', () => {
           quote: {
             ...mockQuoteWithMetadata.quote,
             srcChainId: ChainId.TRON,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true for a Stellar quote with zero network fee', () => {
+    expect(
+      isQuoteNetworkFeeUnavailable(
+        createQuote({
+          quote: {
+            ...mockQuoteWithMetadata.quote,
+            srcChainId: ChainId.STELLAR,
+          },
+          totalNetworkFee: {
+            ...mockQuoteWithMetadata.totalNetworkFee,
+            amount: '0',
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for a Stellar quote with negative network fee', () => {
+    expect(
+      isQuoteNetworkFeeUnavailable(
+        createQuote({
+          quote: {
+            ...mockQuoteWithMetadata.quote,
+            srcChainId: ChainId.STELLAR,
+          },
+          totalNetworkFee: {
+            ...mockQuoteWithMetadata.totalNetworkFee,
+            amount: '-1',
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true for a Stellar quote with missing network fee amount', () => {
+    expect(
+      isQuoteNetworkFeeUnavailable(
+        createQuote({
+          quote: {
+            ...mockQuoteWithMetadata.quote,
+            srcChainId: ChainId.STELLAR,
+          },
+          totalNetworkFee: {
+            ...mockQuoteWithMetadata.totalNetworkFee,
+            amount: undefined,
+          } as unknown as NonNullable<ActiveQuote>['totalNetworkFee'],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for a Stellar quote with positive network fee', () => {
+    expect(
+      isQuoteNetworkFeeUnavailable(
+        createQuote({
+          quote: {
+            ...mockQuoteWithMetadata.quote,
+            srcChainId: ChainId.STELLAR,
           },
         }),
       ),

--- a/app/components/UI/Bridge/hooks/useIsNetworkFeeUnavailable/index.ts
+++ b/app/components/UI/Bridge/hooks/useIsNetworkFeeUnavailable/index.ts
@@ -1,6 +1,10 @@
 import { useMemo } from 'react';
 import { BigNumber } from 'bignumber.js';
-import { isBitcoinChainId, isTronChainId } from '@metamask/bridge-controller';
+import {
+  isBitcoinChainId,
+  isStellarChainId,
+  isTronChainId,
+} from '@metamask/bridge-controller';
 import { useBridgeQuoteData } from '../useBridgeQuoteData';
 
 type ActiveQuote = ReturnType<typeof useBridgeQuoteData>['activeQuote'];
@@ -12,7 +16,9 @@ export const isQuoteNetworkFeeUnavailable = (
 
   if (
     !sourceChainId ||
-    (!isBitcoinChainId(sourceChainId) && !isTronChainId(sourceChainId))
+    (!isBitcoinChainId(sourceChainId) &&
+      !isTronChainId(sourceChainId) &&
+      !isStellarChainId(sourceChainId))
   ) {
     return false;
   }

--- a/app/components/UI/Ramp/constants/networks.ts
+++ b/app/components/UI/Ramp/constants/networks.ts
@@ -29,6 +29,10 @@ export const ARC_MAINNET: DepositNetwork = {
   chainId: 'eip155:5042',
   name: 'Arc',
 };
+export const STELLAR_MAINNET: DepositNetwork = {
+  chainId: 'stellar:pubnet',
+  name: 'Stellar',
+};
 
 export const DEPOSIT_NETWORKS_BY_CHAIN_ID: Record<CaipChainId, DepositNetwork> =
   {
@@ -38,4 +42,5 @@ export const DEPOSIT_NETWORKS_BY_CHAIN_ID: Record<CaipChainId, DepositNetwork> =
     [SOLANA_MAINNET.chainId]: SOLANA_MAINNET,
     [BSC_MAINNET.chainId]: BSC_MAINNET,
     [ARC_MAINNET.chainId]: ARC_MAINNET,
+    [STELLAR_MAINNET.chainId]: STELLAR_MAINNET,
   };

--- a/app/components/UI/Tokens/util/sortAssetsWithPriority.ts
+++ b/app/components/UI/Tokens/util/sortAssetsWithPriority.ts
@@ -1,7 +1,7 @@
 import type { Asset } from '@metamask/assets-controllers';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import type { CaipChainId, Hex } from '@metamask/utils';
-import { BtcScope, SolScope, TrxScope } from '@metamask/keyring-api';
+import { BtcScope, SolScope, TrxScope, XlmScope } from '@metamask/keyring-api';
 import { sortAssets, type SortCriteria } from './sortAssets';
 
 // These are the only two options for sorting assets
@@ -32,6 +32,7 @@ const defaultNativeAssetOrder: (Hex | CaipChainId)[] = [
   TrxScope.Mainnet,
   BtcScope.Mainnet,
   SolScope.Mainnet,
+  XlmScope.Pubnet,
   CHAIN_IDS.LINEA_MAINNET,
   CHAIN_IDS.MAINNET,
 ];

--- a/app/constants/bridge.ts
+++ b/app/constants/bridge.ts
@@ -1,4 +1,4 @@
-import { SolScope, BtcScope, TrxScope } from '@metamask/keyring-api';
+import { SolScope, BtcScope, TrxScope, XlmScope } from '@metamask/keyring-api';
 import { CaipChainId, Hex } from '@metamask/utils';
 import {
   BRIDGE_DEV_API_BASE_URL,
@@ -38,6 +38,7 @@ export const NETWORK_TO_SHORT_NETWORK_NAME_MAP: Record<
   [SolScope.Mainnet]: 'Solana',
   [BtcScope.Mainnet]: 'BTC',
   [TrxScope.Mainnet]: 'Tron',
+  [XlmScope.Pubnet]: 'Stellar',
 };
 
 /**

--- a/app/constants/snaps.ts
+++ b/app/constants/snaps.ts
@@ -66,6 +66,11 @@ export const SNAPS_DERIVATION_PATHS: SnapsDerivationPath[] = [
     name: 'Tron',
   },
   {
+    path: ['m', `44'`, `148'`],
+    curve: 'ed25519',
+    name: 'Stellar',
+  },
+  {
     path: ['m', `44'`, `2'`],
     curve: 'secp256k1',
     name: 'Litecoin',

--- a/app/constants/storage.ts
+++ b/app/constants/storage.ts
@@ -82,6 +82,8 @@ export const BITCOIN_DISCOVERY_PENDING = `${prefix}bitcoinDiscoveryPending`;
 
 export const TRON_DISCOVERY_PENDING = `${prefix}tronDiscoveryPending`;
 
+export const STELLAR_DISCOVERY_PENDING = `${prefix}stellarDiscoveryPending`;
+
 export const PERPS_GTM_MODAL_SHOWN = `${prefix}perpsGTMModalShown`;
 
 export const PERPS_COMPETITION_BANNER_DISMISSED = `${prefix}perpsCompetitionBannerDismissed`;

--- a/app/multichain-stellar/remote-feature-flag.test.ts
+++ b/app/multichain-stellar/remote-feature-flag.test.ts
@@ -1,0 +1,64 @@
+import packageJson from '../../package.json';
+import {
+  isStellarAccountsFeatureEnabled,
+  type StellarAccountsFeatureFlag,
+} from './remote-feature-flag';
+
+describe('isStellarAccountsFeatureEnabled', () => {
+  it('returns true when flag is enabled and version meets minimum', () => {
+    const flag: StellarAccountsFeatureFlag = {
+      enabled: true,
+      minimumVersion: '1.0.0',
+    };
+
+    expect(isStellarAccountsFeatureEnabled(flag)).toBe(true);
+  });
+
+  it('returns false when flag is disabled', () => {
+    const flag: StellarAccountsFeatureFlag = {
+      enabled: false,
+      minimumVersion: '1.0.0',
+    };
+
+    expect(isStellarAccountsFeatureEnabled(flag)).toBe(false);
+  });
+
+  it('returns false when flag is undefined', () => {
+    expect(isStellarAccountsFeatureEnabled(undefined)).toBe(false);
+  });
+
+  it('returns false when flag is null', () => {
+    expect(isStellarAccountsFeatureEnabled(null)).toBe(false);
+  });
+
+  it('returns false when app version is below minimum version', () => {
+    const flag: StellarAccountsFeatureFlag = {
+      enabled: true,
+      minimumVersion: '999.999.999',
+    };
+
+    expect(isStellarAccountsFeatureEnabled(flag)).toBe(false);
+  });
+
+  it('returns true when app version equals minimum version', () => {
+    const flag: StellarAccountsFeatureFlag = {
+      enabled: true,
+      minimumVersion: packageJson.version,
+    };
+
+    expect(isStellarAccountsFeatureEnabled(flag)).toBe(true);
+  });
+
+  it('returns false when flag structure is invalid', () => {
+    expect(
+      isStellarAccountsFeatureEnabled({
+        enabled: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true for simple boolean flag', () => {
+    expect(isStellarAccountsFeatureEnabled(true)).toBe(true);
+    expect(isStellarAccountsFeatureEnabled(false)).toBe(false);
+  });
+});

--- a/app/multichain-stellar/remote-feature-flag.ts
+++ b/app/multichain-stellar/remote-feature-flag.ts
@@ -1,0 +1,54 @@
+import compareVersions from 'compare-versions';
+import packageJson from '../../package.json';
+
+const APP_VERSION = packageJson.version;
+
+/**
+ * Stellar accounts feature flag interface - matches extension pattern
+ */
+export interface StellarAccountsFeatureFlag {
+  enabled: boolean;
+  minimumVersion: string | null;
+}
+
+/**
+ * Shared helper to check whether Stellar accounts feature is enabled
+ * for a given application version. Keeps background and UI logic in sync.
+ * Accepts unknown type to handle JSON parsing from selectors.
+ *
+ * @param flagValue - The feature flag value from remote config
+ * @returns boolean - True if the feature is enabled, false otherwise.
+ */
+export const isStellarAccountsFeatureEnabled = (flagValue: unknown) => {
+  if (!flagValue || !APP_VERSION) {
+    return false;
+  }
+
+  // Simple boolean flag
+  if (typeof flagValue === 'boolean') {
+    return flagValue;
+  }
+
+  // Object with enabled and minimumVersion properties
+  if (typeof flagValue === 'object' && flagValue !== null) {
+    const flag = flagValue as StellarAccountsFeatureFlag;
+    const { enabled, minimumVersion } = flag;
+
+    if (!enabled) {
+      return false;
+    }
+
+    // Require version for safety (following multichain-accounts pattern)
+    if (!minimumVersion) {
+      return false;
+    }
+
+    try {
+      return compareVersions.compare(minimumVersion, APP_VERSION, '<=');
+    } catch {
+      return false;
+    }
+  }
+
+  return false;
+};

--- a/app/selectors/featureFlagController/stellarAccountsEnabled/index.test.ts
+++ b/app/selectors/featureFlagController/stellarAccountsEnabled/index.test.ts
@@ -1,0 +1,97 @@
+import { selectIsStellarAccountsEnabled } from '.';
+import mockedEngine from '../../../core/__mocks__/MockedEngine';
+import { mockedEmptyFlagsState, mockedUndefinedFlagsState } from '../mocks';
+import packageJson from '../../../../package.json';
+import type { StellarAccountsFeatureFlag } from '../../../multichain-stellar/remote-feature-flag';
+import { FeatureFlags } from '@metamask/remote-feature-flag-controller';
+
+jest.mock('../../../core/Engine', () => ({
+  init: () => mockedEngine.init(),
+}));
+
+const originalEnv = process.env;
+beforeEach(() => {
+  jest.resetModules();
+  process.env = { ...originalEnv };
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+  jest.clearAllMocks();
+});
+
+// Helper function to create mock state with stellarAccounts flag
+function mockStateWith(stellarAccounts: StellarAccountsFeatureFlag) {
+  return {
+    engine: {
+      backgroundState: {
+        RemoteFeatureFlagController: {
+          cacheTimestamp: 0,
+          remoteFeatureFlags: {
+            stellarAccounts,
+            // Not sure why this cannot be inferred properly.
+          } as unknown as FeatureFlags,
+        },
+      },
+    },
+  };
+}
+
+describe('selectIsStellarAccountsEnabled', () => {
+  it('returns true when stellarAccounts flag is enabled and version meets minimum', () => {
+    const mockedState = mockStateWith({
+      enabled: true,
+      minimumVersion: '1.0.0',
+    });
+
+    expect(selectIsStellarAccountsEnabled(mockedState)).toBe(true);
+  });
+
+  it('returns false when stellarAccounts flag is disabled', () => {
+    const mockedState = mockStateWith({
+      enabled: false,
+      minimumVersion: '1.0.0',
+    });
+
+    expect(selectIsStellarAccountsEnabled(mockedState)).toBe(false);
+  });
+
+  it('returns false when stellarAccounts flag is undefined', () => {
+    expect(selectIsStellarAccountsEnabled(mockedUndefinedFlagsState)).toBe(
+      false,
+    );
+  });
+
+  it('returns false when stellarAccounts flag is empty', () => {
+    expect(selectIsStellarAccountsEnabled(mockedEmptyFlagsState)).toBe(false);
+  });
+
+  it('returns false when app version is below minimum version', () => {
+    const mockedState = mockStateWith({
+      enabled: true,
+      minimumVersion: '999.999.999',
+    });
+
+    expect(selectIsStellarAccountsEnabled(mockedState)).toBe(false);
+  });
+
+  it('returns true when app version equals minimum version', () => {
+    const currentVersion = packageJson.version;
+    const mockedState = mockStateWith({
+      enabled: true,
+      minimumVersion: currentVersion,
+    });
+
+    expect(selectIsStellarAccountsEnabled(mockedState)).toBe(true);
+  });
+
+  it('returns false when flag structure is invalid', () => {
+    // @ts-expect-error - Testing error case.
+    const mockedState = mockStateWith({
+      enabled: true,
+      // Missing minimumVersion - should return false for safety
+    });
+
+    expect(selectIsStellarAccountsEnabled(mockedState)).toBe(false);
+  });
+});

--- a/app/selectors/featureFlagController/stellarAccountsEnabled/index.ts
+++ b/app/selectors/featureFlagController/stellarAccountsEnabled/index.ts
@@ -1,0 +1,15 @@
+import { createSelector } from 'reselect';
+import { selectRemoteFeatureFlags } from '..';
+import { isStellarAccountsFeatureEnabled } from '../../../multichain-stellar/remote-feature-flag';
+
+/**
+ * Selector to check if the stellarAccounts feature flag is enabled.
+ * Uses shared implementation for consistency with extension.
+ */
+export const selectIsStellarAccountsEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags): boolean => {
+    const { stellarAccounts } = remoteFeatureFlags;
+    return isStellarAccountsFeatureEnabled(stellarAccounts);
+  },
+);

--- a/tests/api-mocking/mock-responses/feature-flags-mocks.ts
+++ b/tests/api-mocking/mock-responses/feature-flags-mocks.ts
@@ -152,6 +152,13 @@ export const remoteFeatureFlagTronAccounts = (enabled = true) => ({
   },
 });
 
+export const remoteFeatureFlagStellarAccounts = (enabled = true) => ({
+  stellarAccounts: {
+    enabled,
+    minimumVersion: '0.0.0',
+  },
+});
+
 /**
  * Enables the Market Insights (AI social market analysis) feature on asset details.
  * Uses minimumVersion '0.0.0' so debug/test builds always pass the version gate.

--- a/tests/feature-flags/feature-flag-registry.test.ts
+++ b/tests/feature-flags/feature-flag-registry.test.ts
@@ -139,6 +139,7 @@ describe('Feature Flag Registry', () => {
 
       expect(flagNames).toContain('bridgeConfigV2');
       expect(flagNames).toContain('bitcoinAccounts');
+      expect(flagNames).toContain('stellarAccounts');
       expect(flagNames).toContain('tronAccounts');
       expect(flagNames).toContain('tronClaimUnstakedTrxButtonEnabled');
     });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

## **Stellar is not live yet, it should no impact to UX**
Adds Stellar (pubnet) plumbing ahead of full Stellar accounts UI, following the same patterns as Bitcoin and Tron.

Introduces a stellarAccounts remote feature flag with shared isStellarAccountsFeatureEnabled logic and selectIsStellarAccountsEnabled, plus E2E/registry test coverage and remoteFeatureFlagStellarAccounts mocks. Adds STELLAR_DISCOVERY_PENDING storage and a BIP-44 44'/148' Stellar snap derivation path.

Wires Stellar into Bridge: pubnet in chain config mocks, default swap destination USDC, Bip44TokensForDefaultPairs, short network name Stellar, and isStellarChainId in network-fee-unavailable handling (treats missing/zero/negative fees like BTC/Tron). Also adds Stellar to Ramp deposit networks, native asset sort priority, and extended Bridge UI test state.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->
## **Stellar is not live yet, it should no impact to UX**
CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

## **Stellar is not live yet, it should no impact to UX**

https://www.loom.com/share/71b531bc92394e709b27f9669638040c

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive config, flags default off in production registry, and test/mock updates with no auth or payment logic changes.
> 
> **Overview**
> Adds **Stellar (pubnet)** plumbing ahead of full Stellar accounts UI, following the same patterns as Bitcoin and Tron.
> 
> Introduces a **`stellarAccounts` remote feature flag** with shared `isStellarAccountsFeatureEnabled` logic and `selectIsStellarAccountsEnabled`, plus E2E/registry test coverage and `remoteFeatureFlagStellarAccounts` mocks. Adds **`STELLAR_DISCOVERY_PENDING`** storage and a **BIP-44 `44'/148'`** Stellar snap derivation path.
> 
> Wires Stellar into **Bridge**: pubnet in chain config mocks, default swap destination **USDC**, `Bip44TokensForDefaultPairs`, short network name **Stellar**, and **`isStellarChainId`** in network-fee-unavailable handling (treats missing/zero/negative fees like BTC/Tron). Also adds Stellar to **Ramp deposit networks**, **native asset sort priority**, and extended Bridge UI test state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7c851b347aaaaefd317ab9f9d3db1ded2eb9d75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->