### PR TITLE
chore(e2e): Appium docs SSOT + ban new UnifiedGestures imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -298,6 +298,14 @@ module.exports = {
         'no-restricted-syntax': [
           'error',
           {
+            selector: 'WithStatement',
+            message: 'With statements are not allowed',
+          },
+          {
+            selector: 'SequenceExpression',
+            message: 'Sequence expressions are not allowed',
+          },
+          {
             selector: "Identifier[name='UnifiedGestures']",
             message: 'Use Gestures instead of UnifiedGestures.',
           },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -261,6 +261,49 @@ module.exports = {
         ],
       },
     },
+    // MMQA-2174: re-apply after *.{ts,tsx} override which replaces no-restricted-syntax
+    {
+      files: ['tests/page-objects/**/*.{js,ts}', 'tests/flows/**/*.{js,ts}'],
+      excludedFiles: [
+        'tests/page-objects/**/*.test.ts',
+        'tests/page-objects/**/*.test.js',
+        'tests/flows/**/*.test.ts',
+        'tests/flows/**/*.test.js',
+      ],
+      rules: {
+        'no-restricted-syntax': [
+          'warn',
+          {
+            selector: 'WithStatement',
+            message: 'With statements are not allowed',
+          },
+          {
+            selector: 'SequenceExpression',
+            message: 'Sequence expressions are not allowed',
+          },
+          {
+            selector: "Identifier[name='UnifiedGestures']",
+            message: 'Use Gestures instead of UnifiedGestures.',
+          },
+        ],
+      },
+    },
+    {
+      files: ['tests/smoke-appium/**/*.{js,ts}', 'tests/smoke/**/*.{js,ts}'],
+      excludedFiles: [
+        'tests/smoke-appium/**/*.test.ts',
+        'tests/smoke/**/*.test.ts',
+      ],
+      rules: {
+        'no-restricted-syntax': [
+          'error',
+          {
+            selector: "Identifier[name='UnifiedGestures']",
+            message: 'Use Gestures instead of UnifiedGestures.',
+          },
+        ],
+      },
+    },
     {
       files: ['*.js', '*.jsx'],
       parser: '@babel/eslint-parser',

--- a/docs/testing/appium-smoke-testing.md
+++ b/docs/testing/appium-smoke-testing.md
@@ -246,4 +246,4 @@ CI uploads per-suite artifacts as `appium-smoke-report-<suite>` and `appium-smok
 - [E2E testing guidelines](./e2e-testing.md) — POM, cross-framework patterns, Detox vs Appium specs
 - [E2E setup (Detox)](../readme/e2e-testing.md) — Metro, debug builds, smoke
 - [Playwright local emulator](../../tests/docs/PLAYWRIGHT_LOCAL_EMULATOR.md) — `buildPath`, reinstall behavior
-- [Unified E2E architecture](../../tests/docs/UNIFIED_E2E_ARCHITECTURE.md) — `resolve()`, `encapsulated()`
+- [E2E architecture (Appium)](../../tests/docs/UNIFIED_E2E_ARCHITECTURE.md) — layers, `resolve()`, `encapsulated()`

--- a/docs/testing/e2e-testing.md
+++ b/docs/testing/e2e-testing.md
@@ -25,13 +25,12 @@
 ## Test Organization - MANDATORY
 
 - Organize tests into folders based on features and scenarios
-- Place smoke specs under `tests/smoke/` (Detox) or `tests/smoke-appium/` (Appium), using the matching smoke tag
+- Place smoke specs under `tests/smoke-appium/`, using the matching smoke tag
 - Each feature team should own one or more folders of tests
 - Follow the same organization pattern as the extension team for consistency
 - Place tests in logical feature directories:
   ```
-  tests/smoke/<feature-name>/<e2e-test-name.spec.ts>
-  tests/smoke/tokens/import/import-erc1155.spec.ts
+  tests/smoke-appium/<feature-name>/<e2e-test-name.spec.ts>
   tests/smoke-appium/wallet/browser/browser-navigation.spec.ts
   ```
 
@@ -47,30 +46,27 @@
 ### Key Features
 
 - ✅ **Auto-retry** - Handles flaky network/UI conditions
-- ✅ **Cross-framework** - `Gestures`, `Assertions`, and `Matchers` work in both Detox and Appium
+- ✅ **Appium / Playwright** - `Gestures`, `Assertions`, and `Matchers` are the canonical facades for Appium smoke
 - ✅ **Configurable element state checking** - Control visibility, enabled, and stability checks per interaction
 - ✅ **Performance optimization** - Stability checking disabled by default for better performance
 - ✅ **Better error messages** - Descriptive errors with retry context and timing
 - ✅ **Type safety** - Full TypeScript support with IntelliSense
 
-### Cross-Framework Support
+### Gestures facade (canonical)
 
-`Gestures`, `Assertions`, and the three common `Matchers` methods (`getElementByID`, `getElementByText`, `getElementByLabel`) automatically route to the correct framework at runtime. Page objects that use them work in both Detox and Appium with no changes.
+Use `Gestures`, `Assertions`, and the common `Matchers` methods (`getElementByID`, `getElementByText`, `getElementByLabel`) from `tests/framework`. Do **not** import `UnifiedGestures` in page objects or specs — it is a legacy dual-runner API retained only as an internal implementation detail until Detox removal finishes.
 
 ```
 Page object calls Gestures.waitAndTap(elem)
         │
-        ├── Detox run  → existing Detox implementation (retry, stability checks)
         └── Appium run → AppiumGestureStrategy → PlaywrightGestures
 ```
 
-This means a Detox smoke test and its Appium counterpart share the same page object calls — only the test runner wrapper and login flow differ between them.
-
 ## Writing Page Objects
 
-### Default Pattern — works in both frameworks
+### Default Pattern — Appium smoke
 
-Use `Matchers.getElementByID/Text/Label` for getters and `Gestures`/`Assertions` for actions. No framework-specific imports needed.
+Use `Matchers.getElementByID/Text/Label` for getters and `Gestures`/`Assertions` for actions. No Playwright-specific imports needed for the common case.
 
 ```typescript
 import Matchers from '../framework/Matchers';
@@ -101,26 +97,45 @@ class LoginPage {
 export default new LoginPage();
 ```
 
-### Edge Case: different selector per framework
+### Edge Case: different selector per platform
 
-When the same element has a different testID or selector strategy between Detox and Appium, use `resolve()` from the framework:
+When the same element needs a different testID or selector strategy between iOS and Android Appium, use `resolve()` from the framework. Legacy dual-runner branches (`detoxTestID`, `appiumTestID`) remain for remaining Detox suites; new work should only need Appium / platform variants.
 
 ```typescript
 import { resolve } from '../framework';
+import { encapsulated } from '../framework/EncapsulatedElement';
+import PlaywrightMatchers from '../framework/PlaywrightMatchers';
 
-// Different testID per framework
+// Different testID on iOS vs Android Appium (Appium-only — no Detox branch)
 get actionButton() {
-  return resolve({
-    detoxTestID: TabBarSelectorIDs.TRADE,
-    appiumTestID: TabBarSelectorIDs.ACTIONS,
+  return encapsulated({
+    appium: {
+      android: () =>
+        PlaywrightMatchers.getElementById(TabBarSelectorIDs.TRADE, {
+          exact: true,
+        }),
+      ios: () =>
+        PlaywrightMatchers.getElementByAccessibilityId(
+          TabBarSelectorIDs.ACTIONS,
+        ),
+    },
   });
 }
 
-// Different testID on iOS Appium vs everything else
+// Same testID on Android; iOS Appium differs
 get container() {
   return resolve({
     testID: WalletViewSelectorsIDs.WALLET_CONTAINER,
     iosAppiumTestID: WalletViewSelectorsIDs.EYE_SLASH_ICON,
+  });
+}
+
+// Legacy dual-runner: Detox + per-platform Appium testIDs
+get legacyActionButton() {
+  return resolve({
+    detoxTestID: TabBarSelectorIDs.TRADE,
+    androidAppiumTestID: TabBarSelectorIDs.TRADE,
+    iosAppiumTestID: TabBarSelectorIDs.ACTIONS,
   });
 }
 ```
@@ -129,21 +144,33 @@ Available `resolve()` shapes:
 
 | Shape                                                   | When to use                                             |
 | ------------------------------------------------------- | ------------------------------------------------------- |
-| `{ testID }`                                            | Same testID works in all frameworks/platforms           |
-| `{ detoxTestID, appiumTestID }`                         | Different testID between Detox and Appium               |
-| `{ detoxTestID, androidAppiumTestID, iosAppiumTestID }` | All three differ                                        |
-| `{ testID, iosAppiumTestID }`                           | Detox + Android Appium share testID; iOS Appium differs |
+| `{ testID }`                                            | Same testID works on iOS and Android Appium             |
+| `{ testID, iosAppiumTestID }`                           | Android Appium shares testID; iOS Appium differs        |
+| `{ detoxTestID, appiumTestID }`                         | Legacy: different testID between Detox and Appium       |
+| `{ detoxTestID, androidAppiumTestID, iosAppiumTestID }` | Legacy dual-runner: Detox + per-platform Appium testIDs |
 | `{ label }`                                             | Match by accessibility label                            |
 | `{ text }`                                              | Match by visible text                                   |
 
-### Edge Case: different selector type per framework
+For Appium-only iOS vs Android testID differences (no Detox), use `encapsulated({ appium: { android: () => ..., ios: () => ... } })` instead of `resolve()`.
 
-When the selector strategy itself differs (e.g. Detox matches by ID+label, Appium matches by text), use `encapsulated()`:
+### Edge Case: different selector type per platform
+
+When the selector strategy itself differs between iOS and Android Appium (e.g. one platform matches by ID+label, the other by text), use `encapsulated()`:
 
 ```typescript
 import { encapsulated } from '../framework/EncapsulatedElement';
 import PlaywrightMatchers from '../framework/PlaywrightMatchers';
 
+getAccountElementByName(accountName: string) {
+  return encapsulated({
+    appium: () => PlaywrightMatchers.getElementByText(accountName),
+  });
+}
+```
+
+Legacy dual-runner branches remain for remaining Detox suites; new work should only need Appium / platform variants:
+
+```typescript
 getAccountElementByName(accountName: string) {
   return encapsulated({
     detox: () => Matchers.getElementByIDAndLabel(AccountCellIds.ADDRESS, accountName),
@@ -152,13 +179,27 @@ getAccountElementByName(accountName: string) {
 }
 ```
 
-### Edge Case: different action flow per framework
+### Edge Case: different action flow per platform
 
-When the action itself must differ structurally between frameworks (e.g. Appium must scroll before tapping, or must hide the keyboard after typing), use `encapsulatedAction()`:
+When the action itself must differ structurally between iOS and Android Appium (e.g. one platform must scroll before tapping, or must hide the keyboard after typing), use `encapsulatedAction()`:
 
 ```typescript
 import { encapsulatedAction } from '../framework/encapsulatedAction';
+import PlaywrightGestures from '../framework/PlaywrightGestures';
 
+async enterPassword(password: string): Promise<void> {
+  await encapsulatedAction({
+    appium: async () => {
+      await Gestures.typeText(this.passwordInput, password);
+      await PlaywrightGestures.hideKeyboard(); // iOS Appium requires explicit dismiss
+    },
+  });
+}
+```
+
+Legacy dual-runner branches remain for remaining Detox suites; new work should only need Appium / platform variants:
+
+```typescript
 async enterPassword(password: string): Promise<void> {
   await encapsulatedAction({
     detox: async () => {
@@ -172,45 +213,33 @@ async enterPassword(password: string): Promise<void> {
 }
 ```
 
-**Only use `encapsulatedAction` when the flow genuinely differs.** If the same `Gestures.*` or `Assertions.*` call works for both, there is no need to branch.
+**Only use `encapsulatedAction` when the flow genuinely differs.** If the same `Gestures.*` or `Assertions.*` call works on both platforms, there is no need to branch.
 
 ### Selector decision tree
 
 ```
-Does the same Matchers.getElementByID/Text/Label call work for both?
+Does the same Matchers.getElementByID/Text/Label call work on Appium (iOS + Android)?
   YES → use it directly, no branching needed
 
-  NO → Does only the testID value differ per framework?
-    YES → resolve({ detoxTestID, appiumTestID, ... })
+  NO → Does only the testID value differ per platform?
+    YES → resolve({ testID, iosAppiumTestID }) when Android shares testID
+          OR encapsulated({ appium: { android: () => ..., ios: () => ... } }) for Appium-only
+          OR legacy resolve({ detoxTestID, androidAppiumTestID, iosAppiumTestID }) if Detox still runs
 
     NO → Does only the selector type differ (ID vs text vs label)?
-      YES → encapsulated({ detox: ..., appium: ... })
+      YES → encapsulated({ appium: ... }) — or legacy detox/appium branches if migrating
 
       NO → Does the action flow itself differ?
-        YES → encapsulatedAction({ detox: ..., appium: ... })
+        YES → encapsulatedAction({ appium: ... }) — or legacy detox/appium branches if migrating
 ```
 
-## Test Organization — Detox vs Appium Specs
+## Test Organization — Appium Specs
 
-Detox smoke tests live in `tests/smoke/`. Appium equivalents live in `tests/smoke-appium/` with the same folder structure. Because page objects are cross-framework, the test body is nearly identical — only the runner wrapper and login helper differ.
+Appium smoke tests live in `tests/smoke-appium/`. Page objects use the `Gestures`/`Assertions`/`Matchers` facades so specs stay runner-agnostic aside from the Playwright fixture wrapper and login helper.
 
 **Running Appium smoke locally:** see [Appium smoke testing](./appium-smoke-testing.md) for builds (`main-e2e-MetaMask.app`), commands (`yarn appium-smoke:ios`), and CI artifact download.
 
 ```typescript
-// Detox: tests/smoke/accounts/my-feature.spec.ts
-describe(SmokeAccounts('My feature'), () => {
-  it('does the thing', async () => {
-    await withFixtures(
-      { fixture: new FixtureBuilder().build(), restartDevice: true },
-      async () => {
-        await loginToApp();
-        await SomePage.tapSomething();
-        await Assertions.expectElementToBeVisible(SomePage.result);
-      },
-    );
-  });
-});
-
 // Appium: tests/smoke-appium/accounts/my-feature.spec.ts
 appiumTest.describe(SmokeAccounts('My feature'), () => {
   appiumTest(
@@ -224,8 +253,8 @@ appiumTest.describe(SmokeAccounts('My feature'), () => {
         },
         async () => {
           await loginToAppPlaywright({ scenarioType: 'e2e' });
-          await SomePage.tapSomething(); // identical
-          await Assertions.expectElementToBeVisible(SomePage.result); // identical
+          await SomePage.tapSomething();
+          await Assertions.expectElementToBeVisible(SomePage.result);
         },
       );
     },
@@ -233,13 +262,12 @@ appiumTest.describe(SmokeAccounts('My feature'), () => {
 });
 ```
 
-The only required differences are:
+Required Appium spec differences:
 
 - `import { test as appiumTest }` from the Playwright fixture index
 - `{ driver: _driver, currentDeviceDetails }` fixture args
 - `currentDeviceDetails` passed to `withFixtures`
-- `loginToAppPlaywright(...)` instead of `loginToApp()`
-- Drop any `device.*` (Detox-only) calls
+- `loginToAppPlaywright(...)` instead of legacy Detox `loginToApp()`
 
 ## Test Atomicity and Coupling
 
@@ -397,10 +425,10 @@ The following patterns are prohibited in test specs:
    await Assertions.expectElementToBeVisible(element);
    ```
 
-4. **Framework-specific imports in page objects when not needed**
+4. **Playwright-specific imports in page objects when not needed**
 
    ```typescript
-   // DON'T — unnecessary when the same call works cross-framework:
+   // DON'T — unnecessary when Gestures/Assertions handle the flow:
    import PlaywrightAssertions from '../framework/PlaywrightAssertions';
    import { asPlaywrightElement } from '../framework/EncapsulatedElement';
 
@@ -480,8 +508,9 @@ Before submitting E2E tests, ensure:
 - [ ] Element selectors defined once and reused
 - [ ] Framework configuration used appropriately
 - [ ] Error handling for expected failure scenarios
-- [ ] `Gestures`/`Assertions`/`Matchers` used directly — `PlaywrightAssertions`, `PlaywrightGestures`, `asPlaywrightElement` only imported when the flow genuinely requires framework-specific branching
-- [ ] `encapsulatedAction` only used when Detox and Appium flows structurally differ — not just to call the same method twice
+- [ ] `Gestures` used for interactions — do **not** import or call `UnifiedGestures`
+- [ ] `Gestures`/`Assertions`/`Matchers` used directly — `PlaywrightAssertions`, `PlaywrightGestures`, `asPlaywrightElement` only imported when the flow genuinely requires platform-specific branching
+- [ ] `encapsulatedAction` only used when iOS and Android Appium flows structurally differ — not just to call the same method twice
 
 ## Debugging Failed Tests
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,13 +1,14 @@
 # tests/ — AGENTS.md
 
-Single agent index for **tests/**, and **wdio/**. Pointers only; details live in the canonical sources below.
+Single agent index for **tests/**. Pointers only; details live in the canonical sources below.
 
 ## Scope
 
-- **tests/smoke** — `tests/smoke/`, `tests/page-objects/`, `tests/selectors/`, config. Specs, Page Objects, selectors. Consumes `tests/framework/` and fixtures.
-- **tests/smoke-appium** — Appium smoke specs (Playwright). Same Page Objects/framework as Detox smoke.
-- **tests/** — `tests/framework/`, `tests/api-mocking/`, `tests/docs/`, `tests/smoke/`, `tests/smoke-appium/`, etc. Framework, fixtures, mocking, smoke specs.
-- **wdio/** — `wdio/helpers/`, `wdio/screen-objects/`, `wdio/utils/`. Legacy WebdriverIO/Appium — **deprecated**. Use Detox + tests/smoke or Playwright for performance.
+- **tests/smoke-appium** — Appium smoke specs (Playwright). Primary E2E path for new coverage.
+- **tests/page-objects**, **tests/selectors** — Shared Page Objects and selectors used by Appium smoke.
+- **tests/** — `tests/framework/`, `tests/api-mocking/`, `tests/docs/`, `tests/smoke-appium/`, etc. Framework, fixtures, mocking, smoke specs.
+- **tests/smoke** — Legacy Detox smoke (do not add new coverage here; treat as gone for new work).
+- **wdio/** — Removed / deprecated legacy WebdriverIO. Do not extend.
 - **component view tests** — `app/**/*.view.test.tsx`. Jest component view tests.
 - **integration tests** — `app/**/*.integration.test.ts?(x)`. Jest controller-app integration tests that use `tests/integration/` harnesses and `jest.config.integration.js`.
 
@@ -19,7 +20,7 @@ Single agent index for **tests/**, and **wdio/**. Pointers only; details live in
 
 - [tests/integration/AGENTS.md](integration/AGENTS.md) — Agent index for integration tests: harnesses, layer boundaries, canonical skill, run commands, enforcement.
 
-### E2E Tests (Detox smoke + Appium smoke)
+### E2E Tests (Appium smoke)
 
 - [docs/testing/e2e-testing.md](../docs/testing/e2e-testing.md) — Canonical guide: patterns, Page Objects, assertions, gestures, prohibited patterns.
 - [docs/testing/appium-smoke-testing.md](../docs/testing/appium-smoke-testing.md) — Appium smoke: main-e2e builds, `yarn appium-smoke:*`, local setup, CI.
@@ -28,9 +29,11 @@ Single agent index for **tests/**, and **wdio/**. Pointers only; details live in
 
 - [docs/testing/e2e-testing.md](../docs/testing/e2e-testing.md) — Patterns, Page Objects, assertions, gestures, prohibited patterns.
 - [docs/testing/appium-smoke-testing.md](../docs/testing/appium-smoke-testing.md) — Appium smoke tests: builds, run commands, local/CI setup.
-- [docs/readme/e2e-testing.md](../docs/readme/e2e-testing.md) — Setup, run commands, build types, Metro, Detox, Flask; Appium smoke quick start.
-- [.github/guidelines/E2E_DECISION_TREE.md](../.github/guidelines/E2E_DECISION_TREE.md) — CI decision flow: when E2E runs, which labels gate it (pr-not-ready-for-e2e, skip-e2e, skip-smart-e2e-selection), AI test selection logic.
+- [docs/readme/e2e-testing.md](../docs/readme/e2e-testing.md) — Setup, run commands, build types, Metro; Appium smoke quick start.
+- [.github/guidelines/E2E_DECISION_TREE.md](../.github/guidelines/E2E_DECISION_TREE.md) — CI decision flow: when E2E runs, which labels gate it, AI test selection logic.
 - [tests/docs/README.md](docs/README.md) — Framework structure, withFixtures, FixtureBuilder, anti-patterns, checklist.
+- [tests/docs/UNIFIED_E2E_ARCHITECTURE.md](docs/UNIFIED_E2E_ARCHITECTURE.md) — Appium layered architecture.
+- [tests/docs/UNIFIED_GESTURES_MIGRATION.md](docs/UNIFIED_GESTURES_MIGRATION.md) — Migrate off UnifiedGestures → Gestures.
 - [tests/docs/PLAYWRIGHT_LOCAL_EMULATOR.md](docs/PLAYWRIGHT_LOCAL_EMULATOR.md) — Local `buildPath` vs pre-installed app, `fullReset` / `noReset` for `EmulatorConfigBuilder`.
 - [tests/docs/MOCKING.md](docs/MOCKING.md) — API mocking, default and test-specific mocks.
 - [tests/docs/analytics-e2e.md](docs/analytics-e2e.md) — MetaMetrics E2E: `analyticsExpectations` on `withFixtures`, presets, `runAnalyticsExpectations`.
@@ -46,8 +49,8 @@ Unit tests under `tests/` (e.g. framework tests): [docs/testing/unit-testing.md]
 
 ## Before working
 
-- **tests/** — Use `withFixtures` + `FixtureBuilder`; Page Object methods only; no `TestHelpers.delay()`; selectors in `tests/selectors/` or page folder; import from `tests/framework/index.ts`. Detox commands: [docs/readme/e2e-testing.md](../docs/readme/e2e-testing.md). Appium smoke: [docs/testing/appium-smoke-testing.md](../docs/testing/appium-smoke-testing.md).
-- **tests/** — Framework/mocking: read tests/docs/README and MOCKING; keep exports in `tests/framework/index.ts`. Smoke: same as e2e (withFixtures, Page Objects, no delay). Yarn only.
+- **E2E (new work)** — Appium smoke only (`tests/smoke-appium/`). Use `withFixtures` + `FixtureBuilder`; Page Object methods only; no `TestHelpers.delay()`; selectors in `tests/selectors/` or page folder; import `Gestures` / `Assertions` / `Matchers` from `tests/framework/index.ts`. **Do not** import `UnifiedGestures`. Runbook: [docs/testing/appium-smoke-testing.md](../docs/testing/appium-smoke-testing.md).
+- **tests/framework** — Framework/mocking: read tests/docs/README and MOCKING; keep exports in `tests/framework/index.ts`. Yarn only.
 - **component view tests** — No fake timers (`jest.useFakeTimers` / `advanceTimersByTime`); use `waitFor` or real delays. See [docs/testing/component-view-tests.md](../docs/testing/component-view-tests.md).
 - **integration tests** — Use `tests/integration/harnesses/<domain>.ts`; no test-local `jest.mock(...)`; run with `yarn jest -c jest.config.integration.js`. See [tests/integration/AGENTS.md](integration/AGENTS.md).
-- **wdio/** — Do not extend. New work: Detox + tests/smoke or Appwright (`tests/`). If maintaining: legacy section in [docs/readme/e2e-testing.md](../docs/readme/e2e-testing.md).
+- **wdio/** / **tests/smoke (Detox)** — Do not extend. New coverage goes to Appium smoke.

--- a/tests/docs/README.md
+++ b/tests/docs/README.md
@@ -13,8 +13,8 @@
 
 ## E2E Framework Structure
 
-- **Smoke Testing Scenarios (`tests/smoke/`)** - Smoke Test files organized by feature (Detox)
-- **Appium smoke (`tests/smoke-appium/`)** - Playwright + Appium smoke parity with `tests/smoke/` — see [appium-smoke-testing.md](../../docs/testing/appium-smoke-testing.md)
+- **Appium smoke (`tests/smoke-appium/`)** — Primary E2E path for new coverage (Playwright + Appium). See [appium-smoke-testing.md](../../docs/testing/appium-smoke-testing.md)
+- **Legacy Detox smoke (`tests/smoke/`)** — Do not add new coverage here; treat as gone for new work
 - **TypeScript Framework (`tests/framework/`)**: Modern testing framework with type safety
 - **Page Objects (`tests/page-objects/`)**: Page Object Model implementation
 - **Selectors (`tests/selectors/`)**: Element selectors organized by feature
@@ -34,8 +34,8 @@
 **Key E2E Directories:**
 
 - `tests/framework/` - TypeScript framework foundation (USE THIS)
-- `tests/smoke/` - Detox smoke tests organized by feature
-- `tests/smoke-appium/` - Appium smoke tests (Playwright); same layout as `tests/smoke/`
+- `tests/smoke-appium/` - Appium smoke tests (Playwright); primary path for new specs
+- `tests/smoke/` - Legacy Detox smoke (do not add new coverage)
 - `tests/page-objects/` - Page Object classes following POM pattern
 - `tests/selectors/` - Element selectors (avoid direct use in tests)
 - `tests/api-mocking/` - API mocking utilities and responses
@@ -74,7 +74,7 @@ await withFixtures(
 - ✅ **ALWAYS** define element selectors in page objects or selector files
 - ✅ **ALWAYS** access UI elements through page object methods
 - ❌ **NEVER** use `element(by.id())` directly in test specs
-- ❌ **NEVER** use raw Detox assertions in test specs
+- ❌ **NEVER** use raw driver assertions or Detox APIs in new specs
 
 **Test Structure Requirements:**
 
@@ -265,7 +265,7 @@ await Assertions.checkIfVisible(element);
 // DON'T: Use direct element selectors in tests
 element(by.id('send-button')).tap();
 
-// DON'T: Use raw Detox assertions
+// DON'T: Use raw driver assertions or Detox APIs in new specs
 await waitFor(element).toBeVisible();
 
 // DON'T: Missing descriptions
@@ -331,9 +331,10 @@ await Utilities.executeWithRetry(
 
 ## Existing tooling
 
-| Tool                 | Type              | Current use          | When to use                                                                                                         | Notes and Limitations                                                                                                                                                                                                                                                                         |
-| -------------------- | ----------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Component View Tests | White box testing | UI integration tests | - When following a full user flow is not needed <br> - When we want to test individual component and view rendering | - Does **not** require builds <br> - Low cost (faster runtime) <br> - Fast feedback loop                                                                                                                                                                                                      |
-| Detox                | Grey box testing  | E2E                  | - When we want to test user flows <br> - Run on PR basis                                                            | - High cost <br> - Low tool (detox) maintenance <br> - JS/TS based test files <br> - Handles deeply nested elements better (easier to find and locate elements) <br> - Uses emulators/simulators <br> - Allows runs with local Builds <br> - Can't be used with real devices (cloud included) |
-| Maestro              | Black box testing | TBD                  | TBD                                                                                                                 | - **Still in experimentation phase (!)** <br> - Struggles with deeply nested elements <br> - YAML based spec files <br> - Allows runs with local builds <br> - Can run on real devices (cloud) but can't be used with real devices                                                            |
-| Appium               | Black box testing | Performance tests    | - When we want to test user flows as a end user <br> - When we want to measure and report performance stats         | - High cost <br> - Struggles with deeply nested <br> - Uses a Cloud provider for real device testing elements <br> - Does not allow runs with local builds                                                                                                                                    |
+| Tool                      | Type              | Current use          | When to use                                                                                                         | Notes and Limitations                                                                                                                                                                                                              |
+| ------------------------- | ----------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Component View Tests      | White box testing | UI integration tests | - When following a full user flow is not needed <br> - When we want to test individual component and view rendering | - Does **not** require builds <br> - Low cost (faster runtime) <br> - Fast feedback loop                                                                                                                                           |
+| Appium smoke (Playwright) | Black box testing | **Current E2E**      | - New smoke / user-flow coverage <br> - PR and CI smoke (`tests/smoke-appium/`)                                     | - Uses `main-e2e` builds and Playwright fixture <br> - See [appium-smoke-testing.md](../../docs/testing/appium-smoke-testing.md) <br> - Page objects use `Gestures` / `Assertions` / `Matchers` facades                            |
+| Detox                     | Grey box testing  | Legacy E2E           | - Maintaining existing `tests/smoke/` specs only — **do not add new Detox coverage**                                | - High cost <br> - JS/TS based test files <br> - Uses emulators/simulators <br> - Being phased out in favor of Appium smoke                                                                                                        |
+| Maestro                   | Black box testing | TBD                  | TBD                                                                                                                 | - **Still in experimentation phase (!)** <br> - Struggles with deeply nested elements <br> - YAML based spec files <br> - Allows runs with local builds <br> - Can run on real devices (cloud) but can't be used with real devices |
+| Appium (WDIO / cloud)     | Black box testing | Performance tests    | - When we want to test user flows as an end user <br> - When we want to measure and report performance stats        | - High cost <br> - Struggles with deeply nested elements <br> - Uses a cloud provider for real device testing <br> - Separate from Appium smoke / Playwright path                                                                  |

--- a/tests/docs/UNIFIED_E2E_ARCHITECTURE.md
+++ b/tests/docs/UNIFIED_E2E_ARCHITECTURE.md
@@ -1,295 +1,59 @@
-# Final Architecture - Unified E2E Framework
+# E2E Architecture (Appium)
 
 ## Overview
 
-A clean, layered architecture for writing page objects that work with **both Detox and WebdriverIO**.
+Page objects and smoke specs target **Appium + Playwright** (`tests/smoke-appium/`). Use the canonical facades from `tests/framework/index.ts`:
 
-## Architecture Layers
+- `Matchers` — element locators
+- `Gestures` — taps, typing, swipes, scrolls
+- `Assertions` — waits and expectations
 
-### Complete Stack
+Do **not** import `UnifiedGestures` in page objects or specs. It remains an internal dual-runner implementation detail used by `Gestures` on Appium until Detox removal is complete.
+
+## Layers
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│              Page Objects (Your Code)                       │
-│       - LoginView, SettingsView, etc.                       │
+│ Page Objects (Your Code) │
+│ - LoginView, SettingsView, etc. │
 └─────────────────────────────────────────────────────────────┘
-                              ↓
-        ┌─────────────────────────────────────┐
-        │   Element Locators (encapsulated)   │
-        │     detox: () => Matchers...        │
-        │     appium: () => PlaywrightMatchers│
-        └─────────────────────────────────────┘
-                              ↓
-                  ┌───────────┴───────────┐
-                  ↓                       ↓
-        ┌─────────────────┐     ┌──────────────────┐
-        │  DetoxElement   │     │ PlaywrightElement │
-        │  (Promise)      │     │  (Promise)        │
-        └─────────────────┘     └──────────────────┘
-                  ↓                       ↓
-        ┌─────────────────┐     ┌──────────────────┐
-        │    Matchers     │     │PlaywrightMatchers│
-        │    (Detox)      │     │  (WebdriverIO)   │
-        │  - getByID      │     │  - getByXPath    │
-        │  - getByText    │     │  - getByText     │
-        │  - getByLabel   │     │  - getByAccessID │
-        └─────────────────┘     └──────────────────┘
-                              ↓
-                  ┌───────────┴───────────┐
-                  ↓                       ↓
-        ┌─────────────────┐     ┌──────────────────┐
-        │    Gestures     │     │PlaywrightGestures│
-        │    (Detox)      │     │  (WebdriverIO)   │
-        └─────────────────┘     └──────────────────┘
-                              ↓
-        ┌─────────────────────────────────────┐
-        │      Detox / WebdriverIO APIs       │
-        │   (Native element interactions)     │
-        └─────────────────────────────────────┘
+↓
+Matchers / Gestures / Assertions
+↓
+Appium (Playwright) adapters & strategies
+↓
+Device / emulator APIs
 ```
 
-### Locator Flow in Detail
-
-```
-Page Object Getter
-       ↓
-encapsulated({
-  detox: () => Matchers.getElementByID('my-id'),      ← Function
-  appium: () => PlaywrightMatchers.getByXPath('...')  ← Function
-})
-       ↓
-FrameworkDetector.detect()
-       ↓
-  ┌────┴─────┐
-  ↓          ↓
-DETOX      APPIUM
-  ↓          ↓
-Execute    Execute
-detox()    appium()
-  ↓          ↓
-Matchers   PlaywrightMatchers
-.getByID   .getByXPath
-  ↓          ↓
-element(   driver.$
-by.id())   (xpath)
-  ↓          ↓
-Returns    Returns
-DetoxElement  Promise<PlaywrightElement>
-```
-
-## Core Components
-
-### 1. Element Locators (Function-Based) - The Foundation
-
-**Pattern:**
+## Default page object pattern
 
 ```typescript
-get passwordInput(): EncapsulatedElementType {
-  return encapsulated({
-    detox: () => Matchers.getElementByID('password-input'),
-    appium: () => PlaywrightMatchers.getByXPath('//*[@resource-id="password-input"]'),
-  });
-}
-```
+import Matchers from '../framework/Matchers';
+import Gestures from '../framework/Gestures';
+import Assertions from '../framework/Assertions';
 
-**Locator Levels Explained:**
+class LoginPage {
+  get passwordInput() {
+    return Matchers.getElementByID('login-password-input');
+  }
 
-```
-Level 1: Page Object Getter
-         ↓
-get passwordInput(): EncapsulatedElementType
-
-Level 2: Encapsulated Configuration
-         ↓
-return encapsulated({
-  detox: () => Matchers.getElementByID('password-input'),
-  appium: () => PlaywrightMatchers.getByXPath('//*[@resource-id="password-input"]')
-})
-
-Level 3: Framework Detection
-         ↓
-FrameworkDetector.detect()
-         ↓
-    ┌────┴────┐
-    ↓         ↓
-  DETOX    APPIUM
-
-Level 4: Execute Locator Function
-         ↓         ↓
-  detox()    appium()
-         ↓         ↓
-  Matchers   PlaywrightMatchers
-
-Level 5: Find Element
-         ↓         ↓
-element(by.id)  driver.$(xpath)
-         ↓         ↓
-  DetoxElement  PlaywrightElement
-```
-
-**Key Points:**
-
-- ✅ **Level 1-2:** Define once in page object
-- ✅ **Level 3:** Automatic framework detection
-- ✅ **Level 4-5:** Execute appropriate locator
-- ✅ **Level 6 (Optional):** Unwrap for direct WebdriverIO access
-- ✅ Use functions that return elements (lazy evaluation)
-- ✅ Leverage existing `Matchers` helpers
-- ✅ No new patterns to learn
-
-**When to Use `unwrap()`:**
-
-```typescript
-// ✅ Most cases - use PlaywrightElement API
-const elem = await asPlaywrightElement(LoginView.passwordInput);
-await elem.fill('text');
-await elem.click();
-
-// ✅ When you need WebdriverIO-specific methods
-const elem = await asPlaywrightElement(LoginView.passwordInput);
-const wdioElem = elem.unwrap();
-await wdioElem.touchAction([{ action: 'longPress', x: 100, y: 200 }]);
-await wdioElem.moveTo({ xOffset: 50, yOffset: 50 });
-await wdioElem.dragAndDrop(targetElement);
-// Any ChainablePromiseElement method!
-```
-
-**Real Example with Values:**
-
-```typescript
-// Level 1: Page Object
-get passwordInput(): EncapsulatedElementType {
-  // Level 2: Encapsulated configuration
-  return encapsulated({
-    detox: () => Matchers.getElementByID('login-password-input'),
-    appium: () => PlaywrightMatchers.getByXPath('//*[@resource-id="login-password-input"]')
-  });
-}
-
-// When used in test:
-await LoginView.enterPassword('MyPassword123');
-         ↓
-// Level 3: Framework detected = APPIUM
-         ↓
-// Level 4: Execute appium() function
-         ↓
-PlaywrightMatchers.getByXPath('//*[@resource-id="login-password-input"]')
-         ↓
-// Level 5: WebdriverIO finds element
-         ↓
-driver.$('//*[@resource-id="login-password-input"]')
-         ↓
-// Returns: PlaywrightElement wrapping the WebdriverIO element
-         ↓
-await elem.fill('MyPassword123');
-
-// Optional Level 6: Unwrap for low-level access
-         ↓
-const wdioElement = elem.unwrap();
-         ↓
-// Direct WebdriverIO API access when needed
-await wdioElement.touchAction([...]);
-await wdioElement.moveTo();
-await wdioElement.getAttribute('content-desc');
-// ... any WebdriverIO ChainablePromiseElement method
-```
-
-**Key Points:**
-
-- ✅ Framework detection encapsulated
-- ✅ Proxies to appropriate implementation
-- ✅ Clean API for page objects
-
-### 3. PlaywrightGestures (WebdriverIO Wrapper)
-
-**Purpose:** Wrapper around PlaywrightElement API, future enhancement point.
-
-**Current:** Simple wrappers
-
-```typescript
-static async tap(elem: PlaywrightElement): Promise<void> {
-  await elem.tap();
-}
-```
-
-**Future:** Can add retries, stability, logging
-
-```typescript
-static async tap(elem: PlaywrightElement): Promise<void> {
-  await Utilities.executeWithRetry(async () => {
-    await elem.waitForDisplayed();
-    await elem.tap();
-  }, { timeout: 10000 });
-}
-```
-
-## Usage Patterns
-
-### Pattern 1: UnifiedGestures (Recommended for Simple Cases)
-
-```typescript
-class LoginView {
-  get passwordInput(): EncapsulatedElementType {
-    return encapsulated({
-      detox: () => Matchers.getElementByID('password'),
-      appium: () =>
-        PlaywrightMatchers.getByXPath('//*[@resource-id="password"]'),
+  async enterPassword(password: string): Promise<void> {
+    await Gestures.typeText(this.passwordInput, password, {
+      elemDescription: 'password input',
     });
   }
-
-  // Clean - no framework detection!
-  async enterPassword(password: string): Promise<void> {
-    await UnifiedGestures.replaceText(this.passwordInput, password);
-  }
-
-  async tapSubmit(): Promise<void> {
-    await UnifiedGestures.tap(this.submitButton);
-  }
 }
+
+export default new LoginPage();
 ```
 
-### Pattern 2: Direct Gestures (For Complex Cases)
+## When to branch
 
-```typescript
-class LoginView {
-  // When you need framework-specific options
-  async complexEntry(password: string): Promise<void> {
-    if (FrameworkDetector.isDetox()) {
-      await Gestures.typeText(this.passwordInput as DetoxElement, password, {
-        checkStability: true,
-        clearFirst: true,
-        hideKeyboard: true,
-      });
-    } else {
-      const elem = (await this.passwordInput) as PlaywrightElement;
-      await PlaywrightGestures.fill(elem, password);
-      // Future: Add custom retry logic here
-    }
-  }
-}
-```
+Prefer the same `Matchers` / `Gestures` / `Assertions` call for iOS and Android.
 
-### Pattern 3: Mixed (Best of Both)
+- Different testID / platform locator → `resolve({ testID, iosAppiumTestID, ... })`
+- Different selector strategy → `encapsulated({ appium: () => ... })` (legacy `detox` key may still exist for unmigrated suites; new work should not add Detox branches)
+- Structurally different action flow → `encapsulatedAction({ appium: async () => ... })`
 
-```typescript
-class MyPage {
-  // Simple actions - use UnifiedGestures
-  async tapButton(): Promise<void> {
-    await UnifiedGestures.tap(this.button);
-  }
-
-  // Complex actions - use direct Gestures
-  async complexFlow(): Promise<void> {
-    if (FrameworkDetector.isDetox()) {
-      await Gestures.tap(this.element as DetoxElement, {
-        checkStability: true,
-        timeout: 10000,
-      });
-    } else {
-      // Direct PlaywrightGestures access
-      const elem = (await this.element) as PlaywrightElement;
-      await PlaywrightGestures.tap(elem);
-    }
-  }
-}
-```
+Canonical guide: [docs/testing/e2e-testing.md](../../docs/testing/e2e-testing.md).  
+Runbook: [docs/testing/appium-smoke-testing.md](../../docs/testing/appium-smoke-testing.md).

--- a/tests/docs/UNIFIED_GESTURES_MIGRATION.md
+++ b/tests/docs/UNIFIED_GESTURES_MIGRATION.md
@@ -1,224 +1,53 @@
-# Unified Gestures Migration Guide
+# Migrate off UnifiedGestures → Gestures
 
-## Overview
+## Why
 
-`UnifiedGestures` is a static facade that lets page objects execute gestures without knowing whether Detox or Appium/WebdriverIO is running. It uses the **Strategy pattern**: a single `GestureStrategy` interface with two implementations (`DetoxGestureStrategy` and `AppiumGestureStrategy`), selected once at startup.
+`Gestures` is the **canonical** interaction API for Appium smoke. `UnifiedGestures` is a legacy dual-runner facade. New page objects and specs must use `Gestures` only (ESLint enforces this: error in smoke specs, warn in page objects).
 
-```
-Page Objects  →  UnifiedGestures (static)  →  GestureStrategy (interface)
-                                                  ├── DetoxGestureStrategy   → Gestures (existing)
-                                                  └── AppiumGestureStrategy  → PlaywrightElement / PlaywrightGestures
-```
+On Appium, `Gestures` already delegates to the Appium strategy — calling `UnifiedGestures` from page objects is redundant and confusing for agents/humans.
 
-This is the **action** counterpart to `encapsulated()` (which handles element locators). Together they let you write fully framework-agnostic page objects.
+## Migration steps (existing POs)
 
-## Available Methods
-
-| Method                                       | Description                                                                    |
-| -------------------------------------------- | ------------------------------------------------------------------------------ |
-| `tap(elem, opts?)`                           | Tap an element                                                                 |
-| `waitAndTap(elem, opts?)`                    | Wait for visibility then tap                                                   |
-| `typeText(elem, text, opts?)`                | Clear field and type text                                                      |
-| `replaceText(elem, text, opts?)`             | Replace existing text                                                          |
-| `swipe(elem, direction, opts?)`              | Swipe in a direction                                                           |
-| `scrollToElement(target, scrollView, opts?)` | Scroll until target is visible                                                 |
-| `longPress(elem, opts?)`                     | Long press an element                                                          |
-| `dblTap(elem, opts?)`                        | Double tap an element                                                          |
-| `tapAtPoint(elem, point, opts?)`             | Tap at specific {x, y} coordinates on an element                               |
-| `tapAtIndex(elem, index, opts?)`             | Tap the nth matching element (accepts single element or `PlaywrightElement[]`) |
-
-All methods accept optional `UnifiedGestureOptions`:
-
-```typescript
-interface UnifiedGestureOptions {
-  timeout?: number; // Max wait time in ms
-  description?: string; // For logging / error messages
-  hideKeyboard?: boolean; // Dismiss keyboard after typing (default: true)
-  clearFirst?: boolean; // Clear field before typing — Detox only (default: true)
-}
-```
-
-## Migration Steps
-
-### 1. Update element getters to use `encapsulated()`
-
-If your page object still uses Detox-only matchers, convert them first:
+### 1. Change the import
 
 ```typescript
 // Before
-get passwordInput(): DetoxElement {
-  return Matchers.getElementByID(LoginViewSelectors.PASSWORD_INPUT);
-}
+import UnifiedGestures from '../../framework/UnifiedGestures';
+// or
+import { UnifiedGestures } from '../../framework';
 
 // After
-get passwordInput(): EncapsulatedElementType {
-  return encapsulated({
-    detox: () => Matchers.getElementByID(LoginViewSelectors.PASSWORD_INPUT),
-    appium: () => PlaywrightMatchers.getElementById(LoginViewSelectors.PASSWORD_INPUT),
-  });
-}
-```
-
-### 2. Replace `Gestures.*` calls with `UnifiedGestures.*`
-
-```typescript
-// Before
+import Gestures from '../../framework/Gestures';
+// or
 import { Gestures } from '../../framework';
-
-async enterPassword(password: string) {
-  await Gestures.typeText(this.passwordInput, password, {
-    hideKeyboard: true,
-    elemDescription: 'password field',
-  });
-}
-
-// After
-import { UnifiedGestures } from '../../framework';
-
-async enterPassword(password: string) {
-  await UnifiedGestures.typeText(this.passwordInput, password, {
-    description: 'password field',
-    hideKeyboard: true,
-  });
-}
 ```
 
-Framework-specific options like `checkStability` are still handled per strategy. `hideKeyboard` and `clearFirst` are unified:
+### 2. Rename call sites
 
-- **Detox**: forwarded to `Gestures.typeText` (`hideKeyboard` appends `\n`; default both `true`)
-- **Appium**: `fill()` then `PlaywrightGestures.hideKeyboard()` when `hideKeyboard` is true (default `true`)
+| Before                                 | After                           |
+| -------------------------------------- | ------------------------------- |
+| `UnifiedGestures.tap(...)`             | `Gestures.tap(...)`             |
+| `UnifiedGestures.waitAndTap(...)`      | `Gestures.waitAndTap(...)`      |
+| `UnifiedGestures.typeText(...)`        | `Gestures.typeText(...)`        |
+| `UnifiedGestures.replaceText(...)`     | `Gestures.replaceText(...)`     |
+| `UnifiedGestures.swipe(...)`           | `Gestures.swipe(...)`           |
+| `UnifiedGestures.scrollToElement(...)` | `Gestures.scrollToElement(...)` |
+| `UnifiedGestures.longPress(...)`       | `Gestures.longPress(...)`       |
+| `UnifiedGestures.dblTap(...)`          | `Gestures.dblTap(...)`          |
+| `UnifiedGestures.tapAtPoint(...)`      | `Gestures.tapAtPoint(...)`      |
+| `UnifiedGestures.tapAtIndex(...)`      | `Gestures.tapAtIndex(...)`      |
 
-### 3. Handle edge cases with `encapsulatedAction()`
+### 3. Option naming
 
-For the rare ~3% of methods where Detox and Appium need structurally different flows:
+Prefer Gestures option names already used in the codebase (`elemDescription`, etc.). If a call used Unified-only `description`, map it to the Gestures equivalent used by neighboring methods in the same file.
 
-```typescript
-import { encapsulatedAction } from '../../framework';
+## Do not
 
-async dismissOnboarding() {
-  await encapsulatedAction({
-    detox: async () => {
-      await Gestures.swipe(this.overlay, 'up');
-      await Gestures.tap(this.dismissButton);
-    },
-    appium: async () => {
-      const btn = await asPlaywrightElement(this.dismissButton);
-      await btn.click();
-    },
-  });
-}
-```
+- Do not add new `UnifiedGestures` imports.
+- Do not remove the `UnifiedGestures` export from `tests/framework/index.ts` until Phase 2 cleanup (breaks remaining call sites and `Gestures` internals).
+- Full repo-wide codemod is **Phase 2** (after Detox smoke is empty).
 
-Both `detox` and `appium` branches are **optional** — you can provide only one when the method only exists for a single framework. This is useful during incremental migration when porting a method that has no equivalent on the other side:
+## Canonical docs
 
-```typescript
-// Only the appium branch is needed — Detox doesn't have this flow
-async waitForScreenToDisplay() {
-  await encapsulatedAction({
-    appium: async () => {
-      const element = await asPlaywrightElement(this.title);
-      await element.waitForDisplayed({ timeout: 15000 });
-    },
-  });
-}
-```
-
-If the active framework doesn't have a matching branch, `encapsulatedAction` throws an error to catch misconfiguration early.
-
-## Escape Hatch
-
-When the unified approach becomes overly complex for a specific case, you can always use `FrameworkDetector` or `PlatformDetector` directly for custom conditional logic:
-
-```typescript
-import { FrameworkDetector } from '../../framework';
-
-async complexSpecialCase() {
-  if (FrameworkDetector.isDetox()) {
-    // Detox-specific multi-step flow
-  } else {
-    // Appium-specific multi-step flow
-  }
-}
-```
-
-This should be the last resort. Prefer `UnifiedGestures` > `encapsulatedAction()` > direct `FrameworkDetector` checks, in that order.
-
-## Full Before/After Example
-
-### Before (Detox-only)
-
-```typescript
-import { Gestures, Matchers } from '../../framework';
-import { LoginViewSelectors } from '../../selectors/LoginView.selectors';
-
-class LoginView {
-  get passwordInput(): DetoxElement {
-    return Matchers.getElementByID(LoginViewSelectors.PASSWORD_INPUT);
-  }
-
-  get loginButton(): DetoxElement {
-    return Matchers.getElementByID(LoginViewSelectors.LOGIN_BUTTON);
-  }
-
-  async login(password: string) {
-    await Gestures.typeText(this.passwordInput, password, {
-      hideKeyboard: true,
-      elemDescription: 'password input',
-    });
-    await Gestures.waitAndTap(this.loginButton, {
-      elemDescription: 'login button',
-    });
-  }
-}
-```
-
-### After (Unified)
-
-```typescript
-import { UnifiedGestures } from '../../framework';
-import {
-  encapsulated,
-  EncapsulatedElementType,
-  Matchers,
-  PlaywrightMatchers,
-} from '../../framework';
-import { LoginViewSelectors } from '../../selectors/LoginView.selectors';
-
-class LoginView {
-  get passwordInput(): EncapsulatedElementType {
-    return encapsulated({
-      detox: () => Matchers.getElementByID(LoginViewSelectors.PASSWORD_INPUT),
-      appium: () =>
-        PlaywrightMatchers.getElementById(LoginViewSelectors.PASSWORD_INPUT),
-    });
-  }
-
-  get loginButton(): EncapsulatedElementType {
-    return encapsulated({
-      detox: () => Matchers.getElementByID(LoginViewSelectors.LOGIN_BUTTON),
-      appium: () =>
-        PlaywrightMatchers.getElementById(LoginViewSelectors.LOGIN_BUTTON),
-    });
-  }
-
-  async login(password: string) {
-    await UnifiedGestures.typeText(this.passwordInput, password, {
-      description: 'password input',
-    });
-    await UnifiedGestures.waitAndTap(this.loginButton, {
-      description: 'login button',
-    });
-  }
-}
-```
-
-## FAQ
-
-**Q: Does this change existing Detox test behavior?**
-No. `DetoxGestureStrategy` wraps the existing `Gestures` class — all retry logic, stability checks, and platform-specific scroll behavior are preserved.
-
-**Q: What if I need a Detox-specific option like `checkStability`?**
-Use `encapsulatedAction()` and call `Gestures` directly in the Detox branch.
-
-**Q: Can I still use `Gestures` directly?**
-Yes. The `Gestures` class is not removed or modified. For Detox-only page objects that haven't been migrated, `Gestures` works exactly as before.
+- [docs/testing/e2e-testing.md](../../docs/testing/e2e-testing.md)
+- [docs/testing/appium-smoke-testing.md](../../docs/testing/appium-smoke-testing.md)

--- a/tests/framework/.eslintrc.js
+++ b/tests/framework/.eslintrc.js
@@ -89,5 +89,69 @@ module.exports = {
         ],
       },
     },
+    {
+      files: ['**/page-objects/**/*.{js,ts}', '**/flows/**/*.{js,ts}'],
+      excludedFiles: [
+        '**/page-objects/**/*.test.ts',
+        '**/page-objects/**/*.test.js',
+        '**/flows/**/*.test.ts',
+        '**/flows/**/*.test.js',
+      ],
+      rules: {
+        'no-restricted-imports': [
+          'warn',
+          {
+            patterns: [
+              {
+                group: ['**/UnifiedGestures', '**/UnifiedGestures.ts'],
+                message:
+                  'Use Gestures from tests/framework (canonical). UnifiedGestures is legacy dual-runner API.',
+              },
+              {
+                group: [
+                  '**/framework',
+                  '**/framework/index',
+                  '**/framework/index.ts',
+                  '**/framework/index.js',
+                ],
+                importNames: ['UnifiedGestures'],
+                message:
+                  'Use Gestures from tests/framework (canonical). UnifiedGestures is legacy dual-runner API.',
+              },
+            ],
+          },
+        ],
+      },
+    },
+    // MMQA-2174: ban UnifiedGestures in smoke specs (error)
+    {
+      files: ['**/smoke-appium/**/*.{js,ts}', '**/smoke/**/*.{js,ts}'],
+      excludedFiles: ['**/smoke-appium/**/*.test.ts', '**/smoke/**/*.test.ts'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          {
+            patterns: [
+              {
+                group: ['**/UnifiedGestures', '**/UnifiedGestures.ts'],
+                message:
+                  'Use Gestures from tests/framework (canonical). UnifiedGestures is legacy dual-runner API.',
+              },
+              {
+                group: [
+                  '**/framework',
+                  '**/framework/index',
+                  '**/framework/index.ts',
+                  '**/framework/index.js',
+                ],
+                importNames: ['UnifiedGestures'],
+                message:
+                  'Use Gestures from tests/framework (canonical). UnifiedGestures is legacy dual-runner API.',
+              },
+            ],
+          },
+        ],
+      },
+    },
   ],
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Phase 0 of the Detox → Appium migration ([MMQA-1941](https://consensyssoftware.atlassian.net/browse/MMQA-1941)): make E2E documentation and agent guidance a single Appium-only source of truth, and stop new code from adopting the dual-runner `UnifiedGestures` API.

**Why:** Canonical guides already prefer `Gestures`, but `tests/docs/UNIFIED_*.md` and `tests/AGENTS.md` still taught dual Detox+Appium / `UnifiedGestures`, so agents kept regenerating the dual style.

**What changed:**
- Rewrote `docs/testing/e2e-testing.md`, `tests/AGENTS.md`, `tests/docs/README.md`, and `UNIFIED_*.md` as Appium / Gestures-canonical (migrate *away* from `UnifiedGestures`).
- ESLint: `no-restricted-imports` (+ barrel `importNames`) and `no-restricted-syntax` ban `UnifiedGestures` — **error** in smoke specs, **warn** in page objects and flows.
- Kept `UnifiedGestures` exported from `tests/framework/index.ts` (still used internally by `Gestures` and by existing POs until Phase 2).
- Did **not** codemod existing PO call sites, ban `encapsulated*`, or delete Detox smoke trees.

Remaining Detox suites / dual-runner internals still exist until Phase 2 (full Unified→Gestures rename after Detox smoke is empty).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-2174

Refs: https://consensyssoftware.atlassian.net/browse/MMQA-1941

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — docs and ESLint-only change; no app runtime behavior.

Verification already run locally:

1. `yarn eslint tests/page-objects/wallet/LoginView.ts` → warns on `UnifiedGestures` (import + usage).
2. `yarn eslint tests/flows/wallet.flow.ts` → warns (not errors) on existing `UnifiedGestures` usage.
3. Temp smoke-appium barrel `import { UnifiedGestures } from '../framework'` → ESLint **error**.
4. `yarn eslint tests/framework/Gestures.ts tests/framework/UnifiedGestures.ts tests/framework/GestureStrategy.ts` → clean.
5. `yarn prettier --check` on touched config/docs files → pass.
6. Doc spot-check: no “prefer UnifiedGestures” / Detox-first new-work guidance in SSOT paths.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — documentation and lint configuration only; no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/UI/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Made with [Cursor](https://cursor.com)

[MMQA-1941]: https://consensyssoftware.atlassian.net/browse/MMQA-1941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ