### PR TITLE
test: fix predict flaky cv test

### DIFF
--- a/app/components/UI/Predict/views/PredictFeed/PredictFeed.view.test.tsx
+++ b/app/components/UI/Predict/views/PredictFeed/PredictFeed.view.test.tsx
@@ -11,7 +11,6 @@ import React from 'react';
 import '../../../../../../tests/component-view/mocks';
 import Engine from '../../../../../../app/core/Engine';
 import { useRoute } from '@react-navigation/native';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import {
   renderPredictFeedView,
   renderPredictFeedViewWithRoutes,
@@ -125,19 +124,6 @@ const PredictRootRouteParamsProbe = () => {
         {predictFeedTab}
       </Text>
     </>
-  );
-};
-
-const PredictRootNavigator = () => {
-  const Stack = createNativeStackNavigator();
-
-  return (
-    <Stack.Navigator>
-      <Stack.Screen
-        name={Routes.PREDICT.MARKET_DETAILS}
-        component={PredictRootRouteParamsProbe}
-      />
-    </Stack.Navigator>
   );
 };
 
@@ -739,9 +725,8 @@ describe('PredictFeed', () => {
         findByTestId,
       } = renderPredictFeedViewWithRoutes({
         overrides: predictUpDownFlagOverrides,
-        extraRoutes: [
-          { name: Routes.PREDICT.ROOT, Component: PredictRootNavigator },
-        ],
+        // Default probe is enough — we only assert navigation occurred.
+        extraRoutes: [{ name: Routes.PREDICT.ROOT }],
       });
 
       fireEvent.press(getByTestId(PredictSearchSelectorsIDs.SEARCH_BUTTON));
@@ -750,12 +735,13 @@ describe('PredictFeed', () => {
         'btc',
       );
 
-      const searchResult = await findByTestId(
-        getPredictSearchSelector.resultCard(0),
-        {},
-        { timeout: 3000 },
-      );
-      expect(searchResult).toBeOnTheScreen();
+      expect(
+        await findByTestId(
+          getPredictSearchSelector.resultCard(0),
+          {},
+          { timeout: 3000 },
+        ),
+      ).toBeOnTheScreen();
       expect(
         await findByTestId(
           PredictCryptoUpDownMarketCardSelectorsIDs.LIVE_BADGE,
@@ -763,7 +749,9 @@ describe('PredictFeed', () => {
       ).toBeOnTheScreen();
       expect(await findAllByText('BTC Up or Down - 5 Minutes')).toHaveLength(1);
 
-      fireEvent.press(searchResult);
+      // Re-query immediately before press: the live card clock re-renders every
+      // second, so a held element reference can go stale under CI load.
+      fireEvent.press(getByTestId(getPredictSearchSelector.resultCard(0)));
 
       expect(
         await findByTestId(`route-${Routes.PREDICT.ROOT}`),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Stabilizes a flaky PredictFeed component-view test that intermittently failed on `main` CI (including the [scheduled Component view tests (2) job](https://github.com/MetaMask/metamask-mobile/actions/runs/30885649921/job/91922530402#step:8:11)), while often passing on the same SHA in other runs.

**Why it failed**

`PredictFeed › crypto Up/Down consolidated card › renders one feed card per series and opens details from the live card` pressed a search-result node captured earlier with `findByTestId`, then asserted navigation to `route-Predict`. The crypto Up/Down live card uses a shared once-per-second clock (`useSyncExternalStore`) for the LIVE countdown, so the card re-renders frequently. Under CI load, that gap between capture and press can leave a stale element reference — `fireEvent.press` becomes a no-op, navigation never happens, and the test times out looking for `route-Predict`. The failure dump still showed the search overlay and LIVE badge, confirming the press never navigated. This is a timing race (amplified by CI), not shard pollution or a broken product change.

**Fix**

1. Register `Routes.PREDICT.ROOT` with the renderer's **default route probe** (`extraRoutes: [{ name: Routes.PREDICT.ROOT }]`) instead of a custom nested `PredictRootNavigator`. Per CV guidance, a probe is enough when the test only asserts that navigation occurred.
2. **Re-query** the result card with `getByTestId` immediately before `fireEvent.press`, so the press always targets a fresh node after live-clock re-renders.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://github.com/MetaMask/metamask-mobile/actions/runs/30885649921/job/91922530402

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — test-only change; no app UI or runtime behavior changed. Covered by:

```bash
yarn jest -c jest.config.view.js app/components/UI/Predict/views/PredictFeed/PredictFeed.view.test.tsx -t "opens details from the live card" --runInBand --silent --coverage=false
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — CI-only flake; see failing job log linked above (`Unable to find an element with testID: route-Predict` while search results remained on screen).

### **After**

N/A — test-only stabilization; no UI change.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
  - N/A — test-only change
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
  - N/A — test-only change
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example
  - N/A — test-only change

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
