### PR TITLE
fix: unblock Money Account rows while quotes load

### DIFF
--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -804,7 +804,7 @@ describe('CustomAmountInfo', () => {
       });
     });
 
-    it('keeps the loading review throughout quote loading', async () => {
+    it('unblocks account and payment rows while waiting for quotes', async () => {
       const { deferred } = arrangePendingPreparation();
       const view = render({
         transactionType: TransactionType.moneyAccountDeposit,
@@ -832,7 +832,7 @@ describe('CustomAmountInfo', () => {
       expect(
         view.getByTestId(CustomAmountInfoTestIds.REVIEW_ROWS).props
           .pointerEvents,
-      ).toBe('none');
+      ).toBe('auto');
       expect(
         view.getByTestId('custom-amount-input').props.onPress,
       ).toBeUndefined();
@@ -1006,6 +1006,10 @@ describe('CustomAmountInfo', () => {
       expect(
         view.getByTestId(ConfirmationFooterSelectorIDs.CONFIRM_BUTTON),
       ).toBeDisabled();
+      expect(
+        view.getByTestId(CustomAmountInfoTestIds.REVIEW_ROWS).props
+          .pointerEvents,
+      ).toBe('none');
 
       await act(async () => {
         deferred.resolve();
@@ -1103,6 +1107,11 @@ describe('CustomAmountInfo', () => {
 
       useIsTransactionPayLoadingMock.mockReturnValue(true);
       view.rerender(createCustomAmountInfo());
+      expect(
+        view.getByTestId(CustomAmountInfoTestIds.REVIEW_ROWS).props
+          .pointerEvents,
+      ).toBe('none');
+
       // A fresh, non-empty quote settles the override into the populated review.
       useIsTransactionPayLoadingMock.mockReturnValue(false);
       useTransactionPayQuotesMock.mockReturnValue([{}] as never);

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -5,6 +5,7 @@ import React, {
   useContext,
   useEffect,
   useRef,
+  useState,
 } from 'react';
 import { View } from 'react-native';
 import {
@@ -42,7 +43,10 @@ import {
   CustomAmount,
   CustomAmountSkeleton,
 } from '../../transactions/custom-amount';
-import { useTransactionPayFiatPayment } from '../../../hooks/pay/useTransactionPayData';
+import {
+  useIsTransactionPayQuoteLoading,
+  useTransactionPayFiatPayment,
+} from '../../../hooks/pay/useTransactionPayData';
 import { usePayWithMoneyAccountSection } from '../../../hooks/pay/sections/usePayWithMoneyAccountSection';
 import { useTransactionPayMetrics } from '../../../hooks/pay/useTransactionPayMetrics';
 import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
@@ -195,6 +199,8 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     // React batches rapid presses before the state update rerenders, so keep a
     // synchronous guard separate from the render state.
     const isAmountUpdateInProgressRef = useRef(false);
+    const [isAmountUpdatePending, setIsAmountUpdatePending] = useState(false);
+    const isQuotesLoading = useIsTransactionPayQuoteLoading();
     useMMPayNavigation(stage, setStage);
     const isFiatAvailable = useIsFiatPaymentAvailable();
     const moneyAccountSection = usePayWithMoneyAccountSection();
@@ -229,6 +235,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       }
 
       isAmountUpdateInProgressRef.current = true;
+      setIsAmountUpdatePending(true);
       // Enter the loading stage: keyboard hidden, totals skeletons shown.
       setStage(CustomAmountStage.Loading);
 
@@ -268,6 +275,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
         return;
       } finally {
         isAmountUpdateInProgressRef.current = false;
+        setIsAmountUpdatePending(false);
       }
       EngineService.flushState();
       hasAutoSubmittedPrefill.current = true;
@@ -354,6 +362,13 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       Boolean(accountOverride) &&
       (hasAccountNoFunds || stage === CustomAmountStage.Loading);
 
+    // Keep payment details fixed while the amount update prepares the request.
+    // Once a Money Account deposit quote is in flight, reopening either picker
+    // is safe and keeps the loading screen responsive.
+    const shouldBlockReviewRows =
+      stage === CustomAmountStage.Loading &&
+      (isAmountUpdatePending || !isMoneyAccountDeposit || !isQuotesLoading);
+
     const { headlessBuyError } = useConfirmationContext();
 
     return (
@@ -416,9 +431,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           )}
           {stage !== CustomAmountStage.AmountInput && (
             <View
-              pointerEvents={
-                stage === CustomAmountStage.Loading ? 'none' : 'auto'
-              }
+              pointerEvents={shouldBlockReviewRows ? 'none' : 'auto'}
               testID={CustomAmountInfoTestIds.REVIEW_ROWS}
             >
               {supportAccountSelection &&


### PR DESCRIPTION
## **Description**

Money Account deposit confirmations blocked the **Pay with** and **Account** rows for the entire quote-loading period, making the screen feel unresponsive.

This change keeps those rows blocked while the amount update prepares the quote request, then re-enables them once the quote request is in flight. Amount editing, totals, and confirmation controls remain in their loading state until quotes settle. Other transaction flows retain their existing behavior.

## **Changelog**

CHANGELOG entry: Fixed the Pay with and Account rows becoming unresponsive while Money Account deposit quotes load

## **Related issues**

Refs: Reported during MetaMask Mobile 8.6.0 RC testing

## **Manual testing steps**

```gherkin
Feature: Money Account deposit payment selection

  Scenario: Open payment selectors while a quote response is pending
    Given a user is entering an amount for a Money Account deposit

    When the user submits the amount
    Then the Pay with and Account rows remain blocked while the quote request is prepared

    When the quote request is in flight
    Then the user can open the Pay with selector
    And the user can open the Account selector
    And the confirmation remains disabled until the quote is displayed
```

## **Screenshots/Recordings**

N/A — this change only affects touch responsiveness during the quote-loading state.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've considered Android performance testing; not applicable to this interaction-state change
- [x] I've considered power-user scenario testing; not applicable to this interaction-state change
- [x] I've considered Sentry tracing; no new key operation is introduced

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI interaction change on the custom amount confirmation screen with targeted tests; no auth, payment execution, or quote logic changes.
> 
> **Overview**
> Money Account deposit confirmations no longer freeze **Pay with** and **Account** for the whole quote-loading phase.
> 
> **`CustomAmountInfo`** now blocks review-row touches only while the amount update is still preparing the quote request (`isAmountUpdatePending`). After that, for **`moneyAccountDeposit`** flows with quotes in flight (`useIsTransactionPayQuoteLoading`), review rows use **`pointerEvents: 'auto'`** so pickers stay tappable. Totals skeletons, disabled confirm, and non-editable amount behavior during loading are unchanged; other transaction types still block review rows for the full loading stage.
> 
> Tests in **`custom-amount-info.test.tsx`** were updated to expect **`auto`** during quote wait and **`none`** while the amount update is pending or for non–Money Account loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf0cc3c071e12464a26c83bdcf6883f3f9c4137c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->