### PR TITLE
chore(ramps): require chainId for addPrecreatedOrder (Core #9777)

### DIFF
--- a/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
@@ -481,6 +481,22 @@ describe('Checkout', () => {
         });
       });
     });
+
+    it('does not register when network/chainId is missing', async () => {
+      mockUseParams.mockReturnValue({
+        url: 'https://provider.example.com/checkout',
+        providerName: 'MoonPay',
+        providerCode: 'moonpay',
+        walletAddress: '0xabcdef1234567890',
+        orderId: 'mp-order-99',
+      });
+
+      renderWithProvider(<Checkout />, {}, true, false);
+
+      await waitFor(() => {
+        expect(mockAddPrecreatedOrder).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe('missing checkout URL', () => {

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
@@ -250,6 +250,13 @@ const mockShouldStartLoadWithRequest = jest.requireMock(
 const mockUseRampSDK = jest.requireMock('../../Aggregator/sdk')
   .useRampSDK as jest.Mock;
 const mockUuidV4 = jest.requireMock('uuid').v4 as jest.Mock;
+const mockUseDispatch = jest.requireMock('react-redux').useDispatch as jest.Mock;
+const mockProtectWalletModalVisible = jest.requireMock(
+  '../../../../../actions/user',
+).protectWalletModalVisible as jest.Mock;
+const mockCreateNavigationDetails = jest.requireMock(
+  '../../../../../util/navigation/navUtils',
+).createNavigationDetails as jest.Mock;
 
 const mockUseParams = jest.requireMock(
   '../../../../../util/navigation/navUtils',
@@ -283,6 +290,8 @@ describe('Checkout', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.resetAllMocks();
+    (Date.now as unknown as jest.Mock).mockReturnValue(123);
     capturedOnNavigationStateChange = undefined;
     mockGetRampCallbackBaseUrl.mockReturnValue(
       'https://on-ramp-content.api.cx.metamask.io/regions/fake-callback',
@@ -290,6 +299,16 @@ describe('Checkout', () => {
     mockShouldStartLoadWithRequest.mockReturnValue(true);
     mockUseRampSDK.mockReturnValue(null);
     mockUuidV4.mockReturnValue('mock-uuid-xyz');
+    mockUseDispatch.mockReturnValue(mockDispatch);
+    mockProtectWalletModalVisible.mockReturnValue({
+      type: 'PROTECT_WALLET_MODAL_VISIBLE',
+    });
+    mockCreateNavigationDetails.mockImplementation(
+      (_root: string, screen: string) => ({
+        name: screen,
+        params: {},
+      }),
+    );
     mockUseParams.mockReturnValue({
       url: 'https://provider.example.com/checkout',
       providerName: 'Test Provider',
@@ -321,10 +340,6 @@ describe('Checkout', () => {
         setOptions: mockHeadlessEntrySetOptions,
       }),
     }));
-  });
-
-  afterEach(() => {
-    jest.resetAllMocks();
   });
 
   describe('handleNavigationStateChange (callback flow)', () => {

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
@@ -250,7 +250,8 @@ const mockShouldStartLoadWithRequest = jest.requireMock(
 const mockUseRampSDK = jest.requireMock('../../Aggregator/sdk')
   .useRampSDK as jest.Mock;
 const mockUuidV4 = jest.requireMock('uuid').v4 as jest.Mock;
-const mockUseDispatch = jest.requireMock('react-redux').useDispatch as jest.Mock;
+const mockUseDispatch = jest.requireMock('react-redux')
+  .useDispatch as jest.Mock;
 const mockProtectWalletModalVisible = jest.requireMock(
   '../../../../../actions/user',
 ).protectWalletModalVisible as jest.Mock;

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.test.tsx
@@ -243,6 +243,14 @@ jest.mock('@metamask/react-native-webview', () => {
   };
 });
 
+const mockGetRampCallbackBaseUrl = getRampCallbackBaseUrl as jest.Mock;
+const mockShouldStartLoadWithRequest = jest.requireMock(
+  '../../../../../util/browser',
+).shouldStartLoadWithRequest as jest.Mock;
+const mockUseRampSDK = jest.requireMock('../../Aggregator/sdk')
+  .useRampSDK as jest.Mock;
+const mockUuidV4 = jest.requireMock('uuid').v4 as jest.Mock;
+
 const mockUseParams = jest.requireMock(
   '../../../../../util/navigation/navUtils',
 ).useParams as jest.Mock;
@@ -275,6 +283,13 @@ describe('Checkout', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    capturedOnNavigationStateChange = undefined;
+    mockGetRampCallbackBaseUrl.mockReturnValue(
+      'https://on-ramp-content.api.cx.metamask.io/regions/fake-callback',
+    );
+    mockShouldStartLoadWithRequest.mockReturnValue(true);
+    mockUseRampSDK.mockReturnValue(null);
+    mockUuidV4.mockReturnValue('mock-uuid-xyz');
     mockUseParams.mockReturnValue({
       url: 'https://provider.example.com/checkout',
       providerName: 'Test Provider',
@@ -297,6 +312,7 @@ describe('Checkout', () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires -- jest mock
     const nav = require('@react-navigation/native');
     nav.useNavigation.mockReturnValue(mockNavigation);
+    mockNavigation.isFocused.mockReturnValue(true);
     mockNavigation.getParent.mockReset();
     mockHeadlessEntrySetOptions.mockReset();
     mockNavigation.getParent.mockImplementation(() => ({
@@ -305,6 +321,10 @@ describe('Checkout', () => {
         setOptions: mockHeadlessEntrySetOptions,
       }),
     }));
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 
   describe('handleNavigationStateChange (callback flow)', () => {

--- a/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
+++ b/app/components/UI/Ramp/Views/Checkout/Checkout.tsx
@@ -395,13 +395,14 @@ const Checkout = () => {
     // providerCode and walletAddress are passed, so hasCallbackFlow is true
     // and we can register. hasCallbackFlow being false means we lack the data
     // required for addPrecreatedOrder anyway.
-    // Note: network/chainId is optional in addPrecreatedOrder; do not require it
-    // in the guard, otherwise orders with unusual chain ID formats (e.g. empty
-    // string from chainId.split(':')[1]) would silently skip registration here
-    // while external-browser flows would still register (BuildQuote passes
-    // chainId: network || undefined without requiring network).
+    // RampsController requires a non-empty chainId (see Core #9777); skip
+    // registration when network is missing rather than seeding an empty stub.
     const canRegister =
-      hasCallbackFlow && effectiveOrderId && providerCode && walletAddress;
+      hasCallbackFlow &&
+      effectiveOrderId &&
+      providerCode &&
+      walletAddress &&
+      network;
     if (!canRegister) return;
     if (registeredOrderIdsRef.current.has(effectiveOrderId)) return;
     registeredOrderIdsRef.current.add(effectiveOrderId);
@@ -409,7 +410,7 @@ const Checkout = () => {
       orderId: effectiveOrderId,
       providerCode,
       walletAddress,
-      chainId: network || undefined,
+      chainId: network,
     });
   }, [
     hasCallbackFlow,

--- a/app/components/UI/Ramp/hooks/useContinueWithQuote.test.ts
+++ b/app/components/UI/Ramp/hooks/useContinueWithQuote.test.ts
@@ -519,6 +519,44 @@ describe('useContinueWithQuote', () => {
       });
     });
 
+    it('registers a precreated order with chainId on the Android external-browser path', async () => {
+      mockDeviceIsAndroid.mockReturnValue(true);
+      mockGetBuyWidgetData.mockResolvedValue({
+        url: 'https://widget.example.com/checkout',
+        orderId: 'ord-android-1',
+      });
+
+      const { result } = renderHook(() => useContinueWithQuote());
+
+      const caught = await invoke(result, WIDGET_PROVIDER_QUOTE);
+
+      expect(caught).toBeUndefined();
+      expect(mockAddPrecreatedOrder).toHaveBeenCalledWith({
+        orderId: 'ord-android-1',
+        providerCode: 'moonpay',
+        walletAddress: '0x1234567890123456789012345678901234567890',
+        chainId: '1',
+      });
+    });
+
+    it('does not register a precreated order when chainId is missing', async () => {
+      mockDeviceIsAndroid.mockReturnValue(true);
+      mockUseRampsController.mockReturnValue(
+        buildController({ selectedToken: null }),
+      );
+      mockGetBuyWidgetData.mockResolvedValue({
+        url: 'https://widget.example.com/checkout',
+        orderId: 'ord-no-chain',
+      });
+
+      const { result } = renderHook(() => useContinueWithQuote());
+
+      const caught = await invoke(result, WIDGET_PROVIDER_QUOTE);
+
+      expect(caught).toBeUndefined();
+      expect(mockAddPrecreatedOrder).not.toHaveBeenCalled();
+    });
+
     it('resets to order details after InAppBrowser success', async () => {
       mockDeviceIsAndroid.mockReturnValue(false);
       mockInAppBrowser.isAvailable.mockResolvedValue(true);

--- a/app/components/UI/Ramp/hooks/useContinueWithQuote.test.ts
+++ b/app/components/UI/Ramp/hooks/useContinueWithQuote.test.ts
@@ -102,6 +102,8 @@ const mockFiatOrdersModule = jest.requireMock(
 ) as {
   selectHasAgreedTransakNativePolicy: jest.Mock;
 };
+const mockUseRampAccountAddress = jest.requireMock('./useRampAccountAddress')
+  .default as jest.Mock;
 const mockDeviceIsAndroid = jest.requireMock('../../../../util/device')
   .isAndroid as jest.Mock;
 const mockLinkingOpenURL = jest.requireMock(
@@ -236,6 +238,11 @@ async function invoke(
 describe('useContinueWithQuote', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseRampAccountAddress.mockReturnValue(
+      '0x1234567890123456789012345678901234567890',
+    );
+    mockDeviceIsAndroid.mockReturnValue(false);
+    mockLinkingOpenURL.mockResolvedValue(undefined);
     mockFiatOrdersModule.selectHasAgreedTransakNativePolicy.mockReturnValue(
       false,
     );
@@ -259,6 +266,10 @@ describe('useContinueWithQuote', () => {
     (useSelector as jest.Mock).mockImplementation((selector) =>
       typeof selector === 'function' ? selector() : undefined,
     );
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
   });
 
   describe('continueWithQuote: native provider', () => {

--- a/app/components/UI/Ramp/hooks/useContinueWithQuote.test.ts
+++ b/app/components/UI/Ramp/hooks/useContinueWithQuote.test.ts
@@ -238,6 +238,8 @@ async function invoke(
 describe('useContinueWithQuote', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.resetAllMocks();
+    (Date.now as unknown as jest.Mock).mockReturnValue(123);
     mockUseRampAccountAddress.mockReturnValue(
       '0x1234567890123456789012345678901234567890',
     );
@@ -266,10 +268,6 @@ describe('useContinueWithQuote', () => {
     (useSelector as jest.Mock).mockImplementation((selector) =>
       typeof selector === 'function' ? selector() : undefined,
     );
-  });
-
-  afterEach(() => {
-    jest.resetAllMocks();
   });
 
   describe('continueWithQuote: native provider', () => {

--- a/app/components/UI/Ramp/hooks/useContinueWithQuote.ts
+++ b/app/components/UI/Ramp/hooks/useContinueWithQuote.ts
@@ -293,12 +293,12 @@ export function useContinueWithQuote(
           );
 
         if (useExternalBrowser) {
-          if (effectiveOrderId && effectiveWallet) {
+          if (effectiveOrderId && effectiveWallet && network) {
             addPrecreatedOrder({
               orderId: effectiveOrderId,
               providerCode,
               walletAddress: effectiveWallet,
-              chainId: network || undefined,
+              chainId: network,
             });
           }
 

--- a/app/components/UI/Ramp/hooks/useContinueWithQuote.ts
+++ b/app/components/UI/Ramp/hooks/useContinueWithQuote.ts
@@ -345,12 +345,12 @@ export function useContinueWithQuote(
           );
 
         if (useExternalBrowser) {
-          if (effectiveOrderId && effectiveWallet) {
+          if (effectiveOrderId && effectiveWallet && network) {
             addPrecreatedOrder({
               orderId: effectiveOrderId,
               providerCode,
               walletAddress: effectiveWallet,
-              chainId: network || undefined,
+              chainId: network,
             });
           }
 

--- a/app/components/UI/Ramp/hooks/useRampsOrders.ts
+++ b/app/components/UI/Ramp/hooks/useRampsOrders.ts
@@ -13,7 +13,8 @@ export interface AddPrecreatedOrderParams {
   orderId: string;
   providerCode: string;
   walletAddress: string;
-  chainId?: string;
+  /** Non-empty chain id (decimal, hex, or CAIP-2). Required by RampsController. */
+  chainId: string;
 }
 
 export interface UseRampsOrdersResult {

--- a/package.json
+++ b/package.json
@@ -183,6 +183,12 @@
       "prettier --write"
     ]
   },
+  "previewBuilds": {
+    "@metamask/ramps-controller": {
+      "type": "breaking",
+      "previewVersion": "18.0.1-preview-0efc7ef01"
+    }
+  },
   "resolutions": {
     "@metamask/network-controller": "34.0.0",
     "@react-native-community/viewpager": "patch:@react-native-community/viewpager@npm%3A3.3.0#~/.yarn/patches/@react-native-community-viewpager-npm-3.3.0.patch",

--- a/package.json
+++ b/package.json
@@ -353,7 +353,7 @@
     "@metamask/preinstalled-example-snap": "^0.8.1",
     "@metamask/profile-metrics-controller": "^4.0.3",
     "@metamask/profile-sync-controller": "^29.0.0",
-    "@metamask/ramps-controller": "^19.0.0",
+    "@metamask/ramps-controller": "^20.0.0",
     "@metamask/react-data-query": "^0.2.2",
     "@metamask/react-native-acm": "patch:@metamask/react-native-acm@npm%3A1.2.0#~/.yarn/patches/@metamask-react-native-acm-npm-1.2.0-944bf863eb.patch",
     "@metamask/react-native-actionsheet": "2.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9957,7 +9957,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ramps-controller@npm:^18.0.0, @metamask/ramps-controller@npm:^18.0.1":
+"@metamask/ramps-controller@npm:@metamask-previews/ramps-controller@18.0.1-preview-0efc7ef01":
+  version: 18.0.1-preview-0efc7ef01
+  resolution: "@metamask-previews/ramps-controller@npm:18.0.1-preview-0efc7ef01"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/profile-sync-controller": "npm:^28.3.0"
+    "@metamask/remote-feature-flag-controller": "npm:^5.0.0"
+  checksum: 10/3eab34819e49eca1db3e6e751ad86eecf8ab0b90ee34278637d18c513e41ebc4b29a7ae969cbf65c43eac2d29f6fae711d44d401b502aff9351b3480b7278526
+  languageName: node
+  linkType: hard
+
+"@metamask/ramps-controller@npm:^18.0.1":
   version: 18.0.1
   resolution: "@metamask/ramps-controller@npm:18.0.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9853,19 +9853,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ramps-controller@npm:^19.0.0":
-  version: 19.0.0
-  resolution: "@metamask/ramps-controller@npm:19.0.0"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.3.0"
-    "@metamask/messenger": "npm:^2.0.0"
-    "@metamask/profile-sync-controller": "npm:^28.3.0"
-    "@metamask/remote-feature-flag-controller": "npm:^5.0.0"
-  checksum: 10/332c9f58fbc77ef53dbebb9488d65d1195d8c5afe43758a4f65e1cb36383bf181f9c9557a492fe740ce9ca198b35ae8b90d68cb5d152626a04349ca3502bf180
-  languageName: node
-  linkType: hard
-
 "@metamask/ramps-controller@npm:^20.0.0":
   version: 20.0.0
   resolution: "@metamask/ramps-controller@npm:20.0.0"
@@ -35818,7 +35805,7 @@ __metadata:
     "@metamask/profile-metrics-controller": "npm:^4.0.3"
     "@metamask/profile-sync-controller": "npm:^29.0.0"
     "@metamask/providers": "npm:^18.3.1"
-    "@metamask/ramps-controller": "npm:^19.0.0"
+    "@metamask/ramps-controller": "npm:^20.0.0"
     "@metamask/react-data-query": "npm:^0.2.2"
     "@metamask/react-native-acm": "patch:@metamask/react-native-acm@npm%3A1.2.0#~/.yarn/patches/@metamask-react-native-acm-npm-1.2.0-944bf863eb.patch"
     "@metamask/react-native-actionsheet": "npm:2.4.2"


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Core [#9777](https://github.com/MetaMask/core/pull/9777) makes `RampsController.addPrecreatedOrder` require a non-empty `chainId` (BREAKING). Without a client update, bumping that controller would either fail TypeScript or silently no-op when `chainId` is omitted/empty.

This PR:
- Bumps `@metamask/ramps-controller` to published `^20.0.0`
- Makes `AddPrecreatedOrderParams.chainId` required
- Only calls `addPrecreatedOrder` when a non-empty network/chainId is available (Checkout + external-browser continue flow)

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://github.com/MetaMask/core/pull/9777

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Ramp precreated order seeding

  Scenario: user continues a buy with a selected token
    Given the user has selected a buyable token on a known network
    And the provider returns a widget orderId

    When the user continues checkout (external browser or WebView)
    Then a precreated order is registered with a non-empty chainId
    And the order can be polled / updated after callback

  Scenario: checkout opens without a network param
    Given Checkout is opened with callback flow params but no network

    When the screen mounts
    Then addPrecreatedOrder is not called
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — no UI changes; controller call-site / typing only.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)