### PR TITLE
fix: wallet activity notif settings first account toggle

### DIFF
--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.test.tsx
@@ -43,6 +43,11 @@ jest.mock('./hooks/useNotificationStoragePreferences', () => ({
   }),
 }));
 
+// The arrange helpers below spy on the notification hook modules; restore the
+// originals between tests so a spy cannot leak into a test that does not set
+// one up (`clearAllMocks` only resets calls, it does not un-spy).
+afterEach(() => jest.restoreAllMocks());
+
 const MOCK_KEYRING_TYPE = 'HD Key Tree' as KeyringTypes;
 const EVM_ADDRESSES = [
   '0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29',

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.test.tsx
@@ -43,9 +43,7 @@ jest.mock('./hooks/useNotificationStoragePreferences', () => ({
   }),
 }));
 
-// The arrange helpers below spy on the notification hook modules; restore the
-// originals between tests so a spy cannot leak into a test that does not set
-// one up (`clearAllMocks` only resets calls, it does not un-spy).
+// Un-spy the notification hook modules between tests (clearAllMocks does not).
 afterEach(() => jest.restoreAllMocks());
 
 const MOCK_KEYRING_TYPE = 'HD Key Tree' as KeyringTypes;
@@ -372,9 +370,6 @@ describe('useNotificationAccountListProps', () => {
   });
 
   it('refetches the preferences blob alongside account settings', async () => {
-    // The controller writes `walletActivity.accounts` behind the cached
-    // preferences copy, so it has to be refreshed or later section writes
-    // persist a stale accounts array.
     const { hook } = arrange(['0x123', '0x456']);
 
     await act(async () => hook.result.current.refetchAccountSettings());

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.test.tsx
@@ -36,6 +36,13 @@ jest.mock(
   }),
 );
 
+const mockRefetchPreferences = jest.fn();
+jest.mock('./hooks/useNotificationStoragePreferences', () => ({
+  useNotificationStoragePreferences: () => ({
+    refetch: mockRefetchPreferences,
+  }),
+}));
+
 const MOCK_KEYRING_TYPE = 'HD Key Tree' as KeyringTypes;
 const EVM_ADDRESSES = [
   '0xb2B92547A92C1aC55EAe3F6632Fa1aF87dc05a29',
@@ -356,6 +363,19 @@ describe('useNotificationAccountListProps', () => {
     // Assert update method is called
     await waitFor(() => {
       expect(mocks.mockUpdate).toHaveBeenCalledWith(addresses);
+    });
+  });
+
+  it('refetches the preferences blob alongside account settings', async () => {
+    // The controller writes `walletActivity.accounts` behind the cached
+    // preferences copy, so it has to be refreshed or later section writes
+    // persist a stale accounts array.
+    const { hook } = arrange(['0x123', '0x456']);
+
+    await act(async () => hook.result.current.refetchAccountSettings());
+
+    await waitFor(() => {
+      expect(mockRefetchPreferences).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.tsx
@@ -10,19 +10,27 @@ import { selectAvatarAccountType } from '../../../../selectors/settings';
 import { selectAccountGroupsByWallet } from '../../../../selectors/multichainAccounts/accountTreeController';
 import { selectInternalAccountsById } from '../../../../selectors/accountsController';
 import { isEvmAccountType } from '@metamask/keyring-api';
+import { useNotificationStoragePreferences } from './hooks/useNotificationStoragePreferences';
 
 export function useNotificationAccountListProps() {
   const accountAddresses = useSelector(getValidNotificationAccounts);
   const accountsMap = useSelector(selectInternalAccountsById);
   const { update, initialLoading, accountsBeingUpdated, data } =
     useFetchAccountNotifications(accountAddresses);
+  const { refetch: refetchPreferences } = useNotificationStoragePreferences();
 
   // Only disable switches during initial data loading, not when individual accounts are updating
   const shouldDisableSwitches = initialLoading;
 
+  // Enabling/disabling an account rewrites `walletActivity.accounts` in the
+  // preferences blob through the controller, which does not update the cached
+  // preferences copy the UI writes from. Refresh it alongside the presence
+  // data, otherwise the next section write (a channel toggle, or the
+  // select/deselect-all channel flip) PUTs a stale accounts array and
+  // resurrects the accounts the user just changed.
   const refetchAccountSettings = useCallback(async () => {
-    await update(accountAddresses);
-  }, [accountAddresses, update]);
+    await Promise.all([update(accountAddresses), refetchPreferences()]);
+  }, [accountAddresses, update, refetchPreferences]);
 
   // Helper to get addresses from account IDs
   const getEvmAddressesFromAccountIds = useCallback(

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.hooks.tsx
@@ -22,12 +22,9 @@ export function useNotificationAccountListProps() {
   // Only disable switches during initial data loading, not when individual accounts are updating
   const shouldDisableSwitches = initialLoading;
 
-  // Enabling/disabling an account rewrites `walletActivity.accounts` in the
-  // preferences blob through the controller, which does not update the cached
-  // preferences copy the UI writes from. Refresh it alongside the presence
-  // data, otherwise the next section write (a channel toggle, or the
-  // select/deselect-all channel flip) PUTs a stale accounts array and
-  // resurrects the accounts the user just changed.
+  // Account toggles rewrite `walletActivity.accounts` behind the cached
+  // preferences, so refresh both — otherwise the next section write PUTs a
+  // stale accounts array.
   const refetchAccountSettings = useCallback(async () => {
     await Promise.all([update(accountAddresses), refetchPreferences()]);
   }, [accountAddresses, update, refetchPreferences]);

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.test.tsx
@@ -92,6 +92,24 @@ jest.mock('./AccountsList.hooks', () => ({
   }),
 }));
 
+interface WalletActivitySection {
+  pushNotificationsEnabled: boolean;
+  inAppNotificationsEnabled: boolean;
+  accounts: { address: string; enabled: boolean }[];
+}
+
+// Wallet-activity section writes pass an updater so they are applied to the
+// latest preferences rather than a render-time copy. Run it to assert on the
+// section that actually gets persisted.
+const applyWalletActivityUpdate = (
+  walletActivity: WalletActivitySection = mockPreferences.walletActivity,
+) => {
+  const [, sectionUpdate] = mockUpdatePreferencesSection.mock.calls[0];
+  return (sectionUpdate as (section: WalletActivitySection) => unknown)(
+    walletActivity,
+  );
+};
+
 const marketingDisclaimer =
   'By turning this on, you agree to receive product news and marketing updates from MetaMask.';
 
@@ -184,12 +202,13 @@ describe('NotificationSettingsSection', () => {
     expect(mockUpdatePreferencesSection).toHaveBeenCalledTimes(1);
     expect(mockUpdatePreferencesSection).toHaveBeenCalledWith(
       'walletActivity',
-      {
-        ...mockPreferences.walletActivity,
-        pushNotificationsEnabled: false,
-        inAppNotificationsEnabled: false,
-      },
+      expect.any(Function),
     );
+    expect(applyWalletActivityUpdate()).toStrictEqual({
+      ...mockPreferences.walletActivity,
+      pushNotificationsEnabled: false,
+      inAppNotificationsEnabled: false,
+    });
   });
 
   it('enables both channels and tracks an ALL update when selecting all accounts', async () => {
@@ -225,12 +244,46 @@ describe('NotificationSettingsSection', () => {
     expect(mockUpdatePreferencesSection).toHaveBeenCalledTimes(1);
     expect(mockUpdatePreferencesSection).toHaveBeenCalledWith(
       'walletActivity',
-      {
-        ...mockPreferences.walletActivity,
-        pushNotificationsEnabled: true,
-        inAppNotificationsEnabled: true,
-      },
+      expect.any(Function),
     );
+    expect(applyWalletActivityUpdate()).toStrictEqual({
+      ...mockPreferences.walletActivity,
+      pushNotificationsEnabled: true,
+      inAppNotificationsEnabled: true,
+    });
+  });
+
+  it('keeps the accounts written by the controller when flipping channels for all accounts', async () => {
+    renderSection({
+      type: 'walletActivity',
+      title: 'Wallet Activity',
+      description: 'Buy, sells, transfers, swaps and rewards',
+    });
+
+    fireEvent.press(
+      screen.getByTestId(
+        NotificationSettingsViewSelectorsIDs.ACCOUNT_NOTIFICATIONS_SELECT_ALL,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(mockUpdatePreferencesSection).toHaveBeenCalledTimes(1);
+    });
+
+    // The section update must be derived from the refreshed preferences, not
+    // from this render's copy - the controller has already disabled every
+    // account by the time this runs.
+    const refreshedWalletActivity = {
+      pushNotificationsEnabled: true,
+      inAppNotificationsEnabled: true,
+      accounts: [{ address: '0x1', enabled: false }],
+    };
+
+    expect(applyWalletActivityUpdate(refreshedWalletActivity)).toStrictEqual({
+      pushNotificationsEnabled: false,
+      inAppNotificationsEnabled: false,
+      accounts: [{ address: '0x1', enabled: false }],
+    });
   });
 
   it('updates and tracks the push channel when toggling push notifications', async () => {

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.test.tsx
@@ -98,9 +98,7 @@ interface WalletActivitySection {
   accounts: { address: string; enabled: boolean }[];
 }
 
-// Wallet-activity section writes pass an updater so they are applied to the
-// latest preferences rather than a render-time copy. Run it to assert on the
-// section that actually gets persisted.
+// Runs the updater passed to updatePreferencesSection to get the persisted section.
 const applyWalletActivityUpdate = (
   walletActivity: WalletActivitySection = mockPreferences.walletActivity,
 ) => {
@@ -276,9 +274,7 @@ describe('NotificationSettingsSection', () => {
       expect(mockUpdatePreferencesSection).toHaveBeenCalledTimes(1);
     });
 
-    // The section update must be derived from the refreshed preferences, not
-    // from this render's copy - the controller has already disabled every
-    // account by the time this runs.
+    // Updater must apply to the refreshed preferences, not this render's copy.
     const refreshedWalletActivity = {
       pushNotificationsEnabled: true,
       inAppNotificationsEnabled: true,

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.test.tsx
@@ -183,7 +183,9 @@ describe('NotificationSettingsSection', () => {
     );
     expect(screen.getByText('Deselect all')).toBeOnTheScreen();
 
-    fireEvent.press(button);
+    await act(async () => {
+      fireEvent.press(button);
+    });
 
     expect(mockToggleAllAccounts).toHaveBeenCalledTimes(1);
     await waitFor(() => {
@@ -225,7 +227,9 @@ describe('NotificationSettingsSection', () => {
     );
     expect(screen.getByText('Select all')).toBeOnTheScreen();
 
-    fireEvent.press(button);
+    await act(async () => {
+      fireEvent.press(button);
+    });
 
     expect(mockToggleAllAccounts).toHaveBeenCalledTimes(1);
     await waitFor(() => {
@@ -260,11 +264,13 @@ describe('NotificationSettingsSection', () => {
       description: 'Buy, sells, transfers, swaps and rewards',
     });
 
-    fireEvent.press(
-      screen.getByTestId(
-        NotificationSettingsViewSelectorsIDs.ACCOUNT_NOTIFICATIONS_SELECT_ALL,
-      ),
-    );
+    await act(async () => {
+      fireEvent.press(
+        screen.getByTestId(
+          NotificationSettingsViewSelectorsIDs.ACCOUNT_NOTIFICATIONS_SELECT_ALL,
+        ),
+      );
+    });
 
     await waitFor(() => {
       expect(mockUpdatePreferencesSection).toHaveBeenCalledTimes(1);

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.tsx
@@ -63,8 +63,7 @@ const CHANNEL_BY_KEY: Record<
 const WalletActivitySectionContent = ({ styles }: SectionContentProps) => {
   const { trackEvent, createEventBuilder } = useAnalytics();
   const { profileId } = useSessionProfileId();
-  const { preferences, updatePreferencesSection } =
-    useNotificationStoragePreferences();
+  const { updatePreferencesSection } = useNotificationStoragePreferences();
   const {
     accountProps,
     notificationAccountListProps,
@@ -75,19 +74,22 @@ const WalletActivitySectionContent = ({ styles }: SectionContentProps) => {
   } = useWalletActivityAccountSelection();
 
   // Toggling all accounts flips both wallet-activity channels in one section
-  // update so they don't race on the shared (stale) preferences snapshot.
+  // update so they don't race on the shared preferences snapshot. The updater
+  // form is required here: `toggleAllAccounts` has just rewritten
+  // `walletActivity.accounts` via the controller, so the section has to be
+  // built from the refreshed preferences. Passing a section object built from
+  // this render's `preferences` would PUT the pre-toggle accounts array and
+  // re-enable every account.
   const handleToggleAllAccounts = useCallback(async () => {
     const nextEnabled = !hasEnabledAccount;
 
     await toggleAllAccounts();
 
-    if (preferences) {
-      await updatePreferencesSection('walletActivity', {
-        ...preferences.walletActivity,
-        pushNotificationsEnabled: nextEnabled,
-        inAppNotificationsEnabled: nextEnabled,
-      });
-    }
+    await updatePreferencesSection('walletActivity', (walletActivity) => ({
+      ...walletActivity,
+      pushNotificationsEnabled: nextEnabled,
+      inAppNotificationsEnabled: nextEnabled,
+    }));
 
     trackEvent(
       createEventBuilder(MetaMetricsEvents.NOTIFICATIONS_SETTINGS_UPDATED)
@@ -101,7 +103,6 @@ const WalletActivitySectionContent = ({ styles }: SectionContentProps) => {
   }, [
     hasEnabledAccount,
     toggleAllAccounts,
-    preferences,
     updatePreferencesSection,
     trackEvent,
     createEventBuilder,

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.tsx
@@ -73,13 +73,10 @@ const WalletActivitySectionContent = ({ styles }: SectionContentProps) => {
     toggleAllAccounts,
   } = useWalletActivityAccountSelection();
 
-  // Toggling all accounts flips both wallet-activity channels in one section
-  // update so they don't race on the shared preferences snapshot. The updater
-  // form is required here: `toggleAllAccounts` has just rewritten
-  // `walletActivity.accounts` via the controller, so the section has to be
-  // built from the refreshed preferences. Passing a section object built from
-  // this render's `preferences` would PUT the pre-toggle accounts array and
-  // re-enable every account.
+  // Flip both channels in one write. The updater form is required:
+  // `toggleAllAccounts` just rewrote the accounts, so building the section
+  // from this render's preferences would PUT the pre-toggle accounts array
+  // and re-enable every account.
   const handleToggleAllAccounts = useCallback(async () => {
     const nextEnabled = !hasEnabledAccount;
 


### PR DESCRIPTION
## **Description**

  Turning notifications off for all wallet-activity accounts and then turning a single account back on re-enabled notifications for **every** account.

  Root cause: "Deselect all" performs two writes. The first (`toggleAllAccounts`) disables every account in the preferences blob via the controller. The second flips the wallet-activity push/in-app channels by
  writing the whole `walletActivity` section — and it built that section by spreading `preferences.walletActivity` captured in the render closure, i.e. the pre-toggle copy where every account was still enabled.
  That second write replaced the blob wholesale and undid the first. The screen showed the accounts as off because presence data was not refetched, so the corruption only surfaced on the next refetch — after
  enabling one account, every switch turned on.

  Fix:
  - `NotificationSettingsSection.tsx` — the toggle-all channel write now uses the updater form of `updatePreferencesSection`, so the section is derived from the latest preferences instead of the render-time copy.
  Also removes the now-redundant `preferences` guard and dependency.
  - `AccountsList.hooks.tsx` — `refetchAccountSettings` now refreshes the cached preferences blob alongside presence data. Account enable/disable is written by the controller behind that cache, so without this any
  later section write (a channel toggle after changing accounts) would persist a stale `accounts` array and resurrect the accounts the user just changed.

  Tests: the two existing toggle-all tests now assert the applied updater result, plus a new regression asserting controller-written accounts survive the channel flip, and a new test asserting preferences are
  refetched alongside presence.

  ## **Changelog**

  <!-- mms-check: type=changelog required=true blocking=true -->

  CHANGELOG entry: Fixed a bug where turning off wallet activity notifications for all accounts and then re-enabling a single account would turn notifications back on for every account

  ## **Related issues**

  <!-- mms-check: type=issue-link required=true -->

  Fixes: https://consensyssoftware.atlassian.net/browse/GE-404

  ## **Manual testing steps**

  <!-- mms-check: type=manual-testing required=true -->

  ```gherkin
  Feature: Wallet activity notification account selection

    Scenario: user re-enables a single account after deselecting all
      Given user has notifications enabled with several EVM accounts
      And user is on Settings > Notifications > Wallet Activity

      When user taps "Deselect all"
      Then every account switch is off
      And the push and in-app switches are off

      When user turns on the switch for a single account
      Then only that account's switch is on
      And all other account switches stay off
      And the state is unchanged after leaving and re-entering the screen

    Scenario: user flips a channel after changing a single account
      Given user is on Settings > Notifications > Wallet Activity
      And every account switch is on

      When user turns off the switch for one account
      And user turns the push notifications switch off and on again
      Then that account's switch stays off
      And all other account switches stay on
  ```

  ## **Screenshots/Recordings**

  <!-- mms-check: type=screenshot required=true -->

  ### **Before**

  <!-- Attach recording: Deselect all -> enable one account -> all accounts turn on -->

  ### **After**

  <!-- Attach recording: Deselect all -> enable one account -> only that account is on -->

  ## **Pre-merge author checklist**

  - [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding
  Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
  - [x] I've completed the PR template to the best of my ability
  - [x] I've included tests if applicable
  - [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
  - [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

  #### Performance checks (if applicable)

  N/A — settings-screen state fix, no rendering, list, or startup path touched.

  - [ ] I've tested on Android
    - Ideally on a mid-range device; emulator is acceptable
  - [ ] I've tested with a power user scenario
    - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and
  tokens
  - [ ] I've instrumented key operations with Sentry traces for production performance metrics
    - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

  For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

  ## **Pre-merge reviewer checklist**

  - [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
  - [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Wallet Activity notification settings UI and preference cache refresh; no auth or payment paths, with regression tests added.
> 
> **Overview**
> Fixes wallet activity notification state where **deselect all** then re-enabling one account could turn every account back on, and where channel toggles after account changes could resurrect disabled accounts.
> 
> **Select/deselect all** now updates push and in-app channels via `updatePreferencesSection`'s **updater callback** instead of spreading render-time `preferences.walletActivity`, so the channel write no longer overwrites controller-updated `accounts` with a stale list.
> 
> **`refetchAccountSettings`** now runs account presence refresh and **`refetchPreferences`** in parallel so the cached preferences blob matches controller-written `walletActivity.accounts` before any later section PUT.
> 
> Tests cover the updater shape, that refreshed account lists survive the channel flip, and that preferences refetch runs with account refetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 568b8c96e9189d3aef535629e3e7423c6570bfb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->