### PR TITLE
fix(money): open support from the Money kebab menu without dismissing the sheet first (MUSD-1242) cp-8.6.0

### DIFF
--- a/app/components/UI/Money/components/MoneyMoreSheet/MoneyMoreSheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyMoreSheet/MoneyMoreSheet.test.tsx
@@ -17,7 +17,10 @@ import {
   SCREEN_NAMES,
 } from '../../constants/moneyEvents';
 
-const mockOpenSupportWithConsent = jest.fn();
+const mockOpenSupportWithConsent: jest.Mock<
+  void,
+  [(url: string) => void, string]
+> = jest.fn();
 jest.mock('../../../../hooks/useSupportConsent', () => ({
   useSupportConsent: () => ({
     openSupportWithConsent: mockOpenSupportWithConsent,
@@ -173,12 +176,39 @@ describe('MoneyMoreSheet', () => {
 
     fireEvent.press(getByTestId(MoneyMoreSheetTestIds.CONTACT_SUPPORT_OPTION));
 
-    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
     expect(Linking.openURL).not.toHaveBeenCalled();
     expect(mockOpenSupportWithConsent).toHaveBeenCalledWith(
       expect.any(Function),
       METAMASK_SUPPORT_URL,
     );
+  });
+
+  it('keeps the sheet open while the support consent sheet is shown', () => {
+    const { getByTestId } = renderWithProvider(<MoneyMoreSheet />);
+
+    fireEvent.press(getByTestId(MoneyMoreSheetTestIds.CONTACT_SUPPORT_OPTION));
+
+    expect(mockOnCloseBottomSheet).not.toHaveBeenCalled();
+    expect(mockGoBack).not.toHaveBeenCalled();
+  });
+
+  it('closes the sheet before opening the consented support URL in the in-app browser', () => {
+    const { getByTestId } = renderWithProvider(<MoneyMoreSheet />);
+    fireEvent.press(getByTestId(MoneyMoreSheetTestIds.CONTACT_SUPPORT_OPTION));
+    const [openSupportUrl] = mockOpenSupportWithConsent.mock.calls[0];
+    const consentedUrl = `${METAMASK_SUPPORT_URL}&metamask_version=1.0.0`;
+
+    openSupportUrl(consentedUrl);
+
+    expect(mockOnCloseBottomSheet).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.BROWSER.HOME, {
+      screen: Routes.BROWSER.VIEW,
+      params: {
+        newTabUrl: consentedUrl,
+        timestamp: expect.any(Number),
+        fromMoney: true,
+      },
+    });
   });
 
   describe('analytics', () => {

--- a/app/components/UI/Money/components/MoneyMoreSheet/MoneyMoreSheet.tsx
+++ b/app/components/UI/Money/components/MoneyMoreSheet/MoneyMoreSheet.tsx
@@ -87,12 +87,10 @@ const MoneyMoreSheet = () => {
       redirect_target: MONEY_URLS.METAMASK_SUPPORT,
     });
 
-    closeAndNavigate(() => {
-      openSupportWithConsent(
-        (url) => openInAppBrowser(navigation, url),
-        METAMASK_SUPPORT_URL,
-      );
-    });
+    openSupportWithConsent(
+      (url) => closeAndNavigate(() => openInAppBrowser(navigation, url)),
+      METAMASK_SUPPORT_URL,
+    );
   }, [
     closeAndNavigate,
     navigation,


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

"Contact support" in the Money home kebab (⋮) sheet now shows the support consent sheet on top of the still-open Money sheet, and only closes that sheet once support is actually opened — at which point the consented URL opens in the in-app browser.

Bug: since the support consent flow was adopted in `MoneyMoreSheet` (#33518), tapping "Contact support" dismissed the Money modal stack (`MoneyModals`, a `transparentModal` screen on the main navigator) and, in the same tick, presented the consent sheet as a second root-level `transparentModal` (`RootModalFlow`). The actual browser navigation was then deferred until after consent, dispatched from a screen that had already been torn down, so the user never reached support.

Every other consent adopter (`MoreSection`, `EligibilityFailedModal`, `LinkedOffDeviceAccountsSheet`) presents the consent sheet without dismissing its own surface first. `MoneyMoreSheet` was the only one that dismissed-then-presented. Ordering the close after the consent decision also restores the sequence that worked before #33518, where the browser navigation ran inside the sheet's close callback.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the "Contact support" option in the Money menu not opening support.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-1242

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Contact support from the Money home kebab menu

  Scenario: User opens support and shares device details
    Given the user is on the Money home screen
    And the user has opened the kebab (⋮) bottom sheet

    When the user taps "Contact support"
    Then the support consent sheet is shown

    When the user taps "Share"
    Then the Money sheet closes
    And the MetaMask support page opens in the in-app browser

  Scenario: User opens support without sharing device details
    Given the support consent sheet is shown from the Money kebab menu

    When the user taps "Don't share"
    Then the Money sheet closes
    And the MetaMask support page opens in the in-app browser without device details

  Scenario: User dismisses the consent sheet
    Given the support consent sheet is shown from the Money kebab menu

    When the user swipes the consent sheet away or taps its close button
    Then no support page is opened
    And the user is back on the Money kebab menu
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

Tapping "Contact support" closed the kebab sheet and nothing else happened.

### **After**

https://github.com/user-attachments/assets/4fde4102-b97b-422b-b8c0-69bf2b83f90c

Tapping "Contact support" shows the consent sheet; confirming or declining opens support in the in-app browser.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small navigation-ordering fix in the Money more sheet with added unit tests; no auth, data, or security-sensitive logic.
> 
> **Overview**
> Fixes **Contact support** in the Money kebab menu so support actually opens after the consent flow.
> 
> `handleContactSupport` no longer calls `closeAndNavigate` before `openSupportWithConsent`. The Money sheet stays open while the consent sheet is shown; closing the sheet and opening the in-app browser only run inside the consent callback once the user chooses Share or Don't share. That avoids tearing down the Money modal stack before the deferred navigation runs.
> 
> Tests cover the new ordering: consent is invoked without closing on tap, and invoking the consent callback closes the sheet and navigates to the browser with the consented URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e317a2ed4182dd1a8dae09274c825cca4540979. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->