### PR TITLE
ci: gate expo dev builds on native fingerprint changes

### DIFF
--- a/.github/workflows/expo-dev-build.yml
+++ b/.github/workflows/expo-dev-build.yml
@@ -2,8 +2,15 @@
 #
 # Expo Dev Build.
 #
-# Triggered on every push to main. Builds the main-dev-expo configuration (Debug)
-# for both iOS and Android using the reusable build.yml workflow.
+# Triggered on every push to main, but only actually builds when the @expo/fingerprint
+# hash (plus a hash of builds.yml, which fingerprint doesn't track) differs from the last
+# successful build — i.e. only when native code changed. A weekly cron (and the
+# `force_build` manual dispatch input) forces a fresh build regardless, so the GitHub
+# Actions artifacts consumed by `yarn install:ios:dev` / `yarn install:android:dev` never
+# go stale for longer than a week even if native code hasn't changed.
+#
+# Builds the main-dev-expo configuration (Debug) for both iOS and Android using the
+# reusable build.yml workflow.
 #
 # Produces simulator .app + device IPA (iOS) and APK + test APK (Android).
 # No version bump or TestFlight upload.
@@ -20,6 +27,10 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # Weekly safety-net build (Monday 06:00 UTC) so GitHub Actions artifacts don't expire
+    # and go stale during long stretches with no native-affecting changes on main.
+    - cron: '0 6 * * 1'
   workflow_dispatch:
     inputs:
       runner_provider:
@@ -30,14 +41,191 @@ on:
           - current
           - namespace
         default: current
+      force_build:
+        description: Force a fresh build even if the fingerprint is unchanged
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
   id-token: write
+  actions: read
+
+concurrency:
+  # Non-cancelling: a burst of merges to main serializes instead of racing, so a queued
+  # run can find the marker artifact uploaded by the run ahead of it and skip its build.
+  group: expo-dev-build-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
+  resolve-dev-build:
+    name: Resolve dev build gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      needs-build: ${{ steps.gate.outputs.needs-build }}
+      gate-key: ${{ steps.gate-key.outputs.gate-key }}
+      reusable-run-id: ${{ steps.gate.outputs.reusable-run-id }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install Yarn dependencies with retry
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: yarn install --immutable
+
+      - name: Compute gate key
+        id: gate-key
+        run: |
+          FINGERPRINT="$(yarn fingerprint:generate)"
+          if [[ -z "$FINGERPRINT" ]]; then
+            echo "::error::yarn fingerprint:generate produced an empty hash"
+            exit 1
+          fi
+          # builds.yml isn't tracked by @expo/fingerprint, but the main-dev-expo entry
+          # (signing, CONFIGURATION, IS_DEVICE_BUILD, code_fencing, ...) affects the
+          # binary, so fold a short hash of it into the gate key.
+          BUILDS_HASH="$(sha256sum builds.yml | cut -c1-8)"
+          GATE_KEY="${FINGERPRINT}-${BUILDS_HASH}"
+          echo "gate-key=${GATE_KEY}" >> "$GITHUB_OUTPUT"
+          echo "Fingerprint: ${FINGERPRINT}"
+          echo "builds.yml hash: ${BUILDS_HASH}"
+          echo "Gate key: ${GATE_KEY}"
+
+      - name: Look up reusable dev build
+        id: lookup
+        if: ${{ github.event_name != 'schedule' && inputs.force_build != true }}
+        uses: actions/github-script@v7
+        env:
+          GATE_KEY: ${{ steps.gate-key.outputs.gate-key }}
+        with:
+          script: |
+            const { GATE_KEY } = process.env;
+            const markerName = `expo-dev-build-key-${GATE_KEY}`;
+            const requiredArtifacts = [
+              'ios-app-main-dev-expo',
+              'ios-ipa-main-dev-expo',
+              'android-apk-main-dev-expo',
+            ];
+
+            const setNotFound = () => {
+              core.setOutput('found', 'false');
+              core.setOutput('run-id', '');
+            };
+
+            let markers;
+            try {
+              markers = await github.paginate(github.rest.actions.listArtifactsForRepo, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: markerName,
+                per_page: 100,
+              });
+            } catch (err) {
+              core.warning(`Failed to list marker artifacts: ${err.message}`);
+              setNotFound();
+              return;
+            }
+
+            const candidates = markers
+              .filter((a) => !a.expired && a.workflow_run && a.workflow_run.head_branch === 'main')
+              .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+            if (candidates.length === 0) {
+              core.info(`No live marker artifact named "${markerName}" found on main.`);
+              setNotFound();
+              return;
+            }
+
+            const runId = candidates[0].workflow_run.id;
+
+            let runArtifacts;
+            try {
+              runArtifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+                per_page: 100,
+              });
+            } catch (err) {
+              core.warning(`listWorkflowRunArtifacts failed for run ${runId}: ${err.message}`);
+              setNotFound();
+              return;
+            }
+
+            const available = new Set(runArtifacts.filter((a) => !a.expired).map((a) => a.name));
+            const missing = requiredArtifacts.filter((n) => !available.has(n));
+            if (missing.length > 0) {
+              core.info(`Run ${runId} is missing artifacts: ${missing.join(', ')}`);
+              setNotFound();
+              return;
+            }
+
+            core.info(`Reusable dev build found: run ${runId} (gate key ${GATE_KEY})`);
+            core.setOutput('found', 'true');
+            core.setOutput('run-id', String(runId));
+
+      - name: Compute build gate
+        id: gate
+        env:
+          FORCE_BUILD: ${{ github.event_name == 'schedule' || inputs.force_build == true }}
+          LOOKUP_FOUND: ${{ steps.lookup.outputs.found }}
+          LOOKUP_RUN_ID: ${{ steps.lookup.outputs.run-id }}
+        run: |
+          if [[ "$FORCE_BUILD" == "true" ]]; then
+            echo "needs-build=true" >> "$GITHUB_OUTPUT"
+            echo "reusable-run-id=" >> "$GITHUB_OUTPUT"
+            echo "Forcing fresh build (schedule or force_build input)."
+          elif [[ "$LOOKUP_FOUND" == "true" ]]; then
+            echo "needs-build=false" >> "$GITHUB_OUTPUT"
+            echo "reusable-run-id=${LOOKUP_RUN_ID}" >> "$GITHUB_OUTPUT"
+            echo "Reusing dev build from run ${LOOKUP_RUN_ID}; fingerprint unchanged."
+          else
+            echo "needs-build=true" >> "$GITHUB_OUTPUT"
+            echo "reusable-run-id=" >> "$GITHUB_OUTPUT"
+            echo "No reusable dev build found; compiling fresh."
+          fi
+
+      - name: Write dev build gate summary
+        if: ${{ always() }}
+        env:
+          GATE_KEY: ${{ steps.gate-key.outputs.gate-key }}
+          NEEDS_BUILD: ${{ steps.gate.outputs.needs-build }}
+          REUSABLE_RUN_ID: ${{ steps.gate.outputs.reusable-run-id }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          decision="Fresh build"
+          reused_run="n/a"
+          if [[ "$NEEDS_BUILD" != "true" ]]; then
+            decision="Reused (fingerprint unchanged)"
+          fi
+          if [[ -n "${REUSABLE_RUN_ID:-}" ]]; then
+            reused_run="[https://github.com/${REPOSITORY}/actions/runs/${REUSABLE_RUN_ID}](https://github.com/${REPOSITORY}/actions/runs/${REUSABLE_RUN_ID})"
+          fi
+          {
+            echo "### Expo Dev Build gate"
+            echo ""
+            echo "| Field | Value |"
+            echo "| --- | --- |"
+            echo "| Decision | ${decision} |"
+            echo "| Gate key | \`${GATE_KEY}\` |"
+            echo "| Reused run | ${reused_run} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   build-dev:
     name: Expo dev build (main-dev-expo)
+    needs: [resolve-dev-build]
+    if: ${{ needs.resolve-dev-build.outputs.needs-build == 'true' }}
     uses: ./.github/workflows/build.yml
     with:
       build_name: main-dev-expo
@@ -45,3 +233,55 @@ jobs:
       source_branch: ${{ github.ref_name }}
       runner_provider: ${{ inputs.runner_provider }}
     secrets: inherit
+
+  record-dev-build:
+    name: Record dev build marker
+    needs: [resolve-dev-build, build-dev]
+    # Inherits workflow-level permissions (contents: write, actions: read) - no
+    # job-level override, since actions/upload-artifact's exact permission
+    # requirements aren't documented and the workflow-level set is a safe superset.
+    if: ${{ !cancelled() && needs.build-dev.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify app artifacts and write marker
+        id: verify
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const requiredArtifacts = [
+              'ios-app-main-dev-expo',
+              'ios-ipa-main-dev-expo',
+              'android-apk-main-dev-expo',
+            ];
+
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId,
+              per_page: 100,
+            });
+
+            const available = new Set(artifacts.filter((a) => !a.expired).map((a) => a.name));
+            const missing = requiredArtifacts.filter((n) => !available.has(n));
+            if (missing.length > 0) {
+              core.setFailed(`Refusing to write marker: missing artifacts ${missing.join(', ')}`);
+              return;
+            }
+            core.info('All required app artifacts present; marker will be uploaded.');
+
+      - name: Write marker file
+        run: |
+          mkdir -p .expo-dev-build-marker
+          {
+            echo "gate_key=${{ needs.resolve-dev-build.outputs.gate-key }}"
+            echo "run_id=${{ github.run_id }}"
+            echo "head_sha=${{ github.sha }}"
+          } > .expo-dev-build-marker/marker.txt
+
+      - name: Upload marker artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: expo-dev-build-key-${{ needs.resolve-dev-build.outputs.gate-key }}
+          path: .expo-dev-build-marker/marker.txt
+          if-no-files-found: error

--- a/.github/workflows/expo-dev-build.yml
+++ b/.github/workflows/expo-dev-build.yml
@@ -62,7 +62,7 @@ jobs:
   resolve-dev-build:
     name: Resolve dev build gate
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     outputs:
       needs-build: ${{ steps.gate.outputs.needs-build }}
       gate-key: ${{ steps.gate-key.outputs.gate-key }}
@@ -204,11 +204,14 @@ jobs:
           REUSABLE_RUN_ID: ${{ steps.gate.outputs.reusable-run-id }}
           REPOSITORY: ${{ github.repository }}
         run: |
-          decision="Fresh build"
+          # NEEDS_BUILD is empty when an earlier step failed (this step runs on always()),
+          # which must not be reported as a reuse decision.
+          case "$NEEDS_BUILD" in
+            true) decision="Fresh build" ;;
+            false) decision="Reused (fingerprint unchanged)" ;;
+            *) decision="Undetermined (gate did not complete)" ;;
+          esac
           reused_run="n/a"
-          if [[ "$NEEDS_BUILD" != "true" ]]; then
-            decision="Reused (fingerprint unchanged)"
-          fi
           if [[ -n "${REUSABLE_RUN_ID:-}" ]]; then
             reused_run="[https://github.com/${REPOSITORY}/actions/runs/${REUSABLE_RUN_ID}](https://github.com/${REPOSITORY}/actions/runs/${REUSABLE_RUN_ID})"
           fi

--- a/.github/workflows/expo-dev-build.yml
+++ b/.github/workflows/expo-dev-build.yml
@@ -108,9 +108,14 @@ jobs:
         uses: actions/github-script@v7
         env:
           GATE_KEY: ${{ steps.gate-key.outputs.gate-key }}
+          # Scoped to the current branch, not hardcoded to main: `yarn install:*:dev`
+          # resolves artifacts per branch, so a marker from another branch must not
+          # authorize skipping here — a manual dispatch on a feature branch would
+          # otherwise reuse main's marker and leave that branch with no artifacts.
+          GATE_BRANCH: ${{ github.ref_name }}
         with:
           script: |
-            const { GATE_KEY } = process.env;
+            const { GATE_KEY, GATE_BRANCH } = process.env;
             const markerName = `expo-dev-build-key-${GATE_KEY}`;
             const requiredArtifacts = [
               'ios-app-main-dev-expo',
@@ -138,11 +143,11 @@ jobs:
             }
 
             const candidates = markers
-              .filter((a) => !a.expired && a.workflow_run && a.workflow_run.head_branch === 'main')
+              .filter((a) => !a.expired && a.workflow_run && a.workflow_run.head_branch === GATE_BRANCH)
               .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
 
             if (candidates.length === 0) {
-              core.info(`No live marker artifact named "${markerName}" found on main.`);
+              core.info(`No live marker artifact named "${markerName}" found on ${GATE_BRANCH}.`);
               setNotFound();
               return;
             }

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ yarn watch
 
 #### Download and install the development build
 
-Expo development builds are produced by the [`Expo Dev Build`](https://github.com/MetaMask/metamask-mobile/actions/workflows/expo-dev-build.yml) GitHub Actions workflow on every push to `main`. Artifacts are stored as GitHub Actions artifacts (not Runway buckets).
+Expo development builds are produced by the [`Expo Dev Build`](https://github.com/MetaMask/metamask-mobile/actions/workflows/expo-dev-build.yml) GitHub Actions workflow. It runs on every push to `main`, but only actually compiles iOS/Android when the `@expo/fingerprint` hash of native code changed since the last build (plus a weekly Monday refresh so artifacts never go stale) — most pushes just reuse the existing build. This means the resolved run may be older than `main` HEAD; that's expected. Artifacts are stored as GitHub Actions artifacts (not Runway buckets).
 
 **Prerequisites:** [GitHub CLI](https://cli.github.com/) (`gh`) authenticated with access to this repository (`gh auth login`).
 
@@ -112,6 +112,8 @@ yarn install:android:dev --force-download
 Artifacts land under `build/` (`MetaMask.app` on iOS, `metamask-dev.apk` on Android). The workflow run id is saved to `build/expo-dev-build-run-id.txt`.
 
 **Manual download from GitHub Actions:**
+
+Note: since most runs skip the actual build (fingerprint unchanged), the most recent successful run may not have build artifacts attached — open the run and check for a `build-dev` job (skipped runs only have `resolve-dev-build`).
 
 ```bash
 # List recent successful Expo Dev Build runs on main

--- a/scripts/lib/download-gha-expo-dev-build.sh
+++ b/scripts/lib/download-gha-expo-dev-build.sh
@@ -8,6 +8,8 @@ readonly IOS_SIMULATOR_ARTIFACT_NAME="ios-app-${EXPO_DEV_BUILD_NAME}"
 readonly ANDROID_APK_ARTIFACT_NAME="android-apk-${EXPO_DEV_BUILD_NAME}"
 readonly IOS_DEVICE_IPA_ARTIFACT_NAME="ios-ipa-${EXPO_DEV_BUILD_NAME}"
 readonly DEFAULT_GITHUB_REPO="MetaMask/metamask-mobile"
+# Upper bound on producing-run verification calls in find_latest_run_with_artifact.
+readonly MAX_CANDIDATE_RUNS=10
 
 export GH_PAGER=cat
 
@@ -57,16 +59,32 @@ run_has_artifact() {
     | grep -q .
 }
 
+# Artifact metadata carries only `workflow_run.{id,head_branch,head_sha}` — not the
+# producing workflow nor its conclusion — so matching on artifact name and branch alone
+# would also accept artifacts from an in-progress or failed run, or from a direct
+# `build.yml` dispatch that uploaded just one platform of a half-finished matrix. Re-check
+# the producing run so lookups stay restricted to completed, successful expo-dev-build.yml
+# runs (the guarantee the previous `gh run list --status=success` path provided).
+run_is_successful_expo_dev_build() {
+  local run_id="$1"
+  local run_meta
+  run_meta="$(gh api "repos/${GITHUB_REPO}/actions/runs/${run_id}" \
+    --jq '"\(.status)|\(.conclusion)|\(.path)"' 2>/dev/null || true)"
+  [[ "$run_meta" == "completed|success|.github/workflows/${EXPO_DEV_WORKFLOW_FILE}" ]]
+}
+
 # expo-dev-build.yml now only builds when the @expo/fingerprint gate key changed (see
 # resolve-dev-build job), skipping every other push to main. That means the run holding
 # the latest artifact can sit arbitrarily far back in the run history, so walking the N
 # most recent `gh run list` entries (the old approach) would routinely miss it. Query the
-# artifact by its exact name instead — one API call, immune to however many runs were
-# skipped in between — and read the producing run id straight off the artifact metadata.
+# artifact by its exact name instead — immune to however many runs were skipped in between
+# — and read the producing run id straight off the artifact metadata.
 find_latest_run_with_artifact() {
   local artifact_name="$1"
   local branch="$2"
-  local run_id
+  local candidate_run_ids
+  local candidate
+  local checked=0
   local matches
   local api_stderr
   api_stderr="$(mktemp)"
@@ -90,18 +108,30 @@ find_latest_run_with_artifact() {
   # ISO 8601 timestamps are fixed-width, so a plain reverse string sort puts the newest
   # artifact first. LC_ALL=C keeps that true regardless of the caller's locale.
   #
-  # `awk NR==1` rather than `head -1`: head exits after the first line, which can leave
-  # sort writing into a closed pipe (exit 141) and, under the callers' `set -o pipefail`,
-  # abort the whole script once the artifact list outgrows the pipe buffer. awk drains
-  # the stream instead.
-  run_id="$(printf '%s\n' "$matches" | LC_ALL=C sort -r | awk -F'|' 'NR == 1 { print $2 }')"
+  # `awk` rather than `head`: head exits after its last wanted line, which can leave sort
+  # writing into a closed pipe (exit 141) and, under the callers' `set -o pipefail`, abort
+  # the whole script once the artifact list outgrows the pipe buffer. awk drains the
+  # stream instead.
+  candidate_run_ids="$(printf '%s\n' "$matches" | LC_ALL=C sort -r | awk -F'|' '{ print $2 }')"
 
-  if [[ -n "$run_id" && "$run_id" != "null" ]]; then
-    echo "$run_id"
-    return 0
-  fi
+  # Newest first, accept the first candidate whose producing run checks out. In practice
+  # that is the first one; the loop only walks further when a build failed or is still
+  # running, and stops at MAX_CANDIDATE_RUNS so a broken streak can't fan out API calls.
+  while IFS= read -r candidate; do
+    [[ -z "$candidate" || "$candidate" == "null" ]] && continue
+    if (( checked >= MAX_CANDIDATE_RUNS )); then
+      echo -e "${YELLOW}Stopped after checking ${MAX_CANDIDATE_RUNS} candidate runs for \"${artifact_name}\"; pass --run <id> to target a specific run.${NC}" >&2
+      break
+    fi
+    checked=$((checked + 1))
+    if run_is_successful_expo_dev_build "$candidate"; then
+      echo "$candidate"
+      return 0
+    fi
+    echo -e "${YELLOW}Skipping run ${candidate}: not a completed successful \"${EXPO_DEV_WORKFLOW_FILE}\" run.${NC}" >&2
+  done <<< "$candidate_run_ids"
 
-  echo -e "${RED}❌ No live artifact named \"${artifact_name}\" found on branch \"${branch}\"${NC}" >&2
+  echo -e "${RED}❌ No live artifact named \"${artifact_name}\" from a successful \"${EXPO_DEV_WORKFLOW_FILE}\" run found on branch \"${branch}\"${NC}" >&2
   echo -e "${YELLOW}The Expo Dev Build workflow only builds when native code changes; its artifacts may have expired.${NC}" >&2
   echo -e "${YELLOW}Re-run it (Actions > Expo Dev Build > Run workflow, with 'force_build' checked) or pass --run <id>.${NC}" >&2
   echo -e "${YELLOW}Browse recent runs: https://github.com/${GITHUB_REPO}/actions/workflows/${EXPO_DEV_WORKFLOW_FILE}${NC}" >&2

--- a/scripts/lib/download-gha-expo-dev-build.sh
+++ b/scripts/lib/download-gha-expo-dev-build.sh
@@ -50,13 +50,53 @@ validate_numeric_run_id() {
   fi
 }
 
+# On an HTTP error `gh api` exits non-zero AND writes the raw JSON error body to STDOUT
+# (CRLF-terminated), so "empty output" never means "no result" here: a 401 hands the caller
+# a `{` line that a downstream parser happily accepts as data. Every call below must
+# therefore branch on the exit status rather than on the output.
+#
+# Runs `gh api "$@"` and returns 0 on success, 1 on a failed request. Results land in the
+# globals GH_API_OUT (stdout) and GH_API_ERROR (stderr) rather than on this function's own
+# stdout: callers must NOT wrap it in `$(...)`, because a command substitution runs in a
+# subshell and the globals would not survive it. On failure GH_API_OUT is cleared, so no
+# fragment of an error body can leak into a digest, a size, or a run id.
+GH_API_OUT=''
+GH_API_ERROR=''
+gh_api_capture() {
+  local err_file
+  local status=0
+
+  err_file="$(mktemp)"
+  GH_API_OUT="$(gh api "$@" 2>"$err_file")" || status=$?
+  GH_API_ERROR="$(cat "$err_file")"
+  rm -f "$err_file"
+
+  if ((status != 0)); then
+    GH_API_OUT=''
+    return 1
+  fi
+}
+
+report_gh_api_failure() {
+  echo -e "${RED}❌ $1${NC}" >&2
+  if [[ -n "$GH_API_ERROR" ]]; then
+    printf '%s\n' "$GH_API_ERROR" >&2
+  fi
+}
+
+# Exit codes: 0 = artifact present, 1 = verified absent, 2 = could not determine.
 run_has_artifact() {
   local run_id="$1"
   local artifact_name="$2"
-  gh api "repos/${GITHUB_REPO}/actions/runs/${run_id}/artifacts" \
+
+  if ! gh_api_capture "repos/${GITHUB_REPO}/actions/runs/${run_id}/artifacts" \
     --paginate \
-    --jq ".artifacts[] | select(.expired == false and .name == \"${artifact_name}\") | .name" \
-    | grep -q .
+    --jq ".artifacts[] | select(.expired == false and .name == \"${artifact_name}\") | .name"; then
+    report_gh_api_failure "Failed to list artifacts for run ${run_id}"
+    return 2
+  fi
+
+  [[ -n "$GH_API_OUT" ]]
 }
 
 # Artifact metadata carries only `workflow_run.{id,head_branch,head_sha}` — not the
@@ -65,12 +105,24 @@ run_has_artifact() {
 # `build.yml` dispatch that uploaded just one platform of a half-finished matrix. Re-check
 # the producing run so lookups stay restricted to completed, successful expo-dev-build.yml
 # runs (the guarantee the previous `gh run list --status=success` path provided).
+#
+# Exit codes: 0 = verified good, 1 = verified not a match, 2 = could not determine. The
+# caller must not collapse 2 into 1: reading an auth, rate-limit, or network error as "bad
+# run" would walk past a live artifact and then report it as expired.
 run_is_successful_expo_dev_build() {
   local run_id="$1"
-  local run_meta
-  run_meta="$(gh api "repos/${GITHUB_REPO}/actions/runs/${run_id}" \
-    --jq '"\(.status)|\(.conclusion)|\(.path)"' 2>/dev/null || true)"
-  [[ "$run_meta" == "completed|success|.github/workflows/${EXPO_DEV_WORKFLOW_FILE}" ]]
+
+  if ! gh_api_capture "repos/${GITHUB_REPO}/actions/runs/${run_id}" \
+    --jq '"\(.status)|\(.conclusion)|\(.path)"'; then
+    # A deleted run is genuinely not a match; every other failure is indeterminate.
+    if [[ "$GH_API_ERROR" == *"HTTP 404"* ]]; then
+      return 1
+    fi
+    report_gh_api_failure "Failed to verify run ${run_id}"
+    return 2
+  fi
+
+  [[ "$GH_API_OUT" == "completed|success|.github/workflows/${EXPO_DEV_WORKFLOW_FILE}" ]]
 }
 
 # expo-dev-build.yml now only builds when the @expo/fingerprint gate key changed (see
@@ -86,24 +138,21 @@ find_latest_run_with_artifact() {
   local candidate
   local checked=0
   local matches
-  local api_stderr
-  api_stderr="$(mktemp)"
+  local verify_status
 
   # `--paginate --jq` runs the filter once per page, so a naive sort_by/first would only
   # reduce within a page rather than across all of them. Emit one "created_at|run_id"
   # line per matching artifact across every page instead, then reduce afterwards.
-  if ! matches="$(gh api "repos/${GITHUB_REPO}/actions/artifacts?name=${artifact_name}&per_page=100" \
+  if ! gh_api_capture "repos/${GITHUB_REPO}/actions/artifacts?name=${artifact_name}&per_page=100" \
     --paginate \
-    --jq ".artifacts[] | select(.expired == false and .workflow_run.head_branch == \"${branch}\") | \"\(.created_at)|\(.workflow_run.id)\"" \
-    2>"$api_stderr")"; then
+    --jq ".artifacts[] | select(.expired == false and .workflow_run.head_branch == \"${branch}\") | \"\(.created_at)|\(.workflow_run.id)\""; then
     # Distinguish a failed API call (auth, rate limit, network) from "no such artifact",
     # which would otherwise send the reader chasing the wrong problem entirely.
-    echo -e "${RED}❌ Failed to query GitHub Actions artifacts for \"${artifact_name}\"${NC}" >&2
-    cat "$api_stderr" >&2
-    rm -f "$api_stderr"
+    report_gh_api_failure "Failed to query GitHub Actions artifacts for \"${artifact_name}\""
     return 1
   fi
-  rm -f "$api_stderr"
+  # Copy out before the verification loop below reuses the globals.
+  matches="$GH_API_OUT"
 
   # ISO 8601 timestamps are fixed-width, so a plain reverse string sort puts the newest
   # artifact first. LC_ALL=C keeps that true regardless of the caller's locale.
@@ -124,11 +173,25 @@ find_latest_run_with_artifact() {
       break
     fi
     checked=$((checked + 1))
-    if run_is_successful_expo_dev_build "$candidate"; then
-      echo "$candidate"
-      return 0
-    fi
-    echo -e "${YELLOW}Skipping run ${candidate}: not a completed successful \"${EXPO_DEV_WORKFLOW_FILE}\" run.${NC}" >&2
+    verify_status=0
+    run_is_successful_expo_dev_build "$candidate" || verify_status=$?
+    case "$verify_status" in
+      0)
+        echo "$candidate"
+        return 0
+        ;;
+      1)
+        echo -e "${YELLOW}Skipping run ${candidate}: not a completed successful \"${EXPO_DEV_WORKFLOW_FILE}\" run.${NC}" >&2
+        ;;
+      *)
+        # Indeterminate, not "bad run": falling through to an older build (or to the
+        # "artifacts may have expired" message below) would misreport a live artifact.
+        # run_is_successful_expo_dev_build has already printed the underlying API error.
+        echo -e "${YELLOW}Refusing to fall back to an older build for \"${artifact_name}\".${NC}" >&2
+        echo -e "${YELLOW}Check 'gh auth status' and your API rate limit, then retry — or pass --run ${candidate}.${NC}" >&2
+        return 1
+        ;;
+    esac
   done <<< "$candidate_run_ids"
 
   echo -e "${RED}❌ No live artifact named \"${artifact_name}\" from a successful \"${EXPO_DEV_WORKFLOW_FILE}\" run found on branch \"${branch}\"${NC}" >&2
@@ -143,10 +206,18 @@ resolve_expo_dev_run() {
   local branch="$2"
   local run_id_override="$3"
   local resolved_run_id
+  local artifact_status
 
   if [[ -n "$run_id_override" ]]; then
     validate_numeric_run_id "$run_id_override" || return 1
-    if ! run_has_artifact "$run_id_override" "$artifact_name"; then
+    artifact_status=0
+    run_has_artifact "$run_id_override" "$artifact_name" || artifact_status=$?
+    # Only claim the artifact is absent when the API actually said so; report_gh_api_failure
+    # has already explained an indeterminate result.
+    if ((artifact_status >= 2)); then
+      return 1
+    fi
+    if ((artifact_status != 0)); then
       echo -e "${RED}❌ Run ${run_id_override} does not contain artifact \"${artifact_name}\"${NC}" >&2
       echo -e "${YELLOW}Inspect: https://github.com/${GITHUB_REPO}/actions/runs/${run_id_override}${NC}" >&2
       return 1
@@ -181,9 +252,16 @@ print_artifact_summary() {
   local artifact_digest
   local artifact_size_mb
 
-  artifact_meta="$(gh api "repos/${GITHUB_REPO}/actions/runs/${run_id}/artifacts" \
+  # Without the exit-status check, a failed request used to reach the parser below as the
+  # `{` first line of the JSON error body, which passed the "not found" guard and printed a
+  # fabricated "✓ Artifact size: 0MB" — a green check for a request that never succeeded.
+  if ! gh_api_capture "repos/${GITHUB_REPO}/actions/runs/${run_id}/artifacts" \
     --paginate \
-    --jq ".artifacts[] | select(.name==\"${artifact_name}\") | \"\(.expired)|\(.size_in_bytes)|\(.digest // \"\")\"" 2>/dev/null | head -1 || true)"
+    --jq ".artifacts[] | select(.name==\"${artifact_name}\") | \"\(.expired)|\(.size_in_bytes)|\(.digest // \"\")\""; then
+    report_gh_api_failure "Failed to list artifacts for run ${run_id}"
+    return 1
+  fi
+  artifact_meta="$(printf '%s\n' "$GH_API_OUT" | awk 'NR == 1')"
 
   if [[ -z "$artifact_meta" ]]; then
     echo -e "${RED}❌ Artifact '${artifact_name}' not found in run ${run_id}${NC}" >&2
@@ -213,13 +291,25 @@ artifact_digest_cache_path() {
   echo "${BUILD_DIR}/gh-expo-dev-build/${artifact_name}.digest"
 }
 
+# Only feeds the download-skip optimisation, so a failed request is not fatal: return
+# nothing and let the caller re-download. Warn rather than swallow, and never return the
+# error body — the caller writes this value to the digest cache, so caching a `{` fragment
+# would corrupt the comparison on subsequent runs.
 fetch_artifact_digest() {
   local run_id="$1"
   local artifact_name="$2"
-  gh api "repos/${GITHUB_REPO}/actions/runs/${run_id}/artifacts" \
+
+  if ! gh_api_capture "repos/${GITHUB_REPO}/actions/runs/${run_id}/artifacts" \
     --paginate \
-    --jq ".artifacts[] | select(.expired == false and .name == \"${artifact_name}\") | .digest // empty" \
-    2>/dev/null | head -1 || true
+    --jq ".artifacts[] | select(.expired == false and .name == \"${artifact_name}\") | .digest // empty"; then
+    echo -e "${YELLOW}⚠️  Could not fetch the digest for '${artifact_name}' (run ${run_id}); re-downloading.${NC}" >&2
+    if [[ -n "$GH_API_ERROR" ]]; then
+      printf '%s\n' "$GH_API_ERROR" >&2
+    fi
+    return 0
+  fi
+
+  printf '%s\n' "$GH_API_OUT" | awk 'NR == 1'
 }
 
 read_cached_artifact_digest() {

--- a/scripts/lib/download-gha-expo-dev-build.sh
+++ b/scripts/lib/download-gha-expo-dev-build.sh
@@ -67,15 +67,34 @@ find_latest_run_with_artifact() {
   local artifact_name="$1"
   local branch="$2"
   local run_id
+  local matches
+  local api_stderr
+  api_stderr="$(mktemp)"
 
   # `--paginate --jq` runs the filter once per page, so a naive sort_by/first would only
   # reduce within a page rather than across all of them. Emit one "created_at|run_id"
-  # line per matching artifact across every page instead, then reduce afterwards -
-  # ISO 8601 timestamps sort correctly as plain strings.
-  run_id="$(gh api "repos/${GITHUB_REPO}/actions/artifacts?name=${artifact_name}&per_page=100" \
+  # line per matching artifact across every page instead, then reduce afterwards.
+  if ! matches="$(gh api "repos/${GITHUB_REPO}/actions/artifacts?name=${artifact_name}&per_page=100" \
     --paginate \
     --jq ".artifacts[] | select(.expired == false and .workflow_run.head_branch == \"${branch}\") | \"\(.created_at)|\(.workflow_run.id)\"" \
-    2>/dev/null | sort -r | head -1 | cut -d'|' -f2 || true)"
+    2>"$api_stderr")"; then
+    # Distinguish a failed API call (auth, rate limit, network) from "no such artifact",
+    # which would otherwise send the reader chasing the wrong problem entirely.
+    echo -e "${RED}❌ Failed to query GitHub Actions artifacts for \"${artifact_name}\"${NC}" >&2
+    cat "$api_stderr" >&2
+    rm -f "$api_stderr"
+    return 1
+  fi
+  rm -f "$api_stderr"
+
+  # ISO 8601 timestamps are fixed-width, so a plain reverse string sort puts the newest
+  # artifact first. LC_ALL=C keeps that true regardless of the caller's locale.
+  #
+  # `awk NR==1` rather than `head -1`: head exits after the first line, which can leave
+  # sort writing into a closed pipe (exit 141) and, under the callers' `set -o pipefail`,
+  # abort the whole script once the artifact list outgrows the pipe buffer. awk drains
+  # the stream instead.
+  run_id="$(printf '%s\n' "$matches" | LC_ALL=C sort -r | awk -F'|' 'NR == 1 { print $2 }')"
 
   if [[ -n "$run_id" && "$run_id" != "null" ]]; then
     echo "$run_id"
@@ -83,6 +102,8 @@ find_latest_run_with_artifact() {
   fi
 
   echo -e "${RED}❌ No live artifact named \"${artifact_name}\" found on branch \"${branch}\"${NC}" >&2
+  echo -e "${YELLOW}The Expo Dev Build workflow only builds when native code changes; its artifacts may have expired.${NC}" >&2
+  echo -e "${YELLOW}Re-run it (Actions > Expo Dev Build > Run workflow, with 'force_build' checked) or pass --run <id>.${NC}" >&2
   echo -e "${YELLOW}Browse recent runs: https://github.com/${GITHUB_REPO}/actions/workflows/${EXPO_DEV_WORKFLOW_FILE}${NC}" >&2
   return 1
 }
@@ -103,7 +124,7 @@ resolve_expo_dev_run() {
     resolved_run_id="$run_id_override"
     echo -e "${GREEN}✓ Using explicit run id: ${resolved_run_id}${NC}" >&2
   else
-    echo -e "${BLUE}Looking up latest successful run on '${branch}' for ${EXPO_DEV_WORKFLOW_FILE}...${NC}" >&2
+    echo -e "${BLUE}Looking up latest '${artifact_name}' artifact on '${branch}'...${NC}" >&2
     resolved_run_id="$(find_latest_run_with_artifact "$artifact_name" "$branch")" || return 1
     echo -e "${GREEN}✓ Latest run with artifact: ${resolved_run_id}${NC}" >&2
   fi

--- a/scripts/lib/download-gha-expo-dev-build.sh
+++ b/scripts/lib/download-gha-expo-dev-build.sh
@@ -57,29 +57,32 @@ run_has_artifact() {
     | grep -q .
 }
 
+# expo-dev-build.yml now only builds when the @expo/fingerprint gate key changed (see
+# resolve-dev-build job), skipping every other push to main. That means the run holding
+# the latest artifact can sit arbitrarily far back in the run history, so walking the N
+# most recent `gh run list` entries (the old approach) would routinely miss it. Query the
+# artifact by its exact name instead — one API call, immune to however many runs were
+# skipped in between — and read the producing run id straight off the artifact metadata.
 find_latest_run_with_artifact() {
   local artifact_name="$1"
   local branch="$2"
   local run_id
 
-  while IFS= read -r run_id; do
-    [[ -z "$run_id" ]] && continue
-    if run_has_artifact "$run_id" "$artifact_name"; then
-      echo "$run_id"
-      return 0
-    fi
-  done < <(
-    gh run list \
-      --repo "$GITHUB_REPO" \
-      --workflow="$EXPO_DEV_WORKFLOW_FILE" \
-      --branch="$branch" \
-      --status=success \
-      --limit=30 \
-      --json databaseId \
-      --jq '.[].databaseId'
-  )
+  # `--paginate --jq` runs the filter once per page, so a naive sort_by/first would only
+  # reduce within a page rather than across all of them. Emit one "created_at|run_id"
+  # line per matching artifact across every page instead, then reduce afterwards -
+  # ISO 8601 timestamps sort correctly as plain strings.
+  run_id="$(gh api "repos/${GITHUB_REPO}/actions/artifacts?name=${artifact_name}&per_page=100" \
+    --paginate \
+    --jq ".artifacts[] | select(.expired == false and .workflow_run.head_branch == \"${branch}\") | \"\(.created_at)|\(.workflow_run.id)\"" \
+    2>/dev/null | sort -r | head -1 | cut -d'|' -f2 || true)"
 
-  echo -e "${RED}❌ No successful \"${EXPO_DEV_WORKFLOW_FILE}\" run on branch \"${branch}\" contains \"${artifact_name}\"${NC}" >&2
+  if [[ -n "$run_id" && "$run_id" != "null" ]]; then
+    echo "$run_id"
+    return 0
+  fi
+
+  echo -e "${RED}❌ No live artifact named \"${artifact_name}\" found on branch \"${branch}\"${NC}" >&2
   echo -e "${YELLOW}Browse recent runs: https://github.com/${GITHUB_REPO}/actions/workflows/${EXPO_DEV_WORKFLOW_FILE}${NC}" >&2
   return 1
 }


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

**Problem:** `expo-dev-build.yml` runs on every push to `main` and always builds `main-dev-expo` for both iOS and Android — a full macOS + Linux native compile (up to 120 min each), regardless of whether the change was native or JS-only. Since `main-dev-expo` is a Debug dev-client build whose JS is served by the developer's local Metro (not bundled in CI), the binary only actually needs to change when native code changes — everything else is wasted CI spend.

**Goal of this PR:**
- Stop rebuilding the dev client on every push; only rebuild when the native surface actually changed.
- Reuse the existing `@expo/fingerprint` mechanism (already used for E2E build reuse in `ci.yml`) as the "did native code change" signal, rather than inventing a new one.
- Guarantee `yarn install:ios:dev` / `yarn install:android:dev` never resolve to a stale or expired GitHub Actions artifact, even during long stretches with no native changes.
- Keep the change self-contained to this workflow, without perturbing the fingerprint semantics used elsewhere (E2E build reuse in `ci.yml`).

**What changed, in detail:**

- **New `resolve-dev-build` gate job** (runs on every trigger, before any build):
  - Computes a `gate_key` = `yarn fingerprint:generate` hash + a short hash of `builds.yml`. The `builds.yml` component covers a real gap: `@expo/fingerprint` doesn't track `builds.yml`, but the `main-dev-expo` entry (`signing`, `CONFIGURATION`, `IS_DEVICE_BUILD`, `code_fencing`) does affect the compiled binary.
  - Looks up a marker artifact named `expo-dev-build-key-<gate_key>` via the GitHub Artifacts API, filtered by exact name (one API call, independent of how many runs were skipped in between — see below for why this matters).
  - Confirms the run that produced that marker still holds all three required app artifacts (`ios-app-main-dev-expo`, `ios-ipa-main-dev-expo`, `android-apk-main-dev-expo`) before deciding to skip; treats a missing/expired artifact or a failed API call as "needs build" (fails open, never silently serves a stale binary).
  - Publishes a step summary (decision, gate key, reused run link) for quick triage on `main`.
- **`build-dev` job is now gated** on `needs.resolve-dev-build.outputs.needs-build == 'true'` — unchanged otherwise (still calls the reusable `build.yml` with `platform: both`).
- **New `record-dev-build` job** runs after a successful build: re-verifies all three app artifacts are present on the current run, then uploads the `expo-dev-build-key-<gate_key>` marker for future runs to find.
- **Weekly safety-net cron** (`0 6 * * 1`, Monday) plus a `force_build` manual `workflow_dispatch` input, both of which force a fresh build regardless of the fingerprint — bounds the worst case (artifact expiry with no native changes) to at most a week of staleness.
- **Non-cancelling `concurrency` group** (`expo-dev-build-${{ github.ref }}`) so a burst of merges to `main` serializes instead of racing past each other's markers.
- **`scripts/lib/download-gha-expo-dev-build.sh`** (used by `yarn install:ios:dev` / `install:android:dev`): replaced `find_latest_run_with_artifact`, which walked the last 30 `expo-dev-build.yml` runs looking for the artifact, with a single exact-name Artifacts API query. This was necessary, not just an optimization — once most pushes are skipped, the run that actually holds the artifact routinely falls outside the last 30 runs, so the old approach would start failing installs.
  - Hardened while in there: separates a failed API call (auth/rate limit/network) from a genuinely missing artifact in the error message, since `2>/dev/null` was previously masking real failures as "artifact not found."
  - Replaced a `sort | head -1` pipe with `awk 'NR==1'`, since `head` closing the pipe early can make `sort` exit 141 (SIGPIPE) once the artifact list outgrows the pipe buffer, which would silently abort the script under `set -o pipefail`.
- **`README.md`**: updated the dev-build section to describe the fingerprint-gated behavior and weekly refresh instead of "on every push to `main`", and noted that manual `gh run download` browsing needs to account for skipped runs.


**Addressed from review:**

- **`download-gha-expo-dev-build.sh` — restored the successful-run filter** (Bugbot, [thread](https://github.com/MetaMask/metamask-mobile/pull/34249#discussion_r3712781433)): the artifacts API exposes only `workflow_run.{id, head_branch, head_sha}`, so filtering by name + branch alone would also accept artifacts from an in-progress or failed run, or from a direct `build.yml` dispatch that had uploaded just one platform of a half-finished matrix. `find_latest_run_with_artifact` now walks name-matched artifacts newest-first and verifies each producing run via `GET /actions/runs/{id}` (`completed` + `success` + `path == .github/workflows/expo-dev-build.yml`) before accepting it, restoring the guarantee the old `gh run list --status=success` path provided. The walk is capped at `MAX_CANDIDATE_RUNS=10` and logs each skipped run rather than silently widening.
- **Gate lookup is now scoped to the current branch** instead of hardcoding `main`: `yarn install:*:dev` resolves artifacts per branch, so a `workflow_dispatch` on a feature branch whose fingerprint matched `main` would previously skip its build against `main`'s marker and leave that branch with no artifacts at all.

Action with current runners: https://github.com/MetaMask/metamask-mobile/actions/runs/30909787253

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: no tracking issue — CI cost cleanup raised directly by the mobile platform team. `expo-dev-build.yml` was doing a full macOS + Linux native compile on every push to `main`, including JS-only pushes that cannot change the resulting dev-client binary.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Fingerprint-gated Expo Dev Build

  Scenario: native code change triggers a fresh build
    Given a push to main changes a file tracked by @expo/fingerprint (e.g. a native dependency bump)
    When the "Expo Dev Build" workflow runs
    Then the "resolve-dev-build" job computes a new gate key and finds no matching marker artifact
    Then needs-build is "true" and the "build-dev" job runs, producing new iOS/Android artifacts
    And the "record-dev-build" job verifies all three app artifacts and uploads a new marker

  Scenario: JS-only change skips the native build
    Given a push to main only changes JS/TS files with no native impact
    When the "Expo Dev Build" workflow runs
    Then the "resolve-dev-build" job's gate key matches an existing live marker artifact
    And needs-build is "false" and the "build-dev" job is skipped entirely
    And the step summary reports "Reused (fingerprint unchanged)"

  Scenario: developer installs the latest dev build locally after several skipped pushes
    Given several consecutive pushes to main were skipped due to an unchanged fingerprint
    When the developer runs `yarn install:ios:dev --skipInstall` (or `install:android:dev`)
    Then the script resolves the correct producing run via the GitHub Artifacts API, even though it is not the most recent successful workflow run
    And the artifact downloads and installs without error

  Scenario: manual force rebuild bypasses the gate
    Given no native code has changed since the last build
    When a maintainer runs "Expo Dev Build" via workflow_dispatch with force_build=true
    Then the build runs regardless of the fingerprint match

  Scenario: weekly cron refresh
    Given the scheduled Monday 06:00 UTC trigger fires
    When the "Expo Dev Build" workflow runs
    Then it forces a fresh build regardless of the fingerprint, refreshing artifacts before they can expire
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — CI workflow change, no UI impact.

### **After**

N/A — CI workflow change, no UI impact.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI gating and local dev install resolution for Expo dev builds; mistakes could skip needed native builds or point installs at wrong runs, but scope is workflows/scripts only with no app runtime impact.
> 
> **Overview**
> **Expo Dev Build** no longer compiles iOS/Android on every push to `main`. A new **`resolve-dev-build`** job builds a **gate key** from `yarn fingerprint:generate` plus a short hash of **`builds.yml`**, looks for a live **`expo-dev-build-key-<gate_key>`** marker (and required app artifacts) on the **current branch**, and only then runs **`build-dev`**. **Weekly Monday cron** and **`force_build`** on manual dispatch always rebuild; **non-cancelling concurrency** serializes bursts on the same ref. **`record-dev-build`** uploads the marker after a successful build.
> 
> **`yarn install:ios:dev` / `install:android:dev`** helpers now find artifacts via the **Artifacts API by exact name** (not the last N workflow runs), verify the producing run is a **completed successful `expo-dev-build.yml`**, and **treat `gh api` failures distinctly** from “artifact missing” so auth/rate-limit errors are not misreported. **README** explains fingerprint gating, reuse vs fresh builds, and that recent successful runs may lack binaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15ec4c34aea6bad1493d0961e6b00641384ea960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

