### PR TITLE
feat(perps): move market About section below Stats cp-8.6.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -1479,20 +1479,6 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   const postMarketInsightsSections = useMemo(
     () => [
       {
-        key: 'about',
-        // Outer guard avoids mounting the component when there is no
-        // description; the component also returns null defensively for
-        // direct/standalone use.
-        visible: hasAboutDescription,
-        onLayout: handleAboutLayout,
-        content: (
-          <PerpsMarketAboutSection
-            description={market?.description}
-            assetName={market?.name}
-          />
-        ),
-      },
-      {
         key: 'stats',
         visible: true,
         content: (
@@ -1506,6 +1492,20 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
             onOrderBookPress={
               isOrderBookEnabled ? handleOrderBookPress : undefined
             }
+          />
+        ),
+      },
+      {
+        key: 'about',
+        // Outer guard avoids mounting the component when there is no
+        // description; the component also returns null defensively for
+        // direct/standalone use. Placed below stats per TAT-2308 follow-up.
+        visible: hasAboutDescription,
+        onLayout: handleAboutLayout,
+        content: (
+          <PerpsMarketAboutSection
+            description={market?.description}
+            assetName={market?.name}
           />
         ),
       },


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

On the Perps market details screen, the **About** section previously rendered above **Stats** in `postMarketInsightsSections`. Product follow-up for TAT-2308 asks for description content to sit under the statistics block so market stats stay higher in the scroll order.

This PR reorders the section list so Stats render before About. Visibility (`hasAboutDescription`) and layout (`handleAboutLayout`) behavior are unchanged — markets without a description still omit About entirely.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Moved the Perps market About section below Stats on the market details screen

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: TAT-2308

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps market details section order

  Scenario: user sees Stats above About when a description exists
    Given the user is on a Perps market details screen for a market with a Terminal description

    When the user scrolls below Market Insights
    Then the Stats section appears above the About section
    And the About section still shows the market description

  Scenario: user does not see About when no description exists
    Given the user is on a Perps market details screen for a market without a description

    When the user scrolls below Market Insights
    Then the Stats section is visible
    And the About section is not rendered
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — layout reorder only; verify via manual testing steps above (Stats above About).

### **Before**

N/A

### **After**

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-04 at 12 48 28" src="https://github.com/user-attachments/assets/eedc0bbf-6cfc-4f4a-b111-26a2fd326319" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
