### PR TITLE
fix(perf): schedule boolean coercion + dual-repack Metro cache isolation

### DIFF
--- a/.github/workflows/build-android-upload-to-browserstack.yml
+++ b/.github/workflows/build-android-upload-to-browserstack.yml
@@ -605,6 +605,24 @@ jobs:
             eval "$(node /tmp/export-profile-secrets.js "$build_name")"
           }
 
+          # Expo export:embed forces resetCache=false when CI=true (see
+          # @expo/cli exportEmbedAsync). Dual with/without-SRP packs therefore
+          # share /tmp/metro-cache and the second pack can reuse babel-inlined
+          # PREDEFINED_PASSWORD / ADDITIONAL_SRP_* from the first. Wipe explicitly.
+          clear_metro_transform_cache() {
+            local label="$1"
+            rm -rf /tmp/metro-cache
+            echo "Cleared /tmp/metro-cache before $label repack (CI disables Metro resetCache)"
+          }
+
+          unset_srp_bake_ins() {
+            unset PREDEFINED_PASSWORD || true
+            local i
+            for i in $(seq 1 20); do
+              unset "ADDITIONAL_SRP_$i" || true
+            done
+          }
+
           repack_profile() {
             local build_name="$1"
             local src_dir="$2"
@@ -623,12 +641,23 @@ jobs:
 
             export_build_env "$build_name"
 
+            # Isolate Metro transform cache keys between with-SRP and without-SRP.
+            export METRO_TRANSFORM_PROFILE="$label"
+
+            # Boolean-only diagnostics — never print secret values.
+            if [ -n "${PREDEFINED_PASSWORD:-}" ] || [ -n "${ADDITIONAL_SRP_1:-}" ]; then
+              echo "Transform bake-ins present=yes (profile=$label)"
+            else
+              echo "Transform bake-ins present=no (profile=$label)"
+            fi
+
             export REPACK_SOURCE_APK="$src_apk"
             export REPACK_OUTPUT_APK="android/app/build/outputs/apk/prod/release/app-prod-release-repack-$label.apk"
             export REPACK_FINAL_APK="$out_dir/app-prod-release.apk"
             export REPACK_WORKING_DIR="android/app/build/repack-working-$label"
             export REPACK_SOURCEMAP_PATH="sourcemaps/android/index.android.bundle.$label.map"
 
+            clear_metro_transform_cache "$label"
             yarn build:repack:android
             echo "✅ Repacked $label → $REPACK_FINAL_APK ($(du -h "$REPACK_FINAL_APK" | cut -f1))"
           }
@@ -636,8 +665,9 @@ jobs:
           # with-SRP first (ADDITIONAL_SRP_1 + PREDEFINED_PASSWORD inlined into JS via metro)
           repack_profile "$WITH_SRP_BUILD_NAME" artifacts/with-srp artifacts/with-srp-repacked with-srp
 
-          # without-SRP: drop with-SRP bake-ins so they are not left in process.env
-          unset ADDITIONAL_SRP_1 PREDEFINED_PASSWORD || true
+          # without-SRP: drop with-SRP bake-ins so they are not left in process.env,
+          # then wipe Metro cache so CI cannot reuse the with-SRP transforms.
+          unset_srp_bake_ins
           repack_profile "$WITHOUT_SRP_BUILD_NAME" artifacts/without-srp artifacts/without-srp-repacked without-srp
 
           # Replace staged dirs so the upload step always reads artifacts/{with,without}-srp

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -419,7 +419,10 @@ jobs:
       branch_name: ${{ needs.determine-branch-name.outputs.branch_name }}
       build_variant: ${{ inputs.build_variant || 'e2e' }}
       source_fingerprint: ${{ needs.ensure-fingerprint.outputs.fingerprint }}
-      main_branch_only: ${{ inputs.reuse_main_builds }}
+      # Coerce to a real boolean. On schedule/push, workflow_dispatch inputs are
+      # unset; passing a blank value into this boolean workflow_call input makes
+      # the reusable Android build job fail to start (no child jobs, tests skip).
+      main_branch_only: ${{ inputs.reuse_main_builds == true }}
     secrets: inherit
 
   trigger-ios-dual-versions:

--- a/metro.config.js
+++ b/metro.config.js
@@ -126,8 +126,21 @@ module.exports = function (baseConfig) {
             ),
           );
 
+      // Isolate Metro transform cache between with-SRP and without-SRP dual
+      // repacks. Expo export:embed forces resetCache=false in CI, so babel
+      // inlines of PREDEFINED_PASSWORD / ADDITIONAL_SRP_* from the first pack
+      // would otherwise be reused from /tmp/metro-cache by the second pack.
+      // Prefer an explicit METRO_TRANSFORM_PROFILE; fall back to presence-only
+      // detection (never put secret values into cacheVersion).
+      const metroTransformProfile =
+        process.env.METRO_TRANSFORM_PROFILE ||
+        (process.env.PREDEFINED_PASSWORD || process.env.ADDITIONAL_SRP_1
+          ? 'with-srp'
+          : 'without-srp');
+
       return wrapWithReanimatedMetroConfig(
         mergeConfig(defaultConfig, {
+          cacheVersion: `${defaultConfig.cacheVersion || '1.0'}:${metroTransformProfile}`,
           resolver: {
             // Exclude mm CLI daemon artifacts from the file watcher so that
             // log writes, state updates and test-artifact captures don't


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

Fixes two separate performance-E2E CI failures that look related but have different root causes.

### 1. Schedule / push never starts Android dual builds

After #34049 (MMQA-2147), `schedule` / `push` runs never start `Trigger Android Dual Versions` because `main_branch_only: ${{ inputs.reuse_main_builds }}` passes a blank value into a **boolean** `workflow_call` input when `workflow_dispatch` inputs are unset.

Fix: coerce with `inputs.reuse_main_builds == true`.

### 2. Onboarding APK behaves like with-SRP after fingerprint JS repack (PR #34163)

[#34211](https://github.com/MetaMask/metamask-mobile/pull/34211) correctly wires without-SRP URLs to onboarding. On [PR #34163 run 30890893391](https://github.com/MetaMask/metamask-mobile/actions/runs/30890893391):

- Onboarding got without-SRP `bs://a8e7b628…`
- Imported wallet got with-SRP `bs://7601f6ea…`

But onboarding still failed with the Unlock screen (wallet already present) — confirmed via Playwright failure screenshots.

Root cause: fingerprint reuse dual-repacks with-SRP then without-SRP in one job. Expo `export:embed` **forces `resetCache=false` when `CI=true`**, so Metro reuses babel-inlined `PREDEFINED_PASSWORD` / `ADDITIONAL_SRP_*` transforms from `/tmp/metro-cache`. Evidence: without-SRP pack was ~40% faster than with-SRP on the same job.

Fix:
- Clear `/tmp/metro-cache` before each dual repack
- Unset all `ADDITIONAL_SRP_*` + `PREDEFINED_PASSWORD` before without-SRP
- Key Metro `cacheVersion` by `METRO_TRANSFORM_PROFILE` so profiles cannot share transform cache entries

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: MMQA-2042
Related: https://github.com/MetaMask/metamask-mobile/pull/34163
Related: https://github.com/MetaMask/metamask-mobile/pull/34211

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Performance Android dual builds work on schedule and fingerprint reuse

  Scenario: schedule run starts Trigger Android Dual Versions
    Given the performance workflow is triggered by schedule on main
    And no manual BrowserStack app URLs are provided
    When ensure-fingerprint succeeds
    Then Trigger Android Dual Versions starts with main_branch_only=false

  Scenario: fingerprint reuse dual repack isolates with/without-SRP JS
    Given fingerprint reuse finds matching Android APKs
    When Upload APKs dual-repacks with-SRP then without-SRP
    Then /tmp/metro-cache is cleared before each pack
    And without-SRP logs "Transform bake-ins present=no"
    And onboarding tests open wallet setup (not Unlock)
    And imported-wallet tests still unlock with the with-SRP APK
```

Validation performed:
- Confirmed #34211 URL selection on PR #34163 and main dispatch.
- Confirmed Unlock-screen screenshots on without-SRP onboarding sessions.
- Confirmed Expo CI disables Metro resetCache; dual-repack timing showed cache hits on the second pack.
- Parsed updated workflow YAML successfully.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — CI workflow / Metro config only; no UI is modified.

Failure evidence (before): onboarding on without-SRP URL showed Unlock screen instead of create-wallet.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - CI workflow / Metro cache isolation; validation documented above.
- [ ] I've tested with a power user scenario
  - N/A — no application behavior changes beyond bake-in isolation.
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A — no production feature code changes.

## **Pre-merge reviewer checklist**

<!-- mms-check: type=checklist required=true -->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3e9c79a-f324-432b-b8af-804e7e204c89?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3e9c79a-f324-432b-b8af-804e7e204c89&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

