### PR TITLE
chore(ci): Android-first iOS E2E on feature PRs to main

### DIFF
--- a/.github/guidelines/E2E_DECISION_TREE.md
+++ b/.github/guidelines/E2E_DECISION_TREE.md
@@ -59,9 +59,22 @@ Runs only when all of the following are true:
 - Label `skip-e2e` can be added to the PR to skip E2E tests (and builds) in case of infra issues.
 - Using this label should be exceptional in case of CI friction and urgencies. Verify new changes and regressions manually before merging.
 
+## Android-first on feature PRs
+
+PRs targeting `main` skip iOS Detox E2E and the iOS native build when Android E2E also runs. iOS still builds/runs on the PR when:
+
+- Any `ios/**` path changes (including mixed with shared files)
+- Android E2E is not needed (iOS-only paths)
+- `run-ios-e2e` label
+- Appium iOS demand (`run-appium-ios-tests`, or smoke-appium / shared smoke infra path changes)
+
+Shared work that skips iOS on the PR still runs iOS (and fixture validation) on the merge queue. `skip-e2e` is honored there too. `@metamaskbot update-mobile-fixture` reuses the CI iOS artifact when present; otherwise it builds iOS in the fixture workflow.
+
+PRs to `release/*` or `stable`, plus `main` push/schedule, are unchanged. CI re-runs when `run-ios-e2e` is added or removed.
+
 ## (Exceptional) force Appium iOS smoke tests on PRs
 
-Appium iOS smoke tests are skipped on PRs by default (they still run on every `main` push/schedule). They also run automatically on a PR when shared smoke infra or Appium specs change (`tests/page-objects/**`, `tests/selectors/**`, `tests/locators/**`, `tests/framework/**`, `tests/smoke-appium/**`). To force them on any other PR, add the `run-appium-ios-tests` label. Smart E2E Selection still controls which suites run. CI re-runs automatically when the label is added or removed.
+Appium iOS smoke tests are skipped on PRs by default (they still run on every `main` push/schedule). They also run automatically on a PR when shared smoke infra or Appium specs change (`tests/page-objects/**`, `tests/selectors/**`, `tests/locators/**`, `tests/framework/**`, `tests/smoke-appium/**`). To force them on any other PR, add the `run-appium-ios-tests` label. On PRs targeting `main`, that label (or the path triggers above) also opts the iOS native build back in so Appium can run. Smart E2E Selection still controls which suites run. CI re-runs automatically when the label is added or removed.
 
 ## E2E flakiness detection in PRs
 

--- a/.github/guidelines/LABELING_GUIDELINES.md
+++ b/.github/guidelines/LABELING_GUIDELINES.md
@@ -43,9 +43,13 @@ Using any of these labels should be exceptional in case of CI friction and urgen
 
 - **run-performance-tests**: Forces the PR performance E2E workflow to run (all performance tests on Android low-profile devices), even when Smart E2E Selection would skip them (e.g. no performance-relevant changes detected, `skip-e2e`, or `pr-not-ready-for-e2e`). Adding or removing this label re-triggers CI. Not honored on fork PRs.
 
+### Force iOS E2E on feature PRs
+
+- **run-ios-e2e**: Opt in to iOS Detox E2E (and the iOS native build) on PRs targeting `main` when Android E2E would also run and no `ios/**` files changed. iOS-only path changes and any `ios/**` changes still build iOS without this label. PRs to `release/*` or `stable` still run iOS without this label. Adding or removing this label re-triggers CI. Not honored on fork PRs.
+
 ### Force Appium iOS Smoke Tests
 
-- **run-appium-ios-tests**: Also runs Appium iOS smoke tests on a PR (normally they run on `main` push/schedule, or automatically when `tests/smoke-appium/**` / shared smoke infra paths change). Uses the same Smart E2E Selection tags as Detox/Appium Android — it does not bypass path filters, build gates, or AI tag selection. Remove `pr-not-ready-for-e2e` when the PR is ready for E2E validation. Adding or removing this label re-triggers CI. Not honored on fork PRs.
+- **run-appium-ios-tests**: Also runs Appium iOS smoke tests on a PR (normally they run on `main` push/schedule, or automatically when `tests/smoke-appium/**` / shared smoke infra paths change). On PRs targeting `main`, this also opts the iOS native build back in so Appium can run. Uses the same Smart E2E Selection tags as Detox/Appium Android — it does not bypass path filters, build gates, or AI tag selection. Remove `pr-not-ready-for-e2e` when the PR is ready for E2E validation. Adding or removing this label re-triggers CI. Not honored on fork PRs.
 
 ### Block merge if any is present
 

--- a/.github/scripts/compute-e2e-platform-flags.cjs
+++ b/.github/scripts/compute-e2e-platform-flags.cjs
@@ -3,6 +3,43 @@
  */
 
 /**
+ * Android-first gate for whether Build iOS Apps should run.
+ * Feature PRs to main skip iOS when Android also runs, unless opted in.
+ *
+ * @param {object} input
+ * @returns {boolean}
+ */
+function shouldBuildIosApps(input) {
+  const {
+    githubEventName,
+    pullRequestBase = '',
+    iosE2eNeeded,
+    androidE2eNeeded,
+    iosPathChanges = false,
+    forceIosE2E = false,
+    runAppiumIos = false,
+  } = input;
+
+  if (!iosE2eNeeded) {
+    return false;
+  }
+
+  if (githubEventName !== 'pull_request') {
+    return true;
+  }
+
+  if (pullRequestBase !== 'main') {
+    return true;
+  }
+
+  if (!androidE2eNeeded) {
+    return true;
+  }
+
+  return iosPathChanges || forceIosE2E || runAppiumIos;
+}
+
+/**
  * @param {object} input
  * @returns {object}
  */
@@ -44,8 +81,6 @@ function computeE2EPlatformFlags(input) {
     message = 'E2E for both platforms (scheduled or push to main)';
     android = true;
     ios = true;
-  } else if (githubEventName === 'merge_group') {
-    message = 'Skipping E2E (merge queue)';
   } else if (isFork) {
     message = 'Skipping E2E (fork PR)';
   } else if (shouldSkipE2E) {
@@ -84,6 +119,18 @@ function computeE2EPlatformFlags(input) {
     changed = changedSpecFiles;
   }
 
+  // Merge queue: Android already ran on the PR. Keep iOS only when path logic selected it.
+  if (githubEventName === 'merge_group' && (android || ios)) {
+    android = false;
+    if (ios) {
+      message = nativeBuildNeeded
+        ? 'E2E iOS only (merge queue)'
+        : 'E2E iOS only (merge queue — reuse main native builds)';
+    } else {
+      message = 'Skipping E2E (merge queue — Android covered on PR)';
+    }
+  }
+
   const e2eNeeded = android || ios;
 
   const runSmartE2ESelection =
@@ -105,4 +152,5 @@ function computeE2EPlatformFlags(input) {
 
 module.exports = {
   computeE2EPlatformFlags,
+  shouldBuildIosApps,
 };

--- a/.github/scripts/compute-e2e-platform-flags.test.ts
+++ b/.github/scripts/compute-e2e-platform-flags.test.ts
@@ -1,4 +1,7 @@
-const { computeE2EPlatformFlags } = require('./compute-e2e-platform-flags.cjs');
+const {
+  computeE2EPlatformFlags,
+  shouldBuildIosApps,
+} = require('./compute-e2e-platform-flags.cjs');
 
 describe('computeE2EPlatformFlags', () => {
   const baseInput = {
@@ -67,5 +70,154 @@ describe('computeE2EPlatformFlags', () => {
     });
 
     expect(result.nativeBuildNeeded).toBe(true);
+  });
+
+  const mergeGroupInput = {
+    ...baseInput,
+    githubEventName: 'merge_group',
+  };
+
+  it('runs iOS only on merge_group for shared path changes', () => {
+    const result = computeE2EPlatformFlags({
+      ...mergeGroupInput,
+      e2eTestFilesCount: 0,
+      e2eTestOrIgnorableCount: 0,
+    });
+
+    expect(result.android).toBe(false);
+    expect(result.ios).toBe(true);
+    expect(result.e2eNeeded).toBe(true);
+    expect(result.message).toContain('merge queue');
+  });
+
+  it('skips E2E on merge_group for android-only changes', () => {
+    const result = computeE2EPlatformFlags({
+      ...mergeGroupInput,
+      e2eTestFilesCount: 0,
+      e2eTestOrIgnorableCount: 0,
+      androidCount: 1,
+      androidOrIgnorableCount: 1,
+    });
+
+    expect(result.e2eNeeded).toBe(false);
+    expect(result.message).toContain('Android covered');
+  });
+
+  it('skips E2E on merge_group for ignorable-only changes', () => {
+    const result = computeE2EPlatformFlags({
+      ...mergeGroupInput,
+      e2eTestFilesCount: 0,
+      ignorableCount: 1,
+      e2eTestOrIgnorableCount: 1,
+      changedSpecFiles: '',
+    });
+
+    expect(result.e2eNeeded).toBe(false);
+    expect(result.message).toContain('ignorable-only');
+  });
+
+  it('runs iOS only on merge_group for ios-only path changes', () => {
+    const result = computeE2EPlatformFlags({
+      ...mergeGroupInput,
+      e2eTestFilesCount: 0,
+      e2eTestOrIgnorableCount: 0,
+      iosCount: 1,
+      iosOrIgnorableCount: 1,
+    });
+
+    expect(result.android).toBe(false);
+    expect(result.ios).toBe(true);
+    expect(result.nativeBuildNeeded).toBe(true);
+  });
+
+  it('runs iOS only on merge_group for test-only changes and reuses main builds', () => {
+    const result = computeE2EPlatformFlags(mergeGroupInput);
+
+    expect(result.android).toBe(false);
+    expect(result.ios).toBe(true);
+    expect(result.nativeBuildNeeded).toBe(false);
+    expect(result.message).toContain('reuse main native builds');
+  });
+
+  it('skips E2E on merge_group when shouldSkipE2E is set', () => {
+    const result = computeE2EPlatformFlags({
+      ...mergeGroupInput,
+      shouldSkipE2E: true,
+      e2eTestFilesCount: 0,
+      e2eTestOrIgnorableCount: 0,
+    });
+
+    expect(result.e2eNeeded).toBe(false);
+    expect(result.message).toContain('skip signal');
+  });
+});
+
+describe('shouldBuildIosApps', () => {
+  const sharedMainPr = {
+    githubEventName: 'pull_request',
+    pullRequestBase: 'main',
+    iosE2eNeeded: true,
+    androidE2eNeeded: true,
+  };
+
+  it('skips iOS on feature PRs to main when Android also runs', () => {
+    expect(shouldBuildIosApps(sharedMainPr)).toBe(false);
+  });
+
+  it('keeps iOS when ios/** paths changed', () => {
+    expect(shouldBuildIosApps({ ...sharedMainPr, iosPathChanges: true })).toBe(
+      true,
+    );
+  });
+
+  it('keeps iOS when run-ios-e2e opts in', () => {
+    expect(shouldBuildIosApps({ ...sharedMainPr, forceIosE2E: true })).toBe(
+      true,
+    );
+  });
+
+  it('keeps iOS when Appium iOS demand opts in', () => {
+    expect(shouldBuildIosApps({ ...sharedMainPr, runAppiumIos: true })).toBe(
+      true,
+    );
+  });
+
+  it('keeps iOS for iOS-only path changes', () => {
+    expect(
+      shouldBuildIosApps({
+        ...sharedMainPr,
+        androidE2eNeeded: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps iOS on release PRs and non-PR events', () => {
+    expect(
+      shouldBuildIosApps({
+        ...sharedMainPr,
+        pullRequestBase: 'release/7.50.0',
+      }),
+    ).toBe(true);
+    expect(
+      shouldBuildIosApps({
+        ...sharedMainPr,
+        githubEventName: 'merge_group',
+      }),
+    ).toBe(true);
+    expect(
+      shouldBuildIosApps({
+        ...sharedMainPr,
+        githubEventName: 'push',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when iOS E2E is not needed', () => {
+    expect(
+      shouldBuildIosApps({
+        ...sharedMainPr,
+        iosE2eNeeded: false,
+      }),
+    ).toBe(false);
   });
 });

--- a/.github/scripts/run-compute-e2e-platform-flags.cjs
+++ b/.github/scripts/run-compute-e2e-platform-flags.cjs
@@ -6,6 +6,7 @@
 const fs = require('node:fs');
 const {
   computeE2EPlatformFlags,
+  shouldBuildIosApps,
 } = require('./compute-e2e-platform-flags.cjs');
 
 function readBool(value) {
@@ -84,11 +85,28 @@ if (
   runPerformance = true;
 }
 
+const iosBuildNeeded = shouldBuildIosApps({
+  githubEventName: process.env.GITHUB_EVENT_NAME || '',
+  pullRequestBase: process.env.PULL_REQUEST_BASE || '',
+  iosE2eNeeded: flags.ios,
+  androidE2eNeeded: flags.android,
+  iosPathChanges: readBool(process.env.IOS_PATH_CHANGES),
+  forceIosE2E: readBool(process.env.FORCE_IOS_E2E),
+  runAppiumIos,
+});
+
+if (flags.ios && !iosBuildNeeded) {
+  console.log(
+    '-> ios_build_needed=false (Android-first on feature PR to main)',
+  );
+}
+
 console.log(flags.message);
 
 const outputLines = [
   `android_final=${flags.android}`,
   `ios_final=${flags.ios}`,
+  `ios_build_needed=${iosBuildNeeded}`,
   `e2e_needed=${flags.e2eNeeded}`,
   `native_build_needed=${flags.nativeBuildNeeded}`,
   `run_smart_e2e_selection=${flags.runSmartE2ESelection}`,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1359,11 +1359,12 @@ jobs:
     name: 'Build iOS Apps'
     # NAMESPACE-SHADOW: iOS pipeline runs on Namespace shadow only when NAMESPACE_SHADOW_AUTO_DISPATCH=true
     # (downstream iOS jobs cascade-skip via needs when this is skipped)
+    # Android-first gate is applied in get-requirements (ios_build_needed).
     if: >-
       ${{
         !cancelled() &&
         (inputs.runner_provider != 'namespace' || vars.NAMESPACE_SHADOW_AUTO_DISPATCH == 'true') &&
-        needs.get_requirements.outputs.ios_e2e_needed == 'true' &&
+        needs.get_requirements.outputs.ios_build_needed == 'true' &&
         !(fromJSON(needs.smart-e2e-selection.outputs.ai_confidence || '0') >= 85 && needs.smart-e2e-selection.outputs.ai_e2e_test_tags == '[]')
       }}
     permissions:
@@ -1485,7 +1486,12 @@ jobs:
   # Fixture validation — ensures committed E2E fixtures match the live app state schema
   validate-e2e-fixtures:
     name: 'Validate E2E Fixtures'
-    if: ${{ needs.ios-tests-ready.result == 'success' && github.event_name == 'pull_request' }}
+    # Also on merge_group when iOS built there (Android-first PRs skip iOS on the PR).
+    if: >-
+      ${{
+        needs.ios-tests-ready.result == 'success' &&
+        (github.event_name == 'pull_request' || github.event_name == 'merge_group')
+      }}
     permissions:
       contents: read
       checks: write
@@ -1509,7 +1515,8 @@ jobs:
     name: 'Report Fixture Validation'
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ci-linux' || 'ubuntu-latest' }}
     # BITRISE/NAMESPACE-SHADOW: skip for iOS-only shadow benchmark (INFRA-3679) — revert to enable full pipeline
-    if: ${{ inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' && !cancelled() && needs.validate-e2e-fixtures.result != 'skipped' }}
+    # PR comments only make sense on pull_request (merge_group has no PR number in event).
+    if: ${{ inputs.runner_provider != 'bitrise' && inputs.runner_provider != 'namespace' && !cancelled() && needs.validate-e2e-fixtures.result != 'skipped' && github.event_name == 'pull_request' }}
     needs: [validate-e2e-fixtures]
     permissions:
       pull-requests: write
@@ -1750,6 +1757,7 @@ jobs:
       - e2e-smoke-tests-ios
       - appium-smoke-tests-android
       - appium-smoke-tests-ios
+      - validate-e2e-fixtures
     steps:
       - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
         if: ${{ inputs.runner_provider == 'namespace' }}
@@ -1770,7 +1778,7 @@ jobs:
         with:
           needs-json: ${{ toJSON(needs) }}
           requirement-context-json: ${{ toJSON(needs.get_requirements.outputs) }}
-          e2e-job-regex: '^(build-android-apks|build-ios-apps|e2e-smoke-tests-android|e2e-smoke-tests-ios|appium-smoke-tests-android|appium-smoke-tests-ios)$'
+          e2e-job-regex: '^(build-android-apks|build-ios-apps|e2e-smoke-tests-android|e2e-smoke-tests-ios|appium-smoke-tests-android|appium-smoke-tests-ios|validate-e2e-fixtures)$'
           event-name: ${{ github.event_name }}
           is-fork: ${{ github.event.pull_request.head.repo.fork == true }}
 

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -17,6 +17,9 @@ on:
       ios_e2e_needed:
         description: 'Whether iOS E2E tests and builds should run (true when iOS-specific or shared files changed)'
         value: ${{ jobs.detect-changes.outputs.ios_e2e_needed }}
+      ios_build_needed:
+        description: 'Whether Build iOS Apps should run after Android-first gating on feature PRs to main'
+        value: ${{ jobs.detect-changes.outputs.ios_build_needed }}
       changed_spec_files:
         description: 'Space-separated list of changed E2E spec file paths only — never the full changed-file list, which overflows ARG_MAX and kills this job on large PRs. Smoke test workflows use this to run modified spec files twice for flakiness detection (catches flaky tests before they land on main)'
         value: ${{ jobs.detect-changes.outputs.changed_spec_files }}
@@ -32,6 +35,12 @@ on:
       run_appium_ios:
         description: 'Whether Appium iOS smoke tests should also run on a PR via the run-appium-ios-tests label or e2e smoke infra / smoke-appium file changes'
         value: ${{ jobs.detect-changes.outputs.run_appium_ios }}
+      run_ios_e2e:
+        description: 'Whether to opt in to iOS Detox E2E (and the iOS native build) on a feature PR targeting main via the run-ios-e2e label'
+        value: ${{ jobs.detect-changes.outputs.run_ios_e2e }}
+      ios_path_changes:
+        description: 'Whether any ios/** files changed (keeps iOS E2E on feature PRs to main even when Android also runs)'
+        value: ${{ jobs.detect-changes.outputs.ios_path_changes }}
       native_build_needed:
         description: 'Whether fresh iOS/Android native E2E builds are required. False when only E2E/performance test files changed — CI reuses main branch builds instead.'
         value: ${{ jobs.detect-changes.outputs.native_build_needed }}
@@ -46,11 +55,14 @@ jobs:
       skip_e2e: ${{ steps.set-outputs.outputs.e2e_needed != 'true' && 'true' || 'false' }}
       android_e2e_needed: ${{ steps.set-outputs.outputs.android_final }}
       ios_e2e_needed: ${{ steps.set-outputs.outputs.ios_final }}
+      ios_build_needed: ${{ steps.set-outputs.outputs.ios_build_needed }}
       changed_spec_files: ${{ steps.set-outputs.outputs.changed_spec_files }}
       block_merge_for_e2e_readiness: ${{ steps.set-outputs.outputs.block_merge }}
       run_smart_e2e_selection: ${{ steps.set-outputs.outputs.run_smart_e2e_selection }}
       run_performance: ${{ steps.set-outputs.outputs.run_performance }}
       run_appium_ios: ${{ steps.set-outputs.outputs.run_appium_ios }}
+      run_ios_e2e: ${{ steps.check-labels.outputs.RUN_IOS_E2E || 'false' }}
+      ios_path_changes: ${{ steps.filter.outputs.ios || 'false' }}
       native_build_needed: ${{ steps.set-outputs.outputs.native_build_needed }}
     env:
       # For a `pull_request` event, the head commit hash is `github.event.pull_request.head.sha`.
@@ -88,10 +100,14 @@ jobs:
 
       - name: Check PR labels
         id: check-labels
-        if: steps.skip-merge-queue.outputs.up-to-date != 'true' && github.event_name == 'pull_request'
+        if: >-
+          steps.skip-merge-queue.outputs.up-to-date != 'true' &&
+          (github.event_name == 'pull_request' || github.event_name == 'merge_group')
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          MERGE_HEAD_REF: ${{ github.event.merge_group.head_ref }}
         run: |
           {
             echo "SKIP_E2E=false"
@@ -99,7 +115,19 @@ jobs:
             echo "SKIP_SMART_SELECTION=false"
             echo "RUN_PERFORMANCE=false"
             echo "RUN_APPIUM_IOS=false"
+            echo "RUN_IOS_E2E=false"
           } >> "$GITHUB_OUTPUT"
+
+          # merge_group.head_ref is gh-readonly-queue/<base>/pr-<N>-<sha>, not the PR branch.
+          if [ "$EVENT_NAME" = "merge_group" ]; then
+            if [[ "$MERGE_HEAD_REF" =~ /pr-([0-9]+)- ]]; then
+              PR_NUMBER="${BASH_REMATCH[1]}"
+              echo "-> Resolved merge group PR #${PR_NUMBER} from ${MERGE_HEAD_REF}"
+            else
+              echo "::error::Could not parse PR number from merge group head ref: ${MERGE_HEAD_REF}"
+              exit 1
+            fi
+          fi
 
           LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name')
 
@@ -131,6 +159,11 @@ jobs:
             echo "-> RUN_APPIUM_IOS=true due to 'run-appium-ios-tests' label on PR"
           fi
 
+          if echo "$LABELS" | grep -qx "run-ios-e2e"; then
+            echo "RUN_IOS_E2E=true" >> "$GITHUB_OUTPUT"
+            echo "-> RUN_IOS_E2E=true due to 'run-ios-e2e' label on PR"
+          fi
+
       - name: Filter changed files
         id: filter
         if: steps.skip-merge-queue.outputs.up-to-date != 'true'
@@ -150,6 +183,9 @@ jobs:
         if: steps.skip-merge-queue.outputs.up-to-date != 'true'
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
+          PULL_REQUEST_BASE: ${{ github.base_ref }}
+          FORCE_IOS_E2E: ${{ steps.check-labels.outputs.RUN_IOS_E2E }}
+          IOS_PATH_CHANGES: ${{ steps.filter.outputs.ios }}
           IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
           SHOULD_SKIP_E2E: ${{ steps.skip-e2e-tag.outputs.SKIP == 'true' || steps.check-labels.outputs.SKIP_E2E == 'true' }}
           LABEL_BLOCKS_MERGE: ${{ steps.check-labels.outputs.LABEL_BLOCKS_MERGE }}

--- a/.github/workflows/rerun-ci-on-skipped-e2e-labels.yml
+++ b/.github/workflows/rerun-ci-on-skipped-e2e-labels.yml
@@ -19,7 +19,8 @@ jobs:
        github.event.label.name == 'pr-not-ready-for-e2e' ||
        github.event.label.name == 'force-builds' ||
        github.event.label.name == 'run-performance-tests' ||
-       github.event.label.name == 'run-appium-ios-tests')
+       github.event.label.name == 'run-appium-ios-tests' ||
+       github.event.label.name == 'run-ios-e2e')
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -110,6 +110,7 @@ jobs:
       BRANCH: ${{ steps.branch.outputs.BRANCH }}
       PR_NUMBER: ${{ needs.is-fork-pull-request.outputs.PR_NUMBER }}
       RUN_ID: ${{ steps.validate-ci.outputs.RUN_ID }}
+      IOS_ARTIFACT_AVAILABLE: ${{ steps.validate-ci.outputs.IOS_ARTIFACT_AVAILABLE }}
     steps:
       - uses: actions/checkout@v4
 
@@ -164,22 +165,60 @@ jobs:
           fi
 
           if [ "${RUN_STATUS}" != "completed" ]; then
-            echo "::error title=CI still running::The CI workflow is still in progress (status: ${RUN_STATUS}). Wait for the 'Build iOS Apps' job to complete, then run @metamaskbot update-mobile-fixture again. View CI: ${RUN_URL}"
+            echo "::error title=CI still running::The CI workflow is still in progress (status: ${RUN_STATUS}). Wait for CI to finish, then run @metamaskbot update-mobile-fixture again. View CI: ${RUN_URL}"
             exit 1
           fi
 
           if [ "${RUN_CONCLUSION}" != "success" ]; then
-            echo "::warning title=CI did not succeed::The CI workflow concluded with '${RUN_CONCLUSION}'. The iOS build artifact may not be available. View CI: ${RUN_URL}"
+            echo "::warning title=CI did not succeed::The CI workflow concluded with '${RUN_CONCLUSION}'. The iOS build artifact may not be available; a fallback iOS build will run if needed. View CI: ${RUN_URL}"
+          fi
+
+          if gh api --paginate "repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts" \
+            --jq '.artifacts[]? | select(.name == "main-e2e-MetaMask.app" and .expired == false) | .id' \
+            | grep -q .; then
+            echo "IOS_ARTIFACT_AVAILABLE=true" >> "$GITHUB_OUTPUT"
+            echo "✅ CI iOS artifact found on run ${RUN_ID}"
+          else
+            echo "IOS_ARTIFACT_AVAILABLE=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=No CI iOS artifact::Build iOS Apps was skipped on this PR CI run. A fallback iOS E2E build will run in this workflow."
           fi
 
           echo "✅ CI run validated. RUN_ID=${RUN_ID}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  build-ios-fallback:
+    name: Build iOS app (fixture fallback)
+    needs: [is-fork-pull-request, prepare]
+    if: >-
+      ${{
+        needs.prepare.result == 'success' &&
+        needs.is-fork-pull-request.outputs.IS_FORK == 'false' &&
+        needs.prepare.outputs.IOS_ARTIFACT_AVAILABLE != 'true'
+      }}
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+      statuses: read
+      pull-requests: read
+    uses: ./.github/workflows/build-ios-e2e.yml
+    with:
+      build_type: 'main'
+      metamask_environment: 'e2e'
+      runner_provider: ${{ inputs.runner_provider || 'current' }}
+    secrets: inherit
+
   update-fixtures:
     name: Export & update fixtures
-    needs: [is-fork-pull-request, prepare]
-    if: ${{ needs.prepare.result == 'success' && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
+    needs: [is-fork-pull-request, prepare, build-ios-fallback]
+    if: >-
+      ${{
+        always() &&
+        needs.prepare.result == 'success' &&
+        needs.is-fork-pull-request.outputs.IS_FORK == 'false' &&
+        (needs.build-ios-fallback.result == 'success' || needs.build-ios-fallback.result == 'skipped')
+      }}
     # Appium fixture update uses Cirrus macOS (current), same as appium-smoke-tests-ios.
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ios-e2e' || (startsWith(github.base_ref, 'release/') && fromJSON('["ghcr.io/cirruslabs/macos-runner:tahoe"]') || fromJSON('["ghcr.io/cirruslabs/macos-runner:tahoe", "low-priority"]')) }}
     timeout-minutes: 60
@@ -233,6 +272,7 @@ jobs:
           runner_provider: current
 
       - name: Download iOS app artifact from CI
+        if: ${{ needs.prepare.outputs.IOS_ARTIFACT_AVAILABLE == 'true' }}
         run: |
           RUN_ID="${{ needs.prepare.outputs.RUN_ID }}"
           ARTIFACT_NAME="main-e2e-MetaMask.app"
@@ -242,12 +282,19 @@ jobs:
           # gh run download uses the ListArtifacts API, which includes artifacts from all
           # attempts of a run — including earlier attempts when only failed jobs were re-run.
           if ! gh run download "${RUN_ID}" -n "${ARTIFACT_NAME}" -D "${APP_PATH}"; then
-            echo "::error title=iOS artifact not found::The iOS build was skipped in CI run ${RUN_ID} — no iOS-impacting changes were detected, so no artifact was produced.%0A%0AIf you need to force fixture regeneration, add the 'skip-smart-e2e-selection' label to your PR and re-run CI, then retry this command.%0A%0ACI run: https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}"
+            echo "::error title=iOS artifact not found::Failed to download iOS artifact from CI run ${RUN_ID}.%0A%0ACI run: https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}"
             exit 1
           fi
           echo "✅ Downloaded iOS artifact from PR CI run ${RUN_ID}."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download iOS app artifact from fallback build
+        if: ${{ needs.prepare.outputs.IOS_ARTIFACT_AVAILABLE != 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: main-e2e-MetaMask.app
+          path: artifacts/main-e2e-MetaMask.app
 
       - name: Restore iOS bundle executable permissions
         env:
@@ -484,7 +531,7 @@ jobs:
         run: |
           passed="${{ needs.check-status.outputs.PASSED }}"
           if [[ $passed != "true" ]]; then
-            body="❌ **E2E fixture update failed.**\n\n**Common causes:**\n- CI workflow is still running — wait for 'Build iOS Apps' to complete\n- CI workflow was skipped — ensure your PR has iOS-impacting changes or use \`skip-smart-e2e-selection\` label\n- iOS build failed — check the CI workflow for errors\n\n[View logs and retry](${ACTION_RUN_URL})"
+            body="❌ **E2E fixture update failed.**\n\n**Common causes:**\n- CI workflow is still running — wait for CI to finish on the latest commit\n- Fallback iOS build failed — check the 'Build iOS app (fixture fallback)' job\n- Fixture export / commit step failed — check workflow logs\n\n[View logs and retry](${ACTION_RUN_URL})"
             gh pr comment "${PR_NUMBER}" --body "$body"
           fi
         env:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Reduces expensive iOS CI on feature PRs targeting `main` (INFRA-3796 Android-first).

**PR CI (`build-ios-apps`):**
- Skip iOS when Android E2E also runs
- Keep iOS when any `ios/**` files changed, iOS-only path changes, `run-ios-e2e`, or Appium iOS demand (`run-appium-ios-tests` / smoke-infra paths)

**Merge queue:**
- Run iOS-only for shared / iOS-only / test-only work (Android already ran on the PR)
- Honor `skip-e2e` by parsing the PR number from `gh-readonly-queue/.../pr-N-...`

**Fixtures:**
- `@metamaskbot update-mobile-fixture` falls back to building iOS when the CI artifact is missing
- Fixture validation also runs on merge_group when iOS built; failures are included in `check-all-jobs-pass` (skipped still allowed)

`release/*` / `stable` PRs and `main` push/schedule are unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: INFRA-3796

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A - CI workflow / flag logic only. Covered by unit tests in `.github/scripts/compute-e2e-platform-flags.test.ts` (platform flags + Android-first `shouldBuildIosApps` gate).

Suggested CI verification on this draft:
1. Feature PR to `main` with shared JS changes: Android E2E runs, iOS build skipped unless opt-in / `ios/**`
2. Feature PR with `ios/**` changes: iOS build runs
3. Label `run-ios-e2e`: iOS build runs and CI re-triggers
4. Merge queue entry for shared work: iOS-only E2E runs; `skip-e2e` labeled PR skips MQ iOS

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A - no UI changes

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)