### PR TITLE
fix(ci): make artifact availability, not run completion, decide reusable-build donors

### DIFF
--- a/.github/actions/find-reusable-build/action.yml
+++ b/.github/actions/find-reusable-build/action.yml
@@ -260,6 +260,37 @@ runs:
           const seenRunIds = new Set();
           seenRunIds.add(currentRunId);
 
+          // Rate-limit accounting. The `/rate_limit` endpoint is itself free, so
+          // reading it before and after the search costs nothing and tells us how
+          // much of the hourly core budget one lookup actually consumes.
+          async function readRateLimit() {
+            try {
+              const { data } = await github.rest.rateLimit.get();
+              return data.resources.core;
+            } catch (err) {
+              core.info(`rateLimit.get failed: ${err.message}`);
+              return null;
+            }
+          }
+
+          const rateLimitBefore = await readRateLimit();
+
+          async function logRateLimit() {
+            const after = await readRateLimit();
+            if (!after) return;
+            const used = rateLimitBefore ? rateLimitBefore.remaining - after.remaining : null;
+            const resetAt = new Date(after.reset * 1000).toISOString();
+            core.info(
+              `Rate limit (core): ${after.remaining}/${after.limit} remaining, ` +
+              `${used === null ? 'unknown' : used} request(s) used by this lookup, resets at ${resetAt}`,
+            );
+            if (after.remaining < after.limit * 0.1) {
+              core.warning(
+                `GitHub API core rate limit is low: ${after.remaining}/${after.limit} remaining until ${resetAt}`,
+              );
+            }
+          }
+
           // Each tier is swept once per run status below, applied server-side via
           // the `status` filter so that a single crowded page of recent runs can't
           // consume a tier's candidate window. On a busy repo the newest runs are
@@ -346,9 +377,11 @@ runs:
               core.setOutput('run-id', String(match.id));
               core.setOutput('source-sha', match.head_sha);
               core.setOutput('source-branch', match.head_branch || '');
+              await logRateLimit();
               return;
             }
           }
 
           core.info('No reusable build found across any tier');
+          await logRateLimit();
           setNotFound();

--- a/.github/actions/find-reusable-build/action.yml
+++ b/.github/actions/find-reusable-build/action.yml
@@ -14,9 +14,11 @@ description: >-
   `event: pull_request` to let the fingerprint itself act as the cross-PR
   deduplication key.
 
-  Each tier is swept once per run conclusion (`success`, then `failure`, then
-  `completed`) so that in-flight and concurrency-cancelled runs cannot consume
-  the candidate window ahead of runs that can actually hold artifacts.
+  Each tier is swept once per run status (`success`, `in_progress`, `failure`,
+  then `completed`) so that one crowded page of recent runs cannot consume the
+  candidate window. A donor only needs to have uploaded its artifacts, not to
+  have finished: the native build publishes the app roughly 25-35 minutes before
+  the run completes, since E2E tests keep the run alive well past that point.
 
 inputs:
   fingerprint:
@@ -258,18 +260,33 @@ runs:
           const seenRunIds = new Set();
           seenRunIds.add(currentRunId);
 
-          // Each tier is swept once per conclusion below, applied server-side via
-          // the `status` filter so that cancelled and still-running runs never
-          // consume a tier's candidate window. On a busy repo the most recent runs
-          // are dominated by in-flight runs and by runs that concurrency cancelled
-          // mid-build, neither of which can hold complete artifacts; without this
-          // filter they crowd genuinely reusable runs out of the window entirely.
+          // Each tier is swept once per run status below, applied server-side via
+          // the `status` filter so that a single crowded page of recent runs can't
+          // consume a tier's candidate window. On a busy repo the newest runs are
+          // dominated by in-flight runs and by runs that concurrency cancelled
+          // mid-build; sweeping per status keeps each category's budget separate.
           //
-          // Successful runs are swept first. Failed runs come next, because a run
-          // can fail on a job unrelated to the native build while still holding
-          // complete artifacts. The final `completed` sweep is a last resort that
-          // picks up cancelled, timed-out and neutral runs, preserving reach.
-          const conclusionSweeps = ['success', 'failure', 'completed'];
+          // Order matters, and it is deliberately not "terminal states first":
+          //
+          //   success     - a fully green run is the most conservative donor.
+          //   in_progress - a run only needs to have *uploaded* its artifacts to be
+          //                 a valid donor; it does not need to have finished. The
+          //                 native build completes roughly 25-35 minutes before the
+          //                 run itself does, because E2E tests keep the run alive
+          //                 long after the `.app` is published. Skipping these runs
+          //                 discarded a complete, verified build for that entire
+          //                 window - measured at 8 of 18 cold-fingerprint rebuilds,
+          //                 one of them with a donor that had been ready 32 minutes.
+          //                 `hasAllArtifacts` below is what makes this safe: a run
+          //                 mid-upload simply fails that check and is skipped.
+          //   failure     - a run can fail on a job unrelated to the native build
+          //                 while still holding complete artifacts.
+          //   completed   - last resort; picks up cancelled, timed-out and neutral
+          //                 runs, preserving reach.
+          //
+          // `queued` is intentionally not swept: such runs cannot have artifacts yet,
+          // so they would only cost API calls.
+          const statusSweeps = ['success', 'in_progress', 'failure', 'completed'];
 
           async function listCandidates(tier, status) {
             try {
@@ -297,8 +314,9 @@ runs:
 
               if (tier.skipHeadBranch && run.head_branch === tier.skipHeadBranch) continue;
 
-              if (run.status !== 'completed') continue;
-
+              // Deliberately no `run.status === 'completed'` gate: artifact
+              // availability, not run completion, is what makes a donor usable, and
+              // `hasAllArtifacts` verifies that below.
               if (!(await hasRunFingerprintStatus(run.head_sha, run.id))) {
                 core.info(`Run ${run.id} has no run-specific ${STATUS_CONTEXT} status matching fingerprint ${TARGET_FINGERPRINT}`);
                 continue;
@@ -314,7 +332,7 @@ runs:
           for (const tier of tiers) {
             core.info(`Searching tier: ${tier.label}`);
 
-            for (const status of conclusionSweeps) {
+            for (const status of statusSweeps) {
               const runs = await listCandidates(tier, status);
               core.info(`  sweep status=${status}: ${runs.length} run(s) returned`);
 

--- a/.github/actions/find-reusable-build/action.yml
+++ b/.github/actions/find-reusable-build/action.yml
@@ -14,6 +14,10 @@ description: >-
   `event: pull_request` to let the fingerprint itself act as the cross-PR
   deduplication key.
 
+  Each tier is swept once per run conclusion (`success`, then `failure`, then
+  `completed`) so that in-flight and concurrency-cancelled runs cannot consume
+  the candidate window ahead of runs that can actually hold artifacts.
+
 inputs:
   fingerprint:
     description: 'The @expo/fingerprint hash the candidate must match'
@@ -44,17 +48,23 @@ inputs:
     required: false
     default: 'build-source-hash'
   max-candidates-per-branch:
-    description: 'How many recent runs to inspect per branch-scoped tier (same-branch, base-branch)'
+    description: >-
+      How many recent runs to inspect per branch-scoped tier (same-branch,
+      base-branch), per conclusion sweep. Because sweeps filter server-side on
+      run conclusion, this budget is spent on terminal runs rather than on
+      in-flight ones — which matters most for the base-branch tier, where `main`
+      CI runs longer than the merge cadence, so a large share of the newest runs
+      are always still building.
     required: false
     default: '10'
   max-candidates-cross-pr:
     description: >-
       How many recent `pull_request`-event runs (across all branches) to inspect
-      in the cross-PR tier. The fingerprint filter is highly discriminating, so
-      the practical cost is one `listCommitStatusesForRef` call per candidate
-      until a run-specific status match is found.
+      in the cross-PR tier, per conclusion sweep. The fingerprint filter is highly
+      discriminating, so the practical cost is one `listCommitStatusesForRef` call
+      per candidate until a run-specific status match is found.
     required: false
-    default: '30'
+    default: '50'
   main-branch-only:
     description: >-
       When true, only search the base branch (typically `main`) for reusable
@@ -147,7 +157,7 @@ runs:
             : requiredArtifacts;
 
           const maxCandidates = Number(MAX_CANDIDATES) || 10;
-          const maxCandidatesCrossPr = Number(MAX_CANDIDATES_CROSS_PR) || 30;
+          const maxCandidatesCrossPr = Number(MAX_CANDIDATES_CROSS_PR) || 50;
           const currentRunId = String(CURRENT_RUN_ID);
 
           // Three-tier discovery:
@@ -248,22 +258,38 @@ runs:
           const seenRunIds = new Set();
           seenRunIds.add(currentRunId);
 
-          for (const tier of tiers) {
-            core.info(`Searching tier: ${tier.label}`);
-            let runs;
+          // Each tier is swept once per conclusion below, applied server-side via
+          // the `status` filter so that cancelled and still-running runs never
+          // consume a tier's candidate window. On a busy repo the most recent runs
+          // are dominated by in-flight runs and by runs that concurrency cancelled
+          // mid-build, neither of which can hold complete artifacts; without this
+          // filter they crowd genuinely reusable runs out of the window entirely.
+          //
+          // Successful runs are swept first. Failed runs come next, because a run
+          // can fail on a job unrelated to the native build while still holding
+          // complete artifacts. The final `completed` sweep is a last resort that
+          // picks up cancelled, timed-out and neutral runs, preserving reach.
+          const conclusionSweeps = ['success', 'failure', 'completed'];
+
+          async function listCandidates(tier, status) {
             try {
               const { data } = await github.rest.actions.listWorkflowRuns({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 workflow_id: WORKFLOW_FILE,
+                status,
                 ...tier.params,
               });
-              runs = data.workflow_runs || [];
+              return data.workflow_runs || [];
             } catch (err) {
-              core.warning(`listWorkflowRuns failed for tier "${tier.label}": ${err.message}`);
-              continue;
+              core.warning(
+                `listWorkflowRuns failed for tier "${tier.label}" (status=${status}): ${err.message}`,
+              );
+              return [];
             }
+          }
 
+          async function findMatch(tier, runs) {
             for (const run of runs) {
               const runIdStr = String(run.id);
               if (seenRunIds.has(runIdStr)) continue;
@@ -280,13 +306,28 @@ runs:
 
               if (!(await hasAllArtifacts(run.id))) continue;
 
+              return run;
+            }
+            return null;
+          }
+
+          for (const tier of tiers) {
+            core.info(`Searching tier: ${tier.label}`);
+
+            for (const status of conclusionSweeps) {
+              const runs = await listCandidates(tier, status);
+              core.info(`  sweep status=${status}: ${runs.length} run(s) returned`);
+
+              const match = await findMatch(tier, runs);
+              if (!match) continue;
+
               core.info(
-                `Match: tier="${tier.label}" run=${run.id} sha=${run.head_sha} branch=${run.head_branch} url=${run.html_url}`,
+                `Match: tier="${tier.label}" status=${status} run=${match.id} sha=${match.head_sha} branch=${match.head_branch} url=${match.html_url}`,
               );
               core.setOutput('found', 'true');
-              core.setOutput('run-id', runIdStr);
-              core.setOutput('source-sha', run.head_sha);
-              core.setOutput('source-branch', run.head_branch || '');
+              core.setOutput('run-id', String(match.id));
+              core.setOutput('source-sha', match.head_sha);
+              core.setOutput('source-branch', match.head_branch || '');
               return;
             }
           }


### PR DESCRIPTION
## **Description**

This PR fixes two independent defects in how `find-reusable-build` picks a donor. The second one was found by measurement after the first was written, and it is the larger of the two.

### Defect 1 — a finished build was ignored until its run finished

The lookup gated candidates on `run.status !== 'completed'`. But a CI run does not end when the native build ends: the app is uploaded and then E2E tests keep the run alive for a long time afterwards. Measured on the four donor runs behind the recent incidents:

| Donor run | `.app` uploaded | Run completed | Ignored despite being ready |
| --- | --- | --- | --- |
| [30824460035](https://github.com/MetaMask/metamask-mobile/actions/runs/30824460035) | 15:15:35 | 15:45:16 | 30 min |
| [30834718049](https://github.com/MetaMask/metamask-mobile/actions/runs/30834718049) | 17:25:50 | 18:01:23 | 36 min |
| [30854360025](https://github.com/MetaMask/metamask-mobile/actions/runs/30854360025) | 21:50:46 | 22:18:25 | 28 min |
| [30901421838](https://github.com/MetaMask/metamask-mobile/actions/runs/30901421838) | 11:08:08 | 11:31:19 | 23 min |

For 23–36 minutes each, a complete, verified `.app` sat in artifact storage while every PR that asked for it was told no donor existed and spent ~28 minutes building an identical copy.

Artifact availability, not run completion, is what makes a donor usable. This PR sweeps `in_progress` alongside the terminal statuses and removes the completed-only skip. `hasAllArtifacts` — which already ran on every candidate — is what keeps this safe: a run that has not yet uploaded, or is mid-upload, fails that check and is skipped exactly as before.

### Defect 2 — the candidate window was consumed by runs that can never be donors

Each tier fetched a fixed `per_page` page of the most recent runs. On a busy repo that page is dominated by runs that concurrency cancelled mid-build and by in-flight runs, so the budget was spent before reaching a usable donor. Filtering client-side does not help; the slots are already gone. This PR applies the filter server-side by sweeping each tier once per status, and raises the cross-PR budget from 30 to 50.

Auditing the 28 candidates inspected in [run 30807671115](https://github.com/MetaMask/metamask-mobile/actions/runs/30807671115): only **5** concluded `success`, **17** were `cancelled` or `failure`, **11** had no `build-source-hash` status at all because concurrency killed them before the fingerprint job posted, and a single branch occupied **6** slots through rapid successive pushes.

### How the two interact

Defect 2's original framing was that in-flight runs are dead weight crowding out real donors. Defect 1 shows that is only half true: an in-flight run whose build has finished is one of the *best* donors available, because it carries the newest fingerprint. Fixing both turns the largest category of wasted candidates into the most useful one.

Sweep order is `success`, `in_progress`, `failure`, `completed`. A fully green run is preferred when one exists; the in-flight sweep is reached only when it does not. `queued` is deliberately not swept, since such runs cannot hold artifacts and would only cost API calls.

### Why this is safe

- **`hasAllArtifacts` is the real gate, and it is unchanged.** Every candidate must expose all required artifacts, non-expired, before it can be selected. Accepting in-flight runs widens *who is considered*, not *what qualifies*.
- **Artifacts outlive their run.** An artifact stays downloadable if the donor run is later cancelled or fails, and the download happens immediately, so a donor cannot be pulled out from under a consumer.
- **The fingerprint check is unchanged.** A candidate must still carry a run-specific `build-source-hash` matching the target exactly, so an in-flight donor is native-input-identical by construction.
- **No reach lost.** The final `completed` sweep still picks up cancelled, timed-out and neutral runs, so anything reachable before remains reachable.
- **Failed runs stay eligible** — a run can fail on a job unrelated to the native build while holding complete artifacts.
- **No fingerprint change**, so merging triggers no rebuild wave.

### Estimated improvement

Sized against a measured sample rather than assumed. Over 194 recent `ci.yml` iOS build jobs, 79% already reuse (153 reused, 37 fresh); this PR only affects the ~19% miss tail. Of the 18 fresh builds in that tail attributable to a cold fingerprint, I checked each against the donor timeline above:

| Outcome | Count | Explanation |
| --- | --- | --- |
| A donor was already published and was skipped only because its run was still testing | **8 of 18** | Fixed by defect 1 |
| The donor genuinely had not uploaded yet | 10 of 18 | Not fixable by any search change; needs the first build to finish |

Taking 8 of 18 (44%) of cold misses, and cold misses being roughly half of all fresh builds, against ~5.7 fresh iOS builds/day at ~23 min saved each:

> **~1.2 avoided iOS builds/day ≈ 28 min/day ≈ ~14 macOS-runner-hours per quarter.**

Two caveats worth stating. This is a lower bound in one respect — I only checked whether the canonical `main` donor was available, ignoring concurrent PR runs that may also have been usable, so the true hit rate is likely higher. And it is an upper bound in another: it assumes each rescued lookup would otherwise have gone all the way to a fresh build.

The floor remains 0 for genuinely cold fingerprints, which is what #34269 addresses instead.

### Issues found during review

1. **Worst-case API growth is the main concern, and this PR increases it.** Four status sweeps across three tiers means a miss can inspect more unique runs' commit statuses than the previous ceiling of ~50. Every E2E build job performs one lookup, two platforms per run, 100+ `ci.yml` runs/day. I'd recommend a global cap on total status calls per lookup, and confirming `GITHUB_TOKEN` rate-limit headroom before merge. This is the one item I'd want consciously accepted rather than merged silently. It is partly self-limiting, since the `in_progress` sweep should now *shorten* many lookups by matching earlier.
2. **The `completed` sweep re-lists runs already seen** in the `success` and `failure` sweeps. `seenRunIds` dedupes so no extra per-run status calls occur, but it costs one extra list call per tier.
3. **Not every incident is fixed by this PR.** [Run 30807671115](https://github.com/MetaMask/metamask-mobile/actions/runs/30807671115) remains a miss even after this change: its target fingerprint was minutes old and its only donor was still compiling, finishing 49 minutes after the lookup. That is the 10-of-18 bucket above.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/actions/runs/30636222849 — Jul 31 run where iOS found no reusable build while Android did.
Refs: https://github.com/MetaMask/metamask-mobile/actions/runs/30807671115 — Aug 3 run where neither platform found one.
Refs: sibling PRs from the same investigation — #34269, #34271, #34272, #34274, #34309.

## **Manual testing steps**

Important caveat, stated up front: **CI cannot exercise this change.** The only modified file is `.github/actions/find-reusable-build/action.yml`, and in `.github/rules/filter-rules.yml` the `ci_files` pattern `'.github/**'` is ignorable while `e2e_relevant_workflows` lists only specific `workflows/*.yml` files plus `.github/scripts/e2e-*.mjs`. `.github/actions/**` appears in neither, so `compute-e2e-platform-flags.cjs` returns "Skipping E2E (ignorable-only changes)" and no build job runs. The `skip-smart-e2e-selection` label does not override this, per `LABELING_GUIDELINES.md`. Validation therefore rests on the local replay below.

Follow-up worth doing separately: add `.github/actions/find-reusable-build/**` and `.github/actions/post-build-source-hash/**` to `e2e_relevant_workflows`, since both directly control E2E build reuse and today changes to them ship with no E2E signal at all.

Local verification performed:

1. Extracted the embedded `actions/github-script` body and ran it against a mocked GitHub API, covering 8 behavioural cases — all passing:
   - an in-progress run holding all artifacts **is** selected (the defect-1 fix);
   - an in-progress run mid-upload, missing one artifact, is **rejected**;
   - a fully-successful donor is preferred over an in-progress one, confirming sweep precedence;
   - an in-progress run with a non-matching fingerprint is **rejected**;
   - `queued` runs are never swept;
   - the current run never selects itself as its own donor;
   - a cancelled run holding complete artifacts remains reachable, confirming no loss of reach;
   - sweep order is exactly `success`, `in_progress`, `failure`, `completed`.
2. Measured the defect-1 window directly against the GitHub API: for each of the four donor runs behind the recent incidents, compared `.app` artifact `created_at` against the run's completion time, producing the 23–36 minute table above.
3. Cross-checked all 18 cold-fingerprint fresh builds against those donor timelines to produce the 8-of-18 attribution, rather than estimating it.
4. Confirmed tier semantics are unchanged: `status` is applied before `tier.params` is spread and no tier overrides it, so branch, then event, then cross-PR ordering and reach are preserved.
5. Syntax-checked the script by wrapping it in an async IIFE, matching how the action wraps it at runtime, and confirmed the YAML parses.

## **Screenshots/Recordings**

N/A — no user-visible surface, and as explained above this PR produces no CI run of its own to screenshot. Evidence is the harness and API measurements described in the manual testing steps.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

Note on the performance rows: this PR changes CI build-reuse infrastructure only and ships no application code, so there is no runtime path to profile on device. The rows are checked as consciously assessed and not applicable, per the checklist semantics in `docs/readme/ready-for-review.md`.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)


