### PR TITLE
fix: Earn insets, Perps confirm header, and small follow-ups

### DIFF
--- a/app/components/UI/Bridge/components/PostTradeBottomSheet/usePostTradeTrendingTokens.ts
+++ b/app/components/UI/Bridge/components/PostTradeBottomSheet/usePostTradeTrendingTokens.ts
@@ -88,7 +88,14 @@ export const usePostTradeTrendingTokens = ({
     staleTime: STALE_TIME_MS,
     cacheTime: STALE_TIME_MS,
   });
+  const isFallbackLoading = shouldFillWithFallback && fallbackQuery.isLoading;
   const tokens = useMemo(() => {
+    // Hold results until the Ethereum backfill finishes so the list is
+    // revealed as one complete set. On fallback failure, show destination-only.
+    if (isFallbackLoading) {
+      return [];
+    }
+
     if (!shouldFillWithFallback || !fallbackQuery.data?.length) {
       return destinationTokens;
     }
@@ -100,14 +107,17 @@ export const usePostTradeTrendingTokens = ({
         POST_TRADE_TRENDING_TOKENS_LIMIT - destinationTokens.length,
       ),
     ];
-  }, [destinationTokens, fallbackQuery.data, shouldFillWithFallback]);
+  }, [
+    destinationTokens,
+    fallbackQuery.data,
+    isFallbackLoading,
+    shouldFillWithFallback,
+  ]);
 
   return {
     tokens,
     isLoading:
-      isQueryEnabled &&
-      (destinationQuery.isLoading ||
-        (shouldFillWithFallback && fallbackQuery.isLoading)),
+      isQueryEnabled && (destinationQuery.isLoading || isFallbackLoading),
     error: destinationQuery.error,
     refetch: destinationQuery.refetch,
   };

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/EarnLendingDepositConfirmationView.styles.ts
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/EarnLendingDepositConfirmationView.styles.ts
@@ -11,9 +11,6 @@ const styleSheet = (params: { theme: Theme }) => {
       height: '100%',
       backgroundColor: colors.background.default,
     },
-    contentContainer: {
-      paddingHorizontal: 16,
-    },
     scrollView: {
       height: '85%',
     },

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx
@@ -801,7 +801,6 @@ const EarnLendingDepositConfirmationView = () => {
       />
       <ScrollView
         style={styles.scrollView}
-        contentContainerStyle={styles.contentContainer}
         showsVerticalScrollIndicator={false}
       >
         <Erc20TokenHero

--- a/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/EarnLendingWithdrawalConfirmationView.styles.ts
+++ b/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/EarnLendingWithdrawalConfirmationView.styles.ts
@@ -11,9 +11,6 @@ const styleSheet = (params: { theme: Theme }) => {
       height: '100%',
       justifyContent: 'space-between',
     },
-    contentContainer: {
-      paddingHorizontal: 16,
-    },
     infoSections: {
       paddingTop: 16,
     },

--- a/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx
@@ -465,7 +465,7 @@ const EarnLendingWithdrawalConfirmationView = () => {
         }}
         includesTopInset
       />
-      <View style={styles.contentContainer}>
+      <View>
         <Erc20TokenHero
           token={token}
           amountTokenMinimalUnit={amountTokenMinimalUnit}

--- a/app/components/UI/Perps/routes/getRedesignedConfirmationsHeaderOptions.test.ts
+++ b/app/components/UI/Perps/routes/getRedesignedConfirmationsHeaderOptions.test.ts
@@ -1,30 +1,25 @@
 import { getRedesignedConfirmationsHeaderOptions } from './index';
 
 describe('getRedesignedConfirmationsHeaderOptions', () => {
-  it('returns push-style options without modal presentation when showPerpsHeader is false', () => {
+  it('hides the stack header when showPerpsHeader is false', () => {
     const options = getRedesignedConfirmationsHeaderOptions({
       showPerpsHeader: false,
     });
 
     expect(options.headerShown).toBe(false);
-    expect(options.headerBackVisible).toBe(false);
-    expect(options).not.toHaveProperty('presentation');
-    expect(options.contentStyle).toBeUndefined();
   });
 
-  it('returns header-visible options when showPerpsHeader is true', () => {
+  it('hides the stack header when showPerpsHeader is true', () => {
     const options = getRedesignedConfirmationsHeaderOptions({
       showPerpsHeader: true,
     });
 
-    expect(options.headerShown).toBe(true);
-    expect(options.headerBackVisible).toBe(false);
-    expect(options).not.toHaveProperty('presentation');
+    expect(options.headerShown).toBe(false);
   });
 
-  it('defaults to showing perps header when no params provided', () => {
+  it('hides the stack header by default', () => {
     const options = getRedesignedConfirmationsHeaderOptions();
 
-    expect(options.headerShown).toBe(true);
+    expect(options.headerShown).toBe(false);
   });
 });

--- a/app/components/UI/Perps/routes/index.tsx
+++ b/app/components/UI/Perps/routes/index.tsx
@@ -2,7 +2,7 @@ import {
   createNativeStackNavigator,
   type NativeStackNavigationOptions,
 } from '@react-navigation/native-stack';
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import type {
   PerpsNavigationParamList,
@@ -48,21 +48,16 @@ import PerpsCrossMarginWarningBottomSheet from '../components/PerpsCrossMarginWa
 import PerpsSelectProviderView from '../Views/PerpsSelectProviderView';
 import { PayWithModal } from '../../../Views/confirmations/components/modals/pay-with-modal/pay-with-modal';
 import { PayWithBottomSheet } from '../../../Views/confirmations/components/modals/pay-with-bottom-sheet/pay-with-bottom-sheet';
-import { RouteProp, useNavigation, useRoute } from '@react-navigation/native';
-import type { AppNavigationProp } from '../../../../core/NavigationService/types';
+import { RouteProp, useRoute } from '@react-navigation/native';
 import {
   buildDefaultProMarket,
   useIsPerpsProModeActive,
 } from '../utils/perpsModeSwitch';
-
-/* eslint-disable-next-line */
-import { NavigationContext } from '@react-navigation/core';
 import { CONFIRMATION_HEADER_CONFIG } from '../constants/perpsConfig';
 import {
   clearNativeStackNavigatorOptions,
   transparentModalScreenOptions,
 } from '../../../../constants/navigation/clearStackNavigatorOptions';
-import { getEmptyNavHeader } from '../../../Views/confirmations/components/UI/navbar/navbar';
 
 const Stack = createNativeStackNavigator<PerpsStackParamList>();
 const ModalStack = createNativeStackNavigator();
@@ -74,17 +69,9 @@ const styles = StyleSheet.create({
 });
 
 export function getRedesignedConfirmationsHeaderOptions(
-  params: PerpsNavigationParamList['RedesignedConfirmations'] = {},
+  _params: PerpsNavigationParamList['RedesignedConfirmations'] = {},
 ): NativeStackNavigationOptions {
-  const showPerpsHeader =
-    params?.showPerpsHeader ??
-    CONFIRMATION_HEADER_CONFIG.DefaultShowPerpsHeader;
-  if (showPerpsHeader) {
-    return {
-      ...getEmptyNavHeader(),
-      headerBackVisible: false,
-    };
-  }
+  // Confirmations render HeaderStandard inline; keep the stack header off.
   return {
     headerShown: false,
     title: '',
@@ -93,38 +80,15 @@ export function getRedesignedConfirmationsHeaderOptions(
 }
 
 const PerpsConfirmScreen = () => {
-  const navigation = useNavigation<AppNavigationProp>();
   const { params } =
     useRoute<RouteProp<PerpsNavigationParamList, 'RedesignedConfirmations'>>();
   const showPerpsHeader =
     params?.showPerpsHeader ??
     CONFIRMATION_HEADER_CONFIG.DefaultShowPerpsHeader;
 
-  // When showPerpsHeader is false (deposit-and-trade / long-short flow), Confirm internally
-  // calls navigation.setOptions({ headerShown: true }) for full-screen confirmations, which
-  // would cause the native nav bar to animate in. We intercept setOptions via NavigationContext
-  // so headerShown: true is never passed to the native stack, preventing any header animation
-  // or reserved header space. This is scoped only to this screen and does not affect Confirm
-  // or any other shared component.
-  const noHeaderNavigation = useMemo(
-    () =>
-      Object.assign({}, navigation, {
-        setOptions: (options: Parameters<typeof navigation.setOptions>[0]) =>
-          navigation.setOptions({ ...options, headerShown: false }),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      }) as any,
-    [navigation],
-  );
-
-  if (showPerpsHeader) {
-    return <Confirm />;
-  }
-
-  return (
-    <NavigationContext.Provider value={noHeaderNavigation}>
-      <Confirm disableSafeArea />
-    </NavigationContext.Provider>
-  );
+  // Deposit-and-trade embeds under Perps chrome without the confirmation header
+  // or SafeArea top inset (see showPerpsHeader === false).
+  return <Confirm disableSafeArea={!showPerpsHeader} />;
 };
 
 const PerpsModalStack = () => {

--- a/tests/page-objects/Perps/PerpsOrderView.ts
+++ b/tests/page-objects/Perps/PerpsOrderView.ts
@@ -133,6 +133,13 @@ class PerpsOrderView {
   }
 
   async tapTakeProfitButton() {
+    await Assertions.expectElementToBeVisible(
+      Matchers.getElementByID(PerpsOrderViewSelectorsIDs.SCROLL_VIEW),
+      {
+        description: 'Perps order view scroll container',
+        timeout: 45000,
+      },
+    );
     await Gestures.scrollToElement(
       this.takeProfitButton,
       Matchers.scrollContainer(PerpsOrderViewSelectorsIDs.SCROLL_VIEW),


### PR DESCRIPTION
## Summary
Follow-up to #34276 (CustomAmount MMDS HelpText):
- **Earn:** remove redundant horizontal padding on lending deposit/withdraw confirms (avoids double inset after info-section owns 16px)
- **Perps:** simplify redesigned confirm routes to rely on inline Confirm header (`headerShown: false`)
- **Swaps:** hold post-trade trending suggestions until Ethereum backfill completes
- **QA:** wait for Perps order view scroll container before TP/SL tap in e2e

## Depends on
https://github.com/MetaMask/metamask-mobile/pull/34276

## Test plan
- [ ] After #34276 is available: Earn lending deposit/withdraw confirms have single 16px horizontal inset
- [ ] Perps redesigned confirm / deposit-and-trade: no duplicate native header; `showPerpsHeader: false` still omits inline confirm header
- [ ] Swaps post-trade bottom sheet: sparse destination chains show complete list after ETH backfill (or destination-only if ETH fails)
- [ ] Perps e2e: order view TP/SL scroll waits for scroll container


Made with [Cursor](https://cursor.com)