### PR TITLE
fix: TSA-970 header layout shift on Follow Trading screens cp-8.6.0

### DIFF
--- a/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.tsx
+++ b/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.tsx
@@ -349,12 +349,18 @@ const SocialTradersTabsView: React.FC = () => {
   ]);
 
   return (
+    // The top edge is deliberately off: a native SafeAreaView top padding is
+    // recalculated as the view is attached, which lands after this screen's
+    // `slide_from_right` push and visibly drops the header into place. The top
+    // inset comes from `includesTopInset` (JS `marginTop` off the already
+    // resolved provider) instead.
     <SafeAreaView
-      edges={['top']}
+      edges={['bottom', 'left', 'right']}
       style={tw.style('flex-1 bg-default')}
       testID={SocialTradersTabsViewSelectorsIDs.CONTAINER}
     >
       <HeaderStandardAnimated
+        includesTopInset
         scrollY={scrollY}
         titleSectionHeight={titleHeightSv}
         title={strings('social_leaderboard.feed.title')}

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
@@ -821,12 +821,18 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
   }
 
   return (
+    // The top edge is deliberately off: a native SafeAreaView top padding is
+    // recalculated as the view is attached, which lands after this screen's
+    // `slide_from_right` push and visibly drops the header into place. The top
+    // inset comes from `includesTopInset` (JS `marginTop` off the already
+    // resolved provider) instead.
     <SafeAreaView
-      edges={['top']}
+      edges={['bottom', 'left', 'right']}
       style={tw.style('flex-1 bg-default')}
       testID={TopTradersViewSelectorsIDs.CONTAINER}
     >
       <HeaderStandardAnimated
+        includesTopInset
         scrollY={scrollYShared}
         titleSectionHeight={titleSectionHeightSv}
         title={title}

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx
@@ -23,7 +23,10 @@ import type {
   AppNavigationProp,
   RootStackParamList,
 } from '../../../../core/NavigationService/types';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { playImpact, ImpactMoment } from '../../../../util/haptics';
 import {
@@ -104,6 +107,7 @@ const TraderPositionView = () => {
   const navigation = useNavigation<AppNavigationProp>();
   const route = useRoute<RouteProp<RootStackParamList, 'TraderPositionView'>>();
   const tw = useTailwind();
+  const insets = useSafeAreaInsets();
   const { colors } = useTheme();
   const { toastRef } = useContext(ToastContext);
 
@@ -601,46 +605,56 @@ const TraderPositionView = () => {
   );
 
   return (
+    // The top edge is deliberately off: a native SafeAreaView top padding is
+    // recalculated as the view is attached, which lands after this screen's
+    // `slide_from_right` push and visibly drops the header into place. The top
+    // inset is applied in JS below instead, off the already resolved provider.
     <SafeAreaView
+      edges={['bottom', 'left', 'right']}
       style={tw.style('flex-1 bg-default')}
       testID={TraderPositionViewSelectorsIDs.CONTAINER}
     >
-      {isInitialLoading ? (
-        <TraderPositionHeader
-          traderName={traderName}
-          traderImageUrl={traderImageUrl}
-          traderAddress={traderAddress}
-          onBack={handleBack}
-          onTraderPress={handleTraderPress}
-          backButtonTestID={TraderPositionViewSelectorsIDs.BACK_BUTTON}
-          traderNameTestID={TraderPositionViewSelectorsIDs.TRADER_NAME_LINK}
-        />
-      ) : hasFailed ? (
-        <TraderPositionHeader
-          traderName={traderName}
-          traderImageUrl={traderImageUrl}
-          traderAddress={traderAddress}
-          onBack={handleBack}
-          onTraderPress={handleTraderPress}
-          backButtonTestID={TraderPositionViewSelectorsIDs.BACK_BUTTON}
-          traderNameTestID={TraderPositionViewSelectorsIDs.TRADER_NAME_LINK}
-        />
-      ) : (
-        <TraderPositionAnimatedHeader
-          scrollY={scrollYShared}
-          titleSectionHeight={titleSectionHeightSv}
-          traderName={traderName}
-          traderImageUrl={traderImageUrl}
-          traderAddress={traderAddress}
-          symbol={symbol}
-          pricePercentChange={displayPercentChange}
-          activeTimePeriodLabel={activeTimePeriod}
-          perpDirection={perpDirection}
-          perpLeverage={displayPosition?.perpLeverage}
-          onBack={handleBack}
-          onTraderPress={handleTraderPress}
-        />
-      )}
+      {/* The inset sits on this wrapper rather than on the headers themselves so
+          all three branches share one value — swapping between the loading,
+          failed and loaded headers must not move the back button. */}
+      <Box style={{ paddingTop: insets.top }}>
+        {isInitialLoading ? (
+          <TraderPositionHeader
+            traderName={traderName}
+            traderImageUrl={traderImageUrl}
+            traderAddress={traderAddress}
+            onBack={handleBack}
+            onTraderPress={handleTraderPress}
+            backButtonTestID={TraderPositionViewSelectorsIDs.BACK_BUTTON}
+            traderNameTestID={TraderPositionViewSelectorsIDs.TRADER_NAME_LINK}
+          />
+        ) : hasFailed ? (
+          <TraderPositionHeader
+            traderName={traderName}
+            traderImageUrl={traderImageUrl}
+            traderAddress={traderAddress}
+            onBack={handleBack}
+            onTraderPress={handleTraderPress}
+            backButtonTestID={TraderPositionViewSelectorsIDs.BACK_BUTTON}
+            traderNameTestID={TraderPositionViewSelectorsIDs.TRADER_NAME_LINK}
+          />
+        ) : (
+          <TraderPositionAnimatedHeader
+            scrollY={scrollYShared}
+            titleSectionHeight={titleSectionHeightSv}
+            traderName={traderName}
+            traderImageUrl={traderImageUrl}
+            traderAddress={traderAddress}
+            symbol={symbol}
+            pricePercentChange={displayPercentChange}
+            activeTimePeriodLabel={activeTimePeriod}
+            perpDirection={perpDirection}
+            perpLeverage={displayPosition?.perpLeverage}
+            onBack={handleBack}
+            onTraderPress={handleTraderPress}
+          />
+        )}
+      </Box>
 
       {isInitialLoading ? (
         <TraderPositionSkeleton />

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
@@ -355,12 +355,18 @@ const TraderProfileView = () => {
   const headerTitle = profile?.profile.name;
 
   return (
+    // The top edge is deliberately off: a native SafeAreaView top padding is
+    // recalculated as the view is attached, which lands after this screen's
+    // `slide_from_right` push and visibly drops the header into place. The top
+    // inset comes from `includesTopInset` (JS `marginTop` off the already
+    // resolved provider) instead.
     <SafeAreaView
-      edges={['top']}
+      edges={['bottom', 'left', 'right']}
       style={tw.style('flex-1 bg-default')}
       testID={TraderProfileViewSelectorsIDs.CONTAINER}
     >
       <HeaderStandardAnimated
+        includesTopInset
         scrollY={scrollYShared}
         titleSectionHeight={titleSectionHeightSv}
         title={


### PR DESCRIPTION
## **Description**

The Follow Trading screens showed a vertical layout shift on open: the header title and back button painted at the very top of the screen and then dropped to their natural position under the Dynamic Island once the push transition ended. It reproduced on both iOS and Android, intermittently.

**Cause.** Each screen applied its top inset as **native** `SafeAreaView` padding. `RNCSafeAreaView` measures its own `safeAreaInsets` as the view is attached, and that measurement lands *after* the screen's `slide_from_right` push completes — so the header renders at `y=0` for a few frames and then jumps down. Because it's a native measurement race rather than a stale JS value, it is intermittent and platform-independent.

**Fix.** Turn the top edge off and apply the inset in JS off the already-resolved `SafeAreaProvider`, so the value is correct on the first committed frame and there is nothing left to recalculate mid-transition. This matches `PerpsMarketDetailsView`, which is pushed with the same navigation options (`headerShown: false` + `slide_from_right`) and is the one screen of its kind that does **not** exhibit the jump.

Same root cause and fix as #34260 (What's Happening detail view, TSA-969), which is verified working on device.

| Screen | Before | After |
| --- | --- | --- |
| `TopTradersView` | `edges={['top']}` | `includesTopInset` on `HeaderStandardAnimated` |
| `SocialTradersTabsView` | `edges={['top']}` | `includesTopInset` on `HeaderStandardAnimated` |
| `TraderProfileView` | `edges={['top']}` | `includesTopInset` on `HeaderStandardAnimated` |
| `TraderPositionView` | no `edges` (all four) | inset on a single wrapper above the header branch |

`includesTopInset` reaches the right place on the animated header: `HeaderStandardAnimated` spreads into `HeaderStandard`, which spreads `...headerBaseProps` into `HeaderBase`, where it becomes `marginTop: insets.top`.

### Why `TraderPositionView` is different

It can't use `includesTopInset`. It swaps between three headers depending on state, and neither accepts the prop: `TraderPositionHeader` (loading and failed states) is a hand-rolled `Box`, and `TraderPositionAnimatedHeader` renders `HeaderStandard` with explicit props and no `{...rest}` spread. Rather than plumb a new prop through two more components, the inset goes on a single wrapper above the branch. That also guarantees the three headers share one value, so switching from the loading header to the loaded one can't introduce a *second* jump.

### Both leaderboard entry points are covered

`SocialTradersView` picks between `SocialTradersTabsView` and standalone `TopTradersView` depending on `aiSocialFeedEnabled`, so both needed the fix. `TopTradersView` in `embeddedInTabs` mode renders a bare list body with no `SafeAreaView` of its own, so that path is covered by the tabs container.

### Related, not addressed here

`app/shims/react-native-safe-area-context.tsx` exists specifically to route `SafeAreaView`'s top inset through JS instead of native padding — added by #28622 (*"fix: Fix UI issue related to SafeAreaView top inset recalculation"*). The Metro `resolveRequest` alias that wired it was removed by the RN 0.81.5 upgrade (#29195), so the shim and its test are now dead code while every `SafeAreaView` in the app is back on native top padding. Restoring that alias would address this class of bug app-wide, rather than screen by screen.

## **Changelog**

CHANGELOG entry: Fixed the header shifting down after the Top Traders, Trader Profile and Trader Position screens finished opening.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TSA-970
Refs: https://github.com/MetaMask/metamask-mobile/pull/34260

## **Manual testing steps**

```gherkin
Feature: Follow Trading header placement

  Scenario Outline: user opens a Follow Trading screen
    Given the user is in the app

    When user opens <screen>
    Then the screen slides in from the right
    And the header title and back button are positioned below the notch / Dynamic Island for the whole transition
    And they do not shift vertically once the transition ends

    Examples:
      | screen                                             |
      | the Top Traders leaderboard                        |
      | a trader profile, from a leaderboard row           |
      | a trader position, from a profile row              |

  Scenario: leaderboard renders correctly with the feed tabs flag on and off
    Given the user toggles aiSocialFeedEnabled
    When user opens the Top Traders leaderboard
    Then the header sits below the notch in both the tabbed and standalone layouts

  Scenario: trader position header does not move as data loads
    Given the user opens a trader position on a cold cache
    When the loading header is replaced by the loaded header
    Then the back button stays in exactly the same position

  Scenario: trader position header does not move when loading fails
    Given the position request fails
    When the fallback state renders
    Then the back button stays in exactly the same position
```

The jump was intermittent before the fix, so repeat each open several times to be confident.

## **Screenshots/Recordings**

### **Before**

<!-- Before/after screen recordings to be attached — this is a transition-timing fix and a still frame does not capture it. -->

### **After**


https://github.com/user-attachments/assets/79a99511-01a9-4411-b251-ba1eef915ed9



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only safe-area handling on four social leaderboard screens; no auth, data, or navigation logic changes.
> 
> **Overview**
> Fixes **TSA-970**: headers on Follow Trading screens no longer jump down after a `slide_from_right` push.
> 
> **Cause:** Native `SafeAreaView` top padding was re-measured after attach, so title/back briefly rendered at `y=0` then dropped under the notch.
> 
> **Change:** Drop the top `SafeAreaView` edge on **SocialTradersTabsView**, **TopTradersView** (standalone), and **TraderProfileView**, and pass **`includesTopInset`** on `HeaderStandardAnimated` so top spacing comes from JS `marginTop` via the provider. **TraderPositionView** uses `useSafeAreaInsets()` and a single `paddingTop` wrapper around loading/failed/animated headers so the back button stays fixed when state changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee630986bffd95aa2429bbe681c2dc0a5c65058. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->