### PR TITLE
feat: add Homepage search entrypoint, swap Explore tab icon, instrument search opens 

### DIFF
--- a/app/component-library/components/Navigation/TabBar/TabBar.constants.ts
+++ b/app/component-library/components/Navigation/TabBar/TabBar.constants.ts
@@ -13,7 +13,7 @@ export const ICON_BY_TAB_BAR_ICON_KEY: IconByTabBarIconKey = {
   [TabBarIconKey.Activity]: IconName.Activity,
   [TabBarIconKey.Setting]: IconName.Setting,
   [TabBarIconKey.Rewards]: IconName.MetamaskFoxOutline,
-  [TabBarIconKey.Trending]: IconName.Search,
+  [TabBarIconKey.Trending]: IconName.TrendUp,
   [TabBarIconKey.Money]: IconName.Musd,
 };
 

--- a/app/component-library/components/Navigation/TabBar/TabBar.tsx
+++ b/app/component-library/components/Navigation/TabBar/TabBar.tsx
@@ -33,7 +33,6 @@ import { useMoneyNavigation } from '../../../../components/UI/Money/hooks/useMon
 const FILLED_ICONS: Partial<Record<TabBarIconKey, IconName>> = {
   [TabBarIconKey.Wallet]: IconName.HomeFilled,
   [TabBarIconKey.Activity]: IconName.ClockFilled,
-  [TabBarIconKey.Trending]: IconName.Search,
   [TabBarIconKey.Rewards]: IconName.MetamaskFoxFilled,
   [TabBarIconKey.Money]: IconName.MusdFilled,
 };

--- a/app/components/Views/TrendingView/TrendingView.test.tsx
+++ b/app/components/Views/TrendingView/TrendingView.test.tsx
@@ -3,6 +3,8 @@ import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MetaMetricsEvents } from '../../../core/Analytics';
+import { analytics } from '../../../util/analytics/analytics';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -129,6 +131,12 @@ jest.mock('../../../components/hooks/useAnalytics/useAnalytics', () => ({
   useAnalytics: () => ({
     isEnabled: mockIsEnabled,
   }),
+}));
+
+jest.mock('../../../util/analytics/analytics', () => ({
+  analytics: {
+    trackEvent: jest.fn(),
+  },
 }));
 
 jest.mock('../../../util/browser', () => ({
@@ -394,6 +402,27 @@ describe('TrendingView', () => {
     fireEvent.press(searchButton);
 
     expect(mockNavigate).toHaveBeenCalledWith('ExploreSearch');
+  });
+
+  it('tracks the search opened event with the explore entry point', () => {
+    const { getByTestId } = renderTrendingView();
+
+    fireEvent.press(getByTestId('explore-view-search-button'));
+
+    const openedEvent = (
+      analytics.trackEvent as jest.MockedFunction<typeof analytics.trackEvent>
+    ).mock.calls
+      .map(([event]) => event)
+      .find((event) => event.properties?.interaction_type === 'opened');
+
+    expect(openedEvent?.name).toBe(
+      MetaMetricsEvents.EXPLORE_SEARCH_INTERACTED.category,
+    );
+    expect(openedEvent?.properties).toEqual({
+      interaction_type: 'opened',
+      search_query: '',
+      entry_point: 'explore',
+    });
   });
 
   describe('tab switching', () => {

--- a/app/components/Views/TrendingView/TrendingView.tsx
+++ b/app/components/Views/TrendingView/TrendingView.tsx
@@ -48,6 +48,7 @@ import DappsTab from './tabs/DappsTab';
 import { TrendingViewSelectorsIDs } from './TrendingView.testIds';
 import {
   trackExploreInteracted,
+  trackExploreSearchOpened,
   type ExploreTabName,
 } from './search/analytics';
 import { EXPLORE_TAB_INDEX } from '../../../constants/navigation/exploreTabIndices';
@@ -256,6 +257,7 @@ export const ExploreFeed: React.FC = () => {
   }, [navigation, portfolioUrl.href, browserTabsCount]);
 
   const handleSearchPress = useCallback(() => {
+    trackExploreSearchOpened('explore');
     navigation.navigate(Routes.EXPLORE_SEARCH);
   }, [navigation]);
 

--- a/app/components/Views/TrendingView/search/analytics.test.ts
+++ b/app/components/Views/TrendingView/search/analytics.test.ts
@@ -5,6 +5,7 @@ import {
   getExploreSearchResultCount,
   getTotalSectionResultCount,
   trackExplorePredictTrendingAssetViewed,
+  trackExploreSearchOpened,
   trackExploreSectionSeeAll,
   useInstrumentedSearchEffect,
 } from './analytics';
@@ -213,6 +214,35 @@ describe('Explore search analytics', () => {
         trade_type: 'Predict',
         implementation_type: 'native',
       });
+    });
+  });
+
+  describe('trackExploreSearchOpened', () => {
+    it.each([['home' as const], ['explore' as const]])(
+      'tracks the opened interaction with entry_point %s',
+      (entryPoint) => {
+        trackExploreSearchOpened(entryPoint);
+
+        expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+
+        const event = mockTrackEvent.mock.calls[0][0];
+
+        expect(event.name).toBe(
+          MetaMetricsEvents.EXPLORE_SEARCH_INTERACTED.category,
+        );
+        expect(event.properties).toEqual({
+          interaction_type: 'opened',
+          search_query: '',
+          entry_point: entryPoint,
+        });
+      },
+    );
+
+    it('fires once per call so re-entering search re-fires', () => {
+      trackExploreSearchOpened('home');
+      trackExploreSearchOpened('explore');
+
+      expect(mockTrackEvent).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/app/components/Views/TrendingView/search/analytics.ts
+++ b/app/components/Views/TrendingView/search/analytics.ts
@@ -34,6 +34,7 @@ export const getExploreSearchResultCount = (
 };
 
 export type SearchInteractionType =
+  | 'opened'
   | 'result_clicked'
   | 'scrolled'
   | 'tab_switched'
@@ -42,9 +43,14 @@ export type SearchInteractionType =
 /** 'all' = aggregated view; other values are a specific feed pill. */
 export type SearchFeedPill = SearchFeedId | 'all';
 
+/** Surface the user tapped to open search. Only set on `opened`. */
+export type SearchEntryPoint = 'home' | 'explore';
+
 export interface ExploreSearchInteractedProperties {
   interaction_type: SearchInteractionType;
   search_query: string;
+  /** Only set on `opened`. */
+  entry_point?: SearchEntryPoint;
   /** Only set on result_clicked when tab_name is 'all'. */
   section_name?: SearchFeedId;
   tab_name?: SearchFeedPill;
@@ -168,6 +174,24 @@ export const trackExploreSearchEvent = (
       .addProperties(properties as unknown as Record<string, unknown>)
       .build(),
   );
+};
+
+/**
+ * Fired when the user opens the search screen, so opens can be attributed to
+ * the surface they came from. Called from the tap handler rather than on screen
+ * mount, so a remount (or a deeplink into search) never duplicates the event.
+ *
+ * `search_query` is sent as an empty string: the schema requires the property
+ * and the user has not typed anything yet.
+ */
+export const trackExploreSearchOpened = (
+  entryPoint: SearchEntryPoint,
+): void => {
+  trackExploreSearchEvent({
+    interaction_type: 'opened',
+    search_query: '',
+    entry_point: entryPoint,
+  });
 };
 
 /**

--- a/app/components/Views/Wallet/Wallet.view.test.tsx
+++ b/app/components/Views/Wallet/Wallet.view.test.tsx
@@ -100,6 +100,43 @@ describeForPlatforms('Wallet', () => {
     ).toBeOnTheScreen();
   });
 
+  it('navigates to Explore search when the header search button is pressed', async () => {
+    const { getByTestId, findByTestId } = renderWalletViewWithRoutes({
+      extraRoutes: [
+        { name: Routes.QR_TAB_SWITCHER },
+        { name: Routes.EXPLORE_SEARCH },
+      ],
+      overrides: {
+        settings: {
+          basicFunctionalityEnabled: true,
+        },
+        engine: {
+          backgroundState: {
+            MultichainNetworkController: {
+              isEvmSelected: true,
+            },
+            RewardsController: {
+              activeAccount: null,
+            },
+            PreferencesController: {
+              tokenSortConfig: {
+                key: 'tokenFiatAmount',
+                order: 'dsc',
+                sortCallback: 'stringNumeric',
+              },
+            },
+          },
+        },
+      } as unknown as Record<string, unknown>,
+    });
+
+    fireEvent.press(getByTestId(WalletViewSelectorsIDs.WALLET_SEARCH_BUTTON));
+
+    expect(
+      await findByTestId(`route-${Routes.EXPLORE_SEARCH}`),
+    ).toBeOnTheScreen();
+  });
+
   const defaultWalletOverrides = {
     overrides: {
       settings: {

--- a/app/components/Views/Wallet/Wallet.view.test.tsx
+++ b/app/components/Views/Wallet/Wallet.view.test.tsx
@@ -12,6 +12,7 @@ import { walletHomeOnboardingVisibleSteps } from '../../UI/WalletHomeOnboardingS
 import { describeForPlatforms } from '../../../../tests/component-view/platform';
 import { fireEvent } from '@testing-library/react-native';
 import Routes from '../../../constants/navigation/Routes';
+import { strings } from '../../../../locales/i18n';
 import Wallet from './index';
 import React from 'react';
 
@@ -130,7 +131,16 @@ describeForPlatforms('Wallet', () => {
       } as unknown as Record<string, unknown>,
     });
 
-    fireEvent.press(getByTestId(WalletViewSelectorsIDs.WALLET_SEARCH_BUTTON));
+    const searchButton = getByTestId(
+      WalletViewSelectorsIDs.WALLET_SEARCH_BUTTON,
+    );
+
+    // Icon-only button, so screen readers have nothing to announce without this.
+    expect(searchButton).toHaveAccessibleName(
+      strings('wallet.search_accessibility_label'),
+    );
+
+    fireEvent.press(searchButton);
 
     expect(
       await findByTestId(`route-${Routes.EXPLORE_SEARCH}`),

--- a/app/components/Views/Wallet/WalletView.testIds.ts
+++ b/app/components/Views/Wallet/WalletView.testIds.ts
@@ -97,6 +97,7 @@ export const WalletViewSelectorsIDs = {
   BALANCE_EMPTY_STATE_ACTION_BUTTON:
     'account-group-balance-empty-state-action-button',
   WALLET_ACTIVITY_BUTTON: 'wallet-activity-button',
+  WALLET_SEARCH_BUTTON: 'wallet-search-button',
   WALLET_HEADER_ROOT: 'wallet-header-root',
   WALLET_SAFE_AREA: 'wallet-safe-area',
   WALLET_SCROLL_VIEW: 'wallet-scroll-view',

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -136,6 +136,8 @@ import { useABTest } from '../../../hooks';
 import { HomepageScrollContext } from '../Homepage/context/HomepageScrollContext';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import type { HomeSectionName } from '../Homepage/hooks/useHomeViewedEvent';
+// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
+import { trackExploreSearchOpened } from '../TrendingView/search/analytics';
 import AccountGroupBalance from '../../UI/Assets/components/Balance/AccountGroupBalance';
 import useCheckNftAutoDetectionModal from '../../hooks/useCheckNftAutoDetectionModal';
 import useCheckMultiRpcModal from '../../hooks/useCheckMultiRpcModal';
@@ -866,6 +868,11 @@ const Wallet = ({
     navigation.navigate(Routes.TRANSACTIONS_VIEW);
   }, [navigation, trackEvent]);
 
+  const handleSearchPress = useCallback(() => {
+    trackExploreSearchOpened('home');
+    navigation.navigate(Routes.EXPLORE_SEARCH);
+  }, [navigation]);
+
   const turnOnBasicFunctionality = useCallback(() => {
     navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
       screen: Routes.SHEET.BASIC_FUNCTIONALITY,
@@ -1126,6 +1133,16 @@ const Wallet = ({
                       style={styles.headerActionButtonsContainer}
                       accessible={false}
                     >
+                      <ButtonIcon
+                        iconProps={{
+                          color: MMDSIconColor.IconDefault,
+                        }}
+                        onPress={handleSearchPress}
+                        iconName={MMDSIconName.Search}
+                        size={ButtonIconSize.Md}
+                        testID={WalletViewSelectorsIDs.WALLET_SEARCH_BUTTON}
+                        hitSlop={touchAreaSlop}
+                      />
                       {isMoneyAccountVisible && (
                         <ButtonIcon
                           iconProps={{

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -1141,6 +1141,9 @@ const Wallet = ({
                         iconName={MMDSIconName.Search}
                         size={ButtonIconSize.Md}
                         testID={WalletViewSelectorsIDs.WALLET_SEARCH_BUTTON}
+                        accessibilityLabel={strings(
+                          'wallet.search_accessibility_label',
+                        )}
                         hitSlop={touchAreaSlop}
                       />
                       {isMoneyAccountVisible && (

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3242,6 +3242,7 @@
   },
   "wallet": {
     "title": "Wallet",
+    "search_accessibility_label": "Search",
     "tokens": "Tokens",
     "view_all_nfts": "View all NFTs",
     "view_all_tokens": "View all tokens",


### PR DESCRIPTION
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Search is one of the main entrances to the Trade funnel, but it was buried: you had to open the Explore tab, then tap a faux search bar that is really a button, which then pushes the actual search screen. Two taps, and completely invisible from the Homepage.

This gives search a direct entrypoint from the Homepage header and starts measuring opens so we can tell whether that entrypoint earns its place.

**1. Homepage search icon ([TMCU-1224](https://consensyssoftware.atlassian.net/browse/TMCU-1224))**

A search `ButtonIcon` in the wallet header that navigates straight to `Routes.EXPLORE_SEARCH`. It sits first in the header action cluster (search → activity/copy/card → menu) to match the design. The Explore search bar stays exactly as it is, so search now has two entrypoints rather than a relocated one.

**2. Explore tab icon ([TMCU-1225](https://consensyssoftware.atlassian.net/browse/TMCU-1225))**

The bottom-nav Explore tab moves from `Search` to `TrendUp`, so the magnifier now means "search" in exactly one place instead of two competing ones.

I also removed the `Trending` entry from `FILLED_ICONS` in `TabBar.tsx`. That is a no-op, not a behaviour change: it mapped the *selected* state to `Search` — the same icon as the unselected state — so it never actually changed anything on tap, and the same is true of `TrendUp` now. There is no `TrendUpFilled` in the icon set, so leaving a stale entry there would only invite confusion.

**3. Search-open instrumentation ([TMCU-1226](https://consensyssoftware.atlassian.net/browse/TMCU-1226))**

Opening search previously fired **nothing** — we only began measuring once a query resolved, so we had no denominator for the search → result-tap → trade funnel and no way to attribute opens to a surface.

This extends the existing `Explore Search Interacted` event rather than adding a new one: `interaction_type` gains `opened`, and a new optional `entry_point` (`home` | `explore`) attributes the open to the surface tapped.

Schema PR: https://github.com/Consensys/segment-schema/pull/698 — **this PR should not merge before that one**, or the property will be dropped downstream.

### Two implementation decisions worth a reviewer's attention

**`search_query` is an empty string on `opened`, not omitted.** TMCU-1226 left this to the team. The property is `required: true` in the schema and the user has not typed anything at open time; relaxing `required` would be a breaking change for existing consumers, so the empty string is the cheaper correct answer. Queries continue to arrive on `searched` exactly as before.

**The event fires from each tap handler, not from the search screen's mount effect.** This satisfies the no-double-fire acceptance criterion structurally rather than with a guard ref: a remount or re-render cannot duplicate it, while backing out and re-entering search correctly fires again.

The trade-off, stated plainly: deeplinks that navigate straight to `ExploreSearch` (`handleTrendingUrl.ts`) fire no open event. That is consistent with TMCU-1226 restricting `entry_point` to `home | explore` — there is no third value to attribute a deeplink to — but it is a real coverage gap if we later want deeplink opens in the funnel. Happy to move to a mount-effect-plus-route-param approach if reviewers would rather capture every open, at the cost of needing an explicit dedupe.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Added a search icon to the wallet home header so search can be opened directly, and changed the Explore tab icon to a trend arrow

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1224
Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1225
Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1226

Schema PR: https://github.com/Consensys/segment-schema/pull/698

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Homepage search entrypoint

  Scenario: user opens search from the Homepage header
    Given the user is on wallet home
    And a search icon is visible in the header, left of the other header actions

    When user taps the header search icon
    Then the Explore search screen opens with the text field focused
    And an "Explore Search Interacted" event fires with interaction_type "opened",
      entry_point "home", and search_query ""

  Scenario: user opens search from the Explore tab
    Given the user is on the Explore tab

    When user taps the search bar
    Then the Explore search screen opens with the text field focused
    And an "Explore Search Interacted" event fires with interaction_type "opened",
      entry_point "explore", and search_query ""

  Scenario: user re-enters search after backing out
    Given the user opened search from the Homepage header
    And exactly one "opened" event has fired

    When user taps Cancel to return to wallet home
    And user taps the header search icon again
    Then a second "opened" event fires with entry_point "home"

  Scenario: user sees the trend icon on the Explore tab
    Given the user is on wallet home

    When user looks at the bottom navigation bar
    Then the Explore tab shows a trend-up arrow instead of a magnifier
    And the icon does not change when the Explore tab is selected

  Scenario: existing search analytics are unaffected
    Given the user is on the Explore search screen

    When user types a query and results resolve
    Then a "searched" event fires with the query and result_count as before
    And switching pills still fires "tab_switched" with previous_tab
```

Validate both entrypoints in the Segment debugger / Mixpanel DebugStream, per TMCU-1226's acceptance criteria.

## **Screenshots/Recordings**

### Demo

https://github.com/user-attachments/assets/59ed9363-5c55-49b4-9de9-f29b3667afdd

### Search Event

https://github.com/user-attachments/assets/816fc5b3-6641-43c9-8c3d-a0e56d892a2f

### Search Events Showing in Segment

<img width="750" alt="Screenshot 2026-08-05 at 11 12 40 AM" src="https://github.com/user-attachments/assets/0793b19a-f4e9-4975-a6d4-56761e536328" />

<img width="750" alt="Screenshot 2026-08-05 at 11 12 48 AM" src="https://github.com/user-attachments/assets/474e212d-b475-4b3e-a9b2-c5ff4aaafcc3" />

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

Tests added:

- `app/components/Views/TrendingView/search/analytics.test.ts` — `trackExploreSearchOpened` emits the right event name and exact property set for both entry points, and fires once per call
- `app/components/Views/TrendingView/TrendingView.test.tsx` — tapping the Explore search bar emits `opened` with `entry_point: explore`
- `app/components/Views/Wallet/Wallet.view.test.tsx` — the header search button renders and navigates to the `ExploreSearch` route

`yarn lint:tsc` is clean, and eslint on the changed files surfaces only pre-existing deprecation warnings.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

Performance boxes left unchecked pending Android verification. No Sentry tracing added: the change is one header button, one icon-constant swap, and a fire-and-forget analytics call on tap — nothing on a render-hot or long-running path. The header button adds one `ButtonIcon` to a cluster that already renders three.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TMCU-1224]: https://consensyssoftware.atlassian.net/browse/TMCU-1224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and navigation/analytics only; no auth, payments, or data-model changes. Depends on upstream segment schema for `entry_point` before merge.
> 
> **Overview**
> Adds a **direct search entry** on wallet home: a header search icon navigates to `EXPLORE_SEARCH` and fires open analytics with `entry_point: 'home'`. The Explore tab search bar continues to work and now records `entry_point: 'explore'`.
> 
> **Explore tab icon** changes from magnifier (`Search`) to **`TrendUp`**, and the redundant `Trending` filled-icon mapping is removed so selected/unselected states stay consistent.
> 
> **Analytics** extends `Explore Search Interacted` with `interaction_type: 'opened'`, optional `entry_point` (`home` | `explore`), and `trackExploreSearchOpened()` invoked from tap handlers (not screen mount). Tests cover the helper, Explore search bar, and wallet header navigation/accessibility; `wallet.search_accessibility_label` is added for the new button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d80be31c8e2175f836dad9394dbd735c1da96f72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->