### PR TITLE
fix(TMCU-1045): Remove useElevatedSurface shim from Core UX bottom sheets

### DIFF
--- a/app/components/UI/CustomNetworkSelector/CustomNetworkSelector.tsx
+++ b/app/components/UI/CustomNetworkSelector/CustomNetworkSelector.tsx
@@ -10,7 +10,6 @@ import { parseCaipChainId } from '@metamask/utils';
 import { toHex } from '@metamask/controller-utils';
 import { useSelector } from 'react-redux';
 import { formatChainIdToCaip } from '@metamask/bridge-controller';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
 // external dependencies
 import { strings } from '../../../../locales/i18n';
@@ -43,7 +42,6 @@ import { useNetworksToUse } from '../../hooks/useNetworksToUse/useNetworksToUse'
 import AccountGroupBalancePerChain from '../Assets/components/Balance/AccountGroupBalancePerChain';
 // internal dependencies
 import createStyles from './CustomNetworkSelector.styles';
-import { useElevatedSurface } from '../../../util/theme/themeUtils';
 
 import {
   CustomNetworkItem,
@@ -65,8 +63,6 @@ const CustomNetworkSelector = ({
 }: CustomNetworkSelectorProps) => {
   const { colors } = useTheme();
   const { styles } = useStyles(createStyles, {});
-  const tw = useTailwind();
-  const surfaceClass = useElevatedSurface();
   const { navigate } = useNavigation<AppNavigationProp>();
   const safeAreaInsets = useSafeAreaInsets();
 
@@ -169,7 +165,6 @@ const CustomNetworkSelector = ({
               caipChainId,
               isSelected,
             )}
-            style={tw.style(surfaceClass)}
           >
             {(!isTestNet(chainId) || showFiatOnTestnets) && (
               <AccountGroupBalancePerChain caipChainId={caipChainId} />
@@ -186,8 +181,6 @@ const CustomNetworkSelector = ({
       createAvatarProps,
       selectedChainIdCaip,
       showFiatOnTestnets,
-      surfaceClass,
-      tw,
     ],
   );
 

--- a/app/components/UI/FundActionMenu/FundActionMenu.tsx
+++ b/app/components/UI/FundActionMenu/FundActionMenu.tsx
@@ -32,12 +32,10 @@ import type {
 } from './FundActionMenu.types';
 import { getDetectedGeolocation } from '../../../reducers/fiatOrders';
 import { useRampsButtonClickData } from '../Ramp/hooks/useRampsButtonClickData';
-import { useElevatedSurface } from '../../../util/theme/themeUtils';
 
 const FundActionMenu = () => {
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation<AppNavigationProp>();
-  const surfaceClass = useElevatedSurface();
   const route = useRoute<FundActionMenuRouteProp>();
 
   const customOnBuy = route.params?.onBuy;
@@ -171,7 +169,6 @@ const FundActionMenu = () => {
       ref={sheetRef}
       goBack={navigation.goBack}
       testID="fund-action-menu-bottom-sheet"
-      twClassName={surfaceClass}
     >
       <Box twClassName="py-4">
         {actionConfigs.map(

--- a/app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.tsx
+++ b/app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.tsx
@@ -59,7 +59,6 @@ import { strings } from '../../../../locales/i18n';
 import TagColored, {
   TagColor,
 } from '../../../component-library/components-temp/TagColored';
-import { useElevatedSurface } from '../../../util/theme/themeUtils';
 
 const SELECTION_DEBOUNCE_DELAY = 150;
 
@@ -106,7 +105,6 @@ const NetworkMultiSelectList = ({
 
   const { styles } = useStyles(styleSheet, {});
   const tw = useTailwind();
-  const surfaceClass = useElevatedSurface();
 
   const processedNetworks = useMemo(
     (): ProcessedNetwork[] =>
@@ -310,7 +308,7 @@ const NetworkMultiSelectList = ({
             disabled={isDisabled}
             showButtonIcon={showButtonIcon}
             buttonProps={createButtonProps(network)}
-            style={tw.style(`${surfaceClass} items-center`)}
+            style={tw.style('items-center')}
             testID={NETWORK_MULTI_SELECTOR_TEST_IDS.NETWORK_LIST_ITEM(
               caipChainId,
               isSelected,
@@ -340,7 +338,6 @@ const NetworkMultiSelectList = ({
       isGasFeesSponsoredNetworkEnabled,
       isHardwareWallet,
       styles.noNetworkFeeContainer,
-      surfaceClass,
       tw,
       styles.networkNameText,
     ],

--- a/app/components/Views/AddressSelector/AddressSelector.tsx
+++ b/app/components/Views/AddressSelector/AddressSelector.tsx
@@ -42,7 +42,6 @@ import { createAccountSelectorNavDetails } from '../AccountSelector';
 import { NetworkConfiguration } from '@metamask/network-controller';
 import { strings } from '../../../../locales/i18n';
 import { AddressSelectorSelectors } from './AddressSelector.testIds';
-import { useElevatedSurface } from '../../../util/theme/themeUtils';
 
 export const createAddressSelectorNavDetails =
   createNavigationDetails<AddressSelectorParams>(
@@ -75,7 +74,6 @@ const AddressSelector = () => {
   );
 
   const accountName = useAccountName();
-  const surfaceClass = useElevatedSurface();
   const selectedCaipChainId = isCaipChainId(selectedChainId)
     ? selectedChainId
     : toEvmCaipChainId(selectedChainId);
@@ -156,12 +154,7 @@ const AddressSelector = () => {
   }, [internalAccountsSpreadByScopes, isEvmOnly, displayOnlyCaipChainIds]);
 
   return (
-    <BottomSheet
-      ref={sheetRef}
-      isFullscreen
-      goBack={navigation.goBack}
-      twClassName={surfaceClass}
-    >
+    <BottomSheet ref={sheetRef} isFullscreen goBack={navigation.goBack}>
       <BottomSheetHeader onClose={() => sheetRef.current?.onCloseBottomSheet()}>
         {strings('address_selector.select_an_address')}
       </BottomSheetHeader>

--- a/app/components/Views/NetworksManagement/components/DeleteNetworkModal.tsx
+++ b/app/components/Views/NetworksManagement/components/DeleteNetworkModal.tsx
@@ -14,7 +14,6 @@ import {
 import { strings } from '../../../../../locales/i18n';
 
 import { NetworksManagementViewSelectorsIDs } from '../NetworksManagementView.testIds';
-import { useElevatedSurface } from '../../../../util/theme/themeUtils';
 
 interface DeleteNetworkModalProps {
   networkName: string;
@@ -38,15 +37,12 @@ const DeleteNetworkModal = forwardRef<BottomSheetRef, DeleteNetworkModalProps>(
       testID: NetworksManagementViewSelectorsIDs.DELETE_CONFIRM_BUTTON,
     };
 
-    const surfaceClass = useElevatedSurface();
-
     return (
       <BottomSheet
         ref={ref}
         onClose={onClose}
         goBack={onClose}
         testID={NetworksManagementViewSelectorsIDs.DELETE_MODAL}
-        twClassName={surfaceClass}
       >
         <BottomSheetHeader onClose={onClose}>
           {`${strings('app_settings.delete')} ${networkName} ${strings('app_settings.network')}`}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Removes the redundant `useElevatedSurface()` shim from Core UX MMDS `BottomSheet` callsites now that MMDS handles pure-black elevated surfaces internally.

The custom `TradeWalletActions` sheet is not an MMDS `BottomSheet` and is out of scope for this cleanup — it retains its existing elevated-surface and pure-black border styling.

Rebased onto latest `main` with conflict resolution. Same change set as #33162 (force-updated).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TMCU-1045](https://consensyssoftware.atlassian.net/browse/TMCU-1045)

## **Manual testing steps**

N/A — styling cleanup with existing unit test coverage. No user-facing behavior change when `MM_PURE_BLACK_PREVIEW` is off.

## **Screenshots/Recordings**

N/A — internal theming cleanup; visual QA for pure-black trade menu should be done on device with `MM_PURE_BLACK_PREVIEW` enabled.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings or screenshots.

## Testing

```bash
yarn jest app/components/Views/TradeWalletActions/TradeWalletActions.test.tsx \
  app/components/Views/AddressSelector/AddressSelector.test.tsx \
  app/components/Views/NetworksManagement/components/DeleteNetworkModal.test.tsx \
  app/components/UI/FundActionMenu/FundActionMenu.test.tsx \
  app/components/UI/CustomNetworkSelector/CustomNetworkSelector.test.tsx \
  app/components/UI/NetworkMultiSelectorList/NetworkMultiSelectorList.test.tsx
```

All 6 suites / 114 tests passed after rebase.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d950f68-2bcc-42b2-9647-dfc33f3f77cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d950f68-2bcc-42b2-9647-dfc33f3f77cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[TMCU-1045]: https://consensyssoftware.atlassian.net/browse/TMCU-1045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ