### PR TITLE
feat(widgets): add a Perps P/L Live Activity

### DIFF
--- a/.cursor/rules/widget-development.mdc
+++ b/.cursor/rules/widget-development.mdc
@@ -13,6 +13,7 @@ alwaysApply: false
 - `app/core/Widgets/` — all JS/TS foundation code (theme bridge, wrappers, `WidgetUpdaterService`)
 - `ios/ExpoWidgetsTarget/` — the native WidgetKit extension target (Swift)
 - `app/core/Widgets/widgets/BalanceWidget.ios.tsx` + `BalanceWidget.ts` (non-iOS fallback) — the reference widget; copy its shape for new widgets
+- `app/core/Widgets/liveActivities/PerpsPnlLiveActivity.ios.tsx` + `.ts` — the reference Live Activity; its lifecycle driver is `app/components/UI/Perps/services/PerpsLiveActivityService.ts`
 
 ## The one non-negotiable rule: no closures inside `'widget'`-directive functions
 
@@ -46,8 +47,9 @@ Do all data-fetching/formatting/masking in `WidgetUpdaterService.computeXProps()
 `expo-widgets`/`@expo/ui`'s JS entry points call a *throwing* `requireNativeModule`/`requireNativeView` at import time — merely importing them on Android crashes the app.
 
 - ✅ `MyThing.ios.ts(x)` — real implementation, imports `expo-widgets`/`@expo/ui/swift-ui`
-- ✅ `MyThing.ts` (plain, extensionless) — no-op fallback, same exported names/types (duplicate small prop interfaces rather than value-importing from the `.ios` file)
-- ✅ Import both via the **extensionless** path (`from './MyThing'`) — Metro resolves `.ios.tsx` on iOS and falls back to the plain `.ts` everywhere else; `tsc` resolves the plain `.ts` directly with default settings
+- ✅ `MyThing.ts(x)` (plain, no platform suffix) — no-op fallback, same exported names/types (duplicate small prop interfaces rather than value-importing from the `.ios` file)
+- ✅ **The two files must share the same extension** — a `.ios.tsx` implementation needs a `.tsx` fallback, even when that fallback contains no JSX. Metro loops `sourceExts` (`['ts', 'tsx', …]`) on the outside and platform on the inside, so with a `.ts` fallback it resolves `MyThing.ts` on iOS *before* it ever tries `MyThing.ios.tsx` — the no-op silently shadows the real implementation. Jest resolves platform-first and does **not** reproduce this, so tests stay green while the app crashes at import time.
+- ✅ Import both via the **extensionless** path (`from './MyThing'`) — Metro resolves the `.ios` variant on iOS and the plain one everywhere else; `tsc` resolves the plain one directly with default settings
 - ❌ Never `import ... from './MyThing.ios'` (explicit `.ios` suffix) for a *value* — this bypasses Metro's platform exclusion and bundles it into Android too. `import type` is fine (fully erased by Babel), but prefer importing the type from the extensionless fallback module anyway.
 - ❌ Never import `expo-widgets` or `@expo/ui/swift-ui` from a file lacking an `.ios.` extension
 
@@ -72,7 +74,7 @@ Do all data-fetching/formatting/masking in `WidgetUpdaterService.computeXProps()
 ## Adding a new widget — checklist
 
 1. `app/core/Widgets/widgets/MyWidget.ios.tsx` — props interface + `'widget'` layout + `createMetaMaskWidget(name, layout)`
-2. `app/core/Widgets/widgets/MyWidget.ts` — no-op fallback, `createMetaMaskWidget` from `../createMetaMaskWidget`
+2. `app/core/Widgets/widgets/MyWidget.tsx` — no-op fallback, `createMetaMaskWidget` from `../createMetaMaskWidget` (`.tsx`, matching the `.ios.tsx` extension — see Platform split)
 3. `WidgetUpdaterService.ts` — `computeMyWidgetProps()` + `pushMyWidgetUpdate()`, called from `pushUpdates()`
 4. `ios/ExpoWidgetsTarget/MyWidget.swift` — copy `BalanceWidget.swift`, matching `name` exactly to the JS registration name
 5. `ios/ExpoWidgetsTarget/index.swift` — add `MyWidget()` to the `WidgetBundle` (4-widget-per-bundle WidgetKit limit)
@@ -81,6 +83,20 @@ Do all data-fetching/formatting/masking in `WidgetUpdaterService.computeXProps()
 8. Tests + a simulator check (light/dark mode, data updates)
 9. No analytics step needed — [adoption tracking](../../docs/widgets/README.md#adoption-analytics) is automatic, keyed on `name`/`MY_WIDGET_NAME`
 
+## Adding a Live Activity — checklist
+
+Every rule above (no closures, platform split, theming) applies unchanged. Only these differ:
+
+1. **No native work whatsoever** — no `.swift` file, no `index.swift` entry, no Xcode target membership, no `app.config.js` entry. `WidgetLiveActivity()` (expo-widgets' generic renderer) is already bundled and `NSSupportsLiveActivities` is already set; `createLiveActivity` writes the stringified layout to the App Group at *import time* and the extension looks it up by `name`. A new Live Activity is a pure-JS change.
+2. `app/core/Widgets/liveActivities/MyActivity.ios.tsx` — props + a `'widget'` layout that returns a **`LiveActivityLayout` object**, not JSX: `{ banner, compactLeading, compactTrailing, minimal, expandedLeading, expandedTrailing, expandedBottom }`. Second param is `LiveActivityEnvironment` (import it from `../createMetaMaskLiveActivity.ios`; `expo-widgets` doesn't re-export it from its package root).
+3. `app/core/Widgets/liveActivities/MyActivity.tsx` — no-op fallback, `createMetaMaskLiveActivity` from `../createMetaMaskLiveActivity` (`.tsx`, matching the `.ios.tsx` extension — see Platform split).
+4. A **feature-owned** lifecycle service calling `.start()` / `.update()` / `.end('immediate')` — NOT `WidgetUpdaterService`, which only exists to fan a debounced Redux snapshot out to widgets. Throttle updates (ActivityKit budgets them) and skip writes when serialized props are unchanged.
+5. Call `endLiveActivitiesFromPreviousLaunch()` once from that service's start.
+6. Prefer suppressing the activity entirely over masking values when privacy mode is on — the Lock Screen is readable without unlocking.
+7. Tests: assert registration from the activity's own file, all real logic from the service. Reading `MM_WIDGETS_ENABLED` at call time requires adding the service *and* its test to `babel.config.tests.js`'s inline-env `exclude` list.
+
+- **NEVER** adopt `getInstances()[0]`. `expo-widgets` renders all Live Activities through one shared `ActivityAttributes` type, so `getInstances()` on any factory returns every instance app-wide, and `update()` rewrites the kind's `name` — adopting blindly repurposes another feature's activity. See `app/core/Widgets/reconcileLiveActivities.ts`.
+
 Note: `ExpoWidgetsTarget` is only embedded in the `MetaMask` scheme — `MetaMask-Flask` ships without widgets (see `docs/widgets/README.md#limitations`). Device/IPA (archive/export) builds also need Apple Developer portal provisioning work not yet done — see `docs/widgets/README.md#provisioning-for-device-and-ipa-builds`; simulator builds and E2E are unaffected.
 
 ## Enforcement
@@ -88,4 +104,4 @@ Note: `ExpoWidgetsTarget` is only embedded in the `MetaMask` scheme — `MetaMas
 - **REJECT** any reference inside a `'widget'`-directive function to something other than its own params/`@expo/ui/swift-ui`
 - **REJECT** `import ... from 'expo-widgets'` / `'@expo/ui/swift-ui'` in a file without an `.ios.` extension
 - **REJECT** explicit `.ios`-suffixed *value* imports of platform-split files
-- **REQUIRE** a plain `.ts(x)` no-op fallback counterpart for every new `.ios.ts(x)` file under `app/core/Widgets/`
+- **REQUIRE** a plain no-op fallback counterpart for every new `.ios.ts(x)` file under `app/core/Widgets/`, **using the same extension** as the `.ios` file

--- a/app/components/UI/Perps/providers/PerpsAlwaysOnProvider.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsAlwaysOnProvider.test.tsx
@@ -5,6 +5,7 @@ import { useSelector } from 'react-redux';
 import Engine from '../../../../core/Engine';
 import { PerpsAlwaysOnProvider } from './PerpsAlwaysOnProvider';
 import { PerpsConnectionManager } from '../services/PerpsConnectionManager';
+import { PerpsLiveActivityService } from '../services/PerpsLiveActivityService';
 import { PERPS_CONNECTION_SOURCE } from '../constants/perpsConfig';
 
 jest.mock('react-redux', () => ({
@@ -12,6 +13,10 @@ jest.mock('react-redux', () => ({
 }));
 
 jest.mock('../services/PerpsConnectionManager');
+
+jest.mock('../services/PerpsLiveActivityService', () => ({
+  PerpsLiveActivityService: { start: jest.fn(), stop: jest.fn() },
+}));
 
 jest.mock('../utils/perpsLifecycleContext', () => ({
   initPerpsLifecycleTracking: jest.fn(() => jest.fn()),
@@ -115,6 +120,40 @@ describe('PerpsAlwaysOnProvider', () => {
       </PerpsAlwaysOnProvider>,
     );
     expect(getByText('child content')).toBeOnTheScreen();
+  });
+
+  it('starts the P/L Live Activity service on mount when perps is enabled', () => {
+    render(
+      <PerpsAlwaysOnProvider>
+        <Text>child</Text>
+      </PerpsAlwaysOnProvider>,
+    );
+
+    expect(PerpsLiveActivityService.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start the P/L Live Activity service when perps is disabled', () => {
+    mockUseSelector.mockReturnValue(false);
+
+    render(
+      <PerpsAlwaysOnProvider>
+        <Text>child</Text>
+      </PerpsAlwaysOnProvider>,
+    );
+
+    expect(PerpsLiveActivityService.start).not.toHaveBeenCalled();
+  });
+
+  it('stops the P/L Live Activity service on unmount', () => {
+    const { unmount } = render(
+      <PerpsAlwaysOnProvider>
+        <Text>child</Text>
+      </PerpsAlwaysOnProvider>,
+    );
+
+    unmount();
+
+    expect(PerpsLiveActivityService.stop).toHaveBeenCalledTimes(1);
   });
 
   it('calls resumeFromForeground on mount when perps is enabled', () => {

--- a/app/components/UI/Perps/providers/PerpsAlwaysOnProvider.tsx
+++ b/app/components/UI/Perps/providers/PerpsAlwaysOnProvider.tsx
@@ -3,6 +3,7 @@ import { AppState } from 'react-native';
 import { useSelector } from 'react-redux';
 import { PERPS_CONSTANTS } from '@metamask/perps-controller';
 import { PerpsConnectionManager } from '../services/PerpsConnectionManager';
+import { PerpsLiveActivityService } from '../services/PerpsLiveActivityService';
 import { PERPS_CONNECTION_SOURCE } from '../constants/perpsConfig';
 import { selectPerpsEnabledFlag } from '../index';
 import Engine from '../../../../core/Engine';
@@ -34,6 +35,20 @@ export const PerpsAlwaysOnProvider: React.FC<{ children: React.ReactNode }> = ({
 
   // Track AppState so Perps CUF spans can tag lifecycle_context.
   useEffect(() => initPerpsLifecycleTracking(), []);
+
+  // Mirror the largest open position's live P/L into an iOS Live Activity.
+  // Attached here because this is where the app-wide Perps connection already
+  // lives, so the position stream is available for the whole app lifetime
+  // rather than only while a Perps screen is mounted. No-op on Android and
+  // unless MM_WIDGETS_ENABLED is 'true' — see PerpsLiveActivityService.
+  useEffect(() => {
+    if (!isPerpsEnabled) {
+      return undefined;
+    }
+
+    PerpsLiveActivityService.start();
+    return () => PerpsLiveActivityService.stop();
+  }, [isPerpsEnabled]);
 
   useEffect(() => {
     const controller = Engine.context.PerpsController;

--- a/app/components/UI/Perps/services/PerpsLiveActivityService.test.ts
+++ b/app/components/UI/Perps/services/PerpsLiveActivityService.test.ts
@@ -1,0 +1,445 @@
+import { Platform } from 'react-native';
+import type { Position, PriceUpdate } from '@metamask/perps-controller';
+
+import ReduxService from '../../../../core/redux/ReduxService';
+import { PerpsPnlLiveActivity } from '../../../../core/Widgets/liveActivities/PerpsPnlLiveActivity';
+import { endLiveActivitiesFromPreviousLaunch } from '../../../../core/Widgets/reconcileLiveActivities';
+import { selectPrivacyMode } from '../../../../selectors/preferencesController';
+import { enrichPositionsWithLivePnL } from '../hooks/stream/usePerpsLivePositions';
+import { getStreamManagerInstance } from '../providers/PerpsStreamManager';
+import { PerpsLiveActivityServiceImplementation } from './PerpsLiveActivityService';
+
+jest.mock('../providers/PerpsStreamManager', () => ({
+  getStreamManagerInstance: jest.fn(),
+}));
+
+jest.mock(
+  '../../../../core/Widgets/liveActivities/PerpsPnlLiveActivity',
+  () => ({
+    PERPS_PNL_LIVE_ACTIVITY_NAME: 'PerpsPnlLiveActivity',
+    PerpsPnlLiveActivity: { start: jest.fn(), getInstances: jest.fn(() => []) },
+  }),
+);
+
+jest.mock('../../../../core/Widgets/reconcileLiveActivities', () => ({
+  endLiveActivitiesFromPreviousLaunch: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../../../selectors/preferencesController', () => ({
+  selectPrivacyMode: jest.fn(),
+}));
+
+// The P/L math itself is covered by usePerpsLivePositions' own tests; here we
+// only care that the service feeds it the right position + price snapshot and
+// renders whatever it returns.
+jest.mock('../hooks/stream/usePerpsLivePositions', () => ({
+  enrichPositionsWithLivePnL: jest.fn((positions) => positions),
+}));
+
+jest.mock('../../../../../locales/i18n', () => ({
+  __esModule: true,
+  strings: jest.fn((key: string, params?: Record<string, string>) =>
+    params ? `${key}:${Object.values(params).join('|')}` : key,
+  ),
+  default: { locale: 'en-US' },
+}));
+
+jest.mock('../utils/formatUtils', () => ({
+  formatPnl: jest.fn((value: number) => `pnl(${value})`),
+  formatPercentage: jest.fn((value: number) => `pct(${value})`),
+  formatPerpsPrice: jest.fn((value: string | number) => `price(${value})`),
+  formatLeverage: jest.fn((value: number) => `${value}x`),
+}));
+
+jest.mock('../../../../util/Logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn(), log: jest.fn() },
+}));
+
+jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
+  DevLogger: { log: jest.fn() },
+}));
+
+function buildPosition(overrides: Partial<Position> = {}): Position {
+  return {
+    symbol: 'BTC',
+    size: '0.5',
+    entryPrice: '60000',
+    positionValue: '32500',
+    unrealizedPnl: '2500',
+    marginUsed: '3000',
+    leverage: { type: 'isolated', value: 10 },
+    liquidationPrice: '55000',
+    maxLeverage: 40,
+    returnOnEquity: '0.25',
+    cumulativeFunding: { allTime: '0', sinceOpen: '0', sinceChange: '0' },
+    takeProfitCount: 0,
+    stopLossCount: 0,
+    ...overrides,
+  };
+}
+
+describe('PerpsLiveActivityService', () => {
+  const mockSelectPrivacyMode = jest.mocked(selectPrivacyMode);
+  const mockGetStreamManagerInstance = jest.mocked(getStreamManagerInstance);
+  const mockEnrich = jest.mocked(enrichPositionsWithLivePnL);
+  const mockStart = jest.mocked(PerpsPnlLiveActivity.start);
+
+  let service: PerpsLiveActivityServiceImplementation;
+  let activity: { update: jest.Mock; end: jest.Mock };
+  let unsubscribeFromPositions: jest.Mock;
+  let unsubscribeFromPrices: jest.Mock;
+  let emitPositions: ((positions: Position[] | null) => void) | undefined;
+  let emitPrices: ((prices: Record<string, PriceUpdate>) => void) | undefined;
+  let subscribeToSymbols: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Platform.OS = 'ios';
+    process.env.MM_WIDGETS_ENABLED = 'true';
+
+    emitPositions = undefined;
+    emitPrices = undefined;
+    unsubscribeFromPositions = jest.fn();
+    unsubscribeFromPrices = jest.fn();
+
+    subscribeToSymbols = jest.fn(
+      ({
+        callback,
+      }: {
+        callback: (prices: Record<string, PriceUpdate>) => void;
+      }) => {
+        emitPrices = callback;
+        return unsubscribeFromPrices;
+      },
+    );
+
+    mockGetStreamManagerInstance.mockReturnValue({
+      positions: {
+        subscribe: jest.fn(
+          ({
+            callback,
+          }: {
+            callback: (positions: Position[] | null) => void;
+          }) => {
+            emitPositions = callback;
+            return unsubscribeFromPositions;
+          },
+        ),
+      },
+      prices: { subscribeToSymbols },
+    } as never);
+
+    activity = {
+      update: jest.fn().mockResolvedValue(undefined),
+      end: jest.fn().mockResolvedValue(undefined),
+    };
+    mockStart.mockReturnValue(activity as never);
+
+    mockEnrich.mockImplementation((positions) => positions);
+    mockSelectPrivacyMode.mockReturnValue(false);
+
+    ReduxService.store = {
+      getState: jest.fn(() => ({}) as never),
+      dispatch: jest.fn(),
+      subscribe: jest.fn(),
+    } as never;
+
+    service = PerpsLiveActivityServiceImplementation.getInstance();
+    service.stop();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    service.stop();
+  });
+
+  describe('start gating', () => {
+    it('does nothing when MM_WIDGETS_ENABLED is not true', () => {
+      process.env.MM_WIDGETS_ENABLED = 'false';
+
+      service.start();
+
+      expect(mockGetStreamManagerInstance).not.toHaveBeenCalled();
+    });
+
+    it('does nothing on Android, where Live Activities do not exist', () => {
+      Platform.OS = 'android';
+
+      service.start();
+
+      expect(mockGetStreamManagerInstance).not.toHaveBeenCalled();
+    });
+
+    it('subscribes to the position stream only once across repeated start calls', () => {
+      service.start();
+      service.start();
+
+      expect(
+        mockGetStreamManagerInstance().positions.subscribe,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('ends activities orphaned by a previous launch before driving its own', () => {
+      service.start();
+
+      expect(endLiveActivitiesFromPreviousLaunch).toHaveBeenCalledWith(
+        PerpsPnlLiveActivity,
+      );
+    });
+  });
+
+  describe('starting an activity', () => {
+    it('starts one with formatted, translated props for the open position', () => {
+      service.start();
+
+      emitPositions?.([buildPosition()]);
+
+      expect(mockStart).toHaveBeenCalledTimes(1);
+      expect(mockStart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          symbol: 'BTC',
+          directionLabel:
+            'widgets.perps_pnl_live_activity.direction:perps.market.long|10x',
+          isProfit: true,
+          pnlLabel: 'perps.unrealized_pnl',
+          pnlDisplay: 'pnl(2500)',
+          roeDisplay: 'pct(25)',
+          entryPriceDisplay: 'price(60000)',
+        }),
+      );
+    });
+
+    it('passes both light and dark themes so the card follows the system appearance', () => {
+      service.start();
+
+      emitPositions?.([buildPosition()]);
+
+      const props = mockStart.mock.calls[0][0];
+      expect(props.theme.light.colorScheme).toBe('light');
+      expect(props.theme.dark.colorScheme).toBe('dark');
+    });
+
+    it('marks a losing position as not profitable so the layout colors it red', () => {
+      service.start();
+
+      emitPositions?.([buildPosition({ unrealizedPnl: '-800' })]);
+
+      expect(mockStart).toHaveBeenCalledWith(
+        expect.objectContaining({ isProfit: false, pnlDisplay: 'pnl(-800)' }),
+      );
+    });
+
+    it('labels a negative size as a short', () => {
+      service.start();
+
+      emitPositions?.([buildPosition({ size: '-0.5' })]);
+
+      expect(mockStart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          directionLabel:
+            'widgets.perps_pnl_live_activity.direction:perps.market.short|10x',
+        }),
+      );
+    });
+
+    it('shows the largest position by notional value when several are open', () => {
+      service.start();
+
+      emitPositions?.([
+        buildPosition({ symbol: 'DOGE', positionValue: '120' }),
+        buildPosition({ symbol: 'ETH', positionValue: '9000' }),
+        buildPosition({ symbol: 'SOL', positionValue: '400' }),
+      ]);
+
+      expect(mockStart).toHaveBeenCalledWith(
+        expect.objectContaining({ symbol: 'ETH' }),
+      );
+    });
+
+    it('derives the mark price from the position until the first price tick arrives', () => {
+      service.start();
+
+      // positionValue 32500 over size 0.5 implies a 65000 mark price.
+      emitPositions?.([buildPosition()]);
+
+      expect(mockStart).toHaveBeenCalledWith(
+        expect.objectContaining({ markPriceDisplay: 'price(65000)' }),
+      );
+    });
+  });
+
+  describe('live price updates', () => {
+    it('subscribes to prices for just the displayed symbol', () => {
+      service.start();
+
+      emitPositions?.([buildPosition({ symbol: 'ETH' })]);
+
+      expect(subscribeToSymbols).toHaveBeenCalledWith(
+        expect.objectContaining({ symbols: ['ETH'] }),
+      );
+    });
+
+    it('re-scopes the price subscription when a different position becomes the largest', () => {
+      service.start();
+      emitPositions?.([buildPosition({ symbol: 'ETH' })]);
+      subscribeToSymbols.mockClear();
+
+      emitPositions?.([
+        buildPosition({ symbol: 'ETH', positionValue: '100' }),
+        buildPosition({ symbol: 'BTC', positionValue: '50000' }),
+      ]);
+
+      expect(unsubscribeFromPrices).toHaveBeenCalled();
+      expect(subscribeToSymbols).toHaveBeenCalledWith(
+        expect.objectContaining({ symbols: ['BTC'] }),
+      );
+    });
+
+    it('recomputes P/L from the latest mark price and updates rather than restarting', () => {
+      service.start();
+      emitPositions?.([buildPosition()]);
+
+      mockEnrich.mockImplementation(([position]) => [
+        { ...position, unrealizedPnl: '3100', returnOnEquity: '0.31' },
+      ]);
+      emitPrices?.({
+        BTC: { symbol: 'BTC', price: '66200', timestamp: 1, isTradable: true },
+      });
+
+      expect(mockStart).toHaveBeenCalledTimes(1);
+      expect(activity.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pnlDisplay: 'pnl(3100)',
+          roeDisplay: 'pct(31)',
+          markPriceDisplay: 'price(66200)',
+        }),
+      );
+    });
+
+    it('feeds the price snapshot into the shared P/L enrichment', () => {
+      service.start();
+      emitPositions?.([buildPosition()]);
+
+      const prices = {
+        BTC: { symbol: 'BTC', price: '66200', timestamp: 1, isTradable: true },
+      };
+      emitPrices?.(prices);
+
+      expect(mockEnrich).toHaveBeenLastCalledWith(
+        [expect.objectContaining({ symbol: 'BTC' })],
+        prices,
+      );
+    });
+
+    it('discards cached prices when the channel signals a cache clear', () => {
+      service.start();
+      emitPositions?.([buildPosition()]);
+      emitPrices?.({
+        BTC: { symbol: 'BTC', price: '66200', timestamp: 1, isTradable: true },
+      });
+
+      emitPrices?.({});
+
+      expect(mockEnrich).toHaveBeenLastCalledWith(expect.anything(), {});
+    });
+
+    it('skips the ActivityKit write when the computed props are unchanged', () => {
+      service.start();
+      emitPositions?.([buildPosition()]);
+
+      emitPositions?.([buildPosition()]);
+
+      expect(activity.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ending an activity', () => {
+    it('ends immediately once the last position is closed', () => {
+      service.start();
+      emitPositions?.([buildPosition()]);
+
+      emitPositions?.([]);
+
+      expect(activity.end).toHaveBeenCalledWith('immediate');
+    });
+
+    it('ends on the account-switch clear signal rather than showing another account\u2019s P/L', () => {
+      service.start();
+      emitPositions?.([buildPosition()]);
+
+      emitPositions?.(null);
+
+      expect(activity.end).toHaveBeenCalledWith('immediate');
+    });
+
+    it('starts a fresh activity after a close, instead of reusing the ended handle', () => {
+      service.start();
+      emitPositions?.([buildPosition()]);
+      emitPositions?.([]);
+
+      emitPositions?.([buildPosition()]);
+
+      expect(mockStart).toHaveBeenCalledTimes(2);
+    });
+
+    it('unsubscribes from both streams and ends the activity on stop', () => {
+      service.start();
+      emitPositions?.([buildPosition()]);
+
+      service.stop();
+
+      expect(unsubscribeFromPositions).toHaveBeenCalled();
+      expect(unsubscribeFromPrices).toHaveBeenCalled();
+      expect(activity.end).toHaveBeenCalledWith('immediate');
+    });
+  });
+
+  describe('privacy mode', () => {
+    it('never starts an activity, since the Lock Screen is readable while locked', () => {
+      mockSelectPrivacyMode.mockReturnValue(true);
+      service.start();
+
+      emitPositions?.([buildPosition()]);
+
+      expect(mockStart).not.toHaveBeenCalled();
+    });
+
+    it('ends a running activity when privacy mode is switched on', () => {
+      service.start();
+      emitPositions?.([buildPosition()]);
+
+      mockSelectPrivacyMode.mockReturnValue(true);
+      emitPositions?.([buildPosition({ unrealizedPnl: '2600' })]);
+
+      expect(activity.end).toHaveBeenCalledWith('immediate');
+    });
+  });
+
+  describe('when ActivityKit refuses the request', () => {
+    it('stops retrying after three consecutive failures', () => {
+      mockStart.mockImplementation(() => {
+        throw new Error('Live Activities are disabled');
+      });
+      service.start();
+
+      for (let attempt = 0; attempt < 5; attempt++) {
+        emitPositions?.([buildPosition({ unrealizedPnl: `${attempt}` })]);
+      }
+
+      expect(mockStart).toHaveBeenCalledTimes(3);
+    });
+
+    it('retries on the next update rather than treating the failed props as delivered', () => {
+      mockStart.mockImplementationOnce(() => {
+        throw new Error('app is backgrounded');
+      });
+      service.start();
+
+      emitPositions?.([buildPosition()]);
+      emitPositions?.([buildPosition()]);
+
+      expect(mockStart).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/app/components/UI/Perps/services/PerpsLiveActivityService.ts
+++ b/app/components/UI/Perps/services/PerpsLiveActivityService.ts
@@ -1,0 +1,368 @@
+import { Platform } from 'react-native';
+import type { Position, PriceUpdate } from '@metamask/perps-controller';
+
+import { strings } from '../../../../../locales/i18n';
+import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import ReduxService from '../../../../core/redux/ReduxService';
+import {
+  PerpsPnlLiveActivity,
+  type PerpsPnlLiveActivityProps,
+} from '../../../../core/Widgets/liveActivities/PerpsPnlLiveActivity';
+import { endLiveActivitiesFromPreviousLaunch } from '../../../../core/Widgets/reconcileLiveActivities';
+import {
+  darkWidgetTheme,
+  lightWidgetTheme,
+} from '../../../../core/Widgets/WidgetTheme';
+import type { WithWidgetTheme } from '../../../../core/Widgets/types';
+import { selectPrivacyMode } from '../../../../selectors/preferencesController';
+import Logger from '../../../../util/Logger';
+import { enrichPositionsWithLivePnL } from '../hooks/stream/usePerpsLivePositions';
+import { getStreamManagerInstance } from '../providers/PerpsStreamManager';
+import {
+  formatLeverage,
+  formatPerpsPrice,
+  formatPercentage,
+  formatPnl,
+} from '../utils/formatUtils';
+
+type PerpsPnlLiveActivityInstance = ReturnType<
+  typeof PerpsPnlLiveActivity.start
+>;
+
+/**
+ * Applied to both the position and the price stream subscriptions.
+ *
+ * ActivityKit budgets how often a Live Activity may be updated, and a perps
+ * price feed ticks far faster than a Lock Screen card is worth redrawing. 2s
+ * keeps the P/L visibly live while staying well inside that budget; combined
+ * with the identical-props check in `sync()` a quiet market produces no
+ * updates at all.
+ */
+const UPDATE_THROTTLE_MS = 2000;
+
+/**
+ * Stop retrying `start()` after this many consecutive failures, so a device
+ * where the user has Live Activities switched off doesn't get a failed
+ * ActivityKit request on every price tick for the rest of the session.
+ */
+const MAX_START_FAILURES = 3;
+
+/**
+ * Drives the Perps P/L Live Activity's start/update/end lifecycle from the
+ * Perps WebSocket streams.
+ *
+ * This is deliberately NOT part of `WidgetUpdaterService`: that service exists
+ * to fan a debounced Redux snapshot out to home screen widgets, whereas
+ * individual perps positions never enter Redux at all — they only exist in
+ * `PerpsStreamManager`'s channels. A Live Activity is also a state machine
+ * (start on open, update while open, end on close) rather than a standing
+ * snapshot, which is why `docs/widgets/README.md` assigns Live Activity
+ * lifecycles to the owning feature.
+ *
+ * Started/stopped by `PerpsAlwaysOnProvider`, which already owns the app-wide
+ * Perps connection lifecycle.
+ */
+class PerpsLiveActivityServiceImplementation {
+  private static instance: PerpsLiveActivityServiceImplementation;
+
+  private unsubscribeFromPositions?: () => void;
+
+  private unsubscribeFromPrices?: () => void;
+
+  /** Symbol the price subscription is currently scoped to, if any. */
+  private subscribedSymbol?: string;
+
+  private activity?: PerpsPnlLiveActivityInstance;
+
+  private positions: Position[] = [];
+
+  private prices: Record<string, PriceUpdate> = {};
+
+  /** Skips redundant ActivityKit writes when the computed props haven't changed. */
+  private lastSerializedProps?: string;
+
+  private startFailureCount = 0;
+
+  private started = false;
+
+  // eslint-disable-next-line no-empty-function -- singleton: construction is intentionally private and does nothing
+  private constructor() {}
+
+  static getInstance(): PerpsLiveActivityServiceImplementation {
+    if (!PerpsLiveActivityServiceImplementation.instance) {
+      PerpsLiveActivityServiceImplementation.instance =
+        new PerpsLiveActivityServiceImplementation();
+    }
+    return PerpsLiveActivityServiceImplementation.instance;
+  }
+
+  /**
+   * Subscribes to the position stream and begins mirroring the largest open
+   * position into a Live Activity. Safe to call on every platform (no-op on
+   * Android, see createMetaMaskLiveActivity.ts), a no-op unless the
+   * build-time `MM_WIDGETS_ENABLED` flag is `'true'`, and safe to call more
+   * than once.
+   */
+  start(): void {
+    if (
+      this.started ||
+      Platform.OS !== 'ios' ||
+      process.env.MM_WIDGETS_ENABLED !== 'true'
+    ) {
+      return;
+    }
+    this.started = true;
+
+    endLiveActivitiesFromPreviousLaunch(PerpsPnlLiveActivity).catch(
+      () => undefined,
+    );
+
+    // A Live Activity is a nice-to-have garnish on the Perps experience, and
+    // this runs from an effect in the wallet's render tree. Swallow everything,
+    // matching PerpsAlwaysOnProvider's contract that a perps-side failure can
+    // never take the wallet down with it.
+    try {
+      this.unsubscribeFromPositions =
+        getStreamManagerInstance().positions.subscribe({
+          callback: this.handlePositions,
+          throttleMs: UPDATE_THROTTLE_MS,
+        });
+      DevLogger.log('PerpsLiveActivityService: started');
+    } catch (error) {
+      Logger.error(
+        error as Error,
+        'PerpsLiveActivityService: Failed to subscribe to the position stream',
+      );
+    }
+  }
+
+  /**
+   * Unsubscribes from both streams and ends any running activity. Idempotent,
+   * and restores the service to the exact state a fresh instance starts in so
+   * a later `start()` behaves identically to the first one.
+   */
+  stop(): void {
+    this.started = false;
+
+    this.unsubscribeFromPositions?.();
+    this.unsubscribeFromPositions = undefined;
+    this.unsubscribeFromPrices?.();
+    this.unsubscribeFromPrices = undefined;
+    this.subscribedSymbol = undefined;
+
+    this.positions = [];
+    this.prices = {};
+    this.startFailureCount = 0;
+    this.endActivity();
+
+    DevLogger.log('PerpsLiveActivityService: stopped');
+  }
+
+  private handlePositions = (positions: Position[] | null): void => {
+    // `null` is the channel's "cleared" signal (account switch): drop the
+    // activity rather than keeping the previous account's P/L on screen.
+    this.positions = positions ?? [];
+    this.syncPriceSubscription();
+    this.sync();
+  };
+
+  private handlePrices = (prices: Record<string, PriceUpdate>): void => {
+    if (!prices) {
+      return;
+    }
+    // An empty payload is the channel's cache-clear signal (reconnect,
+    // provider change, account switch) — reset rather than merge, so a stale
+    // mark price can't drive P/L until fresh ticks arrive.
+    this.prices = Object.keys(prices).length === 0 ? {} : prices;
+    this.sync();
+  };
+
+  /**
+   * Keeps the price subscription scoped to exactly the symbol currently being
+   * displayed, so the activity gets live mark prices without subscribing to
+   * the whole price channel.
+   */
+  private syncPriceSubscription(): void {
+    const symbol = this.selectPosition()?.symbol;
+    if (symbol === this.subscribedSymbol) {
+      return;
+    }
+
+    this.unsubscribeFromPrices?.();
+    this.unsubscribeFromPrices = undefined;
+    this.subscribedSymbol = symbol;
+    this.prices = {};
+
+    if (!symbol) {
+      return;
+    }
+
+    this.unsubscribeFromPrices =
+      getStreamManagerInstance().prices.subscribeToSymbols({
+        symbols: [symbol],
+        callback: this.handlePrices,
+        throttleMs: UPDATE_THROTTLE_MS,
+      });
+  }
+
+  /**
+   * The position to surface. A Live Activity has one banner and one Dynamic
+   * Island slot, so with several positions open this picks the largest by
+   * notional value — the one whose P/L moves the account most.
+   */
+  private selectPosition(): Position | undefined {
+    return this.positions.reduce<Position | undefined>((largest, position) => {
+      if (!largest) {
+        return position;
+      }
+      return notionalValue(position) > notionalValue(largest)
+        ? position
+        : largest;
+    }, undefined);
+  }
+
+  private sync(): void {
+    try {
+      const props = this.computeProps();
+
+      if (!props) {
+        this.endActivity();
+        return;
+      }
+
+      const serialized = JSON.stringify(props);
+      if (serialized === this.lastSerializedProps) {
+        return;
+      }
+      this.lastSerializedProps = serialized;
+
+      if (this.activity) {
+        this.activity.update(props).catch((error) => {
+          Logger.error(
+            error as Error,
+            'PerpsLiveActivityService: Failed to update Live Activity',
+          );
+        });
+        return;
+      }
+
+      this.startActivity(props);
+    } catch (error) {
+      Logger.error(
+        error as Error,
+        'PerpsLiveActivityService: Failed to sync Live Activity',
+      );
+    }
+  }
+
+  private startActivity(
+    props: PerpsPnlLiveActivityProps & WithWidgetTheme,
+  ): void {
+    if (this.startFailureCount >= MAX_START_FAILURES) {
+      return;
+    }
+
+    try {
+      this.activity = PerpsPnlLiveActivity.start(props);
+      this.startFailureCount = 0;
+    } catch (error) {
+      this.startFailureCount += 1;
+      // Expected when the user has Live Activities disabled for MetaMask, or
+      // when iOS refuses the request because the app isn't foregrounded.
+      DevLogger.log('PerpsLiveActivityService: could not start Live Activity', {
+        attempt: this.startFailureCount,
+        error: (error as Error).message,
+      });
+      // Force a retry on the next tick rather than treating the un-pushed
+      // props as already delivered.
+      this.lastSerializedProps = undefined;
+    }
+  }
+
+  private endActivity(): void {
+    const { activity } = this;
+    this.activity = undefined;
+    this.lastSerializedProps = undefined;
+
+    activity?.end('immediate').catch((error) => {
+      Logger.error(
+        error as Error,
+        'PerpsLiveActivityService: Failed to end Live Activity',
+      );
+    });
+  }
+
+  /**
+   * All formatting, translation and privacy handling for the activity lives
+   * here — never in `PerpsPnlLiveActivity.ios.tsx`, whose layout function runs
+   * in a sandbox with no access to imports. Returns `undefined` when no
+   * activity should be on screen.
+   */
+  private computeProps():
+    | (PerpsPnlLiveActivityProps & WithWidgetTheme)
+    | undefined {
+    // A Live Activity is readable on the Lock Screen without unlocking the
+    // device, so privacy mode suppresses it outright rather than masking the
+    // numbers (unlike BalanceWidget, which sits behind Face ID on the home
+    // screen).
+    if (selectPrivacyMode(ReduxService.store.getState())) {
+      return undefined;
+    }
+
+    const rawPosition = this.selectPosition();
+    if (!rawPosition) {
+      return undefined;
+    }
+
+    const [position] = enrichPositionsWithLivePnL([rawPosition], this.prices);
+
+    const size = Number.parseFloat(position.size);
+    const pnl = Number.parseFloat(position.unrealizedPnl);
+    const roe = Number.parseFloat(position.returnOnEquity);
+    const markPrice =
+      this.prices[position.symbol]?.price ?? impliedMarkPrice(position);
+
+    return {
+      symbol: position.symbol,
+      directionLabel: strings('widgets.perps_pnl_live_activity.direction', {
+        direction: strings(
+          size >= 0 ? 'perps.market.long' : 'perps.market.short',
+        ),
+        leverage: formatLeverage(position.leverage?.value ?? 1),
+      }),
+      isProfit: pnl >= 0,
+      pnlLabel: strings('perps.unrealized_pnl'),
+      pnlDisplay: formatPnl(Number.isNaN(pnl) ? 0 : pnl),
+      roeDisplay: formatPercentage(Number.isNaN(roe) ? 0 : roe * 100, 1),
+      entryPriceLabel: strings('perps.tpsl.entry_price'),
+      entryPriceDisplay: formatPerpsPrice(position.entryPrice),
+      markPriceLabel: strings('perps.market.mark_price'),
+      markPriceDisplay: formatPerpsPrice(markPrice),
+      theme: { light: lightWidgetTheme, dark: darkWidgetTheme },
+    };
+  }
+}
+
+/** Absolute notional value of a position, used to pick the most significant one. */
+function notionalValue(position: Position): number {
+  const value = Math.abs(Number.parseFloat(position.positionValue));
+  return Number.isNaN(value) ? 0 : value;
+}
+
+/**
+ * Mark price implied by the position itself, for the window between the
+ * activity starting and the first price tick arriving.
+ */
+function impliedMarkPrice(position: Position): string {
+  const size = Math.abs(Number.parseFloat(position.size));
+  const value = Math.abs(Number.parseFloat(position.positionValue));
+  if (!size || Number.isNaN(size) || Number.isNaN(value)) {
+    return position.entryPrice;
+  }
+  return (value / size).toString();
+}
+
+export const PerpsLiveActivityService =
+  PerpsLiveActivityServiceImplementation.getInstance();
+
+export { PerpsLiveActivityServiceImplementation };

--- a/app/core/Widgets/createMetaMaskLiveActivity.ios.ts
+++ b/app/core/Widgets/createMetaMaskLiveActivity.ios.ts
@@ -7,6 +7,17 @@ import {
 import type { WithWidgetTheme } from './types';
 
 /**
+ * The second argument every Live Activity layout function receives, the
+ * counterpart of `WidgetEnvironment` for widgets.
+ *
+ * `expo-widgets` defines this type but omits it from the re-export list in its
+ * package root (node_modules/expo-widgets/src/index.ts) while exporting
+ * `LiveActivityComponent`, which consumes it. Deriving it from there keeps us
+ * off the non-public `expo-widgets/src/Widgets.types` deep import.
+ */
+export type LiveActivityEnvironment = Parameters<LiveActivityComponent>[1];
+
+/**
  * Thin, typed wrapper around `expo-widgets`' `createLiveActivity`.
  *
  * Same closure/serialization caveats as `createMetaMaskWidget` apply here —
@@ -15,13 +26,12 @@ import type { WithWidgetTheme } from './types';
  * genuine prop by whoever calls `.start(props)` / `.update(props)`, not
  * injected by wrapping the function. See docs/widgets/README.md.
  *
- * This is foundation only: no MetaMask Live Activity (e.g. a Perps P/L
- * activity) is registered in `ios/ExpoWidgetsTarget/index.swift` yet. Adding
- * one requires both a `createMetaMaskLiveActivity(...)` call here on the JS
- * side AND — since `WidgetLiveActivity()` (expo-widgets' generic Live
- * Activity renderer) is already included in the widget bundle — no further
- * native changes for the *first* Live Activity. See
- * docs/widgets/README.md#live-activities for the full walkthrough.
+ * Registering a Live Activity needs NO native change at all: `WidgetLiveActivity()`
+ * (expo-widgets' generic renderer) is already in the widget bundle, and this
+ * call writes the stringified layout into the shared App Group container at
+ * import time, keyed by `name`, for the extension to read back at render
+ * time. See `./liveActivities/PerpsPnlLiveActivity.ios.tsx` for the worked
+ * example and docs/widgets/README.md#live-activities for the walkthrough.
  */
 export function createMetaMaskLiveActivity<TProps extends object = object>(
   name: string,

--- a/app/core/Widgets/liveActivities/PerpsPnlLiveActivity.ios.tsx
+++ b/app/core/Widgets/liveActivities/PerpsPnlLiveActivity.ios.tsx
@@ -1,0 +1,288 @@
+import React from 'react';
+import { HStack, Spacer, Text, VStack } from '@expo/ui/swift-ui';
+import { font, foregroundStyle, padding } from '@expo/ui/swift-ui/modifiers';
+
+import {
+  createMetaMaskLiveActivity,
+  type LiveActivityEnvironment,
+} from '../createMetaMaskLiveActivity.ios';
+import type { WithWidgetTheme } from '../types';
+
+/**
+ * Reference Live Activity: shows an open Perps position's live unrealized
+ * P/L on the Lock Screen and in the Dynamic Island.
+ *
+ * Read this alongside `../widgets/BalanceWidget.ios.tsx` (the reference home
+ * screen *widget*). The two differ in exactly one way: a widget layout
+ * returns a single JSX tree, while a Live Activity layout returns a
+ * `LiveActivityLayout` — an object whose keys are the presentation regions
+ * iOS asks for (`banner` on the Lock Screen / Notification Center,
+ * `compact*`/`minimal` for the collapsed Dynamic Island, `expanded*` for the
+ * long-pressed Dynamic Island). Every other rule is identical, in
+ * particular the no-closures rule below.
+ *
+ * The lifecycle (start/update/end) is owned by the Perps feature, not by
+ * `WidgetUpdaterService` — see
+ * `app/components/UI/Perps/services/PerpsLiveActivityService.ts`.
+ */
+export interface PerpsPnlLiveActivityProps {
+  /** Market symbol, e.g. "BTC". */
+  symbol: string;
+  /** Pre-formatted direction + leverage, e.g. "Long · 10x". Composed (and translated) by PerpsLiveActivityService. */
+  directionLabel: string;
+  /**
+   * Whether the position is currently up. Drives which theme color the P/L
+   * is rendered in. Passed as a boolean rather than a color so the layout
+   * can still pick the right *light or dark* variant of that color from
+   * `theme` on an OS appearance change — see WithWidgetTheme in ../types.ts.
+   */
+  isProfit: boolean;
+  /** e.g. "Unrealized P&L". */
+  pnlLabel: string;
+  /** Already-formatted, privacy-mode-aware unrealized P/L, e.g. "+$123.45". */
+  pnlDisplay: string;
+  /** Already-formatted, privacy-mode-aware return on equity, e.g. "+5.25%". */
+  roeDisplay: string;
+  /** e.g. "Entry price". */
+  entryPriceLabel: string;
+  /** Already-formatted entry price, e.g. "$65,000.00". */
+  entryPriceDisplay: string;
+  /** e.g. "Mark price". */
+  markPriceLabel: string;
+  /** Already-formatted live mark price, e.g. "$67,120.50". */
+  markPriceDisplay: string;
+}
+
+/**
+ * The `'widget'`-directive layout. Everything it needs arrives via `props` —
+ * no imports, no selectors, no `strings()`, no module constants are reachable
+ * from inside here at runtime (the whole function is replaced by a string
+ * literal at build time and re-evaluated in a bare JavaScriptCore sandbox
+ * inside the widget extension process). See docs/widgets/README.md.
+ */
+function PerpsPnlLiveActivityLayout(
+  props: PerpsPnlLiveActivityProps & WithWidgetTheme,
+  environment: LiveActivityEnvironment,
+) {
+  'widget';
+
+  const {
+    symbol,
+    directionLabel,
+    isProfit,
+    pnlLabel,
+    pnlDisplay,
+    roeDisplay,
+    entryPriceLabel,
+    entryPriceDisplay,
+    markPriceLabel,
+    markPriceDisplay,
+    theme,
+  } = props;
+
+  const activeTheme =
+    environment.colorScheme === 'dark' ? theme.dark : theme.light;
+  const pnlColor = isProfit
+    ? activeTheme.colors.success
+    : activeTheme.colors.error;
+
+  const symbolText = (
+    <Text
+      modifiers={[
+        foregroundStyle(activeTheme.colors.textDefault),
+        font({
+          size: activeTheme.typography.headingMd.size,
+          weight: activeTheme.typography.headingMd.weight,
+        }),
+      ]}
+    >
+      {symbol}
+    </Text>
+  );
+
+  const directionText = (
+    <Text
+      modifiers={[
+        foregroundStyle(activeTheme.colors.textAlternative),
+        font({
+          size: activeTheme.typography.bodySm.size,
+          weight: activeTheme.typography.bodySm.weight,
+        }),
+      ]}
+    >
+      {directionLabel}
+    </Text>
+  );
+
+  const roeText = (
+    <Text
+      modifiers={[
+        foregroundStyle(pnlColor),
+        font({
+          size: activeTheme.typography.bodySm.size,
+          weight: activeTheme.typography.bodySm.weight,
+        }),
+      ]}
+    >
+      {roeDisplay}
+    </Text>
+  );
+
+  const pnlText = (
+    <Text
+      modifiers={[
+        foregroundStyle(pnlColor),
+        font({
+          size: activeTheme.typography.amountDisplay.size,
+          weight: activeTheme.typography.amountDisplay.weight,
+        }),
+      ]}
+    >
+      {pnlDisplay}
+    </Text>
+  );
+
+  // Entry/mark are rendered as label + value pairs rather than one
+  // pre-composed string so the layout stays free of any string building.
+  const priceRow = (
+    <HStack spacing={activeTheme.spacing.md}>
+      <HStack spacing={activeTheme.spacing.xs}>
+        <Text
+          modifiers={[
+            foregroundStyle(activeTheme.colors.textMuted),
+            font({
+              size: activeTheme.typography.bodyXs.size,
+              weight: activeTheme.typography.bodyXs.weight,
+            }),
+          ]}
+        >
+          {entryPriceLabel}
+        </Text>
+        <Text
+          modifiers={[
+            foregroundStyle(activeTheme.colors.textAlternative),
+            font({
+              size: activeTheme.typography.bodyXs.size,
+              weight: activeTheme.typography.bodyXs.weight,
+            }),
+          ]}
+        >
+          {entryPriceDisplay}
+        </Text>
+      </HStack>
+      <HStack spacing={activeTheme.spacing.xs}>
+        <Text
+          modifiers={[
+            foregroundStyle(activeTheme.colors.textMuted),
+            font({
+              size: activeTheme.typography.bodyXs.size,
+              weight: activeTheme.typography.bodyXs.weight,
+            }),
+          ]}
+        >
+          {markPriceLabel}
+        </Text>
+        <Text
+          modifiers={[
+            foregroundStyle(activeTheme.colors.textAlternative),
+            font({
+              size: activeTheme.typography.bodyXs.size,
+              weight: activeTheme.typography.bodyXs.weight,
+            }),
+          ]}
+        >
+          {markPriceDisplay}
+        </Text>
+      </HStack>
+    </HStack>
+  );
+
+  return {
+    banner: (
+      <VStack
+        alignment="leading"
+        spacing={activeTheme.spacing.sm}
+        modifiers={[padding({ all: activeTheme.spacing.md })]}
+      >
+        <HStack spacing={activeTheme.spacing.sm}>
+          {symbolText}
+          {directionText}
+          <Spacer />
+          {roeText}
+        </HStack>
+        <VStack alignment="leading" spacing={activeTheme.spacing.xs}>
+          <Text
+            modifiers={[
+              foregroundStyle(activeTheme.colors.textAlternative),
+              font({
+                size: activeTheme.typography.bodyXs.size,
+                weight: activeTheme.typography.bodyXs.weight,
+              }),
+            ]}
+          >
+            {pnlLabel}
+          </Text>
+          {pnlText}
+        </VStack>
+        {priceRow}
+      </VStack>
+    ),
+    compactLeading: symbolText,
+    compactTrailing: (
+      <Text
+        modifiers={[
+          foregroundStyle(pnlColor),
+          font({
+            size: activeTheme.typography.bodySm.size,
+            weight: activeTheme.typography.bodySm.weight,
+          }),
+        ]}
+      >
+        {pnlDisplay}
+      </Text>
+    ),
+    minimal: roeText,
+    expandedLeading: (
+      <VStack alignment="leading" spacing={activeTheme.spacing.xs}>
+        {symbolText}
+        {directionText}
+      </VStack>
+    ),
+    expandedTrailing: (
+      <VStack alignment="trailing" spacing={activeTheme.spacing.xs}>
+        <Text
+          modifiers={[
+            foregroundStyle(pnlColor),
+            font({
+              size: activeTheme.typography.headingMd.size,
+              weight: activeTheme.typography.headingMd.weight,
+            }),
+          ]}
+        >
+          {pnlDisplay}
+        </Text>
+        {roeText}
+      </VStack>
+    ),
+    expandedBottom: priceRow,
+  };
+}
+
+/**
+ * The Live Activity's registered name.
+ *
+ * Unlike a home screen widget, this needs NO matching `.swift` file and no
+ * Xcode target change: `expo-widgets`' generic `WidgetLiveActivity()`
+ * renderer is already in `ios/ExpoWidgetsTarget/index.swift`'s bundle, and it
+ * dispatches to the right layout purely by this name (the string is written
+ * into the shared App Group container by `createLiveActivity` at import time,
+ * and read back by the extension via
+ * `__expo_widgets_live_activity_<name>_layout`).
+ */
+export const PERPS_PNL_LIVE_ACTIVITY_NAME = 'PerpsPnlLiveActivity';
+
+export const PerpsPnlLiveActivity =
+  createMetaMaskLiveActivity<PerpsPnlLiveActivityProps>(
+    PERPS_PNL_LIVE_ACTIVITY_NAME,
+    PerpsPnlLiveActivityLayout,
+  );

--- a/app/core/Widgets/liveActivities/PerpsPnlLiveActivity.test.ts
+++ b/app/core/Widgets/liveActivities/PerpsPnlLiveActivity.test.ts
@@ -1,0 +1,33 @@
+import { createLiveActivity } from 'expo-widgets';
+
+// Extensionless import: Jest's haste config (via `@react-native/jest-preset`)
+// defaults to resolving platform files as `ios`, matching how production code
+// (PerpsLiveActivityService.ts) imports this module. See
+// PerpsPnlLiveActivity.ts for the non-iOS fallback, which is trivial enough
+// (a no-op) not to need its own test.
+import {
+  PERPS_PNL_LIVE_ACTIVITY_NAME,
+  PerpsPnlLiveActivity,
+} from './PerpsPnlLiveActivity';
+
+describe('PerpsPnlLiveActivity', () => {
+  it('registers under the name the ExpoWidgetsTarget extension looks up in the App Group', () => {
+    expect(PERPS_PNL_LIVE_ACTIVITY_NAME).toBe('PerpsPnlLiveActivity');
+  });
+
+  it('is created via expo-widgets createLiveActivity exactly once at module load', () => {
+    expect(createLiveActivity).toHaveBeenCalledWith(
+      PERPS_PNL_LIVE_ACTIVITY_NAME,
+      // A string, not a function: proof that babel-preset-expo's widgets
+      // plugin actually stringified the `'widget'`-directive layout. If this
+      // ever regresses to a function, the layout would be shipped to the
+      // extension as `undefined` and render nothing.
+      expect.any(String),
+    );
+  });
+
+  it('exposes the start/getInstances factory API the service drives it through', () => {
+    expect(typeof PerpsPnlLiveActivity.start).toBe('function');
+    expect(typeof PerpsPnlLiveActivity.getInstances).toBe('function');
+  });
+});

--- a/app/core/Widgets/liveActivities/PerpsPnlLiveActivity.tsx
+++ b/app/core/Widgets/liveActivities/PerpsPnlLiveActivity.tsx
@@ -1,0 +1,36 @@
+import { createMetaMaskLiveActivity } from '../createMetaMaskLiveActivity';
+
+// See createMetaMaskLiveActivity.ts — Live Activities are an iOS-only OS
+// feature, so this base file is the non-iOS fallback. It keeps the same
+// exported shape as PerpsPnlLiveActivity.ios.tsx (name, props type, factory
+// instance) so PerpsLiveActivityService (platform-agnostic) can import this
+// module without a Platform.OS branch.
+//
+// It is `.tsx` despite containing no JSX so that its extension matches the
+// `.ios` counterpart — see the same note in ../widgets/BalanceWidget.tsx for
+// why a `.ts` fallback would shadow an `.ios.tsx` file on iOS.
+//
+// `PerpsPnlLiveActivityProps` is duplicated here rather than imported from
+// `./PerpsPnlLiveActivity.ios` — even a type-only import of an explicit
+// `.ios` path risks Metro adding it as a real dependency edge and bundling
+// that file (with its `@expo/ui/swift-ui` imports) into the Android build.
+export interface PerpsPnlLiveActivityProps {
+  symbol: string;
+  directionLabel: string;
+  isProfit: boolean;
+  pnlLabel: string;
+  pnlDisplay: string;
+  roeDisplay: string;
+  entryPriceLabel: string;
+  entryPriceDisplay: string;
+  markPriceLabel: string;
+  markPriceDisplay: string;
+}
+
+export const PERPS_PNL_LIVE_ACTIVITY_NAME = 'PerpsPnlLiveActivity';
+
+export const PerpsPnlLiveActivity =
+  createMetaMaskLiveActivity<PerpsPnlLiveActivityProps>(
+    PERPS_PNL_LIVE_ACTIVITY_NAME,
+    () => undefined,
+  );

--- a/app/core/Widgets/reconcileLiveActivities.test.ts
+++ b/app/core/Widgets/reconcileLiveActivities.test.ts
@@ -1,0 +1,57 @@
+import {
+  endLiveActivitiesFromPreviousLaunch,
+  resetLiveActivityReconciliationForTests,
+} from './reconcileLiveActivities';
+
+function createFactory(instanceCount: number) {
+  const instances = Array.from({ length: instanceCount }, () => ({
+    end: jest.fn().mockResolvedValue(undefined),
+  }));
+  return {
+    getInstances: jest.fn().mockReturnValue(instances),
+    instances,
+  };
+}
+
+describe('endLiveActivitiesFromPreviousLaunch', () => {
+  beforeEach(() => {
+    resetLiveActivityReconciliationForTests();
+  });
+
+  it('ends every activity left over from a previous launch', async () => {
+    const factory = createFactory(2);
+
+    await endLiveActivitiesFromPreviousLaunch(factory);
+
+    expect(factory.instances[0].end).toHaveBeenCalledWith('immediate');
+    expect(factory.instances[1].end).toHaveBeenCalledWith('immediate');
+  });
+
+  it('does nothing on a launch with no leftover activities', async () => {
+    const factory = createFactory(0);
+
+    await endLiveActivitiesFromPreviousLaunch(factory);
+
+    expect(factory.getInstances).toHaveBeenCalledTimes(1);
+  });
+
+  it('only reconciles once per process, so a second feature cannot end the first one\u2019s live activity', async () => {
+    const first = createFactory(1);
+    const second = createFactory(1);
+
+    await endLiveActivitiesFromPreviousLaunch(first);
+    await endLiveActivitiesFromPreviousLaunch(second);
+
+    expect(first.instances[0].end).toHaveBeenCalledTimes(1);
+    expect(second.getInstances).not.toHaveBeenCalled();
+  });
+
+  it('resolves even when ending an activity rejects', async () => {
+    const factory = createFactory(1);
+    factory.instances[0].end.mockRejectedValue(new Error('not found'));
+
+    await expect(
+      endLiveActivitiesFromPreviousLaunch(factory),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/app/core/Widgets/reconcileLiveActivities.ts
+++ b/app/core/Widgets/reconcileLiveActivities.ts
@@ -1,0 +1,73 @@
+/**
+ * Launch-time cleanup for Live Activities that outlived the process that
+ * started them.
+ *
+ * iOS deliberately keeps a Live Activity on the Lock Screen after its host
+ * app is terminated (that's how a rideshare ETA survives a force-quit), but
+ * the JS `LiveActivity` handle needed to `update()`/`end()` it does not
+ * survive. Without this, force-quitting the app while an activity is running
+ * leaves a frozen, un-endable card on the Lock Screen until the OS expires it
+ * hours later.
+ *
+ * WHY THIS IS APP-WIDE RATHER THAN PER-FEATURE: `expo-widgets` renders every
+ * Live Activity through a single shared `ActivityAttributes` type
+ * (`LiveActivityAttributes` in node_modules/expo-widgets/ios/Widgets/WidgetLiveActivity.swift),
+ * discriminating between kinds only by a `name` field inside the content
+ * state. `getInstances()` therefore returns EVERY live instance regardless of
+ * which factory started it, and `LiveActivity.update()` rewrites that `name`
+ * from the factory it was obtained through — so a feature that "adopted"
+ * `getInstances()[0]` could silently repurpose an unrelated feature's
+ * activity.
+ *
+ * Two consequences follow, both enforced here. Orphan cleanup must be
+ * indiscriminate ("end everything"), so it may only run at launch, before any
+ * feature has started an activity of its own. And it must run at most once per
+ * process, or the second caller would end the first caller's freshly started
+ * activity.
+ *
+ * Platform-agnostic on purpose: it never imports `expo-widgets`, it only
+ * accepts anything structurally shaped like a factory. On Android the
+ * no-op fallback factory reports zero instances, so this is a cheap no-op.
+ */
+
+interface EndableLiveActivity {
+  end(dismissalPolicy?: unknown): Promise<void>;
+}
+
+interface LiveActivityInstanceSource {
+  getInstances(): EndableLiveActivity[];
+}
+
+let hasReconciled = false;
+
+/**
+ * Ends every Live Activity still running from a previous app launch. Safe to
+ * call from more than one feature — only the first call in a process does
+ * anything.
+ *
+ * @param source Any registered Live Activity factory. Which one is irrelevant
+ * (see the module comment) — `getInstances()` is app-wide.
+ */
+export async function endLiveActivitiesFromPreviousLaunch(
+  source: LiveActivityInstanceSource,
+): Promise<void> {
+  if (hasReconciled) {
+    return;
+  }
+  hasReconciled = true;
+
+  await Promise.all(
+    source
+      .getInstances()
+      .map((instance) => instance.end('immediate').catch(() => undefined)),
+  );
+}
+
+/**
+ * Test-only escape hatch for the once-per-process guard above. Production code
+ * must never call this — doing so would let a second caller end an activity
+ * that is currently being driven.
+ */
+export function resetLiveActivityReconciliationForTests(): void {
+  hasReconciled = false;
+}

--- a/app/core/Widgets/widgets/BalanceWidget.tsx
+++ b/app/core/Widgets/widgets/BalanceWidget.tsx
@@ -5,6 +5,14 @@ import { createMetaMaskWidget } from '../createMetaMaskWidget';
 // (name, props type, `BalanceWidget` instance) so `WidgetUpdaterService`
 // (platform-agnostic) can import this module without a Platform.OS branch.
 //
+// This file is `.tsx` despite containing no JSX, and that is load-bearing: it
+// MUST use the same extension as its `.ios` counterpart. Metro loops over
+// `sourceExts` (`['ts', 'tsx', ...]`) on the outside and platform on the
+// inside, so `./BalanceWidget` matches `BalanceWidget.ts` before it ever tries
+// `BalanceWidget.ios.tsx`. Named `.ts`, this no-op fallback would silently win
+// on iOS too — and pass its `() => undefined` layout into the real native
+// `createWidget`, which throws at import time.
+//
 // `BalanceWidgetProps` is duplicated here rather than imported from
 // `./BalanceWidget.ios` — even a type-only import of an explicit `.ios`
 // path risks Metro adding it as a real dependency edge and bundling that

--- a/babel.config.tests.js
+++ b/babel.config.tests.js
@@ -65,6 +65,8 @@ const newOverrides = [
       // toggle the flag to exercise both the enabled and disabled paths.
       'app/core/Widgets/WidgetUpdaterService.ts',
       'app/core/Widgets/WidgetUpdaterService.test.ts',
+      'app/components/UI/Perps/services/PerpsLiveActivityService.ts',
+      'app/components/UI/Perps/services/PerpsLiveActivityService.test.ts',
       // LLM workflow session manager reads process.env at runtime (e.g. MM_METRO_PORT)
       'tests/llm-workflow/metamask-provider.ts',
       'app/core/devApiEnv.ts',

--- a/docs/widgets/README.md
+++ b/docs/widgets/README.md
@@ -27,7 +27,7 @@ whole document as agent-usable instructions.
 - [Adoption analytics](#adoption-analytics)
 - [The reference widget: `BalanceWidget`](#the-reference-widget-balancewidget)
 - [Adding a new widget](#adding-a-new-widget)
-- [Adding a Live Activity](#adding-a-live-activity)
+- [Live Activities](#live-activities)
 - [Testing widgets](#testing-widgets)
 - [Possibilities](#possibilities)
 - [Limitations](#limitations)
@@ -65,10 +65,17 @@ app/core/Widgets/
 ├── getInstalledWidgets.ios.ts         Bridges RCTWidgetInfo -> installed widget {kind, family}[]
 ├── getInstalledWidgets.ts            No-op fallback (returns [])
 ├── trackWidgetAdoption.ts            Reports install-based widget adoption to analytics
+├── reconcileLiveActivities.ts        Launch-time cleanup of activities orphaned by a previous process
 ├── index.ts                          Barrel (WidgetUpdaterService, WidgetTheme helpers, types)
-└── widgets/
-    ├── BalanceWidget.ios.tsx         Reference widget: layout + registration
-    └── BalanceWidget.ts              No-op fallback with the same exported shape
+├── widgets/
+│   ├── BalanceWidget.ios.tsx         Reference widget: layout + registration
+│   └── BalanceWidget.tsx             No-op fallback with the same exported shape
+└── liveActivities/
+    ├── PerpsPnlLiveActivity.ios.tsx  Reference Live Activity: layout + registration
+    └── PerpsPnlLiveActivity.tsx      No-op fallback with the same exported shape
+
+app/components/UI/Perps/services/
+└── PerpsLiveActivityService.ts       Feature-owned start/update/end lifecycle for the above
 
 ios/MetaMask/NativeModules/RCTWidgetInfo/   Swift + RCT_EXTERN_MODULE bridge for WidgetCenter.getCurrentConfigurations
 ├── RCTWidgetInfo.swift               getInstalledWidgets() -> [{ kind, family }] (used for adoption analytics)
@@ -213,7 +220,7 @@ neither native module is registered on Android.
 
 Every module in `app/core/Widgets/` that touches `expo-widgets` or
 `@expo/ui` therefore ships as a pair: a real `.ios.ts(x)` implementation, and
-a plain, extensionless `.ts` fallback (same exported names/types, does
+a plain, platform-suffix-free fallback (same exported names/types, does
 nothing) that Metro/`tsc` resolve on every other platform:
 
 | File                                | Runs on         | Behavior                                  |
@@ -223,18 +230,44 @@ nothing) that Metro/`tsc` resolve on every other platform:
 | `createMetaMaskLiveActivity.ios.ts` | iOS             | Real `expo-widgets` wrapper               |
 | `createMetaMaskLiveActivity.ts`     | Everywhere else | No-op fallback                            |
 | `widgets/BalanceWidget.ios.tsx`     | iOS             | Real widget (SwiftUI-in-JS layout)        |
-| `widgets/BalanceWidget.ts`          | Everywhere else | No-op fallback, same exported names/types |
+| `widgets/BalanceWidget.tsx`         | Everywhere else | No-op fallback, same exported names/types |
 
 Metro's bundler resolves an **extensionless** import (`import { BalanceWidget } from './widgets/BalanceWidget'`)
-to `BalanceWidget.ios.tsx` on iOS and falls back to the plain `BalanceWidget.ts`
+to `BalanceWidget.ios.tsx` on iOS and falls back to the plain `BalanceWidget.tsx`
 everywhere else, excluding the other file from that platform's bundle
 entirely. `WidgetUpdaterService.ts` relies on this — it imports every widget
 module extensionlessly so it works, unmodified, on both platforms (no-op on
 Android). `tsc` uses its own default (non-platform-aware) module resolution
-for the same extensionless import, which also lands on the plain `.ts`
-fallback — that's fine, since each platform file is still fully type-checked
-on its own when `tsc` walks it directly, and the fallback is written to
-mirror the `.ios` file's exported shape exactly.
+for the same extensionless import, which also lands on the plain fallback —
+that's fine, since each platform file is still fully type-checked on its own
+when `tsc` walks it directly, and the fallback is written to mirror the `.ios`
+file's exported shape exactly.
+
+### Both files in a pair must share the same extension
+
+`BalanceWidget.tsx` contains no JSX, yet it is deliberately not named
+`BalanceWidget.ts`. Metro builds its resolution candidates by looping over
+`sourceExts` (`['ts', 'tsx', 'mjs', 'js', …]`) on the **outside** and platform
+on the **inside** — for each extension it tries `.ios.<ext>`, then
+`.native.<ext>`, then `.<ext>`, and returns the first hit. So a `.ts` fallback
+paired with an `.ios.tsx` implementation resolves like this on iOS:
+
+```
+./BalanceWidget → BalanceWidget.ios.ts   ✗
+                → BalanceWidget.native.ts ✗
+                → BalanceWidget.ts        ✓  ← no-op fallback wins, on iOS
+                  (BalanceWidget.ios.tsx never reached)
+```
+
+The failure mode is nasty: the no-op fallback passes its `() => undefined`
+layout to the **real** `createMetaMaskWidget.ios.ts` (whose own pair does share
+an extension, so it resolves correctly), and `expo-widgets`' native
+`createWidget` throws `The 2nd argument cannot be cast to type String` at
+import time, taking the app down at startup.
+
+Jest does **not** reproduce this — its resolver tries all platform variants
+before any bare extension — so unit tests keep passing while the app is broken.
+Extension parity is the only thing keeping the two resolvers in agreement.
 
 **Rule of thumb:** never write `import ... from 'expo-widgets'` or
 `from '@expo/ui/swift-ui'` in a file that doesn't have an `.ios.` extension,
@@ -460,11 +493,13 @@ used elsewhere in the app), and reads the label from
      via `environment.colorScheme` (see [Theming](#theming)).
    - Export `export const MY_WIDGET_NAME = 'MyWidget';` and
      `export const MyWidget = createMetaMaskWidget<MyWidgetProps>(MY_WIDGET_NAME, MyWidgetLayout);`.
-3. **Non-iOS fallback — `app/core/Widgets/widgets/MyWidget.ts`:**
+3. **Non-iOS fallback — `app/core/Widgets/widgets/MyWidget.tsx`:**
    Duplicate the `MyWidgetProps` interface (don't type-import it from the
    `.ios.tsx` file's _value_ export — see [Platform split](#platform-split-iosts--base-ts)),
    and call `createMetaMaskWidget<MyWidgetProps>(MY_WIDGET_NAME, () => undefined)`
-   from `../createMetaMaskWidget`.
+   from `../createMetaMaskWidget`. Name it `.tsx`, not `.ts`, even though it has
+   no JSX — see
+   [Both files in a pair must share the same extension](#both-files-in-a-pair-must-share-the-same-extension).
 4. **Data — `WidgetUpdaterService.ts`:** add `computeMyWidgetProps()` and
    `pushMyWidgetUpdate()` methods (mirroring the Balance ones), and call the
    push method from `pushUpdates()`.
@@ -500,28 +535,121 @@ used elsewhere in the app), and reads the label from
 No analytics work is needed — [adoption tracking](#adoption-analytics) is
 automatic for every widget kind, keyed on `name`/`MY_WIDGET_NAME`.
 
-## Adding a Live Activity
+## Live Activities
 
-The foundation includes `createMetaMaskLiveActivity` (iOS) / a plain `.ts`
-no-op fallback, mirroring `createMetaMaskWidget`. `WidgetLiveActivity()`
-— `expo-widgets`' built-in generic Live Activity renderer — is already
-included in `ios/ExpoWidgetsTarget/index.swift`'s bundle, so **no further
-native/Xcode changes are needed for the first Live Activity** you register.
+A Live Activity is the Lock Screen / Dynamic Island counterpart of a home
+screen widget. Everything in [How widget code actually runs](#how-widget-code-actually-runs),
+[Platform split](#platform-split-iosts--base-ts) and [Theming](#theming)
+applies unchanged — the `'widget'` directive, the no-closures rule, the
+`.ios.tsx` + plain `.tsx` pair, and passing both theme variants.
 
-To add one (e.g. a Perps P/L Live Activity, a natural follow-up to this PR):
+Three things differ, and they're the whole delta:
 
-1. Define `MyActivityProps` (JSON-serializable content, e.g. `{ symbol, pnl, entryPrice, currentPrice }`).
-2. Write a `.ios.ts(x)` file with a `'widget'`-directive component and
-   `export const MyActivity = createMetaMaskLiveActivity<MyActivityProps>('MyActivity', MyActivityLayout);`,
-   plus a plain `.ts` no-op counterpart (same pattern as widgets).
-3. Wherever the feature's state machine knows an activity should start (e.g.
-   a Perps position opening), call
-   `MyActivity.start(initialProps)` and keep the returned `LiveActivity`
-   instance around; call `.update(newProps)` on subsequent changes and
-   `.end()` when it should go away. This is feature-owned, not part of
-   `WidgetUpdaterService` (Live Activities are usually driven by an event/state
-   machine, not a Redux-subscription debounce).
-4. Follow the same theming rules — pass both `theme.light`/`theme.dark`.
+1. **No native work at all.** Unlike a widget, a Live Activity needs no
+   `.swift` file, no `index.swift` bundle entry, no Xcode target membership,
+   and no `app.config.js` entry. `expo-widgets`' generic
+   `WidgetLiveActivity()` renderer is already in
+   `ios/ExpoWidgetsTarget/index.swift`'s bundle, `NSSupportsLiveActivities` is
+   already `true` in `ios/MetaMask/Info.plist`, and
+   `createLiveActivity(name, layout)` writes the stringified layout into the
+   shared App Group container at **import time**
+   (`__expo_widgets_live_activity_<name>_layout`). The extension reads it back
+   by name at render time. Adding a Live Activity is therefore a pure-JS
+   change — it ships over Metro/OTA like any other JS.
+2. **The layout returns an object, not a JSX tree.** A widget layout returns
+   one view; a Live Activity layout returns a `LiveActivityLayout` whose keys
+   are the presentation regions iOS asks for:
+
+   | Key                                                                          | Where it appears                              |
+   | ---------------------------------------------------------------------------- | --------------------------------------------- |
+   | `banner`                                                                     | Lock Screen and Notification Center           |
+   | `bannerSmall`                                                                | CarPlay / watchOS (falls back to `banner`)    |
+   | `compactLeading`                                                             | Collapsed Dynamic Island, left of the camera  |
+   | `compactTrailing`                                                            | Collapsed Dynamic Island, right of the camera |
+   | `minimal`                                                                    | Dynamic Island when another app shares it     |
+   | `expandedLeading` / `expandedTrailing` / `expandedCenter` / `expandedBottom` | Long-pressed Dynamic Island                   |
+
+   The second argument is a `LiveActivityEnvironment` rather than a
+   `WidgetEnvironment` — same `colorScheme` field, no `widgetFamily`. It isn't
+   re-exported from `expo-widgets`' package root, so
+   `createMetaMaskLiveActivity.ios.ts` re-exports a derived version; import it
+   from there.
+
+3. **The lifecycle is feature-owned.** `WidgetUpdaterService` exists to fan a
+   debounced Redux snapshot out to widgets. A Live Activity is a state machine
+   (start on open, update while open, end on close) and its data often isn't
+   in Redux at all, so the owning feature drives it.
+
+### The reference Live Activity: `PerpsPnlLiveActivity`
+
+`app/core/Widgets/liveActivities/PerpsPnlLiveActivity.ios.tsx` shows an open
+Perps position's live unrealized P/L. Read it alongside `BalanceWidget.ios.tsx`
+— together they cover both shapes.
+
+`app/components/UI/Perps/services/PerpsLiveActivityService.ts` is the data
+side, and is the more instructive half. It subscribes imperatively to
+`PerpsStreamManager`'s `positions` and `prices` channels (individual perps
+positions never enter Redux), picks the largest open position by notional
+value, reuses `enrichPositionsWithLivePnL` to recompute P/L from the live mark
+price, formats everything with the Perps formatters, and starts / updates /
+ends the activity accordingly. It is attached to `PerpsAlwaysOnProvider`,
+which already owns the app-wide Perps connection.
+
+Two behaviors there are worth copying:
+
+- **Throttle, then dedupe.** Both stream subscriptions use a 2s throttle, and
+  the service skips the ActivityKit write entirely when the newly computed
+  props are `JSON.stringify`-identical to the last push — the same pattern
+  `WidgetUpdaterService` uses. ActivityKit budgets update frequency, and a
+  price feed ticks far faster than a Lock Screen card is worth redrawing.
+- **Privacy mode suppresses the activity outright** rather than masking the
+  numbers, because a Lock Screen is readable without unlocking the device.
+  That's a deliberate difference from `BalanceWidget`, which masks instead.
+
+### Adding a Live Activity
+
+1. **Design the props.** Flat and JSON-serializable, everything pre-formatted
+   and pre-translated. Pass semantic flags (e.g. `isProfit: boolean`) rather
+   than resolved colors, so the layout can still pick the right light/dark
+   variant on an OS appearance change.
+2. **`app/core/Widgets/liveActivities/MyActivity.ios.tsx`** — props interface,
+   a `'widget'`-directive layout returning a `LiveActivityLayout`, and
+   `export const MyActivity = createMetaMaskLiveActivity<MyActivityProps>(MY_ACTIVITY_NAME, MyActivityLayout);`.
+3. **`app/core/Widgets/liveActivities/MyActivity.tsx`** — no-op fallback
+   duplicating the props interface, calling `createMetaMaskLiveActivity` from
+   `../createMetaMaskLiveActivity`. `.tsx`, matching the `.ios.tsx` extension —
+   see
+   [Both files in a pair must share the same extension](#both-files-in-a-pair-must-share-the-same-extension).
+4. **A feature-owned lifecycle service** that calls `.start(props)`,
+   `.update(props)` and `.end('immediate')`. Call
+   `endLiveActivitiesFromPreviousLaunch()` once when it starts (see
+   [Orphaned activities](#orphaned-activities-and-the-shared-attributes-type)),
+   and gate the whole thing on `Platform.OS === 'ios'` and
+   `process.env.MM_WIDGETS_ENABLED === 'true'`.
+5. **Tests.** Same split as widgets: assert registration from the activity's
+   own file (name + that the layout is now a `string`), and test all real
+   logic from the service. If the service reads `MM_WIDGETS_ENABLED`, add both
+   it and its test to `babel.config.tests.js`'s inline-env `exclude` list so
+   the disabled path is reachable.
+6. **Verify in a simulator.** No rebuild needed if `ExpoWidgetsTarget` is
+   already installed — reloading JS is enough, since registration happens at
+   import time.
+
+### Orphaned activities and the shared attributes type
+
+`expo-widgets` renders every Live Activity through a single shared
+`ActivityAttributes` type, discriminating kinds only by a `name` string inside
+the content state. Two consequences:
+
+- `getInstances()` on **any** factory returns **every** live instance,
+  regardless of which factory started it, and `LiveActivity.update()` rewrites
+  that `name` from the factory the handle came from. Never "adopt"
+  `getInstances()[0]` — you may silently repurpose another feature's activity.
+- iOS keeps a Live Activity alive after its host app is terminated, but the JS
+  handle needed to end it does not survive. `app/core/Widgets/reconcileLiveActivities.ts`
+  therefore ends everything, once per process, at launch — before any feature
+  has started an activity of its own. It's guarded so a second caller can't
+  end the first caller's freshly started activity.
 
 ## Testing widgets
 
@@ -629,6 +757,13 @@ auto-discovered root `__mocks__/` convention):
 - **No push-based remote updates** are wired up yet (Live Activities support
   APNs push updates via `getPushToken()`/`addPushTokenListener()` on
   `expo-widgets`' API, but no server-side integration exists in this repo).
+- **Live Activity updates are budgeted by ActivityKit**, and a Live Activity
+  can only be _started_ while the app is foregrounded. A feature whose data
+  changes many times a second must throttle before calling `.update()` — see
+  `PerpsLiveActivityService`.
+- **Live Activity kinds are not distinguishable at runtime.** `getInstances()`
+  is app-wide because `expo-widgets` uses one shared `ActivityAttributes`
+  type — see [Orphaned activities](#orphaned-activities-and-the-shared-attributes-type).
 - **`MetaMask-Flask` ships without widgets.** `ExpoWidgetsTarget` is only
   embedded in and depended on by the `MetaMask` scheme/target — the
   `MetaMask-Flask` scheme has no dependency on it and no

--- a/ios/ExpoWidgetsTarget/index.swift
+++ b/ios/ExpoWidgetsTarget/index.swift
@@ -19,9 +19,10 @@ internal import ExpoWidgets
 // widgets into groups of 4 and chains them via nested `body` calls. We only
 // ship one widget today, so there is a single bundle. `WidgetLiveActivity()`
 // (expo-widgets' built-in Live Activity renderer) must always be present in
-// the last bundle — without it, `createLiveActivity(...)` calls from the app
-// (e.g. a future Perps P/L Live Activity) would have no native counterpart to
-// render into, even though no Live Activity is registered yet.
+// the last bundle — it renders EVERY Live Activity the app registers, looked
+// up by name from the shared App Group container. That is why adding one
+// (e.g. app/core/Widgets/liveActivities/PerpsPnlLiveActivity.ios.tsx) requires
+// no change to this file, unlike adding a widget kind.
 @main
 struct ExportWidgets0: WidgetBundle {
   var body: some Widget {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3241,6 +3241,9 @@
   "widgets": {
     "balance_widget": {
       "label": "Total balance"
+    },
+    "perps_pnl_live_activity": {
+      "direction": "{{direction}} · {{leverage}}"
     }
   },
   "wallet": {


### PR DESCRIPTION
> Stacked on #34255 (which is stacked on #34223). Review the last commit only.

## What

Mirrors the largest open Perps position's live unrealized P/L onto the Lock Screen and the Dynamic Island, for as long as the position is open.

| Surface | Shows |
| ------- | ----- |
| Lock Screen banner | Symbol, direction + leverage, ROE, unrealized P/L, entry and mark price |
| Collapsed Dynamic Island | Symbol / P/L |
| Expanded Dynamic Island | The same, laid out across the leading, trailing and bottom regions |
| Minimal | ROE |

This is the second worked example for the widgets foundation, alongside `BalanceWidget` — a Live Activity layout returns a `LiveActivityLayout` object (one JSX tree per presentation region) rather than a single tree, and needs no native/Xcode change at all: `expo-widgets`' generic `WidgetLiveActivity()` renderer is already in the bundle and looks layouts up by name from the App Group.

## How

`PerpsLiveActivityService` subscribes imperatively to `PerpsStreamManager`'s `positions` and `prices` channels, because individual perps positions never enter Redux. It picks the largest open position by notional value, reuses `enrichPositionsWithLivePnL` to recompute P/L from the live mark price, formats everything with the existing Perps formatters, and starts / updates / ends the activity. It's attached to `PerpsAlwaysOnProvider`, which already owns the app-wide Perps connection.

Two deliberate behaviors:

- **Throttle, then dedupe.** Both subscriptions throttle at 2s, and the ActivityKit write is skipped entirely when the newly computed props are `JSON.stringify`-identical to the last push. ActivityKit budgets update frequency and a price feed ticks far faster than a Lock Screen card is worth redrawing.
- **Privacy mode suppresses the activity outright** rather than masking the numbers, because a Lock Screen is readable without unlocking the device. That's a deliberate difference from `BalanceWidget`, which masks and stays.

`reconcileLiveActivities.ts` ends activities orphaned by a previous process once per launch. It's a shared helper rather than Perps-owned because `expo-widgets` renders every Live Activity through one shared `ActivityAttributes` type — `getInstances()` on any factory returns every instance app-wide, so this has to run before any feature starts one of its own.

## Also fixes a foundation bug

`BalanceWidget.ts` (the no-op non-iOS fallback) was shadowing `BalanceWidget.ios.tsx` **on iOS**, crashing the app at import time with `The 2nd argument cannot be cast to type String`.

Metro builds resolution candidates by looping `sourceExts` (`['ts', 'tsx', …]`) on the outside and platform on the inside, so `./BalanceWidget` matched `BalanceWidget.ts` before it ever tried `BalanceWidget.ios.tsx`. Jest resolves platform-first and does not reproduce it, which is why the unit tests stayed green. Both fallbacks are now `.tsx`, matching their `.ios.tsx` counterparts, and the rule + docs now spell out that extension parity is mandatory.

Happy to move this fix down into #34223 instead if you'd rather keep the stack clean.

## Test plan

- [x] `yarn jest app/core/Widgets app/components/UI/Perps/services/PerpsLiveActivityService.test.ts app/components/UI/Perps/providers/PerpsAlwaysOnProvider.test.tsx`
- [x] `yarn lint:tsc`, `yarn lint`
- [x] iOS simulator: app launches (previously crashed at startup via the resolution bug above)
- [ ] iOS simulator with an open Perps position: activity appears on the Lock Screen, P/L updates live, ends when the position closes
- [ ] Privacy mode on: activity disappears
- [ ] Android: no-op, no crash

## Notes

Requires `MM_WIDGETS_ENABLED="true"` in `.js.env` — the flag defaults to `false` in `builds.yml` while this is in development.

Made with [Cursor](https://cursor.com)