### PR TITLE
feat(widgets): add a balance Live Activity

### DIFF
--- a/.cursor/rules/widget-development.mdc
+++ b/.cursor/rules/widget-development.mdc
@@ -13,7 +13,8 @@ alwaysApply: false
 - `app/core/Widgets/` — all JS/TS foundation code (theme bridge, wrappers, `WidgetUpdaterService`)
 - `ios/ExpoWidgetsTarget/` — the native WidgetKit extension target (Swift)
 - `app/core/Widgets/widgets/BalanceWidget.ios.tsx` + `BalanceWidget.ts` (non-iOS fallback) — the reference widget; copy its shape for new widgets
-- `app/core/Widgets/liveActivities/PerpsPnlLiveActivity.ios.tsx` + `.ts` — the reference Live Activity; its lifecycle driver is `app/components/UI/Perps/services/PerpsLiveActivityService.ts`
+- `app/core/Widgets/liveActivities/PerpsPnlLiveActivity.ios.tsx` + `.tsx` — the reference Live Activity; its lifecycle driver is `app/components/UI/Perps/services/PerpsLiveActivityService.ts` (stream-driven)
+- `app/core/Widgets/liveActivities/BalanceLiveActivity.ios.tsx` + `.tsx` — the Redux-driven Live Activity; its lifecycle driver is `app/core/Widgets/BalanceLiveActivityService.ts`, started by hand from Developer Options
 
 ## The one non-negotiable rule: no closures inside `'widget'`-directive functions
 
@@ -90,7 +91,7 @@ Every rule above (no closures, platform split, theming) applies unchanged. Only 
 1. **No native work whatsoever** — no `.swift` file, no `index.swift` entry, no Xcode target membership, no `app.config.js` entry. `WidgetLiveActivity()` (expo-widgets' generic renderer) is already bundled and `NSSupportsLiveActivities` is already set; `createLiveActivity` writes the stringified layout to the App Group at *import time* and the extension looks it up by `name`. A new Live Activity is a pure-JS change.
 2. `app/core/Widgets/liveActivities/MyActivity.ios.tsx` — props + a `'widget'` layout that returns a **`LiveActivityLayout` object**, not JSX: `{ banner, compactLeading, compactTrailing, minimal, expandedLeading, expandedTrailing, expandedBottom }`. Second param is `LiveActivityEnvironment` (import it from `../createMetaMaskLiveActivity.ios`; `expo-widgets` doesn't re-export it from its package root).
 3. `app/core/Widgets/liveActivities/MyActivity.tsx` — no-op fallback, `createMetaMaskLiveActivity` from `../createMetaMaskLiveActivity` (`.tsx`, matching the `.ios.tsx` extension — see Platform split).
-4. A **feature-owned** lifecycle service calling `.start()` / `.update()` / `.end('immediate')` — NOT `WidgetUpdaterService`, which only exists to fan a debounced Redux snapshot out to widgets. Throttle updates (ActivityKit budgets them) and skip writes when serialized props are unchanged.
+4. A **dedicated** lifecycle service calling `.start()` / `.update()` / `.end('immediate')` — never `WidgetUpdaterService`, which only pushes standing snapshots to always-installed widgets. Own it from the feature when the data isn't in Redux (`PerpsLiveActivityService`), or from a Redux subscription when it is (`BalanceLiveActivityService`). Either way: throttle updates (ActivityKit budgets them) and skip writes when serialized props are unchanged.
 5. Call `endLiveActivitiesFromPreviousLaunch()` once from that service's start.
 6. Prefer suppressing the activity entirely over masking values when privacy mode is on — the Lock Screen is readable without unlocking.
 7. Tests: assert registration from the activity's own file, all real logic from the service. Reading `MM_WIDGETS_ENABLED` at call time requires adding the service *and* its test to `babel.config.tests.js`'s inline-env `exclude` list.

--- a/app/components/Views/Settings/DeveloperOptions/WidgetsDeveloperOptionsSection.test.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/WidgetsDeveloperOptionsSection.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { fireEvent, waitFor } from '@testing-library/react-native';
+
+import { strings } from '../../../../../locales/i18n';
+import { BalanceLiveActivityService } from '../../../../core/Widgets/BalanceLiveActivityService';
+import renderWithProvider from '../../../../util/test/renderWithProvider';
+import WidgetsDeveloperOptionsSection from './WidgetsDeveloperOptionsSection';
+
+jest.mock('../../../../core/Widgets/BalanceLiveActivityService', () => ({
+  BalanceLiveActivityService: {
+    isSupported: jest.fn(),
+    isRunning: jest.fn(),
+    start: jest.fn(),
+    stop: jest.fn(),
+  },
+}));
+
+const TOGGLE_TEST_ID = 'widgets-dev-balance-live-activity-toggle';
+
+describe('WidgetsDeveloperOptionsSection', () => {
+  const mockService = jest.mocked(BalanceLiveActivityService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockService.isSupported.mockReturnValue(true);
+    mockService.isRunning.mockReturnValue(false);
+    mockService.start.mockResolvedValue(true);
+  });
+
+  it('renders nothing on a build that cannot show Live Activities', () => {
+    mockService.isSupported.mockReturnValue(false);
+
+    const { queryByTestId } = renderWithProvider(
+      <WidgetsDeveloperOptionsSection />,
+    );
+
+    expect(queryByTestId(TOGGLE_TEST_ID)).toBeNull();
+  });
+
+  it('starts the activity when the button is pressed', async () => {
+    const { getByTestId } = renderWithProvider(
+      <WidgetsDeveloperOptionsSection />,
+    );
+
+    fireEvent.press(getByTestId(TOGGLE_TEST_ID));
+
+    await waitFor(() => expect(mockService.start).toHaveBeenCalledTimes(1));
+  });
+
+  it('offers to stop the activity once it is running', async () => {
+    const { getByTestId, getByText } = renderWithProvider(
+      <WidgetsDeveloperOptionsSection />,
+    );
+    mockService.isRunning.mockReturnValue(true);
+
+    fireEvent.press(getByTestId(TOGGLE_TEST_ID));
+    await waitFor(() =>
+      expect(
+        getByText(
+          strings(
+            'app_settings.developer_options.widgets.stop_balance_live_activity',
+          ),
+        ),
+      ).toBeDefined(),
+    );
+
+    fireEvent.press(getByTestId(TOGGLE_TEST_ID));
+
+    expect(mockService.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('explains why nothing appeared when iOS refuses the request', async () => {
+    mockService.start.mockResolvedValue(false);
+
+    const { getByTestId, getByText } = renderWithProvider(
+      <WidgetsDeveloperOptionsSection />,
+    );
+    fireEvent.press(getByTestId(TOGGLE_TEST_ID));
+
+    await waitFor(() =>
+      expect(
+        getByText(
+          strings('app_settings.developer_options.widgets.start_failed'),
+        ),
+      ).toBeDefined(),
+    );
+  });
+});

--- a/app/components/Views/Settings/DeveloperOptions/WidgetsDeveloperOptionsSection.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/WidgetsDeveloperOptionsSection.tsx
@@ -1,0 +1,97 @@
+import React, { useCallback, useState } from 'react';
+import {
+  Button,
+  ButtonVariant,
+  ButtonSize,
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
+
+import { strings } from '../../../../../locales/i18n';
+import { BalanceLiveActivityService } from '../../../../core/Widgets/BalanceLiveActivityService';
+import { useStyles } from '../../../../component-library/hooks';
+import { useTheme } from '../../../../util/theme';
+import styleSheet from './DeveloperOptions.styles';
+
+/**
+ * Starts and stops the balance Live Activity by hand.
+ *
+ * A Live Activity has no "installed" state a user can discover the way a home
+ * screen widget does — something has to explicitly start it. Until product
+ * decides what that trigger should be (an entry point in the wallet, an
+ * opt-in setting), this section is it.
+ */
+export function WidgetsDeveloperOptionsSection() {
+  const theme = useTheme();
+  const { styles } = useStyles(styleSheet, { theme });
+
+  const [isRunning, setIsRunning] = useState(() =>
+    BalanceLiveActivityService.isRunning(),
+  );
+  const [error, setError] = useState<string | undefined>();
+
+  const handleStart = useCallback(async () => {
+    const started = await BalanceLiveActivityService.start();
+    setIsRunning(BalanceLiveActivityService.isRunning());
+    setError(
+      started
+        ? undefined
+        : strings('app_settings.developer_options.widgets.start_failed'),
+    );
+  }, []);
+
+  const handleStop = useCallback(() => {
+    BalanceLiveActivityService.stop();
+    setIsRunning(BalanceLiveActivityService.isRunning());
+    setError(undefined);
+  }, []);
+
+  if (!BalanceLiveActivityService.isSupported()) {
+    return null;
+  }
+
+  return (
+    <>
+      <Text
+        color={TextColor.TextDefault}
+        variant={TextVariant.HeadingLg}
+        style={styles.heading}
+      >
+        {strings('app_settings.developer_options.widgets.title')}
+      </Text>
+      <Text
+        color={TextColor.TextAlternative}
+        variant={TextVariant.BodyMd}
+        style={styles.desc}
+      >
+        {strings('app_settings.developer_options.widgets.description')}
+      </Text>
+      {error ? (
+        <Text
+          color={TextColor.ErrorDefault}
+          variant={TextVariant.BodyMd}
+          style={styles.desc}
+        >
+          {error}
+        </Text>
+      ) : null}
+      <Button
+        variant={ButtonVariant.Secondary}
+        size={ButtonSize.Lg}
+        onPress={isRunning ? handleStop : handleStart}
+        isFullWidth
+        style={styles.accessory}
+        testID="widgets-dev-balance-live-activity-toggle"
+      >
+        {strings(
+          isRunning
+            ? 'app_settings.developer_options.widgets.stop_balance_live_activity'
+            : 'app_settings.developer_options.widgets.start_balance_live_activity',
+        )}
+      </Button>
+    </>
+  );
+}
+
+export default WidgetsDeveloperOptionsSection;

--- a/app/components/Views/Settings/DeveloperOptions/index.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/index.tsx
@@ -16,6 +16,7 @@ import styleSheet from './DeveloperOptions.styles';
 import SentryTest from './SentryTest';
 import HapticsDeveloperOptionsSection from './HapticsDeveloperOptionsSection';
 import IdentityDeveloperOptionsSection from './IdentityDeveloperOptionsSection';
+import WidgetsDeveloperOptionsSection from './WidgetsDeveloperOptionsSection';
 ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
 import SampleFeatureDevSettingsEntryPoint from '../../../../features/SampleFeature/components/views/SampleFeatureDevSettingsEntryPoint/SampleFeatureDevSettingsEntryPoint';
 ///: END:ONLY_INCLUDE_IF
@@ -100,6 +101,7 @@ const DeveloperOptions = () => {
           <SocialLeaderboardDeveloperOptionsSection />
         )}
         <HapticsDeveloperOptionsSection />
+        <WidgetsDeveloperOptionsSection />
       </ScrollView>
     </SafeAreaView>
   );

--- a/app/core/Widgets/BalanceLiveActivityService.test.ts
+++ b/app/core/Widgets/BalanceLiveActivityService.test.ts
@@ -1,0 +1,273 @@
+import { Platform } from 'react-native';
+
+import ReduxService from '../redux/ReduxService';
+import { selectPrivacyMode } from '../../selectors/preferencesController';
+import { BalanceLiveActivity } from './liveActivities/BalanceLiveActivity';
+import { endLiveActivitiesFromPreviousLaunch } from './reconcileLiveActivities';
+import {
+  formatSelectedAccountGroupBalance,
+  getSelectedAccountGroupName,
+} from './balanceSnapshot';
+import { BalanceLiveActivityServiceImplementation } from './BalanceLiveActivityService';
+
+jest.mock('./liveActivities/BalanceLiveActivity', () => ({
+  BALANCE_LIVE_ACTIVITY_NAME: 'BalanceLiveActivity',
+  BalanceLiveActivity: { start: jest.fn(), getInstances: jest.fn(() => []) },
+}));
+
+jest.mock('./reconcileLiveActivities', () => ({
+  endLiveActivitiesFromPreviousLaunch: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('./balanceSnapshot', () => ({
+  formatSelectedAccountGroupBalance: jest.fn(),
+  getSelectedAccountGroupName: jest.fn(),
+}));
+
+jest.mock('../../selectors/preferencesController', () => ({
+  selectPrivacyMode: jest.fn(),
+}));
+
+jest.mock('../../../locales/i18n', () => ({
+  __esModule: true,
+  strings: jest.fn((key: string) => key),
+  default: { locale: 'en-US' },
+}));
+
+jest.mock('../../util/Logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn(), log: jest.fn() },
+}));
+
+describe('BalanceLiveActivityService', () => {
+  const mockStart = jest.mocked(BalanceLiveActivity.start);
+  const mockFormatBalance = jest.mocked(formatSelectedAccountGroupBalance);
+  const mockGetAccountName = jest.mocked(getSelectedAccountGroupName);
+  const mockSelectPrivacyMode = jest.mocked(selectPrivacyMode);
+
+  let service: BalanceLiveActivityServiceImplementation;
+  let activity: { update: jest.Mock; end: jest.Mock };
+  let unsubscribeFromStore: jest.Mock;
+  let notifyStoreChange: (() => void) | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    Platform.OS = 'ios';
+    process.env.MM_WIDGETS_ENABLED = 'true';
+
+    activity = {
+      update: jest.fn().mockResolvedValue(undefined),
+      end: jest.fn().mockResolvedValue(undefined),
+    };
+    mockStart.mockReturnValue(activity as never);
+
+    mockFormatBalance.mockReturnValue('$1,234.56');
+    mockGetAccountName.mockReturnValue('Account 1');
+    mockSelectPrivacyMode.mockReturnValue(false);
+
+    notifyStoreChange = undefined;
+    unsubscribeFromStore = jest.fn();
+    ReduxService.store = {
+      getState: jest.fn(() => ({}) as never),
+      dispatch: jest.fn(),
+      subscribe: jest.fn((listener: () => void) => {
+        notifyStoreChange = listener;
+        return unsubscribeFromStore;
+      }),
+    } as never;
+
+    service = BalanceLiveActivityServiceImplementation.getInstance();
+    service.stop();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    service.stop();
+    jest.useRealTimers();
+  });
+
+  describe('support gating', () => {
+    it('is unsupported when MM_WIDGETS_ENABLED is not true', () => {
+      process.env.MM_WIDGETS_ENABLED = 'false';
+
+      expect(service.isSupported()).toBe(false);
+    });
+
+    it('is unsupported on Android, where Live Activities do not exist', () => {
+      Platform.OS = 'android';
+
+      expect(service.isSupported()).toBe(false);
+    });
+
+    it('does not touch ActivityKit when unsupported', async () => {
+      Platform.OS = 'android';
+
+      await expect(service.start()).resolves.toBe(false);
+
+      expect(mockStart).not.toHaveBeenCalled();
+      expect(ReduxService.store.subscribe).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('start', () => {
+    it('ends activities orphaned by a previous launch before starting its own', async () => {
+      await service.start();
+
+      expect(endLiveActivitiesFromPreviousLaunch).toHaveBeenCalledWith(
+        BalanceLiveActivity,
+      );
+    });
+
+    it('starts an activity with the formatted balance and account name', async () => {
+      await expect(service.start()).resolves.toBe(true);
+
+      expect(mockStart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountLabel: 'Account 1',
+          label: 'widgets.balance_widget.label',
+          balanceDisplay: '$1,234.56',
+        }),
+      );
+    });
+
+    it('passes both theme variants so the layout can follow the OS appearance', async () => {
+      await service.start();
+
+      const [props] = mockStart.mock.calls[0];
+      expect(props.theme.light.colorScheme).toBe('light');
+      expect(props.theme.dark.colorScheme).toBe('dark');
+    });
+
+    it('falls back to a generic account label when the group has no name', async () => {
+      mockGetAccountName.mockReturnValue(undefined);
+
+      await service.start();
+
+      expect(mockStart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountLabel: 'widgets.balance_live_activity.default_account_label',
+        }),
+      );
+    });
+
+    it('subscribes to the store only once across repeated start calls', async () => {
+      await service.start();
+      await service.start();
+
+      expect(ReduxService.store.subscribe).toHaveBeenCalledTimes(1);
+      expect(mockStart).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports failure when iOS refuses the ActivityKit request', async () => {
+      mockStart.mockImplementation(() => {
+        throw new Error('Live Activities are disabled');
+      });
+
+      await expect(service.start()).resolves.toBe(false);
+      expect(service.isRunning()).toBe(true);
+    });
+  });
+
+  describe('updates', () => {
+    it('pushes a debounced update when the balance changes', async () => {
+      await service.start();
+      mockFormatBalance.mockReturnValue('$2,000.00');
+
+      notifyStoreChange?.();
+      jest.advanceTimersByTime(2000);
+
+      expect(activity.update).toHaveBeenCalledWith(
+        expect.objectContaining({ balanceDisplay: '$2,000.00' }),
+      );
+    });
+
+    it('coalesces a burst of store changes into a single write', async () => {
+      await service.start();
+      mockFormatBalance.mockReturnValue('$2,000.00');
+
+      notifyStoreChange?.();
+      notifyStoreChange?.();
+      notifyStoreChange?.();
+      jest.advanceTimersByTime(2000);
+
+      expect(activity.update).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips the write entirely when the computed props are unchanged', async () => {
+      await service.start();
+
+      notifyStoreChange?.();
+      jest.advanceTimersByTime(2000);
+
+      expect(activity.update).not.toHaveBeenCalled();
+    });
+
+    it('retries the start on the next change after iOS refused the first request', async () => {
+      mockStart.mockImplementationOnce(() => {
+        throw new Error('app is backgrounded');
+      });
+
+      await service.start();
+      notifyStoreChange?.();
+      jest.advanceTimersByTime(2000);
+
+      expect(mockStart).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('privacy mode', () => {
+    it('does not start an activity while privacy mode is on', async () => {
+      mockSelectPrivacyMode.mockReturnValue(true);
+
+      await expect(service.start()).resolves.toBe(false);
+
+      expect(mockStart).not.toHaveBeenCalled();
+    });
+
+    it('ends a running activity when privacy mode is switched on', async () => {
+      await service.start();
+      mockSelectPrivacyMode.mockReturnValue(true);
+
+      notifyStoreChange?.();
+      jest.advanceTimersByTime(2000);
+
+      expect(activity.end).toHaveBeenCalledWith('immediate');
+    });
+  });
+
+  describe('stop', () => {
+    it('ends the activity and unsubscribes from the store', async () => {
+      await service.start();
+
+      service.stop();
+
+      expect(activity.end).toHaveBeenCalledWith('immediate');
+      expect(unsubscribeFromStore).toHaveBeenCalledTimes(1);
+      expect(service.isRunning()).toBe(false);
+    });
+
+    it('drops a pending debounced update so nothing is written after stopping', async () => {
+      await service.start();
+      mockFormatBalance.mockReturnValue('$2,000.00');
+      notifyStoreChange?.();
+
+      service.stop();
+      jest.advanceTimersByTime(2000);
+
+      expect(activity.update).not.toHaveBeenCalled();
+    });
+
+    it('is safe to call when nothing is running', () => {
+      expect(() => service.stop()).not.toThrow();
+    });
+
+    it('starts cleanly again after being stopped', async () => {
+      await service.start();
+      service.stop();
+
+      await expect(service.start()).resolves.toBe(true);
+      expect(mockStart).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/app/core/Widgets/BalanceLiveActivityService.ts
+++ b/app/core/Widgets/BalanceLiveActivityService.ts
@@ -1,0 +1,229 @@
+import { Platform } from 'react-native';
+
+import { strings } from '../../../locales/i18n';
+import ReduxService from '../redux/ReduxService';
+import Logger from '../../util/Logger';
+import { selectPrivacyMode } from '../../selectors/preferencesController';
+
+import {
+  BalanceLiveActivity,
+  type BalanceLiveActivityProps,
+} from './liveActivities/BalanceLiveActivity';
+import {
+  formatSelectedAccountGroupBalance,
+  getSelectedAccountGroupName,
+} from './balanceSnapshot';
+import { endLiveActivitiesFromPreviousLaunch } from './reconcileLiveActivities';
+import { darkWidgetTheme, lightWidgetTheme } from './WidgetTheme';
+import type { WithWidgetTheme } from './types';
+
+type BalanceLiveActivityInstance = ReturnType<typeof BalanceLiveActivity.start>;
+
+/**
+ * Coalesces rapid Redux updates (balances stream in token-by-token) into a
+ * single ActivityKit write. Matches `WidgetUpdaterService`'s debounce, which
+ * is fed by the same store subscription.
+ */
+const UPDATE_DEBOUNCE_MS = 2000;
+
+/**
+ * Drives the balance Live Activity's start/update/end lifecycle.
+ *
+ * Unlike `PerpsLiveActivityService`, this activity's data is plain Redux state
+ * — the same balance `WidgetUpdaterService` already pushes to the home screen
+ * widget — so it is driven by a store subscription rather than a feature state
+ * machine. It is nonetheless a separate service, because its lifetime is not
+ * the app's: a Live Activity is explicitly started and ended by the user (from
+ * Settings > Developer Options while this is a demo), whereas a widget is
+ * always installed or not.
+ */
+class BalanceLiveActivityServiceImplementation {
+  private static instance: BalanceLiveActivityServiceImplementation;
+
+  private unsubscribeFromStore?: () => void;
+
+  private debounceTimer?: ReturnType<typeof setTimeout>;
+
+  private activity?: BalanceLiveActivityInstance;
+
+  /** Skips redundant ActivityKit writes when the computed props haven't changed. */
+  private lastSerializedProps?: string;
+
+  private running = false;
+
+  // eslint-disable-next-line no-empty-function -- singleton: construction is intentionally private and does nothing
+  private constructor() {}
+
+  static getInstance(): BalanceLiveActivityServiceImplementation {
+    if (!BalanceLiveActivityServiceImplementation.instance) {
+      BalanceLiveActivityServiceImplementation.instance =
+        new BalanceLiveActivityServiceImplementation();
+    }
+    return BalanceLiveActivityServiceImplementation.instance;
+  }
+
+  /**
+   * Whether this build can show the activity at all: iOS only (see
+   * createMetaMaskLiveActivity.ts) and behind the build-time
+   * `MM_WIDGETS_ENABLED` flag. Read by the Developer Options section so it can
+   * explain itself rather than offering a button that silently does nothing.
+   */
+  isSupported(): boolean {
+    return Platform.OS === 'ios' && process.env.MM_WIDGETS_ENABLED === 'true';
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  /**
+   * Starts the activity and keeps it in sync with the store until `stop()`.
+   * Resolves to whether an activity is now on screen — `false` when the build
+   * doesn't support it, when privacy mode is suppressing it, or when iOS
+   * refused the request (Live Activities disabled for MetaMask in Settings).
+   * Safe to call more than once.
+   */
+  async start(): Promise<boolean> {
+    if (!this.isSupported()) {
+      return false;
+    }
+    if (this.running) {
+      return this.activity !== undefined;
+    }
+
+    await endLiveActivitiesFromPreviousLaunch(BalanceLiveActivity).catch(
+      () => undefined,
+    );
+
+    this.running = true;
+    this.unsubscribeFromStore = ReduxService.store.subscribe(
+      this.handleStateChange,
+    );
+    this.sync();
+
+    return this.activity !== undefined;
+  }
+
+  /** Ends the activity and unsubscribes. Idempotent. */
+  stop(): void {
+    this.running = false;
+
+    this.unsubscribeFromStore?.();
+    this.unsubscribeFromStore = undefined;
+
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = undefined;
+    }
+
+    this.endActivity();
+  }
+
+  private handleStateChange = (): void => {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = undefined;
+      this.sync();
+    }, UPDATE_DEBOUNCE_MS);
+  };
+
+  private sync(): void {
+    try {
+      const props = this.computeProps();
+
+      if (!props) {
+        this.endActivity();
+        return;
+      }
+
+      const serialized = JSON.stringify(props);
+      if (serialized === this.lastSerializedProps) {
+        return;
+      }
+      this.lastSerializedProps = serialized;
+
+      if (this.activity) {
+        this.activity.update(props).catch((error) => {
+          Logger.error(
+            error as Error,
+            'BalanceLiveActivityService: Failed to update Live Activity',
+          );
+        });
+        return;
+      }
+
+      this.startActivity(props);
+    } catch (error) {
+      Logger.error(
+        error as Error,
+        'BalanceLiveActivityService: Failed to sync Live Activity',
+      );
+    }
+  }
+
+  private startActivity(
+    props: BalanceLiveActivityProps & WithWidgetTheme,
+  ): void {
+    try {
+      this.activity = BalanceLiveActivity.start(props);
+    } catch (error) {
+      // Expected when the user has Live Activities switched off for MetaMask,
+      // or when iOS refuses the request because the app isn't foregrounded.
+      Logger.log(
+        'BalanceLiveActivityService: could not start Live Activity',
+        (error as Error).message,
+      );
+      // Force a retry on the next store change rather than treating the
+      // un-pushed props as already delivered.
+      this.lastSerializedProps = undefined;
+    }
+  }
+
+  private endActivity(): void {
+    const { activity } = this;
+    this.activity = undefined;
+    this.lastSerializedProps = undefined;
+
+    activity?.end('immediate').catch((error) => {
+      Logger.error(
+        error as Error,
+        'BalanceLiveActivityService: Failed to end Live Activity',
+      );
+    });
+  }
+
+  /**
+   * All formatting, translation and privacy handling lives here — never in
+   * `BalanceLiveActivity.ios.tsx`, whose layout runs in a sandbox with no
+   * access to imports. Returns `undefined` when no activity should be on
+   * screen.
+   */
+  private computeProps():
+    | (BalanceLiveActivityProps & WithWidgetTheme)
+    | undefined {
+    const state = ReduxService.store.getState();
+
+    // A Live Activity is readable on the Lock Screen without unlocking the
+    // device, so privacy mode suppresses it outright rather than masking the
+    // balance (unlike BalanceWidget, which masks and stays on screen).
+    if (selectPrivacyMode(state)) {
+      return undefined;
+    }
+
+    return {
+      accountLabel:
+        getSelectedAccountGroupName(state) ??
+        strings('widgets.balance_live_activity.default_account_label'),
+      label: strings('widgets.balance_widget.label'),
+      balanceDisplay: formatSelectedAccountGroupBalance(state),
+      theme: { light: lightWidgetTheme, dark: darkWidgetTheme },
+    };
+  }
+}
+
+export const BalanceLiveActivityService =
+  BalanceLiveActivityServiceImplementation.getInstance();
+
+export { BalanceLiveActivityServiceImplementation };

--- a/app/core/Widgets/WidgetUpdaterService.ts
+++ b/app/core/Widgets/WidgetUpdaterService.ts
@@ -1,13 +1,11 @@
 import { Platform } from 'react-native';
-import { createFormatters } from '@metamask/client-utils';
 
 import ReduxService from '../redux/ReduxService';
 import Logger from '../../util/Logger';
-import { getLocaleLanguageCode } from '../../components/hooks/useFormatters';
-import { selectBalanceBySelectedAccountGroup } from '../../selectors/assets/balances';
 import { selectPrivacyMode } from '../../selectors/preferencesController';
 import { strings } from '../../../locales/i18n';
 
+import { formatSelectedAccountGroupBalance } from './balanceSnapshot';
 import { darkWidgetTheme, lightWidgetTheme } from './WidgetTheme';
 import {
   BalanceWidget,
@@ -26,14 +24,6 @@ const UPDATE_DEBOUNCE_MS = 2000;
  * in-app when privacy mode is on.
  */
 const HIDDEN_BALANCE_DISPLAY = '•'.repeat(9);
-
-/**
- * `selectBalanceBySelectedAccountGroup` is a selector *factory* — each call
- * builds a fresh `createSelector` instance. It must be instantiated once and
- * reused, otherwise every read re-runs the (expensive) all-wallets balance
- * aggregation from scratch and re-triggers Reselect's dev-only warnings.
- */
-const selectBalance = selectBalanceBySelectedAccountGroup();
 
 /**
  * Subscribes to the Redux store and pushes throttled snapshot updates to
@@ -148,15 +138,10 @@ class WidgetUpdaterServiceImplementation {
 
   private computeBalanceWidgetProps(): BalanceWidgetProps & WithWidgetTheme {
     const state = ReduxService.store.getState();
-    const balance = selectBalance(state);
-    const isPrivacyModeEnabled = selectPrivacyMode(state);
 
-    const balanceDisplay = isPrivacyModeEnabled
+    const balanceDisplay = selectPrivacyMode(state)
       ? HIDDEN_BALANCE_DISPLAY
-      : createFormatters({ locale: getLocaleLanguageCode() }).formatCurrency(
-          balance?.totalBalanceInUserCurrency ?? 0,
-          balance?.userCurrency ?? 'usd',
-        );
+      : formatSelectedAccountGroupBalance(state);
 
     return {
       balanceDisplay,

--- a/app/core/Widgets/balanceSnapshot.ts
+++ b/app/core/Widgets/balanceSnapshot.ts
@@ -1,0 +1,40 @@
+import { createFormatters } from '@metamask/client-utils';
+
+import { getLocaleLanguageCode } from '../../components/hooks/useFormatters';
+import { selectBalanceBySelectedAccountGroup } from '../../selectors/assets/balances';
+import { selectSelectedAccountGroup } from '../../selectors/multichainAccounts/accountTreeController';
+import type { RootState } from '../../reducers';
+
+/**
+ * `selectBalanceBySelectedAccountGroup` is a selector *factory* — each call
+ * builds a fresh `createSelector` instance. It must be instantiated once and
+ * reused, otherwise every read re-runs the (expensive) all-wallets balance
+ * aggregation from scratch and re-triggers Reselect's dev-only warnings.
+ */
+const selectBalance = selectBalanceBySelectedAccountGroup();
+
+/**
+ * The selected account group's total balance, formatted in the user's
+ * currency and locale.
+ *
+ * Shared by `WidgetUpdaterService` (home screen widget) and
+ * `BalanceLiveActivityService` (Lock Screen / Dynamic Island) so the two
+ * surfaces can never drift apart on rounding, currency or locale. Privacy mode
+ * is deliberately NOT handled here: the widget masks the value while the Live
+ * Activity suppresses itself entirely, so each caller decides.
+ */
+export function formatSelectedAccountGroupBalance(state: RootState): string {
+  const balance = selectBalance(state);
+
+  return createFormatters({ locale: getLocaleLanguageCode() }).formatCurrency(
+    balance?.totalBalanceInUserCurrency ?? 0,
+    balance?.userCurrency ?? 'usd',
+  );
+}
+
+/** The selected account group's display name, e.g. "Account 1". */
+export function getSelectedAccountGroupName(
+  state: RootState,
+): string | undefined {
+  return selectSelectedAccountGroup(state)?.metadata?.name;
+}

--- a/app/core/Widgets/balanceSnapshot.ts
+++ b/app/core/Widgets/balanceSnapshot.ts
@@ -5,13 +5,25 @@ import { selectBalanceBySelectedAccountGroup } from '../../selectors/assets/bala
 import { selectSelectedAccountGroup } from '../../selectors/multichainAccounts/accountTreeController';
 import type { RootState } from '../../reducers';
 
+let balanceSelector: ReturnType<typeof selectBalanceBySelectedAccountGroup>;
+
 /**
  * `selectBalanceBySelectedAccountGroup` is a selector *factory* — each call
  * builds a fresh `createSelector` instance. It must be instantiated once and
  * reused, otherwise every read re-runs the (expensive) all-wallets balance
  * aggregation from scratch and re-triggers Reselect's dev-only warnings.
+ *
+ * Built on first use rather than at module scope: this module sits inside an
+ * import cycle with the balance selectors, so at evaluation time the factory
+ * binding may not be initialized yet (Hermes throws
+ * `Property 'selectBalanceBySelectedAccountGroup' doesn't exist`).
  */
-const selectBalance = selectBalanceBySelectedAccountGroup();
+function getBalanceSelector() {
+  if (!balanceSelector) {
+    balanceSelector = selectBalanceBySelectedAccountGroup();
+  }
+  return balanceSelector;
+}
 
 /**
  * The selected account group's total balance, formatted in the user's
@@ -24,7 +36,7 @@ const selectBalance = selectBalanceBySelectedAccountGroup();
  * Activity suppresses itself entirely, so each caller decides.
  */
 export function formatSelectedAccountGroupBalance(state: RootState): string {
-  const balance = selectBalance(state);
+  const balance = getBalanceSelector()(state);
 
   return createFormatters({ locale: getLocaleLanguageCode() }).formatCurrency(
     balance?.totalBalanceInUserCurrency ?? 0,

--- a/app/core/Widgets/liveActivities/BalanceLiveActivity.ios.tsx
+++ b/app/core/Widgets/liveActivities/BalanceLiveActivity.ios.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { HStack, Spacer, Text, VStack } from '@expo/ui/swift-ui';
+import { font, foregroundStyle, padding } from '@expo/ui/swift-ui/modifiers';
+
+import {
+  createMetaMaskLiveActivity,
+  type LiveActivityEnvironment,
+} from '../createMetaMaskLiveActivity.ios';
+import type { WithWidgetTheme } from '../types';
+
+/**
+ * Shows the selected account's total balance on the Lock Screen and in the
+ * Dynamic Island, refreshed in place as balances stream in.
+ *
+ * The Redux-driven counterpart of `./PerpsPnlLiveActivity.ios.tsx`: because its
+ * data is exactly what `../widgets/BalanceWidget.ios.tsx` already renders on
+ * the home screen, its lifecycle is driven by `../BalanceLiveActivityService.ts`
+ * off the same store subscription rather than by a feature's state machine.
+ */
+export interface BalanceLiveActivityProps {
+  /** The selected account group's name, e.g. "Account 1". */
+  accountLabel: string;
+  /** e.g. "Total balance". */
+  label: string;
+  /**
+   * Already-formatted balance string, e.g. "$12,345.67". Computed by
+   * `BalanceLiveActivityService`, NOT here — the sandbox this layout runs in
+   * has no access to `createFormatters` or Redux. See docs/widgets/README.md.
+   */
+  balanceDisplay: string;
+}
+
+/**
+ * The `'widget'`-directive layout. Everything it needs arrives via `props` —
+ * no imports, no selectors, no `strings()`, no module constants are reachable
+ * from inside here at runtime (the whole function is replaced by a string
+ * literal at build time and re-evaluated in a bare JavaScriptCore sandbox
+ * inside the widget extension process). See docs/widgets/README.md.
+ */
+function BalanceLiveActivityLayout(
+  props: BalanceLiveActivityProps & WithWidgetTheme,
+  environment: LiveActivityEnvironment,
+) {
+  'widget';
+
+  const { accountLabel, label, balanceDisplay, theme } = props;
+
+  const activeTheme =
+    environment.colorScheme === 'dark' ? theme.dark : theme.light;
+
+  const labelText = (
+    <Text
+      modifiers={[
+        foregroundStyle(activeTheme.colors.textAlternative),
+        font({
+          size: activeTheme.typography.bodySm.size,
+          weight: activeTheme.typography.bodySm.weight,
+        }),
+      ]}
+    >
+      {label}
+    </Text>
+  );
+
+  const accountText = (
+    <Text
+      modifiers={[
+        foregroundStyle(activeTheme.colors.textMuted),
+        font({
+          size: activeTheme.typography.bodyXs.size,
+          weight: activeTheme.typography.bodyXs.weight,
+        }),
+      ]}
+    >
+      {accountLabel}
+    </Text>
+  );
+
+  const balanceText = (
+    <Text
+      modifiers={[
+        foregroundStyle(activeTheme.colors.textDefault),
+        font({
+          size: activeTheme.typography.amountDisplay.size,
+          weight: activeTheme.typography.amountDisplay.weight,
+        }),
+      ]}
+    >
+      {balanceDisplay}
+    </Text>
+  );
+
+  const compactBalanceText = (
+    <Text
+      modifiers={[
+        foregroundStyle(activeTheme.colors.textDefault),
+        font({
+          size: activeTheme.typography.bodySm.size,
+          weight: activeTheme.typography.bodySm.weight,
+        }),
+      ]}
+    >
+      {balanceDisplay}
+    </Text>
+  );
+
+  return {
+    banner: (
+      <VStack
+        alignment="leading"
+        spacing={activeTheme.spacing.sm}
+        modifiers={[padding({ all: activeTheme.spacing.md })]}
+      >
+        <HStack spacing={activeTheme.spacing.sm}>
+          {labelText}
+          <Spacer />
+          {accountText}
+        </HStack>
+        {balanceText}
+      </VStack>
+    ),
+    compactLeading: accountText,
+    compactTrailing: compactBalanceText,
+    minimal: compactBalanceText,
+    expandedLeading: (
+      <VStack alignment="leading" spacing={activeTheme.spacing.xs}>
+        {labelText}
+        {accountText}
+      </VStack>
+    ),
+    expandedTrailing: (
+      <VStack alignment="trailing" spacing={activeTheme.spacing.xs}>
+        {balanceText}
+      </VStack>
+    ),
+  };
+}
+
+/**
+ * The Live Activity's registered name.
+ *
+ * Unlike a home screen widget, this needs NO matching `.swift` file and no
+ * Xcode target change — see `./PerpsPnlLiveActivity.ios.tsx` and
+ * docs/widgets/README.md#live-activities.
+ */
+export const BALANCE_LIVE_ACTIVITY_NAME = 'BalanceLiveActivity';
+
+export const BalanceLiveActivity =
+  createMetaMaskLiveActivity<BalanceLiveActivityProps>(
+    BALANCE_LIVE_ACTIVITY_NAME,
+    BalanceLiveActivityLayout,
+  );

--- a/app/core/Widgets/liveActivities/BalanceLiveActivity.test.ts
+++ b/app/core/Widgets/liveActivities/BalanceLiveActivity.test.ts
@@ -1,0 +1,33 @@
+import { createLiveActivity } from 'expo-widgets';
+
+// Extensionless import: Jest's haste config (via `@react-native/jest-preset`)
+// defaults to resolving platform files as `ios`, matching how production code
+// (BalanceLiveActivityService.ts) imports this module. See
+// BalanceLiveActivity.tsx for the non-iOS fallback, which is trivial enough
+// (a no-op) not to need its own test.
+import {
+  BALANCE_LIVE_ACTIVITY_NAME,
+  BalanceLiveActivity,
+} from './BalanceLiveActivity';
+
+describe('BalanceLiveActivity', () => {
+  it('registers under the name the ExpoWidgetsTarget extension looks up in the App Group', () => {
+    expect(BALANCE_LIVE_ACTIVITY_NAME).toBe('BalanceLiveActivity');
+  });
+
+  it('is created via expo-widgets createLiveActivity exactly once at module load', () => {
+    expect(createLiveActivity).toHaveBeenCalledWith(
+      BALANCE_LIVE_ACTIVITY_NAME,
+      // A string, not a function: proof that babel-preset-expo's widgets
+      // plugin actually stringified the `'widget'`-directive layout, and that
+      // Metro resolved the `.ios.tsx` implementation rather than the `.tsx`
+      // no-op fallback.
+      expect.any(String),
+    );
+  });
+
+  it('exposes the start/getInstances factory API the service drives it through', () => {
+    expect(typeof BalanceLiveActivity.start).toBe('function');
+    expect(typeof BalanceLiveActivity.getInstances).toBe('function');
+  });
+});

--- a/app/core/Widgets/liveActivities/BalanceLiveActivity.tsx
+++ b/app/core/Widgets/liveActivities/BalanceLiveActivity.tsx
@@ -1,0 +1,29 @@
+import { createMetaMaskLiveActivity } from '../createMetaMaskLiveActivity';
+
+// See createMetaMaskLiveActivity.ts — Live Activities are an iOS-only OS
+// feature, so this base file is the non-iOS fallback. It keeps the same
+// exported shape as BalanceLiveActivity.ios.tsx (name, props type, factory
+// instance) so BalanceLiveActivityService (platform-agnostic) can import this
+// module without a Platform.OS branch.
+//
+// It is `.tsx` despite containing no JSX so that its extension matches the
+// `.ios` counterpart — see the same note in ../widgets/BalanceWidget.tsx for
+// why a `.ts` fallback would shadow an `.ios.tsx` file on iOS.
+//
+// `BalanceLiveActivityProps` is duplicated here rather than imported from
+// `./BalanceLiveActivity.ios` — even a type-only import of an explicit `.ios`
+// path risks Metro adding it as a real dependency edge and bundling that file
+// (with its `@expo/ui/swift-ui` imports) into the Android build.
+export interface BalanceLiveActivityProps {
+  accountLabel: string;
+  label: string;
+  balanceDisplay: string;
+}
+
+export const BALANCE_LIVE_ACTIVITY_NAME = 'BalanceLiveActivity';
+
+export const BalanceLiveActivity =
+  createMetaMaskLiveActivity<BalanceLiveActivityProps>(
+    BALANCE_LIVE_ACTIVITY_NAME,
+    () => undefined,
+  );

--- a/babel.config.tests.js
+++ b/babel.config.tests.js
@@ -67,6 +67,8 @@ const newOverrides = [
       'app/core/Widgets/WidgetUpdaterService.test.ts',
       'app/components/UI/Perps/services/PerpsLiveActivityService.ts',
       'app/components/UI/Perps/services/PerpsLiveActivityService.test.ts',
+      'app/core/Widgets/BalanceLiveActivityService.ts',
+      'app/core/Widgets/BalanceLiveActivityService.test.ts',
       // LLM workflow session manager reads process.env at runtime (e.g. MM_METRO_PORT)
       'tests/llm-workflow/metamask-provider.ts',
       'app/core/devApiEnv.ts',

--- a/docs/widgets/README.md
+++ b/docs/widgets/README.md
@@ -66,13 +66,17 @@ app/core/Widgets/
 ├── getInstalledWidgets.ts            No-op fallback (returns [])
 ├── trackWidgetAdoption.ts            Reports install-based widget adoption to analytics
 ├── reconcileLiveActivities.ts        Launch-time cleanup of activities orphaned by a previous process
+├── balanceSnapshot.ts                Shared balance formatting for the widget and the Live Activity
+├── BalanceLiveActivityService.ts     Redux-driven start/update/end for BalanceLiveActivity
 ├── index.ts                          Barrel (WidgetUpdaterService, WidgetTheme helpers, types)
 ├── widgets/
 │   ├── BalanceWidget.ios.tsx         Reference widget: layout + registration
 │   └── BalanceWidget.tsx             No-op fallback with the same exported shape
 └── liveActivities/
     ├── PerpsPnlLiveActivity.ios.tsx  Reference Live Activity: layout + registration
-    └── PerpsPnlLiveActivity.tsx      No-op fallback with the same exported shape
+    ├── PerpsPnlLiveActivity.tsx      No-op fallback with the same exported shape
+    ├── BalanceLiveActivity.ios.tsx   Redux-driven Live Activity: layout + registration
+    └── BalanceLiveActivity.tsx       No-op fallback with the same exported shape
 
 app/components/UI/Perps/services/
 └── PerpsLiveActivityService.ts       Feature-owned start/update/end lifecycle for the above
@@ -575,10 +579,14 @@ Three things differ, and they're the whole delta:
    `createMetaMaskLiveActivity.ios.ts` re-exports a derived version; import it
    from there.
 
-3. **The lifecycle is feature-owned.** `WidgetUpdaterService` exists to fan a
-   debounced Redux snapshot out to widgets. A Live Activity is a state machine
-   (start on open, update while open, end on close) and its data often isn't
-   in Redux at all, so the owning feature drives it.
+3. **The lifecycle belongs to whoever owns the data.** `WidgetUpdaterService`
+   exists to fan a debounced Redux snapshot out to widgets, and a widget is
+   either installed or not. A Live Activity is a state machine (start, update
+   while running, end), so it always needs a service of its own — either
+   feature-owned when the data isn't in Redux (`PerpsLiveActivityService`, which
+   reads perps streams directly), or Redux-driven when it is
+   (`BalanceLiveActivityService`, which subscribes to the store exactly like
+   `WidgetUpdaterService` does).
 
 ### The reference Live Activity: `PerpsPnlLiveActivity`
 
@@ -605,6 +613,26 @@ Two behaviors there are worth copying:
 - **Privacy mode suppresses the activity outright** rather than masking the
   numbers, because a Lock Screen is readable without unlocking the device.
   That's a deliberate difference from `BalanceWidget`, which masks instead.
+
+### The Redux-driven one: `BalanceLiveActivity`
+
+`app/core/Widgets/liveActivities/BalanceLiveActivity.ios.tsx` shows the selected
+account's total balance — the same number `BalanceWidget` puts on the home
+screen. It's the counterpart worth reading when your activity's data already
+lives in Redux.
+
+`app/core/Widgets/BalanceLiveActivityService.ts` drives it from a store
+subscription with the same 2s debounce and identical-props check
+`WidgetUpdaterService` uses, and both read the balance through
+`app/core/Widgets/balanceSnapshot.ts` so the widget and the activity can't
+drift apart on rounding, currency or locale.
+
+It is a separate service rather than another method pair on
+`WidgetUpdaterService` because its _lifetime_ is different: a widget is
+installed or not, whereas a Live Activity has to be explicitly started and
+ended. There is no product-agreed trigger for that yet, so for now
+`app/components/Views/Settings/DeveloperOptions/WidgetsDeveloperOptionsSection.tsx`
+starts and stops it by hand from Settings > Developer Options.
 
 ### Adding a Live Activity
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3244,6 +3244,9 @@
     },
     "perps_pnl_live_activity": {
       "direction": "{{direction}} · {{leverage}}"
+    },
+    "balance_live_activity": {
+      "default_account_label": "Wallet"
     }
   },
   "wallet": {
@@ -4342,6 +4345,13 @@
         "description": "Reset the Social Leaderboard onboarding so it shows again the next time the feature is opened.",
         "onboarding_seen": "Onboarding seen: {{seen}}",
         "reset_onboarding": "Reset onboarding"
+      },
+      "widgets": {
+        "title": "Widgets",
+        "description": "Start the balance Live Activity to see the selected account's total balance on the Lock Screen and in the Dynamic Island. It follows the wallet in real time and ends when you stop it here. Privacy mode hides it entirely.",
+        "start_balance_live_activity": "Start balance Live Activity",
+        "stop_balance_live_activity": "Stop balance Live Activity",
+        "start_failed": "Could not start. Check that Live Activities are enabled for MetaMask in iOS Settings, and that privacy mode is off."
       },
       "haptics": {
         "title": "Haptics",


### PR DESCRIPTION
> Stacked on #34304. Review the last commit only.

## What

Puts the selected account's total balance — the same number `BalanceWidget` shows on the home screen — on the Lock Screen and in the Dynamic Island, refreshed in place as balances stream in.

| Surface | Shows |
| ------- | ----- |
| Lock Screen banner | "Total balance", account name, the balance |
| Collapsed Dynamic Island | Account name / balance |
| Expanded Dynamic Island | The same, split across leading and trailing |

## How

Where `PerpsLiveActivityService` (#34304) reads a feature's own WebSocket streams, this one is driven by a plain Redux subscription with the same 2s debounce and identical-props check `WidgetUpdaterService` uses. Both now read the balance through a shared `app/core/Widgets/balanceSnapshot.ts`, so the widget and the activity can't drift apart on rounding, currency or locale.

It stays a **separate service** rather than another `computeXProps`/`pushXUpdate` pair on `WidgetUpdaterService` because the lifetimes differ: a widget is installed or it isn't, while a Live Activity has to be explicitly started and ended. Together the two PRs cover both shapes a Live Activity lifecycle can take, which is the point of having both as reference implementations.

Privacy mode suppresses the activity entirely rather than masking the balance, matching the Perps one and for the same reason: a Lock Screen is readable without unlocking the device.

## Starting it

There's no product-agreed trigger for starting a balance Live Activity yet, so for the demo **Settings > Developer Options > Widgets** starts and stops it by hand. The section hides itself on builds that can't show it (Android, or `MM_WIDGETS_ENABLED` unset) and surfaces a readable reason when iOS refuses the request — most often because Live Activities are switched off for MetaMask in iOS Settings.

## Test plan

- [x] `yarn jest app/core/Widgets app/components/Views/Settings/DeveloperOptions`
- [x] `yarn lint:tsc`, `yarn lint`
- [ ] iOS simulator: start from Developer Options, balance appears on the Lock Screen and updates as it changes; stop removes it
- [ ] Privacy mode on: activity disappears
- [ ] Android: the Developer Options section is absent, no crash

## Notes

Requires `MM_WIDGETS_ENABLED="true"` in `.js.env` — the flag defaults to `false` in `builds.yml` while this is in development.

Made with [Cursor](https://cursor.com)