### PR TITLE
feat: Swaps CTA button AB test

### DIFF
--- a/app/components/UI/Bridge/components/SwapsConfirmButton/SwapsConfirmButton.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsConfirmButton/SwapsConfirmButton.test.tsx
@@ -31,8 +31,14 @@ import {
 } from '@metamask/bridge-controller';
 import { PriceImpactModalType } from '../PriceImpactModal/constants';
 import { TokenWarningModalMode } from '../TokenWarningModal/constants';
-import { SecurityDataType } from '../../types';
+import { SecurityDataType , BridgeViewMode } from '../../types';
 import { useInsufficientNativeReserveError } from '../../hooks/useInsufficientNativeReserveError';
+import { ButtonVariant } from '@metamask/design-system-react-native';
+import {
+  SWAPS_CTA_BUTTON_COLOR_AB_KEY,
+  SwapsCtaButtonColorVariant,
+} from './abTestConfig';
+import { createActiveABTestAssignment } from '../../../../../util/analytics/activeABTestAssignments';
 // Mock the account-tree-controller file that imports the problematic module
 jest.mock(
   '../../../../../multichain-accounts/controllers/account-tree-controller',
@@ -304,6 +310,33 @@ const mockState: DeepPartial<RootState> = {
   },
 };
 
+function createAbTestState(
+  variantName?: SwapsCtaButtonColorVariant,
+  bridgeViewMode = BridgeViewMode.Unified,
+): DeepPartial<RootState> {
+  return {
+    ...mockState,
+    engine: {
+      ...mockState.engine,
+      backgroundState: {
+        ...mockState.engine?.backgroundState,
+        RemoteFeatureFlagController: {
+          remoteFeatureFlags: {
+            bridgeConfigV2: defaultBridgeConfigV2,
+            ...(variantName && {
+              [SWAPS_CTA_BUTTON_COLOR_AB_KEY]: { name: variantName },
+            }),
+          },
+        },
+      },
+    },
+    bridge: {
+      ...mockState.bridge,
+      bridgeViewMode,
+    },
+  };
+}
+
 describe('SwapsConfirmButton', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -324,6 +357,110 @@ describe('SwapsConfirmButton', () => {
       id: 'tx-meta-id',
       hash: '0xabc',
       status: 'submitted',
+    });
+  });
+
+  describe('CTA color A/B test', () => {
+    it('uses Primary when the CTA experiment is unresolved', () => {
+      const { UNSAFE_getByProps } = renderWithProvider(
+        <SwapsConfirmButton
+          latestSourceBalance={mockLatestSourceBalance}
+          location={MetaMetricsSwapsEventSource.MainView}
+        />,
+        { state: createAbTestState() },
+      );
+
+      const button = UNSAFE_getByProps({
+        variant: ButtonVariant.Primary,
+      });
+
+      expect(button.props.variant).toBe(ButtonVariant.Primary);
+    });
+
+    it('uses Primary for the control assignment', () => {
+      const { UNSAFE_getByProps } = renderWithProvider(
+        <SwapsConfirmButton
+          latestSourceBalance={mockLatestSourceBalance}
+          location={MetaMetricsSwapsEventSource.MainView}
+        />,
+        {
+          state: createAbTestState(SwapsCtaButtonColorVariant.Control),
+        },
+      );
+
+      const button = UNSAFE_getByProps({
+        variant: ButtonVariant.Primary,
+      });
+
+      expect(button.props.variant).toBe(ButtonVariant.Primary);
+    });
+
+    it('uses Secondary for the treatment assignment', () => {
+      const { UNSAFE_getByProps } = renderWithProvider(
+        <SwapsConfirmButton
+          latestSourceBalance={mockLatestSourceBalance}
+          location={MetaMetricsSwapsEventSource.MainView}
+        />,
+        {
+          state: createAbTestState(SwapsCtaButtonColorVariant.Treatment),
+        },
+      );
+
+      const button = UNSAFE_getByProps({
+        variant: ButtonVariant.Secondary,
+      });
+
+      expect(button.props.variant).toBe(ButtonVariant.Secondary);
+    });
+
+    it('uses Secondary outside Unified mode for a treatment assignment', () => {
+      const { UNSAFE_getByProps } = renderWithProvider(
+        <SwapsConfirmButton
+          latestSourceBalance={mockLatestSourceBalance}
+          location={MetaMetricsSwapsEventSource.MainView}
+        />,
+        {
+          state: createAbTestState(
+            SwapsCtaButtonColorVariant.Treatment,
+            BridgeViewMode.Swap,
+          ),
+        },
+      );
+
+      const button = UNSAFE_getByProps({
+        variant: ButtonVariant.Secondary,
+      });
+
+      expect(button.props.variant).toBe(ButtonVariant.Secondary);
+    });
+
+    it('preserves existing transaction attribution when submitting treatment', async () => {
+      const existingAssignment = createActiveABTestAssignment(
+        'existingExperiment',
+        'control',
+      );
+      const { getByTestId } = renderWithProvider(
+        <SwapsConfirmButton
+          latestSourceBalance={mockLatestSourceBalance}
+          location={MetaMetricsSwapsEventSource.MainView}
+          transactionActiveAbTests={[existingAssignment]}
+        />,
+        {
+          state: createAbTestState(SwapsCtaButtonColorVariant.Treatment),
+        },
+      );
+
+      await act(async () => {
+        fireEvent.press(getByTestId(BridgeViewSelectorsIDs.CONFIRM_BUTTON));
+      });
+
+      await waitFor(() => {
+        expect(mockSubmitBridgeTx).toHaveBeenCalledWith({
+          quoteResponse: mockActiveQuote,
+          location: MetaMetricsSwapsEventSource.MainView,
+          transactionActiveAbTests: [existingAssignment],
+        });
+      });
     });
   });
 

--- a/app/components/UI/Bridge/components/SwapsConfirmButton/SwapsConfirmButton.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsConfirmButton/SwapsConfirmButton.test.tsx
@@ -31,14 +31,15 @@ import {
 } from '@metamask/bridge-controller';
 import { PriceImpactModalType } from '../PriceImpactModal/constants';
 import { TokenWarningModalMode } from '../TokenWarningModal/constants';
-import { SecurityDataType , BridgeViewMode } from '../../types';
+import { SecurityDataType, BridgeViewMode } from '../../types';
 import { useInsufficientNativeReserveError } from '../../hooks/useInsufficientNativeReserveError';
-import { ButtonVariant } from '@metamask/design-system-react-native';
+import { ButtonVariant, TextColor } from '@metamask/design-system-react-native';
 import {
   SWAPS_CTA_BUTTON_COLOR_AB_KEY,
   SwapsCtaButtonColorVariant,
 } from './abTestConfig';
 import { createActiveABTestAssignment } from '../../../../../util/analytics/activeABTestAssignments';
+import { LIGHT_MODE_SUCCESS_GREEN } from '../../../../../util/theme';
 // Mock the account-tree-controller file that imports the problematic module
 jest.mock(
   '../../../../../multichain-accounts/controllers/account-tree-controller',
@@ -375,6 +376,8 @@ describe('SwapsConfirmButton', () => {
       });
 
       expect(button.props.variant).toBe(ButtonVariant.Primary);
+      expect(button.props.twClassName).toBeUndefined();
+      expect(button.props.textProps).toBeUndefined();
     });
 
     it('uses Primary for the control assignment', () => {
@@ -393,9 +396,11 @@ describe('SwapsConfirmButton', () => {
       });
 
       expect(button.props.variant).toBe(ButtonVariant.Primary);
+      expect(button.props.twClassName).toBeUndefined();
+      expect(button.props.textProps).toBeUndefined();
     });
 
-    it('uses Secondary for the treatment assignment', () => {
+    it('uses the success color for the treatment assignment', () => {
       const { UNSAFE_getByProps } = renderWithProvider(
         <SwapsConfirmButton
           latestSourceBalance={mockLatestSourceBalance}
@@ -407,13 +412,16 @@ describe('SwapsConfirmButton', () => {
       );
 
       const button = UNSAFE_getByProps({
-        variant: ButtonVariant.Secondary,
+        variant: ButtonVariant.Primary,
       });
 
-      expect(button.props.variant).toBe(ButtonVariant.Secondary);
+      expect(button.props.twClassName).toBe(`bg-[${LIGHT_MODE_SUCCESS_GREEN}]`);
+      expect(button.props.textProps).toEqual({
+        color: TextColor.SuccessInverse,
+      });
     });
 
-    it('uses Secondary outside Unified mode for a treatment assignment', () => {
+    it('uses the success color outside Unified mode for treatment', () => {
       const { UNSAFE_getByProps } = renderWithProvider(
         <SwapsConfirmButton
           latestSourceBalance={mockLatestSourceBalance}
@@ -428,10 +436,10 @@ describe('SwapsConfirmButton', () => {
       );
 
       const button = UNSAFE_getByProps({
-        variant: ButtonVariant.Secondary,
+        variant: ButtonVariant.Primary,
       });
 
-      expect(button.props.variant).toBe(ButtonVariant.Secondary);
+      expect(button.props.twClassName).toBe(`bg-[${LIGHT_MODE_SUCCESS_GREEN}]`);
     });
 
     it('preserves existing transaction attribution when submitting treatment', async () => {

--- a/app/components/UI/Bridge/components/SwapsConfirmButton/abTestConfig.ts
+++ b/app/components/UI/Bridge/components/SwapsConfirmButton/abTestConfig.ts
@@ -1,0 +1,33 @@
+import { ButtonVariant } from '@metamask/design-system-react-native';
+
+export const SWAPS_CTA_BUTTON_COLOR_AB_KEY =
+  'swapsSWAPS4784AbtestCTAButtonColor';
+
+export enum SwapsCtaButtonColorVariant {
+  Control = 'control',
+  Treatment = 'treatment',
+}
+
+export interface SwapsCtaButtonColorVariantConfig {
+  buttonVariant: ButtonVariant;
+}
+
+export const SWAPS_CTA_BUTTON_COLOR_VARIANTS: Record<
+  SwapsCtaButtonColorVariant,
+  SwapsCtaButtonColorVariantConfig
+> = {
+  [SwapsCtaButtonColorVariant.Control]: {
+    buttonVariant: ButtonVariant.Primary,
+  },
+  [SwapsCtaButtonColorVariant.Treatment]: {
+    buttonVariant: ButtonVariant.Secondary,
+  },
+};
+
+export const SWAPS_CTA_BUTTON_COLOR_EXPOSURE_METADATA = {
+  experimentName: 'Swap CTA Button Color',
+  variationNames: {
+    [SwapsCtaButtonColorVariant.Control]: 'Current primary',
+    [SwapsCtaButtonColorVariant.Treatment]: 'Green secondary',
+  },
+};

--- a/app/components/UI/Bridge/components/SwapsConfirmButton/abTestConfig.ts
+++ b/app/components/UI/Bridge/components/SwapsConfirmButton/abTestConfig.ts
@@ -1,5 +1,3 @@
-import { ButtonVariant } from '@metamask/design-system-react-native';
-
 export const SWAPS_CTA_BUTTON_COLOR_AB_KEY =
   'swapsSWAPS4784AbtestCTAButtonColor';
 
@@ -9,7 +7,7 @@ export enum SwapsCtaButtonColorVariant {
 }
 
 export interface SwapsCtaButtonColorVariantConfig {
-  buttonVariant: ButtonVariant;
+  hasSuccessColor: boolean;
 }
 
 export const SWAPS_CTA_BUTTON_COLOR_VARIANTS: Record<
@@ -17,10 +15,10 @@ export const SWAPS_CTA_BUTTON_COLOR_VARIANTS: Record<
   SwapsCtaButtonColorVariantConfig
 > = {
   [SwapsCtaButtonColorVariant.Control]: {
-    buttonVariant: ButtonVariant.Primary,
+    hasSuccessColor: false,
   },
   [SwapsCtaButtonColorVariant.Treatment]: {
-    buttonVariant: ButtonVariant.Secondary,
+    hasSuccessColor: true,
   },
 };
 
@@ -28,6 +26,6 @@ export const SWAPS_CTA_BUTTON_COLOR_EXPOSURE_METADATA = {
   experimentName: 'Swap CTA Button Color',
   variationNames: {
     [SwapsCtaButtonColorVariant.Control]: 'Current primary',
-    [SwapsCtaButtonColorVariant.Treatment]: 'Green secondary',
+    [SwapsCtaButtonColorVariant.Treatment]: 'Green success',
   },
 };

--- a/app/components/UI/Bridge/components/SwapsConfirmButton/index.tsx
+++ b/app/components/UI/Bridge/components/SwapsConfirmButton/index.tsx
@@ -1,5 +1,10 @@
 import React, { useMemo, useEffect, useRef } from 'react';
-import { Button, ButtonBaseSize } from '@metamask/design-system-react-native';
+import {
+  Button,
+  ButtonBaseSize,
+  ButtonVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { BridgeViewSelectorsIDs } from '../../Views/BridgeView/BridgeView.testIds';
 import { useSelector } from 'react-redux';
@@ -46,6 +51,10 @@ import {
   SWAPS_CTA_BUTTON_COLOR_EXPOSURE_METADATA,
   SWAPS_CTA_BUTTON_COLOR_VARIANTS,
 } from './abTestConfig';
+import { LIGHT_MODE_SUCCESS_GREEN, useTheme } from '../../../../../util/theme';
+import { AppThemeKey } from '../../../../../util/theme/models';
+
+const SUCCESS_TEXT_PROPS = { color: TextColor.SuccessInverse } as const;
 
 interface Props {
   latestSourceBalance: ReturnType<typeof useLatestBalance>;
@@ -61,11 +70,16 @@ export const SwapsConfirmButton = ({
   location,
   transactionActiveAbTests,
 }: Props) => {
-  const { variant } = useABTest(
+  const { variant: ctaButtonColorVariant } = useABTest(
     SWAPS_CTA_BUTTON_COLOR_AB_KEY,
     SWAPS_CTA_BUTTON_COLOR_VARIANTS,
     SWAPS_CTA_BUTTON_COLOR_EXPOSURE_METADATA,
   );
+  const { themeAppearance } = useTheme();
+  const treatmentBackground =
+    themeAppearance === AppThemeKey.light
+      ? `bg-[${LIGHT_MODE_SUCCESS_GREEN}]`
+      : 'bg-success-default';
   const navigation = useNavigation<AppNavigationProp>();
 
   const bridgeFeatureFlags = useSelector(selectBridgeFeatureFlags);
@@ -303,7 +317,13 @@ export const SwapsConfirmButton = ({
 
   return (
     <Button
-      variant={variant.buttonVariant}
+      variant={ButtonVariant.Primary}
+      twClassName={
+        ctaButtonColorVariant.hasSuccessColor ? treatmentBackground : undefined
+      }
+      textProps={
+        ctaButtonColorVariant.hasSuccessColor ? SUCCESS_TEXT_PROPS : undefined
+      }
       size={ButtonBaseSize.Lg}
       isLoading={buttonIsInLoadingState}
       onPress={needsNewQuote ? handleGetNewQuote : handleContinue}

--- a/app/components/UI/Bridge/components/SwapsConfirmButton/index.tsx
+++ b/app/components/UI/Bridge/components/SwapsConfirmButton/index.tsx
@@ -1,9 +1,5 @@
 import React, { useMemo, useEffect, useRef } from 'react';
-import {
-  Button,
-  ButtonVariant,
-  ButtonBaseSize,
-} from '@metamask/design-system-react-native';
+import { Button, ButtonBaseSize } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { BridgeViewSelectorsIDs } from '../../Views/BridgeView/BridgeView.testIds';
 import { useSelector } from 'react-redux';
@@ -44,6 +40,12 @@ import { TokenWarningModalMode } from '../TokenWarningModal/constants';
 import type { TransactionActiveAbTestEntry } from '../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
 import { useInsufficientNativeReserveError } from '../../hooks/useInsufficientNativeReserveError';
 import { useIsNetworkFeeUnavailable } from '../../hooks/useIsNetworkFeeUnavailable';
+import { useABTest } from '../../../../../hooks';
+import {
+  SWAPS_CTA_BUTTON_COLOR_AB_KEY,
+  SWAPS_CTA_BUTTON_COLOR_EXPOSURE_METADATA,
+  SWAPS_CTA_BUTTON_COLOR_VARIANTS,
+} from './abTestConfig';
 
 interface Props {
   latestSourceBalance: ReturnType<typeof useLatestBalance>;
@@ -59,6 +61,11 @@ export const SwapsConfirmButton = ({
   location,
   transactionActiveAbTests,
 }: Props) => {
+  const { variant } = useABTest(
+    SWAPS_CTA_BUTTON_COLOR_AB_KEY,
+    SWAPS_CTA_BUTTON_COLOR_VARIANTS,
+    SWAPS_CTA_BUTTON_COLOR_EXPOSURE_METADATA,
+  );
   const navigation = useNavigation<AppNavigationProp>();
 
   const bridgeFeatureFlags = useSelector(selectBridgeFeatureFlags);
@@ -296,7 +303,7 @@ export const SwapsConfirmButton = ({
 
   return (
     <Button
-      variant={ButtonVariant.Primary}
+      variant={variant.buttonVariant}
       size={ButtonBaseSize.Lg}
       isLoading={buttonIsInLoadingState}
       onPress={needsNewQuote ? handleGetNewQuote : handleContinue}

--- a/app/util/bridge/hooks/useSubmitBridgeTx.test.tsx
+++ b/app/util/bridge/hooks/useSubmitBridgeTx.test.tsx
@@ -13,6 +13,8 @@ import { backgroundState } from '../../test/initial-root-state';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { selectSourceWalletAddress } from '../../../selectors/bridge';
 import { useABTest } from '../../../hooks';
+import { createActiveABTestAssignment } from '../../analytics/activeABTestAssignments';
+import { SWAPS_CTA_BUTTON_COLOR_AB_KEY } from '../../../components/UI/Bridge/components/SwapsConfirmButton/abTestConfig';
 
 type BridgeQuoteResponse = QuoteResponse & QuoteMetadata;
 interface MockABTestResult {
@@ -102,10 +104,12 @@ describe('useSubmitBridgeTx', () => {
     numpad = inactiveABTestResult,
     tokenSelector = inactiveABTestResult,
     ambientColor = inactiveABTestResult,
+    ctaButtonColor = inactiveABTestResult,
   }: {
     numpad?: MockABTestResult;
     tokenSelector?: MockABTestResult;
     ambientColor?: MockABTestResult;
+    ctaButtonColor?: MockABTestResult;
   } = {}) => {
     jest
       .mocked(useABTest)
@@ -113,7 +117,8 @@ describe('useSubmitBridgeTx', () => {
       .mockReturnValue(inactiveABTestResult)
       .mockReturnValueOnce(numpad)
       .mockReturnValueOnce(tokenSelector)
-      .mockReturnValueOnce(ambientColor);
+      .mockReturnValueOnce(ambientColor)
+      .mockReturnValueOnce(ctaButtonColor);
   };
 
   beforeEach(() => {
@@ -547,6 +552,102 @@ describe('useSubmitBridgeTx', () => {
     });
     expect(mockSubmitTx).not.toHaveBeenCalled();
     expect(txResult).toEqual(mockIntentResult);
+  });
+
+  it('forwards caller-supplied active A/B tests via submitTx', async () => {
+    const transactionActiveAbTests = [
+      createActiveABTestAssignment('callerExperiment', 'treatment'),
+    ];
+    const mockQuoteResponse = {
+      ...DummyQuotesNoApproval.OP_0_005_ETH_TO_ARB[0],
+      ...DummyQuoteMetadata,
+    };
+    mockSubmitTx.mockResolvedValueOnce({
+      chainId: '0x1',
+      id: '1',
+      networkClientId: '1',
+      status: 'submitted',
+      time: Date.now(),
+      txParams: {
+        from: '0x1234567890123456789012345678901234567890',
+      },
+    } as TransactionMeta);
+    const { result } = renderHook(() => useSubmitBridgeTx(), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.submitBridgeTx({
+      quoteResponse: mockQuoteResponse as BridgeQuoteResponse,
+      transactionActiveAbTests,
+    });
+
+    expect(mockSubmitTx).toHaveBeenLastCalledWith(
+      '0x1234567890123456789012345678901234567890',
+      {
+        ...mockQuoteResponse,
+        approval: undefined,
+      },
+      true,
+      undefined,
+      undefined,
+      undefined,
+      transactionActiveAbTests,
+      null,
+      undefined,
+      'token_amount',
+    );
+  });
+
+  it('forwards CTA button color A/B test assignment via submitTx', async () => {
+    mockABTests({
+      ctaButtonColor: {
+        variant: {},
+        variantName: 'treatment',
+        isActive: true,
+      },
+    });
+    const mockQuoteResponse = {
+      ...DummyQuotesNoApproval.OP_0_005_ETH_TO_ARB[0],
+      ...DummyQuoteMetadata,
+    };
+    mockSubmitTx.mockResolvedValueOnce({
+      chainId: '0x1',
+      id: '1',
+      networkClientId: '1',
+      status: 'submitted',
+      time: Date.now(),
+      txParams: {
+        from: '0x1234567890123456789012345678901234567890',
+      },
+    } as TransactionMeta);
+    const { result } = renderHook(() => useSubmitBridgeTx(), {
+      wrapper: createWrapper(),
+    });
+
+    await result.current.submitBridgeTx({
+      quoteResponse: mockQuoteResponse as BridgeQuoteResponse,
+    });
+
+    expect(mockSubmitTx).toHaveBeenLastCalledWith(
+      '0x1234567890123456789012345678901234567890',
+      {
+        ...mockQuoteResponse,
+        approval: undefined,
+      },
+      true,
+      undefined,
+      undefined,
+      undefined,
+      [
+        createActiveABTestAssignment(
+          SWAPS_CTA_BUTTON_COLOR_AB_KEY,
+          'treatment',
+        ),
+      ],
+      null,
+      undefined,
+      'token_amount',
+    );
   });
 
   it('forwards ambient color AB test assignment via submitTx when active', async () => {

--- a/app/util/bridge/hooks/useSubmitBridgeTx.ts
+++ b/app/util/bridge/hooks/useSubmitBridgeTx.ts
@@ -23,6 +23,11 @@ import {
   TOKEN_SELECTOR_BALANCE_LAYOUT_VARIANTS,
 } from '../../../components/UI/Bridge/components/TokenSelectorItem.abTestConfig';
 import {
+  SWAPS_CTA_BUTTON_COLOR_AB_KEY,
+  SWAPS_CTA_BUTTON_COLOR_EXPOSURE_METADATA,
+  SWAPS_CTA_BUTTON_COLOR_VARIANTS,
+} from '../../../components/UI/Bridge/components/SwapsConfirmButton/abTestConfig';
+import {
   AMBIENT_PRICE_COLOR_AB_KEY,
   AMBIENT_PRICE_COLOR_VARIANTS,
 } from '../../../components/UI/TokenDetails/components/abTestConfig';
@@ -69,6 +74,14 @@ export default function useSubmitBridgeTx() {
     variantName: ambientColorVariantName,
     isActive: isAmbientColorAbActive,
   } = useABTest(AMBIENT_PRICE_COLOR_AB_KEY, AMBIENT_PRICE_COLOR_VARIANTS);
+  const {
+    variantName: ctaButtonColorVariantName,
+    isActive: isCtaButtonColorAbActive,
+  } = useABTest(
+    SWAPS_CTA_BUTTON_COLOR_AB_KEY,
+    SWAPS_CTA_BUTTON_COLOR_VARIANTS,
+    SWAPS_CTA_BUTTON_COLOR_EXPOSURE_METADATA,
+  );
 
   const abTests = abTestContext?.assetsASSETS2493AbtestTokenDetailsLayout
     ? {
@@ -106,6 +119,15 @@ export default function useSubmitBridgeTx() {
       );
     }
 
+    if (isCtaButtonColorAbActive) {
+      tests.push(
+        createActiveABTestAssignment(
+          SWAPS_CTA_BUTTON_COLOR_AB_KEY,
+          ctaButtonColorVariantName,
+        ),
+      );
+    }
+
     return tests.length > 0 ? tests : undefined;
   }, [
     isNumpadAbActive,
@@ -114,6 +136,8 @@ export default function useSubmitBridgeTx() {
     tokenSelectorVariantName,
     isAmbientColorAbActive,
     ambientColorVariantName,
+    isCtaButtonColorAbActive,
+    ctaButtonColorVariantName,
   ]);
 
   const submitBridgeTx = async ({

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -5160,6 +5160,29 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  swapsSWAPS4784AbtestCTAButtonColor: {
+    name: 'swapsSWAPS4784AbtestCTAButtonColor',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: [
+      {
+        name: 'control',
+        scope: {
+          type: 'percentage_rollout',
+          value: 0.5,
+        },
+      },
+      {
+        name: 'treatment',
+        scope: {
+          type: 'percentage_rollout',
+          value: 1,
+        },
+      },
+    ],
+    status: FeatureFlagStatus.Active,
+  },
+
   tempoConfig: {
     name: 'tempoConfig',
     type: FeatureFlagType.Remote,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds the SWAPS-4784 CTA button color A/B test to the Unified Swaps, same-chain Swap, and cross-chain Bridge confirmation CTA. The control keeps the current primary color, while the treatment uses the success green shown on Asset Details, including the higher-contrast light-mode green.

The experiment records exposure and forwards active assignments through transaction submission attribution so submission and downstream transaction events can be compared by variant. LaunchDarkly setup for `swapsSWAPS4784AbtestCTAButtonColor` will be handled separately.

Automated tests cover unresolved, control, treatment, legacy-mode rendering, and transaction attribution behavior. The targeted CTA assertions passed locally, but the Jest process did not exit cleanly after reporting results.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added an experiment for the Swap confirmation button color

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4784

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Swap CTA button color experiment

  Scenario: Control preserves the current CTA color
    Given the swapsSWAPS4784AbtestCTAButtonColor flag assigns "control"
    And a valid quote is available in Unified Swaps, Swap, or Bridge mode
    When the confirmation CTA is displayed
    Then the CTA uses the current primary color

  Scenario: Treatment displays the success green in light and dark modes
    Given the swapsSWAPS4784AbtestCTAButtonColor flag assigns "treatment"
    And a valid quote is available in Unified Swaps, Swap, or Bridge mode
    When the confirmation CTA is displayed in light mode
    Then the CTA uses the darker success green with inverse text
    When the app is switched to dark mode
    Then the CTA uses the dark-theme success green with inverse text

  Scenario: Treatment assignment is attributed to submission
    Given the swapsSWAPS4784AbtestCTAButtonColor flag assigns "treatment"
    And a valid quote is available
    When the user submits the transaction
    Then submission analytics include the treatment assignment
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — the control preserves the existing CTA appearance.

### **After**

<!-- [screenshots/recordings] -->

<img width="598" height="1144" alt="Screenshot 2026-08-04 at 5 37 25 PM" src="https://github.com/user-attachments/assets/921a83f4-0818-4774-bcf8-8ccd61fc8ae0" />
<img width="598" height="1144" alt="Screenshot 2026-08-04 at 5 44 14 PM" src="https://github.com/user-attachments/assets/e65fb0a9-93cd-4209-986d-a1b8bd75390c" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and analytics-only changes on the existing confirm path; submission behavior is unchanged aside from forwarding another A/B assignment using the same pattern as other swap experiments.
> 
> **Overview**
> Introduces **SWAPS-4784** (`swapsSWAPS4784AbtestCTAButtonColor`): control keeps the primary confirm button; **treatment** applies success-green background (light-mode custom green, dark-mode `bg-success-default`) and inverse success text on `SwapsConfirmButton` across Unified, Swap, and Bridge flows, with exposure metadata wired through `useABTest`.
> 
> **Submission attribution** is extended in `useSubmitBridgeTx` so an active CTA-color assignment is merged into `transactionActiveAbTests` on `submitTx` / `submitIntent`, matching other swap experiments. The remote feature-flag registry gets a 50/50 control vs treatment rollout definition.
> 
> Tests cover unresolved/control/treatment rendering, non-Unified modes, preserving caller-supplied attribution on submit, and hook forwarding of the CTA experiment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e1563431af88a256b22f72ff23c38985ebc094b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->