### PR TITLE
fix(perps): remove useElevatedSurface shim from Perps BottomSheets (TMCU-1040)

### DIFF
--- a/app/components/UI/Perps/components/PerpsActionSheet/PerpsActionSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsActionSheet/PerpsActionSheet.tsx
@@ -8,7 +8,6 @@ import {
   IconSize,
   ListItem,
 } from '@metamask/design-system-react-native';
-import { useElevatedSurface } from '../../../../../util/theme/themeUtils';
 import type { PerpsActionSheetProps } from './PerpsActionSheet.types';
 
 function PerpsActionSheet<T extends string>({
@@ -20,7 +19,6 @@ function PerpsActionSheet<T extends string>({
   sheetRef: externalSheetRef,
   testID,
 }: PerpsActionSheetProps<T>) {
-  const surfaceClass = useElevatedSurface();
   const internalSheetRef = useRef<BottomSheetRef>(null);
   const sheetRef = externalSheetRef || internalSheetRef;
 
@@ -46,7 +44,6 @@ function PerpsActionSheet<T extends string>({
       ref={sheetRef}
       goBack={!externalSheetRef ? onClose : undefined}
       onClose={externalSheetRef ? onClose : undefined}
-      twClassName={surfaceClass}
       testID={testID}
     >
       <BottomSheetHeader onClose={handleClose}>{title}</BottomSheetHeader>

--- a/app/components/UI/Perps/components/PerpsAdjustMarginActionSheet/PerpsAdjustMarginActionSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsAdjustMarginActionSheet/PerpsAdjustMarginActionSheet.test.tsx
@@ -2,10 +2,6 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react-native';
 import PerpsAdjustMarginActionSheet from './PerpsAdjustMarginActionSheet';
 
-jest.mock('../../../../../util/theme/themeUtils', () => ({
-  useElevatedSurface: () => 'bg-default',
-}));
-
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key) => {
     const translations: Record<string, string> = {

--- a/app/components/UI/Perps/components/PerpsModifyActionSheet/PerpsModifyActionSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsModifyActionSheet/PerpsModifyActionSheet.test.tsx
@@ -4,10 +4,6 @@ import PerpsModifyActionSheet from './PerpsModifyActionSheet';
 import { type Position } from '@metamask/perps-controller';
 import { PerpsModifyActionSheetSelectorsIDs } from '../../Perps.testIds';
 
-jest.mock('../../../../../util/theme/themeUtils', () => ({
-  useElevatedSurface: () => 'bg-default',
-}));
-
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key) => {
     const translations: Record<string, string> = {


### PR DESCRIPTION
## **Description**

MMDS `BottomSheet` now handles pure-black elevated surface styling internally. This PR removes the redundant `useElevatedSurface()` shim from the Perps BottomSheet callsites that were missed when TMCU-1040 was originally closed.

**Changes:**
- `app/components/UI/Perps/components/PerpsActionSheet/PerpsActionSheet.tsx` — removed `useElevatedSurface` import, `surfaceClass` variable, and `twClassName` prop from `BottomSheet`
- `app/components/UI/Perps/components/PerpsAdjustMarginActionSheet/PerpsAdjustMarginActionSheet.test.tsx` — removed no-longer-needed `useElevatedSurface` mock from themeUtils
- `app/components/UI/Perps/components/PerpsModifyActionSheet/PerpsModifyActionSheet.test.tsx` — removed no-longer-needed `useElevatedSurface` mock from themeUtils

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1040

## **Manual testing steps**

N/A — internal styling cleanup with no user-facing behavior change. MMDS `BottomSheet` applies the elevated surface class internally. Existing unit tests cover the modified components.

## **Screenshots/Recordings**

N/A — no visual change expected.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Styling cleanup only; behavior should match other BottomSheets already migrated under TMCU-1040, with no logic or data changes.
> 
> **Overview**
> Removes the redundant **`useElevatedSurface()`** wiring from shared **`PerpsActionSheet`**, which backs Perps adjust-margin and modify-position bottom sheets. **`BottomSheet`** from MMDS is no longer passed **`twClassName`** for elevated surface styling because that behavior is handled inside the design-system component.
> 
> Test files for **`PerpsAdjustMarginActionSheet`** and **`PerpsModifyActionSheet`** drop the obsolete **`themeUtils`** mock for **`useElevatedSurface`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76124ee9e8c59f1294a9cf0a50b6b2c5ba5eb560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->