### PR TITLE
fix(snaps): Ensure `fontWeight` is properly inherited

### DIFF
--- a/app/components/Snaps/SnapUIRenderer/components/bold.ts
+++ b/app/components/Snaps/SnapUIRenderer/components/bold.ts
@@ -12,7 +12,7 @@ export const bold: UIComponentFactory<BoldElement> = ({
   element: 'Text',
   children: mapTextToTemplate(
     getJsxChildren(e) as NonEmptyArray<string | JSXElement>,
-    params,
+    { ...params, textFontWeight: FontWeight.Bold },
   ),
   props: {
     variant: TextVariant.BodyMd,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Ensure `fontWeight` is properly inherited for Snaps UI elements. 

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```typescript
export const onRpcRequest: OnRpcRequestHandler = async ({
  origin,
  request,
}) => {
  switch (request.method) {
    case 'hello':
      return snap.request({
        method: 'snap_dialog',
        params: {
          content: (
            <Container>
              <Box>
                <Text color='error'>Hello <Italic>world!</Italic></Text>
                <Text color='success'>Hello <Bold>world!</Bold></Text>
                <Text>Hello <Italic><Bold>world!</Bold></Italic></Text>
              </Box>
              <Footer>
                <Button name="confirm" variant="primary">
                  Confirm
                </Button>
              </Footer>
            </Container>
          ),
        },
      });
    default:
      throw new Error('Method not found.');
  }
};
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="301" height="655" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-04 at 16 14 58" src="https://github.com/user-attachments/assets/709f93fc-60f8-42d6-9587-59a9bdbea91a" />

### **After**

<img width="301" height="655" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-05 at 10 22 34" src="https://github.com/user-attachments/assets/3d333abc-772f-4111-ac75-598f7ed5083b" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Snap UI renderer change with no auth, data, or API impact—only nested text styling in Snap dialogs.
> 
> **Overview**
> Fixes Snap dialog text so **bold** styling applies to nested content (e.g. `<Bold>` inside colored `<Text>`, or `<Italic><Bold>`), not only the outer `Bold` node.
> 
> The `bold` factory now passes `textFontWeight: FontWeight.Bold` into `mapTextToTemplate`, matching how other elements (like `Text` and `Button`) propagate inherited typography to child segments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 364455b1a16e1a523ffda23c92e299e22bcc8793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->