### PR TITLE
feat(perps): add shared Pro order edit hook and sheets

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderEditSheets.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderEditSheets.tsx
@@ -1,0 +1,80 @@
+import type { Order } from '@metamask/perps-controller';
+import React from 'react';
+import PerpsLimitPriceBottomSheet from '../../../components/PerpsLimitPriceBottomSheet/PerpsLimitPriceBottomSheet';
+import PerpsOrderSizeBottomSheet from '../../../components/PerpsOrderSizeBottomSheet/PerpsOrderSizeBottomSheet';
+import { isClosingOrder } from '../../../utils/orderDirection';
+import {
+  getOrderEditableLimitPrice,
+  getOrderEditableSize,
+  type OrderEditField,
+} from '../../../utils/orderEditUtils';
+import { getOrderPositionDirection } from '../../../utils/orderUtils';
+import PerpsProPositionsModalPortal from './PerpsProPositionsModalPortal';
+
+interface PerpsProOrderEditSheetsProps {
+  editingOrder: Order | null;
+  editingOrderSheet: OrderEditField | null;
+  editingOrderSzDecimals: number;
+  editingOrderLeverage: number;
+  isEditingOrderMarketDataReady: boolean;
+  onClose: () => void;
+  onConfirmPrice: (limitPrice: string) => void;
+  onConfirmSize: (size: string) => void;
+}
+
+/**
+ * Shared Pro order edit sheets (limit price and size) rendered in a portal.
+ */
+const PerpsProOrderEditSheets = ({
+  editingOrder,
+  editingOrderSheet,
+  editingOrderSzDecimals,
+  editingOrderLeverage,
+  isEditingOrderMarketDataReady,
+  onClose,
+  onConfirmPrice,
+  onConfirmSize,
+}: PerpsProOrderEditSheetsProps) => {
+  if (!editingOrder || !editingOrderSheet) {
+    return null;
+  }
+
+  if (editingOrderSheet === 'price') {
+    return (
+      <PerpsProPositionsModalPortal onRequestClose={onClose}>
+        <PerpsLimitPriceBottomSheet
+          isVisible
+          asset={editingOrder.symbol}
+          limitPrice={getOrderEditableLimitPrice(editingOrder)}
+          direction={getOrderPositionDirection(editingOrder)}
+          isClosingPosition={isClosingOrder(editingOrder)}
+          restingOrderSize={getOrderEditableSize(editingOrder)}
+          leverage={editingOrderLeverage}
+          reduceOnly={editingOrder.reduceOnly}
+          isMarketDataReady={isEditingOrderMarketDataReady}
+          onClose={onClose}
+          onConfirm={onConfirmPrice}
+        />
+      </PerpsProPositionsModalPortal>
+    );
+  }
+
+  return (
+    <PerpsProPositionsModalPortal onRequestClose={onClose}>
+      <PerpsOrderSizeBottomSheet
+        isVisible
+        asset={editingOrder.symbol}
+        orderSize={getOrderEditableSize(editingOrder)}
+        limitPrice={getOrderEditableLimitPrice(editingOrder)}
+        szDecimals={editingOrderSzDecimals}
+        leverage={editingOrderLeverage}
+        reduceOnly={editingOrder.reduceOnly}
+        isMarketDataReady={isEditingOrderMarketDataReady}
+        onClose={onClose}
+        onConfirm={onConfirmSize}
+      />
+    </PerpsProPositionsModalPortal>
+  );
+};
+
+export default React.memo(PerpsProOrderEditSheets);

--- a/app/components/UI/Perps/hooks/usePerpsProOrderEdit.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsProOrderEdit.test.tsx
@@ -1,0 +1,479 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
+import type { Order, OrderResult } from '@metamask/perps-controller';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { usePerpsProOrderEdit } from './usePerpsProOrderEdit';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(() => true),
+}));
+
+const mockEditOrder = jest.fn();
+const mockShowToast = jest.fn();
+const mockUpdateOrderOptimistic = jest.fn();
+const mockGetSnapshot = jest.fn(() => null as Order[] | null);
+const mockRunGatedEligibleAction = jest.fn(
+  (_source: string, action: () => void) => action(),
+);
+const mockSubmittingToast = jest.fn(() => ({ type: 'submitting' }));
+const mockConfirmedToast = jest.fn(() => ({ type: 'confirmed' }));
+const mockFailedToast = jest.fn(() => ({ type: 'failed' }));
+
+jest.mock('./usePerpsTrading', () => ({
+  usePerpsTrading: () => ({
+    editOrder: mockEditOrder,
+  }),
+}));
+
+jest.mock('../providers/PerpsStreamManager', () => ({
+  usePerpsStream: () => ({
+    orders: {
+      updateOrderOptimistic: mockUpdateOrderOptimistic,
+      getSnapshot: mockGetSnapshot,
+    },
+  }),
+}));
+
+jest.mock('./usePerpsMarketData', () => ({
+  usePerpsMarketData: () => ({
+    marketData: { szDecimals: 3, maxLeverage: 25 },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+jest.mock('./stream', () => ({
+  usePerpsLivePositions: () => ({
+    positions: [],
+    isInitialLoading: false,
+  }),
+}));
+
+jest.mock('./usePerpsSelector', () => ({
+  usePerpsSelector: () => undefined,
+}));
+
+jest.mock('./usePerpsToasts', () => ({
+  __esModule: true,
+  default: () => ({
+    showToast: mockShowToast,
+    PerpsToastOptions: {
+      orderManagement: {
+        shared: { submitting: mockSubmittingToast },
+        limit: {
+          confirmed: mockConfirmedToast,
+          creationFailed: mockFailedToast,
+        },
+      },
+    },
+  }),
+}));
+
+jest.mock(
+  '../Views/PerpsProMarketView/components/PerpsProOrderEditSheets',
+  () => {
+    const { View, Pressable, Text } = jest.requireActual('react-native');
+    return function PerpsProOrderEditSheets({
+      editingOrderSheet,
+      editingOrderLeverage,
+      onConfirmPrice,
+      onConfirmSize,
+    }: {
+      editingOrderSheet: 'price' | 'size' | null;
+      editingOrderLeverage: number;
+      onConfirmPrice: (price: string) => void;
+      onConfirmSize: (size: string) => void;
+    }) {
+      if (!editingOrderSheet) {
+        return null;
+      }
+
+      return (
+        <View testID={`perps-order-edit-sheet-${editingOrderSheet}`}>
+          <Text testID="perps-order-edit-leverage">{editingOrderLeverage}</Text>
+          <Pressable
+            testID={`perps-order-edit-confirm-${editingOrderSheet}`}
+            onPress={() =>
+              editingOrderSheet === 'price'
+                ? onConfirmPrice('170')
+                : onConfirmSize('2')
+            }
+          >
+            <Text>Confirm</Text>
+          </Pressable>
+          <Pressable
+            testID={`perps-order-edit-confirm-same-${editingOrderSheet}`}
+            onPress={() =>
+              editingOrderSheet === 'price'
+                ? onConfirmPrice('160.71')
+                : onConfirmSize('1')
+            }
+          >
+            <Text>Confirm same</Text>
+          </Pressable>
+        </View>
+      );
+    };
+  },
+);
+
+const order: Order = {
+  orderId: 'order-1',
+  symbol: 'SOL',
+  side: 'buy',
+  size: '1',
+  originalSize: '1',
+  filledSize: '0',
+  remainingSize: '1',
+  price: '160.71',
+  orderType: 'limit',
+  status: 'open',
+  timestamp: 1_711_756_800_000, // 2024-03-30T00:00:00.000Z — fixed for determinism
+  reduceOnly: false,
+  isTrigger: false,
+};
+
+const EditHarness = ({
+  isMutationBlocked = false,
+  onReady,
+}: {
+  isMutationBlocked?: boolean;
+  onReady: (value: ReturnType<typeof usePerpsProOrderEdit>) => void;
+}) => {
+  const orderEdit = usePerpsProOrderEdit({
+    isMutationBlocked,
+    runGatedEligibleAction: mockRunGatedEligibleAction,
+  });
+
+  React.useEffect(() => {
+    onReady(orderEdit);
+  }, [onReady, orderEdit]);
+
+  return <>{orderEdit.renderOrderEditSheets()}</>;
+};
+
+const renderOrderEditHarness = async (isMutationBlocked = false) => {
+  let orderEdit: ReturnType<typeof usePerpsProOrderEdit> | undefined;
+
+  render(
+    <EditHarness
+      isMutationBlocked={isMutationBlocked}
+      onReady={(readyOrderEdit) => {
+        orderEdit = readyOrderEdit;
+      }}
+    />,
+  );
+
+  await waitFor(() => {
+    expect(orderEdit).toBeDefined();
+  });
+
+  if (!orderEdit) {
+    throw new Error('orderEdit harness failed to initialize');
+  }
+
+  return orderEdit;
+};
+
+const openEditSheet = async (
+  orderEdit: ReturnType<typeof usePerpsProOrderEdit>,
+  field: 'price' | 'size',
+  targetOrder: Order = order,
+) => {
+  await act(async () => {
+    if (field === 'price') {
+      orderEdit.handleEditOrderPrice(targetOrder);
+    } else {
+      orderEdit.handleEditOrderSize(targetOrder);
+    }
+  });
+
+  await waitFor(() => {
+    expect(
+      screen.getByTestId(`perps-order-edit-sheet-${field}`),
+    ).toBeOnTheScreen();
+  });
+};
+
+const confirmEdit = async (field: 'price' | 'size') => {
+  await act(async () => {
+    fireEvent.press(screen.getByTestId(`perps-order-edit-confirm-${field}`));
+  });
+};
+
+describe('usePerpsProOrderEdit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useSelector as jest.Mock).mockReturnValue(true);
+    mockEditOrder.mockResolvedValue({ success: true });
+    mockGetSnapshot.mockReturnValue(null);
+  });
+
+  it('forwards the effective leverage to the edit sheets', async () => {
+    const orderEdit = await renderOrderEditHarness();
+
+    await openEditSheet(orderEdit, 'size');
+
+    expect(screen.getByTestId('perps-order-edit-leverage')).toHaveTextContent(
+      '25',
+    );
+  });
+
+  it.each(['price', 'size'] as const)(
+    'submits a %s edit through the shared flow',
+    async (field) => {
+      const orderEdit = await renderOrderEditHarness();
+
+      await openEditSheet(orderEdit, field);
+      await confirmEdit(field);
+
+      expect(mockUpdateOrderOptimistic).toHaveBeenCalledWith(
+        order.orderId,
+        field === 'price' ? { limitPrice: '170' } : { size: '2' },
+      );
+      expect(mockEditOrder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderId: order.orderId,
+          watchPriceUpdate: field === 'price',
+          newOrder: expect.objectContaining({
+            symbol: order.symbol,
+            orderType: 'limit',
+            ...(field === 'price' ? { price: '170' } : { size: '2' }),
+          }),
+        }),
+      );
+      expect(mockSubmittingToast).toHaveBeenCalled();
+      expect(mockConfirmedToast).toHaveBeenCalled();
+      expect(mockFailedToast).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['price', 'size'] as const)(
+    'rolls back optimistic %s edit when editOrder fails',
+    async (field) => {
+      mockEditOrder.mockResolvedValue({ success: false, error: 'edit failed' });
+      const orderEdit = await renderOrderEditHarness();
+
+      await openEditSheet(orderEdit, field);
+      await confirmEdit(field);
+
+      await waitFor(() => {
+        expect(mockEditOrder).toHaveBeenCalled();
+      });
+
+      expect(mockUpdateOrderOptimistic).toHaveBeenNthCalledWith(
+        1,
+        order.orderId,
+        field === 'price' ? { limitPrice: '170' } : { size: '2' },
+      );
+      expect(mockUpdateOrderOptimistic).toHaveBeenNthCalledWith(
+        2,
+        order.orderId,
+        field === 'price' ? { limitPrice: order.price } : { size: '1' },
+      );
+      expect(mockFailedToast).toHaveBeenCalled();
+      expect(mockConfirmedToast).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['price', 'size'] as const)(
+    'rolls back optimistic %s edit when editOrder throws',
+    async (field) => {
+      mockEditOrder.mockRejectedValue(new Error('network error'));
+      const orderEdit = await renderOrderEditHarness();
+
+      await openEditSheet(orderEdit, field);
+      await confirmEdit(field);
+
+      await waitFor(() => {
+        expect(mockEditOrder).toHaveBeenCalled();
+      });
+
+      expect(mockUpdateOrderOptimistic).toHaveBeenNthCalledWith(
+        1,
+        order.orderId,
+        field === 'price' ? { limitPrice: '170' } : { size: '2' },
+      );
+      expect(mockUpdateOrderOptimistic).toHaveBeenNthCalledWith(
+        2,
+        order.orderId,
+        field === 'price' ? { limitPrice: order.price } : { size: '1' },
+      );
+      expect(mockFailedToast).toHaveBeenCalled();
+      expect(mockConfirmedToast).not.toHaveBeenCalled();
+    },
+  );
+
+  it('ignores a second confirm tap while an edit is in flight', async () => {
+    let resolveEdit: (value: OrderResult) => void = () => undefined;
+    mockEditOrder.mockImplementation(
+      () =>
+        new Promise<OrderResult>((resolve) => {
+          resolveEdit = resolve;
+        }),
+    );
+    const orderEdit = await renderOrderEditHarness();
+    await openEditSheet(orderEdit, 'price');
+
+    // Two presses fired without an intervening await: both reuse the same
+    // `editingOrder` closure before React flushes the state update from the
+    // first tap, which is exactly the race the isSubmittingEditRef guards.
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('perps-order-edit-confirm-price'));
+      fireEvent.press(screen.getByTestId('perps-order-edit-confirm-price'));
+    });
+
+    expect(mockEditOrder).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveEdit({ success: true, orderId: order.orderId });
+    });
+  });
+
+  it('closes the sheet without submitting when the value is unchanged', async () => {
+    const orderEdit = await renderOrderEditHarness();
+    await openEditSheet(orderEdit, 'price');
+
+    await act(async () => {
+      fireEvent.press(
+        screen.getByTestId('perps-order-edit-confirm-same-price'),
+      );
+    });
+
+    expect(mockEditOrder).not.toHaveBeenCalled();
+    expect(mockUpdateOrderOptimistic).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('perps-order-edit-sheet-price'),
+      ).not.toBeOnTheScreen();
+    });
+  });
+
+  it('does not open the sheet when a mutation is blocked', async () => {
+    const orderEdit = await renderOrderEditHarness(true);
+
+    await act(async () => {
+      orderEdit.handleEditOrderPrice(order);
+    });
+
+    expect(
+      screen.queryByTestId('perps-order-edit-sheet-price'),
+    ).not.toBeOnTheScreen();
+    expect(mockRunGatedEligibleAction).not.toHaveBeenCalled();
+  });
+
+  it('aborts confirm when a mutation becomes blocked while the sheet is open', async () => {
+    let orderEdit: ReturnType<typeof usePerpsProOrderEdit> | undefined;
+    const { rerender } = render(
+      <EditHarness
+        isMutationBlocked={false}
+        onReady={(readyOrderEdit) => {
+          orderEdit = readyOrderEdit;
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(orderEdit).toBeDefined();
+    });
+    if (!orderEdit) {
+      throw new Error('orderEdit harness failed to initialize');
+    }
+
+    await openEditSheet(orderEdit, 'price');
+
+    rerender(
+      <EditHarness
+        isMutationBlocked
+        onReady={(readyOrderEdit) => {
+          orderEdit = readyOrderEdit;
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(orderEdit).toBeDefined();
+    });
+    await confirmEdit('price');
+
+    expect(mockEditOrder).not.toHaveBeenCalled();
+    expect(mockUpdateOrderOptimistic).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('perps-order-edit-sheet-price'),
+      ).not.toBeOnTheScreen();
+    });
+  });
+
+  it('does not open the size sheet for orders with attached TP/SL', async () => {
+    const orderEdit = await renderOrderEditHarness();
+    const orderWithTpSl: Order = {
+      ...order,
+      takeProfitPrice: '200',
+      stopLossPrice: '100',
+    };
+
+    await act(async () => {
+      orderEdit.handleEditOrderSize(orderWithTpSl);
+    });
+
+    expect(
+      screen.queryByTestId('perps-order-edit-sheet-size'),
+    ).not.toBeOnTheScreen();
+    expect(mockRunGatedEligibleAction).not.toHaveBeenCalled();
+  });
+
+  it('re-checks live order eligibility from the stream snapshot on confirm', async () => {
+    mockGetSnapshot.mockReturnValue([
+      {
+        ...order,
+        filledSize: '0.5',
+        remainingSize: '0.5',
+      },
+    ]);
+    const orderEdit = await renderOrderEditHarness();
+    await openEditSheet(orderEdit, 'price');
+    await confirmEdit('price');
+
+    expect(mockEditOrder).not.toHaveBeenCalled();
+    expect(mockUpdateOrderOptimistic).not.toHaveBeenCalled();
+  });
+
+  it('aborts confirm when the order is absent from a loaded snapshot', async () => {
+    // Snapshot exists but the editing order was cancelled/filled while open —
+    // must not fall back to the stale open-time editingOrder and submit.
+    mockGetSnapshot.mockReturnValue([]);
+    const orderEdit = await renderOrderEditHarness();
+    await openEditSheet(orderEdit, 'price');
+    await confirmEdit('price');
+
+    expect(mockEditOrder).not.toHaveBeenCalled();
+    expect(mockUpdateOrderOptimistic).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('perps-order-edit-sheet-price'),
+      ).not.toBeOnTheScreen();
+    });
+  });
+
+  it('submits using the open-time order when the stream snapshot is unavailable', async () => {
+    mockGetSnapshot.mockReturnValue(null);
+    const orderEdit = await renderOrderEditHarness();
+    await openEditSheet(orderEdit, 'price');
+    await confirmEdit('price');
+
+    expect(mockEditOrder).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderId: order.orderId,
+        newOrder: expect.objectContaining({ price: '170' }),
+      }),
+    );
+  });
+});

--- a/app/components/UI/Perps/hooks/usePerpsProOrderEdit.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsProOrderEdit.test.tsx
@@ -22,9 +22,9 @@ const mockGetSnapshot = jest.fn(() => null as Order[] | null);
 const mockRunGatedEligibleAction = jest.fn(
   (_source: string, action: () => void) => action(),
 );
-const mockSubmittingToast = jest.fn(() => ({ type: 'submitting' }));
-const mockConfirmedToast = jest.fn(() => ({ type: 'confirmed' }));
-const mockFailedToast = jest.fn(() => ({ type: 'failed' }));
+const mockEditSubmittingToast = jest.fn(() => ({ type: 'edit-submitting' }));
+const mockEditConfirmedToast = jest.fn(() => ({ type: 'edit-confirmed' }));
+const mockEditFailedToast = jest.fn(() => ({ type: 'edit-failed' }));
 
 jest.mock('./usePerpsTrading', () => ({
   usePerpsTrading: () => ({
@@ -66,10 +66,10 @@ jest.mock('./usePerpsToasts', () => ({
     showToast: mockShowToast,
     PerpsToastOptions: {
       orderManagement: {
-        shared: { submitting: mockSubmittingToast },
         limit: {
-          confirmed: mockConfirmedToast,
-          creationFailed: mockFailedToast,
+          editSubmitting: mockEditSubmittingToast,
+          editConfirmed: mockEditConfirmedToast,
+          editFailed: mockEditFailedToast,
         },
       },
     },
@@ -249,9 +249,9 @@ describe('usePerpsProOrderEdit', () => {
           }),
         }),
       );
-      expect(mockSubmittingToast).toHaveBeenCalled();
-      expect(mockConfirmedToast).toHaveBeenCalled();
-      expect(mockFailedToast).not.toHaveBeenCalled();
+      expect(mockEditSubmittingToast).toHaveBeenCalled();
+      expect(mockEditConfirmedToast).toHaveBeenCalled();
+      expect(mockEditFailedToast).not.toHaveBeenCalled();
     },
   );
 
@@ -278,8 +278,8 @@ describe('usePerpsProOrderEdit', () => {
         order.orderId,
         field === 'price' ? { limitPrice: order.price } : { size: '1' },
       );
-      expect(mockFailedToast).toHaveBeenCalled();
-      expect(mockConfirmedToast).not.toHaveBeenCalled();
+      expect(mockEditFailedToast).toHaveBeenCalled();
+      expect(mockEditConfirmedToast).not.toHaveBeenCalled();
     },
   );
 
@@ -306,8 +306,8 @@ describe('usePerpsProOrderEdit', () => {
         order.orderId,
         field === 'price' ? { limitPrice: order.price } : { size: '1' },
       );
-      expect(mockFailedToast).toHaveBeenCalled();
-      expect(mockConfirmedToast).not.toHaveBeenCalled();
+      expect(mockEditFailedToast).toHaveBeenCalled();
+      expect(mockEditConfirmedToast).not.toHaveBeenCalled();
     },
   );
 

--- a/app/components/UI/Perps/hooks/usePerpsProOrderEdit.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsProOrderEdit.tsx
@@ -12,12 +12,10 @@ import {
   buildOrderEditParams,
   buildOrderOptimisticEdit,
   getOrderEditConfirmedSize,
-  getOrderEditMarketPrice,
   getOrderEditPreviousValue,
   hasOrderEditValueChanged,
   type OrderEditField,
 } from '../utils/orderEditUtils';
-import { toPerpsEntryAttribution } from '../utils/perpsAnalyticsAttribution';
 import {
   getOrderPositionDirection,
   isLimitOrderEditable,
@@ -213,19 +211,22 @@ export const usePerpsProOrderEdit = ({
       closeEditSheet();
       setEditingOrderId(orderToEdit.orderId);
       stream.orders.updateOrderOptimistic(orderToEdit.orderId, optimisticEdit);
-      showToast(PerpsToastOptions.orderManagement.shared.submitting());
+      showToast(PerpsToastOptions.orderManagement.limit.editSubmitting());
 
       try {
         const result = await editOrder({
           orderId: orderToEdit.orderId,
-          newOrder: buildOrderEditParams(orderToEdit, field, newValue, {
-            totalFee: 0,
-            marketPrice: getOrderEditMarketPrice(orderToEdit, field, newValue),
-            source: PRO_MARKET_SOURCE,
-            ...toPerpsEntryAttribution({
+          newOrder: buildOrderEditParams(
+            orderToEdit,
+            field,
+            newValue,
+            editingOrderLeverage,
+            {
+              totalFee: 0,
+              marketPrice: 0,
               source: PRO_MARKET_SOURCE,
-            }),
-          }),
+            },
+          ),
           // Size-only edits still send price (venue needs it) but the price
           // does not change — skip the ORDER_PRICE_UPDATED watcher so CUF
           // does not end on an unrelated orders refresh.
@@ -234,7 +235,7 @@ export const usePerpsProOrderEdit = ({
 
         if (result.success) {
           showToast(
-            PerpsToastOptions.orderManagement.limit.confirmed(
+            PerpsToastOptions.orderManagement.limit.editConfirmed(
               orderDirection,
               getOrderEditConfirmedSize(orderToEdit, field, newValue),
               orderToEdit.symbol,
@@ -248,9 +249,7 @@ export const usePerpsProOrderEdit = ({
             );
           }
           showToast(
-            PerpsToastOptions.orderManagement.limit.creationFailed(
-              result.error,
-            ),
+            PerpsToastOptions.orderManagement.limit.editFailed(result.error),
           );
         }
       } catch {
@@ -260,7 +259,7 @@ export const usePerpsProOrderEdit = ({
             buildOrderOptimisticEdit(field, previousValue),
           );
         }
-        showToast(PerpsToastOptions.orderManagement.limit.creationFailed());
+        showToast(PerpsToastOptions.orderManagement.limit.editFailed());
       } finally {
         setEditingOrderId(null);
         isSubmittingEditRef.current = false;

--- a/app/components/UI/Perps/hooks/usePerpsProOrderEdit.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsProOrderEdit.tsx
@@ -1,0 +1,324 @@
+import {
+  DECIMAL_PRECISION_CONFIG,
+  PERPS_CONSTANTS,
+  PERPS_EVENT_VALUE,
+  selectTradeConfiguration,
+  type Order,
+} from '@metamask/perps-controller';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import PerpsProOrderEditSheets from '../Views/PerpsProMarketView/components/PerpsProOrderEditSheets';
+import { usePerpsStream } from '../providers/PerpsStreamManager';
+import {
+  buildOrderEditParams,
+  buildOrderOptimisticEdit,
+  getOrderEditConfirmedSize,
+  getOrderEditMarketPrice,
+  getOrderEditPreviousValue,
+  hasOrderEditValueChanged,
+  type OrderEditField,
+} from '../utils/orderEditUtils';
+import { toPerpsEntryAttribution } from '../utils/perpsAnalyticsAttribution';
+import {
+  getOrderPositionDirection,
+  isLimitOrderEditable,
+  isLimitOrderSizeEditable,
+} from '../utils/orderUtils';
+import { usePerpsLivePositions } from './stream';
+import { usePerpsMarketData } from './usePerpsMarketData';
+import { usePerpsSelector } from './usePerpsSelector';
+import { usePerpsTrading } from './usePerpsTrading';
+import usePerpsToasts from './usePerpsToasts';
+
+const PRO_MARKET_SOURCE = PERPS_EVENT_VALUE.SOURCE.PERP_ASSET_SCREEN;
+
+export interface UsePerpsProOrderEditParams {
+  isMutationBlocked: boolean;
+  runGatedEligibleAction: (
+    source: string,
+    action: () => void | Promise<void>,
+  ) => void;
+}
+
+export interface UsePerpsProOrderEditReturn {
+  editingOrderId: string | null;
+  isOrderEditable: (order: Order) => boolean;
+  isOrderSizeEditable: (order: Order) => boolean;
+  handleEditOrderPrice: (order: Order) => void;
+  handleEditOrderSize: (order: Order) => void;
+  renderOrderEditSheets: () => React.ReactNode;
+}
+
+const isFieldEditable = (order: Order, field: OrderEditField): boolean =>
+  field === 'price'
+    ? isLimitOrderEditable(order)
+    : isLimitOrderSizeEditable(order);
+
+/**
+ * Shared Pro open-order edit flow for limit price and size.
+ */
+export const usePerpsProOrderEdit = ({
+  isMutationBlocked,
+  runGatedEligibleAction,
+}: UsePerpsProOrderEditParams): UsePerpsProOrderEditReturn => {
+  const { editOrder } = usePerpsTrading();
+  const stream = usePerpsStream();
+  const { showToast, PerpsToastOptions } = usePerpsToasts();
+
+  const [editingOrder, setEditingOrder] = useState<Order | null>(null);
+  const [editingOrderSheet, setEditingOrderSheet] =
+    useState<OrderEditField | null>(null);
+  const [editingOrderId, setEditingOrderId] = useState<string | null>(null);
+  // React state updates are batched/async, so a fast double-tap on confirm can
+  // re-enter handleConfirmEdit before editingOrderId reflects the first call.
+  // This ref is set synchronously to block that race regardless of render timing.
+  const isSubmittingEditRef = useRef(false);
+
+  const {
+    marketData: editingOrderMarketData,
+    isLoading: isEditingOrderMarketDataLoading,
+  } = usePerpsMarketData(editingOrder?.symbol ?? '');
+  const isEditingOrderMarketDataReady =
+    Boolean(editingOrderMarketData) && !isEditingOrderMarketDataLoading;
+  // Only expose real market precision/leverage once loaded — fallbacks are
+  // more permissive (decimals) or stricter (leverage) than most markets and
+  // must not drive keypad/confirm while loading.
+  const editingOrderSzDecimals = isEditingOrderMarketDataReady
+    ? (editingOrderMarketData?.szDecimals ??
+      DECIMAL_PRECISION_CONFIG.FallbackSizeDecimals)
+    : DECIMAL_PRECISION_CONFIG.FallbackSizeDecimals;
+  const editingOrderMaxLeverage = isEditingOrderMarketDataReady
+    ? (editingOrderMarketData?.maxLeverage ??
+      PERPS_CONSTANTS.DefaultMaxLeverage)
+    : PERPS_CONSTANTS.DefaultMaxLeverage;
+
+  // Prefer position leverage, then saved trade-config leverage, then market max.
+  // Max alone understates required margin when the user trades below the cap.
+  const { positions } = usePerpsLivePositions({ throttleMs: 1000 });
+  const savedTradeConfig = usePerpsSelector((state) =>
+    selectTradeConfiguration(state, editingOrder?.symbol ?? ''),
+  );
+  const editingOrderLeverage = useMemo(() => {
+    const symbol = editingOrder?.symbol;
+    if (!symbol) {
+      return editingOrderMaxLeverage;
+    }
+    const positionLeverage = positions.find((p) => p.symbol === symbol)
+      ?.leverage?.value;
+    if (typeof positionLeverage === 'number' && positionLeverage > 0) {
+      return positionLeverage;
+    }
+    const configLeverage = savedTradeConfig?.leverage;
+    if (typeof configLeverage === 'number' && configLeverage > 0) {
+      return configLeverage;
+    }
+    return editingOrderMaxLeverage;
+  }, [
+    editingOrder?.symbol,
+    editingOrderMaxLeverage,
+    positions,
+    savedTradeConfig?.leverage,
+  ]);
+
+  const isOrderEditable = useCallback(
+    (order: Order) => isLimitOrderEditable(order),
+    [],
+  );
+
+  const isOrderSizeEditable = useCallback(
+    (order: Order) => isLimitOrderSizeEditable(order),
+    [],
+  );
+
+  const closeEditSheet = useCallback(() => {
+    setEditingOrder(null);
+    setEditingOrderSheet(null);
+  }, []);
+
+  const openEditSheet = useCallback(
+    (order: Order, field: OrderEditField) => {
+      if (
+        !isFieldEditable(order, field) ||
+        isMutationBlocked ||
+        editingOrderId
+      ) {
+        return;
+      }
+
+      runGatedEligibleAction(
+        PERPS_EVENT_VALUE.SOURCE.MODIFY_POSITION_ACTION,
+        () => {
+          setEditingOrder(order);
+          setEditingOrderSheet(field);
+        },
+      );
+    },
+    [editingOrderId, isMutationBlocked, runGatedEligibleAction],
+  );
+
+  const handleEditOrderPrice = useCallback(
+    (order: Order) => openEditSheet(order, 'price'),
+    [openEditSheet],
+  );
+
+  const handleEditOrderSize = useCallback(
+    (order: Order) => openEditSheet(order, 'size'),
+    [openEditSheet],
+  );
+
+  const handleConfirmEdit = useCallback(
+    async (field: OrderEditField, newValue: string) => {
+      if (isSubmittingEditRef.current) {
+        return;
+      }
+
+      if (!editingOrder) {
+        return;
+      }
+
+      // Cancel (or another mutation) in flight — do not race editOrder against it.
+      if (isMutationBlocked || editingOrderId) {
+        closeEditSheet();
+        return;
+      }
+
+      // Re-read live order state at confirm — the sheet seed is a snapshot from
+      // open time and can miss partial fills / cancels that arrived while open.
+      const snapshot = stream.orders.getSnapshot?.() ?? null;
+      const liveOrder = snapshot?.find(
+        (cachedOrder) => cachedOrder.orderId === editingOrder.orderId,
+      );
+
+      // Snapshot loaded and order absent → cancelled/filled while sheet was open.
+      if (snapshot !== null && !liveOrder) {
+        closeEditSheet();
+        return;
+      }
+
+      const orderToEdit = liveOrder ?? editingOrder;
+      if (!isFieldEditable(orderToEdit, field)) {
+        closeEditSheet();
+        return;
+      }
+
+      if (!hasOrderEditValueChanged(orderToEdit, field, newValue)) {
+        closeEditSheet();
+        return;
+      }
+
+      const orderDirection = getOrderPositionDirection(orderToEdit);
+      const previousValue = getOrderEditPreviousValue(orderToEdit, field);
+      const optimisticEdit = buildOrderOptimisticEdit(field, newValue);
+
+      isSubmittingEditRef.current = true;
+      closeEditSheet();
+      setEditingOrderId(orderToEdit.orderId);
+      stream.orders.updateOrderOptimistic(orderToEdit.orderId, optimisticEdit);
+      showToast(PerpsToastOptions.orderManagement.shared.submitting());
+
+      try {
+        const result = await editOrder({
+          orderId: orderToEdit.orderId,
+          newOrder: buildOrderEditParams(orderToEdit, field, newValue, {
+            totalFee: 0,
+            marketPrice: getOrderEditMarketPrice(orderToEdit, field, newValue),
+            source: PRO_MARKET_SOURCE,
+            ...toPerpsEntryAttribution({
+              source: PRO_MARKET_SOURCE,
+            }),
+          }),
+          // Size-only edits still send price (venue needs it) but the price
+          // does not change — skip the ORDER_PRICE_UPDATED watcher so CUF
+          // does not end on an unrelated orders refresh.
+          watchPriceUpdate: field === 'price',
+        });
+
+        if (result.success) {
+          showToast(
+            PerpsToastOptions.orderManagement.limit.confirmed(
+              orderDirection,
+              getOrderEditConfirmedSize(orderToEdit, field, newValue),
+              orderToEdit.symbol,
+            ),
+          );
+        } else {
+          if (previousValue) {
+            stream.orders.updateOrderOptimistic(
+              orderToEdit.orderId,
+              buildOrderOptimisticEdit(field, previousValue),
+            );
+          }
+          showToast(
+            PerpsToastOptions.orderManagement.limit.creationFailed(
+              result.error,
+            ),
+          );
+        }
+      } catch {
+        if (previousValue) {
+          stream.orders.updateOrderOptimistic(
+            orderToEdit.orderId,
+            buildOrderOptimisticEdit(field, previousValue),
+          );
+        }
+        showToast(PerpsToastOptions.orderManagement.limit.creationFailed());
+      } finally {
+        setEditingOrderId(null);
+        isSubmittingEditRef.current = false;
+      }
+    },
+    [
+      closeEditSheet,
+      editOrder,
+      editingOrder,
+      editingOrderId,
+      isMutationBlocked,
+      PerpsToastOptions,
+      showToast,
+      stream,
+    ],
+  );
+
+  const handleConfirmEditPrice = useCallback(
+    (newLimitPrice: string) => handleConfirmEdit('price', newLimitPrice),
+    [handleConfirmEdit],
+  );
+
+  const handleConfirmEditSize = useCallback(
+    (newSize: string) => handleConfirmEdit('size', newSize),
+    [handleConfirmEdit],
+  );
+
+  const renderOrderEditSheets = useCallback(
+    () => (
+      <PerpsProOrderEditSheets
+        editingOrder={editingOrder}
+        editingOrderSheet={editingOrderSheet}
+        editingOrderSzDecimals={editingOrderSzDecimals}
+        editingOrderLeverage={editingOrderLeverage}
+        isEditingOrderMarketDataReady={isEditingOrderMarketDataReady}
+        onClose={closeEditSheet}
+        onConfirmPrice={handleConfirmEditPrice}
+        onConfirmSize={handleConfirmEditSize}
+      />
+    ),
+    [
+      closeEditSheet,
+      editingOrder,
+      editingOrderSheet,
+      editingOrderSzDecimals,
+      editingOrderLeverage,
+      handleConfirmEditPrice,
+      handleConfirmEditSize,
+      isEditingOrderMarketDataReady,
+    ],
+  );
+
+  return {
+    editingOrderId,
+    isOrderEditable,
+    isOrderSizeEditable,
+    handleEditOrderPrice,
+    handleEditOrderSize,
+    renderOrderEditSheets,
+  };
+};

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -132,6 +132,13 @@ export interface PerpsToastOptionsConfig {
         assetSymbol: string,
       ) => PerpsToastOptions;
       creationFailed: (error?: string) => PerpsToastOptions;
+      editSubmitting: () => PerpsToastOptions;
+      editConfirmed: (
+        direction: OrderDirection,
+        amount: string,
+        assetSymbol: string,
+      ) => PerpsToastOptions;
+      editFailed: (error?: string) => PerpsToastOptions;
     };
   };
   positionManagement: {
@@ -613,6 +620,40 @@ const usePerpsToasts = (): {
                 error,
                 fallbackMessage: strings(
                   'perps.order.your_funds_have_been_returned_to_you',
+                ),
+              }),
+            ),
+          }),
+          editSubmitting: () => ({
+            ...perpsBaseToastOptions.inProgress,
+            hasNoTimeout: true,
+            labelOptions: getPerpsToastLabels(
+              strings('perps.order.updating_your_order'),
+            ),
+          }),
+          editConfirmed: (
+            direction: OrderDirection,
+            amount: string,
+            assetSymbol: string,
+          ) => ({
+            ...perpsBaseToastOptions.success,
+            labelOptions: getPerpsToastLabels(
+              strings('perps.order.order_updated'),
+              strings('perps.order.order_placement_subtitle', {
+                direction: capitalize(direction),
+                amount,
+                assetSymbol: getPerpsDisplaySymbol(assetSymbol),
+              }),
+            ),
+          }),
+          editFailed: (error?: string) => ({
+            ...perpsBaseToastOptions.error,
+            labelOptions: getPerpsToastLabels(
+              strings('perps.order.order_update_failed'),
+              handlePerpsError({
+                error,
+                fallbackMessage: strings(
+                  'perps.order.order_update_failed_subtitle',
                 ),
               }),
             ),

--- a/app/components/UI/Perps/utils/orderEditUtils.ts
+++ b/app/components/UI/Perps/utils/orderEditUtils.ts
@@ -97,10 +97,12 @@ export const buildOrderEditParams = (
   order: Order,
   field: OrderEditField,
   newValue: string,
+  leverage: number,
   trackingData: OrderTrackingData,
 ): OrderParams =>
   buildEditOrderParamsFromOrder({
     order,
+    leverage,
     ...(field === 'price'
       ? { newLimitPrice: newValue }
       : { newSize: newValue }),

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1741,7 +1741,11 @@
       "order_cancelled_success": "{{detailedOrderType}} order cancelled",
       "pay_with_token_required": "Token selection required",
       "select_token_to_pay_with": "Please select a token to pay with before placing your order",
-      "initializing": "Initializing order..."
+      "initializing": "Initializing order...",
+      "updating_your_order": "Updating your order",
+      "order_updated": "Order updated",
+      "order_update_failed": "Failed to update order",
+      "order_update_failed_subtitle": "Your order is still open at its previous price and size."
     },
     "slippage": {
       "config_title": "Set slippage",


### PR DESCRIPTION
## **Description**

Stack **3/4** for [TAT-3642](https://consensyssoftware.atlassian.net/browse/TAT-3642) — Pro open-order price and size edit.

Adds the shared edit orchestration layer:

- `usePerpsProOrderEdit` — sheet state, confirm handler, optimistic apply/rollback, eligibility gates, mutation blocking
- `PerpsProOrderEditSheets` — renders limit price or size sheet from shared edit state
- Edit-specific toast copy (`updating your order` / `order updated` / `failed to update order`)
- Passes effective **leverage** into edit `OrderParams` for analytics

Depends on #34324. **Merge stack in order:** #34323 → #34324 → **#34325** → #34254

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #34254

Fixes:

## **Manual testing steps**

```gherkin
Feature: Pro open-order edit hook

  Scenario: Confirm applies optimistic patch and rolls back on failure
    Given an eligible open limit order
    When I confirm a price or size change and the venue edit fails
    Then the optimistic cache reverts and an edit-failed toast is shown

  Scenario: Unchanged value short-circuits without a network call
    Given the edit sheet is open
    When I confirm the same price or size as the resting order
    Then the sheet closes without calling editOrder
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TAT-3642]: https://consensyssoftware.atlassian.net/browse/TAT-3642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ