### PR TITLE
fix: cp-8.6.0 Fix re-selecting selected token in pay-with-modal

### DIFF
--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
@@ -317,6 +317,14 @@ describe('PayWithModal', () => {
       });
     });
 
+    it('does not call setPayToken when the selected token matches the current payToken', async () => {
+      const { findByText } = render();
+
+      fireEvent.press(await findByText('Native Token 1'));
+
+      expect(setPayTokenMock).not.toHaveBeenCalled();
+    });
+
     it('calls onPerpsPaymentTokenChange via close callback when type is perpsDepositAndOrder', async () => {
       useTransactionMetadataRequestMock.mockReturnValue({
         id: transactionIdMock,

--- a/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -137,6 +137,19 @@ export function PayWithModal() {
 
   const handleTokenSelect = useCallback(
     (token: AssetType) => {
+      if (
+        payToken &&
+        payToken.address.toLowerCase() === token.address.toLowerCase() &&
+        payToken.chainId.toLowerCase() === token.chainId?.toLowerCase()
+      ) {
+        close(() => {
+          if (dismissOnSelectCount > 1) {
+            navigation.dispatch(StackActions.pop(dismissOnSelectCount));
+          }
+        });
+        return;
+      }
+
       const onClosed = async () => {
         if (dismissOnSelectCount > 1) {
           navigation.dispatch(StackActions.pop(dismissOnSelectCount));
@@ -223,6 +236,7 @@ export function PayWithModal() {
       onMusdPaymentTokenChange,
       onPerpsPaymentTokenChange,
       onPredictPaymentTokenChange,
+      payToken,
       setPayToken,
       transactionMeta,
     ],

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.test.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.test.tsx
@@ -587,17 +587,14 @@ describe('usePayWithCryptoSection', () => {
     expect(goBackMock).toHaveBeenCalledTimes(1);
   });
 
-  it('dismisses the sheet when the already-selected preferred token row is pressed', () => {
+  it('does not call setPayToken but still dismisses the sheet when the already-selected preferred token row is pressed', () => {
     const { result } = renderHook(() => usePayWithCryptoSection());
 
     act(() => {
       result.current?.rows[0].onPress?.();
     });
 
-    expect(setPayTokenMock).toHaveBeenCalledWith({
-      address: TOKEN_MOCK.address,
-      chainId: TOKEN_MOCK.chainId,
-    });
+    expect(setPayTokenMock).not.toHaveBeenCalled();
     expect(goBackMock).toHaveBeenCalledTimes(1);
   });
 
@@ -1053,6 +1050,24 @@ describe('usePayWithCryptoSection', () => {
     it('does not call setTransactionConfig when no paymentOverride is active', () => {
       useSelectorMock.mockReturnValue(undefined);
 
+      // Use a distinct selected token so the preferred token is NOT already
+      // selected — otherwise the early-return guard skips setPayToken.
+      const distinctSelectedToken = {
+        ...TOKEN_MOCK,
+        address: SELECTED_TOKEN_MOCK.address,
+        symbol: SELECTED_TOKEN_MOCK.symbol,
+      };
+      usePayWithPreferredTokenMock.mockReturnValue({
+        hasTokens: true,
+        preferredToken: TOKEN_MOCK,
+        selectedToken: distinctSelectedToken,
+      });
+      usePayWithSelectedTokenMock.mockReturnValue({
+        isSelectedDistinctFromAutomatic: true,
+        selectedToken: SELECTED_TOKEN_MOCK,
+        selectToken: selectTokenMock,
+      });
+
       useTransactionMetadataRequestMock.mockReturnValue({
         id: 'tx-1',
         txParams: {},
@@ -1365,5 +1380,135 @@ describe('usePayWithCryptoSection', () => {
         }
       },
     );
+
+    it('does not call setPayToken when the no-fee token is already selected', () => {
+      const noFeeTokenMock = {
+        address: '0xnoFee' as Hex,
+        chainId: '0x1' as Hex,
+        symbol: 'USDT',
+        balanceUsd: '10',
+      };
+      const noFeeTokenFullMock: TransactionPaymentToken = {
+        ...TOKEN_MOCK,
+        address: noFeeTokenMock.address,
+        chainId: noFeeTokenMock.chainId,
+        symbol: noFeeTokenMock.symbol,
+        balanceUsd: noFeeTokenMock.balanceUsd,
+      };
+      usePayWithNoFeeTokenMock.mockReturnValue({
+        noFeeToken: noFeeTokenMock,
+        isNoFeeToken: isNoFeeTokenSharedMock,
+        renderNoFeeTag: jest.fn().mockReturnValue(null),
+        renderNoFeeTagForToken: renderNoFeeTagForTokenSharedMock,
+      });
+      usePayWithPreferredTokenMock.mockReturnValue({
+        hasTokens: true,
+        preferredToken: TOKEN_MOCK,
+        selectedToken: noFeeTokenFullMock,
+      });
+
+      const { result } = renderHook(() => usePayWithCryptoSection());
+
+      const noFeeRow = result.current?.rows.find(
+        (row) => row.id === 'crypto-no-fee-token',
+      );
+
+      act(() => {
+        noFeeRow?.onPress?.();
+      });
+
+      expect(setPayTokenMock).not.toHaveBeenCalled();
+      expect(onPerpsPaymentTokenChangeMock).not.toHaveBeenCalled();
+      expect(goBackMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('already-selected token early return', () => {
+    it('does not call setPayToken when pressing the preferred token that is already selected', () => {
+      const { result } = renderHook(() => usePayWithCryptoSection());
+
+      act(() => {
+        result.current?.rows[0].onPress?.();
+      });
+
+      expect(setPayTokenMock).not.toHaveBeenCalled();
+      expect(onPerpsPaymentTokenChangeMock).not.toHaveBeenCalled();
+      expect(onPredictPaymentTokenChangeMock).not.toHaveBeenCalled();
+      expect(goBackMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('still calls setPayToken when pressing a preferred token that is not selected', () => {
+      const distinctSelectedToken = {
+        ...TOKEN_MOCK,
+        address: SELECTED_TOKEN_MOCK.address,
+        symbol: SELECTED_TOKEN_MOCK.symbol,
+      };
+      usePayWithPreferredTokenMock.mockReturnValue({
+        hasTokens: true,
+        preferredToken: TOKEN_MOCK,
+        selectedToken: distinctSelectedToken,
+      });
+      usePayWithSelectedTokenMock.mockReturnValue({
+        isSelectedDistinctFromAutomatic: true,
+        selectedToken: SELECTED_TOKEN_MOCK,
+        selectToken: selectTokenMock,
+      });
+
+      const { result } = renderHook(() => usePayWithCryptoSection());
+
+      act(() => {
+        result.current?.rows[0].onPress?.();
+      });
+
+      expect(setPayTokenMock).toHaveBeenCalledWith({
+        address: TOKEN_MOCK.address,
+        chainId: TOKEN_MOCK.chainId,
+      });
+      expect(goBackMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onPerpsPaymentTokenChange on perpsDepositAndOrder when the preferred token is already selected', () => {
+      useTransactionMetadataRequestMock.mockReturnValue({
+        type: TransactionType.perpsDepositAndOrder,
+        txParams: {},
+      } as never);
+      useIsPerpsBalanceSelectedMock.mockReturnValue(false);
+
+      const { result } = renderHook(() => usePayWithCryptoSection());
+
+      act(() => {
+        result.current?.rows[0].onPress?.();
+      });
+
+      expect(onPerpsPaymentTokenChangeMock).not.toHaveBeenCalled();
+      expect(setPayTokenMock).not.toHaveBeenCalled();
+      expect(goBackMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onPredictPaymentTokenChange on predictDepositAndOrder when the preferred token is already selected', () => {
+      useTransactionMetadataRequestMock.mockReturnValue({
+        type: TransactionType.predictDepositAndOrder,
+        txParams: {},
+      } as never);
+      usePredictPaymentTokenMock.mockReturnValue({
+        onPaymentTokenChange: onPredictPaymentTokenChangeMock,
+        isPredictBalanceSelected: false,
+        selectedPaymentToken: {
+          address: TOKEN_MOCK.address,
+          chainId: TOKEN_MOCK.chainId,
+        },
+        resetSelectedPaymentToken: resetPredictPaymentTokenMock,
+      });
+
+      const { result } = renderHook(() => usePayWithCryptoSection());
+
+      act(() => {
+        result.current?.rows[0].onPress?.();
+      });
+
+      expect(onPredictPaymentTokenChangeMock).not.toHaveBeenCalled();
+      expect(setPayTokenMock).not.toHaveBeenCalled();
+      expect(goBackMock).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.test.tsx
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.test.tsx
@@ -15,6 +15,7 @@ import { MUSD_TOKEN_ADDRESS } from '../../../../../UI/Earn/constants/musd';
 import { useTransactionMetadataRequest } from '../../transactions/useTransactionMetadataRequest';
 import { useIsPerpsBalanceSelected } from '../../../../../UI/Perps/hooks/useIsPerpsBalanceSelected';
 import { usePerpsPaymentToken } from '../../../../../UI/Perps/hooks/usePerpsPaymentToken';
+import { markPerpsPaymentTokenSelection } from '../../../../../UI/Perps/utils/perpsPaymentTokenSelection';
 import { usePredictPaymentToken } from '../../../../../UI/Predict/hooks/usePredictPaymentToken';
 import { useLastUsedPaymentMethod } from '../useLastUsedPaymentMethod';
 import { usePayWithNoFeeToken } from '../usePayWithNoFeeToken';
@@ -61,6 +62,7 @@ jest.mock('../../../../../../core/Engine', () => ({
 }));
 jest.mock('../../../../../UI/Perps/hooks/useIsPerpsBalanceSelected');
 jest.mock('../../../../../UI/Perps/hooks/usePerpsPaymentToken');
+jest.mock('../../../../../UI/Perps/utils/perpsPaymentTokenSelection');
 jest.mock('../../../../../UI/Predict/hooks/usePredictPaymentToken');
 jest.mock('../useLastUsedPaymentMethod');
 jest.mock('../usePayWithNoFeeToken');
@@ -1467,7 +1469,7 @@ describe('usePayWithCryptoSection', () => {
       expect(goBackMock).toHaveBeenCalledTimes(1);
     });
 
-    it('does not call onPerpsPaymentTokenChange on perpsDepositAndOrder when the preferred token is already selected', () => {
+    it('does not call onPerpsPaymentTokenChange but still marks selection on perpsDepositAndOrder when the preferred token is already selected', () => {
       useTransactionMetadataRequestMock.mockReturnValue({
         type: TransactionType.perpsDepositAndOrder,
         txParams: {},
@@ -1480,6 +1482,7 @@ describe('usePayWithCryptoSection', () => {
         result.current?.rows[0].onPress?.();
       });
 
+      expect(markPerpsPaymentTokenSelection).toHaveBeenCalled();
       expect(onPerpsPaymentTokenChangeMock).not.toHaveBeenCalled();
       expect(setPayTokenMock).not.toHaveBeenCalled();
       expect(goBackMock).toHaveBeenCalledTimes(1);

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.ts
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.ts
@@ -162,6 +162,9 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
 
   const handlePreferredTokenPress = useCallback(() => {
     if (isPreferredTokenSelected) {
+      if (isPerpsDepositAndOrder) {
+        markPerpsPaymentTokenSelection();
+      }
       navigation.goBack();
       return;
     }
@@ -200,6 +203,9 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
 
   const handleNoFeeTokenPress = useCallback(() => {
     if (isNoFeeTokenSelected) {
+      if (isPerpsDepositAndOrder) {
+        markPerpsPaymentTokenSelection();
+      }
       navigation.goBack();
       return;
     }

--- a/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.ts
+++ b/app/components/Views/confirmations/hooks/pay/sections/usePayWithCryptoSection.ts
@@ -124,6 +124,18 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
 
   const clearPaymentOverride = useClearPaymentOverride();
 
+  const isPreferredTokenSelected = useMemo(
+    () =>
+      !isDedicatedSectionOwningSelection &&
+      isMatchingPayToken(selectedToken, preferredToken),
+    [isDedicatedSectionOwningSelection, preferredToken, selectedToken],
+  );
+
+  const isNoFeeTokenSelected = useMemo(
+    () => isMatchingPayToken(selectedToken, noFeeToken),
+    [noFeeToken, selectedToken],
+  );
+
   const isDeposit = hasTransactionType(transactionMeta, [
     TransactionType.perpsDeposit,
     TransactionType.predictDeposit,
@@ -149,6 +161,11 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
   }, [clearPaymentOverride, navigation]);
 
   const handlePreferredTokenPress = useCallback(() => {
+    if (isPreferredTokenSelected) {
+      navigation.goBack();
+      return;
+    }
+
     if (!preferredToken) {
       return;
     }
@@ -172,6 +189,7 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
   }, [
     clearPaymentOverride,
     isPerpsDepositAndOrder,
+    isPreferredTokenSelected,
     isPredictDepositAndOrder,
     navigation,
     onPerpsPaymentTokenChange,
@@ -181,6 +199,10 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
   ]);
 
   const handleNoFeeTokenPress = useCallback(() => {
+    if (isNoFeeTokenSelected) {
+      navigation.goBack();
+      return;
+    }
     if (!noFeeToken) {
       return;
     }
@@ -202,6 +224,7 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
     navigation.goBack();
   }, [
     clearPaymentOverride,
+    isNoFeeTokenSelected,
     isPerpsDepositAndOrder,
     isPredictDepositAndOrder,
     navigation,
@@ -241,13 +264,6 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
       });
 
     if (preferredToken && !isPreferredTokenMoneyAccountToken) {
-      // Suppress the checkmark when another section owns the selection
-      // (perps/predict balance or fiat). The flag flips back to false when the
-      // user explicitly picks a crypto token via "Other assets".
-      const isPreferredTokenSelected =
-        !isDedicatedSectionOwningSelection &&
-        isMatchingPayToken(selectedToken, preferredToken);
-
       const preferredAddress = preferredToken.address as Hex;
       const preferredChainId = preferredToken.chainId as Hex;
 
@@ -335,11 +351,6 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
       !isDedicatedSectionOwningSelection &&
       !noFeeTokenDuplicatesSelectedRow
     ) {
-      const isNoFeeTokenSelected = isMatchingPayToken(
-        selectedToken,
-        noFeeToken,
-      );
-
       const noFeeAddress = noFeeToken.address;
       const noFeeChainId = noFeeToken.chainId;
 
@@ -408,6 +419,8 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
     isDedicatedSectionOwningSelection,
     isDeposit,
     isMoneyAccountSelected,
+    isNoFeeTokenSelected,
+    isPreferredTokenSelected,
     isSelectedDistinctFromAutomatic,
     isWithdraw,
     noFeeToken,
@@ -416,7 +429,6 @@ export function usePayWithCryptoSection(): PayWithSectionConfig | null {
     preferredTokenBalance,
     renderLastUsedTag,
     renderNoFeeTagForToken,
-    selectedToken,
     selectedTokenBalance,
     selectedTokenDisplay,
     shouldShowNoFeeTokens,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

When a user taps a token that is already selected in the Pay With bottom sheet, the full selection handlers (setPayToken, onPerpsPaymentTokenChange, onPredictPaymentTokenChange, clearPaymentOverride, etc.) fire unnecessarily. This causes redundant state updates and controller calls for a no-op selection.

This PR adds early-return guards to all token press handlers so that re-selecting the currently active token skips the selection logic and simply dismisses the sheet:

- **`handlePreferredTokenPress`** — returns early (with `navigation.goBack()`) when `isPreferredTokenSelected` is already true.
- **`handleNoFeeTokenPress`** — returns early (with `navigation.goBack()`) when `isNoFeeTokenSelected` is already true.
- **`handleTokenSelect` (pay-with-modal)** — returns early (with `close()`) when the tapped token matches the current `payToken` by address and chainId.

To support this, `isPreferredTokenSelected` and `isNoFeeTokenSelected` were hoisted from the render-only `useMemo` into their own standalone `useMemo` hooks so both the handlers and the row config can reference them.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed redundant token selection logic when re-selecting the already active payment token in the Pay With sheet

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/34322

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Pay With token re-selection guard

  Scenario: user taps the already-selected preferred token
    Given the Pay With bottom sheet is open
    And the preferred token row shows a checkmark (already selected)

    When user taps the preferred token row
    Then the sheet dismisses
    And no setPayToken or controller calls are made

  Scenario: user taps a different token
    Given the Pay With bottom sheet is open
    And a non-selected token row is visible

    When user taps that token row
    Then the token is selected as the payment token
    And the sheet dismisses

  Scenario: user taps the already-selected token in Other Assets modal
    Given the Pay With Modal (Other Assets) is open
    And the currently active payToken is visible in the list

    When user taps that token
    Then the modal dismisses
    And no setPayToken or controller calls are made
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

See task detail for pre-existing issue

### **After**


https://github.com/user-attachments/assets/84324f7d-f485-4eee-9de9-27981f61db72



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX guard in confirmation pay flows with broad test coverage; no auth, payments execution, or data-model changes.
> 
> **Overview**
> **Pay With** no longer runs full payment-token selection when the user taps a token that is already active. The sheet or modal still closes.
> 
> In **`usePayWithCryptoSection`**, `isPreferredTokenSelected` and `isNoFeeTokenSelected` are hoisted into dedicated `useMemo` hooks so **`handlePreferredTokenPress`** and **`handleNoFeeTokenPress`** can bail out early: they call `navigation.goBack()` (and still call **`markPerpsPaymentTokenSelection`** on perps deposit-and-order when appropriate) without **`setPayToken`**, perps/predict change callbacks, or **`clearPaymentOverride`**. Choosing a different token behaves as before.
> 
> In **`pay-with-modal`**, **`handleTokenSelect`** compares the tapped token to **`payToken`** (case-insensitive address and chainId) and only **`close()`**s—skipping **`setPayToken`** and the rest of the selection path.
> 
> Tests were updated and expanded for these no-op re-select paths across preferred, no-fee, modal, and perps/predict flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f14e352fc4e34c50f2b05015578d7ffe2f5e8ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->