### PR TITLE
fix: MMQA-remove-system-tags-from-performance

### DIFF
--- a/tests/performance/login/asset-balances.spec.ts
+++ b/tests/performance/login/asset-balances.spec.ts
@@ -5,10 +5,13 @@ import TimerHelper from '../../framework/TimerHelper';
 import WalletView from '../../page-objects/wallet/WalletView';
 import { loginToAppPlaywright } from '../../flows/wallet.flow';
 
-import { System, PerformanceAssetLoading } from '../../tags.performance.js';
+import {
+  Performance,
+  PerformanceAssetLoading,
+} from '../../tags.performance.js';
 
 /* Scenario: Aggregated Balance Loading Time, SRP 1 + SRP 2 + SRP 3 */
-test.describe(`${System} ${PerformanceAssetLoading}`, () => {
+test.describe(`${Performance} ${PerformanceAssetLoading}`, () => {
   test(
     'Aggregated Balance Loading Time, SRP 1 + SRP 2 + SRP 3',
     { tag: '@assets-dev-team' },

--- a/tests/performance/login/cross-chain-swap-flow.spec.ts
+++ b/tests/performance/login/cross-chain-swap-flow.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '../../framework/fixtures/playwright';
 import TimerHelper from '../../framework/TimerHelper.js';
-import { System, PerformanceSwaps } from '../../tags.performance.js';
+import { Performance, PerformanceSwaps } from '../../tags.performance.js';
 import { loginToAppPlaywright } from '../../flows/wallet.flow.js';
 import { asPlaywrightElement, PlaywrightAssertions } from '../../framework';
 import WalletView from '../../page-objects/wallet/WalletView.js';
@@ -8,7 +8,7 @@ import QuoteView from '../../page-objects/swaps/QuoteView.js';
 import { checkSwapActivity } from '../../helpers/swap/swap-unified-ui';
 
 /* Scenario 7: Cross-chain swap flow - ETH to SOL - 50+ accounts, SRP 1 + SRP 2 + SRP 3 */
-test.describe(`${System} ${PerformanceSwaps}`, () => {
+test.describe(`${Performance} ${PerformanceSwaps}`, () => {
   test(
     'Cross-chain swap flow - ETH to SOL - 50+ accounts, SRP 1 + SRP 2 + SRP 3',
     { tag: '@swap-bridge-dev-team' },

--- a/tests/performance/login/eth-swap-flow.spec.ts
+++ b/tests/performance/login/eth-swap-flow.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '../../framework/fixtures/playwright';
 import TimerHelper from '../../framework/TimerHelper';
-import { System, PerformanceSwaps } from '../../tags.performance.js';
+import { Performance, PerformanceSwaps } from '../../tags.performance.js';
 import { loginToAppPlaywright } from '../../flows/wallet.flow';
 import WalletView from '../../page-objects/wallet/WalletView';
 import QuoteView from '../../page-objects/swaps/QuoteView';
@@ -8,7 +8,7 @@ import { checkSwapActivity } from '../../helpers/swap/swap-unified-ui';
 import { aiVisualTest, createTestConfig } from '../../framework/ai-visual';
 
 /* Scenario 6: Swap flow - ETH to LINK, SRP 1 + SRP 2 + SRP 3 */
-test.describe(`${System} ${PerformanceSwaps}`, () => {
+test.describe(`${Performance} ${PerformanceSwaps}`, () => {
   test(
     'Swap flow - ETH to LINK, SRP 1 + SRP 2 + SRP 3',
     { tag: '@swap-bridge-dev-team' },

--- a/tests/performance/login/import-multiple-srps.spec.ts
+++ b/tests/performance/login/import-multiple-srps.spec.ts
@@ -6,10 +6,10 @@ import ImportWalletView from '../../page-objects/Onboarding/ImportWalletView';
 import AddAccountBottomSheet from '../../page-objects/wallet/AddAccountBottomSheet';
 import AccountListBottomSheet from '../../page-objects/wallet/AccountListBottomSheet';
 import WalletView from '../../page-objects/wallet/WalletView';
-import { PerformanceAccountList } from '../../tags.performance.js';
+import { Performance, PerformanceAccountList } from '../../tags.performance.js';
 import PlaywrightGestures from '../../framework/PlaywrightGestures';
 /* Scenario 4: Import SRP with +50 accounts, SRP 1, SRP 2, SRP 3 */
-perfTest.describe(PerformanceAccountList, () => {
+perfTest.describe(`${Performance} ${PerformanceAccountList}`, () => {
   perfTest.setTimeout(30 * 60 * 1000);
   perfTest(
     'Import SRP with +50 accounts, SRP 1, SRP 2, SRP 3',

--- a/tests/performance/onboarding/import-wallet.spec.ts
+++ b/tests/performance/onboarding/import-wallet.spec.ts
@@ -27,7 +27,7 @@ import WalletView from '../../page-objects/wallet/WalletView.js';
 const testEnvironment = 'test'; // hard coding this for now. We need a new FF env in LD for e2e. An admin needs to create it..
 
 /* Scenario 4: Imported wallet with +50 accounts */
-test.describe(PerformanceOnboarding, () => {
+test.describe(`${Performance} ${PerformanceOnboarding}`, () => {
   test(
     'Onboarding Import SRP with +50 accounts, SRP 3',
     { tag: '@metamask-onboarding-team' },


### PR DESCRIPTION
## **Description**

The four performance specs used area tags (@PerformanceSwaps, @PerformanceAccountList, etc.) and, in some cases, @System, but they did not include the base @Performance tag.

Since tests/playwright.config.ts selects performance tests using @Performance, these scenarios were not being picked up by the performance suite. @System is replaced with @Performance, and @Performance is added where it was missing, while keeping the existing area tags.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: MMQA-remove-system-tags-from-performance

## **Manual testing steps**

```gherkin
Feature: Performance test tag selection

  Scenario: Select performance scenarios by the base performance tag
    Given the performance specs contain the @Performance tag
    When the Playwright performance configuration applies its @Performance grep
    Then the four scenarios are selected for performance execution
    And the scenarios are not selected by the @System grep
```

Validation commands:
- `yarn eslint tests/performance/login/asset-balances.spec.ts tests/performance/login/cross-chain-swap-flow.spec.ts tests/performance/login/eth-swap-flow.spec.ts tests/performance/login/import-multiple-srps.spec.ts`
- `git diff --check`

## **Screenshots/Recordings**

### **Before**

N/A — test-tagging-only change; no user interface changes.

### **After**

N/A — test-tagging-only change; no user interface changes.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android — runtime execution is delegated to the performance CI; the change only modifies Playwright selection tags.
- [x] I've tested with a power user scenario — existing power-user scenarios are unchanged; only their selection tags were corrected.
- [x] I've instrumented key operations with Sentry traces for production performance metrics — no instrumentation changes are required for this tag-only PR.
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test tagging only; no app or measurement logic changes.
> 
> **Overview**
> Several performance Playwright specs were labeled with area tags (and sometimes **`@System`**) but not the base **`@Performance`** tag. Because **`tests/playwright.config.ts`** runs performance work via **`grep: /@Performance\b/`**, those scenarios were not included in the performance suite.
> 
> **`test.describe`** titles now use **`${Performance} …`** (keeping existing area tags like **`@PerformanceSwaps`** and **`@PerformanceAccountList`**) in the login performance specs and onboarding import-wallet spec, replacing **`@System`** where it was used alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57dc20968eb42128d114a1a72930ba8616d17fcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->