### PR TITLE
feat: mirror token watchlist add/remove to Price Alerts ASSETS-3822

### DIFF
--- a/app/components/UI/Assets/PriceAlerts/api.test.ts
+++ b/app/components/UI/Assets/PriceAlerts/api.test.ts
@@ -13,8 +13,8 @@ import {
   updateAlertByType,
   deleteAlertByType,
   fetchSupportedChains,
-  addWatchlistAlert,
-  removeWatchlistAlert,
+  addWatchlistAlerts,
+  removeWatchlistAlerts,
   priceAlertsQueryKey,
   assertOkResponse,
   useSubmitPriceAlert,
@@ -134,29 +134,45 @@ describe('fetchSupportedChains', () => {
 
 const WATCHLIST_URL = `${ALERTS_URL}/watchlist`;
 
-describe('addWatchlistAlert', () => {
-  it('POSTs the CAIP-19 asset to /v1/alerts/watchlist', async () => {
-    await addWatchlistAlert('eip155:1/slip44:60');
+describe('addWatchlistAlerts', () => {
+  it('POSTs assetIds JSON body to /v1/alerts/watchlist', async () => {
+    const assetIds = [
+      'eip155:1/slip44:60',
+      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:So11111111111111111111111111111111111111112',
+    ];
+    await addWatchlistAlerts(assetIds);
     expect(mockGetBearerToken).toHaveBeenCalledTimes(1);
     const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
     expect(url).toBe(WATCHLIST_URL);
     expect(init.method).toBe('POST');
-    expect(init.body).toBe(JSON.stringify({ asset: 'eip155:1/slip44:60' }));
+    expect(init.body).toBe(JSON.stringify({ assetIds }));
     expect((init.headers as Record<string, string>)['Content-Type']).toBe(
       'application/json',
     );
   });
+
+  it('preserves Solana mint casing in the request body', async () => {
+    const mint =
+      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+    await addWatchlistAlerts([mint]);
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(init.body).toContain(mint);
+    expect(init.body).not.toContain(mint.toLowerCase());
+  });
 });
 
-describe('removeWatchlistAlert', () => {
-  it('DELETEs with the asset URL-encoded as a query param', async () => {
-    await removeWatchlistAlert('eip155:1/erc20:0xABCDEF');
+describe('removeWatchlistAlerts', () => {
+  it('DELETEs with the same assetIds JSON body (not query params)', async () => {
+    const assetIds = ['eip155:1/erc20:0xABCDEF'];
+    await removeWatchlistAlerts(assetIds);
     expect(mockGetBearerToken).toHaveBeenCalledTimes(1);
     const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe(
-      `${WATCHLIST_URL}?asset=${encodeURIComponent('eip155:1/erc20:0xABCDEF')}`,
-    );
+    expect(url).toBe(WATCHLIST_URL);
     expect(init.method).toBe('DELETE');
+    expect(init.body).toBe(JSON.stringify({ assetIds }));
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe(
+      'application/json',
+    );
   });
 });
 

--- a/app/components/UI/Assets/PriceAlerts/api.test.ts
+++ b/app/components/UI/Assets/PriceAlerts/api.test.ts
@@ -13,6 +13,8 @@ import {
   updateAlertByType,
   deleteAlertByType,
   fetchSupportedChains,
+  addWatchlistAlert,
+  removeWatchlistAlert,
   priceAlertsQueryKey,
   assertOkResponse,
   useSubmitPriceAlert,
@@ -127,6 +129,34 @@ describe('fetchSupportedChains', () => {
     const response = makeOkResponse({ chains: ['eip155:1'] });
     mockFetch.mockResolvedValue(response);
     expect(await fetchSupportedChains()).toBe(response);
+  });
+});
+
+const WATCHLIST_URL = `${ALERTS_URL}/watchlist`;
+
+describe('addWatchlistAlert', () => {
+  it('POSTs the CAIP-19 asset to /v1/alerts/watchlist', async () => {
+    await addWatchlistAlert('eip155:1/slip44:60');
+    expect(mockGetBearerToken).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(WATCHLIST_URL);
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe(JSON.stringify({ asset: 'eip155:1/slip44:60' }));
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe(
+      'application/json',
+    );
+  });
+});
+
+describe('removeWatchlistAlert', () => {
+  it('DELETEs with the asset URL-encoded as a query param', async () => {
+    await removeWatchlistAlert('eip155:1/erc20:0xABCDEF');
+    expect(mockGetBearerToken).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      `${WATCHLIST_URL}?asset=${encodeURIComponent('eip155:1/erc20:0xABCDEF')}`,
+    );
+    expect(init.method).toBe('DELETE');
   });
 });
 

--- a/app/components/UI/Assets/PriceAlerts/api.ts
+++ b/app/components/UI/Assets/PriceAlerts/api.ts
@@ -44,25 +44,32 @@ export const fetchSupportedChains = (): Promise<Response> =>
   });
 
 /**
- * Mirrors a real-watchlist add into Price Alerts.
- * Idempotent — `201` whether the asset was already present or newly created.
+ * Mirrors real-watchlist adds into Price Alerts.
+ * Body: `{ assetIds: string[] }`. Response 200 includes processed/unprocessed.
  */
-export const addWatchlistAlert = (asset: string): Promise<Response> =>
+export const addWatchlistAlerts = (assetIds: string[]): Promise<Response> =>
   authenticatedFetch(WATCHLIST_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ asset }),
+    body: JSON.stringify({ assetIds }),
   });
 
 /**
- * Mirrors a real-watchlist remove into Price Alerts.
- * Idempotent — `204` even when the asset was not present (never `404`).
+ * Mirrors real-watchlist removes into Price Alerts.
+ * Same JSON body as POST (not query params). Idempotent when already absent.
  */
-export const removeWatchlistAlert = (asset: string): Promise<Response> =>
-  authenticatedFetch(`${WATCHLIST_URL}?asset=${encodeURIComponent(asset)}`, {
+export const removeWatchlistAlerts = (assetIds: string[]): Promise<Response> =>
+  authenticatedFetch(WATCHLIST_URL, {
     method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ assetIds }),
   });
 
+/** 200 response body from POST/DELETE `/v1/alerts/watchlist`. */
+export interface WatchlistAlertsResult {
+  processedAssetIds: string[];
+  unprocessedAssetIds: string[];
+}
 export const createAlert = (params: SaveAlertParams): Promise<Response> =>
   authenticatedFetch(ALERTS_URL, {
     method: 'POST',

--- a/app/components/UI/Assets/PriceAlerts/api.ts
+++ b/app/components/UI/Assets/PriceAlerts/api.ts
@@ -13,6 +13,7 @@ import type {
 
 const ALERTS_URL = `${AppConstants.PRICE_ALERTS_API.URL}/v1/alerts`;
 const PERCENT_ALERTS_URL = `${ALERTS_URL}/percent-change`;
+const WATCHLIST_URL = `${ALERTS_URL}/watchlist`;
 
 export const priceAlertsQueryKey = (assetId: string) =>
   ['priceAlerts', assetId] as const;
@@ -40,6 +41,26 @@ export const fetchSupportedChains = (): Promise<Response> =>
   fetch(`${ALERTS_URL}/supported-chains`, {
     headers: { Accept: 'application/json' },
     credentials: 'omit',
+  });
+
+/**
+ * Mirrors a real-watchlist add into Price Alerts.
+ * Idempotent — `201` whether the asset was already present or newly created.
+ */
+export const addWatchlistAlert = (asset: string): Promise<Response> =>
+  authenticatedFetch(WATCHLIST_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ asset }),
+  });
+
+/**
+ * Mirrors a real-watchlist remove into Price Alerts.
+ * Idempotent — `204` even when the asset was not present (never `404`).
+ */
+export const removeWatchlistAlert = (asset: string): Promise<Response> =>
+  authenticatedFetch(`${WATCHLIST_URL}?asset=${encodeURIComponent(asset)}`, {
+    method: 'DELETE',
   });
 
 export const createAlert = (params: SaveAlertParams): Promise<Response> =>

--- a/app/components/UI/Assets/PriceAlerts/syncWatchlistMirror.test.ts
+++ b/app/components/UI/Assets/PriceAlerts/syncWatchlistMirror.test.ts
@@ -1,13 +1,6 @@
 import Logger from '../../../../util/Logger';
-import {
-  addWatchlistAlert,
-  fetchSupportedChains,
-  removeWatchlistAlert,
-} from './api';
-import {
-  resetSupportedChainsCacheForTests,
-  syncPriceAlertsWatchlistMirror,
-} from './syncWatchlistMirror';
+import { addWatchlistAlert, removeWatchlistAlert } from './api';
+import { syncPriceAlertsWatchlistMirror } from './syncWatchlistMirror';
 
 jest.mock('../../../../util/Logger', () => ({
   __esModule: true,
@@ -19,7 +12,6 @@ jest.mock('../../../../util/Logger', () => ({
 jest.mock('./api', () => ({
   addWatchlistAlert: jest.fn(),
   removeWatchlistAlert: jest.fn(),
-  fetchSupportedChains: jest.fn(),
   assertOkResponse: jest.requireActual('./api').assertOkResponse,
 }));
 
@@ -28,9 +20,6 @@ const mockedAdd = addWatchlistAlert as jest.MockedFunction<
 >;
 const mockedRemove = removeWatchlistAlert as jest.MockedFunction<
   typeof removeWatchlistAlert
->;
-const mockedFetchSupportedChains = fetchSupportedChains as jest.MockedFunction<
-  typeof fetchSupportedChains
 >;
 
 const ETH = 'eip155:1/slip44:60';
@@ -55,16 +44,12 @@ const makeErrorResponse = (status: number, bodyText = 'error') =>
 
 beforeEach(() => {
   jest.clearAllMocks();
-  resetSupportedChainsCacheForTests();
-  mockedFetchSupportedChains.mockResolvedValue(
-    makeOkResponse(['eip155:1', 'eip155:137']),
-  );
   mockedAdd.mockResolvedValue(makeOkResponse(undefined, 201));
   mockedRemove.mockResolvedValue(makeOkResponse(undefined, 204));
 });
 
 describe('syncPriceAlertsWatchlistMirror', () => {
-  it('POSTs newly added assets on supported chains', async () => {
+  it('POSTs newly added assets', async () => {
     await syncPriceAlertsWatchlistMirror([], [ETH, USDC]);
 
     expect(mockedAdd).toHaveBeenCalledTimes(2);
@@ -73,7 +58,7 @@ describe('syncPriceAlertsWatchlistMirror', () => {
     expect(mockedRemove).not.toHaveBeenCalled();
   });
 
-  it('DELETEs removed assets on supported chains', async () => {
+  it('DELETEs removed assets', async () => {
     await syncPriceAlertsWatchlistMirror([ETH, USDC], [ETH]);
 
     expect(mockedRemove).toHaveBeenCalledTimes(1);
@@ -81,28 +66,19 @@ describe('syncPriceAlertsWatchlistMirror', () => {
     expect(mockedAdd).not.toHaveBeenCalled();
   });
 
-  it('skips assets on unsupported chains', async () => {
+  it('always mirrors every net membership change (API decides support)', async () => {
     await syncPriceAlertsWatchlistMirror([], [ETH, BSC_TOKEN]);
 
-    expect(mockedAdd).toHaveBeenCalledTimes(1);
+    expect(mockedAdd).toHaveBeenCalledTimes(2);
     expect(mockedAdd).toHaveBeenCalledWith(ETH);
-    expect(mockedAdd).not.toHaveBeenCalledWith(BSC_TOKEN);
+    expect(mockedAdd).toHaveBeenCalledWith(BSC_TOKEN);
   });
 
   it('no-ops when membership is unchanged (reorder only)', async () => {
     await syncPriceAlertsWatchlistMirror([ETH, USDC], [USDC, ETH]);
 
-    expect(mockedFetchSupportedChains).not.toHaveBeenCalled();
     expect(mockedAdd).not.toHaveBeenCalled();
     expect(mockedRemove).not.toHaveBeenCalled();
-  });
-
-  it('skips all mirrors when supported-chains cannot be loaded', async () => {
-    mockedFetchSupportedChains.mockResolvedValue(makeErrorResponse(500));
-
-    await syncPriceAlertsWatchlistMirror([], [ETH]);
-
-    expect(mockedAdd).not.toHaveBeenCalled();
   });
 
   it('soft-fails POST errors without throwing', async () => {
@@ -123,13 +99,5 @@ describe('syncPriceAlertsWatchlistMirror', () => {
     ).resolves.toBeUndefined();
 
     expect(Logger.error).toHaveBeenCalled();
-  });
-
-  it('caches supported chains across calls', async () => {
-    await syncPriceAlertsWatchlistMirror([], [ETH]);
-    await syncPriceAlertsWatchlistMirror([ETH], [ETH, USDC]);
-
-    expect(mockedFetchSupportedChains).toHaveBeenCalledTimes(1);
-    expect(mockedAdd).toHaveBeenCalledTimes(2);
   });
 });

--- a/app/components/UI/Assets/PriceAlerts/syncWatchlistMirror.test.ts
+++ b/app/components/UI/Assets/PriceAlerts/syncWatchlistMirror.test.ts
@@ -1,0 +1,135 @@
+import Logger from '../../../../util/Logger';
+import {
+  addWatchlistAlert,
+  fetchSupportedChains,
+  removeWatchlistAlert,
+} from './api';
+import {
+  resetSupportedChainsCacheForTests,
+  syncPriceAlertsWatchlistMirror,
+} from './syncWatchlistMirror';
+
+jest.mock('../../../../util/Logger', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('./api', () => ({
+  addWatchlistAlert: jest.fn(),
+  removeWatchlistAlert: jest.fn(),
+  fetchSupportedChains: jest.fn(),
+  assertOkResponse: jest.requireActual('./api').assertOkResponse,
+}));
+
+const mockedAdd = addWatchlistAlert as jest.MockedFunction<
+  typeof addWatchlistAlert
+>;
+const mockedRemove = removeWatchlistAlert as jest.MockedFunction<
+  typeof removeWatchlistAlert
+>;
+const mockedFetchSupportedChains = fetchSupportedChains as jest.MockedFunction<
+  typeof fetchSupportedChains
+>;
+
+const ETH = 'eip155:1/slip44:60';
+const USDC = 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+const BSC_TOKEN = 'eip155:56/slip44:714';
+
+const makeOkResponse = (body?: unknown, status = 200) =>
+  ({
+    ok: true,
+    status,
+    json: jest.fn().mockResolvedValue(body ?? []),
+    text: jest.fn().mockResolvedValue(''),
+  }) as unknown as Response;
+
+const makeErrorResponse = (status: number, bodyText = 'error') =>
+  ({
+    ok: false,
+    status,
+    json: jest.fn().mockResolvedValue({}),
+    text: jest.fn().mockResolvedValue(bodyText),
+  }) as unknown as Response;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetSupportedChainsCacheForTests();
+  mockedFetchSupportedChains.mockResolvedValue(
+    makeOkResponse(['eip155:1', 'eip155:137']),
+  );
+  mockedAdd.mockResolvedValue(makeOkResponse(undefined, 201));
+  mockedRemove.mockResolvedValue(makeOkResponse(undefined, 204));
+});
+
+describe('syncPriceAlertsWatchlistMirror', () => {
+  it('POSTs newly added assets on supported chains', async () => {
+    await syncPriceAlertsWatchlistMirror([], [ETH, USDC]);
+
+    expect(mockedAdd).toHaveBeenCalledTimes(2);
+    expect(mockedAdd).toHaveBeenCalledWith(ETH);
+    expect(mockedAdd).toHaveBeenCalledWith(USDC);
+    expect(mockedRemove).not.toHaveBeenCalled();
+  });
+
+  it('DELETEs removed assets on supported chains', async () => {
+    await syncPriceAlertsWatchlistMirror([ETH, USDC], [ETH]);
+
+    expect(mockedRemove).toHaveBeenCalledTimes(1);
+    expect(mockedRemove).toHaveBeenCalledWith(USDC);
+    expect(mockedAdd).not.toHaveBeenCalled();
+  });
+
+  it('skips assets on unsupported chains', async () => {
+    await syncPriceAlertsWatchlistMirror([], [ETH, BSC_TOKEN]);
+
+    expect(mockedAdd).toHaveBeenCalledTimes(1);
+    expect(mockedAdd).toHaveBeenCalledWith(ETH);
+    expect(mockedAdd).not.toHaveBeenCalledWith(BSC_TOKEN);
+  });
+
+  it('no-ops when membership is unchanged (reorder only)', async () => {
+    await syncPriceAlertsWatchlistMirror([ETH, USDC], [USDC, ETH]);
+
+    expect(mockedFetchSupportedChains).not.toHaveBeenCalled();
+    expect(mockedAdd).not.toHaveBeenCalled();
+    expect(mockedRemove).not.toHaveBeenCalled();
+  });
+
+  it('skips all mirrors when supported-chains cannot be loaded', async () => {
+    mockedFetchSupportedChains.mockResolvedValue(makeErrorResponse(500));
+
+    await syncPriceAlertsWatchlistMirror([], [ETH]);
+
+    expect(mockedAdd).not.toHaveBeenCalled();
+  });
+
+  it('soft-fails POST errors without throwing', async () => {
+    mockedAdd.mockResolvedValue(makeErrorResponse(422, 'unsupported asset'));
+
+    await expect(
+      syncPriceAlertsWatchlistMirror([], [ETH]),
+    ).resolves.toBeUndefined();
+
+    expect(Logger.error).toHaveBeenCalled();
+  });
+
+  it('soft-fails DELETE errors without throwing', async () => {
+    mockedRemove.mockRejectedValue(new Error('network down'));
+
+    await expect(
+      syncPriceAlertsWatchlistMirror([ETH], []),
+    ).resolves.toBeUndefined();
+
+    expect(Logger.error).toHaveBeenCalled();
+  });
+
+  it('caches supported chains across calls', async () => {
+    await syncPriceAlertsWatchlistMirror([], [ETH]);
+    await syncPriceAlertsWatchlistMirror([ETH], [ETH, USDC]);
+
+    expect(mockedFetchSupportedChains).toHaveBeenCalledTimes(1);
+    expect(mockedAdd).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/components/UI/Assets/PriceAlerts/syncWatchlistMirror.test.ts
+++ b/app/components/UI/Assets/PriceAlerts/syncWatchlistMirror.test.ts
@@ -1,36 +1,43 @@
 import Logger from '../../../../util/Logger';
-import { addWatchlistAlert, removeWatchlistAlert } from './api';
+import { addWatchlistAlerts, removeWatchlistAlerts } from './api';
 import { syncPriceAlertsWatchlistMirror } from './syncWatchlistMirror';
 
 jest.mock('../../../../util/Logger', () => ({
   __esModule: true,
   default: {
     error: jest.fn(),
+    log: jest.fn(),
   },
 }));
 
 jest.mock('./api', () => ({
-  addWatchlistAlert: jest.fn(),
-  removeWatchlistAlert: jest.fn(),
+  addWatchlistAlerts: jest.fn(),
+  removeWatchlistAlerts: jest.fn(),
   assertOkResponse: jest.requireActual('./api').assertOkResponse,
 }));
 
-const mockedAdd = addWatchlistAlert as jest.MockedFunction<
-  typeof addWatchlistAlert
+const mockedAdd = addWatchlistAlerts as jest.MockedFunction<
+  typeof addWatchlistAlerts
 >;
-const mockedRemove = removeWatchlistAlert as jest.MockedFunction<
-  typeof removeWatchlistAlert
+const mockedRemove = removeWatchlistAlerts as jest.MockedFunction<
+  typeof removeWatchlistAlerts
 >;
 
 const ETH = 'eip155:1/slip44:60';
 const USDC = 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
-const BSC_TOKEN = 'eip155:56/slip44:714';
+const APE = 'eip155:33139/slip44:60';
+const SOLANA_MINT =
+  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 
 const makeOkResponse = (body?: unknown, status = 200) =>
   ({
     ok: true,
     status,
-    json: jest.fn().mockResolvedValue(body ?? []),
+    json: jest
+      .fn()
+      .mockResolvedValue(
+        body ?? { processedAssetIds: [], unprocessedAssetIds: [] },
+      ),
     text: jest.fn().mockResolvedValue(''),
   }) as unknown as Response;
 
@@ -44,34 +51,72 @@ const makeErrorResponse = (status: number, bodyText = 'error') =>
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockedAdd.mockResolvedValue(makeOkResponse(undefined, 201));
-  mockedRemove.mockResolvedValue(makeOkResponse(undefined, 204));
+  mockedAdd.mockResolvedValue(
+    makeOkResponse({
+      processedAssetIds: [ETH],
+      unprocessedAssetIds: [],
+    }),
+  );
+  mockedRemove.mockResolvedValue(
+    makeOkResponse({
+      processedAssetIds: [ETH],
+      unprocessedAssetIds: [],
+    }),
+  );
 });
 
 describe('syncPriceAlertsWatchlistMirror', () => {
-  it('POSTs newly added assets', async () => {
+  it('POSTs newly added assets as a single assetIds batch', async () => {
     await syncPriceAlertsWatchlistMirror([], [ETH, USDC]);
 
-    expect(mockedAdd).toHaveBeenCalledTimes(2);
-    expect(mockedAdd).toHaveBeenCalledWith(ETH);
-    expect(mockedAdd).toHaveBeenCalledWith(USDC);
+    expect(mockedAdd).toHaveBeenCalledTimes(1);
+    expect(mockedAdd).toHaveBeenCalledWith([ETH, USDC]);
     expect(mockedRemove).not.toHaveBeenCalled();
   });
 
-  it('DELETEs removed assets', async () => {
+  it('DELETEs removed assets as a single assetIds batch', async () => {
     await syncPriceAlertsWatchlistMirror([ETH, USDC], [ETH]);
 
     expect(mockedRemove).toHaveBeenCalledTimes(1);
-    expect(mockedRemove).toHaveBeenCalledWith(USDC);
+    expect(mockedRemove).toHaveBeenCalledWith([USDC]);
     expect(mockedAdd).not.toHaveBeenCalled();
   });
 
-  it('always mirrors every net membership change (API decides support)', async () => {
-    await syncPriceAlertsWatchlistMirror([], [ETH, BSC_TOKEN]);
+  it('logs unprocessedAssetIds on 200 without throwing', async () => {
+    mockedAdd.mockResolvedValue(
+      makeOkResponse({
+        processedAssetIds: [ETH],
+        unprocessedAssetIds: [APE],
+      }),
+    );
 
-    expect(mockedAdd).toHaveBeenCalledTimes(2);
-    expect(mockedAdd).toHaveBeenCalledWith(ETH);
-    expect(mockedAdd).toHaveBeenCalledWith(BSC_TOKEN);
+    await expect(
+      syncPriceAlertsWatchlistMirror([], [ETH, APE]),
+    ).resolves.toBeUndefined();
+
+    expect(mockedAdd).toHaveBeenCalledWith([ETH, APE]);
+    expect(Logger.log).toHaveBeenCalledWith(
+      'Price Alerts watchlist partial processing',
+      expect.objectContaining({
+        action: 'POST',
+        unprocessedAssetIds: [APE],
+        processedAssetIds: [ETH],
+      }),
+    );
+    expect(Logger.error).not.toHaveBeenCalled();
+  });
+
+  it('preserves Solana mint casing when mirroring adds', async () => {
+    mockedAdd.mockResolvedValue(
+      makeOkResponse({
+        processedAssetIds: [SOLANA_MINT],
+        unprocessedAssetIds: [],
+      }),
+    );
+
+    await syncPriceAlertsWatchlistMirror([], [SOLANA_MINT]);
+
+    expect(mockedAdd).toHaveBeenCalledWith([SOLANA_MINT]);
   });
 
   it('no-ops when membership is unchanged (reorder only)', async () => {
@@ -81,17 +126,20 @@ describe('syncPriceAlertsWatchlistMirror', () => {
     expect(mockedRemove).not.toHaveBeenCalled();
   });
 
-  it('soft-fails POST errors without throwing', async () => {
-    mockedAdd.mockResolvedValue(makeErrorResponse(422, 'unsupported asset'));
+  it.each([400, 401, 500])(
+    'soft-fails POST HTTP %s without throwing',
+    async (status) => {
+      mockedAdd.mockResolvedValue(makeErrorResponse(status, 'failed'));
 
-    await expect(
-      syncPriceAlertsWatchlistMirror([], [ETH]),
-    ).resolves.toBeUndefined();
+      await expect(
+        syncPriceAlertsWatchlistMirror([], [ETH]),
+      ).resolves.toBeUndefined();
 
-    expect(Logger.error).toHaveBeenCalled();
-  });
+      expect(Logger.error).toHaveBeenCalled();
+    },
+  );
 
-  it('soft-fails DELETE errors without throwing', async () => {
+  it('soft-fails DELETE network errors without throwing', async () => {
     mockedRemove.mockRejectedValue(new Error('network down'));
 
     await expect(

--- a/app/components/UI/Assets/PriceAlerts/syncWatchlistMirror.ts
+++ b/app/components/UI/Assets/PriceAlerts/syncWatchlistMirror.ts
@@ -1,0 +1,128 @@
+import { isCaipAssetType, parseCaipAssetType } from '@metamask/utils';
+
+import Logger from '../../../../util/Logger';
+import {
+  addWatchlistAlert,
+  assertOkResponse,
+  fetchSupportedChains,
+  removeWatchlistAlert,
+} from './api';
+
+const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
+
+let cachedSupportedChains: string[] | null = null;
+let cachedSupportedChainsAt = 0;
+
+/**
+ * Clears the in-memory supported-chains cache. Test-only.
+ */
+export const resetSupportedChainsCacheForTests = (): void => {
+  cachedSupportedChains = null;
+  cachedSupportedChainsAt = 0;
+};
+
+async function getSupportedChains(): Promise<string[] | null> {
+  const now = Date.now();
+  if (
+    cachedSupportedChains !== null &&
+    now - cachedSupportedChainsAt < TWENTY_FOUR_HOURS_MS
+  ) {
+    return cachedSupportedChains;
+  }
+
+  try {
+    const response = await fetchSupportedChains();
+    if (!response.ok) {
+      return cachedSupportedChains;
+    }
+    const body = (await response.json()) as string[];
+    if (!Array.isArray(body)) {
+      return cachedSupportedChains;
+    }
+    cachedSupportedChains = body;
+    cachedSupportedChainsAt = now;
+    return cachedSupportedChains;
+  } catch (error) {
+    Logger.error(error as Error, {
+      message:
+        'Failed to fetch Price Alerts supported chains for watchlist mirror',
+    });
+    return cachedSupportedChains;
+  }
+}
+
+const isSupportedAsset = (
+  asset: string,
+  supportedChains: readonly string[],
+): boolean => {
+  if (!isCaipAssetType(asset)) {
+    return false;
+  }
+  const { chainId } = parseCaipAssetType(asset);
+  return supportedChains.includes(chainId);
+};
+
+const softFailMirror = async (
+  action: 'POST' | 'DELETE',
+  asset: string,
+  request: () => Promise<Response>,
+): Promise<void> => {
+  try {
+    const response = await request();
+    await assertOkResponse(response);
+  } catch (error) {
+    Logger.error(error as Error, {
+      message: `Price Alerts watchlist ${action} soft-fail`,
+      asset,
+    });
+  }
+};
+
+/**
+ * After the real token watchlist blob is updated, mirror net membership
+ * changes into Price Alerts for supported chains only.
+ *
+ * Soft-fails on every Price Alerts error — never throws, never rolls back
+ * the real watchlist write.
+ */
+export async function syncPriceAlertsWatchlistMirror(
+  previousAssets: readonly string[],
+  nextAssets: readonly string[],
+): Promise<void> {
+  const previousLower = new Set(
+    previousAssets.map((asset) => asset.toLowerCase()),
+  );
+  const nextLower = new Set(nextAssets.map((asset) => asset.toLowerCase()));
+
+  const added = nextAssets.filter(
+    (asset) => !previousLower.has(asset.toLowerCase()),
+  );
+  const removed = previousAssets.filter(
+    (asset) => !nextLower.has(asset.toLowerCase()),
+  );
+
+  if (added.length === 0 && removed.length === 0) {
+    return;
+  }
+
+  const supportedChains = await getSupportedChains();
+  if (supportedChains === null) {
+    return;
+  }
+
+  const supportedAdded = added.filter((asset) =>
+    isSupportedAsset(asset, supportedChains),
+  );
+  const supportedRemoved = removed.filter((asset) =>
+    isSupportedAsset(asset, supportedChains),
+  );
+
+  await Promise.all([
+    ...supportedAdded.map((asset) =>
+      softFailMirror('POST', asset, () => addWatchlistAlert(asset)),
+    ),
+    ...supportedRemoved.map((asset) =>
+      softFailMirror('DELETE', asset, () => removeWatchlistAlert(asset)),
+    ),
+  ]);
+}

--- a/app/components/UI/Assets/PriceAlerts/syncWatchlistMirror.ts
+++ b/app/components/UI/Assets/PriceAlerts/syncWatchlistMirror.ts
@@ -1,66 +1,9 @@
-import { isCaipAssetType, parseCaipAssetType } from '@metamask/utils';
-
 import Logger from '../../../../util/Logger';
 import {
   addWatchlistAlert,
   assertOkResponse,
-  fetchSupportedChains,
   removeWatchlistAlert,
 } from './api';
-
-const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
-
-let cachedSupportedChains: string[] | null = null;
-let cachedSupportedChainsAt = 0;
-
-/**
- * Clears the in-memory supported-chains cache. Test-only.
- */
-export const resetSupportedChainsCacheForTests = (): void => {
-  cachedSupportedChains = null;
-  cachedSupportedChainsAt = 0;
-};
-
-async function getSupportedChains(): Promise<string[] | null> {
-  const now = Date.now();
-  if (
-    cachedSupportedChains !== null &&
-    now - cachedSupportedChainsAt < TWENTY_FOUR_HOURS_MS
-  ) {
-    return cachedSupportedChains;
-  }
-
-  try {
-    const response = await fetchSupportedChains();
-    if (!response.ok) {
-      return cachedSupportedChains;
-    }
-    const body = (await response.json()) as string[];
-    if (!Array.isArray(body)) {
-      return cachedSupportedChains;
-    }
-    cachedSupportedChains = body;
-    cachedSupportedChainsAt = now;
-    return cachedSupportedChains;
-  } catch (error) {
-    Logger.error(error as Error, {
-      message:
-        'Failed to fetch Price Alerts supported chains for watchlist mirror',
-    });
-    return cachedSupportedChains;
-  }
-}
-
-const isSupportedAsset = (
-  asset: string,
-  supportedChains: readonly string[],
-): boolean => {
-  if (!isCaipAssetType(asset)) {
-    return false;
-  }
-  const { chainId } = parseCaipAssetType(asset);
-  return supportedChains.includes(chainId);
-};
 
 const softFailMirror = async (
   action: 'POST' | 'DELETE',
@@ -80,10 +23,9 @@ const softFailMirror = async (
 
 /**
  * After the real token watchlist blob is updated, mirror net membership
- * changes into Price Alerts for supported chains only.
- *
- * Soft-fails on every Price Alerts error — never throws, never rolls back
- * the real watchlist write.
+ * changes into Price Alerts. The client always calls the API; support /
+ * validation is handled server-side. Soft-fails on every Price Alerts
+ * error — never throws, never rolls back the real watchlist write.
  */
 export async function syncPriceAlertsWatchlistMirror(
   previousAssets: readonly string[],
@@ -105,23 +47,11 @@ export async function syncPriceAlertsWatchlistMirror(
     return;
   }
 
-  const supportedChains = await getSupportedChains();
-  if (supportedChains === null) {
-    return;
-  }
-
-  const supportedAdded = added.filter((asset) =>
-    isSupportedAsset(asset, supportedChains),
-  );
-  const supportedRemoved = removed.filter((asset) =>
-    isSupportedAsset(asset, supportedChains),
-  );
-
   await Promise.all([
-    ...supportedAdded.map((asset) =>
+    ...added.map((asset) =>
       softFailMirror('POST', asset, () => addWatchlistAlert(asset)),
     ),
-    ...supportedRemoved.map((asset) =>
+    ...removed.map((asset) =>
       softFailMirror('DELETE', asset, () => removeWatchlistAlert(asset)),
     ),
   ]);

--- a/app/components/UI/Assets/PriceAlerts/syncWatchlistMirror.ts
+++ b/app/components/UI/Assets/PriceAlerts/syncWatchlistMirror.ts
@@ -1,36 +1,54 @@
 import Logger from '../../../../util/Logger';
 import {
-  addWatchlistAlert,
+  addWatchlistAlerts,
   assertOkResponse,
-  removeWatchlistAlert,
+  removeWatchlistAlerts,
+  type WatchlistAlertsResult,
 } from './api';
 
-const softFailMirror = async (
+const softFailBatchMirror = async (
   action: 'POST' | 'DELETE',
-  asset: string,
+  assetIds: string[],
   request: () => Promise<Response>,
 ): Promise<void> => {
+  if (assetIds.length === 0) {
+    return;
+  }
+
   try {
     const response = await request();
     await assertOkResponse(response);
+    const body = (await response.json()) as WatchlistAlertsResult;
+    if (body.unprocessedAssetIds?.length) {
+      // Expected for unsupported chains / rejected assets — do not fail UX.
+      Logger.log('Price Alerts watchlist partial processing', {
+        action,
+        unprocessedAssetIds: body.unprocessedAssetIds,
+        processedAssetIds: body.processedAssetIds ?? [],
+      });
+    }
   } catch (error) {
     Logger.error(error as Error, {
       message: `Price Alerts watchlist ${action} soft-fail`,
-      asset,
+      assetIds,
     });
   }
 };
 
 /**
  * After the real token watchlist blob is updated, mirror net membership
- * changes into Price Alerts. The client always calls the API; support /
- * validation is handled server-side. Soft-fails on every Price Alerts
- * error — never throws, never rolls back the real watchlist write.
+ * changes into Price Alerts as batched POST/DELETE `{ assetIds }`.
+ *
+ * Soft-fails on every Price Alerts error or partial processing — never
+ * throws, never rolls back the real watchlist write. CAIP-19 IDs are sent
+ * with original casing (Solana mint refs must not be lowercased).
  */
 export async function syncPriceAlertsWatchlistMirror(
   previousAssets: readonly string[],
   nextAssets: readonly string[],
 ): Promise<void> {
+  // EVM identity is case-insensitive; keep original strings for the request
+  // body so Solana mint casing is preserved when sent.
   const previousLower = new Set(
     previousAssets.map((asset) => asset.toLowerCase()),
   );
@@ -48,11 +66,9 @@ export async function syncPriceAlertsWatchlistMirror(
   }
 
   await Promise.all([
-    ...added.map((asset) =>
-      softFailMirror('POST', asset, () => addWatchlistAlert(asset)),
-    ),
-    ...removed.map((asset) =>
-      softFailMirror('DELETE', asset, () => removeWatchlistAlert(asset)),
+    softFailBatchMirror('POST', added, () => addWatchlistAlerts(added)),
+    softFailBatchMirror('DELETE', removed, () =>
+      removeWatchlistAlerts(removed),
     ),
   ]);
 }

--- a/app/components/UI/Assets/watchlist/hooks/useTokenWatchlistMutations.test.tsx
+++ b/app/components/UI/Assets/watchlist/hooks/useTokenWatchlistMutations.test.tsx
@@ -119,12 +119,20 @@ const readHydratedCache = (queryClient: QueryClient) =>
   );
 
 const baseBeforeEach = (initialStorage: WatchlistBlob = EMPTY_BLOB) => {
+  // Reset any leaked client from a prior test that skipped afterEach (J9).
+  if (activeQueryClient) {
+    activeQueryClient.getMutationCache().clear();
+    activeQueryClient.getQueryCache().clear();
+    activeQueryClient.clear();
+    activeQueryClient = null;
+  }
   jest.clearAllMocks();
   mockedRead.mockResolvedValue(initialStorage);
   mockedWrite.mockResolvedValue(undefined);
 };
 
 const baseAfterEach = async () => {
+  jest.restoreAllMocks();
   // Drain any pending batch left over from the test so it cannot fire
   // against the next test's mocks. `flush()` is a no-op when the queue
   // is empty.

--- a/app/components/UI/Assets/watchlist/hooks/useTokenWatchlistMutations.test.tsx
+++ b/app/components/UI/Assets/watchlist/hooks/useTokenWatchlistMutations.test.tsx
@@ -22,8 +22,13 @@ import {
   useTokenWatchlistRemoveItemMutation,
   useTokenWatchlistUpdateListMutation,
 } from './useTokenWatchlistMutations';
+import { syncPriceAlertsWatchlistMirror } from '../../PriceAlerts/syncWatchlistMirror';
 
 const drainBatcher = () => tokenWatchlistBatcher.flush();
+
+const mockedSyncMirror = syncPriceAlertsWatchlistMirror as jest.MockedFunction<
+  typeof syncPriceAlertsWatchlistMirror
+>;
 
 // Override React Query's batch notify function to prevent teardown crashes.
 // The default uses react-native's unstable_batchedUpdates which tries to
@@ -49,6 +54,10 @@ jest.mock('../storage', () => ({
   EMPTY_BLOB: { assets: [], version: 1 },
   readFromTokenWatchList: jest.fn(),
   writeToTokenWatchList: jest.fn(),
+}));
+
+jest.mock('../../PriceAlerts/syncWatchlistMirror', () => ({
+  syncPriceAlertsWatchlistMirror: jest.fn().mockResolvedValue(undefined),
 }));
 
 const mockedRead = readFromTokenWatchList as jest.MockedFunction<
@@ -209,6 +218,10 @@ describe.each(scenarios)('useTokenWatchlist $name mutation', (scenario) => {
       assets: scenario.expectedWrittenAssets,
       version: 1,
     });
+    expect(mockedSyncMirror).toHaveBeenCalledWith(
+      scenario.initialStorage.assets,
+      scenario.expectedWrittenAssets,
+    );
   });
 
   it('optimistically updates the blob cache before the storage write completes', async () => {

--- a/app/components/UI/Assets/watchlist/hooks/useTokenWatchlistMutations.ts
+++ b/app/components/UI/Assets/watchlist/hooks/useTokenWatchlistMutations.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { CaipAssetType } from '@metamask/utils';
 
+import { syncPriceAlertsWatchlistMirror } from '../../PriceAlerts/syncWatchlistMirror';
 import {
   EMPTY_BLOB,
   readFromTokenWatchList,
@@ -108,13 +109,16 @@ const applyOp = (acc: string[], op: WatchlistOp): string[] => {
 export const tokenWatchlistBatcher = createAsyncBatcher<WatchlistOp>(
   async (ops) => {
     const current = await readFromTokenWatchList();
+    const nextAssets = ops.reduce<string[]>(
+      (acc, op) => applyOp(acc, op),
+      [...current.assets],
+    );
     await writeToTokenWatchList({
       ...current,
-      assets: ops.reduce<string[]>(
-        (acc, op) => applyOp(acc, op),
-        [...current.assets],
-      ),
+      assets: nextAssets,
     });
+    // Soft-fail mirror — never rolls back a successful real-watchlist write.
+    await syncPriceAlertsWatchlistMirror(current.assets, nextAssets);
   },
 );
 


### PR DESCRIPTION
After a successful watchlist blob write, soft-fail POST/DELETE to /v1/alerts/watchlist for supported chains so Price Alerts stays in sync without becoming source of truth.

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: mirror token watchlist add/remove to Price Alerts

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/61b14a7e-42ab-497a-b8cc-79a5d90cd3bb




## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the watchlist write path with extra authenticated API calls; failures are isolated but Price Alerts can drift if sync fails silently.
> 
> **Overview**
> After a successful local token watchlist write, the app now **mirrors net add/remove** to Price Alerts via authenticated `POST`/`DELETE` on `/v1/alerts/watchlist` with a JSON `{ assetIds }` body (not query params).
> 
> New **`syncPriceAlertsWatchlistMirror`** diffs previous vs next membership (case-insensitive for EVM, **original casing** for Solana mints), batches adds and removes, skips reorder-only changes, and **soft-fails** on HTTP errors, partial `unprocessedAssetIds`, or network issues—logging only, never throwing or rolling back the real watchlist.
> 
> **`useTokenWatchlistMutations`** invokes this sync from the shared batcher immediately after `writeToTokenWatchList`. API helpers and unit tests cover the watchlist endpoints and mutation wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e4b85d07a98f95d3bb1489b13e16d9349ee8278. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->