### PR TITLE
fix: skip gas sponsorship reserve warning for MM Pay transactions cp-8.6.0

### DIFF
--- a/app/components/Views/confirmations/hooks/alerts/useGasSponsorshipWarningAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useGasSponsorshipWarningAlert.test.ts
@@ -9,6 +9,7 @@ import { renderHookWithProvider } from '../../../../../util/test/renderWithProvi
 import { useGasSponsorshipWarningAlert } from './useGasSponsorshipWarningAlert';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { AlertKeys } from '../../constants/alerts';
+import { MM_PAY_TRANSACTION_TYPES } from '../../constants/confirmations';
 import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { Severity } from '../../types/alerts';
 import { NETWORKS_CHAIN_ID } from '../../../../../constants/network';
@@ -19,7 +20,9 @@ import { useIsGasSponsored } from '../gas/useIsGasSponsored';
 jest.mock('../../../../UI/Ramp/hooks/useRampNavigation', () => ({
   useRampNavigation: jest.fn(),
 }));
-jest.mock('../useConfirmActions');
+jest.mock('../useConfirmActions', () => ({
+  useConfirmActions: jest.fn(),
+}));
 jest.mock('../transactions/useTransactionMetadataRequest');
 jest.mock('../gas/useIsGasSponsored');
 
@@ -240,6 +243,44 @@ describe('useGasSponsorshipWarningAlert', () => {
       const { result } = renderHookWithProvider(() =>
         useGasSponsorshipWarningAlert(),
       );
+      expect(result.current).toEqual([]);
+    });
+
+    it.each(MM_PAY_TRANSACTION_TYPES)(
+      'when transaction type is MM Pay type %s',
+      (transactionType: TransactionType) => {
+        const transactionMeta = createMockTransactionMeta({
+          type: transactionType,
+          chainId: MONAD_CHAIN_ID,
+          isGasFeeSponsored: false,
+          simulationData: createMockSimulationData([
+            'reserve balance violation',
+          ]),
+        });
+        mockUseTransactionMetadataRequest.mockReturnValue(transactionMeta);
+
+        const { result } = renderHookWithProvider(() =>
+          useGasSponsorshipWarningAlert(),
+        );
+
+        expect(result.current).toEqual([]);
+      },
+    );
+
+    it('when nested transaction type is an MM Pay type', () => {
+      const transactionMeta = createMockTransactionMeta({
+        type: TransactionType.contractInteraction,
+        chainId: MONAD_CHAIN_ID,
+        isGasFeeSponsored: false,
+        simulationData: createMockSimulationData(['reserve balance violation']),
+        nestedTransactions: [{ type: TransactionType.perpsDeposit }],
+      });
+      mockUseTransactionMetadataRequest.mockReturnValue(transactionMeta);
+
+      const { result } = renderHookWithProvider(() =>
+        useGasSponsorshipWarningAlert(),
+      );
+
       expect(result.current).toEqual([]);
     });
   });

--- a/app/components/Views/confirmations/hooks/alerts/useGasSponsorshipWarningAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useGasSponsorshipWarningAlert.ts
@@ -1,10 +1,14 @@
 import { useMemo } from 'react';
 import type { Hex } from '@metamask/utils';
-import { SimulationData } from '@metamask/transaction-controller';
+import {
+  hasTransactionType,
+  SimulationData,
+} from '@metamask/transaction-controller';
 
 import { strings } from '../../../../../../locales/i18n';
 import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { AlertKeys } from '../../constants/alerts';
+import { MM_PAY_TRANSACTION_TYPES } from '../../constants/confirmations';
 import { Alert, Severity } from '../../types/alerts';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { NETWORKS_CHAIN_ID } from '../../../../../constants/network';
@@ -98,6 +102,11 @@ export const useGasSponsorshipWarningAlert = (): Alert[] => {
 
   const { chainId, simulationData } = transactionMetadata ?? {};
 
+  const isMMPayTransaction = hasTransactionType(
+    transactionMetadata,
+    MM_PAY_TRANSACTION_TYPES,
+  );
+
   const callTraceErrors = (
     simulationData as SimulationDataWithCallTraceErrors | undefined
   )?.callTraceErrors;
@@ -114,7 +123,8 @@ export const useGasSponsorshipWarningAlert = (): Alert[] => {
   // Only show warning when:
   // 1. We have a warning match from configured rules
   // 2. Gas Sponsorship is expected to be enabled for this transaction.
-  const shouldShow = hasWarning && isGasSponsored;
+  // 3. This is not an MM Pay transaction (pay flows use their own alerts).
+  const shouldShow = hasWarning && isGasSponsored && !isMMPayTransaction;
 
   return useMemo(() => {
     if (!shouldShow || !chainId) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Confirmation alerts are assembled in one shared `useTransactionAlerts()` bag, so every redesigned confirmation — including MetaMask Pay — runs `useGasSponsorshipWarningAlert`.

That hook only gated on a Monad reserve-balance simulation match and `isGasSponsored`. On MM Pay confirmations that hit the same simulation error, the blocking gas sponsorship reserve warning could still appear even though Pay flows already have their own balance/pay alerts.

Skip the alert when the transaction (or a nested transaction) is in `MM_PAY_TRANSACTION_TYPES`, matching other confirmation alerts such as first-time interaction and batched unused approvals.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed gas sponsorship reserve balance warning incorrectly showing on MetaMask Pay confirmations

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1770

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: gas sponsorship reserve warning skipped for MM Pay

  Scenario: MM Pay confirmation does not show reserve balance warning
    Given user is on Monad with a MetaMask Pay confirmation
    And the transaction simulation includes a reserve balance violation
    And gas sponsorship is expected for the transaction

    When the confirmation alerts are evaluated
    Then the gas sponsorship reserve balance warning is not shown
    And MetaMask Pay balance/pay alerts continue to apply as usual

  Scenario: non-MM Pay confirmation still shows reserve balance warning
    Given user is on Monad with a non-MM Pay confirmation
    And the transaction simulation includes a reserve balance violation
    And gas sponsorship is expected for the transaction

    When the confirmation alerts are evaluated
    Then the gas sponsorship reserve balance warning is shown
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — unit-tested alert gating change; no visual design change beyond suppressing the alert on MM Pay confirmations.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow alert-display gating with unit tests; no auth, payment execution, or data-path changes.
> 
> **Overview**
> **Suppresses the Monad gas sponsorship reserve-balance blocking alert on MetaMask Pay confirmations** when simulation still reports a reserve violation and sponsorship is expected.
> 
> `useGasSponsorshipWarningAlert` now treats MM Pay like other shared confirmation alerts: it uses `hasTransactionType` with `MM_PAY_TRANSACTION_TYPES` (including nested transactions) and only shows the warning when `hasWarning && isGasSponsored && !isMMPayTransaction`. Non–MM Pay confirmations keep the existing behavior.
> 
> Tests cover every MM Pay transaction type plus a nested `perpsDeposit` case; the `useConfirmActions` mock is aligned with the other alert hook tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8370d5dff97994d70b52d3885272b28a32435ce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->