### PR TITLE
test: skip Appium MMConnect multichain browser connect suite

### DIFF
--- a/.github/workflows/run-appium-smoke-tests-android.yml
+++ b/.github/workflows/run-appium-smoke-tests-android.yml
@@ -152,7 +152,6 @@ jobs:
       runner_provider: ${{ inputs.runner_provider }}
     secrets: inherit
 
-
   appium-snaps-android-smoke:
     if: >-
       ${{
@@ -273,30 +272,30 @@ jobs:
       runner_provider: ${{ inputs.runner_provider }}
     secrets: inherit
 
-  appium-mmconnect-android-smoke:
-    if: >-
-      ${{
-        !cancelled() &&
-        (contains(fromJson(inputs.selected_tags), 'ALL') ||
-         contains(fromJson(inputs.selected_tags), 'SmokeMMConnect'))
-      }}
-    strategy:
-      matrix:
-        split: [1]
-      fail-fast: false
-    uses: ./.github/workflows/run-appium-e2e-workflow.yml
-    with:
-      test-suite-name: appium-mmconnect-android-smoke-${{ matrix.split }}
-      platform: android
-      test_suite_tag: SmokeMMConnect
-      split_number: ${{ matrix.split }}
-      total_splits: 1
-      test-timeout-minutes: 35
-      android-tag: google_apis
-      build_type: ${{ inputs.build_type }}
-      metamask_environment: ${{ inputs.metamask_environment }}
-      runner_provider: ${{ inputs.runner_provider }}
-    secrets: inherit
+  # appium-mmconnect-android-smoke:
+  #   if: >-
+  #     ${{
+  #       !cancelled() &&
+  #       (contains(fromJson(inputs.selected_tags), 'ALL') ||
+  #        contains(fromJson(inputs.selected_tags), 'SmokeMMConnect'))
+  #     }}
+  #   strategy:
+  #     matrix:
+  #       split: [1]
+  #     fail-fast: false
+  #   uses: ./.github/workflows/run-appium-e2e-workflow.yml
+  #   with:
+  #     test-suite-name: appium-mmconnect-android-smoke-${{ matrix.split }}
+  #     platform: android
+  #     test_suite_tag: SmokeMMConnect
+  #     split_number: ${{ matrix.split }}
+  #     total_splits: 1
+  #     test-timeout-minutes: 35
+  #     android-tag: google_apis
+  #     build_type: ${{ inputs.build_type }}
+  #     metamask_environment: ${{ inputs.metamask_environment }}
+  #     runner_provider: ${{ inputs.runner_provider }}
+  #   secrets: inherit
 
   appium-money-android-smoke:
     if: >-

--- a/tests/smoke-appium/mm-connect/connection-multichain.spec.ts
+++ b/tests/smoke-appium/mm-connect/connection-multichain.spec.ts
@@ -36,7 +36,7 @@ const playgroundServer = new DappServer({
 const scopeCardTestId = (scope: string): string =>
   `${MMConnectDappTestIds.SCOPE_CARD}-${scope.toLowerCase().replace(/:/g, '-')}`;
 
-appiumTest.describe(SmokeMMConnect('Multichain browser connect'), () => {
+appiumTest.describe.skip(SmokeMMConnect('Multichain browser connect'), () => {
   appiumTest.beforeAll(async () => {
     playgroundServer.setServerPort(DAPP_PORT);
     await playgroundServer.start();


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Temporarily skip the Appium MMConnect Multichain browser connect suite (`connection-multichain.spec.ts`) so it does not block CI while the suite is unstable.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — test-only change; no product behavior change.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — test-only change.

## **Pre-merge checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I have tested this change locally / CI will run Appium smoke
- [x] I have added/updated tests as appropriate (skipped flaky suite)
- [x] PR is submitted as draft initially for CI

## **Test plan**

- [ ] Confirm Appium CI no longer runs / fails on `Multichain browser connect`
- [ ] Confirm remaining Appium suites still execute as expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI workflow changes only; no application or production behavior is modified.
> 
> **Overview**
> Temporarily disables **SmokeMMConnect** Android Appium CI and skips the **Multichain browser connect** spec so flaky MM Connect coverage does not fail pipelines.
> 
> The `appium-mmconnect-android-smoke` reusable workflow job in `run-appium-smoke-tests-android.yml` is fully commented out, so `SmokeMMConnect` / `ALL` tag runs no longer fan out that shard. In `connection-multichain.spec.ts`, the suite is switched from `appiumTest.describe` to `appiumTest.describe.skip`, matching other already-skipped MM Connect specs in the folder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9bc288e03509e3490464e8020ad7af2d2123d31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->