### PR TITLE
fix: prevent infinite MM Pay payment token loading

### DIFF
--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -54,6 +54,7 @@ import Logger from '../../../../../../util/Logger';
 import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmationOnBackSwipe';
 import { useAccountNoFundsAlert } from '../../../hooks/alerts/useAccountNoFundsAlert';
 import { mockTheme } from '../../../../../../util/theme';
+import { useAutomaticTransactionPayToken } from '../../../hooks/pay/useAutomaticTransactionPayToken';
 
 jest.mock('../../../hooks/ui/useClearConfirmationOnBackSwipe');
 jest.mock('../../../hooks/ui/useMMPayNavigation');
@@ -338,6 +339,9 @@ describe('CustomAmountInfo', () => {
   );
   const setIsConfirmationSubmittingMock = jest.fn();
   const useAccountNoFundsAlertMock = jest.mocked(useAccountNoFundsAlert);
+  const useAutomaticTransactionPayTokenMock = jest.mocked(
+    useAutomaticTransactionPayToken,
+  );
 
   const useRouteMock = jest.mocked(useRoute);
 
@@ -359,6 +363,7 @@ describe('CustomAmountInfo', () => {
 
     useTransactionAccountOverrideMock.mockReturnValue(undefined);
     useTransactionPayFiatPaymentMock.mockReturnValue(undefined);
+    useAutomaticTransactionPayTokenMock.mockReturnValue(undefined);
 
     useTransactionPayWithdrawMock.mockReturnValue({
       isWithdraw: false,
@@ -1923,6 +1928,39 @@ describe('CustomAmountInfo', () => {
   });
 
   describe('PayWithRow visibility for moneyAccountDeposit', () => {
+    it('renders the automatic token when controller selection fails', () => {
+      const automaticToken = {
+        address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Hex,
+        chainId: '0x1' as Hex,
+      };
+      useAutomaticTransactionPayTokenMock.mockReturnValue(automaticToken);
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: undefined,
+        setPayToken: noop as never,
+      });
+      useTransactionPayAvailableTokensMock.mockReturnValue({
+        availableTokens: [
+          {
+            ...automaticToken,
+            fiat: { balance: 42 },
+            symbol: 'AUTO',
+          } as AssetType,
+        ],
+        hasTokens: true,
+      });
+      useTransactionMetadataRequestMock.mockReturnValue({
+        type: TransactionType.moneyAccountDeposit,
+        txParams: { from: '0x123' },
+      } as never);
+
+      const { getByTestId, queryByTestId } = render({
+        transactionType: TransactionType.moneyAccountDeposit,
+      });
+
+      expect(queryByTestId('pay-with-row-skeleton')).not.toBeOnTheScreen();
+      expect(getByTestId('pay-with-symbol')).toHaveTextContent(/^AUTO/);
+    });
+
     it('renders PayWithRow while keyboard is visible for non-addMusd moneyAccountDeposit', () => {
       useTransactionMetadataRequestMock.mockReturnValue({
         type: TransactionType.moneyAccountDeposit,

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -14,7 +14,10 @@ import { transactionApprovalControllerMock } from '../../../__mocks__/controller
 import { otherControllersMock } from '../../../__mocks__/controllers/other-controllers-mock';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useTransactionCustomAmount } from '../../../hooks/transactions/useTransactionCustomAmount';
-import { useConfirmationContext } from '../../../context/confirmation-context';
+import {
+  useConfirmationContext,
+  usePayTokenSelectionContext,
+} from '../../../context/confirmation-context';
 import { Alert, Severity } from '../../../types/alerts';
 import { AlertKeys } from '../../../constants/alerts';
 import {
@@ -284,6 +287,9 @@ function render(
 describe('CustomAmountInfo', () => {
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
   const useConfirmationContextMock = jest.mocked(useConfirmationContext);
+  const usePayTokenSelectionContextMock = jest.mocked(
+    usePayTokenSelectionContext,
+  );
   const useAlertsMock = jest.mocked(useAlerts);
   const useAccountTokensMock = jest.mocked(useAccountTokens);
   const useConfirmActionsMock = jest.mocked(useConfirmActions);
@@ -419,6 +425,10 @@ describe('CustomAmountInfo', () => {
       isMaxDeposit: false,
       setIsMaxDeposit: noop,
     } as ReturnType<typeof useConfirmationContext>);
+    usePayTokenSelectionContextMock.mockReturnValue({
+      isPayTokenSelectionFailed: false,
+      setIsPayTokenSelectionFailed: noop,
+    });
 
     useAlertsMock.mockReturnValue({
       alerts: [] as Alert[],
@@ -2547,6 +2557,44 @@ describe('CustomAmountInfo', () => {
       const { queryByTestId, getByTestId } = render();
 
       expect(queryByTestId('custom-amount-skeleton')).toBeNull();
+      expect(getByTestId('custom-amount-input')).toBeOnTheScreen();
+    });
+
+    it('stops prefill loading after pay token selection fails', () => {
+      useTransactionCustomAmountMock.mockReturnValue({
+        amountFiat: '0',
+        amountHuman: '0',
+        amountHumanDebounced: '0',
+        amountFiatDebounced: '0',
+        hasInput: false,
+        hasPrefetchedQuote: false,
+        isDepositPrefillEnabled: true,
+        isDepositPrefilled: false,
+        isInputChanged: false,
+        isPrefillPending: false,
+        isDepositPrefillLoading: true,
+        updatePendingAmount: noop,
+        updatePendingAmountPercentage: () => false,
+        updateTokenAmount: jest.fn(),
+      });
+      useTransactionPayTokenMock.mockReturnValue({
+        payToken: undefined,
+        setPayToken: noop as never,
+      });
+      useTransactionMetadataRequestMock.mockReturnValue({
+        type: TransactionType.moneyAccountDeposit,
+        txParams: { from: '0x123' },
+      } as never);
+      usePayTokenSelectionContextMock.mockReturnValue({
+        isPayTokenSelectionFailed: true,
+        setIsPayTokenSelectionFailed: noop,
+      });
+
+      const { getByTestId, queryByTestId } = render({
+        transactionType: TransactionType.moneyAccountDeposit,
+      });
+
+      expect(queryByTestId('custom-amount-skeleton')).not.toBeOnTheScreen();
       expect(getByTestId('custom-amount-input')).toBeOnTheScreen();
     });
 

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -72,13 +72,20 @@ import { PerpsAccountPickerRow } from '../../rows/perps-account-picker-row';
 import { PredictAccountPickerRow } from '../../rows/predict-account-picker-row';
 import { useTransactionAccountOverride } from '../../../hooks/transactions/useTransactionAccountOverride';
 import { CustomAmountInfoTestIds } from './custom-amount-info.testIds';
-import { useConfirmationContext } from '../../../context/confirmation-context';
+import {
+  useConfirmationContext,
+  usePayTokenSelectionContext,
+} from '../../../context/confirmation-context';
 import { useFiatFunnelMetricsAdapter } from '../../../../../UI/Ramp/hooks/useFiatFunnelMetricsAdapter';
 import { getMoneyAccountDepositIntent } from '../../../../../UI/Money/hooks/useMoneyAccount';
 import { Skeleton } from '../../../../../../component-library/components-temp/Skeleton';
 import { CustomAmountBuy } from '../../custom-amount/custom-amount-buy';
 import { CustomAmountTotals } from '../../custom-amount/custom-amount-totals';
 import { CustomAmountConfirmButton } from '../../custom-amount/custom-amount-confirm-button';
+import {
+  PAY_TOKEN_REQUIRED_TRANSACTION_TYPES,
+  QUOTE_REQUIRED_TRANSACTION_TYPES,
+} from '../../../constants/confirmations';
 
 const AMOUNT_UPDATE_ERROR_PREFIX = 'MetaMask Pay: Amount Update: ';
 
@@ -150,6 +157,8 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       useFiatFunnelMetricsAdapter();
 
     const { isNative: isNativePayToken, payToken } = useTransactionPayToken();
+    const { headlessBuyError } = useConfirmationContext();
+    const { isPayTokenSelectionFailed } = usePayTokenSelectionContext();
     const { isMoneyNoFeeToken: isMoneyDepositNoFee } = useMoneyNoFeeTokens();
     const { styles } = useStyles(styleSheet, {});
 
@@ -184,6 +193,17 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
 
     const accountNoFundsAlert = useAccountNoFundsAlert();
     const hasAccountNoFunds = accountNoFundsAlert.length > 0;
+    const isPayTokenRequired =
+      hasTransactionType(
+        transactionMeta,
+        PAY_TOKEN_REQUIRED_TRANSACTION_TYPES,
+      ) ||
+      hasTransactionType(transactionMeta, QUOTE_REQUIRED_TRANSACTION_TYPES);
+    const isPayTokenUnavailable =
+      isPayTokenRequired &&
+      isPayTokenSelectionFailed &&
+      !payToken &&
+      !selectedFiatPaymentMethodId;
 
     const { stage, setStage } = useCustomAmountStage({
       amountFiat,
@@ -193,6 +213,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       isAddMusdIntent,
       isDepositPrefillEnabled,
       isDepositPrefillLoading,
+      isPayTokenUnavailable,
       skipDepositPrefill,
     });
 
@@ -369,8 +390,6 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       stage === CustomAmountStage.Loading &&
       (isAmountUpdatePending || !isMoneyAccountDeposit || !isQuotesLoading);
 
-    const { headlessBuyError } = useConfirmationContext();
-
     return (
       <Box style={styles.container}>
         <Box style={styles.inputContainer}>
@@ -381,6 +400,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               stage !== CustomAmountStage.Loading && Boolean(alertMessage)
             }
             isLoading={
+              !isPayTokenUnavailable &&
               !hasAccountNoFunds &&
               !skipDepositPrefill &&
               (isPrefillPending || isDepositPrefillLoading)

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -136,7 +136,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
 
     const { canSelectWithdrawToken } = useTransactionPayWithdraw();
 
-    useAutomaticTransactionPayToken({
+    const automaticPayToken = useAutomaticTransactionPayToken({
       autoSelectFiatPayment,
       disable: disablePay,
       preferredToken,
@@ -426,7 +426,9 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               <PerpsAccountPickerRow />
               <PredictAccountPickerRow />
               {disablePay !== true &&
-                (hasPaymentOption || hasAccountNoFunds) && <PayWithRow />}
+                (hasPaymentOption || hasAccountNoFunds) && (
+                  <PayWithRow automaticPayToken={automaticPayToken} />
+                )}
             </>
           )}
           {stage !== CustomAmountStage.AmountInput && (
@@ -440,7 +442,10 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
               <PerpsAccountPickerRow />
               <PredictAccountPickerRow />
               {disablePay !== true && hasPaymentOption && (
-                <PayWithRow isResultReady />
+                <PayWithRow
+                  automaticPayToken={automaticPayToken}
+                  isResultReady
+                />
               )}
               {!hasAccountNoFunds && (
                 <CustomAmountTotals

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -11,7 +11,10 @@ import { PayWithRow } from './pay-with-row';
 import { TokenIconProps } from '../../token-icon';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
-import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
+import {
+  useTransactionPayFiatPayment,
+  useTransactionPayRequiredTokens,
+} from '../../../hooks/pay/useTransactionPayData';
 import { useAccountNoFundsAlert } from '../../../hooks/alerts/useAccountNoFundsAlert';
 import { useTransactionPaySelectedFiatPaymentMethod } from '../../../hooks/pay/useTransactionPaySelectedFiatPaymentMethod';
 import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
@@ -25,6 +28,7 @@ import { useParams } from '../../../../../../util/navigation/navUtils';
 import useMoneyAccountBalance from '../../../../../UI/Money/hooks/useMoneyAccountBalance';
 import { useIsMoneyAccountFlagDefault } from '../../../hooks/pay/useIsMoneyAccountFlagDefault';
 import { usePayTokenAccountBalance } from '../../../hooks/pay/usePayTokenAccountBalance';
+import { AssetType } from '../../../types/token';
 
 jest.mock('../../../hooks/transactions/useTransactionMetadataRequest');
 jest.mock('../../../../../../util/navigation/navUtils');
@@ -54,6 +58,7 @@ jest.mock('../../../hooks/pay/useTransactionPayWithdraw', () => ({
   useTransactionPayWithdraw: jest.fn(),
 }));
 jest.mock('../../../hooks/pay/useTransactionPayData', () => ({
+  useTransactionPayFiatPayment: jest.fn(),
   useTransactionPayRequiredTokens: jest.fn(),
 }));
 jest.mock('../../../hooks/alerts/useAccountNoFundsAlert', () => ({
@@ -85,6 +90,8 @@ jest.mock('../../token-icon/', () => ({
 
 const ADDRESS_MOCK = '0x1234567890abcdef1234567890abcdef12345678';
 const CHAIN_ID_MOCK = '0x123';
+const AUTOMATIC_ADDRESS_MOCK = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+const AUTOMATIC_CHAIN_ID_MOCK = '0x456';
 
 const STATE_MOCK = {
   engine: {
@@ -92,8 +99,8 @@ const STATE_MOCK = {
   },
 };
 
-function render() {
-  return renderWithProvider(<PayWithRow />, { state: STATE_MOCK });
+function render(props: React.ComponentProps<typeof PayWithRow> = {}) {
+  return renderWithProvider(<PayWithRow {...props} />, { state: STATE_MOCK });
 }
 
 describe('PayWithRow', () => {
@@ -124,6 +131,7 @@ describe('PayWithRow', () => {
     });
 
     useTransactionPayRequiredTokensMock.mockReturnValue(undefined as never);
+    jest.mocked(useTransactionPayFiatPayment).mockReturnValue(undefined);
 
     jest
       .mocked(useTransactionPaySelectedFiatPaymentMethod)
@@ -183,15 +191,90 @@ describe('PayWithRow', () => {
     );
   });
 
-  it('renders skeleton when no pay token selected but tokens are available', () => {
+  it('renders the automatic token without fiat metadata when controller selection fails', () => {
     jest.mocked(useTransactionPayToken).mockReturnValue({
       payToken: undefined,
       setPayToken: jest.fn(),
     });
+    jest.mocked(useTransactionPayAvailableTokens).mockReturnValue({
+      availableTokens: [
+        {
+          address: AUTOMATIC_ADDRESS_MOCK,
+          chainId: AUTOMATIC_CHAIN_ID_MOCK,
+          symbol: 'AUTO',
+        } as AssetType,
+      ],
+      hasTokens: true,
+    });
 
-    const { getByTestId } = render();
+    const { getByTestId, getByText, queryByTestId } = render({
+      automaticPayToken: {
+        address: AUTOMATIC_ADDRESS_MOCK,
+        chainId: AUTOMATIC_CHAIN_ID_MOCK,
+      },
+    });
 
-    expect(getByTestId('pay-with-row-skeleton')).toBeDefined();
+    expect(queryByTestId('pay-with-row-skeleton')).not.toBeOnTheScreen();
+    expect(
+      getByText(`${AUTOMATIC_ADDRESS_MOCK} ${AUTOMATIC_CHAIN_ID_MOCK}`),
+    ).toBeOnTheScreen();
+    expect(getByTestId('pay-with-symbol')).toHaveTextContent(/^AUTO/);
+    expect(getByTestId('pay-with-balance')).toHaveTextContent('($0)');
+  });
+
+  it('renders empty state when the automatic token has no display metadata', () => {
+    jest.mocked(useTransactionPayToken).mockReturnValue({
+      payToken: undefined,
+      setPayToken: jest.fn(),
+    });
+    jest.mocked(useTransactionPayAvailableTokens).mockReturnValue({
+      availableTokens: [
+        {
+          address: ADDRESS_MOCK,
+          chainId: CHAIN_ID_MOCK,
+          symbol: 'OTHER',
+        } as AssetType,
+      ],
+      hasTokens: true,
+    });
+
+    const { getByTestId, queryByTestId } = render({
+      automaticPayToken: {
+        address: AUTOMATIC_ADDRESS_MOCK,
+        chainId: AUTOMATIC_CHAIN_ID_MOCK,
+      },
+    });
+
+    expect(queryByTestId('pay-with-row-skeleton')).not.toBeOnTheScreen();
+    expect(getByTestId('pay-with-symbol')).toHaveTextContent(
+      'Select payment method',
+    );
+  });
+
+  it('renders the controller token instead of the automatic token', () => {
+    jest.mocked(useTransactionPayAvailableTokens).mockReturnValue({
+      availableTokens: [
+        {
+          address: AUTOMATIC_ADDRESS_MOCK,
+          chainId: AUTOMATIC_CHAIN_ID_MOCK,
+          fiat: { balance: 12.34 },
+          symbol: 'AUTO',
+        } as AssetType,
+      ],
+      hasTokens: true,
+    });
+
+    const { getByText, queryByText } = render({
+      automaticPayToken: {
+        address: AUTOMATIC_ADDRESS_MOCK,
+        chainId: AUTOMATIC_CHAIN_ID_MOCK,
+      },
+    });
+
+    expect(getByText(`${ADDRESS_MOCK} ${CHAIN_ID_MOCK}`)).toBeOnTheScreen();
+    expect(
+      queryByText(`${AUTOMATIC_ADDRESS_MOCK} ${AUTOMATIC_CHAIN_ID_MOCK}`),
+    ).not.toBeOnTheScreen();
   });
 
   it('renders empty state when no pay token and no available tokens', () => {
@@ -312,7 +395,7 @@ describe('PayWithRow', () => {
       expect(getByText(`${requiredAddress} ${requiredChainId}`)).toBeDefined();
     });
 
-    it('shows skeleton when no payToken and no required token in withdraw mode', () => {
+    it('shows empty state when no payToken and no required token in withdraw mode', () => {
       jest.mocked(useTransactionPayToken).mockReturnValue({
         payToken: undefined,
         setPayToken: jest.fn(),
@@ -320,8 +403,12 @@ describe('PayWithRow', () => {
 
       useTransactionPayRequiredTokensMock.mockReturnValue(undefined as never);
 
-      const { getByTestId } = render();
-      expect(getByTestId('pay-with-row-skeleton')).toBeDefined();
+      const { getByTestId, queryByTestId } = render();
+
+      expect(queryByTestId('pay-with-row-skeleton')).not.toBeOnTheScreen();
+      expect(getByTestId('pay-with-symbol')).toHaveTextContent(
+        'Select payment method',
+      );
     });
   });
 
@@ -333,6 +420,38 @@ describe('PayWithRow', () => {
       score: 1,
       icon: 'card-icon',
     } as PaymentMethod;
+
+    it('renders empty state when selected fiat method metadata is unavailable', () => {
+      jest.mocked(useTransactionPayToken).mockReturnValue({
+        payToken: undefined,
+        setPayToken: jest.fn(),
+      });
+      jest.mocked(useTransactionPayFiatPayment).mockReturnValue({
+        selectedPaymentMethodId: FIAT_PAYMENT_METHOD_MOCK.id,
+      });
+      jest.mocked(useTransactionPayAvailableTokens).mockReturnValue({
+        availableTokens: [
+          {
+            address: AUTOMATIC_ADDRESS_MOCK,
+            chainId: AUTOMATIC_CHAIN_ID_MOCK,
+            symbol: 'AUTO',
+          } as AssetType,
+        ],
+        hasTokens: true,
+      });
+
+      const { getByTestId, queryByText } = render({
+        automaticPayToken: {
+          address: AUTOMATIC_ADDRESS_MOCK,
+          chainId: AUTOMATIC_CHAIN_ID_MOCK,
+        },
+      });
+
+      expect(getByTestId('pay-with-symbol')).toHaveTextContent(
+        'Select payment method',
+      );
+      expect(queryByText('AUTO')).not.toBeOnTheScreen();
+    });
 
     it('renders fiat payment method row when selected', () => {
       jest

--- a/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/app/components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -9,7 +9,10 @@ import { selectPaymentOverrideByTransactionId } from '../../../../../../selector
 import { TokenIcon, TokenIconVariant } from '../../token-icon';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useTransactionPayWithdraw } from '../../../hooks/pay/useTransactionPayWithdraw';
-import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
+import {
+  useTransactionPayFiatPayment,
+  useTransactionPayRequiredTokens,
+} from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
 import { useAccountNoFundsAlert } from '../../../hooks/alerts/useAccountNoFundsAlert';
 import { useTransactionPaySelectedFiatPaymentMethod } from '../../../hooks/pay/useTransactionPaySelectedFiatPaymentMethod';
@@ -57,14 +60,19 @@ import { useIsMoneyAccountFlagDefault } from '../../../hooks/pay/useIsMoneyAccou
 import { useConfirmationContext } from '../../../context/confirmation-context';
 import { useTheme } from '../../../../../../util/theme';
 import { usePayTokenAccountBalance } from '../../../hooks/pay/usePayTokenAccountBalance';
+import { isMatchingPayToken } from '../../../utils/transaction-pay';
 
 interface PayWithRouteParams {
   preferredPaymentToken?: SetPayTokenRequest;
 }
 
 function PayWithRowComponent({
+  automaticPayToken,
   isResultReady,
-}: { isResultReady?: boolean } = {}) {
+}: {
+  automaticPayToken?: SetPayTokenRequest;
+  isResultReady?: boolean;
+} = {}) {
   const transactionMeta = useTransactionMetadataRequest();
   const transactionId = transactionMeta?.id ?? '';
   const paymentOverride = useSelector((state: RootState) =>
@@ -96,7 +104,7 @@ function PayWithRowComponent({
     return <PayWithRowMoneyAccount />;
   }
 
-  return <PayWithRowInteractive />;
+  return <PayWithRowInteractive automaticPayToken={automaticPayToken} />;
 }
 
 export const PayWithRow = memo(PayWithRowComponent);
@@ -153,14 +161,19 @@ function PayWithRowLayout({
   );
 }
 
-function PayWithRowInteractive() {
+function PayWithRowInteractive({
+  automaticPayToken,
+}: {
+  automaticPayToken?: SetPayTokenRequest;
+}) {
   const navigation = useNavigation<AppNavigationProp>();
   const { payToken } = useTransactionPayToken();
   const { isWithdraw } = useTransactionPayWithdraw();
   const requiredTokens = useTransactionPayRequiredTokens();
+  const fiatPayment = useTransactionPayFiatPayment();
   const accountNoFundsAlert = useAccountNoFundsAlert();
   const hasAccountNoFunds = accountNoFundsAlert.length > 0;
-  const { hasTokens: hasAvailableTokens } = useTransactionPayAvailableTokens();
+  const { availableTokens } = useTransactionPayAvailableTokens();
   const selectedFiatPaymentMethod =
     useTransactionPaySelectedFiatPaymentMethod();
   const formatFiat = useFiatFormatter({ currency: 'usd' });
@@ -200,22 +213,51 @@ function PayWithRowInteractive() {
   const defaultWithdrawToken = requiredTokens?.find(
     (token) => !token.skipIfBalance && !token.allowUnderMinimum,
   );
+  // Controller selection can fail when token metadata or fiat rates are
+  // unavailable. Keep the intended candidate display-only so the row reaches a
+  // terminal state while controller payToken remains authoritative for quotes.
+  const automaticDisplayToken = useMemo(() => {
+    if (!automaticPayToken) {
+      return undefined;
+    }
+
+    const availableToken = availableTokens.find((token) =>
+      isMatchingPayToken(token, automaticPayToken),
+    );
+
+    return availableToken
+      ? {
+          ...availableToken,
+          address: automaticPayToken.address,
+          chainId: automaticPayToken.chainId,
+        }
+      : undefined;
+  }, [automaticPayToken, availableTokens]);
   const displayToken = useMemo(() => {
     if (hasAccountNoFunds) {
       return null;
     }
     if (isWithdraw) {
-      return payToken ?? defaultWithdrawToken ?? null;
+      return payToken ?? defaultWithdrawToken ?? automaticDisplayToken ?? null;
     }
-    return payToken ?? null;
-  }, [hasAccountNoFunds, isWithdraw, payToken, defaultWithdrawToken]);
+    return payToken ?? automaticDisplayToken ?? null;
+  }, [
+    automaticDisplayToken,
+    defaultWithdrawToken,
+    hasAccountNoFunds,
+    isWithdraw,
+    payToken,
+  ]);
 
+  const displayBalanceUsd = payToken
+    ? accountBalanceUsd
+    : `${automaticDisplayToken?.fiat?.balance ?? 0}`;
   const balanceUsdFormatted = useMemo(
     () =>
       formatFiat(
-        new BigNumber(accountBalanceUsd).decimalPlaces(2, BigNumber.ROUND_DOWN),
+        new BigNumber(displayBalanceUsd).decimalPlaces(2, BigNumber.ROUND_DOWN),
       ),
-    [formatFiat, accountBalanceUsd],
+    [displayBalanceUsd, formatFiat],
   );
 
   if (selectedFiatPaymentMethod) {
@@ -230,14 +272,7 @@ function PayWithRowInteractive() {
     );
   }
 
-  if (!displayToken) {
-    // Show skeleton only while tokens exist to auto-select from.
-    // Without available tokens the skeleton never resolves (e.g. perps
-    // deposit with zero balance and no fiat payment method selected).
-    if (!hasAccountNoFunds && hasAvailableTokens) {
-      return <PayWithRowSkeleton />;
-    }
-
+  if (fiatPayment?.selectedPaymentMethodId || !displayToken) {
     return (
       <PayWithRowEmpty
         label={label}

--- a/app/components/Views/confirmations/context/confirmation-context/confirmation-context.test.tsx
+++ b/app/components/Views/confirmations/context/confirmation-context/confirmation-context.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, act } from '@testing-library/react-native';
 import {
   ConfirmationContextProvider,
   useConfirmationContext,
+  usePayTokenSelectionContext,
 } from './confirmation-context';
 
 describe('ConfirmationContext', () => {
@@ -75,6 +76,24 @@ describe('ConfirmationContext', () => {
     });
 
     expect(result.current.isHeadlessBuyInProgress).toBe(false);
+  });
+
+  it('updates pay token selection failure state', () => {
+    const { result } = renderHook(() => usePayTokenSelectionContext(), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.setIsPayTokenSelectionFailed(true);
+    });
+
+    expect(result.current.isPayTokenSelectionFailed).toBe(true);
+
+    act(() => {
+      result.current.setIsPayTokenSelectionFailed(false);
+    });
+
+    expect(result.current.isPayTokenSelectionFailed).toBe(false);
   });
 
   it('updates isTransactionDataUpdating state when calling setIsTransactionDataUpdating', () => {

--- a/app/components/Views/confirmations/context/confirmation-context/confirmation-context.tsx
+++ b/app/components/Views/confirmations/context/confirmation-context/confirmation-context.tsx
@@ -52,6 +52,17 @@ const ConfirmationContext = React.createContext<ConfirmationContextParams>({
   setIsMaxDeposit: noop,
 });
 
+export interface PayTokenSelectionContextParams {
+  isPayTokenSelectionFailed: boolean;
+  setIsPayTokenSelectionFailed: (isPayTokenSelectionFailed: boolean) => void;
+}
+
+const PayTokenSelectionContext =
+  React.createContext<PayTokenSelectionContextParams>({
+    isPayTokenSelectionFailed: false,
+    setIsPayTokenSelectionFailed: noop,
+  });
+
 interface ConfirmationContextProviderProps {
   children: React.ReactNode;
 }
@@ -71,6 +82,9 @@ export const ConfirmationContextProvider: React.FC<
   >();
 
   const [isHeadlessBuyInProgress, setIsHeadlessBuyInProgress] = useState(false);
+
+  const [isPayTokenSelectionFailed, setIsPayTokenSelectionFailed] =
+    useState(false);
 
   const [isTransactionDataUpdating, setIsTransactionDataUpdating] =
     useState<boolean>(false);
@@ -127,12 +141,25 @@ export const ConfirmationContextProvider: React.FC<
     ],
   );
 
+  const payTokenSelectionContextValue = useMemo(
+    () => ({
+      isPayTokenSelectionFailed,
+      setIsPayTokenSelectionFailed,
+    }),
+    [isPayTokenSelectionFailed],
+  );
+
   return (
-    <ConfirmationContext.Provider value={contextValue}>
-      {children}
-    </ConfirmationContext.Provider>
+    <PayTokenSelectionContext.Provider value={payTokenSelectionContextValue}>
+      <ConfirmationContext.Provider value={contextValue}>
+        {children}
+      </ConfirmationContext.Provider>
+    </PayTokenSelectionContext.Provider>
   );
 };
+
+export const usePayTokenSelectionContext = () =>
+  useContext(PayTokenSelectionContext);
 
 export const useConfirmationContext = () => {
   const context = useContext(ConfirmationContext);

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
@@ -26,11 +26,13 @@ import {
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useTransactionPayWithdraw } from '../pay/useTransactionPayWithdraw';
 import { TransactionType } from '@metamask/transaction-controller';
+import { usePayTokenSelectionContext } from '../../context/confirmation-context';
 
 jest.mock('../pay/useTransactionPayToken');
 jest.mock('../pay/useTransactionPayData');
 jest.mock('../pay/useTransactionPayWithdraw');
 jest.mock('../transactions/useTransactionMetadataRequest');
+jest.mock('../../context/confirmation-context');
 
 const STATE_MOCK = merge(
   {},
@@ -64,6 +66,9 @@ describe('useNoPayTokenQuotesAlert', () => {
     useTransactionPayRequiredTokens,
   );
   const useTransactionPayWithdrawMock = jest.mocked(useTransactionPayWithdraw);
+  const usePayTokenSelectionContextMock = jest.mocked(
+    usePayTokenSelectionContext,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -86,6 +91,10 @@ describe('useNoPayTokenQuotesAlert', () => {
     jest.mocked(useTransactionPayFiatPayment).mockReturnValue(undefined);
     jest.mocked(useTransactionPayIsMaxAmount).mockReturnValue(false);
     jest.mocked(useTransactionPayQuoteError).mockReturnValue(undefined);
+    usePayTokenSelectionContextMock.mockReturnValue({
+      isPayTokenSelectionFailed: false,
+      setIsPayTokenSelectionFailed: jest.fn(),
+    });
   });
 
   it('returns alert if pay token selected and no quotes available', () => {
@@ -295,12 +304,21 @@ describe('useNoPayTokenQuotesAlert', () => {
       });
       jest.mocked(useTransactionPayFiatPayment).mockReturnValue(undefined);
       jest.mocked(useTransactionPayIsMaxAmount).mockReturnValue(false);
+      usePayTokenSelectionContextMock.mockReturnValue({
+        isPayTokenSelectionFailed: false,
+        setIsPayTokenSelectionFailed: jest.fn(),
+      });
       jest.mocked(useTransactionMetadataRequest).mockReturnValue({
         type: TransactionType.moneyAccountDeposit,
       } as never);
     });
 
-    it('returns alert for moneyAccountDeposit with no quotes and positive required amount', () => {
+    it('returns alert for moneyAccountDeposit after pay token selection fails', () => {
+      usePayTokenSelectionContextMock.mockReturnValue({
+        isPayTokenSelectionFailed: true,
+        setIsPayTokenSelectionFailed: jest.fn(),
+      });
+
       const { result } = runHook();
 
       expect(result.current).toEqual([
@@ -343,15 +361,25 @@ describe('useNoPayTokenQuotesAlert', () => {
       expect(result.current).toStrictEqual([]);
     });
 
-    it('returns no alert for moneyAccountDeposit while quotes are loading', () => {
+    it('returns alert for moneyAccountDeposit failure while loading is stale', () => {
       jest.mocked(useTransactionMetadataRequest).mockReturnValue({
         type: TransactionType.moneyAccountDeposit,
       } as never);
       useIsTransactionPayLoadingMock.mockReturnValue(true);
+      usePayTokenSelectionContextMock.mockReturnValue({
+        isPayTokenSelectionFailed: true,
+        setIsPayTokenSelectionFailed: jest.fn(),
+      });
 
       const { result } = runHook();
 
-      expect(result.current).toStrictEqual([]);
+      expect(result.current).toEqual([
+        expect.objectContaining({
+          key: AlertKeys.NoPayTokenQuotes,
+          severity: Severity.Danger,
+          isBlocking: true,
+        }),
+      ]);
     });
   });
 
@@ -463,11 +491,47 @@ describe('useNoPayTokenQuotesAlert', () => {
       } as never);
     });
 
-    it('returns alert for perps deposit when no payment token is set', () => {
+    it('returns alert for perps deposit after pay token selection fails', () => {
+      usePayTokenSelectionContextMock.mockReturnValue({
+        isPayTokenSelectionFailed: true,
+        setIsPayTokenSelectionFailed: jest.fn(),
+      });
+
       const { result } = runHook();
 
       expect(result.current).toEqual([BLOCKING_ALERT]);
     });
+
+    it('returns alert after pay token selection fails before the required amount resolves', () => {
+      useIsTransactionPayLoadingMock.mockReturnValue(true);
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        {
+          address: ADDRESS_MOCK,
+          chainId: CHAIN_ID_MOCK,
+          amountRaw: undefined,
+          skipIfBalance: false,
+        } as unknown as TransactionPayRequiredToken,
+      ]);
+      usePayTokenSelectionContextMock.mockReturnValue({
+        isPayTokenSelectionFailed: true,
+        setIsPayTokenSelectionFailed: jest.fn(),
+      });
+
+      const { result } = runHook();
+
+      expect(result.current).toEqual([BLOCKING_ALERT]);
+    });
+
+    it.each([true, false])(
+      'returns no alerts while pay token selection is pending and loading is %s',
+      (isLoading) => {
+        useIsTransactionPayLoadingMock.mockReturnValue(isLoading);
+
+        const { result } = runHook();
+
+        expect(result.current).toStrictEqual([]);
+      },
+    );
 
     it('returns no alerts when a fiat payment method is selected', () => {
       jest.mocked(useTransactionPayFiatPayment).mockReturnValue({

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.tsx
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.tsx
@@ -22,6 +22,7 @@ import {
   QUOTE_REQUIRED_TRANSACTION_TYPES,
 } from '../../constants/confirmations';
 import { useTransactionPayWithdraw } from '../pay/useTransactionPayWithdraw';
+import { usePayTokenSelectionContext } from '../../context/confirmation-context';
 
 export function useNoPayTokenQuotesAlert() {
   const { payToken } = useTransactionPayToken();
@@ -34,6 +35,7 @@ export function useNoPayTokenQuotesAlert() {
   const transactionMeta = useTransactionMetadataRequest();
   const { canSelectWithdrawToken } = useTransactionPayWithdraw();
   const quoteError = useTransactionPayQuoteError();
+  const { isPayTokenSelectionFailed } = usePayTokenSelectionContext();
 
   const fiatAmount = Number(fiatPayment?.amountFiat);
   const hasValidFiatAmount = Number.isFinite(fiatAmount) && fiatAmount > 0;
@@ -70,6 +72,7 @@ export function useNoPayTokenQuotesAlert() {
 
   const shouldShowQuoteRequiredNoQuotesAlert =
     hasTransactionType(transactionMeta, QUOTE_REQUIRED_TRANSACTION_TYPES) &&
+    Boolean(payToken) &&
     !isQuotesLoading &&
     !quotes?.length &&
     hasPositiveRequiredAmount;
@@ -90,13 +93,16 @@ export function useNoPayTokenQuotesAlert() {
     !isPostQuote;
 
   // Pay-type deposits and conversions must have a payment token set on the
-  // controller (or a fiat payment method selected) before confirming. Blocks
-  // the timing races where auto-selection never completed, so no quotes were
-  // fetched and the transaction previously submitted directly without funds.
+  // controller (or a fiat payment method selected) before confirming. Once an
+  // actual selection attempt fails, a stale loading flag cannot make progress,
+  // so surface the terminal alert even while that flag remains set.
+  const isPayTokenRequired =
+    hasTransactionType(transactionMeta, PAY_TOKEN_REQUIRED_TRANSACTION_TYPES) ||
+    hasTransactionType(transactionMeta, QUOTE_REQUIRED_TRANSACTION_TYPES);
   const shouldShowPayTokenNotSelectedAlert =
-    hasTransactionType(transactionMeta, PAY_TOKEN_REQUIRED_TRANSACTION_TYPES) &&
-    !isQuotesLoading &&
-    hasPositiveRequiredAmount &&
+    isPayTokenRequired &&
+    isPayTokenSelectionFailed &&
+    !quotes?.length &&
     !payToken &&
     !hasSelectedFiatPaymentMethod;
 

--- a/app/components/Views/confirmations/hooks/custom-amount/useCustomAmountStage.test.ts
+++ b/app/components/Views/confirmations/hooks/custom-amount/useCustomAmountStage.test.ts
@@ -55,6 +55,7 @@ const DEFAULT_OPTIONS: HookOptions = {
   isAddMusdIntent: false,
   isDepositPrefillEnabled: false,
   isDepositPrefillLoading: false,
+  isPayTokenUnavailable: false,
   skipDepositPrefill: false,
   hasAccountNoFunds: false,
 };
@@ -132,6 +133,27 @@ describe('useCustomAmountStage', () => {
       const { result } = runDerived();
 
       expect(result.current.stage).toBe(CustomAmountStage.Loading);
+    });
+
+    it('derives NoQuote when a required pay token is unavailable', () => {
+      setupState({ isQuotesLoading: true, amountRaw: undefined });
+
+      const { result } = runDerived({ isPayTokenUnavailable: true });
+
+      expect(result.current.stage).toBe(CustomAmountStage.NoQuote);
+    });
+
+    it('derives NoQuote after selection fails during prefill loading', () => {
+      setupState({ isQuotesLoading: true, amountRaw: undefined });
+
+      const { result } = runDerived({
+        amountFiat: '0',
+        isDepositPrefillEnabled: true,
+        isDepositPrefillLoading: true,
+        isPayTokenUnavailable: true,
+      });
+
+      expect(result.current.stage).toBe(CustomAmountStage.NoQuote);
     });
 
     it('derives ShowTotals once quotes are present', () => {
@@ -305,6 +327,28 @@ describe('useCustomAmountStage', () => {
       });
 
       expect(result.current.stage).toBe(CustomAmountStage.ShowTotals);
+    });
+
+    it('keeps the Loading override while pay token selection is pending', () => {
+      setupState({ isQuotesLoading: true, amountRaw: undefined });
+      const { result } = runHook();
+
+      act(() => {
+        result.current.setStage(CustomAmountStage.Loading);
+      });
+
+      expect(result.current.stage).toBe(CustomAmountStage.Loading);
+    });
+
+    it('leaves the Loading override when a required pay token is unavailable', () => {
+      setupState({ isQuotesLoading: true, amountRaw: undefined });
+      const { result } = runHook({ isPayTokenUnavailable: true });
+
+      act(() => {
+        result.current.setStage(CustomAmountStage.Loading);
+      });
+
+      expect(result.current.stage).toBe(CustomAmountStage.NoQuote);
     });
 
     it('leaves the Loading override once the quote fetch takes over', () => {

--- a/app/components/Views/confirmations/hooks/custom-amount/useCustomAmountStage.ts
+++ b/app/components/Views/confirmations/hooks/custom-amount/useCustomAmountStage.ts
@@ -31,6 +31,7 @@ export enum CustomAmountStage {
  * @param options.isAddMusdIntent - Whether this is an add-mUSD deposit.
  * @param options.isDepositPrefillEnabled - Whether deposit prefill is enabled.
  * @param options.isDepositPrefillLoading - Whether a deposit prefill is loading.
+ * @param options.isPayTokenUnavailable - Whether a required crypto payment token failed to resolve.
  * @param options.skipDepositPrefill - Whether deposit prefill is skipped.
  * @returns The current stage and a setter to override it.
  */
@@ -42,6 +43,7 @@ export function useCustomAmountStage({
   isAddMusdIntent,
   isDepositPrefillEnabled,
   isDepositPrefillLoading,
+  isPayTokenUnavailable,
   skipDepositPrefill,
 }: {
   amountFiat: string;
@@ -51,6 +53,7 @@ export function useCustomAmountStage({
   isAddMusdIntent: boolean;
   isDepositPrefillEnabled: boolean;
   isDepositPrefillLoading: boolean;
+  isPayTokenUnavailable: boolean;
   skipDepositPrefill: boolean;
 }): {
   stage: CustomAmountStage;
@@ -111,7 +114,12 @@ export function useCustomAmountStage({
       // required-token amount may never resolve. There is nothing to await once
       // the amount is committed, so settle on the arm frame itself — the settle
       // branch below is never re-entered when no reactive input changes.
-      if (isNoOpRecommit || disablePay || hasPrefetchedQuote) {
+      if (
+        isNoOpRecommit ||
+        disablePay ||
+        hasPrefetchedQuote ||
+        isPayTokenUnavailable
+      ) {
         setStage(null);
       }
       return;
@@ -125,7 +133,10 @@ export function useCustomAmountStage({
       (loadingBaselineRef.current === undefined ||
         quotesLastUpdated > loadingBaselineRef.current);
 
-    if (hasAmount && (hasFreshQuote || isQuotesLoading)) {
+    if (
+      (hasAmount && (hasFreshQuote || isQuotesLoading)) ||
+      isPayTokenUnavailable
+    ) {
       setStage(null);
     }
   }, [
@@ -135,12 +146,16 @@ export function useCustomAmountStage({
     hasAmount,
     hasPrefetchedQuote,
     hasQuotes,
+    isPayTokenUnavailable,
     isQuotesLoading,
     quotesLastUpdated,
   ]);
 
   const isAwaitingPrefillResult =
-    !hasAccountNoFunds && !skipDepositPrefill && isDepositPrefillLoading;
+    !isPayTokenUnavailable &&
+    !hasAccountNoFunds &&
+    !skipDepositPrefill &&
+    isDepositPrefillLoading;
 
   // `disablePay` flows never fetch quotes, so totals (a plain `TotalRow`) show
   // as soon as the override clears — they must never fall through to `NoQuote`.
@@ -167,7 +182,12 @@ export function useCustomAmountStage({
   // Derive from reactive inputs. Stay in Loading while quotes fetch or a
   // prefill preload resolves; otherwise show totals when quotes exist, or fall
   // through to NoQuote when a settled fetch produced none.
-  if ((isQuotesLoading && !hasPrefetchedQuote) || isAwaitingPrefillResult) {
+  const isQuoteImpossible = isPayTokenUnavailable;
+
+  if (
+    (isQuotesLoading && !hasPrefetchedQuote && !isQuoteImpossible) ||
+    isAwaitingPrefillResult
+  ) {
     return { setStage, stage: CustomAmountStage.Loading };
   }
 

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
@@ -148,6 +148,7 @@ describe('useAutomaticTransactionPayToken', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+    setPayTokenMock.mockReturnValue(true);
 
     useTransactionPayTokenMock.mockReturnValue({
       payToken: undefined,
@@ -231,6 +232,54 @@ describe('useAutomaticTransactionPayToken', () => {
       address: TOKEN_ADDRESS_2_MOCK,
       chainId: CHAIN_ID_2_MOCK,
     });
+  });
+
+  it('retries failed automatic selection when token data changes', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: [
+        {
+          address: TOKEN_ADDRESS_2_MOCK,
+          chainId: CHAIN_ID_2_MOCK,
+        },
+      ] as AssetType[],
+      hasTokens: true,
+    });
+    setPayTokenMock.mockReturnValueOnce(false);
+    const { rerender } = runHook();
+
+    rerender(undefined);
+
+    expect(setPayTokenMock).toHaveBeenCalledTimes(1);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: [
+        {
+          address: TOKEN_ADDRESS_3_MOCK,
+          chainId: CHAIN_ID_2_MOCK,
+        },
+      ] as AssetType[],
+      hasTokens: true,
+    });
+    rerender(undefined);
+
+    expect(setPayTokenMock).toHaveBeenCalledTimes(2);
+    expect(setPayTokenMock).toHaveBeenLastCalledWith({
+      address: TOKEN_ADDRESS_3_MOCK,
+      chainId: CHAIN_ID_2_MOCK,
+    });
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: [
+        {
+          address: TOKEN_ADDRESS_1_MOCK,
+          chainId: CHAIN_ID_1_MOCK,
+        },
+      ] as AssetType[],
+      hasTokens: true,
+    });
+    rerender(undefined);
+
+    expect(setPayTokenMock).toHaveBeenCalledTimes(2);
   });
 
   it('does not select token when no tokens with balance and fiat unavailable', () => {
@@ -1146,6 +1195,42 @@ describe('useAutomaticTransactionPayToken', () => {
     expect(setPayTokenMock).not.toHaveBeenCalled();
   });
 
+  it('does not re-select after a fiat-selected account override transition', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: [
+        {
+          address: TOKEN_ADDRESS_1_MOCK,
+          chainId: CHAIN_ID_1_MOCK,
+        },
+      ] as AssetType[],
+      hasTokens: true,
+    });
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: transactionIdMock,
+      type: TransactionType.moneyAccountDeposit,
+      txParams: { from: '0xAddress1' },
+    } as never);
+    const { rerender } = runHook({ autoSelectFiatPayment: true });
+    useTransactionPayFiatPaymentMock.mockReturnValue({
+      selectedPaymentMethodId: 'payment-method-id',
+    } as never);
+    useTransactionAccountOverrideMock.mockReturnValue('0xOverrideA' as Hex);
+
+    rerender(undefined);
+
+    useTransactionPayFiatPaymentMock.mockReturnValue(undefined);
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: {
+        address: TOKEN_ADDRESS_2_MOCK,
+        chainId: CHAIN_ID_2_MOCK,
+      } as unknown as ReturnType<typeof useTransactionPayToken>['payToken'],
+      setPayToken: setPayTokenMock,
+    });
+    rerender(undefined);
+
+    expect(setPayTokenMock).not.toHaveBeenCalled();
+  });
+
   it('re-selects pay token on accountOverride change in fiat flow after a pay token was selected', () => {
     useTransactionPayAvailableTokensMock.mockReturnValue({
       availableTokens: [
@@ -1220,6 +1305,65 @@ describe('useAutomaticTransactionPayToken', () => {
       address: TOKEN_ADDRESS_1_MOCK,
       chainId: CHAIN_ID_1_MOCK,
     });
+  });
+
+  it('retries pay token selection after an account override change', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: [
+        {
+          address: TOKEN_ADDRESS_1_MOCK,
+          chainId: CHAIN_ID_1_MOCK,
+        },
+      ] as AssetType[],
+      hasTokens: true,
+    });
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: transactionIdMock,
+      type: TransactionType.moneyAccountDeposit,
+      txParams: { from: '0xAddress1' },
+    } as never);
+    const { rerender } = runHook();
+    setPayTokenMock.mockClear();
+    setPayTokenMock.mockReturnValueOnce(false);
+    useTransactionAccountOverrideMock.mockReturnValue('0xOverrideA' as Hex);
+
+    rerender(undefined);
+
+    expect(setPayTokenMock).toHaveBeenCalledTimes(1);
+
+    rerender(undefined);
+
+    expect(setPayTokenMock).toHaveBeenCalledTimes(1);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: [
+        {
+          address: TOKEN_ADDRESS_2_MOCK,
+          chainId: CHAIN_ID_2_MOCK,
+        },
+      ] as AssetType[],
+      hasTokens: true,
+    });
+    rerender(undefined);
+
+    expect(setPayTokenMock).toHaveBeenCalledTimes(2);
+    expect(setPayTokenMock).toHaveBeenLastCalledWith({
+      address: TOKEN_ADDRESS_2_MOCK,
+      chainId: CHAIN_ID_2_MOCK,
+    });
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: [
+        {
+          address: TOKEN_ADDRESS_3_MOCK,
+          chainId: CHAIN_ID_2_MOCK,
+        },
+      ] as AssetType[],
+      hasTokens: true,
+    });
+    rerender(undefined);
+
+    expect(setPayTokenMock).toHaveBeenCalledTimes(2);
   });
 
   it('does not re-select pay token when accountOverride changes for post-quote withdraws', () => {
@@ -1368,6 +1512,88 @@ describe('useAutomaticTransactionPayToken', () => {
       address: MUSD_TOKEN_ADDRESS,
       chainId: CHAIN_IDS.MONAD,
     });
+  });
+
+  it('retries pay token selection after a money override change', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: [
+        {
+          address: TOKEN_ADDRESS_2_MOCK,
+          chainId: CHAIN_ID_2_MOCK,
+        },
+      ] as AssetType[],
+      hasTokens: true,
+    });
+    const { rerender } = runHook();
+    setPayTokenMock.mockClear();
+    setPayTokenMock.mockReturnValueOnce(false);
+    jest
+      .mocked(selectPaymentOverrideByTransactionId)
+      .mockReturnValue(PaymentOverride.MoneyAccount);
+
+    rerender(undefined);
+
+    expect(setPayTokenMock).toHaveBeenCalledTimes(1);
+
+    rerender(undefined);
+
+    expect(setPayTokenMock).toHaveBeenCalledTimes(1);
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: [
+        {
+          address: TOKEN_ADDRESS_3_MOCK,
+          chainId: CHAIN_ID_2_MOCK,
+        },
+      ] as AssetType[],
+      hasTokens: true,
+    });
+    rerender(undefined);
+
+    expect(setPayTokenMock).toHaveBeenCalledTimes(2);
+    expect(setPayTokenMock).toHaveBeenLastCalledWith({
+      address: MUSD_TOKEN_ADDRESS,
+      chainId: CHAIN_IDS.MONAD,
+    });
+
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: [
+        {
+          address: TOKEN_ADDRESS_1_MOCK,
+          chainId: CHAIN_ID_1_MOCK,
+        },
+      ] as AssetType[],
+      hasTokens: true,
+    });
+    rerender(undefined);
+
+    expect(setPayTokenMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not re-select after a fiat-selected money override transition', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue({
+      availableTokens: [
+        {
+          address: TOKEN_ADDRESS_2_MOCK,
+          chainId: CHAIN_ID_2_MOCK,
+        },
+      ] as AssetType[],
+      hasTokens: true,
+    });
+    const { rerender } = runHook({ autoSelectFiatPayment: true });
+    useTransactionPayFiatPaymentMock.mockReturnValue({
+      selectedPaymentMethodId: 'payment-method-id',
+    } as never);
+    jest
+      .mocked(selectPaymentOverrideByTransactionId)
+      .mockReturnValue(PaymentOverride.MoneyAccount);
+
+    rerender(undefined);
+
+    useTransactionPayFiatPaymentMock.mockReturnValue(undefined);
+    rerender(undefined);
+
+    expect(setPayTokenMock).not.toHaveBeenCalled();
   });
 
   it('does not re-select on money override change when disabled', () => {

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
@@ -41,6 +41,7 @@ import { selectLastWithdrawTokenByType } from '../../../../../selectors/transact
 import { selectPaymentOverrideByTransactionId } from '../../../../../selectors/transactionPayController';
 import { useIsFiatPaymentAvailable } from './useIsFiatPaymentAvailable';
 import { useMMPayFiatConfig } from './useMMPayFiatConfig';
+import { usePayTokenSelectionContext } from '../../context/confirmation-context';
 
 jest.mock('../transactions/useTransactionMetadataRequest');
 jest.mock('../transactions/useTransactionAccountOverride');
@@ -53,6 +54,7 @@ jest.mock('./useWithdrawTokenFilter');
 jest.mock('../../../../UI/Ramp/hooks/useRampsPaymentMethods');
 jest.mock('./useIsFiatPaymentAvailable');
 jest.mock('./useMMPayFiatConfig');
+jest.mock('../../context/confirmation-context');
 jest.mock('../../../../../selectors/transactionController', () => ({
   ...jest.requireActual('../../../../../selectors/transactionController'),
   selectLastWithdrawTokenByType: jest.fn(),
@@ -145,10 +147,15 @@ describe('useAutomaticTransactionPayToken', () => {
   const setPayTokenMock: jest.MockedFn<
     ReturnType<typeof useTransactionPayToken>['setPayToken']
   > = jest.fn();
+  const setIsPayTokenSelectionFailedMock = jest.fn();
 
   beforeEach(() => {
     jest.resetAllMocks();
     setPayTokenMock.mockReturnValue(true);
+    jest.mocked(usePayTokenSelectionContext).mockReturnValue({
+      isPayTokenSelectionFailed: false,
+      setIsPayTokenSelectionFailed: setIsPayTokenSelectionFailedMock,
+    });
 
     useTransactionPayTokenMock.mockReturnValue({
       payToken: undefined,
@@ -247,6 +254,8 @@ describe('useAutomaticTransactionPayToken', () => {
     setPayTokenMock.mockReturnValueOnce(false);
     const { rerender } = runHook();
 
+    expect(setIsPayTokenSelectionFailedMock).toHaveBeenLastCalledWith(true);
+
     rerender(undefined);
 
     expect(setPayTokenMock).toHaveBeenCalledTimes(1);
@@ -267,6 +276,7 @@ describe('useAutomaticTransactionPayToken', () => {
       address: TOKEN_ADDRESS_3_MOCK,
       chainId: CHAIN_ID_2_MOCK,
     });
+    expect(setIsPayTokenSelectionFailedMock).toHaveBeenLastCalledWith(false);
 
     useTransactionPayAvailableTokensMock.mockReturnValue({
       availableTokens: [

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -45,6 +45,7 @@ import { MUSD_TOKEN_ADDRESS } from '../../../../UI/Earn/constants/musd';
 import { useWithdrawTokenFilter } from './useWithdrawTokenFilter';
 import { useTransactionAccountOverride } from '../transactions/useTransactionAccountOverride';
 import { useRampsPaymentMethods } from '../../../../UI/Ramp/hooks/useRampsPaymentMethods';
+import { usePayTokenSelectionContext } from '../../context/confirmation-context';
 
 export interface SetPayTokenRequest {
   address: Hex;
@@ -166,10 +167,23 @@ export function useAutomaticTransactionPayToken({
   );
 
   const automaticToken = useMemo(() => selectBestToken(), [selectBestToken]);
+  const { setIsPayTokenSelectionFailed } = usePayTokenSelectionContext();
 
   const { paymentMethods } = useRampsPaymentMethods();
   const { maxDelayMinutesForPaymentMethods } = useMMPayFiatConfig();
   const isFiatEnabled = useIsFiatPaymentAvailable();
+
+  useEffect(() => {
+    if (disable || payToken || hasFiatPaymentSelected || !automaticToken) {
+      setIsPayTokenSelectionFailed(false);
+    }
+  }, [
+    automaticToken,
+    disable,
+    hasFiatPaymentSelected,
+    payToken,
+    setIsPayTokenSelectionFailed,
+  ]);
 
   useEffect(() => {
     if (
@@ -183,6 +197,7 @@ export function useAutomaticTransactionPayToken({
     }
 
     if (autoSelectFiatPayment || tokens.length === 0) {
+      setIsPayTokenSelectionFailed(false);
       if (!isFiatEnabled || paymentMethods.length === 0) {
         return;
       }
@@ -215,6 +230,8 @@ export function useAutomaticTransactionPayToken({
       chainId: automaticToken.chainId,
     });
 
+    setIsPayTokenSelectionFailed(!didSetPayToken);
+
     if (didSetPayToken) {
       isUpdated.current = transactionId;
       log('Automatically selected pay token', automaticToken);
@@ -229,6 +246,7 @@ export function useAutomaticTransactionPayToken({
     payToken,
     paymentMethods,
     requiredTokens,
+    setIsPayTokenSelectionFailed,
     setPayToken,
     tokens,
     transactionId,
@@ -276,6 +294,8 @@ export function useAutomaticTransactionPayToken({
         chainId: automaticToken.chainId,
       });
 
+      setIsPayTokenSelectionFailed(!didSetPayToken);
+
       if (didSetPayToken) {
         prevAccountKeyRef.current = accountKey;
         log('Re-selected pay token after account change', automaticToken);
@@ -289,6 +309,7 @@ export function useAutomaticTransactionPayToken({
     from,
     hasFiatPaymentSelected,
     postQuoteTransactionType,
+    setIsPayTokenSelectionFailed,
     setPayToken,
   ]);
 
@@ -318,6 +339,8 @@ export function useAutomaticTransactionPayToken({
         chainId: automaticToken.chainId,
       });
 
+      setIsPayTokenSelectionFailed(!didSetPayToken);
+
       if (didSetPayToken) {
         previousMoneyPaymentOverrideRef.current = true;
         log('Re-selected pay token after money account change', automaticToken);
@@ -328,6 +351,7 @@ export function useAutomaticTransactionPayToken({
     disable,
     from,
     hasFiatPaymentSelected,
+    setIsPayTokenSelectionFailed,
     setPayToken,
     isMoneyPaymentOverride,
   ]);

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -210,14 +210,15 @@ export function useAutomaticTransactionPayToken({
       return;
     }
 
-    setPayToken({
+    const didSetPayToken = setPayToken({
       address: automaticToken.address,
       chainId: automaticToken.chainId,
     });
 
-    isUpdated.current = transactionId;
-
-    log('Automatically selected pay token', automaticToken);
+    if (didSetPayToken) {
+      isUpdated.current = transactionId;
+      log('Automatically selected pay token', automaticToken);
+    }
   }, [
     autoSelectFiatPayment,
     automaticToken,
@@ -250,27 +251,35 @@ export function useAutomaticTransactionPayToken({
   const prevAccountKeyRef = useRef(`${from ?? ''}:${accountOverride ?? ''}`);
   useEffect(() => {
     const accountKey = `${from ?? ''}:${accountOverride ?? ''}`;
+    if (hasFiatPaymentSelected) {
+      prevAccountKeyRef.current = accountKey;
+      return;
+    }
+
     if (
       disable ||
-      hasFiatPaymentSelected ||
       !from ||
       prevAccountKeyRef.current === accountKey ||
       postQuoteTransactionType
     ) {
       return;
     }
-    prevAccountKeyRef.current = accountKey;
 
     if (autoSelectFiatPayment && !payTokenEverSelectedRef.current) {
+      prevAccountKeyRef.current = accountKey;
       return;
     }
 
     if (automaticToken) {
-      setPayToken({
+      const didSetPayToken = setPayToken({
         address: automaticToken.address,
         chainId: automaticToken.chainId,
       });
-      log('Re-selected pay token after account change', automaticToken);
+
+      if (didSetPayToken) {
+        prevAccountKeyRef.current = accountKey;
+        log('Re-selected pay token after account change', automaticToken);
+      }
     }
   }, [
     accountOverride,
@@ -285,27 +294,34 @@ export function useAutomaticTransactionPayToken({
 
   // Re-select the pay token when the user switches between global account and
   // money account. Money account deposits are locked to MUSD on MONAD.
-  const previsMoneyPaymentOverrideRef = useRef(false);
+  const previousMoneyPaymentOverrideRef = useRef(false);
   useEffect(() => {
-    const prev = previsMoneyPaymentOverrideRef.current;
-    previsMoneyPaymentOverrideRef.current = !!isMoneyPaymentOverride;
+    const previousOverride = previousMoneyPaymentOverrideRef.current;
 
-    if (
-      disable ||
-      hasFiatPaymentSelected ||
-      !from ||
-      isMoneyPaymentOverride !== true ||
-      isMoneyPaymentOverride === prev
-    ) {
+    if (!isMoneyPaymentOverride) {
+      previousMoneyPaymentOverrideRef.current = false;
+      return;
+    }
+
+    if (hasFiatPaymentSelected) {
+      previousMoneyPaymentOverrideRef.current = true;
+      return;
+    }
+
+    if (disable || !from || isMoneyPaymentOverride === previousOverride) {
       return;
     }
 
     if (automaticToken) {
-      setPayToken({
+      const didSetPayToken = setPayToken({
         address: automaticToken.address,
         chainId: automaticToken.chainId,
       });
-      log('Re-selected pay token after money account change', automaticToken);
+
+      if (didSetPayToken) {
+        previousMoneyPaymentOverrideRef.current = true;
+        log('Re-selected pay token after money account change', automaticToken);
+      }
     }
   }, [
     automaticToken,

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.test.ts
@@ -17,6 +17,7 @@ import {
 import Engine from '../../../../../core/Engine';
 import { flushPromises } from '../../../../../util/test/utils';
 import { updateTransaction } from '../../../../../util/transaction-controller';
+import EngineService from '../../../../../core/EngineService';
 
 jest.mock('../../../../../core/Engine', () => ({
   context: {
@@ -123,6 +124,8 @@ describe('useTransactionPayToken', () => {
     Engine.context.GasFeeController.fetchGasFeeEstimates,
   );
 
+  const flushStateMock = jest.spyOn(EngineService, 'flushState');
+
   beforeEach(() => {
     jest.resetAllMocks();
 
@@ -146,21 +149,37 @@ describe('useTransactionPayToken', () => {
     expect(result.current.isNative).toBe(false);
   });
 
-  it('sets token in state', async () => {
+  it('returns true when token is set in state', async () => {
     const { result } = runHook();
 
-    result.current.setPayToken({
+    const didSetPayToken = result.current.setPayToken({
       address: PAY_TOKEN_MOCK.address,
       chainId: PAY_TOKEN_MOCK.chainId as ChainId,
     });
 
     await flushPromises();
 
+    expect(didSetPayToken).toBe(true);
     expect(updatePaymentTokenMock).toHaveBeenCalledWith({
       transactionId: TRANSACTION_ID_MOCK,
       tokenAddress: PAY_TOKEN_MOCK.address,
       chainId: PAY_TOKEN_MOCK.chainId,
     });
+  });
+
+  it('returns false when the payment token update fails', () => {
+    updatePaymentTokenMock.mockImplementationOnce(() => {
+      throw new Error('Payment token not found');
+    });
+    const { result } = runHook();
+
+    const didSetPayToken = result.current.setPayToken({
+      address: PAY_TOKEN_MOCK.address,
+      chainId: PAY_TOKEN_MOCK.chainId as ChainId,
+    });
+
+    expect(didSetPayToken).toBe(false);
+    expect(flushStateMock).not.toHaveBeenCalled();
   });
 
   it('returns isNative true when pay token is native address', () => {
@@ -179,6 +198,24 @@ describe('useTransactionPayToken', () => {
 
     beforeEach(() => {
       updateTransactionMock.mockClear();
+    });
+
+    it('does not update the gas token when the payment token update fails', () => {
+      updatePaymentTokenMock.mockImplementationOnce(() => {
+        throw new Error('Payment token not found');
+      });
+      const { result } = runHook({
+        payToken: PAY_TOKEN_MOCK,
+        type: TransactionType.predictDeposit,
+        requiredTokens: [REQUIRED_TOKEN_MOCK],
+      });
+
+      result.current.setPayToken({
+        address: PAY_TOKEN_MOCK.address,
+        chainId: PAY_TOKEN_MOCK.chainId as ChainId,
+      });
+
+      expect(updateTransactionMock).not.toHaveBeenCalled();
     });
 
     it('updates transaction with selectedGasFeeToken for predictDeposit when pay token matches required token', async () => {

--- a/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useTransactionPayToken.ts
@@ -21,7 +21,7 @@ import Logger from '../../../../../util/Logger';
 export function useTransactionPayToken(): {
   isNative?: boolean;
   payToken: TransactionPaymentToken | undefined;
-  setPayToken: (newPayToken: { address: Hex; chainId: Hex }) => void;
+  setPayToken: (newPayToken: { address: Hex; chainId: Hex }) => boolean;
 } {
   const transactionMeta = useTransactionMetadataRequest();
   const { id: transactionId } = transactionMeta || { id: '' };
@@ -59,6 +59,7 @@ export function useTransactionPayToken(): {
         });
       } catch (error) {
         Logger.error(error as Error, 'Error updating payment token');
+        return false;
       }
 
       // perps deposits only use relay, so doesn't need gasFeeToken update
@@ -87,6 +88,7 @@ export function useTransactionPayToken(): {
       }
 
       EngineService.flushState();
+      return true;
     },
     [
       transactionId,


### PR DESCRIPTION
## **Description**

This change prevents the MM Pay **Pay with** row from remaining on an infinite skeleton when automatic payment-token selection cannot be committed because token metadata, asset state, or fiat-rate data is slow, unavailable, or inconsistent.

### Root cause

The Mobile UI treated this state as loading indefinitely:

- account assets contained one or more available tokens;
- `TransactionPayController.updatePaymentToken` rejected the automatic candidate (for example, with `Payment token not found` while controller metadata/rates were unavailable);
- the controller therefore had no `paymentToken`;
- Mobile swallowed the failure but still marked automatic/account selection as handled;
- `PayWithRow` interpreted `paymentToken === undefined && availableTokens.length > 0` as an unresolved loading state forever.

This was particularly visible in Money Account deposits, but the lifecycle is shared by MM Pay deposit flows.

### What changed

1. **Payment-token selection is success-aware.**
   - `setPayToken` now returns whether `TransactionPayController` accepted the token.
   - Predict gas-token updates and the state flush only happen after successful selection.

2. **Failed automatic selection remains retryable.**
   - The transaction, account, and Money Account transition latches advance only after successful token selection.
   - Later reactive asset/rate/token updates can retry the selection.
   - Unchanged rerenders do not retry, so this does not introduce a render/request loop.
   - Intentional fiat transitions are still consumed so a later crypto update cannot overwrite a fiat selection.

3. **The Pay with row has a terminal presentation even during a persistent outage.**
   - `CustomAmountInfo` passes the already-computed automatic candidate to `PayWithRow`.
   - If the controller token is unavailable, the row displays that candidate using Mobile's available-token metadata.
   - The candidate is display-only: controller `paymentToken` remains authoritative for quote generation and submission.
   - Controller tokens, selected fiat methods, Money Account rows, withdraw destinations, no-funds state, and hardware-wallet edit restrictions retain precedence.
   - If no candidate can be resolved to display metadata, the row shows **Select payment method** instead of an unbounded skeleton.

4. **Selection failures now terminate quote loading.**
   - An actual rejected `setPayToken` attempt is shared with the confirmation alert and amount-stage state machines.
   - A stale controller loading flag or prefill loader can no longer keep the quote UI spinning when no controller payment token exists.
   - The screen settles to the existing blocking **No quotes** state, including when the required raw amount could not resolve.
   - Pending selection is kept distinct from failed selection, so normal token, fiat, quote, and prefill loading does not show a premature error.

5. **No-quote safety is preserved.**
   - The blocking no-quote alert still reads authoritative controller token/quote state, not the optimistic display candidate.
   - Showing the candidate therefore does not enable submission when MM Pay has no valid quote.

### Price/assets API retry behavior

This PR does **not** add timer-based polling or directly refetch the price/assets API from the UI. Existing asset controllers continue to own those requests. Mobile retries payment-token selection when their reactive state changes. This avoids an uncontrolled retry storm during an outage, while the display-only fallback guarantees that the Pay with row no longer remains an infinite skeleton if the API never recovers.

Current `main` already includes the earlier missing-price correction from #33461 (`useTokenFiatRates` returns `undefined` rather than inventing a price). This PR adds the lifecycle and terminal-UI hardening around that behavior.

This PR is intentionally opened as a draft until repeated Android verification and before/after recording are complete.

## **Changelog**

CHANGELOG entry: Fixed MM Pay Pay with remaining stuck in a loading state when token price or asset data was unavailable

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1769

Refs: https://consensyssoftware.atlassian.net/browse/CONF-1702

CONF-1702 is referenced rather than closed because it also covers broader API-outage handling across all Mobile and Extension MM Pay surfaces. This PR addresses the Mobile payment-token selection and Pay with row portion.

## **Manual testing steps**

```gherkin
Feature: MM Pay payment-token loading resilience

  Scenario: Money Account deposit resolves the Pay with row
    Given MetaMask Mobile is running on Android
    And the wallet has a Money Account and at least one funded crypto token
    When the user opens Money Account deposit repeatedly
    Then the Pay with row displays a token or Select payment method
    And the Pay with row does not remain on a skeleton

  Scenario: automatic token price or controller metadata is unavailable
    Given the automatic payment token is present in Mobile account assets
    And its price or TransactionPayController asset metadata is unavailable
    When automatic payment-token selection is attempted
    Then the intended token remains visible in the Pay with row
    And entering an amount without a valid quote shows the blocking no-quote state
    And the transaction cannot be confirmed without a valid controller token and quote

  Scenario: asset and price data recover after initial selection failure
    Given the first payment-token update is rejected because controller data is unavailable
    When the asset or rate state later updates with valid data
    Then Mobile retries payment-token selection
    And the controller token replaces the display-only fallback
    And MM Pay can request a quote normally

  Scenario: fiat payment metadata is still loading
    Given a fiat payment method ID is selected
    And the corresponding payment-method metadata has not resolved
    When the Pay with row renders
    Then it shows the empty selectable state
    And it does not display an unrelated automatic crypto candidate
```

Automated validation completed:

- 10 focused Jest suites: 312 tests passed
- `yarn lint:tsc`
- targeted ESLint: 0 errors (pre-existing deprecation warnings only)
- Prettier check
- `git diff --check`

## **Screenshots/Recordings**

### **Before**

N/A — Android recording is pending while this PR remains in draft.

### **After**

N/A — Android recording is pending while this PR remains in draft.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
