### PR TITLE
fix(predict): keep PWAT auto-select on betslip reopen

### DIFF
--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.test.ts
@@ -200,6 +200,13 @@ describe('usePredictBuyActions', () => {
       expect(mockInitPayWithAnyToken).toHaveBeenCalledTimes(1);
     });
 
+    it('does not reset payment token during init', () => {
+      renderHook(() => usePredictBuyActions(createDefaultParams()));
+
+      expect(mockResetSelectedPaymentToken).not.toHaveBeenCalled();
+      expect(mockInitPayWithAnyToken).toHaveBeenCalledTimes(1);
+    });
+
     it('does not call initPayWithAnyToken when pay with any token is disabled', () => {
       mockPayWithAnyTokenEnabled = false;
 
@@ -218,6 +225,18 @@ describe('usePredictBuyActions', () => {
       expect(mockTransitionEndUnsubscribe).toHaveBeenCalledTimes(1);
       expect(mockBeforeRemoveUnsubscribe).toHaveBeenCalledTimes(1);
       expect(mockOnConfirmActionsReject).toHaveBeenCalledTimes(1);
+    });
+
+    it('resets payment token on beforeRemove cleanup', () => {
+      renderHook(() => usePredictBuyActions(createDefaultParams()));
+
+      act(() => {
+        mockBeforeRemoveCallbacks[0]();
+      });
+
+      expect(mockResetSelectedPaymentToken).toHaveBeenCalledTimes(1);
+      expect(mockOnConfirmActionsReject).toHaveBeenCalledWith(undefined, true);
+      expect(mockClearActiveOrderTransactionId).toHaveBeenCalled();
     });
 
     it('only calls initPayWithAnyToken once even if transitionEnd fires again', () => {
@@ -753,9 +772,11 @@ describe('usePredictBuyActions', () => {
         'beforeRemove',
         expect.any(Function),
       );
+      expect(mockResetSelectedPaymentToken).not.toHaveBeenCalled();
 
       unmount();
 
+      expect(mockResetSelectedPaymentToken).toHaveBeenCalledTimes(1);
       expect(mockOnConfirmActionsReject).toHaveBeenCalledWith(undefined, true);
       expect(mockClearActiveOrderTransactionId).toHaveBeenCalled();
     });
@@ -783,9 +804,11 @@ describe('usePredictBuyActions', () => {
 
       mockOnConfirmActionsReject.mockClear();
       mockClearActiveOrderTransactionId.mockClear();
+      mockResetSelectedPaymentToken.mockClear();
 
       unmount();
 
+      expect(mockResetSelectedPaymentToken).toHaveBeenCalledTimes(1);
       expect(mockOnConfirmActionsReject).toHaveBeenCalledWith(undefined, true);
       expect(mockClearActiveOrderTransactionId).toHaveBeenCalled();
     });

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.ts
@@ -121,7 +121,8 @@ export const usePredictBuyActions = ({
     const doInit = async () => {
       batchIdRef.current = undefined;
       rejectPendingTransactions();
-      resetSelectedPaymentToken();
+      // Reset payment token on dismiss instead, so default auto-select is not
+      // overwritten when leftover PREVIEW lets that effect run before doInit.
       const result = await initPayWithAnyToken();
       if (result?.success && result.response?.batchId) {
         batchIdRef.current = result.response.batchId;
@@ -149,7 +150,6 @@ export const usePredictBuyActions = ({
     initPayWithAnyToken,
     payWithAnyTokenEnabled,
     PredictController,
-    resetSelectedPaymentToken,
     isSheetMode,
   ]);
 
@@ -160,6 +160,7 @@ export const usePredictBuyActions = ({
 
     if (isSheetMode) {
       return () => {
+        resetSelectedPaymentToken();
         onRejectRef.current(undefined, true);
         clearActiveOrderTransactionIdRef.current();
       };
@@ -184,6 +185,7 @@ export const usePredictBuyActions = ({
           activeAbTests: transactionActiveAbTests,
         });
       }
+      resetSelectedPaymentToken();
       onRejectRef.current(undefined, true);
       clearActiveOrderTransactionIdRef.current();
     });
@@ -193,6 +195,7 @@ export const usePredictBuyActions = ({
     isSheetMode,
     analyticsProperties,
     transactionActiveAbTests,
+    resetSelectedPaymentToken,
   ]);
 
   const handlePlaceOrder = useCallback(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

When Predict balance is below the $1 minimum bet, Pay With Any Token should auto-select the highest-balance ERC-20 as the payment method. That worked on the first betslip open, but after closing and reopening (same or different market) the UI stayed on Predict balance.

Root cause: `usePredictBuyActions` reset the payment token during init, while `usePredictDefaultPaymentToken` could already auto-select against leftover `PREVIEW` active-order state (child effect runs before parent). The init reset then overwrote the selection, and `hasInitializedRef` blocked a second auto-select.

Fix: reset the selected payment token on dismiss/unmount instead of during init, so auto-select is not overwritten on reopen.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed Predict betslip defaulting to Predict balance on reopen when balance is below $1 instead of the highest-balance token

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-1057

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Predict Pay With Any Token default payment method

  Scenario: user opens betslip with Predict balance below $1
    Given Predict balance is below $1
    And the wallet has at least one ERC-20 with positive fiat balance
    And Pay With Any Token is enabled

    When user opens a Predict betslip
    Then the selected payment method is the highest-balance ERC-20 token

  Scenario: user reopens betslip after dismissing
    Given Predict balance is below $1
    And the wallet has at least one ERC-20 with positive fiat balance
    And user previously opened and dismissed a betslip

    When user opens the same or a different Predict betslip again
    Then the selected payment method is again the highest-balance ERC-20 token
    And it does not remain on Predict balance

  Scenario: user with sufficient Predict balance still defaults to Predict balance
    Given Predict balance is at least $1

    When user opens a Predict betslip
    Then the selected payment method is Predict balance
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — please attach before/after recordings from local verification before marking ready for review. Related bug recording: https://www.loom.com/share/d972d14d1a2f434f8218ba5119064dc7

### **Before**

<!-- [screenshots/recordings] -->

First open auto-selects ERC-20; reopen stays on Predict balance.

### **After**

<!-- [screenshots/recordings] -->

First open and subsequent reopens both auto-select the highest-balance ERC-20 when Predict balance is below $1.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Predict betslip payment-selection lifecycle change with matching unit tests; no auth, security, or broad payment-path changes.
> 
> **Overview**
> Fixes Predict betslip **Pay With Any Token** defaulting back to Predict balance after dismiss/reopen when Predict balance is below the $1 minimum.
> 
> **`usePredictBuyActions`** no longer calls **`resetSelectedPaymentToken`** inside Pay With Any Token init (`doInit`). That reset ran after **`usePredictDefaultPaymentToken`** could auto-pick the highest-balance ERC-20 (child effect before parent), wiping the selection and blocking a second auto-select via **`hasInitializedRef`**. The selected payment token is now cleared on **dismiss**—**`beforeRemove`** (stack) and **sheet unmount**—alongside existing reject/cleanup, so reopen can auto-select again.
> 
> Tests assert init does not reset, **`beforeRemove`** and sheet unmount do reset, and in-flight sheet flows still reset on unmount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38f0e91c7bd537f7003540cc69269bf27b455218. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->