### PR TITLE
refactor(confirmations): migrate banners to MMDS BannerAlert

### DIFF
--- a/app/components/Views/confirmations/components/alert-banner/alert-banner.test.tsx
+++ b/app/components/Views/confirmations/components/alert-banner/alert-banner.test.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
+import { Text } from 'react-native';
 import { render } from '@testing-library/react-native';
-import { BannerAlertSeverity } from '../../../../../component-library/components/Banners/Banner';
-import Text from '../../../../../component-library/components/Texts/Text';
+import { TransactionType } from '@metamask/transaction-controller';
 import { Alert, Severity } from '../../types/alerts';
 import { useAlerts } from '../../context/alert-system-context';
 import AlertBanner from './alert-banner';
-import { getBannerAlertSeverity } from '../../utils/alert-system';
 import { RowAlertKey } from '../UI/info-row/alert-row/constants';
 import { useTransactionMetadataRequest } from '../../hooks/transactions/useTransactionMetadataRequest';
-import { TransactionType } from '@metamask/transaction-controller';
 import { AlertKeys } from '../../constants/alerts';
 
 jest.mock('../../hooks/transactions/useTransactionMetadataRequest');
@@ -75,14 +73,12 @@ describe('AlertBanner', () => {
     (useTransactionMetadataRequest as jest.Mock).mockReturnValue({});
   });
 
-  it('renders correctly when there are general alerts', () => {
-    const { getByText, queryByText } = render(<AlertBanner />);
+  it('renders general alert banners', () => {
+    const { getByTestId, queryByTestId } = render(<AlertBanner />);
 
-    expect(getByText('Alert 1')).toBeDefined();
-    expect(getByText('Alert 2')).toBeDefined();
-    expect(queryByText('Alert 3')).toBeNull();
-    expect(queryByText('Alert 4')).toBeNull();
-    expect(queryByText('Alert 5')).toBeNull();
+    expect(getByTestId('security-alert-banner-0')).toBeOnTheScreen();
+    expect(getByTestId('security-alert-banner-1')).toBeOnTheScreen();
+    expect(queryByTestId('security-alert-banner-2')).toBeNull();
   });
 
   it('does not render when there are no general alerts', () => {
@@ -90,60 +86,47 @@ describe('AlertBanner', () => {
       generalAlerts: [],
     });
 
-    const { toJSON } = render(<AlertBanner />);
-    expect(toJSON()).toBeNull();
+    const { queryByTestId } = render(<AlertBanner />);
+
+    expect(queryByTestId('security-alert-banner-0')).toBeNull();
   });
 
-  it('converts severity correctly', () => {
-    expect(getBannerAlertSeverity(Severity.Danger)).toBe(
-      BannerAlertSeverity.Error,
-    );
+  it('renders field alerts when includeFields is set', () => {
+    const { getByTestId } = render(<AlertBanner includeFields />);
 
-    expect(getBannerAlertSeverity(Severity.Warning)).toBe(
-      BannerAlertSeverity.Warning,
-    );
-
-    expect(getBannerAlertSeverity(Severity.Info)).toBe(
-      BannerAlertSeverity.Info,
-    );
+    expect(getByTestId('security-alert-banner-0')).toBeOnTheScreen();
+    expect(getByTestId('security-alert-banner-1')).toBeOnTheScreen();
+    expect(getByTestId('security-alert-banner-2')).toBeOnTheScreen();
+    expect(getByTestId('security-alert-banner-3')).toBeOnTheScreen();
+    expect(getByTestId('security-alert-banner-4')).toBeOnTheScreen();
   });
 
-  it('renders field alerts if includeFields set', () => {
-    const { getByText } = render(<AlertBanner includeFields />);
-
-    expect(getByText('Alert 1')).toBeDefined();
-    expect(getByText('Alert 2')).toBeDefined();
-    expect(getByText('Alert 3')).toBeDefined();
-    expect(getByText('Alert 4')).toBeDefined();
-    expect(getByText('Alert 5')).toBeDefined();
-  });
-
-  it('renders blocking only if set', () => {
-    const { getByText, queryByText } = render(
+  it('renders only blocking alerts when blockingOnly is set', () => {
+    const { getByTestId, queryByTestId, getByText } = render(
       <AlertBanner blockingOnly includeFields />,
     );
 
-    expect(queryByText('Alert 1')).toBeNull();
-    expect(queryByText('Alert 2')).toBeNull();
-    expect(getByText('Alert 3')).toBeDefined();
-    expect(getByText('Alert 4')).toBeDefined();
-    expect(queryByText('Alert 5')).toBeNull();
+    expect(getByTestId('security-alert-banner-0')).toBeOnTheScreen();
+    expect(getByTestId('security-alert-banner-1')).toBeOnTheScreen();
+    expect(queryByTestId('security-alert-banner-2')).toBeNull();
+    expect(getByText('Alert 3')).toBeOnTheScreen();
+    expect(getByText('Alert 4')).toBeOnTheScreen();
   });
 
-  it('renders nothing if transaction type ignored', () => {
+  it('renders nothing when transaction type is ignored', () => {
     (useTransactionMetadataRequest as jest.Mock).mockReturnValue({
       type: TransactionType.perpsDeposit,
     });
 
-    const { toJSON } = render(
+    const { queryByTestId } = render(
       <AlertBanner ignoreTypes={[TransactionType.perpsDeposit]} />,
     );
 
-    expect(toJSON()).toBeNull();
+    expect(queryByTestId('security-alert-banner-0')).toBeNull();
   });
 
   it('does not render excluded keys', () => {
-    const { getByText, queryByText } = render(
+    const { getByTestId, queryByTestId, getByText, queryByText } = render(
       <AlertBanner
         blockingOnly
         includeFields
@@ -151,10 +134,9 @@ describe('AlertBanner', () => {
       />,
     );
 
-    expect(queryByText('Alert 1')).toBeNull();
-    expect(queryByText('Alert 2')).toBeNull();
-    expect(getByText('Alert 3')).toBeDefined();
+    expect(getByTestId('security-alert-banner-0')).toBeOnTheScreen();
+    expect(queryByTestId('security-alert-banner-1')).toBeNull();
+    expect(getByText('Alert 3')).toBeOnTheScreen();
     expect(queryByText('Alert 4')).toBeNull();
-    expect(queryByText('Alert 5')).toBeNull();
   });
 });

--- a/app/components/Views/confirmations/components/alert-banner/alert-banner.tsx
+++ b/app/components/Views/confirmations/components/alert-banner/alert-banner.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { useAlerts } from '../../context/alert-system-context';
-import BannerAlert from '../../../../../component-library/components/Banners/Banner/variants/BannerAlert';
-import styleSheet from './alert-banner.styles';
-import { useStyles } from '../../../../hooks/useStyles';
-import { getBannerAlertSeverity } from '../../utils/alert-system';
+import { BannerAlert } from '@metamask/design-system-react-native';
 import {
   TransactionType,
   hasTransactionType,
 } from '@metamask/transaction-controller';
+import { useAlerts } from '../../context/alert-system-context';
+import styleSheet from './alert-banner.styles';
+import { useStyles } from '../../../../hooks/useStyles';
+import { getBannerAlertSeverity } from '../../utils/alert-system';
 import { useTransactionMetadataRequest } from '../../hooks/transactions/useTransactionMetadataRequest';
 import { AlertKeys } from '../../constants/alerts';
 export interface AlertBannerProps {

--- a/app/components/Views/confirmations/components/send/recipient/recipient.tsx
+++ b/app/components/Views/confirmations/components/send/recipient/recipient.tsx
@@ -1,4 +1,6 @@
 import {
+  BannerAlert,
+  BannerAlertSeverity,
   Box,
   Button,
   ButtonBaseSize,
@@ -9,10 +11,6 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { KeyboardAvoidingView, Platform, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { strings } from '../../../../../../../locales/i18n';
-import Banner, {
-  BannerAlertSeverity,
-  BannerVariant,
-} from '../../../../../../component-library/components/Banners/Banner';
 import { useSendContext } from '../../../context/send-context/send-context';
 import { RecipientInputMethod } from '../../../context/send-context/send-metrics-context';
 import { useSendAlerts } from '../../../hooks/send/alerts/useSendAlerts';
@@ -251,10 +249,9 @@ export const Recipient = () => {
           {(to || '').length > 0 && !isRecipientSelectedFromList && (
             <Box twClassName="px-4 py-4">
               {poisoningMatch && recipientCandidateAddress && (
-                <Banner
+                <BannerAlert
                   testID="address-poisoning-warning-banner"
-                  variant={BannerVariant.Alert}
-                  severity={BannerAlertSeverity.Error}
+                  severity={BannerAlertSeverity.Danger}
                   style={styles.banner}
                   title={strings('alert_system.address_poisoning.title')}
                   description={strings(
@@ -266,17 +263,16 @@ export const Recipient = () => {
                     knownAddress={poisoningMatch.knownAddress}
                     diffIndices={poisoningMatch.diffIndices}
                   />
-                </Banner>
+                </BannerAlert>
               )}
               {toAddressWarning && (
-                <Banner
+                <BannerAlert
                   testID="to-address-warning-banner"
-                  variant={BannerVariant.Alert}
                   severity={
                     // Confusable character validation is send both error and warning for invisible characters
                     // hence we are showing error for invisible characters
                     toAddressError && toAddressWarning
-                      ? BannerAlertSeverity.Error
+                      ? BannerAlertSeverity.Danger
                       : BannerAlertSeverity.Warning
                   }
                   style={styles.banner}

--- a/app/components/Views/confirmations/utils/alert-system.test.ts
+++ b/app/components/Views/confirmations/utils/alert-system.test.ts
@@ -1,6 +1,6 @@
+import { BannerAlertSeverity } from '@metamask/design-system-react-native';
 import { ThemeColors } from '@metamask/design-tokens';
 import { Severity } from '../types/alerts';
-import { BannerAlertSeverity } from '../../../../component-library/components/Banners/Banner';
 import { getSeverityStyle, getBannerAlertSeverity } from './alert-system';
 
 describe('getSeverityStyle', () => {
@@ -50,7 +50,7 @@ describe('getSeverityStyle', () => {
 describe('getBannerAlertSeverity', () => {
   it('returns the correct BannerAlertSeverity for Danger severity', () => {
     const result = getBannerAlertSeverity(Severity.Danger);
-    expect(result).toBe(BannerAlertSeverity.Error);
+    expect(result).toBe(BannerAlertSeverity.Danger);
   });
 
   it('returns the correct BannerAlertSeverity for Warning severity', () => {

--- a/app/components/Views/confirmations/utils/alert-system.ts
+++ b/app/components/Views/confirmations/utils/alert-system.ts
@@ -1,6 +1,6 @@
+import { BannerAlertSeverity } from '@metamask/design-system-react-native';
 import { ThemeColors } from '@metamask/design-tokens';
 import { Severity } from '../types/alerts';
-import { BannerAlertSeverity } from '../../../../component-library/components/Banners/Banner';
 
 /**
  * Returns the style object based on the severity level.
@@ -40,7 +40,7 @@ export function getBannerAlertSeverity(
 ): BannerAlertSeverity {
   switch (severity) {
     case Severity.Danger:
-      return BannerAlertSeverity.Error;
+      return BannerAlertSeverity.Danger;
     case Severity.Warning:
       return BannerAlertSeverity.Warning;
     default:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Component-library `Banner` / `BannerAlert` is deprecated in favor of MMDS. Confirmations still rendered alert banners through the old API (`BannerAlertSeverity.Error`, `BannerVariant.Alert`).

This PR migrates confirmation banners to `@metamask/design-system-react-native` `BannerAlert`, and updates `getBannerAlertSeverity` so `Severity.Danger` maps to `BannerAlertSeverity.Danger` (MMDS has no `Error` severity).

**What changed:**
- `AlertBanner` now renders MMDS `BannerAlert`
- Send recipient address-poisoning and to-address warning banners use MMDS `BannerAlert` (dropped `variant`)
- `getBannerAlertSeverity` imports severity from MMDS and maps Danger → `BannerAlertSeverity.Danger`
- Unit tests assert banners via existing `testID`s instead of duplicating severity helper coverage

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-990 https://consensyssoftware.atlassian.net/browse/DSYS-997

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: confirmations MMDS BannerAlert migration

  Scenario: security alert banner on confirmation
    Given the redesigned confirmation flow is enabled
    And a transaction or signature request produces a general security alert

    When the user opens the confirmation screen
    Then an MMDS BannerAlert is shown with the expected title and severity
    And the banner is selectable by testID security-alert-banner-0

  Scenario: to-address warning on send recipient
    Given the user is on the redesigned Send recipient screen
    And the entered address produces a to-address warning

    When the recipient field is filled without selecting from the list
    Then the to-address-warning-banner BannerAlert is visible
    And severity is Warning, or Danger when both error and warning are present

  Scenario: address poisoning warning on send recipient
    Given the user enters a recipient that matches a known address-poisoning pattern

    When the address is typed (not selected from the list)
    Then the address-poisoning-warning-banner BannerAlert is visible at Danger severity
```

Unit tests:

```bash
yarn jest app/components/Views/confirmations/utils/alert-system.test.ts
yarn jest app/components/Views/confirmations/components/alert-banner/alert-banner.test.tsx
yarn jest app/components/Views/confirmations/components/send/recipient/recipient.test.tsx
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — visual parity migration from component-library BannerAlert to MMDS BannerAlert; attach before/after captures of a confirmation security banner and a send recipient warning banner if design wants visual QA evidence.

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI parity migration in confirmations/send with updated tests; no auth, data, or transaction logic changes.
> 
> **Overview**
> Confirmation alert UI moves off deprecated component-library **`Banner` / `BannerAlert`** to **`@metamask/design-system-react-native` `BannerAlert`**.
> 
> **`AlertBanner`** now imports and renders MMDS **`BannerAlert`** (same props flow via **`getBannerAlertSeverity`**). Send **recipient** address-poisoning and to-address warning banners use MMDS **`BannerAlert`** without **`BannerVariant.Alert`**; highest-severity cases use **`BannerAlertSeverity.Danger`** instead of **`Error`**.
> 
> **`getBannerAlertSeverity`** pulls severities from MMDS and maps **`Severity.Danger`** → **`BannerAlertSeverity.Danger`** (MMDS has no Error tier). Unit tests for **`AlertBanner`** assert presence via **`security-alert-banner-*`** testIDs and drop duplicated severity-helper coverage now owned by **`alert-system.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4275d45a41daf6d7860391a0832cfeabdb8f41ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->