### PR TITLE
fix(TMCU-1240): Remove getElevatedSurfaceColor shim from component-library styles

### DIFF
--- a/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.styles.ts
+++ b/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.styles.ts
@@ -4,7 +4,6 @@ import { Platform, StyleSheet, ViewStyle } from 'react-native';
 
 // External dependencies.
 import { Theme } from '../../../../../../util/theme/models';
-import { getElevatedSurfaceColor } from '../../../../../../util/theme/themeUtils';
 
 // Internal dependencies.
 import { BottomSheetDialogStyleSheetVars } from './BottomSheetDialog.types';
@@ -23,7 +22,13 @@ const styleSheet = (params: {
 }) => {
   const { vars, theme } = params;
   const { colors, shadows } = theme;
-  const { isFullscreen, maxSheetHeight, screenBottomPadding, style } = vars;
+  const {
+    isFullscreen,
+    isPureBlack,
+    maxSheetHeight,
+    screenBottomPadding,
+    style,
+  } = vars;
 
   return StyleSheet.create({
     base: Object.assign({
@@ -34,7 +39,9 @@ const styleSheet = (params: {
     } as ViewStyle) as ViewStyle,
     sheet: Object.assign(
       {
-        backgroundColor: getElevatedSurfaceColor(theme),
+        backgroundColor: isPureBlack
+          ? theme.colors.background.section
+          : theme.colors.background.default,
         borderTopLeftRadius: 24,
         borderTopRightRadius: 24,
         maxHeight: maxSheetHeight,

--- a/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.tsx
+++ b/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.tsx
@@ -27,6 +27,7 @@ import {
   useSafeAreaInsets,
 } from 'react-native-safe-area-context';
 // External dependencies.
+import { usePureBlack } from '@metamask/design-system-twrnc-preset';
 import { useStyles } from '../../../../../hooks';
 
 // Internal dependencies.
@@ -69,11 +70,13 @@ const BottomSheetDialog = forwardRef<
     const { y: frameY, height: screenHeight } = useSafeAreaFrame();
 
     const maxSheetHeight = screenHeight - screenTopPadding;
+    const isPureBlack = usePureBlack();
     const { styles } = useStyles(styleSheet, {
       maxSheetHeight,
       screenBottomPadding,
       style,
       isFullscreen,
+      isPureBlack,
     });
     // X and Y values start on top left of the DIALOG
     // currentYOffset will be used to animate the Y position of the Dialog

--- a/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.types.ts
+++ b/app/component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.types.ts
@@ -47,4 +47,5 @@ export interface BottomSheetDialogStyleSheetVars {
   screenBottomPadding: number;
   style: StyleProp<ViewStyle>;
   isFullscreen: boolean;
+  isPureBlack: boolean;
 }

--- a/app/component-library/components/Form/TextField/foundation/Input/Input.styles.ts
+++ b/app/component-library/components/Form/TextField/foundation/Input/Input.styles.ts
@@ -4,7 +4,6 @@ import { Platform, StyleSheet, TextStyle } from 'react-native';
 // External dependencies.
 import { Theme } from '../../../../../../util/theme/models';
 import { colors } from '../../../../../../styles/common';
-import { getElevatedSurfaceColor } from '../../../../../../util/theme/themeUtils';
 import { getFontFamily } from '../../../../Texts/Text/';
 
 // Internal dependencies
@@ -26,6 +25,7 @@ const styleSheet = (params: { theme: Theme; vars: InputStyleSheetVars }) => {
     isDisabled,
     isStateStylesDisabled,
     isFocused,
+    isPureBlack,
     value = '',
     placeholder,
   } = vars;
@@ -51,7 +51,9 @@ const styleSheet = (params: { theme: Theme; vars: InputStyleSheetVars }) => {
         color: theme.colors.text.default,
         borderWidth: 1,
         borderColor: colors.transparent,
-        backgroundColor: getElevatedSurfaceColor(theme),
+        backgroundColor: isPureBlack
+          ? theme.colors.background.section
+          : theme.colors.background.default,
         ...stateObj,
         fontFamily: getFontFamily(textVariant),
         fontWeight: theme.typography[textVariant].fontWeight,

--- a/app/component-library/components/Form/TextField/foundation/Input/Input.tsx
+++ b/app/component-library/components/Form/TextField/foundation/Input/Input.tsx
@@ -5,6 +5,7 @@ import React, { useCallback, useState } from 'react';
 import { TextInput, type BlurEvent, type FocusEvent } from 'react-native';
 
 // External dependencies.
+import { usePureBlack } from '@metamask/design-system-twrnc-preset';
 import { useStyles } from '../../../../../hooks';
 import { DEFAULT_TEXT_VARIANT } from '../../../../Texts/Text/Text.constants';
 
@@ -39,6 +40,7 @@ const Input = React.forwardRef<TextInput, InputProps>(
     ref,
   ) => {
     const [isFocused, setIsFocused] = useState(autoFocus);
+    const isPureBlack = usePureBlack();
 
     const { styles, theme } = useStyles(styleSheet, {
       style,
@@ -46,6 +48,7 @@ const Input = React.forwardRef<TextInput, InputProps>(
       isStateStylesDisabled,
       isDisabled,
       isFocused,
+      isPureBlack,
       value: value ?? '',
       placeholder,
     });

--- a/app/component-library/components/Form/TextField/foundation/Input/Input.types.ts
+++ b/app/component-library/components/Form/TextField/foundation/Input/Input.types.ts
@@ -39,5 +39,6 @@ export type InputStyleSheetVars = Pick<
   'style' | 'isStateStylesDisabled' | 'isDisabled' | 'value' | 'placeholder'
 > & {
   isFocused: boolean;
+  isPureBlack: boolean;
   textVariant: TextVariant;
 };

--- a/app/component-library/components/Modals/ModalConfirmation/ModalConfirmation.styles.ts
+++ b/app/component-library/components/Modals/ModalConfirmation/ModalConfirmation.styles.ts
@@ -1,10 +1,6 @@
 // Third party dependencies.
 import { StyleSheet } from 'react-native';
-import { AppThemeKey, Theme } from '../../../../util/theme/models';
-import {
-  getElevatedSurfaceColor,
-  isPureBlackEnabled,
-} from '../../../../util/theme/themeUtils';
+import { Theme } from '../../../../util/theme/models';
 
 /**
  * Style sheet function for ModalConfirmation component.
@@ -14,16 +10,21 @@ import {
  * @param params.vars Inputs that the style sheet depends on.
  * @returns StyleSheet object.
  */
-const styleSheet = (params: { theme: Theme }) => {
-  const { theme } = params;
+const styleSheet = (params: {
+  theme: Theme;
+  vars: { isPureBlack: boolean };
+}) => {
+  const { theme, vars } = params;
   const { colors } = theme;
+  const { isPureBlack } = vars;
 
   return StyleSheet.create({
     screen: { justifyContent: 'center' },
     modal: {
-      // Pure Black: use elevated surface color and add a subtle border
-      backgroundColor: getElevatedSurfaceColor(theme),
-      ...(isPureBlackEnabled && theme.themeAppearance === AppThemeKey.dark
+      backgroundColor: isPureBlack
+        ? theme.colors.background.section
+        : theme.colors.background.default,
+      ...(isPureBlack
         ? {
             borderWidth: 1,
             borderColor: colors.border.muted,

--- a/app/component-library/components/Modals/ModalConfirmation/ModalConfirmation.tsx
+++ b/app/component-library/components/Modals/ModalConfirmation/ModalConfirmation.tsx
@@ -3,6 +3,7 @@ import React, { useRef } from 'react';
 import { View } from 'react-native';
 
 // External dependencies.
+import { usePureBlack } from '@metamask/design-system-twrnc-preset';
 import ReusableModal, {
   ReusableModalRef,
 } from '../../../../components/UI/ReusableModal';
@@ -30,7 +31,8 @@ const ModalConfirmation = ({ route }: ModalConfirmationProps) => {
     isDanger = false,
   } = route.params;
   const modalRef = useRef<ReusableModalRef>(null);
-  const { styles } = useStyles(stylesheet, {});
+  const isPureBlack = usePureBlack();
+  const { styles } = useStyles(stylesheet, { isPureBlack });
 
   const triggerCancel = () => modalRef.current?.dismissModal(onCancel);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Replaces `getElevatedSurfaceColor()` shim calls in three legacy component-library StyleSheet files with the `usePureBlack()` hook pattern. When pure black is enabled, elevated surfaces use `theme.colors.background.section`; otherwise they use `theme.colors.background.default`.

This is a transitional approach as part of the Pure Black cleanup epic (TMCU-1083). Once a `bg-elevated` semantic token ships in the design tokens package, the conditional can be replaced by a single token lookup.

**Updated files:**
- `BottomSheetDialog.styles.ts` / `BottomSheetDialog.tsx`
- `Input.styles.ts` / `Input.tsx`
- `ModalConfirmation.styles.ts` / `ModalConfirmation.tsx`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TMCU-1240](https://consensyssoftware.atlassian.net/browse/TMCU-1240)

## **Manual testing steps**

```gherkin
Feature: Pure Black elevated surface colors in component-library

  Scenario: Bottom sheet dialog uses elevated surface in pure black dark mode
    Given the MM_PURE_BLACK_PREVIEW flag is enabled
    And the app is in dark mode
    When a bottom sheet dialog is displayed
    Then the sheet background uses the section background color

  Scenario: Input field uses default background when pure black is off
    Given the MM_PURE_BLACK_PREVIEW flag is disabled
    When an input field is rendered
    Then the input background uses the default background color

  Scenario: Modal confirmation shows border in pure black dark mode
    Given the MM_PURE_BLACK_PREVIEW flag is enabled
    And the app is in dark mode
    When a modal confirmation is displayed
    Then the modal has a muted border and section background color
```

## **Screenshots/Recordings**

N/A — styling change behind a preview feature flag with no visual change for users without the flag enabled.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef0746c1-f1a4-4b83-b46a-e6c3491f1c17?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef0746c1-f1a4-4b83-b46a-e6c3491f1c17&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[TMCU-1240]: https://consensyssoftware.atlassian.net/browse/TMCU-1240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ