### PR TITLE
refactor: replace getElevatedSurfaceColor shim with usePureBlack in misc UI components (TMCU-1241)

### DIFF
--- a/app/components/UI/ActionModal/ActionContent/index.js
+++ b/app/components/UI/ActionModal/ActionContent/index.js
@@ -5,7 +5,6 @@ import StyledButton from '../../StyledButton';
 import { strings } from '../../../../../locales/i18n';
 import { usePureBlack } from '@metamask/design-system-twrnc-preset';
 import { useTheme } from '../../../../util/theme';
-import { getElevatedSurfaceColor } from '../../../../util/theme/themeUtils';
 
 export const createStyles = (theme, isPureBlack = false) =>
   StyleSheet.create({
@@ -16,11 +15,13 @@ export const createStyles = (theme, isPureBlack = false) =>
       marginHorizontal: 24,
     },
     // TODO(Pure Black): Remove once MMDS ships pure-black-aware surface tokens.
-    // Drop getElevatedSurfaceColor, usePureBlack(), and the isPureBlack param.
+    // Drop usePureBlack() and the isPureBlack param.
     // Use: backgroundColor: theme.colors.background.default, borderWidth: 0
     viewContainer: {
       width: '100%',
-      backgroundColor: getElevatedSurfaceColor(theme),
+      backgroundColor: isPureBlack
+        ? theme.colors.background.section
+        : theme.colors.background.default,
       borderRadius: 10,
       borderWidth: isPureBlack ? 1 : 0,
       borderColor: isPureBlack ? theme.colors.border.muted : undefined,

--- a/app/components/UI/ActionModal/ActionContent/index.test.js
+++ b/app/components/UI/ActionModal/ActionContent/index.test.js
@@ -38,13 +38,13 @@ describe('ActionContent styles', () => {
     expect(styles.viewContainer.borderColor).toBeUndefined();
   });
 
-  it('uses alternative background and muted border in pure black dark mode', () => {
+  it('uses section background and muted border in pure black dark mode', () => {
     mockIsPureBlackEnabled = true;
     const theme = createTheme(AppThemeKey.dark);
     const styles = createStyles(theme, true);
 
     expect(styles.viewContainer.backgroundColor).toBe(
-      theme.colors.background.alternative,
+      theme.colors.background.section,
     );
     expect(styles.viewContainer.borderWidth).toBe(1);
     expect(styles.viewContainer.borderColor).toBe(theme.colors.border.muted);

--- a/app/components/UI/NetworkManager/index.styles.ts
+++ b/app/components/UI/NetworkManager/index.styles.ts
@@ -4,7 +4,6 @@ import {
   TextVariant,
 } from '../../../component-library/components/Texts/Text';
 import { Theme } from '../../../util/theme/models';
-import { getElevatedSurfaceColor } from '../../../util/theme/themeUtils';
 
 const UNDERLINE_HEIGHT = 2;
 const TAB_PADDING_BOTTOM = 8;
@@ -14,8 +13,14 @@ const DELETE_CONTAINER_PADDING_RIGHT = 8;
 
 const BODY_MD_FONT_FAMILY = getFontFamily(TextVariant.BodyMD);
 
-const createStyles = (params: { theme: Theme }) => {
-  const { theme } = params;
+const createStyles = (params: {
+  theme: Theme;
+  vars: { isPureBlack: boolean };
+}) => {
+  const {
+    theme,
+    vars: { isPureBlack },
+  } = params;
   const { colors, typography } = theme;
 
   const borderMuted = colors.border.muted;
@@ -43,7 +48,9 @@ const createStyles = (params: { theme: Theme }) => {
     },
     tabBar: {
       borderColor: borderMuted,
-      backgroundColor: getElevatedSurfaceColor(theme),
+      backgroundColor: isPureBlack
+        ? colors.background.section
+        : colors.background.default,
     },
     // edit network menu
     editNetworkMenu: {

--- a/app/components/UI/NetworkManager/index.tsx
+++ b/app/components/UI/NetworkManager/index.tsx
@@ -1,6 +1,7 @@
 // third party dependencies
 import { View } from 'react-native';
 import { HeaderStandard, Text } from '@metamask/design-system-react-native';
+import { usePureBlack } from '@metamask/design-system-twrnc-preset';
 import React, { useRef, useMemo, useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
@@ -82,7 +83,8 @@ const NetworkManager = () => {
 
   const navigation = useNavigation<AppNavigationProp>();
   const { colors } = useTheme();
-  const { styles } = useStyles(createStyles, { colors });
+  const isPureBlack = usePureBlack();
+  const { styles } = useStyles(createStyles, { isPureBlack });
   const { trackEvent, createEventBuilder, identify } = useAnalytics();
   const { disableNetwork, enabledNetworksByNamespace } = useNetworkEnablement();
 

--- a/app/components/UI/NetworkMultiSelector/NetworkMultiSelector.styles.ts
+++ b/app/components/UI/NetworkMultiSelector/NetworkMultiSelector.styles.ts
@@ -1,14 +1,21 @@
 import { StyleSheet } from 'react-native';
 import { Theme } from '../../../util/theme/models';
-import { getElevatedSurfaceColor } from '../../../util/theme/themeUtils';
 
-const stylesheet = (params: { theme: Theme }) => {
-  const { theme } = params;
+const stylesheet = (params: {
+  theme: Theme;
+  vars: { isPureBlack: boolean };
+}) => {
+  const {
+    theme,
+    vars: { isPureBlack },
+  } = params;
   const { colors } = theme;
   return StyleSheet.create({
     bodyContainer: {
       flex: 1,
-      backgroundColor: getElevatedSurfaceColor(theme),
+      backgroundColor: isPureBlack
+        ? colors.background.section
+        : colors.background.default,
     },
     // custom network
     customNetworkContainer: {

--- a/app/components/UI/NetworkMultiSelector/NetworkMultiSelector.tsx
+++ b/app/components/UI/NetworkMultiSelector/NetworkMultiSelector.tsx
@@ -11,9 +11,9 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 // external dependencies
 import hideKeyFromUrl from '../../../util/hideKeyFromUrl';
-import { useTheme } from '../../../util/theme';
 import { useStyles } from '../../../component-library/hooks/useStyles';
 import { Box } from '@metamask/design-system-react-native';
+import { usePureBlack } from '@metamask/design-system-twrnc-preset';
 import { ExtendedNetwork } from '../../Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.types';
 import CustomNetwork from '../../Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork';
 import { strings } from '../../../../locales/i18n';
@@ -83,8 +83,8 @@ const NetworkMultiSelector = ({
   openRpcModal,
 }: NetworkMultiSelectorProps) => {
   const insets = useSafeAreaInsets();
-  const theme = useTheme();
-  const { styles } = useStyles(stylesheet, { theme });
+  const isPureBlack = usePureBlack();
+  const { styles } = useStyles(stylesheet, { isPureBlack });
 
   const [modalState, setModalState] = useState<ModalState>(initialModalState);
 

--- a/app/components/UI/Notification/TransactionNotification/index.js
+++ b/app/components/UI/Notification/TransactionNotification/index.js
@@ -17,11 +17,8 @@ import BaseNotification from '../../../../component-library/components-temp/Base
 import { CANCEL_RATE, SPEED_UP_RATE } from '@metamask/transaction-controller';
 import BigNumber from 'bignumber.js';
 import { collectibleContractsSelector } from '../../../../reducers/collectibles';
+import { usePureBlack } from '@metamask/design-system-twrnc-preset';
 import { useTheme } from '../../../../util/theme';
-import {
-  getElevatedSurfaceColor,
-  isPureBlackEnabled,
-} from '../../../../util/theme/themeUtils';
 import {
   selectChainId,
   selectTickerByChainId,
@@ -40,7 +37,7 @@ const WINDOW_WIDTH = Dimensions.get('window').width;
 const ACTION_CANCEL = 'cancel';
 const ACTION_SPEEDUP = 'speedup';
 
-const createStyles = (theme) => {
+const createStyles = (theme, isPureBlack = false) => {
   const { colors } = theme;
 
   return StyleSheet.create({
@@ -84,8 +81,10 @@ const createStyles = (theme) => {
     modalContainer: {
       width: '90%',
       borderRadius: 10,
-      backgroundColor: getElevatedSurfaceColor(theme),
-      ...(isPureBlackEnabled && {
+      backgroundColor: isPureBlack
+        ? colors.background.section
+        : colors.background.default,
+      ...(isPureBlack && {
         borderWidth: 1,
         borderColor: colors.border.muted,
       }),
@@ -120,7 +119,8 @@ function TransactionNotification(props) {
   const detailsAnimated = useSharedValue(0);
 
   const theme = useTheme();
-  const styles = createStyles(theme);
+  const isPureBlack = usePureBlack();
+  const styles = createStyles(theme, isPureBlack);
 
   const detailsFadeIn = useCallback(async () => {
     setTransactionDetailsIsVisible(true);

--- a/app/components/UI/SelectComponent/index.js
+++ b/app/components/UI/SelectComponent/index.js
@@ -13,9 +13,6 @@ import Modal from 'react-native-modal';
 import IconCheck from 'react-native-vector-icons/MaterialCommunityIcons';
 import Device from '../../../util/device';
 import { ThemeContext, mockTheme } from '../../../util/theme';
-import { AppThemeKey } from '../../../util/theme/models';
-import { isPureBlackEnabled } from '../../../util/theme/pureBlackPreview';
-import { getElevatedSurfaceColor } from '../../../util/theme/themeUtils';
 import PickerBase from '../../../component-library/components/Pickers/PickerBase';
 import {
   HeaderStandard,
@@ -24,9 +21,10 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
+import { usePureBlack } from '@metamask/design-system-twrnc-preset';
 
 const ROW_HEIGHT = 35;
-export const createStyles = (theme) => {
+export const createStyles = (theme, isPureBlack = false) => {
   const { colors } = theme;
 
   return StyleSheet.create({
@@ -49,22 +47,18 @@ export const createStyles = (theme) => {
       padding: 60,
     },
     // TODO(Pure Black): Remove once MMDS ships pure-black-aware surface tokens.
-    // Drop getElevatedSurfaceColor, isPureBlackEnabled, and AppThemeKey checks.
+    // Drop usePureBlack() and the isPureBlack param.
     // Use: backgroundColor: colors.background.default, borderWidth: 0
     modalView: {
-      backgroundColor: getElevatedSurfaceColor(theme),
+      backgroundColor: isPureBlack
+        ? colors.background.section
+        : colors.background.default,
       justifyContent: 'center',
       alignItems: 'center',
       borderRadius: 10,
       maxHeight: Device.getDeviceHeight() - 120, // Subtract top and bottom padding
-      borderWidth:
-        isPureBlackEnabled && theme.themeAppearance === AppThemeKey.dark
-          ? 1
-          : 0,
-      borderColor:
-        isPureBlackEnabled && theme.themeAppearance === AppThemeKey.dark
-          ? colors.border.muted
-          : undefined,
+      borderWidth: isPureBlack ? 1 : 0,
+      borderColor: isPureBlack ? colors.border.muted : undefined,
     },
     list: {
       width: '100%',
@@ -93,8 +87,12 @@ export const createStyles = (theme) => {
   });
 };
 
-export default class SelectComponent extends PureComponent {
+class SelectComponentInner extends PureComponent {
   static propTypes = {
+    /**
+     * Whether pure black theme is active
+     */
+    isPureBlack: PropTypes.bool,
     /**
      * Default value to show
      */
@@ -172,7 +170,8 @@ export default class SelectComponent extends PureComponent {
   renderDropdownSelector = () => {
     const theme = this.context || mockTheme;
     const { colors } = theme;
-    const styles = createStyles(theme);
+    const { isPureBlack = false } = this.props;
+    const styles = createStyles(theme, isPureBlack);
 
     return (
       <View style={baseStyles.flexGrow}>
@@ -240,4 +239,12 @@ export default class SelectComponent extends PureComponent {
   );
 }
 
-SelectComponent.contextType = ThemeContext;
+SelectComponentInner.contextType = ThemeContext;
+
+function SelectComponent(props) {
+  const isPureBlack = usePureBlack();
+  return <SelectComponentInner {...props} isPureBlack={isPureBlack} />;
+}
+
+export { SelectComponentInner };
+export default SelectComponent;

--- a/app/components/UI/SelectComponent/index.test.tsx
+++ b/app/components/UI/SelectComponent/index.test.tsx
@@ -12,6 +12,11 @@ jest.mock('../../../util/theme/pureBlackPreview', () => ({
   },
 }));
 
+jest.mock('@metamask/design-system-twrnc-preset', () => ({
+  ...jest.requireActual('@metamask/design-system-twrnc-preset'),
+  usePureBlack: () => mockIsPureBlackEnabled,
+}));
+
 jest.mock('../../../core/Engine', () => ({
   context: {
     colors: {},
@@ -60,7 +65,7 @@ describe('SelectComponent styles', () => {
 
   it('uses default background without pure black border', () => {
     const theme = createTheme(AppThemeKey.dark);
-    const styles = createStyles(theme);
+    const styles = createStyles(theme, false);
 
     expect(styles.modalView.backgroundColor).toBe(
       theme.colors.background.default,
@@ -69,13 +74,13 @@ describe('SelectComponent styles', () => {
     expect(styles.modalView.borderColor).toBeUndefined();
   });
 
-  it('uses alternative background and muted border in pure black dark mode', () => {
+  it('uses section background and muted border in pure black dark mode', () => {
     mockIsPureBlackEnabled = true;
     const theme = createTheme(AppThemeKey.dark);
-    const styles = createStyles(theme);
+    const styles = createStyles(theme, true);
 
     expect(styles.modalView.backgroundColor).toBe(
-      theme.colors.background.alternative,
+      theme.colors.background.section,
     );
     expect(styles.modalView.borderWidth).toBe(1);
     expect(styles.modalView.borderColor).toBe(theme.colors.border.muted);
@@ -84,7 +89,7 @@ describe('SelectComponent styles', () => {
   it('keeps default background in pure black light mode', () => {
     mockIsPureBlackEnabled = true;
     const theme = createTheme(AppThemeKey.light);
-    const styles = createStyles(theme);
+    const styles = createStyles(theme, false);
 
     expect(styles.modalView.backgroundColor).toBe(
       theme.colors.background.default,

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -39,10 +39,6 @@ import {
   usePureBlack,
   useTailwind,
 } from '@metamask/design-system-twrnc-preset';
-import {
-  getElevatedSurfaceColor,
-  useElevatedSurface,
-} from '../../../util/theme/themeUtils';
 import { BatchSellMetricsLocation } from '@metamask/bridge-controller';
 import {
   useSafeAreaFrame,
@@ -129,10 +125,10 @@ function TradeWalletActions() {
   const insetsTop = Platform.OS === 'android' ? insets.top : 0;
 
   const tw = useTailwind();
-  const surfaceClass = useElevatedSurface();
   const isPureBlack = usePureBlack();
   const theme = useTheme();
   const { colors } = theme;
+  const surfaceClass = isPureBlack ? 'bg-section' : 'bg-default';
 
   const backdropOpacity = useSharedValue(0);
   const backdropAnimatedStyle = useAnimatedStyle(() => ({
@@ -391,7 +387,9 @@ function TradeWalletActions() {
     [dismissRootModalFlow, exitingAnimationWithCallback],
   );
 
-  const elevatedSurfaceColor = getElevatedSurfaceColor(theme);
+  const elevatedSurfaceColor = isPureBlack
+    ? colors.background.section
+    : colors.background.default;
   const layout = buttonLayout as NonNullable<
     TradeWalletActionsParams['buttonLayout']
   >;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Replaces remaining `getElevatedSurfaceColor()` shim usage in six UI components with the `usePureBlack()` hook and conditional `background.section` / `background.default` tokens. This is part of the Pure Black cleanup epic (TMCU-1083) and unblocks eventual removal of the shim in `themeUtils.ts` (TMCU-1051).

**Updated files:**
- `app/components/UI/ActionModal/ActionContent/index.js`
- `app/components/UI/NetworkManager/index.styles.ts`
- `app/components/UI/NetworkMultiSelector/NetworkMultiSelector.styles.ts`
- `app/components/UI/Notification/TransactionNotification/index.js`
- `app/components/UI/SelectComponent/index.js`
- `app/components/Views/TradeWalletActions/TradeWalletActions.tsx`

**Replacement pattern applied:**
```ts
const isPureBlack = usePureBlack();
backgroundColor: isPureBlack
  ? theme.colors.background.section
  : theme.colors.background.default
```

`TradeWalletActions` also drops `useElevatedSurface()` in favor of `bg-section` / `bg-default` Tailwind classes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1241

## **Manual testing steps**

```gherkin
Feature: Pure Black elevated surface backgrounds

  Scenario: Verify elevated surfaces in default theme
    Given the app is running with Pure Black preview disabled
    When the user opens Network Manager, SelectComponent modal, Transaction Notification modal, Trade Wallet Actions sheet, or Action Modal content
    Then elevated surfaces use background.default styling

  Scenario: Verify elevated surfaces in Pure Black dark mode
    Given the app is running with Pure Black preview enabled in dark mode
    When the user opens the same surfaces listed above
    Then elevated surfaces use background.section styling with muted borders where applicable
```

## **Screenshots/Recordings**

N/A — background color token swap with no layout or interaction changes. Visual verification requires device/simulator with Pure Black preview flag enabled.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba880616-55e4-4817-89bb-dd2e3526e3d6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba880616-55e4-4817-89bb-dd2e3526e3d6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

