### PR TITLE
feat: add Pro only reduce only validation cp-8.7.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.view.test.tsx
@@ -168,4 +168,31 @@ describeForPlatforms('PerpsProMarketView input journeys', () => {
       });
     },
   );
+
+  itForPlatforms(
+    'blocks reduce-only orders when size exceeds the open position',
+    async () => {
+      renderPerpsProMarketView({
+        streamOverrides: {
+          account: createFundedAccountForViews('100000'),
+          positions: [createLongPositionForViews({ size: '-1' })],
+          orders: [],
+        },
+      });
+      const sizeInput = await findSizeInput();
+
+      fireEvent.press(screen.getByTestId(ids.REDUCE_ONLY));
+      fireEvent.changeText(sizeInput, '3000');
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId(`${ids.NOTICE}-reduce-only`),
+        ).toHaveTextContent(
+          strings('perps.order.validation.reduce_only_too_large'),
+        );
+        expect(screen.getByTestId(ids.PLACE_ORDER_BUTTON)).toBeDisabled();
+        expect(screen.queryByTestId(ids.TPSL)).not.toBeOnTheScreen();
+      });
+    },
+  );
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.view.test.tsx
@@ -11,7 +11,11 @@ import {
   describeForPlatforms,
   itForPlatforms,
 } from '../../../../../../tests/component-view/platform';
-import { createFundedAccountForViews } from '../../../../../../tests/component-view/fixtures/perpsViewFixtures';
+import {
+  createFundedAccountForViews,
+  createLongPositionForViews,
+} from '../../../../../../tests/component-view/fixtures/perpsViewFixtures';
+import { strings } from '../../../../../../locales/i18n';
 import {
   PerpsOrderTypeBottomSheetSelectorsIDs,
   PerpsProOrderFormSelectorsIDs,
@@ -110,6 +114,58 @@ describeForPlatforms('PerpsProMarketView input journeys', () => {
       fireEvent(slider, 'dragEnd', 50);
 
       await waitFor(() => expect(sizeInput).toHaveProp('value', previewValue));
+    },
+  );
+
+  itForPlatforms(
+    'blocks reduce-only orders when there is no open position',
+    async () => {
+      renderPerpsProMarketView({
+        streamOverrides: {
+          account: createFundedAccountForViews('1000'),
+          positions: [],
+          orders: [],
+        },
+      });
+      await findSizeInput();
+
+      fireEvent.press(screen.getByTestId(ids.REDUCE_ONLY));
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId(`${ids.NOTICE}-reduce-only`),
+        ).toHaveTextContent(
+          strings('perps.order.validation.reduce_only_no_position'),
+        );
+        expect(screen.getByTestId(ids.PLACE_ORDER_BUTTON)).toBeDisabled();
+        expect(screen.queryByTestId(ids.TPSL)).not.toBeOnTheScreen();
+      });
+    },
+  );
+
+  itForPlatforms(
+    'blocks reduce-only orders that match the open position direction',
+    async () => {
+      renderPerpsProMarketView({
+        streamOverrides: {
+          account: createFundedAccountForViews('1000'),
+          positions: [createLongPositionForViews()],
+          orders: [],
+        },
+      });
+      await findSizeInput();
+
+      fireEvent.press(screen.getByTestId(ids.REDUCE_ONLY));
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId(`${ids.NOTICE}-reduce-only`),
+        ).toHaveTextContent(
+          strings('perps.order.validation.reduce_only_wrong_side'),
+        );
+        expect(screen.getByTestId(ids.PLACE_ORDER_BUTTON)).toBeDisabled();
+        expect(screen.queryByTestId(ids.TPSL)).not.toBeOnTheScreen();
+      });
     },
   );
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -345,6 +345,12 @@ describe('PerpsProOrderForm', () => {
       expect(onReduceOnlyChange).toHaveBeenCalledWith(true);
     });
 
+    it('hides the TP/SL row when Reduce Only is on', () => {
+      renderForm({ reduceOnly: true, onTPSLPress: jest.fn() });
+
+      expect(screen.queryByTestId(ids.TPSL)).not.toBeOnTheScreen();
+    });
+
     it('exposes TP/SL as a button action', () => {
       renderForm({ onTPSLPress: jest.fn() });
 
@@ -352,7 +358,6 @@ describe('PerpsProOrderForm', () => {
         'accessibilityRole',
         'button',
       );
-      expect(screen.getByTestId(`${ids.TPSL}-arrow`)).toBeOnTheScreen();
     });
 
     it('calls onTPSLPress when TP/SL is pressed', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -10,7 +10,6 @@ import {
   ButtonIconSize,
   ButtonSemantic,
   ButtonSemanticSeverity,
-  Checkbox,
   FilterButton,
   FontWeight,
   Icon,
@@ -68,13 +67,63 @@ const summaryValueTextProps = {
   fontWeight: FontWeight.Medium,
 };
 
-interface TPSLRowProps {
-  label: string;
-  onPress?: () => void;
+interface SelectionIndicatorProps {
+  isSelected: boolean;
   testID: string;
 }
 
-const TPSLRow = ({ label, onPress, testID }: TPSLRowProps) => {
+const SelectionIndicator = ({ isSelected, testID }: SelectionIndicatorProps) =>
+  isSelected ? (
+    <Box
+      twClassName="size-5 items-center justify-center rounded-full bg-icon-default"
+      testID={`${testID}-indicator`}
+    >
+      <Icon
+        name={IconName.CheckBold}
+        size={IconSize.Xs}
+        color={IconColor.PrimaryInverse}
+      />
+    </Box>
+  ) : (
+    <Box
+      twClassName="size-5 rounded-full border-2 border-muted"
+      testID={`${testID}-indicator`}
+    />
+  );
+
+interface ReduceOnlyRowProps extends SelectionIndicatorProps {
+  label: string;
+  onChange: (value: boolean) => void;
+}
+
+const ReduceOnlyRow = ({
+  label,
+  isSelected,
+  onChange,
+  testID,
+}: ReduceOnlyRowProps) => (
+  <Pressable
+    accessibilityRole="checkbox"
+    accessibilityState={{ checked: isSelected }}
+    accessibilityLabel={label}
+    onPress={() => onChange(!isSelected)}
+    testID={testID}
+  >
+    <Box twClassName="h-12 flex-row items-center justify-between rounded-xl bg-muted px-3">
+      <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+        {label}
+      </Text>
+      <SelectionIndicator isSelected={isSelected} testID={testID} />
+    </Box>
+  </Pressable>
+);
+
+interface TPSLRowProps extends SelectionIndicatorProps {
+  label: string;
+  onPress?: () => void;
+}
+
+const TPSLRow = ({ label, isSelected, onPress, testID }: TPSLRowProps) => {
   const isDisabled = !onPress;
 
   return (
@@ -94,12 +143,7 @@ const TPSLRow = ({ label, onPress, testID }: TPSLRowProps) => {
         <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
           {label}
         </Text>
-        <Icon
-          name={IconName.ArrowDown}
-          size={IconSize.Sm}
-          color={IconColor.IconDefault}
-          testID={`${testID}-arrow`}
-        />
+        <SelectionIndicator isSelected={isSelected} testID={testID} />
       </Box>
     </Pressable>
   );
@@ -129,6 +173,7 @@ const Notices = ({ notices }: { notices: PerpsProOrderNotice[] }) =>
         notice.variant === 'banner' ? (
           <BannerAlert
             key={notice.id}
+            alignItems={BoxAlignItems.Center}
             severity={BannerAlertSeverity.Warning}
             title={notice.title}
             description={notice.message}
@@ -268,6 +313,7 @@ const PerpsProOrderForm = ({
   onAddFundsPress,
   reduceOnly,
   onReduceOnlyChange,
+  isTPSLConfigured,
   onTPSLPress,
   notices,
   summary,
@@ -436,25 +482,20 @@ const PerpsProOrderForm = ({
             availableBalance={availableBalance}
             onAddFundsPress={onAddFundsPress}
           />
-          <Box twClassName="h-12 justify-center rounded-xl bg-muted px-3">
-            <Checkbox
-              label={strings('perps.order.reduce_only')}
-              labelProps={{
-                variant: TextVariant.BodySm,
-                fontWeight: FontWeight.Medium,
-                style: { marginLeft: 0, flex: 1 },
-              }}
-              isSelected={reduceOnly}
-              onChange={onReduceOnlyChange}
-              testID={ids.REDUCE_ONLY}
-              twClassName="w-full flex-row-reverse justify-between"
-            />
-          </Box>
-          <TPSLRow
-            label={strings('perps.pro_order_form.tpsl')}
-            onPress={onTPSLPress}
-            testID={ids.TPSL}
+          <ReduceOnlyRow
+            label={strings('perps.order.reduce_only')}
+            isSelected={reduceOnly}
+            onChange={onReduceOnlyChange}
+            testID={ids.REDUCE_ONLY}
           />
+          {!reduceOnly ? (
+            <TPSLRow
+              label={strings('perps.pro_order_form.tpsl')}
+              isSelected={isTPSLConfigured}
+              onPress={onTPSLPress}
+              testID={ids.TPSL}
+            />
+          ) : null}
           <Notices notices={notices} />
           <ButtonSemantic
             severity={

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
@@ -98,8 +98,6 @@ jest.mock('../../../../contexts/PerpsOrderContext', () => ({
 }));
 
 let mockPositionStreamLoading = false;
-let mockOrdersStreamLoading = false;
-let mockOpenOrders: unknown[] = [];
 
 jest.mock('../../../../hooks', () => ({
   useHasExistingPosition: () => ({
@@ -146,10 +144,6 @@ jest.mock('../../../../hooks/stream', () => ({
     BTC: { price: '90000', markPrice: '90000', percentChange24h: '1' },
   }),
   usePerpsTopOfBook: () => ({ bestBid: '89999', bestAsk: '90001' }),
-  usePerpsLiveOrders: () => ({
-    orders: mockOpenOrders,
-    isInitialLoading: mockOrdersStreamLoading,
-  }),
 }));
 
 let mockIsInitialized = true;
@@ -224,8 +218,6 @@ describe('usePerpsProOrderForm', () => {
     mockEstimatedSlippageBps = 50;
     mockIsInitialized = true;
     mockPositionStreamLoading = false;
-    mockOrdersStreamLoading = false;
-    mockOpenOrders = [];
     mockUpdatePositionTPSL.mockResolvedValue({ success: true });
   });
 
@@ -367,9 +359,9 @@ describe('usePerpsProOrderForm', () => {
       );
     });
 
-    it('suppresses stale validation notices while reduce-only streams are loading', () => {
+    it('suppresses stale validation notices while the position is loading', () => {
       // Arrange: retain a prior margin error (skipValidation freezes errors)
-      // while position streams are still loading after Reduce Only is enabled.
+      // while the position is still loading after Reduce Only is enabled.
       mockValidation.isValid = false;
       mockValidation.errors = ['Insufficient funds'];
       mockPositionStreamLoading = true;
@@ -814,7 +806,7 @@ describe('usePerpsProOrderForm', () => {
       expect(result.current.isPlaceOrderDisabled).toBe(false);
     });
 
-    it('disables Place Order while reduce-only position streams are loading', () => {
+    it('disables Place Order while the reduce-only position is loading', () => {
       mockPositionStreamLoading = true;
       mockExistingPosition = {
         size: '-1',

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
@@ -97,8 +97,15 @@ jest.mock('../../../../contexts/PerpsOrderContext', () => ({
   usePerpsOrderContext: () => mockContextValue,
 }));
 
+let mockPositionStreamLoading = false;
+let mockOrdersStreamLoading = false;
+let mockOpenOrders: unknown[] = [];
+
 jest.mock('../../../../hooks', () => ({
-  useHasExistingPosition: () => ({ existingPosition: mockExistingPosition }),
+  useHasExistingPosition: () => ({
+    existingPosition: mockExistingPosition,
+    isLoading: mockPositionStreamLoading,
+  }),
   usePerpsLiquidationPrice: () => ({ liquidationPrice: '80000' }),
   usePerpsMarketData: () => ({
     marketData: { szDecimals: 3, maxLeverage: 40 },
@@ -139,6 +146,10 @@ jest.mock('../../../../hooks/stream', () => ({
     BTC: { price: '90000', markPrice: '90000', percentChange24h: '1' },
   }),
   usePerpsTopOfBook: () => ({ bestBid: '89999', bestAsk: '90001' }),
+  usePerpsLiveOrders: () => ({
+    orders: mockOpenOrders,
+    isInitialLoading: mockOrdersStreamLoading,
+  }),
 }));
 
 let mockIsInitialized = true;
@@ -212,6 +223,9 @@ describe('usePerpsProOrderForm', () => {
     mockIsAtCap = false;
     mockEstimatedSlippageBps = 50;
     mockIsInitialized = true;
+    mockPositionStreamLoading = false;
+    mockOrdersStreamLoading = false;
+    mockOpenOrders = [];
     mockUpdatePositionTPSL.mockResolvedValue({ success: true });
   });
 
@@ -258,7 +272,7 @@ describe('usePerpsProOrderForm', () => {
   });
 
   describe('notices', () => {
-    it('maps a validation error to an inline notice', () => {
+    it('maps a margin validation error to a priority banner', () => {
       // Arrange
       mockValidation.isValid = false;
       mockValidation.errors = ['Insufficient funds'];
@@ -267,8 +281,9 @@ describe('usePerpsProOrderForm', () => {
       const { result } = renderProForm();
 
       // Assert
-      const inline = result.current.notices.find((n) => n.variant === 'inline');
-      expect(inline?.message).toBe('Insufficient funds');
+      const banner = result.current.notices.find((n) => n.id === 'margin');
+      expect(banner?.variant).toBe('banner');
+      expect(banner?.message).toBe('Insufficient funds');
     });
 
     it('maps an OI cap to a banner notice', () => {
@@ -315,11 +330,52 @@ describe('usePerpsProOrderForm', () => {
         result.current.notices.find((n) => n.id === 'sl-invalid'),
       ).toBeDefined();
     });
+
+    it('shows the reduce-only no-position banner and suppresses TP/SL notices', () => {
+      mockOrderForm.takeProfitPrice = '85000';
+      const { result } = renderProForm();
+
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+
+      expect(
+        result.current.notices.find((n) => n.id === 'reduce-only')?.message,
+      ).toBe(
+        'You need to have an open position in this market to place reduce-only orders',
+      );
+      expect(
+        result.current.notices.find((n) => n.id === 'tp-invalid'),
+      ).toBeUndefined();
+    });
+
+    it('shows the reduce-only wrong-side banner for same-direction orders', () => {
+      mockExistingPosition = {
+        size: '1',
+        leverage: { type: 'isolated', value: 5 },
+      };
+      const { result } = renderProForm();
+
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+
+      expect(
+        result.current.notices.find((n) => n.id === 'reduce-only')?.message,
+      ).toBe(
+        'Reduce-only orders can only reduce an existing position. Switch to the opposite side.',
+      );
+    });
   });
 
   describe('handlePlaceOrder', () => {
     it('builds OrderParams including reduceOnly and calls executeOrder', async () => {
-      // Arrange
+      // Arrange: long form reduces a short position; stale TP must be ignored.
+      mockExistingPosition = {
+        size: '-1',
+        leverage: { type: 'isolated', value: 5 },
+      };
+      mockOrderForm.takeProfitPrice = '95000';
       const { result } = renderProForm();
       act(() => {
         result.current.onReduceOnlyChange(true);
@@ -340,6 +396,8 @@ describe('usePerpsProOrderForm', () => {
         usdAmount: '100',
         reduceOnly: true,
       });
+      expect(params).not.toHaveProperty('takeProfitPrice');
+      expect(mockUpdatePositionTPSL).not.toHaveBeenCalled();
       expect(submitted).toHaveBeenCalled();
       expect(mockClearPendingTradeConfiguration).toHaveBeenCalledWith('BTC');
       expect(mockUpdateOrderForm).toHaveBeenCalledWith({
@@ -407,6 +465,20 @@ describe('usePerpsProOrderForm', () => {
       expect(mockExecuteOrder.mock.calls[0][0]).toMatchObject({
         usdAmount: '100',
       });
+    });
+
+    it('blocks reduce-only submit when there is no open position', async () => {
+      const { result } = renderProForm();
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+
+      await act(async () => {
+        await result.current.onPlaceOrderPress();
+      });
+
+      expect(mockExecuteOrder).not.toHaveBeenCalled();
+      expect(result.current.isPlaceOrderDisabled).toBe(true);
     });
 
     it('blocks submit and shows a toast when validation is invalid', async () => {
@@ -490,7 +562,11 @@ describe('usePerpsProOrderForm', () => {
     });
 
     it('skips clearPendingConfig when the order fails (plain else path)', async () => {
-      // Arrange: no TP/SL, controller returns failure
+      // Arrange: valid reduce-only order with no TP/SL; controller returns failure
+      mockExistingPosition = {
+        size: '-1',
+        leverage: { type: 'isolated', value: 5 },
+      };
       mockExecuteOrder.mockResolvedValueOnce({
         success: false,
         error: 'rejected',
@@ -699,6 +775,52 @@ describe('usePerpsProOrderForm', () => {
 
       // Assert
       expect(result.current.isPlaceOrderDisabled).toBe(true);
+    });
+
+    it('ignores TP/SL blockers while Reduce Only is on with a valid closing side', () => {
+      mockExistingPosition = {
+        size: '-1',
+        leverage: { type: 'isolated', value: 5 },
+      };
+      mockOrderForm.takeProfitPrice = '85000';
+      const { result } = renderProForm();
+
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+
+      expect(result.current.isPlaceOrderDisabled).toBe(false);
+    });
+
+    it('disables Place Order while reduce-only position streams are loading', () => {
+      mockPositionStreamLoading = true;
+      mockExistingPosition = {
+        size: '-1',
+        leverage: { type: 'isolated', value: 5 },
+      };
+      const { result } = renderProForm();
+
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+
+      expect(result.current.isPlaceOrderDisabled).toBe(true);
+    });
+  });
+
+  describe('reduceOnly toggle', () => {
+    it('clears TP/SL state when Reduce Only turns on', () => {
+      mockOrderForm.takeProfitPrice = '95000';
+      mockOrderForm.stopLossPrice = '80000';
+      const { result } = renderProForm();
+
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+
+      expect(mockSetTakeProfitPrice).toHaveBeenCalledWith(undefined);
+      expect(mockSetStopLossPrice).toHaveBeenCalledWith(undefined);
+      expect(result.current.reduceOnly).toBe(true);
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
@@ -366,6 +366,28 @@ describe('usePerpsProOrderForm', () => {
         'Reduce-only orders can only reduce an existing position. Switch to the opposite side.',
       );
     });
+
+    it('suppresses stale validation notices while reduce-only streams are loading', () => {
+      // Arrange: retain a prior margin error (skipValidation freezes errors)
+      // while position streams are still loading after Reduce Only is enabled.
+      mockValidation.isValid = false;
+      mockValidation.errors = ['Insufficient funds'];
+      mockPositionStreamLoading = true;
+      const { result } = renderProForm();
+
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+
+      // Assert: no stale margin/limit banner, and Place Order stays disabled.
+      expect(
+        result.current.notices.find((n) => n.id === 'margin'),
+      ).toBeUndefined();
+      expect(
+        result.current.notices.find((n) => n.id === 'reduce-only'),
+      ).toBeUndefined();
+      expect(result.current.isPlaceOrderDisabled).toBe(true);
+    });
   });
 
   describe('handlePlaceOrder', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
@@ -359,6 +359,24 @@ describe('usePerpsProOrderForm', () => {
       );
     });
 
+    it('shows the reduce-only too-large banner and disables submit when size exceeds position', () => {
+      mockExistingPosition = {
+        size: '-1',
+        leverage: { type: 'isolated', value: 5 },
+      };
+      mockOrderForm.amount = '100000';
+      const { result } = renderProForm();
+
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+
+      expect(
+        result.current.notices.find((n) => n.id === 'reduce-only')?.message,
+      ).toBe('Reduce only order is larger than your open position');
+      expect(result.current.isPlaceOrderDisabled).toBe(true);
+    });
+
     it('suppresses stale validation notices while the position is loading', () => {
       // Arrange: retain a prior margin error (skipValidation freezes errors)
       // while the position is still loading after Reduce Only is enabled.
@@ -483,6 +501,26 @@ describe('usePerpsProOrderForm', () => {
 
     it('blocks reduce-only submit when there is no open position', async () => {
       const { result } = renderProForm();
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+
+      await act(async () => {
+        await result.current.onPlaceOrderPress();
+      });
+
+      expect(mockExecuteOrder).not.toHaveBeenCalled();
+      expect(result.current.isPlaceOrderDisabled).toBe(true);
+    });
+
+    it('blocks reduce-only submit when size exceeds the open position', async () => {
+      mockExistingPosition = {
+        size: '-1',
+        leverage: { type: 'isolated', value: 5 },
+      };
+      mockOrderForm.amount = '100000';
+      const { result } = renderProForm();
+
       act(() => {
         result.current.onReduceOnlyChange(true);
       });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
@@ -38,6 +38,7 @@ import {
 } from '../../../../hooks';
 import { usePerpsHomeActions } from '../../../../hooks/usePerpsHomeActions';
 import {
+  usePerpsLiveOrders,
   usePerpsLivePrices,
   usePerpsTopOfBook,
 } from '../../../../hooks/stream';
@@ -60,6 +61,10 @@ import {
 } from '../../../../utils/orderParams';
 import { deriveOrderSizing } from '../../../../utils/orderSizing';
 import { willFlipPosition } from '../../../../utils/orderUtils';
+import {
+  validateReduceOnlyOrder,
+  type ReduceOnlyValidationCode,
+} from '../../../../utils/reduceOnlyValidation';
 import { getPerpsOrderTpSlWarnings } from '../../../../utils/tpslValidation';
 import { MAX_PERPS_INPUT_DIGITS } from '../../../../constants/perpsConfig';
 import {
@@ -75,6 +80,32 @@ import type {
   PerpsProSizeSliderModel,
 } from './PerpsProOrderForm.types';
 import { usePerpsProSizeInput } from './usePerpsProSizeInput';
+
+const REDUCE_ONLY_ERROR_I18N_KEYS: Record<ReduceOnlyValidationCode, string> = {
+  no_position: 'perps.order.validation.reduce_only_no_position',
+  wrong_side: 'perps.order.validation.reduce_only_wrong_side',
+  too_large: 'perps.order.validation.reduce_only_too_large',
+};
+
+/** Prefix of the interpolated insufficient-balance message (stable across amounts). */
+const INSUFFICIENT_BALANCE_PREFIX = strings(
+  'perps.order.validation.insufficient_balance',
+  { required: '__REQ__', available: '__AVAIL__' },
+).split('__REQ__')[0];
+
+const isMarginValidationError = (message: string): boolean =>
+  message.startsWith(INSUFFICIENT_BALANCE_PREFIX) ||
+  message === strings('perps.order.validation.insufficient_funds') ||
+  message ===
+    strings('perps.order.validation.insufficient_funds_to_cover_trade');
+
+const isLimitPriceValidationError = (message: string): boolean =>
+  message === strings('perps.order.validation.limit_price_required') ||
+  message === strings('perps.order.validation.please_set_a_limit_price') ||
+  message ===
+    strings(
+      'perps.order.validation.limit_price_must_be_set_before_configuring_tpsl',
+    );
 
 export interface UsePerpsProOrderFormParams {
   market: PerpsMarketData;
@@ -212,10 +243,16 @@ export const usePerpsProOrderForm = ({
     marketData?.maxLeverage ?? PERPS_CONSTANTS.DefaultMaxLeverage;
   const isLoadingMarketData = isMarketDataLoading && marketData === null;
 
-  const { existingPosition: currentMarketPosition } = useHasExistingPosition({
+  const {
+    existingPosition: currentMarketPosition,
+    isLoading: isPositionStreamLoading,
+  } = useHasExistingPosition({
     asset: symbol,
     loadOnMount: true,
   });
+
+  const { orders: openOrders, isInitialLoading: isOrdersStreamLoading } =
+    usePerpsLiveOrders();
 
   const prices = usePerpsLivePrices({ symbols: [symbol], throttleMs: 1000 });
   const currentPrice = prices[symbol];
@@ -347,6 +384,29 @@ export const usePerpsProOrderForm = ({
     [effectiveUsdAmount, orderForm],
   );
 
+  const isReduceOnlyStreamLoading =
+    reduceOnly && (isPositionStreamLoading || isOrdersStreamLoading);
+
+  const reduceOnlyValidation = useMemo(
+    () =>
+      validateReduceOnlyOrder({
+        reduceOnly,
+        direction: orderForm.direction,
+        orderSize: positionSize,
+        position: currentMarketPosition,
+        openOrders,
+        symbol,
+      }),
+    [
+      reduceOnly,
+      orderForm.direction,
+      positionSize,
+      currentMarketPosition,
+      openOrders,
+      symbol,
+    ],
+  );
+
   const orderValidation = usePerpsOrderValidation({
     orderForm: effectiveOrderForm,
     positionSize,
@@ -357,8 +417,12 @@ export const usePerpsProOrderForm = ({
     // for a valid close/reduce when free collateral is low.
     marginRequired: reduceOnly ? '0' : marginRequired || '0',
     existingPositionLeverage: existingPositionLeverageForValidation,
-    skipValidation: false,
+    // Skip protocol validation until streams are ready so we don't flash
+    // unrelated errors while waiting for position/order snapshots.
+    skipValidation: isReduceOnlyStreamLoading,
     originalUsdAmount: effectiveUsdAmount,
+    reduceOnly,
+    isFullClose: reduceOnlyValidation.isFullClose,
   });
 
   const filteredErrors = useMemo(() => {
@@ -401,9 +465,10 @@ export const usePerpsProOrderForm = ({
   });
 
   const hasTpslBlocker =
-    doesStopLossRiskLiquidation ||
-    isTakeProfitPriceInvalid ||
-    isStopLossPriceInvalid;
+    !reduceOnly &&
+    (doesStopLossRiskLiquidation ||
+      isTakeProfitPriceInvalid ||
+      isStopLossPriceInvalid);
   const directionTrackingValue =
     orderForm.direction === 'long'
       ? PERPS_EVENT_VALUE.DIRECTION.LONG
@@ -446,6 +511,13 @@ export const usePerpsProOrderForm = ({
     }
 
     if (hasTpslBlocker) {
+      return;
+    }
+
+    if (
+      isReduceOnlyStreamLoading ||
+      (reduceOnly && !reduceOnlyValidation.isValid)
+    ) {
       return;
     }
 
@@ -510,6 +582,7 @@ export const usePerpsProOrderForm = ({
         takeProfitPrice: orderForm.takeProfitPrice,
         stopLossPrice: orderForm.stopLossPrice,
         reduceOnly,
+        isFullClose: reduceOnly ? reduceOnlyValidation.isFullClose : undefined,
         trackingData: buildPerpsOrderTrackingData({
           marginRequired,
           feeResults,
@@ -531,6 +604,7 @@ export const usePerpsProOrderForm = ({
       );
 
       const shouldHandleTPSLSeparately =
+        !reduceOnly &&
         (orderForm.takeProfitPrice || orderForm.stopLossPrice) &&
         ((!currentMarketPosition && orderForm.type === 'market') ||
           (currentMarketPosition &&
@@ -599,6 +673,9 @@ export const usePerpsProOrderForm = ({
     maxSlippageBps,
     maxSlippageSource,
     hasTpslBlocker,
+    isReduceOnlyStreamLoading,
+    reduceOnlyValidation.isValid,
+    reduceOnlyValidation.isFullClose,
     directionTrackingValue,
     orderValidation.isValid,
     orderValidation.errors,
@@ -776,47 +853,82 @@ export const usePerpsProOrderForm = ({
   const notices = useMemo<PerpsProOrderNotice[]>(() => {
     const list: PerpsProOrderNotice[] = [];
 
-    filteredErrors.forEach((message, index) => {
-      list.push({ id: `validation-${index}`, variant: 'inline', message });
-    });
+    // Blocking banners (one at a time): reduce-only → margin → limit price.
+    if (
+      reduceOnly &&
+      !isReduceOnlyStreamLoading &&
+      reduceOnlyValidation.errorCode
+    ) {
+      list.push({
+        id: 'reduce-only',
+        variant: 'banner',
+        message: strings(
+          REDUCE_ONLY_ERROR_I18N_KEYS[reduceOnlyValidation.errorCode],
+        ),
+      });
+    } else {
+      const marginError = filteredErrors.find(isMarginValidationError);
+      const limitPriceError = filteredErrors.find(isLimitPriceValidationError);
 
-    if (doesStopLossRiskLiquidation) {
-      list.push({
-        id: 'sl-liq-risk',
-        variant: 'inline',
-        message: strings('perps.tpsl.stop_loss_order_view_warning', {
-          direction:
-            orderForm.direction === 'long'
-              ? strings('perps.tpsl.below')
-              : strings('perps.tpsl.above'),
-        }),
-      });
+      if (marginError) {
+        list.push({
+          id: 'margin',
+          variant: 'banner',
+          message: marginError,
+        });
+      } else if (limitPriceError) {
+        list.push({
+          id: 'limit-price',
+          variant: 'banner',
+          message: limitPriceError,
+        });
+      } else {
+        filteredErrors.forEach((message, index) => {
+          list.push({ id: `validation-${index}`, variant: 'inline', message });
+        });
+      }
     }
-    if (isTakeProfitPriceInvalid) {
-      list.push({
-        id: 'tp-invalid',
-        variant: 'inline',
-        message: strings('perps.tpsl.take_profit_wrong_side_warning', {
-          direction:
-            orderForm.direction === 'long'
-              ? strings('perps.tpsl.above')
-              : strings('perps.tpsl.below'),
-          priceType: tpslPriceType,
-        }),
-      });
-    }
-    if (isStopLossPriceInvalid) {
-      list.push({
-        id: 'sl-invalid',
-        variant: 'inline',
-        message: strings('perps.tpsl.stop_loss_wrong_side_warning', {
-          direction:
-            orderForm.direction === 'long'
-              ? strings('perps.tpsl.below')
-              : strings('perps.tpsl.above'),
-          priceType: tpslPriceType,
-        }),
-      });
+
+    // TP/SL warnings are irrelevant while Reduce Only is on (row is hidden).
+    if (!reduceOnly) {
+      if (doesStopLossRiskLiquidation) {
+        list.push({
+          id: 'sl-liq-risk',
+          variant: 'inline',
+          message: strings('perps.tpsl.stop_loss_order_view_warning', {
+            direction:
+              orderForm.direction === 'long'
+                ? strings('perps.tpsl.below')
+                : strings('perps.tpsl.above'),
+          }),
+        });
+      }
+      if (isTakeProfitPriceInvalid) {
+        list.push({
+          id: 'tp-invalid',
+          variant: 'inline',
+          message: strings('perps.tpsl.take_profit_wrong_side_warning', {
+            direction:
+              orderForm.direction === 'long'
+                ? strings('perps.tpsl.above')
+                : strings('perps.tpsl.below'),
+            priceType: tpslPriceType,
+          }),
+        });
+      }
+      if (isStopLossPriceInvalid) {
+        list.push({
+          id: 'sl-invalid',
+          variant: 'inline',
+          message: strings('perps.tpsl.stop_loss_wrong_side_warning', {
+            direction:
+              orderForm.direction === 'long'
+                ? strings('perps.tpsl.below')
+                : strings('perps.tpsl.above'),
+            priceType: tpslPriceType,
+          }),
+        });
+      }
     }
     if (isAtCap) {
       list.push({
@@ -828,6 +940,9 @@ export const usePerpsProOrderForm = ({
 
     return list;
   }, [
+    reduceOnly,
+    isReduceOnlyStreamLoading,
+    reduceOnlyValidation.errorCode,
     filteredErrors,
     doesStopLossRiskLiquidation,
     isTakeProfitPriceInvalid,
@@ -889,9 +1004,9 @@ export const usePerpsProOrderForm = ({
     isAtCap ||
     isPlacing ||
     isLoadingMarketData ||
-    doesStopLossRiskLiquidation ||
-    isTakeProfitPriceInvalid ||
-    isStopLossPriceInvalid;
+    isReduceOnlyStreamLoading ||
+    (reduceOnly && !reduceOnlyValidation.isValid) ||
+    hasTpslBlocker;
 
   const onDirectionChange = useCallback(
     (direction: PerpsProOrderDirection) => {
@@ -954,7 +1069,13 @@ export const usePerpsProOrderForm = ({
     availableBalance,
     onAddFundsPress: handleAddFunds,
     reduceOnly,
-    onReduceOnlyChange: setReduceOnly,
+    onReduceOnlyChange: (value: boolean) => {
+      setReduceOnly(value);
+      if (value) {
+        setTakeProfitPrice(undefined);
+        setStopLossPrice(undefined);
+      }
+    },
     isTPSLConfigured: Boolean(
       orderForm.takeProfitPrice || orderForm.stopLossPrice,
     ),

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
@@ -65,7 +65,10 @@ import {
   validateReduceOnlyOrder,
   type ReduceOnlyValidationCode,
 } from '../../../../utils/reduceOnlyValidation';
-import { getPerpsOrderTpSlWarnings } from '../../../../utils/tpslValidation';
+import {
+  getPerpsOrderTpSlWarnings,
+  type PerpsOrderTpSlWarnings,
+} from '../../../../utils/tpslValidation';
 import { MAX_PERPS_INPUT_DIGITS } from '../../../../constants/perpsConfig';
 import {
   finalizeNumericTextInput,
@@ -106,6 +109,105 @@ const isLimitPriceValidationError = (message: string): boolean =>
     strings(
       'perps.order.validation.limit_price_must_be_set_before_configuring_tpsl',
     );
+
+const getBlockingNotices = ({
+  reduceOnlyErrorCode,
+  isReduceOnlyStreamLoading,
+  filteredErrors,
+}: {
+  reduceOnlyErrorCode?: ReduceOnlyValidationCode;
+  isReduceOnlyStreamLoading: boolean;
+  filteredErrors: string[];
+}): PerpsProOrderNotice[] => {
+  if (reduceOnlyErrorCode && !isReduceOnlyStreamLoading) {
+    return [
+      {
+        id: 'reduce-only',
+        variant: 'banner',
+        message: strings(REDUCE_ONLY_ERROR_I18N_KEYS[reduceOnlyErrorCode]),
+      },
+    ];
+  }
+
+  const marginError = filteredErrors.find(isMarginValidationError);
+  if (marginError) {
+    return [{ id: 'margin', variant: 'banner', message: marginError }];
+  }
+
+  const limitPriceError = filteredErrors.find(isLimitPriceValidationError);
+  if (limitPriceError) {
+    return [
+      {
+        id: 'limit-price',
+        variant: 'banner',
+        message: limitPriceError,
+      },
+    ];
+  }
+
+  return filteredErrors.map((message, index) => ({
+    id: `validation-${index}`,
+    variant: 'inline',
+    message,
+  }));
+};
+
+const getTpslNotices = ({
+  reduceOnly,
+  direction,
+  doesStopLossRiskLiquidation,
+  isTakeProfitPriceInvalid,
+  isStopLossPriceInvalid,
+  tpslPriceType,
+}: {
+  reduceOnly: boolean;
+  direction: PerpsProOrderDirection;
+  doesStopLossRiskLiquidation: boolean;
+  isTakeProfitPriceInvalid: boolean;
+  isStopLossPriceInvalid: boolean;
+  tpslPriceType: PerpsOrderTpSlWarnings['tpslPriceType'];
+}): PerpsProOrderNotice[] => {
+  if (reduceOnly) {
+    return [];
+  }
+
+  const notices: PerpsProOrderNotice[] = [];
+  const isLong = direction === 'long';
+
+  if (doesStopLossRiskLiquidation) {
+    notices.push({
+      id: 'sl-liq-risk',
+      variant: 'inline',
+      message: strings('perps.tpsl.stop_loss_order_view_warning', {
+        direction: strings(isLong ? 'perps.tpsl.below' : 'perps.tpsl.above'),
+      }),
+    });
+  }
+
+  if (isTakeProfitPriceInvalid) {
+    notices.push({
+      id: 'tp-invalid',
+      variant: 'inline',
+      message: strings('perps.tpsl.take_profit_wrong_side_warning', {
+        direction: strings(isLong ? 'perps.tpsl.above' : 'perps.tpsl.below'),
+        priceType: tpslPriceType,
+      }),
+    });
+  }
+
+  if (isStopLossPriceInvalid) {
+    notices.push({
+      id: 'sl-invalid',
+      variant: 'inline',
+      message: strings('perps.tpsl.stop_loss_wrong_side_warning', {
+        direction: strings(isLong ? 'perps.tpsl.below' : 'perps.tpsl.above'),
+        priceType: tpslPriceType,
+      }),
+    });
+  }
+
+  return notices;
+};
 
 export interface UsePerpsProOrderFormParams {
   market: PerpsMarketData;
@@ -851,85 +953,24 @@ export const usePerpsProOrderForm = ({
   }, [isInitialized, spendableBalance]);
 
   const notices = useMemo<PerpsProOrderNotice[]>(() => {
-    const list: PerpsProOrderNotice[] = [];
+    const list = [
+      ...getBlockingNotices({
+        reduceOnlyErrorCode: reduceOnly
+          ? reduceOnlyValidation.errorCode
+          : undefined,
+        isReduceOnlyStreamLoading,
+        filteredErrors,
+      }),
+      ...getTpslNotices({
+        reduceOnly,
+        direction: orderForm.direction,
+        doesStopLossRiskLiquidation,
+        isTakeProfitPriceInvalid,
+        isStopLossPriceInvalid,
+        tpslPriceType,
+      }),
+    ];
 
-    // Blocking banners (one at a time): reduce-only → margin → limit price.
-    if (
-      reduceOnly &&
-      !isReduceOnlyStreamLoading &&
-      reduceOnlyValidation.errorCode
-    ) {
-      list.push({
-        id: 'reduce-only',
-        variant: 'banner',
-        message: strings(
-          REDUCE_ONLY_ERROR_I18N_KEYS[reduceOnlyValidation.errorCode],
-        ),
-      });
-    } else {
-      const marginError = filteredErrors.find(isMarginValidationError);
-      const limitPriceError = filteredErrors.find(isLimitPriceValidationError);
-
-      if (marginError) {
-        list.push({
-          id: 'margin',
-          variant: 'banner',
-          message: marginError,
-        });
-      } else if (limitPriceError) {
-        list.push({
-          id: 'limit-price',
-          variant: 'banner',
-          message: limitPriceError,
-        });
-      } else {
-        filteredErrors.forEach((message, index) => {
-          list.push({ id: `validation-${index}`, variant: 'inline', message });
-        });
-      }
-    }
-
-    // TP/SL warnings are irrelevant while Reduce Only is on (row is hidden).
-    if (!reduceOnly) {
-      if (doesStopLossRiskLiquidation) {
-        list.push({
-          id: 'sl-liq-risk',
-          variant: 'inline',
-          message: strings('perps.tpsl.stop_loss_order_view_warning', {
-            direction:
-              orderForm.direction === 'long'
-                ? strings('perps.tpsl.below')
-                : strings('perps.tpsl.above'),
-          }),
-        });
-      }
-      if (isTakeProfitPriceInvalid) {
-        list.push({
-          id: 'tp-invalid',
-          variant: 'inline',
-          message: strings('perps.tpsl.take_profit_wrong_side_warning', {
-            direction:
-              orderForm.direction === 'long'
-                ? strings('perps.tpsl.above')
-                : strings('perps.tpsl.below'),
-            priceType: tpslPriceType,
-          }),
-        });
-      }
-      if (isStopLossPriceInvalid) {
-        list.push({
-          id: 'sl-invalid',
-          variant: 'inline',
-          message: strings('perps.tpsl.stop_loss_wrong_side_warning', {
-            direction:
-              orderForm.direction === 'long'
-                ? strings('perps.tpsl.below')
-                : strings('perps.tpsl.above'),
-            priceType: tpslPriceType,
-          }),
-        });
-      }
-    }
     if (isAtCap) {
       list.push({
         id: 'oi-cap',

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
@@ -119,7 +119,13 @@ const getBlockingNotices = ({
   isReduceOnlyStreamLoading: boolean;
   filteredErrors: string[];
 }): PerpsProOrderNotice[] => {
-  if (reduceOnlyErrorCode && !isReduceOnlyStreamLoading) {
+  // Streams are unresolved — skipValidation retains prior errors, so hide all
+  // blocking notices until live reduce-only state can be evaluated.
+  if (isReduceOnlyStreamLoading) {
+    return [];
+  }
+
+  if (reduceOnlyErrorCode) {
     return [
       {
         id: 'reduce-only',

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
@@ -1085,6 +1085,17 @@ export const usePerpsProOrderForm = ({
     handlePlaceOrder();
   }, [commitPendingSliderPreview, handlePlaceOrder]);
 
+  const onReduceOnlyChange = useCallback(
+    (value: boolean) => {
+      setReduceOnly(value);
+      if (value) {
+        setTakeProfitPrice(undefined);
+        setStopLossPrice(undefined);
+      }
+    },
+    [setTakeProfitPrice, setStopLossPrice],
+  );
+
   return {
     direction: orderForm.direction,
     onDirectionChange,
@@ -1102,13 +1113,7 @@ export const usePerpsProOrderForm = ({
     availableBalance,
     onAddFundsPress: handleAddFunds,
     reduceOnly,
-    onReduceOnlyChange: (value: boolean) => {
-      setReduceOnly(value);
-      if (value) {
-        setTakeProfitPrice(undefined);
-        setStopLossPrice(undefined);
-      }
-    },
+    onReduceOnlyChange,
     isTPSLConfigured: Boolean(
       orderForm.takeProfitPrice || orderForm.stopLossPrice,
     ),

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
@@ -38,7 +38,6 @@ import {
 } from '../../../../hooks';
 import { usePerpsHomeActions } from '../../../../hooks/usePerpsHomeActions';
 import {
-  usePerpsLiveOrders,
   usePerpsLivePrices,
   usePerpsTopOfBook,
 } from '../../../../hooks/stream';
@@ -112,16 +111,16 @@ const isLimitPriceValidationError = (message: string): boolean =>
 
 const getBlockingNotices = ({
   reduceOnlyErrorCode,
-  isReduceOnlyStreamLoading,
+  isReduceOnlyPositionLoading,
   filteredErrors,
 }: {
   reduceOnlyErrorCode?: ReduceOnlyValidationCode;
-  isReduceOnlyStreamLoading: boolean;
+  isReduceOnlyPositionLoading: boolean;
   filteredErrors: string[];
 }): PerpsProOrderNotice[] => {
-  // Streams are unresolved — skipValidation retains prior errors, so hide all
-  // blocking notices until live reduce-only state can be evaluated.
-  if (isReduceOnlyStreamLoading) {
+  // Position data is unresolved — skipValidation retains prior errors, so hide
+  // blocking notices until the live reduce-only state can be evaluated.
+  if (isReduceOnlyPositionLoading) {
     return [];
   }
 
@@ -359,9 +358,6 @@ export const usePerpsProOrderForm = ({
     loadOnMount: true,
   });
 
-  const { orders: openOrders, isInitialLoading: isOrdersStreamLoading } =
-    usePerpsLiveOrders();
-
   const prices = usePerpsLivePrices({ symbols: [symbol], throttleMs: 1000 });
   const currentPrice = prices[symbol];
   const currentTopOfBook = usePerpsTopOfBook({ symbol });
@@ -492,8 +488,7 @@ export const usePerpsProOrderForm = ({
     [effectiveUsdAmount, orderForm],
   );
 
-  const isReduceOnlyStreamLoading =
-    reduceOnly && (isPositionStreamLoading || isOrdersStreamLoading);
+  const isReduceOnlyPositionLoading = reduceOnly && isPositionStreamLoading;
 
   const reduceOnlyValidation = useMemo(
     () =>
@@ -502,17 +497,8 @@ export const usePerpsProOrderForm = ({
         direction: orderForm.direction,
         orderSize: positionSize,
         position: currentMarketPosition,
-        openOrders,
-        symbol,
       }),
-    [
-      reduceOnly,
-      orderForm.direction,
-      positionSize,
-      currentMarketPosition,
-      openOrders,
-      symbol,
-    ],
+    [reduceOnly, orderForm.direction, positionSize, currentMarketPosition],
   );
 
   const orderValidation = usePerpsOrderValidation({
@@ -525,9 +511,9 @@ export const usePerpsProOrderForm = ({
     // for a valid close/reduce when free collateral is low.
     marginRequired: reduceOnly ? '0' : marginRequired || '0',
     existingPositionLeverage: existingPositionLeverageForValidation,
-    // Skip protocol validation until streams are ready so we don't flash
-    // unrelated errors while waiting for position/order snapshots.
-    skipValidation: isReduceOnlyStreamLoading,
+    // Skip protocol validation until position data is ready so we don't flash
+    // unrelated errors while waiting for the position snapshot.
+    skipValidation: isReduceOnlyPositionLoading,
     originalUsdAmount: effectiveUsdAmount,
     reduceOnly,
     isFullClose: reduceOnlyValidation.isFullClose,
@@ -623,7 +609,7 @@ export const usePerpsProOrderForm = ({
     }
 
     if (
-      isReduceOnlyStreamLoading ||
+      isReduceOnlyPositionLoading ||
       (reduceOnly && !reduceOnlyValidation.isValid)
     ) {
       return;
@@ -781,7 +767,7 @@ export const usePerpsProOrderForm = ({
     maxSlippageBps,
     maxSlippageSource,
     hasTpslBlocker,
-    isReduceOnlyStreamLoading,
+    isReduceOnlyPositionLoading,
     reduceOnlyValidation.isValid,
     reduceOnlyValidation.isFullClose,
     directionTrackingValue,
@@ -964,7 +950,7 @@ export const usePerpsProOrderForm = ({
         reduceOnlyErrorCode: reduceOnly
           ? reduceOnlyValidation.errorCode
           : undefined,
-        isReduceOnlyStreamLoading,
+        isReduceOnlyPositionLoading,
         filteredErrors,
       }),
       ...getTpslNotices({
@@ -988,7 +974,7 @@ export const usePerpsProOrderForm = ({
     return list;
   }, [
     reduceOnly,
-    isReduceOnlyStreamLoading,
+    isReduceOnlyPositionLoading,
     reduceOnlyValidation.errorCode,
     filteredErrors,
     doesStopLossRiskLiquidation,
@@ -1051,7 +1037,7 @@ export const usePerpsProOrderForm = ({
     isAtCap ||
     isPlacing ||
     isLoadingMarketData ||
-    isReduceOnlyStreamLoading ||
+    isReduceOnlyPositionLoading ||
     (reduceOnly && !reduceOnlyValidation.isValid) ||
     hasTpslBlocker;
 

--- a/app/components/UI/Perps/hooks/usePerpsOrderValidation.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderValidation.test.ts
@@ -26,6 +26,7 @@ jest.mock('../../../../../locales/i18n', () => ({
     const translations: Record<string, string> = {
       'perps.order.validation.existing_position': `Existing position for ${values?.asset}`,
       'perps.order.validation.insufficient_balance': `Insufficient balance: need ${values?.required}, have ${values?.available}`,
+      'perps.order.validation.minimum_amount': `Minimum order size is $${values?.amount}`,
       'perps.order.validation.high_leverage_warning': 'High leverage warning',
       'perps.order.validation.limit_price_required': 'Limit price required',
       'perps.order.validation.error': 'Validation error',
@@ -482,6 +483,64 @@ describe('usePerpsOrderValidation', () => {
       expect(result.current.errors).toContain(
         'Insufficient balance: need 10.00, have 5',
       );
+    });
+  });
+
+  describe('reduce-only full close', () => {
+    it('passes reduceOnly and isFullClose through to protocol validation', async () => {
+      mockValidateOrder.mockResolvedValue({ isValid: true });
+
+      renderHook(() =>
+        usePerpsOrderValidation({
+          ...defaultParams,
+          orderForm: { ...defaultOrderForm, amount: '5' },
+          originalUsdAmount: '5',
+          reduceOnly: true,
+          isFullClose: true,
+          marginRequired: '0',
+        }),
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      await fastWaitFor(() => {
+        expect(mockValidateOrder).toHaveBeenCalled();
+      });
+
+      expect(mockValidateOrder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reduceOnly: true,
+          isFullClose: true,
+        }),
+      );
+    });
+
+    it('skips the UI minimum-amount error for a full reduce-only close', async () => {
+      mockValidateOrder.mockResolvedValue({ isValid: true });
+
+      const { result } = renderHook(() =>
+        usePerpsOrderValidation({
+          ...defaultParams,
+          orderForm: { ...defaultOrderForm, amount: '5' },
+          originalUsdAmount: '5',
+          reduceOnly: true,
+          isFullClose: true,
+          marginRequired: '0',
+        }),
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      await fastWaitFor(() => {
+        expect(result.current.isValidating).toBe(false);
+      });
+
+      expect(result.current.isValid).toBe(true);
+      expect(result.current.errors).not.toContain('Minimum order size is $10');
     });
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsOrderValidation.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderValidation.ts
@@ -27,6 +27,13 @@ interface UsePerpsOrderValidationParams {
   existingPositionLeverage?: number;
   skipValidation?: boolean;
   originalUsdAmount?: string; // Original USD input for validation (prevents precision loss from recalculation)
+  /** When true, passes reduceOnly through to protocol validation. */
+  reduceOnly?: boolean;
+  /**
+   * When true with reduceOnly, skips the UI minimum-amount check and tells the
+   * controller to apply its full-close minimum exemption.
+   */
+  isFullClose?: boolean;
 }
 
 interface ValidationResult {
@@ -59,6 +66,8 @@ export function usePerpsOrderValidation(
     existingPositionLeverage,
     skipValidation,
     originalUsdAmount,
+    reduceOnly,
+    isFullClose,
   } = params;
 
   const { validateOrder } = usePerpsTrading();
@@ -111,7 +120,10 @@ export function usePerpsOrderValidation(
         ? TRADING_DEFAULTS.amount.mainnet
         : TRADING_DEFAULTS.amount.testnet;
 
-    if (usdAmount > 0 && usdAmount < minimumOrderSize) {
+    // Full reduce-only closes may be below the normal minimum notional (dust);
+    // the controller skips ORDER_SIZE_MIN when reduceOnly && isFullClose.
+    const skipMinimumAmount = Boolean(reduceOnly && isFullClose);
+    if (!skipMinimumAmount && usdAmount > 0 && usdAmount < minimumOrderSize) {
       immediateErrors.push(
         strings('perps.order.validation.minimum_amount', {
           amount: minimumOrderSize.toString(),
@@ -131,6 +143,8 @@ export function usePerpsOrderValidation(
         currentPrice: assetPrice,
         existingPositionLeverage,
         usdAmount: originalUsdAmount, // Pass USD as source of truth for validation
+        ...(reduceOnly !== undefined ? { reduceOnly } : {}),
+        ...(isFullClose !== undefined ? { isFullClose } : {}),
       };
 
       // Get protocol-specific validation
@@ -233,6 +247,8 @@ export function usePerpsOrderValidation(
     marginRequired,
     existingPositionLeverage,
     originalUsdAmount,
+    reduceOnly,
+    isFullClose,
     validateOrder,
     network,
   ]);

--- a/app/components/UI/Perps/utils/orderParams.test.ts
+++ b/app/components/UI/Perps/utils/orderParams.test.ts
@@ -97,6 +97,22 @@ describe('buildPerpsOrderParams', () => {
     expect(withTpSl.takeProfitPrice).toBe('95000');
     expect(withTpSl).not.toHaveProperty('stopLossPrice');
   });
+
+  it('omits TP/SL when reduceOnly is true even if values are present', () => {
+    const params = buildPerpsOrderParams({
+      ...base,
+      orderType: 'market',
+      reduceOnly: true,
+      isFullClose: true,
+      takeProfitPrice: '95000',
+      stopLossPrice: '80000',
+    });
+
+    expect(params.reduceOnly).toBe(true);
+    expect(params.isFullClose).toBe(true);
+    expect(params).not.toHaveProperty('takeProfitPrice');
+    expect(params).not.toHaveProperty('stopLossPrice');
+  });
 });
 
 describe('buildPerpsOrderTrackingData', () => {

--- a/app/components/UI/Perps/utils/orderParams.ts
+++ b/app/components/UI/Perps/utils/orderParams.ts
@@ -104,7 +104,7 @@ export interface BuildPerpsOrderParamsInput {
   /** Reduce-only flag (Pro only); omitted for lite. */
   reduceOnly?: boolean;
   /**
-   * True when the order consumes the full remaining closable position.
+   * True when the order consumes the full open position.
    * Enables the controller's minimum-notional exemption for dust closes.
    */
   isFullClose?: boolean;

--- a/app/components/UI/Perps/utils/orderParams.ts
+++ b/app/components/UI/Perps/utils/orderParams.ts
@@ -103,6 +103,11 @@ export interface BuildPerpsOrderParamsInput {
   stopLossPrice?: string;
   /** Reduce-only flag (Pro only); omitted for lite. */
   reduceOnly?: boolean;
+  /**
+   * True when the order consumes the full remaining closable position.
+   * Enables the controller's minimum-notional exemption for dust closes.
+   */
+  isFullClose?: boolean;
   trackingData: OrderTrackingData;
 }
 
@@ -110,7 +115,7 @@ export interface BuildPerpsOrderParamsInput {
  * Pure assembly of the controller `OrderParams` shared by the lite
  * (`PerpsOrderView`) and Pro (`usePerpsProOrderForm`) order forms. Limit orders
  * use the fixed default slippage; TP/SL/limit price and `reduceOnly` are only
- * included when present. Mirrors the lite form's original inline object exactly.
+ * included when present. TP/SL are never attached to reduce-only orders.
  *
  * @param input - Order params inputs.
  * @returns The controller `OrderParams`.
@@ -128,6 +133,7 @@ export const buildPerpsOrderParams = ({
   takeProfitPrice,
   stopLossPrice,
   reduceOnly,
+  isFullClose,
   trackingData,
 }: BuildPerpsOrderParamsInput): OrderParams => ({
   symbol: asset,
@@ -143,9 +149,11 @@ export const buildPerpsOrderParams = ({
       ? ORDER_SLIPPAGE_CONFIG.DefaultLimitSlippageBps
       : maxSlippageBps,
   ...(reduceOnly !== undefined ? { reduceOnly } : {}),
+  ...(isFullClose !== undefined ? { isFullClose } : {}),
   ...(orderType === 'limit' && limitPrice ? { price: limitPrice } : {}),
-  ...(takeProfitPrice?.trim() ? { takeProfitPrice } : {}),
-  ...(stopLossPrice?.trim() ? { stopLossPrice } : {}),
+  // Reduce-only closes cannot attach TP/SL — omit even if stale values remain.
+  ...(!reduceOnly && takeProfitPrice?.trim() ? { takeProfitPrice } : {}),
+  ...(!reduceOnly && stopLossPrice?.trim() ? { stopLossPrice } : {}),
   trackingData,
 });
 

--- a/app/components/UI/Perps/utils/reduceOnlyValidation.test.ts
+++ b/app/components/UI/Perps/utils/reduceOnlyValidation.test.ts
@@ -1,8 +1,5 @@
-import type { Order, Position } from '@metamask/perps-controller';
-import {
-  getReservedReduceOnlySize,
-  validateReduceOnlyOrder,
-} from './reduceOnlyValidation';
+import type { Position } from '@metamask/perps-controller';
+import { validateReduceOnlyOrder } from './reduceOnlyValidation';
 
 const createPosition = (overrides: Partial<Position> = {}): Position =>
   ({
@@ -22,125 +19,6 @@ const createPosition = (overrides: Partial<Position> = {}): Position =>
     ...overrides,
   }) as Position;
 
-const createOrder = (overrides: Partial<Order> = {}): Order =>
-  ({
-    orderId: 'order-1',
-    symbol: 'BTC',
-    side: 'sell',
-    orderType: 'limit',
-    size: '0.2',
-    originalSize: '0.2',
-    price: '51000',
-    filledSize: '0',
-    remainingSize: '0.2',
-    status: 'open',
-    timestamp: 1,
-    reduceOnly: true,
-    isTrigger: false,
-    detailedOrderType: 'Limit',
-    ...overrides,
-  }) as Order;
-
-describe('getReservedReduceOnlySize', () => {
-  it('sums remaining size of matching open reduce-only closing orders', () => {
-    const openOrders = [
-      createOrder({ orderId: 'a', remainingSize: '0.2' }),
-      createOrder({ orderId: 'b', remainingSize: '0.3' }),
-    ];
-
-    const reserved = getReservedReduceOnlySize({
-      openOrders,
-      symbol: 'BTC',
-      positionDirection: 'long',
-    });
-
-    expect(reserved).toBeCloseTo(0.5);
-  });
-
-  it('excludes TP/SL trigger orders from reserved capacity', () => {
-    const openOrders = [
-      createOrder({
-        orderId: 'trigger',
-        remainingSize: '1',
-        isTrigger: true,
-        detailedOrderType: 'Take Profit Limit',
-      }),
-      createOrder({
-        orderId: 'tpsl-type',
-        remainingSize: '1',
-        isTrigger: false,
-        detailedOrderType: 'Stop Market',
-      }),
-      createOrder({ orderId: 'resting', remainingSize: '0.1' }),
-    ];
-
-    const reserved = getReservedReduceOnlySize({
-      openOrders,
-      symbol: 'BTC',
-      positionDirection: 'long',
-    });
-
-    expect(reserved).toBeCloseTo(0.1);
-  });
-
-  it('excludes orders for a different symbol, side, status, or non-reduce-only', () => {
-    const openOrders = [
-      createOrder({
-        orderId: 'other-symbol',
-        symbol: 'ETH',
-        remainingSize: '1',
-      }),
-      createOrder({
-        orderId: 'wrong-side',
-        side: 'buy',
-        remainingSize: '1',
-      }),
-      createOrder({
-        orderId: 'filled',
-        status: 'filled',
-        remainingSize: '1',
-      }),
-      createOrder({
-        orderId: 'not-reduce',
-        reduceOnly: false,
-        remainingSize: '1',
-      }),
-      createOrder({ orderId: 'match', remainingSize: '0.25' }),
-    ];
-
-    const reserved = getReservedReduceOnlySize({
-      openOrders,
-      symbol: 'BTC',
-      positionDirection: 'long',
-    });
-
-    expect(reserved).toBeCloseTo(0.25);
-  });
-
-  it('reserves buy-side reduce-only orders when closing a short', () => {
-    const openOrders = [
-      createOrder({
-        orderId: 'close-short',
-        side: 'buy',
-        remainingSize: '0.4',
-      }),
-      createOrder({
-        orderId: 'wrong-side',
-        side: 'sell',
-        remainingSize: '0.9',
-      }),
-    ];
-
-    const reserved = getReservedReduceOnlySize({
-      openOrders,
-      symbol: 'BTC',
-      positionDirection: 'short',
-    });
-
-    expect(reserved).toBeCloseTo(0.4);
-  });
-});
-
 describe('validateReduceOnlyOrder', () => {
   it('returns valid when reduceOnly is false', () => {
     const result = validateReduceOnlyOrder({
@@ -148,14 +26,11 @@ describe('validateReduceOnlyOrder', () => {
       direction: 'long',
       orderSize: '10',
       position: null,
-      openOrders: [],
-      symbol: 'BTC',
     });
 
     expect(result).toEqual({
       isValid: true,
       isFullClose: false,
-      remainingClosableSize: 0,
     });
   });
 
@@ -165,8 +40,6 @@ describe('validateReduceOnlyOrder', () => {
       direction: 'short',
       orderSize: '0.1',
       position: null,
-      openOrders: [],
-      symbol: 'BTC',
     });
 
     expect(result.errorCode).toBe('no_position');
@@ -180,147 +53,93 @@ describe('validateReduceOnlyOrder', () => {
       direction: 'short',
       orderSize: '0.1',
       position: createPosition({ size: '0' }),
-      openOrders: [],
-      symbol: 'BTC',
     });
 
     expect(result.errorCode).toBe('no_position');
     expect(result.isValid).toBe(false);
   });
 
-  it('returns wrong_side when the order matches the position direction', () => {
+  it('returns wrong_side when the order matches a long position', () => {
     const result = validateReduceOnlyOrder({
       reduceOnly: true,
       direction: 'long',
       orderSize: '0.1',
       position: createPosition({ size: '1' }),
-      openOrders: [],
-      symbol: 'BTC',
     });
 
     expect(result.errorCode).toBe('wrong_side');
     expect(result.isValid).toBe(false);
   });
 
-  it('returns wrong_side for a short position with a short order', () => {
+  it('returns wrong_side when the order matches a short position', () => {
     const result = validateReduceOnlyOrder({
       reduceOnly: true,
       direction: 'short',
       orderSize: '0.1',
       position: createPosition({ size: '-1' }),
-      openOrders: [],
-      symbol: 'BTC',
     });
 
     expect(result.errorCode).toBe('wrong_side');
     expect(result.isValid).toBe(false);
   });
 
-  it('returns too_large when order size exceeds remaining closable capacity', () => {
+  it('returns too_large when order size exceeds the open position', () => {
     const result = validateReduceOnlyOrder({
       reduceOnly: true,
       direction: 'short',
       orderSize: '1.1',
       position: createPosition({ size: '1' }),
-      openOrders: [],
-      symbol: 'BTC',
     });
 
     expect(result.errorCode).toBe('too_large');
     expect(result.isValid).toBe(false);
-    expect(result.remainingClosableSize).toBeCloseTo(1);
   });
 
-  it('subtracts reserved resting reduce-only size before the too_large check', () => {
+  it('accepts an order smaller than the open position', () => {
     const result = validateReduceOnlyOrder({
       reduceOnly: true,
       direction: 'short',
       orderSize: '0.9',
       position: createPosition({ size: '1' }),
-      openOrders: [createOrder({ remainingSize: '0.2' })],
-      symbol: 'BTC',
     });
 
-    expect(result.errorCode).toBe('too_large');
-    expect(result.remainingClosableSize).toBeCloseTo(0.8);
+    expect(result.isValid).toBe(true);
+    expect(result.isFullClose).toBe(false);
   });
 
-  it('ignores TP/SL trigger orders when computing remaining closable size', () => {
+  it('marks an order equal to the open position as a full close', () => {
     const result = validateReduceOnlyOrder({
       reduceOnly: true,
       direction: 'short',
       orderSize: '1',
       position: createPosition({ size: '1' }),
-      openOrders: [
-        createOrder({
-          remainingSize: '1',
-          isTrigger: true,
-          detailedOrderType: 'Take Profit Market',
-        }),
-      ],
-      symbol: 'BTC',
     });
 
     expect(result.isValid).toBe(true);
     expect(result.isFullClose).toBe(true);
-    expect(result.remainingClosableSize).toBeCloseTo(1);
   });
 
-  it('marks a full close when order size equals remaining closable capacity', () => {
-    const result = validateReduceOnlyOrder({
-      reduceOnly: true,
-      direction: 'short',
-      orderSize: '0.8',
-      position: createPosition({ size: '1' }),
-      openOrders: [createOrder({ remainingSize: '0.2' })],
-      symbol: 'BTC',
-    });
-
-    expect(result.isValid).toBe(true);
-    expect(result.isFullClose).toBe(true);
-    expect(result.remainingClosableSize).toBeCloseTo(0.8);
-  });
-
-  it('accepts a partial reduce-only order below remaining capacity', () => {
+  it('accepts a partial reduce-only order against a short position', () => {
     const result = validateReduceOnlyOrder({
       reduceOnly: true,
       direction: 'long',
       orderSize: '0.25',
       position: createPosition({ size: '-1' }),
-      openOrders: [],
-      symbol: 'BTC',
     });
 
     expect(result.isValid).toBe(true);
     expect(result.isFullClose).toBe(false);
-    expect(result.remainingClosableSize).toBeCloseTo(1);
   });
 
-  it('treats empty or non-positive order size as valid when side and position match', () => {
+  it('treats an empty order size as valid for the closing side', () => {
     const result = validateReduceOnlyOrder({
       reduceOnly: true,
       direction: 'short',
       orderSize: '',
       position: createPosition({ size: '1' }),
-      openOrders: [],
-      symbol: 'BTC',
     });
 
     expect(result.isValid).toBe(true);
     expect(result.isFullClose).toBe(false);
-  });
-
-  it('clamps remaining closable size at zero when reserved exceeds position', () => {
-    const result = validateReduceOnlyOrder({
-      reduceOnly: true,
-      direction: 'short',
-      orderSize: '0.01',
-      position: createPosition({ size: '0.5' }),
-      openOrders: [createOrder({ remainingSize: '0.8' })],
-      symbol: 'BTC',
-    });
-
-    expect(result.errorCode).toBe('too_large');
-    expect(result.remainingClosableSize).toBe(0);
   });
 });

--- a/app/components/UI/Perps/utils/reduceOnlyValidation.test.ts
+++ b/app/components/UI/Perps/utils/reduceOnlyValidation.test.ts
@@ -1,0 +1,326 @@
+import type { Order, Position } from '@metamask/perps-controller';
+import {
+  getReservedReduceOnlySize,
+  validateReduceOnlyOrder,
+} from './reduceOnlyValidation';
+
+const createPosition = (overrides: Partial<Position> = {}): Position =>
+  ({
+    symbol: 'BTC',
+    size: '1',
+    entryPrice: '50000',
+    positionValue: '50000',
+    unrealizedPnl: '0',
+    marginUsed: '5000',
+    leverage: { type: 'isolated', value: 10 },
+    liquidationPrice: '45000',
+    maxLeverage: 50,
+    returnOnEquity: '0',
+    cumulativeFunding: { allTime: '0', sinceOpen: '0', sinceChange: '0' },
+    takeProfitCount: 0,
+    stopLossCount: 0,
+    ...overrides,
+  }) as Position;
+
+const createOrder = (overrides: Partial<Order> = {}): Order =>
+  ({
+    orderId: 'order-1',
+    symbol: 'BTC',
+    side: 'sell',
+    orderType: 'limit',
+    size: '0.2',
+    originalSize: '0.2',
+    price: '51000',
+    filledSize: '0',
+    remainingSize: '0.2',
+    status: 'open',
+    timestamp: 1,
+    reduceOnly: true,
+    isTrigger: false,
+    detailedOrderType: 'Limit',
+    ...overrides,
+  }) as Order;
+
+describe('getReservedReduceOnlySize', () => {
+  it('sums remaining size of matching open reduce-only closing orders', () => {
+    const openOrders = [
+      createOrder({ orderId: 'a', remainingSize: '0.2' }),
+      createOrder({ orderId: 'b', remainingSize: '0.3' }),
+    ];
+
+    const reserved = getReservedReduceOnlySize({
+      openOrders,
+      symbol: 'BTC',
+      positionDirection: 'long',
+    });
+
+    expect(reserved).toBeCloseTo(0.5);
+  });
+
+  it('excludes TP/SL trigger orders from reserved capacity', () => {
+    const openOrders = [
+      createOrder({
+        orderId: 'trigger',
+        remainingSize: '1',
+        isTrigger: true,
+        detailedOrderType: 'Take Profit Limit',
+      }),
+      createOrder({
+        orderId: 'tpsl-type',
+        remainingSize: '1',
+        isTrigger: false,
+        detailedOrderType: 'Stop Market',
+      }),
+      createOrder({ orderId: 'resting', remainingSize: '0.1' }),
+    ];
+
+    const reserved = getReservedReduceOnlySize({
+      openOrders,
+      symbol: 'BTC',
+      positionDirection: 'long',
+    });
+
+    expect(reserved).toBeCloseTo(0.1);
+  });
+
+  it('excludes orders for a different symbol, side, status, or non-reduce-only', () => {
+    const openOrders = [
+      createOrder({
+        orderId: 'other-symbol',
+        symbol: 'ETH',
+        remainingSize: '1',
+      }),
+      createOrder({
+        orderId: 'wrong-side',
+        side: 'buy',
+        remainingSize: '1',
+      }),
+      createOrder({
+        orderId: 'filled',
+        status: 'filled',
+        remainingSize: '1',
+      }),
+      createOrder({
+        orderId: 'not-reduce',
+        reduceOnly: false,
+        remainingSize: '1',
+      }),
+      createOrder({ orderId: 'match', remainingSize: '0.25' }),
+    ];
+
+    const reserved = getReservedReduceOnlySize({
+      openOrders,
+      symbol: 'BTC',
+      positionDirection: 'long',
+    });
+
+    expect(reserved).toBeCloseTo(0.25);
+  });
+
+  it('reserves buy-side reduce-only orders when closing a short', () => {
+    const openOrders = [
+      createOrder({
+        orderId: 'close-short',
+        side: 'buy',
+        remainingSize: '0.4',
+      }),
+      createOrder({
+        orderId: 'wrong-side',
+        side: 'sell',
+        remainingSize: '0.9',
+      }),
+    ];
+
+    const reserved = getReservedReduceOnlySize({
+      openOrders,
+      symbol: 'BTC',
+      positionDirection: 'short',
+    });
+
+    expect(reserved).toBeCloseTo(0.4);
+  });
+});
+
+describe('validateReduceOnlyOrder', () => {
+  it('returns valid when reduceOnly is false', () => {
+    const result = validateReduceOnlyOrder({
+      reduceOnly: false,
+      direction: 'long',
+      orderSize: '10',
+      position: null,
+      openOrders: [],
+      symbol: 'BTC',
+    });
+
+    expect(result).toEqual({
+      isValid: true,
+      isFullClose: false,
+      remainingClosableSize: 0,
+    });
+  });
+
+  it('returns no_position when there is no open position', () => {
+    const result = validateReduceOnlyOrder({
+      reduceOnly: true,
+      direction: 'short',
+      orderSize: '0.1',
+      position: null,
+      openOrders: [],
+      symbol: 'BTC',
+    });
+
+    expect(result.errorCode).toBe('no_position');
+    expect(result.isValid).toBe(false);
+    expect(result.isFullClose).toBe(false);
+  });
+
+  it('returns no_position when position size is zero', () => {
+    const result = validateReduceOnlyOrder({
+      reduceOnly: true,
+      direction: 'short',
+      orderSize: '0.1',
+      position: createPosition({ size: '0' }),
+      openOrders: [],
+      symbol: 'BTC',
+    });
+
+    expect(result.errorCode).toBe('no_position');
+    expect(result.isValid).toBe(false);
+  });
+
+  it('returns wrong_side when the order matches the position direction', () => {
+    const result = validateReduceOnlyOrder({
+      reduceOnly: true,
+      direction: 'long',
+      orderSize: '0.1',
+      position: createPosition({ size: '1' }),
+      openOrders: [],
+      symbol: 'BTC',
+    });
+
+    expect(result.errorCode).toBe('wrong_side');
+    expect(result.isValid).toBe(false);
+  });
+
+  it('returns wrong_side for a short position with a short order', () => {
+    const result = validateReduceOnlyOrder({
+      reduceOnly: true,
+      direction: 'short',
+      orderSize: '0.1',
+      position: createPosition({ size: '-1' }),
+      openOrders: [],
+      symbol: 'BTC',
+    });
+
+    expect(result.errorCode).toBe('wrong_side');
+    expect(result.isValid).toBe(false);
+  });
+
+  it('returns too_large when order size exceeds remaining closable capacity', () => {
+    const result = validateReduceOnlyOrder({
+      reduceOnly: true,
+      direction: 'short',
+      orderSize: '1.1',
+      position: createPosition({ size: '1' }),
+      openOrders: [],
+      symbol: 'BTC',
+    });
+
+    expect(result.errorCode).toBe('too_large');
+    expect(result.isValid).toBe(false);
+    expect(result.remainingClosableSize).toBeCloseTo(1);
+  });
+
+  it('subtracts reserved resting reduce-only size before the too_large check', () => {
+    const result = validateReduceOnlyOrder({
+      reduceOnly: true,
+      direction: 'short',
+      orderSize: '0.9',
+      position: createPosition({ size: '1' }),
+      openOrders: [createOrder({ remainingSize: '0.2' })],
+      symbol: 'BTC',
+    });
+
+    expect(result.errorCode).toBe('too_large');
+    expect(result.remainingClosableSize).toBeCloseTo(0.8);
+  });
+
+  it('ignores TP/SL trigger orders when computing remaining closable size', () => {
+    const result = validateReduceOnlyOrder({
+      reduceOnly: true,
+      direction: 'short',
+      orderSize: '1',
+      position: createPosition({ size: '1' }),
+      openOrders: [
+        createOrder({
+          remainingSize: '1',
+          isTrigger: true,
+          detailedOrderType: 'Take Profit Market',
+        }),
+      ],
+      symbol: 'BTC',
+    });
+
+    expect(result.isValid).toBe(true);
+    expect(result.isFullClose).toBe(true);
+    expect(result.remainingClosableSize).toBeCloseTo(1);
+  });
+
+  it('marks a full close when order size equals remaining closable capacity', () => {
+    const result = validateReduceOnlyOrder({
+      reduceOnly: true,
+      direction: 'short',
+      orderSize: '0.8',
+      position: createPosition({ size: '1' }),
+      openOrders: [createOrder({ remainingSize: '0.2' })],
+      symbol: 'BTC',
+    });
+
+    expect(result.isValid).toBe(true);
+    expect(result.isFullClose).toBe(true);
+    expect(result.remainingClosableSize).toBeCloseTo(0.8);
+  });
+
+  it('accepts a partial reduce-only order below remaining capacity', () => {
+    const result = validateReduceOnlyOrder({
+      reduceOnly: true,
+      direction: 'long',
+      orderSize: '0.25',
+      position: createPosition({ size: '-1' }),
+      openOrders: [],
+      symbol: 'BTC',
+    });
+
+    expect(result.isValid).toBe(true);
+    expect(result.isFullClose).toBe(false);
+    expect(result.remainingClosableSize).toBeCloseTo(1);
+  });
+
+  it('treats empty or non-positive order size as valid when side and position match', () => {
+    const result = validateReduceOnlyOrder({
+      reduceOnly: true,
+      direction: 'short',
+      orderSize: '',
+      position: createPosition({ size: '1' }),
+      openOrders: [],
+      symbol: 'BTC',
+    });
+
+    expect(result.isValid).toBe(true);
+    expect(result.isFullClose).toBe(false);
+  });
+
+  it('clamps remaining closable size at zero when reserved exceeds position', () => {
+    const result = validateReduceOnlyOrder({
+      reduceOnly: true,
+      direction: 'short',
+      orderSize: '0.01',
+      position: createPosition({ size: '0.5' }),
+      openOrders: [createOrder({ remainingSize: '0.8' })],
+      symbol: 'BTC',
+    });
+
+    expect(result.errorCode).toBe('too_large');
+    expect(result.remainingClosableSize).toBe(0);
+  });
+});

--- a/app/components/UI/Perps/utils/reduceOnlyValidation.ts
+++ b/app/components/UI/Perps/utils/reduceOnlyValidation.ts
@@ -1,0 +1,171 @@
+import {
+  isTPSLOrder,
+  type Order,
+  type Position,
+} from '@metamask/perps-controller';
+import { getPositionDirection } from './positionCalculations';
+
+/** Tolerance for token-size comparisons (covers floating-point / szDecimals noise). */
+const SIZE_EPSILON = 1e-10;
+
+export type ReduceOnlyValidationCode =
+  | 'no_position'
+  | 'wrong_side'
+  | 'too_large';
+
+export type ReduceOnlyOrderDirection = 'long' | 'short';
+
+export interface ValidateReduceOnlyOrderParams {
+  reduceOnly: boolean;
+  /** Form direction: long = buy, short = sell. */
+  direction: ReduceOnlyOrderDirection;
+  /** Proposed order size in token units. */
+  orderSize: string;
+  /** Current position for the market, if any. */
+  position: Position | null;
+  /** Open orders from the live stream (unfiltered). */
+  openOrders: Order[];
+  /** Market symbol used to match position/orders. */
+  symbol: string;
+}
+
+export interface ValidateReduceOnlyOrderResult {
+  isValid: boolean;
+  errorCode?: ReduceOnlyValidationCode;
+  /**
+   * True when the order consumes all remaining closable capacity.
+   * Callers may pass `isFullClose` to the controller so dust closes skip the
+   * minimum-notional gate.
+   */
+  isFullClose: boolean;
+  /** Token units still available to close after reserving resting reduce-only. */
+  remainingClosableSize: number;
+}
+
+/**
+ * Sums remaining size of active, non-trigger reduce-only orders that close the
+ * same side of the given position. TP/SL trigger orders are excluded because
+ * they are conditional alternatives and must not double-count reserved capacity.
+ */
+export const getReservedReduceOnlySize = ({
+  openOrders,
+  symbol,
+  positionDirection,
+}: {
+  openOrders: Order[];
+  symbol: string;
+  positionDirection: ReduceOnlyOrderDirection;
+}): number => {
+  // Closing a long requires sell; closing a short requires buy.
+  const closingSide: Order['side'] =
+    positionDirection === 'long' ? 'sell' : 'buy';
+
+  return openOrders.reduce((sum, order) => {
+    if (order.symbol !== symbol) {
+      return sum;
+    }
+    if (order.status !== 'open') {
+      return sum;
+    }
+    if (order.reduceOnly !== true) {
+      return sum;
+    }
+    if (order.isTrigger === true || isTPSLOrder(order.detailedOrderType)) {
+      return sum;
+    }
+    if (order.side !== closingSide) {
+      return sum;
+    }
+
+    const remaining = Number.parseFloat(
+      order.remainingSize || order.size || '0',
+    );
+    if (!Number.isFinite(remaining) || remaining <= 0) {
+      return sum;
+    }
+
+    return sum + remaining;
+  }, 0);
+};
+
+/**
+ * Validates reduce-only order semantics against the live position and open
+ * orders. Returns the first blocking error in priority order:
+ * no-position → wrong-side → too-large.
+ *
+ * When `reduceOnly` is false, the result is always valid.
+ */
+export const validateReduceOnlyOrder = ({
+  reduceOnly,
+  direction,
+  orderSize,
+  position,
+  openOrders,
+  symbol,
+}: ValidateReduceOnlyOrderParams): ValidateReduceOnlyOrderResult => {
+  if (!reduceOnly) {
+    return {
+      isValid: true,
+      isFullClose: false,
+      remainingClosableSize: 0,
+    };
+  }
+
+  const positionDirection = position
+    ? getPositionDirection(position.size)
+    : 'unknown';
+
+  if (!position || positionDirection === 'unknown') {
+    return {
+      isValid: false,
+      errorCode: 'no_position',
+      isFullClose: false,
+      remainingClosableSize: 0,
+    };
+  }
+
+  if (direction === positionDirection) {
+    return {
+      isValid: false,
+      errorCode: 'wrong_side',
+      isFullClose: false,
+      remainingClosableSize: 0,
+    };
+  }
+
+  const absolutePositionSize = Math.abs(Number.parseFloat(position.size));
+  const reservedSize = getReservedReduceOnlySize({
+    openOrders,
+    symbol,
+    positionDirection,
+  });
+  const remainingClosableSize = Math.max(
+    0,
+    absolutePositionSize - reservedSize,
+  );
+
+  const parsedOrderSize = Number.parseFloat(orderSize);
+  const orderSizeValue =
+    Number.isFinite(parsedOrderSize) && parsedOrderSize > 0
+      ? parsedOrderSize
+      : 0;
+
+  if (orderSizeValue > remainingClosableSize + SIZE_EPSILON) {
+    return {
+      isValid: false,
+      errorCode: 'too_large',
+      isFullClose: false,
+      remainingClosableSize,
+    };
+  }
+
+  const isFullClose =
+    remainingClosableSize > 0 &&
+    orderSizeValue + SIZE_EPSILON >= remainingClosableSize;
+
+  return {
+    isValid: true,
+    isFullClose,
+    remainingClosableSize,
+  };
+};

--- a/app/components/UI/Perps/utils/reduceOnlyValidation.ts
+++ b/app/components/UI/Perps/utils/reduceOnlyValidation.ts
@@ -1,8 +1,4 @@
-import {
-  isTPSLOrder,
-  type Order,
-  type Position,
-} from '@metamask/perps-controller';
+import type { Position } from '@metamask/perps-controller';
 import { getPositionDirection } from './positionCalculations';
 
 /** Tolerance for token-size comparisons (covers floating-point / szDecimals noise). */
@@ -23,74 +19,22 @@ export interface ValidateReduceOnlyOrderParams {
   orderSize: string;
   /** Current position for the market, if any. */
   position: Position | null;
-  /** Open orders from the live stream (unfiltered). */
-  openOrders: Order[];
-  /** Market symbol used to match position/orders. */
-  symbol: string;
 }
 
 export interface ValidateReduceOnlyOrderResult {
   isValid: boolean;
   errorCode?: ReduceOnlyValidationCode;
   /**
-   * True when the order consumes all remaining closable capacity.
+   * True when the order consumes the full open position.
    * Callers may pass `isFullClose` to the controller so dust closes skip the
    * minimum-notional gate.
    */
   isFullClose: boolean;
-  /** Token units still available to close after reserving resting reduce-only. */
-  remainingClosableSize: number;
 }
 
 /**
- * Sums remaining size of active, non-trigger reduce-only orders that close the
- * same side of the given position. TP/SL trigger orders are excluded because
- * they are conditional alternatives and must not double-count reserved capacity.
- */
-export const getReservedReduceOnlySize = ({
-  openOrders,
-  symbol,
-  positionDirection,
-}: {
-  openOrders: Order[];
-  symbol: string;
-  positionDirection: ReduceOnlyOrderDirection;
-}): number => {
-  // Closing a long requires sell; closing a short requires buy.
-  const closingSide: Order['side'] =
-    positionDirection === 'long' ? 'sell' : 'buy';
-
-  return openOrders.reduce((sum, order) => {
-    if (order.symbol !== symbol) {
-      return sum;
-    }
-    if (order.status !== 'open') {
-      return sum;
-    }
-    if (order.reduceOnly !== true) {
-      return sum;
-    }
-    if (order.isTrigger === true || isTPSLOrder(order.detailedOrderType)) {
-      return sum;
-    }
-    if (order.side !== closingSide) {
-      return sum;
-    }
-
-    const remaining = Number.parseFloat(
-      order.remainingSize || order.size || '0',
-    );
-    if (!Number.isFinite(remaining) || remaining <= 0) {
-      return sum;
-    }
-
-    return sum + remaining;
-  }, 0);
-};
-
-/**
- * Validates reduce-only order semantics against the live position and open
- * orders. Returns the first blocking error in priority order:
+ * Validates reduce-only order semantics against the live position. Returns the
+ * first blocking error in priority order:
  * no-position → wrong-side → too-large.
  *
  * When `reduceOnly` is false, the result is always valid.
@@ -100,14 +44,11 @@ export const validateReduceOnlyOrder = ({
   direction,
   orderSize,
   position,
-  openOrders,
-  symbol,
 }: ValidateReduceOnlyOrderParams): ValidateReduceOnlyOrderResult => {
   if (!reduceOnly) {
     return {
       isValid: true,
       isFullClose: false,
-      remainingClosableSize: 0,
     };
   }
 
@@ -120,7 +61,6 @@ export const validateReduceOnlyOrder = ({
       isValid: false,
       errorCode: 'no_position',
       isFullClose: false,
-      remainingClosableSize: 0,
     };
   }
 
@@ -129,20 +69,10 @@ export const validateReduceOnlyOrder = ({
       isValid: false,
       errorCode: 'wrong_side',
       isFullClose: false,
-      remainingClosableSize: 0,
     };
   }
 
   const absolutePositionSize = Math.abs(Number.parseFloat(position.size));
-  const reservedSize = getReservedReduceOnlySize({
-    openOrders,
-    symbol,
-    positionDirection,
-  });
-  const remainingClosableSize = Math.max(
-    0,
-    absolutePositionSize - reservedSize,
-  );
 
   const parsedOrderSize = Number.parseFloat(orderSize);
   const orderSizeValue =
@@ -150,22 +80,20 @@ export const validateReduceOnlyOrder = ({
       ? parsedOrderSize
       : 0;
 
-  if (orderSizeValue > remainingClosableSize + SIZE_EPSILON) {
+  if (orderSizeValue > absolutePositionSize + SIZE_EPSILON) {
     return {
       isValid: false,
       errorCode: 'too_large',
       isFullClose: false,
-      remainingClosableSize,
     };
   }
 
   const isFullClose =
-    remainingClosableSize > 0 &&
-    orderSizeValue + SIZE_EPSILON >= remainingClosableSize;
+    absolutePositionSize > 0 &&
+    orderSizeValue + SIZE_EPSILON >= absolutePositionSize;
 
   return {
     isValid: true,
     isFullClose,
-    remainingClosableSize,
   };
 };

--- a/app/components/UI/Perps/utils/reduceOnlyValidation.ts
+++ b/app/components/UI/Perps/utils/reduceOnlyValidation.ts
@@ -75,6 +75,8 @@ export const validateReduceOnlyOrder = ({
   const absolutePositionSize = Math.abs(Number.parseFloat(position.size));
 
   const parsedOrderSize = Number.parseFloat(orderSize);
+  // Empty/zero size is not `too_large`; usePerpsOrderValidation already marks
+  // the form invalid when positionSize <= 0 before controller validation runs.
   const orderSizeValue =
     Number.isFinite(parsedOrderSize) && parsedOrderSize > 0
       ? parsedOrderSize

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1643,7 +1643,10 @@
         "limit_price_must_be_set_before_configuring_tpsl": "Limit price must be set before configuring TP/SL",
         "only_hyperliquid_usdc": "Only USDC on Hyperliquid is currently supported for payment",
         "limit_price_far_warning": "Limit price is far from current market price",
-        "oi_cap_reached": "Open interest cap reached. New positions cannot be opened at this time."
+        "oi_cap_reached": "Open interest cap reached. New positions cannot be opened at this time.",
+        "reduce_only_no_position": "You need to have an open position in this market to place reduce-only orders",
+        "reduce_only_wrong_side": "Reduce-only orders can only reduce an existing position. Switch to the opposite side.",
+        "reduce_only_too_large": "Reduce only order is larger than your open position"
       },
       "error": {
         "placement_failed": "Order placement failed",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Reason for the change: Perps Pro users could hit confusing or blocking errors when using Reduce Only — including cases where Place Order failed without clear guidance, TP/SL stayed visible/active when it should not, and validation banners looked misaligned when messages wrapped to multiple lines.

Improvement/solution: This PR adds Pro-only reduce-only validation that runs before submission, shows the TAT-3255 banner copy, disables Place Order for invalid states, hides/clears TP/SL while reduce-only is on, and starts the size input empty. Validation banner icons are vertically centered with the message text for better readability on wrapped copy.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Perps Pro Reduce Only validation so invalid orders show clear warnings before submission, and improved validation banner layout.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3648 and https://consensyssoftware.atlassian.net/browse/TAT-3678

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps Pro Reduce Only validation and banner layout

  Scenario: Reduce only with no open position shows banner and disables Place Order
    Given I am on the Perps Pro market view for a market where I have no position
    When I enable "Reduce only"
    Then I should see a warning banner about having no position to reduce
    And the "Place order" button should be disabled
    And the TP/SL row should be hidden

  Scenario: Reduce only on the wrong side shows banner and disables Place Order
    Given I am on the Perps Pro market view with an open long position
    When I select "Short" and enable "Reduce only"
    Then I should see a warning banner that reduce only must match my position side
    And the "Place order" button should be disabled
    And the TP/SL row should be hidden

  Scenario: Reduce only size larger than closable position shows centered warning banner
    Given I am on the Perps Pro market view with an open position
    And I have enabled "Reduce only"
    When I enter a size larger than my closable position
    Then I should see a warning banner that the reduce only order is too large
    And the warning icon should be vertically centered with the banner text
    And the "Place order" button should be disabled

  Scenario: Valid reduce only order can be submitted
    Given I am on the Perps Pro market view with an open position
    When I enable "Reduce only" on the matching side
    And I enter a valid size within my closable position
    Then I should not see a reduce only validation banner
    And the "Place order" button should be enabled

  Scenario: TP/SL is hidden and not submitted while reduce only is on
    Given I am on the Perps Pro market view
    When I configure TP/SL and then enable "Reduce only"
    Then the TP/SL row should be hidden
    And submitting an order should not include TP/SL values

  Scenario: Limit order clears TP/SL after successful submission
    Given I am on the Perps Pro market view with a limit order form
    When I configure TP/SL and successfully place a limit order
    Then the TP/SL checkbox should reset to unchecked
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/87b3612d-6035-43bb-afa6-d332afa29d3f


https://github.com/user-attachments/assets/3e86973b-2fc9-48d8-a058-20ecb2288d7e


https://github.com/user-attachments/assets/7a555e65-def8-4b01-aca6-f613723d9b76


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes order submission and validation on the Pro trading path (reduce-only, TP/SL stripping, minimum-notional exemption); well tested but incorrect logic could block valid closes or allow invalid orders.
> 
> **Overview**
> **Perps Pro Reduce Only** now validates against the live position before submit: no position, wrong side (same direction as the open leg), or size larger than the position each show a warning banner, disable **Place order**, and hide the TP/SL row.
> 
> Enabling Reduce Only **clears TP/SL** in form state; submitted orders **omit TP/SL** even if stale values remained. New `validateReduceOnlyOrder` drives notices and `isFullClose`; full closes skip the UI minimum-notional check and pass `reduceOnly` / `isFullClose` through to protocol validation. Margin and limit-price errors surface as **banners**; validation is skipped while the position stream loads to avoid stale errors.
> 
> The Pro form replaces the Reduce Only checkbox with row-style **selection indicators** (shared with TP/SL), centers banner alert icons, and adds i18n strings for the three reduce-only messages. Coverage spans hook, form, view, and util tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57b625dba5c6329536b8e8bbd60c8dd7df19eb25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->