### PR TITLE
fix: keep SRP backspace focus at end of previous word

### DIFF
--- a/app/components/UI/SrpInputGrid/index.test.tsx
+++ b/app/components/UI/SrpInputGrid/index.test.tsx
@@ -205,6 +205,23 @@ describe('SrpInputGrid', () => {
       expect(queryByText('2.')).toBeNull();
     });
 
+    it('exits sticky grid mode when the last word is fully deleted', () => {
+      const { getByText, queryByText, rerender } = renderWithProvider(
+        <SrpInputGrid {...defaultProps} seedPhrase={['wallet', 'abandon']} />,
+      );
+
+      // Latch sticky grid with 2+ cells, then delete down to one word.
+      rerender(<SrpInputGrid {...defaultProps} seedPhrase={['wallet']} />);
+      expect(getByText('1.')).toBeOnTheScreen();
+
+      // Fully empty — Paste replaces Clear, so sticky mode must release or
+      // the numbered empty cell (no placeholder) becomes unreachable to reset.
+      rerender(<SrpInputGrid {...defaultProps} seedPhrase={['']} />);
+
+      expect(queryByText('1.')).toBeNull();
+      expect(getByText('Paste')).toBeOnTheScreen();
+    });
+
     it('dismisses keyboard on submit editing', () => {
       const seedPhrase = ['wallet', ''];
       const { getByTestId } = renderWithProvider(

--- a/app/components/UI/SrpInputGrid/index.test.tsx
+++ b/app/components/UI/SrpInputGrid/index.test.tsx
@@ -148,7 +148,61 @@ describe('SrpInputGrid', () => {
         nativeEvent: { key: 'Backspace' },
       });
 
-      expect(mockOnSeedPhraseChange).toHaveBeenCalled();
+      expect(mockOnSeedPhraseChange).toHaveBeenCalledWith(['wallet']);
+    });
+
+    it('does not collapse the last remaining blank cell on backspace', () => {
+      const seedPhrase = [''];
+      const { getByTestId } = renderWithProvider(
+        <SrpInputGrid {...defaultProps} seedPhrase={seedPhrase} />,
+      );
+
+      const input = getByTestId(`${ImportSRPIDs.SEED_PHRASE_INPUT_ID}_0`);
+      fireEvent(input, 'keyPress', {
+        nativeEvent: { key: 'Backspace' },
+      });
+
+      expect(mockOnSeedPhraseChange).not.toHaveBeenCalled();
+    });
+
+    it('stays in grid mode after deleting down to a single word', () => {
+      const { getByTestId, getByText, queryByText, rerender } =
+        renderWithProvider(
+          <SrpInputGrid
+            {...defaultProps}
+            seedPhrase={['wallet', 'abandon', '']}
+          />,
+        );
+
+      const thirdInput = getByTestId(`${ImportSRPIDs.SEED_PHRASE_INPUT_ID}_2`);
+      fireEvent(thirdInput, 'keyPress', {
+        nativeEvent: { key: 'Backspace' },
+      });
+
+      expect(mockOnSeedPhraseChange).toHaveBeenCalledWith([
+        'wallet',
+        'abandon',
+      ]);
+
+      rerender(<SrpInputGrid {...defaultProps} seedPhrase={['wallet', '']} />);
+
+      const secondInput = getByTestId(`${ImportSRPIDs.SEED_PHRASE_INPUT_ID}_1`);
+      fireEvent(secondInput, 'keyPress', {
+        nativeEvent: { key: 'Backspace' },
+      });
+
+      expect(mockOnSeedPhraseChange).toHaveBeenCalledWith(['wallet']);
+
+      // After sticky-grid mode is latched, a single remaining word must still
+      // render as a numbered grid cell — not switch back to the textarea
+      // (which would steal focus and break continued backspaces).
+      rerender(<SrpInputGrid {...defaultProps} seedPhrase={['wallet']} />);
+
+      expect(
+        getByTestId(`${ImportSRPIDs.SEED_PHRASE_INPUT_ID}_0`),
+      ).toBeOnTheScreen();
+      expect(getByText('1.')).toBeOnTheScreen();
+      expect(queryByText('2.')).toBeNull();
     });
 
     it('dismisses keyboard on submit editing', () => {

--- a/app/components/UI/SrpInputGrid/index.tsx
+++ b/app/components/UI/SrpInputGrid/index.tsx
@@ -125,8 +125,12 @@ const SrpInputGrid = React.forwardRef<SrpInputGridRef, SrpInputGridProps>(
     useEffect(() => {
       if (seedPhrase.length > 1) {
         setPreferGridMode(true);
+        return;
       }
-    }, [seedPhrase.length]);
+      if (trimmedSeedPhraseLength === 0) {
+        setPreferGridMode(false);
+      }
+    }, [seedPhrase.length, trimmedSeedPhraseLength]);
 
     // Determine if we're in single input (textarea) mode
     const isFirstInput = useMemo(

--- a/app/components/UI/SrpInputGrid/index.tsx
+++ b/app/components/UI/SrpInputGrid/index.tsx
@@ -105,6 +105,10 @@ const SrpInputGrid = React.forwardRef<SrpInputGridRef, SrpInputGridProps>(
       Record<number, boolean>
     >({});
 
+    const [preferGridMode, setPreferGridMode] = useState(
+      () => seedPhrase.length > 1,
+    );
+
     const focusedInputIndexRef = useRef<number | null>(null);
 
     const seedPhraseInputRefs = useRef<Map<
@@ -118,10 +122,16 @@ const SrpInputGrid = React.forwardRef<SrpInputGridRef, SrpInputGridProps>(
       [seedPhrase],
     );
 
+    useEffect(() => {
+      if (seedPhrase.length > 1) {
+        setPreferGridMode(true);
+      }
+    }, [seedPhrase.length]);
+
     // Determine if we're in single input (textarea) mode
     const isFirstInput = useMemo(
-      () => isFirstInputUtil(seedPhrase),
-      [seedPhrase],
+      () => !preferGridMode && isFirstInputUtil(seedPhrase),
+      [preferGridMode, seedPhrase],
     );
 
     // Initialize seed phrase input refs
@@ -209,19 +219,29 @@ const SrpInputGrid = React.forwardRef<SrpInputGridRef, SrpInputGridProps>(
 
     const handleKeyPress = useCallback(
       (e: { nativeEvent: { key: string } }, index: number) => {
-        if (e.nativeEvent.key === 'Backspace') {
-          if (seedPhrase[index] === '') {
-            const newData = seedPhrase.filter((_, idx) => idx !== index);
-            if (index > 0) {
-              const prevInputRef = seedPhraseInputRefs.current?.get(index - 1);
-              if (prevInputRef) {
-                prevInputRef.focus();
-              }
-              setNextSeedPhraseInputFocusedIndex(index - 1);
-            }
-            onSeedPhraseChange([...newData]);
-          }
+        if (e.nativeEvent.key !== 'Backspace') {
+          return;
         }
+
+        if (seedPhrase[index] !== '') {
+          return;
+        }
+
+        if (seedPhrase.length <= 1) {
+          return;
+        }
+
+        const newData = seedPhrase.filter((_, idx) => idx !== index);
+
+        if (index > 0) {
+          const prevInputRef = seedPhraseInputRefs.current?.get(index - 1);
+          if (prevInputRef) {
+            prevInputRef.focus();
+          }
+          setNextSeedPhraseInputFocusedIndex(index - 1);
+        }
+
+        onSeedPhraseChange([...newData]);
       },
       [seedPhrase, onSeedPhraseChange],
     );
@@ -247,6 +267,7 @@ const SrpInputGrid = React.forwardRef<SrpInputGridRef, SrpInputGridProps>(
     }, [handleSeedPhraseChange]);
 
     const handleClear = useCallback(() => {
+      setPreferGridMode(false);
       onSeedPhraseChange(['']);
       setErrorWordIndexes({});
       setNextSeedPhraseInputFocusedIndex(null);

--- a/app/components/Views/SrpInput/index.test.tsx
+++ b/app/components/Views/SrpInput/index.test.tsx
@@ -10,9 +10,6 @@ import {
   TEXTFIELD_ENDACCESSORY_TEST_ID,
 } from '../../../component-library/components/Form/TextField/TextField.constants';
 import { act, fireEvent, render } from '@testing-library/react-native';
-import Device from '../../../util/device';
-
-jest.mock('../../../util/device');
 
 const INPUT_TEST_ID = 'testingInputID';
 describe('SrpInput', () => {
@@ -57,161 +54,130 @@ describe('SrpInput', () => {
   });
 
   describe('selection updates', () => {
-    describe('Android', () => {
-      beforeEach(() => {
-        (Device.isAndroid as jest.Mock).mockReturnValue(true);
+    it('sets selection to end of value on focus', () => {
+      const testValue = 'test recovery phrase';
+      const wrapper = render(
+        <SrpInput value={testValue} testID={INPUT_TEST_ID} />,
+      );
+      const input = wrapper.getByTestId(INPUT_TEST_ID);
+
+      act(() => {
+        fireEvent(input, 'focus');
       });
 
-      it('sets selection to end of value on focus', () => {
-        const testValue = 'test recovery phrase';
-        const wrapper = render(
-          <SrpInput value={testValue} testID={INPUT_TEST_ID} />,
-        );
-        const input = wrapper.getByTestId(INPUT_TEST_ID);
-
-        act(() => {
-          fireEvent(input, 'focus');
-        });
-
-        expect(input.props.selection).toEqual({
-          start: testValue.length,
-          end: testValue.length,
-        });
-      });
-
-      it('sets selection to beginning on blur', () => {
-        const wrapper = render(
-          <SrpInput value="test value" testID={INPUT_TEST_ID} />,
-        );
-        const input = wrapper.getByTestId(INPUT_TEST_ID);
-
-        act(() => {
-          fireEvent(input, 'focus');
-        });
-
-        act(() => {
-          fireEvent(input, 'blur');
-        });
-
-        expect(input.props.selection).toEqual({
-          start: 0,
-          end: 0,
-        });
-      });
-
-      it('updates selection state on selection change', () => {
-        const wrapper = render(
-          <SrpInput value="test value" testID={INPUT_TEST_ID} />,
-        );
-        const input = wrapper.getByTestId(INPUT_TEST_ID);
-        const mockSelection = { start: 5, end: 5 };
-
-        act(() => {
-          fireEvent(input, 'selectionChange', {
-            nativeEvent: { selection: mockSelection },
-          });
-        });
-
-        expect(input.props.selection).toEqual(mockSelection);
-      });
-
-      it('does not update selection when disabled on focus', () => {
-        const wrapper = render(
-          <SrpInput value="test" isDisabled testID={INPUT_TEST_ID} />,
-        );
-        const input = wrapper.getByTestId(INPUT_TEST_ID);
-
-        const initialSelection = input.props.selection;
-
-        act(() => {
-          fireEvent(input, 'focus');
-        });
-
-        expect(input.props.selection).toBe(initialSelection);
+      expect(input.props.selection).toEqual({
+        start: testValue.length,
+        end: testValue.length,
       });
     });
 
-    describe('iOS', () => {
-      beforeEach(() => {
-        (Device.isAndroid as jest.Mock).mockReturnValue(false);
+    it('keeps selection at end of value on blur', () => {
+      const testValue = 'test value';
+      const wrapper = render(
+        <SrpInput value={testValue} testID={INPUT_TEST_ID} />,
+      );
+      const input = wrapper.getByTestId(INPUT_TEST_ID);
+
+      act(() => {
+        fireEvent(input, 'focus');
       });
 
-      it('does not set selection on focus', () => {
-        const testValue = 'test recovery phrase';
-        const wrapper = render(
-          <SrpInput value={testValue} testID={INPUT_TEST_ID} />,
-        );
-        const input = wrapper.getByTestId(INPUT_TEST_ID);
-
-        act(() => {
-          fireEvent(input, 'focus');
+      act(() => {
+        fireEvent(input, 'selectionChange', {
+          nativeEvent: { selection: { start: 0, end: 0 } },
         });
-
-        expect(input.props.selection).toBeUndefined();
       });
 
-      it('does not set selection on blur', () => {
-        const wrapper = render(
-          <SrpInput value="test value" testID={INPUT_TEST_ID} />,
-        );
-        const input = wrapper.getByTestId(INPUT_TEST_ID);
-
-        act(() => {
-          fireEvent(input, 'focus');
-        });
-
-        act(() => {
-          fireEvent(input, 'blur');
-        });
-
-        expect(input.props.selection).toBeUndefined();
+      act(() => {
+        fireEvent(input, 'blur');
       });
 
-      it('does not update selection on selection change', () => {
-        const wrapper = render(
-          <SrpInput value="test value" testID={INPUT_TEST_ID} />,
-        );
-        const input = wrapper.getByTestId(INPUT_TEST_ID);
-        const mockSelection = { start: 5, end: 5 };
-
-        act(() => {
-          fireEvent(input, 'selectionChange', {
-            nativeEvent: { selection: mockSelection },
-          });
-        });
-
-        expect(input.props.selection).toBeUndefined();
+      expect(input.props.selection).toEqual({
+        start: testValue.length,
+        end: testValue.length,
       });
     });
 
-    describe('callbacks', () => {
-      it('calls provided onFocus callback when focused', () => {
-        const mockOnFocus = jest.fn();
-        const wrapper = render(
-          <SrpInput onFocus={mockOnFocus} testID={INPUT_TEST_ID} />,
-        );
-        const input = wrapper.getByTestId(INPUT_TEST_ID);
+    it('places caret at end again after blur then focus', () => {
+      const testValue = 'wallet';
+      const wrapper = render(
+        <SrpInput value={testValue} testID={INPUT_TEST_ID} />,
+      );
+      const input = wrapper.getByTestId(INPUT_TEST_ID);
 
-        act(() => {
-          fireEvent(input, 'focus');
-        });
-
-        expect(mockOnFocus).toHaveBeenCalledTimes(1);
+      act(() => {
+        fireEvent(input, 'focus');
+      });
+      act(() => {
+        fireEvent(input, 'blur');
+      });
+      act(() => {
+        fireEvent(input, 'focus');
       });
 
-      it('calls provided onBlur callback when blurred', () => {
-        const mockOnBlur = jest.fn();
-        const wrapper = render(
-          <SrpInput onBlur={mockOnBlur} testID={INPUT_TEST_ID} />,
-        );
-        const input = wrapper.getByTestId(INPUT_TEST_ID);
-
-        act(() => {
-          fireEvent(input, 'blur');
-        });
-
-        expect(mockOnBlur).toHaveBeenCalledTimes(1);
+      expect(input.props.selection).toEqual({
+        start: testValue.length,
+        end: testValue.length,
       });
+    });
+
+    it('updates selection state on selection change', () => {
+      const wrapper = render(
+        <SrpInput value="test value" testID={INPUT_TEST_ID} />,
+      );
+      const input = wrapper.getByTestId(INPUT_TEST_ID);
+      const mockSelection = { start: 5, end: 5 };
+
+      act(() => {
+        fireEvent(input, 'selectionChange', {
+          nativeEvent: { selection: mockSelection },
+        });
+      });
+
+      expect(input.props.selection).toEqual(mockSelection);
+    });
+
+    it('does not update selection when disabled on focus', () => {
+      const wrapper = render(
+        <SrpInput value="test" isDisabled testID={INPUT_TEST_ID} />,
+      );
+      const input = wrapper.getByTestId(INPUT_TEST_ID);
+
+      const initialSelection = input.props.selection;
+
+      act(() => {
+        fireEvent(input, 'focus');
+      });
+
+      expect(input.props.selection).toBe(initialSelection);
+    });
+
+    it('calls provided onFocus callback when focused', () => {
+      const mockOnFocus = jest.fn();
+      const wrapper = render(
+        <SrpInput onFocus={mockOnFocus} testID={INPUT_TEST_ID} />,
+      );
+      const input = wrapper.getByTestId(INPUT_TEST_ID);
+
+      act(() => {
+        fireEvent(input, 'focus');
+      });
+
+      expect(mockOnFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls provided onBlur callback when blurred', () => {
+      const mockOnBlur = jest.fn();
+      const wrapper = render(
+        <SrpInput onBlur={mockOnBlur} testID={INPUT_TEST_ID} />,
+      );
+      const input = wrapper.getByTestId(INPUT_TEST_ID);
+
+      act(() => {
+        fireEvent(input, 'blur');
+      });
+
+      expect(mockOnBlur).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/components/Views/SrpInput/index.tsx
+++ b/app/components/Views/SrpInput/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import {
   StyleProp,
   StyleSheet,
@@ -24,7 +24,6 @@ import {
   TEXTFIELD_ENDACCESSORY_TEST_ID,
 } from '../../../component-library/components/Form/TextField/TextField.constants';
 import { TextVariant } from '../../../component-library/components/Texts/Text';
-import Device from '../../../util/device';
 
 const TextField = React.forwardRef<
   TextInput,
@@ -53,10 +52,30 @@ const TextField = React.forwardRef<
     ref,
   ) => {
     const tw = useTailwind();
+    const inputRef = useRef<TextInput | null>(null);
     const [isFocused, setIsFocused] = useState(false);
     const [inputSelection, setInputSelection] = useState<
       { start: number; end: number } | undefined
     >(undefined);
+
+    const assignRef = useCallback(
+      (node: TextInput | null) => {
+        inputRef.current = node;
+        if (typeof ref === 'function') {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+      },
+      [ref],
+    );
+
+    const placeCaretAtEnd = useCallback(() => {
+      const end = value?.length ?? 0;
+      const selection = { start: end, end };
+      setInputSelection(selection);
+      inputRef.current?.setNativeProps({ selection });
+    }, [value]);
 
     const onBlurHandler = useCallback(
       (e: BlurEvent) => {
@@ -64,11 +83,10 @@ const TextField = React.forwardRef<
           setIsFocused(false);
           onBlur?.(e);
         }
-        if (Device.isAndroid()) {
-          setInputSelection({ start: 0, end: 0 });
-        }
+        const end = value?.length ?? 0;
+        setInputSelection({ start: end, end });
       },
-      [isDisabled, setIsFocused, onBlur],
+      [isDisabled, onBlur, value],
     );
 
     const onFocusHandler = useCallback(
@@ -76,24 +94,16 @@ const TextField = React.forwardRef<
         if (!isDisabled) {
           setIsFocused(true);
           onFocus?.(e);
-
-          if (Device.isAndroid()) {
-            setInputSelection({
-              start: value?.length ?? 0,
-              end: value?.length ?? 0,
-            });
-          }
+          placeCaretAtEnd();
         }
       },
-      [isDisabled, setIsFocused, onFocus, value],
+      [isDisabled, onFocus, placeCaretAtEnd],
     );
 
     const handleSelectionChange = (
       event: NativeSyntheticEvent<TextInputSelectionChangeEventData>,
     ) => {
-      if (Device.isAndroid()) {
-        setInputSelection(event.nativeEvent.selection);
-      }
+      setInputSelection(event.nativeEvent.selection);
     };
 
     let borderStyleClass = 'border-muted';
@@ -129,7 +139,7 @@ const TextField = React.forwardRef<
                 onFocus={onFocusHandler}
                 testID={testID}
                 {...props}
-                ref={ref}
+                ref={assignRef}
                 isStateStylesDisabled
                 inputStyle={inputStyle}
                 selection={inputSelection}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
On Import Secret Recovery Phrase, backspacing from an empty word cell moved focus to the previous cell but placed the caret at the **start** of that word, so continued deletes felt broken. Deleting down to a single word could also flip the grid back to textarea mode and steal focus.

This PR places the caret at the **end** of the value on focus/blur in `SrpInput`.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Secret Recovery Phrase backspace so the cursor stays at the end of the previous word

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TO-995

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Import Secret Recovery Phrase backspace

 Scenario: user backspaces from an empty word into the previous word
    Given the user is on Import Secret Recovery Phrase
    And the seed phrase grid has at least two words entered
    And the current cell is empty
    When the user presses Backspace
    Then focus moves to the previous word cell
    And the caret is at the end of that word
    And further Backspace presses delete from the end of the word
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/20efe733-a8ad-43a2-8caa-4d24f3dccaa1


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/e09c5dfe-20f2-422b-9aa9-629afc73e377


https://github.com/user-attachments/assets/93d99994-1aaa-47ae-97ee-05e9f6356180


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX changes to SRP input components and tests; no auth, crypto, or network logic.
> 
> **Overview**
> Fixes **Import Secret Recovery Phrase** backspace behavior so focus moves to the previous word with the caret at the **end** of that word, and deleting down to one word no longer flips back to the single textarea (which stole focus).
> 
> **`SrpInput`** now always moves the caret to the end on focus (via controlled `selection` and `setNativeProps`), keeps selection at the end on blur, and tracks selection on all platforms—replacing the old Android-only selection logic.
> 
> **`SrpInputGrid`** adds sticky **`preferGridMode`**: once the phrase has more than one cell, the numbered grid stays even when only one word remains; backspace on an empty cell is ignored when there is only one slot; **Clear all** resets grid mode. Backspace handling is tightened with early returns and explicit `onSeedPhraseChange` payloads in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fefa2fdab1da74904e9672eea049a2dfa2ddae9e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->