### PR TITLE
test: skip Appium token approve smoke suites

### DIFF
--- a/tests/smoke-appium/confirmations/transactions/token-approve/approve.spec.ts
+++ b/tests/smoke-appium/confirmations/transactions/token-approve/approve.spec.ts
@@ -64,7 +64,7 @@ const testSpecificMock = async (mockServer: Mockttp) => {
   );
 };
 
-appiumTest.describe(
+appiumTest.describe.skip(
   SmokeConfirmations('Token Approve - approve method'),
   () => {
     appiumTest.describe.configure({ timeout: 2500000 });

--- a/tests/smoke-appium/confirmations/transactions/token-approve/set-approval-for-all.spec.ts
+++ b/tests/smoke-appium/confirmations/transactions/token-approve/set-approval-for-all.spec.ts
@@ -64,7 +64,7 @@ const testSpecificMock = async (mockServer: Mockttp) => {
   );
 };
 
-appiumTest.describe(
+appiumTest.describe.skip(
   SmokeConfirmations('Token Approve - setApprovalForAll method'),
   () => {
     appiumTest.describe.configure({ timeout: 2500000 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

Temporarily skip the Appium Token Approve smoke suites so they do not block CI while unstable:

- `tests/smoke-appium/confirmations/transactions/token-approve/approve.spec.ts`
- `tests/smoke-appium/confirmations/transactions/token-approve/set-approval-for-all.spec.ts`

Uses `appiumTest.describe.skip`, matching the established Appium smoke quarantine pattern.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — test-only change; no product behavior change.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — test-only change.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Test plan**

- [ ] Confirm Appium CI no longer runs / fails on `Token Approve - approve method`
- [ ] Confirm Appium CI no longer runs / fails on `Token Approve - setApprovalForAll method`
- [ ] Confirm remaining Appium confirmation suites still execute as expected

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd5b4-c682-7291-abdf-2e17888ca96a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd5b4-c682-7291-abdf-2e17888ca96a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

