### PR TITLE
fix: Update `remote-feature-flag-controller` to `5.0.0`

### DIFF
--- a/app/components/Views/FeatureFlagOverride/FeatureFlagOverride.test.tsx
+++ b/app/components/Views/FeatureFlagOverride/FeatureFlagOverride.test.tsx
@@ -100,6 +100,7 @@ interface MockReduxState {
     backgroundState: {
       RemoteFeatureFlagController: {
         remoteFeatureFlags: Record<string, unknown>;
+        rawRemoteFeatureFlags: Record<string, unknown>;
         localOverrides: Record<string, unknown>;
       };
     };
@@ -114,7 +115,8 @@ const createMockStore = (
     engine: {
       backgroundState: {
         RemoteFeatureFlagController: {
-          remoteFeatureFlags: rawFlags,
+          remoteFeatureFlags: { ...rawFlags, ...overrides },
+          rawRemoteFeatureFlags: rawFlags,
           localOverrides: overrides,
         },
       },

--- a/app/contexts/FeatureFlagOverrideContext.test.tsx
+++ b/app/contexts/FeatureFlagOverrideContext.test.tsx
@@ -16,7 +16,7 @@ import { FeatureFlagType, getFeatureFlagType } from '../util/feature-flags';
 import {
   selectRemoteFeatureFlagsUnfiltered,
   selectLocalOverrides,
-  selectRawFeatureFlags,
+  selectRawRemoteFeatureFlags,
 } from '../selectors/featureFlagController';
 
 jest.mock('react-redux', () => ({
@@ -45,7 +45,7 @@ jest.mock('../core/Engine', () => ({
 jest.mock('../selectors/featureFlagController', () => ({
   selectRemoteFeatureFlagsUnfiltered: jest.fn(),
   selectLocalOverrides: jest.fn(),
-  selectRawFeatureFlags: jest.fn(),
+  selectRawRemoteFeatureFlags: jest.fn(),
 }));
 
 // Mock whenEngineReady to prevent Engine access after Jest teardown
@@ -131,7 +131,7 @@ describe('FeatureFlagOverrideContext', () => {
       if (selector === selectLocalOverrides) {
         return { ...currentOverrides };
       }
-      if (selector === selectRawFeatureFlags) {
+      if (selector === selectRawRemoteFeatureFlags) {
         return currentRawFlags;
       }
       return undefined;

--- a/app/contexts/FeatureFlagOverrideContext.tsx
+++ b/app/contexts/FeatureFlagOverrideContext.tsx
@@ -9,7 +9,7 @@ import { useSelector } from 'react-redux';
 import {
   selectRemoteFeatureFlagsUnfiltered,
   selectLocalOverrides,
-  selectRawFeatureFlags,
+  selectRawRemoteFeatureFlags,
 } from '../selectors/featureFlagController';
 import { FeatureFlagInfo, getFeatureFlagType } from '../util/feature-flags';
 import Engine from '../core/Engine';
@@ -45,7 +45,7 @@ export const FeatureFlagOverrideProvider: React.FC<
   const featureFlagsWithOverrides = useSelector(
     selectRemoteFeatureFlagsUnfiltered,
   );
-  const rawFeatureFlags = useSelector(selectRawFeatureFlags);
+  const rawRemoteFeatureFlags = useSelector(selectRawRemoteFeatureFlags);
 
   const overrides = useSelector(selectLocalOverrides);
 
@@ -71,13 +71,13 @@ export const FeatureFlagOverrideProvider: React.FC<
 
   const featureFlags = useMemo(() => {
     const allKeys = new Set([
-      ...Object.keys(rawFeatureFlags || {}),
+      ...Object.keys(rawRemoteFeatureFlags || {}),
       ...Object.keys(featureFlagsWithOverrides || {}),
     ]);
     const allFlags: { [key: string]: FeatureFlagInfo } = {};
 
     Array.from(allKeys).forEach((key: string) => {
-      const originalValue = rawFeatureFlags?.[key];
+      const originalValue = rawRemoteFeatureFlags?.[key];
       const currentValue = featureFlagsWithOverrides?.[key];
       const isOverridden = hasOverride(key);
 
@@ -91,7 +91,7 @@ export const FeatureFlagOverrideProvider: React.FC<
       allFlags[key] = flagValue;
     });
     return allFlags;
-  }, [rawFeatureFlags, featureFlagsWithOverrides, hasOverride]);
+  }, [rawRemoteFeatureFlags, featureFlagsWithOverrides, hasOverride]);
 
   const featureFlagsList = useMemo(
     () =>
@@ -107,7 +107,7 @@ export const FeatureFlagOverrideProvider: React.FC<
   const contextValue: FeatureFlagOverrideContextType = useMemo(
     () => ({
       featureFlags,
-      originalFlags: rawFeatureFlags,
+      originalFlags: rawRemoteFeatureFlags,
       featureFlagsList,
       overrides,
       setOverride,
@@ -118,7 +118,7 @@ export const FeatureFlagOverrideProvider: React.FC<
     }),
     [
       featureFlags,
-      rawFeatureFlags,
+      rawRemoteFeatureFlags,
       featureFlagsList,
       overrides,
       setOverride,

--- a/app/core/Engine/controllers/bridge-status-controller/bridge-status-controller-init.test.ts
+++ b/app/core/Engine/controllers/bridge-status-controller/bridge-status-controller-init.test.ts
@@ -33,6 +33,7 @@ function buildRemoteFeatureFlagControllerMock(
     state: {
       remoteFeatureFlags: {
         bridgeQuoteStatusManager,
+        ...localOverrides,
       },
       localOverrides,
     },

--- a/app/core/Engine/controllers/bridge-status-controller/bridge-status-controller-init.ts
+++ b/app/core/Engine/controllers/bridge-status-controller/bridge-status-controller-init.ts
@@ -58,15 +58,11 @@ export const bridgeStatusControllerInit: MessengerClientInitFunction<
         }
       },
       isQuoteStatusManagerEnabled: () => {
-        const { remoteFeatureFlags, localOverrides } =
-          remoteFeatureFlagController.state;
-        const flags = {
-          ...remoteFeatureFlags,
-          ...(localOverrides ?? {}),
-        };
-        const bridgeQuoteStatusManager = flags.bridgeQuoteStatusManager as
-          | BridgeQuoteStatusManagerFeatureFlag
-          | undefined;
+        const { remoteFeatureFlags } = remoteFeatureFlagController.state;
+        const bridgeQuoteStatusManager =
+          remoteFeatureFlags.bridgeQuoteStatusManager as
+            | BridgeQuoteStatusManagerFeatureFlag
+            | undefined;
         return bridgeQuoteStatusManager?.enabled === true;
       },
     });

--- a/app/core/Engine/controllers/money-account-controller-init.ts
+++ b/app/core/Engine/controllers/money-account-controller-init.ts
@@ -29,12 +29,9 @@ export const moneyAccountControllerInit: MessengerClientInitFunction<
   // Re-check the Money account feature flag whenever remote flags are updated.
   initMessenger.subscribe(
     'RemoteFeatureFlagController:stateChange',
-    async ({ remoteFeatureFlags, localOverrides }) => {
+    async ({ remoteFeatureFlags }) => {
       try {
-        const isEnabled = isMoneyAccountEnabled({
-          ...remoteFeatureFlags,
-          ...localOverrides,
-        });
+        const isEnabled = isMoneyAccountEnabled(remoteFeatureFlags);
         const hasMoneyAccount =
           Object.keys(controller.state.moneyAccounts).length > 0;
 

--- a/app/core/Engine/controllers/money-account-upgrade-controller-init.ts
+++ b/app/core/Engine/controllers/money-account-upgrade-controller-init.ts
@@ -145,14 +145,10 @@ export const moneyAccountUpgradeControllerInit: MessengerClientInitFunction<
     });
   };
 
-  const mergedFlags = (state: RemoteFeatureFlagControllerState) => ({
-    ...state.remoteFeatureFlags,
-    ...(state.localOverrides ?? {}),
-  });
-
   const readVaultConfig = (): MoneyAccountVaultConfig | undefined =>
     getMoneyAccountVaultConfig(
-      mergedFlags(initMessenger.call('RemoteFeatureFlagController:getState')),
+      initMessenger.call('RemoteFeatureFlagController:getState')
+        .remoteFeatureFlags,
     );
 
   const configsEqual = (
@@ -221,7 +217,7 @@ export const moneyAccountUpgradeControllerInit: MessengerClientInitFunction<
   };
 
   const onFlagState = (state: RemoteFeatureFlagControllerState) => {
-    const flags = mergedFlags(state);
+    const flags = state.remoteFeatureFlags;
     if (!isMoneyAccountEnabled(flags)) {
       return;
     }

--- a/app/selectors/featureFlagController/index.ts
+++ b/app/selectors/featureFlagController/index.ts
@@ -23,16 +23,11 @@ export const selectRawFeatureFlags = createSelector(
 
 const selectRemoteFeatureFlagsMerged = createSelector(
   selectRemoteFeatureFlagControllerState,
-  (remoteFeatureFlagControllerState) => {
-    const localOverrides =
-      remoteFeatureFlagControllerState?.localOverrides ?? {};
-    const remoteFeatureFlags =
-      remoteFeatureFlagControllerState?.remoteFeatureFlags ?? {};
-    return {
-      ...remoteFeatureFlags,
-      ...localOverrides,
-    };
-  },
+  // As of @metamask/remote-feature-flag-controller@5.0.0, localOverrides are
+  // merged into remoteFeatureFlags at the controller level, so consumers
+  // receive effective flag values directly.
+  (remoteFeatureFlagControllerState) =>
+    remoteFeatureFlagControllerState?.remoteFeatureFlags ?? {},
 );
 
 /**

--- a/app/selectors/featureFlagController/index.ts
+++ b/app/selectors/featureFlagController/index.ts
@@ -23,9 +23,6 @@ export const selectRawFeatureFlags = createSelector(
 
 const selectRemoteFeatureFlagsMerged = createSelector(
   selectRemoteFeatureFlagControllerState,
-  // As of @metamask/remote-feature-flag-controller@5.0.0, localOverrides are
-  // merged into remoteFeatureFlags at the controller level, so consumers
-  // receive effective flag values directly.
   (remoteFeatureFlagControllerState) =>
     remoteFeatureFlagControllerState?.remoteFeatureFlags ?? {},
 );

--- a/package.json
+++ b/package.json
@@ -221,6 +221,7 @@
     "bn.js@npm:4.11.6": "4.12.3",
     "bn.js@npm:5.2.1": "5.2.3",
     "@metamask/messenger": "^2.0.0",
+    "@metamask/remote-feature-flag-controller": "^5.0.0",
     "@metamask/keyring-internal-api": "^11.0.1",
     "@metamask/keyring-api": "^23.7.0",
     "@metamask/multichain-account-service": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -347,7 +347,7 @@
     "@metamask/react-native-payments": "patch:@metamask/react-native-payments@npm%3A2.0.2#~/.yarn/patches/@metamask-react-native-payments-npm-2.0.2-4ddc5f9862.patch",
     "@metamask/react-native-search-api": "1.0.1",
     "@metamask/react-native-webview": "patch:@metamask/react-native-webview@npm%3A14.6.0#~/.yarn/patches/@metamask-react-native-webview-npm-14.6.0-f12ccc06ff.patch",
-    "@metamask/remote-feature-flag-controller": "^4.2.2",
+    "@metamask/remote-feature-flag-controller": "^5.0.0",
     "@metamask/rpc-errors": "^7.0.2",
     "@metamask/sample-controllers": "^3.0.0",
     "@metamask/scure-bip39": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36299,7 +36299,7 @@ __metadata:
     "@metamask/react-native-payments": "patch:@metamask/react-native-payments@npm%3A2.0.2#~/.yarn/patches/@metamask-react-native-payments-npm-2.0.2-4ddc5f9862.patch"
     "@metamask/react-native-search-api": "npm:1.0.1"
     "@metamask/react-native-webview": "patch:@metamask/react-native-webview@npm%3A14.6.0#~/.yarn/patches/@metamask-react-native-webview-npm-14.6.0-f12ccc06ff.patch"
-    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
+    "@metamask/remote-feature-flag-controller": "npm:^5.0.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/sample-controllers": "npm:^3.0.0"
     "@metamask/scure-bip39": "npm:^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10200,19 +10200,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/remote-feature-flag-controller@npm:^4.2.1, @metamask/remote-feature-flag-controller@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@metamask/remote-feature-flag-controller@npm:4.2.2"
-  dependencies:
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.1.0"
-    "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/utils": "npm:^11.9.0"
-    uuid: "npm:^8.3.2"
-  checksum: 10/ed03ff1ba63c7a0f2b221c3514eb71a8be4200ec543b90676a44930dc731920ac2c92dcc2b13a32ed4e4e8e7e7b28a26db443af9f4bf30f5e2b5785580b286ab
-  languageName: node
-  linkType: hard
-
 "@metamask/remote-feature-flag-controller@npm:^5.0.0":
   version: 5.0.0
   resolution: "@metamask/remote-feature-flag-controller@npm:5.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Updates `@metamask/remote-feature-flag-controller` from `4.2.2` to `5.0.0`.

**Reason for the change:** Keep the controller current and pick up the 5.0.0 improvements — most notably that `localOverrides` are now merged into `remoteFeatureFlags` at the controller level, so consumers receive effective flag values directly.

**Breaking change assessment:** The only breaking change in 5.0.0 is that threshold feature flags now return the selected `value` directly instead of a `{ name, value }` wrapper (the selected group name moves to the new `featureFlagThresholdGroups` state field). This does **not** affect mobile:

- The only threshold-flag consumer in mobile (`app/core/DeeplinkManager/handlers/legacy/handleMoney.ts`) already uses `thresholdVersion: 2` (direct-value) and reads the resolved flag directly (`resolvedFlag.enabled` / `resolvedFlag.minimumVersion`); it never reads the `{ name }` wrapper.
- All transitive dependency bumps required by 5.0.0 (`@metamask/messenger@^2.0.0`, `@metamask/base-controller@^9.1.0`, `@metamask/controller-utils@^12.3.0`, `@metamask/utils@^11.11.0`) are already satisfied by the current lockfile.
- The controller constructor signature is unchanged, so the instantiation in `app/core/Engine/wallet-init/instance-options/remote-feature-flag-controller.ts` needs no changes.

**Improvement / solution:** Because 5.0.0 merges `localOverrides` into `remoteFeatureFlags` at the controller level, the manual `{ ...remoteFeatureFlags, ...localOverrides }` merges that mobile performed in several places are now redundant no-ops. This PR removes them so consumers read the already-effective `remoteFeatureFlags` directly:

- `app/selectors/featureFlagController/index.ts` — `selectRemoteFeatureFlagsMerged` now returns `remoteFeatureFlags` directly.
- `app/core/Engine/controllers/bridge-status-controller/bridge-status-controller-init.ts`
- `app/core/Engine/controllers/money-account-controller-init.ts`
- `app/core/Engine/controllers/money-account-upgrade-controller-init.ts`

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A — routine dependency maintenance.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Remote feature flags continue to work after controller upgrade

  Scenario: Remote feature flags resolve correctly
    Given the app is built with remote-feature-flag-controller 5.0.0
    When the app fetches remote feature flags on startup
    Then flag-gated features behave the same as before the upgrade

  Scenario: Local overrides still take effect
    Given the dev feature-flag override UI is open
    When the user sets a local override for a feature flag
    Then the override value is reflected in the app (remoteFeatureFlags now includes localOverrides at the controller level)

  Scenario: Money account gradual-rollout (threshold) flag resolves
    Given the moneyEnableMoneyAccount flag is configured as a thresholdVersion 2 rollout
    When the user triggers the Money deeplink
    Then the resolved flag value is read directly and the correct enabled/version-gated behavior is applied
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — no user-facing UI changes; this is a dependency upgrade plus removal of redundant flag-merge logic.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches feature-flag gating for bridge quote status and Money account flows; behavior should match prior merges but rollout/threshold flag semantics changed in the major version.
> 
> **Overview**
> Upgrades **`@metamask/remote-feature-flag-controller`** from **4.2.2** to **5.0.0**, where the controller now applies **`localOverrides` into `remoteFeatureFlags`** and exposes unmerged remote values via **`rawRemoteFeatureFlags`**.
> 
> App code stops doing redundant **`{ ...remoteFeatureFlags, ...localOverrides }`** merges in **`selectRemoteFeatureFlagsMerged`**, bridge status init, and Money account init/upgrade paths—they read **`remoteFeatureFlags`** directly. The dev **Feature Flag Override** flow switches to **`selectRawRemoteFeatureFlags`** so “original” vs effective values stay correct; related tests mock **`rawRemoteFeatureFlags`** and merged **`remoteFeatureFlags`** like production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b463a968c81372225516c1918c9264ffb76f815. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->