### PR TITLE
fix: Update `eth-json-rpc-middleware` package to latest

### DIFF
--- a/app/core/RPCMethods/RPCMethodMiddleware.test.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.test.ts
@@ -1345,11 +1345,11 @@ describe('getRpcMethodMiddleware', () => {
     });
 
     it('skips account validation if the account is missing from the transaction parameters', async () => {
-      // Downcast needed here because `from` is required by this type
-      const mockTransactionParameters = { chainId: '0x1' };
+      const mockAddress = '0x0000000000000000000000000000000000000001';
+      const mockTransactionParameters = { chainId: '0x1', from: mockAddress };
       setupGlobalState({
         addTransactionResult: Promise.resolve('fake-hash'),
-        // Set minimal network controller state to support validation
+        permittedAccounts: { 'example.metamask.io': [mockAddress] },
         selectedNetworkClientId: 'mainnet',
         networksMetadata: {},
         networkConfigurationsByChainId: {
@@ -1412,10 +1412,9 @@ describe('getRpcMethodMiddleware', () => {
     });
 
     it('returns a JSON-RPC error if an error is thrown when adding this transaction', async () => {
-      // Omit `from` and `chainId` here to skip validation for simplicity
-      // Downcast needed here because `from` is required by this type
-      const mockTransactionParameters = {} as (TransactionParams &
-        JsonRpcParams)[];
+      const mockTransactionParameters = {
+        from: '0x0000000000000000000000000000000000000001',
+      } as unknown as (TransactionParams & JsonRpcParams)[];
       // Transaction fails before returning a result
       mockAddTransaction.mockImplementation(async () => {
         throw new Error('Failed to add transaction');
@@ -1446,15 +1445,16 @@ describe('getRpcMethodMiddleware', () => {
     });
 
     it('returns a JSON-RPC error if an error is thrown after approval', async () => {
-      // Omit `from` and `chainId` here to skip validation for simplicity
-      // Downcast needed here because `from` is required by this type
-      const mockTransactionParameters = {} as (TransactionParams &
-        JsonRpcParams)[];
+      const mockTransactionParameters = {
+        from: '0x0000000000000000000000000000000000000001',
+      } as unknown as (TransactionParams & JsonRpcParams)[];
+      const rejectResult = Promise.reject(
+        new Error('Failed to process transaction'),
+      );
+      rejectResult.catch(() => undefined);
       setupGlobalState({
-        addTransactionResult: Promise.reject(
-          new Error('Failed to process transaction'),
-        ),
-        selectedNetworkClientId: 'mainnet', // Added to fix the linting error
+        addTransactionResult: rejectResult,
+        selectedNetworkClientId: 'mainnet',
       });
       const middleware = getRpcMethodMiddleware({
         ...getMinimalOptions(),

--- a/app/core/RPCMethods/eth_sendTransaction.test.ts
+++ b/app/core/RPCMethods/eth_sendTransaction.test.ts
@@ -325,6 +325,66 @@ describe('eth_sendTransaction', () => {
     expect(spy).toBeCalledTimes(1);
   });
 
+  it('throws if transaction params contain an extraneous top-level key', async () => {
+    const mockAddress = '0x0000000000000000000000000000000000000001';
+    const maliciousParams = { from: mockAddress, evil: { a: { b: 'nested' } } };
+
+    await expect(
+      async () =>
+        await eth_sendTransaction({
+          hostname: 'example.metamask.io',
+          // @ts-expect-error - intentionally injecting extraneous key for test
+          req: constructSendTransactionRequest([maliciousParams]),
+          res: constructPendingJsonRpcResponse(),
+          sendTransaction: getMockAddTransaction({ returnValue: 'fake-hash' }),
+          validateAccountAndChainId: jest.fn(),
+          analytics,
+        }),
+    ).rejects.toThrow();
+  });
+
+  it('throws if transaction params exceed the max serialized size', async () => {
+    const mockAddress = '0x0000000000000000000000000000000000000001';
+    const oversizedData = '0x' + 'aa'.repeat(105 * 1024);
+    const oversizedParams = { from: mockAddress, data: oversizedData };
+
+    await expect(
+      async () =>
+        await eth_sendTransaction({
+          hostname: 'example.metamask.io',
+          // @ts-expect-error - intentionally oversized param for test
+          req: constructSendTransactionRequest([oversizedParams]),
+          res: constructPendingJsonRpcResponse(),
+          sendTransaction: getMockAddTransaction({ returnValue: 'fake-hash' }),
+          validateAccountAndChainId: jest.fn(),
+          analytics,
+        }),
+    ).rejects.toThrow('Request too large');
+  });
+
+  it('does not call sendTransaction when validateTransactionParams throws', async () => {
+    const mockAddress = '0x0000000000000000000000000000000000000001';
+    const maliciousParams = { from: mockAddress, evil: 'injected' };
+    const mockSendTransaction = getMockAddTransaction({
+      returnValue: 'fake-hash',
+    });
+
+    await expect(
+      async () =>
+        await eth_sendTransaction({
+          hostname: 'example.metamask.io',
+          // @ts-expect-error - intentionally injecting extraneous key for test
+          req: constructSendTransactionRequest([maliciousParams]),
+          res: constructPendingJsonRpcResponse(),
+          sendTransaction: mockSendTransaction,
+          validateAccountAndChainId: jest.fn(),
+          analytics,
+        }),
+    ).rejects.toThrow();
+
+    expect(mockSendTransaction).not.toHaveBeenCalled();
+  });
+
   it('dispatches updateConfirmationMetric with analytics payload', async () => {
     const mockAddress = '0x0000000000000000000000000000000000000001';
     const mockTransactionParameters = { from: mockAddress };

--- a/app/core/RPCMethods/eth_sendTransaction.test.ts
+++ b/app/core/RPCMethods/eth_sendTransaction.test.ts
@@ -333,7 +333,6 @@ describe('eth_sendTransaction', () => {
       async () =>
         await eth_sendTransaction({
           hostname: 'example.metamask.io',
-          // @ts-expect-error - intentionally injecting extraneous key for test
           req: constructSendTransactionRequest([maliciousParams]),
           res: constructPendingJsonRpcResponse(),
           sendTransaction: getMockAddTransaction({ returnValue: 'fake-hash' }),
@@ -352,7 +351,6 @@ describe('eth_sendTransaction', () => {
       async () =>
         await eth_sendTransaction({
           hostname: 'example.metamask.io',
-          // @ts-expect-error - intentionally oversized param for test
           req: constructSendTransactionRequest([oversizedParams]),
           res: constructPendingJsonRpcResponse(),
           sendTransaction: getMockAddTransaction({ returnValue: 'fake-hash' }),
@@ -373,7 +371,6 @@ describe('eth_sendTransaction', () => {
       async () =>
         await eth_sendTransaction({
           hostname: 'example.metamask.io',
-          // @ts-expect-error - intentionally injecting extraneous key for test
           req: constructSendTransactionRequest([maliciousParams]),
           res: constructPendingJsonRpcResponse(),
           sendTransaction: mockSendTransaction,

--- a/app/core/RPCMethods/eth_sendTransaction.ts
+++ b/app/core/RPCMethods/eth_sendTransaction.ts
@@ -10,6 +10,7 @@ import {
   WalletDevice,
 } from '@metamask/transaction-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
+import { validateTransactionParams } from '@metamask/eth-json-rpc-middleware';
 import ppomUtil, { PPOMRequest } from '../../lib/ppom/ppom-util';
 import { updateConfirmationMetric } from '../redux/slices/confirmationMetrics';
 import { store } from '../../store';
@@ -103,6 +104,7 @@ async function eth_sendTransaction({
       message: `Invalid parameters: expected the first parameter to be an object`,
     });
   }
+  validateTransactionParams(transactionParameters);
   // TODO: Normalize chainId to Hex string
   const nChainId =
     typeof req.params[0].chainId === 'number'

--- a/app/core/WalletConnect/WalletConnect2Session.test.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.test.ts
@@ -1109,7 +1109,7 @@ describe('WalletConnect2Session', () => {
         }),
       }));
 
-      const requestId = Math.floor(Math.random() * 1000000);
+      const requestId = 111111;
       const request: WalletKitTypes.SessionRequest = {
         id: requestId,
         topic: mockSession.topic,
@@ -1156,7 +1156,7 @@ describe('WalletConnect2Session', () => {
         }),
       }));
 
-      const requestId = Math.floor(Math.random() * 1000000);
+      const requestId = 222222;
       const oversizedData = '0x' + 'aa'.repeat(105 * 1024);
       const request: WalletKitTypes.SessionRequest = {
         id: requestId,

--- a/app/core/WalletConnect/WalletConnect2Session.test.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.test.ts
@@ -1101,6 +1101,76 @@ describe('WalletConnect2Session', () => {
       expect(handleSwitchToChainSpy).toHaveBeenCalled();
     });
 
+    it('rejects eth_sendTransaction with extraneous top-level param key', async () => {
+      const requestId = Math.floor(Math.random() * 1000000);
+      const request: WalletKitTypes.SessionRequest = {
+        id: requestId,
+        topic: mockSession.topic,
+        params: {
+          request: {
+            method: 'eth_sendTransaction',
+            params: [
+              {
+                from: '0x1234567890abcdef1234567890abcdef12345678',
+                to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef',
+                evil: { nested: { deeply: 'junk' } },
+              },
+            ],
+          },
+          chainId: testChainCaip,
+        },
+        verifyContext: {
+          verified: {
+            origin: 'https://example.com',
+            validation: 'UNKNOWN',
+            verifyUrl: '',
+          },
+        },
+      };
+
+      const rejectRequestSpy = jest.spyOn(session, 'rejectRequest');
+      await buildCase(request, testChainId, testChainCaip);
+
+      expect(rejectRequestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ id: requestId + '' }),
+      );
+    });
+
+    it('rejects eth_sendTransaction when params exceed max serialized size', async () => {
+      const requestId = Math.floor(Math.random() * 1000000);
+      const oversizedData = '0x' + 'aa'.repeat(105 * 1024);
+      const request: WalletKitTypes.SessionRequest = {
+        id: requestId,
+        topic: mockSession.topic,
+        params: {
+          request: {
+            method: 'eth_sendTransaction',
+            params: [
+              {
+                from: '0x1234567890abcdef1234567890abcdef12345678',
+                data: oversizedData,
+              },
+            ],
+          },
+          chainId: testChainCaip,
+        },
+        verifyContext: {
+          verified: {
+            origin: 'https://example.com',
+            validation: 'UNKNOWN',
+            verifyUrl: '',
+          },
+        },
+      };
+
+      const rejectRequestSpy = jest.spyOn(session, 'rejectRequest');
+      await buildCase(request, testChainId, testChainCaip);
+
+      expect(rejectRequestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ id: requestId + '' }),
+      );
+    });
+
     it('handles eth_signTypedData_v3 correctly with valid chainId that it has permissions for', async () => {
       jest.mock('./wc-utils', () => jest.requireActual('./wc-utils'));
       const requestId = Math.floor(Math.random() * 1000000);

--- a/app/core/WalletConnect/WalletConnect2Session.test.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.test.ts
@@ -1102,6 +1102,13 @@ describe('WalletConnect2Session', () => {
     });
 
     it('rejects eth_sendTransaction with extraneous top-level param key', async () => {
+      jest.mock('../../util/transaction-controller', () => ({
+        addTransaction: jest.fn().mockResolvedValue({
+          result: Promise.resolve('0xhash'),
+          transactionMeta: { id: 'mock-id' },
+        }),
+      }));
+
       const requestId = Math.floor(Math.random() * 1000000);
       const request: WalletKitTypes.SessionRequest = {
         id: requestId,
@@ -1132,11 +1139,23 @@ describe('WalletConnect2Session', () => {
       await buildCase(request, testChainId, testChainCaip);
 
       expect(rejectRequestSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ id: requestId + '' }),
+        expect.objectContaining({
+          id: requestId + '',
+          error: expect.objectContaining({
+            message: expect.stringMatching(/invalid/i),
+          }),
+        }),
       );
     });
 
     it('rejects eth_sendTransaction when params exceed max serialized size', async () => {
+      jest.mock('../../util/transaction-controller', () => ({
+        addTransaction: jest.fn().mockResolvedValue({
+          result: Promise.resolve('0xhash'),
+          transactionMeta: { id: 'mock-id' },
+        }),
+      }));
+
       const requestId = Math.floor(Math.random() * 1000000);
       const oversizedData = '0x' + 'aa'.repeat(105 * 1024);
       const request: WalletKitTypes.SessionRequest = {
@@ -1167,7 +1186,10 @@ describe('WalletConnect2Session', () => {
       await buildCase(request, testChainId, testChainCaip);
 
       expect(rejectRequestSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ id: requestId + '' }),
+        expect.objectContaining({
+          id: requestId + '',
+          error: expect.objectContaining({ message: 'Request too large' }),
+        }),
       );
     });
 

--- a/app/core/WalletConnect/WalletConnect2Session.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.ts
@@ -1,4 +1,5 @@
 import { WalletDevice } from '@metamask/transaction-controller';
+import { validateTransactionParams } from '@metamask/eth-json-rpc-middleware';
 import {
   NavigationContainerRef,
   ParamListBase,
@@ -840,6 +841,7 @@ class WalletConnect2Session {
     unverifiedOrigin: string,
   ) {
     try {
+      validateTransactionParams(methodParams[0]);
       const networkClientId = getNetworkClientIdForCaipChainId(caip2ChainId);
       const trx = await addTransaction(methodParams[0], {
         deviceConfirmedOn: WalletDevice.MM_MOBILE,

--- a/package.json
+++ b/package.json
@@ -287,7 +287,7 @@
     "@metamask/ens-resolver-snap": "^1.2.0",
     "@metamask/eth-hd-keyring": "^14.1.1",
     "@metamask/eth-json-rpc-filters": "^9.0.0",
-    "@metamask/eth-json-rpc-middleware": "^23.1.2",
+    "@metamask/eth-json-rpc-middleware": "^24.0.0",
     "@metamask/eth-ledger-bridge-keyring": "^12.1.0",
     "@metamask/eth-money-keyring": "^3.0.0",
     "@metamask/eth-qr-keyring": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8789,7 +8789,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-middleware@npm:^23.1.2, @metamask/eth-json-rpc-middleware@npm:^23.1.3":
+"@metamask/eth-json-rpc-middleware@npm:^23.1.3":
   version: 23.1.3
   resolution: "@metamask/eth-json-rpc-middleware@npm:23.1.3"
   dependencies:
@@ -8805,6 +8805,24 @@ __metadata:
     pify: "npm:^5.0.0"
     safe-stable-stringify: "npm:^2.4.3"
   checksum: 10/aee4866afa78cb21aed9daa1211ee9a3515cb9549d9b325d5904b8769fb54790296224b58ec3555eb34a7125d2fd5180d6cba915bb1ca8dc3f04bf75e502c6b0
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-json-rpc-middleware@npm:^24.0.0":
+  version: 24.0.0
+  resolution: "@metamask/eth-json-rpc-middleware@npm:24.0.0"
+  dependencies:
+    "@metamask/eth-block-tracker": "npm:^15.0.1"
+    "@metamask/eth-json-rpc-provider": "npm:^6.0.1"
+    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/json-rpc-engine": "npm:^10.5.0"
+    "@metamask/message-manager": "npm:^14.1.2"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.11.0"
+    klona: "npm:^2.0.6"
+    safe-stable-stringify: "npm:^2.4.3"
+  checksum: 10/d78b93518b2914bdf049cbc7a3c8a6a353c1c79727b106c7eb108813528dc0f8a26ed7feef5b9e27a94239e58286af0d0fe4e4d15323ba4db13e1b64d97e5d48
   languageName: node
   linkType: hard
 
@@ -9358,19 +9376,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/message-manager@npm:^14.1.1":
-  version: 14.1.1
-  resolution: "@metamask/message-manager@npm:14.1.1"
+"@metamask/message-manager@npm:^14.1.1, @metamask/message-manager@npm:^14.1.2":
+  version: 14.1.2
+  resolution: "@metamask/message-manager@npm:14.1.2"
   dependencies:
-    "@metamask/base-controller": "npm:^9.0.1"
-    "@metamask/controller-utils": "npm:^11.19.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.0.0"
     "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/messenger": "npm:^1.0.0"
+    "@metamask/messenger": "npm:^1.2.0"
     "@metamask/utils": "npm:^11.9.0"
     "@types/uuid": "npm:^8.3.0"
     jsonschema: "npm:^1.4.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/1e1ca365378e7ba762a150805121053d0360ae7230818ed48521702e2d7a32bc8233c3ef470c269fd4cbe16454674e328a5ebda22133ffd7b1190b04897e81d4
+  checksum: 10/82e3965069f0eb34e2141ca4dff452c118f54502d0b5d6b832af1906c6413ba1d923b13f1ed6af7f8a7b3087ef7f3b1a700bcffa56b10b06df53972ff2cf9a4f
   languageName: node
   linkType: hard
 
@@ -36234,7 +36252,7 @@ __metadata:
     "@metamask/eslint-plugin-design-tokens": "npm:^1.0.0"
     "@metamask/eth-hd-keyring": "npm:^14.1.1"
     "@metamask/eth-json-rpc-filters": "npm:^9.0.0"
-    "@metamask/eth-json-rpc-middleware": "npm:^23.1.2"
+    "@metamask/eth-json-rpc-middleware": "npm:^24.0.0"
     "@metamask/eth-ledger-bridge-keyring": "npm:^12.1.0"
     "@metamask/eth-money-keyring": "npm:^3.0.0"
     "@metamask/eth-qr-keyring": "npm:^2.1.0"


### PR DESCRIPTION
## **Description**

Updates `@metamask/eth-json-rpc-middleware` from `^23.1.2` to `^24.0.0`.

The key change in v24.0.0 is **strict validation for `eth_sendTransaction` and `eth_signTransaction` params**:
- Requests with params that don't match the transaction schema (extraneous top-level keys, ill-typed fields like non-hex `to`/`data`, malformed `accessList`/`authorizationList` entries) or that exceed `MAX_TRANSACTION_PARAMS_SIZE_BYTES` when serialized are now rejected upfront.
- This prevents downstream normalization and PPOM WASM from crashing on deeply-nested junk fields or padded payloads, and prevents those malformed requests from silently bypassing security scans.

Also bumps `@metamask/message-manager` from `14.1.1` → `14.1.2` (transitive, pulled in by the new middleware version) and drops the unused `pify` dependency.

## **Changelog**

CHANGELOG entry: Updated `@metamask/eth-json-rpc-middleware` to `^24.0.0` which adds strict validation for `eth_sendTransaction`/`eth_signTransaction` params to prevent malformed requests from bypassing PPOM security scans.

## **Related issues**

Fixes:

## **Manual testing steps**

Feature: eth-json-rpc-middleware upgrade

  Scenario: user sends a normal transaction
    Given the app is on the send transaction screen with valid params

    When user submits the transaction
    Then the transaction should proceed normally without errors

  Scenario: user sends a transaction with malformed params
    Given the app receives a dApp request with extraneous/ill-typed transaction fields

    When the request is processed by the middleware
    Then the request is rejected with an RPC error before reaching PPOM

## **Screenshots/Recordings**

N/A — dependency bump, no UI changes.

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all dApp and WalletConnect send-transaction entry points; stricter rejection could affect unusual but previously accepted param shapes, while reducing crash/bypass risk on malicious payloads.
> 
> **Overview**
> Upgrades **`@metamask/eth-json-rpc-middleware`** to **^24.0.0** and runs **`validateTransactionParams`** on dApp and WalletConnect **`eth_sendTransaction`** paths **before** account checks and **`addTransaction`**, so malformed or oversized payloads fail early with RPC errors instead of reaching PPOM or the transaction controller.
> 
> **`eth_sendTransaction`** and **`WalletConnect2Session.handleSendTransaction`** now reject extraneous top-level keys and params over the max serialized size (e.g. **"Request too large"**). New unit/integration tests cover those cases and assert **`sendTransaction`** is not invoked when validation throws. Middleware tests were adjusted to supply **`from`** and permitted accounts where validation now always runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd19834e9b5374f0664325b48baf042ff3f4fa05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->