### PR TITLE
fix: keep QuickBuy quick-amount K/M suffixes visible at large font sizes cp-8.6.0

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyQuickAmounts.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyQuickAmounts.test.tsx
@@ -18,15 +18,6 @@ jest.mock('../../../../../../../../locales/i18n', () => ({
   strings: (key: string) => key,
 }));
 
-jest.mock('../utils/quickBuyQuickAmounts', () => {
-  const actual = jest.requireActual('../utils/quickBuyQuickAmounts');
-  return {
-    ...actual,
-    formatQuickBuyPillLabel: (value: number, currency: string) =>
-      `${currency}:${value}`,
-  };
-});
-
 const mockPlayImpact = jest.fn();
 
 jest.mock('../../../../../../../util/haptics', () => ({
@@ -173,5 +164,43 @@ describe('QuickBuyQuickAmounts', () => {
     fireEvent.press(screen.getByTestId('quick-buy-keypad-done'));
 
     expect(onDonePress).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the compact suffix of a custom buy amount readable at large OS font sizes', () => {
+    (useQuickBuyContext as jest.Mock).mockReturnValue({
+      ...baseContext,
+      buyQuickAmounts: [10, 50, 100, 25000] as [number, number, number, number],
+    });
+
+    renderWithProvider(
+      <QuickBuyQuickAmounts showDone onDonePress={jest.fn()} />,
+    );
+
+    // Without these guards ButtonBase clips the label (numberOfLines: 1 +
+    // ellipsizeMode: 'clip'), turning "$25K" into "$25".
+    const label = screen.getByText('$25K');
+    expect(label.props.maxFontSizeMultiplier).toBe(1.2);
+    expect(label.props.adjustsFontSizeToFit).toBe(true);
+    expect(label.props.minimumFontScale).toBe(0.7);
+    expect(label.props.numberOfLines).toBe(1);
+    expect(label.props.ellipsizeMode).toBe('tail');
+  });
+
+  it('applies the same font-scaling guards to sell pills and the Done button', () => {
+    (useQuickBuyContext as jest.Mock).mockReturnValue({
+      ...baseContext,
+      tradeMode: 'sell',
+    });
+
+    renderWithProvider(
+      <QuickBuyQuickAmounts showDone onDonePress={jest.fn()} />,
+    );
+
+    for (const label of [screen.getByText('75%'), screen.getByText('Done')]) {
+      expect(label.props.maxFontSizeMultiplier).toBe(1.2);
+      expect(label.props.adjustsFontSizeToFit).toBe(true);
+      expect(label.props.minimumFontScale).toBe(0.7);
+      expect(label.props.ellipsizeMode).toBe('tail');
+    }
   });
 });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyQuickAmounts.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyQuickAmounts.test.tsx
@@ -172,18 +172,33 @@ describe('QuickBuyQuickAmounts', () => {
       buyQuickAmounts: [10, 50, 100, 25000] as [number, number, number, number],
     });
 
+    renderWithProvider(<QuickBuyQuickAmounts />);
+
+    // Without the cap ButtonBase clips the label (numberOfLines: 1 +
+    // ellipsizeMode: 'clip'), turning "$25K" into "$25".
+    const label = screen.getByText('$25K');
+    expect(label.props.maxFontSizeMultiplier).toBe(1);
+    expect(label.props.numberOfLines).toBe(1);
+    expect(label.props.ellipsizeMode).toBe('tail');
+  });
+
+  it('sizes every pill in the row identically regardless of label length', () => {
+    (useQuickBuyContext as jest.Mock).mockReturnValue({
+      ...baseContext,
+      buyQuickAmounts: [10, 50, 100, 25000] as [number, number, number, number],
+    });
+
     renderWithProvider(
       <QuickBuyQuickAmounts showDone onDonePress={jest.fn()} />,
     );
 
-    // Without these guards ButtonBase clips the label (numberOfLines: 1 +
-    // ellipsizeMode: 'clip'), turning "$25K" into "$25".
-    const label = screen.getByText('$25K');
-    expect(label.props.maxFontSizeMultiplier).toBe(1.2);
-    expect(label.props.adjustsFontSizeToFit).toBe(true);
-    expect(label.props.minimumFontScale).toBe(0.7);
-    expect(label.props.numberOfLines).toBe(1);
-    expect(label.props.ellipsizeMode).toBe('tail');
+    // Per-label auto-shrink would size "$25K" down while "$10" stays put,
+    // leaving a ragged row.
+    for (const text of ['$10', '$50', '$100', '$25K', 'Done']) {
+      const label = screen.getByText(text);
+      expect(label.props.adjustsFontSizeToFit).toBeUndefined();
+      expect(label.props.maxFontSizeMultiplier).toBe(1);
+    }
   });
 
   it('applies the same font-scaling guards to sell pills and the Done button', () => {
@@ -197,9 +212,7 @@ describe('QuickBuyQuickAmounts', () => {
     );
 
     for (const label of [screen.getByText('75%'), screen.getByText('Done')]) {
-      expect(label.props.maxFontSizeMultiplier).toBe(1.2);
-      expect(label.props.adjustsFontSizeToFit).toBe(true);
-      expect(label.props.minimumFontScale).toBe(0.7);
+      expect(label.props.maxFontSizeMultiplier).toBe(1);
       expect(label.props.ellipsizeMode).toBe('tail');
     }
   });

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyQuickAmounts.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyQuickAmounts.tsx
@@ -17,6 +17,27 @@ import {
 } from '../utils/quickBuyQuickAmounts';
 
 /**
+ * Pill labels use compact magnitudes ("$1K", "$1.5M"), and ButtonBase renders
+ * labels with `numberOfLines: 1` and `ellipsizeMode: 'clip'` — overflow is cut
+ * off with no ellipsis. At large OS font scales that drops the suffix, so a
+ * "$10K" pill reads as "$10": a 1000x wrong amount on a button that spends
+ * money.
+ *
+ * `maxFontSizeMultiplier` caps how far the OS text-size setting can push the
+ * label, `adjustsFontSizeToFit` shrinks whatever still overflows (long labels
+ * in suffix-symbol currencies, or the five-pill keypad row), and `tail`
+ * replaces the inherited `clip` so a label that exhausts both budgets shows an
+ * ellipsis instead of a plausible-looking wrong number.
+ */
+const QUICK_AMOUNT_PILL_TEXT_PROPS = {
+  maxFontSizeMultiplier: 1.2,
+  adjustsFontSizeToFit: true,
+  minimumFontScale: 0.7,
+  numberOfLines: 1,
+  ellipsizeMode: 'tail',
+} as const;
+
+/**
  * Shared pill chrome.
  * ButtonSize.Md (40px) matches the Figma height; px-2 overrides the default
  * 16px horizontal padding so all four labels fit on one row without clipping.
@@ -24,6 +45,7 @@ import {
 const QUICK_AMOUNT_PILL_PROPS = {
   variant: ButtonVariant.Secondary,
   size: ButtonSize.Md,
+  textProps: QUICK_AMOUNT_PILL_TEXT_PROPS,
 } as const;
 
 const QUICK_AMOUNT_PILL_TW_CLASS = 'min-w-0 flex-1 px-2';
@@ -113,6 +135,7 @@ const QuickBuyQuickAmounts: React.FC<QuickBuyQuickAmountsProps> = ({
         size={ButtonSize.Md}
         onPress={onDonePress}
         twClassName={QUICK_AMOUNT_PILL_TW_CLASS}
+        textProps={QUICK_AMOUNT_PILL_TEXT_PROPS}
         testID="quick-buy-keypad-done"
       >
         Done

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyQuickAmounts.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/components/QuickBuyQuickAmounts.tsx
@@ -23,16 +23,19 @@ import {
  * "$10K" pill reads as "$10": a 1000x wrong amount on a button that spends
  * money.
  *
- * `maxFontSizeMultiplier` caps how far the OS text-size setting can push the
- * label, `adjustsFontSizeToFit` shrinks whatever still overflows (long labels
- * in suffix-symbol currencies, or the five-pill keypad row), and `tail`
- * replaces the inherited `clip` so a label that exhausts both budgets shows an
- * ellipsis instead of a plausible-looking wrong number.
+ * `maxFontSizeMultiplier: 1` pins the label to the size the four-pill row was
+ * designed around, so the OS text-size setting can no longer overflow it. The
+ * cap is deliberately one-directional: a user who picks a *smaller* system
+ * font still gets a smaller label, which only ever helps the fit.
+ *
+ * Per-`Text` auto-shrink (`adjustsFontSizeToFit`) is intentionally not used
+ * here — it sizes each label against its own pill, so one long amount in the
+ * row would render visibly smaller than its neighbours. `tail` replaces the
+ * inherited `clip` instead, so a label that somehow still overflows shows an
+ * ellipsis rather than a plausible-looking wrong number.
  */
 const QUICK_AMOUNT_PILL_TEXT_PROPS = {
-  maxFontSizeMultiplier: 1.2,
-  adjustsFontSizeToFit: true,
-  minimumFontScale: 0.7,
+  maxFontSizeMultiplier: 1,
   numberOfLines: 1,
   ellipsizeMode: 'tail',
 } as const;


### PR DESCRIPTION
## **Description**

**What is the reason for the change?**

QuickBuy quick-amount pills show a compact magnitude once the amount reaches 1,000 (`$1K`, `$1.5M`). The design-system `ButtonBase` renders its label with `numberOfLines: 1` **and `ellipsizeMode: 'clip'`**, so a label that does not fit is cut off with no ellipsis and no other visual signal.

On devices configured with a large OS text size, the label outgrows the pill and the suffix is the first thing to go — a `$10K` pill renders as `$10`. The button then advertises an amount 1000x smaller than the one it actually commits. Custom amounts configured via the cog wheel (`Edit quick amounts`) make this easy to hit, because they are the values large enough to be formatted compactly in the first place.

The row is tight by construction: four `flex-1` pills with `gap-2` inside a `px-4` container leave roughly 60pt of text width per pill on a 360pt-wide device, against a 16px base label.

**What is the improvement/solution?**

Pass `textProps` to every quick-amount pill (buy, sell, and the keypad `Done` button):

- `maxFontSizeMultiplier: 1` — pins the label to the 16px size the four-pill row was designed around, so the OS text-size setting can no longer overflow it. The cap is one-directional: a user who picks a *smaller* system font still gets a smaller label, which only helps the fit. Preferred over `allowFontScaling={false}` for exactly that reason.
- `ellipsizeMode: 'tail'` — replaces the inherited `clip`, so a label that somehow still overflows (a long suffix-symbol currency such as `1.5M kr` on a narrow screen) shows an ellipsis instead of a plausible-looking wrong number. Backstop, not the primary mechanism.

Per-`Text` auto-shrink (`adjustsFontSizeToFit`) was considered and deliberately rejected: it sizes each label against its own pill, so a row containing both `$10` and `$250K` would render them at visibly different sizes. A row-wide shrink factor would preserve more accessibility scaling, but needs either a hardcoded character-width heuristic or an `onLayout` measurement pass — more moving parts than this fix warrants.

**Accessibility trade-off:** these four pills no longer grow with the system text size. The amount headline, the confirm button, and the rest of the sheet are unaffected and still scale. A silently wrong amount on a button that spends money is the worse failure.

Also removes a `formatQuickBuyPillLabel` mock from the test file that never took effect: `resolveBuyQuickAmounts` calls it through a local binding, so the pills always rendered real labels. Leaving it in place made the new label-based assertions look fragile.

## **Changelog**

CHANGELOG entry: Fixed QuickBuy quick-amount buttons showing a truncated amount (for example "$10" instead of "$10K") on devices with a large system font size.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TSA-974

## **Manual testing steps**

```gherkin
Feature: QuickBuy quick-amount pills at large system font sizes

  Scenario: custom quick amounts keep their compact suffix
    Given the device text size is set to the largest available value
      # iOS: Settings > Accessibility > Display & Text Size > Larger Text
      # Android: Settings > Display > Font size (and Display size)
    And the user opens a trader position and taps Quick Buy

    When user taps the cog wheel and sets the buy quick amounts to 10, 500, 10000 and 250000
    And user confirms and returns to the main Quick Buy screen
    Then the four pills read "$10", "$500", "$10K" and "$250K"
    And no pill has lost its "K" or "M" suffix

  Scenario: the committed amount matches the pill label
    Given the device text size is set to the largest available value
    And the buy quick amounts include 10000

    When user taps the "$10K" pill
    Then the amount headline shows 10,000 in the display currency

  Scenario: no regression at the default text size
    Given the device text size is at its default value

    When user opens the Quick Buy screen
    Then the quick-amount pills render at their normal size and are unchanged
```

## **Screenshots/Recordings**

### **Before**

<!-- TODO before marking ready for review: device capture at the largest OS text size showing a custom "$10K" pill rendering as "$10". -->

### **After**

<!-- TODO before marking ready for review: same device and text size showing the full "$10K" label. -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized QuickBuy pill label styling with tests; no change to trade amounts or payment logic beyond correct display.
> 
> **Overview**
> Fixes QuickBuy quick-amount pills showing **truncated labels** (e.g. `$10` instead of `$10K`) when the OS text size is large. `ButtonBase` clips overflowing label text with no ellipsis, which can hide compact magnitude suffixes on money buttons.
> 
> **`QuickBuyQuickAmounts`** now passes shared `textProps` on all buy/sell pills and the keypad **Done** button: `maxFontSizeMultiplier: 1` so labels don’t outgrow the four-pill row, `ellipsizeMode: 'tail'` as a backstop, and no per-pill `adjustsFontSizeToFit` so the row stays visually even. JSDoc documents the trade-off (these pills no longer scale up with system text).
> 
> Tests drop an ineffective `formatQuickBuyPillLabel` mock and assert the new label props for buy, sell, and Done.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7d6cbb43348dc2fd3be263999ab0afe5b4496c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->