### PR TITLE
refactor: encapsulate custom amount update state

### DIFF
--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -817,6 +817,11 @@ describe('CustomAmountInfo', () => {
         deferred.resolve();
         await deferred.promise;
       });
+      view.rerender(
+        createCustomAmountInfo({
+          transactionType: TransactionType.moneyAccountDeposit,
+        }),
+      );
 
       expect(view.getByTestId('bridge-fee-row-skeleton')).toBeOnTheScreen();
       expect(view.queryByTestId('bridge-fee-row')).not.toBeOnTheScreen();
@@ -988,7 +993,7 @@ describe('CustomAmountInfo', () => {
       expect(view.getByTestId('bridge-fee-row')).toBeOnTheScreen();
     });
 
-    it('keeps preparation active while the amount update is pending', async () => {
+    it('unblocks review rows when quote loading starts before the amount update settles', async () => {
       const { deferred } = arrangePendingPreparation();
       const view = render({
         transactionType: TransactionType.moneyAccountDeposit,
@@ -1009,7 +1014,7 @@ describe('CustomAmountInfo', () => {
       expect(
         view.getByTestId(CustomAmountInfoTestIds.REVIEW_ROWS).props
           .pointerEvents,
-      ).toBe('none');
+      ).toBe('auto');
 
       await act(async () => {
         deferred.resolve();

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -1076,7 +1076,7 @@ describe('CustomAmountInfo', () => {
       expect(mockShowToast).toHaveBeenCalledTimes(1);
     });
 
-    it('keeps the universal loading review until Redux observes controller loading', async () => {
+    it('unblocks non-Money review rows once quote loading starts', async () => {
       const deferred = createDeferredPromise();
       const nonMoneyTransactionId = 'non-money-transaction';
       useTransactionMetadataRequestMock.mockReturnValue({
@@ -1115,7 +1115,7 @@ describe('CustomAmountInfo', () => {
       expect(
         view.getByTestId(CustomAmountInfoTestIds.REVIEW_ROWS).props
           .pointerEvents,
-      ).toBe('none');
+      ).toBe('auto');
 
       // A fresh, non-empty quote settles the override into the populated review.
       useIsTransactionPayLoadingMock.mockReturnValue(false);

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -362,11 +362,9 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       (hasAccountNoFunds || stage === CustomAmountStage.Loading);
 
     // Keep payment details fixed while the amount update prepares the request.
-    // Once a Money Account deposit quote is in flight, reopening either picker
-    // is safe and keeps the loading screen responsive.
-    const shouldBlockReviewRows =
-      stage === CustomAmountStage.Loading &&
-      (!isMoneyAccountDeposit || isAmountUpdating);
+    // Once quote loading takes over, reopening a picker is safe and keeps the
+    // loading screen responsive.
+    const shouldBlockReviewRows = isAmountUpdating;
 
     const { headlessBuyError } = useConfirmationContext();
 

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -181,13 +181,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const accountNoFundsAlert = useAccountNoFundsAlert();
     const hasAccountNoFunds = accountNoFundsAlert.length > 0;
 
-    const {
-      beginAmountUpdate,
-      endAmountUpdate,
-      isAmountUpdating,
-      stage,
-      setStage,
-    } = useCustomAmountStage({
+    const { isAmountUpdating, stage, setStage } = useCustomAmountStage({
       amountFiat,
       disablePay,
       hasAccountNoFunds,
@@ -198,6 +192,9 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       skipDepositPrefill,
     });
 
+    // React batches rapid presses before the state update rerenders, so keep a
+    // synchronous guard separate from the render state.
+    const isAmountUpdateInProgressRef = useRef(false);
     useMMPayNavigation(stage, setStage);
     const isFiatAvailable = useIsFiatPaymentAvailable();
     const moneyAccountSection = usePayWithMoneyAccountSection();
@@ -227,11 +224,13 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const hasAutoSubmittedPrefill = useRef(false);
 
     const handleDone = useCallback(async () => {
-      // Enter the loading stage synchronously so rapid presses cannot start
-      // duplicate amount updates before React rerenders.
-      if (!beginAmountUpdate()) {
+      if (isAmountUpdateInProgressRef.current) {
         return;
       }
+
+      isAmountUpdateInProgressRef.current = true;
+      // Enter the loading stage: keyboard hidden, totals skeletons shown.
+      setStage(CustomAmountStage.Loading);
 
       try {
         await updateTokenAmount();
@@ -268,7 +267,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
         setStage(CustomAmountStage.AmountInput);
         return;
       } finally {
-        endAmountUpdate();
+        isAmountUpdateInProgressRef.current = false;
       }
       EngineService.flushState();
       hasAutoSubmittedPrefill.current = true;
@@ -279,8 +278,6 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       onAmountSubmit?.();
     }, [
       amountFiat,
-      beginAmountUpdate,
-      endAmountUpdate,
       onAmountSubmit,
       selectedFiatPaymentMethodId,
       setStage,

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -5,7 +5,6 @@ import React, {
   useContext,
   useEffect,
   useRef,
-  useState,
 } from 'react';
 import { View } from 'react-native';
 import {
@@ -43,10 +42,7 @@ import {
   CustomAmount,
   CustomAmountSkeleton,
 } from '../../transactions/custom-amount';
-import {
-  useIsTransactionPayQuoteLoading,
-  useTransactionPayFiatPayment,
-} from '../../../hooks/pay/useTransactionPayData';
+import { useTransactionPayFiatPayment } from '../../../hooks/pay/useTransactionPayData';
 import { usePayWithMoneyAccountSection } from '../../../hooks/pay/sections/usePayWithMoneyAccountSection';
 import { useTransactionPayMetrics } from '../../../hooks/pay/useTransactionPayMetrics';
 import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
@@ -185,7 +181,13 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const accountNoFundsAlert = useAccountNoFundsAlert();
     const hasAccountNoFunds = accountNoFundsAlert.length > 0;
 
-    const { stage, setStage } = useCustomAmountStage({
+    const {
+      beginAmountUpdate,
+      endAmountUpdate,
+      isAmountUpdating,
+      stage,
+      setStage,
+    } = useCustomAmountStage({
       amountFiat,
       disablePay,
       hasAccountNoFunds,
@@ -196,11 +198,6 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       skipDepositPrefill,
     });
 
-    // React batches rapid presses before the state update rerenders, so keep a
-    // synchronous guard separate from the render state.
-    const isAmountUpdateInProgressRef = useRef(false);
-    const [isAmountUpdatePending, setIsAmountUpdatePending] = useState(false);
-    const isQuotesLoading = useIsTransactionPayQuoteLoading();
     useMMPayNavigation(stage, setStage);
     const isFiatAvailable = useIsFiatPaymentAvailable();
     const moneyAccountSection = usePayWithMoneyAccountSection();
@@ -230,14 +227,11 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const hasAutoSubmittedPrefill = useRef(false);
 
     const handleDone = useCallback(async () => {
-      if (isAmountUpdateInProgressRef.current) {
+      // Enter the loading stage synchronously so rapid presses cannot start
+      // duplicate amount updates before React rerenders.
+      if (!beginAmountUpdate()) {
         return;
       }
-
-      isAmountUpdateInProgressRef.current = true;
-      setIsAmountUpdatePending(true);
-      // Enter the loading stage: keyboard hidden, totals skeletons shown.
-      setStage(CustomAmountStage.Loading);
 
       try {
         await updateTokenAmount();
@@ -274,8 +268,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
         setStage(CustomAmountStage.AmountInput);
         return;
       } finally {
-        isAmountUpdateInProgressRef.current = false;
-        setIsAmountUpdatePending(false);
+        endAmountUpdate();
       }
       EngineService.flushState();
       hasAutoSubmittedPrefill.current = true;
@@ -286,6 +279,8 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       onAmountSubmit?.();
     }, [
       amountFiat,
+      beginAmountUpdate,
+      endAmountUpdate,
       onAmountSubmit,
       selectedFiatPaymentMethodId,
       setStage,
@@ -374,7 +369,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     // is safe and keeps the loading screen responsive.
     const shouldBlockReviewRows =
       stage === CustomAmountStage.Loading &&
-      (isAmountUpdatePending || !isMoneyAccountDeposit || !isQuotesLoading);
+      (!isMoneyAccountDeposit || isAmountUpdating);
 
     const { headlessBuyError } = useConfirmationContext();
 

--- a/app/components/Views/confirmations/hooks/custom-amount/useCustomAmountStage.test.ts
+++ b/app/components/Views/confirmations/hooks/custom-amount/useCustomAmountStage.test.ts
@@ -91,12 +91,14 @@ describe('useCustomAmountStage', () => {
       const { result } = runHook();
 
       expect(result.current.stage).toBe(CustomAmountStage.AmountInput);
+      expect(result.current.isAmountUpdating).toBe(false);
     });
 
     it('starts in Loading for an add-mUSD intent', () => {
       const { result } = runHook({ isAddMusdIntent: true });
 
       expect(result.current.stage).toBe(CustomAmountStage.Loading);
+      expect(result.current.isAmountUpdating).toBe(true);
     });
 
     it('starts in Loading when deposit prefill is enabled', () => {
@@ -132,6 +134,7 @@ describe('useCustomAmountStage', () => {
       const { result } = runDerived();
 
       expect(result.current.stage).toBe(CustomAmountStage.Loading);
+      expect(result.current.isAmountUpdating).toBe(false);
     });
 
     it('derives ShowTotals once quotes are present', () => {
@@ -184,6 +187,7 @@ describe('useCustomAmountStage', () => {
       });
 
       expect(result.current.stage).toBe(CustomAmountStage.Loading);
+      expect(result.current.isAmountUpdating).toBe(true);
     });
   });
 
@@ -234,6 +238,26 @@ describe('useCustomAmountStage', () => {
       });
 
       expect(result.current.stage).toBe(CustomAmountStage.Loading);
+      expect(result.current.isAmountUpdating).toBe(true);
+    });
+
+    it('keeps the current amount update active while an older quote request is loading', () => {
+      setupState({ isQuotesLoading: true });
+      const { result } = runHook();
+
+      act(() => {
+        result.current.beginAmountUpdate();
+      });
+
+      expect(result.current.stage).toBe(CustomAmountStage.Loading);
+      expect(result.current.isAmountUpdating).toBe(true);
+
+      act(() => {
+        result.current.endAmountUpdate();
+      });
+
+      expect(result.current.stage).toBe(CustomAmountStage.Loading);
+      expect(result.current.isAmountUpdating).toBe(false);
     });
 
     it('clears a Loading commit immediately when the current amount was prefetched', () => {
@@ -322,6 +346,7 @@ describe('useCustomAmountStage', () => {
       });
 
       expect(result.current.stage).toBe(CustomAmountStage.Loading);
+      expect(result.current.isAmountUpdating).toBe(false);
     });
   });
 
@@ -337,6 +362,7 @@ describe('useCustomAmountStage', () => {
       });
 
       expect(view.result.current.stage).toBe(CustomAmountStage.ShowTotals);
+      expect(view.result.current.isAmountUpdating).toBe(false);
     });
 
     it('never derives NoQuote even after a settled empty fetch', () => {
@@ -353,6 +379,29 @@ describe('useCustomAmountStage', () => {
 
       expect(view.result.current.stage).not.toBe(CustomAmountStage.NoQuote);
       expect(view.result.current.stage).toBe(CustomAmountStage.ShowTotals);
+    });
+
+    it('keeps Loading until a direct-transfer amount commit resolves', () => {
+      setupState({
+        isQuotesLoading: false,
+        quotes: [],
+        amountRaw: undefined,
+      });
+      const { result } = runHook({ disablePay: true });
+
+      act(() => {
+        result.current.beginAmountUpdate();
+      });
+
+      expect(result.current.stage).toBe(CustomAmountStage.Loading);
+      expect(result.current.isAmountUpdating).toBe(true);
+
+      act(() => {
+        result.current.endAmountUpdate();
+      });
+
+      expect(result.current.stage).toBe(CustomAmountStage.ShowTotals);
+      expect(result.current.isAmountUpdating).toBe(false);
     });
 
     it('settles the commit Loading override on the arm frame, with no quote and no resolved amount', () => {

--- a/app/components/Views/confirmations/hooks/custom-amount/useCustomAmountStage.test.ts
+++ b/app/components/Views/confirmations/hooks/custom-amount/useCustomAmountStage.test.ts
@@ -241,19 +241,12 @@ describe('useCustomAmountStage', () => {
       expect(result.current.isAmountUpdating).toBe(true);
     });
 
-    it('keeps the current amount update active while an older quote request is loading', () => {
+    it('reports quote fetching rather than an amount update when quotes are already loading', () => {
       setupState({ isQuotesLoading: true });
       const { result } = runHook();
 
       act(() => {
-        result.current.beginAmountUpdate();
-      });
-
-      expect(result.current.stage).toBe(CustomAmountStage.Loading);
-      expect(result.current.isAmountUpdating).toBe(true);
-
-      act(() => {
-        result.current.endAmountUpdate();
+        result.current.setStage(CustomAmountStage.Loading);
       });
 
       expect(result.current.stage).toBe(CustomAmountStage.Loading);
@@ -379,29 +372,6 @@ describe('useCustomAmountStage', () => {
 
       expect(view.result.current.stage).not.toBe(CustomAmountStage.NoQuote);
       expect(view.result.current.stage).toBe(CustomAmountStage.ShowTotals);
-    });
-
-    it('keeps Loading until a direct-transfer amount commit resolves', () => {
-      setupState({
-        isQuotesLoading: false,
-        quotes: [],
-        amountRaw: undefined,
-      });
-      const { result } = runHook({ disablePay: true });
-
-      act(() => {
-        result.current.beginAmountUpdate();
-      });
-
-      expect(result.current.stage).toBe(CustomAmountStage.Loading);
-      expect(result.current.isAmountUpdating).toBe(true);
-
-      act(() => {
-        result.current.endAmountUpdate();
-      });
-
-      expect(result.current.stage).toBe(CustomAmountStage.ShowTotals);
-      expect(result.current.isAmountUpdating).toBe(false);
     });
 
     it('settles the commit Loading override on the arm frame, with no quote and no resolved amount', () => {

--- a/app/components/Views/confirmations/hooks/custom-amount/useCustomAmountStage.ts
+++ b/app/components/Views/confirmations/hooks/custom-amount/useCustomAmountStage.ts
@@ -1,11 +1,4 @@
-import {
-  Dispatch,
-  SetStateAction,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import {
   useIsTransactionPayQuoteLoading,
   useTransactionPayPrimaryRequiredToken,
@@ -25,9 +18,9 @@ export enum CustomAmountStage {
  * Owns the rendering state machine for `CustomAmountInfo`.
  *
  * Stage is computed from two layers: a stateful override (`AmountInput` when
- * the keyboard is open, `Loading` while an amount update is in flight) set by
- * the lifecycle controls or `setStage`; and a pure derivation from reactive
- * inputs (quotes, prefill flags) used whenever the override is `null`.
+ * the keyboard is open, `Loading` while an amount update is in flight) set via
+ * `setStage`; and a pure derivation from reactive inputs (quotes, prefill flags)
+ * used whenever the override is `null`.
  * The hook reads quote state itself so the component renders purely
  * off the returned `stage`.
  *
@@ -39,8 +32,8 @@ export enum CustomAmountStage {
  * @param options.isDepositPrefillEnabled - Whether deposit prefill is enabled.
  * @param options.isDepositPrefillLoading - Whether a deposit prefill is loading.
  * @param options.skipDepositPrefill - Whether deposit prefill is skipped.
- * @returns The current stage, amount-update lifecycle controls and state, and
- * a setter to override the stage.
+ * @returns The current stage, whether the amount is updating, and a setter to
+ * override the stage.
  */
 export function useCustomAmountStage({
   amountFiat,
@@ -61,8 +54,6 @@ export function useCustomAmountStage({
   isDepositPrefillLoading: boolean;
   skipDepositPrefill: boolean;
 }): {
-  beginAmountUpdate: () => boolean;
-  endAmountUpdate: () => void;
   isAmountUpdating: boolean;
   stage: CustomAmountStage;
   setStage: Dispatch<SetStateAction<CustomAmountStage | null>>;
@@ -74,24 +65,6 @@ export function useCustomAmountStage({
       ? CustomAmountStage.AmountInput
       : CustomAmountStage.Loading,
   );
-  const [isAmountUpdatePending, setIsAmountUpdatePending] = useState(false);
-  const isAmountUpdateInProgressRef = useRef(false);
-
-  const beginAmountUpdate = useCallback(() => {
-    if (isAmountUpdateInProgressRef.current) {
-      return false;
-    }
-
-    isAmountUpdateInProgressRef.current = true;
-    setIsAmountUpdatePending(true);
-    setStage(CustomAmountStage.Loading);
-    return true;
-  }, []);
-
-  const endAmountUpdate = useCallback(() => {
-    isAmountUpdateInProgressRef.current = false;
-    setIsAmountUpdatePending(false);
-  }, []);
 
   const isQuotesLoading = useIsTransactionPayQuoteLoading();
   const quotesLastUpdated = useTransactionPayQuotesLastUpdated();
@@ -106,7 +79,6 @@ export function useCustomAmountStage({
   // quote, not a stale one predating the amount update.
   const loadingBaselineRef = useRef<number | undefined>(undefined);
   const wasLoadingRef = useRef(false);
-  const settleOnCommitRef = useRef(false);
   // `amountFiat` from the previous commit, to recognise a no-op re-commit.
   const lastCommittedFiatRef = useRef<string | undefined>(undefined);
 
@@ -119,16 +91,14 @@ export function useCustomAmountStage({
    * amount. Compare the new amount against the *prior* commit ONLY here, before
    * overwriting the ref — a no-op re-commit fetches nothing, so clear at once.
    *
-   * Settle (later renders): after the amount commit resolves, clear on
-   * `hasFreshQuote` or `isQuotesLoading`. Key off *current* loading, not a
-   * latch: the controller pulses `isLoading` for an empty pre-fetch update
-   * before the real fetch, and a latch would clear in the gap and briefly
-   * derive `NoQuote`.
+   * Settle (later renders): clear on `hasFreshQuote` or `isQuotesLoading`. Key
+   * off *current* loading, not a latch: the controller pulses `isLoading` for
+   * an empty pre-fetch update before the real fetch, and a latch would clear in
+   * the gap and briefly derive `NoQuote`.
    */
   useEffect(() => {
     if (stageOverride !== CustomAmountStage.Loading) {
       wasLoadingRef.current = false;
-      settleOnCommitRef.current = false;
       return;
     }
 
@@ -138,21 +108,14 @@ export function useCustomAmountStage({
       wasLoadingRef.current = true;
       loadingBaselineRef.current = quotesLastUpdated;
       lastCommittedFiatRef.current = amountFiat;
-      settleOnCommitRef.current =
-        isNoOpRecommit || Boolean(disablePay) || hasPrefetchedQuote;
 
       // `disablePay` flows are direct transfers: no pay token, no quote, and the
-      // required-token amount may never resolve. Once the amount commit ends,
-      // there is nothing else to await. The same applies to no-op re-commits and
-      // amounts that already have a prefetched quote.
-      if (settleOnCommitRef.current && !isAmountUpdatePending) {
+      // required-token amount may never resolve. There is nothing to await once
+      // the amount is committed, so settle on the arm frame itself — the settle
+      // branch below is never re-entered when no reactive input changes.
+      if (isNoOpRecommit || disablePay || hasPrefetchedQuote) {
         setStage(null);
       }
-      return;
-    }
-
-    if (settleOnCommitRef.current && !isAmountUpdatePending) {
-      setStage(null);
       return;
     }
 
@@ -164,11 +127,7 @@ export function useCustomAmountStage({
       (loadingBaselineRef.current === undefined ||
         quotesLastUpdated > loadingBaselineRef.current);
 
-    if (
-      !isAmountUpdatePending &&
-      hasAmount &&
-      (hasFreshQuote || isQuotesLoading)
-    ) {
+    if (hasAmount && (hasFreshQuote || isQuotesLoading)) {
       setStage(null);
     }
   }, [
@@ -178,7 +137,6 @@ export function useCustomAmountStage({
     hasAmount,
     hasPrefetchedQuote,
     hasQuotes,
-    isAmountUpdatePending,
     isQuotesLoading,
     quotesLastUpdated,
   ]);
@@ -220,18 +178,8 @@ export function useCustomAmountStage({
     stage = CustomAmountStage.NoQuote;
   }
 
-  // Keep the amount update active until its commit settles, even if an older
-  // quote request was already loading. Afterwards, remain active only until
-  // quote fetching takes over.
   const isAmountUpdating =
-    stage === CustomAmountStage.Loading &&
-    (isAmountUpdatePending || !isQuotesLoading);
+    stage === CustomAmountStage.Loading && !isQuotesLoading;
 
-  return {
-    beginAmountUpdate,
-    endAmountUpdate,
-    isAmountUpdating,
-    setStage,
-    stage,
-  };
+  return { isAmountUpdating, setStage, stage };
 }

--- a/app/components/Views/confirmations/hooks/custom-amount/useCustomAmountStage.ts
+++ b/app/components/Views/confirmations/hooks/custom-amount/useCustomAmountStage.ts
@@ -1,4 +1,11 @@
-import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import {
   useIsTransactionPayQuoteLoading,
   useTransactionPayPrimaryRequiredToken,
@@ -19,8 +26,8 @@ export enum CustomAmountStage {
  *
  * Stage is computed from two layers: a stateful override (`AmountInput` when
  * the keyboard is open, `Loading` while an amount update is in flight) set by
- * the component via `setStage`; and a pure derivation from reactive inputs
- * (quotes, prefill flags) used whenever the override is `null`.
+ * the lifecycle controls or `setStage`; and a pure derivation from reactive
+ * inputs (quotes, prefill flags) used whenever the override is `null`.
  * The hook reads quote state itself so the component renders purely
  * off the returned `stage`.
  *
@@ -32,7 +39,8 @@ export enum CustomAmountStage {
  * @param options.isDepositPrefillEnabled - Whether deposit prefill is enabled.
  * @param options.isDepositPrefillLoading - Whether a deposit prefill is loading.
  * @param options.skipDepositPrefill - Whether deposit prefill is skipped.
- * @returns The current stage and a setter to override it.
+ * @returns The current stage, amount-update lifecycle controls and state, and
+ * a setter to override the stage.
  */
 export function useCustomAmountStage({
   amountFiat,
@@ -53,6 +61,9 @@ export function useCustomAmountStage({
   isDepositPrefillLoading: boolean;
   skipDepositPrefill: boolean;
 }): {
+  beginAmountUpdate: () => boolean;
+  endAmountUpdate: () => void;
+  isAmountUpdating: boolean;
   stage: CustomAmountStage;
   setStage: Dispatch<SetStateAction<CustomAmountStage | null>>;
 } {
@@ -63,6 +74,24 @@ export function useCustomAmountStage({
       ? CustomAmountStage.AmountInput
       : CustomAmountStage.Loading,
   );
+  const [isAmountUpdatePending, setIsAmountUpdatePending] = useState(false);
+  const isAmountUpdateInProgressRef = useRef(false);
+
+  const beginAmountUpdate = useCallback(() => {
+    if (isAmountUpdateInProgressRef.current) {
+      return false;
+    }
+
+    isAmountUpdateInProgressRef.current = true;
+    setIsAmountUpdatePending(true);
+    setStage(CustomAmountStage.Loading);
+    return true;
+  }, []);
+
+  const endAmountUpdate = useCallback(() => {
+    isAmountUpdateInProgressRef.current = false;
+    setIsAmountUpdatePending(false);
+  }, []);
 
   const isQuotesLoading = useIsTransactionPayQuoteLoading();
   const quotesLastUpdated = useTransactionPayQuotesLastUpdated();
@@ -77,6 +106,7 @@ export function useCustomAmountStage({
   // quote, not a stale one predating the amount update.
   const loadingBaselineRef = useRef<number | undefined>(undefined);
   const wasLoadingRef = useRef(false);
+  const settleOnCommitRef = useRef(false);
   // `amountFiat` from the previous commit, to recognise a no-op re-commit.
   const lastCommittedFiatRef = useRef<string | undefined>(undefined);
 
@@ -89,14 +119,16 @@ export function useCustomAmountStage({
    * amount. Compare the new amount against the *prior* commit ONLY here, before
    * overwriting the ref — a no-op re-commit fetches nothing, so clear at once.
    *
-   * Settle (later renders): clear on `hasFreshQuote` or `isQuotesLoading`. Key
-   * off *current* loading, not a latch: the controller pulses `isLoading` for
-   * an empty pre-fetch update before the real fetch, and a latch would clear in
-   * the gap and briefly derive `NoQuote`.
+   * Settle (later renders): after the amount commit resolves, clear on
+   * `hasFreshQuote` or `isQuotesLoading`. Key off *current* loading, not a
+   * latch: the controller pulses `isLoading` for an empty pre-fetch update
+   * before the real fetch, and a latch would clear in the gap and briefly
+   * derive `NoQuote`.
    */
   useEffect(() => {
     if (stageOverride !== CustomAmountStage.Loading) {
       wasLoadingRef.current = false;
+      settleOnCommitRef.current = false;
       return;
     }
 
@@ -106,14 +138,21 @@ export function useCustomAmountStage({
       wasLoadingRef.current = true;
       loadingBaselineRef.current = quotesLastUpdated;
       lastCommittedFiatRef.current = amountFiat;
+      settleOnCommitRef.current =
+        isNoOpRecommit || Boolean(disablePay) || hasPrefetchedQuote;
 
       // `disablePay` flows are direct transfers: no pay token, no quote, and the
-      // required-token amount may never resolve. There is nothing to await once
-      // the amount is committed, so settle on the arm frame itself — the settle
-      // branch below is never re-entered when no reactive input changes.
-      if (isNoOpRecommit || disablePay || hasPrefetchedQuote) {
+      // required-token amount may never resolve. Once the amount commit ends,
+      // there is nothing else to await. The same applies to no-op re-commits and
+      // amounts that already have a prefetched quote.
+      if (settleOnCommitRef.current && !isAmountUpdatePending) {
         setStage(null);
       }
+      return;
+    }
+
+    if (settleOnCommitRef.current && !isAmountUpdatePending) {
+      setStage(null);
       return;
     }
 
@@ -125,7 +164,11 @@ export function useCustomAmountStage({
       (loadingBaselineRef.current === undefined ||
         quotesLastUpdated > loadingBaselineRef.current);
 
-    if (hasAmount && (hasFreshQuote || isQuotesLoading)) {
+    if (
+      !isAmountUpdatePending &&
+      hasAmount &&
+      (hasFreshQuote || isQuotesLoading)
+    ) {
       setStage(null);
     }
   }, [
@@ -135,6 +178,7 @@ export function useCustomAmountStage({
     hasAmount,
     hasPrefetchedQuote,
     hasQuotes,
+    isAmountUpdatePending,
     isQuotesLoading,
     quotesLastUpdated,
   ]);
@@ -159,21 +203,35 @@ export function useCustomAmountStage({
     }
   }, [isDepositPrefillEnabled, skipDepositPrefill]);
 
-  // All hooks have run, so we can early-return. The override wins while set.
+  // The override wins while set. Otherwise derive from reactive inputs: stay
+  // in Loading while quotes fetch or a prefill preload resolves, show totals
+  // when quotes exist, or fall through to NoQuote after a settled empty fetch.
+  let stage: CustomAmountStage;
   if (stageOverride !== null) {
-    return { setStage, stage: stageOverride };
+    stage = stageOverride;
+  } else if (
+    (isQuotesLoading && !hasPrefetchedQuote) ||
+    isAwaitingPrefillResult
+  ) {
+    stage = CustomAmountStage.Loading;
+  } else if (showTotals) {
+    stage = CustomAmountStage.ShowTotals;
+  } else {
+    stage = CustomAmountStage.NoQuote;
   }
 
-  // Derive from reactive inputs. Stay in Loading while quotes fetch or a
-  // prefill preload resolves; otherwise show totals when quotes exist, or fall
-  // through to NoQuote when a settled fetch produced none.
-  if ((isQuotesLoading && !hasPrefetchedQuote) || isAwaitingPrefillResult) {
-    return { setStage, stage: CustomAmountStage.Loading };
-  }
+  // Keep the amount update active until its commit settles, even if an older
+  // quote request was already loading. Afterwards, remain active only until
+  // quote fetching takes over.
+  const isAmountUpdating =
+    stage === CustomAmountStage.Loading &&
+    (isAmountUpdatePending || !isQuotesLoading);
 
-  if (showTotals) {
-    return { setStage, stage: CustomAmountStage.ShowTotals };
-  }
-
-  return { setStage, stage: CustomAmountStage.NoQuote };
+  return {
+    beginAmountUpdate,
+    endAmountUpdate,
+    isAmountUpdating,
+    setStage,
+    stage,
+  };
 }


### PR DESCRIPTION
## **Description**

Follow-up to #34244 based on late review feedback.

`useCustomAmountStage` now returns `isAmountUpdating`, derived from the existing stage and quote-loading state. `CustomAmountInfo` no longer owns render state or subscribes to quote loading to interpret the loading phase; it retains only the synchronous ref needed to prevent duplicate submissions before React rerenders.

Review rows are blocked while the screen is in the pre-quote loading phase and become interactive once quote loading takes over. This behavior is generic across custom-amount confirmation flows, while amount editing and confirmation remain unavailable until the stage settles.

## **Changelog**

CHANGELOG entry: Fixed custom amount review controls remaining unavailable while quotes load

## **Related issues**

Refs: #34244

## **Manual testing steps**

```gherkin
Feature: Custom amount review-row loading behavior

  Scenario: Review rows become interactive when quote loading begins
    Given a user is entering a custom amount in a supported confirmation flow

    When the user submits the amount
    Then the review rows remain blocked before quote loading begins

    When quote loading begins
    Then the review rows become interactive
    And amount editing remains unavailable
    And confirmation remains disabled until quotes settle
```

## **Test evidence**

- `yarn jest app/components/Views/confirmations/hooks/custom-amount/useCustomAmountStage.test.ts --runInBand` — 25 passed
- `NODE_OPTIONS=--max-old-space-size=8192 yarn jest app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx --runInBand` — 94 passed
- Prettier on changed files — passed
- ESLint on changed files — no errors; existing deprecated-component warnings only

`yarn lint:tsc` is currently blocked by unrelated missing `app/util/termsOfUse/termsOfUseContent` imports on `main`.

## **Screenshots/Recordings**

N/A — state-management refactor with no visual changes.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Not applicable to this state-management refactor; behavior is covered by unit tests.
- [x] I've tested with a power user scenario
  - Considered rapid duplicate submissions and overlapping quote-loading state.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - Not applicable; no new key operation is introduced.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused confirmation UI state refactor with unit test coverage; no auth, payments execution, or broad architectural changes.
> 
> **Overview**
> **Moves custom-amount “pre-quote” loading into `useCustomAmountStage`** by returning **`isAmountUpdating`** (`Loading` while quotes are *not* yet loading). **`CustomAmountInfo`** drops local `isAmountUpdatePending` and **`useIsTransactionPayQuoteLoading`**; review-row blocking is now **`shouldBlockReviewRows = isAmountUpdating`** only.
> 
> **UX fix:** payment/review rows stay blocked while the amount update prepares, but become **interactive as soon as quote loading starts**—confirm and amount editing stay gated until the stage settles. Tests were updated for that behavior (including a rerender in one Money Account deposit case).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d12b87ff38a00dfb64c4b8cd69df1f0adb78906. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->