### PR TITLE
test: fix appium stale webview cdp cache

### DIFF
--- a/tests/framework/services/appium/softReloadApp.test.ts
+++ b/tests/framework/services/appium/softReloadApp.test.ts
@@ -5,6 +5,7 @@ import {
 } from './softReloadApp.ts';
 import type { CurrentDeviceDetails } from '../../fixtures/playwright';
 import AndroidWebViewCdpHelpers from '../../AndroidWebViewCdpHelpers.ts';
+import ChromeCdpHelpers from '../../ChromeCdpHelpers.ts';
 import PlaywrightUtilities from '../../PlaywrightUtilities.ts';
 import { shouldHandleMetroDevLauncherLocally } from '../../Constants.ts';
 import { switchToNativeContext } from './sessionHealth.ts';
@@ -18,6 +19,13 @@ jest.mock('../../AndroidWebViewCdpHelpers.ts', () => ({
   __esModule: true,
   default: {
     resetCache: jest.fn(),
+  },
+}));
+
+jest.mock('../../ChromeCdpHelpers.ts', () => ({
+  __esModule: true,
+  default: {
+    resetMetaMaskWebViewCache: jest.fn(),
   },
 }));
 
@@ -104,6 +112,7 @@ describe('softReloadAppForFixtures', () => {
     });
 
     expect(AndroidWebViewCdpHelpers.resetCache).toHaveBeenCalled();
+    expect(ChromeCdpHelpers.resetMetaMaskWebViewCache).toHaveBeenCalled();
     expect(clearAppData).toHaveBeenCalledTimes(1);
     expect(switchToNativeContextMock).toHaveBeenCalledWith(drv);
     expect(waitForNextStateRequest).toHaveBeenCalledWith(5_000);

--- a/tests/framework/services/appium/softReloadApp.ts
+++ b/tests/framework/services/appium/softReloadApp.ts
@@ -5,6 +5,7 @@ import {
   shouldHandleMetroDevLauncherLocally,
 } from '../../Constants.ts';
 import AndroidWebViewCdpHelpers from '../../AndroidWebViewCdpHelpers.ts';
+import ChromeCdpHelpers from '../../ChromeCdpHelpers.ts';
 import PlaywrightUtilities from '../../PlaywrightUtilities.ts';
 import { createPlaywrightLogger } from '../../playwrightLogger.ts';
 import { dismissDevelopmentServerPickerPlaywright } from '../../../flows/general.flow';
@@ -87,7 +88,9 @@ export async function softReloadAppForFixtures(
     drv = globalThis.driver,
   } = options;
 
+  // Both caches key on the WebView socket, whose name embeds the app pid.
   AndroidWebViewCdpHelpers.resetCache();
+  ChromeCdpHelpers.resetMetaMaskWebViewCache();
 
   let clearAppDataMs = 0;
   if (deviceCommands) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Fixes a flaky Appium Android smoke failure caused by a stale MetaMask in-app WebView CDP socket cache surviving an app restart.

**Reason for the change.** `ChromeCdpHelpers` caches the MetaMask WebView devtools socket name (`webview_devtools_remote_<pid>`) so the slow `mobile: getContexts` call runs at most once per test. That name embeds the WebView process id, so it is invalidated whenever the app is relaunched. Clearing it was left to individual page objects (`BitcoinTestDapp`, `SolanaTestDApp`, `MultichainTestDApp`, `multiple-provider-connections.spec`), so any spec that used `restartDevice: true` without calling `resetMetaMaskWebViewCache()` could keep using a dead socket. Because `adb forward` succeeds even against a dead abstract socket, the resolver returned a healthy-looking endpoint that served nothing, and the next CDP call blocked for the full `DAPP_PAGE_TIMEOUT_MS` (30s).

This surfaced in `tests/smoke-appium/multichain/network-abstraction/permission-system-remove.spec.ts` as `Timed out waiting for connect sheet after #connectButton click (attempts=1, lastClick=null, diagnostics=null)`. In the failing trace the WebView socket was resolved fresh at 09:12:46 (`@webview_devtools_remote_5611`), the app was cold-restarted at 09:13:23–09:13:25 (killing pid 5611), and the next test issued no `mobile: getContexts` at all before a 30.07s gap with zero WebDriver traffic — i.e. it took the cached branch against a dead socket.

**Solution.** Invalidate the cache where it actually goes stale — the app relaunch — rather than in each page object. `softReloadAppForFixtures` already clears the sibling `AndroidWebViewCdpHelpers` cache for the same reason, so `ChromeCdpHelpers.resetMetaMaskWebViewCache()` is now called alongside it. Every `restartDevice: true` spec gets a fresh socket automatically, with no per-spec bookkeeping and no change to the resolver itself.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

Refs: no tracking issue — found while analysing the Appium network-abstraction smoke failure on [PR #34353](https://github.com/MetaMask/metamask-mobile/actions/runs/31086613548/job/92570149556?pr=34353).

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — E2E framework-only change with no runtime app surface. Verified by the Appium Android smoke suites in CI plus the `softReloadApp` unit test.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

Failing Appium Android network-abstraction smoke run: https://github.com/MetaMask/metamask-mobile/actions/runs/31086613548/job/92570149556?pr=34353

```
[TestDApp] tapDappConnectButton timed out after 1 click attempt(s);
  lastClick=null; diagnostics=null
Error: Timed out waiting for connect sheet after #connectButton click
  (attempts=1, lastClick=null, diagnostics=null)
```

Relevant trace showing the socket resolved once, then reused after a cold restart:

```
09:12:46.515 COMMAND executeScript("mobile: getContexts")
09:12:47.362 RESULT [ { proc: '@webview_devtools_remote_5611', ... } ]
09:13:23–09:13:25 app terminated and cold-started (LaunchState: COLD)
09:14:10.2 → 09:14:40.3  (no getContexts, 30.07s with zero WebDriver traffic)
```

### **After**

Appium Android smoke jobs pass on this branch; the WebView socket is re-resolved after each soft reload.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
