### PR TITLE
fix(NetworkListBottomSheet): wrap FlashList in Box for better bottom sheet rendering

### DIFF
--- a/app/components/Views/AddAsset/components/NetworkListBottomSheet/NetworkListBottomSheet.tsx
+++ b/app/components/Views/AddAsset/components/NetworkListBottomSheet/NetworkListBottomSheet.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useMemo } from 'react';
-import type { ScrollViewProps } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { FlashList, type ListRenderItem } from '@shopify/flash-list';
 import BottomSheet, {
@@ -149,17 +148,19 @@ export default function NetworkListBottomSheet({
         }}
       />
 
-      <FlashList
-        data={filteredNetworkConfigurations}
-        renderItem={renderItem}
-        keyExtractor={keyExtractor}
+      <Box
         style={tw.style(
+          'grow shrink flex-row min-h-[200px]',
           `max-h-[${Math.round(Device.getDeviceHeight() * 0.7)}px]`,
         )}
-        renderScrollComponent={
-          ScrollView as React.ComponentType<ScrollViewProps>
-        }
-      />
+      >
+        <FlashList
+          data={filteredNetworkConfigurations}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          renderScrollComponent={ScrollView}
+        />
+      </Box>
     </BottomSheet>
   );
 }


### PR DESCRIPTION
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Bottom sheet failed to fully open due to this performance ticket to move to FlashList
https://consensyssoftware.atlassian.net/browse/ASSETS-3729

Fix was to move the styling to the a view wrapper (the flashlist itself does not apply size styling)

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix(NetworkListBottomSheet): wrap FlashList in Box for better bottom sheet rendering

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3729

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="389" height="842" alt="Screenshot 2026-08-06 at 4 15 52 PM" src="https://github.com/user-attachments/assets/444d0c11-aa49-4f2e-a4b2-26635326d843" />

### **After**

https://www.loom.com/share/b19d4fd119fb4a3d8ed4626b315bb51c

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized layout change in the network selector bottom sheet with no auth, data, or API impact.
> 
> **Overview**
> Fixes the **Add Asset** network picker bottom sheet not opening fully after switching the list to **FlashList** (ASSETS-3729).
> 
> The list is now wrapped in a **`Box`** with `grow`/`shrink`, a **200px** minimum height, and a **70%** screen max height so the sheet can measure and lay out correctly. **`renderScrollComponent`** is simplified to pass **`ScrollView`** directly, and the unused **`ScrollViewProps`** import is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cdf37777fa2fef084f5e4240ef68f0e55034978. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->