### PR TITLE
feat(ramps): attribute PayPal quote fetch CUF outcomes (TRAM-3805)

### DIFF
--- a/app/components/UI/BalanceEmptyState/BalanceEmptyState.tsx
+++ b/app/components/UI/BalanceEmptyState/BalanceEmptyState.tsx
@@ -22,6 +22,7 @@ import { getDecimalChainId } from '../../../util/networks';
 import { selectChainId } from '../../../selectors/networkController';
 import { trace, TraceName } from '../../../util/trace';
 import { useRampNavigation } from '../Ramp/hooks/useRampNavigation';
+import { RAMPS_BUY_CUF_SURFACE } from '../Ramp/constants/rampsBuyCufTags';
 import { BalanceEmptyStateProps } from './BalanceEmptyState.types';
 import bankTransferImage from '../../../images/bank-transfer.png';
 import { getDetectedGeolocation } from '../../../reducers/fiatOrders';
@@ -43,7 +44,7 @@ const BalanceEmptyState: React.FC<BalanceEmptyStateProps> = ({
   const buttonClickData = useRampsButtonClickData();
 
   const handleAction = () => {
-    goToBuy();
+    goToBuy(undefined, { surface: RAMPS_BUY_CUF_SURFACE.EMPTY_STATE });
 
     trackEvent(
       createEventBuilder(MetaMetricsEvents.RAMPS_BUTTON_CLICKED)

--- a/app/components/UI/Card/components/AddFundsBottomSheet/AddFundsBottomSheet.test.tsx
+++ b/app/components/UI/Card/components/AddFundsBottomSheet/AddFundsBottomSheet.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent } from '@testing-library/react-native';
+import { act, fireEvent } from '@testing-library/react-native';
 import AddFundsBottomSheet from './AddFundsBottomSheet';
 import { useOpenSwaps } from '../../hooks/useOpenSwaps';
 import useDepositEnabled from '../../../Ramp/hooks/useDepositEnabled';
@@ -220,10 +220,12 @@ describe('AddFundsBottomSheet', () => {
     expect(getByText('Swap tokens into USDC on Linea')).toBeTruthy();
   });
 
-  it('tracks analytics and trace with UNIFIED_BUY_2 ramp_type when Fund with cash is pressed', () => {
+  it('tracks analytics and trace with UNIFIED_BUY_2 ramp_type when Fund with cash is pressed', async () => {
     const { getByText } = setupComponent();
 
-    fireEvent.press(getByText('Fund with cash'));
+    await act(async () => {
+      fireEvent.press(getByText('Fund with cash'));
+    });
 
     expect(mockCreateEventBuilder).toHaveBeenCalledWith(
       MetaMetricsEvents.CARD_ADD_FUNDS_DEPOSIT_CLICKED,
@@ -248,10 +250,12 @@ describe('AddFundsBottomSheet', () => {
     });
   });
 
-  it('handles swap option press correctly', () => {
+  it('handles swap option press correctly', async () => {
     const { getByText } = setupComponent();
 
-    fireEvent.press(getByText('Fund with crypto'));
+    await act(async () => {
+      fireEvent.press(getByText('Fund with crypto'));
+    });
 
     expect(mockOpenSwaps).toHaveBeenCalledWith({
       beforeNavigate: expect.any(Function),
@@ -317,14 +321,13 @@ describe('AddFundsBottomSheet', () => {
     expect(getByText('Swap tokens into ETH on Linea')).toBeTruthy();
   });
 
-  it('routes Fund with cash through goToBuy (UB2-aware) with the priority token CAIP-19 assetId', () => {
+  it('routes Fund with cash through goToBuy (UB2-aware) with the priority token CAIP-19 assetId', async () => {
     const { getByText } = setupComponent();
 
-    fireEvent.press(getByText('Fund with cash'));
+    await act(async () => {
+      fireEvent.press(getByText('Fund with cash'));
+    });
 
-    // goToBuy is the smart router in useRampNavigation; when V2 is enabled
-    // (default for this suite), it dispatches to UB2 (BuildQuote). See
-    // useRampNavigation.test.ts > 'goToBuy > when unified V2 is enabled'.
     expect(mockGoToBuy).toHaveBeenCalledWith(
       {
         assetId: `${mockPriorityToken.caipChainId}/erc20:${mockPriorityToken.address}`,
@@ -333,9 +336,7 @@ describe('AddFundsBottomSheet', () => {
     );
   });
 
-  it('falls back to goToBuy() with no intent when the priority token has no address', () => {
-    // No assetId → useRampNavigation routes UB2 to TokenSelection
-    // (see useRampNavigation.ts, 'V2: If no assetId and V2 is enabled').
+  it('falls back to goToBuy() with no intent when the priority token has no address', async () => {
     const tokenWithoutAddress: CardFundingToken = {
       ...mockPriorityToken,
       address: null,
@@ -343,7 +344,9 @@ describe('AddFundsBottomSheet', () => {
 
     const { getByText } = setupComponent(tokenWithoutAddress);
 
-    fireEvent.press(getByText('Fund with cash'));
+    await act(async () => {
+      fireEvent.press(getByText('Fund with cash'));
+    });
 
     expect(mockGoToBuy).toHaveBeenCalledWith(undefined, { surface: 'card' });
   });

--- a/app/components/UI/Card/components/AddFundsBottomSheet/AddFundsBottomSheet.test.tsx
+++ b/app/components/UI/Card/components/AddFundsBottomSheet/AddFundsBottomSheet.test.tsx
@@ -325,10 +325,12 @@ describe('AddFundsBottomSheet', () => {
     // goToBuy is the smart router in useRampNavigation; when V2 is enabled
     // (default for this suite), it dispatches to UB2 (BuildQuote). See
     // useRampNavigation.test.ts > 'goToBuy > when unified V2 is enabled'.
-    expect(mockGoToBuy).toHaveBeenCalledTimes(1);
-    expect(mockGoToBuy).toHaveBeenCalledWith({
-      assetId: `${mockPriorityToken.caipChainId}/erc20:${mockPriorityToken.address}`,
-    });
+    expect(mockGoToBuy).toHaveBeenCalledWith(
+      {
+        assetId: `${mockPriorityToken.caipChainId}/erc20:${mockPriorityToken.address}`,
+      },
+      { surface: 'card' },
+    );
   });
 
   it('falls back to goToBuy() with no intent when the priority token has no address', () => {
@@ -343,8 +345,7 @@ describe('AddFundsBottomSheet', () => {
 
     fireEvent.press(getByText('Fund with cash'));
 
-    expect(mockGoToBuy).toHaveBeenCalledTimes(1);
-    expect(mockGoToBuy).toHaveBeenCalledWith(undefined);
+    expect(mockGoToBuy).toHaveBeenCalledWith(undefined, { surface: 'card' });
   });
 
   it('renders component correctly', () => {

--- a/app/components/UI/Card/components/AddFundsBottomSheet/AddFundsBottomSheet.tsx
+++ b/app/components/UI/Card/components/AddFundsBottomSheet/AddFundsBottomSheet.tsx
@@ -32,6 +32,7 @@ import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { strings } from '../../../../../../locales/i18n';
 import { CardHomeSelectors } from '../../Views/CardHome/CardHome.testIds';
 import { useRampNavigation } from '../../../Ramp/hooks/useRampNavigation';
+import { RAMPS_BUY_CUF_SURFACE } from '../../../Ramp/constants/rampsBuyCufTags';
 import { safeFormatChainIdToHex } from '../../util/safeFormatChainIdToHex';
 import { getDetectedGeolocation } from '../../../../../reducers/fiatOrders';
 import { useRampsButtonClickData } from '../../../Ramp/hooks/useRampsButtonClickData';
@@ -88,7 +89,9 @@ const AddFundsBottomSheet: React.FC = () => {
         : undefined;
 
     closeBottomSheetAndNavigate(() => {
-      goToBuy(assetId ? { assetId } : undefined);
+      goToBuy(assetId ? { assetId } : undefined, {
+        surface: RAMPS_BUY_CUF_SURFACE.CARD,
+      });
     });
     trackEvent(
       createEventBuilder(

--- a/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnMusdConversionEducationView/index.tsx
@@ -46,6 +46,7 @@ import {
 import { useMusdConversionFlowData } from '../../hooks/useMusdConversionFlowData';
 import Routes from '../../../../../constants/navigation/Routes';
 import { useRampNavigation } from '../../../Ramp/hooks/useRampNavigation';
+import { RAMPS_BUY_CUF_SURFACE } from '../../../Ramp/constants/rampsBuyCufTags';
 import { RampIntent } from '../../../Ramp/types';
 import { EARN_TEST_IDS } from '../../constants/testIds';
 import { MusdNavigationTarget } from '../../types/musd.types';
@@ -325,7 +326,7 @@ const EarnMusdConversionEducationView = () => {
           const rampIntent: RampIntent = {
             assetId: MUSD_TOKEN_ASSET_ID_BY_CHAIN[chainId],
           };
-          goToBuy(rampIntent);
+          goToBuy(rampIntent, { surface: RAMPS_BUY_CUF_SURFACE.DEEP_LINK });
           return;
         }
 

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.test.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/MusdConversionAssetListCta.test.tsx
@@ -313,9 +313,13 @@ describe('MusdConversionAssetListCta', () => {
 
       fireEvent.press(getByText('Buy mUSD'));
 
-      expect(mockGoToBuy).toHaveBeenCalledWith({
-        assetId: MUSD_TOKEN_ASSET_ID_BY_CHAIN[MUSD_CONVERSION_DEFAULT_CHAIN_ID],
-      });
+      expect(mockGoToBuy).toHaveBeenCalledWith(
+        {
+          assetId:
+            MUSD_TOKEN_ASSET_ID_BY_CHAIN[MUSD_CONVERSION_DEFAULT_CHAIN_ID],
+        },
+        { surface: 'earn' },
+      );
     });
 
     it('calls goToBuy when earn percentage text is pressed', () => {
@@ -330,9 +334,13 @@ describe('MusdConversionAssetListCta', () => {
       const bonusTextElement = getByText(bonusText);
       fireEvent.press(bonusTextElement.parent as never);
 
-      expect(mockGoToBuy).toHaveBeenCalledWith({
-        assetId: MUSD_TOKEN_ASSET_ID_BY_CHAIN[MUSD_CONVERSION_DEFAULT_CHAIN_ID],
-      });
+      expect(mockGoToBuy).toHaveBeenCalledWith(
+        {
+          assetId:
+            MUSD_TOKEN_ASSET_ID_BY_CHAIN[MUSD_CONVERSION_DEFAULT_CHAIN_ID],
+        },
+        { surface: 'earn' },
+      );
     });
 
     it('does not call initiateCustomConversion when wallet is empty', () => {

--- a/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/index.tsx
+++ b/app/components/UI/Earn/components/Musd/MusdConversionAssetListCta/index.tsx
@@ -16,6 +16,7 @@ import {
   MUSD_TOKEN_ASSET_ID_BY_CHAIN,
 } from '../../../constants/musd';
 import { useRampNavigation } from '../../../../Ramp/hooks/useRampNavigation';
+import { RAMPS_BUY_CUF_SURFACE } from '../../../../Ramp/constants/rampsBuyCufTags';
 import { RampIntent } from '../../../../Ramp/types';
 import { strings } from '../../../../../../../locales/i18n';
 import { EARN_TEST_IDS } from '../../../constants/testIds';
@@ -116,7 +117,7 @@ const MusdConversionAssetListCta = () => {
       const rampIntent: RampIntent = {
         assetId: MUSD_TOKEN_ASSET_ID_BY_CHAIN[chainId],
       };
-      goToBuy(rampIntent);
+      goToBuy(rampIntent, { surface: RAMPS_BUY_CUF_SURFACE.EARN });
       return;
     }
 

--- a/app/components/UI/FundActionMenu/FundActionMenu.test.tsx
+++ b/app/components/UI/FundActionMenu/FundActionMenu.test.tsx
@@ -205,9 +205,12 @@ describe('FundActionMenu', () => {
       );
 
       await waitFor(() => {
-        expect(mockGoToBuy).toHaveBeenCalledWith({
-          assetId: 'eip155:1/slip44:60',
-        });
+        expect(mockGoToBuy).toHaveBeenCalledWith(
+          {
+            assetId: 'eip155:1/slip44:60',
+          },
+          { surface: 'fund_menu' },
+        );
       });
     });
 
@@ -264,9 +267,12 @@ describe('FundActionMenu', () => {
       );
 
       await waitFor(() => {
-        expect(mockGoToBuy).toHaveBeenCalledWith({
-          assetId: 'eip155:137/slip44:60',
-        });
+        expect(mockGoToBuy).toHaveBeenCalledWith(
+          {
+            assetId: 'eip155:137/slip44:60',
+          },
+          { surface: 'fund_menu' },
+        );
       });
     });
 
@@ -282,9 +288,12 @@ describe('FundActionMenu', () => {
       );
 
       await waitFor(() => {
-        expect(mockGoToBuy).toHaveBeenCalledWith({
-          assetId: undefined,
-        });
+        expect(mockGoToBuy).toHaveBeenCalledWith(
+          {
+            assetId: undefined,
+          },
+          { surface: 'fund_menu' },
+        );
       });
     });
 
@@ -397,9 +406,12 @@ describe('FundActionMenu', () => {
       );
 
       await waitFor(() => {
-        expect(mockGoToBuy).toHaveBeenCalledWith({
-          assetId: undefined,
-        });
+        expect(mockGoToBuy).toHaveBeenCalledWith(
+          {
+            assetId: undefined,
+          },
+          { surface: 'fund_menu' },
+        );
       });
     });
 
@@ -418,9 +430,12 @@ describe('FundActionMenu', () => {
       );
 
       await waitFor(() => {
-        expect(mockGoToBuy).toHaveBeenCalledWith({
-          assetId: undefined,
-        });
+        expect(mockGoToBuy).toHaveBeenCalledWith(
+          {
+            assetId: undefined,
+          },
+          { surface: 'fund_menu' },
+        );
       });
     });
   });

--- a/app/components/UI/FundActionMenu/FundActionMenu.test.tsx
+++ b/app/components/UI/FundActionMenu/FundActionMenu.test.tsx
@@ -206,9 +206,7 @@ describe('FundActionMenu', () => {
 
       await waitFor(() => {
         expect(mockGoToBuy).toHaveBeenCalledWith(
-          {
-            assetId: 'eip155:1/slip44:60',
-          },
+          { assetId: 'eip155:1/slip44:60' },
           { surface: 'fund_menu' },
         );
       });
@@ -268,9 +266,7 @@ describe('FundActionMenu', () => {
 
       await waitFor(() => {
         expect(mockGoToBuy).toHaveBeenCalledWith(
-          {
-            assetId: 'eip155:137/slip44:60',
-          },
+          { assetId: 'eip155:137/slip44:60' },
           { surface: 'fund_menu' },
         );
       });
@@ -289,9 +285,7 @@ describe('FundActionMenu', () => {
 
       await waitFor(() => {
         expect(mockGoToBuy).toHaveBeenCalledWith(
-          {
-            assetId: undefined,
-          },
+          { assetId: undefined },
           { surface: 'fund_menu' },
         );
       });
@@ -407,9 +401,7 @@ describe('FundActionMenu', () => {
 
       await waitFor(() => {
         expect(mockGoToBuy).toHaveBeenCalledWith(
-          {
-            assetId: undefined,
-          },
+          { assetId: undefined },
           { surface: 'fund_menu' },
         );
       });
@@ -431,9 +423,7 @@ describe('FundActionMenu', () => {
 
       await waitFor(() => {
         expect(mockGoToBuy).toHaveBeenCalledWith(
-          {
-            assetId: undefined,
-          },
+          { assetId: undefined },
           { surface: 'fund_menu' },
         );
       });

--- a/app/components/UI/FundActionMenu/FundActionMenu.tsx
+++ b/app/components/UI/FundActionMenu/FundActionMenu.tsx
@@ -24,6 +24,7 @@ import { trace, TraceName } from '../../../util/trace';
 import { selectCanSignTransactions } from '../../../selectors/accountsController';
 import { RampType } from '../../../reducers/fiatOrders/types';
 import { useRampNavigation } from '../Ramp/hooks/useRampNavigation';
+import { RAMPS_BUY_CUF_SURFACE } from '../Ramp/constants/rampsBuyCufTags';
 
 // Types
 import type {
@@ -124,7 +125,10 @@ const FundActionMenu = () => {
             if (customOnBuy) {
               customOnBuy();
             } else {
-              goToBuy({ assetId: assetContext?.assetId });
+              goToBuy(
+                { assetId: assetContext?.assetId },
+                { surface: RAMPS_BUY_CUF_SURFACE.FUND_MENU },
+              );
             }
           },
           traceName: TraceName.LoadRampExperience,

--- a/app/components/UI/Ramp/Aggregator/Views/OrdersList/OrdersList.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/OrdersList/OrdersList.test.tsx
@@ -338,6 +338,8 @@ describe('OrdersList', () => {
     fireEvent.press(screen.getByRole('button', { name: 'Purchased' }));
     fireEvent.press(screen.getByRole('button', { name: /Purchased USDT/ }));
 
-    expect(mockGoToBuy).toHaveBeenCalledWith();
+    expect(mockGoToBuy).toHaveBeenCalledWith(undefined, {
+      surface: 'orders_list',
+    });
   });
 });

--- a/app/components/UI/Ramp/Aggregator/Views/OrdersList/OrdersList.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/OrdersList/OrdersList.tsx
@@ -11,6 +11,7 @@ import { createOrderDetailsNavDetails } from '../OrderDetails/OrderDetails';
 import { createRampsOrderDetailsNavDetails } from '../../../Views/OrderDetails';
 import { createDepositOrderDetailsNavDetails } from '../../../Views/OrderDetails/DepositOrderDetails/DepositOrderDetails';
 import { useRampNavigation } from '../../../hooks/useRampNavigation';
+import { RAMPS_BUY_CUF_SURFACE } from '../../../constants/rampsBuyCufTags';
 import createStyles from './OrdersList.styles';
 import { TabEmptyState } from '../../../../../../component-library/components-temp/TabEmptyState';
 
@@ -241,7 +242,7 @@ function OrdersList() {
         order?.state === FIAT_ORDER_STATES.CREATED &&
         order?.provider === FIAT_ORDER_PROVIDERS.DEPOSIT
       ) {
-        goToBuy();
+        goToBuy(undefined, { surface: RAMPS_BUY_CUF_SURFACE.ORDERS_LIST });
       } else if (order?.provider === FIAT_ORDER_PROVIDERS.DEPOSIT) {
         navigateWithDetails(
           navigation,

--- a/app/components/UI/Ramp/Views/NativeFlow/BankDetails.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/BankDetails.tsx
@@ -39,6 +39,9 @@ import { selectTokens } from '../../../../../selectors/rampsController';
 import { parseUserFacingError } from '../../utils/parseUserFacingError';
 import { useRampsOrders } from '../../hooks/useRampsOrders';
 import { useSelector } from 'react-redux';
+import { endOpenRampsBuyCufChildrenByName } from '../../utils/rampsBuyCufTrace';
+import { RAMPS_BUY_CUF_TAG } from '../../constants/rampsBuyCufTags';
+import { TraceName } from '../../../../../util/trace';
 import { BANK_DETAILS_TEST_IDS } from './BankDetails.testIds';
 import { isHttpUnauthorized } from '../../utils/isHttpUnauthorized';
 
@@ -145,6 +148,10 @@ const V2BankDetails = () => {
       TERMINAL_STATUSES.has(order.status) ||
       order.status === RampsOrderStatus.Pending
     ) {
+      endOpenRampsBuyCufChildrenByName(TraceName.RampBuyNativeToOrderCreated, {
+        [RAMPS_BUY_CUF_TAG.SUCCESS]: true,
+        orderId: order.providerOrderId,
+      });
       // @ts-expect-error navigation prop mismatch
       navigation.replace(Routes.RAMP.RAMPS_ORDER_DETAILS, {
         orderId: order.providerOrderId,

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
@@ -44,6 +44,12 @@ import { showV2OrderToast } from '../../utils/v2OrderToast';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { RampsOrderDetailsSelectorsIDs } from './OrderDetails.testIds';
+import { endRampsBuyCufTrace } from '../../utils/rampsBuyCufTrace';
+import {
+  RAMPS_BUY_CUF_BOUNDARY,
+  RAMPS_BUY_CUF_END_REASON,
+  RAMPS_BUY_CUF_TAG,
+} from '../../constants/rampsBuyCufTags';
 
 export const createRampsOrderDetailsNavDetails =
   createNavigationDetails<RampsOrderDetailsParams>(
@@ -107,6 +113,12 @@ const OrderDetails = () => {
           walletAddress,
         );
         if (!fetchedOrder || isBailedOrderStatus(fetchedOrder.status)) {
+          endRampsBuyCufTrace({
+            data: {
+              [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+              [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.BAILED,
+            },
+          });
           resetWithRoutes(navigation, {
             index: 0,
             routes: getNavigateAfterExternalBrowserRoutes({
@@ -193,6 +205,7 @@ const OrderDetails = () => {
   ]);
 
   const hasTrackedScreenView = useRef(false);
+  const hasEndedBuyCuf = useRef(false);
   useEffect(() => {
     if (order && !hasTrackedScreenView.current) {
       hasTrackedScreenView.current = true;
@@ -206,6 +219,21 @@ const OrderDetails = () => {
       );
     }
   }, [order, createEventBuilder, trackEvent]);
+
+  // Buy E2E CUF success boundary: order is known and Order Details is shown.
+  useEffect(() => {
+    if (!order || hasEndedBuyCuf.current) {
+      return;
+    }
+    hasEndedBuyCuf.current = true;
+    endRampsBuyCufTrace({
+      data: {
+        [RAMPS_BUY_CUF_TAG.SUCCESS]: true,
+        [RAMPS_BUY_CUF_TAG.BOUNDARY]: RAMPS_BUY_CUF_BOUNDARY.ORDER_DETAILS,
+        orderId: order.providerOrderId,
+      },
+    });
+  }, [order]);
 
   const handleOnRefresh = useCallback(async () => {
     if (!order) return;

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
@@ -220,7 +220,6 @@ const OrderDetails = () => {
     }
   }, [order, createEventBuilder, trackEvent]);
 
-  // Buy E2E CUF success boundary: order is known and Order Details is shown.
   useEffect(() => {
     if (!order || hasEndedBuyCuf.current) {
       return;

--- a/app/components/UI/Ramp/constants/rampsBuyCufTags.ts
+++ b/app/components/UI/Ramp/constants/rampsBuyCufTags.ts
@@ -34,11 +34,9 @@ export const RAMPS_BUY_CUF_PATH = {
   WIDGET: 'widget',
   NATIVE: 'native',
 } as const;
-
 export const RAMPS_BUY_CUF_BOUNDARY = {
   ORDER_DETAILS: 'order_details',
 } as const;
-
 export const RAMPS_BUY_CUF_END_REASON = {
   SUPERSEDED: 'superseded',
   TIMEOUT: 'timeout',
@@ -48,5 +46,4 @@ export const RAMPS_BUY_CUF_END_REASON = {
   ABANDONED: 'abandoned',
   HEADLESS: 'headless',
 } as const;
-
 export const RAMPS_BUY_CUF_TIMEOUT_MS = 10 * 60 * 1000;

--- a/app/components/UI/Ramp/constants/rampsBuyCufTags.ts
+++ b/app/components/UI/Ramp/constants/rampsBuyCufTags.ts
@@ -1,3 +1,5 @@
+import { TRACES_CLEANUP_INTERVAL } from '../../../../util/trace';
+
 export const RAMPS_BUY_CUF_TAG = {
   FEATURE: 'feature',
   SURFACE: 'surface',
@@ -46,4 +48,5 @@ export const RAMPS_BUY_CUF_END_REASON = {
   ABANDONED: 'abandoned',
   HEADLESS: 'headless',
 } as const;
-export const RAMPS_BUY_CUF_TIMEOUT_MS = 10 * 60 * 1000;
+/** Must not exceed `TRACES_CLEANUP_INTERVAL` or Sentry ends the span first. */
+export const RAMPS_BUY_CUF_TIMEOUT_MS = TRACES_CLEANUP_INTERVAL;

--- a/app/components/UI/Ramp/constants/rampsBuyCufTags.ts
+++ b/app/components/UI/Ramp/constants/rampsBuyCufTags.ts
@@ -8,6 +8,8 @@ export const RAMPS_BUY_CUF_TAG = {
   REASON: 'reason',
   BOUNDARY: 'boundary',
   RAMP_TYPE: 'ramp_type',
+  PROVIDER: 'provider',
+  CUSTOM_ACTION: 'custom_action',
 } as const;
 
 export const RAMPS_BUY_CUF_FEATURE = 'buy';
@@ -35,6 +37,7 @@ export type RampsBuyCufSurface =
 export const RAMPS_BUY_CUF_PATH = {
   WIDGET: 'widget',
   NATIVE: 'native',
+  CUSTOM_ACTION: 'custom_action',
 } as const;
 export const RAMPS_BUY_CUF_BOUNDARY = {
   ORDER_DETAILS: 'order_details',
@@ -47,6 +50,7 @@ export const RAMPS_BUY_CUF_END_REASON = {
   CANCELLED: 'cancelled',
   ABANDONED: 'abandoned',
   HEADLESS: 'headless',
+  NO_QUOTE: 'no_quote',
 } as const;
 /** Must not exceed `TRACES_CLEANUP_INTERVAL` or Sentry ends the span first. */
 export const RAMPS_BUY_CUF_TIMEOUT_MS = TRACES_CLEANUP_INTERVAL;

--- a/app/components/UI/Ramp/constants/rampsBuyCufTags.ts
+++ b/app/components/UI/Ramp/constants/rampsBuyCufTags.ts
@@ -1,0 +1,54 @@
+/** Sentry tag / span-attribute keys for Unified Buy CUF spans (TRAM-3779). */
+export const RAMPS_BUY_CUF_TAG = {
+  FEATURE: 'feature',
+  SURFACE: 'surface',
+  PATH: 'path',
+  SUCCESS: 'success',
+  REASON: 'reason',
+  BOUNDARY: 'boundary',
+  RAMP_TYPE: 'ramp_type',
+} as const;
+
+/** Feature tag value for Buy CUF spans (dashboard filter). */
+export const RAMPS_BUY_CUF_FEATURE = 'buy';
+
+/** Entry-surface tag values for the Buy E2E parent span. */
+export const RAMPS_BUY_CUF_SURFACE = {
+  FUND_MENU: 'fund_menu',
+  EMPTY_STATE: 'empty_state',
+  DEEP_LINK: 'deep_link',
+  TOKEN_BUY: 'token_buy',
+  HOME_TOKEN_LIST: 'home_token_list',
+  UNKNOWN: 'unknown',
+} as const;
+
+export type RampsBuyCufSurface =
+  (typeof RAMPS_BUY_CUF_SURFACE)[keyof typeof RAMPS_BUY_CUF_SURFACE];
+
+/** Widget vs native happy-path tag values. */
+export const RAMPS_BUY_CUF_PATH = {
+  WIDGET: 'widget',
+  NATIVE: 'native',
+} as const;
+
+/** Which surface closed the Buy E2E CUF span. */
+export const RAMPS_BUY_CUF_BOUNDARY = {
+  ORDER_DETAILS: 'order_details',
+} as const;
+
+/** Terminal reasons when the Buy E2E (or a child) ends as unsuccessful. */
+export const RAMPS_BUY_CUF_END_REASON = {
+  SUPERSEDED: 'superseded',
+  TIMEOUT: 'timeout',
+  BAILED: 'bailed',
+  ERROR: 'error',
+  CANCELLED: 'cancelled',
+  ABANDONED: 'abandoned',
+  HEADLESS: 'headless',
+} as const;
+
+/**
+ * How long the Buy E2E parent may stay open before a fallback end.
+ * Buy can include KYC / bank steps, so this is longer than Perps stream CUFs.
+ */
+export const RAMPS_BUY_CUF_TIMEOUT_MS = 10 * 60 * 1000;

--- a/app/components/UI/Ramp/constants/rampsBuyCufTags.ts
+++ b/app/components/UI/Ramp/constants/rampsBuyCufTags.ts
@@ -19,8 +19,14 @@ export const RAMPS_BUY_CUF_SURFACE = {
   DEEP_LINK: 'deep_link',
   TOKEN_BUY: 'token_buy',
   HOME_TOKEN_LIST: 'home_token_list',
-  /** Homepage action grid Buy / onboarding "Add funds" entry. */
   HOME: 'home',
+  ACCOUNTS_MENU: 'accounts_menu',
+  ACTIVITY: 'activity',
+  CONFIRMATION: 'confirmation',
+  CARD: 'card',
+  ORDERS_LIST: 'orders_list',
+  CASH: 'cash',
+  EARN: 'earn',
   UNKNOWN: 'unknown',
 } as const;
 

--- a/app/components/UI/Ramp/constants/rampsBuyCufTags.ts
+++ b/app/components/UI/Ramp/constants/rampsBuyCufTags.ts
@@ -1,4 +1,3 @@
-/** Sentry tag / span-attribute keys for Unified Buy CUF spans (TRAM-3779). */
 export const RAMPS_BUY_CUF_TAG = {
   FEATURE: 'feature',
   SURFACE: 'surface',
@@ -9,10 +8,8 @@ export const RAMPS_BUY_CUF_TAG = {
   RAMP_TYPE: 'ramp_type',
 } as const;
 
-/** Feature tag value for Buy CUF spans (dashboard filter). */
 export const RAMPS_BUY_CUF_FEATURE = 'buy';
 
-/** Entry-surface tag values for the Buy E2E parent span. */
 export const RAMPS_BUY_CUF_SURFACE = {
   FUND_MENU: 'fund_menu',
   EMPTY_STATE: 'empty_state',
@@ -33,18 +30,15 @@ export const RAMPS_BUY_CUF_SURFACE = {
 export type RampsBuyCufSurface =
   (typeof RAMPS_BUY_CUF_SURFACE)[keyof typeof RAMPS_BUY_CUF_SURFACE];
 
-/** Widget vs native happy-path tag values. */
 export const RAMPS_BUY_CUF_PATH = {
   WIDGET: 'widget',
   NATIVE: 'native',
 } as const;
 
-/** Which surface closed the Buy E2E CUF span. */
 export const RAMPS_BUY_CUF_BOUNDARY = {
   ORDER_DETAILS: 'order_details',
 } as const;
 
-/** Terminal reasons when the Buy E2E (or a child) ends as unsuccessful. */
 export const RAMPS_BUY_CUF_END_REASON = {
   SUPERSEDED: 'superseded',
   TIMEOUT: 'timeout',
@@ -55,8 +49,4 @@ export const RAMPS_BUY_CUF_END_REASON = {
   HEADLESS: 'headless',
 } as const;
 
-/**
- * How long the Buy E2E parent may stay open before a fallback end.
- * Buy can include KYC / bank steps, so this is longer than Perps stream CUFs.
- */
 export const RAMPS_BUY_CUF_TIMEOUT_MS = 10 * 60 * 1000;

--- a/app/components/UI/Ramp/constants/rampsBuyCufTags.ts
+++ b/app/components/UI/Ramp/constants/rampsBuyCufTags.ts
@@ -19,6 +19,8 @@ export const RAMPS_BUY_CUF_SURFACE = {
   DEEP_LINK: 'deep_link',
   TOKEN_BUY: 'token_buy',
   HOME_TOKEN_LIST: 'home_token_list',
+  /** Homepage action grid Buy / onboarding "Add funds" entry. */
+  HOME: 'home',
   UNKNOWN: 'unknown',
 } as const;
 

--- a/app/components/UI/Ramp/deeplink/handleRampUrl.test.ts
+++ b/app/components/UI/Ramp/deeplink/handleRampUrl.test.ts
@@ -7,6 +7,7 @@ import { UNKNOWN_LOCATION } from '@metamask/geolocation-controller';
 import type { Country, UserRegion } from '@metamask/ramps-controller';
 import Engine from '../../../../core/Engine';
 import ReduxService from '../../../../core/redux';
+import { backgroundState } from '../../../../util/test/initial-root-state';
 
 jest.mock('../../../../core/NavigationService', () => ({
   navigation: {
@@ -21,7 +22,7 @@ jest.mock('../../../../core/redux', () => ({
   __esModule: true,
   default: {
     store: {
-      getState: jest.fn(() => ({})),
+      getState: jest.fn(),
     },
   },
 }));
@@ -148,6 +149,11 @@ describe('handleRampUrl', () => {
     jest.clearAllMocks();
     (NavigationService.navigation.navigate as jest.Mock).mockClear();
     (handleRedirection as jest.Mock).mockClear();
+    jest.mocked(ReduxService.store.getState).mockReturnValue({
+      engine: {
+        backgroundState,
+      },
+    } as ReturnType<typeof ReduxService.store.getState>);
     mockSelectGeolocationLocation.mockReturnValue('us-ca');
     mockSelectUserRegion.mockReturnValue(null);
     mockSelectCountries.mockReturnValue({ data: [] });

--- a/app/components/UI/Ramp/deeplink/handleRampUrl.test.ts
+++ b/app/components/UI/Ramp/deeplink/handleRampUrl.test.ts
@@ -137,6 +137,12 @@ jest.mock('../../../../core/Engine', () => ({
 const mockRefreshGeolocation = Engine.context.GeolocationController
   .refreshGeolocation as jest.Mock;
 
+const mockStartRampsBuyCufTrace = jest.fn();
+jest.mock('../utils/rampsBuyCufTrace', () => ({
+  startRampsBuyCufTrace: (...args: unknown[]) =>
+    mockStartRampsBuyCufTrace(...args),
+}));
+
 describe('handleRampUrl', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -207,6 +213,7 @@ describe('handleRampUrl', () => {
       expect(NavigationService.navigation.navigate).toHaveBeenCalledWith(
         'ELIGIBILITY_FAILED_MODAL_ROUTE',
       );
+      expect(mockStartRampsBuyCufTrace).not.toHaveBeenCalled();
     });
 
     it('continues to TokenSelection when geolocation refresh resolves a known region', async () => {
@@ -224,6 +231,9 @@ describe('handleRampUrl', () => {
       expect(NavigationService.navigation.navigate).toHaveBeenCalledWith(
         'TOKEN_SELECTION_ROUTE',
       );
+      expect(mockStartRampsBuyCufTrace).toHaveBeenCalledWith({
+        surface: 'deep_link',
+      });
     });
 
     it('does not refresh geolocation when a known location is already in state', async () => {

--- a/app/components/UI/Ramp/deeplink/handleRampUrl.ts
+++ b/app/components/UI/Ramp/deeplink/handleRampUrl.ts
@@ -26,6 +26,8 @@ import { isRampsServiceDisruptionActive } from '../utils/rampsServiceDisruption'
 import { createRampsServiceDisruptionModalNavigationDetails } from '../components/RampsServiceDisruptionModal/RampsServiceDisruptionModal';
 import { selectRampsServiceDisruptionRegions } from '../../../../selectors/featureFlagController/rampsServiceDisruption';
 import { resolveRampControllerAssetId } from '../utils/resolveRampControllerAssetId';
+import { startRampsBuyCufTrace } from '../utils/rampsBuyCufTrace';
+import { RAMPS_BUY_CUF_SURFACE } from '../constants/rampsBuyCufTags';
 import Engine from '../../../../core/Engine';
 
 interface RampUrlOptions {
@@ -96,6 +98,8 @@ async function navigateUnifiedV2Buy(
     );
     return;
   }
+
+  startRampsBuyCufTrace({ surface: RAMPS_BUY_CUF_SURFACE.DEEP_LINK });
 
   if (rampIntent?.assetId) {
     const allTokens = selectTokens(state).data?.allTokens ?? [];

--- a/app/components/UI/Ramp/hooks/useContinueWithQuote.ts
+++ b/app/components/UI/Ramp/hooks/useContinueWithQuote.ts
@@ -334,7 +334,6 @@ export function useContinueWithQuote(
         );
       }
 
-      // Checkout URL ready — success boundary for this child CUF.
       endCheckoutCuf(true);
 
       try {

--- a/app/components/UI/Ramp/hooks/useContinueWithQuote.ts
+++ b/app/components/UI/Ramp/hooks/useContinueWithQuote.ts
@@ -37,6 +37,17 @@ import { useRampsController } from './useRampsController';
 import { useTransakController } from './useTransakController';
 import { useTransakRouting } from './useTransakRouting';
 import useRampAccountAddress from './useRampAccountAddress';
+import {
+  endOpenRampsBuyCufChildrenByName,
+  endRampsBuyCufChildTrace,
+  startRampsBuyCufChildTrace,
+} from '../utils/rampsBuyCufTrace';
+import {
+  RAMPS_BUY_CUF_END_REASON,
+  RAMPS_BUY_CUF_PATH,
+  RAMPS_BUY_CUF_TAG,
+} from '../constants/rampsBuyCufTags';
+import { TraceName } from '../../../../util/trace';
 
 export interface ContinueWithQuoteContext {
   amount: number;
@@ -172,6 +183,14 @@ export function useContinueWithQuote(
           ),
         );
       }
+      endOpenRampsBuyCufChildrenByName(TraceName.RampBuyNativeToOrderCreated, {
+        [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+        [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.SUPERSEDED,
+      });
+      const nativeCufOpId = startRampsBuyCufChildTrace({
+        name: TraceName.RampBuyNativeToOrderCreated,
+        tags: { [RAMPS_BUY_CUF_TAG.PATH]: RAMPS_BUY_CUF_PATH.NATIVE },
+      });
       try {
         const hasToken = await transakCheckExistingToken();
 
@@ -209,6 +228,15 @@ export function useContinueWithQuote(
           );
         }
       } catch (error) {
+        if (nativeCufOpId) {
+          endRampsBuyCufChildTrace({
+            id: nativeCufOpId,
+            data: {
+              [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+              [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.ERROR,
+            },
+          });
+        }
         throw new Error(
           reportRampsError(
             error,
@@ -249,6 +277,26 @@ export function useContinueWithQuote(
       let useExternalBrowser: boolean;
       let redirectUrl: string;
       let buyWidget: Awaited<ReturnType<typeof getBuyWidgetData>>;
+      endOpenRampsBuyCufChildrenByName(TraceName.RampBuyContinueToCheckout, {
+        [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+        [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.SUPERSEDED,
+      });
+      const checkoutCufOpId = startRampsBuyCufChildTrace({
+        name: TraceName.RampBuyContinueToCheckout,
+        tags: { [RAMPS_BUY_CUF_TAG.PATH]: RAMPS_BUY_CUF_PATH.WIDGET },
+      });
+      const endCheckoutCuf = (success: boolean, reason?: string) => {
+        if (!checkoutCufOpId) {
+          return;
+        }
+        endRampsBuyCufChildTrace({
+          id: checkoutCufOpId,
+          data: {
+            [RAMPS_BUY_CUF_TAG.SUCCESS]: success,
+            ...(reason ? { [RAMPS_BUY_CUF_TAG.REASON]: reason } : {}),
+          },
+        });
+      };
       try {
         providerCode = quote.provider;
         const isCustom = isCustomAction(quote);
@@ -262,6 +310,7 @@ export function useContinueWithQuote(
         const quoteForWidget = buildQuoteWithRedirectUrl(quote, redirectUrl);
         buyWidget = await getBuyWidgetData(quoteForWidget);
       } catch (error) {
+        endCheckoutCuf(false, RAMPS_BUY_CUF_END_REASON.ERROR);
         throw new Error(
           reportRampsError(
             error,
@@ -275,6 +324,7 @@ export function useContinueWithQuote(
       }
 
       if (!buyWidget?.url) {
+        endCheckoutCuf(false, RAMPS_BUY_CUF_END_REASON.ERROR);
         throw new Error(
           reportRampsError(
             new Error('No widget URL available for provider'),
@@ -283,6 +333,9 @@ export function useContinueWithQuote(
           ),
         );
       }
+
+      // Checkout URL ready — success boundary for this child CUF.
+      endCheckoutCuf(true);
 
       try {
         const { network, effectiveWallet, effectiveOrderId } =

--- a/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
@@ -301,6 +301,35 @@ describe('useRampNavigation', () => {
       });
     });
 
+    it('ignores a concurrent goToBuy while another is still in flight', async () => {
+      let resolveRefresh: (value: string) => void = () => undefined;
+      mockRefreshGeolocation.mockReturnValue(
+        new Promise<string>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+      );
+      const mockNavDetails = [Routes.RAMP.TOKEN_SELECTION, undefined] as const;
+      mockCreateTokenSelectionNavigationDetails.mockReturnValue(mockNavDetails);
+
+      const { result } = renderUseRampNavigation({
+        engine: {
+          backgroundState: {
+            GeolocationController: { location: 'UNKNOWN' },
+          },
+        },
+      });
+
+      const first = result.current.goToBuy(undefined, { surface: 'home' });
+      const second = result.current.goToBuy(undefined, { surface: 'home' });
+
+      resolveRefresh('us-ca');
+      await Promise.all([first, second]);
+
+      expect(mockRefreshGeolocation).toHaveBeenCalledTimes(1);
+      expect(mockStartRampsBuyCufTrace).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+    });
+
     it('does not navigate to BuildQuote when overrideUnifiedRouting is true', () => {
       const intent = { assetId: 'eip155:1/erc20:0x123' };
       const mockNavDetails = [Routes.RAMP.BUY] as const;

--- a/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
@@ -110,6 +110,14 @@ jest.mock('../../../../core/Engine', () => ({
   },
 }));
 
+const mockStartRampsBuyCufTrace = jest.fn();
+jest.mock('../utils/rampsBuyCufTrace', () => ({
+  startRampsBuyCufTrace: (...args: unknown[]) =>
+    mockStartRampsBuyCufTrace(...args),
+  surfaceFromBuyFlowOrigin: jest.requireActual('../utils/rampsBuyCufTrace')
+    .surfaceFromBuyFlowOrigin,
+}));
+
 const mockNavigate = jest.fn();
 const mockUseNavigation = useNavigation as jest.MockedFunction<
   typeof useNavigation
@@ -223,6 +231,9 @@ describe('useRampNavigation', () => {
       });
       expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
       expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
+      expect(mockStartRampsBuyCufTrace).toHaveBeenCalledWith({
+        surface: 'unknown',
+      });
     });
 
     it('passes buyFlowOrigin through to BuildQuote params', () => {
@@ -236,6 +247,9 @@ describe('useRampNavigation', () => {
         assetId: intent.assetId,
         buyFlowOrigin: 'tokenInfo',
       });
+      expect(mockStartRampsBuyCufTrace).toHaveBeenCalledWith({
+        surface: 'token_buy',
+      });
     });
 
     it('passes homeTokenList buyFlowOrigin through to BuildQuote params', () => {
@@ -248,6 +262,24 @@ describe('useRampNavigation', () => {
       expect(mockCreateBuildQuoteNavDetails).toHaveBeenCalledWith({
         assetId: intent.assetId,
         buyFlowOrigin: 'homeTokenList',
+      });
+      expect(mockStartRampsBuyCufTrace).toHaveBeenCalledWith({
+        surface: 'home_token_list',
+      });
+    });
+
+    it('starts Buy E2E CUF with an explicit surface tag', () => {
+      const intent = { assetId: 'eip155:1/erc20:0x123' };
+      mockCreateBuildQuoteNavDetails.mockReturnValue([
+        Routes.RAMP.AMOUNT_INPUT,
+      ] as never);
+
+      const { result } = renderUseRampNavigation();
+
+      result.current.goToBuy(intent, { surface: 'fund_menu' });
+
+      expect(mockStartRampsBuyCufTrace).toHaveBeenCalledWith({
+        surface: 'fund_menu',
       });
     });
 
@@ -264,6 +296,9 @@ describe('useRampNavigation', () => {
       expect(mockCreateTokenSelectionNavigationDetails).toHaveBeenCalled();
       expect(mockNavigate).toHaveBeenCalledWith(...mockNavDetails);
       expect(mockCreateRampNavigationDetails).not.toHaveBeenCalled();
+      expect(mockStartRampsBuyCufTrace).toHaveBeenCalledWith({
+        surface: 'unknown',
+      });
     });
 
     it('does not navigate to BuildQuote when overrideUnifiedRouting is true', () => {
@@ -277,6 +312,7 @@ describe('useRampNavigation', () => {
 
       expect(mockSetSelectedToken).not.toHaveBeenCalled();
       expect(mockCreateBuildQuoteNavDetails).not.toHaveBeenCalled();
+      expect(mockStartRampsBuyCufTrace).not.toHaveBeenCalled();
       expect(mockCreateRampNavigationDetails).toHaveBeenCalledWith(
         AggregatorRampType.BUY,
         intent,

--- a/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.test.ts
@@ -301,35 +301,6 @@ describe('useRampNavigation', () => {
       });
     });
 
-    it('ignores a concurrent goToBuy while another is still in flight', async () => {
-      let resolveRefresh: (value: string) => void = () => undefined;
-      mockRefreshGeolocation.mockReturnValue(
-        new Promise<string>((resolve) => {
-          resolveRefresh = resolve;
-        }),
-      );
-      const mockNavDetails = [Routes.RAMP.TOKEN_SELECTION, undefined] as const;
-      mockCreateTokenSelectionNavigationDetails.mockReturnValue(mockNavDetails);
-
-      const { result } = renderUseRampNavigation({
-        engine: {
-          backgroundState: {
-            GeolocationController: { location: 'UNKNOWN' },
-          },
-        },
-      });
-
-      const first = result.current.goToBuy(undefined, { surface: 'home' });
-      const second = result.current.goToBuy(undefined, { surface: 'home' });
-
-      resolveRefresh('us-ca');
-      await Promise.all([first, second]);
-
-      expect(mockRefreshGeolocation).toHaveBeenCalledTimes(1);
-      expect(mockStartRampsBuyCufTrace).toHaveBeenCalledTimes(1);
-      expect(mockNavigate).toHaveBeenCalledTimes(1);
-    });
-
     it('does not navigate to BuildQuote when overrideUnifiedRouting is true', () => {
       const intent = { assetId: 'eip155:1/erc20:0x123' };
       const mockNavDetails = [Routes.RAMP.BUY] as const;

--- a/app/components/UI/Ramp/hooks/useRampNavigation.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.ts
@@ -65,7 +65,6 @@ export const useRampNavigation = () => {
       options?: {
         overrideUnifiedRouting?: boolean;
         buyFlowOrigin?: BuyFlowOrigin;
-        /** Buy E2E CUF surface tag (TRAM-3779). Falls back from buyFlowOrigin. */
         surface?: RampsBuyCufSurface;
       },
     ) => {

--- a/app/components/UI/Ramp/hooks/useRampNavigation.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.ts
@@ -25,6 +25,11 @@ import Engine from '../../../../core/Engine';
 import { selectGeolocationLocation } from '../../../../selectors/geolocationController';
 import { UNKNOWN_LOCATION } from '@metamask/geolocation-controller';
 import { selectProviders } from '../../../../selectors/rampsController';
+import {
+  startRampsBuyCufTrace,
+  surfaceFromBuyFlowOrigin,
+} from '../utils/rampsBuyCufTrace';
+import type { RampsBuyCufSurface } from '../constants/rampsBuyCufTags';
 
 /**
  * Hook that returns functions to navigate to ramp flows.
@@ -60,11 +65,24 @@ export const useRampNavigation = () => {
       options?: {
         overrideUnifiedRouting?: boolean;
         buyFlowOrigin?: BuyFlowOrigin;
+        /** Buy E2E CUF surface tag (TRAM-3779). Falls back from buyFlowOrigin. */
+        surface?: RampsBuyCufSurface;
       },
     ) => {
       const { overrideUnifiedRouting = false } = options || {};
 
       const isUnifiedRoutingEnabled = !overrideUnifiedRouting;
+
+      const startBuyCufIfUnified = () => {
+        if (!isUnifiedRoutingEnabled) {
+          return;
+        }
+        startRampsBuyCufTrace({
+          surface:
+            options?.surface ??
+            surfaceFromBuyFlowOrigin(options?.buyFlowOrigin),
+        });
+      };
 
       // Resolve the best available geolocation; only the unified path refreshes.
       let location: string | undefined = geolocationLocation;
@@ -162,6 +180,7 @@ export const useRampNavigation = () => {
         } catch {
           // Token may not be in controller's list yet (still loading).
         }
+        startBuyCufIfUnified();
         navigateWithDetails(
           navigation,
           createBuildQuoteNavDetails({
@@ -173,6 +192,7 @@ export const useRampNavigation = () => {
       }
 
       if (!intent?.assetId && !overrideUnifiedRouting) {
+        startBuyCufIfUnified();
         navigateWithDetails(navigation, createTokenSelectionNavDetails());
         return;
       }

--- a/app/components/UI/Ramp/hooks/useRampNavigation.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.ts
@@ -31,6 +31,9 @@ import {
 } from '../utils/rampsBuyCufTrace';
 import type { RampsBuyCufSurface } from '../constants/rampsBuyCufTags';
 
+/** Prevents concurrent goToBuy from racing past the await and double-starting CUF. */
+let goToBuyInFlight = false;
+
 /**
  * Hook that returns functions to navigate to ramp flows.
  *
@@ -69,104 +72,91 @@ export const useRampNavigation = () => {
         surface?: RampsBuyCufSurface;
       },
     ) => {
-      const { overrideUnifiedRouting = false } = options || {};
-
-      const isUnifiedRoutingEnabled = !overrideUnifiedRouting;
-
-      const startBuyCufIfUnified = () => {
-        if (!isUnifiedRoutingEnabled) {
-          return;
-        }
-        startRampsBuyCufTrace({
-          surface:
-            options?.surface ??
-            surfaceFromBuyFlowOrigin(options?.buyFlowOrigin),
-        });
-      };
-
-      // Resolve the best available geolocation; only the unified path refreshes.
-      let location: string | undefined = geolocationLocation;
-      if (
-        isUnifiedRoutingEnabled &&
-        (!location || location === UNKNOWN_LOCATION)
-      ) {
-        location = await Promise.resolve(
-          Engine.context.GeolocationController?.refreshGeolocation?.(),
-        ).catch(() => undefined);
-      }
-
-      // Region service disruption kill-switch — applies to every buy entry point (including
-      // the deprecated aggregator/reorder path) and takes precedence over the
-      // eligibility/unsupported gating below.
-      if (
-        isRampsServiceDisruptionActive(
-          rampsServiceDisruptionRegions,
-          userRegion,
-          location,
-        )
-      ) {
-        navigateWithDetails(
-          navigation,
-          createRampsServiceDisruptionModalNavigationDetails(),
-        );
+      if (goToBuyInFlight) {
         return;
       }
+      goToBuyInFlight = true;
 
-      // Treat a fully-loaded V2 catalog with no providers or no buyable tokens
-      // as region-unavailable. Only fires once provider/token data has settled
-      // (not loading, no error) so transient states don't trip the modal.
-      const v2CatalogHasLoaded =
-        !overrideUnifiedRouting &&
-        !providersLoading &&
-        !tokensLoading &&
-        !providersError &&
-        !tokensError;
-      const v2CatalogHasNoProviders =
-        v2CatalogHasLoaded && rampsTokens && providers.length === 0;
-      const v2CatalogHasNoBuyableTokens =
-        v2CatalogHasLoaded &&
-        rampsTokens &&
-        !rampsTokens.allTokens.some((token) => token.tokenSupported);
-      const isV2CatalogUnsupported =
-        v2CatalogHasNoProviders || v2CatalogHasNoBuyableTokens;
+      try {
+        const { overrideUnifiedRouting = false } = options || {};
 
-      if (isUnifiedRoutingEnabled) {
-        if (!location || location === UNKNOWN_LOCATION) {
+        const isUnifiedRoutingEnabled = !overrideUnifiedRouting;
+
+        const startBuyCufIfUnified = () => {
+          if (!isUnifiedRoutingEnabled) {
+            return;
+          }
+          startRampsBuyCufTrace({
+            surface:
+              options?.surface ??
+              surfaceFromBuyFlowOrigin(options?.buyFlowOrigin),
+          });
+        };
+
+        // Resolve the best available geolocation; only the unified path refreshes.
+        let location: string | undefined = geolocationLocation;
+        if (
+          isUnifiedRoutingEnabled &&
+          (!location || location === UNKNOWN_LOCATION)
+        ) {
+          location = await Promise.resolve(
+            Engine.context.GeolocationController?.refreshGeolocation?.(),
+          ).catch(() => undefined);
+        }
+
+        // Region service disruption kill-switch — applies to every buy entry point (including
+        // the deprecated aggregator/reorder path) and takes precedence over the
+        // eligibility/unsupported gating below.
+        if (
+          isRampsServiceDisruptionActive(
+            rampsServiceDisruptionRegions,
+            userRegion,
+            location,
+          )
+        ) {
           navigateWithDetails(
             navigation,
-            createEligibilityFailedModalNavigationDetails(),
+            createRampsServiceDisruptionModalNavigationDetails(),
           );
           return;
         }
 
-        if (isRampRegionDefinitivelyUnsupported(userRegion, countries)) {
-          navigateWithDetails(
-            navigation,
-            createRampUnsupportedModalNavigationDetails(),
-          );
-          return;
-        }
+        // Treat a fully-loaded V2 catalog with no providers or no buyable tokens
+        // as region-unavailable. Only fires once provider/token data has settled
+        // (not loading, no error) so transient states don't trip the modal.
+        const v2CatalogHasLoaded =
+          !overrideUnifiedRouting &&
+          !providersLoading &&
+          !tokensLoading &&
+          !providersError &&
+          !tokensError;
+        const v2CatalogHasNoProviders =
+          v2CatalogHasLoaded && rampsTokens && providers.length === 0;
+        const v2CatalogHasNoBuyableTokens =
+          v2CatalogHasLoaded &&
+          rampsTokens &&
+          !rampsTokens.allTokens.some((token) => token.tokenSupported);
+        const isV2CatalogUnsupported =
+          v2CatalogHasNoProviders || v2CatalogHasNoBuyableTokens;
 
-        if (isV2CatalogUnsupported) {
-          navigateWithDetails(
-            navigation,
-            createRampUnsupportedModalNavigationDetails(),
-          );
-          return;
-        }
-      }
+        if (isUnifiedRoutingEnabled) {
+          if (!location || location === UNKNOWN_LOCATION) {
+            navigateWithDetails(
+              navigation,
+              createEligibilityFailedModalNavigationDetails(),
+            );
+            return;
+          }
 
-      if (intent?.assetId && !overrideUnifiedRouting) {
-        const controllerAssetId = resolveRampControllerAssetId(
-          intent.assetId,
-          rampsTokens?.allTokens ?? [],
-        );
+          if (isRampRegionDefinitivelyUnsupported(userRegion, countries)) {
+            navigateWithDetails(
+              navigation,
+              createRampUnsupportedModalNavigationDetails(),
+            );
+            return;
+          }
 
-        if (rampsTokens) {
-          const matchedToken = rampsTokens.allTokens.find(
-            (tok) => tok.assetId === controllerAssetId,
-          );
-          if (!matchedToken || !matchedToken.tokenSupported) {
+          if (isV2CatalogUnsupported) {
             navigateWithDetails(
               navigation,
               createRampUnsupportedModalNavigationDetails(),
@@ -175,32 +165,54 @@ export const useRampNavigation = () => {
           }
         }
 
-        try {
-          setSelectedToken(controllerAssetId);
-        } catch {
-          // Token may not be in controller's list yet (still loading).
+        if (intent?.assetId && !overrideUnifiedRouting) {
+          const controllerAssetId = resolveRampControllerAssetId(
+            intent.assetId,
+            rampsTokens?.allTokens ?? [],
+          );
+
+          if (rampsTokens) {
+            const matchedToken = rampsTokens.allTokens.find(
+              (tok) => tok.assetId === controllerAssetId,
+            );
+            if (!matchedToken || !matchedToken.tokenSupported) {
+              navigateWithDetails(
+                navigation,
+                createRampUnsupportedModalNavigationDetails(),
+              );
+              return;
+            }
+          }
+
+          try {
+            setSelectedToken(controllerAssetId);
+          } catch {
+            // Token may not be in controller's list yet (still loading).
+          }
+          startBuyCufIfUnified();
+          navigateWithDetails(
+            navigation,
+            createBuildQuoteNavDetails({
+              assetId: controllerAssetId,
+              buyFlowOrigin: options?.buyFlowOrigin,
+            }),
+          );
+          return;
         }
-        startBuyCufIfUnified();
+
+        if (!intent?.assetId && !overrideUnifiedRouting) {
+          startBuyCufIfUnified();
+          navigateWithDetails(navigation, createTokenSelectionNavDetails());
+          return;
+        }
+
         navigateWithDetails(
           navigation,
-          createBuildQuoteNavDetails({
-            assetId: controllerAssetId,
-            buyFlowOrigin: options?.buyFlowOrigin,
-          }),
+          createRampNavigationDetails(AggregatorRampType.BUY, intent),
         );
-        return;
+      } finally {
+        goToBuyInFlight = false;
       }
-
-      if (!intent?.assetId && !overrideUnifiedRouting) {
-        startBuyCufIfUnified();
-        navigateWithDetails(navigation, createTokenSelectionNavDetails());
-        return;
-      }
-
-      navigateWithDetails(
-        navigation,
-        createRampNavigationDetails(AggregatorRampType.BUY, intent),
-      );
     },
     [
       setSelectedToken,

--- a/app/components/UI/Ramp/hooks/useRampNavigation.ts
+++ b/app/components/UI/Ramp/hooks/useRampNavigation.ts
@@ -31,9 +31,6 @@ import {
 } from '../utils/rampsBuyCufTrace';
 import type { RampsBuyCufSurface } from '../constants/rampsBuyCufTags';
 
-/** Prevents concurrent goToBuy from racing past the await and double-starting CUF. */
-let goToBuyInFlight = false;
-
 /**
  * Hook that returns functions to navigate to ramp flows.
  *
@@ -72,147 +69,138 @@ export const useRampNavigation = () => {
         surface?: RampsBuyCufSurface;
       },
     ) => {
-      if (goToBuyInFlight) {
-        return;
+      const { overrideUnifiedRouting = false } = options || {};
+
+      const isUnifiedRoutingEnabled = !overrideUnifiedRouting;
+
+      const startBuyCufIfUnified = () => {
+        if (!isUnifiedRoutingEnabled) {
+          return;
+        }
+        startRampsBuyCufTrace({
+          surface:
+            options?.surface ??
+            surfaceFromBuyFlowOrigin(options?.buyFlowOrigin),
+        });
+      };
+
+      // Resolve the best available geolocation; only the unified path refreshes.
+      let location: string | undefined = geolocationLocation;
+      if (
+        isUnifiedRoutingEnabled &&
+        (!location || location === UNKNOWN_LOCATION)
+      ) {
+        location = await Promise.resolve(
+          Engine.context.GeolocationController?.refreshGeolocation?.(),
+        ).catch(() => undefined);
       }
-      goToBuyInFlight = true;
 
-      try {
-        const { overrideUnifiedRouting = false } = options || {};
-
-        const isUnifiedRoutingEnabled = !overrideUnifiedRouting;
-
-        const startBuyCufIfUnified = () => {
-          if (!isUnifiedRoutingEnabled) {
-            return;
-          }
-          startRampsBuyCufTrace({
-            surface:
-              options?.surface ??
-              surfaceFromBuyFlowOrigin(options?.buyFlowOrigin),
-          });
-        };
-
-        // Resolve the best available geolocation; only the unified path refreshes.
-        let location: string | undefined = geolocationLocation;
-        if (
-          isUnifiedRoutingEnabled &&
-          (!location || location === UNKNOWN_LOCATION)
-        ) {
-          location = await Promise.resolve(
-            Engine.context.GeolocationController?.refreshGeolocation?.(),
-          ).catch(() => undefined);
-        }
-
-        // Region service disruption kill-switch — applies to every buy entry point (including
-        // the deprecated aggregator/reorder path) and takes precedence over the
-        // eligibility/unsupported gating below.
-        if (
-          isRampsServiceDisruptionActive(
-            rampsServiceDisruptionRegions,
-            userRegion,
-            location,
-          )
-        ) {
-          navigateWithDetails(
-            navigation,
-            createRampsServiceDisruptionModalNavigationDetails(),
-          );
-          return;
-        }
-
-        // Treat a fully-loaded V2 catalog with no providers or no buyable tokens
-        // as region-unavailable. Only fires once provider/token data has settled
-        // (not loading, no error) so transient states don't trip the modal.
-        const v2CatalogHasLoaded =
-          !overrideUnifiedRouting &&
-          !providersLoading &&
-          !tokensLoading &&
-          !providersError &&
-          !tokensError;
-        const v2CatalogHasNoProviders =
-          v2CatalogHasLoaded && rampsTokens && providers.length === 0;
-        const v2CatalogHasNoBuyableTokens =
-          v2CatalogHasLoaded &&
-          rampsTokens &&
-          !rampsTokens.allTokens.some((token) => token.tokenSupported);
-        const isV2CatalogUnsupported =
-          v2CatalogHasNoProviders || v2CatalogHasNoBuyableTokens;
-
-        if (isUnifiedRoutingEnabled) {
-          if (!location || location === UNKNOWN_LOCATION) {
-            navigateWithDetails(
-              navigation,
-              createEligibilityFailedModalNavigationDetails(),
-            );
-            return;
-          }
-
-          if (isRampRegionDefinitivelyUnsupported(userRegion, countries)) {
-            navigateWithDetails(
-              navigation,
-              createRampUnsupportedModalNavigationDetails(),
-            );
-            return;
-          }
-
-          if (isV2CatalogUnsupported) {
-            navigateWithDetails(
-              navigation,
-              createRampUnsupportedModalNavigationDetails(),
-            );
-            return;
-          }
-        }
-
-        if (intent?.assetId && !overrideUnifiedRouting) {
-          const controllerAssetId = resolveRampControllerAssetId(
-            intent.assetId,
-            rampsTokens?.allTokens ?? [],
-          );
-
-          if (rampsTokens) {
-            const matchedToken = rampsTokens.allTokens.find(
-              (tok) => tok.assetId === controllerAssetId,
-            );
-            if (!matchedToken || !matchedToken.tokenSupported) {
-              navigateWithDetails(
-                navigation,
-                createRampUnsupportedModalNavigationDetails(),
-              );
-              return;
-            }
-          }
-
-          try {
-            setSelectedToken(controllerAssetId);
-          } catch {
-            // Token may not be in controller's list yet (still loading).
-          }
-          startBuyCufIfUnified();
-          navigateWithDetails(
-            navigation,
-            createBuildQuoteNavDetails({
-              assetId: controllerAssetId,
-              buyFlowOrigin: options?.buyFlowOrigin,
-            }),
-          );
-          return;
-        }
-
-        if (!intent?.assetId && !overrideUnifiedRouting) {
-          startBuyCufIfUnified();
-          navigateWithDetails(navigation, createTokenSelectionNavDetails());
-          return;
-        }
-
+      // Region service disruption kill-switch — applies to every buy entry point (including
+      // the deprecated aggregator/reorder path) and takes precedence over the
+      // eligibility/unsupported gating below.
+      if (
+        isRampsServiceDisruptionActive(
+          rampsServiceDisruptionRegions,
+          userRegion,
+          location,
+        )
+      ) {
         navigateWithDetails(
           navigation,
-          createRampNavigationDetails(AggregatorRampType.BUY, intent),
+          createRampsServiceDisruptionModalNavigationDetails(),
         );
-      } finally {
-        goToBuyInFlight = false;
+        return;
       }
+
+      // Treat a fully-loaded V2 catalog with no providers or no buyable tokens
+      // as region-unavailable. Only fires once provider/token data has settled
+      // (not loading, no error) so transient states don't trip the modal.
+      const v2CatalogHasLoaded =
+        !overrideUnifiedRouting &&
+        !providersLoading &&
+        !tokensLoading &&
+        !providersError &&
+        !tokensError;
+      const v2CatalogHasNoProviders =
+        v2CatalogHasLoaded && rampsTokens && providers.length === 0;
+      const v2CatalogHasNoBuyableTokens =
+        v2CatalogHasLoaded &&
+        rampsTokens &&
+        !rampsTokens.allTokens.some((token) => token.tokenSupported);
+      const isV2CatalogUnsupported =
+        v2CatalogHasNoProviders || v2CatalogHasNoBuyableTokens;
+
+      if (isUnifiedRoutingEnabled) {
+        if (!location || location === UNKNOWN_LOCATION) {
+          navigateWithDetails(
+            navigation,
+            createEligibilityFailedModalNavigationDetails(),
+          );
+          return;
+        }
+
+        if (isRampRegionDefinitivelyUnsupported(userRegion, countries)) {
+          navigateWithDetails(
+            navigation,
+            createRampUnsupportedModalNavigationDetails(),
+          );
+          return;
+        }
+
+        if (isV2CatalogUnsupported) {
+          navigateWithDetails(
+            navigation,
+            createRampUnsupportedModalNavigationDetails(),
+          );
+          return;
+        }
+      }
+
+      if (intent?.assetId && !overrideUnifiedRouting) {
+        const controllerAssetId = resolveRampControllerAssetId(
+          intent.assetId,
+          rampsTokens?.allTokens ?? [],
+        );
+
+        if (rampsTokens) {
+          const matchedToken = rampsTokens.allTokens.find(
+            (tok) => tok.assetId === controllerAssetId,
+          );
+          if (!matchedToken || !matchedToken.tokenSupported) {
+            navigateWithDetails(
+              navigation,
+              createRampUnsupportedModalNavigationDetails(),
+            );
+            return;
+          }
+        }
+
+        try {
+          setSelectedToken(controllerAssetId);
+        } catch {
+          // Token may not be in controller's list yet (still loading).
+        }
+        startBuyCufIfUnified();
+        navigateWithDetails(
+          navigation,
+          createBuildQuoteNavDetails({
+            assetId: controllerAssetId,
+            buyFlowOrigin: options?.buyFlowOrigin,
+          }),
+        );
+        return;
+      }
+
+      if (!intent?.assetId && !overrideUnifiedRouting) {
+        startBuyCufIfUnified();
+        navigateWithDetails(navigation, createTokenSelectionNavDetails());
+        return;
+      }
+
+      navigateWithDetails(
+        navigation,
+        createRampNavigationDetails(AggregatorRampType.BUY, intent),
+      );
     },
     [
       setSelectedToken,

--- a/app/components/UI/Ramp/hooks/useRampsQuotes.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsQuotes.test.ts
@@ -8,6 +8,7 @@ import type { Quote } from '../types';
 import Engine from '../../../../core/Engine';
 import {
   RAMPS_BUY_CUF_END_REASON,
+  RAMPS_BUY_CUF_PATH,
   RAMPS_BUY_CUF_TAG,
 } from '../constants/rampsBuyCufTags';
 
@@ -23,13 +24,21 @@ jest.mock('../../../../core/Engine', () => ({
 
 const mockStartRampsBuyQuoteFetchTrace = jest.fn(() => 'quote-cuf-op-1');
 const mockEndRampsBuyQuoteFetchTrace = jest.fn();
-jest.mock('../utils/rampsBuyCufTrace', () => ({
-  // Cast through a rest-param signature so tsc accepts the spread (TS2556).
-  startRampsBuyQuoteFetchTrace: (...args: unknown[]) =>
-    (mockStartRampsBuyQuoteFetchTrace as (...a: unknown[]) => string)(...args),
-  endRampsBuyQuoteFetchTrace: (...args: unknown[]) =>
-    (mockEndRampsBuyQuoteFetchTrace as (...a: unknown[]) => void)(...args),
-}));
+jest.mock('../utils/rampsBuyCufTrace', () => {
+  const actual = jest.requireActual<typeof import('../utils/rampsBuyCufTrace')>(
+    '../utils/rampsBuyCufTrace',
+  );
+  return {
+    ...actual,
+    // Cast through a rest-param signature so tsc accepts the spread (TS2556).
+    startRampsBuyQuoteFetchTrace: (...args: unknown[]) =>
+      (mockStartRampsBuyQuoteFetchTrace as (...a: unknown[]) => string)(
+        ...args,
+      ),
+    endRampsBuyQuoteFetchTrace: (...args: unknown[]) =>
+      (mockEndRampsBuyQuoteFetchTrace as (...a: unknown[]) => void)(...args),
+  };
+});
 
 const createMockStore = () =>
   configureStore({
@@ -66,10 +75,19 @@ const createWrapper = (store: ReturnType<typeof createMockStore>) => {
 };
 
 const mockQuotesResponse = {
-  success: [{ provider: 'test', quote: { amountIn: 100 } }],
+  success: [{ provider: '/providers/transak', quote: { amountIn: 100 } }],
   sorted: [],
   error: [],
   customActions: [],
+};
+
+const createDeferred = <T>() => {
+  let resolvePromise: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return { promise, resolve: resolvePromise };
 };
 
 describe('useRampsQuotes', () => {
@@ -194,7 +212,9 @@ describe('useRampsQuotes', () => {
       expect(result.current.loading).toBe(true);
       expect(result.current.status).toBe('loading');
       expect(result.current.data).toBeNull();
-      expect(mockStartRampsBuyQuoteFetchTrace).toHaveBeenCalled();
+      expect(mockStartRampsBuyQuoteFetchTrace).toHaveBeenCalledWith({
+        tags: { [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/transak' },
+      });
 
       await waitFor(() => {
         expect(result.current.status).toBe('success');
@@ -206,7 +226,11 @@ describe('useRampsQuotes', () => {
       expect(result.current.error).toBeNull();
       expect(mockEndRampsBuyQuoteFetchTrace).toHaveBeenCalledWith({
         id: 'quote-cuf-op-1',
-        data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
+        data: {
+          [RAMPS_BUY_CUF_TAG.SUCCESS]: true,
+          [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/transak',
+          [RAMPS_BUY_CUF_TAG.CUSTOM_ACTION]: false,
+        },
       });
       expect(Engine.context.RampsController.getQuotes).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -243,7 +267,172 @@ describe('useRampsQuotes', () => {
         data: {
           [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
           [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.ERROR,
+          [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/transak',
         },
+      });
+    });
+
+    it('records a PayPal custom-action quote as a provider success', async () => {
+      const store = createMockStore();
+      const { Wrapper } = createWrapper(store);
+      const paypalOptions: GetQuotesOptions = {
+        ...options,
+        providers: ['/providers/paypal'],
+        paymentMethods: ['/payments/paypal'],
+      };
+      (Engine.context.RampsController.getQuotes as jest.Mock).mockResolvedValue(
+        {
+          success: [
+            {
+              provider: '/providers/paypal',
+              quote: { amountIn: 100, isCustomAction: true },
+            },
+          ],
+          sorted: [],
+          error: [],
+          customActions: [],
+        },
+      );
+
+      const { result } = renderHook(() => useRampsQuotes(paypalOptions), {
+        wrapper: Wrapper,
+      });
+
+      expect(mockStartRampsBuyQuoteFetchTrace).toHaveBeenCalledWith({
+        tags: { [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/paypal' },
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      expect(mockEndRampsBuyQuoteFetchTrace).toHaveBeenCalledWith({
+        id: 'quote-cuf-op-1',
+        data: {
+          [RAMPS_BUY_CUF_TAG.SUCCESS]: true,
+          [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/paypal',
+          [RAMPS_BUY_CUF_TAG.PATH]: RAMPS_BUY_CUF_PATH.CUSTOM_ACTION,
+          [RAMPS_BUY_CUF_TAG.CUSTOM_ACTION]: true,
+        },
+      });
+    });
+
+    it('records an HTTP-ok PayPal miss as a no-quote failure', async () => {
+      const store = createMockStore();
+      const { Wrapper } = createWrapper(store);
+      const paypalOptions: GetQuotesOptions = {
+        ...options,
+        providers: ['/providers/paypal'],
+        paymentMethods: ['/payments/paypal'],
+      };
+      (Engine.context.RampsController.getQuotes as jest.Mock).mockResolvedValue(
+        {
+          success: [],
+          sorted: [],
+          error: [
+            { provider: '/providers/paypal', error: 'PayPal unavailable' },
+          ],
+          customActions: [],
+        },
+      );
+
+      const { result } = renderHook(() => useRampsQuotes(paypalOptions), {
+        wrapper: Wrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      expect(mockEndRampsBuyQuoteFetchTrace).toHaveBeenCalledWith({
+        id: 'quote-cuf-op-1',
+        data: {
+          [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+          [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.NO_QUOTE,
+          [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/paypal',
+        },
+      });
+    });
+
+    it('supersedes an in-flight span when the requested provider changes', async () => {
+      const store = createMockStore();
+      const { Wrapper } = createWrapper(store);
+      const transakDeferred = createDeferred<typeof mockQuotesResponse>();
+      const paypalDeferred = createDeferred<{
+        success: {
+          provider: string;
+          quote: { amountIn: number; isCustomAction: boolean };
+        }[];
+        sorted: never[];
+        error: never[];
+        customActions: never[];
+      }>();
+      const paypalOptions: GetQuotesOptions = {
+        ...options,
+        providers: ['/providers/paypal'],
+        paymentMethods: ['/payments/paypal'],
+      };
+      const paypalResponse = {
+        success: [
+          {
+            provider: '/providers/paypal',
+            quote: { amountIn: 100, isCustomAction: true },
+          },
+        ],
+        sorted: [],
+        error: [],
+        customActions: [],
+      };
+      (Engine.context.RampsController.getQuotes as jest.Mock)
+        .mockReturnValueOnce(transakDeferred.promise)
+        .mockReturnValueOnce(paypalDeferred.promise);
+      mockStartRampsBuyQuoteFetchTrace
+        .mockReturnValueOnce('transak-cuf-op')
+        .mockReturnValueOnce('paypal-cuf-op');
+
+      const { result, rerender } = renderHook<
+        ReturnType<typeof useRampsQuotes>,
+        { params: GetQuotesOptions }
+      >(({ params }) => useRampsQuotes(params), {
+        wrapper: Wrapper,
+        initialProps: { params: options },
+      });
+
+      rerender({ params: paypalOptions });
+
+      await waitFor(() => {
+        expect(mockStartRampsBuyQuoteFetchTrace).toHaveBeenCalledTimes(2);
+      });
+
+      expect(mockEndRampsBuyQuoteFetchTrace).toHaveBeenCalledWith({
+        id: 'transak-cuf-op',
+        data: {
+          [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+          [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.SUPERSEDED,
+        },
+      });
+
+      await act(async () => {
+        paypalDeferred.resolve(paypalResponse);
+        await paypalDeferred.promise;
+      });
+      await waitFor(() => {
+        expect(result.current.status).toBe('success');
+      });
+
+      expect(mockEndRampsBuyQuoteFetchTrace).toHaveBeenCalledWith({
+        id: 'paypal-cuf-op',
+        data: {
+          [RAMPS_BUY_CUF_TAG.SUCCESS]: true,
+          [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/paypal',
+          [RAMPS_BUY_CUF_TAG.PATH]: RAMPS_BUY_CUF_PATH.CUSTOM_ACTION,
+          [RAMPS_BUY_CUF_TAG.CUSTOM_ACTION]: true,
+        },
+      });
+
+      await act(async () => {
+        transakDeferred.resolve(mockQuotesResponse);
+        await transakDeferred.promise;
       });
     });
 

--- a/app/components/UI/Ramp/hooks/useRampsQuotes.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsQuotes.test.ts
@@ -6,6 +6,10 @@ import React from 'react';
 import { useRampsQuotes, type GetQuotesOptions } from './useRampsQuotes';
 import type { Quote } from '../types';
 import Engine from '../../../../core/Engine';
+import {
+  RAMPS_BUY_CUF_END_REASON,
+  RAMPS_BUY_CUF_TAG,
+} from '../constants/rampsBuyCufTags';
 
 const mockGetBuyWidgetData = jest.fn();
 jest.mock('../../../../core/Engine', () => ({
@@ -15,6 +19,15 @@ jest.mock('../../../../core/Engine', () => ({
       getBuyWidgetData: (...args: unknown[]) => mockGetBuyWidgetData(...args),
     },
   },
+}));
+
+const mockStartRampsBuyQuoteFetchTrace = jest.fn(() => 'quote-cuf-op-1');
+const mockEndRampsBuyQuoteFetchTrace = jest.fn();
+jest.mock('../utils/rampsBuyCufTrace', () => ({
+  startRampsBuyQuoteFetchTrace: (...args: unknown[]) =>
+    mockStartRampsBuyQuoteFetchTrace(...args),
+  endRampsBuyQuoteFetchTrace: (...args: unknown[]) =>
+    mockEndRampsBuyQuoteFetchTrace(...args),
 }));
 
 const createMockStore = () =>
@@ -180,6 +193,7 @@ describe('useRampsQuotes', () => {
       expect(result.current.loading).toBe(true);
       expect(result.current.status).toBe('loading');
       expect(result.current.data).toBeNull();
+      expect(mockStartRampsBuyQuoteFetchTrace).toHaveBeenCalled();
 
       await waitFor(() => {
         expect(result.current.status).toBe('success');
@@ -189,6 +203,10 @@ describe('useRampsQuotes', () => {
       expect(result.current.data).toEqual(mockQuotesResponse);
       expect(result.current.isSuccess).toBe(true);
       expect(result.current.error).toBeNull();
+      expect(mockEndRampsBuyQuoteFetchTrace).toHaveBeenCalledWith({
+        id: 'quote-cuf-op-1',
+        data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
+      });
       expect(Engine.context.RampsController.getQuotes).toHaveBeenCalledWith(
         expect.objectContaining({
           amount: 100,
@@ -219,6 +237,13 @@ describe('useRampsQuotes', () => {
       expect(result.current.loading).toBe(false);
       expect(result.current.error).toBe(networkError);
       expect(result.current.data).toBeNull();
+      expect(mockEndRampsBuyQuoteFetchTrace).toHaveBeenCalledWith({
+        id: 'quote-cuf-op-1',
+        data: {
+          [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+          [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.ERROR,
+        },
+      });
     });
 
     it('preserves enriched error metadata when the request rejects', async () => {

--- a/app/components/UI/Ramp/hooks/useRampsQuotes.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsQuotes.test.ts
@@ -24,9 +24,9 @@ jest.mock('../../../../core/Engine', () => ({
 const mockStartRampsBuyQuoteFetchTrace = jest.fn(() => 'quote-cuf-op-1');
 const mockEndRampsBuyQuoteFetchTrace = jest.fn();
 jest.mock('../utils/rampsBuyCufTrace', () => ({
-  startRampsBuyQuoteFetchTrace: (...args: unknown[]) =>
+  startRampsBuyQuoteFetchTrace: (...args: never[]) =>
     mockStartRampsBuyQuoteFetchTrace(...args),
-  endRampsBuyQuoteFetchTrace: (...args: unknown[]) =>
+  endRampsBuyQuoteFetchTrace: (...args: never[]) =>
     mockEndRampsBuyQuoteFetchTrace(...args),
 }));
 

--- a/app/components/UI/Ramp/hooks/useRampsQuotes.test.ts
+++ b/app/components/UI/Ramp/hooks/useRampsQuotes.test.ts
@@ -24,10 +24,11 @@ jest.mock('../../../../core/Engine', () => ({
 const mockStartRampsBuyQuoteFetchTrace = jest.fn(() => 'quote-cuf-op-1');
 const mockEndRampsBuyQuoteFetchTrace = jest.fn();
 jest.mock('../utils/rampsBuyCufTrace', () => ({
-  startRampsBuyQuoteFetchTrace: (...args: never[]) =>
-    mockStartRampsBuyQuoteFetchTrace(...args),
-  endRampsBuyQuoteFetchTrace: (...args: never[]) =>
-    mockEndRampsBuyQuoteFetchTrace(...args),
+  // Cast through a rest-param signature so tsc accepts the spread (TS2556).
+  startRampsBuyQuoteFetchTrace: (...args: unknown[]) =>
+    (mockStartRampsBuyQuoteFetchTrace as (...a: unknown[]) => string)(...args),
+  endRampsBuyQuoteFetchTrace: (...args: unknown[]) =>
+    (mockEndRampsBuyQuoteFetchTrace as (...a: unknown[]) => void)(...args),
 }));
 
 const createMockStore = () =>

--- a/app/components/UI/Ramp/hooks/useRampsQuotes.ts
+++ b/app/components/UI/Ramp/hooks/useRampsQuotes.ts
@@ -6,6 +6,8 @@ import Engine from '../../../../core/Engine';
 import { rampsQueries } from '../queries';
 import type { RampsQueryStatus } from './useRampsPaymentMethods';
 import {
+  buildRampsBuyQuoteFetchCufCompletion,
+  buildRampsBuyQuoteFetchStartTags,
   endRampsBuyQuoteFetchTrace,
   startRampsBuyQuoteFetchTrace,
 } from '../utils/rampsBuyCufTrace';
@@ -37,6 +39,12 @@ export interface UseRampsQuotesResult {
   error: unknown | null;
 }
 
+interface ActiveQuoteCufOperation {
+  id: string;
+  requestedProviders?: string[];
+  requestedProvidersKey: string;
+}
+
 export function useRampsQuotes(
   options?: GetQuotesOptions | null,
 ): UseRampsQuotesResult {
@@ -57,6 +65,16 @@ export function useRampsQuotes(
     options?.assetId && options.walletAddress && options.amount > 0,
   );
 
+  const requestedProvidersKey = (options?.providers ?? []).join(',');
+  const hasRequestedProviders = options?.providers !== undefined;
+  const requestedProviders = useMemo(() => {
+    if (!hasRequestedProviders) {
+      return undefined;
+    }
+
+    return requestedProvidersKey ? requestedProvidersKey.split(',') : [];
+  }, [hasRequestedProviders, requestedProvidersKey]);
+
   const quotesQuery = useQuery({
     ...rampsQueries.quotes.options({
       assetId: options?.assetId,
@@ -64,51 +82,81 @@ export function useRampsQuotes(
       walletAddress: options?.walletAddress ?? '',
       redirectUrl: options?.redirectUrl,
       paymentMethods: options?.paymentMethods,
-      providers: options?.providers,
+      providers: requestedProviders,
       forceRefresh: options?.forceRefresh,
       ttl: options?.ttl,
     }),
     enabled: queryEnabled,
   });
 
-  const quoteCufOpIdRef = useRef<string | null>(null);
+  const quoteCufOpRef = useRef<ActiveQuoteCufOperation | null>(null);
 
-  // Buy Quote Fetch CUF (TRAM-3780): fetch start → quotes rendered or error.
+  // Buy Quote Fetch CUF (TRAM-3780 / TRAM-3805): fetch start → usable quotes
+  // or a query/provider-level failure.
   // Fires for every Unified Buy quote fetch; nests under E2E parent when active.
   useEffect(() => {
     if (!queryEnabled) {
-      if (quoteCufOpIdRef.current) {
+      if (quoteCufOpRef.current) {
         endRampsBuyQuoteFetchTrace({
-          id: quoteCufOpIdRef.current,
+          id: quoteCufOpRef.current.id,
           data: {
             [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
             [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.CANCELLED,
           },
         });
-        quoteCufOpIdRef.current = null;
+        quoteCufOpRef.current = null;
       }
       return;
     }
 
-    if (quotesQuery.isFetching && !quoteCufOpIdRef.current) {
-      quoteCufOpIdRef.current = startRampsBuyQuoteFetchTrace();
+    if (
+      quoteCufOpRef.current &&
+      quoteCufOpRef.current.requestedProvidersKey !== requestedProvidersKey
+    ) {
+      endRampsBuyQuoteFetchTrace({
+        id: quoteCufOpRef.current.id,
+        data: {
+          [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+          [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.SUPERSEDED,
+        },
+      });
+      quoteCufOpRef.current = null;
+    }
+
+    if (quotesQuery.isFetching && !quoteCufOpRef.current) {
+      const providersAtStart = requestedProviders
+        ? [...requestedProviders]
+        : undefined;
+      quoteCufOpRef.current = {
+        id: startRampsBuyQuoteFetchTrace({
+          tags: buildRampsBuyQuoteFetchStartTags(providersAtStart),
+        }),
+        requestedProviders: providersAtStart,
+        requestedProvidersKey,
+      };
       return;
     }
 
-    if (!quotesQuery.isFetching && quoteCufOpIdRef.current) {
-      const opId = quoteCufOpIdRef.current;
-      quoteCufOpIdRef.current = null;
+    if (!quotesQuery.isFetching && quoteCufOpRef.current) {
+      const operation = quoteCufOpRef.current;
+      quoteCufOpRef.current = null;
       endRampsBuyQuoteFetchTrace({
-        id: opId,
-        data: quotesQuery.isError
-          ? {
-              [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
-              [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.ERROR,
-            }
-          : { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
+        id: operation.id,
+        data: buildRampsBuyQuoteFetchCufCompletion({
+          isQueryError: quotesQuery.isError,
+          response: quotesQuery.data,
+          requestedProviders: operation.requestedProviders,
+        }),
       });
     }
-  }, [queryEnabled, quotesQuery.isFetching, quotesQuery.isError]);
+  }, [
+    queryEnabled,
+    quotesQuery.isFetching,
+    quotesQuery.isError,
+    quotesQuery.data,
+    requestedProviders,
+    requestedProvidersKey,
+  ]);
 
   const status = useMemo<RampsQueryStatus>(() => {
     if (!queryEnabled) {

--- a/app/components/UI/Ramp/hooks/useRampsQuotes.ts
+++ b/app/components/UI/Ramp/hooks/useRampsQuotes.ts
@@ -1,19 +1,10 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { BuyWidget, QuotesResponse } from '@metamask/ramps-controller';
 import type { Quote } from '../types';
 import Engine from '../../../../core/Engine';
 import { rampsQueries } from '../queries';
 import type { RampsQueryStatus } from './useRampsPaymentMethods';
-import {
-  endRampsBuyCufChildTrace,
-  startRampsBuyCufChildTrace,
-} from '../utils/rampsBuyCufTrace';
-import {
-  RAMPS_BUY_CUF_END_REASON,
-  RAMPS_BUY_CUF_TAG,
-} from '../constants/rampsBuyCufTags';
-import { TraceName } from '../../../../util/trace';
 
 export interface GetQuotesOptions {
   region?: string;
@@ -71,46 +62,6 @@ export function useRampsQuotes(
     }),
     enabled: queryEnabled,
   });
-
-  const quoteCufOpIdRef = useRef<string | null>(null);
-
-  // Nested Buy Quote Fetch CUF: fetch start → quotes rendered or error.
-  useEffect(() => {
-    if (!queryEnabled) {
-      if (quoteCufOpIdRef.current) {
-        endRampsBuyCufChildTrace({
-          id: quoteCufOpIdRef.current,
-          data: {
-            [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
-            [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.CANCELLED,
-          },
-        });
-        quoteCufOpIdRef.current = null;
-      }
-      return;
-    }
-
-    if (quotesQuery.isFetching && !quoteCufOpIdRef.current) {
-      quoteCufOpIdRef.current = startRampsBuyCufChildTrace({
-        name: TraceName.RampBuyQuoteFetch,
-      });
-      return;
-    }
-
-    if (!quotesQuery.isFetching && quoteCufOpIdRef.current) {
-      const opId = quoteCufOpIdRef.current;
-      quoteCufOpIdRef.current = null;
-      endRampsBuyCufChildTrace({
-        id: opId,
-        data: quotesQuery.isError
-          ? {
-              [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
-              [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.ERROR,
-            }
-          : { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
-      });
-    }
-  }, [queryEnabled, quotesQuery.isFetching, quotesQuery.isError]);
 
   const status = useMemo<RampsQueryStatus>(() => {
     if (!queryEnabled) {

--- a/app/components/UI/Ramp/hooks/useRampsQuotes.ts
+++ b/app/components/UI/Ramp/hooks/useRampsQuotes.ts
@@ -1,10 +1,18 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { BuyWidget, QuotesResponse } from '@metamask/ramps-controller';
 import type { Quote } from '../types';
 import Engine from '../../../../core/Engine';
 import { rampsQueries } from '../queries';
 import type { RampsQueryStatus } from './useRampsPaymentMethods';
+import {
+  endRampsBuyQuoteFetchTrace,
+  startRampsBuyQuoteFetchTrace,
+} from '../utils/rampsBuyCufTrace';
+import {
+  RAMPS_BUY_CUF_END_REASON,
+  RAMPS_BUY_CUF_TAG,
+} from '../constants/rampsBuyCufTags';
 
 export interface GetQuotesOptions {
   region?: string;
@@ -62,6 +70,45 @@ export function useRampsQuotes(
     }),
     enabled: queryEnabled,
   });
+
+  const quoteCufOpIdRef = useRef<string | null>(null);
+
+  // Buy Quote Fetch CUF (TRAM-3780): fetch start → quotes rendered or error.
+  // Fires for every Unified Buy quote fetch; nests under E2E parent when active.
+  useEffect(() => {
+    if (!queryEnabled) {
+      if (quoteCufOpIdRef.current) {
+        endRampsBuyQuoteFetchTrace({
+          id: quoteCufOpIdRef.current,
+          data: {
+            [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+            [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.CANCELLED,
+          },
+        });
+        quoteCufOpIdRef.current = null;
+      }
+      return;
+    }
+
+    if (quotesQuery.isFetching && !quoteCufOpIdRef.current) {
+      quoteCufOpIdRef.current = startRampsBuyQuoteFetchTrace();
+      return;
+    }
+
+    if (!quotesQuery.isFetching && quoteCufOpIdRef.current) {
+      const opId = quoteCufOpIdRef.current;
+      quoteCufOpIdRef.current = null;
+      endRampsBuyQuoteFetchTrace({
+        id: opId,
+        data: quotesQuery.isError
+          ? {
+              [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+              [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.ERROR,
+            }
+          : { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
+      });
+    }
+  }, [queryEnabled, quotesQuery.isFetching, quotesQuery.isError]);
 
   const status = useMemo<RampsQueryStatus>(() => {
     if (!queryEnabled) {

--- a/app/components/UI/Ramp/hooks/useRampsQuotes.ts
+++ b/app/components/UI/Ramp/hooks/useRampsQuotes.ts
@@ -1,10 +1,19 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { BuyWidget, QuotesResponse } from '@metamask/ramps-controller';
 import type { Quote } from '../types';
 import Engine from '../../../../core/Engine';
 import { rampsQueries } from '../queries';
 import type { RampsQueryStatus } from './useRampsPaymentMethods';
+import {
+  endRampsBuyCufChildTrace,
+  startRampsBuyCufChildTrace,
+} from '../utils/rampsBuyCufTrace';
+import {
+  RAMPS_BUY_CUF_END_REASON,
+  RAMPS_BUY_CUF_TAG,
+} from '../constants/rampsBuyCufTags';
+import { TraceName } from '../../../../util/trace';
 
 export interface GetQuotesOptions {
   region?: string;
@@ -62,6 +71,46 @@ export function useRampsQuotes(
     }),
     enabled: queryEnabled,
   });
+
+  const quoteCufOpIdRef = useRef<string | null>(null);
+
+  // Nested Buy Quote Fetch CUF: fetch start → quotes rendered or error.
+  useEffect(() => {
+    if (!queryEnabled) {
+      if (quoteCufOpIdRef.current) {
+        endRampsBuyCufChildTrace({
+          id: quoteCufOpIdRef.current,
+          data: {
+            [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+            [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.CANCELLED,
+          },
+        });
+        quoteCufOpIdRef.current = null;
+      }
+      return;
+    }
+
+    if (quotesQuery.isFetching && !quoteCufOpIdRef.current) {
+      quoteCufOpIdRef.current = startRampsBuyCufChildTrace({
+        name: TraceName.RampBuyQuoteFetch,
+      });
+      return;
+    }
+
+    if (!quotesQuery.isFetching && quoteCufOpIdRef.current) {
+      const opId = quoteCufOpIdRef.current;
+      quoteCufOpIdRef.current = null;
+      endRampsBuyCufChildTrace({
+        id: opId,
+        data: quotesQuery.isError
+          ? {
+              [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+              [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.ERROR,
+            }
+          : { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
+      });
+    }
+  }, [queryEnabled, quotesQuery.isFetching, quotesQuery.isError]);
 
   const status = useMemo<RampsQueryStatus>(() => {
     if (!queryEnabled) {

--- a/app/components/UI/Ramp/hooks/useTransakRouting.ts
+++ b/app/components/UI/Ramp/hooks/useTransakRouting.ts
@@ -51,6 +51,15 @@ import { dismissHeadlessFlow } from '../headless/headlessEntryNavigation';
 import { getChainIdFromAssetId } from '../headless';
 import { setHeadlessOrderContext } from '../../../../core/Engine/controllers/ramps-controller/headlessOrderContextRegistry';
 import { emitTerminalOrderAnalyticsFromCallback } from '../../../../core/Engine/controllers/ramps-controller/event-handlers/analytics';
+import {
+  endOpenRampsBuyCufChildrenByName,
+  endRampsBuyCufTrace,
+} from '../utils/rampsBuyCufTrace';
+import {
+  RAMPS_BUY_CUF_END_REASON,
+  RAMPS_BUY_CUF_TAG,
+} from '../constants/rampsBuyCufTags';
+import { TraceName } from '../../../../util/trace';
 
 // The native provider code must match the environment that `refreshOrder` /
 // `getOrderFromCallback` poll (from `getRampsEnvironment()`). Dev/UAT expose
@@ -437,6 +446,12 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
 
   const navigateToOrderProcessingCallback = useCallback(
     ({ orderId }: { orderId: string }) => {
+      // Native child CUF ends when the order is created (before Order Details).
+      endOpenRampsBuyCufChildrenByName(TraceName.RampBuyNativeToOrderCreated, {
+        [RAMPS_BUY_CUF_TAG.SUCCESS]: true,
+        orderId,
+      });
+
       // Headless mode: fire `onOrderCreated`, close the session, and pop
       // out of the ramp stack so the caller regains foreground. The
       // consumer drives post-order UI themselves — no RAMPS_ORDER_DETAILS.
@@ -450,6 +465,14 @@ export const useTransakRouting = (config?: UseTransakRoutingConfig) => {
             'useTransakRouting: onOrderCreated callback threw',
           );
         }
+        // Parent Buy E2E CUF expects Order Details; headless never shows it.
+        endRampsBuyCufTrace({
+          data: {
+            [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+            [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.HEADLESS,
+            orderId,
+          },
+        });
         closeSession(headlessSessionId, { reason: 'completed' });
         dismissActiveHeadlessFlow();
         return;

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
@@ -12,6 +12,8 @@ import {
   endOpenRampsBuyCufChildrenByName,
   startRampsBuyQuoteFetchTrace,
   endRampsBuyQuoteFetchTrace,
+  buildRampsBuyQuoteFetchStartTags,
+  buildRampsBuyQuoteFetchCufCompletion,
   getRampsBuyCufParentContext,
   hasActiveRampsBuyCufTrace,
   surfaceFromBuyFlowOrigin,
@@ -20,6 +22,7 @@ import {
 import {
   RAMPS_BUY_CUF_FEATURE,
   RAMPS_BUY_CUF_SURFACE,
+  RAMPS_BUY_CUF_PATH,
   RAMPS_BUY_CUF_TAG,
   RAMPS_BUY_CUF_END_REASON,
   RAMPS_BUY_CUF_TIMEOUT_MS,
@@ -259,6 +262,106 @@ describe('rampsBuyCufTrace', () => {
           },
         }),
       );
+    });
+  });
+
+  describe('Buy Quote Fetch provider attribution (TRAM-3805)', () => {
+    it('tags a single-provider start with the provider id', () => {
+      const result = buildRampsBuyQuoteFetchStartTags(['/providers/paypal']);
+
+      expect(result).toEqual({
+        [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/paypal',
+      });
+    });
+
+    it.each([undefined, [], ['/providers/paypal', '/providers/transak']])(
+      'omits provider tags when the start is not single-provider',
+      (input) => {
+        const result = buildRampsBuyQuoteFetchStartTags(input);
+
+        expect(result).toBeUndefined();
+      },
+    );
+
+    it('marks a PayPal custom-action quote as a custom-action success', () => {
+      const result = buildRampsBuyQuoteFetchCufCompletion({
+        isQueryError: false,
+        requestedProviders: ['/providers/paypal'],
+        response: {
+          success: [
+            {
+              provider: '/providers/paypal',
+              quote: { isCustomAction: true },
+            },
+          ],
+        },
+      });
+
+      expect(result).toEqual({
+        [RAMPS_BUY_CUF_TAG.SUCCESS]: true,
+        [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/paypal',
+        [RAMPS_BUY_CUF_TAG.PATH]: RAMPS_BUY_CUF_PATH.CUSTOM_ACTION,
+        [RAMPS_BUY_CUF_TAG.CUSTOM_ACTION]: true,
+      });
+    });
+
+    it('marks an HTTP-ok PayPal miss as a no-quote failure', () => {
+      const result = buildRampsBuyQuoteFetchCufCompletion({
+        isQueryError: false,
+        requestedProviders: ['/providers/paypal'],
+        response: { success: [] },
+      });
+
+      expect(result).toEqual({
+        [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+        [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.NO_QUOTE,
+        [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/paypal',
+      });
+    });
+
+    it('ignores quotes returned for a provider other than the requested one', () => {
+      const result = buildRampsBuyQuoteFetchCufCompletion({
+        isQueryError: false,
+        requestedProviders: ['/providers/paypal'],
+        response: {
+          success: [{ provider: '/providers/transak', quote: {} }],
+        },
+      });
+
+      expect(result).toEqual({
+        [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+        [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.NO_QUOTE,
+        [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/paypal',
+      });
+    });
+
+    it('keeps transport errors separate from provider-level misses', () => {
+      const result = buildRampsBuyQuoteFetchCufCompletion({
+        isQueryError: true,
+        requestedProviders: ['/providers/paypal'],
+        response: null,
+      });
+
+      expect(result).toEqual({
+        [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+        [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.ERROR,
+        [RAMPS_BUY_CUF_TAG.PROVIDER]: '/providers/paypal',
+      });
+    });
+
+    it('does not attribute a multi-provider success to the first quote', () => {
+      const result = buildRampsBuyQuoteFetchCufCompletion({
+        isQueryError: false,
+        requestedProviders: ['/providers/paypal', '/providers/transak'],
+        response: {
+          success: [{ provider: '/providers/transak', quote: {} }],
+        },
+      });
+
+      expect(result).toEqual({
+        [RAMPS_BUY_CUF_TAG.SUCCESS]: true,
+        [RAMPS_BUY_CUF_TAG.CUSTOM_ACTION]: false,
+      });
     });
   });
 });

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
@@ -84,6 +84,7 @@ describe('rampsBuyCufTrace', () => {
         name: TraceName.RampBuyToOrderDetails,
         id: opId,
         op: TraceOperation.RampOperation,
+        forceTransaction: true,
         tags: startFields,
         data: startFields,
       }),

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
@@ -206,13 +206,13 @@ describe('rampsBuyCufTrace', () => {
     mockTrace.mockClear();
 
     const childId = startRampsBuyCufChildTrace({
-      name: TraceName.RampBuyQuoteFetch,
+      name: TraceName.RampBuyContinueToCheckout,
     });
 
-    expect(childId).toContain(TraceName.RampBuyQuoteFetch);
+    expect(childId).toContain(TraceName.RampBuyContinueToCheckout);
     expect(mockTrace).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: TraceName.RampBuyQuoteFetch,
+        name: TraceName.RampBuyContinueToCheckout,
         id: childId,
         op: TraceOperation.RampOperation,
         parentContext: { mocked: 'parent-span' },
@@ -225,7 +225,7 @@ describe('rampsBuyCufTrace', () => {
 
   it('skips child start when no parent is active', () => {
     const childId = startRampsBuyCufChildTrace({
-      name: TraceName.RampBuyQuoteFetch,
+      name: TraceName.RampBuyContinueToCheckout,
     });
 
     expect(childId).toBeNull();
@@ -264,7 +264,7 @@ describe('rampsBuyCufTrace', () => {
       name: TraceName.RampBuyNativeToOrderCreated,
     });
     const b = startRampsBuyCufChildTrace({
-      name: TraceName.RampBuyQuoteFetch,
+      name: TraceName.RampBuyContinueToCheckout,
     });
 
     const ended = endOpenRampsBuyCufChildrenByName(
@@ -280,7 +280,7 @@ describe('rampsBuyCufTrace', () => {
         data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
       }),
     );
-    // Quote child remains open until ended explicitly or parent ends.
+    // Other child remains open until ended explicitly or parent ends.
     expect(mockEndTrace).not.toHaveBeenCalledWith(
       expect.objectContaining({ id: b }),
     );
@@ -289,7 +289,7 @@ describe('rampsBuyCufTrace', () => {
   it('abandons open children when the parent ends', () => {
     startRampsBuyCufTrace();
     const childId = startRampsBuyCufChildTrace({
-      name: TraceName.RampBuyQuoteFetch,
+      name: TraceName.RampBuyContinueToCheckout,
     });
     mockEndTrace.mockClear();
 
@@ -297,7 +297,7 @@ describe('rampsBuyCufTrace', () => {
 
     expect(mockEndTrace).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: TraceName.RampBuyQuoteFetch,
+        name: TraceName.RampBuyContinueToCheckout,
         id: childId,
         data: {
           [RAMPS_BUY_CUF_TAG.SUCCESS]: false,

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
@@ -179,6 +179,7 @@ describe('rampsBuyCufTrace', () => {
           id: opId,
           op: TraceOperation.RampOperation,
           parentContext: undefined,
+          forceTransaction: true,
           tags: expect.objectContaining({
             [RAMPS_BUY_CUF_TAG.FEATURE]: RAMPS_BUY_CUF_FEATURE,
           }),
@@ -201,6 +202,7 @@ describe('rampsBuyCufTrace', () => {
           name: TraceName.RampBuyQuoteFetch,
           id: opId,
           parentContext: { mocked: 'parent-span' },
+          forceTransaction: false,
         }),
       );
     });

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
@@ -1,0 +1,315 @@
+import {
+  trace,
+  endTrace,
+  TraceName,
+  TraceOperation,
+} from '../../../../util/trace';
+import {
+  startRampsBuyCufTrace,
+  endRampsBuyCufTrace,
+  endRampsBuyCufTraceAfter,
+  startRampsBuyCufChildTrace,
+  endRampsBuyCufChildTrace,
+  endOpenRampsBuyCufChildrenByName,
+  getRampsBuyCufParentContext,
+  hasActiveRampsBuyCufTrace,
+  surfaceFromBuyFlowOrigin,
+  resetRampsBuyCufTraceForTests,
+} from './rampsBuyCufTrace';
+import {
+  RAMPS_BUY_CUF_FEATURE,
+  RAMPS_BUY_CUF_SURFACE,
+  RAMPS_BUY_CUF_TAG,
+  RAMPS_BUY_CUF_END_REASON,
+  RAMPS_BUY_CUF_TIMEOUT_MS,
+} from '../constants/rampsBuyCufTags';
+
+jest.mock('../../../../util/trace', () => ({
+  ...jest.requireActual('../../../../util/trace'),
+  trace: jest.fn(() => ({ mocked: 'parent-span' })),
+  endTrace: jest.fn(),
+}));
+
+const mockTrace = trace as jest.Mock;
+const mockEndTrace = endTrace as jest.Mock;
+
+describe('rampsBuyCufTrace', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    resetRampsBuyCufTraceForTests();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('surfaceFromBuyFlowOrigin', () => {
+    it('maps tokenInfo to token_buy', () => {
+      expect(surfaceFromBuyFlowOrigin('tokenInfo')).toBe(
+        RAMPS_BUY_CUF_SURFACE.TOKEN_BUY,
+      );
+    });
+
+    it('maps homeTokenList to home_token_list', () => {
+      expect(surfaceFromBuyFlowOrigin('homeTokenList')).toBe(
+        RAMPS_BUY_CUF_SURFACE.HOME_TOKEN_LIST,
+      );
+    });
+
+    it('returns unknown when buyFlowOrigin is omitted', () => {
+      expect(surfaceFromBuyFlowOrigin()).toBe(RAMPS_BUY_CUF_SURFACE.UNKNOWN);
+    });
+  });
+
+  it('starts a parent span with feature, ramp_type, and surface tags', () => {
+    const opId = startRampsBuyCufTrace({
+      surface: RAMPS_BUY_CUF_SURFACE.FUND_MENU,
+    });
+
+    expect(opId).toContain(TraceName.RampBuyToOrderDetails);
+    expect(hasActiveRampsBuyCufTrace()).toBe(true);
+    expect(mockTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.RampBuyToOrderDetails,
+        id: opId,
+        op: TraceOperation.RampOperation,
+        tags: {
+          [RAMPS_BUY_CUF_TAG.FEATURE]: RAMPS_BUY_CUF_FEATURE,
+          [RAMPS_BUY_CUF_TAG.RAMP_TYPE]: 'UNIFIED_BUY_2',
+          [RAMPS_BUY_CUF_TAG.SURFACE]: RAMPS_BUY_CUF_SURFACE.FUND_MENU,
+        },
+      }),
+    );
+    expect(getRampsBuyCufParentContext()).toEqual({ mocked: 'parent-span' });
+  });
+
+  it('mints a distinct id for each parent start', () => {
+    const a = startRampsBuyCufTrace();
+    // Second start supersedes the first but keeps minting a new op id.
+    const b = startRampsBuyCufTrace();
+
+    expect(a).not.toEqual(b);
+  });
+
+  it('supersedes a prior parent when a new Buy E2E starts', () => {
+    const first = startRampsBuyCufTrace({
+      surface: RAMPS_BUY_CUF_SURFACE.EMPTY_STATE,
+    });
+
+    const second = startRampsBuyCufTrace({
+      surface: RAMPS_BUY_CUF_SURFACE.DEEP_LINK,
+    });
+
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.RampBuyToOrderDetails,
+        id: first,
+        data: {
+          [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+          [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.SUPERSEDED,
+        },
+      }),
+    );
+    expect(second).not.toEqual(first);
+    expect(hasActiveRampsBuyCufTrace()).toBe(true);
+  });
+
+  it('ends a started parent by the current single-flight id', () => {
+    const opId = startRampsBuyCufTrace();
+
+    endRampsBuyCufTrace({
+      data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
+    });
+
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.RampBuyToOrderDetails,
+        id: opId,
+        data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
+      }),
+    );
+    expect(hasActiveRampsBuyCufTrace()).toBe(false);
+    expect(getRampsBuyCufParentContext()).toBeUndefined();
+  });
+
+  it('end is idempotent: only the first end reaches endTrace', () => {
+    startRampsBuyCufTrace();
+
+    endRampsBuyCufTrace({ data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true } });
+    endRampsBuyCufTrace({ data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true } });
+
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores end when id does not match the active parent', () => {
+    startRampsBuyCufTrace();
+
+    endRampsBuyCufTrace({ id: 'other-id' });
+
+    expect(mockEndTrace).not.toHaveBeenCalled();
+    expect(hasActiveRampsBuyCufTrace()).toBe(true);
+  });
+
+  it('ends the parent as timeout after the fallback delay', () => {
+    const opId = startRampsBuyCufTrace();
+
+    jest.advanceTimersByTime(RAMPS_BUY_CUF_TIMEOUT_MS);
+
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.RampBuyToOrderDetails,
+        id: opId,
+        data: {
+          [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+          [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.TIMEOUT,
+        },
+      }),
+    );
+  });
+
+  it('timeout fallback no-ops when the parent already ended', () => {
+    startRampsBuyCufTrace();
+    endRampsBuyCufTrace({ data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true } });
+    mockEndTrace.mockClear();
+
+    jest.advanceTimersByTime(RAMPS_BUY_CUF_TIMEOUT_MS);
+
+    expect(mockEndTrace).not.toHaveBeenCalled();
+  });
+
+  it('endRampsBuyCufTraceAfter only ends the parent it was scheduled for', () => {
+    const first = startRampsBuyCufTrace();
+    endRampsBuyCufTraceAfter(
+      {
+        data: {
+          [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+          [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.TIMEOUT,
+        },
+      },
+      1000,
+    );
+    // Supersede: first ends as superseded; second becomes active.
+    startRampsBuyCufTrace();
+    mockEndTrace.mockClear();
+
+    jest.advanceTimersByTime(1000);
+
+    // The short timer was for `first`, which is no longer active.
+    expect(mockEndTrace).not.toHaveBeenCalledWith(
+      expect.objectContaining({ id: first }),
+    );
+  });
+
+  it('starts a child nested under the active parent context', () => {
+    startRampsBuyCufTrace();
+    mockTrace.mockClear();
+
+    const childId = startRampsBuyCufChildTrace({
+      name: TraceName.RampBuyQuoteFetch,
+    });
+
+    expect(childId).toContain(TraceName.RampBuyQuoteFetch);
+    expect(mockTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.RampBuyQuoteFetch,
+        id: childId,
+        op: TraceOperation.RampOperation,
+        parentContext: { mocked: 'parent-span' },
+        tags: expect.objectContaining({
+          [RAMPS_BUY_CUF_TAG.FEATURE]: RAMPS_BUY_CUF_FEATURE,
+        }),
+      }),
+    );
+  });
+
+  it('skips child start when no parent is active', () => {
+    const childId = startRampsBuyCufChildTrace({
+      name: TraceName.RampBuyQuoteFetch,
+    });
+
+    expect(childId).toBeNull();
+    expect(mockTrace).not.toHaveBeenCalled();
+  });
+
+  it('ends a child by op id and is idempotent', () => {
+    startRampsBuyCufTrace();
+    const childId = startRampsBuyCufChildTrace({
+      name: TraceName.RampBuyContinueToCheckout,
+    });
+    expect(childId).not.toBeNull();
+
+    endRampsBuyCufChildTrace({
+      id: childId as string,
+      data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
+    });
+    endRampsBuyCufChildTrace({
+      id: childId as string,
+      data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
+    });
+
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.RampBuyContinueToCheckout,
+        id: childId,
+        data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
+      }),
+    );
+  });
+
+  it('ends open children by name', () => {
+    startRampsBuyCufTrace();
+    const a = startRampsBuyCufChildTrace({
+      name: TraceName.RampBuyNativeToOrderCreated,
+    });
+    const b = startRampsBuyCufChildTrace({
+      name: TraceName.RampBuyQuoteFetch,
+    });
+
+    const ended = endOpenRampsBuyCufChildrenByName(
+      TraceName.RampBuyNativeToOrderCreated,
+      { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
+    );
+
+    expect(ended).toBe(1);
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.RampBuyNativeToOrderCreated,
+        id: a,
+        data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
+      }),
+    );
+    // Quote child remains open until ended explicitly or parent ends.
+    expect(mockEndTrace).not.toHaveBeenCalledWith(
+      expect.objectContaining({ id: b }),
+    );
+  });
+
+  it('abandons open children when the parent ends', () => {
+    startRampsBuyCufTrace();
+    const childId = startRampsBuyCufChildTrace({
+      name: TraceName.RampBuyQuoteFetch,
+    });
+    mockEndTrace.mockClear();
+
+    endRampsBuyCufTrace({ data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true } });
+
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.RampBuyQuoteFetch,
+        id: childId,
+        data: {
+          [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+          [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.ABANDONED,
+        },
+      }),
+    );
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: TraceName.RampBuyToOrderDetails,
+        data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
+      }),
+    );
+  });
+});

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
@@ -10,6 +10,8 @@ import {
   endRampsBuyCufTrace,
   startRampsBuyCufChildTrace,
   endOpenRampsBuyCufChildrenByName,
+  startRampsBuyQuoteFetchTrace,
+  endRampsBuyQuoteFetchTrace,
   getRampsBuyCufParentContext,
   hasActiveRampsBuyCufTrace,
   surfaceFromBuyFlowOrigin,
@@ -164,5 +166,93 @@ describe('rampsBuyCufTrace', () => {
         },
       }),
     );
+  });
+
+  describe('Buy Quote Fetch CUF (TRAM-3780)', () => {
+    it('starts a standalone quote span when no E2E parent is active', () => {
+      const opId = startRampsBuyQuoteFetchTrace();
+
+      expect(opId).toContain(TraceName.RampBuyQuoteFetch);
+      expect(mockTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.RampBuyQuoteFetch,
+          id: opId,
+          op: TraceOperation.RampOperation,
+          parentContext: undefined,
+          tags: expect.objectContaining({
+            [RAMPS_BUY_CUF_TAG.FEATURE]: RAMPS_BUY_CUF_FEATURE,
+          }),
+        }),
+      );
+    });
+
+    it('nests under the active Buy E2E parent when one is open', () => {
+      startRampsBuyCufTrace();
+      mockTrace.mockClear();
+
+      const opId = startRampsBuyQuoteFetchTrace();
+
+      expect(mockTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.RampBuyQuoteFetch,
+          id: opId,
+          parentContext: { mocked: 'parent-span' },
+        }),
+      );
+    });
+
+    it('supersedes a prior open quote fetch', () => {
+      const first = startRampsBuyQuoteFetchTrace();
+      const second = startRampsBuyQuoteFetchTrace();
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.RampBuyQuoteFetch,
+          id: first,
+          data: {
+            [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+            [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.SUPERSEDED,
+          },
+        }),
+      );
+      expect(second).not.toEqual(first);
+    });
+
+    it('ends success and error completions by op id', () => {
+      const successId = startRampsBuyQuoteFetchTrace();
+      endRampsBuyQuoteFetchTrace({
+        id: successId,
+        data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
+      });
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.RampBuyQuoteFetch,
+          id: successId,
+          data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
+        }),
+      );
+
+      mockEndTrace.mockClear();
+      const errorId = startRampsBuyQuoteFetchTrace();
+      endRampsBuyQuoteFetchTrace({
+        id: errorId,
+        data: {
+          [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+          [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.ERROR,
+        },
+      });
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.RampBuyQuoteFetch,
+          id: errorId,
+          data: {
+            [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+            [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.ERROR,
+          },
+        }),
+      );
+    });
   });
 });

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
@@ -62,10 +62,16 @@ describe('rampsBuyCufTrace', () => {
     });
   });
 
-  it('starts a parent span with feature, ramp_type, and surface tags', () => {
+  it('starts a parent span with feature, ramp_type, and surface as tags and attributes', () => {
     const opId = startRampsBuyCufTrace({
       surface: RAMPS_BUY_CUF_SURFACE.FUND_MENU,
     });
+
+    const startFields = {
+      [RAMPS_BUY_CUF_TAG.FEATURE]: RAMPS_BUY_CUF_FEATURE,
+      [RAMPS_BUY_CUF_TAG.RAMP_TYPE]: 'UNIFIED_BUY_2',
+      [RAMPS_BUY_CUF_TAG.SURFACE]: RAMPS_BUY_CUF_SURFACE.FUND_MENU,
+    };
 
     expect(opId).toContain(TraceName.RampBuyToOrderDetails);
     expect(hasActiveRampsBuyCufTrace()).toBe(true);
@@ -74,11 +80,9 @@ describe('rampsBuyCufTrace', () => {
         name: TraceName.RampBuyToOrderDetails,
         id: opId,
         op: TraceOperation.RampOperation,
-        tags: {
-          [RAMPS_BUY_CUF_TAG.FEATURE]: RAMPS_BUY_CUF_FEATURE,
-          [RAMPS_BUY_CUF_TAG.RAMP_TYPE]: 'UNIFIED_BUY_2',
-          [RAMPS_BUY_CUF_TAG.SURFACE]: RAMPS_BUY_CUF_SURFACE.FUND_MENU,
-        },
+        // tags → transaction filters; data → Attributes panel (with success)
+        tags: startFields,
+        data: startFields,
       }),
     );
     expect(getRampsBuyCufParentContext()).toEqual({ mocked: 'parent-span' });
@@ -218,6 +222,10 @@ describe('rampsBuyCufTrace', () => {
         parentContext: { mocked: 'parent-span' },
         tags: expect.objectContaining({
           [RAMPS_BUY_CUF_TAG.FEATURE]: RAMPS_BUY_CUF_FEATURE,
+        }),
+        data: expect.objectContaining({
+          [RAMPS_BUY_CUF_TAG.FEATURE]: RAMPS_BUY_CUF_FEATURE,
+          [RAMPS_BUY_CUF_TAG.RAMP_TYPE]: 'UNIFIED_BUY_2',
         }),
       }),
     );

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
@@ -80,7 +80,6 @@ describe('rampsBuyCufTrace', () => {
         name: TraceName.RampBuyToOrderDetails,
         id: opId,
         op: TraceOperation.RampOperation,
-        // tags → transaction filters; data → Attributes panel (with success)
         tags: startFields,
         data: startFields,
       }),
@@ -185,8 +184,6 @@ describe('rampsBuyCufTrace', () => {
       },
       1000,
     );
-    // Close the first parent, then open a new one — the short timer must not
-    // touch the newer op (end clears the prior schedule).
     endRampsBuyCufTrace({
       data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
     });
@@ -283,7 +280,6 @@ describe('rampsBuyCufTrace', () => {
         data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
       }),
     );
-    // Other child remains open until ended explicitly or parent ends.
     expect(mockEndTrace).not.toHaveBeenCalledWith(
       expect.objectContaining({ id: b }),
     );

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
@@ -8,7 +8,6 @@ import {
 import {
   startRampsBuyCufTrace,
   endRampsBuyCufTrace,
-  endRampsBuyCufTraceAfter,
   startRampsBuyCufChildTrace,
   endRampsBuyCufChildTrace,
   endOpenRampsBuyCufChildrenByName,
@@ -48,22 +47,12 @@ describe('rampsBuyCufTrace', () => {
     jest.useRealTimers();
   });
 
-  describe('surfaceFromBuyFlowOrigin', () => {
-    it('maps tokenInfo to token_buy', () => {
-      expect(surfaceFromBuyFlowOrigin('tokenInfo')).toBe(
-        RAMPS_BUY_CUF_SURFACE.TOKEN_BUY,
-      );
-    });
-
-    it('maps homeTokenList to home_token_list', () => {
-      expect(surfaceFromBuyFlowOrigin('homeTokenList')).toBe(
-        RAMPS_BUY_CUF_SURFACE.HOME_TOKEN_LIST,
-      );
-    });
-
-    it('returns unknown when buyFlowOrigin is omitted', () => {
-      expect(surfaceFromBuyFlowOrigin()).toBe(RAMPS_BUY_CUF_SURFACE.UNKNOWN);
-    });
+  it.each([
+    ['tokenInfo', RAMPS_BUY_CUF_SURFACE.TOKEN_BUY],
+    ['homeTokenList', RAMPS_BUY_CUF_SURFACE.HOME_TOKEN_LIST],
+    [undefined, RAMPS_BUY_CUF_SURFACE.UNKNOWN],
+  ] as const)('surfaceFromBuyFlowOrigin(%s) → %s', (origin, expected) => {
+    expect(surfaceFromBuyFlowOrigin(origin)).toBe(expected);
   });
 
   it('starts a parent span with feature, ramp_type, and surface as tags and attributes', () => {
@@ -148,29 +137,18 @@ describe('rampsBuyCufTrace', () => {
     expect(getRampsBuyCufParentContext()).toBeUndefined();
   });
 
-  it('end is idempotent: only the first end reaches endTrace', () => {
+  it('end is idempotent and ignores mismatched ids', () => {
     startRampsBuyCufTrace();
-
+    endRampsBuyCufTrace({ id: 'other-id' });
+    expect(mockEndTrace).not.toHaveBeenCalled();
     endRampsBuyCufTrace({ data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true } });
     endRampsBuyCufTrace({ data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true } });
-
     expect(mockEndTrace).toHaveBeenCalledTimes(1);
   });
 
-  it('ignores end when id does not match the active parent', () => {
-    startRampsBuyCufTrace();
-
-    endRampsBuyCufTrace({ id: 'other-id' });
-
-    expect(mockEndTrace).not.toHaveBeenCalled();
-    expect(hasActiveRampsBuyCufTrace()).toBe(true);
-  });
-
-  it('ends the parent as timeout after the fallback delay', () => {
+  it('times out the open parent and no-ops after a prior end', () => {
     const opId = startRampsBuyCufTrace();
-
     jest.advanceTimersByTime(RAMPS_BUY_CUF_TIMEOUT_MS);
-
     expect(mockEndTrace).toHaveBeenCalledWith(
       expect.objectContaining({
         name: TraceName.RampBuyToOrderDetails,
@@ -181,40 +159,11 @@ describe('rampsBuyCufTrace', () => {
         },
       }),
     );
-  });
-
-  it('timeout fallback no-ops when the parent already ended', () => {
     startRampsBuyCufTrace();
     endRampsBuyCufTrace({ data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true } });
     mockEndTrace.mockClear();
-
     jest.advanceTimersByTime(RAMPS_BUY_CUF_TIMEOUT_MS);
-
     expect(mockEndTrace).not.toHaveBeenCalled();
-  });
-
-  it('endRampsBuyCufTraceAfter only ends the parent it was scheduled for', () => {
-    const first = startRampsBuyCufTrace();
-    endRampsBuyCufTraceAfter(
-      {
-        data: {
-          [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
-          [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.TIMEOUT,
-        },
-      },
-      1000,
-    );
-    endRampsBuyCufTrace({
-      data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
-    });
-    const second = startRampsBuyCufTrace();
-    mockEndTrace.mockClear();
-
-    jest.advanceTimersByTime(1000);
-
-    expect(mockEndTrace).not.toHaveBeenCalled();
-    expect(hasActiveRampsBuyCufTrace()).toBe(true);
-    expect(second).not.toEqual(first);
   });
 
   it('starts a child nested under the active parent context', () => {

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
@@ -81,42 +81,24 @@ describe('rampsBuyCufTrace', () => {
     expect(getRampsBuyCufParentContext()).toEqual({ mocked: 'parent-span' });
   });
 
-  it('mints a distinct id for each parent start after the prior ends', () => {
-    const a = startRampsBuyCufTrace();
-    endRampsBuyCufTrace({ data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true } });
-    const b = startRampsBuyCufTrace();
-
-    expect(a).not.toEqual(b);
-  });
-
-  it('ignores duplicate parent starts while a Buy E2E is already open', () => {
+  it('keeps one parent while open, remints after end or Sentry cleanup', () => {
     const first = startRampsBuyCufTrace({
       surface: RAMPS_BUY_CUF_SURFACE.EMPTY_STATE,
     });
-
-    const second = startRampsBuyCufTrace({
-      surface: RAMPS_BUY_CUF_SURFACE.DEEP_LINK,
-    });
-
-    expect(second).toEqual(first);
+    expect(
+      startRampsBuyCufTrace({ surface: RAMPS_BUY_CUF_SURFACE.DEEP_LINK }),
+    ).toEqual(first);
     expect(mockTrace).toHaveBeenCalledTimes(1);
-    expect(mockEndTrace).not.toHaveBeenCalled();
-    expect(hasActiveRampsBuyCufTrace()).toBe(true);
-  });
 
-  it('starts a new parent when the prior Sentry span was cleaned up out-of-band', () => {
-    const first = startRampsBuyCufTrace({
-      surface: RAMPS_BUY_CUF_SURFACE.EMPTY_STATE,
-    });
+    endRampsBuyCufTrace({ data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true } });
+    const afterEnd = startRampsBuyCufTrace();
+    expect(afterEnd).not.toEqual(first);
+
     mockGetTraceContext.mockReturnValue(undefined);
-
-    const second = startRampsBuyCufTrace({
+    const afterCleanup = startRampsBuyCufTrace({
       surface: RAMPS_BUY_CUF_SURFACE.DEEP_LINK,
     });
-
-    expect(second).not.toEqual(first);
-    expect(mockTrace).toHaveBeenCalledTimes(2);
-    expect(hasActiveRampsBuyCufTrace()).toBe(true);
+    expect(afterCleanup).not.toEqual(afterEnd);
   });
 
   it('ends a started parent by the current single-flight id', () => {

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
@@ -1,6 +1,7 @@
 import {
   trace,
   endTrace,
+  getTraceContext,
   TraceName,
   TraceOperation,
 } from '../../../../util/trace';
@@ -28,16 +29,19 @@ jest.mock('../../../../util/trace', () => ({
   ...jest.requireActual('../../../../util/trace'),
   trace: jest.fn(() => ({ mocked: 'parent-span' })),
   endTrace: jest.fn(),
+  getTraceContext: jest.fn(() => ({ mocked: 'parent-span' })),
 }));
 
 const mockTrace = trace as jest.Mock;
 const mockEndTrace = endTrace as jest.Mock;
+const mockGetTraceContext = getTraceContext as jest.Mock;
 
 describe('rampsBuyCufTrace', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
     resetRampsBuyCufTraceForTests();
+    mockGetTraceContext.mockReturnValue({ mocked: 'parent-span' });
   });
 
   afterEach(() => {
@@ -107,6 +111,21 @@ describe('rampsBuyCufTrace', () => {
     expect(second).toEqual(first);
     expect(mockTrace).toHaveBeenCalledTimes(1);
     expect(mockEndTrace).not.toHaveBeenCalled();
+    expect(hasActiveRampsBuyCufTrace()).toBe(true);
+  });
+
+  it('starts a new parent when the prior Sentry span was cleaned up out-of-band', () => {
+    const first = startRampsBuyCufTrace({
+      surface: RAMPS_BUY_CUF_SURFACE.EMPTY_STATE,
+    });
+    mockGetTraceContext.mockReturnValue(undefined);
+
+    const second = startRampsBuyCufTrace({
+      surface: RAMPS_BUY_CUF_SURFACE.DEEP_LINK,
+    });
+
+    expect(second).not.toEqual(first);
+    expect(mockTrace).toHaveBeenCalledTimes(2);
     expect(hasActiveRampsBuyCufTrace()).toBe(true);
   });
 

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
@@ -182,6 +182,10 @@ describe('rampsBuyCufTrace', () => {
           tags: expect.objectContaining({
             [RAMPS_BUY_CUF_TAG.FEATURE]: RAMPS_BUY_CUF_FEATURE,
           }),
+          data: expect.objectContaining({
+            [RAMPS_BUY_CUF_TAG.FEATURE]: RAMPS_BUY_CUF_FEATURE,
+            [RAMPS_BUY_CUF_TAG.RAMP_TYPE]: 'UNIFIED_BUY_2',
+          }),
         }),
       );
     });

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
@@ -88,15 +88,15 @@ describe('rampsBuyCufTrace', () => {
     expect(getRampsBuyCufParentContext()).toEqual({ mocked: 'parent-span' });
   });
 
-  it('mints a distinct id for each parent start', () => {
+  it('mints a distinct id for each parent start after the prior ends', () => {
     const a = startRampsBuyCufTrace();
-    // Second start supersedes the first but keeps minting a new op id.
+    endRampsBuyCufTrace({ data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true } });
     const b = startRampsBuyCufTrace();
 
     expect(a).not.toEqual(b);
   });
 
-  it('supersedes a prior parent when a new Buy E2E starts', () => {
+  it('ignores duplicate parent starts while a Buy E2E is already open', () => {
     const first = startRampsBuyCufTrace({
       surface: RAMPS_BUY_CUF_SURFACE.EMPTY_STATE,
     });
@@ -105,17 +105,9 @@ describe('rampsBuyCufTrace', () => {
       surface: RAMPS_BUY_CUF_SURFACE.DEEP_LINK,
     });
 
-    expect(mockEndTrace).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: TraceName.RampBuyToOrderDetails,
-        id: first,
-        data: {
-          [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
-          [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.SUPERSEDED,
-        },
-      }),
-    );
-    expect(second).not.toEqual(first);
+    expect(second).toEqual(first);
+    expect(mockTrace).toHaveBeenCalledTimes(1);
+    expect(mockEndTrace).not.toHaveBeenCalled();
     expect(hasActiveRampsBuyCufTrace()).toBe(true);
   });
 
@@ -193,16 +185,19 @@ describe('rampsBuyCufTrace', () => {
       },
       1000,
     );
-    // Supersede: first ends as superseded; second becomes active.
-    startRampsBuyCufTrace();
+    // Close the first parent, then open a new one — the short timer must not
+    // touch the newer op (end clears the prior schedule).
+    endRampsBuyCufTrace({
+      data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
+    });
+    const second = startRampsBuyCufTrace();
     mockEndTrace.mockClear();
 
     jest.advanceTimersByTime(1000);
 
-    // The short timer was for `first`, which is no longer active.
-    expect(mockEndTrace).not.toHaveBeenCalledWith(
-      expect.objectContaining({ id: first }),
-    );
+    expect(mockEndTrace).not.toHaveBeenCalled();
+    expect(hasActiveRampsBuyCufTrace()).toBe(true);
+    expect(second).not.toEqual(first);
   });
 
   it('starts a child nested under the active parent context', () => {

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.test.ts
@@ -9,7 +9,6 @@ import {
   startRampsBuyCufTrace,
   endRampsBuyCufTrace,
   startRampsBuyCufChildTrace,
-  endRampsBuyCufChildTrace,
   endOpenRampsBuyCufChildrenByName,
   getRampsBuyCufParentContext,
   hasActiveRampsBuyCufTrace,
@@ -59,13 +58,11 @@ describe('rampsBuyCufTrace', () => {
     const opId = startRampsBuyCufTrace({
       surface: RAMPS_BUY_CUF_SURFACE.FUND_MENU,
     });
-
     const startFields = {
       [RAMPS_BUY_CUF_TAG.FEATURE]: RAMPS_BUY_CUF_FEATURE,
       [RAMPS_BUY_CUF_TAG.RAMP_TYPE]: 'UNIFIED_BUY_2',
       [RAMPS_BUY_CUF_TAG.SURFACE]: RAMPS_BUY_CUF_SURFACE.FUND_MENU,
     };
-
     expect(opId).toContain(TraceName.RampBuyToOrderDetails);
     expect(hasActiveRampsBuyCufTrace()).toBe(true);
     expect(mockTrace).toHaveBeenCalledWith(
@@ -89,52 +86,31 @@ describe('rampsBuyCufTrace', () => {
       startRampsBuyCufTrace({ surface: RAMPS_BUY_CUF_SURFACE.DEEP_LINK }),
     ).toEqual(first);
     expect(mockTrace).toHaveBeenCalledTimes(1);
-
     endRampsBuyCufTrace({ data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true } });
     const afterEnd = startRampsBuyCufTrace();
     expect(afterEnd).not.toEqual(first);
-
     mockGetTraceContext.mockReturnValue(undefined);
-    const afterCleanup = startRampsBuyCufTrace({
-      surface: RAMPS_BUY_CUF_SURFACE.DEEP_LINK,
-    });
-    expect(afterCleanup).not.toEqual(afterEnd);
+    expect(
+      startRampsBuyCufTrace({ surface: RAMPS_BUY_CUF_SURFACE.DEEP_LINK }),
+    ).not.toEqual(afterEnd);
   });
 
-  it('ends a started parent by the current single-flight id', () => {
-    const opId = startRampsBuyCufTrace();
-
-    endRampsBuyCufTrace({
-      data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
-    });
-
-    expect(mockEndTrace).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: TraceName.RampBuyToOrderDetails,
-        id: opId,
-        data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
-      }),
-    );
-    expect(hasActiveRampsBuyCufTrace()).toBe(false);
-    expect(getRampsBuyCufParentContext()).toBeUndefined();
-  });
-
-  it('end is idempotent and ignores mismatched ids', () => {
+  it('ends parents idempotently, ignores mismatched ids, and times out', () => {
     startRampsBuyCufTrace();
     endRampsBuyCufTrace({ id: 'other-id' });
     expect(mockEndTrace).not.toHaveBeenCalled();
     endRampsBuyCufTrace({ data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true } });
     endRampsBuyCufTrace({ data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true } });
     expect(mockEndTrace).toHaveBeenCalledTimes(1);
-  });
+    expect(hasActiveRampsBuyCufTrace()).toBe(false);
+    expect(getRampsBuyCufParentContext()).toBeUndefined();
 
-  it('times out the open parent and no-ops after a prior end', () => {
-    const opId = startRampsBuyCufTrace();
+    const timedOutId = startRampsBuyCufTrace();
     jest.advanceTimersByTime(RAMPS_BUY_CUF_TIMEOUT_MS);
     expect(mockEndTrace).toHaveBeenCalledWith(
       expect.objectContaining({
         name: TraceName.RampBuyToOrderDetails,
-        id: opId,
+        id: timedOutId,
         data: {
           [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
           [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.TIMEOUT,
@@ -148,103 +124,36 @@ describe('rampsBuyCufTrace', () => {
     expect(mockEndTrace).not.toHaveBeenCalled();
   });
 
-  it('starts a child nested under the active parent context', () => {
+  it('nests, ends, and abandons child spans under the parent', () => {
+    expect(
+      startRampsBuyCufChildTrace({ name: TraceName.RampBuyContinueToCheckout }),
+    ).toBeNull();
     startRampsBuyCufTrace();
     mockTrace.mockClear();
-
     const childId = startRampsBuyCufChildTrace({
       name: TraceName.RampBuyContinueToCheckout,
     });
-
-    expect(childId).toContain(TraceName.RampBuyContinueToCheckout);
     expect(mockTrace).toHaveBeenCalledWith(
       expect.objectContaining({
         name: TraceName.RampBuyContinueToCheckout,
         id: childId,
-        op: TraceOperation.RampOperation,
         parentContext: { mocked: 'parent-span' },
-        tags: expect.objectContaining({
-          [RAMPS_BUY_CUF_TAG.FEATURE]: RAMPS_BUY_CUF_FEATURE,
-        }),
-        data: expect.objectContaining({
-          [RAMPS_BUY_CUF_TAG.FEATURE]: RAMPS_BUY_CUF_FEATURE,
-          [RAMPS_BUY_CUF_TAG.RAMP_TYPE]: 'UNIFIED_BUY_2',
-        }),
       }),
     );
-  });
-
-  it('skips child start when no parent is active', () => {
-    const childId = startRampsBuyCufChildTrace({
-      name: TraceName.RampBuyContinueToCheckout,
-    });
-
-    expect(childId).toBeNull();
-    expect(mockTrace).not.toHaveBeenCalled();
-  });
-
-  it('ends a child by op id and is idempotent', () => {
-    startRampsBuyCufTrace();
-    const childId = startRampsBuyCufChildTrace({
-      name: TraceName.RampBuyContinueToCheckout,
-    });
-    expect(childId).not.toBeNull();
-
-    endRampsBuyCufChildTrace({
-      id: childId as string,
-      data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
-    });
-    endRampsBuyCufChildTrace({
-      id: childId as string,
-      data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
-    });
-
-    expect(mockEndTrace).toHaveBeenCalledTimes(1);
-    expect(mockEndTrace).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: TraceName.RampBuyContinueToCheckout,
-        id: childId,
-        data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
-      }),
-    );
-  });
-
-  it('ends open children by name', () => {
-    startRampsBuyCufTrace();
-    const a = startRampsBuyCufChildTrace({
+    const nativeId = startRampsBuyCufChildTrace({
       name: TraceName.RampBuyNativeToOrderCreated,
     });
-    const b = startRampsBuyCufChildTrace({
-      name: TraceName.RampBuyContinueToCheckout,
-    });
-
-    const ended = endOpenRampsBuyCufChildrenByName(
-      TraceName.RampBuyNativeToOrderCreated,
-      { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
-    );
-
-    expect(ended).toBe(1);
-    expect(mockEndTrace).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: TraceName.RampBuyNativeToOrderCreated,
-        id: a,
-        data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
-      }),
-    );
-    expect(mockEndTrace).not.toHaveBeenCalledWith(
-      expect.objectContaining({ id: b }),
-    );
-  });
-
-  it('abandons open children when the parent ends', () => {
-    startRampsBuyCufTrace();
-    const childId = startRampsBuyCufChildTrace({
-      name: TraceName.RampBuyContinueToCheckout,
-    });
     mockEndTrace.mockClear();
-
+    expect(
+      endOpenRampsBuyCufChildrenByName(TraceName.RampBuyNativeToOrderCreated, {
+        [RAMPS_BUY_CUF_TAG.SUCCESS]: true,
+      }),
+    ).toBe(1);
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({ id: nativeId }),
+    );
+    mockEndTrace.mockClear();
     endRampsBuyCufTrace({ data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true } });
-
     expect(mockEndTrace).toHaveBeenCalledWith(
       expect.objectContaining({
         name: TraceName.RampBuyContinueToCheckout,
@@ -253,12 +162,6 @@ describe('rampsBuyCufTrace', () => {
           [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
           [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.ABANDONED,
         },
-      }),
-    );
-    expect(mockEndTrace).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: TraceName.RampBuyToOrderDetails,
-        data: { [RAMPS_BUY_CUF_TAG.SUCCESS]: true },
       }),
     );
   });

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
@@ -32,7 +32,6 @@ function nextCufOpId(name: TraceName): string {
   return `${name}#${cufOpCounter}`;
 }
 
-/** Drop module parent state when Sentry cleanup ended the span out-of-band. */
 function clearStaleParentState(): void {
   if (parentTimeoutId) {
     clearTimeout(parentTimeoutId);
@@ -42,24 +41,17 @@ function clearStaleParentState(): void {
   parentSpan = undefined;
 }
 
-function isParentSpanStillActive(): boolean {
-  if (!parentOpId) {
-    return false;
-  }
-  return (
+function resolveParentContext(): TraceContext {
+  if (
+    !parentOpId ||
     getTraceContext({
       name: TraceName.RampBuyToOrderDetails,
       id: parentOpId,
-    }) !== undefined
-  );
-}
-
-function resolveParentContext(): TraceContext {
-  if (!parentOpId) {
-    return undefined;
-  }
-  if (!isParentSpanStillActive()) {
-    clearStaleParentState();
+    }) === undefined
+  ) {
+    if (parentOpId) {
+      clearStaleParentState();
+    }
     return undefined;
   }
   return parentSpan;
@@ -110,11 +102,8 @@ export function startRampsBuyCufTrace({
   startTime,
   data,
 }: StartRampsBuyCufTraceOptions = {}): string {
-  if (parentOpId) {
-    if (isParentSpanStillActive()) {
-      return parentOpId;
-    }
-    clearStaleParentState();
+  if (resolveParentContext() && parentOpId) {
+    return parentOpId;
   }
 
   const opId = nextCufOpId(TraceName.RampBuyToOrderDetails);
@@ -164,13 +153,7 @@ export function endRampsBuyCufTrace({
   }
 
   abandonOpenChildTraces(RAMPS_BUY_CUF_END_REASON.ABANDONED);
-
-  if (parentTimeoutId) {
-    clearTimeout(parentTimeoutId);
-    parentTimeoutId = null;
-  }
-  parentOpId = null;
-  parentSpan = undefined;
+  clearStaleParentState();
   endTrace({
     name: TraceName.RampBuyToOrderDetails,
     id: targetId,
@@ -283,12 +266,7 @@ function abandonOpenChildTraces(reason: string): void {
 }
 
 export function resetRampsBuyCufTraceForTests(): void {
-  if (parentTimeoutId) {
-    clearTimeout(parentTimeoutId);
-    parentTimeoutId = null;
-  }
+  clearStaleParentState();
   pendingChildMeta.clear();
-  parentOpId = null;
-  parentSpan = undefined;
   cufOpCounter = 0;
 }

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
@@ -23,7 +23,9 @@ import type { BuyFlowOrigin } from '../Views/BuildQuote/BuildQuote';
  * `RampsOrderDetails` has a known order. Child spans (quote / checkout /
  * native) nest under the parent via `parentContext` when a parent is active.
  *
- * Single-flight: a newer Buy entry supersedes any still-open parent.
+ * Single-flight: while a parent is open, duplicate starts are ignored (keeps
+ * the existing span). A new parent only begins after the prior one ends
+ * (success, bail, timeout, etc.). Quote-fetch children still supersede.
  */
 
 const CUF_META = {
@@ -87,8 +89,10 @@ export interface StartRampsBuyCufTraceOptions {
 }
 
 /**
- * Start the Buy E2E parent span. Supersedes any still-open parent.
+ * Start the Buy E2E parent span.
  * Returns the op id used to end it (also tracked module-level for cross-surface end).
+ * If a parent is already open, returns that id and does not start a new span
+ * (avoids false `superseded` from double-taps / concurrent `goToBuy`).
  */
 export function startRampsBuyCufTrace({
   surface = RAMPS_BUY_CUF_SURFACE.UNKNOWN,
@@ -97,12 +101,7 @@ export function startRampsBuyCufTrace({
   data,
 }: StartRampsBuyCufTraceOptions = {}): string {
   if (parentOpId) {
-    endRampsBuyCufTrace({
-      data: {
-        [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
-        [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.SUPERSEDED,
-      },
-    });
+    return parentOpId;
   }
 
   const opId = nextCufOpId(TraceName.RampBuyToOrderDetails);

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
@@ -1,0 +1,284 @@
+import {
+  trace,
+  endTrace,
+  TraceName,
+  TraceOperation,
+  type TraceContext,
+  type TraceValue,
+} from '../../../../util/trace';
+import {
+  RAMPS_BUY_CUF_FEATURE,
+  RAMPS_BUY_CUF_TAG,
+  RAMPS_BUY_CUF_SURFACE,
+  RAMPS_BUY_CUF_END_REASON,
+  RAMPS_BUY_CUF_TIMEOUT_MS,
+  type RampsBuyCufSurface,
+} from '../constants/rampsBuyCufTags';
+import type { BuyFlowOrigin } from '../Views/BuildQuote/BuildQuote';
+
+/**
+ * Helpers for the Unified Buy user-perceived CUF spans (TRAM-3779).
+ *
+ * The parent span starts at Buy entry (`goToBuy` / deep link) and ends when
+ * `RampsOrderDetails` has a known order. Child spans (quote / checkout /
+ * native) nest under the parent via `parentContext` when a parent is active.
+ *
+ * Single-flight: a newer Buy entry supersedes any still-open parent.
+ */
+
+const CUF_META = {
+  NAME: 'name',
+} as const;
+
+const pendingChildMeta = new Map<string, Record<string, TraceValue>>();
+let parentOpId: string | null = null;
+let parentSpan: TraceContext;
+let parentTimeoutId: ReturnType<typeof setTimeout> | null = null;
+let cufOpCounter = 0;
+
+function nextCufOpId(name: TraceName): string {
+  cufOpCounter += 1;
+  return `${name}#${cufOpCounter}`;
+}
+
+export function buildRampsBuyCufStartTags(
+  extra?: Record<string, TraceValue>,
+): Record<string, TraceValue> {
+  return {
+    [RAMPS_BUY_CUF_TAG.FEATURE]: RAMPS_BUY_CUF_FEATURE,
+    [RAMPS_BUY_CUF_TAG.RAMP_TYPE]: 'UNIFIED_BUY_2',
+    ...extra,
+  };
+}
+
+/** Map BuildQuote `buyFlowOrigin` to a CUF surface tag when callers omit surface. */
+export function surfaceFromBuyFlowOrigin(
+  buyFlowOrigin?: BuyFlowOrigin,
+): RampsBuyCufSurface {
+  if (buyFlowOrigin === 'tokenInfo') {
+    return RAMPS_BUY_CUF_SURFACE.TOKEN_BUY;
+  }
+  if (buyFlowOrigin === 'homeTokenList') {
+    return RAMPS_BUY_CUF_SURFACE.HOME_TOKEN_LIST;
+  }
+  return RAMPS_BUY_CUF_SURFACE.UNKNOWN;
+}
+
+export interface StartRampsBuyCufTraceOptions {
+  surface?: RampsBuyCufSurface;
+  tags?: Record<string, TraceValue>;
+  startTime?: number;
+  data?: Record<string, TraceValue>;
+}
+
+/**
+ * Start the Buy E2E parent span. Supersedes any still-open parent.
+ * Returns the op id used to end it (also tracked module-level for cross-surface end).
+ */
+export function startRampsBuyCufTrace({
+  surface = RAMPS_BUY_CUF_SURFACE.UNKNOWN,
+  tags,
+  startTime,
+  data,
+}: StartRampsBuyCufTraceOptions = {}): string {
+  if (parentOpId) {
+    endRampsBuyCufTrace({
+      data: {
+        [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+        [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.SUPERSEDED,
+      },
+    });
+  }
+
+  const opId = nextCufOpId(TraceName.RampBuyToOrderDetails);
+  const startTags = buildRampsBuyCufStartTags({
+    [RAMPS_BUY_CUF_TAG.SURFACE]: surface,
+    ...tags,
+  });
+
+  parentOpId = opId;
+  parentSpan = trace({
+    name: TraceName.RampBuyToOrderDetails,
+    id: opId,
+    op: TraceOperation.RampOperation,
+    startTime,
+    data,
+    tags: startTags,
+  });
+
+  endRampsBuyCufTraceAfter(
+    {
+      data: {
+        [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+        [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.TIMEOUT,
+      },
+    },
+    RAMPS_BUY_CUF_TIMEOUT_MS,
+  );
+
+  return opId;
+}
+
+export interface EndRampsBuyCufTraceOptions {
+  /** When omitted, ends the current single-flight parent. */
+  id?: string;
+  data?: Record<string, TraceValue>;
+  timestamp?: number;
+}
+
+/**
+ * End the Buy E2E parent span. Idempotent: no-ops unless the targeted (or
+ * current) parent is still pending. Also abandons any open child spans.
+ */
+export function endRampsBuyCufTrace({
+  id,
+  data,
+  timestamp,
+}: EndRampsBuyCufTraceOptions = {}): void {
+  const targetId = id ?? parentOpId;
+  if (!targetId || targetId !== parentOpId) {
+    return;
+  }
+
+  abandonOpenChildTraces(RAMPS_BUY_CUF_END_REASON.ABANDONED);
+
+  if (parentTimeoutId) {
+    clearTimeout(parentTimeoutId);
+    parentTimeoutId = null;
+  }
+  parentOpId = null;
+  parentSpan = undefined;
+  endTrace({
+    name: TraceName.RampBuyToOrderDetails,
+    id: targetId,
+    data,
+    timestamp,
+  });
+}
+
+/** Schedule a fallback end; no-ops if the parent already ended. */
+export function endRampsBuyCufTraceAfter(
+  options: EndRampsBuyCufTraceOptions,
+  delayMs: number,
+): void {
+  if (parentTimeoutId) {
+    clearTimeout(parentTimeoutId);
+  }
+  const scheduledFor = parentOpId;
+  parentTimeoutId = setTimeout(() => {
+    parentTimeoutId = null;
+    if (scheduledFor && scheduledFor === parentOpId) {
+      endRampsBuyCufTrace(options);
+    }
+  }, delayMs);
+}
+
+/** Parent span context for nesting child CUF spans. */
+export function getRampsBuyCufParentContext(): TraceContext {
+  return parentSpan;
+}
+
+/** Whether a Buy E2E parent span is currently open. */
+export function hasActiveRampsBuyCufTrace(): boolean {
+  return parentOpId !== null;
+}
+
+export interface StartRampsBuyCufChildTraceOptions {
+  name: TraceName;
+  tags?: Record<string, TraceValue>;
+  startTime?: number;
+  data?: Record<string, TraceValue>;
+}
+
+/**
+ * Start a child CUF span nested under the active Buy E2E parent.
+ * Returns null when no parent is active (child is skipped).
+ */
+export function startRampsBuyCufChildTrace({
+  name,
+  tags,
+  startTime,
+  data,
+}: StartRampsBuyCufChildTraceOptions): string | null {
+  if (!parentOpId) {
+    return null;
+  }
+
+  const opId = nextCufOpId(name);
+  pendingChildMeta.set(opId, { [CUF_META.NAME]: name });
+  trace({
+    name,
+    id: opId,
+    op: TraceOperation.RampOperation,
+    parentContext: parentSpan,
+    startTime,
+    data,
+    tags: buildRampsBuyCufStartTags(tags),
+  });
+  return opId;
+}
+
+export interface EndRampsBuyCufChildTraceOptions {
+  id: string;
+  data?: Record<string, TraceValue>;
+  timestamp?: number;
+}
+
+/**
+ * End a child CUF span by op id. Idempotent: no-ops if already ended.
+ */
+export function endRampsBuyCufChildTrace({
+  id,
+  data,
+  timestamp,
+}: EndRampsBuyCufChildTraceOptions): void {
+  const meta = pendingChildMeta.get(id);
+  if (!meta) {
+    return;
+  }
+  pendingChildMeta.delete(id);
+  const name = meta[CUF_META.NAME] as TraceName;
+  endTrace({ name, id, data, timestamp });
+}
+
+/**
+ * End every open child with the given name (e.g. supersede prior quote fetch).
+ * Returns the number of children ended.
+ */
+export function endOpenRampsBuyCufChildrenByName(
+  name: TraceName,
+  data?: Record<string, TraceValue>,
+): number {
+  let ended = 0;
+  for (const [opId, meta] of Array.from(pendingChildMeta.entries())) {
+    if (meta[CUF_META.NAME] === name) {
+      endRampsBuyCufChildTrace({ id: opId, data });
+      ended += 1;
+    }
+  }
+  return ended;
+}
+
+function abandonOpenChildTraces(reason: string): void {
+  for (const [opId] of Array.from(pendingChildMeta.entries())) {
+    endRampsBuyCufChildTrace({
+      id: opId,
+      data: {
+        [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+        [RAMPS_BUY_CUF_TAG.REASON]: reason,
+      },
+    });
+  }
+}
+
+/** Test-only: drop parent + child state between tests. */
+export function resetRampsBuyCufTraceForTests(): void {
+  if (parentTimeoutId) {
+    clearTimeout(parentTimeoutId);
+    parentTimeoutId = null;
+  }
+  pendingChildMeta.clear();
+  parentOpId = null;
+  parentSpan = undefined;
+  cufOpCounter = 0;
+}

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
@@ -51,6 +51,21 @@ export function buildRampsBuyCufStartTags(
   };
 }
 
+/**
+ * Mirror start tags onto span `data` so they appear in Sentry's Attributes
+ * panel alongside end fields like `success` / `reason`. `trace()` maps
+ * `tags` → scope.setTag (transaction filters) and `data` → span attributes.
+ */
+function withStartSpanAttributes(
+  startTags: Record<string, TraceValue>,
+  data?: Record<string, TraceValue>,
+): Record<string, TraceValue> {
+  return {
+    ...startTags,
+    ...data,
+  };
+}
+
 /** Map BuildQuote `buyFlowOrigin` to a CUF surface tag when callers omit surface. */
 export function surfaceFromBuyFlowOrigin(
   buyFlowOrigin?: BuyFlowOrigin,
@@ -102,7 +117,7 @@ export function startRampsBuyCufTrace({
     id: opId,
     op: TraceOperation.RampOperation,
     startTime,
-    data,
+    data: withStartSpanAttributes(startTags, data),
     tags: startTags,
   });
 
@@ -205,6 +220,7 @@ export function startRampsBuyCufChildTrace({
   }
 
   const opId = nextCufOpId(name);
+  const startTags = buildRampsBuyCufStartTags(tags);
   pendingChildMeta.set(opId, { [CUF_META.NAME]: name });
   trace({
     name,
@@ -212,8 +228,8 @@ export function startRampsBuyCufChildTrace({
     op: TraceOperation.RampOperation,
     parentContext: parentSpan,
     startTime,
-    data,
-    tags: buildRampsBuyCufStartTags(tags),
+    data: withStartSpanAttributes(startTags, data),
+    tags: startTags,
   });
   return opId;
 }

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
@@ -129,6 +129,7 @@ export function startRampsBuyCufTrace({
     id: opId,
     op: TraceOperation.RampOperation,
     startTime,
+    forceTransaction: true,
     data: withStartSpanAttributes(startTags, data),
     tags: startTags,
   });

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
@@ -11,6 +11,7 @@ import {
   RAMPS_BUY_CUF_FEATURE,
   RAMPS_BUY_CUF_TAG,
   RAMPS_BUY_CUF_SURFACE,
+  RAMPS_BUY_CUF_PATH,
   RAMPS_BUY_CUF_END_REASON,
   RAMPS_BUY_CUF_TIMEOUT_MS,
   type RampsBuyCufSurface,
@@ -223,6 +224,79 @@ export interface StartRampsBuyQuoteFetchTraceOptions {
   tags?: Record<string, TraceValue>;
   startTime?: number;
   data?: Record<string, TraceValue>;
+}
+
+export function buildRampsBuyQuoteFetchStartTags(
+  providers?: string[],
+): Record<string, TraceValue> | undefined {
+  if (providers?.length !== 1) {
+    return undefined;
+  }
+
+  return { [RAMPS_BUY_CUF_TAG.PROVIDER]: providers[0] };
+}
+
+export interface BuildRampsBuyQuoteFetchCufCompletionParams {
+  isQueryError: boolean;
+  response?: {
+    success?: {
+      provider?: string;
+      quote?: unknown;
+    }[];
+  } | null;
+  requestedProviders?: string[];
+}
+
+/**
+ * Provider errors arrive in a successful HTTP response, so query status alone
+ * cannot distinguish a usable quote from a provider-level miss.
+ */
+export function buildRampsBuyQuoteFetchCufCompletion({
+  isQueryError,
+  response,
+  requestedProviders,
+}: BuildRampsBuyQuoteFetchCufCompletionParams): Record<string, TraceValue> {
+  const singleProvider =
+    requestedProviders?.length === 1 ? requestedProviders[0] : undefined;
+  const providerData: Record<string, TraceValue> = singleProvider
+    ? { [RAMPS_BUY_CUF_TAG.PROVIDER]: singleProvider }
+    : {};
+
+  if (isQueryError) {
+    return {
+      [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+      [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.ERROR,
+      ...providerData,
+    };
+  }
+
+  const successQuotes = response?.success ?? [];
+  const usableQuotes = singleProvider
+    ? successQuotes.filter(({ provider }) => provider === singleProvider)
+    : successQuotes;
+
+  if (usableQuotes.length === 0) {
+    return {
+      [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+      [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.NO_QUOTE,
+      ...providerData,
+    };
+  }
+
+  const isCustomAction =
+    (usableQuotes[0].quote as { isCustomAction?: boolean } | undefined)
+      ?.isCustomAction === true;
+
+  return {
+    [RAMPS_BUY_CUF_TAG.SUCCESS]: true,
+    ...providerData,
+    ...(isCustomAction
+      ? {
+          [RAMPS_BUY_CUF_TAG.PATH]: RAMPS_BUY_CUF_PATH.CUSTOM_ACTION,
+          [RAMPS_BUY_CUF_TAG.CUSTOM_ACTION]: true,
+        }
+      : { [RAMPS_BUY_CUF_TAG.CUSTOM_ACTION]: false }),
+  };
 }
 
 /**

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
@@ -243,12 +243,14 @@ export function startRampsBuyQuoteFetchTrace({
 
   const opId = nextCufOpId(TraceName.RampBuyQuoteFetch);
   const startTags = buildRampsBuyCufStartTags(tags);
+  const parentContext = resolveParentContext();
   pendingChildMeta.set(opId, { [CUF_META.NAME]: TraceName.RampBuyQuoteFetch });
   trace({
     name: TraceName.RampBuyQuoteFetch,
     id: opId,
     op: TraceOperation.RampOperation,
-    parentContext: parentSpan,
+    parentContext,
+    forceTransaction: !parentContext,
     startTime,
     data: withStartSpanAttributes(startTags, data),
     tags: startTags,

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
@@ -242,6 +242,7 @@ export function startRampsBuyQuoteFetchTrace({
   });
 
   const opId = nextCufOpId(TraceName.RampBuyQuoteFetch);
+  const startTags = buildRampsBuyCufStartTags(tags);
   pendingChildMeta.set(opId, { [CUF_META.NAME]: TraceName.RampBuyQuoteFetch });
   trace({
     name: TraceName.RampBuyQuoteFetch,
@@ -249,8 +250,8 @@ export function startRampsBuyQuoteFetchTrace({
     op: TraceOperation.RampOperation,
     parentContext: parentSpan,
     startTime,
-    data,
-    tags: buildRampsBuyCufStartTags(tags),
+    data: withStartSpanAttributes(startTags, data),
+    tags: startTags,
   });
   return opId;
 }

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
@@ -219,6 +219,57 @@ export function startRampsBuyCufChildTrace({
   return opId;
 }
 
+export interface StartRampsBuyQuoteFetchTraceOptions {
+  tags?: Record<string, TraceValue>;
+  startTime?: number;
+  data?: Record<string, TraceValue>;
+}
+
+/**
+ * Start the Buy Quote Fetch CUF (TRAM-3780).
+ *
+ * Always fires (standalone CUF). When a Buy E2E parent is open, nests under it
+ * via `parentContext`. A newer quote fetch supersedes any still-open one.
+ */
+export function startRampsBuyQuoteFetchTrace({
+  tags,
+  startTime,
+  data,
+}: StartRampsBuyQuoteFetchTraceOptions = {}): string {
+  endOpenRampsBuyCufChildrenByName(TraceName.RampBuyQuoteFetch, {
+    [RAMPS_BUY_CUF_TAG.SUCCESS]: false,
+    [RAMPS_BUY_CUF_TAG.REASON]: RAMPS_BUY_CUF_END_REASON.SUPERSEDED,
+  });
+
+  const opId = nextCufOpId(TraceName.RampBuyQuoteFetch);
+  pendingChildMeta.set(opId, { [CUF_META.NAME]: TraceName.RampBuyQuoteFetch });
+  trace({
+    name: TraceName.RampBuyQuoteFetch,
+    id: opId,
+    op: TraceOperation.RampOperation,
+    parentContext: parentSpan,
+    startTime,
+    data,
+    tags: buildRampsBuyCufStartTags(tags),
+  });
+  return opId;
+}
+
+export interface EndRampsBuyQuoteFetchTraceOptions {
+  id: string;
+  data?: Record<string, TraceValue>;
+  timestamp?: number;
+}
+
+/** End a Buy Quote Fetch CUF by op id. Idempotent. */
+export function endRampsBuyQuoteFetchTrace({
+  id,
+  data,
+  timestamp,
+}: EndRampsBuyQuoteFetchTraceOptions): void {
+  endRampsBuyCufChildTrace({ id, data, timestamp });
+}
+
 export interface EndRampsBuyCufChildTraceOptions {
   id: string;
   data?: Record<string, TraceValue>;

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
@@ -16,18 +16,6 @@ import {
 } from '../constants/rampsBuyCufTags';
 import type { BuyFlowOrigin } from '../Views/BuildQuote/BuildQuote';
 
-/**
- * Helpers for the Unified Buy user-perceived CUF spans (TRAM-3779).
- *
- * The parent span starts at Buy entry (`goToBuy` / deep link) and ends when
- * `RampsOrderDetails` has a known order. Child spans (quote / checkout /
- * native) nest under the parent via `parentContext` when a parent is active.
- *
- * Single-flight: while a parent is open, duplicate starts are ignored (keeps
- * the existing span). A new parent only begins after the prior one ends
- * (success, bail, timeout, etc.). Quote-fetch children still supersede.
- */
-
 const CUF_META = {
   NAME: 'name',
 } as const;
@@ -53,11 +41,6 @@ export function buildRampsBuyCufStartTags(
   };
 }
 
-/**
- * Mirror start tags onto span `data` so they appear in Sentry's Attributes
- * panel alongside end fields like `success` / `reason`. `trace()` maps
- * `tags` → scope.setTag (transaction filters) and `data` → span attributes.
- */
 function withStartSpanAttributes(
   startTags: Record<string, TraceValue>,
   data?: Record<string, TraceValue>,
@@ -68,7 +51,6 @@ function withStartSpanAttributes(
   };
 }
 
-/** Map BuildQuote `buyFlowOrigin` to a CUF surface tag when callers omit surface. */
 export function surfaceFromBuyFlowOrigin(
   buyFlowOrigin?: BuyFlowOrigin,
 ): RampsBuyCufSurface {
@@ -88,12 +70,6 @@ export interface StartRampsBuyCufTraceOptions {
   data?: Record<string, TraceValue>;
 }
 
-/**
- * Start the Buy E2E parent span.
- * Returns the op id used to end it (also tracked module-level for cross-surface end).
- * If a parent is already open, returns that id and does not start a new span
- * (avoids false `superseded` from double-taps / concurrent `goToBuy`).
- */
 export function startRampsBuyCufTrace({
   surface = RAMPS_BUY_CUF_SURFACE.UNKNOWN,
   tags,
@@ -134,16 +110,11 @@ export function startRampsBuyCufTrace({
 }
 
 export interface EndRampsBuyCufTraceOptions {
-  /** When omitted, ends the current single-flight parent. */
   id?: string;
   data?: Record<string, TraceValue>;
   timestamp?: number;
 }
 
-/**
- * End the Buy E2E parent span. Idempotent: no-ops unless the targeted (or
- * current) parent is still pending. Also abandons any open child spans.
- */
 export function endRampsBuyCufTrace({
   id,
   data,
@@ -170,7 +141,6 @@ export function endRampsBuyCufTrace({
   });
 }
 
-/** Schedule a fallback end; no-ops if the parent already ended. */
 export function endRampsBuyCufTraceAfter(
   options: EndRampsBuyCufTraceOptions,
   delayMs: number,
@@ -187,12 +157,10 @@ export function endRampsBuyCufTraceAfter(
   }, delayMs);
 }
 
-/** Parent span context for nesting child CUF spans. */
 export function getRampsBuyCufParentContext(): TraceContext {
   return parentSpan;
 }
 
-/** Whether a Buy E2E parent span is currently open. */
 export function hasActiveRampsBuyCufTrace(): boolean {
   return parentOpId !== null;
 }
@@ -204,10 +172,6 @@ export interface StartRampsBuyCufChildTraceOptions {
   data?: Record<string, TraceValue>;
 }
 
-/**
- * Start a child CUF span nested under the active Buy E2E parent.
- * Returns null when no parent is active (child is skipped).
- */
 export function startRampsBuyCufChildTrace({
   name,
   tags,
@@ -239,9 +203,6 @@ export interface EndRampsBuyCufChildTraceOptions {
   timestamp?: number;
 }
 
-/**
- * End a child CUF span by op id. Idempotent: no-ops if already ended.
- */
 export function endRampsBuyCufChildTrace({
   id,
   data,
@@ -256,10 +217,6 @@ export function endRampsBuyCufChildTrace({
   endTrace({ name, id, data, timestamp });
 }
 
-/**
- * End every open child with the given name (e.g. supersede prior quote fetch).
- * Returns the number of children ended.
- */
 export function endOpenRampsBuyCufChildrenByName(
   name: TraceName,
   data?: Record<string, TraceValue>,
@@ -286,7 +243,6 @@ function abandonOpenChildTraces(reason: string): void {
   }
 }
 
-/** Test-only: drop parent + child state between tests. */
 export function resetRampsBuyCufTraceForTests(): void {
   if (parentTimeoutId) {
     clearTimeout(parentTimeoutId);

--- a/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
+++ b/app/components/UI/Ramp/utils/rampsBuyCufTrace.ts
@@ -1,6 +1,7 @@
 import {
   trace,
   endTrace,
+  getTraceContext,
   TraceName,
   TraceOperation,
   type TraceContext,
@@ -29,6 +30,39 @@ let cufOpCounter = 0;
 function nextCufOpId(name: TraceName): string {
   cufOpCounter += 1;
   return `${name}#${cufOpCounter}`;
+}
+
+/** Drop module parent state when Sentry cleanup ended the span out-of-band. */
+function clearStaleParentState(): void {
+  if (parentTimeoutId) {
+    clearTimeout(parentTimeoutId);
+    parentTimeoutId = null;
+  }
+  parentOpId = null;
+  parentSpan = undefined;
+}
+
+function isParentSpanStillActive(): boolean {
+  if (!parentOpId) {
+    return false;
+  }
+  return (
+    getTraceContext({
+      name: TraceName.RampBuyToOrderDetails,
+      id: parentOpId,
+    }) !== undefined
+  );
+}
+
+function resolveParentContext(): TraceContext {
+  if (!parentOpId) {
+    return undefined;
+  }
+  if (!isParentSpanStillActive()) {
+    clearStaleParentState();
+    return undefined;
+  }
+  return parentSpan;
 }
 
 export function buildRampsBuyCufStartTags(
@@ -77,7 +111,10 @@ export function startRampsBuyCufTrace({
   data,
 }: StartRampsBuyCufTraceOptions = {}): string {
   if (parentOpId) {
-    return parentOpId;
+    if (isParentSpanStillActive()) {
+      return parentOpId;
+    }
+    clearStaleParentState();
   }
 
   const opId = nextCufOpId(TraceName.RampBuyToOrderDetails);
@@ -178,7 +215,8 @@ export function startRampsBuyCufChildTrace({
   startTime,
   data,
 }: StartRampsBuyCufChildTraceOptions): string | null {
-  if (!parentOpId) {
+  const parentContext = resolveParentContext();
+  if (!parentContext || !parentOpId) {
     return null;
   }
 
@@ -189,7 +227,7 @@ export function startRampsBuyCufChildTrace({
     name,
     id: opId,
     op: TraceOperation.RampOperation,
-    parentContext: parentSpan,
+    parentContext,
     startTime,
     data: withStartSpanAttributes(startTags, data),
     tags: startTags,

--- a/app/components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingChecklistFundPress.test.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingChecklistFundPress.test.ts
@@ -84,7 +84,9 @@ describe('useWalletHomeOnboardingChecklistFundPress', () => {
       order_count: 2,
     });
     expect(mockTrackEvent).toHaveBeenCalledWith({ event: 'built' });
-    expect(goToBuy).toHaveBeenCalledWith(undefined);
+    expect(goToBuy).toHaveBeenCalledWith(undefined, {
+      surface: 'home',
+    });
   });
 
   it('passes resolved ramp intent to goToBuy when available', () => {
@@ -101,8 +103,11 @@ describe('useWalletHomeOnboardingChecklistFundPress', () => {
       result.current();
     });
 
-    expect(goToBuy).toHaveBeenCalledWith({
-      assetId: MAINNET_MUSD_RAMP_ASSET_ID,
-    });
+    expect(goToBuy).toHaveBeenCalledWith(
+      {
+        assetId: MAINNET_MUSD_RAMP_ASSET_ID,
+      },
+      { surface: 'home' },
+    );
   });
 });

--- a/app/components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingChecklistFundPress.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingChecklistFundPress.ts
@@ -5,6 +5,7 @@ import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { ActionLocation } from '../../../util/analytics/actionButtonTracking';
 import { getDetectedGeolocation } from '../../../reducers/fiatOrders';
 import { useRampsButtonClickData } from '../Ramp/hooks/useRampsButtonClickData';
+import { RAMPS_BUY_CUF_SURFACE } from '../Ramp/constants/rampsBuyCufTags';
 import { walletHomeOnboardingPrimaryLabelForStep } from './walletHomeOnboardingStepsStrings';
 import { useWalletHomeOnboardingFundRampIntent } from './useWalletHomeOnboardingFundRampIntent';
 
@@ -39,7 +40,7 @@ export function useWalletHomeOnboardingChecklistFundPress(
         .build(),
     );
 
-    goToBuy(rampIntent);
+    goToBuy(rampIntent, { surface: RAMPS_BUY_CUF_SURFACE.HOME });
   }, [
     buttonClickData.is_authenticated,
     buttonClickData.order_count,

--- a/app/components/Views/AccountsMenu/AccountsMenu.tsx
+++ b/app/components/Views/AccountsMenu/AccountsMenu.tsx
@@ -35,6 +35,7 @@ import { useRampsButtonClickData } from '../../UI/Ramp/hooks/useRampsButtonClick
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { WalletViewSelectorsIDs } from '../Wallet/WalletView.testIds';
 import { useRampNavigation } from '../../UI/Ramp/hooks/useRampNavigation';
+import { RAMPS_BUY_CUF_SURFACE } from '../../UI/Ramp/constants/rampsBuyCufTags';
 import { isNotificationsFeatureEnabled } from '../../../util/notifications';
 import {
   getMetamaskNotificationsReadCount,
@@ -76,7 +77,7 @@ const AccountsMenu = () => {
         })
         .build(),
     );
-    goToBuy();
+    goToBuy(undefined, { surface: RAMPS_BUY_CUF_SURFACE.ACCOUNTS_MENU });
   }, [
     goToBuy,
     createEventBuilder,

--- a/app/components/Views/ActivityList/ActivityList.tsx
+++ b/app/components/Views/ActivityList/ActivityList.tsx
@@ -130,6 +130,7 @@ import {
   resolveRampOrderTarget,
 } from './utils/resolveRampOrderTarget';
 import { useRampNavigation } from '../../UI/Ramp/hooks/useRampNavigation';
+import { RAMPS_BUY_CUF_SURFACE } from '../../UI/Ramp/constants/rampsBuyCufTags';
 import {
   INITIAL_PERPS_ACTIVITY_SOURCE_STATE,
   PerpsActivitySource,
@@ -837,7 +838,7 @@ const ActivityList = forwardRef<ActivityListHandle, ActivityListProps>(
         // Continue → Send Transaction flow which ActivityDetails does not.
         if (raw.type === 'rampOrder') {
           if (resolveRampOrderTarget(raw.data) === 'deposit-resume-buy') {
-            goToBuy();
+            goToBuy(undefined, { surface: RAMPS_BUY_CUF_SURFACE.ACTIVITY });
             return;
           }
 

--- a/app/components/Views/ActivityList/utils/resolveRampOrderTarget.ts
+++ b/app/components/Views/ActivityList/utils/resolveRampOrderTarget.ts
@@ -15,6 +15,7 @@ import {
 import { createOrderDetailsNavDetails } from '../../../UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails';
 import { createRampsOrderDetailsNavDetails } from '../../../UI/Ramp/Views/OrderDetails';
 import { createDepositOrderDetailsNavDetails } from '../../../UI/Ramp/Views/OrderDetails/DepositOrderDetails/DepositOrderDetails';
+import { RAMPS_BUY_CUF_SURFACE } from '../../../UI/Ramp/constants/rampsBuyCufTags';
 
 export type RampOrderTarget =
   | 'ramps-v2-details'
@@ -47,7 +48,8 @@ export interface NavigateToRampOrderTargetArgs {
   data: FiatOrder | RampsOrder;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mirrors React Navigation's navigate spread of create*NavDetails
   navigation: { navigate: (...args: any[]) => void };
-  goToBuy: () => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- useRampNavigation().goToBuy
+  goToBuy: (...args: any[]) => any;
 }
 
 /**
@@ -64,7 +66,7 @@ export function navigateToRampOrderTarget({
   const target = resolveRampOrderTarget(data);
 
   if (target === 'deposit-resume-buy') {
-    goToBuy();
+    goToBuy(undefined, { surface: RAMPS_BUY_CUF_SURFACE.ACTIVITY });
     return;
   }
 

--- a/app/components/Views/ActivityScreen/components/ActivityEmptyState/ActivityEmptyState.tsx
+++ b/app/components/Views/ActivityScreen/components/ActivityEmptyState/ActivityEmptyState.tsx
@@ -14,6 +14,7 @@ import ActivityEmptyDarkIcon from '../../../../../images/activity-empty-dark.svg
 import ActivityEmptyLightIcon from '../../../../../images/activity-empty-light.svg';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { useRampNavigation } from '../../../../UI/Ramp/hooks/useRampNavigation';
+import { RAMPS_BUY_CUF_SURFACE } from '../../../../UI/Ramp/constants/rampsBuyCufTags';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { ActivityScreenSelectorsIDs } from '../../ActivityScreen.testIds';
 import { ActivityTypeFilter } from '../../types';
@@ -61,7 +62,7 @@ const ActivityEmptyState: React.FC<ActivityEmptyStateProps> = ({
         });
         return;
       case ActivityEmptyStateAction.AddFunds:
-        goToBuy();
+        goToBuy(undefined, { surface: RAMPS_BUY_CUF_SURFACE.EMPTY_STATE });
         return;
       case ActivityEmptyStateAction.MakePrediction:
         navigation.navigate(Routes.PREDICT.ROOT, {

--- a/app/components/Views/CashTokensFullView/CashTokensFullView.tsx
+++ b/app/components/Views/CashTokensFullView/CashTokensFullView.tsx
@@ -43,6 +43,7 @@ import {
   MUSD_TOKEN_ASSET_ID_BY_CHAIN,
 } from '../../UI/Earn/constants/musd';
 import { useRampNavigation } from '../../UI/Ramp/hooks/useRampNavigation';
+import { RAMPS_BUY_CUF_SURFACE } from '../../UI/Ramp/constants/rampsBuyCufTags';
 import {
   useSwapBridgeNavigation,
   SwapBridgeNavigationLocation,
@@ -215,9 +216,12 @@ const CashTokensFullView = () => {
         .build(),
     );
 
-    goToBuy({
-      assetId: MUSD_TOKEN_ASSET_ID_BY_CHAIN[MUSD_CONVERSION_DEFAULT_CHAIN_ID],
-    });
+    goToBuy(
+      {
+        assetId: MUSD_TOKEN_ASSET_ID_BY_CHAIN[MUSD_CONVERSION_DEFAULT_CHAIN_ID],
+      },
+      { surface: RAMPS_BUY_CUF_SURFACE.CASH },
+    );
   }, [createEventBuilder, goToBuy, trackEvent]);
 
   const balanceHeading = useMemo(

--- a/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.test.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.test.tsx
@@ -126,6 +126,7 @@ describe('CashGetMusdEmptyState', () => {
       expect.objectContaining({
         assetId: expect.stringContaining('eip155:1/erc20:'),
       }),
+      { surface: 'cash' },
     );
     expect(mockInitiateCustomConversion).not.toHaveBeenCalled();
   });

--- a/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.test.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, screen } from '@testing-library/react-native';
+import { act, fireEvent, screen } from '@testing-library/react-native';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import CashGetMusdEmptyState from './CashGetMusdEmptyState';
@@ -109,18 +109,26 @@ describe('CashGetMusdEmptyState', () => {
   it('calls initiateCustomConversion when Get mUSD pressed and has convertible tokens', async () => {
     renderWithProvider(<CashGetMusdEmptyState />);
 
-    fireEvent.press(screen.getByTestId(CashGetMusdEmptyStateSelectors.BUTTON));
+    await act(async () => {
+      fireEvent.press(
+        screen.getByTestId(CashGetMusdEmptyStateSelectors.BUTTON),
+      );
+    });
 
     expect(mockInitiateCustomConversion).toHaveBeenCalled();
     expect(mockGoToBuy).not.toHaveBeenCalled();
   });
 
-  it('calls goToBuy when Get mUSD pressed and mUSD buyable (no convertible tokens)', () => {
+  it('calls goToBuy when Get mUSD pressed and mUSD buyable (no convertible tokens)', async () => {
     mockUseMusdConversionFlowData.hasConvertibleTokens = false;
 
     renderWithProvider(<CashGetMusdEmptyState />);
 
-    fireEvent.press(screen.getByTestId(CashGetMusdEmptyStateSelectors.BUTTON));
+    await act(async () => {
+      fireEvent.press(
+        screen.getByTestId(CashGetMusdEmptyStateSelectors.BUTTON),
+      );
+    });
 
     expect(mockGoToBuy).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.tsx
+++ b/app/components/Views/Homepage/Sections/Cash/CashGetMusdEmptyState.tsx
@@ -28,6 +28,7 @@ import {
   MUSD_TOKEN_ASSET_ID_BY_CHAIN,
 } from '../../../../UI/Earn/constants/musd';
 import { useRampNavigation } from '../../../../UI/Ramp/hooks/useRampNavigation';
+import { RAMPS_BUY_CUF_SURFACE } from '../../../../UI/Ramp/constants/rampsBuyCufTags';
 import { RampIntent } from '../../../../UI/Ramp/types';
 import { useMusdConversion } from '../../../../UI/Earn/hooks/useMusdConversion';
 import { useMusdConversionFlowData } from '../../../../UI/Earn/hooks/useMusdConversionFlowData';
@@ -259,7 +260,7 @@ const CashGetMusdEmptyState = ({
       const rampIntent: RampIntent = {
         assetId: MUSD_TOKEN_ASSET_ID_BY_CHAIN[chainId],
       };
-      goToBuy(rampIntent);
+      goToBuy(rampIntent, { surface: RAMPS_BUY_CUF_SURFACE.CASH });
     }
   }, [
     isMusdBuyableOnAnyChain,

--- a/app/components/Views/Homepage/Sections/Tokens/TokensSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Tokens/TokensSection.test.tsx
@@ -243,7 +243,10 @@ jest.mock('./components/PopularTokenRow', () => {
               jest
                 .requireMock('../../../../UI/Ramp/hooks/useRampNavigation')
                 .useRampNavigation()
-                .goToBuy({ assetId: token.assetId }),
+                .goToBuy(
+                  { assetId: token.assetId },
+                  { buyFlowOrigin: 'homeTokenList' },
+                ),
           },
           ReactActual.createElement(Text, null, 'Buy'),
         ),
@@ -428,9 +431,12 @@ describe('TokensSection', () => {
     const buyButtons = screen.getAllByText('Buy');
     fireEvent.press(buyButtons[0]);
 
-    expect(mockGoToBuy).toHaveBeenCalledWith({
-      assetId: 'eip155:1/erc20:0xaca92e438df0b2401ff60da7e4337b687a2435da',
-    });
+    expect(mockGoToBuy).toHaveBeenCalledWith(
+      {
+        assetId: 'eip155:1/erc20:0xaca92e438df0b2401ff60da7e4337b687a2435da',
+      },
+      { buyFlowOrigin: 'homeTokenList' },
+    );
   });
 
   it('uses popular network list for token list (selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance)', () => {

--- a/app/components/Views/Homepage/components/HomepageActionButtonsGrid/buttons/BuyButton.tsx
+++ b/app/components/Views/Homepage/components/HomepageActionButtonsGrid/buttons/BuyButton.tsx
@@ -5,6 +5,7 @@ import { strings } from '../../../../../../../locales/i18n';
 import { selectCanSignTransactions } from '../../../../../../selectors/accountsController';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
 import { useRampNavigation } from '../../../../../UI/Ramp/hooks/useRampNavigation';
+import { RAMPS_BUY_CUF_SURFACE } from '../../../../../UI/Ramp/constants/rampsBuyCufTags';
 import {
   ActionButtonType,
   ActionLocation,
@@ -30,7 +31,7 @@ const BuyButton = ({
       button_label: label,
       location: ActionLocation.HOME,
     });
-    goToBuy();
+    goToBuy(undefined, { surface: RAMPS_BUY_CUF_SURFACE.HOME });
   }, [actionPosition, createEventBuilder, goToBuy, label, trackEvent]);
 
   return (

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -672,9 +672,12 @@ describe('CustomAmountInfo', () => {
     fireEvent.press(getByText(strings('confirm.custom_amount.buy_button')));
 
     expect(mockGoToBuy).toHaveBeenCalledTimes(1);
-    expect(mockGoToBuy).toHaveBeenCalledWith({
-      assetId: 'eip155:1/erc20:0x123',
-    });
+    expect(mockGoToBuy).toHaveBeenCalledWith(
+      {
+        assetId: 'eip155:1/erc20:0x123',
+      },
+      { surface: 'confirmation' },
+    );
   });
 
   it.each([TransactionType.predictWithdraw, TransactionType.perpsWithdraw])(

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -60,6 +60,7 @@ import Text, {
   TextVariant,
 } from '../../../../../../component-library/components/Texts/Text';
 import { useRampNavigation } from '../../../../../UI/Ramp/hooks/useRampNavigation';
+import { RAMPS_BUY_CUF_SURFACE } from '../../../../../UI/Ramp/constants/rampsBuyCufTags';
 import { useAccountTokens } from '../../../hooks/send/useAccountTokens';
 import { AlignItems } from '../../../../../UI/Box/box.types';
 import { strings } from '../../../../../../../locales/i18n';
@@ -617,7 +618,7 @@ function BuySection() {
   const { goToBuy } = useRampNavigation();
 
   const handleBuyPress = useCallback(() => {
-    goToBuy({ assetId });
+    goToBuy({ assetId }, { surface: RAMPS_BUY_CUF_SURFACE.CONFIRMATION });
   }, [assetId, goToBuy]);
 
   let message: string | undefined;

--- a/app/components/Views/confirmations/hooks/alerts/useGasSponsorshipWarningAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useGasSponsorshipWarningAlert.ts
@@ -9,6 +9,7 @@ import { Alert, Severity } from '../../types/alerts';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { NETWORKS_CHAIN_ID } from '../../../../../constants/network';
 import { useRampNavigation } from '../../../../UI/Ramp/hooks/useRampNavigation';
+import { RAMPS_BUY_CUF_SURFACE } from '../../../../UI/Ramp/constants/rampsBuyCufTags';
 import { useConfirmActions } from '../useConfirmActions';
 import { useIsGasSponsored } from '../gas/useIsGasSponsored';
 
@@ -135,7 +136,7 @@ export const useGasSponsorshipWarningAlert = (): Alert[] => {
             nativeCurrency,
           }),
           callback: () => {
-            goToBuy();
+            goToBuy(undefined, { surface: RAMPS_BUY_CUF_SURFACE.CONFIRMATION });
             onReject(undefined, true);
           },
         },

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientBalanceAlert.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
 import { useRampNavigation } from '../../../../UI/Ramp/hooks/useRampNavigation';
+import { RAMPS_BUY_CUF_SURFACE } from '../../../../UI/Ramp/constants/rampsBuyCufTags';
 import { RowAlertKey } from '../../components/UI/info-row/alert-row/constants';
 import { AlertKeys } from '../../constants/alerts';
 import { Alert, Severity } from '../../types/alerts';
@@ -113,7 +114,7 @@ export const useInsufficientBalanceAlert = ({
             nativeCurrency,
           }),
           callback: () => {
-            goToBuy();
+            goToBuy(undefined, { surface: RAMPS_BUY_CUF_SURFACE.CONFIRMATION });
             onReject(undefined, true);
           },
         },

--- a/app/util/trace.test.ts
+++ b/app/util/trace.test.ts
@@ -7,6 +7,7 @@ import {
   Scope,
   type Span,
   withIsolationScope,
+  startNewTrace,
   SPAN_STATUS_ERROR,
 } from '@sentry/core';
 import {
@@ -36,6 +37,8 @@ jest.mock('@sentry/react-native', () => ({
 
 jest.mock('@sentry/core', () => ({
   withIsolationScope: jest.fn(),
+  startNewTrace: jest.fn((fn: () => unknown) => fn()),
+  SPAN_STATUS_ERROR: 2,
 }));
 
 jest.mock('../store/storage-wrapper', () => ({
@@ -87,6 +90,7 @@ describe('Trace', () => {
   const startSpanManualMock = jest.mocked(startSpanManual);
   // mockImplementation doesn't choose the correct overload, so we ignore the types by casting to jest.Mock
   const withIsolationScopeMock = jest.mocked(withIsolationScope) as jest.Mock;
+  const startNewTraceMock = jest.mocked(startNewTrace) as jest.Mock;
   const setMeasurementMock = jest.mocked(setMeasurement);
   const setTagMock = jest.fn();
 
@@ -111,6 +115,7 @@ describe('Trace', () => {
     withIsolationScopeMock.mockImplementation((fn: (arg: Scope) => unknown) =>
       fn({ setTag: setTagMock } as unknown as Scope),
     );
+    startNewTraceMock.mockImplementation((fn: () => unknown) => fn());
 
     flushBufferedTraces();
     updateCachedConsent(false);
@@ -262,6 +267,41 @@ describe('Trace', () => {
 
       expect(setMeasurementMock).toHaveBeenCalledTimes(1);
       expect(setMeasurementMock).toHaveBeenCalledWith('tag3', 123, 'none');
+    });
+
+    it('starts a new trace when forceTransaction is set without parentContext', () => {
+      updateCachedConsent(true);
+
+      trace({
+        id: ID_MOCK,
+        name: NAME_MOCK,
+        forceTransaction: true,
+      });
+      endTrace({ name: NAME_MOCK, id: ID_MOCK });
+
+      expect(startNewTraceMock).toHaveBeenCalledTimes(1);
+      expect(startSpanManualMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: NAME_MOCK,
+          forceTransaction: true,
+          parentSpan: null,
+        }),
+        expect.any(Function),
+      );
+    });
+
+    it('does not start a new trace when forceTransaction has parentContext', () => {
+      updateCachedConsent(true);
+
+      trace({
+        id: ID_MOCK,
+        name: NAME_MOCK,
+        forceTransaction: true,
+        parentContext: PARENT_CONTEXT_MOCK,
+      });
+      endTrace({ name: NAME_MOCK, id: ID_MOCK });
+
+      expect(startNewTraceMock).not.toHaveBeenCalled();
     });
 
     it('falls back to Date.now when performance.timeOrigin is broken (RN Android)', () => {

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -64,9 +64,9 @@ export enum TraceName {
   RampBuyContinueToCheckout = 'Ramp Buy Continue To Checkout',
   RampBuyNativeToOrderCreated = 'Ramp Buy Native To Order Created',
   /**
-   * Buy Quote Fetch CUF (TRAM-3780): amount/payment/provider change → quotes
-   * rendered or error. Standalone; nests under RampBuyToOrderDetails when that
-   * parent is active.
+   * Buy Quote Fetch CUF (TRAM-3780 / TRAM-3805): amount/payment/provider change
+   * → usable quotes or a provider-level miss. Standalone; nests under
+   * RampBuyToOrderDetails when that parent is active.
    */
   RampBuyQuoteFetch = 'Ramp Buy Quote Fetch',
   RevealSrp = 'Reveal SRP',

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -63,6 +63,12 @@ export enum TraceName {
   RampBuyToOrderDetails = 'Ramp Buy To Order Details',
   RampBuyContinueToCheckout = 'Ramp Buy Continue To Checkout',
   RampBuyNativeToOrderCreated = 'Ramp Buy Native To Order Created',
+  /**
+   * Buy Quote Fetch CUF (TRAM-3780): amount/payment/provider change → quotes
+   * rendered or error. Standalone; nests under RampBuyToOrderDetails when that
+   * parent is active.
+   */
+  RampBuyQuoteFetch = 'Ramp Buy Quote Fetch',
   RevealSrp = 'Reveal SRP',
   RevealPrivateKey = 'Reveal Private Key',
   EvmDiscoverAccounts = 'EVM Discover Accounts',

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -59,11 +59,8 @@ export enum TraceName {
   LoadDepositExperience = 'Load Deposit Experience',
   DepositContinueFlow = 'Deposit Continue Flow',
   DepositInputOtp = 'Deposit Input OTP',
-  /** Unified Buy E2E CUF: goToBuy → RampsOrderDetails (TRAM-3779). */
   RampBuyToOrderDetails = 'Ramp Buy To Order Details',
-  /** Nested under RampBuyToOrderDetails: Continue (widget) → checkout URL ready. */
   RampBuyContinueToCheckout = 'Ramp Buy Continue To Checkout',
-  /** Nested under RampBuyToOrderDetails: Continue (native) → order created. */
   RampBuyNativeToOrderCreated = 'Ramp Buy Native To Order Created',
   RevealSrp = 'Reveal SRP',
   RevealPrivateKey = 'Reveal Private Key',
@@ -335,7 +332,6 @@ export enum TraceOperation {
   // Money Home Performance
   MoneyHomePerformance = 'money.home.performance',
   MoneyAccountDataFetch = 'money.account.data_fetch',
-  // Ramp / Buy CUF
   RampOperation = 'ramp.operation',
   /** Token overview OHLCV WebView: initial load or asset/currency change */
   TokenOverviewAdvancedChart = 'token_overview.advanced_chart',

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -61,8 +61,6 @@ export enum TraceName {
   DepositInputOtp = 'Deposit Input OTP',
   /** Unified Buy E2E CUF: goToBuy → RampsOrderDetails (TRAM-3779). */
   RampBuyToOrderDetails = 'Ramp Buy To Order Details',
-  /** Nested under RampBuyToOrderDetails: quote fetch → quotes rendered/error. */
-  RampBuyQuoteFetch = 'Ramp Buy Quote Fetch',
   /** Nested under RampBuyToOrderDetails: Continue (widget) → checkout URL ready. */
   RampBuyContinueToCheckout = 'Ramp Buy Continue To Checkout',
   /** Nested under RampBuyToOrderDetails: Continue (native) → order created. */

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -459,10 +459,7 @@ export interface TraceRequest {
    */
   parentContext?: TraceContext;
 
-  /**
-   * When true, emit this span as its own Sentry transaction even if another
-   * span (e.g. navigation.initialization) is currently active on the scope.
-   */
+  /** Emit as a root Sentry transaction instead of nesting under the active span. */
   forceTransaction?: boolean;
 
   /**

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -460,6 +460,12 @@ export interface TraceRequest {
   parentContext?: TraceContext;
 
   /**
+   * When true, emit this span as its own Sentry transaction even if another
+   * span (e.g. navigation.initialization) is currently active on the scope.
+   */
+  forceTransaction?: boolean;
+
+  /**
    * Override the start time of the trace.
    */
   startTime?: number;
@@ -1089,7 +1095,7 @@ function startSpan<T>(
   request: TraceRequest,
   callback: (spanOptions: StartSpanOptions) => T,
 ) {
-  const { name, parentContext, startTime, op } = request;
+  const { name, parentContext, startTime, op, forceTransaction } = request;
   const parentSpan = (parentContext ?? null) as Span | null;
 
   const spanOptions: StartSpanOptions = {
@@ -1098,6 +1104,7 @@ function startSpan<T>(
     op: op || OP_DEFAULT,
     parentSpan,
     startTime,
+    forceTransaction,
   };
 
   return withIsolationScope((scope) => {

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -8,6 +8,7 @@ import {
   type StartSpanOptions,
   type Span,
   withIsolationScope,
+  startNewTrace,
   SPAN_STATUS_ERROR,
 } from '@sentry/core';
 import performance from 'react-native-performance';
@@ -459,7 +460,11 @@ export interface TraceRequest {
    */
   parentContext?: TraceContext;
 
-  /** Emit as a root Sentry transaction instead of nesting under the active span. */
+  /**
+   * Emit as a root Sentry transaction instead of nesting under the active span.
+   * When set without `parentContext`, also starts a new trace ID so Trace Details
+   * does not open the long-lived app session tree (e.g. Load Scripts).
+   */
   forceTransaction?: boolean;
 
   /**
@@ -1106,6 +1111,13 @@ function startSpan<T>(
 
   return withIsolationScope((scope) => {
     setScopeTags(scope, request);
+
+    // forceTransaction alone still inherits the active session trace ID, so
+    // Trace Details loads every span under Load Scripts / ui.load. Root CUFs
+    // need a fresh propagation context for a stand-alone waterfall.
+    if (forceTransaction && !parentSpan) {
+      return startNewTrace(() => callback(spanOptions));
+    }
 
     return callback(spanOptions);
   }) as T;

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -59,6 +59,14 @@ export enum TraceName {
   LoadDepositExperience = 'Load Deposit Experience',
   DepositContinueFlow = 'Deposit Continue Flow',
   DepositInputOtp = 'Deposit Input OTP',
+  /** Unified Buy E2E CUF: goToBuy → RampsOrderDetails (TRAM-3779). */
+  RampBuyToOrderDetails = 'Ramp Buy To Order Details',
+  /** Nested under RampBuyToOrderDetails: quote fetch → quotes rendered/error. */
+  RampBuyQuoteFetch = 'Ramp Buy Quote Fetch',
+  /** Nested under RampBuyToOrderDetails: Continue (widget) → checkout URL ready. */
+  RampBuyContinueToCheckout = 'Ramp Buy Continue To Checkout',
+  /** Nested under RampBuyToOrderDetails: Continue (native) → order created. */
+  RampBuyNativeToOrderCreated = 'Ramp Buy Native To Order Created',
   RevealSrp = 'Reveal SRP',
   RevealPrivateKey = 'Reveal Private Key',
   EvmDiscoverAccounts = 'EVM Discover Accounts',
@@ -329,6 +337,8 @@ export enum TraceOperation {
   // Money Home Performance
   MoneyHomePerformance = 'money.home.performance',
   MoneyAccountDataFetch = 'money.account.data_fetch',
+  // Ramp / Buy CUF
+  RampOperation = 'ramp.operation',
   /** Token overview OHLCV WebView: initial load or asset/currency change */
   TokenOverviewAdvancedChart = 'token_overview.advanced_chart',
   /** Token overview OHLCV WebView: time range change only */


### PR DESCRIPTION
## Description

Fixes the PayPal quote observability gap tracked by [TRAM-3805](https://consensyssoftware.atlassian.net/browse/TRAM-3805).

The quotes API can return provider failures as HTTP 200 responses with an empty `success[]`. The Buy Quote Fetch CUF previously treated every resolved query as `success:true`, so PayPal quote misses appeared healthy in the downstream SLO. The span also lacked provider and custom-action attribution.

This draft:

- tags single-provider quote fetches with the requested provider
- records HTTP-ok responses without a usable requested-provider quote as `success:false`, `reason:no_quote`
- records PayPal custom-action quotes as `success:true`, `path:custom_action`, `custom_action:true`
- preserves transport errors as `success:false`, `reason:error`
- supersedes an in-flight span when the requested provider changes, preventing cross-provider attribution
- avoids assigning multi-provider requests to whichever provider returned the first quote

## Impact

PayPal quote availability can be measured directly from the emitted CUF attributes without query arithmetic that conflates transport success with a usable quote. Other providers retain their existing successful quote behavior while gaining accurate no-quote classification.

## Validation

- Focused Jest suites: 31 tests passed
- Prettier check: passed
- Targeted ESLint: passed with one pre-existing deprecation warning in `app/util/trace.ts`
- TypeScript: changed files pass; the full repository check is blocked by two pre-existing missing `app/util/termsOfUse/termsOfUseContent` imports on the base branch

## Related issues

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3805

Depends on: https://github.com/MetaMask/metamask-mobile/pull/33916

## Changelog

CHANGELOG entry: null


[TRAM-3805]: https://consensyssoftware.atlassian.net/browse/TRAM-3805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ