### PR TITLE
chore: bump typescript to 5.8.3

### DIFF
--- a/app/components/UI/Assets/components/AssetLogo/AssetLogo.utils.ts
+++ b/app/components/UI/Assets/components/AssetLogo/AssetLogo.utils.ts
@@ -58,7 +58,10 @@ export function createRotatingSet<T>(maxSize: number = 100): {
     add(value: T): void {
       set.add(value);
       if (set.size > maxSize) {
-        set.delete(set.values().next().value);
+        const oldest = set.values().next().value;
+        if (oldest !== undefined) {
+          set.delete(oldest);
+        }
       }
     },
     has(value: T): boolean {

--- a/app/components/hooks/useAddressBalance/useAddressBalance.test.tsx
+++ b/app/components/hooks/useAddressBalance/useAddressBalance.test.tsx
@@ -148,7 +148,7 @@ describe('useAddressBalance', () => {
   });
 
   it('render balance if asset is undefined', () => {
-    let asset: Asset;
+    let asset: Asset | undefined;
     let res = renderHook(() => useAddressBalance(asset, MOCK_ADDRESS_1), {
       wrapper: Wrapper,
     });

--- a/app/components/hooks/useCheckNftAutoDetectionModal/useCheckNftAutoDetectionModal.test.ts
+++ b/app/components/hooks/useCheckNftAutoDetectionModal/useCheckNftAutoDetectionModal.test.ts
@@ -47,7 +47,7 @@ describe('useCheckNftAutoDetectionModal', () => {
           return false;
       }
     });
-    (isMainNet as jest.Mock).mockReturnValue(true);
+    (isMainNet as unknown as jest.Mock).mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -66,7 +66,7 @@ describe('useCheckNftAutoDetectionModal', () => {
   });
 
   it('should not navigate or dispatch action when conditions are not met', () => {
-    (isMainNet as jest.Mock).mockReturnValue(false);
+    (isMainNet as unknown as jest.Mock).mockReturnValue(false);
 
     renderHook(() => useCheckNftAutoDetectionModal());
 

--- a/app/util/conversion/index.test.ts
+++ b/app/util/conversion/index.test.ts
@@ -184,7 +184,6 @@ describe('conversion utils', () => {
         conversionUtil('1', {
           fromNumericBase: 'dec',
           toNumericBase: 'dec',
-          //@ts-expect-error - conversion.js file needs conversion to ts file
           toCurrency: 'usd',
           conversionRate: 468.58,
           numberOfDecimals: 2,
@@ -197,7 +196,6 @@ describe('conversion utils', () => {
         conversionUtil('1.5', {
           fromNumericBase: 'dec',
           toNumericBase: 'dec',
-          //@ts-expect-error - conversion.js file needs conversion to ts file
           toCurrency: 'usd',
           conversionRate: 468.58,
           numberOfDecimals: 2,
@@ -212,7 +210,6 @@ describe('conversion utils', () => {
         conversionUtil('468.58', {
           fromNumericBase: 'dec',
           toNumericBase: 'dec',
-          //@ts-expect-error - conversion.js file needs conversion to ts file
           toCurrency: 'usd',
           conversionRate: 468.58,
           numberOfDecimals: 2,
@@ -225,7 +222,6 @@ describe('conversion utils', () => {
         conversionUtil('702.87', {
           fromNumericBase: 'dec',
           toNumericBase: 'dec',
-          //@ts-expect-error - conversion.js file needs conversion to ts file
           toCurrency: 'usd',
           conversionRate: 468.58,
           numberOfDecimals: 2,

--- a/app/util/scaling.js
+++ b/app/util/scaling.js
@@ -38,6 +38,10 @@ const _getSizes = (scaleVertical, baseModel) => {
   return { currSize, baseScreenSize };
 };
 
+/**
+ * @param {number} size
+ * @param {{ factor?: number, scaleVertical?: boolean, scaleUp?: boolean, baseSize?: number, baseModel?: number }} [options]
+ */
 const scale = (
   size,
   {

--- a/package.json
+++ b/package.json
@@ -740,7 +740,7 @@
     "ts-loader": "^9.5.0",
     "ts-node": "^10.9.2",
     "tsx": "^4.21.0",
-    "typescript": "~5.4.5",
+    "typescript": "~5.8.3",
     "webdriverio": "^9.27.0",
     "webextension-polyfill": "^0.12.0",
     "webpack": "^5.88.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36657,7 +36657,7 @@ __metadata:
     ts-loader: "npm:^9.5.0"
     ts-node: "npm:^10.9.2"
     tsx: "npm:^4.21.0"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.8.3"
     unicode-confusables: "npm:^0.1.1"
     uri-js: "npm:^4.4.1"
     url: "npm:0.11.0"
@@ -46151,7 +46151,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.8.3, typescript@npm:^5.2.2":
+"typescript@npm:5.8.3, typescript@npm:^5.2.2, typescript@npm:~5.8.3":
   version: 5.8.3
   resolution: "typescript@npm:5.8.3"
   bin:
@@ -46161,33 +46161,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.4.5":
-  version: 5.4.5
-  resolution: "typescript@npm:5.4.5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10/d04a9e27e6d83861f2126665aa8d84847e8ebabcea9125b9ebc30370b98cb38b5dff2508d74e2326a744938191a83a69aa9fddab41f193ffa43eabfdf3f190a5
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.2.2#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.2.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A~5.8.3#optional!builtin<compat/typescript>":
   version: 5.8.3
   resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10/b9b1e73dabac5dc730c041325dbd9c99467c1b0d239f1b74ec3b90d831384af3e2ba973946232df670519147eb51a2c20f6f96163cea2b359f03de1e2091cc4f
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A~5.4.5#optional!builtin<compat/typescript>":
-  version: 5.4.5
-  resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=5adc0c"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10/760f7d92fb383dbf7dee2443bf902f4365db2117f96f875cf809167f6103d55064de973db9f78fe8f31ec08fff52b2c969aee0d310939c0a3798ec75d0bca2e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Bumps `typescript` from `~5.4.5` to `~5.8.3`.

**Why:** pre-upgrade toolchain bump extracted from the RN 0.85 upgrade PR (#34283) so that the upgrade PR only carries changes that are interlocked with RN 0.85 / Expo SDK 56. TS 5.8 is required by the RN 0.85 toolchain; landing it on main first shrinks the upgrade diff and de-risks review.

**What:** the version bump plus fixes for the 9 type errors surfaced by TS 5.8's stricter checks — no runtime behavior changes:

- `app/components/UI/Assets/components/AssetLogo/AssetLogo.utils.ts` — `Set.values().next().value` is now typed `T | undefined` (TS 5.6+ iterator types); added an undefined guard before `set.delete()`.
- `app/util/scaling.js` — typed the `scale()` options via JSDoc; TS 5.8's JS inference no longer accepted the (valid) `baseModel` option at call sites (`CollectibleMedia.styles.ts`).
- `app/components/hooks/useCheckNftAutoDetectionModal/useCheckNftAutoDetectionModal.test.ts` — `isMainNet` is a type-guard function; casting to `jest.Mock` now needs `as unknown as jest.Mock` (stricter cast-overlap check).
- `app/components/hooks/useAddressBalance/useAddressBalance.test.tsx` — `let asset: Asset` used unassigned now trips definite-assignment analysis; typed as `Asset | undefined` (matches the hook's `asset?: Asset` signature).
- `app/util/conversion/index.test.ts` — removed 4 `@ts-expect-error` directives that no longer error under 5.8.

`yarn.lock` shrinks: all transitive `typescript` ranges dedupe to the single 5.8.3 entry.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #34283

## **Manual testing steps**

```gherkin
Feature: TypeScript 5.8 toolchain bump

  Scenario: developer type-checks and tests the codebase
    Given yarn install has completed on this branch

    When the developer runs yarn lint:tsc
    Then it exits 0 with no type errors

    When the developer runs yarn jest on the touched suites
    Then all 42 tests in the 6 suites pass
```

## **Screenshots/Recordings**

N/A — devDependency/toolchain change, no UI impact.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.