### PR TITLE
chore: bump react-native-keyboard-controller to 1.21.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -519,7 +519,7 @@
     "react-native-inappbrowser-reborn": "^3.7.0",
     "react-native-jazzicon": "^0.1.2",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
-    "react-native-keyboard-controller": "1.20.7",
+    "react-native-keyboard-controller": "1.21.14",
     "react-native-keychain": "^9.0.0",
     "react-native-level-fs": "3.0.1",
     "react-native-linear-gradient": "^2.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36584,7 +36584,7 @@ __metadata:
     react-native-inappbrowser-reborn: "npm:^3.7.0"
     react-native-jazzicon: "npm:^0.1.2"
     react-native-keyboard-aware-scroll-view: "npm:^0.9.5"
-    react-native-keyboard-controller: "npm:1.20.7"
+    react-native-keyboard-controller: "npm:1.21.14"
     react-native-keychain: "npm:^9.0.0"
     react-native-launch-arguments: "npm:^4.0.1"
     react-native-level-fs: "npm:3.0.1"
@@ -40938,16 +40938,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-keyboard-controller@npm:1.20.7":
-  version: 1.20.7
-  resolution: "react-native-keyboard-controller@npm:1.20.7"
+"react-native-keyboard-controller@npm:1.21.14":
+  version: 1.21.14
+  resolution: "react-native-keyboard-controller@npm:1.21.14"
   dependencies:
     react-native-is-edge-to-edge: "npm:^1.2.1"
   peerDependencies:
     react: "*"
     react-native: "*"
     react-native-reanimated: ">=3.0.0"
-  checksum: 10/675cc1b9ce4eb2f8f6c8bc8f4d4673dd1563bff8f393d6ff8d6e656a9779c931dc778d07eb6501973a04c3757b13da1166962af4bd4b2b60669cb63e855e48ec
+  checksum: 10/6067852f6f76cd2298af9345bfd8bf01dc07d5c57825cb8e979fcc04853c26cf5a77f23f8455abb97d330418ceb5a7b3a0b30ab286d1ac03e1d6a1e2bc3ce3c1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Bumps `react-native-keyboard-controller` from `1.20.7` to `1.21.14`.

**Why:** pre-upgrade library bump extracted from the RN 0.85 upgrade PR (#34283) so it lands and soaks on main first, keeping the upgrade PR limited to changes interlocked with RN 0.85 / Expo SDK 56. 1.21.14 is the vetted target from the upgrade planning notes.

**What:** version-only bump — no app code changes needed:

- Only peer dependency is `react-native-reanimated >=3.0.0`, satisfied by main's 4.2.1 (no worklets peer).
- All 7 APIs we import (`KeyboardProvider`, `KeyboardAwareScrollView`, `KeyboardStickyView`, `KeyboardController`, `AndroidSoftInputModes`, `useKeyboardState`, `useResizeMode`) verified present in 1.21.14.
- Unit tests use a fully manual jest mock (`app/util/test/testSetup.js`), so they're insulated from lib internals.

**Watch item (does not affect this PR):** upstream kirillzyusko/react-native-keyboard-controller#1470 (worklets warnings) is still open, but it only manifests with worklets 0.8+ / RN 0.85 / New Arch — main is on worklets 0.7.4 / RN 0.83. It remains a tracking item for the upgrade branch.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #34283

## **Manual testing steps**

```gherkin
Feature: keyboard handling after keyboard-controller bump

  Scenario: user types in keyboard-aware screens
    Given the app is installed and onboarded

    When user opens Login, Import SRP, Choose Password, or the
      Onboarding Interest Questionnaire bottom sheet and focuses an input
    Then the keyboard opens, content scrolls/avoids correctly, and
      sticky views track the keyboard on both iOS and Android
```

## **Screenshots/Recordings**

N/A — dependency bump, no intended visual change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.