### PR TITLE
fix(perps): commit cleaned USD amount on blur with trailing decimal

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProSizeInput.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProSizeInput.test.ts
@@ -95,11 +95,16 @@ describe('usePerpsProSizeInput', () => {
   });
 
   it('finalizes a trailing USD decimal on blur', () => {
-    const params = createParams();
-    const { result } = renderHook(() => usePerpsProSizeInput(params));
+    const { result, rerender } = renderHook(
+      (params: UsePerpsProSizeInputParams) => usePerpsProSizeInput(params),
+      { initialProps: createParams() },
+    );
+
     act(() => {
       result.current.sizeInput.onChange('12.');
     });
+
+    rerender(createParams({ usdAmount: '12.' }));
 
     act(() => {
       result.current.sizeInput.onBlur();
@@ -107,6 +112,19 @@ describe('usePerpsProSizeInput', () => {
 
     expect(result.current.sizeInput.value).toBe('12');
     expect(mockSetAmount).toHaveBeenLastCalledWith('12');
+  });
+
+  it('does not update USD amount on blur when already finalized', () => {
+    const { result } = renderHook(() =>
+      usePerpsProSizeInput(createParams({ usdAmount: '12' })),
+    );
+
+    act(() => {
+      result.current.sizeInput.onBlur();
+    });
+
+    expect(result.current.sizeInput.value).toBe('12');
+    expect(mockSetAmount).not.toHaveBeenCalled();
   });
 
   it('does not leave a pending commit after an unchanged USD blur', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProSizeInput.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProSizeInput.ts
@@ -85,6 +85,8 @@ const clampSliderUsdAmount = (
   return Math.floor(clamped).toString();
 };
 
+const isEmptyUsdAmount = (value: string) => value === '' || value === '0';
+
 const getSliderDisplayValue = (
   usdAmount: string,
   maxPossibleAmount: number,
@@ -147,7 +149,12 @@ export const usePerpsProSizeInput = ({
 
   const commitUsdAmount = useCallback(
     (nextUsdAmount: string) => {
-      if (new BigNumber(nextUsdAmount || 0).eq(new BigNumber(usdAmount || 0))) {
+      if (nextUsdAmount === usdAmount) {
+        pendingInternalUsdRef.current = null;
+        return false;
+      }
+
+      if (isEmptyUsdAmount(nextUsdAmount) && isEmptyUsdAmount(usdAmount)) {
         pendingInternalUsdRef.current = null;
         return false;
       }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- Fix Pro order form USD size blur so `orderForm.amount` is updated when a trailing decimal is removed (e.g. `"12."` → `"12"`).
- Align `commitUsdAmount` with limit-price blur by comparing canonical strings instead of numeric equality.
- Strengthen unit tests to cover the real onChange → parent echo → blur flow.

## Motivation

When a user types a USD size with a trailing decimal separator and blurs the field, the UI correctly finalizes the draft (e.g. `"12."` displays as `"12"`), but `commitUsdAmount` could skip updating canonical order state.

**Why:** `onChange` already commits the intermediate value (`"12."`) to `orderForm.amount`. On blur, finalization produces `"12"`, but `BigNumber("12").eq(BigNumber("12."))` is `true`, so `setAmount` was not called again. The field looked correct while `orderForm.amount` still contained the trailing separator.

## Solution

- Replace BigNumber-based skip logic in `commitUsdAmount` with string equality so `"12."` and `"12"` are treated as different canonical values.
- Preserve existing empty-amount behavior (`""` vs `"0"`) with an explicit empty check so denomination toggles and zero handling are unchanged.
- Update the trailing-decimal blur test to rerender with `usdAmount: "12."` after `onChange`, and add a case asserting blur does not re-commit when the amount is already finalized.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3688

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Pro order form USD size blur finalization

  Scenario: user blurs a USD size input with a trailing decimal separator
    Given the user is on the Perps Pro order form
    And the USD size field is focused
    And the canonical order size is not already "12."

    When the user types "12." into the USD size field
    And the user blurs the USD size field

    Then the USD size field displays "12"
    And the canonical order size is "12"
    And the canonical order size does not contain a trailing decimal separator
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

N/A - no visible UI change. The field displayed the finalized value before and after; the fix aligns canonical orderForm.amount with the finalized draft.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to Perps Pro size input commit logic with added unit tests; no auth, security, or broad architectural impact.
> 
> **Overview**
> Fixes a mismatch where the Pro order form **USD size field** looked finalized on blur but **`orderForm.amount`** could still hold a trailing decimal (e.g. `"12."`).
> 
> **`commitUsdAmount`** no longer treats `"12."` and `"12"` as the same via `BigNumber` equality. It compares **canonical strings** first, with **`isEmptyUsdAmount`** so `""` vs `"0"` behavior stays the same for empty/zero handling.
> 
> Tests now **rerender** with parent-echoed `usdAmount: "12."` before blur, and add a case that blur does not call **`setAmount`** when the amount is already `"12"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcad6d3128a44384259afc6567dee1d0f7cca57a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->