### PR TITLE
fix(social-leaderboard): keep QuickBuy Sell enabled when position price ticks cp-8.7.0

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -601,6 +601,37 @@ export function useQuickBuyController(
     liveSourceCurrencyExchangeRate && liveSourceCurrencyExchangeRate > 0,
   );
 
+  // Buy mode freezes the quote conversion rate via the pay-with `useState`
+  // snapshot (`selectedSourceToken`). Sell mode's `positionToken` is
+  // selector-driven, so without an explicit freeze every market-data tick
+  // retargets `sourceTokenAmount` for the same fiat input — quotes look
+  // stale/`isPendingQuoteRefresh` and Sell stays disabled with no error label
+  // (TSA-976). Keep display rates live above; freeze only the rate used to
+  // convert committed fiat into the quote request amount.
+  const sellQuoteExchangeRateRef = useRef<number | undefined>(undefined);
+  const sellQuoteSourceTokenKeyRef = useRef<string | undefined>(undefined);
+  const positionTokenKey =
+    positionToken?.address != null && positionToken.chainId != null
+      ? getTokenKey(positionToken)
+      : undefined;
+  if (positionTokenKey !== sellQuoteSourceTokenKeyRef.current) {
+    sellQuoteSourceTokenKeyRef.current = positionTokenKey;
+    sellQuoteExchangeRateRef.current = positionToken?.currencyExchangeRate;
+  } else if (
+    sellQuoteExchangeRateRef.current == null &&
+    positionToken?.currencyExchangeRate != null &&
+    positionToken.currencyExchangeRate > 0
+  ) {
+    // Price arrived after the token was already selected — adopt it once so
+    // the first committed amount can convert; later ticks stay frozen.
+    sellQuoteExchangeRateRef.current = positionToken.currencyExchangeRate;
+  }
+  const sellQuoteExchangeRate = sellQuoteExchangeRateRef.current;
+  const quoteSourceExchangeRate =
+    tradeMode === 'sell'
+      ? sellQuoteExchangeRate
+      : sourceToken?.currencyExchangeRate;
+
   // The live balance for whichever token is the *source* this mode: the
   // resynced pay-with token in buy mode, or the already-live position token in
   // sell mode.
@@ -632,14 +663,14 @@ export function useQuickBuyController(
       return latestSourceBalance.displayBalance;
     }
     if (hasSourcePrice) {
-      if (!quotedFiatAmount || !sourceToken?.currencyExchangeRate) {
+      if (!quotedFiatAmount || !quoteSourceExchangeRate) {
         return undefined;
       }
       // `currencyExchangeRate` is user-currency-per-token and `quotedFiatAmount`
       // is in the user's display currency, so fiat / rate yields token units.
       const fiat = parseFloat(quotedFiatAmount);
       if (isNaN(fiat) || fiat <= 0) return undefined;
-      return (fiat / sourceToken.currencyExchangeRate).toString();
+      return (fiat / quoteSourceExchangeRate).toString();
     }
     // Unpriced path: source amount is entered directly in token units.
     if (!sourceAmountTokens) return undefined;
@@ -650,9 +681,9 @@ export function useQuickBuyController(
     hasSourcePrice,
     isMaxSourceAmount,
     latestSourceBalance?.displayBalance,
+    quoteSourceExchangeRate,
     quotedFiatAmount,
     sourceAmountTokens,
-    sourceToken?.currencyExchangeRate,
   ]);
 
   useEffect(() => {
@@ -1627,11 +1658,27 @@ export function useQuickBuyController(
         sourceTokenAmount,
         sourceToken.decimals,
       ).toFixed(0);
-      const sent = calcTokenValue(
-        activeQuote.sentAmount?.amount,
-        sourceToken.decimals,
-      ).toFixed(0);
-      return sent === requested;
+      // Prefer `sentAmount` (full wallet deduction). Required for gas-included /
+      // gas-sponsored quotes where `quote.srcTokenAmount` is the post-fee
+      // routing amount and would never equal the request.
+      const sentAmountDecimal = activeQuote.sentAmount?.amount;
+      if (sentAmountDecimal != null && sentAmountDecimal !== '') {
+        const sent = calcTokenValue(
+          sentAmountDecimal,
+          sourceToken.decimals,
+        ).toFixed(0);
+        if (sent === requested) {
+          return true;
+        }
+      }
+      // Fallback when `sentAmount` is missing (partial QuoteMetadata) or inflated
+      // by src-token protocol fees on top of an already-full request amount:
+      // match the quote's atomic routing amount against the request.
+      const srcTokenAmountAtomic = activeQuote.quote?.srcTokenAmount;
+      return (
+        srcTokenAmountAtomic != null &&
+        String(srcTokenAmountAtomic) === requested
+      );
     } catch {
       return false;
     }

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -1537,6 +1537,48 @@ describe('useQuickBuyController', () => {
       expect(result.current.isConfirmDisabled).toBe(false);
     });
 
+    it('enables the CTA when sentAmount is missing but quote.srcTokenAmount matches the request', () => {
+      // Partial QuoteMetadata (#33559) can omit sentAmount. Without a fallback
+      // to quote.srcTokenAmount the CTA stayed disabled with a valid quote.
+      const quoteState: UseQuickBuyQuotesResult = {
+        activeQuote: undefined,
+        destTokenAmount: undefined,
+        isQuoteLoading: false,
+        isNoQuotesAvailable: false,
+        quoteFetchError: null,
+        isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
+        sortedQuotes: [],
+        quoteCount: 0,
+        quotesLastFetchedAt: null,
+        refreshCount: 0,
+        quoteRefreshRateMs: 30000,
+        maxRefreshCount: 5,
+        refetchQuotes: jest.fn(),
+      };
+      (useQuickBuyQuotes as jest.Mock).mockImplementation(() => quoteState);
+
+      const props = {
+        target: createTarget(),
+        onClose: jest.fn(),
+      };
+      const { result, rerender } = renderHook(
+        ({ target, onClose }) => useQuickBuyController(target, onClose),
+        { initialProps: props },
+      );
+
+      act(() => {
+        result.current.handleAmountChange('20');
+      });
+      quoteState.activeQuote = createActiveQuote({
+        quote: { srcTokenAmount: '10000000000000000' },
+        sentAmount: { amount: undefined },
+      });
+      rerender(props);
+
+      expect(result.current.isConfirmDisabled).toBe(false);
+    });
+
     it('enables the CTA for a gas-included quote whose srcTokenAmount is the post-fee amount', () => {
       const quoteState: UseQuickBuyQuotesResult = {
         activeQuote: undefined,
@@ -2389,12 +2431,91 @@ describe('useQuickBuyController', () => {
   });
 
   describe('sell mode availability', () => {
-    const createPositionToken = () =>
+    const createPositionToken = (overrides: Partial<BridgeToken> = {}) =>
       createSourceToken({
         address: '0xDEST',
         chainId: '0x1',
         symbol: 'TARGET',
+        ...overrides,
       });
+
+    const createSellReceiveNative = () =>
+      createSourceToken({
+        address: '0x0000000000000000000000000000000000000000',
+        chainId: '0x1',
+        symbol: 'ETH',
+        currencyExchangeRate: 2000,
+      });
+
+    it('keeps Sell enabled when the position token price ticks after a quote settles', () => {
+      // Regression (TSA-976): sell mode derived sourceTokenAmount from the live
+      // position-token rate. Market-data ticks changed the amount for the same
+      // fiat input, so isPendingQuoteRefresh stayed true and Sell remained
+      // disabled even with a valid quote on screen (no error label).
+      let positionToken = createPositionToken({ currencyExchangeRate: 2000 });
+      (usePositionTokenBalance as jest.Mock).mockImplementation(
+        () => positionToken,
+      );
+      (useReceiveTokens as jest.Mock).mockReturnValue([
+        createSellReceiveNative(),
+      ]);
+      (useLatestBalance as jest.Mock).mockReturnValue({
+        displayBalance: '1.0',
+        atomicBalance: '1000000000000000000',
+      });
+
+      const quoteState: UseQuickBuyQuotesResult = {
+        activeQuote: undefined,
+        destTokenAmount: undefined,
+        isQuoteLoading: false,
+        isNoQuotesAvailable: false,
+        quoteFetchError: null,
+        isActiveQuoteForCurrentTokenPair: true,
+        isQuoteRequestStale: false,
+        sortedQuotes: [],
+        quoteCount: 0,
+        quotesLastFetchedAt: null,
+        refreshCount: 0,
+        quoteRefreshRateMs: 30000,
+        maxRefreshCount: 5,
+        refetchQuotes: jest.fn(),
+      };
+      (useQuickBuyQuotes as jest.Mock).mockImplementation(() => quoteState);
+
+      const props = {
+        target: createTarget(),
+        onClose: jest.fn(),
+      };
+      const { result, rerender } = renderHook(
+        ({ target, onClose }) => useQuickBuyController(target, onClose),
+        { initialProps: props },
+      );
+
+      act(() => {
+        result.current.setTradeMode('sell');
+      });
+      act(() => {
+        result.current.handleAmountChange('20');
+      });
+
+      const committedSourceAmount = result.current.sourceTokenAmount;
+      expect(committedSourceAmount).toBe('0.01');
+
+      quoteState.activeQuote = createActiveQuote({
+        sentAmount: { amount: '0.01' },
+      });
+      rerender(props);
+      expect(result.current.isConfirmDisabled).toBe(false);
+
+      // Price tick: same token identity, new exchange rate. The committed sell
+      // amount (and CTA) must stay stable — buy mode gets this for free via the
+      // pay-with useState snapshot; sell must freeze the quote conversion rate.
+      positionToken = createPositionToken({ currencyExchangeRate: 2500 });
+      rerender(props);
+
+      expect(result.current.sourceTokenAmount).toBe(committedSourceAmount);
+      expect(result.current.isConfirmDisabled).toBe(false);
+    });
 
     it('resets tradeMode to buy when the position token balance becomes zero', () => {
       (usePositionTokenBalance as jest.Mock).mockReturnValue(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes QuickBuy **Sell** staying disabled after entering a valid amount even when a quote is on screen (silent \"Sell\" label, no insufficient-funds/gas/no-quotes error).

**Root cause:** In sell mode, `sourceTokenAmount` was derived from the live `positionToken.currencyExchangeRate`. Market-data ticks changed the token amount for the same fiat input, so `isPendingQuoteRefresh` stayed true and the CTA never enabled. Buy mode avoids this because the pay-with token is a `useState` snapshot.

**Fix:**
1. Freeze the sell-mode exchange rate used for quote amount conversion (display/balance rates stay live).
2. Fall back to matching `quote.srcTokenAmount` when `sentAmount` is missing/mismatched (partial `QuoteMetadata`).

## Changelog

CHANGELOG entry: Fixed Quick Buy Sell button staying disabled after entering a valid amount

## Related issues

Fixes: https://consensyssoftware.atlassian.net/browse/TSA-976

## Manual testing steps

```gherkin
Feature: Quick Buy sell CTA

  Scenario: sell remains actionable after a price tick
    Given Quick Buy is open in Sell mode for a priced position token
    And the user enters a valid fiat amount
    And a quote is shown (total includes network fee)

    When the position token market price updates
    Then the Sell button stays enabled
    And the committed source token amount does not change
```

## Screenshots/Recordings

N/A — logic-only fix; covered by unit regression tests.

## Pre-merge author checklist

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## Pre-merge reviewer checklist

- [ ] I've manually tested the PR
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C092MDPA0LU/p1786029924237309?thread_ts=1786029924.237309&cid=C092MDPA0LU)

<div><a href="https://cursor.com/agents/bc-9542177a-2aa0-5981-af17-a72f396a726a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9542177a-2aa0-5981-af17-a72f396a726a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

