### PR TITLE
chore: replace deprecated StyleSheet.absoluteFillObject with absoluteFill (all remaining files)

### DIFF
--- a/app/components/UI/AssetOverview/Price/Price.styles.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.styles.tsx
@@ -55,7 +55,7 @@ const styleSheet = (params: { theme: Theme }) =>
       alignSelf: 'stretch',
     } as ViewStyle,
     noDataOverlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'center',
       alignItems: 'center',
       zIndex: 2,

--- a/app/components/UI/AssetOverview/PriceChart/PriceChart.styles.tsx
+++ b/app/components/UI/AssetOverview/PriceChart/PriceChart.styles.tsx
@@ -30,12 +30,12 @@ const styleSheet = (params: {
     },
     /** Same pattern as AdvancedChart: overlay does not participate in flex layout with AreaChart. */
     loadingOverlayContainer: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'center',
       alignItems: 'center',
     },
     noDataOverlayContainer: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     chartLoading: {
       width: '100%',

--- a/app/components/UI/Assets/watchlist/Views/WatchlistFullScreenView/WatchlistSearchContent.styles.ts
+++ b/app/components/UI/Assets/watchlist/Views/WatchlistFullScreenView/WatchlistSearchContent.styles.ts
@@ -28,7 +28,7 @@ const styleSheet = (params: {
       paddingVertical: 16,
     },
     skeletonOverlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       paddingHorizontal: 16,
       backgroundColor: theme.colors.background.default,
     },

--- a/app/components/UI/Bridge/components/TransactionDetails/PulsingCircle.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/PulsingCircle.tsx
@@ -32,7 +32,7 @@ const styleSheet = (params: { theme: Theme }) =>
       borderRadius: 8,
     },
     hollowCircleContainer: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'center',
       alignItems: 'center',
     },

--- a/app/components/UI/ButtonReveal/index.tsx
+++ b/app/components/UI/ButtonReveal/index.tsx
@@ -45,20 +45,20 @@ const createStyles = (colors: any) =>
       marginRight: 12,
     },
     absoluteFillWithCenter: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       alignItems: 'center',
       justifyContent: 'center',
     },
     absoluteFill: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     preCompletedContainerStyle: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       borderRadius: radius,
       backgroundColor: colors.primary.default,
     },
     outerCircle: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       borderRadius: radius,
       backgroundColor: colors.primary.inverse,
     },

--- a/app/components/UI/Card/Views/SpendingLimit/components/ShimmerOverlay.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/components/ShimmerOverlay.tsx
@@ -37,7 +37,7 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   overlay: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     overflow: 'hidden',
   },
 });

--- a/app/components/UI/Card/components/DaimoPayModal/DaimoPayModal.tsx
+++ b/app/components/UI/Card/components/DaimoPayModal/DaimoPayModal.tsx
@@ -54,7 +54,7 @@ export interface DaimoPayModalParams {
 
 const baseStyles = StyleSheet.create({
   absoluteFill: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
   },
 });
 

--- a/app/components/UI/CollectibleMedia/CollectibleMedia.styles.ts
+++ b/app/components/UI/CollectibleMedia/CollectibleMedia.styles.ts
@@ -66,7 +66,7 @@ const styleSheet = (params: {
     mediaPlayer: {
       minHeight: 10,
     },
-    imageFallBackTextContainer: StyleSheet.absoluteFillObject,
+    imageFallBackTextContainer: StyleSheet.absoluteFill,
     imageFallBackShowContainer: {
       bottom: 32,
     },

--- a/app/components/UI/DesignerMode/DesignerModeRN.tsx
+++ b/app/components/UI/DesignerMode/DesignerModeRN.tsx
@@ -1295,7 +1295,7 @@ function createDesignerStyles() {
 
     // Backdrop
     backdrop: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: C.backdrop,
     } as ViewStyle,
 

--- a/app/components/UI/HardwareWallet/Swaps/HwQrScanner.tsx
+++ b/app/components/UI/HardwareWallet/Swaps/HwQrScanner.tsx
@@ -131,7 +131,7 @@ const styles = StyleSheet.create({
     position: 'relative',
   },
   overlayCenter: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -374,7 +374,7 @@ export function HwQrScanner() {
     return (
       <>
         <Camera
-          style={StyleSheet.absoluteFillObject}
+          style={StyleSheet.absoluteFill}
           device={cameraDevice}
           isActive={isFocused && hasPermission}
           codeScanner={codeScanner}

--- a/app/components/UI/Money/Views/MoneyFirstTimeDepositView/MoneyFirstTimeDepositView.tsx
+++ b/app/components/UI/Money/Views/MoneyFirstTimeDepositView/MoneyFirstTimeDepositView.tsx
@@ -143,7 +143,7 @@ const MoneyFirstTimeDepositView = () => {
         dataBinding={AutoBind(true)}
         fit={Fit.Layout}
         layoutScaleFactor={PixelRatio.get()}
-        style={StyleSheet.absoluteFillObject}
+        style={StyleSheet.absoluteFill}
         onError={handleError}
         testID={MoneyFirstTimeDepositViewTestIds.RIVE_ANIMATION}
       />

--- a/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx
+++ b/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx
@@ -518,7 +518,7 @@ const MoneyOnboardingView = () => {
         layoutScaleFactor={PixelRatio.get()}
         onStateChanged={handleStateChanged}
         onError={handleError}
-        style={StyleSheet.absoluteFillObject}
+        style={StyleSheet.absoluteFill}
         testID={MoneyOnboardingViewTestIds.RIVE_ANIMATION}
       />
       <MoneyOnboardingTextOverlay

--- a/app/components/UI/Notification/TransactionNotification/index.js
+++ b/app/components/UI/Notification/TransactionNotification/index.js
@@ -45,7 +45,7 @@ const createStyles = (theme) => {
 
   return StyleSheet.create({
     absoluteFill: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     titleWrapper: {
       borderBottomWidth: StyleSheet.hairlineWidth,

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.styles.ts
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.styles.ts
@@ -5,7 +5,7 @@ export const createStyles = () =>
     // Offscreen remount target after a slider gesture — keep StyleSheet for
     // absoluteFill; Tailwind cannot express this cleanly.
     sliderIncoming: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       opacity: 0,
     },
     helpTextContainer: {

--- a/app/components/UI/Predict/components/PredictDetailsChart/PredictDetailsChart.tsx
+++ b/app/components/UI/Predict/components/PredictDetailsChart/PredictDetailsChart.tsx
@@ -531,7 +531,7 @@ const PredictDetailsChart: React.FC<PredictDetailsChartProps> = ({
           {overlaySeries.map((series, index) => (
             <LineChart
               key={`${series.label}-${index}`}
-              style={StyleSheet.absoluteFillObject}
+              style={StyleSheet.absoluteFill}
               data={series.data.map((point) => point.value)}
               svg={{ stroke: series.color, strokeWidth: 2 }}
               contentInset={CHART_CONTENT_INSET}
@@ -543,7 +543,7 @@ const PredictDetailsChart: React.FC<PredictDetailsChartProps> = ({
           ))}
           {/* Tooltip overlay - rendered last to appear on top */}
           <LineChart
-            style={StyleSheet.absoluteFillObject}
+            style={StyleSheet.absoluteFill}
             data={primaryChartData}
             svg={{ stroke: 'transparent', strokeWidth: 0 }}
             contentInset={CHART_CONTENT_INSET}

--- a/app/components/UI/Ramp/Aggregator/components/LoadingAnimation/index.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/LoadingAnimation/index.tsx
@@ -77,7 +77,7 @@ const createStyles = (
       zIndex: 2,
     },
     backgroundShapes: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       zIndex: 1,
       justifyContent: 'center',
       alignItems: 'center',

--- a/app/components/UI/ReusableModal/styles.ts
+++ b/app/components/UI/ReusableModal/styles.ts
@@ -16,10 +16,10 @@ const styleSheet = (params: { theme: Theme }) => {
   const { colors } = theme;
   return StyleSheet.create({
     absoluteFill: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     overlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: colors.overlay.default,
     },
   });

--- a/app/components/UI/SlippageSlider/index.js
+++ b/app/components/UI/SlippageSlider/index.js
@@ -88,7 +88,7 @@ const createStyles = (colors, shadows) =>
       top: 4,
     },
     tooltipText: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       textAlign: 'center',
       ...fontStyles.normal,
       color: colors.overlay.inverse,

--- a/app/components/UI/Tabs/TabThumbnail/TabThumbnail.styles.ts
+++ b/app/components/UI/Tabs/TabThumbnail/TabThumbnail.styles.ts
@@ -47,7 +47,7 @@ const createStyles = (colors: ThemeColors) =>
       flex: 1,
     },
     tabImage: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       resizeMode: 'cover',
     },
     activeTab: {

--- a/app/components/UI/UrlAutocomplete/styles.ts
+++ b/app/components/UI/UrlAutocomplete/styles.ts
@@ -8,7 +8,7 @@ import {
 const styleSheet = ({ theme: { colors, typography } }: { theme: Theme }) =>
   StyleSheet.create({
     wrapper: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: colors.background.default,
       // Hidden by default
       display: 'none',

--- a/app/components/UI/WebviewError/index.js
+++ b/app/components/UI/WebviewError/index.js
@@ -10,7 +10,7 @@ import { WebviewErrorSelectorsIDs } from './WebviewError.testIds';
 const createStyles = (colors) =>
   StyleSheet.create({
     wrapper: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: colors.background.default,
       justifyContent: 'center',
       alignItems: 'center',

--- a/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.styles.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.styles.ts
@@ -38,7 +38,7 @@ const styleSheet = (params: {
       marginBottom: 16,
     },
     shimmerOverlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: theme.colors.icon.alternative,
       borderRadius: CARD_BORDER_RADIUS,
     },

--- a/app/components/Views/MediaPlayer/index.js
+++ b/app/components/Views/MediaPlayer/index.js
@@ -34,7 +34,7 @@ const styleSheet = ({ theme: { colors }, vars: { isPlaying } }) =>
       alignItems: 'center',
     },
     videoControlsStyle: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'center',
       alignItems: 'center',
     },

--- a/app/components/Views/Notifications/PushNotificationOnboarding/NotifCard.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/NotifCard.tsx
@@ -101,7 +101,7 @@ const NotifCard = ({
 
       {/* Border overlay — MaskedView fades the border top-to-transparent */}
       <MaskedView
-        style={StyleSheet.absoluteFillObject}
+        style={StyleSheet.absoluteFill}
         maskElement={
           <LinearGradient
             colors={['black', 'black', 'transparent']}
@@ -112,7 +112,7 @@ const NotifCard = ({
       >
         <View
           style={[
-            StyleSheet.absoluteFillObject,
+            StyleSheet.absoluteFill,
             styles.border,
             { borderColor: mutedBorderColor },
           ]}

--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -204,7 +204,7 @@ async function isDeviceOffline(): Promise<boolean> {
 
 const styles = StyleSheet.create({
   androidNotificationOverlay: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     zIndex: 999,
     elevation: 999,
   },

--- a/app/components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.tsx
+++ b/app/components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.tsx
@@ -54,7 +54,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   labelActive: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.styles.ts
+++ b/app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.styles.ts
@@ -37,7 +37,7 @@ export const OVERLAY_TOP_OFFSET = 80;
  * visual (background, trader cards, buttons). In the v4 ("hybrid") artboard the
  * step title + description are NOT baked into the Rive, so React Native renders
  * them as a non-interactive overlay pinned to the top of the screen, above the
- * Rive element which fills the container via `StyleSheet.absoluteFillObject`.
+ * Rive element which fills the container via `StyleSheet.absoluteFill`.
  */
 const createStyles = () =>
   StyleSheet.create({
@@ -45,7 +45,7 @@ const createStyles = () =>
       flex: 1,
     },
     gradient: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     textOverlay: {
       position: 'absolute',

--- a/app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx
+++ b/app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx
@@ -850,7 +850,7 @@ const SocialLeaderboardOnboarding: React.FC = () => {
           shows. */}
       {referencedAssets && (
         <Animated.View
-          style={[StyleSheet.absoluteFillObject, { opacity: riveOpacity }]}
+          style={[StyleSheet.absoluteFill, { opacity: riveOpacity }]}
         >
           <Rive
             ref={ref}
@@ -863,7 +863,7 @@ const SocialLeaderboardOnboarding: React.FC = () => {
             layoutScaleFactor={PixelRatio.get()}
             onPlay={revealRive}
             onError={handleError}
-            style={StyleSheet.absoluteFillObject}
+            style={StyleSheet.absoluteFill}
             testID={SocialLeaderboardOnboardingSelectorsIDs.RIVE_ANIMATION}
           />
         </Animated.View>

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionAnimatedHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionAnimatedHeader.tsx
@@ -41,7 +41,7 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   layer: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -535,13 +535,8 @@ function TradeWalletActions() {
 
   return (
     <View style={tw.style('flex-1 justify-end')}>
-      <Animated.View
-        style={[StyleSheet.absoluteFillObject, backdropAnimatedStyle]}
-      >
-        <Pressable
-          style={StyleSheet.absoluteFillObject}
-          onPress={handleNavigateBack}
-        >
+      <Animated.View style={[StyleSheet.absoluteFill, backdropAnimatedStyle]}>
+        <Pressable style={StyleSheet.absoluteFill} onPress={handleNavigateBack}>
           <OverlayWithHole
             width={windowWidth}
             height={windowHeight + insetsTop}


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

`StyleSheet.absoluteFillObject` is removed in React Native 0.85 (deprecated since 0.82). This PR replaces all 41 remaining usages across 30 files with `StyleSheet.absoluteFill` as pre-upgrade work for the RN 0.85 upgrade (#34283).

This is a single combined PR that supersedes the stalled per-team split PRs #33838, #33839, #33840, #33841, #33842, #33843, #33844 (split from #33192) and additionally covers 4 files the codemod series missed:

- `app/components/UI/Notification/TransactionNotification/index.js`
- `app/components/UI/WebviewError/index.js`
- `app/components/UI/SlippageSlider/index.js`
- `app/components/Views/MediaPlayer/index.js`

On our current RN 0.83.6 this is a guaranteed no-op: `absoluteFillObject` is literally defined as an alias of `absoluteFill` (`StyleSheetExports.js: absoluteFillObject: absoluteFill`), and both share the same `AbsoluteFillStyle` TypeScript type. Runtime behavior, spread usage (`...StyleSheet.absoluteFill`), and type checking are all identical — no visual or functional change. A few files have minor prettier line-collapses from the pre-commit hook (the shorter name lets JSX fit on one line).

Verification:
- `git grep absoluteFillObject -- app/` returns zero matches after this PR
- ESLint on all 30 changed files: 0 errors
- Unit tests for all 11 touched components that have tests: 301/301 pass

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #33192 (original combined PR), supersedes #33838–#33844, pre-work for RN 0.85 upgrade #34283

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Absolute-fill overlay styling (no-op refactor)

  Scenario: user opens surfaces that use absolute-fill overlays
    Given the app is built from this branch
    When user opens screens using full-screen overlays (media player, price chart, onboarding, modals, notifications)
    Then overlays cover the full screen exactly as before
    When user interacts with sliders, button-reveal, and QR scanner surfaces
    Then layout and hit areas are unchanged
```

Since `absoluteFill` and `absoluteFillObject` are the same object in RN 0.83, no visual difference is expected on any screen.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — pure rename of a deprecated alias to its identical replacement; no visual change.

### **After**

N/A — see above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Style-only alias swap with no logic changes; on RN 0.83 `absoluteFillObject` is the same object as `absoluteFill`, so layout and visuals should be unchanged.
> 
> **Overview**
> Replaces every remaining `StyleSheet.absoluteFillObject` usage in `app/` with `StyleSheet.absoluteFill` ahead of React Native 0.85, where the old name is removed.
> 
> The change is mechanical across **30 files**—overlays, chart layers, Rive full-screen layouts, modals, camera preview, shimmer/skeleton overlays, and similar full-bleed positioning. A few call sites only collapse JSX onto fewer lines after the shorter identifier; behavior is unchanged on current RN where the two APIs are equivalent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af1ba9358b894f4a2f0189f3c26735d168474f46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->