### PR TITLE
chore: upgrade design system packages (v58.0.0)

### DIFF
--- a/app/component-library/components/Form/HelpText/HelpText.tsx
+++ b/app/component-library/components/Form/HelpText/HelpText.tsx
@@ -15,6 +15,11 @@ import {
   TEXT_COLOR_BY_HELPTEXT_SEVERITY,
 } from './HelpText.constants';
 
+/**
+ * @deprecated This component is deprecated and will be removed in a future release.
+ * Please use the HelpText component from @metamask/design-system-react-native instead.
+ * @see {@link https://github.com/MetaMask/metamask-design-system/tree/main/packages/design-system-react-native/src/components/HelpText | Component Source}
+ */
 const HelpText: React.FC<HelpTextProps> = ({
   severity = DEFAULT_HELPTEXT_SEVERITY,
   ...props

--- a/package.json
+++ b/package.json
@@ -278,7 +278,7 @@
     "@metamask/core-backend": "^8.0.0",
     "@metamask/delegation-controller": "^3.0.2",
     "@metamask/delegation-deployments": "^1.0.0",
-    "@metamask/design-system-react-native": "^0.38.1",
+    "@metamask/design-system-react-native": "^0.39.0",
     "@metamask/design-system-twrnc-preset": "^0.8.0",
     "@metamask/design-tokens": "^8.7.0",
     "@metamask/earn-controller": "^12.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8597,11 +8597,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-system-react-native@npm:^0.38.1":
-  version: 0.38.1
-  resolution: "@metamask/design-system-react-native@npm:0.38.1"
+"@metamask/design-system-react-native@npm:^0.39.0":
+  version: 0.39.0
+  resolution: "@metamask/design-system-react-native@npm:0.39.0"
   dependencies:
-    "@metamask/design-system-shared": "npm:^0.31.0"
+    "@metamask/design-system-shared": "npm:^0.32.0"
     react-native-jazzicon: "npm:^0.1.2"
   peerDependencies:
     "@metamask/design-system-twrnc-preset": ^0.8.0
@@ -8614,18 +8614,18 @@ __metadata:
     react-native-reanimated: ">=4.2.0"
     react-native-safe-area-context: ">=5.0.0"
     react-native-worklets: ">=0.7.4"
-  checksum: 10/494a94756a0e6da4d64665c99cd88b8ee17bf8a88d2910fdd95d110315387a78099c22c2a15ca6b9728633edcc7a3f4f02fba751b60732583701e1d652197f0c
+  checksum: 10/664ba221283a7a09824aa857578d1a98670f266d154a6a87d1884594555b314d299feb0c5c3a00137faafa9f878e9a308b870b6c876aa90ee76b72cdcfdffeca
   languageName: node
   linkType: hard
 
-"@metamask/design-system-shared@npm:^0.31.0":
-  version: 0.31.0
-  resolution: "@metamask/design-system-shared@npm:0.31.0"
+"@metamask/design-system-shared@npm:^0.32.0":
+  version: 0.32.0
+  resolution: "@metamask/design-system-shared@npm:0.32.0"
   dependencies:
     "@metamask/utils": "npm:^11.11.0"
   peerDependencies:
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10/87e65ed36ea3ccb1f0cf7e0bced4ee1b0d7e42573f7989e0524b2aeb125eed74db401d54c518b499b2cbd5785aa50e304d5cb24282f89b4b9a18b0fc3c2a1039
+  checksum: 10/17efdeb0787713dc00e0c9598d570648f93f90b325e1c37c7107a939a8ccb56d27d196c52997b5d8db1e2a888b3c9072a394885741ef033a11eba1c43aabc462
   languageName: node
   linkType: hard
 
@@ -36222,7 +36222,7 @@ __metadata:
     "@metamask/core-backend": "npm:^8.0.0"
     "@metamask/delegation-controller": "npm:^3.0.2"
     "@metamask/delegation-deployments": "npm:^1.0.0"
-    "@metamask/design-system-react-native": "npm:^0.38.1"
+    "@metamask/design-system-react-native": "npm:^0.39.0"
     "@metamask/design-system-twrnc-preset": "npm:^0.8.0"
     "@metamask/design-tokens": "npm:^8.7.0"
     "@metamask/device-mcp": "npm:^0.3.0"


### PR DESCRIPTION
## **Description**

Upgrades design system packages to align with the [v58.0.0 release](https://github.com/MetaMask/metamask-design-system/releases/tag/v58.0.0).

**Packages upgraded:**
- `@metamask/design-system-react-native`: `^0.38.1` → `^0.39.0`

**Packages not upgraded (not in v58.0.0 release notes):**
- `@metamask/design-tokens`: `^8.7.0` (unchanged)
- `@metamask/design-system-twrnc-preset`: `^0.8.0` (unchanged)

**Breaking changes addressed:**

No breaking changes in this release.

### Other breaking changes (no code changes needed)
- None — this release contains bug fixes and a new Toast swipe-to-dismiss feature only.

**New additions available for future use:**
- **Toast**: Swipe-to-dismiss gesture support with configurable distance and velocity thresholds
- **Checkbox**: Selected state now uses monochromatic icon colors instead of primary blue (upstream fix)
- **IconColor.IconInverse**: New design token in `@metamask/design-system-shared@0.32.0` (transitive dependency)

**Legacy component deprecations:**
- Added `@deprecated` JSDoc to `HelpText` in `app/component-library/components/Form/HelpText/HelpText.tsx` — matches `HelpText` from `@metamask/design-system-react-native`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

Feature: Design system upgrade to v58.0.0

```gherkin
Feature: Design system upgrade to v58.0.0

  Scenario: Core app functionality is unaffected
    Given I am on the main app screen
    When I navigate through the primary user flows
    Then the UI renders correctly with no visual regressions

  Scenario: Checkbox selected state renders correctly
    Given I am on a screen with checkboxes (e.g. settings or onboarding)
    When I select a checkbox
    Then the selected icon uses monochromatic colors instead of primary blue

  Scenario: Toast interactions still work
    Given a toast notification is displayed
    When I dismiss the toast via tap or swipe
    Then the toast dismisses as expected
```

## **Screenshots/Recordings**

### **Before**

N/A – dependency-only update

### **After**

N/A – dependency-only update

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)