### PR TITLE
chore(analytics): rename Transaction Detail List Item Clicked to Activity Details Opened

### DIFF
--- a/app/components/UI/MultichainBridgeTransactionListItem/MultichainBridgeTransactionListItem.test.tsx
+++ b/app/components/UI/MultichainBridgeTransactionListItem/MultichainBridgeTransactionListItem.test.tsx
@@ -9,7 +9,7 @@ import type { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import { StatusTypes } from '@metamask/bridge-controller';
 import { MonetizedPrimitive } from '../../../core/Analytics/MetaMetrics.types';
 import {
-  TRANSACTION_DETAIL_EVENTS,
+  ACTIVITY_DETAIL_EVENTS,
   TransactionDetailLocation,
 } from '../../../core/Analytics/events/transactions';
 
@@ -260,7 +260,7 @@ describe('MultichainBridgeTransactionListItem', () => {
   });
 
   describe('analytics tracking', () => {
-    it('tracks Transaction Detail List Item Clicked for a bridge transaction', () => {
+    it('tracks Activity Details Opened for a bridge transaction', () => {
       const { getByTestId } = renderWithProvider(
         <MultichainBridgeTransactionListItem
           transaction={mockTransaction}
@@ -274,7 +274,7 @@ describe('MultichainBridgeTransactionListItem', () => {
       fireEvent.press(getByTestId('transaction-item-0'));
 
       expect(mockCreateEventBuilder).toHaveBeenCalledWith(
-        TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED,
+        ACTIVITY_DETAIL_EVENTS.OPENED,
       );
       expect(mockAddProperties).toHaveBeenCalledWith({
         transaction_type: 'bridge',

--- a/app/components/UI/MultichainBridgeTransactionListItem/MultichainBridgeTransactionListItem.tsx
+++ b/app/components/UI/MultichainBridgeTransactionListItem/MultichainBridgeTransactionListItem.tsx
@@ -33,7 +33,7 @@ import { parseCaipAssetType } from '@metamask/utils';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import { MonetizedPrimitive } from '../../../core/Analytics/MetaMetrics.types';
 import {
-  TRANSACTION_DETAIL_EVENTS,
+  ACTIVITY_DETAIL_EVENTS,
   TransactionDetailLocation,
 } from '../../../core/Analytics/events/transactions';
 
@@ -64,7 +64,7 @@ const MultichainBridgeTransactionListItem = ({
 
   const handlePress = () => {
     trackEvent(
-      createEventBuilder(TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED)
+      createEventBuilder(ACTIVITY_DETAIL_EVENTS.OPENED)
         .addProperties({
           transaction_type: isSwap ? 'swap' : 'bridge',
           transaction_status: transaction.status ?? 'unknown',

--- a/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.test.tsx
+++ b/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.test.tsx
@@ -7,7 +7,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import MultichainTransactionListItem from '../MultichainTransactionListItem';
 import Routes from '../../../constants/navigation/Routes';
 import {
-  TRANSACTION_DETAIL_EVENTS,
+  ACTIVITY_DETAIL_EVENTS,
   TransactionDetailLocation,
 } from '../../../core/Analytics/events/transactions';
 
@@ -366,7 +366,7 @@ describe('MultichainTransactionListItem', () => {
   });
 
   describe('analytics tracking', () => {
-    it('tracks Transaction Detail List Item Clicked with default home location', () => {
+    it('tracks Activity Details Opened with default home location', () => {
       const { getByTestId } = renderWithProvider(
         <MultichainTransactionListItem
           transaction={mockTransaction}
@@ -380,7 +380,7 @@ describe('MultichainTransactionListItem', () => {
       fireEvent.press(getByTestId('transaction-item-0'));
 
       expect(mockCreateEventBuilder).toHaveBeenCalledWith(
-        TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED,
+        ACTIVITY_DETAIL_EVENTS.OPENED,
       );
       expect(mockAddProperties).toHaveBeenCalledWith({
         transaction_type: 'send',

--- a/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.tsx
+++ b/app/components/UI/MultichainTransactionListItem/MultichainTransactionListItem.tsx
@@ -26,7 +26,7 @@ import { getNetworkImageSource } from '../../../util/networks';
 import Routes from '../../../constants/navigation/Routes';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import {
-  TRANSACTION_DETAIL_EVENTS,
+  ACTIVITY_DETAIL_EVENTS,
   TransactionDetailLocation,
 } from '../../../core/Analytics/events/transactions';
 import { selectAppTheme } from '../../../selectors/user';
@@ -62,7 +62,7 @@ const MultichainTransactionListItem = ({
 
   const handlePress = useCallback(() => {
     trackEvent(
-      createEventBuilder(TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED)
+      createEventBuilder(ACTIVITY_DETAIL_EVENTS.OPENED)
         .addProperties({
           transaction_type: transaction.type?.toLowerCase() ?? 'unknown',
           transaction_status: transaction.status ?? 'unknown',

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
@@ -20,7 +20,7 @@ import {
 import type { CaipAccountId } from '@metamask/utils';
 import { createMockAccountsControllerState } from '../../../../../util/test/accountsControllerTestUtils';
 import { mockNetworkState } from '../../../../../util/test/network';
-import { TRANSACTION_DETAIL_EVENTS } from '../../../../../core/Analytics/events/transactions';
+import { ACTIVITY_DETAIL_EVENTS } from '../../../../../core/Analytics/events/transactions';
 import { MonetizedPrimitive } from '../../../../../core/Analytics/MetaMetrics.types';
 import { usePerpsMeasurement } from '../../hooks/usePerpsMeasurement';
 import { AccountGroupType, AccountWalletType } from '@metamask/account-api';
@@ -1010,7 +1010,7 @@ describe('PerpsTransactionsView', () => {
   });
 
   describe('Analytics Tracking', () => {
-    it('tracks Transaction Detail List Item Clicked when a transaction item is pressed', async () => {
+    it('tracks Activity Details Opened when a transaction item is pressed', async () => {
       const component = renderWithProvider(<PerpsTransactionsView />, {
         state: mockInitialState,
       });
@@ -1032,7 +1032,7 @@ describe('PerpsTransactionsView', () => {
       });
 
       expect(mockCreateEventBuilder).toHaveBeenCalledWith(
-        TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED,
+        ACTIVITY_DETAIL_EVENTS.OPENED,
       );
       expect(mockAddProperties).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
@@ -41,7 +41,7 @@ import { usePerpsConnection, usePerpsTransactionHistory } from '../../hooks';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MonetizedPrimitive } from '../../../../../core/Analytics/MetaMetrics.types';
 import {
-  TRANSACTION_DETAIL_EVENTS,
+  ACTIVITY_DETAIL_EVENTS,
   TransactionDetailLocation,
 } from '../../../../../core/Analytics/events/transactions';
 import { PERPS_BALANCE_CHAIN_ID } from '../../constants/perpsConfig';
@@ -313,7 +313,7 @@ const PerpsTransactionsView: React.FC = () => {
 
   const handleTransactionPress = (transaction: PerpsTransaction) => {
     trackEvent(
-      createEventBuilder(TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED)
+      createEventBuilder(ACTIVITY_DETAIL_EVENTS.OPENED)
         .addProperties({
           transaction_type: `perps_${transaction.type}`,
           transaction_status:

--- a/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.test.tsx
@@ -5,7 +5,7 @@ import PerpsMarketTradesList from './PerpsMarketTradesList';
 import Routes from '../../../../../constants/navigation/Routes';
 import { usePerpsMarketFills } from '../../hooks/usePerpsMarketFills';
 import { type OrderFill } from '@metamask/perps-controller';
-import { TRANSACTION_DETAIL_EVENTS } from '../../../../../core/Analytics/events/transactions';
+import { ACTIVITY_DETAIL_EVENTS } from '../../../../../core/Analytics/events/transactions';
 import { MonetizedPrimitive } from '../../../../../core/Analytics/MetaMetrics.types';
 
 const mockTrackEvent = jest.fn();
@@ -581,7 +581,7 @@ describe('PerpsMarketTradesList', () => {
   });
 
   describe('Analytics Tracking', () => {
-    it('tracks Transaction Detail List Item Clicked when a trade is pressed', () => {
+    it('tracks Activity Details Opened when a trade is pressed', () => {
       mockUsePerpsMarketFills.mockReturnValue(
         createMockFillsReturn(mockOrderFills),
       );
@@ -592,7 +592,7 @@ describe('PerpsMarketTradesList', () => {
       fireEvent.press(tradeItem.parent?.parent || tradeItem);
 
       expect(mockCreateEventBuilder).toHaveBeenCalledWith(
-        TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED,
+        ACTIVITY_DETAIL_EVENTS.OPENED,
       );
       expect(mockAddProperties).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.tsx
@@ -29,7 +29,7 @@ import { transformFillsToTransactions } from '../../utils/transactionTransforms'
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MonetizedPrimitive } from '../../../../../core/Analytics/MetaMetrics.types';
 import {
-  TRANSACTION_DETAIL_EVENTS,
+  ACTIVITY_DETAIL_EVENTS,
   TransactionDetailLocation,
 } from '../../../../../core/Analytics/events/transactions';
 import {
@@ -76,7 +76,7 @@ const PerpsMarketTradesList: React.FC<PerpsMarketTradesListProps> = ({
   const handleTradePress = useCallback(
     (transaction: PerpsTransaction) => {
       trackEvent(
-        createEventBuilder(TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED)
+        createEventBuilder(ACTIVITY_DETAIL_EVENTS.OPENED)
           .addProperties({
             transaction_type: `perps_${transaction.type}`,
             transaction_status: 'confirmed',

--- a/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.test.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react-native';
 import PerpsRecentActivityList from './PerpsRecentActivityList';
 import Routes from '../../../../../constants/navigation/Routes';
 import { FillType } from '../../types/transactionHistory';
-import { TRANSACTION_DETAIL_EVENTS } from '../../../../../core/Analytics/events/transactions';
+import { ACTIVITY_DETAIL_EVENTS } from '../../../../../core/Analytics/events/transactions';
 import { MonetizedPrimitive } from '../../../../../core/Analytics/MetaMetrics.types';
 
 const mockTrackEvent = jest.fn();
@@ -703,14 +703,14 @@ describe('PerpsRecentActivityList', () => {
   });
 
   describe('Analytics Tracking', () => {
-    it('tracks Transaction Detail List Item Clicked when a trade is pressed', () => {
+    it('tracks Activity Details Opened when a trade is pressed', () => {
       render(<PerpsRecentActivityList transactions={mockTransactions} />);
 
       const transactionItem = screen.getByText('Opened long');
       fireEvent.press(transactionItem.parent?.parent || transactionItem);
 
       expect(mockCreateEventBuilder).toHaveBeenCalledWith(
-        TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED,
+        ACTIVITY_DETAIL_EVENTS.OPENED,
       );
       expect(mockAddProperties).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.tsx
@@ -25,7 +25,7 @@ import PerpsRowSkeleton from '../PerpsRowSkeleton';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MonetizedPrimitive } from '../../../../../core/Analytics/MetaMetrics.types';
 import {
-  TRANSACTION_DETAIL_EVENTS,
+  ACTIVITY_DETAIL_EVENTS,
   TransactionDetailLocation,
 } from '../../../../../core/Analytics/events/transactions';
 
@@ -55,7 +55,7 @@ const PerpsRecentActivityList: React.FC<PerpsRecentActivityListProps> = ({
     (transaction: PerpsTransaction) => {
       if (transaction.fill) {
         trackEvent(
-          createEventBuilder(TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED)
+          createEventBuilder(ACTIVITY_DETAIL_EVENTS.OPENED)
             .addProperties({
               transaction_type: `perps_${transaction.type}`,
               transaction_status: 'confirmed',

--- a/app/components/UI/Predict/components/PredictActivity/PredictActivity.test.tsx
+++ b/app/components/UI/Predict/components/PredictActivity/PredictActivity.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react-native';
 import PredictActivity from './PredictActivity';
 import { PredictActivityType, type PredictActivityItem } from '../../types';
 import Routes from '../../../../../constants/navigation/Routes';
-import { TRANSACTION_DETAIL_EVENTS } from '../../../../../core/Analytics/events/transactions';
+import { ACTIVITY_DETAIL_EVENTS } from '../../../../../core/Analytics/events/transactions';
 import { MonetizedPrimitive } from '../../../../../core/Analytics/MetaMetrics.types';
 
 const mockTrackEvent = jest.fn();
@@ -150,14 +150,14 @@ describe('PredictActivity', () => {
   });
 
   describe('Analytics Tracking', () => {
-    it('tracks Transaction Detail List Item Clicked when pressed', () => {
+    it('tracks Activity Details Opened when pressed', () => {
       const item = createActivityItem();
 
       render(<PredictActivity item={item} />);
       fireEvent.press(screen.getByText('Buy'));
 
       expect(mockCreateEventBuilder).toHaveBeenCalledWith(
-        TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED,
+        ACTIVITY_DETAIL_EVENTS.OPENED,
       );
       expect(mockEventBuilder.addProperties).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/app/components/UI/Predict/components/PredictActivity/PredictActivity.tsx
+++ b/app/components/UI/Predict/components/PredictActivity/PredictActivity.tsx
@@ -18,7 +18,7 @@ import { PredictActivityItem, PredictActivityType } from '../../types';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MonetizedPrimitive } from '../../../../../core/Analytics/MetaMetrics.types';
 import {
-  TRANSACTION_DETAIL_EVENTS,
+  ACTIVITY_DETAIL_EVENTS,
   TransactionDetailLocation,
 } from '../../../../../core/Analytics/events/transactions';
 import { POLYGON_MAINNET_CHAIN_ID } from '../../providers/polymarket/constants';
@@ -57,7 +57,7 @@ const PredictActivity: React.FC<PredictActivityProps> = ({
 
   const handlePress = () => {
     trackEvent(
-      createEventBuilder(TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED)
+      createEventBuilder(ACTIVITY_DETAIL_EVENTS.OPENED)
         .addProperties({
           transaction_type: `predict_${item.type.toLowerCase()}`,
           transaction_status: 'confirmed',

--- a/app/components/UI/TransactionElement/index.js
+++ b/app/components/UI/TransactionElement/index.js
@@ -70,7 +70,7 @@ import {
 } from '../../Views/confirmations/utils/transaction';
 import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 import {
-  TRANSACTION_DETAIL_EVENTS,
+  ACTIVITY_DETAIL_EVENTS,
   TransactionDetailLocation,
   getMonetizedPrimitive,
 } from '../../../core/Analytics/events/transactions';
@@ -827,7 +827,7 @@ const TransactionElementWithBridge = (props) => {
       bridgeTxHistoryData?.bridgeTxHistoryItem?.quote?.destChainId;
 
     trackEvent(
-      createEventBuilder(TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED)
+      createEventBuilder(ACTIVITY_DETAIL_EVENTS.OPENED)
         .addProperties({
           transaction_type: getTransactionTypeValue(tx.type, tx),
           transaction_status: tx.status,

--- a/app/components/UI/TransactionElement/index.test.tsx
+++ b/app/components/UI/TransactionElement/index.test.tsx
@@ -12,7 +12,7 @@ import { MOCK_ACCOUNTS_CONTROLLER_STATE } from '../../../util/test/accountsContr
 import renderWithProvider from '../../../util/test/renderWithProvider';
 import Routes from '../../../constants/navigation/Routes';
 import {
-  TRANSACTION_DETAIL_EVENTS,
+  ACTIVITY_DETAIL_EVENTS,
   TransactionDetailLocation,
 } from '../../../core/Analytics/events/transactions';
 
@@ -368,7 +368,7 @@ describe('TransactionElement', () => {
   });
 
   describe('analytics tracking', () => {
-    it('tracks Transaction Detail List Item Clicked when pressed', async () => {
+    it('tracks Activity Details Opened when pressed', async () => {
       const tx = {
         id: 'tx-analytics-1',
         type: TransactionType.simpleSend,
@@ -395,7 +395,7 @@ describe('TransactionElement', () => {
       fireEvent.press(getByText('Test Action'));
 
       expect(mockCreateEventBuilder).toHaveBeenCalledWith(
-        TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED,
+        ACTIVITY_DETAIL_EVENTS.OPENED,
       );
       expect(mockAddProperties).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.tsx
+++ b/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.tsx
@@ -20,7 +20,7 @@ import { getActivityDetailsRoute } from '../ActivityList/getActivityDetailsRoute
 import { mapKeyringTransaction } from '../../../util/activity-adapters';
 import {
   getMultichainTransactionDetailEventProperties,
-  TRANSACTION_DETAIL_EVENTS,
+  ACTIVITY_DETAIL_EVENTS,
 } from './MultichainAssetDetailsActivityListItem.utils';
 
 interface MultichainAssetDetailsActivityListItemProps {
@@ -56,7 +56,7 @@ export const MultichainAssetDetailsActivityListItem = ({
 
   const handlePress = useCallback(() => {
     trackEvent(
-      createEventBuilder(TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED)
+      createEventBuilder(ACTIVITY_DETAIL_EVENTS.OPENED)
         .addProperties(
           getMultichainTransactionDetailEventProperties({
             transaction,

--- a/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.utils.ts
+++ b/app/components/Views/MultichainTransactionsView/MultichainAssetDetailsActivityListItem.utils.ts
@@ -2,7 +2,7 @@ import type { Transaction } from '@metamask/keyring-api';
 import type { SupportedCaipChainId } from '@metamask/multichain-network-controller';
 import type { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import {
-  TRANSACTION_DETAIL_EVENTS,
+  ACTIVITY_DETAIL_EVENTS,
   TransactionDetailLocation,
 } from '../../../core/Analytics/events/transactions';
 import { MonetizedPrimitive } from '../../../core/Analytics/MetaMetrics.types';
@@ -44,4 +44,4 @@ export const getMultichainTransactionDetailEventProperties = ({
   };
 };
 
-export { TRANSACTION_DETAIL_EVENTS };
+export { ACTIVITY_DETAIL_EVENTS };

--- a/app/core/Analytics/events/transactions/events.test.ts
+++ b/app/core/Analytics/events/transactions/events.test.ts
@@ -1,0 +1,31 @@
+import { ACTIVITY_DETAIL_EVENTS } from './events';
+
+const LEGACY_EVENT_NAME = 'Transaction Detail List Item Clicked';
+
+describe('ACTIVITY_DETAIL_EVENTS', () => {
+  it('emits the event name "Activity Details Opened"', () => {
+    // Arrange / Act
+    const { category } = ACTIVITY_DETAIL_EVENTS.OPENED;
+
+    // Assert
+    expect(category).toBe('Activity Details Opened');
+  });
+
+  it('no longer emits the legacy event name', () => {
+    // Arrange / Act
+    const emittedNames = Object.values(ACTIVITY_DETAIL_EVENTS).map(
+      (event) => event.category,
+    );
+
+    // Assert
+    expect(emittedNames).not.toContain(LEGACY_EVENT_NAME);
+  });
+
+  it('carries no default properties, so call sites own the payload', () => {
+    // Arrange / Act
+    const event = ACTIVITY_DETAIL_EVENTS.OPENED;
+
+    // Assert
+    expect(event).toStrictEqual({ category: 'Activity Details Opened' });
+  });
+});

--- a/app/core/Analytics/events/transactions/events.ts
+++ b/app/core/Analytics/events/transactions/events.ts
@@ -4,12 +4,9 @@ import {
 } from '../../MetaMetrics.events';
 
 enum EVENT_NAME {
-  // Renamed from 'Transaction Detail List Item Clicked' (TMCU-835) to match the
-  // name extension already emits, so both platforms share one funnel.
   ACTIVITY_DETAILS_OPENED = 'Activity Details Opened',
 }
 
-// This function helps prevent repeat of type conversions
 const createEvent = (name: EVENT_NAME) =>
   generateOpt(name as unknown as METRICS_EVENT_NAME);
 

--- a/app/core/Analytics/events/transactions/events.ts
+++ b/app/core/Analytics/events/transactions/events.ts
@@ -4,15 +4,15 @@ import {
 } from '../../MetaMetrics.events';
 
 enum EVENT_NAME {
-  TRANSACTION_DETAIL_LIST_ITEM_CLICKED = 'Transaction Detail List Item Clicked',
+  // Renamed from 'Transaction Detail List Item Clicked' (TMCU-835) to match the
+  // name extension already emits, so both platforms share one funnel.
+  ACTIVITY_DETAILS_OPENED = 'Activity Details Opened',
 }
 
 // This function helps prevent repeat of type conversions
 const createEvent = (name: EVENT_NAME) =>
   generateOpt(name as unknown as METRICS_EVENT_NAME);
 
-export const TRANSACTION_DETAIL_EVENTS = {
-  LIST_ITEM_CLICKED: createEvent(
-    EVENT_NAME.TRANSACTION_DETAIL_LIST_ITEM_CLICKED,
-  ),
+export const ACTIVITY_DETAIL_EVENTS = {
+  OPENED: createEvent(EVENT_NAME.ACTIVITY_DETAILS_OPENED),
 };

--- a/app/core/Analytics/events/transactions/properties.ts
+++ b/app/core/Analytics/events/transactions/properties.ts
@@ -4,7 +4,7 @@ import type { JsonMap, MonetizedPrimitive } from '../../MetaMetrics.types';
 import { TransactionDetailLocation } from './constants';
 
 /**
- * Properties for the "Transaction Detail List Item Clicked" event.
+ * Properties for the "Activity Details Opened" event.
  *
  * @property transaction_type - TX type value from getTransactionTypeValue()
  * (e.g. 'simple_send', 'swap', 'bridge', 'contract_interaction').
@@ -17,7 +17,7 @@ import { TransactionDetailLocation } from './constants';
  * @property monetized_primitive - Only propagated when the transaction
  * involves a monetized primitive.
  */
-export interface TransactionDetailListItemClickedProperties extends JsonMap {
+export interface ActivityDetailsOpenedProperties extends JsonMap {
   transaction_type: string;
   transaction_status: TransactionStatus;
   location: TransactionDetailLocation;


### PR DESCRIPTION
## **Description**

Renames the mobile analytics event `Transaction Detail List Item Clicked` to `Activity Details Opened`, matching the name extension already emits, so activity-details funnels can be compared across platforms. All existing properties are retained unchanged; extension closes the property gap in a paired CEUX ticket.

**Two corrections to the ticket, found while validating against extension:**

1. **TMCU-835 points at the wrong constant.** It asks to update `ACTIVITY_CLICKED` in `app/core/Analytics/MetaMetrics.events.ts`. That is a *different, live* event — `'Activity Clicked'`, fired when the wallet-home Activity button is pressed. Editing it would have silently broken an unrelated event. The event actually being renamed is `TRANSACTION_DETAIL_LIST_ITEM_CLICKED` in `app/core/Analytics/events/transactions/events.ts`.
2. **`id` is not a property of this event.** The ticket lists it among properties to retain, but it comes from `metamask-mobile-globals`, so there was nothing to preserve.

What changed:

- `EVENT_NAME.TRANSACTION_DETAIL_LIST_ITEM_CLICKED` → `ACTIVITY_DETAILS_OPENED`, emitting `'Activity Details Opened'`
- `TRANSACTION_DETAIL_EVENTS.LIST_ITEM_CLICKED` → `ACTIVITY_DETAIL_EVENTS.OPENED`, updated at all 8 call sites so the code no longer implies the old name
- `TransactionDetailListItemClickedProperties` → `ActivityDetailsOpenedProperties` (as the ticket asks)
- New `events.test.ts` pins the emitted string and asserts the legacy name is no longer emitted anywhere in the module

No behaviour, UI, or payload change — only the event name and identifiers.

**Depends on** the segment-schema PR that adds the `Activity Details Opened` entry: https://github.com/Consensys/segment-schema/pull/704. Note extension currently emits this event with **no schema entry at all**; that PR creates it.

⚠️ **Downstream impact:** `Transaction Detail List Item Clicked` is a `kpi: true` event. Dashboards, ETL models, and alerts keyed on that string will go to zero when this ships. Mobile emits only the new name — there is no dual-fire window. Say the word if one is wanted instead.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-835

## **Manual testing steps**

```gherkin
Feature: Activity details analytics event rename

  Scenario: user opens activity details from the wallet home activity feed
    Given the user has at least one confirmed transaction
    And MetaMetrics is opted in
    And the Segment debugger is open

    When user taps a transaction row in the Activity list
    Then an "Activity Details Opened" event is received
    And no "Transaction Detail List Item Clicked" event is received
    And the payload still contains transaction_type, transaction_status, location,
      chain_id_source and chain_id_destination

  Scenario: user opens activity details from an asset details page
    Given the user is on a token details page with transaction history

    When user taps a transaction row
    Then an "Activity Details Opened" event is received with location "asset_details"

  Scenario: user opens a perps trade from the perps activity list
    Given the user has perps activity

    When user taps a perps trade row
    Then an "Activity Details Opened" event is received
    And monetized_primitive is "perps"
```

## **Screenshots/Recordings**

`~`

### **Before**

`~`

### **After**

`~`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

Not applicable: this is a string-and-identifier rename with no added work on any code path, no new renders, and no new instrumentation points.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Analytics-only code change is low risk, but renaming a kpi event without dual-firing will break downstream dashboards, ETL, and alerts tied to the legacy string.
> 
> **Overview**
> Renames the mobile MetaMetrics event from **Transaction Detail List Item Clicked** to **Activity Details Opened** so activity-detail funnels align with extension. The emitted string, module constants (`ACTIVITY_DETAIL_EVENTS.OPENED`), and the payload type (`ActivityDetailsOpenedProperties`) are updated; **event properties are unchanged**.
> 
> All activity-row tap sites now fire the new event—EVM `TransactionElement`, multichain list items, bridge rows, Perps/Predict activity UIs, and asset-details multichain rows. Tests and a new `events.test.ts` assert the legacy name is no longer emitted from the transactions events module.
> 
> **Operational note:** dashboards and pipelines keyed on the old KPI event name will stop receiving data when this ships; mobile does not dual-fire both names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0307b3bc4e37ef24a1fce593bf6032334dab7cdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->