### PR TITLE
fix(predict): fix pwat telemetry so success failure is measurable and comparable to non pwat payments

### DIFF
--- a/app/components/UI/Predict/constants/errors.ts
+++ b/app/components/UI/Predict/constants/errors.ts
@@ -37,6 +37,10 @@ export const PREDICT_ERROR_CODES = {
   MARKET_BETTABLE_CHECK_FAILED: 'PREDICT_MARKET_BETTABLE_CHECK_FAILED',
 } as const;
 
+export const PREDICT_BUY_CANCELLATION_REASONS = {
+  RETRY_PROMPT_EXPIRED: 'Retry prompt expired after a retryable order failure',
+} as const;
+
 export const getPredictErrorMessages = () =>
   ({
     [PREDICT_ERROR_CODES.PREVIEW_NO_ORDER_BOOK]: strings(

--- a/app/components/UI/Predict/constants/eventNames.ts
+++ b/app/components/UI/Predict/constants/eventNames.ts
@@ -256,8 +256,16 @@ export const PredictTradeStatus = {
   FAILED_ORDER: 'failed_order',
 } as const;
 
+export const MAX_TRACKED_PREDICT_BUY_TERMINALS = 500;
+
 export type PredictTradeStatusValue =
   (typeof PredictTradeStatus)[keyof typeof PredictTradeStatus];
+
+export type PredictBuyTerminalStatus =
+  | typeof PredictTradeStatus.SUCCEEDED
+  | typeof PredictTradeStatus.FAILED_SWAP
+  | typeof PredictTradeStatus.FAILED_ORDER
+  | typeof PredictTradeStatus.CANCELLED;
 
 export type PredictPaymentMethodValue =
   (typeof PredictEventValues.PAYMENT_METHOD)[keyof typeof PredictEventValues.PAYMENT_METHOD];

--- a/app/components/UI/Predict/constants/eventNames.ts
+++ b/app/components/UI/Predict/constants/eventNames.ts
@@ -81,6 +81,10 @@ export const PredictEventProperties = {
   // Payment token (buy-with-any-token flow only)
   PAYMENT_TOKEN_ADDRESS: 'payment_token_address',
   PAYMENT_TOKEN_SYMBOL: 'payment_token_symbol',
+  PAYMENT_METHOD: 'payment_method',
+  ATTEMPT_ID: 'attempt_id',
+  FAILURE_STAGE: 'failure_stage',
+  FAILURE_CATEGORY: 'failure_category',
 
   // Betslip dismissal
   DISMISSAL_METHOD: 'dismissal_method',
@@ -155,6 +159,24 @@ export const PredictEventValues = {
     USER_REJECTED: 'user_rejected',
     UNKNOWN: 'unknown',
   },
+  PAYMENT_METHOD: {
+    PAY_WITH_ANY_TOKEN: 'pay_with_any_token',
+    PREDICT_BALANCE: 'predict_balance',
+  },
+  FAILURE_STAGE: {
+    SWAP: 'swap',
+    ORDER: 'order',
+  },
+  FAILURE_CATEGORY: {
+    GAS_LIMIT: 'gas_limit',
+    INSUFFICIENT_BALANCE: 'insufficient_balance',
+    NOT_ELIGIBLE: 'not_eligible',
+    NO_MATCH: 'no_match',
+    RELAYER: 'relayer',
+    NETWORK: 'network',
+    USER_REJECTED: 'user_rejected',
+    OTHER: 'other',
+  },
   MARKET_TYPE: {
     BINARY: 'binary',
     MULTI_OUTCOME: 'multi-outcome',
@@ -225,10 +247,26 @@ export const PredictTradeStatus = {
   RETRY_SUBMITTED: 'retry_submitted',
   PAYMENT_FAILURE_PROMPTED: 'payment_failure_prompted',
   ADD_FUNDS_SUBMITTED: 'add_funds_submitted',
+  ATTEMPT_STARTED: 'attempt_started',
+  SWAP_STARTED: 'swap_started',
+  SWAP_SUCCEEDED: 'swap_succeeded',
+  ORDER_SUBMITTED: 'order_submitted',
+  ORDER_FAILED: 'order_failed',
+  FAILED_SWAP: 'failed_swap',
+  FAILED_ORDER: 'failed_order',
 } as const;
 
 export type PredictTradeStatusValue =
   (typeof PredictTradeStatus)[keyof typeof PredictTradeStatus];
+
+export type PredictPaymentMethodValue =
+  (typeof PredictEventValues.PAYMENT_METHOD)[keyof typeof PredictEventValues.PAYMENT_METHOD];
+
+export type PredictFailureStageValue =
+  (typeof PredictEventValues.FAILURE_STAGE)[keyof typeof PredictEventValues.FAILURE_STAGE];
+
+export type PredictFailureCategoryValue =
+  (typeof PredictEventValues.FAILURE_CATEGORY)[keyof typeof PredictEventValues.FAILURE_CATEGORY];
 
 /**
  * Dismissal method values for the Predict Betslip Dismissed event

--- a/app/components/UI/Predict/constants/eventNames.ts
+++ b/app/components/UI/Predict/constants/eventNames.ts
@@ -248,12 +248,7 @@ export const PredictTradeStatus = {
   PAYMENT_FAILURE_PROMPTED: 'payment_failure_prompted',
   ADD_FUNDS_SUBMITTED: 'add_funds_submitted',
   ATTEMPT_STARTED: 'attempt_started',
-  SWAP_STARTED: 'swap_started',
-  SWAP_SUCCEEDED: 'swap_succeeded',
-  ORDER_SUBMITTED: 'order_submitted',
   ORDER_FAILED: 'order_failed',
-  FAILED_SWAP: 'failed_swap',
-  FAILED_ORDER: 'failed_order',
 } as const;
 
 export const MAX_TRACKED_PREDICT_BUY_TERMINALS = 500;
@@ -263,8 +258,7 @@ export type PredictTradeStatusValue =
 
 export type PredictBuyTerminalStatus =
   | typeof PredictTradeStatus.SUCCEEDED
-  | typeof PredictTradeStatus.FAILED_SWAP
-  | typeof PredictTradeStatus.FAILED_ORDER
+  | typeof PredictTradeStatus.FAILED
   | typeof PredictTradeStatus.CANCELLED;
 
 export type PredictPaymentMethodValue =

--- a/app/components/UI/Predict/contexts/PredictPreviewSheetContext.test.tsx
+++ b/app/components/UI/Predict/contexts/PredictPreviewSheetContext.test.tsx
@@ -1150,6 +1150,18 @@ describe('PredictPreviewSheetContext', () => {
       expect(mockCancelRetryablePredictBuyAttempt).not.toHaveBeenCalled();
     });
 
+    it('does not cancel the attempt if the sheet reopens another way', () => {
+      showRetryToast();
+
+      act(() => {
+        fireEvent.press(screen.getByTestId('open-buy'));
+        jest.advanceTimersByTime(10000);
+      });
+
+      expect(mockClearOrderError).not.toHaveBeenCalled();
+      expect(mockCancelRetryablePredictBuyAttempt).not.toHaveBeenCalled();
+    });
+
     it('cancels the pending clear timer on provider unmount', () => {
       const { unmount } = showRetryToast();
 

--- a/app/components/UI/Predict/contexts/PredictPreviewSheetContext.test.tsx
+++ b/app/components/UI/Predict/contexts/PredictPreviewSheetContext.test.tsx
@@ -12,6 +12,7 @@ import type {
   PredictBuyPreviewParams,
   PredictSellPreviewParams,
 } from '../types/navigation';
+import { PREDICT_BUY_CANCELLATION_REASONS } from '../constants/errors';
 import Routes from '../../../../constants/navigation/Routes';
 import { predictBuyPreviewOrderInitiatedRef } from '../views/PredictBuyPreview/PredictBuyPreview';
 
@@ -1100,6 +1101,11 @@ describe('PredictPreviewSheetContext', () => {
       );
       fireEvent.press(screen.getByTestId('dismiss-sheet'));
 
+      // `clearOrderError` is called by the dismiss path; reset so subsequent
+      // assertions only count timer-driven calls.
+      mockClearOrderError.mockClear();
+      mockCancelRetryablePredictBuyAttempt.mockClear();
+
       mockActiveOrder = { state: 'preview', error: 'order/failed' };
       rerender(
         <PredictPreviewSheetProvider>
@@ -1110,15 +1116,20 @@ describe('PredictPreviewSheetContext', () => {
       return { rerender, unmount };
     };
 
-    it('clears the order error after the toast auto-dismisses (~3s)', () => {
+    it('cancels the attempt and clears the error after toast auto-dismiss', () => {
       showRetryToast();
       expect(mockToastShowToast).toHaveBeenCalledTimes(1);
       expect(mockClearOrderError).not.toHaveBeenCalled();
+      expect(mockCancelRetryablePredictBuyAttempt).not.toHaveBeenCalled();
 
       act(() => {
         jest.advanceTimersByTime(3000);
       });
 
+      expect(mockCancelRetryablePredictBuyAttempt).toHaveBeenCalledTimes(1);
+      expect(mockCancelRetryablePredictBuyAttempt).toHaveBeenCalledWith(
+        PREDICT_BUY_CANCELLATION_REASONS.RETRY_PROMPT_EXPIRED,
+      );
       expect(mockClearOrderError).toHaveBeenCalledTimes(1);
     });
 
@@ -1136,6 +1147,7 @@ describe('PredictPreviewSheetContext', () => {
       });
 
       expect(mockClearOrderError).not.toHaveBeenCalled();
+      expect(mockCancelRetryablePredictBuyAttempt).not.toHaveBeenCalled();
     });
 
     it('cancels the pending clear timer on provider unmount', () => {
@@ -1148,6 +1160,7 @@ describe('PredictPreviewSheetContext', () => {
       });
 
       expect(mockClearOrderError).not.toHaveBeenCalled();
+      expect(mockCancelRetryablePredictBuyAttempt).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Predict/contexts/PredictPreviewSheetContext.test.tsx
+++ b/app/components/UI/Predict/contexts/PredictPreviewSheetContext.test.tsx
@@ -18,6 +18,7 @@ import { predictBuyPreviewOrderInitiatedRef } from '../views/PredictBuyPreview/P
 const mockNavigate = jest.fn();
 const mockTrackBetslipDismissed = jest.fn();
 const mockTrackPredictOrderEvent = jest.fn();
+const mockTrackPredictBuyTerminalEvent = jest.fn();
 
 jest.mock('../../../../core/Engine', () => ({
   context: {
@@ -26,6 +27,8 @@ jest.mock('../../../../core/Engine', () => ({
         mockTrackBetslipDismissed(...args),
       trackPredictOrderEvent: (...args: unknown[]) =>
         mockTrackPredictOrderEvent(...args),
+      trackPredictBuyTerminalEvent: (...args: unknown[]) =>
+        mockTrackPredictBuyTerminalEvent(...args),
     },
   },
 }));

--- a/app/components/UI/Predict/contexts/PredictPreviewSheetContext.test.tsx
+++ b/app/components/UI/Predict/contexts/PredictPreviewSheetContext.test.tsx
@@ -18,7 +18,7 @@ import { predictBuyPreviewOrderInitiatedRef } from '../views/PredictBuyPreview/P
 const mockNavigate = jest.fn();
 const mockTrackBetslipDismissed = jest.fn();
 const mockTrackPredictOrderEvent = jest.fn();
-const mockTrackPredictBuyTerminalEvent = jest.fn();
+const mockCancelRetryablePredictBuyAttempt = jest.fn();
 
 jest.mock('../../../../core/Engine', () => ({
   context: {
@@ -27,8 +27,8 @@ jest.mock('../../../../core/Engine', () => ({
         mockTrackBetslipDismissed(...args),
       trackPredictOrderEvent: (...args: unknown[]) =>
         mockTrackPredictOrderEvent(...args),
-      trackPredictBuyTerminalEvent: (...args: unknown[]) =>
-        mockTrackPredictBuyTerminalEvent(...args),
+      cancelRetryablePredictBuyAttempt: (...args: unknown[]) =>
+        mockCancelRetryablePredictBuyAttempt(...args),
     },
   },
 }));
@@ -300,6 +300,7 @@ describe('PredictPreviewSheetContext', () => {
     mockToastCloseToast.mockReset();
     mockClearOrderError.mockReset();
     mockTrackBetslipDismissed.mockReset();
+    mockCancelRetryablePredictBuyAttempt.mockReset();
   });
 
   it('provides openBuySheet and openSellSheet to consumers', () => {
@@ -527,6 +528,8 @@ describe('PredictPreviewSheetContext', () => {
     expect(screen.getByTestId('predict-buy-preview-sheet')).toBeOnTheScreen();
 
     fireEvent.press(screen.getByTestId('dismiss-sheet'));
+
+    expect(mockCancelRetryablePredictBuyAttempt).toHaveBeenCalledTimes(1);
     expect(
       screen.queryByTestId('predict-buy-preview-sheet'),
     ).not.toBeOnTheScreen();

--- a/app/components/UI/Predict/contexts/PredictPreviewSheetContext.tsx
+++ b/app/components/UI/Predict/contexts/PredictPreviewSheetContext.tsx
@@ -52,10 +52,6 @@ import PredictBuyPreview, {
   predictBuyPreviewSessionRef,
 } from '../views/PredictBuyPreview/PredictBuyPreview';
 import PredictBuyWithAnyToken from '../views/PredictBuyWithAnyToken/PredictBuyWithAnyToken';
-import {
-  predictBuyAttemptRef,
-  predictBuyHasRetryableFailureRef,
-} from '../views/PredictBuyWithAnyToken/predictBuyAttemptRefs';
 import PredictSellPreview from '../views/PredictSellPreview/PredictSellPreview';
 import { PredictMarketDetailsSelectorsIDs } from '../Predict.testIds';
 import { usePredictActiveOrder } from '../hooks/usePredictActiveOrder';
@@ -518,29 +514,7 @@ export const PredictPreviewSheetProvider: React.FC<
       activeOrder?.state === ActiveOrderState.DEPOSITING ||
       activeOrder?.state === ActiveOrderState.PLACING_ORDER;
 
-    const attempt = predictBuyAttemptRef.current;
-    if (
-      orderWasInitiated &&
-      predictBuyHasRetryableFailureRef.current &&
-      attempt &&
-      buyParams
-    ) {
-      Engine.context.PredictController.trackPredictBuyTerminalEvent({
-        status: PredictTradeStatus.CANCELLED,
-        amountUsd: attempt.amountUsd,
-        analyticsProperties: parseAnalyticsProperties(
-          buyParams.market,
-          buyParams.outcomeToken,
-          buyParams.entryPoint,
-        ),
-        attemptId: attempt.attemptId,
-        paymentMethod: attempt.paymentMethod,
-        failureStage: PredictEventValues.FAILURE_STAGE.ORDER,
-        failureCategory: PredictEventValues.FAILURE_CATEGORY.USER_REJECTED,
-        failureReason: 'User cancelled after a retryable order failure',
-        activeAbTests: buyParams.transactionActiveAbTests,
-      });
-    }
+    Engine.context.PredictController.cancelRetryablePredictBuyAttempt();
 
     // Fire Predict Betslip Dismissed for swipe / hardware-back paths.
     // Skip if: the back-button handler already fired it, or the sheet is
@@ -565,8 +539,6 @@ export const PredictPreviewSheetProvider: React.FC<
     }
     predictBuyPreviewDismissedViaBackRef.current = false;
     predictBuyPreviewOrderInitiatedRef.current = false;
-    predictBuyAttemptRef.current = undefined;
-    predictBuyHasRetryableFailureRef.current = false;
 
     setBuyParams(null);
     const orderMayStartAfterDismiss = orderWasInitiated && !activeOrder?.error;

--- a/app/components/UI/Predict/contexts/PredictPreviewSheetContext.tsx
+++ b/app/components/UI/Predict/contexts/PredictPreviewSheetContext.tsx
@@ -55,6 +55,7 @@ import PredictBuyWithAnyToken from '../views/PredictBuyWithAnyToken/PredictBuyWi
 import PredictSellPreview from '../views/PredictSellPreview/PredictSellPreview';
 import { PredictMarketDetailsSelectorsIDs } from '../Predict.testIds';
 import { usePredictActiveOrder } from '../hooks/usePredictActiveOrder';
+import { PREDICT_BUY_CANCELLATION_REASONS } from '../constants/errors';
 import { parseAnalyticsProperties } from '../utils/analytics';
 import PredictRegTimeTag from '../components/PredictRegTimeTag';
 import { getBuyOutcomeImage } from '../utils/sports';
@@ -488,6 +489,9 @@ export const PredictPreviewSheetProvider: React.FC<
     if (!isPaymentFailure) {
       clearErrorTimerRef.current = setTimeout(() => {
         clearErrorTimerRef.current = null;
+        Engine.context.PredictController.cancelRetryablePredictBuyAttempt(
+          PREDICT_BUY_CANCELLATION_REASONS.RETRY_PROMPT_EXPIRED,
+        );
         clearOrderError();
       }, 3000);
     }

--- a/app/components/UI/Predict/contexts/PredictPreviewSheetContext.tsx
+++ b/app/components/UI/Predict/contexts/PredictPreviewSheetContext.tsx
@@ -269,9 +269,8 @@ export const PredictPreviewSheetProvider: React.FC<
   /**
    * Pending timer that auto-clears `activeOrder.error` after the failure
    * toast finishes auto-dismissing (~3s — `visibilityDuration` 2750ms +
-   * exit animation in `Toast.tsx`). Cancelled when the user taps Retry
-   * (so the reopened slip surfaces the error banner) and on unmount (so
-   * we don't fire `clearOrderError` after teardown).
+   * exit animation in `Toast.tsx`). Cancelled whenever the buy sheet reopens
+   * (so the reopened slip surfaces the error banner) and on unmount.
    */
   const clearErrorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -309,6 +308,11 @@ export const PredictPreviewSheetProvider: React.FC<
 
   const openBuySheet = useCallback(
     (params: PredictBuyPreviewParams) => {
+      if (clearErrorTimerRef.current) {
+        clearTimeout(clearErrorTimerRef.current);
+        clearErrorTimerRef.current = null;
+      }
+
       if (bottomSheetEnabled) {
         lastBuyParamsRef.current = params;
         setBuyParams(params);
@@ -455,10 +459,6 @@ export const PredictPreviewSheetProvider: React.FC<
           : strings('predict.order.retry'),
         variant: ButtonVariants.Link,
         onPress: () => {
-          if (clearErrorTimerRef.current) {
-            clearTimeout(clearErrorTimerRef.current);
-            clearErrorTimerRef.current = null;
-          }
           if (isPaymentFailure) {
             Engine.context.PredictController.trackPredictOrderEvent({
               status: PredictTradeStatus.ADD_FUNDS_SUBMITTED,
@@ -481,8 +481,8 @@ export const PredictPreviewSheetProvider: React.FC<
     // ~250ms exit anim). When that finishes without the user tapping
     // Retry, clear order-stage errors so the next slip open is clean.
     // Payment-stage errors persist so reopening the slip still explains
-    // what happened. Tapping Retry cancels this timer so the reopened
-    // slip can show the banner explaining what went wrong.
+    // what happened. Reopening the sheet by any path cancels this timer
+    // so the slip can show the banner explaining what went wrong.
     if (clearErrorTimerRef.current) {
       clearTimeout(clearErrorTimerRef.current);
     }

--- a/app/components/UI/Predict/contexts/PredictPreviewSheetContext.tsx
+++ b/app/components/UI/Predict/contexts/PredictPreviewSheetContext.tsx
@@ -52,6 +52,10 @@ import PredictBuyPreview, {
   predictBuyPreviewSessionRef,
 } from '../views/PredictBuyPreview/PredictBuyPreview';
 import PredictBuyWithAnyToken from '../views/PredictBuyWithAnyToken/PredictBuyWithAnyToken';
+import {
+  predictBuyAttemptRef,
+  predictBuyHasRetryableFailureRef,
+} from '../views/PredictBuyWithAnyToken/predictBuyAttemptRefs';
 import PredictSellPreview from '../views/PredictSellPreview/PredictSellPreview';
 import { PredictMarketDetailsSelectorsIDs } from '../Predict.testIds';
 import { usePredictActiveOrder } from '../hooks/usePredictActiveOrder';
@@ -514,6 +518,30 @@ export const PredictPreviewSheetProvider: React.FC<
       activeOrder?.state === ActiveOrderState.DEPOSITING ||
       activeOrder?.state === ActiveOrderState.PLACING_ORDER;
 
+    const attempt = predictBuyAttemptRef.current;
+    if (
+      orderWasInitiated &&
+      predictBuyHasRetryableFailureRef.current &&
+      attempt &&
+      buyParams
+    ) {
+      Engine.context.PredictController.trackPredictBuyTerminalEvent({
+        status: PredictTradeStatus.CANCELLED,
+        amountUsd: attempt.amountUsd,
+        analyticsProperties: parseAnalyticsProperties(
+          buyParams.market,
+          buyParams.outcomeToken,
+          buyParams.entryPoint,
+        ),
+        attemptId: attempt.attemptId,
+        paymentMethod: attempt.paymentMethod,
+        failureStage: PredictEventValues.FAILURE_STAGE.ORDER,
+        failureCategory: PredictEventValues.FAILURE_CATEGORY.USER_REJECTED,
+        failureReason: 'User cancelled after a retryable order failure',
+        activeAbTests: buyParams.transactionActiveAbTests,
+      });
+    }
+
     // Fire Predict Betslip Dismissed for swipe / hardware-back paths.
     // Skip if: the back-button handler already fired it, or the sheet is
     // closing because the user confirmed an order (not a dismissal).
@@ -537,6 +565,8 @@ export const PredictPreviewSheetProvider: React.FC<
     }
     predictBuyPreviewDismissedViaBackRef.current = false;
     predictBuyPreviewOrderInitiatedRef.current = false;
+    predictBuyAttemptRef.current = undefined;
+    predictBuyHasRetryableFailureRef.current = false;
 
     setBuyParams(null);
     const orderMayStartAfterDismiss = orderWasInitiated && !activeOrder?.error;

--- a/app/components/UI/Predict/controllers/PredictAnalytics.test.ts
+++ b/app/components/UI/Predict/controllers/PredictAnalytics.test.ts
@@ -237,6 +237,27 @@ describe('PredictAnalytics', () => {
       });
     });
 
+    it('uses executed value for Trade Completed and requested value for lifecycle', async () => {
+      await predictAnalytics.trackPredictOrderEvent({
+        status: PredictTradeStatus.SUCCEEDED,
+        amountUsd: 150,
+        tradeCompletedAmountUsd: 125,
+        analyticsProperties: {
+          marketId: 'm1',
+          transactionType: PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_BUY,
+        },
+      });
+
+      const predictTradeEvent = getTrackedEvent();
+      const tradeCompletedEvent = getTrackedEvent(1);
+
+      expect(predictTradeEvent.sensitiveProperties?.amount_usd).toBe(150);
+      expect(tradeCompletedEvent.sensitiveProperties).toMatchObject({
+        amount_usd: 150,
+        usd_trade_value: 125,
+      });
+    });
+
     it('does not track Trade Completed for a succeeded Predict deposit', async () => {
       await predictAnalytics.trackPredictOrderEvent({
         status: PredictTradeStatus.SUCCEEDED,

--- a/app/components/UI/Predict/controllers/PredictAnalytics.test.ts
+++ b/app/components/UI/Predict/controllers/PredictAnalytics.test.ts
@@ -154,6 +154,52 @@ describe('PredictAnalytics', () => {
       expect(getTrackEventMock()).toHaveBeenCalledTimes(1);
     });
 
+    it('tracks attempt properties on a Predict buy lifecycle event', async () => {
+      await predictAnalytics.trackPredictOrderEvent({
+        status: PredictTradeStatus.FAILED_ORDER,
+        amountUsd: 42,
+        analyticsProperties: {
+          marketId: 'm1',
+          transactionType: PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_BUY,
+        },
+        attemptId: 'attempt-1',
+        paymentMethod: PredictEventValues.PAYMENT_METHOD.PAY_WITH_ANY_TOKEN,
+        failureStage: PredictEventValues.FAILURE_STAGE.ORDER,
+        failureCategory: PredictEventValues.FAILURE_CATEGORY.NETWORK,
+        failureReason: 'Network request failed',
+      });
+
+      const event = getTrackedEvent();
+
+      expect(event.properties).toMatchObject({
+        status: 'failed_order',
+        attempt_id: 'attempt-1',
+        payment_method: 'pay_with_any_token',
+        failure_stage: 'order',
+        failure_category: 'network',
+        failure_reason: 'Network request failed',
+      });
+      expect(event.sensitiveProperties).toMatchObject({ amount_usd: 42 });
+    });
+  });
+
+  describe('trackTradeConsidered', () => {
+    it('tracks Trade Considered independently from trade status', () => {
+      predictAnalytics.trackTradeConsidered();
+
+      const tradeConsideredEvent = getTrackedEvent();
+
+      expect(tradeConsideredEvent.name).toBe(
+        MetaMetricsEvents.TRADE_CONSIDERED.category,
+      );
+      expect(tradeConsideredEvent.properties).toEqual({
+        trade_type: 'predict',
+        implementation_type: 'native',
+      });
+    });
+  });
+
+  describe('trackPredictOrderEvent completion events', () => {
     it('tracks Trade Completed after Predict Trade Transaction with matching properties', async () => {
       await predictAnalytics.trackPredictOrderEvent({
         status: PredictTradeStatus.SUCCEEDED,

--- a/app/components/UI/Predict/controllers/PredictAnalytics.test.ts
+++ b/app/components/UI/Predict/controllers/PredictAnalytics.test.ts
@@ -156,7 +156,7 @@ describe('PredictAnalytics', () => {
 
     it('tracks attempt properties on a Predict buy lifecycle event', async () => {
       await predictAnalytics.trackPredictOrderEvent({
-        status: PredictTradeStatus.FAILED_ORDER,
+        status: PredictTradeStatus.FAILED,
         amountUsd: 42,
         analyticsProperties: {
           marketId: 'm1',
@@ -172,7 +172,7 @@ describe('PredictAnalytics', () => {
       const event = getTrackedEvent();
 
       expect(event.properties).toMatchObject({
-        status: 'failed_order',
+        status: 'failed',
         attempt_id: 'attempt-1',
         payment_method: 'pay_with_any_token',
         failure_stage: 'order',

--- a/app/components/UI/Predict/controllers/PredictAnalytics.ts
+++ b/app/components/UI/Predict/controllers/PredictAnalytics.ts
@@ -28,6 +28,7 @@ export interface PredictAnalyticsContext {
 export interface TrackPredictOrderEventArgs {
   status: PredictTradeStatusValue;
   amountUsd?: number;
+  tradeCompletedAmountUsd?: number;
   analyticsProperties?: PlaceOrderParams['analyticsProperties'];
   completionDuration?: number;
   failureReason?: string;
@@ -220,6 +221,7 @@ export class PredictAnalytics {
   public async trackPredictOrderEvent({
     status,
     amountUsd,
+    tradeCompletedAmountUsd,
     analyticsProperties,
     completionDuration,
     failureReason,
@@ -375,9 +377,10 @@ export class PredictAnalytics {
       this.trackTradeConsidered();
     }
 
+    const completedAmountUsd = tradeCompletedAmountUsd ?? amountUsd;
     if (
       status === PredictTradeStatus.SUCCEEDED &&
-      amountUsd !== undefined &&
+      completedAmountUsd !== undefined &&
       (analyticsProperties.transactionType ===
         PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_BUY ||
         analyticsProperties.transactionType ===
@@ -396,7 +399,7 @@ export class PredictAnalytics {
           })
           .addSensitiveProperties({
             ...sensitiveProperties,
-            [PredictEventProperties.USD_TRADE_VALUE]: amountUsd,
+            [PredictEventProperties.USD_TRADE_VALUE]: completedAmountUsd,
           })
           .build(),
       );

--- a/app/components/UI/Predict/controllers/PredictAnalytics.ts
+++ b/app/components/UI/Predict/controllers/PredictAnalytics.ts
@@ -10,6 +10,9 @@ import {
   PredictDismissalMethodValue,
   PredictEventProperties,
   PredictEventValues,
+  PredictFailureCategoryValue,
+  PredictFailureStageValue,
+  PredictPaymentMethodValue,
   PredictShareStatusValue,
   PredictTradeStatus,
   PredictTradeStatusValue,
@@ -33,6 +36,10 @@ export interface TrackPredictOrderEventArgs {
   orderType?: PredictOrderType;
   paymentTokenAddress?: string;
   paymentTokenSymbol?: string;
+  attemptId?: string;
+  paymentMethod?: PredictPaymentMethodValue;
+  failureStage?: PredictFailureStageValue;
+  failureCategory?: PredictFailureCategoryValue;
   activeAbTests?: TransactionActiveAbTestEntry[];
 }
 
@@ -221,6 +228,10 @@ export class PredictAnalytics {
     orderType,
     paymentTokenAddress,
     paymentTokenSymbol,
+    attemptId,
+    paymentMethod,
+    failureStage,
+    failureCategory,
     activeAbTests,
   }: TrackPredictOrderEventArgs): Promise<void> {
     if (!analyticsProperties) {
@@ -314,6 +325,18 @@ export class PredictAnalytics {
       ...(paymentTokenSymbol && {
         [PredictEventProperties.PAYMENT_TOKEN_SYMBOL]: paymentTokenSymbol,
       }),
+      ...(attemptId && {
+        [PredictEventProperties.ATTEMPT_ID]: attemptId,
+      }),
+      ...(paymentMethod && {
+        [PredictEventProperties.PAYMENT_METHOD]: paymentMethod,
+      }),
+      ...(failureStage && {
+        [PredictEventProperties.FAILURE_STAGE]: failureStage,
+      }),
+      ...(failureCategory && {
+        [PredictEventProperties.FAILURE_CATEGORY]: failureCategory,
+      }),
       ...(activeAbTests &&
         activeAbTests.length > 0 && {
           [PredictEventProperties.ACTIVE_AB_TESTS]: activeAbTests,
@@ -349,18 +372,7 @@ export class PredictAnalytics {
       analyticsProperties.transactionType ===
         PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_BUY
     ) {
-      analytics.trackEvent(
-        AnalyticsEventBuilder.createEventBuilder(
-          MetaMetricsEvents.TRADE_CONSIDERED,
-        )
-          .addProperties({
-            [PredictEventProperties.TRADE_TYPE]:
-              PredictEventValues.TRADE_TYPE.PREDICT,
-            [PredictEventProperties.IMPLEMENTATION_TYPE]:
-              PredictEventValues.IMPLEMENTATION_TYPE.NATIVE,
-          })
-          .build(),
-      );
+      this.trackTradeConsidered();
     }
 
     if (
@@ -389,6 +401,21 @@ export class PredictAnalytics {
           .build(),
       );
     }
+  }
+
+  public trackTradeConsidered(): void {
+    analytics.trackEvent(
+      AnalyticsEventBuilder.createEventBuilder(
+        MetaMetricsEvents.TRADE_CONSIDERED,
+      )
+        .addProperties({
+          [PredictEventProperties.TRADE_TYPE]:
+            PredictEventValues.TRADE_TYPE.PREDICT,
+          [PredictEventProperties.IMPLEMENTATION_TYPE]:
+            PredictEventValues.IMPLEMENTATION_TYPE.NATIVE,
+        })
+        .build(),
+    );
   }
 
   public trackBetslipDismissed({

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -1842,7 +1842,7 @@ describe('PredictController', () => {
 
         expect(attemptEvents.map((event) => event.properties.status)).toEqual([
           'attempt_started',
-          'order_submitted',
+          'submitted',
           'succeeded',
         ]);
         expect(
@@ -1864,7 +1864,7 @@ describe('PredictController', () => {
       },
       {
         error: 'Network request failed',
-        expectedStatus: 'failed_order',
+        expectedStatus: 'failed',
       },
     ])(
       'classifies an order error as $expectedStatus',
@@ -1895,7 +1895,7 @@ describe('PredictController', () => {
             );
 
           expect(attemptEvents.map((event) => event.properties.status)).toEqual(
-            ['order_submitted', expectedStatus],
+            ['submitted', expectedStatus],
           );
         });
       },
@@ -1952,9 +1952,9 @@ describe('PredictController', () => {
 
         expect(attemptEvents.map((event) => event.properties.status)).toEqual([
           'attempt_started',
-          'order_submitted',
+          'submitted',
           'order_failed',
-          'order_submitted',
+          'submitted',
           'succeeded',
         ]);
         expect(controller.getRetryablePredictBuyAttempt()).toBeUndefined();
@@ -11158,7 +11158,7 @@ describe('PredictController', () => {
         });
         controller.trackPredictBuyTerminalEvent({
           ...commonProperties,
-          status: 'failed_order',
+          status: 'failed',
           failureStage: 'order',
           failureCategory: 'other',
         });
@@ -11174,7 +11174,7 @@ describe('PredictController', () => {
           (event) => event.properties.status === 'attempt_started',
         );
         const terminalEvents = attemptEvents.filter((event) =>
-          ['succeeded', 'failed_swap', 'failed_order', 'cancelled'].includes(
+          ['succeeded', 'failed', 'cancelled'].includes(
             event.properties.status,
           ),
         );
@@ -11191,13 +11191,13 @@ describe('PredictController', () => {
 
         for (let index = 0; index <= 500; index += 1) {
           controller.trackPredictBuyTerminalEvent({
-            status: 'failed_order',
+            status: 'failed',
             analyticsProperties,
             attemptId: `attempt-${index}`,
           });
         }
         controller.trackPredictBuyTerminalEvent({
-          status: 'failed_order',
+          status: 'failed',
           analyticsProperties,
           attemptId: 'attempt-0',
         });
@@ -11709,7 +11709,7 @@ describe('PredictController', () => {
       );
     });
 
-    it('emits swap_started with the PWAT attempt context', async () => {
+    it('emits swap_initiated with the PWAT attempt context', async () => {
       await withController(
         async ({ controller }) => {
           setActiveOrderForTest(controller, {
@@ -11735,7 +11735,7 @@ describe('PredictController', () => {
           expect(analytics.trackEvent).toHaveBeenCalledWith(
             expect.objectContaining({
               properties: expect.objectContaining({
-                status: 'swap_started',
+                status: 'swap_initiated',
                 attempt_id: 'pwat-attempt',
                 payment_method: 'pay_with_any_token',
               }),

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -241,7 +241,9 @@ describe('PredictController', () => {
     };
   }
 
-  function createMockMarket(overrides?: Partial<PredictMarket>): PredictMarket {
+  function createPredictMarket(
+    overrides?: Partial<PredictMarket>,
+  ): PredictMarket {
     return {
       id: 'market-1',
       providerId: POLYMARKET_PROVIDER_ID,
@@ -353,7 +355,7 @@ describe('PredictController', () => {
       transactionHash: undefined,
     });
     mockPolymarketProvider.getMarketDetails.mockResolvedValue(
-      createMockMarket(),
+      createPredictMarket(),
     );
 
     // Default safe mocks for async fire-and-forget methods
@@ -1800,6 +1802,95 @@ describe('PredictController', () => {
       );
     });
 
+    it('emits the attempt lifecycle for a Predict balance buy', async () => {
+      await withController(async ({ controller }) => {
+        mockPolymarketProvider.placeOrder.mockResolvedValue({
+          success: true,
+          response: {
+            id: 'order-123',
+            spentAmount: '25',
+            receivedAmount: '50',
+          },
+        });
+        const preview = createMockOrderPreview({ side: Side.BUY });
+
+        await controller.placeOrder({
+          preview,
+          analyticsProperties: {
+            marketId: 'market-1',
+            transactionType: 'mm_predict_buy',
+          },
+          attempt: {
+            attemptId: 'balance-attempt',
+            amountUsd: 25,
+            paymentMethod: 'predict_balance',
+          },
+        });
+
+        const attemptEvents = (analytics.trackEvent as jest.Mock).mock.calls
+          .map(([event]) => event)
+          .filter(
+            (event) =>
+              event.name === 'Predict Trade Transaction' &&
+              event.properties?.attempt_id === 'balance-attempt',
+          );
+
+        expect(attemptEvents.map((event) => event.properties.status)).toEqual([
+          'order_submitted',
+          'succeeded',
+        ]);
+        expect(
+          attemptEvents.every(
+            (event) => event.sensitiveProperties?.amount_usd === 25,
+          ),
+        ).toBe(true);
+      });
+    });
+
+    it.each([
+      {
+        error: PREDICT_ERROR_CODES.BUY_ORDER_NOT_FULLY_FILLED,
+        expectedStatus: 'order_failed',
+      },
+      {
+        error: 'Network request failed',
+        expectedStatus: 'failed_order',
+      },
+    ])(
+      'classifies an order error as $expectedStatus',
+      async ({ error, expectedStatus }) => {
+        await withController(async ({ controller }) => {
+          mockPolymarketProvider.placeOrder.mockRejectedValue(new Error(error));
+          const preview = createMockOrderPreview({ side: Side.BUY });
+
+          await expect(
+            controller.placeOrder({
+              preview,
+              analyticsProperties: {
+                marketId: 'market-1',
+                transactionType: 'mm_predict_buy',
+              },
+              attempt: {
+                attemptId: 'failed-attempt',
+                amountUsd: 25,
+                paymentMethod: 'predict_balance',
+              },
+            }),
+          ).rejects.toThrow(error);
+
+          const attemptEvents = (analytics.trackEvent as jest.Mock).mock.calls
+            .map(([event]) => event)
+            .filter(
+              (event) => event.properties?.attempt_id === 'failed-attempt',
+            );
+
+          expect(attemptEvents.map((event) => event.properties.status)).toEqual(
+            ['order_submitted', expectedStatus],
+          );
+        });
+      },
+    );
+
     it.each([
       ['proposed_resolution', PREDICT_ERROR_CODES.MARKET_PENDING_RESOLUTION],
       ['in_dispute', PREDICT_ERROR_CODES.MARKET_PENDING_RESOLUTION],
@@ -1809,7 +1900,7 @@ describe('PredictController', () => {
       'blocks orders before provider submission when live outcome status is %s',
       async (resolutionStatus, errorCode) => {
         await withController(async ({ controller }) => {
-          const market = createMockMarket();
+          const market = createPredictMarket();
           mockPolymarketProvider.getMarketDetails.mockResolvedValue({
             ...market,
             outcomes: [
@@ -1835,7 +1926,7 @@ describe('PredictController', () => {
 
     it('blocks sell orders when the live outcome is not accepting orders', async () => {
       await withController(async ({ controller }) => {
-        const market = createMockMarket();
+        const market = createPredictMarket();
         mockPolymarketProvider.getMarketDetails.mockResolvedValue({
           ...market,
           outcomes: [
@@ -1862,7 +1953,7 @@ describe('PredictController', () => {
     it('blocks orders when the live market is inactive', async () => {
       await withController(async ({ controller }) => {
         mockPolymarketProvider.getMarketDetails.mockResolvedValue(
-          createMockMarket({
+          createPredictMarket({
             active: false,
           }),
         );
@@ -1880,7 +1971,7 @@ describe('PredictController', () => {
     it('fails closed when the live market does not include the preview outcome', async () => {
       await withController(async ({ controller }) => {
         mockPolymarketProvider.getMarketDetails.mockResolvedValue({
-          ...createMockMarket(),
+          ...createPredictMarket(),
           outcomes: [],
         });
 
@@ -1966,7 +2057,7 @@ describe('PredictController', () => {
           setActiveOrderForTest(controller, {
             state: ActiveOrderState.PAY_WITH_ANY_TOKEN,
           });
-          const market = createMockMarket();
+          const market = createPredictMarket();
           mockPolymarketProvider.getMarketDetails.mockResolvedValue({
             ...market,
             outcomes: [
@@ -10828,6 +10919,55 @@ describe('PredictController', () => {
       });
     });
 
+    it('reconciles one start and one terminal event per attempt', async () => {
+      await withController(async ({ controller }) => {
+        const commonProperties = {
+          amountUsd: 25,
+          analyticsProperties: {
+            marketId: 'market-1',
+            transactionType: 'mm_predict_buy' as const,
+          },
+          attemptId: 'attempt-1',
+          paymentMethod: 'predict_balance' as const,
+        };
+
+        await controller.trackPredictOrderEvent({
+          ...commonProperties,
+          status: 'attempt_started',
+        });
+        controller.trackPredictBuyTerminalEvent({
+          ...commonProperties,
+          status: 'succeeded',
+        });
+        controller.trackPredictBuyTerminalEvent({
+          ...commonProperties,
+          status: 'failed_order',
+          failureStage: 'order',
+          failureCategory: 'other',
+        });
+
+        const attemptEvents = (analytics.trackEvent as jest.Mock).mock.calls
+          .map(([event]) => event)
+          .filter(
+            (event) =>
+              event.name === 'Predict Trade Transaction' &&
+              event.properties?.attempt_id === commonProperties.attemptId,
+          );
+        const startEvents = attemptEvents.filter(
+          (event) => event.properties.status === 'attempt_started',
+        );
+        const terminalEvents = attemptEvents.filter((event) =>
+          ['succeeded', 'failed_swap', 'failed_order', 'cancelled'].includes(
+            event.properties.status,
+          ),
+        );
+
+        expect(startEvents).toHaveLength(1);
+        expect(terminalEvents).toHaveLength(1);
+        expect(attemptEvents).toHaveLength(2);
+      });
+    });
+
     it('does not call analytics.trackEvent when analyticsProperties is missing for trackPredictOrderEvent', async () => {
       await withController(async ({ controller }) => {
         await controller.trackPredictOrderEvent({
@@ -11317,6 +11457,52 @@ describe('PredictController', () => {
                 status: 'swap_initiated',
                 payment_token_address: '0xtoken',
                 payment_token_symbol: 'MATIC',
+              }),
+            }),
+          );
+        },
+        {
+          mocks: {
+            getRemoteFeatureFlagState: jest
+              .fn()
+              .mockReturnValue(REMOTE_FEATURE_FLAG_STATE_WITH_PAY_ANY_TOKEN),
+          },
+        },
+      );
+    });
+
+    it('emits swap_started with the PWAT attempt context', async () => {
+      await withController(
+        async ({ controller }) => {
+          setActiveOrderForTest(controller, {
+            state: ActiveOrderState.PAY_WITH_ANY_TOKEN,
+            transactionId: 'tx-200',
+          });
+          const preview = createMockOrderPreview({ side: Side.BUY });
+
+          await controller.placeOrder({
+            analyticsProperties: {
+              marketId: 'market-1',
+              transactionType: 'mm_predict_buy',
+            },
+            preview,
+            transactionId: 'tx-200',
+            attempt: {
+              attemptId: 'pwat-attempt',
+              amountUsd: 30,
+              paymentMethod: 'pay_with_any_token',
+            },
+          });
+
+          expect(analytics.trackEvent).toHaveBeenCalledWith(
+            expect.objectContaining({
+              properties: expect.objectContaining({
+                status: 'swap_started',
+                attempt_id: 'pwat-attempt',
+                payment_method: 'pay_with_any_token',
+              }),
+              sensitiveProperties: expect.objectContaining({
+                amount_usd: 30,
               }),
             }),
           );

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -1808,34 +1808,40 @@ describe('PredictController', () => {
           success: true,
           response: {
             id: 'order-123',
-            spentAmount: '25',
+            spentAmount: '20',
             receivedAmount: '50',
           },
         });
         const preview = createMockOrderPreview({ side: Side.BUY });
+        const analyticsProperties = {
+          marketId: 'market-1',
+          transactionType: 'mm_predict_buy' as const,
+        };
+        const attempt = controller.startPredictBuyAttempt({
+          amountUsd: 25,
+          paymentMethod: 'predict_balance',
+          analyticsProperties,
+          sharePrice: preview.sharePrice,
+          orderType: preview.orderType,
+        });
 
         await controller.placeOrder({
           preview,
-          analyticsProperties: {
-            marketId: 'market-1',
-            transactionType: 'mm_predict_buy',
-          },
-          attempt: {
-            attemptId: 'balance-attempt',
-            amountUsd: 25,
-            paymentMethod: 'predict_balance',
-          },
+          analyticsProperties,
+          attempt,
         });
 
-        const attemptEvents = (analytics.trackEvent as jest.Mock).mock.calls
-          .map(([event]) => event)
-          .filter(
-            (event) =>
-              event.name === 'Predict Trade Transaction' &&
-              event.properties?.attempt_id === 'balance-attempt',
-          );
+        const trackedEvents = (
+          analytics.trackEvent as jest.Mock
+        ).mock.calls.map(([event]) => event);
+        const attemptEvents = trackedEvents.filter(
+          (event) =>
+            event.name === 'Predict Trade Transaction' &&
+            event.properties?.attempt_id === attempt.attemptId,
+        );
 
         expect(attemptEvents.map((event) => event.properties.status)).toEqual([
+          'attempt_started',
           'order_submitted',
           'succeeded',
         ]);
@@ -1844,6 +1850,10 @@ describe('PredictController', () => {
             (event) => event.sensitiveProperties?.amount_usd === 25,
           ),
         ).toBe(true);
+        expect(
+          trackedEvents.find((event) => event.name === 'Trade Completed')
+            ?.sensitiveProperties?.usd_trade_value,
+        ).toBe(20);
       });
     });
 
@@ -1890,6 +1900,170 @@ describe('PredictController', () => {
         });
       },
     );
+
+    it('preserves one attempt through a retryable failure and retry', async () => {
+      await withController(async ({ controller }) => {
+        const preview = createMockOrderPreview({ side: Side.BUY });
+        const analyticsProperties = {
+          marketId: 'market-1',
+          transactionType: 'mm_predict_buy' as const,
+        };
+        const attempt = controller.startPredictBuyAttempt({
+          amountUsd: 25,
+          paymentMethod: 'predict_balance',
+          analyticsProperties,
+        });
+        mockPolymarketProvider.placeOrder
+          .mockRejectedValueOnce(
+            new Error(PREDICT_ERROR_CODES.BUY_ORDER_NOT_FULLY_FILLED),
+          )
+          .mockResolvedValueOnce({
+            success: true,
+            response: {
+              id: 'order-123',
+              spentAmount: '25',
+              receivedAmount: '50',
+            },
+          });
+
+        await expect(
+          controller.placeOrder({
+            preview,
+            analyticsProperties,
+            attempt,
+          }),
+        ).rejects.toThrow(PREDICT_ERROR_CODES.BUY_ORDER_NOT_FULLY_FILLED);
+
+        expect(controller.getRetryablePredictBuyAttempt()).toEqual(attempt);
+
+        await controller.placeOrder({
+          preview,
+          analyticsProperties,
+          attempt: controller.getRetryablePredictBuyAttempt(),
+        });
+
+        const attemptEvents = (analytics.trackEvent as jest.Mock).mock.calls
+          .map(([event]) => event)
+          .filter(
+            (event) =>
+              event.name === 'Predict Trade Transaction' &&
+              event.properties?.attempt_id === attempt.attemptId,
+          );
+
+        expect(attemptEvents.map((event) => event.properties.status)).toEqual([
+          'attempt_started',
+          'order_submitted',
+          'order_failed',
+          'order_submitted',
+          'succeeded',
+        ]);
+        expect(controller.getRetryablePredictBuyAttempt()).toBeUndefined();
+      });
+    });
+
+    it('cancels one retryable attempt once', async () => {
+      await withController(async ({ controller }) => {
+        const preview = createMockOrderPreview({ side: Side.BUY });
+        const analyticsProperties = {
+          marketId: 'market-1',
+          transactionType: 'mm_predict_buy' as const,
+        };
+        const attempt = controller.startPredictBuyAttempt({
+          amountUsd: 25,
+          paymentMethod: 'predict_balance',
+          analyticsProperties,
+        });
+        mockPolymarketProvider.placeOrder.mockRejectedValue(
+          new Error(PREDICT_ERROR_CODES.BUY_ORDER_NOT_FULLY_FILLED),
+        );
+
+        await expect(
+          controller.placeOrder({
+            preview,
+            analyticsProperties,
+            attempt,
+          }),
+        ).rejects.toThrow(PREDICT_ERROR_CODES.BUY_ORDER_NOT_FULLY_FILLED);
+
+        expect(controller.cancelRetryablePredictBuyAttempt()).toBe(true);
+        expect(controller.cancelRetryablePredictBuyAttempt()).toBe(false);
+
+        const terminalEvents = (analytics.trackEvent as jest.Mock).mock.calls
+          .map(([event]) => event)
+          .filter(
+            (event) =>
+              event.properties?.attempt_id === attempt.attemptId &&
+              event.properties?.status === 'cancelled',
+          );
+
+        expect(terminalEvents).toHaveLength(1);
+      });
+    });
+
+    it('keeps retryable attempts isolated by account', async () => {
+      let accountAddress = MOCK_ADDRESS;
+      const secondAddress = '0x2222222222222222222222222222222222222222';
+      const getAccountsFromSelectedAccountGroup = jest.fn(() => [
+        {
+          id: `account-${accountAddress}`,
+          address: accountAddress,
+          type: 'eip155:eoa',
+          name: 'Test Account',
+          metadata: { lastSelected: 0 },
+        },
+      ]);
+
+      await withController(
+        async ({ controller }) => {
+          const preview = createMockOrderPreview({ side: Side.BUY });
+          const analyticsProperties = {
+            marketId: 'market-1',
+            transactionType: 'mm_predict_buy' as const,
+          };
+          mockPolymarketProvider.placeOrder.mockRejectedValue(
+            new Error(PREDICT_ERROR_CODES.BUY_ORDER_NOT_FULLY_FILLED),
+          );
+
+          const firstAttempt = controller.startPredictBuyAttempt({
+            amountUsd: 25,
+            paymentMethod: 'predict_balance',
+            analyticsProperties,
+          });
+          await expect(
+            controller.placeOrder({
+              address: accountAddress,
+              preview,
+              analyticsProperties,
+              attempt: firstAttempt,
+            }),
+          ).rejects.toThrow(PREDICT_ERROR_CODES.BUY_ORDER_NOT_FULLY_FILLED);
+
+          accountAddress = secondAddress;
+          const secondAttempt = controller.startPredictBuyAttempt({
+            amountUsd: 30,
+            paymentMethod: 'pay_with_any_token',
+            analyticsProperties,
+          });
+          await expect(
+            controller.placeOrder({
+              address: accountAddress,
+              preview,
+              analyticsProperties,
+              attempt: secondAttempt,
+            }),
+          ).rejects.toThrow(PREDICT_ERROR_CODES.BUY_ORDER_NOT_FULLY_FILLED);
+
+          expect(controller.getRetryablePredictBuyAttempt()).toEqual(
+            secondAttempt,
+          );
+          accountAddress = MOCK_ADDRESS;
+          expect(controller.getRetryablePredictBuyAttempt()).toEqual(
+            firstAttempt,
+          );
+        },
+        { mocks: { getAccountsFromSelectedAccountGroup } },
+      );
+    });
 
     it.each([
       ['proposed_resolution', PREDICT_ERROR_CODES.MARKET_PENDING_RESOLUTION],
@@ -5995,6 +6169,45 @@ describe('PredictController', () => {
         ...overrides,
       }) as any;
 
+    it('cancels a retryable attempt when payment changes', async () => {
+      await withController(async ({ controller }) => {
+        const preview = createMockOrderPreview({ side: Side.BUY });
+        const analyticsProperties = {
+          marketId: 'market-1',
+          transactionType: 'mm_predict_buy' as const,
+        };
+        const attempt = controller.startPredictBuyAttempt({
+          amountUsd: 25,
+          paymentMethod: 'predict_balance',
+          analyticsProperties,
+        });
+        mockPolymarketProvider.placeOrder.mockRejectedValue(
+          new Error(PREDICT_ERROR_CODES.BUY_ORDER_NOT_FULLY_FILLED),
+        );
+        await expect(
+          controller.placeOrder({
+            preview,
+            analyticsProperties,
+            attempt,
+          }),
+        ).rejects.toThrow(PREDICT_ERROR_CODES.BUY_ORDER_NOT_FULLY_FILLED);
+
+        controller.selectPaymentToken(createAssetToken({}));
+
+        const cancellationEvent = (analytics.trackEvent as jest.Mock).mock.calls
+          .map(([event]) => event)
+          .find(
+            (event) =>
+              event.properties?.attempt_id === attempt.attemptId &&
+              event.properties?.status === 'cancelled',
+          );
+        expect(cancellationEvent?.properties.failure_reason).toBe(
+          'User changed payment method after a retryable order failure',
+        );
+        expect(controller.getRetryablePredictBuyAttempt()).toBeUndefined();
+      });
+    });
+
     it('treats null as balance token and clears selectedPaymentToken', () => {
       withController(({ controller }) => {
         const existingToken = {
@@ -9345,6 +9558,8 @@ describe('PredictController', () => {
             from: '0xFrom',
             to: '0xOldTarget',
             data: '0xolddata',
+            gas: '0x1111',
+            gasLimit: '0x2222',
           },
         };
 
@@ -9352,6 +9567,8 @@ describe('PredictController', () => {
 
         expect(testTransaction.txParams.data).toBe('0xmodifieddata');
         expect(testTransaction.txParams.to).toBe('0xPredictAddress');
+        expect(testTransaction.txParams.gas).toBe('0x5208');
+        expect(testTransaction.txParams.gasLimit).toBe('0x5208');
         expect(testTransaction.assetsFiatValues).toEqual({
           receiving: '100',
         });
@@ -10965,6 +11182,27 @@ describe('PredictController', () => {
         expect(startEvents).toHaveLength(1);
         expect(terminalEvents).toHaveLength(1);
         expect(attemptEvents).toHaveLength(2);
+      });
+    });
+
+    it('bounds retained terminal attempt IDs', async () => {
+      await withController(async ({ controller }) => {
+        const analyticsProperties = { marketId: 'market-1' };
+
+        for (let index = 0; index <= 500; index += 1) {
+          controller.trackPredictBuyTerminalEvent({
+            status: 'failed_order',
+            analyticsProperties,
+            attemptId: `attempt-${index}`,
+          });
+        }
+        controller.trackPredictBuyTerminalEvent({
+          status: 'failed_order',
+          analyticsProperties,
+          attemptId: 'attempt-0',
+        });
+
+        expect(analytics.trackEvent).toHaveBeenCalledTimes(502);
       });
     });
 

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -1,8 +1,9 @@
 import { AccountTreeControllerGetAccountsFromSelectedAccountGroupAction } from '@metamask/account-tree-controller';
+import { AccountsControllerGetSelectedAccountAction } from '@metamask/accounts-controller';
 import {
   BaseController,
   ControllerGetStateAction,
-  ControllerStateChangedEvent,
+  ControllerStateChangeEvent,
   StateMetadata,
 } from '@metamask/base-controller';
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
@@ -96,6 +97,7 @@ import {
   PredictAccountMeta,
   PredictActivity,
   PredictBalance,
+  PredictBuyAttempt,
   PredictClaim,
   PredictClaimStatus,
   PredictFilterOption,
@@ -128,6 +130,7 @@ import {
 } from '../utils/analytics';
 import { resolveCryptoTargetPrice } from '../utils/cryptoUpDown';
 import { validateMarketBettable } from '../utils/marketState';
+import { generateOrderId } from '../utils/orders';
 import { ensureError } from '../utils/predictErrorHandler';
 import { resolvePredictFeatureFlags } from '../utils/resolvePredictFeatureFlags';
 import {
@@ -325,7 +328,9 @@ export type PredictTransactionStatusChangedPayload =
   PredictControllerTransactionStatusChangedEvent['payload'][0];
 
 export type PredictControllerEvents =
-  | ControllerStateChangedEvent<'PredictController', PredictControllerState>
+  // EngineService still subscribes to the legacy `stateChange` event.
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  | ControllerStateChangeEvent<'PredictController', PredictControllerState>
   | PredictControllerTransactionStatusChangedEvent;
 
 interface TransactionReceiptLog {
@@ -366,6 +371,9 @@ export type PredictControllerActions =
  * External actions the PredictController can call
  */
 type AllowedActions =
+  // Keep the legacy action in the messenger contract until its delegation is removed separately.
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  | AccountsControllerGetSelectedAccountAction
   | AccountTreeControllerGetAccountsFromSelectedAccountGroupAction
   | NetworkControllerGetStateAction
   | NetworkControllerFindNetworkClientIdByChainIdAction
@@ -490,6 +498,32 @@ const HIGHLIGHT_SERIES_FUTURE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
  */
 export const OPTIMISTIC_BALANCE_MAX_AGE_MS = 30 * 1000;
 
+const MAX_TRACKED_PREDICT_BUY_TERMINALS = 500;
+
+type PredictBuyTerminalStatus =
+  | typeof PredictTradeStatus.SUCCEEDED
+  | typeof PredictTradeStatus.FAILED_SWAP
+  | typeof PredictTradeStatus.FAILED_ORDER
+  | typeof PredictTradeStatus.CANCELLED;
+
+interface PredictBuyAttemptContext {
+  attempt: PredictBuyAttempt;
+  address: string;
+  analyticsProperties?: PlaceOrderParams['analyticsProperties'];
+  sharePrice?: number;
+  orderType?: OrderPreview['orderType'];
+  activeAbTests?: PlaceOrderParams['activeAbTests'];
+}
+
+interface StartPredictBuyAttemptArgs {
+  amountUsd: number;
+  paymentMethod: PredictBuyAttempt['paymentMethod'];
+  analyticsProperties?: PlaceOrderParams['analyticsProperties'];
+  sharePrice?: number;
+  orderType?: OrderPreview['orderType'];
+  activeAbTests?: PlaceOrderParams['activeAbTests'];
+}
+
 /**
  * PredictController - Protocol-agnostic prediction markets trading controller
  *
@@ -533,6 +567,12 @@ export class PredictController extends BaseController<
   private flowTerminalMetricEmitted = new Set<string>();
 
   private predictBuyTerminalEmitted = new Set<string>();
+
+  private predictBuyTerminalEmissionOrder: string[] = [];
+
+  private predictBuyAttempts = new Map<string, PredictBuyAttemptContext>();
+
+  private retryablePredictBuyAttemptIdsByAddress = new Map<string, string>();
 
   private readonly traceable: TraceableController = {
     update: (updater) => this.update(updater),
@@ -1324,8 +1364,99 @@ export class PredictController extends BaseController<
     this.analytics.trackTradeConsidered();
   }
 
+  public startPredictBuyAttempt({
+    amountUsd,
+    paymentMethod,
+    analyticsProperties,
+    sharePrice,
+    orderType,
+    activeAbTests,
+  }: StartPredictBuyAttemptArgs): PredictBuyAttempt {
+    this.cancelRetryablePredictBuyAttempt(
+      'User started a new attempt after a retryable order failure',
+    );
+
+    const address = this.requireEvmAccountAddress().toLowerCase();
+    const attempt: PredictBuyAttempt = {
+      attemptId: generateOrderId(),
+      amountUsd,
+      paymentMethod,
+    };
+
+    this.predictBuyAttempts.set(attempt.attemptId, {
+      attempt,
+      address,
+      analyticsProperties,
+      sharePrice,
+      orderType,
+      activeAbTests,
+    });
+
+    this.trackPredictOrderEvent({
+      status: PredictTradeStatus.ATTEMPT_STARTED,
+      amountUsd,
+      analyticsProperties,
+      sharePrice,
+      orderType,
+      attemptId: attempt.attemptId,
+      paymentMethod,
+      activeAbTests,
+    });
+
+    return attempt;
+  }
+
+  public getRetryablePredictBuyAttempt(): PredictBuyAttempt | undefined {
+    const address = this.getEvmAccountAddress()?.toLowerCase();
+    if (!address) {
+      return undefined;
+    }
+
+    const attemptId = this.retryablePredictBuyAttemptIdsByAddress.get(address);
+    return attemptId
+      ? this.predictBuyAttempts.get(attemptId)?.attempt
+      : undefined;
+  }
+
+  public cancelRetryablePredictBuyAttempt(
+    failureReason = 'User cancelled after a retryable order failure',
+  ): boolean {
+    const address = this.getEvmAccountAddress()?.toLowerCase();
+    if (!address) {
+      return false;
+    }
+
+    const attemptId = this.retryablePredictBuyAttemptIdsByAddress.get(address);
+    const context = attemptId
+      ? this.predictBuyAttempts.get(attemptId)
+      : undefined;
+    if (!context) {
+      return false;
+    }
+
+    this.trackPredictBuyTerminalEvent({
+      status: PredictTradeStatus.CANCELLED,
+      amountUsd: context.attempt.amountUsd,
+      analyticsProperties: context.analyticsProperties,
+      sharePrice: context.sharePrice,
+      orderType: context.orderType,
+      attemptId: context.attempt.attemptId,
+      paymentMethod: context.attempt.paymentMethod,
+      failureStage: PredictEventValues.FAILURE_STAGE.ORDER,
+      failureCategory: PredictEventValues.FAILURE_CATEGORY.USER_REJECTED,
+      failureReason,
+      activeAbTests: context.activeAbTests,
+    });
+
+    return true;
+  }
+
   public trackPredictBuyTerminalEvent(
-    args: Parameters<PredictAnalytics['trackPredictOrderEvent']>[0] & {
+    args: Omit<
+      Parameters<PredictAnalytics['trackPredictOrderEvent']>[0],
+      'status'
+    > & {
+      status: PredictBuyTerminalStatus;
       attemptId: string;
     },
   ): void {
@@ -1334,7 +1465,42 @@ export class PredictController extends BaseController<
     }
 
     this.predictBuyTerminalEmitted.add(args.attemptId);
+    this.predictBuyTerminalEmissionOrder.push(args.attemptId);
+    if (
+      this.predictBuyTerminalEmissionOrder.length >
+      MAX_TRACKED_PREDICT_BUY_TERMINALS
+    ) {
+      const oldestAttemptId = this.predictBuyTerminalEmissionOrder.shift();
+      if (oldestAttemptId) {
+        this.predictBuyTerminalEmitted.delete(oldestAttemptId);
+      }
+    }
+
+    const context = this.predictBuyAttempts.get(args.attemptId);
+    if (
+      context &&
+      this.retryablePredictBuyAttemptIdsByAddress.get(context.address) ===
+        args.attemptId
+    ) {
+      this.retryablePredictBuyAttemptIdsByAddress.delete(context.address);
+    }
+    this.predictBuyAttempts.delete(args.attemptId);
+
     this.trackPredictOrderEvent(args);
+  }
+
+  private markPredictBuyAttemptRetryable(
+    attemptId: string,
+    address: string,
+  ): void {
+    if (!this.predictBuyAttempts.has(attemptId)) {
+      return;
+    }
+
+    this.retryablePredictBuyAttemptIdsByAddress.set(
+      address.toLowerCase(),
+      attemptId,
+    );
   }
 
   private trackPredictFlowMetric({
@@ -2081,6 +2247,7 @@ export class PredictController extends BaseController<
         orderType: preview.orderType,
         paymentTokenAddress,
         paymentTokenSymbol,
+        tradeCompletedAmountUsd: realAmountUsd,
         attemptId: params.attempt?.attemptId,
         paymentMethod: params.attempt?.paymentMethod,
         activeAbTests: params.activeAbTests,
@@ -2114,14 +2281,7 @@ export class PredictController extends BaseController<
           error,
           PredictEventValues.FAILURE_STAGE.ORDER,
         );
-        let status: PredictTradeStatusValue = PredictTradeStatus.FAILED_ORDER;
-        if (failure.isUserRejected) {
-          status = PredictTradeStatus.CANCELLED;
-        } else if (failure.isRetryable) {
-          status = PredictTradeStatus.ORDER_FAILED;
-        }
         const failureEvent = {
-          status,
           amountUsd: params.attempt.amountUsd,
           analyticsProperties,
           sharePrice,
@@ -2138,9 +2298,21 @@ export class PredictController extends BaseController<
         };
 
         if (failure.isRetryable) {
-          this.trackPredictOrderEvent(failureEvent);
+          this.markPredictBuyAttemptRetryable(
+            params.attempt.attemptId,
+            activeOrderAddress,
+          );
+          this.trackPredictOrderEvent({
+            ...failureEvent,
+            status: PredictTradeStatus.ORDER_FAILED,
+          });
         } else {
-          this.trackPredictBuyTerminalEvent(failureEvent);
+          this.trackPredictBuyTerminalEvent({
+            ...failureEvent,
+            status: failure.isUserRejected
+              ? PredictTradeStatus.CANCELLED
+              : PredictTradeStatus.FAILED_ORDER,
+          });
         }
       } else {
         this.trackPredictOrderEvent({
@@ -2941,6 +3113,10 @@ export class PredictController extends BaseController<
   public selectPaymentToken(token: AssetType | null): void {
     const isBalanceToken =
       !token || token.address === PREDICT_BALANCE_PLACEHOLDER_ADDRESS;
+
+    this.cancelRetryablePredictBuyAttempt(
+      'User changed payment method after a retryable order failure',
+    );
 
     this.setSelectedPaymentToken(
       isBalanceToken
@@ -4440,6 +4616,9 @@ export class PredictController extends BaseController<
         // Only update gas if estimation succeeded
         if (updatedGas) {
           transaction.txParams.gas = updatedGas;
+          // Keep the legacy field synchronized for existing transaction consumers.
+          // eslint-disable-next-line @typescript-eslint/no-deprecated
+          transaction.txParams.gasLimit = updatedGas;
         }
       },
     };

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -1,9 +1,8 @@
 import { AccountTreeControllerGetAccountsFromSelectedAccountGroupAction } from '@metamask/account-tree-controller';
-import { AccountsControllerGetSelectedAccountAction } from '@metamask/accounts-controller';
 import {
   BaseController,
   ControllerGetStateAction,
-  ControllerStateChangeEvent,
+  ControllerStateChangedEvent,
   StateMetadata,
 } from '@metamask/base-controller';
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
@@ -123,7 +122,10 @@ import {
 } from '../types';
 import { PredictFeatureFlags, PredictHiddenMarketsFlag } from '../types/flags';
 
-import { mapClaimFailureReason } from '../utils/analytics';
+import {
+  classifyPredictBuyFailure,
+  mapClaimFailureReason,
+} from '../utils/analytics';
 import { resolveCryptoTargetPrice } from '../utils/cryptoUpDown';
 import { validateMarketBettable } from '../utils/marketState';
 import { ensureError } from '../utils/predictErrorHandler';
@@ -323,7 +325,7 @@ export type PredictTransactionStatusChangedPayload =
   PredictControllerTransactionStatusChangedEvent['payload'][0];
 
 export type PredictControllerEvents =
-  | ControllerStateChangeEvent<'PredictController', PredictControllerState>
+  | ControllerStateChangedEvent<'PredictController', PredictControllerState>
   | PredictControllerTransactionStatusChangedEvent;
 
 interface TransactionReceiptLog {
@@ -364,7 +366,6 @@ export type PredictControllerActions =
  * External actions the PredictController can call
  */
 type AllowedActions =
-  | AccountsControllerGetSelectedAccountAction
   | AccountTreeControllerGetAccountsFromSelectedAccountGroupAction
   | NetworkControllerGetStateAction
   | NetworkControllerFindNetworkClientIdByChainIdAction
@@ -530,6 +531,8 @@ export class PredictController extends BaseController<
   private claimTerminalEmitted = new Set<string>();
 
   private flowTerminalMetricEmitted = new Set<string>();
+
+  private predictBuyTerminalEmitted = new Set<string>();
 
   private readonly traceable: TraceableController = {
     update: (updater) => this.update(updater),
@@ -1317,6 +1320,23 @@ export class PredictController extends BaseController<
     return this.analytics.trackPredictOrderEvent(args);
   }
 
+  public trackTradeConsidered(): void {
+    this.analytics.trackTradeConsidered();
+  }
+
+  public trackPredictBuyTerminalEvent(
+    args: Parameters<PredictAnalytics['trackPredictOrderEvent']>[0] & {
+      attemptId: string;
+    },
+  ): void {
+    if (this.predictBuyTerminalEmitted.has(args.attemptId)) {
+      return;
+    }
+
+    this.predictBuyTerminalEmitted.add(args.attemptId);
+    this.trackPredictOrderEvent(args);
+  }
+
   private trackPredictFlowMetric({
     transactionType,
     status,
@@ -1756,6 +1776,26 @@ export class PredictController extends BaseController<
         });
       }
 
+      if (params.attempt && params.preview.side === Side.BUY) {
+        const failure = classifyPredictBuyFailure(
+          errorMessage,
+          PredictEventValues.FAILURE_STAGE.ORDER,
+        );
+        this.trackPredictBuyTerminalEvent({
+          status: PredictTradeStatus.FAILED_ORDER,
+          amountUsd: params.attempt.amountUsd,
+          analyticsProperties: params.analyticsProperties,
+          sharePrice: params.preview.sharePrice,
+          orderType: params.preview.orderType,
+          attemptId: params.attempt.attemptId,
+          paymentMethod: params.attempt.paymentMethod,
+          failureStage: failure.failureStage,
+          failureCategory: failure.failureCategory,
+          failureReason: failure.failureReason,
+          activeAbTests: params.activeAbTests,
+        });
+      }
+
       if (
         params.transactionId &&
         this.pendingOrderPreviews[params.transactionId]
@@ -1779,6 +1819,7 @@ export class PredictController extends BaseController<
           signerAddress: activeOrderAddress,
           analyticsProperties: params.analyticsProperties,
           activeAbTests: params.activeAbTests,
+          attempt: params.attempt,
         };
       }
       this.update((state) => {
@@ -1807,8 +1848,10 @@ export class PredictController extends BaseController<
       }
 
       this.trackPredictOrderEvent({
-        status: PredictTradeStatus.SWAP_INITIATED,
-        amountUsd: params.preview?.maxAmountSpent,
+        status: params.attempt
+          ? PredictTradeStatus.SWAP_STARTED
+          : PredictTradeStatus.SWAP_INITIATED,
+        amountUsd: params.attempt?.amountUsd ?? params.preview?.maxAmountSpent,
         analyticsProperties: params.analyticsProperties,
         sharePrice: params.preview?.sharePrice,
         orderType: params.preview.orderType,
@@ -1821,6 +1864,8 @@ export class PredictController extends BaseController<
           params.preview.side === Side.BUY
             ? this.state.activeBuyOrders[activeOrderAddress]?.paymentTokenSymbol
             : undefined,
+        attemptId: params.attempt?.attemptId,
+        paymentMethod: params.attempt?.paymentMethod,
         activeAbTests: params.activeAbTests,
       });
 
@@ -1867,9 +1912,10 @@ export class PredictController extends BaseController<
 
     const sharePrice = preview?.sharePrice;
     const amountUsd =
-      preview.side === Side.BUY
+      params.attempt?.amountUsd ??
+      (preview.side === Side.BUY
         ? preview?.maxAmountSpent
-        : preview?.minAmountReceived;
+        : preview?.minAmountReceived);
 
     // Start Sentry trace for place order operation
     const traceId = `place-order-${Date.now()}`;
@@ -1900,13 +1946,17 @@ export class PredictController extends BaseController<
 
       // Track Predict Trade Transaction with submitted status (fire and forget)
       this.trackPredictOrderEvent({
-        status: PredictTradeStatus.SUBMITTED,
+        status: params.attempt
+          ? PredictTradeStatus.ORDER_SUBMITTED
+          : PredictTradeStatus.SUBMITTED,
         amountUsd,
         analyticsProperties,
         sharePrice,
         orderType: preview.orderType,
         paymentTokenAddress,
         paymentTokenSymbol,
+        attemptId: params.attempt?.attemptId,
+        paymentMethod: params.attempt?.paymentMethod,
         activeAbTests: params.activeAbTests,
       });
 
@@ -2022,17 +2072,28 @@ export class PredictController extends BaseController<
       }
 
       // Track Predict Trade Transaction with succeeded status (fire and forget)
-      this.trackPredictOrderEvent({
+      const successEvent = {
         status: PredictTradeStatus.SUCCEEDED,
-        amountUsd: realAmountUsd,
+        amountUsd: params.attempt?.amountUsd ?? realAmountUsd,
         analyticsProperties,
         completionDuration,
         sharePrice: realSharePrice,
         orderType: preview.orderType,
         paymentTokenAddress,
         paymentTokenSymbol,
+        attemptId: params.attempt?.attemptId,
+        paymentMethod: params.attempt?.paymentMethod,
         activeAbTests: params.activeAbTests,
-      });
+      };
+
+      if (params.attempt) {
+        this.trackPredictBuyTerminalEvent({
+          ...successEvent,
+          attemptId: params.attempt.attemptId,
+        });
+      } else {
+        this.trackPredictOrderEvent(successEvent);
+      }
 
       traceData = { success: true, side: preview.side };
       return result as unknown as Result;
@@ -2048,19 +2109,53 @@ export class PredictController extends BaseController<
       const isPostDepositOrderFailure =
         isBuyWithAnyToken && pendingOrder !== undefined;
 
-      // Track Predict Trade Transaction with failed status (fire and forget)
-      this.trackPredictOrderEvent({
-        status: PredictTradeStatus.FAILED,
-        amountUsd,
-        analyticsProperties,
-        sharePrice,
-        completionDuration,
-        failureReason: errorMessage,
-        orderType: preview.orderType,
-        paymentTokenAddress,
-        paymentTokenSymbol,
-        activeAbTests: params.activeAbTests,
-      });
+      if (params.attempt && preview.side === Side.BUY) {
+        const failure = classifyPredictBuyFailure(
+          error,
+          PredictEventValues.FAILURE_STAGE.ORDER,
+        );
+        let status: PredictTradeStatusValue = PredictTradeStatus.FAILED_ORDER;
+        if (failure.isUserRejected) {
+          status = PredictTradeStatus.CANCELLED;
+        } else if (failure.isRetryable) {
+          status = PredictTradeStatus.ORDER_FAILED;
+        }
+        const failureEvent = {
+          status,
+          amountUsd: params.attempt.amountUsd,
+          analyticsProperties,
+          sharePrice,
+          completionDuration,
+          failureReason: failure.failureReason,
+          failureStage: failure.failureStage,
+          failureCategory: failure.failureCategory,
+          orderType: preview.orderType,
+          paymentTokenAddress,
+          paymentTokenSymbol,
+          attemptId: params.attempt.attemptId,
+          paymentMethod: params.attempt.paymentMethod,
+          activeAbTests: params.activeAbTests,
+        };
+
+        if (failure.isRetryable) {
+          this.trackPredictOrderEvent(failureEvent);
+        } else {
+          this.trackPredictBuyTerminalEvent(failureEvent);
+        }
+      } else {
+        this.trackPredictOrderEvent({
+          status: PredictTradeStatus.FAILED,
+          amountUsd,
+          analyticsProperties,
+          sharePrice,
+          completionDuration,
+          failureReason: errorMessage,
+          orderType: preview.orderType,
+          paymentTokenAddress,
+          paymentTokenSymbol,
+          activeAbTests: params.activeAbTests,
+        });
+      }
 
       if (isPostDepositOrderFailure) {
         this.handlePostDepositOrderFailure({
@@ -3459,13 +3554,18 @@ export class PredictController extends BaseController<
 
       // Track swap/deposit success — the token swap confirmed, order placement begins
       this.trackPredictOrderEvent({
-        status: PredictTradeStatus.SWAP_SUCCESS,
+        status: pendingOrder.attempt
+          ? PredictTradeStatus.SWAP_SUCCEEDED
+          : PredictTradeStatus.SWAP_SUCCESS,
+        amountUsd: pendingOrder.attempt?.amountUsd,
         analyticsProperties: pendingOrder.analyticsProperties,
         paymentTokenAddress:
           this.state.activeBuyOrders[address]?.paymentTokenAddress,
         paymentTokenSymbol:
           this.state.activeBuyOrders[address]?.paymentTokenSymbol,
         orderType: pendingOrder.preview?.orderType,
+        attemptId: pendingOrder.attempt?.attemptId,
+        paymentMethod: pendingOrder.attempt?.paymentMethod,
         activeAbTests: pendingOrder.activeAbTests,
       });
 
@@ -3474,6 +3574,7 @@ export class PredictController extends BaseController<
         signerAddress,
         analyticsProperties: pendingAnalytics,
         activeAbTests: pendingActiveAbTests,
+        attempt,
       } = pendingOrder;
 
       (depositWalletSyncPromise ?? Promise.resolve())
@@ -3484,6 +3585,7 @@ export class PredictController extends BaseController<
             preview,
             address: signerAddress,
             transactionId,
+            attempt,
           }),
         )
         .catch((error) => {
@@ -3522,11 +3624,33 @@ export class PredictController extends BaseController<
         this.provider.clearOptimisticPosition(address, outcomeTokenId);
       }
 
-      if (failedActiveOrder) {
-        const errorMessage =
-          transactionMeta.error?.message ?? PREDICT_ERROR_CODES.DEPOSIT_FAILED;
+      const swapError =
+        transactionMeta.error ?? PREDICT_ERROR_CODES.DEPOSIT_FAILED;
+      const errorMessage =
+        transactionMeta.error?.message ?? PREDICT_ERROR_CODES.DEPOSIT_FAILED;
 
-        // PWAT active order: swap/deposit step failed before order placement
+      if (pendingOrder?.attempt) {
+        const failure = classifyPredictBuyFailure(
+          swapError,
+          PredictEventValues.FAILURE_STAGE.SWAP,
+        );
+        this.trackPredictBuyTerminalEvent({
+          status: failure.isUserRejected
+            ? PredictTradeStatus.CANCELLED
+            : PredictTradeStatus.FAILED_SWAP,
+          amountUsd: pendingOrder.attempt.amountUsd,
+          analyticsProperties: pendingOrder.analyticsProperties,
+          paymentTokenAddress: failedPaymentTokenAddress,
+          paymentTokenSymbol: failedPaymentTokenSymbol,
+          failureReason: failure.failureReason,
+          failureStage: failure.failureStage,
+          failureCategory: failure.failureCategory,
+          orderType: pendingOrder.preview.orderType,
+          attemptId: pendingOrder.attempt.attemptId,
+          paymentMethod: pendingOrder.attempt.paymentMethod,
+          activeAbTests: pendingOrder.activeAbTests,
+        });
+      } else if (failedActiveOrder) {
         this.trackPredictOrderEvent({
           status: PredictTradeStatus.SWAP_FAILED,
           analyticsProperties: pendingOrder?.analyticsProperties,
@@ -3535,7 +3659,20 @@ export class PredictController extends BaseController<
           failureReason: errorMessage,
           activeAbTests: pendingOrder?.activeAbTests,
         });
+      } else {
+        // Background deposit with no active PWAT order — track as a generic failure
+        this.trackPredictOrderEvent({
+          status: PredictTradeStatus.FAILED,
+          analyticsProperties: pendingOrder?.analyticsProperties,
+          failureReason: errorMessage,
+          paymentTokenAddress: failedPaymentTokenAddress,
+          paymentTokenSymbol: failedPaymentTokenSymbol,
+          orderType: pendingOrder?.preview?.orderType,
+          activeAbTests: pendingOrder?.activeAbTests,
+        });
+      }
 
+      if (failedActiveOrder) {
         this.update((state) => {
           if (state.activeBuyOrders[address]) {
             state.activeBuyOrders[address].state =
@@ -3552,19 +3689,6 @@ export class PredictController extends BaseController<
               operation: 'initPayWithAnyToken',
             }),
           );
-        });
-      } else {
-        // Background deposit with no active PWAT order — track as a generic failure
-        this.trackPredictOrderEvent({
-          status: PredictTradeStatus.FAILED,
-          analyticsProperties: pendingOrder?.analyticsProperties,
-          failureReason:
-            transactionMeta.error?.message ??
-            PREDICT_ERROR_CODES.DEPOSIT_FAILED,
-          paymentTokenAddress: failedPaymentTokenAddress,
-          paymentTokenSymbol: failedPaymentTokenSymbol,
-          orderType: pendingOrder?.preview?.orderType,
-          activeAbTests: pendingOrder?.activeAbTests,
         });
       }
 
@@ -3588,17 +3712,41 @@ export class PredictController extends BaseController<
         delete this.pendingOrderPreviews[transactionId];
       }
 
-      if (this.state.activeBuyOrders[address]) {
+      const rejectedActiveOrder = this.state.activeBuyOrders[address];
+      if (rejectedPendingOrder?.attempt) {
+        const failure = classifyPredictBuyFailure(
+          {
+            code: errorCodes.provider.userRejectedRequest,
+            message:
+              transactionMeta.error?.message ?? 'User rejected transaction',
+          },
+          PredictEventValues.FAILURE_STAGE.SWAP,
+        );
+        this.trackPredictBuyTerminalEvent({
+          status: PredictTradeStatus.CANCELLED,
+          amountUsd: rejectedPendingOrder.attempt.amountUsd,
+          analyticsProperties: rejectedPendingOrder.analyticsProperties,
+          paymentTokenAddress: rejectedActiveOrder?.paymentTokenAddress,
+          paymentTokenSymbol: rejectedActiveOrder?.paymentTokenSymbol,
+          failureReason: failure.failureReason,
+          failureStage: failure.failureStage,
+          failureCategory: failure.failureCategory,
+          orderType: rejectedPendingOrder.preview.orderType,
+          attemptId: rejectedPendingOrder.attempt.attemptId,
+          paymentMethod: rejectedPendingOrder.attempt.paymentMethod,
+          activeAbTests: rejectedPendingOrder.activeAbTests,
+        });
+      } else if (rejectedActiveOrder) {
         this.trackPredictOrderEvent({
           status: PredictTradeStatus.CANCELLED,
           analyticsProperties: rejectedPendingOrder?.analyticsProperties,
-          paymentTokenAddress:
-            this.state.activeBuyOrders[address]?.paymentTokenAddress,
-          paymentTokenSymbol:
-            this.state.activeBuyOrders[address]?.paymentTokenSymbol,
+          paymentTokenAddress: rejectedActiveOrder.paymentTokenAddress,
+          paymentTokenSymbol: rejectedActiveOrder.paymentTokenSymbol,
           activeAbTests: rejectedPendingOrder?.activeAbTests,
         });
+      }
 
+      if (this.state.activeBuyOrders[address]) {
         this.update((state) => {
           if (state.activeBuyOrders[address]) {
             state.activeBuyOrders[address].state = ActiveOrderState.PREVIEW;
@@ -4292,7 +4440,6 @@ export class PredictController extends BaseController<
         // Only update gas if estimation succeeded
         if (updatedGas) {
           transaction.txParams.gas = updatedGas;
-          transaction.txParams.gasLimit = updatedGas;
         }
       },
     };

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -53,6 +53,8 @@ import { addTransactionBatch } from '../../../../util/transaction-controller';
 import { AssetType } from '../../../Views/confirmations/types/token';
 import { PREDICT_CONSTANTS, PREDICT_ERROR_CODES } from '../constants/errors';
 import {
+  MAX_TRACKED_PREDICT_BUY_TERMINALS,
+  type PredictBuyTerminalStatus,
   PredictEventValues,
   PredictTradeStatus,
   type PredictTradeStatusValue,
@@ -98,6 +100,7 @@ import {
   PredictActivity,
   PredictBalance,
   PredictBuyAttempt,
+  PredictBuyAttemptContext,
   PredictClaim,
   PredictClaimStatus,
   PredictFilterOption,
@@ -120,6 +123,7 @@ import {
   Result,
   SearchMarketsParams,
   Side,
+  StartPredictBuyAttemptArgs,
   UnrealizedPnL,
 } from '../types';
 import { PredictFeatureFlags, PredictHiddenMarketsFlag } from '../types/flags';
@@ -497,32 +501,6 @@ const HIGHLIGHT_SERIES_FUTURE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
  * on-chain value is fetched.
  */
 export const OPTIMISTIC_BALANCE_MAX_AGE_MS = 30 * 1000;
-
-const MAX_TRACKED_PREDICT_BUY_TERMINALS = 500;
-
-type PredictBuyTerminalStatus =
-  | typeof PredictTradeStatus.SUCCEEDED
-  | typeof PredictTradeStatus.FAILED_SWAP
-  | typeof PredictTradeStatus.FAILED_ORDER
-  | typeof PredictTradeStatus.CANCELLED;
-
-interface PredictBuyAttemptContext {
-  attempt: PredictBuyAttempt;
-  address: string;
-  analyticsProperties?: PlaceOrderParams['analyticsProperties'];
-  sharePrice?: number;
-  orderType?: OrderPreview['orderType'];
-  activeAbTests?: PlaceOrderParams['activeAbTests'];
-}
-
-interface StartPredictBuyAttemptArgs {
-  amountUsd: number;
-  paymentMethod: PredictBuyAttempt['paymentMethod'];
-  analyticsProperties?: PlaceOrderParams['analyticsProperties'];
-  sharePrice?: number;
-  orderType?: OrderPreview['orderType'];
-  activeAbTests?: PlaceOrderParams['activeAbTests'];
-}
 
 /**
  * PredictController - Protocol-agnostic prediction markets trading controller

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -1926,7 +1926,7 @@ export class PredictController extends BaseController<
           PredictEventValues.FAILURE_STAGE.ORDER,
         );
         this.trackPredictBuyTerminalEvent({
-          status: PredictTradeStatus.FAILED_ORDER,
+          status: PredictTradeStatus.FAILED,
           amountUsd: params.attempt.amountUsd,
           analyticsProperties: params.analyticsProperties,
           sharePrice: params.preview.sharePrice,
@@ -1992,9 +1992,7 @@ export class PredictController extends BaseController<
       }
 
       this.trackPredictOrderEvent({
-        status: params.attempt
-          ? PredictTradeStatus.SWAP_STARTED
-          : PredictTradeStatus.SWAP_INITIATED,
+        status: PredictTradeStatus.SWAP_INITIATED,
         amountUsd: params.attempt?.amountUsd ?? params.preview?.maxAmountSpent,
         analyticsProperties: params.analyticsProperties,
         sharePrice: params.preview?.sharePrice,
@@ -2090,9 +2088,7 @@ export class PredictController extends BaseController<
 
       // Track Predict Trade Transaction with submitted status (fire and forget)
       this.trackPredictOrderEvent({
-        status: params.attempt
-          ? PredictTradeStatus.ORDER_SUBMITTED
-          : PredictTradeStatus.SUBMITTED,
+        status: PredictTradeStatus.SUBMITTED,
         amountUsd,
         analyticsProperties,
         sharePrice,
@@ -2289,7 +2285,7 @@ export class PredictController extends BaseController<
             ...failureEvent,
             status: failure.isUserRejected
               ? PredictTradeStatus.CANCELLED
-              : PredictTradeStatus.FAILED_ORDER,
+              : PredictTradeStatus.FAILED,
           });
         }
       } else {
@@ -3708,9 +3704,7 @@ export class PredictController extends BaseController<
 
       // Track swap/deposit success — the token swap confirmed, order placement begins
       this.trackPredictOrderEvent({
-        status: pendingOrder.attempt
-          ? PredictTradeStatus.SWAP_SUCCEEDED
-          : PredictTradeStatus.SWAP_SUCCESS,
+        status: PredictTradeStatus.SWAP_SUCCESS,
         amountUsd: pendingOrder.attempt?.amountUsd,
         analyticsProperties: pendingOrder.analyticsProperties,
         paymentTokenAddress:
@@ -3791,7 +3785,7 @@ export class PredictController extends BaseController<
         this.trackPredictBuyTerminalEvent({
           status: failure.isUserRejected
             ? PredictTradeStatus.CANCELLED
-            : PredictTradeStatus.FAILED_SWAP,
+            : PredictTradeStatus.FAILED,
           amountUsd: pendingOrder.attempt.amountUsd,
           analyticsProperties: pendingOrder.analyticsProperties,
           paymentTokenAddress: failedPaymentTokenAddress,

--- a/app/components/UI/Predict/hooks/usePredictOrderRetry.test.ts
+++ b/app/components/UI/Predict/hooks/usePredictOrderRetry.test.ts
@@ -59,6 +59,7 @@ function createParamsObj(overrides?: Record<string, unknown>) {
     isOrderNotFilled: false,
     resetOrderNotFilled: jest.fn(),
     isSheetMode: false as boolean | undefined,
+    attempt: undefined as PlaceOrderParams['attempt'],
     ...overrides,
   };
 }
@@ -133,6 +134,22 @@ describe('usePredictOrderRetry', () => {
       expect(promptedCalls).toHaveLength(1);
     });
 
+    it('does not track retry status for a Predict buy', () => {
+      const params = createDefaultParams({
+        isOrderNotFilled: false,
+        analyticsProperties: {
+          marketId: 'market-123',
+          transactionType: 'mm_predict_buy',
+        },
+      });
+      const { rerender } = renderHook(() => usePredictOrderRetry(params));
+
+      params.isOrderNotFilled = true;
+      rerender();
+
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
+
     it('opens the retry sheet ref when isOrderNotFilled becomes true and isSheetMode is false', () => {
       const params = createDefaultParams({ isOrderNotFilled: false });
       const { result, rerender } = renderHook(() =>
@@ -205,6 +222,24 @@ describe('usePredictOrderRetry', () => {
         expect.objectContaining({
           preview: expect.objectContaining({ slippage: 0.99 }),
         }),
+      );
+    });
+
+    it('passes the same attempt to a retry', async () => {
+      const attempt = {
+        attemptId: 'attempt-1',
+        amountUsd: 8,
+        paymentMethod: 'predict_balance' as const,
+      };
+      const params = createDefaultParams({ attempt });
+      const { result } = renderHook(() => usePredictOrderRetry(params));
+
+      await act(async () => {
+        await result.current.handleRetryWithBestPrice();
+      });
+
+      expect(params.placeOrder).toHaveBeenCalledWith(
+        expect.objectContaining({ attempt }),
       );
     });
 

--- a/app/components/UI/Predict/hooks/usePredictOrderRetry.ts
+++ b/app/components/UI/Predict/hooks/usePredictOrderRetry.ts
@@ -1,8 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { SLIPPAGE_BEST_AVAILABLE } from '../providers/polymarket/constants';
-import { PredictTradeStatus } from '../constants/eventNames';
+import {
+  PredictEventValues,
+  PredictTradeStatus,
+} from '../constants/eventNames';
 import Engine from '../../../../core/Engine';
-import type { OrderPreview, PlaceOrderParams } from '../types';
+import type {
+  OrderPreview,
+  PlaceOrderParams,
+  PredictBuyAttempt,
+} from '../types';
 import type { PlaceOrderOutcome } from './usePredictPlaceOrder';
 import type {
   PredictOrderRetrySheetRef,
@@ -20,6 +27,7 @@ interface UsePredictOrderRetryParams {
    * inline buy-sheet error banner can handle the retry UX instead.
    */
   isSheetMode?: boolean;
+  attempt?: PredictBuyAttempt;
 }
 
 export function usePredictOrderRetry({
@@ -29,6 +37,7 @@ export function usePredictOrderRetry({
   isOrderNotFilled,
   resetOrderNotFilled,
   isSheetMode = false,
+  attempt,
 }: UsePredictOrderRetryParams) {
   const [isRetrying, setIsRetrying] = useState(false);
   const [retrySheetVariant, setRetrySheetVariant] =
@@ -40,17 +49,24 @@ export function usePredictOrderRetry({
     if (!preview) return;
     setIsRetrying(true);
 
-    Engine.context.PredictController.trackPredictOrderEvent({
-      status: PredictTradeStatus.RETRY_SUBMITTED,
-      analyticsProperties,
-      sharePrice: preview.sharePrice,
-    });
+    const isPredictBuy =
+      analyticsProperties?.transactionType ===
+      PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_BUY;
+
+    if (!isPredictBuy) {
+      Engine.context.PredictController.trackPredictOrderEvent({
+        status: PredictTradeStatus.RETRY_SUBMITTED,
+        analyticsProperties,
+        sharePrice: preview.sharePrice,
+      });
+    }
 
     try {
       const retryPreview = { ...preview, slippage: SLIPPAGE_BEST_AVAILABLE };
       const outcome = await placeOrder({
         analyticsProperties,
         preview: retryPreview,
+        attempt,
       });
 
       if (
@@ -75,6 +91,7 @@ export function usePredictOrderRetry({
     preview,
     placeOrder,
     analyticsProperties,
+    attempt,
     resetOrderNotFilled,
     isSheetMode,
   ]);
@@ -98,11 +115,16 @@ export function usePredictOrderRetry({
         retrySheetRef.current?.onOpenBottomSheet();
       }
 
-      Engine.context.PredictController.trackPredictOrderEvent({
-        status: PredictTradeStatus.RETRY_PROMPTED,
-        analyticsProperties,
-        sharePrice: preview?.sharePrice,
-      });
+      if (
+        analyticsProperties?.transactionType !==
+        PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_BUY
+      ) {
+        Engine.context.PredictController.trackPredictOrderEvent({
+          status: PredictTradeStatus.RETRY_PROMPTED,
+          analyticsProperties,
+          sharePrice: preview?.sharePrice,
+        });
+      }
     }
 
     wasOrderNotFilledRef.current = isOrderNotFilled;

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -3,6 +3,7 @@
 import { Hex } from '@metamask/utils';
 import type { TransactionActiveAbTestEntry } from '../../../../util/transactions/transaction-active-ab-test-attribution-registry';
 import type { PredictMarketListOrder } from '../constants/flags';
+import type { PredictPaymentMethodValue } from '../constants/eventNames';
 
 export enum Side {
   BUY = 'BUY',
@@ -779,12 +780,19 @@ export type OrderResult = Result<{
   txHashes?: string[];
 }>;
 
+export interface PredictBuyAttempt {
+  attemptId: string;
+  amountUsd: number;
+  paymentMethod: PredictPaymentMethodValue;
+}
+
 export interface PlaceOrderParams {
   preview: OrderPreview;
   address?: string;
   transactionId?: string;
   activeAbTests?: TransactionActiveAbTestEntry[];
   analyticsProperties?: PredictTradeAnalyticsProperties;
+  attempt?: PredictBuyAttempt;
 }
 
 /**
@@ -799,6 +807,7 @@ export interface PendingOrderPreview {
   analyticsProperties?: PlaceOrderParams['analyticsProperties'];
   activeAbTests?: PlaceOrderParams['activeAbTests'];
   depositedAmount?: number;
+  attempt?: PlaceOrderParams['attempt'];
 }
 
 export interface PreviewOrderParams {

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -810,6 +810,24 @@ export interface PendingOrderPreview {
   attempt?: PlaceOrderParams['attempt'];
 }
 
+export interface PredictBuyAttemptContext {
+  attempt: PredictBuyAttempt;
+  address: string;
+  analyticsProperties?: PlaceOrderParams['analyticsProperties'];
+  sharePrice?: number;
+  orderType?: OrderPreview['orderType'];
+  activeAbTests?: PlaceOrderParams['activeAbTests'];
+}
+
+export interface StartPredictBuyAttemptArgs {
+  amountUsd: number;
+  paymentMethod: PredictBuyAttempt['paymentMethod'];
+  analyticsProperties?: PlaceOrderParams['analyticsProperties'];
+  sharePrice?: number;
+  orderType?: OrderPreview['orderType'];
+  activeAbTests?: PlaceOrderParams['activeAbTests'];
+}
+
 export interface PreviewOrderParams {
   marketId: string;
   outcomeId: string;

--- a/app/components/UI/Predict/utils/analytics.test.ts
+++ b/app/components/UI/Predict/utils/analytics.test.ts
@@ -1,4 +1,9 @@
-import { mapClaimFailureReason, parseAnalyticsProperties } from './analytics';
+import {
+  classifyPredictBuyFailure,
+  mapClaimFailureReason,
+  parseAnalyticsProperties,
+  sanitizePredictFailureReason,
+} from './analytics';
 import {
   Recurrence,
   type PredictMarket,
@@ -24,6 +29,20 @@ jest.mock('../constants/eventNames', () => ({
       NETWORK_ERROR: 'network_error',
       USER_REJECTED: 'user_rejected',
       UNKNOWN: 'unknown',
+    },
+    FAILURE_STAGE: {
+      SWAP: 'swap',
+      ORDER: 'order',
+    },
+    FAILURE_CATEGORY: {
+      GAS_LIMIT: 'gas_limit',
+      INSUFFICIENT_BALANCE: 'insufficient_balance',
+      NOT_ELIGIBLE: 'not_eligible',
+      NO_MATCH: 'no_match',
+      RELAYER: 'relayer',
+      NETWORK: 'network',
+      USER_REJECTED: 'user_rejected',
+      OTHER: 'other',
     },
   },
 }));
@@ -535,6 +554,75 @@ describe('parseAnalyticsProperties', () => {
     it('returns unknown for undefined or non-error values', () => {
       expect(mapClaimFailureReason(undefined)).toBe('unknown');
       expect(mapClaimFailureReason({ some: 'object' })).toBe('unknown');
+    });
+  });
+
+  describe('classifyPredictBuyFailure', () => {
+    it.each([
+      ['RPC transaction gas limit too high', 'gas_limit'],
+      ['insufficient balance for bet', 'insufficient_balance'],
+      ['PREDICT_NOT_ELIGIBLE', 'not_eligible'],
+      ['PREDICT_BUY_ORDER_NOT_FULLY_FILLED', 'no_match'],
+      ['Polymarket relayer unavailable', 'relayer'],
+      ['Network request timed out', 'network'],
+      ['User rejected the request', 'user_rejected'],
+      ['Unexpected provider error', 'other'],
+    ])('maps "%s" to "%s"', (message, expected) => {
+      const result = classifyPredictBuyFailure(new Error(message), 'order');
+
+      expect(result.failureCategory).toBe(expected);
+    });
+
+    it('marks no-match failures as retryable', () => {
+      const result = classifyPredictBuyFailure(
+        new Error('PREDICT_BUY_ORDER_NOT_FULLY_FILLED'),
+        'order',
+      );
+
+      expect(result.isRetryable).toBe(true);
+      expect(result.isUserRejected).toBe(false);
+    });
+
+    it('marks provider rejection code as user rejected', () => {
+      const result = classifyPredictBuyFailure(
+        { code: 4001, message: 'Request rejected' },
+        'swap',
+      );
+
+      expect(result.failureCategory).toBe('user_rejected');
+      expect(result.isUserRejected).toBe(true);
+    });
+  });
+
+  describe('sanitizePredictFailureReason', () => {
+    it('removes HTML and limits output to 255 characters', () => {
+      const result = sanitizePredictFailureReason(
+        `<html>${'failure '.repeat(80)}</html>`,
+      );
+
+      expect(result).not.toContain('<html>');
+      expect(result).toHaveLength(255);
+    });
+
+    it('extracts a message from a JSON error without sending the full payload', () => {
+      const result = sanitizePredictFailureReason(
+        JSON.stringify({
+          message: 'Relayer request failed',
+          response: { privatePayload: 'do-not-send' },
+        }),
+      );
+
+      expect(result).toBe('Relayer request failed');
+    });
+
+    it('redacts addresses, URLs, and credentials', () => {
+      const result = sanitizePredictFailureReason(
+        'Request https://rpc.example/path failed for 0x1111111111111111111111111111111111111111 token=secret',
+      );
+
+      expect(result).toBe(
+        'Request [redacted] failed for [redacted] token=[redacted]',
+      );
     });
   });
 });

--- a/app/components/UI/Predict/utils/analytics.ts
+++ b/app/components/UI/Predict/utils/analytics.ts
@@ -1,8 +1,24 @@
-import { PredictEventValues } from '../constants/eventNames';
+import { errorCodes } from '@metamask/rpc-errors';
+import {
+  PredictEventValues,
+  type PredictFailureCategoryValue,
+  type PredictFailureStageValue,
+} from '../constants/eventNames';
 import { PREDICT_ERROR_CODES } from '../constants/errors';
 import type { PredictMarket, PredictOutcomeToken } from '../types';
 import type { PredictEntryPoint } from '../types/navigation';
 import { getDisplayBuyPrice } from './prices';
+
+const MAX_FAILURE_REASON_LENGTH = 255;
+const REDACTED_VALUE = '[redacted]';
+
+export interface PredictBuyFailureDetails {
+  failureCategory: PredictFailureCategoryValue;
+  failureReason: string;
+  failureStage: PredictFailureStageValue;
+  isUserRejected: boolean;
+  isRetryable: boolean;
+}
 
 export function parseAnalyticsProperties(
   market: PredictMarket | undefined,
@@ -95,4 +111,130 @@ export function mapClaimFailureReason(error?: unknown): string {
   }
 
   return CLAIM_FAILURE_REASON.UNKNOWN;
+}
+
+function getPredictErrorMessage(error?: unknown): string {
+  if (error instanceof Error) {
+    return getPredictErrorMessage(error.message);
+  }
+
+  if (typeof error === 'string') {
+    const trimmed = error.trim();
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(trimmed) as unknown;
+        const parsedMessage = (
+          parsed as { message?: unknown; error?: unknown } | null
+        )?.message;
+        const parsedError = (
+          parsed as { message?: unknown; error?: unknown } | null
+        )?.error;
+
+        if (typeof parsedMessage === 'string') {
+          return parsedMessage;
+        }
+        if (typeof parsedError === 'string') {
+          return parsedError;
+        }
+        return PREDICT_ERROR_CODES.UNKNOWN_ERROR;
+      } catch {
+        return PREDICT_ERROR_CODES.UNKNOWN_ERROR;
+      }
+    }
+
+    return trimmed;
+  }
+
+  const message = (error as { message?: unknown } | null | undefined)?.message;
+  return typeof message === 'string'
+    ? getPredictErrorMessage(message)
+    : PREDICT_ERROR_CODES.UNKNOWN_ERROR;
+}
+
+export function sanitizePredictFailureReason(error?: unknown): string {
+  return getPredictErrorMessage(error)
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/https?:\/\/\S+/gi, REDACTED_VALUE)
+    .replace(/0x[a-fA-F0-9]{40}\b/g, REDACTED_VALUE)
+    .replace(/\bBearer\s+\S+/gi, `Bearer ${REDACTED_VALUE}`)
+    .replace(
+      /\b(api[_-]?key|token|authorization|password)\s*[:=]\s*[^\s,;]+/gi,
+      `$1=${REDACTED_VALUE}`,
+    )
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, MAX_FAILURE_REASON_LENGTH);
+}
+
+export function classifyPredictBuyFailure(
+  error: unknown,
+  failureStage: PredictFailureStageValue,
+): PredictBuyFailureDetails {
+  const { FAILURE_CATEGORY } = PredictEventValues;
+  const errorCode = (error as { code?: unknown } | null | undefined)?.code;
+  const failureReason = sanitizePredictFailureReason(error);
+  const normalized = failureReason.toLowerCase();
+
+  let failureCategory: PredictFailureCategoryValue = FAILURE_CATEGORY.OTHER;
+
+  if (
+    errorCode === errorCodes.provider.userRejectedRequest ||
+    normalized.includes('user denied') ||
+    normalized.includes('user rejected') ||
+    normalized.includes('user cancelled') ||
+    normalized.includes('user canceled')
+  ) {
+    failureCategory = FAILURE_CATEGORY.USER_REJECTED;
+  } else if (
+    normalized.includes('gas limit') ||
+    normalized.includes('out of gas') ||
+    normalized.includes('gas required') ||
+    normalized.includes('intrinsic gas')
+  ) {
+    failureCategory = FAILURE_CATEGORY.GAS_LIMIT;
+  } else if (
+    normalized.includes('insufficient balance') ||
+    normalized.includes('insufficient funds') ||
+    normalized.includes('not enough balance')
+  ) {
+    failureCategory = FAILURE_CATEGORY.INSUFFICIENT_BALANCE;
+  } else if (
+    normalized.includes(PREDICT_ERROR_CODES.NOT_ELIGIBLE.toLowerCase()) ||
+    normalized.includes('not eligible')
+  ) {
+    failureCategory = FAILURE_CATEGORY.NOT_ELIGIBLE;
+  } else if (
+    normalized.includes(
+      PREDICT_ERROR_CODES.BUY_ORDER_NOT_FULLY_FILLED.toLowerCase(),
+    ) ||
+    normalized.includes(
+      PREDICT_ERROR_CODES.ORDER_NOT_FULLY_FILLED.toLowerCase(),
+    ) ||
+    normalized.includes(
+      PREDICT_ERROR_CODES.PREVIEW_NO_ORDER_MATCH_BUY.toLowerCase(),
+    ) ||
+    normalized.includes('not fully filled') ||
+    normalized.includes('no match')
+  ) {
+    failureCategory = FAILURE_CATEGORY.NO_MATCH;
+  } else if (normalized.includes('relayer')) {
+    failureCategory = FAILURE_CATEGORY.RELAYER;
+  } else if (
+    normalized.includes('network') ||
+    normalized.includes('timeout') ||
+    normalized.includes('timed out') ||
+    normalized.includes('connection') ||
+    normalized.includes('fetch') ||
+    normalized.includes('rpc')
+  ) {
+    failureCategory = FAILURE_CATEGORY.NETWORK;
+  }
+
+  return {
+    failureCategory,
+    failureReason,
+    failureStage,
+    isUserRejected: failureCategory === FAILURE_CATEGORY.USER_REJECTED,
+    isRetryable: failureCategory === FAILURE_CATEGORY.NO_MATCH,
+  };
 }

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
@@ -6,7 +6,6 @@ import PredictBuyWithAnyToken from './PredictBuyWithAnyToken';
 import type { PredictBuyPreviewProps } from '../../types/navigation';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
-import { predictBuyAttemptRef } from './predictBuyAttemptRefs';
 
 const mockHandleConfirm = jest.fn();
 const mockPlaceOrder = jest.fn();
@@ -20,13 +19,21 @@ const mockSetIsKeypadOpen = jest.fn();
 const mockSetIsUserInputChange = jest.fn();
 const mockSetIsConfirming = jest.fn();
 const mockHandleRetryWithBestPrice = jest.fn();
-const mockTrackPredictBuyTerminalEvent = jest.fn();
+const mockCancelRetryablePredictBuyAttempt = jest.fn();
+let mockRetryableAttempt:
+  | {
+      attemptId: string;
+      amountUsd: number;
+      paymentMethod: 'pay_with_any_token' | 'predict_balance';
+    }
+  | undefined;
 
 jest.mock('../../../../../core/Engine', () => ({
   context: {
     PredictController: {
-      trackPredictBuyTerminalEvent: (...args: unknown[]) =>
-        mockTrackPredictBuyTerminalEvent(...args),
+      getRetryablePredictBuyAttempt: () => mockRetryableAttempt,
+      cancelRetryablePredictBuyAttempt: (...args: unknown[]) =>
+        mockCancelRetryablePredictBuyAttempt(...args),
       trackPredictOrderEvent: jest.fn(),
     },
   },
@@ -124,13 +131,16 @@ jest.mock('../../hooks/usePredictOrderPreview', () => ({
   }),
 }));
 
+const mockUsePredictOrderRetry = jest.fn((..._args: unknown[]) => ({
+  retrySheetRef: { current: null },
+  retrySheetVariant: 'busy',
+  isRetrying: false,
+  handleRetryWithBestPrice: mockHandleRetryWithBestPrice,
+}));
+
 jest.mock('../../hooks/usePredictOrderRetry', () => ({
-  usePredictOrderRetry: () => ({
-    retrySheetRef: { current: null },
-    retrySheetVariant: 'busy',
-    isRetrying: false,
-    handleRetryWithBestPrice: mockHandleRetryWithBestPrice,
-  }),
+  usePredictOrderRetry: (...args: unknown[]) =>
+    mockUsePredictOrderRetry(...args),
 }));
 
 jest.mock('../../hooks/usePredictPlaceOrder', () => ({
@@ -481,7 +491,7 @@ describe('PredictBuyWithAnyToken', () => {
     mockHasBlockingPayAlerts = false;
     mockCurrentValue = 20;
     mockIsOrderNotFilled = false;
-    predictBuyAttemptRef.current = undefined;
+    mockRetryableAttempt = undefined;
     mockUseSelector.mockImplementation((selector) => {
       if (typeof selector === 'function') {
         return selector({
@@ -525,7 +535,7 @@ describe('PredictBuyWithAnyToken', () => {
 
   it('cancels a retryable attempt when the user changes the amount', () => {
     mockIsOrderNotFilled = true;
-    predictBuyAttemptRef.current = {
+    mockRetryableAttempt = {
       attemptId: 'attempt-1',
       amountUsd: 20,
       paymentMethod: 'pay_with_any_token',
@@ -535,13 +545,20 @@ describe('PredictBuyWithAnyToken', () => {
     mockCurrentValue = 21;
     rerender(<PredictBuyWithAnyToken />);
 
-    expect(mockTrackPredictBuyTerminalEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        status: 'cancelled',
-        attemptId: 'attempt-1',
-        amountUsd: 20,
-        failureCategory: 'user_rejected',
-      }),
+    expect(mockCancelRetryablePredictBuyAttempt).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the controller retryable attempt to the retry hook', () => {
+    mockRetryableAttempt = {
+      attemptId: 'attempt-1',
+      amountUsd: 20,
+      paymentMethod: 'pay_with_any_token',
+    };
+
+    renderWithProvider(<PredictBuyWithAnyToken />);
+
+    expect(mockUsePredictOrderRetry).toHaveBeenCalledWith(
+      expect.objectContaining({ attempt: mockRetryableAttempt }),
     );
   });
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
@@ -6,6 +6,7 @@ import PredictBuyWithAnyToken from './PredictBuyWithAnyToken';
 import type { PredictBuyPreviewProps } from '../../types/navigation';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
+import { predictBuyAttemptRef } from './predictBuyAttemptRefs';
 
 const mockHandleConfirm = jest.fn();
 const mockPlaceOrder = jest.fn();
@@ -19,6 +20,17 @@ const mockSetIsKeypadOpen = jest.fn();
 const mockSetIsUserInputChange = jest.fn();
 const mockSetIsConfirming = jest.fn();
 const mockHandleRetryWithBestPrice = jest.fn();
+const mockTrackPredictBuyTerminalEvent = jest.fn();
+
+jest.mock('../../../../../core/Engine', () => ({
+  context: {
+    PredictController: {
+      trackPredictBuyTerminalEvent: (...args: unknown[]) =>
+        mockTrackPredictBuyTerminalEvent(...args),
+      trackPredictOrderEvent: jest.fn(),
+    },
+  },
+}));
 
 let mockPayWithAnyTokenEnabled = true;
 let mockFakOrdersEnabled = false;
@@ -89,14 +101,6 @@ jest.mock('../../hooks/usePredictActiveOrder', () => ({
   }),
 }));
 
-jest.mock('../../../../../core/Engine', () => ({
-  context: {
-    PredictController: {
-      trackPredictOrderEvent: jest.fn(),
-    },
-  },
-}));
-
 const mockDeposit = jest.fn();
 
 jest.mock('../../hooks/usePredictDeposit', () => ({
@@ -143,8 +147,11 @@ jest.mock('./hooks/usePredictBuyAvailableBalance', () => ({
   }),
 }));
 
+let mockCurrentValue = 20;
+let mockIsOrderNotFilled = false;
+
 const mockUsePredictBuyInputState = jest.fn((..._args: unknown[]) => ({
-  currentValue: 20,
+  currentValue: mockCurrentValue,
   setCurrentValue: mockSetCurrentValue,
   currentValueUSDString: '$20.00',
   setCurrentValueUSDString: mockSetCurrentValueUSDString,
@@ -204,7 +211,7 @@ const mockUsePredictBuyError = jest.fn((..._args: unknown[]) => ({
   errorMessage: mockErrorMessage,
   errorMessageSource: mockErrorMessageSource,
   buyErrorBanner: mockBuyErrorBanner,
-  isOrderNotFilled: false,
+  isOrderNotFilled: mockIsOrderNotFilled,
   resetOrderNotFilled: mockResetOrderNotFilled,
   clearBuyErrorBanner: mockClearBuyErrorBanner,
 }));
@@ -472,6 +479,9 @@ describe('PredictBuyWithAnyToken', () => {
     mockIsPaymentSelectorNavigationLocked = false;
     mockBlockingPayAlertMessage = null;
     mockHasBlockingPayAlerts = false;
+    mockCurrentValue = 20;
+    mockIsOrderNotFilled = false;
+    predictBuyAttemptRef.current = undefined;
     mockUseSelector.mockImplementation((selector) => {
       if (typeof selector === 'function') {
         return selector({
@@ -511,6 +521,28 @@ describe('PredictBuyWithAnyToken', () => {
     expect(
       screen.queryByTestId('predict-fee-breakdown-sheet'),
     ).not.toBeOnTheScreen();
+  });
+
+  it('cancels a retryable attempt when the user changes the amount', () => {
+    mockIsOrderNotFilled = true;
+    predictBuyAttemptRef.current = {
+      attemptId: 'attempt-1',
+      amountUsd: 20,
+      paymentMethod: 'pay_with_any_token',
+    };
+    const { rerender } = renderWithProvider(<PredictBuyWithAnyToken />);
+
+    mockCurrentValue = 21;
+    rerender(<PredictBuyWithAnyToken />);
+
+    expect(mockTrackPredictBuyTerminalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'cancelled',
+        attemptId: 'attempt-1',
+        amountUsd: 20,
+        failureCategory: 'user_rejected',
+      }),
+    );
   });
 
   it('hides the pay with row when the feature flag is disabled', () => {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
@@ -19,6 +19,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
 import { BottomSheetRef } from '../../../../../component-library/components/BottomSheets/BottomSheet';
+import Engine from '../../../../../core/Engine';
 import { TraceName } from '../../../../../util/trace';
 import { PredictBuyPreviewSelectorsIDs } from '../../Predict.testIds';
 import PredictBuyActionButton from './components/PredictBuyActionButton';
@@ -55,8 +56,6 @@ import {
   PredictNavigationParamList,
 } from '../../types/navigation';
 import Routes from '../../../../../constants/navigation/Routes';
-import Engine from '../../../../../core/Engine';
-import { PredictTradeStatus } from '../../constants/eventNames';
 import { parseAnalyticsProperties } from '../../utils/analytics';
 import { formatPrice } from '../../utils/format';
 import { getDisplayBuyPrice } from '../../utils/prices';
@@ -64,9 +63,17 @@ import { usePredictBuyError } from './hooks/usePredictBuyError';
 import { usePredictActiveOrder } from '../../hooks/usePredictActiveOrder';
 import { usePredictDeposit } from '../../hooks/usePredictDeposit';
 import {
+  PredictEventValues,
+  PredictTradeStatus,
+} from '../../constants/eventNames';
+import {
   predictBuyPreviewDismissedViaBackRef,
   predictBuyPreviewSessionRef,
 } from '../PredictBuyPreview/PredictBuyPreview';
+import {
+  predictBuyAttemptRef,
+  predictBuyHasRetryableFailureRef,
+} from './predictBuyAttemptRefs';
 
 interface BuyActionButtonStateParams {
   isPaymentSelectorNavigationLocked: boolean;
@@ -343,6 +350,7 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
   const { handleConfirm, placeOrder } = usePredictBuyActions({
     analyticsProperties,
     preview,
+    amountUsd: currentValue,
     setIsConfirming,
     isSheetMode,
     onClose,
@@ -363,6 +371,10 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
     }
   }, [currentValue]);
 
+  useEffect(() => {
+    predictBuyHasRetryableFailureRef.current = isOrderNotFilled;
+  }, [isOrderNotFilled]);
+
   const {
     retrySheetRef,
     retrySheetVariant,
@@ -377,14 +389,46 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
     isSheetMode,
   });
 
+  const handleRetryDismiss = useCallback(() => {
+    const attempt = predictBuyAttemptRef.current;
+    if (isOrderNotFilled && attempt) {
+      Engine.context.PredictController.trackPredictBuyTerminalEvent({
+        status: PredictTradeStatus.CANCELLED,
+        amountUsd: attempt.amountUsd,
+        analyticsProperties,
+        attemptId: attempt.attemptId,
+        paymentMethod: attempt.paymentMethod,
+        failureStage: PredictEventValues.FAILURE_STAGE.ORDER,
+        failureCategory: PredictEventValues.FAILURE_CATEGORY.USER_REJECTED,
+        failureReason: 'User cancelled after a retryable order failure',
+        activeAbTests: transactionActiveAbTests,
+      });
+    }
+    resetOrderNotFilled();
+  }, [
+    analyticsProperties,
+    isOrderNotFilled,
+    resetOrderNotFilled,
+    transactionActiveAbTests,
+  ]);
+
   const isBannerActive = !!buyErrorBanner;
   const previousValueRef = useRef(currentValue);
   useEffect(() => {
     if (previousValueRef.current !== currentValue && isUserInputChange) {
+      if (isOrderNotFilled) {
+        handleRetryDismiss();
+      }
       clearBuyErrorBanner();
     }
     previousValueRef.current = currentValue;
-  }, [currentValue, isUserInputChange, clearBuyErrorBanner]);
+  }, [
+    currentValue,
+    isUserInputChange,
+    isOrderNotFilled,
+    handleRetryDismiss,
+    clearBuyErrorBanner,
+  ]);
 
   // When the banner appears in sheet mode, close the keypad so the Retry CTA
   // + banner are immediately visible without the user having to dismiss the
@@ -651,7 +695,7 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
         }
         side={Side.BUY}
         onRetry={handleRetryWithBestPrice}
-        onDismiss={resetOrderNotFilled}
+        onDismiss={handleRetryDismiss}
         isRetrying={isRetrying}
       />
       <PredictPayWithAnyTokenInfo

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
@@ -56,6 +56,7 @@ import {
   PredictNavigationParamList,
 } from '../../types/navigation';
 import Routes from '../../../../../constants/navigation/Routes';
+import { PredictTradeStatus } from '../../constants/eventNames';
 import { parseAnalyticsProperties } from '../../utils/analytics';
 import { formatPrice } from '../../utils/format';
 import { getDisplayBuyPrice } from '../../utils/prices';
@@ -63,17 +64,9 @@ import { usePredictBuyError } from './hooks/usePredictBuyError';
 import { usePredictActiveOrder } from '../../hooks/usePredictActiveOrder';
 import { usePredictDeposit } from '../../hooks/usePredictDeposit';
 import {
-  PredictEventValues,
-  PredictTradeStatus,
-} from '../../constants/eventNames';
-import {
   predictBuyPreviewDismissedViaBackRef,
   predictBuyPreviewSessionRef,
 } from '../PredictBuyPreview/PredictBuyPreview';
-import {
-  predictBuyAttemptRef,
-  predictBuyHasRetryableFailureRef,
-} from './predictBuyAttemptRefs';
 
 interface BuyActionButtonStateParams {
   isPaymentSelectorNavigationLocked: boolean;
@@ -371,10 +364,6 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
     }
   }, [currentValue]);
 
-  useEffect(() => {
-    predictBuyHasRetryableFailureRef.current = isOrderNotFilled;
-  }, [isOrderNotFilled]);
-
   const {
     retrySheetRef,
     retrySheetVariant,
@@ -387,30 +376,15 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
     isOrderNotFilled,
     resetOrderNotFilled,
     isSheetMode,
+    attempt: Engine.context.PredictController.getRetryablePredictBuyAttempt(),
   });
 
   const handleRetryDismiss = useCallback(() => {
-    const attempt = predictBuyAttemptRef.current;
-    if (isOrderNotFilled && attempt) {
-      Engine.context.PredictController.trackPredictBuyTerminalEvent({
-        status: PredictTradeStatus.CANCELLED,
-        amountUsd: attempt.amountUsd,
-        analyticsProperties,
-        attemptId: attempt.attemptId,
-        paymentMethod: attempt.paymentMethod,
-        failureStage: PredictEventValues.FAILURE_STAGE.ORDER,
-        failureCategory: PredictEventValues.FAILURE_CATEGORY.USER_REJECTED,
-        failureReason: 'User cancelled after a retryable order failure',
-        activeAbTests: transactionActiveAbTests,
-      });
+    if (isOrderNotFilled) {
+      Engine.context.PredictController.cancelRetryablePredictBuyAttempt();
     }
     resetOrderNotFilled();
-  }, [
-    analyticsProperties,
-    isOrderNotFilled,
-    resetOrderNotFilled,
-    transactionActiveAbTests,
-  ]);
+  }, [isOrderNotFilled, resetOrderNotFilled]);
 
   const isBannerActive = !!buyErrorBanner;
   const previousValueRef = useRef(currentValue);

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.test.ts
@@ -19,7 +19,9 @@ const mockSetSelectedPaymentToken = jest.fn();
 const mockOnPlaceOrderSuccess = jest.fn();
 const mockTrackPredictOrderEvent = jest.fn();
 const mockTrackTradeConsidered = jest.fn();
-const mockTrackPredictBuyTerminalEvent = jest.fn();
+const mockStartPredictBuyAttempt = jest.fn();
+const mockGetRetryablePredictBuyAttempt = jest.fn();
+const mockCancelRetryablePredictBuyAttempt = jest.fn();
 const mockPlaceOrder = jest.fn<Promise<unknown>, [PlaceOrderParams]>();
 const mockOnOrderCancelled = jest.fn();
 const mockInitPayWithAnyToken = jest.fn();
@@ -128,8 +130,12 @@ jest.mock('../../../../../../core/Engine', () => ({
         mockTrackPredictOrderEvent(...args),
       trackTradeConsidered: (...args: unknown[]) =>
         mockTrackTradeConsidered(...args),
-      trackPredictBuyTerminalEvent: (...args: unknown[]) =>
-        mockTrackPredictBuyTerminalEvent(...args),
+      startPredictBuyAttempt: (...args: unknown[]) =>
+        mockStartPredictBuyAttempt(...args),
+      getRetryablePredictBuyAttempt: (...args: unknown[]) =>
+        mockGetRetryablePredictBuyAttempt(...args),
+      cancelRetryablePredictBuyAttempt: (...args: unknown[]) =>
+        mockCancelRetryablePredictBuyAttempt(...args),
       trackBetslipDismissed: (...args: unknown[]) =>
         mockTrackBetslipDismissed(...args),
       initPayWithAnyToken: (...args: unknown[]) =>
@@ -188,6 +194,20 @@ describe('usePredictBuyActions', () => {
     mockBeforeRemoveCallbacks.length = 0;
     mockAddListener.mockImplementation(createAddListenerMock());
     mockTransactions.length = 0;
+    mockStartPredictBuyAttempt.mockImplementation(
+      ({
+        amountUsd,
+        paymentMethod,
+      }: {
+        amountUsd: number;
+        paymentMethod: 'pay_with_any_token' | 'predict_balance';
+      }) => ({
+        attemptId: 'attempt-1',
+        amountUsd,
+        paymentMethod,
+      }),
+    );
+    mockGetRetryablePredictBuyAttempt.mockReturnValue(undefined);
   });
 
   describe('mount effect', () => {
@@ -349,7 +369,7 @@ describe('usePredictBuyActions', () => {
           analyticsProperties: { marketId: 'market-1' },
           preview: params.preview,
           attempt: {
-            attemptId: expect.any(String),
+            attemptId: 'attempt-1',
             amountUsd: 175,
             paymentMethod: 'predict_balance',
           },
@@ -357,7 +377,7 @@ describe('usePredictBuyActions', () => {
       );
     });
 
-    it('tracks one attempt started event on confirm', async () => {
+    it('starts one attempt on confirm', async () => {
       const params = createDefaultParams();
       const { result } = renderHook(() => usePredictBuyActions(params));
 
@@ -365,15 +385,15 @@ describe('usePredictBuyActions', () => {
         await result.current.handleConfirm();
       });
 
-      expect(mockTrackPredictOrderEvent).toHaveBeenCalledTimes(1);
-      expect(mockTrackPredictOrderEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          status: 'attempt_started',
-          amountUsd: 175,
-          attemptId: expect.any(String),
-          paymentMethod: 'predict_balance',
-        }),
-      );
+      expect(mockStartPredictBuyAttempt).toHaveBeenCalledTimes(1);
+      expect(mockStartPredictBuyAttempt).toHaveBeenCalledWith({
+        amountUsd: 175,
+        paymentMethod: 'predict_balance',
+        analyticsProperties: { marketId: 'market-1' },
+        sharePrice: 0.5,
+        orderType: undefined,
+        activeAbTests: undefined,
+      });
     });
 
     it('calls approval confirm when the order is paying with any token', async () => {
@@ -578,6 +598,29 @@ describe('usePredictBuyActions', () => {
   });
 
   describe('placeOrder helper', () => {
+    it('uses the controller retryable attempt after the sheet remounts', async () => {
+      const retryableAttempt = {
+        attemptId: 'retryable-attempt',
+        amountUsd: 175,
+        paymentMethod: 'pay_with_any_token' as const,
+      };
+      mockGetRetryablePredictBuyAttempt.mockReturnValue(retryableAttempt);
+      const { result } = renderHook(() =>
+        usePredictBuyActions(createDefaultParams()),
+      );
+
+      await act(async () => {
+        await result.current.placeOrder({
+          analyticsProperties: { marketId: 'market-1' },
+          preview: createDefaultParams().preview as OrderPreview,
+        });
+      });
+
+      expect(mockPlaceOrder).toHaveBeenCalledWith(
+        expect.objectContaining({ attempt: retryableAttempt }),
+      );
+    });
+
     it('returns a success result when placeOrder resolves', async () => {
       const placeOrderResult = { success: true };
       mockPlaceOrder.mockResolvedValue(placeOrderResult);
@@ -851,6 +894,7 @@ describe('usePredictBuyActions', () => {
       unmount();
 
       expect(mockResetSelectedPaymentToken).toHaveBeenCalledTimes(1);
+      expect(mockCancelRetryablePredictBuyAttempt).toHaveBeenCalledTimes(1);
       expect(mockOnConfirmActionsReject).toHaveBeenCalledWith(undefined, true);
       expect(mockClearActiveOrderTransactionId).toHaveBeenCalled();
     });

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.test.ts
@@ -18,6 +18,8 @@ const mockUnsubscribe = jest.fn();
 const mockSetSelectedPaymentToken = jest.fn();
 const mockOnPlaceOrderSuccess = jest.fn();
 const mockTrackPredictOrderEvent = jest.fn();
+const mockTrackTradeConsidered = jest.fn();
+const mockTrackPredictBuyTerminalEvent = jest.fn();
 const mockPlaceOrder = jest.fn<Promise<unknown>, [PlaceOrderParams]>();
 const mockOnOrderCancelled = jest.fn();
 const mockInitPayWithAnyToken = jest.fn();
@@ -124,6 +126,10 @@ jest.mock('../../../../../../core/Engine', () => ({
       onOrderCancelled: (...args: unknown[]) => mockOnOrderCancelled(...args),
       trackPredictOrderEvent: (...args: unknown[]) =>
         mockTrackPredictOrderEvent(...args),
+      trackTradeConsidered: (...args: unknown[]) =>
+        mockTrackTradeConsidered(...args),
+      trackPredictBuyTerminalEvent: (...args: unknown[]) =>
+        mockTrackPredictBuyTerminalEvent(...args),
       trackBetslipDismissed: (...args: unknown[]) =>
         mockTrackBetslipDismissed(...args),
       initPayWithAnyToken: (...args: unknown[]) =>
@@ -164,6 +170,7 @@ const createDefaultParams = (): Parameters<typeof usePredictBuyActions>[0] => ({
     negRisk: false,
     fees: { totalFee: 5 },
   } as OrderPreview,
+  amountUsd: 175,
   analyticsProperties: { marketId: 'market-1' },
   setIsConfirming: mockSetIsConfirming,
 });
@@ -184,14 +191,11 @@ describe('usePredictBuyActions', () => {
   });
 
   describe('mount effect', () => {
-    it('tracks an initiated order event on mount', () => {
+    it('tracks Trade Considered on mount', () => {
       renderHook(() => usePredictBuyActions(createDefaultParams()));
 
-      expect(mockTrackPredictOrderEvent).toHaveBeenCalledWith({
-        status: 'initiated',
-        analyticsProperties: { marketId: 'market-1' },
-        sharePrice: undefined,
-      });
+      expect(mockTrackTradeConsidered).toHaveBeenCalledTimes(1);
+      expect(mockTrackPredictOrderEvent).not.toHaveBeenCalled();
     });
 
     it('calls initPayWithAnyToken on mount when pay with any token is enabled', () => {
@@ -340,10 +344,36 @@ describe('usePredictBuyActions', () => {
         await result.current.handleConfirm();
       });
 
-      expect(mockPlaceOrder).toHaveBeenCalledWith({
-        analyticsProperties: { marketId: 'market-1' },
-        preview: params.preview,
+      expect(mockPlaceOrder).toHaveBeenCalledWith(
+        expect.objectContaining({
+          analyticsProperties: { marketId: 'market-1' },
+          preview: params.preview,
+          attempt: {
+            attemptId: expect.any(String),
+            amountUsd: 175,
+            paymentMethod: 'predict_balance',
+          },
+        }),
+      );
+    });
+
+    it('tracks one attempt started event on confirm', async () => {
+      const params = createDefaultParams();
+      const { result } = renderHook(() => usePredictBuyActions(params));
+
+      await act(async () => {
+        await result.current.handleConfirm();
       });
+
+      expect(mockTrackPredictOrderEvent).toHaveBeenCalledTimes(1);
+      expect(mockTrackPredictOrderEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'attempt_started',
+          amountUsd: 175,
+          attemptId: expect.any(String),
+          paymentMethod: 'predict_balance',
+        }),
+      );
     });
 
     it('calls approval confirm when the order is paying with any token', async () => {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.ts
@@ -5,7 +5,6 @@ import {
   ActiveOrderState,
   OrderPreview,
   PlaceOrderParams,
-  PredictBuyAttempt,
 } from '../../../types';
 import { TransactionStatus } from '@metamask/transaction-controller';
 import { providerErrors } from '@metamask/rpc-errors';
@@ -17,7 +16,6 @@ import { selectPredictWithAnyTokenEnabledFlag } from '../../../selectors/feature
 import {
   PredictDismissalMethod,
   PredictEventValues,
-  PredictTradeStatus,
 } from '../../../constants/eventNames';
 import type { TransactionActiveAbTestEntry } from '../../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
 import { usePredictTrading } from '../../../hooks/usePredictTrading';
@@ -26,16 +24,11 @@ import {
   predictBuyPreviewOrderInitiatedRef,
   predictBuyPreviewSessionRef,
 } from '../../PredictBuyPreview/PredictBuyPreview';
-import {
-  predictBuyAttemptRef,
-  predictBuyHasRetryableFailureRef,
-} from '../predictBuyAttemptRefs';
 import { PlaceOrderOutcome } from '../../../hooks/usePredictPlaceOrder';
 import { PREDICT_ERROR_CODES } from '../../../constants/errors';
 import { useConfirmActions } from '../../../../../Views/confirmations/hooks/useConfirmActions';
 import { usePredictPaymentToken } from '../../../hooks/usePredictPaymentToken';
 import Logger from '../../../../../../util/Logger';
-import { generateOrderId } from '../../../utils/orders';
 
 /**
  * Rejects all unapproved transactions to prevent stale approvals from
@@ -94,7 +87,6 @@ export const usePredictBuyActions = ({
   const hasInitializedPayWithAnyTokenRef = useRef(false);
   const didInitiateOrderRef = useRef(false);
   const batchIdRef = useRef<string | undefined>(undefined);
-  const attemptRef = useRef<PredictBuyAttempt | undefined>(undefined);
   const onRejectRef = useRef(onReject);
   const clearActiveOrderTransactionIdRef = useRef(
     clearActiveOrderTransactionId,
@@ -112,8 +104,6 @@ export const usePredictBuyActions = ({
     predictBuyPreviewSessionRef.hadEnteredAmount = false;
     predictBuyPreviewDismissedViaBackRef.current = false;
     predictBuyPreviewOrderInitiatedRef.current = false;
-    predictBuyAttemptRef.current = undefined;
-    predictBuyHasRetryableFailureRef.current = false;
 
     controller.trackTradeConsidered();
     // eslint-disable-next-line react-compiler/react-compiler
@@ -175,29 +165,15 @@ export const usePredictBuyActions = ({
     if (isSheetMode) {
       return () => {
         resetSelectedPaymentToken();
+        PredictController.cancelRetryablePredictBuyAttempt();
         onRejectRef.current(undefined, true);
         clearActiveOrderTransactionIdRef.current();
       };
     }
 
     return navigation.addListener('beforeRemove', () => {
-      const attempt = attemptRef.current;
-      if (
-        didInitiateOrderRef.current &&
-        predictBuyHasRetryableFailureRef.current &&
-        attempt
-      ) {
-        Engine.context.PredictController.trackPredictBuyTerminalEvent({
-          status: PredictTradeStatus.CANCELLED,
-          amountUsd: attempt.amountUsd,
-          analyticsProperties,
-          attemptId: attempt.attemptId,
-          paymentMethod: attempt.paymentMethod,
-          failureStage: PredictEventValues.FAILURE_STAGE.ORDER,
-          failureCategory: PredictEventValues.FAILURE_CATEGORY.USER_REJECTED,
-          failureReason: 'User cancelled after a retryable order failure',
-          activeAbTests: transactionActiveAbTests,
-        });
+      if (didInitiateOrderRef.current) {
+        PredictController.cancelRetryablePredictBuyAttempt();
       }
 
       // Only fire dismiss if the user didn't confirm an order. StackActions.pop()
@@ -227,6 +203,7 @@ export const usePredictBuyActions = ({
     payWithAnyTokenEnabled,
     isSheetMode,
     analyticsProperties,
+    PredictController,
     transactionActiveAbTests,
     resetSelectedPaymentToken,
   ]);
@@ -236,7 +213,9 @@ export const usePredictBuyActions = ({
       try {
         const result = await placeOrder({
           ...orderParams,
-          attempt: orderParams.attempt ?? attemptRef.current,
+          attempt:
+            orderParams.attempt ??
+            PredictController.getRetryablePredictBuyAttempt(),
           activeAbTests: orderParams.activeAbTests ?? transactionActiveAbTests,
         });
         return { status: 'success', result };
@@ -250,7 +229,7 @@ export const usePredictBuyActions = ({
         };
       }
     },
-    [placeOrder, transactionActiveAbTests],
+    [placeOrder, PredictController, transactionActiveAbTests],
   );
 
   const stopConfirming = useCallback(() => {
@@ -308,25 +287,15 @@ export const usePredictBuyActions = ({
       };
     }
 
-    const attempt: PredictBuyAttempt = {
-      attemptId: generateOrderId(),
+    const attempt = PredictController.startPredictBuyAttempt({
       amountUsd,
       paymentMethod:
         currentState === ActiveOrderState.PAY_WITH_ANY_TOKEN
           ? PredictEventValues.PAYMENT_METHOD.PAY_WITH_ANY_TOKEN
           : PredictEventValues.PAYMENT_METHOD.PREDICT_BALANCE,
-    };
-    attemptRef.current = attempt;
-    predictBuyAttemptRef.current = attempt;
-
-    PredictController.trackPredictOrderEvent({
-      status: PredictTradeStatus.ATTEMPT_STARTED,
-      amountUsd: attempt.amountUsd,
       analyticsProperties,
       sharePrice: preview.sharePrice,
       orderType: preview.orderType,
-      attemptId: attempt.attemptId,
-      paymentMethod: attempt.paymentMethod,
       activeAbTests: transactionActiveAbTests,
     });
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.ts
@@ -5,6 +5,7 @@ import {
   ActiveOrderState,
   OrderPreview,
   PlaceOrderParams,
+  PredictBuyAttempt,
 } from '../../../types';
 import { TransactionStatus } from '@metamask/transaction-controller';
 import { providerErrors } from '@metamask/rpc-errors';
@@ -15,6 +16,7 @@ import { useSelector } from 'react-redux';
 import { selectPredictWithAnyTokenEnabledFlag } from '../../../selectors/featureFlags';
 import {
   PredictDismissalMethod,
+  PredictEventValues,
   PredictTradeStatus,
 } from '../../../constants/eventNames';
 import type { TransactionActiveAbTestEntry } from '../../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
@@ -24,11 +26,16 @@ import {
   predictBuyPreviewOrderInitiatedRef,
   predictBuyPreviewSessionRef,
 } from '../../PredictBuyPreview/PredictBuyPreview';
+import {
+  predictBuyAttemptRef,
+  predictBuyHasRetryableFailureRef,
+} from '../predictBuyAttemptRefs';
 import { PlaceOrderOutcome } from '../../../hooks/usePredictPlaceOrder';
 import { PREDICT_ERROR_CODES } from '../../../constants/errors';
 import { useConfirmActions } from '../../../../../Views/confirmations/hooks/useConfirmActions';
 import { usePredictPaymentToken } from '../../../hooks/usePredictPaymentToken';
 import Logger from '../../../../../../util/Logger';
+import { generateOrderId } from '../../../utils/orders';
 
 /**
  * Rejects all unapproved transactions to prevent stale approvals from
@@ -53,6 +60,7 @@ function rejectPendingTransactions() {
 }
 interface UsePredictBuyActionsParams {
   preview?: OrderPreview | null;
+  amountUsd: number;
   analyticsProperties: PlaceOrderParams['analyticsProperties'];
   setIsConfirming: (value: boolean) => void;
   isSheetMode?: boolean;
@@ -62,6 +70,7 @@ interface UsePredictBuyActionsParams {
 
 export const usePredictBuyActions = ({
   preview,
+  amountUsd,
   analyticsProperties,
   setIsConfirming,
   isSheetMode = false,
@@ -85,6 +94,7 @@ export const usePredictBuyActions = ({
   const hasInitializedPayWithAnyTokenRef = useRef(false);
   const didInitiateOrderRef = useRef(false);
   const batchIdRef = useRef<string | undefined>(undefined);
+  const attemptRef = useRef<PredictBuyAttempt | undefined>(undefined);
   const onRejectRef = useRef(onReject);
   const clearActiveOrderTransactionIdRef = useRef(
     clearActiveOrderTransactionId,
@@ -102,13 +112,10 @@ export const usePredictBuyActions = ({
     predictBuyPreviewSessionRef.hadEnteredAmount = false;
     predictBuyPreviewDismissedViaBackRef.current = false;
     predictBuyPreviewOrderInitiatedRef.current = false;
+    predictBuyAttemptRef.current = undefined;
+    predictBuyHasRetryableFailureRef.current = false;
 
-    controller.trackPredictOrderEvent({
-      status: PredictTradeStatus.INITIATED,
-      analyticsProperties,
-      sharePrice: analyticsProperties?.sharePrice,
-      activeAbTests: transactionActiveAbTests,
-    });
+    controller.trackTradeConsidered();
     // eslint-disable-next-line react-compiler/react-compiler
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -174,6 +181,25 @@ export const usePredictBuyActions = ({
     }
 
     return navigation.addListener('beforeRemove', () => {
+      const attempt = attemptRef.current;
+      if (
+        didInitiateOrderRef.current &&
+        predictBuyHasRetryableFailureRef.current &&
+        attempt
+      ) {
+        Engine.context.PredictController.trackPredictBuyTerminalEvent({
+          status: PredictTradeStatus.CANCELLED,
+          amountUsd: attempt.amountUsd,
+          analyticsProperties,
+          attemptId: attempt.attemptId,
+          paymentMethod: attempt.paymentMethod,
+          failureStage: PredictEventValues.FAILURE_STAGE.ORDER,
+          failureCategory: PredictEventValues.FAILURE_CATEGORY.USER_REJECTED,
+          failureReason: 'User cancelled after a retryable order failure',
+          activeAbTests: transactionActiveAbTests,
+        });
+      }
+
       // Only fire dismiss if the user didn't confirm an order. StackActions.pop()
       // after success/deposit also triggers beforeRemove, which is not a dismissal.
       if (!didInitiateOrderRef.current) {
@@ -208,7 +234,11 @@ export const usePredictBuyActions = ({
   const handlePlaceOrder = useCallback(
     async (orderParams: PlaceOrderParams): Promise<PlaceOrderOutcome> => {
       try {
-        const result = await placeOrder(orderParams);
+        const result = await placeOrder({
+          ...orderParams,
+          attempt: orderParams.attempt ?? attemptRef.current,
+          activeAbTests: orderParams.activeAbTests ?? transactionActiveAbTests,
+        });
         return { status: 'success', result };
       } catch (error) {
         return {
@@ -220,7 +250,7 @@ export const usePredictBuyActions = ({
         };
       }
     },
-    [placeOrder],
+    [placeOrder, transactionActiveAbTests],
   );
 
   const stopConfirming = useCallback(() => {
@@ -242,43 +272,6 @@ export const usePredictBuyActions = ({
     predictBuyPreviewOrderInitiatedRef.current = true;
     setIsConfirming(true);
 
-    if (currentState === ActiveOrderState.PAY_WITH_ANY_TOKEN) {
-      if (approvalRequest?.id) {
-        onApprovalConfirm({
-          deleteAfterResult: true,
-          waitForResult: true,
-          handleErrors: false,
-        })?.catch((err: unknown) => {
-          Logger.log(
-            'usePredictBuyActions: onApprovalConfirm rejected',
-            err instanceof Error ? err.message : String(err),
-          );
-        });
-      } else {
-        Logger.log(
-          'usePredictBuyActions: PAY_WITH_ANY_TOKEN approval missing — attempting re-init',
-        );
-        batchIdRef.current = undefined;
-        rejectPendingTransactions();
-        const result = await initPayWithAnyToken();
-        if (result?.success && result.response?.batchId) {
-          batchIdRef.current = result.response.batchId;
-        } else {
-          Logger.log(
-            'usePredictBuyActions: initPayWithAnyToken failed on confirm re-init',
-            result && 'error' in result ? result.error : 'unknown',
-          );
-        }
-        resetImmediateConfirmFailure();
-        return {
-          status: 'error',
-          error:
-            result && 'error' in result && result.error
-              ? result.error
-              : PREDICT_ERROR_CODES.PLACE_ORDER_FAILED,
-        };
-      }
-    }
     if (!preview) {
       resetImmediateConfirmFailure();
       return {
@@ -287,9 +280,73 @@ export const usePredictBuyActions = ({
       };
     }
 
+    if (
+      currentState === ActiveOrderState.PAY_WITH_ANY_TOKEN &&
+      !approvalRequest?.id
+    ) {
+      Logger.log(
+        'usePredictBuyActions: PAY_WITH_ANY_TOKEN approval missing — attempting re-init',
+      );
+      batchIdRef.current = undefined;
+      rejectPendingTransactions();
+      const result = await initPayWithAnyToken();
+      if (result?.success && result.response?.batchId) {
+        batchIdRef.current = result.response.batchId;
+      } else {
+        Logger.log(
+          'usePredictBuyActions: initPayWithAnyToken failed on confirm re-init',
+          result && 'error' in result ? result.error : 'unknown',
+        );
+      }
+      resetImmediateConfirmFailure();
+      return {
+        status: 'error',
+        error:
+          result && 'error' in result && result.error
+            ? result.error
+            : PREDICT_ERROR_CODES.PLACE_ORDER_FAILED,
+      };
+    }
+
+    const attempt: PredictBuyAttempt = {
+      attemptId: generateOrderId(),
+      amountUsd,
+      paymentMethod:
+        currentState === ActiveOrderState.PAY_WITH_ANY_TOKEN
+          ? PredictEventValues.PAYMENT_METHOD.PAY_WITH_ANY_TOKEN
+          : PredictEventValues.PAYMENT_METHOD.PREDICT_BALANCE,
+    };
+    attemptRef.current = attempt;
+    predictBuyAttemptRef.current = attempt;
+
+    PredictController.trackPredictOrderEvent({
+      status: PredictTradeStatus.ATTEMPT_STARTED,
+      amountUsd: attempt.amountUsd,
+      analyticsProperties,
+      sharePrice: preview.sharePrice,
+      orderType: preview.orderType,
+      attemptId: attempt.attemptId,
+      paymentMethod: attempt.paymentMethod,
+      activeAbTests: transactionActiveAbTests,
+    });
+
+    if (currentState === ActiveOrderState.PAY_WITH_ANY_TOKEN) {
+      onApprovalConfirm({
+        deleteAfterResult: true,
+        waitForResult: true,
+        handleErrors: false,
+      })?.catch((err: unknown) => {
+        Logger.log(
+          'usePredictBuyActions: onApprovalConfirm rejected',
+          err instanceof Error ? err.message : String(err),
+        );
+      });
+    }
+
     const outcome = await handlePlaceOrder({
       analyticsProperties,
       preview,
+      attempt,
       transactionId:
         currentState === ActiveOrderState.PAY_WITH_ANY_TOKEN
           ? approvalRequest?.id
@@ -306,6 +363,7 @@ export const usePredictBuyActions = ({
     return outcome;
   }, [
     setIsConfirming,
+    amountUsd,
     approvalRequest,
     currentState,
     handlePlaceOrder,
@@ -315,6 +373,8 @@ export const usePredictBuyActions = ({
     initPayWithAnyToken,
     resetImmediateConfirmFailure,
     stopConfirming,
+    PredictController,
+    transactionActiveAbTests,
   ]);
 
   useEffect(() => {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/predictBuyAttemptRefs.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/predictBuyAttemptRefs.ts
@@ -1,7 +1,0 @@
-import type { PredictBuyAttempt } from '../../types';
-
-export const predictBuyAttemptRef: {
-  current: PredictBuyAttempt | undefined;
-} = { current: undefined };
-
-export const predictBuyHasRetryableFailureRef = { current: false };

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/predictBuyAttemptRefs.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/predictBuyAttemptRefs.ts
@@ -1,0 +1,7 @@
+import type { PredictBuyAttempt } from '../../types';
+
+export const predictBuyAttemptRef: {
+  current: PredictBuyAttempt | undefined;
+} = { current: undefined };
+
+export const predictBuyHasRetryableFailureRef = { current: false };


### PR DESCRIPTION
<!-- Suggested PR title: fix(predict): reconcile PWAT telemetry by payment attempt -->

## **Description**

<!-- mms-check: type=text required=true -->

Predict buy events could not reliably reconcile one confirmation with one terminal result.

This change:

- Creates a stable attempt ID when the user confirms a buy.
- Keeps retryable attempt state in `PredictController`, isolated by account.
- Preserves the attempt through PWAT deposit, sheet closure, toast reopening, and retry.
- Adds explicit payment methods, lifecycle stages, and bounded failure categories.
- Emits one terminal status for each attempt.
- Uses requested value for lifecycle volume and executed value for completed trade volume.
- Restores synchronized withdrawal `gas` and `gasLimit` values.

### Validation

- 698 focused Jest tests passed.
- TypeScript validation passed.
- ESLint validation passed for changed files.
- The Segment schema branch already supports all new statuses and properties.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-1027

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Predict buy telemetry reconciliation

  Scenario: Complete a Predict balance buy
    Given the user opens an active Predict market
    And the user selects Predict balance
    When the user confirms and completes the buy
    Then one attempt_started event uses payment_method predict_balance
    And all lifecycle events use the same attempt_id
    And exactly one succeeded terminal event is sent

  Scenario: Complete a PWAT buy
    Given the user opens an active Predict market
    And the user selects an external payment token
    When the user confirms and completes the buy
    Then one attempt_started event uses payment_method pay_with_any_token
    And swap and order events use the same attempt_id
    And closing the sheet during deposit does not cancel the attempt

  Scenario: Retry an unmatched order
    Given a confirmed buy receives an order_failed no_match result
    When the user retries with the best available price
    Then the retry uses the original attempt_id
    And exactly one terminal event is sent

  Scenario: Abandon a retryable order
    Given a confirmed buy receives an order_failed result
    When the user dismisses the retry flow
    Then one cancelled terminal event is sent
    And failure_category is user_rejected
```

Inspect MetaMetrics output to verify each event and property.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — this telemetry change has no visual output.

### **Before**

N/A — no visual change.

### **After**

N/A — no visual change.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A — this change only affects telemetry processing.
- [x] I've tested with a power user scenario
  - N/A — this change does not depend on wallet size.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A — this change does not add a performance-sensitive operation.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PredictController buy/order analytics paths and retry cancellation behavior across PWAT and balance flows. Core trading execution is largely unchanged, but incorrect attempt terminalization could skew metrics or cancel retries unexpectedly.
> 
> **Overview**
> Reconciles Predict buy telemetry so each confirmation maps to **one attempt** with a stable `attempt_id`, making PWAT and Predict-balance outcomes comparable.
> 
> On confirm, `PredictController` starts an attempt (`attempt_started`) with `payment_method`, then carries that context through swap/order lifecycle events. Failures are classified into bounded `failure_stage` / `failure_category` values (with sanitized reasons). Retryable no-match failures keep the same attempt for retry; dismissals, payment/amount changes, and expired retry toasts emit a single `cancelled` terminal. Success/failure/cancel terminals are deduped per attempt.
> 
> Also separates **requested** `amount_usd` on lifecycle events from **executed** `usd_trade_value` on Trade Completed, and restores synchronized withdrawal `gas` / `gasLimit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9d5bf00fddeb9259b1fe0c1a67acb4befd79558. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->