### PR TITLE
fix(homepage): emit data fetch spans for every section mount

### DIFF
--- a/app/components/Views/Homepage/hooks/useSectionPerformance.test.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.test.ts
@@ -305,6 +305,43 @@ describe('useSectionPerformance', () => {
       expect(fetchTraceCalls).toHaveLength(0);
     });
 
+    it('does not reopen the data fetch span when enabled toggles back on after the span closed', () => {
+      const { rerender } = renderHook(
+        ({ enabled, isLoading }) =>
+          useSectionPerformance({ ...defaultConfig, enabled, isLoading }),
+        { initialProps: { enabled: true, isLoading: true } },
+      );
+      rerender({ enabled: true, isLoading: false });
+      jest.clearAllMocks();
+
+      rerender({ enabled: false, isLoading: false });
+      rerender({ enabled: true, isLoading: true });
+
+      const fetchTraceCalls = (mockTrace as jest.Mock).mock.calls.filter(
+        (call: [{ name: string }]) =>
+          call[0].name === TraceName.HomepageSectionDataFetch,
+      );
+      expect(fetchTraceCalls).toHaveLength(0);
+    });
+
+    it('does not reopen the data fetch span when enabled toggles back on while still loading', () => {
+      const { rerender } = renderHook(
+        ({ enabled, isLoading }) =>
+          useSectionPerformance({ ...defaultConfig, enabled, isLoading }),
+        { initialProps: { enabled: true, isLoading: true } },
+      );
+      jest.clearAllMocks();
+
+      rerender({ enabled: false, isLoading: true });
+      rerender({ enabled: true, isLoading: true });
+
+      const fetchTraceCalls = (mockTrace as jest.Mock).mock.calls.filter(
+        (call: [{ name: string }]) =>
+          call[0].name === TraceName.HomepageSectionDataFetch,
+      );
+      expect(fetchTraceCalls).toHaveLength(0);
+    });
+
     it('ends the fetch trace with failure on unmount if still loading', () => {
       const { unmount } = renderHook(() =>
         useSectionPerformance({ ...defaultConfig, isLoading: true }),

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.test.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.test.ts
@@ -201,6 +201,7 @@ describe('useSectionPerformance', () => {
           tags: {
             section_id: HomeSectionNames.TOKENS,
             loading_at_span_open: true,
+            phase: 'mount',
           },
         }),
       );
@@ -238,6 +239,7 @@ describe('useSectionPerformance', () => {
           tags: {
             section_id: HomeSectionNames.TOKENS,
             loading_at_span_open: false,
+            phase: 'mount',
           },
         }),
       );
@@ -377,6 +379,7 @@ describe('useSectionPerformance', () => {
       expect(fetchTraceCalls[0][0].tags).toEqual({
         section_id: HomeSectionNames.TOKENS,
         loading_at_span_open: false,
+        phase: 'enabled',
       });
       expect(mockDevLoggerLog).toHaveBeenCalledWith(
         '[homepage.section.performance] data_fetch start section=tokens phase=enabled loading_at_span_open=false',
@@ -413,6 +416,16 @@ describe('useSectionPerformance', () => {
 
       expect(mockDevLoggerLog).toHaveBeenCalledWith(
         '[homepage.section.performance] data_fetch start section=tokens phase=mount loading_at_span_open=false',
+      );
+    });
+
+    it('logs the mount span open for a cold mount that is still loading', () => {
+      renderHook(() =>
+        useSectionPerformance({ ...defaultConfig, isLoading: true }),
+      );
+
+      expect(mockDevLoggerLog).toHaveBeenCalledWith(
+        '[homepage.section.performance] data_fetch start section=tokens phase=mount loading_at_span_open=true',
       );
     });
 

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.test.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.test.ts
@@ -200,7 +200,7 @@ describe('useSectionPerformance', () => {
           op: TraceOperation.HomepageSectionPerformance,
           tags: {
             section_id: HomeSectionNames.TOKENS,
-            first_render_loading: true,
+            loading_at_span_open: true,
           },
         }),
       );
@@ -226,7 +226,7 @@ describe('useSectionPerformance', () => {
       );
     });
 
-    it('starts the data fetch span at mount when the section is already loaded', () => {
+    it('opens and closes the data fetch span at mount when the section is already loaded', () => {
       renderHook(() =>
         useSectionPerformance({ ...defaultConfig, isLoading: false }),
       );
@@ -237,7 +237,7 @@ describe('useSectionPerformance', () => {
           op: TraceOperation.HomepageSectionPerformance,
           tags: {
             section_id: HomeSectionNames.TOKENS,
-            first_render_loading: false,
+            loading_at_span_open: false,
           },
         }),
       );
@@ -258,6 +258,7 @@ describe('useSectionPerformance', () => {
           useSectionPerformance({ ...defaultConfig, isLoading }),
         { initialProps: { isLoading: false } },
       );
+
       jest.clearAllMocks();
 
       rerender({ isLoading: true });
@@ -325,6 +326,7 @@ describe('useSectionPerformance', () => {
           useSectionPerformance({ ...defaultConfig, enabled, isLoading }),
         { initialProps: { enabled: true, isLoading: true } },
       );
+
       rerender({ enabled: true, isLoading: false });
       jest.clearAllMocks();
 
@@ -344,6 +346,7 @@ describe('useSectionPerformance', () => {
           useSectionPerformance({ ...defaultConfig, enabled, isLoading }),
         { initialProps: { enabled: true, isLoading: true } },
       );
+
       jest.clearAllMocks();
 
       rerender({ enabled: false, isLoading: true });
@@ -354,6 +357,30 @@ describe('useSectionPerformance', () => {
           call[0].name === TraceName.HomepageSectionDataFetch,
       );
       expect(fetchTraceCalls).toHaveLength(0);
+    });
+
+    it('tags the span with the loading state at open when a flag enables the section after loading finished', () => {
+      const { rerender } = renderHook(
+        ({ enabled, isLoading }) =>
+          useSectionPerformance({ ...defaultConfig, enabled, isLoading }),
+        { initialProps: { enabled: false, isLoading: true } },
+      );
+
+      rerender({ enabled: false, isLoading: false });
+      rerender({ enabled: true, isLoading: false });
+
+      const fetchTraceCalls = (mockTrace as jest.Mock).mock.calls.filter(
+        (call: [{ name: string }]) =>
+          call[0].name === TraceName.HomepageSectionDataFetch,
+      );
+      expect(fetchTraceCalls).toHaveLength(1);
+      expect(fetchTraceCalls[0][0].tags).toEqual({
+        section_id: HomeSectionNames.TOKENS,
+        loading_at_span_open: false,
+      });
+      expect(mockDevLoggerLog).toHaveBeenCalledWith(
+        '[homepage.section.performance] data_fetch start section=tokens phase=enabled loading_at_span_open=false',
+      );
     });
 
     it('ends the fetch trace with failure on unmount if still loading', () => {
@@ -379,13 +406,13 @@ describe('useSectionPerformance', () => {
   // span boundary on a live device (artifacts/recipe.json). Pin the grammar
   // here so a field rename cannot pass CI while silently voiding that proof.
   describe('Data Fetch dev log grammar', () => {
-    it('logs the mount span open with the section and first-render loading state', () => {
+    it('logs the mount span open with the section and the loading state at open', () => {
       renderHook(() =>
         useSectionPerformance({ ...defaultConfig, isLoading: false }),
       );
 
       expect(mockDevLoggerLog).toHaveBeenCalledWith(
-        '[homepage.section.performance] data_fetch start section=tokens phase=mount first_render_loading=false',
+        '[homepage.section.performance] data_fetch start section=tokens phase=mount loading_at_span_open=false',
       );
     });
 

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.test.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.test.ts
@@ -215,20 +215,74 @@ describe('useSectionPerformance', () => {
       );
     });
 
-    it('does not end the fetch trace if isLoading was never true', () => {
+    it('starts the data fetch span at mount when the section is already loaded', () => {
+      renderHook(() =>
+        useSectionPerformance({ ...defaultConfig, isLoading: false }),
+      );
+
+      expect(mockTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.HomepageSectionDataFetch,
+          op: TraceOperation.HomepageSectionPerformance,
+          tags: { section_id: HomeSectionNames.TOKENS },
+        }),
+      );
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.HomepageSectionDataFetch,
+          data: expect.objectContaining({
+            success: true,
+            section_id: HomeSectionNames.TOKENS,
+          }),
+        }),
+      );
+    });
+
+    it('ignores a loading cycle that begins after mount', () => {
       const { rerender } = renderHook(
         ({ isLoading }) =>
           useSectionPerformance({ ...defaultConfig, isLoading }),
         { initialProps: { isLoading: false } },
       );
+      jest.clearAllMocks();
 
+      rerender({ isLoading: true });
+      rerender({ isLoading: false });
+
+      const fetchTraceCalls = (mockTrace as jest.Mock).mock.calls.filter(
+        (call: [{ name: string }]) =>
+          call[0].name === TraceName.HomepageSectionDataFetch,
+      );
+      const fetchEndCalls = (mockEndTrace as jest.Mock).mock.calls.filter(
+        (call: [{ name: string }]) =>
+          call[0].name === TraceName.HomepageSectionDataFetch,
+      );
+      expect(fetchTraceCalls).toHaveLength(0);
+      expect(fetchEndCalls).toHaveLength(0);
+    });
+
+    it('ends the data fetch span once on the first non-loading render', () => {
+      const { rerender } = renderHook(
+        ({ isLoading }) =>
+          useSectionPerformance({ ...defaultConfig, isLoading }),
+        { initialProps: { isLoading: true } },
+      );
+
+      rerender({ isLoading: false });
       rerender({ isLoading: false });
 
       const fetchEndCalls = (mockEndTrace as jest.Mock).mock.calls.filter(
         (call: [{ name: string }]) =>
           call[0].name === TraceName.HomepageSectionDataFetch,
       );
-      expect(fetchEndCalls).toHaveLength(0);
+      expect(fetchEndCalls).toHaveLength(1);
+      expect(fetchEndCalls[0][0].data).toEqual(
+        expect.objectContaining({
+          success: true,
+          section_id: HomeSectionNames.TOKENS,
+          content_state: 'filled',
+        }),
+      );
     });
 
     it('only tracks the first fetch cycle', () => {

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.test.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.test.ts
@@ -227,7 +227,7 @@ describe('useSectionPerformance', () => {
       );
     });
 
-    it('opens and closes the data fetch span at mount when the section is already loaded', () => {
+    it('opens the data fetch span at mount when the section is already loaded', () => {
       renderHook(() =>
         useSectionPerformance({ ...defaultConfig, isLoading: false }),
       );
@@ -243,6 +243,13 @@ describe('useSectionPerformance', () => {
           },
         }),
       );
+    });
+
+    it('closes the data fetch span at mount when the section is already loaded', () => {
+      renderHook(() =>
+        useSectionPerformance({ ...defaultConfig, isLoading: false }),
+      );
+
       expect(mockEndTrace).toHaveBeenCalledWith(
         expect.objectContaining({
           name: TraceName.HomepageSectionDataFetch,
@@ -381,9 +388,6 @@ describe('useSectionPerformance', () => {
         loading_at_span_open: false,
         phase: 'enabled',
       });
-      expect(mockDevLoggerLog).toHaveBeenCalledWith(
-        '[homepage.section.performance] data_fetch start section=tokens phase=enabled loading_at_span_open=false',
-      );
     });
 
     it('ends the fetch trace with failure on unmount if still loading', () => {
@@ -429,6 +433,21 @@ describe('useSectionPerformance', () => {
       );
     });
 
+    it('logs the span open with the enabled phase when a flag opens it after mount', () => {
+      const { rerender } = renderHook(
+        ({ enabled, isLoading }) =>
+          useSectionPerformance({ ...defaultConfig, enabled, isLoading }),
+        { initialProps: { enabled: false, isLoading: true } },
+      );
+
+      rerender({ enabled: false, isLoading: false });
+      rerender({ enabled: true, isLoading: false });
+
+      expect(mockDevLoggerLog).toHaveBeenCalledWith(
+        '[homepage.section.performance] data_fetch start section=tokens phase=enabled loading_at_span_open=false',
+      );
+    });
+
     it('logs the span close with the success and content state', () => {
       const { rerender } = renderHook(
         ({ isLoading }) =>
@@ -440,6 +459,18 @@ describe('useSectionPerformance', () => {
 
       expect(mockDevLoggerLog).toHaveBeenCalledWith(
         '[homepage.section.performance] data_fetch end section=tokens success=true content_state=filled',
+      );
+    });
+
+    it('logs the aborted span close when the section unmounts while still loading', () => {
+      const { unmount } = renderHook(() =>
+        useSectionPerformance({ ...defaultConfig, isLoading: true }),
+      );
+
+      unmount();
+
+      expect(mockDevLoggerLog).toHaveBeenCalledWith(
+        '[homepage.section.performance] data_fetch end section=tokens success=false reason=unmounted',
       );
     });
 

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.test.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.test.ts
@@ -16,6 +16,11 @@ jest.mock('../../../../util/trace', () => ({
   },
 }));
 
+jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
+  __esModule: true,
+  default: { log: jest.fn() },
+}));
+
 let mockPerfNowValue = 0;
 jest.mock('react-native-performance', () => ({
   now: jest.fn(() => mockPerfNowValue),
@@ -24,6 +29,9 @@ jest.mock('react-native-performance', () => ({
 const { trace: mockTrace, endTrace: mockEndTrace } = jest.requireMock(
   '../../../../util/trace',
 );
+const mockDevLoggerLog = jest.requireMock(
+  '../../../../core/SDKConnect/utils/DevLogger',
+).default.log as jest.Mock;
 const mockAddBreadcrumb = addBreadcrumb as jest.MockedFunction<
   typeof addBreadcrumb
 >;
@@ -181,7 +189,7 @@ describe('useSectionPerformance', () => {
       expect(fetchTraceCalls).toHaveLength(0);
     });
 
-    it('starts a fetch trace when isLoading starts as true', () => {
+    it('starts the data fetch span at mount when the section is still loading', () => {
       renderHook(() =>
         useSectionPerformance({ ...defaultConfig, isLoading: true }),
       );
@@ -190,12 +198,15 @@ describe('useSectionPerformance', () => {
         expect.objectContaining({
           name: TraceName.HomepageSectionDataFetch,
           op: TraceOperation.HomepageSectionPerformance,
-          tags: { section_id: HomeSectionNames.TOKENS },
+          tags: {
+            section_id: HomeSectionNames.TOKENS,
+            first_render_loading: true,
+          },
         }),
       );
     });
 
-    it('ends the fetch trace when isLoading transitions from true to false', () => {
+    it('ends the data fetch span on the first render after loading completes', () => {
       const { rerender } = renderHook(
         ({ isLoading }) =>
           useSectionPerformance({ ...defaultConfig, isLoading }),
@@ -224,7 +235,10 @@ describe('useSectionPerformance', () => {
         expect.objectContaining({
           name: TraceName.HomepageSectionDataFetch,
           op: TraceOperation.HomepageSectionPerformance,
-          tags: { section_id: HomeSectionNames.TOKENS },
+          tags: {
+            section_id: HomeSectionNames.TOKENS,
+            first_render_loading: false,
+          },
         }),
       );
       expect(mockEndTrace).toHaveBeenCalledWith(
@@ -285,7 +299,7 @@ describe('useSectionPerformance', () => {
       );
     });
 
-    it('only tracks the first fetch cycle', () => {
+    it('ignores a second loading cycle after a cold mount span closed', () => {
       const { rerender } = renderHook(
         ({ isLoading }) =>
           useSectionPerformance({ ...defaultConfig, isLoading }),
@@ -295,7 +309,7 @@ describe('useSectionPerformance', () => {
       rerender({ isLoading: false });
       jest.clearAllMocks();
 
-      // Second loading cycle — should not start a new trace
+      // Second loading cycle — must not start a new span
       rerender({ isLoading: true });
 
       const fetchTraceCalls = (mockTrace as jest.Mock).mock.calls.filter(
@@ -358,6 +372,56 @@ describe('useSectionPerformance', () => {
           }),
         }),
       );
+    });
+  });
+
+  // The validation recipe greps these exact strings out of Metro to prove the
+  // span boundary on a live device (artifacts/recipe.json). Pin the grammar
+  // here so a field rename cannot pass CI while silently voiding that proof.
+  describe('Data Fetch dev log grammar', () => {
+    it('logs the mount span open with the section and first-render loading state', () => {
+      renderHook(() =>
+        useSectionPerformance({ ...defaultConfig, isLoading: false }),
+      );
+
+      expect(mockDevLoggerLog).toHaveBeenCalledWith(
+        '[homepage.section.performance] data_fetch start section=tokens phase=mount first_render_loading=false',
+      );
+    });
+
+    it('logs the span close with the success and content state', () => {
+      const { rerender } = renderHook(
+        ({ isLoading }) =>
+          useSectionPerformance({ ...defaultConfig, isLoading }),
+        { initialProps: { isLoading: true } },
+      );
+
+      rerender({ isLoading: false });
+
+      expect(mockDevLoggerLog).toHaveBeenCalledWith(
+        '[homepage.section.performance] data_fetch end section=tokens success=true content_state=filled',
+      );
+    });
+
+    it('logs the skipped reload once when loading restarts after the span closed', () => {
+      const { rerender } = renderHook(
+        ({ isLoading }) =>
+          useSectionPerformance({ ...defaultConfig, isLoading }),
+        { initialProps: { isLoading: false } },
+      );
+
+      rerender({ isLoading: true });
+      rerender({ isLoading: false });
+      rerender({ isLoading: true });
+
+      const skipCalls = mockDevLoggerLog.mock.calls.filter((call: [string]) =>
+        call[0].includes('data_fetch skip'),
+      );
+      expect(skipCalls).toEqual([
+        [
+          '[homepage.section.performance] data_fetch skip section=tokens reason=post_mount_reload',
+        ],
+      ]);
     });
   });
 

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../../util/trace';
 import type { HomeSectionName } from './useHomeViewedEvent';
 import { useRenderStormMonitor } from '../../../../hooks/performance/useRenderStormMonitor';
+import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 
 interface UseSectionPerformanceConfig {
   /** Section identifier — primary Sentry tag for filtering. */
@@ -26,9 +27,12 @@ interface UseSectionPerformanceConfig {
    */
   contentStateForTrace?: 'filled' | 'empty' | 'error';
   /**
-   * When provided, tracks **full** data loading (including background work) via
-   * the first `isLoading` true→false transition per mount. Can stay true after
-   * `contentReady` if the section still fetches optional/secondary data.
+   * When provided, tracks **full** data loading (including background work).
+   * The span opens at mount and closes on the first render where this is
+   * `false`, so every mount emits exactly one sample — near-zero when the
+   * section is already warm — and a later refresh cycle never opens a span.
+   * Can stay true after `contentReady` if the section still fetches
+   * optional/secondary data.
    */
   isLoading?: boolean;
   /** Skip all tracing when false. Use for feature-flagged sections that return null. @default true */
@@ -43,11 +47,18 @@ const DEFAULT_RE_RENDER_THRESHOLD = 3;
 const DEFAULT_RE_RENDER_WINDOW_MS = 500;
 
 /**
+ * Prefix for the dev-only structured log emitted next to every Data Fetch span
+ * boundary. The span itself is only observable in Sentry, so this is the sole
+ * way to verify the boundary on a live device (validation recipes grep Metro).
+ */
+const DATA_FETCH_LOG_PREFIX = '[homepage.section.performance] data_fetch';
+
+/**
  * Reusable performance telemetry for homepage sections.
  *
  * Captures three metrics via the existing trace/endTrace Sentry integration:
  * 1. **Time to Content** — mount until `contentReady` (valuable non-skeleton UI).
- * 2. **Data Fetch Latency** — first full `isLoading` cycle per mount (opt-in; refresh excluded).
+ * 2. **Data Fetch Latency** — mount until the first non-loading render (opt-in; one sample per mount, refresh excluded).
  * 3. **Re-render Monitoring** — breadcrumb when commits exceed threshold in a window (runs after every commit).
  *
  * Bookkeeping is ref-based; the hook does not intentionally trigger extra re-renders.
@@ -71,7 +82,14 @@ export const useSectionPerformance = ({
   const fetchTraceId = useRef(uuidv4());
   const fetchStarted = useRef(false);
   const fetchEnded = useRef(false);
-  const prevIsLoading = useRef<boolean | undefined>(undefined);
+  // Whether this section opted into Data Fetch tracing. Read at mount so the
+  // span boundary can never depend on a later render's `isLoading` value.
+  const tracksDataFetch = useRef(isLoading !== undefined);
+  // Loading state on the very first render, logged with the span start so a
+  // warm mount (already loaded) is distinguishable from a cold one on device.
+  const isLoadingAtFirstRender = useRef(isLoading);
+  // Guards the skip log so one post-mount reload logs once, not once per render.
+  const skipLogged = useRef(false);
 
   const traceContentState =
     contentStateForTrace ?? (isEmpty ? 'empty' : 'filled');
@@ -101,6 +119,25 @@ export const useSectionPerformance = ({
       tags: { section_id: sectionId },
     });
     ttcStarted.current = true;
+
+    // Data Fetch Latency — start on mount so every mount produces a sample,
+    // including warm mounts that are already loaded (near-zero duration).
+    if (tracksDataFetch.current) {
+      fetchTraceId.current = uuidv4();
+      fetchEnded.current = false;
+      trace({
+        name: TraceName.HomepageSectionDataFetch,
+        op: TraceOperation.HomepageSectionPerformance,
+        id: fetchTraceId.current,
+        tags: { section_id: sectionId },
+      });
+      fetchStarted.current = true;
+      DevLogger.log(
+        `${DATA_FETCH_LOG_PREFIX} start section=${sectionId} phase=mount first_render_loading=${String(
+          isLoadingAtFirstRender.current,
+        )}`,
+      );
+    }
 
     return () => {
       if (ttcStarted.current && !ttcEnded.current) {
@@ -139,33 +176,15 @@ export const useSectionPerformance = ({
   }, [enabled, contentReady, sectionId, traceContentState]);
 
   // ──────────────────────────────────────────────
-  // 2. Data Fetch Latency — track isLoading transitions
+  // 2. Data Fetch Latency — end the mount-scoped span once loading is done
   // ──────────────────────────────────────────────
   useEffect(() => {
     if (!enabled || isLoading === undefined) return;
 
-    const wasLoading = prevIsLoading.current;
-    prevIsLoading.current = isLoading;
-
-    // Start: first loading spell only (subsequent refresh cycles are not traced)
-    if (isLoading && !fetchStarted.current && !fetchEnded.current) {
-      fetchTraceId.current = uuidv4();
-      trace({
-        name: TraceName.HomepageSectionDataFetch,
-        op: TraceOperation.HomepageSectionPerformance,
-        id: fetchTraceId.current,
-        tags: { section_id: sectionId },
-      });
-      fetchStarted.current = true;
-    }
-
-    // End: isLoading transitioned from true → false
-    if (
-      wasLoading === true &&
-      !isLoading &&
-      fetchStarted.current &&
-      !fetchEnded.current
-    ) {
+    // End: first render of this mount that is no longer loading. The span is
+    // opened by the mount effect above, so a later refresh cycle can neither
+    // open a new span nor reopen this one.
+    if (!isLoading && fetchStarted.current && !fetchEnded.current) {
       endTrace({
         name: TraceName.HomepageSectionDataFetch,
         id: fetchTraceId.current,
@@ -177,6 +196,18 @@ export const useSectionPerformance = ({
       });
       fetchStarted.current = false;
       fetchEnded.current = true;
+      DevLogger.log(
+        `${DATA_FETCH_LOG_PREFIX} end section=${sectionId} success=true content_state=${traceContentState}`,
+      );
+    }
+
+    // A refresh that starts after the mount span already closed is deliberately
+    // not measured — logged so the boundary is verifiable on a live device.
+    if (isLoading && fetchEnded.current && !skipLogged.current) {
+      skipLogged.current = true;
+      DevLogger.log(
+        `${DATA_FETCH_LOG_PREFIX} skip section=${sectionId} reason=post_mount_reload`,
+      );
     }
   }, [enabled, isLoading, sectionId, traceContentState]);
 };

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../../util/trace';
 import type { HomeSectionName } from './useHomeViewedEvent';
 import { useRenderStormMonitor } from '../../../../hooks/performance/useRenderStormMonitor';
+import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 
 interface UseSectionPerformanceConfig {
   /** Section identifier — primary Sentry tag for filtering. */
@@ -73,6 +74,10 @@ export const useSectionPerformance = ({
   const fetchEnded = useRef(false);
   const prevIsLoading = useRef<boolean | undefined>(undefined);
 
+  // [PR-TAT-3662] reproduction marker state — removed before the fix commit
+  const isLoadingAtMount = useRef(isLoading);
+  const mountedAt = useRef(0);
+
   const traceContentState =
     contentStateForTrace ?? (isEmpty ? 'empty' : 'filled');
 
@@ -101,6 +106,14 @@ export const useSectionPerformance = ({
       tags: { section_id: sectionId },
     });
     ttcStarted.current = true;
+
+    // [PR-TAT-3662] reproduction marker — remove before the fix commit
+    mountedAt.current = Date.now();
+    if (isLoadingAtMount.current === false) {
+      DevLogger.log(
+        `[PR-TAT-3662] BUG_MARKER: mount with isLoading=false — Data Fetch span not started at mount, section=${sectionId}`,
+      );
+    }
 
     return () => {
       if (ttcStarted.current && !ttcEnded.current) {
@@ -157,6 +170,12 @@ export const useSectionPerformance = ({
         tags: { section_id: sectionId },
       });
       fetchStarted.current = true;
+      // [PR-TAT-3662] reproduction marker — remove before the fix commit
+      DevLogger.log(
+        `[PR-TAT-3662] BUG_MARKER: Data Fetch span started ${
+          Date.now() - mountedAt.current
+        }ms after mount, section=${sectionId}`,
+      );
     }
 
     // End: isLoading transitioned from true → false

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.ts
@@ -82,9 +82,14 @@ export const useSectionPerformance = ({
   const fetchTraceId = useRef(uuidv4());
   const fetchStarted = useRef(false);
   const fetchEnded = useRef(false);
-  // Whether this section opted into Data Fetch tracing. Read at mount so the
-  // span boundary can never depend on a later render's `isLoading` value.
+  // Whether this section opted into Data Fetch tracing. Frozen at the first
+  // render and used by BOTH the open and close paths, so one span never has two
+  // different opt-in guards.
   const tracksDataFetch = useRef(isLoading !== undefined);
+  // Sticky for the whole hook instance: the span may open at most once, so
+  // re-runs of the effect below (e.g. an `enabled` false→true toggle) can never
+  // open a second span at an arbitrary post-mount moment.
+  const fetchSpanOpened = useRef(false);
   // Loading state on the very first render, logged with the span start so a
   // warm mount (already loaded) is distinguishable from a cold one on device.
   const isLoadingAtFirstRender = useRef(isLoading);
@@ -122,9 +127,9 @@ export const useSectionPerformance = ({
 
     // Data Fetch Latency — start on mount so every mount produces a sample,
     // including warm mounts that are already loaded (near-zero duration).
-    if (tracksDataFetch.current) {
+    if (tracksDataFetch.current && !fetchSpanOpened.current) {
+      fetchSpanOpened.current = true;
       fetchTraceId.current = uuidv4();
-      fetchEnded.current = false;
       trace({
         name: TraceName.HomepageSectionDataFetch,
         op: TraceOperation.HomepageSectionPerformance,
@@ -179,11 +184,11 @@ export const useSectionPerformance = ({
   // 2. Data Fetch Latency — end the mount-scoped span once loading is done
   // ──────────────────────────────────────────────
   useEffect(() => {
-    if (!enabled || isLoading === undefined) return;
+    if (!enabled || !tracksDataFetch.current) return;
 
     // End: first render of this mount that is no longer loading. The span is
-    // opened by the mount effect above, so a later refresh cycle can neither
-    // open a new span nor reopen this one.
+    // opened once by the mount effect above, so neither a later refresh cycle
+    // nor an `enabled` toggle can open a new span or reopen this one.
     if (!isLoading && fetchStarted.current && !fetchEnded.current) {
       endTrace({
         name: TraceName.HomepageSectionDataFetch,

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.ts
@@ -127,6 +127,9 @@ export const useSectionPerformance = ({
 
     // Data Fetch Latency — start on mount so every mount produces a sample,
     // including warm mounts that are already loaded (near-zero duration).
+    // `first_render_loading` tags warm vs cold so the two populations stay
+    // separable in Sentry: without it the near-zero warm samples would be
+    // indistinguishable from real fetches in any percentile.
     if (tracksDataFetch.current && !fetchSpanOpened.current) {
       fetchSpanOpened.current = true;
       fetchTraceId.current = uuidv4();
@@ -134,7 +137,10 @@ export const useSectionPerformance = ({
         name: TraceName.HomepageSectionDataFetch,
         op: TraceOperation.HomepageSectionPerformance,
         id: fetchTraceId.current,
-        tags: { section_id: sectionId },
+        tags: {
+          section_id: sectionId,
+          first_render_loading: isLoadingAtFirstRender.current ?? false,
+        },
       });
       fetchStarted.current = true;
       DevLogger.log(

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.ts
@@ -50,6 +50,13 @@ const DEFAULT_RE_RENDER_WINDOW_MS = 500;
  * Prefix for the dev-only structured log emitted next to every Data Fetch span
  * boundary. The span itself is only observable in Sentry, so this is the sole
  * way to verify the boundary on a live device (validation recipes grep Metro).
+ *
+ * Every boundary the span can reach is logged, so a missing line means a
+ * missing span rather than an unlogged path:
+ * - `start section=… phase=… loading_at_span_open=…`
+ * - `end section=… success=true content_state=…`
+ * - `end section=… success=false reason=unmounted` (aborted by unmount/disable)
+ * - `skip section=… reason=post_mount_reload`
  */
 const DATA_FETCH_LOG_PREFIX = '[homepage.section.performance] data_fetch';
 
@@ -180,6 +187,9 @@ export const useSectionPerformance = ({
           data: { success: false, reason: 'unmounted', section_id: sectionId },
         });
         fetchStarted.current = false;
+        DevLogger.log(
+          `${DATA_FETCH_LOG_PREFIX} end section=${sectionId} success=false reason=unmounted`,
+        );
       }
     };
   }, [enabled, sectionId]);

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.ts
@@ -110,7 +110,7 @@ export const useSectionPerformance = ({
   });
 
   // ──────────────────────────────────────────────
-  // 1. Time to Content — start span on mount
+  // 1. Time to Content + Data Fetch Latency — start spans on mount
   // ──────────────────────────────────────────────
   useEffect(() => {
     if (!enabled) return;

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.ts
@@ -90,9 +90,17 @@ export const useSectionPerformance = ({
   // re-runs of the effect below (e.g. an `enabled` false→true toggle) can never
   // open a second span at an arbitrary post-mount moment.
   const fetchSpanOpened = useRef(false);
-  // Loading state on the very first render, logged with the span start so a
-  // warm mount (already loaded) is distinguishable from a cold one on device.
-  const isLoadingAtFirstRender = useRef(isLoading);
+  // Mirrors `isLoading` on every render so the span can be tagged with the
+  // value that is live *when it opens*. Flag-gated sections open the span on
+  // the commit where `enabled` flips true, which can be long after the first
+  // render — reading a first-render snapshot there would file a warm sample
+  // under the cold population.
+  const isLoadingLatest = useRef(isLoading);
+  isLoadingLatest.current = isLoading;
+  // Whether `enabled` was already true on the first render, i.e. whether the
+  // effect below runs at mount or only once a remote flag resolves. Labels the
+  // span's `phase` honestly instead of always claiming `mount`.
+  const enabledAtFirstRender = useRef(enabled);
   // Guards the skip log so one post-mount reload logs once, not once per render.
   const skipLogged = useRef(false);
 
@@ -127,25 +135,27 @@ export const useSectionPerformance = ({
 
     // Data Fetch Latency — start on mount so every mount produces a sample,
     // including warm mounts that are already loaded (near-zero duration).
-    // `first_render_loading` tags warm vs cold so the two populations stay
+    // `loading_at_span_open` tags warm vs cold so the two populations stay
     // separable in Sentry: without it the near-zero warm samples would be
     // indistinguishable from real fetches in any percentile.
     if (tracksDataFetch.current && !fetchSpanOpened.current) {
       fetchSpanOpened.current = true;
       fetchTraceId.current = uuidv4();
+      const loadingAtSpanOpen = isLoadingLatest.current ?? false;
+      const spanOpenPhase = enabledAtFirstRender.current ? 'mount' : 'enabled';
       trace({
         name: TraceName.HomepageSectionDataFetch,
         op: TraceOperation.HomepageSectionPerformance,
         id: fetchTraceId.current,
         tags: {
           section_id: sectionId,
-          first_render_loading: isLoadingAtFirstRender.current ?? false,
+          loading_at_span_open: loadingAtSpanOpen,
         },
       });
       fetchStarted.current = true;
       DevLogger.log(
-        `${DATA_FETCH_LOG_PREFIX} start section=${sectionId} phase=mount first_render_loading=${String(
-          isLoadingAtFirstRender.current,
+        `${DATA_FETCH_LOG_PREFIX} start section=${sectionId} phase=${spanOpenPhase} loading_at_span_open=${String(
+          loadingAtSpanOpen,
         )}`,
       );
     }

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.ts
@@ -8,7 +8,6 @@ import {
 } from '../../../../util/trace';
 import type { HomeSectionName } from './useHomeViewedEvent';
 import { useRenderStormMonitor } from '../../../../hooks/performance/useRenderStormMonitor';
-import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 
 interface UseSectionPerformanceConfig {
   /** Section identifier — primary Sentry tag for filtering. */
@@ -74,10 +73,6 @@ export const useSectionPerformance = ({
   const fetchEnded = useRef(false);
   const prevIsLoading = useRef<boolean | undefined>(undefined);
 
-  // [PR-TAT-3662] reproduction marker state — removed before the fix commit
-  const isLoadingAtMount = useRef(isLoading);
-  const mountedAt = useRef(0);
-
   const traceContentState =
     contentStateForTrace ?? (isEmpty ? 'empty' : 'filled');
 
@@ -106,14 +101,6 @@ export const useSectionPerformance = ({
       tags: { section_id: sectionId },
     });
     ttcStarted.current = true;
-
-    // [PR-TAT-3662] reproduction marker — remove before the fix commit
-    mountedAt.current = Date.now();
-    if (isLoadingAtMount.current === false) {
-      DevLogger.log(
-        `[PR-TAT-3662] BUG_MARKER: mount with isLoading=false — Data Fetch span not started at mount, section=${sectionId}`,
-      );
-    }
 
     return () => {
       if (ttcStarted.current && !ttcEnded.current) {
@@ -170,12 +157,6 @@ export const useSectionPerformance = ({
         tags: { section_id: sectionId },
       });
       fetchStarted.current = true;
-      // [PR-TAT-3662] reproduction marker — remove before the fix commit
-      DevLogger.log(
-        `[PR-TAT-3662] BUG_MARKER: Data Fetch span started ${
-          Date.now() - mountedAt.current
-        }ms after mount, section=${sectionId}`,
-      );
     }
 
     // End: isLoading transitioned from true → false

--- a/app/components/Views/Homepage/hooks/useSectionPerformance.ts
+++ b/app/components/Views/Homepage/hooks/useSectionPerformance.ts
@@ -150,6 +150,10 @@ export const useSectionPerformance = ({
         tags: {
           section_id: sectionId,
           loading_at_span_open: loadingAtSpanOpen,
+          // `mount` measures mount → loaded; `enabled` measures flag-flip →
+          // loaded. Different intervals, so they must stay splittable in Sentry
+          // rather than only in the dev-gated log.
+          phase: spanOpenPhase,
         },
       });
       fetchStarted.current = true;


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

This draft publishes the existing TAT-3662 branch for review. It fixes a sampling defect in the legacy Homepage `Data Fetch` span: the span previously started only when the hook observed a loading transition, so warm and already-resolved mounts were omitted. The branch instead opens one span when the section is enabled, closes it on the first non-loading render, tags the opening phase/loading state, and adds dev-only boundary logs plus unit coverage.

This is not a complete user-visible performance measurement. Connected Android validation at `b1484e875baba289a7af386c7414dee4860054f1` produced a cold-process Perps span of approximately 8 ms with `content_state=empty`, before fresh socket data was displayed. The diff measures mount/enable to `isLoading=false`; it does not measure socket receipt, cache propagation, React commit, or native paint. Keep this draft as a review artifact until the legacy metric is either explicitly retained for diagnostics or replaced with delivery-correlated time-to-visible instrumentation.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: TAT-3662

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Homepage section data-fetch diagnostic span

  Scenario: section mounts while loading
    Given a Homepage section is enabled and loading on its first render
    When the section finishes loading
    Then exactly one Data Fetch span should open at mount
    And the span should close on the first non-loading render
    And the span should be tagged with loading_at_span_open=true

  Scenario: section mounts with resolved content
    Given a Homepage section is enabled and not loading on its first render
    When the section mounts
    Then exactly one Data Fetch span should open and close
    And the span should be tagged with loading_at_span_open=false
```

Focused automated validation:

`yarn jest app/components/Views/Homepage/hooks/useSectionPerformance.test.ts --runInBand`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — telemetry-only change.

### **After**

N/A — telemetry-only change.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

