### PR TITLE
fix: cp-8.6.0 Fix unintentional `no_pay_token_quotes` alert triggers …

### DIFF
--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.test.ts
@@ -77,7 +77,14 @@ describe('useNoPayTokenQuotesAlert', () => {
     useIsTransactionPayLoadingMock.mockReturnValue(false);
     useTransactionPayQuotesRawMock.mockReturnValue(undefined);
     useTransactionPayIsPostQuoteMock.mockReturnValue(false);
-    useTransactionPayRequiredTokensMock.mockReturnValue([]);
+    useTransactionPayRequiredTokensMock.mockReturnValue([
+      {
+        address: ADDRESS_MOCK,
+        chainId: CHAIN_ID_MOCK,
+        amountRaw: '10000',
+        skipIfBalance: false,
+      } as TransactionPayRequiredToken,
+    ]);
     useTransactionPayWithdrawMock.mockReturnValue({
       isWithdraw: false,
       canSelectWithdrawToken: false,
@@ -173,6 +180,105 @@ describe('useNoPayTokenQuotesAlert', () => {
     const { result } = runHook();
 
     expect(result.current).toStrictEqual([]);
+  });
+
+  describe('non-fiat input gating', () => {
+    it('returns no alert when no required token amount has reached the controller', () => {
+      useTransactionPayRequiredTokensMock.mockReturnValue([]);
+
+      const { result } = runHook();
+
+      expect(result.current).toStrictEqual([]);
+    });
+
+    it('returns no alert when the required token amount is zero', () => {
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        {
+          address: ADDRESS_MOCK,
+          chainId: CHAIN_ID_MOCK,
+          amountRaw: '0',
+          skipIfBalance: false,
+        } as TransactionPayRequiredToken,
+      ]);
+
+      const { result } = runHook();
+
+      expect(result.current).toStrictEqual([]);
+    });
+
+    it('returns no alert when the only required token is skipped by balance', () => {
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        {
+          address: ADDRESS_MOCK,
+          chainId: CHAIN_ID_MOCK,
+          amountRaw: '10000',
+          skipIfBalance: true,
+        } as TransactionPayRequiredToken,
+      ]);
+
+      const { result } = runHook();
+
+      expect(result.current).toStrictEqual([]);
+    });
+
+    it('returns alert once a positive required token amount has reached the controller', () => {
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        {
+          address: ADDRESS_MOCK,
+          chainId: CHAIN_ID_MOCK,
+          amountRaw: '10000',
+          skipIfBalance: false,
+        } as TransactionPayRequiredToken,
+      ]);
+
+      const { result } = runHook();
+
+      expect(result.current).toEqual([
+        expect.objectContaining({
+          key: AlertKeys.NoPayTokenQuotes,
+          severity: Severity.Danger,
+          isBlocking: true,
+        }),
+      ]);
+    });
+
+    it('returns no alert when isMaxAmount is set but the amount has not yet reached the controller', () => {
+      jest.mocked(useTransactionPayIsMaxAmount).mockReturnValue(true);
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        {
+          address: ADDRESS_MOCK,
+          chainId: CHAIN_ID_MOCK,
+          amountRaw: '0',
+          skipIfBalance: false,
+        } as TransactionPayRequiredToken,
+      ]);
+
+      const { result } = runHook();
+
+      expect(result.current).toStrictEqual([]);
+    });
+
+    it('returns alert when isMaxAmount is set and a positive amount has reached the controller', () => {
+      jest.mocked(useTransactionPayIsMaxAmount).mockReturnValue(true);
+      useTransactionPayRequiredTokensMock.mockReturnValue([
+        {
+          address: ADDRESS_MOCK,
+          chainId: CHAIN_ID_MOCK,
+          amountRaw: '10000',
+          skipIfBalance: false,
+        } as TransactionPayRequiredToken,
+      ]);
+
+      const { result } = runHook();
+
+      expect(result.current).toEqual([
+        expect.objectContaining({
+          key: AlertKeys.NoPayTokenQuotes,
+          severity: Severity.Danger,
+          isBlocking: true,
+        }),
+      ]);
+    });
   });
 
   it('returns alert for post-quote when a required token has a positive amount and no quotes', () => {

--- a/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useNoPayTokenQuotesAlert.ts
@@ -38,8 +38,31 @@ export function useNoPayTokenQuotesAlert() {
     fiatPayment?.selectedPaymentMethodId,
   );
 
+  // Controller-backed (not UI-local keypad state), so every hook instance sees
+  // the same value. True once a positive amount has reached the controller via
+  // keypad input, prefill, or Max. isMaxAmount counts because post-quote flows
+  // substitute the token balance for a zero amountRaw when max is set.
+  const hasPositiveRequiredAmount = (requiredTokens ?? []).some(
+    (t) =>
+      !t.skipIfBalance &&
+      (isMaxAmount || (Boolean(t.amountRaw) && t.amountRaw !== '0')),
+  );
+
+  // Deposits set isMaxAmount synchronously (Max / uncapped 100% prefill) before
+  // the debounced amount update pushes amountRaw, and a pre-quote max with a
+  // zero amount never starts quote loading. Gating the non-fiat branch on
+  // amountRaw alone — not isMaxAmount — keeps the alert quiet through that
+  // in-flight window; once the amount lands amountRaw is positive and a genuine
+  // no-quote case still fires.
+  const hasPositiveRequiredTokenAmount = (requiredTokens ?? []).some(
+    (t) => !t.skipIfBalance && Boolean(t.amountRaw) && t.amountRaw !== '0',
+  );
+
   const shouldShowNonFiatNoQuotesAlert =
-    payToken && !isQuotesLoading && !quotes?.length;
+    payToken &&
+    !isQuotesLoading &&
+    !quotes?.length &&
+    hasPositiveRequiredTokenAmount;
 
   const shouldShowFiatNoQuotesAlert =
     hasSelectedFiatPaymentMethod &&
@@ -47,16 +70,6 @@ export function useNoPayTokenQuotesAlert() {
     !isQuotesLoading &&
     !fiatPayment?.rampsQuote &&
     quotes?.length === 0;
-
-  // Post-quote flows (e.g. money account withdraw) where `sourceAmounts` is
-  // non-empty but no quote was returned. The non-fiat branch above may not
-  // fire, so we also emit the alert when the user has entered a positive
-  // input amount but no quote is available.
-  const hasPositiveRequiredAmount = (requiredTokens ?? []).some(
-    (t) =>
-      !t.skipIfBalance &&
-      (isMaxAmount || (Boolean(t.amountRaw) && t.amountRaw !== '0')),
-  );
 
   const shouldShowPostQuoteNoQuotesAlert =
     isPostQuote &&


### PR DESCRIPTION
…(#34388)

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by
.github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
type=issue-link Section must have a Fixes:/Closes:/Refs: line with a
value.
type=manual-testing Section must have real testing steps or an explicit
N/A.
type=screenshot Section must have evidence (image/URL) or an explicit
N/A.
type=checklist Section must have all checkboxes consciously checked.
required=true|false Whether a missing/invalid section runs the validator
at all.
blocking=true|false Whether a failure of this check fails the CI
workflow.
Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only. -->

## **Description**

<!-- mms-check: type=text required=true -->

### What is the reason for the change?

The `no_pay_token_quotes` (`AlertKeys.NoPayTokenQuotes`) blocking alert was firing unintentionally on nearly every `MoneyAccountDeposit` confirmation, regardless of whether the `confirmations_pay_extended` prefilled-amount flag was on or off.

The root cause is a mount-time race in the non-fiat branch of `useNoPayTokenQuotesAlert`. On mount, the pay token is auto-selected (so `payToken` is truthy) and quotes are still empty (`!quotes?.length`) simply because no amount has been pushed to the controller yet. The previous condition —

```ts
const shouldShowNonFiatNoQuotesAlert =
  payToken && !isQuotesLoading && !quotes?.length;
```

— had no gate for "has a positive amount actually reached the controller yet?", so the blocking alert surfaced during that empty-input / prefill-in-flight window.

### What is the improvement/solution?

Gate the non-fiat branch on a controller-backed "the amount actually landed" signal, derived from the controller's `requiredTokens`. Two closely related signals are used, and the distinction matters:

```ts
// Used by the post-quote / quote-required / withdraw / pay-token-required
// branches. isMaxAmount counts because those post-quote flows substitute the
// token balance for a zero amountRaw when max is set.
const hasPositiveRequiredAmount = (requiredTokens ?? []).some(
  (t) =>
    !t.skipIfBalance &&
    (isMaxAmount || (Boolean(t.amountRaw) && t.amountRaw !== '0')),
);

// Used only by the non-fiat branch. Excludes isMaxAmount: on deposits, Max /
// uncapped 100% prefill set isMaxAmount synchronously before the debounced
// amount update pushes amountRaw, and a pre-quote max with a zero amount never
// starts quote loading — so trusting isMaxAmount here would re-open the
// in-flight window. Once the amount lands amountRaw is positive and a genuine
// no-quote case still fires.
const hasPositiveRequiredTokenAmount = (requiredTokens ?? []).some(
  (t) => !t.skipIfBalance && Boolean(t.amountRaw) && t.amountRaw !== '0',
);

const shouldShowNonFiatNoQuotesAlert =
  payToken &&
  !isQuotesLoading &&
  !quotes?.length &&
  hasPositiveRequiredTokenAmount;
```

Only the non-fiat branch changes; the fiat, post-quote, quote-required, withdraw-initialisation, pay-token-required, and quote-error branches are untouched (they keep `hasPositiveRequiredAmount`).

**Why not read the amount from `useTransactionCustomAmount`?** An earlier iteration gated on `hasInput` / `isPrefillPending` / `isDepositPrefillLoading` from that hook. That was incorrect: `useTransactionCustomAmount` keeps those values in component-local `useState`, and the alert hook instantiates a *separate* copy from the one driven by the keypad UI (`CustomAmountInfo`). The alert instance would never observe keypad input, leaving the blocking alert stuck `false` (confirmation unblocked with no quote) and duplicating the hook's amount/prefill side effects against the pay controller. The controller-backed `requiredTokens` signal avoids this entirely because it is shared across every hook instance.

**Why the separate `hasPositiveRequiredTokenAmount`?** Reusing `hasPositiveRequiredAmount` (which includes `isMaxAmount`) for the non-fiat branch re-opened the mount-time race: pressing Max — or an uncapped 100% deposit prefill — sets `isMaxAmount` on the controller synchronously, before `amountRaw` is committed and before quote loading begins, so the blocking alert fired again during that in-flight window. Gating the non-fiat branch on `amountRaw` alone closes that window without hiding a real no-quote case, since `amountRaw` becomes positive once the amount lands.

This suppresses the alert during the mount-time / prefill-in-flight / pre-quote-max window while still surfacing it once a positive amount has reached the controller but no quote is available. Unit tests drive the non-fiat gate through the controller-backed
`useTransactionPayRequiredTokens` mock — no amount → no alert; positive amount → alert; zero amount, `skipIfBalance`, and both `isMaxAmount` windows (pre-commit zero amount → no alert, positive amount → alert) — 29 tests total, all passing.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed a bug that caused the "no pay token quotes" error to appear unintentionally on deposit confirmations before an amount was entered.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1773

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: No pay token quotes alert on deposits

  Scenario: Prefilled amount disabled — alert does not appear on mount
    Given the "confirmations_pay_extended" prefilled-amount flag is off
    When the user opens a MoneyAccountDeposit confirmation
    And no amount has reached the controller yet
    Then the blocking "no_pay_token_quotes" alert is not shown

  Scenario: Prefilled amount enabled — alert does not appear while prefill is in flight
    Given the "confirmations_pay_extended" prefilled-amount flag is on
    When the user opens a MoneyAccountDeposit confirmation
    And the prefilled amount has not yet been pushed to the controller
    Then the blocking "no_pay_token_quotes" alert is not shown

  Scenario: Alert still surfaces when genuinely no quote is available
    Given the user has entered a positive amount
    And that amount has reached the controller (required token amount is positive)
    And no quote is returned for that amount
    Then the blocking "no_pay_token_quotes" alert is shown
    And confirmation is blocked
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — logic-only change to alert-gating conditions with no user-facing visual change beyond the alert no longer appearing spuriously. Behaviour is covered by unit tests.

### **Before**



https://github.com/user-attachments/assets/5c4af071-4a18-47ce-814d-02874d29cdb0



### **After**



https://github.com/user-attachments/assets/5e683d84-b524-494f-a738-aa97755a579a

After the fix but intentionally corrupting quote URL



https://github.com/user-attachments/assets/c359f6ca-2357-4624-87d0-9a94e66fb375




## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
- Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
- See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously assessed that responsibility. See `docs/readme/ready-for-review.md`. -->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow alert-gating change in confirmation pay UI with expanded unit tests; no auth, payment execution, or data-layer changes.
> 
> **Overview**
> Fixes spurious **no pay token quotes** blocking alerts on deposit confirmations when a pay token is selected but quotes are still empty before any amount reaches the pay controller.
> 
> The non-fiat alert path now requires **`hasPositiveRequiredTokenAmount`**—a positive, non-skipped `requiredTokens[].amountRaw` from the controller—instead of firing whenever `payToken` is set and quotes are missing. **`hasPositiveRequiredAmount`** (which still treats **`isMaxAmount`** as sufficient) remains for post-quote, quote-required, withdraw, and pay-token-required branches so Max flows there still behave correctly.
> 
> Deposit Max / prefill can set **`isMaxAmount`** before **`amountRaw`** updates; excluding **`isMaxAmount`** from the non-fiat gate avoids re-triggering the alert during that window while still showing it when a real positive amount has no quote. Tests add a **non-fiat input gating** suite and adjust default mocks so the happy-path no-quotes case includes a positive required amount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3a0f848a405a7bd4b1ec70d33c5bebe5b60196e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
