### PR TITLE
fix: remove isMaxDeposit context now that isMaxAmount covers money account deposits

### DIFF
--- a/app/components/Views/confirmations/components/custom-amount/custom-amount-confirm-button/custom-amount-confirm-button.test.tsx
+++ b/app/components/Views/confirmations/components/custom-amount/custom-amount-confirm-button/custom-amount-confirm-button.test.tsx
@@ -94,8 +94,6 @@ describe('CustomAmountConfirmButton', () => {
       setIsHeadlessBuyInProgress: noop,
       setIsTransactionDataUpdating: noop,
       setIsTransactionValueUpdating: noop,
-      isMaxDeposit: false,
-      setIsMaxDeposit: noop,
     } as ReturnType<typeof useConfirmationContext>);
 
     useConfirmActionsMock.mockReturnValue({

--- a/app/components/Views/confirmations/components/footer/footer.test.tsx
+++ b/app/components/Views/confirmations/components/footer/footer.test.tsx
@@ -136,8 +136,6 @@ describe('Footer', () => {
       setIsHeadlessBuyInProgress: jest.fn(),
       setIsTransactionDataUpdating: jest.fn(),
       setIsTransactionValueUpdating: jest.fn(),
-      isMaxDeposit: false,
-      setIsMaxDeposit: jest.fn(),
     });
 
     (useAlerts as jest.Mock).mockReturnValue({
@@ -258,8 +256,6 @@ describe('Footer', () => {
       setIsHeadlessBuyInProgress: jest.fn(),
       setIsTransactionDataUpdating: jest.fn(),
       setIsTransactionValueUpdating: jest.fn(),
-      isMaxDeposit: false,
-      setIsMaxDeposit: jest.fn(),
     });
     const { getByTestId } = renderWithProvider(<Footer />, {
       state: personalSignatureConfirmationState,
@@ -365,8 +361,6 @@ describe('Footer', () => {
       setIsHeadlessBuyInProgress: jest.fn(),
       setIsTransactionDataUpdating: jest.fn(),
       setIsTransactionValueUpdating: jest.fn(),
-      isMaxDeposit: false,
-      setIsMaxDeposit: jest.fn(),
     });
 
     const moneyAccountDepositConfirmation = {
@@ -407,8 +401,6 @@ describe('Footer', () => {
       setIsHeadlessBuyInProgress: jest.fn(),
       setIsTransactionDataUpdating: jest.fn(),
       setIsTransactionValueUpdating: jest.fn(),
-      isMaxDeposit: false,
-      setIsMaxDeposit: jest.fn(),
     });
 
     const moneyAccountWithdrawConfirmation = {
@@ -449,8 +441,6 @@ describe('Footer', () => {
       setIsHeadlessBuyInProgress: jest.fn(),
       setIsTransactionDataUpdating: jest.fn(),
       setIsTransactionValueUpdating: jest.fn(),
-      isMaxDeposit: false,
-      setIsMaxDeposit: jest.fn(),
     });
 
     const { queryByTestId } = renderWithProvider(<Footer />, {

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -411,8 +411,6 @@ describe('CustomAmountInfo', () => {
       setIsHeadlessBuyInProgress: noop,
       setIsTransactionDataUpdating: noop,
       setIsTransactionValueUpdating: noop,
-      isMaxDeposit: false,
-      setIsMaxDeposit: noop,
     } as ReturnType<typeof useConfirmationContext>);
 
     useAlertsMock.mockReturnValue({

--- a/app/components/Views/confirmations/context/confirmation-context/confirmation-context.test.tsx
+++ b/app/components/Views/confirmations/context/confirmation-context/confirmation-context.test.tsx
@@ -24,14 +24,12 @@ describe('ConfirmationContext', () => {
       isHeadlessBuyInProgress: false,
       isTransactionDataUpdating: false,
       isTransactionValueUpdating: false,
-      isMaxDeposit: false,
       setHeadlessBuyError: expect.any(Function),
       setIsFooterVisible: expect.any(Function),
       setIsConfirmationSubmitting: expect.any(Function),
       setIsHeadlessBuyInProgress: expect.any(Function),
       setIsTransactionDataUpdating: expect.any(Function),
       setIsTransactionValueUpdating: expect.any(Function),
-      setIsMaxDeposit: expect.any(Function),
     });
   });
 
@@ -91,22 +89,6 @@ describe('ConfirmationContext', () => {
     });
 
     expect(result.current.isTransactionDataUpdating).toBe(false);
-  });
-
-  it('updates isMaxDeposit state when calling setIsMaxDeposit', () => {
-    const { result } = renderHook(() => useConfirmationContext(), { wrapper });
-
-    act(() => {
-      result.current.setIsMaxDeposit(true);
-    });
-
-    expect(result.current.isMaxDeposit).toBe(true);
-
-    act(() => {
-      result.current.setIsMaxDeposit(false);
-    });
-
-    expect(result.current.isMaxDeposit).toBe(false);
   });
 
   it('updates isConfirmationSubmitting state when calling setIsConfirmationSubmitting', () => {

--- a/app/components/Views/confirmations/context/confirmation-context/confirmation-context.tsx
+++ b/app/components/Views/confirmations/context/confirmation-context/confirmation-context.tsx
@@ -18,17 +18,12 @@ export interface ConfirmationContextParams {
   isHeadlessBuyInProgress: boolean;
   isTransactionValueUpdating: boolean;
   isTransactionDataUpdating: boolean;
-  // Whether the user selected the maximum amount for a money account deposit.
-  // Shared so the insufficient-funds alert can skip a Max deposit that only
-  // marginally exceeds the balance due to fiat rounding.
-  isMaxDeposit: boolean;
   setHeadlessBuyError: (error: string | undefined) => void;
   setIsConfirmationSubmitting: (isConfirmationSubmitting: boolean) => void;
   setIsFooterVisible: (isFooterVisible: boolean) => void;
   setIsHeadlessBuyInProgress: (isHeadlessBuyInProgress: boolean) => void;
   setIsTransactionValueUpdating: (isTransactionValueUpdating: boolean) => void;
   setIsTransactionDataUpdating: (isTransactionDataUpdating: boolean) => void;
-  setIsMaxDeposit: (isMaxDeposit: boolean) => void;
 }
 
 // This context is used to share the valuable information between the components
@@ -42,14 +37,12 @@ const ConfirmationContext = React.createContext<ConfirmationContextParams>({
   isHeadlessBuyInProgress: false,
   isTransactionDataUpdating: false,
   isTransactionValueUpdating: false,
-  isMaxDeposit: false,
   setHeadlessBuyError: noop,
   setIsConfirmationSubmitting: noop,
   setIsFooterVisible: noop,
   setIsHeadlessBuyInProgress: noop,
   setIsTransactionDataUpdating: noop,
   setIsTransactionValueUpdating: noop,
-  setIsMaxDeposit: noop,
 });
 
 interface ConfirmationContextProviderProps {
@@ -75,8 +68,6 @@ export const ConfirmationContextProvider: React.FC<
   const [isTransactionDataUpdating, setIsTransactionDataUpdating] =
     useState<boolean>(false);
 
-  const [isMaxDeposit, setIsMaxDeposit] = useState<boolean>(false);
-
   const isConfirmationSubmittingRef = useRef(false);
   const [isConfirmationSubmitting, setIsConfirmationSubmittingState] =
     useState<boolean>(false);
@@ -98,14 +89,12 @@ export const ConfirmationContextProvider: React.FC<
       isTransactionValueUpdating,
       isConfirmationSubmitting,
       isConfirmationSubmittingRef,
-      isMaxDeposit,
       setHeadlessBuyError,
       setIsFooterVisible,
       setIsHeadlessBuyInProgress,
       setIsTransactionDataUpdating,
       setIsTransactionValueUpdating,
       setIsConfirmationSubmitting,
-      setIsMaxDeposit,
     }),
     [
       mmPayRequestInProgressNavHandler,
@@ -116,14 +105,12 @@ export const ConfirmationContextProvider: React.FC<
       isTransactionValueUpdating,
       isConfirmationSubmitting,
       isConfirmationSubmittingRef,
-      isMaxDeposit,
       setHeadlessBuyError,
       setIsFooterVisible,
       setIsHeadlessBuyInProgress,
       setIsTransactionDataUpdating,
       setIsTransactionValueUpdating,
       setIsConfirmationSubmitting,
-      setIsMaxDeposit,
     ],
   );
 

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.test.ts
@@ -31,7 +31,6 @@ import { useTransactionPaySelectedFiatPaymentMethod } from '../pay/useTransactio
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 import { useTokenWithBalance } from '../tokens/useTokenWithBalance';
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
-import { useConfirmationContext } from '../../context/confirmation-context';
 import { useInsufficientPayTokenBalanceAlert } from './useInsufficientPayTokenBalanceAlert';
 
 jest.mock('../pay/useTransactionPayToken');
@@ -40,7 +39,6 @@ jest.mock('../pay/useTransactionPayData');
 jest.mock('../tokens/useTokenWithBalance');
 jest.mock('../pay/useTransactionPaySelectedFiatPaymentMethod');
 jest.mock('../../../../UI/Money/hooks/useMoneyAccountBalance');
-jest.mock('../../context/confirmation-context');
 
 const PAY_TOKEN_MOCK = {
   address: '0x123' as Hex,
@@ -101,14 +99,9 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
   const useTransactionMetadataRequestMock = jest.mocked(
     useTransactionMetadataRequest,
   );
-  const useConfirmationContextMock = jest.mocked(useConfirmationContext);
 
   beforeEach(() => {
     jest.resetAllMocks();
-
-    useConfirmationContextMock.mockReturnValue({
-      isMaxDeposit: false,
-    } as ReturnType<typeof useConfirmationContext>);
 
     useTransactionPayRequiredTokensMock.mockReturnValue([REQUIRED_TOKEN_MOCK]);
     useTransactionPayTotalsMock.mockReturnValue(TOTALS_MOCK);
@@ -221,16 +214,6 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
         ]);
       });
 
-      it('returns no alert when isMaxDeposit is true (same Max path as isMax)', () => {
-        useConfirmationContextMock.mockReturnValue({
-          isMaxDeposit: true,
-        } as ReturnType<typeof useConfirmationContext>);
-
-        const { result } = runHook();
-
-        expect(result.current).toStrictEqual([]);
-      });
-
       it('returns no alert when isMax is true for a money account deposit', () => {
         useTransactionPayIsMaxAmountMock.mockReturnValue(true);
 
@@ -240,33 +223,6 @@ describe('useInsufficientPayTokenBalanceAlert', () => {
       });
 
       it('returns an alert when the deposit is not a Max deposit', () => {
-        useConfirmationContextMock.mockReturnValue({
-          isMaxDeposit: false,
-        } as ReturnType<typeof useConfirmationContext>);
-
-        const { result } = runHook();
-
-        expect(result.current).toStrictEqual([
-          {
-            key: AlertKeys.InsufficientPayTokenBalance,
-            field: RowAlertKey.Amount,
-            isBlocking: true,
-            message: strings(
-              'alert_system.insufficient_pay_token_balance.message',
-            ),
-            severity: Severity.Danger,
-          },
-        ]);
-      });
-
-      it('still flags a non-money-account deposit even when isMaxDeposit is true', () => {
-        useTransactionMetadataRequestMock.mockReturnValue(
-          undefined as unknown as TransactionMeta,
-        );
-        useConfirmationContextMock.mockReturnValue({
-          isMaxDeposit: true,
-        } as ReturnType<typeof useConfirmationContext>);
-
         const { result } = runHook();
 
         expect(result.current).toStrictEqual([

--- a/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
+++ b/app/components/Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert.ts
@@ -23,9 +23,7 @@ import useMoneyAccountBalance from '../../../../UI/Money/hooks/useMoneyAccountBa
 import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
 import { useTransactionPaySelectedFiatPaymentMethod } from '../pay/useTransactionPaySelectedFiatPaymentMethod';
 import { usePayTokenAccountBalance } from '../pay/usePayTokenAccountBalance';
-import { CHAIN_IDS, TransactionType } from '@metamask/transaction-controller';
-import { hasTransactionType } from '../../utils/transaction';
-import { useConfirmationContext } from '../../context/confirmation-context';
+import { CHAIN_IDS } from '@metamask/transaction-controller';
 
 export function useInsufficientPayTokenBalanceAlert({
   pendingAmountUsd,
@@ -43,14 +41,6 @@ export function useInsufficientPayTokenBalanceAlert({
   const transactionMeta = useTransactionMetadataRequest();
   const selectedFiatPaymentMethod =
     useTransactionPaySelectedFiatPaymentMethod();
-  const isMoneyAccountDeposit = hasTransactionType(transactionMeta, [
-    TransactionType.moneyAccountDeposit,
-  ]);
-  const { isMaxDeposit } = useConfirmationContext();
-  // Single Max path for all deposit types. `isMaxDeposit` covers the
-  // React-sync gap where controller `isMaxAmount` can lag one frame behind
-  // a money-account Max/prefill (fiat-rounding false positives).
-  const isMaxTransaction = isMax || (isMoneyAccountDeposit && isMaxDeposit);
 
   // In post-quote (withdrawal) flows, payToken is the *destination* token,
   // so payToken.chainId is the destination chain. The source chain (where gas
@@ -96,7 +86,7 @@ export function useInsufficientPayTokenBalanceAlert({
   // between a Max snapshot and the live balance cannot false-positive.
   const totalAmountUsd = useMemo(
     () =>
-      isMaxTransaction
+      isMax
         ? new BigNumber(balanceUsd ?? '0')
         : pendingAmountUsd
           ? new BigNumber(pendingAmountUsd)
@@ -106,7 +96,7 @@ export function useInsufficientPayTokenBalanceAlert({
                 (acc, t) => acc.plus(new BigNumber(t.amountUsd)),
                 new BigNumber(0),
               ),
-    [balanceUsd, isMaxTransaction, pendingAmountUsd, requiredTokens],
+    [balanceUsd, isMax, pendingAmountUsd, requiredTokens],
   );
 
   const totalSourceAmountRaw = useMemo(() => {
@@ -165,14 +155,14 @@ export function useInsufficientPayTokenBalanceAlert({
   const isInsufficientForMoneyAccountTotal = useMemo(
     () =>
       isMoneyPaymentOverride &&
-      !isMaxTransaction &&
+      !isMax &&
       !isPostQuote &&
       !isPendingAlert &&
       totals?.total?.usd !== undefined &&
       new BigNumber(totals.total.usd).isGreaterThan(balanceUsd ?? '0'),
     [
       balanceUsd,
-      isMaxTransaction,
+      isMax,
       isMoneyPaymentOverride,
       isPendingAlert,
       isPostQuote,

--- a/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/app/components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -42,7 +42,6 @@ import { useTransactionPayHasSourceAmount } from '../pay/useTransactionPayHasSou
 import { useConfirmationMetricEvents } from '../metrics/useConfirmationMetricEvents';
 import { getMoneyAccountDepositIntent } from '../../../../UI/Money/hooks/useMoneyAccount';
 import { useDepositPrefillAmount } from './useDepositPrefillAmount';
-import { useConfirmationContext } from '../../context/confirmation-context';
 
 export const MAX_LENGTH = 28;
 const DEBOUNCE_DELAY = 300;
@@ -145,7 +144,6 @@ export function useTransactionCustomAmount({
   const payTokenKey = `${payToken?.chainId ?? ''}:${
     payToken?.address.toLowerCase() ?? ''
   }`;
-  const { setIsMaxDeposit } = useConfirmationContext();
 
   useEffect(() => {
     depositMaxHumanRef.current = null;
@@ -155,8 +153,7 @@ export function useTransactionCustomAmount({
     prefetchedQuotePayTokenKeyRef.current = undefined;
     setPrefetchedQuoteAmountHuman(undefined);
     setPrefetchedQuotePayTokenKey(undefined);
-    setIsMaxDeposit(false);
-  }, [payToken?.address, payToken?.chainId, setIsMaxDeposit]);
+  }, [payToken?.address, payToken?.chainId]);
 
   const { isAmountUpdateQuotePipelineEnabled, updateTransactionPayAmount } =
     useUpdateTransactionPayAmount();
@@ -365,7 +362,6 @@ export function useTransactionCustomAmount({
       depositMaxHumanRef.current = null;
       userHasEditedRef.current = true;
       amountChangeTimeRef.current = Date.now();
-      setIsMaxDeposit(false);
 
       if (lastAmountInputTypeRef.current !== 'manual') {
         lastAmountInputTypeRef.current = 'manual';
@@ -384,7 +380,6 @@ export function useTransactionCustomAmount({
       fiatMaxAmount,
       isMaxAmount,
       setIsMax,
-      setIsMaxDeposit,
       setConfirmationMetric,
     ],
   );
@@ -453,11 +448,6 @@ export function useTransactionCustomAmount({
         depositMaxHumanRef.current = null;
       }
 
-      // Flag a Max money account deposit so the insufficient-funds alert can
-      // skip it — the submitted token amount is clamped to the raw balance, so
-      // it can never truly exceed the balance despite fiat-rounding drift.
-      setIsMaxDeposit(isMaxMoneyAccountDeposit);
-
       setAmountFiat(newAmount);
       return true;
     },
@@ -471,7 +461,6 @@ export function useTransactionCustomAmount({
       payToken?.balanceRaw,
       payToken?.decimals,
       setIsMax,
-      setIsMaxDeposit,
       setConfirmationMetric,
     ],
   );
@@ -488,9 +477,9 @@ export function useTransactionCustomAmount({
     if (depositPrefill.hasPrefilled) {
       amountChangeTimeRef.current = Date.now();
       // Uncapped percentage prefills go through the same Max/percentage path
-      // as the keypad buttons so money-account Max gets isMaxAmount,
-      // isMaxDeposit, and depositMaxHumanRef — matching other Max deposits.
-      // Limit-capped amounts are not a true Max and must use the literal value.
+      // as the keypad buttons so money-account Max gets isMaxAmount and
+      // depositMaxHumanRef — matching other Max deposits. Limit-capped
+      // amounts are not a true Max and must use the literal value.
       if (
         depositPrefill.percentage !== undefined &&
         !depositPrefill.isLimitCapped
@@ -502,7 +491,6 @@ export function useTransactionCustomAmount({
     } else if (prevHasPrefilled.current) {
       setAmountFiat('0');
       depositMaxHumanRef.current = null;
-      setIsMaxDeposit(false);
       if (isMaxAmount) {
         setIsMax(false);
       }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Money account deposits now set controller `isMaxAmount` on Max / uncapped 100% prefill, so the confirmation-context `isMaxDeposit` workaround is no longer needed.

This PR removes `isMaxDeposit` / `setIsMaxDeposit` from confirmation context, drops the related wiring from `useTransactionCustomAmount`, and has the insufficient-funds alert rely solely on `useTransactionPayIsMaxAmount()`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: follow-up cleanup after money account deposits began setting controller `isMaxAmount`

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: money account deposit Max insufficient-funds alert

  Scenario: user taps Max on a money account deposit
    Given the user is on a money account deposit amount screen with a positive token balance

    When the user taps Max
    Then isMaxAmount is set on the transaction pay config
    And the insufficient-funds alert does not false-positive from fiat rounding

  Scenario: user edits the amount after Max
    Given the user previously tapped Max on a money account deposit

    When the user manually changes the amount above their balance
    Then isMaxAmount is cleared
    And the insufficient-funds alert can show again
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — internal cleanup with no UI change; Max deposit alert behavior is covered by unit tests and the manual steps above.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches confirmation pay amount and insufficient-balance alert behavior for money-account Max/prefill; wrong `isMaxAmount` timing could bring back fiat-rounding false positives or miss real insufficiency.
> 
> **Overview**
> Removes **`isMaxDeposit` / `setIsMaxDeposit`** from confirmation context and all related test mocks, including the context test that asserted that state.
> 
> **`useInsufficientPayTokenBalanceAlert`** no longer reads confirmation context or treats money-account deposits specially via `isMaxDeposit`; Max handling uses **`useTransactionPayIsMaxAmount()`** (`isMax`) for spend totals and money-account total checks, matching other deposit types.
> 
> **`useTransactionCustomAmount`** drops context wiring that set/cleared `isMaxDeposit` on token change, manual edits, Max percentage, and prefill; money-account Max still sets controller **`isMaxAmount`** and **`depositMaxHumanRef`** through the existing percentage path.
> 
> Tests for the insufficient-balance alert are trimmed to the **`isMax`** path for money-account Max deposits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 038098511f4b79dc21ad44332380e57250dcf0e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

