### PR TITLE
test(e2e): stabilize and unskip token-approve Appium smokes

### DIFF
--- a/tests/flows/confirmations.flow.ts
+++ b/tests/flows/confirmations.flow.ts
@@ -19,7 +19,6 @@ import SwitchAccountModal from '../page-objects/wallet/SwitchAccountModal';
 import ActivitiesView from '../page-objects/Transactions/ActivitiesView';
 import TabBarComponent from '../page-objects/wallet/TabBarComponent';
 import WalletView from '../page-objects/wallet/WalletView';
-import { TestDappSelectorsWebIDs } from '../selectors/Browser/TestDapp.selectors';
 import { navigateToBrowserView, waitForTestDappToLoad } from './browser.flow';
 import {
   dismissPushNotificationExistingUserSheet,
@@ -30,8 +29,6 @@ const LOCAL_CHAIN_NAME = 'Local RPC';
 const LOCAL_CHAIN_CAIP = 'eip155:1337';
 const SMART_ACCOUNT_UPGRADED_ACTIVITY = 'Smart account upgraded';
 const SMART_ACCOUNT_UPGRADING_ACTIVITY = 'Upgrading smart account';
-const TEST_DAPP_READY_TIMEOUT_MS = 30_000;
-const TEST_DAPP_READY_POLL_MS = 500;
 const ANDROID_CONFIRM_SHEET_TIMEOUT_MS = 60_000;
 const ANDROID_CONFIRM_POLL_MS = 3_000;
 
@@ -39,86 +36,6 @@ export {
   LOCAL_CHAIN_CAIP,
   SMART_ACCOUNT_UPGRADED_ACTIVITY,
   SMART_ACCOUNT_UPGRADING_ACTIVITY,
-};
-
-/**
- * Wait until the provider has a selected account and the target control is
- * DOM-enabled.
- */
-const waitForTestDappReadyForTap = async (
-  pageUrl: string,
-  buttonId: string,
-  description: string,
-): Promise<void> => {
-  await Utilities.executeWithRetry(
-    async () => {
-      const readiness = await ChromeCdpHelpers.evaluateInWebView<{
-        selectedAddress: string | null;
-        buttonEnabled: boolean;
-        buttonHidden: boolean;
-        accountsText: string | null;
-      }>(
-        pageUrl,
-        `(() => {
-          const el = document.getElementById(${JSON.stringify(buttonId)});
-          const accountsEl = document.getElementById(${JSON.stringify(
-            TestDappSelectorsWebIDs.ACCOUNTS_TEXT,
-          )});
-          const buttonEnabled = Boolean(
-            el &&
-              !('disabled' in el && Boolean(el.disabled)) &&
-              el.getAttribute('aria-disabled') !== 'true',
-          );
-          const buttonHidden = Boolean(
-            el &&
-              (Boolean(el.hidden) ||
-                el.getAttribute('hidden') !== null ||
-                window.getComputedStyle(el).display === 'none'),
-          );
-          return {
-            selectedAddress: window.ethereum?.selectedAddress ?? null,
-            buttonEnabled,
-            buttonHidden,
-            accountsText: accountsEl ? accountsEl.textContent || null : null,
-          };
-        })()`,
-      );
-      if (!readiness?.selectedAddress) {
-        throw new Error(
-          `Test dapp has no selectedAddress before tapping #${buttonId} (${description})`,
-        );
-      }
-      if (!readiness.buttonEnabled) {
-        throw new Error(
-          `Test dapp #${buttonId} is not enabled before tap (${description})`,
-        );
-      }
-      if (
-        buttonId === TestDappSelectorsWebIDs.SEND_EIP_1559_BUTTON_ID &&
-        readiness.buttonHidden
-      ) {
-        throw new Error(
-          `Test dapp #${buttonId} is still hidden before tap (${description})`,
-        );
-      }
-      const accountsConnected = Boolean(
-        readiness.accountsText?.replace(/^Accounts:\s*/i, '').trim(),
-      );
-      if (
-        buttonId === TestDappSelectorsWebIDs.SEND_CALLS_BUTTON &&
-        !accountsConnected
-      ) {
-        throw new Error(
-          `Test dapp has no connected accounts before tapping #${buttonId} (${description})`,
-        );
-      }
-    },
-    {
-      description: `Wait for selectedAddress and #${buttonId} enabled (${description})`,
-      timeout: TEST_DAPP_READY_TIMEOUT_MS,
-      interval: TEST_DAPP_READY_POLL_MS,
-    },
-  );
 };
 
 /**
@@ -130,8 +47,6 @@ const tapTestDappButtonAndWaitForConfirm = async (
 ): Promise<void> => {
   const pageUrl = getDappUrl(0);
   const confirmTimeoutMs = 30_000;
-
-  await waitForTestDappReadyForTap(pageUrl, buttonId, description);
 
   if (PlatformDetector.isAndroidAppium()) {
     let dismissedPushSheet = false;

--- a/tests/flows/confirmations.flow.ts
+++ b/tests/flows/confirmations.flow.ts
@@ -19,6 +19,7 @@ import SwitchAccountModal from '../page-objects/wallet/SwitchAccountModal';
 import ActivitiesView from '../page-objects/Transactions/ActivitiesView';
 import TabBarComponent from '../page-objects/wallet/TabBarComponent';
 import WalletView from '../page-objects/wallet/WalletView';
+import { TestDappSelectorsWebIDs } from '../selectors/Browser/TestDapp.selectors';
 import { navigateToBrowserView, waitForTestDappToLoad } from './browser.flow';
 import {
   dismissPushNotificationExistingUserSheet,
@@ -31,8 +32,8 @@ const SMART_ACCOUNT_UPGRADED_ACTIVITY = 'Smart account upgraded';
 const SMART_ACCOUNT_UPGRADING_ACTIVITY = 'Upgrading smart account';
 const TEST_DAPP_READY_TIMEOUT_MS = 30_000;
 const TEST_DAPP_READY_POLL_MS = 500;
-const ANDROID_CONFIRM_SHEET_TIMEOUT_MS = 45_000;
-const ANDROID_CONFIRM_POLL_MS = 1_000;
+const ANDROID_CONFIRM_SHEET_TIMEOUT_MS = 60_000;
+const ANDROID_CONFIRM_POLL_MS = 3_000;
 
 export {
   LOCAL_CHAIN_CAIP,
@@ -54,18 +55,31 @@ const waitForTestDappReadyForTap = async (
       const readiness = await ChromeCdpHelpers.evaluateInWebView<{
         selectedAddress: string | null;
         buttonEnabled: boolean;
+        buttonHidden: boolean;
+        accountsText: string | null;
       }>(
         pageUrl,
         `(() => {
           const el = document.getElementById(${JSON.stringify(buttonId)});
+          const accountsEl = document.getElementById(${JSON.stringify(
+            TestDappSelectorsWebIDs.ACCOUNTS_TEXT,
+          )});
           const buttonEnabled = Boolean(
             el &&
               !('disabled' in el && Boolean(el.disabled)) &&
               el.getAttribute('aria-disabled') !== 'true',
           );
+          const buttonHidden = Boolean(
+            el &&
+              (Boolean(el.hidden) ||
+                el.getAttribute('hidden') !== null ||
+                window.getComputedStyle(el).display === 'none'),
+          );
           return {
             selectedAddress: window.ethereum?.selectedAddress ?? null,
             buttonEnabled,
+            buttonHidden,
+            accountsText: accountsEl ? accountsEl.textContent || null : null,
           };
         })()`,
       );
@@ -77,6 +91,25 @@ const waitForTestDappReadyForTap = async (
       if (!readiness.buttonEnabled) {
         throw new Error(
           `Test dapp #${buttonId} is not enabled before tap (${description})`,
+        );
+      }
+      if (
+        buttonId === TestDappSelectorsWebIDs.SEND_EIP_1559_BUTTON_ID &&
+        readiness.buttonHidden
+      ) {
+        throw new Error(
+          `Test dapp #${buttonId} is still hidden before tap (${description})`,
+        );
+      }
+      const accountsConnected = Boolean(
+        readiness.accountsText?.replace(/^Accounts:\s*/i, '').trim(),
+      );
+      if (
+        buttonId === TestDappSelectorsWebIDs.SEND_CALLS_BUTTON &&
+        !accountsConnected
+      ) {
+        throw new Error(
+          `Test dapp has no connected accounts before tapping #${buttonId} (${description})`,
         );
       }
     },
@@ -101,28 +134,24 @@ const tapTestDappButtonAndWaitForConfirm = async (
   await waitForTestDappReadyForTap(pageUrl, buttonId, description);
 
   if (PlatformDetector.isAndroidAppium()) {
+    let dismissedPushSheet = false;
     await Utilities.executeWithRetry(
       async () => {
-        const clicked = await ChromeCdpHelpers.clickByIdInWebView(
+        await WebView.tapById(buttonId, {
           pageUrl,
-          buttonId,
-        );
-        if (!clicked) {
-          throw new Error(`CDP could not click #${buttonId} (${description})`);
-        }
+          description,
+        });
         try {
           await FooterActions.waitForConfirmButton(ANDROID_CONFIRM_POLL_MS);
         } catch (error) {
-          // Push onboarding sheet can sit above the confirmation UI.
-          await dismissPushNotificationExistingUserSheet();
+          if (!dismissedPushSheet) {
+            dismissedPushSheet = true;
+            await dismissPushNotificationExistingUserSheet();
+          }
           throw error;
         }
       },
-      {
-        timeout: ANDROID_CONFIRM_SHEET_TIMEOUT_MS,
-        interval: 0,
-        description: `CDP click #${buttonId} and wait for confirm (${description})`,
-      },
+      { timeout: ANDROID_CONFIRM_SHEET_TIMEOUT_MS },
     );
     return;
   }

--- a/tests/flows/confirmations.flow.ts
+++ b/tests/flows/confirmations.flow.ts
@@ -29,11 +29,42 @@ const LOCAL_CHAIN_NAME = 'Local RPC';
 const LOCAL_CHAIN_CAIP = 'eip155:1337';
 const SMART_ACCOUNT_UPGRADED_ACTIVITY = 'Smart account upgraded';
 const SMART_ACCOUNT_UPGRADING_ACTIVITY = 'Upgrading smart account';
+const TEST_DAPP_READY_TIMEOUT_MS = 30_000;
+const TEST_DAPP_READY_POLL_MS = 500;
 
 export {
   LOCAL_CHAIN_CAIP,
   SMART_ACCOUNT_UPGRADED_ACTIVITY,
   SMART_ACCOUNT_UPGRADING_ACTIVITY,
+};
+
+/**
+ * Wait until the target control is DOM-enabled and the provider has a
+ * selected account.
+ */
+const waitForTestDappReadyForTap = async (
+  pageUrl: string,
+  buttonId: string,
+  description: string,
+): Promise<void> => {
+  await ChromeCdpHelpers.waitForElementEnabledByIdInWebView(pageUrl, buttonId);
+  await Utilities.executeWithRetry(
+    async () => {
+      const selectedAddress = await ChromeCdpHelpers.evaluateInWebView<
+        string | null
+      >(pageUrl, `(() => window.ethereum?.selectedAddress ?? null)()`);
+      if (!selectedAddress) {
+        throw new Error(
+          `Test dapp has no selectedAddress before tapping #${buttonId} (${description})`,
+        );
+      }
+    },
+    {
+      description: `Wait for selectedAddress before tapping #${buttonId} (${description})`,
+      timeout: TEST_DAPP_READY_TIMEOUT_MS,
+      interval: TEST_DAPP_READY_POLL_MS,
+    },
+  );
 };
 
 /**
@@ -48,6 +79,8 @@ const tapTestDappButtonAndWaitForConfirm = async (
 ): Promise<void> => {
   const pageUrl = getDappUrl(0);
   const confirmTimeoutMs = 30_000;
+
+  await waitForTestDappReadyForTap(pageUrl, buttonId, description);
 
   if (PlatformDetector.isAndroidAppium()) {
     ChromeCdpHelpers.resetMetaMaskWebViewCache();
@@ -73,6 +106,9 @@ const tapTestDappButtonAndWaitForConfirm = async (
         await FooterActions.waitForConfirmButton(perAttemptConfirmTimeoutMs);
         return;
       } catch (error) {
+        // Push onboarding sheet can sit above the confirmation UI; clear it
+        // before the next CDP re-click.
+        await dismissPushNotificationExistingUserSheet();
         lastError = error;
       }
     }
@@ -83,7 +119,6 @@ const tapTestDappButtonAndWaitForConfirm = async (
         );
   }
 
-  await ChromeCdpHelpers.waitForElementEnabledByIdInWebView(pageUrl, buttonId);
   await WebView.tapById(buttonId, {
     pageUrl,
     description,

--- a/tests/flows/confirmations.flow.ts
+++ b/tests/flows/confirmations.flow.ts
@@ -31,6 +31,8 @@ const SMART_ACCOUNT_UPGRADED_ACTIVITY = 'Smart account upgraded';
 const SMART_ACCOUNT_UPGRADING_ACTIVITY = 'Upgrading smart account';
 const TEST_DAPP_READY_TIMEOUT_MS = 30_000;
 const TEST_DAPP_READY_POLL_MS = 500;
+const ANDROID_CONFIRM_SHEET_TIMEOUT_MS = 45_000;
+const ANDROID_CONFIRM_POLL_MS = 1_000;
 
 export {
   LOCAL_CHAIN_CAIP,
@@ -39,28 +41,47 @@ export {
 };
 
 /**
- * Wait until the target control is DOM-enabled and the provider has a
- * selected account.
+ * Wait until the provider has a selected account and the target control is
+ * DOM-enabled.
  */
 const waitForTestDappReadyForTap = async (
   pageUrl: string,
   buttonId: string,
   description: string,
 ): Promise<void> => {
-  await ChromeCdpHelpers.waitForElementEnabledByIdInWebView(pageUrl, buttonId);
   await Utilities.executeWithRetry(
     async () => {
-      const selectedAddress = await ChromeCdpHelpers.evaluateInWebView<
-        string | null
-      >(pageUrl, `(() => window.ethereum?.selectedAddress ?? null)()`);
-      if (!selectedAddress) {
+      const readiness = await ChromeCdpHelpers.evaluateInWebView<{
+        selectedAddress: string | null;
+        buttonEnabled: boolean;
+      }>(
+        pageUrl,
+        `(() => {
+          const el = document.getElementById(${JSON.stringify(buttonId)});
+          const buttonEnabled = Boolean(
+            el &&
+              !('disabled' in el && Boolean(el.disabled)) &&
+              el.getAttribute('aria-disabled') !== 'true',
+          );
+          return {
+            selectedAddress: window.ethereum?.selectedAddress ?? null,
+            buttonEnabled,
+          };
+        })()`,
+      );
+      if (!readiness?.selectedAddress) {
         throw new Error(
           `Test dapp has no selectedAddress before tapping #${buttonId} (${description})`,
         );
       }
+      if (!readiness.buttonEnabled) {
+        throw new Error(
+          `Test dapp #${buttonId} is not enabled before tap (${description})`,
+        );
+      }
     },
     {
-      description: `Wait for selectedAddress before tapping #${buttonId} (${description})`,
+      description: `Wait for selectedAddress and #${buttonId} enabled (${description})`,
       timeout: TEST_DAPP_READY_TIMEOUT_MS,
       interval: TEST_DAPP_READY_POLL_MS,
     },
@@ -69,9 +90,6 @@ const waitForTestDappReadyForTap = async (
 
 /**
  * Tap a test-dapp WebView button and wait for the confirmation sheet.
- *
- * Android: CDP can report a successful DOM click without MetaMask opening
- * the confirmation sheet. Retry the click when confirm-button never appears.
  */
 const tapTestDappButtonAndWaitForConfirm = async (
   buttonId: string,
@@ -83,40 +101,30 @@ const tapTestDappButtonAndWaitForConfirm = async (
   await waitForTestDappReadyForTap(pageUrl, buttonId, description);
 
   if (PlatformDetector.isAndroidAppium()) {
-    ChromeCdpHelpers.resetMetaMaskWebViewCache();
-    const maxAttempts = 3;
-    // Short per-attempt wait so we can re-click within a reasonable budget.
-    const perAttemptConfirmTimeoutMs = 12_000;
-    let lastError: unknown;
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      if (attempt > 1) {
-        ChromeCdpHelpers.resetMetaMaskWebViewCache();
-      }
-      const clicked = await ChromeCdpHelpers.clickByIdInWebView(
-        pageUrl,
-        buttonId,
-      );
-      if (!clicked) {
-        lastError = new Error(
-          `CDP could not click #${buttonId} (${description}) on attempt ${attempt}/${maxAttempts}`,
+    await Utilities.executeWithRetry(
+      async () => {
+        const clicked = await ChromeCdpHelpers.clickByIdInWebView(
+          pageUrl,
+          buttonId,
         );
-        continue;
-      }
-      try {
-        await FooterActions.waitForConfirmButton(perAttemptConfirmTimeoutMs);
-        return;
-      } catch (error) {
-        // Push onboarding sheet can sit above the confirmation UI; clear it
-        // before the next CDP re-click.
-        await dismissPushNotificationExistingUserSheet();
-        lastError = error;
-      }
-    }
-    throw lastError instanceof Error
-      ? lastError
-      : new Error(
-          `Confirmation sheet did not open after clicking #${buttonId} (${description}) in ${maxAttempts} attempts`,
-        );
+        if (!clicked) {
+          throw new Error(`CDP could not click #${buttonId} (${description})`);
+        }
+        try {
+          await FooterActions.waitForConfirmButton(ANDROID_CONFIRM_POLL_MS);
+        } catch (error) {
+          // Push onboarding sheet can sit above the confirmation UI.
+          await dismissPushNotificationExistingUserSheet();
+          throw error;
+        }
+      },
+      {
+        timeout: ANDROID_CONFIRM_SHEET_TIMEOUT_MS,
+        interval: 0,
+        description: `CDP click #${buttonId} and wait for confirm (${description})`,
+      },
+    );
+    return;
   }
 
   await WebView.tapById(buttonId, {

--- a/tests/smoke-appium/confirmations/transactions/token-approve/approve.spec.ts
+++ b/tests/smoke-appium/confirmations/transactions/token-approve/approve.spec.ts
@@ -64,9 +64,7 @@ const testSpecificMock = async (mockServer: Mockttp) => {
   );
 };
 
-// Skipped: Android CI flake — CDP dapp click can succeed without opening
-// confirm-button (ERC-721 especially). Un-skip after sheet-open is stable.
-appiumTest.describe.skip(
+appiumTest.describe(
   SmokeConfirmations('Token Approve - approve method'),
   () => {
     appiumTest.describe.configure({ timeout: 2500000 });

--- a/tests/smoke-appium/confirmations/transactions/token-approve/increase-allowance.spec.ts
+++ b/tests/smoke-appium/confirmations/transactions/token-approve/increase-allowance.spec.ts
@@ -67,9 +67,7 @@ const testSpecificMock = async (mockServer: Mockttp) => {
   );
 };
 
-// Skipped with other token-approve suites pending Android confirm-sheet
-// stability after CDP click. Un-skip after Appium validation on main-e2e.
-appiumTest.describe.skip(
+appiumTest.describe(
   SmokeConfirmations('Token Approve - increaseAllowance method'),
   () => {
     appiumTest.describe.configure({ timeout: 2500000 });

--- a/tests/smoke-appium/confirmations/transactions/token-approve/set-approval-for-all.spec.ts
+++ b/tests/smoke-appium/confirmations/transactions/token-approve/set-approval-for-all.spec.ts
@@ -64,9 +64,7 @@ const testSpecificMock = async (mockServer: Mockttp) => {
   );
 };
 
-// Skipped: Android CI flake — CDP click succeeds but confirm-button never
-// appears (flaky/failed in CI). Un-skip after sheet-open is stable.
-appiumTest.describe.skip(
+appiumTest.describe(
   SmokeConfirmations('Token Approve - setApprovalForAll method'),
   () => {
     appiumTest.describe.configure({ timeout: 2500000 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Token-approve Appium smoke suites were quarantined because Android CDP
test-dapp clicks could report success without opening the confirmation sheet
(`confirm-button` never appeared).

This PR stabilizes the shared confirmations flow used by those specs:

1. Wait for the target dapp control to be DOM-enabled
2. Wait for `window.ethereum.selectedAddress` before tapping
3. Keep the existing Android CDP re-click retry when the sheet does not open,
   and dismiss the push-notification sheet on a miss before retrying

Then unskips:

- `approve.spec.ts`
- `increase-allowance.spec.ts`
- `set-approval-for-all.spec.ts`

Local Android main-e2e validation: all six token-approve cases passed.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-2232

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Token approve Appium smoke stability

  Scenario: Android token-approve confirmations open and submit
    Given a main-e2e Android build and emulator
    And fixtures with the test dapp connected on Anvil

    When the Appium smoke runs approve, increase-allowance, and setApprovalForAll
    Then each case opens the confirmation sheet after the dapp tap
    And Activity shows the expected Confirmed row
```

Local commands used:

```bash
ANDROID_APK_PATH=build/ci-main-e2e/app-prod-release.apk \
ANDROID_AVD_NAME=Pixel_5_Pro_API_34 \
yarn appium-smoke:android -- confirmations/transactions/token-approve/
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — test/infra-only change; no product UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to E2E helpers and unskipping smoke specs; no production app behavior.
> 
> **Overview**
> **Android confirmation flow** in `tapTestDappButtonAndWaitForConfirm` no longer uses CDP clicks and a fixed three-attempt loop. It now taps the test-dapp control via `WebView.tapById`, polls for `confirm-button` inside `Utilities.executeWithRetry` (60s budget, 3s polls), and on the first miss dismisses the push-notification sheet before retrying.
> 
> Non-Android paths drop the CDP “wait for enabled” pre-step and rely on the same `WebView.tapById` + confirm wait pattern.
> 
> **Token-approve Appium smokes** (`approve`, `increase-allowance`, `set-approval-for-all`) are re-enabled by removing `describe.skip` and the flake quarantine comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 692946f1d91faad90c0535f47f629c0a04b116a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->