### PR TITLE
test: skip trending feed View All navigation smoke

### DIFF
--- a/tests/smoke-appium/trending/trending-feed.spec.ts
+++ b/tests/smoke-appium/trending/trending-feed.spec.ts
@@ -83,7 +83,7 @@ appiumTest.describe(
         });
     };
 
-    appiumTest(
+    appiumTest.skip(
       'Navigate to all sections full views via View All and return to feed',
       async ({ driver: _driver, currentDeviceDetails }) => {
         await withFixtures(


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Temporarily skips the Appium smoke `Navigate to all sections full views via View All and return to feed` while investigating an Explore → Perps market details regression.

Local baseline on a fresh `main` main-e2e iOS build (`a1db7820b9`, including #34326 / #34395) reproduces CI:

`element ("~perps-market-details-view") still not displayed` at `TrendingView.verifyPerpDetailsVisible` after tapping the BTC Perps pill.

An older Aug 5 main-e2e binary still passed the same spec. A follow-up fix PR will harden the Perps details assertion/fixture/mocks and re-enable this test.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: Explore trending feed Appium smoke failure on `perps-market-details-view` after Perps Pro-mode navigation changes (#34326, #34395)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — test skip only; no product behavior change.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — test skip only.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for draft PRs.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no product or runtime behavior impact.
> 
> **Overview**
> **Temporarily skips** the Appium smoke test `Navigate to all sections full views via View All and return to feed` in `trending-feed.spec.ts` by changing `appiumTest` to `appiumTest.skip`.
> 
> CI and fresh `main` builds fail when the flow taps the BTC Perps row and waits for `perps-market-details-view` (`TrendingView.verifyPerpDetailsVisible`), tied to recent Explore → Perps market details navigation changes. A follow-up PR is expected to fix assertions/fixtures/mocks and re-enable the test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fa5e56b2e7abed03584d6a18d70bf4502625879. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->