### PR TITLE
fix: round down money account deposit amounts past source balance cp-8.6.0

### DIFF
--- a/app/components/UI/Money/utils/moneyAccountTransactions.ts
+++ b/app/components/UI/Money/utils/moneyAccountTransactions.ts
@@ -255,9 +255,11 @@ export async function updateMoneyAccountDepositTokenAmount(
   const provider = getProviderByChainId(chainIdHex);
   if (!provider) return [];
 
+  // ROUND_DOWN so Max / near-Max from an 18-decimal pay token never encodes
+  // more mUSD than the source balance can fund (ROUND_UP was pushing past it).
   const amount = BigInt(
     calcTokenValue(amountHuman, MUSD_DECIMALS)
-      .decimalPlaces(0, BigNumber.ROUND_UP)
+      .decimalPlaces(0, BigNumber.ROUND_DOWN)
       .toFixed(0),
   );
 

--- a/app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.test.ts
@@ -523,7 +523,7 @@ describe('useUpdateTransactionPayAmount', () => {
       );
     });
 
-    it('rounds fractional atomic amounts up before encoding', async () => {
+    it('rounds fractional atomic amounts down before encoding', async () => {
       const { result } = runHook({
         transactionMeta: moneyAccountDepositMetaWithRequiredAssets,
       });
@@ -532,7 +532,8 @@ describe('useUpdateTransactionPayAmount', () => {
 
       expect(updateTransactionMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          requiredAssets: [{ ...existingRequiredAsset, amount: '0xf4241' }],
+          // 1.0000005 floored to 6 decimals → 1000000 (0xf4240)
+          requiredAssets: [{ ...existingRequiredAsset, amount: '0xf4240' }],
         }),
         expect.any(String),
       );

--- a/app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.ts
+++ b/app/components/Views/confirmations/hooks/pay/useUpdateTransactionPayAmount.ts
@@ -223,10 +223,12 @@ function syncMoneyAccountDepositRequiredAssets(
   if (!existing?.length || decimals === undefined) return;
 
   try {
+    // ROUND_DOWN so Max / near-Max from an 18-decimal pay token never encodes
+    // more than the source balance can fund (ROUND_UP was pushing past it).
     const amount = toHex(
       new BigNumber(amountHuman)
         .shiftedBy(decimals)
-        .decimalPlaces(0, BigNumber.ROUND_UP)
+        .decimalPlaces(0, BigNumber.ROUND_DOWN)
         .toFixed(0),
     ) as Hex;
     if (existing[0].amount === amount) return;

--- a/app/core/Engine/controllers/transaction-pay-controller/money-account-amount-update.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/money-account-amount-update.test.ts
@@ -140,7 +140,8 @@ describe('updateMoneyAccountDepositAmount', () => {
     ).resolves.toBe(true);
 
     expect(buildDepositBatchMock).toHaveBeenCalledWith({
-      amount: 1_000_001n,
+      // 1.0000001 floored to 6 mUSD decimals (ROUND_DOWN), not rounded up.
+      amount: 1_000_000n,
       chainId: CHAIN_ID,
       boringVault: VAULT_CONFIG.boringVault,
       tellerAddress: VAULT_CONFIG.tellerAddress,
@@ -162,7 +163,7 @@ describe('updateMoneyAccountDepositAmount', () => {
       ],
     });
     expect(currentTransaction.requiredAssets).toStrictEqual([
-      { address: MUSD_ADDRESS, amount: '0xf4241', standard: 'erc20' },
+      { address: MUSD_ADDRESS, amount: '0xf4240', standard: 'erc20' },
       {
         address: SECOND_ASSET_ADDRESS,
         amount: '0x7',

--- a/app/core/Engine/controllers/transaction-pay-controller/money-account-amount-update.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/money-account-amount-update.ts
@@ -88,8 +88,10 @@ async function updateMoneyAccountDepositAmountInternal(
     failUpdate('missing provider');
   }
 
+  // ROUND_DOWN so Max / near-Max from an 18-decimal pay token never encodes
+  // more mUSD than the source balance can fund (ROUND_UP was pushing past it).
   const amountRaw = calcTokenValue(amountHuman, MUSD_DECIMALS)
-    .decimalPlaces(0, BigNumber.ROUND_UP)
+    .decimalPlaces(0, BigNumber.ROUND_DOWN)
     .toFixed(0);
   const depositAssetAddress = getMoneyAccountDepositAssetAddress(chainId);
   const buildResult = await buildMoneyAccountDepositBatch({

--- a/app/core/Engine/controllers/transaction-pay-controller/paymentoverride-callback.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/paymentoverride-callback.ts
@@ -135,9 +135,11 @@ async function getMoneyAccountDepositPaymentOverrideData<
   const provider = getProviderByChainId(chainId);
   if (!provider) return { calls: [] };
 
+  // ROUND_DOWN so Max / near-Max from an 18-decimal pay token never encodes
+  // more mUSD than the source balance can fund (ROUND_UP was pushing past it).
   const amount = BigInt(
     calcTokenValue(amountHuman, MUSD_DECIMALS)
-      .decimalPlaces(0, BigNumber.ROUND_UP)
+      .decimalPlaces(0, BigNumber.ROUND_DOWN)
       .toFixed(0),
   );
 

--- a/app/selectors/featureFlagController/stableTokens/index.ts
+++ b/app/selectors/featureFlagController/stableTokens/index.ts
@@ -3,7 +3,7 @@ import { selectRemoteFeatureFlags } from '..';
 import type { Hex } from '@metamask/utils';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 
-export const STABLE_TOKENS_FLAG = 'stable-tokens' as const;
+export const STABLE_TOKENS_FLAG = 'stableTokens' as const;
 
 const DEFAULT_STABLECOINS: Record<Hex, Hex[]> = {
   [CHAIN_IDS.MAINNET]: [

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -5880,8 +5880,8 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
-  'stable-tokens': {
-    name: 'stable-tokens',
+  stableTokens: {
+    name: 'stableTokens',
     type: FeatureFlagType.Remote,
     inProd: false,
     productionDefault: {},


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Max Money Account deposits funded by 18-decimal pay tokens (e.g. BNB USD) were encoding the deposit amount with `ROUND_UP` into 6-decimal mUSD. That inflated the required Relay `sourceAmount` slightly above the wallet balance, which blocked confirmation with insufficient funds and failed Relay submit if the alert was bypassed.

This changes Money Account deposit amount encoding to `ROUND_DOWN` (matching the existing withdraw Max path) so the encoded mUSD amount never exceeds what the source balance can fund. It also renames the remote stablecoins feature-flag key from `stable-tokens` to `stableTokens` so mobile reads the same camelCase flag name.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed Money Account Max deposits failing for some BNB stablecoins due to amount rounding

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money Account Add funds Max with BNB USD

  Scenario: user Max-deposits with BNB USD pay token
    Given a wallet with a non-exact 18-decimal BNB USD balance
    And the user opens Money Account Add funds
    And the user selects BNB USD as Pay with

    When user taps Max
    Then the insufficient-funds alert does not block due to mUSD ROUND_UP dust
    And confirming the deposit does not fail with Relay insufficient source token balance
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment amount encoding across multiple deposit paths; incorrect rounding could still affect Relay quotes and confirmation, but the change is narrowly scoped to floor vs ceil and aligns with the existing withdraw Max behavior.
> 
> **Overview**
> Fixes **Max / near-Max Money Account deposits** when funding from **18-decimal pay tokens** (e.g. BNB USD). Human amounts are converted to **6-decimal mUSD** with **`ROUND_DOWN`** instead of **`ROUND_UP`** everywhere deposit amounts are encoded for Pay—deposit batch updates, `requiredAssets` sync on confirmation, the quote-pipeline amount coordinator, and Relay payment-override deposit calls—so Relay never asks for slightly more source token than the wallet can cover.
> 
> Tests are updated to expect floored atomic values (e.g. `1.0000005` → `0xf4240`).
> 
> Separately, the remote feature flag key for stablecoin lists is renamed from **`stable-tokens`** to **`stableTokens`** in the selector and feature-flag registry so mobile reads the same camelCase name as other platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88d9393c38d19f6fa02128003fb3be1935ea115d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->