### PR TITLE
test: fix trending-feed spec and unskip smoke (MMQA-2235)

### DIFF
--- a/tests/page-objects/Trending/TrendingView.ts
+++ b/tests/page-objects/Trending/TrendingView.ts
@@ -15,6 +15,7 @@ import {
 import { PredictMarketListSelectorsIDs } from '../../../app/components/UI/Predict/Predict.testIds';
 import TabBarComponent from '../wallet/TabBarComponent';
 import BrowserView from '../Browser/BrowserView';
+import PerpsMarketDetailsView from '../Perps/PerpsMarketDetailsView';
 
 class TrendingView {
   private activeScrollViewID: string = TrendingViewSelectorsIDs.NOW_SCROLL_VIEW;
@@ -443,13 +444,7 @@ class TrendingView {
   }
 
   async verifyPerpDetailsVisible(): Promise<void> {
-    // Verify we are on Perps market details page by checking for the container
-    await Assertions.expectElementToBeVisible(
-      Matchers.getElementByID('perps-market-details-view'),
-      {
-        description: 'Perps market details view should be visible',
-      },
-    );
+    await PerpsMarketDetailsView.isContainerDisplayed();
   }
 
   async verifyPredictionsTabsVisible(): Promise<void> {

--- a/tests/smoke-appium/trending/trending-feed.spec.ts
+++ b/tests/smoke-appium/trending/trending-feed.spec.ts
@@ -83,7 +83,7 @@ appiumTest.describe(
         });
     };
 
-    appiumTest.skip(
+    appiumTest(
       'Navigate to all sections full views via View All and return to feed',
       async ({ driver: _driver, currentDeviceDetails }) => {
         await withFixtures(


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Unskips the Appium smoke `Navigate to all sections full views via View All and return to feed` after fixing a flaky Perps details visibility assert.

After recent Perps Lite/Pro market-details layout changes, waiting on Lite container `perps-market-details-view` failed in CI/local main-e2e even though market details opened. Dedicated Perps smoke already waits on the Lite header via `PerpsMarketDetailsView.isContainerDisplayed()` (20s).

**Changes:**
- `TrendingView.verifyPerpDetailsVisible()` now delegates to `PerpsMarketDetailsView.isContainerDisplayed()` (`perps-market-header`)
- Re-enables the previously skipped trending feed View All navigation smoke

**Local validation:** same main-e2e iOS binary that failed on `~perps-market-details-view` passed after this POM change.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MMQA-2235](https://consensyssoftware.atlassian.net/browse/MMQA-2235)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Trending Feed View All Navigation Appium smoke

  Scenario: Explore View All and Perps details navigation
    Given a main-e2e iOS build is installed on the simulator
    And trending/predict feature flags and TRENDING_API_MOCKS are configured

    When I run
      """
      IOS_APP_PATH=build/ci-main-e2e/MetaMask.app \
      yarn appium-smoke:ios --grep "Navigate to all sections full views via View All"
      """
    Then the smoke passes including Perps details via header visibility
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — Appium smoke assert/unskip only; validated via local iOS Appium run (passed).

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for draft PRs.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MMQA-2235]: https://consensyssoftware.atlassian.net/browse/MMQA-2235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ