### PR TITLE
chore: bump react-native-screens to 4.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -543,7 +543,7 @@
     "react-native-render-html": "^6.3.4",
     "react-native-reorderable-list": "^0.18.1",
     "react-native-safe-area-context": "~5.8.0",
-    "react-native-screens": "~4.25.2",
+    "react-native-screens": "~4.26.0",
     "react-native-sensors": "patch:react-native-sensors@npm%3A5.3.0#~/.yarn/patches/react-native-sensors-npm-5.3.0-318d1d324d.patch",
     "react-native-share": "patch:react-native-share@npm%3A12.3.1#~/.yarn/patches/react-native-share-npm-12.3.1-be09b19fc2.patch",
     "react-native-size-matters": "0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -36620,7 +36620,7 @@ __metadata:
     react-native-render-html: "npm:^6.3.4"
     react-native-reorderable-list: "npm:^0.18.1"
     react-native-safe-area-context: "npm:~5.8.0"
-    react-native-screens: "npm:~4.25.2"
+    react-native-screens: "npm:~4.26.0"
     react-native-sensors: "patch:react-native-sensors@npm%3A5.3.0#~/.yarn/patches/react-native-sensors-npm-5.3.0-318d1d324d.patch"
     react-native-share: "patch:react-native-share@npm%3A12.3.1#~/.yarn/patches/react-native-share-npm-12.3.1-be09b19fc2.patch"
     react-native-size-matters: "npm:0.4.0"
@@ -41327,16 +41327,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-screens@npm:~4.25.2":
-  version: 4.25.2
-  resolution: "react-native-screens@npm:4.25.2"
+"react-native-screens@npm:~4.26.0":
+  version: 4.26.2
+  resolution: "react-native-screens@npm:4.26.2"
   dependencies:
     react-freeze: "npm:^1.0.0"
     warn-once: "npm:^0.1.0"
   peerDependencies:
     react: "*"
-    react-native: ">=0.82.0"
-  checksum: 10/b0fca70d7aafbd8ff993c0e0329ee78fe453391eaff9556e87fb619d0d58b93b497e47ff5477a1028ecad35d4165f47c833ccb22049e59c5d55a1c55a13029b0
+    react-native: "*"
+  checksum: 10/9d171ca538ba511ea30a7e7f47088d408f9bb565b7bfeedbb5443ffe430ac0c48f805fb2b89b7b16e61c9b81480a01049864ecd2651f77e3d0d0b1f5d6ce54f1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Bumps `react-native-screens` from `~4.25.2` to `~4.26.0` (resolves to 4.26.2).

This is a pre-upgrade extraction from the RN 0.85 upgrade PR (#34283): landing this minor bump on main independently keeps the upgrade diff limited to the interlocked core set (RN + Expo SDK 56). screens 4.26 is compatible with RN 0.83, so it can ship ahead of the upgrade.

## Changelog

CHANGELOG entry not required — dependency bump with no user-facing behavior change.

## Related issues

Relates to #34283 (RN 0.85.3 upgrade)

## Manual testing steps

1. `yarn setup` and build both platforms
2. Navigate across stack/tab navigators (wallet, settings, modals) and verify transitions render correctly

## Pre-merge author checklist

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `react-native-screens` sits on the native navigation stack path; a minor bump can affect transitions and modals on iOS/Android even with no JS diff, so manual navigator smoke testing matters.
> 
> **Overview**
> Bumps **`react-native-screens`** from **`~4.25.2`** (4.25.2) to **`~4.26.0`** (lockfile resolves to **4.26.2**) in `package.json` and `yarn.lock`. There are **no application code changes**—only the dependency version and lock entry.
> 
> The resolved package’s **`react-native` peer** moves from **`>=0.82.0`** to **`*`**, which broadens the declared compatibility range without changing how the app imports or configures screens.
> 
> This is intended to land ahead of the RN 0.85 upgrade so navigation stack behavior stays on a newer screens line while keeping that larger upgrade PR smaller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4358bd05ad441b9adc6f5e27e24f6b1dc28af8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->