### PR TITLE
Refresh Quick Buy sell quote rate on re-entry

### DIFF
--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/hooks/useQuickBuyController.ts
@@ -587,7 +587,8 @@ export function useQuickBuyController(
   // the displayed fiat balance and slider cap stay in sync with the option list
   // when `usePayWithTokens` refreshes rates without a balance string change
   // (Bugbot: "Stale rate with live balance"). In sell mode `sourceToken` is
-  // `positionToken` (already selector-driven), so the frozen value is live.
+  // `positionToken` (already selector-driven), so the display rate stays live;
+  // quote conversion is intentionally frozen via `sellQuoteExchangeRateRef`.
   //
   // Intentionally NOT used in `sourceTokenAmount` (the quote pipeline): a rate
   // tick must not churn quote requests — only balance changes do.
@@ -610,11 +611,18 @@ export function useQuickBuyController(
   // convert committed fiat into the quote request amount.
   const sellQuoteExchangeRateRef = useRef<number | undefined>(undefined);
   const sellQuoteSourceTokenKeyRef = useRef<string | undefined>(undefined);
+  const prevTradeModeForSellQuoteRef = useRef<QuickBuyTradeMode>(tradeMode);
   const positionTokenKey =
     positionToken?.address != null && positionToken.chainId != null
       ? getTokenKey(positionToken)
       : undefined;
-  if (positionTokenKey !== sellQuoteSourceTokenKeyRef.current) {
+  const didEnterSellMode =
+    prevTradeModeForSellQuoteRef.current !== 'sell' && tradeMode === 'sell';
+  prevTradeModeForSellQuoteRef.current = tradeMode;
+  if (
+    positionTokenKey !== sellQuoteSourceTokenKeyRef.current ||
+    didEnterSellMode
+  ) {
     sellQuoteSourceTokenKeyRef.current = positionTokenKey;
     sellQuoteExchangeRateRef.current = positionToken?.currencyExchangeRate;
   } else if (

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts
@@ -2517,6 +2517,48 @@ describe('useQuickBuyController', () => {
       expect(result.current.isConfirmDisabled).toBe(false);
     });
 
+    it('refreshes the frozen sell quote rate when re-entering sell mode for the same token', () => {
+      let positionToken = createPositionToken({ currencyExchangeRate: 2000 });
+      (usePositionTokenBalance as jest.Mock).mockImplementation(
+        () => positionToken,
+      );
+      (useReceiveTokens as jest.Mock).mockReturnValue([
+        createSellReceiveNative(),
+      ]);
+
+      const props = {
+        target: createTarget(),
+        onClose: jest.fn(),
+      };
+      const { result, rerender } = renderHook(
+        ({ target, onClose }) => useQuickBuyController(target, onClose),
+        { initialProps: props },
+      );
+
+      act(() => {
+        result.current.setTradeMode('sell');
+      });
+      act(() => {
+        result.current.handleAmountChange('20');
+      });
+      expect(result.current.sourceTokenAmount).toBe('0.01');
+
+      act(() => {
+        result.current.setTradeMode('buy');
+      });
+      positionToken = createPositionToken({ currencyExchangeRate: 2500 });
+      rerender(props);
+
+      act(() => {
+        result.current.setTradeMode('sell');
+      });
+      act(() => {
+        result.current.handleAmountChange('20');
+      });
+
+      expect(result.current.sourceTokenAmount).toBe('0.008');
+    });
+
     it('resets tradeMode to buy when the position token balance becomes zero', () => {
       (usePositionTokenBalance as jest.Mock).mockReturnValue(
         createPositionToken(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update the Quick Buy sell-rate comment to clarify display rates stay live while quote conversion is frozen
- refresh the frozen sell quote exchange rate whenever the user re-enters sell mode for the same token
- add a regression test covering buy -> sell re-entry after a same-token price move

## Testing
- `yarn jest app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts -t "refreshes the frozen sell quote rate"` — assertion reported `PASS`, but the Jest process later exited with Node OOM in this cloud environment
- `NODE_OPTIONS="--max-old-space-size=8192" yarn jest --runInBand --forceExit app/components/Views/SocialLeaderboard/TraderPositionView/components/QuickBuy/useQuickBuyController.test.ts -t "refreshes the frozen sell quote rate"` — assertion reported `PASS`; process hung after printing results and was terminated
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/D0BEW7886U9/p1783620917095449?thread_ts=1783620917.095449&cid=D0BEW7886U9)

<div><a href="https://cursor.com/agents/bc-e8a9be3e-b172-5d03-baf3-e333da1ae7e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8a9be3e-b172-5d03-baf3-e333da1ae7e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

