### PR TITLE
fix(perps): fix truncated market names and Pro fees layout cp-8.7.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -149,6 +149,7 @@ const Notices = ({ notices }: { notices: PerpsProOrderNotice[] }) =>
   ) : null;
 
 const summaryRowClassName = 'h-5 px-0';
+const summaryFeesRowClassName = 'min-h-6 h-auto px-0';
 const summaryRowStyle = { paddingHorizontal: 0 } as const;
 
 interface SlippageValueProps {
@@ -192,7 +193,7 @@ const OrderSummary = ({
   onSlippagePress,
   onFeesInfoPress,
 }: PerpsProOrderSummaryProps) => (
-  <Box twClassName="w-full gap-1 overflow-hidden" testID={ids.SUMMARY}>
+  <Box twClassName="w-full gap-1" testID={ids.SUMMARY}>
     <KeyValueRow
       keyLabel={strings('perps.order.margin')}
       value={margin}
@@ -231,6 +232,8 @@ const OrderSummary = ({
           feeDiscountPercentage={feeDiscountPercentage}
           testID={ids.SUMMARY_FEES_VALUE}
           variant={TextVariant.BodyXs}
+          color={TextColor.TextDefault}
+          fontWeight={FontWeight.Medium}
         />
       }
       keyEndButtonIconProps={buttonIcon(
@@ -240,7 +243,7 @@ const OrderSummary = ({
       )}
       keyTextProps={summaryKeyTextProps}
       valueTextProps={summaryValueTextProps}
-      twClassName={summaryRowClassName}
+      twClassName={summaryFeesRowClassName}
       style={summaryRowStyle}
       testID={ids.SUMMARY_FEES}
     />

--- a/app/components/UI/Perps/components/PerpsFeesDisplay/PerpsFeesDisplay.styles.ts
+++ b/app/components/UI/Perps/components/PerpsFeesDisplay/PerpsFeesDisplay.styles.ts
@@ -6,7 +6,12 @@ const createStyles = (_colors: Theme['colors']) =>
     feeRowContent: {
       flexDirection: 'row',
       alignItems: 'center',
+      flexShrink: 1,
       gap: 4,
+    },
+    vipBadgeContainer: {
+      flexShrink: 0,
+      alignSelf: 'center',
     },
   });
 

--- a/app/components/UI/Perps/components/PerpsFeesDisplay/PerpsFeesDisplay.tsx
+++ b/app/components/UI/Perps/components/PerpsFeesDisplay/PerpsFeesDisplay.tsx
@@ -11,6 +11,7 @@ import {
   Text,
   TextVariant,
   TextColor,
+  FontWeight,
 } from '@metamask/design-system-react-native';
 
 interface PerpsFeesDisplayProps {
@@ -34,6 +35,9 @@ interface PerpsFeesDisplayProps {
   placeholder?: string;
   testID?: string;
   variant?: TextVariant;
+  /** Main fee value color. Defaults to `TextAlternative` for legacy screens. */
+  color?: TextColor;
+  fontWeight?: FontWeight;
 }
 
 const PerpsFeesDisplay: React.FC<PerpsFeesDisplayProps> = ({
@@ -43,6 +47,8 @@ const PerpsFeesDisplay: React.FC<PerpsFeesDisplayProps> = ({
   placeholder = '--',
   testID,
   variant = TextVariant.BodyMd,
+  color = TextColor.TextAlternative,
+  fontWeight,
 }) => {
   const { colors } = useTheme();
   const styles = createStyles(colors);
@@ -71,7 +77,11 @@ const PerpsFeesDisplay: React.FC<PerpsFeesDisplayProps> = ({
 
   return (
     <View style={styles.feeRowContent}>
-      {showVipBadge ? <RewardsVipBadge /> : null}
+      {showVipBadge ? (
+        <View style={styles.vipBadgeContainer}>
+          <RewardsVipBadge />
+        </View>
+      ) : null}
       {originalFeeText !== undefined ? (
         <Text
           variant={variant}
@@ -83,7 +93,12 @@ const PerpsFeesDisplay: React.FC<PerpsFeesDisplayProps> = ({
           {originalFeeText}
         </Text>
       ) : null}
-      <Text variant={variant} color={TextColor.TextAlternative} testID={testID}>
+      <Text
+        variant={variant}
+        color={color}
+        fontWeight={fontWeight}
+        testID={testID}
+      >
         {feeText}
       </Text>
     </View>

--- a/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.tsx
@@ -42,9 +42,6 @@ const styles = StyleSheet.create({
   container: {
     height: PERPS_MARKET_HEADER_HEIGHT,
   },
-  nameText: {
-    maxWidth: 120,
-  },
   subtitleCrossfade: {
     height: SUBTITLE_CROSSFADE_HEIGHT,
     justifyContent: 'center',
@@ -284,7 +281,6 @@ const PerpsMarketHeader = ({
             maxLeverage={market.maxLeverage}
             size={32}
             gap={2}
-            nameStyle={styles.nameText}
             onPress={onIdentityPress}
             subtitleContent={displaySubtitleAndPrice}
             testIDs={{

--- a/app/components/UI/Perps/components/PerpsMarketIdentity/PerpsMarketIdentity.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketIdentity/PerpsMarketIdentity.tsx
@@ -79,20 +79,22 @@ const PerpsMarketIdentity = ({
       flexDirection={BoxFlexDirection.Row}
       alignItems={BoxAlignItems.Center}
       gap={gap}
-      twClassName={`self-start rounded-lg p-1 ${pressed ? 'bg-pressed' : ''}`}
+      twClassName={`rounded-lg p-1 ${pressed ? 'bg-pressed' : ''}`}
     >
       <PerpsTokenLogo symbol={symbol} size={size} testID={testIDs?.assetIcon} />
-      <Box flexDirection={BoxFlexDirection.Column}>
+      <Box flexDirection={BoxFlexDirection.Column} twClassName="flex-1 min-w-0">
         <Box
           flexDirection={BoxFlexDirection.Row}
           alignItems={BoxAlignItems.Center}
           gap={1}
+          twClassName="min-w-0"
         >
           <Text
             variant={TextVariant.BodyMd}
             fontWeight={FontWeight.Medium}
             numberOfLines={1}
-            style={nameStyle}
+            // eslint-disable-next-line react-native/no-inline-styles
+            style={[{ flexShrink: 1 }, nameStyle]}
             testID={testIDs?.assetName}
           >
             {displayTitle}

--- a/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketRowItem/PerpsMarketRowItem.tsx
@@ -196,6 +196,10 @@ const PerpsMarketRowItem = ({
       titleProps={{
         testID: getPerpsMarketRowItemSelector.assetLabel(displayMarket.symbol),
         numberOfLines: 1,
+        // flexShrink lets the title text yield space to the leverage badge so
+        // it doesn't overflow into the price column on long asset names.
+        // eslint-disable-next-line react-native/no-inline-styles
+        style: { flexShrink: 1 },
       }}
       titleEndAccessory={
         <PerpsLeverage maxLeverage={displayMarket.maxLeverage} />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

Long ETF and equity market names were overlapping the leverage badge and price column in the market list, and the Pro market header title was clipped too aggressively because it used a fixed `maxWidth`. The Pro order summary fees row also cropped the VIP badge and used a different text color than the other summary values.

This PR makes the market list title and header identity text shrink around the leverage badge and right-side actions, removes the hardcoded header name width, and adjusts the Pro fees summary row so the VIP badge is fully visible and the fee value matches the other summary values.

## **Changelog**

CHANGELOG entry: Fixed truncated market names in Perps market lists and headers, and improved Pro order summary fees layout.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Perps market layout truncation

  Scenario: market list shows long ETF names without overlapping price
    Given I am on the Perps Markets screen
    And I open the ETFs category
    When I view markets with long names such as "iShares MSCI South Korea ETF"
    Then the leverage badge stays within the row
    And the price column is not overlapped or clipped

  Scenario: Pro market header adapts to right-side actions
    Given I open a long-named market in Pro mode
    When the header shows wallet, favorite, and Pro toggle actions
    Then the market name truncates within the available center space
    And the leverage badge and chevron remain visible

  Scenario: Pro order summary fees row displays correctly
    Given I am on a Pro market order form with an active VIP fee discount
    When I view the order summary fees row
    Then the VIP badge is fully visible
    And the fee value uses the same color and weight as margin and liquidation values
```

## **Screenshots/Recordings**

### **Before**

| Scenario | Screenshot |
| --- | --- |
| Pro order summary fees row | - |
| Market list (long ETF names) | <img width="300" alt="Market list ETFs" src="https://github.com/user-attachments/assets/7c735f0a-c676-4816-9c48-c6be0652f439" /> |
| Pro market header | <img width="300" alt="Pro market header" src="https://github.com/user-attachments/assets/bca8b008-9b1c-4955-891d-5c564c7e4d5d" /> |

### **After**

| Scenario | Screenshot |
| --- | --- |
| Pro order summary fees row | <img width="300" alt="Pro order summary fees row" src="https://github.com/user-attachments/assets/ff6ac1a3-63aa-4318-be5c-acfa8e32e68d" /> |
| Market list (long ETF names) | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-07 at 16 31 30" src="https://github.com/user-attachments/assets/5ee0af4a-845f-4e65-bba7-ad58cc278dc2" /> |
| Pro market header | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-07 at 16 31 34" src="https://github.com/user-attachments/assets/0766d1ae-73be-445a-b251-070d523b79a2" /> |

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)