### PR TITLE
test: skip Appium 7702 wallet_sendCalls batch smoke

### DIFF
--- a/tests/smoke-appium/confirmations/transactions/7702/batch-transaction.spec.ts
+++ b/tests/smoke-appium/confirmations/transactions/7702/batch-transaction.spec.ts
@@ -100,7 +100,9 @@ const testSpecificMock = async (mockServer: Mockttp) => {
 appiumTest.describe(SmokeConfirmations('7702 - smart account'), () => {
   appiumTest.describe.configure({ timeout: 2500000 });
 
-  appiumTest(
+  // Skipped: Appium 7702 wallet_sendCalls batch smoke is unstable in CI.
+  // Un-skip once batch confirmation + smart-account upgrade activity asserts are stable.
+  appiumTest.skip(
     'submits a wallet_sendCalls batch of two transactions',
     async ({ driver: _driver, currentDeviceDetails }) => {
       await withFixtures(


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Temporarily skip the Appium smoke case `submits a wallet_sendCalls batch of two transactions` in `tests/smoke-appium/confirmations/transactions/7702/batch-transaction.spec.ts` so flaky CI does not block SmokeConfirmations while the batch confirmation / smart-account upgrade activity path is stabilized.

The sibling case `upgrades an account to a smart account` remains enabled.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — test skip only; no product behavior change.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — test skip only.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I’ve followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for draft PRs.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code or runtime behavior impact.
> 
> **Overview**
> **Temporarily skips** the Appium smoke test `submits a wallet_sendCalls batch of two transactions` in `batch-transaction.spec.ts` by switching `appiumTest` to `appiumTest.skip`, with comments noting CI instability around batch confirmation and smart-account upgrade activity assertions.
> 
> The related case **`upgrades an account to a smart account`** stays enabled. No app or confirmation logic changes—only test execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8545f3710a1e3673222ea1decb3f0408d3f2a35e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->