### PR TITLE
chore: move deeplink handlers code ownership to engagement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -161,6 +161,7 @@ app/core/NotificationsManager.test.ts @MetaMask/engagement
 **/Engagement/** @MetaMask/engagement
 **/engagement/** @MetaMask/engagement
 app/constants/engagement.ts @MetaMask/engagement
+app/core/DeeplinkManager/handlers/ @MetaMask/engagement
 
 # LavaMoat Team
 ses.cjs                              @MetaMask/supply-chain


### PR DESCRIPTION
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Adds `app/core/DeeplinkManager/handlers/` to the Engagement team block in `.github/CODEOWNERS`, so changes to deeplink handlers request review from `@MetaMask/engagement`.

**Reason:** deeplink handlers are maintained day to day by Engagement, but the directory was only covered by the broader `app/core/DeeplinkManager` entry owned by `@MetaMask/mobile-platform`, which routed every handler change to Platform instead of the team that owns the code.

**Solution:** one new CODEOWNERS line scoped to the `handlers/` directory. The broader `app/core/DeeplinkManager` entry (line 36) stays with `@MetaMask/mobile-platform` for everything outside `handlers/`, and the more specific per-file entries later in the file (`handlePerpsUrl.ts` → `@MetaMask/perps`, `handleSocialLeaderboardUrl.ts` / `handleSocialTraderPositionUrl.ts` → `@MetaMask/social-ai`, `handlePredictUrl.ts` → `@MetaMask/predict`) are unchanged and still win for those files under GitHub's last-matching-pattern rule.

No application code or runtime behavior changes.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A — repository ownership metadata only; no tracking issue. Requested by the Engagement team as the owner of the deeplink handlers.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — CODEOWNERS is GitHub review-routing metadata, not shipped code, so there is nothing to exercise in the app. Verified by inspection instead:

1. The new pattern `app/core/DeeplinkManager/handlers/` matches the existing directory (handlers live at `app/core/DeeplinkManager/handlers/`, including `handlers/legacy/`).
2. It is placed above the per-file `@MetaMask/perps` / `@MetaMask/social-ai` / `@MetaMask/predict` entries, so those files keep their current owners (last match wins).
3. `CODEOWNERS` still parses cleanly (the "Validate CODEOWNERS" / lint checks on this PR pass), and no existing owner line was removed or reordered.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — no user-facing or visual change. Full diff is a single line:

```diff
+app/core/DeeplinkManager/handlers/ @MetaMask/engagement
```

### **Before**

`app/core/DeeplinkManager/handlers/**` reviews routed to `@MetaMask/mobile-platform` via `app/core/DeeplinkManager`.

### **After**

`app/core/DeeplinkManager/handlers/**` reviews route to `@MetaMask/engagement`, except the perps/social-ai/predict files that have their own more specific entries.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

Assessed and not applicable: this PR changes only GitHub review-routing metadata, so it cannot affect runtime performance on any device.

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates code ownership metadata; no application code or runtime behavior changes.
> 
> **Overview**
> Adds **`app/core/DeeplinkManager/handlers/`** to the Engagement team section in **`.github/CODEOWNERS`**, so changes under that directory require **`@MetaMask/engagement`** review.
> 
> The broader **`app/core/DeeplinkManager`** path stays owned by **`@MetaMask/mobile-platform`**. Existing, more specific handler entries (e.g. perps, social, predict) are unchanged and can still apply to individual files per GitHub’s last-match rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8aa706a4842e9c2a3769f433f8b3db3fbd58e4d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
