### PR TITLE
fix: revert unreleased Arc default-network migration cp-8.6.0 (#34445)

### DIFF
--- a/app/store/migrations/148.test.ts
+++ b/app/store/migrations/148.test.ts
@@ -1,0 +1,610 @@
+import { captureException } from '@sentry/react-native';
+import { cloneDeep } from 'lodash';
+
+import { ensureValidState } from './util';
+import migrate, { migrationVersion } from './148';
+import migrateArc, { ARC_CHAIN_ID } from './145';
+
+jest.mock('@sentry/react-native', () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock('./util', () => ({
+  ensureValidState: jest.fn(),
+}));
+
+jest.mock('uuid', () => ({ v4: () => 'mock-uuid' }));
+
+const mockedCaptureException = jest.mocked(captureException);
+const mockedEnsureValidState = jest.mocked(ensureValidState);
+
+const unitTestInfuraId = 'unitTestInfuraId';
+const defaultArcUrl = `https://arc-mainnet.infura.io/v3/${unitTestInfuraId}`;
+
+interface EnablementState {
+  enabledNetworkMap: {
+    eip155: Record<string, boolean>;
+  };
+}
+
+const defaultArcRpcEndpoint = {
+  networkClientId: 'arc-network-client-id',
+  type: 'custom',
+  url: defaultArcUrl,
+  failoverUrls: [] as string[],
+};
+
+const defaultArcConfiguration = {
+  chainId: ARC_CHAIN_ID,
+  name: 'Arc',
+  nativeCurrency: 'USDC',
+  blockExplorerUrls: ['https://explorer.arc.io/'],
+  defaultBlockExplorerUrlIndex: 0,
+  defaultRpcEndpointIndex: 0,
+  rpcEndpoints: [defaultArcRpcEndpoint],
+};
+
+const baseState = {
+  engine: {
+    backgroundState: {
+      NetworkController: {
+        networkConfigurationsByChainId: {
+          '0x1': {
+            chainId: '0x1',
+            name: 'Ethereum',
+            nativeCurrency: 'ETH',
+            blockExplorerUrls: ['https://etherscan.io'],
+            defaultRpcEndpointIndex: 0,
+            defaultBlockExplorerUrlIndex: 0,
+            rpcEndpoints: [
+              {
+                networkClientId: 'mainnet',
+                type: 'custom',
+                url: 'https://mainnet.infura.io/v3/test',
+              },
+            ],
+          },
+        },
+        selectedNetworkClientId: 'mainnet',
+      },
+      NetworkEnablementController: {
+        enabledNetworkMap: {
+          eip155: {
+            '0x1': true,
+            '0xe708': true,
+            '0x2105': true,
+          },
+        },
+      },
+    },
+  },
+};
+
+function stateWithArc(
+  overrides: Partial<typeof defaultArcConfiguration> = {},
+  enablementValue: boolean | undefined = true,
+) {
+  const state = cloneDeep(baseState);
+  (
+    state.engine.backgroundState.NetworkController
+      .networkConfigurationsByChainId as Record<string, unknown>
+  )[ARC_CHAIN_ID] = {
+    ...cloneDeep(defaultArcConfiguration),
+    ...overrides,
+  };
+  if (enablementValue !== undefined) {
+    (
+      state.engine.backgroundState.NetworkEnablementController.enabledNetworkMap
+        .eip155 as Record<string, boolean>
+    )[ARC_CHAIN_ID] = enablementValue;
+  }
+  return state;
+}
+
+describe(`Migration ${migrationVersion}: Revert unreleased Arc default-add`, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedEnsureValidState.mockReturnValue(true);
+    process.env.MM_INFURA_PROJECT_ID = unitTestInfuraId;
+  });
+
+  afterEach(() => {
+    delete process.env.MM_INFURA_PROJECT_ID;
+  });
+
+  it('returns state unchanged if ensureValidState fails', () => {
+    mockedEnsureValidState.mockReturnValue(false);
+    const state = stateWithArc();
+    const result = migrate(state);
+    expect(result).toStrictEqual(state);
+  });
+
+  it('returns state unchanged if NetworkController is missing', () => {
+    const state = {
+      engine: {
+        backgroundState: {},
+      },
+    };
+    const result = migrate(state);
+    expect(result).toEqual(state);
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('missing NetworkController'),
+      }),
+    );
+  });
+
+  it('returns state unchanged if Arc is not present', () => {
+    const state = cloneDeep(baseState);
+    const result = migrate(state);
+    expect(result).toEqual(state);
+  });
+
+  it('removes Arc from both controllers without touching unrelated networks', () => {
+    const state = stateWithArc();
+    const result = migrate(state) as typeof baseState;
+
+    const configs = result.engine.backgroundState.NetworkController
+      .networkConfigurationsByChainId as Record<string, unknown>;
+    expect(configs[ARC_CHAIN_ID]).toBeUndefined();
+    expect(configs['0x1']).toEqual(
+      baseState.engine.backgroundState.NetworkController
+        .networkConfigurationsByChainId['0x1'],
+    );
+    expect(
+      result.engine.backgroundState.NetworkEnablementController
+        .enabledNetworkMap.eip155,
+    ).not.toHaveProperty(ARC_CHAIN_ID);
+  });
+
+  it.each([
+    [
+      'force-enables mainnet if Arc was the only enabled EVM network',
+      { '0x1': false, '0xe708': false, '0x2105': false, [ARC_CHAIN_ID]: true },
+      true,
+    ],
+    [
+      'does not force-enable mainnet if another network was already enabled alongside Arc',
+      { '0x1': false, '0xe708': true, '0x2105': false, [ARC_CHAIN_ID]: true },
+      false,
+    ],
+  ])('%s', (_description, eip155Override, expectMainnetEnabled) => {
+    const state = stateWithArc();
+    state.engine.backgroundState.NetworkEnablementController.enabledNetworkMap.eip155 =
+      eip155Override;
+
+    const result = migrate(state) as typeof baseState;
+
+    const eip155Map =
+      result.engine.backgroundState.NetworkEnablementController
+        .enabledNetworkMap.eip155;
+    expect(eip155Map).not.toHaveProperty(ARC_CHAIN_ID);
+    expect(eip155Map['0x1']).toBe(expectMainnetEnabled);
+    // selectedNetworkClientId is already 'mainnet' in the base fixture either way.
+    expect(
+      result.engine.backgroundState.NetworkController.selectedNetworkClientId,
+    ).toBe('mainnet');
+  });
+
+  it.each([
+    [
+      'falls back selectedNetworkClientId to mainnet if the user was on the Arc client',
+      defaultArcRpcEndpoint.networkClientId,
+    ],
+    [
+      'leaves selectedNetworkClientId untouched if the user was on a different network',
+      'mainnet',
+    ],
+  ])('%s', (_description, initialSelectedNetworkClientId) => {
+    const state = stateWithArc();
+    state.engine.backgroundState.NetworkController.selectedNetworkClientId =
+      initialSelectedNetworkClientId;
+
+    const result = migrate(state) as typeof baseState;
+
+    expect(
+      result.engine.backgroundState.NetworkController.selectedNetworkClientId,
+    ).toBe('mainnet');
+  });
+
+  it.each([
+    [
+      'RPC URL replaced by the user',
+      {
+        rpcEndpoints: [
+          { ...defaultArcRpcEndpoint, url: 'https://rpc.arc.network' },
+        ],
+      },
+    ],
+    [
+      'failover URL added by the user',
+      {
+        rpcEndpoints: [
+          {
+            ...defaultArcRpcEndpoint,
+            failoverUrls: ['https://failover.example.com'],
+          },
+        ],
+      },
+    ],
+    [
+      'extra RPC endpoint added by the user',
+      {
+        rpcEndpoints: [
+          defaultArcRpcEndpoint,
+          {
+            networkClientId: 'user-added',
+            type: 'custom',
+            url: 'https://second-endpoint.example.com',
+            failoverUrls: [],
+          },
+        ],
+      },
+    ],
+  ])(
+    'leaves the Arc network configuration untouched when %s',
+    (_description, overrides) => {
+      const state = stateWithArc(overrides);
+      const before = cloneDeep(state);
+
+      const result = migrate(state) as typeof baseState;
+
+      const configs = result.engine.backgroundState.NetworkController
+        .networkConfigurationsByChainId as Record<string, unknown>;
+      expect(configs[ARC_CHAIN_ID]).toEqual(
+        (
+          before.engine.backgroundState.NetworkController
+            .networkConfigurationsByChainId as Record<string, unknown>
+        )[ARC_CHAIN_ID],
+      );
+      expect(
+        result.engine.backgroundState.NetworkEnablementController
+          .enabledNetworkMap.eip155,
+      ).toHaveProperty(ARC_CHAIN_ID);
+    },
+  );
+
+  it.each([
+    ['renamed by the user', { name: 'My Arc' }],
+    ['currency changed by the user', { nativeCurrency: 'ARC' }],
+    [
+      'block explorer changed by the user',
+      { blockExplorerUrls: ['https://custom-explorer.example.com'] },
+    ],
+    [
+      'block explorer index changed by the user',
+      { defaultBlockExplorerUrlIndex: undefined },
+    ],
+  ])(
+    'still reverts the Arc network when only a cosmetic field was %s (the private RPC endpoint is untouched)',
+    (_description, overrides) => {
+      const state = stateWithArc(overrides);
+
+      const result = migrate(state) as typeof baseState;
+
+      const configs = result.engine.backgroundState.NetworkController
+        .networkConfigurationsByChainId as Record<string, unknown>;
+      expect(configs[ARC_CHAIN_ID]).toBeUndefined();
+      expect(
+        result.engine.backgroundState.NetworkEnablementController
+          .enabledNetworkMap.eip155,
+      ).not.toHaveProperty(ARC_CHAIN_ID);
+    },
+  );
+
+  it('leaves a manually-added Arc network (added before the auto-migration existed) untouched', () => {
+    const state = stateWithArc(
+      {
+        rpcEndpoints: [
+          {
+            networkClientId: 'user-added-arc',
+            type: 'custom',
+            url: 'https://rpc.arc.network',
+            failoverUrls: [],
+          },
+        ],
+      },
+      undefined,
+    );
+
+    const result = migrate(state) as typeof baseState;
+
+    const configs = result.engine.backgroundState.NetworkController
+      .networkConfigurationsByChainId as Record<string, unknown>;
+    expect(configs[ARC_CHAIN_ID]).toBeDefined();
+  });
+
+  it('does not revert if the Infura project ID is unset (nothing of ours to recognize)', () => {
+    process.env.MM_INFURA_PROJECT_ID = '';
+    const state = stateWithArc();
+
+    const result = migrate(state) as typeof baseState;
+
+    const configs = result.engine.backgroundState.NetworkController
+      .networkConfigurationsByChainId as Record<string, unknown>;
+    expect(configs[ARC_CHAIN_ID]).toBeDefined();
+  });
+
+  it('does not revert if the Infura project ID is the literal string "null"', () => {
+    process.env.MM_INFURA_PROJECT_ID = 'null';
+    // Build the RPC URL as it would look if 'null' were used unguarded as the
+    // project ID (i.e. what migration 145 would have written had it not
+    // special-cased this env var quirk), so this test actually exercises the
+    // 'null' -> '' guard: without that guard, this URL would match and Arc
+    // would incorrectly get reverted.
+    const state = stateWithArc({
+      rpcEndpoints: [
+        {
+          ...defaultArcRpcEndpoint,
+          url: 'https://arc-mainnet.infura.io/v3/null',
+        },
+      ],
+    });
+
+    const result = migrate(state) as typeof baseState;
+
+    const configs = result.engine.backgroundState.NetworkController
+      .networkConfigurationsByChainId as Record<string, unknown>;
+    expect(configs[ARC_CHAIN_ID]).toBeDefined();
+  });
+
+  it('reverts Arc without touching the enablement map if Arc was never tracked there', () => {
+    const state = stateWithArc();
+    delete (
+      state.engine.backgroundState.NetworkEnablementController.enabledNetworkMap
+        .eip155 as Record<string, boolean>
+    )[ARC_CHAIN_ID];
+
+    const result = migrate(state) as typeof baseState;
+
+    const configs = result.engine.backgroundState.NetworkController
+      .networkConfigurationsByChainId as Record<string, unknown>;
+    expect(configs[ARC_CHAIN_ID]).toBeUndefined();
+    expect(
+      result.engine.backgroundState.NetworkEnablementController
+        .enabledNetworkMap.eip155,
+    ).not.toHaveProperty(ARC_CHAIN_ID);
+  });
+
+  it('skips the NetworkEnablementController cleanup gracefully if it is missing', () => {
+    const state = stateWithArc();
+    delete (state.engine.backgroundState as Record<string, unknown>)
+      .NetworkEnablementController;
+
+    const result = migrate(state) as Record<string, unknown>;
+    const backgroundState = (result.engine as Record<string, unknown>)
+      .backgroundState as Record<string, unknown>;
+    const networkController = backgroundState.NetworkController as Record<
+      string,
+      unknown
+    >;
+    const configs = networkController.networkConfigurationsByChainId as Record<
+      string,
+      unknown
+    >;
+
+    expect(configs[ARC_CHAIN_ID]).toBeUndefined();
+    expect(backgroundState.NetworkEnablementController).toBeUndefined();
+  });
+
+  it('returns original state on unexpected error', () => {
+    mockedEnsureValidState.mockImplementation(() => {
+      throw new Error('Unexpected error');
+    });
+
+    const state = stateWithArc();
+    const result = migrate(state);
+
+    expect(result).toBe(state);
+    expect(mockedCaptureException).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('Unexpected error'),
+      }),
+    );
+  });
+
+  describe('state validation edge cases', () => {
+    it('returns state unchanged if the Arc entry itself is not an object', () => {
+      const state = stateWithArc();
+      (
+        state.engine.backgroundState.NetworkController
+          .networkConfigurationsByChainId as Record<string, unknown>
+      )[ARC_CHAIN_ID] = 'not-an-object';
+
+      const result = migrate(state) as typeof baseState;
+
+      const configs = result.engine.backgroundState.NetworkController
+        .networkConfigurationsByChainId as Record<string, unknown>;
+      expect(configs[ARC_CHAIN_ID]).toBe('not-an-object');
+    });
+
+    it.each([
+      [
+        'NetworkController is not an object',
+        { engine: { backgroundState: { NetworkController: 'not-an-object' } } },
+        'NetworkController state is not an object',
+      ],
+      [
+        'networkConfigurationsByChainId is missing',
+        {
+          engine: {
+            backgroundState: {
+              NetworkController: { selectedNetworkClientId: 'mainnet' },
+            },
+          },
+        },
+        'missing networkConfigurationsByChainId property',
+      ],
+      [
+        'networkConfigurationsByChainId is not a valid Record<Hex, unknown>',
+        {
+          engine: {
+            backgroundState: {
+              NetworkController: {
+                networkConfigurationsByChainId: { 'not-hex': {} },
+                selectedNetworkClientId: 'mainnet',
+              },
+            },
+          },
+        },
+        'networkConfigurationsByChainId is not a valid',
+      ],
+      [
+        'selectedNetworkClientId is missing',
+        {
+          engine: {
+            backgroundState: {
+              NetworkController: { networkConfigurationsByChainId: {} },
+            },
+          },
+        },
+        'missing selectedNetworkClientId property',
+      ],
+      [
+        'selectedNetworkClientId is not a string',
+        {
+          engine: {
+            backgroundState: {
+              NetworkController: {
+                networkConfigurationsByChainId: {},
+                selectedNetworkClientId: 123,
+              },
+            },
+          },
+        },
+        'selectedNetworkClientId is not a string',
+      ],
+    ])(
+      'returns state unchanged when %s',
+      (_description, state, expectedMessage) => {
+        const result = migrate(state);
+        expect(result).toEqual(state);
+        expect(mockedCaptureException).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: expect.stringContaining(expectedMessage),
+          }),
+        );
+      },
+    );
+
+    it.each([
+      [
+        'NetworkEnablementController is not an object',
+        'not-an-object',
+        'Invalid NetworkEnablementController state',
+      ],
+      [
+        'enabledNetworkMap is missing',
+        {},
+        'missing property enabledNetworkMap',
+      ],
+      [
+        'enabledNetworkMap is not an object',
+        { enabledNetworkMap: 'not-an-object' },
+        'enabledNetworkMap is not an object',
+      ],
+      [
+        'the eip155 namespace is missing',
+        { enabledNetworkMap: { solana: {} } },
+        'missing property eip155',
+      ],
+      [
+        'the eip155 map is invalid',
+        { enabledNetworkMap: { eip155: { '0x1': 'not-a-boolean' } } },
+        'enabledNetworkMap[eip155] is not valid',
+      ],
+    ])(
+      'reverts Arc but skips enablement cleanup when %s',
+      (_description, enablementControllerOverride, expectedMessage) => {
+        const state = stateWithArc();
+        (
+          state.engine.backgroundState as Record<string, unknown>
+        ).NetworkEnablementController = enablementControllerOverride;
+
+        const result = migrate(state) as typeof baseState;
+
+        const configs = result.engine.backgroundState.NetworkController
+          .networkConfigurationsByChainId as Record<string, unknown>;
+        expect(configs[ARC_CHAIN_ID]).toBeUndefined();
+        expect(mockedCaptureException).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: expect.stringContaining(expectedMessage),
+          }),
+        );
+      },
+    );
+  });
+
+  describe('running after migration 145, in sequence', () => {
+    it('removes Arc for a user who never touched the auto-added network', () => {
+      mockedEnsureValidState.mockReturnValue(true);
+
+      const stateAfter145 = migrateArc(
+        cloneDeep(baseState),
+      ) as typeof baseState;
+      const configsAfter145 = stateAfter145.engine.backgroundState
+        .NetworkController.networkConfigurationsByChainId as Record<
+        string,
+        unknown
+      >;
+      expect(configsAfter145[ARC_CHAIN_ID]).toBeDefined();
+
+      const stateAfter148 = migrate(stateAfter145) as typeof baseState;
+      const configsAfter148 = stateAfter148.engine.backgroundState
+        .NetworkController.networkConfigurationsByChainId as Record<
+        string,
+        unknown
+      >;
+      expect(configsAfter148[ARC_CHAIN_ID]).toBeUndefined();
+      expect(
+        stateAfter148.engine.backgroundState.NetworkEnablementController
+          .enabledNetworkMap.eip155,
+      ).not.toHaveProperty(ARC_CHAIN_ID);
+    });
+
+    it('keeps Arc for a user who had already replaced its RPC endpoint between the two migrations', () => {
+      mockedEnsureValidState.mockReturnValue(true);
+
+      const stateAfter145 = migrateArc(
+        cloneDeep(baseState),
+      ) as typeof baseState;
+      const configs = stateAfter145.engine.backgroundState.NetworkController
+        .networkConfigurationsByChainId as Record<
+        string,
+        { rpcEndpoints: { url: string }[] }
+      >;
+      // Simulate the user replacing the private RPC endpoint before 148 ever runs.
+      configs[ARC_CHAIN_ID].rpcEndpoints[0].url = 'https://rpc.arc.network';
+
+      const stateAfter148 = migrate(stateAfter145) as typeof baseState;
+      const configsAfter148 = stateAfter148.engine.backgroundState
+        .NetworkController.networkConfigurationsByChainId as Record<
+        string,
+        { rpcEndpoints: { url: string }[] }
+      >;
+      expect(configsAfter148[ARC_CHAIN_ID]).toBeDefined();
+      expect(configsAfter148[ARC_CHAIN_ID].rpcEndpoints[0].url).toBe(
+        'https://rpc.arc.network',
+      );
+    });
+
+    it('still reverts Arc for a user who only renamed it (cosmetic-only edit) between the two migrations', () => {
+      mockedEnsureValidState.mockReturnValue(true);
+
+      const stateAfter145 = migrateArc(
+        cloneDeep(baseState),
+      ) as typeof baseState;
+      const configs = stateAfter145.engine.backgroundState.NetworkController
+        .networkConfigurationsByChainId as Record<string, { name: string }>;
+      configs[ARC_CHAIN_ID].name = 'My Custom Arc';
+
+      const stateAfter148 = migrate(stateAfter145) as typeof baseState;
+      const configsAfter148 = stateAfter148.engine.backgroundState
+        .NetworkController.networkConfigurationsByChainId as Record<
+        string,
+        unknown
+      >;
+      expect(configsAfter148[ARC_CHAIN_ID]).toBeUndefined();
+    });
+  });
+});

--- a/app/store/migrations/148.ts
+++ b/app/store/migrations/148.ts
@@ -1,0 +1,358 @@
+import { captureException } from '@sentry/react-native';
+import {
+  getErrorMessage,
+  hasProperty,
+  Hex,
+  isHexString,
+  isObject,
+  KnownCaipNamespace,
+} from '@metamask/utils';
+
+import { ensureValidState, ValidState } from './util';
+import { cloneDeep } from 'lodash';
+import { ARC_CHAIN_ID } from './145';
+
+interface RpcEndpoint {
+  failoverUrls?: string[];
+  name?: string;
+  networkClientId: string;
+  url: string;
+  type: string;
+}
+
+interface NetworkConfiguration {
+  blockExplorerUrls: string[];
+  chainId: Hex;
+  defaultBlockExplorerUrlIndex?: number;
+  defaultRpcEndpointIndex: number;
+  name: string;
+  nativeCurrency: string;
+  rpcEndpoints: RpcEndpoint[];
+}
+
+export const migrationVersion = 148;
+
+/**
+ * Migration 145 added the Arc network to every user's NetworkController state
+ * ahead of schedule (it was meant for a mid-June release; Arc now ships
+ * mid-September instead). Migrations are append-only and run sequentially, so
+ * 145 can't be removed or skipped for users who already applied it.
+ *
+ * This migration undoes 145's effect, but only when the Arc network still
+ * has the single, private, not-yet-public Infura RPC endpoint 145 would have
+ * written unattended - nobody else could produce that exact URL, since it's
+ * built from this build's own (undisclosed) Infura project ID. Cosmetic
+ * edits (rename, currency, block explorer) don't prevent reversion. But if
+ * the user replaced/removed that RPC endpoint, added a failover to it, added
+ * an additional endpoint, or added Arc manually with their own RPC, that's a
+ * real customization and the network is left alone entirely.
+ *
+ * @param versionedState - MetaMask state, exactly what we persist to disk.
+ * @returns Updated MetaMask state.
+ */
+export default function migrate(versionedState: unknown) {
+  const state = cloneDeep(versionedState);
+  try {
+    if (!ensureValidState(state, migrationVersion)) {
+      return state;
+    }
+
+    const networkState = validateNetworkController(state);
+    if (networkState === undefined) {
+      console.warn(
+        `Migration ${migrationVersion}: Missing or invalid NetworkController state, skip the migration`,
+      );
+      return state;
+    }
+
+    const { networkConfigurationsByChainId, selectedNetworkClientId } =
+      networkState;
+
+    if (!hasProperty(networkConfigurationsByChainId, ARC_CHAIN_ID)) {
+      return state;
+    }
+
+    const arcConfiguration = networkConfigurationsByChainId[ARC_CHAIN_ID];
+
+    if (!isDefaultArcConfiguration(arcConfiguration)) {
+      // The user customized this entry (or added it manually themselves);
+      // leave it as-is.
+      return state;
+    }
+
+    const arcNetworkClientId = arcConfiguration.rpcEndpoints[0].networkClientId;
+
+    delete networkConfigurationsByChainId[ARC_CHAIN_ID];
+
+    if (selectedNetworkClientId === arcNetworkClientId) {
+      networkState.selectedNetworkClientId = 'mainnet';
+    }
+
+    const networkEnablementState = validateNetworkEnablementController(state);
+    if (networkEnablementState === undefined) {
+      console.warn(
+        `Migration ${migrationVersion}: Missing or invalid NetworkEnablementController state, skip the NetworkEnablementController migration`,
+      );
+    } else {
+      const eip155NetworkMap =
+        networkEnablementState.enabledNetworkMap[KnownCaipNamespace.Eip155];
+
+      if (hasProperty(eip155NetworkMap, ARC_CHAIN_ID)) {
+        // If Arc was the only enabled EVM network, removing it would leave
+        // the user with none enabled. Mirror migration 111's precedent for
+        // removing an exclusively-enabled network: fall back to mainnet.
+        const wasArcTheOnlyEnabledNetwork =
+          eip155NetworkMap[ARC_CHAIN_ID] === true &&
+          Object.entries(eip155NetworkMap).every(
+            ([chainId, isEnabled]) =>
+              chainId === ARC_CHAIN_ID || isEnabled !== true,
+          );
+
+        delete eip155NetworkMap[ARC_CHAIN_ID];
+
+        if (wasArcTheOnlyEnabledNetwork) {
+          eip155NetworkMap['0x1'] = true;
+          networkState.selectedNetworkClientId = 'mainnet';
+        }
+      }
+    }
+
+    return state;
+  } catch (error) {
+    console.error(error);
+    captureException(
+      new Error(`Migration ${migrationVersion}: ${getErrorMessage(error)}`),
+    );
+
+    return versionedState;
+  }
+}
+
+/**
+ * Checks whether the given Arc network configuration still has the single,
+ * private, not-yet-public `arc-mainnet.infura.io` RPC endpoint migration 145
+ * would have written unattended, with no failover URLs. Only the RPC
+ * endpoint is checked - display fields (name, currency, block explorer,
+ * default indexes) are allowed to differ, since editing those isn't the kind
+ * of customization that should block reverting the premature auto-add.
+ */
+function isDefaultArcConfiguration(
+  value: unknown,
+): value is NetworkConfiguration & {
+  rpcEndpoints: [RpcEndpoint];
+} {
+  const INFURA_KEY = process.env.MM_INFURA_PROJECT_ID;
+  const infuraProjectId = INFURA_KEY === 'null' ? '' : INFURA_KEY;
+
+  // Migration 145 never writes an Arc entry without an Infura project ID, so
+  // there is nothing of ours to recognize (and therefore nothing to revert).
+  if (!infuraProjectId) {
+    return false;
+  }
+
+  if (!isObject(value)) {
+    return false;
+  }
+
+  const expectedUrl = `https://arc-mainnet.infura.io/v3/${infuraProjectId}`;
+
+  return (
+    value.chainId === ARC_CHAIN_ID &&
+    Array.isArray(value.rpcEndpoints) &&
+    value.rpcEndpoints.length === 1 &&
+    isDefaultArcRpcEndpoint(value.rpcEndpoints[0], expectedUrl)
+  );
+}
+
+function isDefaultArcRpcEndpoint(
+  value: unknown,
+  expectedUrl: string,
+): value is RpcEndpoint {
+  return (
+    isObject(value) &&
+    value.type === 'custom' &&
+    value.url === expectedUrl &&
+    typeof value.networkClientId === 'string' &&
+    Array.isArray(value.failoverUrls) &&
+    value.failoverUrls.length === 0
+  );
+}
+
+function validateNetworkController(state: ValidState):
+  | {
+      networkConfigurationsByChainId: Record<Hex, unknown>;
+      selectedNetworkClientId: string;
+    }
+  | undefined {
+  if (!hasProperty(state.engine.backgroundState, 'NetworkController')) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkController state: missing NetworkController`,
+      ),
+    );
+    return undefined;
+  }
+
+  const networkState = state.engine.backgroundState.NetworkController;
+
+  if (!isValidNetworkControllerState(networkState)) {
+    return undefined;
+  }
+
+  return networkState;
+}
+
+function isValidNetworkControllerState(value: unknown): value is {
+  networkConfigurationsByChainId: Record<Hex, unknown>;
+  selectedNetworkClientId: string;
+} {
+  if (!isObject(value)) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkController state: NetworkController state is not an object: '${typeof value}'`,
+      ),
+    );
+    return false;
+  }
+
+  if (!hasProperty(value, 'networkConfigurationsByChainId')) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkController state: missing networkConfigurationsByChainId property`,
+      ),
+    );
+    return false;
+  }
+
+  if (
+    !isValidNetworkConfigurationsByChainId(value.networkConfigurationsByChainId)
+  ) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkController state: networkConfigurationsByChainId is not a valid Record<Hex, unknown>`,
+      ),
+    );
+    return false;
+  }
+
+  if (!hasProperty(value, 'selectedNetworkClientId')) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkController state: missing selectedNetworkClientId property`,
+      ),
+    );
+    return false;
+  }
+
+  if (typeof value.selectedNetworkClientId !== 'string') {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkController state: selectedNetworkClientId is not a string`,
+      ),
+    );
+    return false;
+  }
+
+  return true;
+}
+
+function isValidNetworkConfigurationsByChainId(
+  value: unknown,
+): value is Record<Hex, unknown> {
+  return (
+    isObject(value) &&
+    Object.entries(value).every(
+      ([chainId]) => typeof chainId === 'string' && isHexString(chainId),
+    )
+  );
+}
+
+function validateNetworkEnablementController(state: ValidState):
+  | {
+      enabledNetworkMap: {
+        [KnownCaipNamespace.Eip155]: Record<string, boolean>;
+      };
+    }
+  | undefined {
+  if (
+    !hasProperty(state.engine.backgroundState, 'NetworkEnablementController')
+  ) {
+    return undefined;
+  }
+
+  const networkEnablementState =
+    state.engine.backgroundState.NetworkEnablementController;
+
+  if (!isValidNetworkEnablementControllerState(networkEnablementState)) {
+    return undefined;
+  }
+
+  return networkEnablementState;
+}
+
+function isValidNetworkEnablementControllerState(value: unknown): value is {
+  enabledNetworkMap: {
+    [KnownCaipNamespace.Eip155]: Record<string, boolean>;
+  };
+} {
+  if (!isObject(value)) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkEnablementController state: '${typeof value}'`,
+      ),
+    );
+    return false;
+  }
+
+  if (!hasProperty(value, 'enabledNetworkMap')) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkEnablementController state: missing property enabledNetworkMap.`,
+      ),
+    );
+    return false;
+  }
+
+  if (!isObject(value.enabledNetworkMap)) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkEnablementController state: enabledNetworkMap is not an object: ${typeof value.enabledNetworkMap}.`,
+      ),
+    );
+    return false;
+  }
+
+  if (!hasProperty(value.enabledNetworkMap, KnownCaipNamespace.Eip155)) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkEnablementController state: enabledNetworkMap missing property eip155.`,
+      ),
+    );
+    return false;
+  }
+
+  if (
+    !isValidEip155NetworkMap(value.enabledNetworkMap[KnownCaipNamespace.Eip155])
+  ) {
+    captureException(
+      new Error(
+        `Migration ${migrationVersion}: Invalid NetworkEnablementController state: enabledNetworkMap[eip155] is not valid.`,
+      ),
+    );
+    return false;
+  }
+
+  return true;
+}
+
+function isValidEip155NetworkMap(
+  value: unknown,
+): value is Record<string, boolean> {
+  return (
+    isObject(value) &&
+    Object.entries(value).every(
+      ([chainId, isEnabled]) =>
+        typeof chainId === 'string' && typeof isEnabled === 'boolean',
+    )
+  );
+}

--- a/app/store/migrations/index.ts
+++ b/app/store/migrations/index.ts
@@ -148,6 +148,7 @@ import migration144 from './144';
 import migration145 from './145';
 import migration146 from './146';
 import migration147 from './147';
+import migration148 from './148';
 
 // Add migrations above this line
 import { ControllerStorage } from '../persistConfig';
@@ -315,6 +316,7 @@ export const migrationList: MigrationsList = {
   145: migration145,
   146: migration146,
   147: migration147,
+  148: migration148,
 };
 
 // Enable both synchronous and asynchronous migrations


### PR DESCRIPTION
since 148 not in prod yet we "swapped" and set `148.ts` as THIS FIX and old 148.ts becomes 149.ts. This way, cherry-picks will be easier and numbering will be preserved.

**Context:**

Back in June, migration 145 added the Arc network to every user's NetworkController state ahead of schedule (it was meant for a mid-June release; Arc now ships mid-September). Migrations run sequentially and can't be retroactively removed, so 145 still runs for anyone on it.

As a result, some users a now seeing Arc as enabled network on their account, when it should have been hidden - unless added manually.

Note that this is unrelated to Feature Flags: Although Arc is turned off via Feature Flags added networks aren't affected by Feature Flags whitelists or blacklist, only non-added Networks are. This means that when Arc was added (by the user or by migration 145) it will show to the user regardless of Feature Flags. This is a known behavior, not a bug. The issue is that the network is enabled when it shouldn't have been.

**Solution:**

New Migration 149:
- Undoes 145's effect, but only where the resulting Arc network configuration has the RPC URL that has been set by 145. When other RPC URLs, it will be considered as a "custom network" addition - user added network manually and network was not auto-added.
- Also falls back selectedNetworkClientId to `mainnet` if the user happened to be on the removed Arc client, mirroring the existing precedent in migration 111.
- And manually enables `mainnet` in the unlikely event where Arc is the only enabled network.

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by
.github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
type=issue-link Section must have a Fixes:/Closes:/Refs: line with a
value.
type=manual-testing Section must have real testing steps or an explicit
N/A.
type=screenshot Section must have evidence (image/URL) or an explicit
N/A.
type=checklist Section must have all checkboxes consciously checked.
required=true|false Whether a missing/invalid section runs the validator
at all.
blocking=true|false Whether a failure of this check fails the CI
workflow.
Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only. -->

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution? -->

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs` `CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: prevent Arc from showing as added for some users

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/WPN-1803

Case 1: Gradual upgrades
- Install release 7.81.0 on a fresh state (new account with seed phrase) and setup account.
- Install release 8.1.0 ontop of existing install (triggers migration 145) -> Arc is enabled when it shouldn't.
- Install build from this PR ontop of existing install -> Arc should not be enabled (and should not be in the default list either).

Case 2: Skip-the-line upgrades
- Install release 7.81.0 on a fresh state (new account with seed phrase) and setup account.
- Install build from this PR ontop of existing install -> Arc should not be enabled (and should not be in the default list either). Essentially both migration 145 and this fix migration should run in sequence and Arc should never appear to the user.

Case 3: Custom network preserved
- Install release 7.81.0 on a fresh state (new account with seed phrase) and setup account.
- Add Arc manually as a custom network (Ex: with dummy RPC).
- Install build from this PR ontop of existing install -> Arc should still be enabled with user-specific configuration.

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

<!-- [screenshots/recordings] -->

<!-- [screenshots/recordings] -->

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding
Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
- Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
- See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously assessed that responsibility. See `docs/readme/ready-for-review.md`. -->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> It mutates persisted network and enablement state on upgrade; logic is guarded and heavily tested, but incorrect matching could remove networks users expect to keep.
> 
> **Overview**
> Adds **migration 148** to undo migration 145’s premature Arc network auto-add for users who still have the untouched default Infura RPC (`arc-mainnet.infura.io/v3/{projectId}`). Custom or user-edited Arc setups (different RPC, failover, extra endpoints, or manual add) are left alone; cosmetic-only edits still qualify for removal.
> 
> When reverting, Arc is removed from `NetworkController` and `NetworkEnablementController`, `selectedNetworkClientId` is reset to `mainnet` if the user was on Arc, and mainnet is force-enabled if Arc was the only enabled EVM network (same pattern as migration 111). The migration is registered in `app/store/migrations/index.ts`, with broad unit tests including a 145→148 sequence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2b39bcc5fbda170c26909eb3ee53667346c546d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
