### PR TITLE
feat: add btc network to crypto search

### DIFF
--- a/app/components/UI/Trending/utils/trendingNetworksList.ts
+++ b/app/components/UI/Trending/utils/trendingNetworksList.ts
@@ -1,7 +1,5 @@
 import {
-  ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
   BtcScope,
-  ///: END:ONLY_INCLUDE_IF
   ///: BEGIN:ONLY_INCLUDE_IF(tron)
   TrxScope,
   ///: END:ONLY_INCLUDE_IF
@@ -144,7 +142,6 @@ export const TRENDING_NETWORKS_LIST: ProcessedNetwork[] = [
       chainId: NetworkToCaipChainId.ROBINHOOD,
     }),
   },
-  ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
   {
     id: BtcScope.Mainnet,
     name: 'Bitcoin',
@@ -152,7 +149,6 @@ export const TRENDING_NETWORKS_LIST: ProcessedNetwork[] = [
     isSelected: false,
     imageSource: getNetworkImageSource({ chainId: BtcScope.Mainnet }),
   },
-  ///: END:ONLY_INCLUDE_IF
 ];
 
 /**

--- a/app/components/UI/Trending/utils/trendingNetworksList.ts
+++ b/app/components/UI/Trending/utils/trendingNetworksList.ts
@@ -1,4 +1,7 @@
 import {
+  ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
+  BtcScope,
+  ///: END:ONLY_INCLUDE_IF
   ///: BEGIN:ONLY_INCLUDE_IF(tron)
   TrxScope,
   ///: END:ONLY_INCLUDE_IF
@@ -141,6 +144,15 @@ export const TRENDING_NETWORKS_LIST: ProcessedNetwork[] = [
       chainId: NetworkToCaipChainId.ROBINHOOD,
     }),
   },
+  ///: BEGIN:ONLY_INCLUDE_IF(bitcoin)
+  {
+    id: BtcScope.Mainnet,
+    name: 'Bitcoin',
+    caipChainId: BtcScope.Mainnet,
+    isSelected: false,
+    imageSource: getNetworkImageSource({ chainId: BtcScope.Mainnet }),
+  },
+  ///: END:ONLY_INCLUDE_IF
 ];
 
 /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Explore's Crypto search results are a compound of two Token API calls — `/tokens/search` and `/v3/tokens/trending` — merged client-side. Both requests default their chain scope to the hardcoded `TRENDING_NETWORKS_LIST`, which did not include Bitcoin's chain (`bip122:…`). As a result, native BTC was never requested from either endpoint and never appeared in Crypto search, even though "BTC" is an obvious, high-intent query.

This PR adds Bitcoin mainnet (`BtcScope.Mainnet` = `bip122:000000000019d6689c085ae165831e93`) to `TRENDING_NETWORKS_LIST`, so both the search and trending endpoints now include the Bitcoin chain and native BTC surfaces in Crypto search results.

The entry follows the existing non-EVM conventions in the file: it uses the `BtcScope` scope from `@metamask/keyring-api` (mirroring how Tron uses `TrxScope`) and is guarded by the `bitcoin` build flag (`ONLY_INCLUDE_IF(bitcoin)`), matching how Solana and Tron are gated.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Added Bitcoin to the Explore Crypto search results.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Bitcoin appears in Explore Crypto search

  Scenario: User searches for BTC in the Crypto tab
    Given the user is on the Explore search screen in a bitcoin-enabled build
    And the "Crypto" pill is selected

    When the user types "btc" in the search bar
    Then native Bitcoin (BTC) appears in the results
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

Crypto search `/tokens/search` request — `networks` param has no Bitcoin chain (`bip122:…`), so native BTC is never returned:

```
https://token.api.cx.metamask.io/tokens/search?networks=eip155%3A1,solana%3A5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp,eip155%3A56,eip155%3A8453,tron%3A728126428,eip155%3A42161,eip155%3A43114,eip155%3A137,eip155%3A143,eip155%3A59144,eip155%3A10,eip155%3A1329,eip155%3A324,eip155%3A4663&query=btc&first=20&includeMarketData=true&includeRwaData=true&includeTokenSecurityData=true
```

### **After**

Same request now includes the Bitcoin chain (`bip122:000000000019d6689c085ae165831e93`) as the last entry in `networks`, and native BTC is returned first (ahead of WBTC/BTCB):

```
https://token.api.cx.metamask.io/tokens/search?networks=eip155%3A1,solana%3A5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp,eip155%3A56,eip155%3A8453,tron%3A728126428,eip155%3A42161,eip155%3A43114,eip155%3A137,eip155%3A143,eip155%3A59144,eip155%3A10,eip155%3A1329,eip155%3A324,eip155%3A4663,bip122%3A000000000019d6689c085ae165831e93&query=btc&first=20&includeMarketData=true&includeRwaData=true&includeTokenSecurityData=true
```
<img width="419" height="925" alt="Screenshot 2026-08-07 at 17 09 09" src="https://github.com/user-attachments/assets/a2db4ee3-52cb-46bf-a708-cd5ab297be80" />



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single static list entry that widens default chain scope for token search/trending; no auth, payment, or core wallet logic changes.
> 
> **Overview**
> **Adds Bitcoin mainnet** to `TRENDING_NETWORKS_LIST` so Explore Crypto search and trending token requests include the `bip122:…` chain and native BTC can appear in results (e.g. when searching “btc”).
> 
> The new entry uses `BtcScope.Mainnet` from `@metamask/keyring-api` and the same `ProcessedNetwork` shape as other non-EVM chains (e.g. Tron). `RWA_NETWORKS_LIST` is unchanged—it still only keeps Ethereum and BNB from that list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7f2334317c4ea874953adaebb1555e6e7c74b2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->