### PR TITLE
test: fix PredictMarketDetails Positions tab CV flake

### DIFF
--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.view.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.view.test.tsx
@@ -465,11 +465,19 @@ describe('PredictMarketDetails', () => {
     it('shows the user position and a cash out CTA on the Positions tab', async () => {
       givenPositions([buildMockPredictPosition()]);
 
-      const { findByTestId } = renderPredictMarketDetailsView({
-        initialParams: { marketId: MARKET_ID },
-      });
+      const { findByTestId, findByText, getByTestId } =
+        renderPredictMarketDetailsView({
+          initialParams: { marketId: MARKET_ID },
+        });
 
-      const positionsTab = await findByTestId(
+      await findByTestId(
+        PredictMarketDetailsSelectorsIDs.POSITIONS_TAB_CONTENT,
+      );
+      // The current value stays behind a skeleton until the sell-order preview
+      // query settles, which happens after the tab content is already on screen.
+      await findByText('$60');
+
+      const positionsTab = getByTestId(
         PredictMarketDetailsSelectorsIDs.POSITIONS_TAB_CONTENT,
       );
       expect(


### PR DESCRIPTION
## **Description**

Stabilizes a flaky PredictMarketDetails component-view test that intermittently failed on `main` CI ([Component view tests (1)](https://github.com/MetaMask/metamask-mobile/actions/runs/31153864409/job/92796190520#step:8:601)).

**Why it failed**

`PredictMarketDetails › tabs › shows the user position and a cash out CTA on the Positions tab` awaited the Positions tab container, then synchronously asserted `$60`. That value stays behind a `Skeleton` until `usePredictOrderPreview` settles (100 ms debounce + React Query). Under CI load the container can mount while the value is still loading, so `getByText('$60')` fails. Neighbouring asserts on static position props (`$50 on Yes to win $50`) keep passing, which is why the flake looks inconsistent.

**Fix**

Await `$60` with `findByText`, then re-query the Positions tab container and keep the scoped `within(...)` asserts against the settled tree. Same class of “assert before async state settles” flake as #34241, different mechanism (gated leaf value vs stale press target).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/actions/runs/31153864409/job/92796190520

## **Manual testing steps**

N/A — test-only change; no app UI or runtime behavior changed. Covered by:

```bash
yarn jest -c jest.config.view.js app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.view.test.tsx --runInBand --silent --coverage=false
```

## **Screenshots/Recordings**

### **Before**

N/A — CI-only flake; see failing job log linked above (`Unable to find an element with text: $60` while Positions tab content and cash-out CTA were already on screen).

### **After**

N/A — test-only stabilization; no UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A — test-only change
- [x] I've tested with a power user scenario
  - N/A — test-only change
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A — test-only change

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Made with [Cursor](https://cursor.com)