### PR TITLE
feat(predict-next): add Kalshi market data adapter

### DIFF
--- a/app/components/UI/PredictNext/CONTEXT.md
+++ b/app/components/UI/PredictNext/CONTEXT.md
@@ -120,6 +120,14 @@ _Avoid_: UI request, transient loading state
 The Predict User's available settlement-currency amount in a Venue Account, ready for placing Orders.
 _Avoid_: Funds, wallet balance, raw token amount
 
+**Ask Price**:
+The lowest currently available per-share price to buy an Outcome, expressed in settlement currency. A missing Ask Price means no current buy quote; it does not mean zero.
+_Avoid_: Price, buy price, Yes ask
+
+**Bid Price**:
+The highest currently available per-share price to sell an Outcome, expressed in settlement currency. A missing Bid Price means no current sell quote; it does not mean zero.
+_Avoid_: Price, sell price, Yes bid
+
 **Volume**:
 Total settlement currency traded on a Market or Event across all users.
 _Avoid_: Liquidity

--- a/app/components/UI/PredictNext/adapters/remote/KalshiRemoteAdapter.test.ts
+++ b/app/components/UI/PredictNext/adapters/remote/KalshiRemoteAdapter.test.ts
@@ -1,0 +1,163 @@
+import { PredictErrorCode } from '../../errors';
+import type { PredictEntityId } from '../../types';
+import { KalshiRemoteAdapter } from './KalshiRemoteAdapter';
+import {
+  type PredictApiReadTransport,
+  PredictHttpError,
+} from './PredictApiReadClient';
+
+const eventId = 'event-1' as PredictEntityId;
+
+const createEvent = (overrides = {}) => ({
+  venueId: 'kalshi',
+  id: 'event-1',
+  title: 'Game outcome',
+  markets: [
+    {
+      id: 'market-1',
+      question: 'Will the team win?',
+      status: 'open',
+      outcomes: [
+        {
+          id: 'market-1-yes',
+          side: 'yes',
+          label: 'Yes',
+          askPrice: '0.42',
+          bidPrice: '0.40',
+        },
+        {
+          id: 'market-1-no',
+          side: 'no',
+          label: 'No',
+          askPrice: '0.61',
+          bidPrice: '0.58',
+        },
+      ],
+    },
+  ],
+  ...overrides,
+});
+
+const createClient = (): jest.Mocked<PredictApiReadTransport> => ({
+  fetchVenueStatus: jest.fn(),
+  fetchEvents: jest.fn(),
+  fetchEvent: jest.fn(),
+});
+
+describe('KalshiRemoteAdapter', () => {
+  let client: jest.Mocked<PredictApiReadTransport>;
+  let adapter: KalshiRemoteAdapter;
+
+  beforeEach(() => {
+    client = createClient();
+    adapter = new KalshiRemoteAdapter(client);
+  });
+
+  it('parses canonical Events from the Predict API', async () => {
+    client.fetchEvents.mockResolvedValue({ items: [createEvent()] });
+
+    const result = await adapter.marketData.fetchEvents({ limit: 20 });
+
+    expect(result.items[0].markets[0].outcomes[0].askPrice).toBe('0.42');
+  });
+
+  it('forwards Event query parameters and cancellation', async () => {
+    client.fetchEvents.mockResolvedValue({ items: [createEvent()] });
+    const signal = new AbortController().signal;
+
+    await adapter.marketData.fetchEvents({ limit: 20 }, { signal });
+
+    expect(client.fetchEvents).toHaveBeenCalledWith(
+      adapter.venueId,
+      { limit: 20 },
+      { signal },
+    );
+  });
+
+  it('rejects an Event list containing another Venue', async () => {
+    client.fetchEvents.mockResolvedValue({
+      items: [createEvent({ venueId: 'other' })],
+    });
+
+    await expect(adapter.marketData.fetchEvents({})).rejects.toEqual(
+      expect.objectContaining({ code: PredictErrorCode.UNKNOWN }),
+    );
+  });
+
+  it('parses Event detail from the Predict API', async () => {
+    client.fetchEvent.mockResolvedValue(createEvent());
+
+    const result = await adapter.marketData.fetchEvent(eventId);
+
+    expect(result.id).toBe(eventId);
+  });
+
+  it('rejects Event detail with another Event ID', async () => {
+    client.fetchEvent.mockResolvedValue(createEvent({ id: 'event-2' }));
+
+    await expect(adapter.marketData.fetchEvent(eventId)).rejects.toEqual(
+      expect.objectContaining({ code: PredictErrorCode.UNKNOWN }),
+    );
+  });
+
+  it('parses Venue Status', async () => {
+    client.fetchVenueStatus.mockResolvedValue({
+      venueId: 'kalshi',
+      status: 'degraded',
+      checkedAt: '2026-08-07T12:00:00Z',
+    });
+
+    const result = await adapter.marketData.fetchVenueStatus();
+
+    expect(result.status).toBe('degraded');
+  });
+
+  it('rejects Venue Status for another Venue', async () => {
+    client.fetchVenueStatus.mockResolvedValue({
+      venueId: 'other',
+      status: 'available',
+      checkedAt: '2026-08-07T12:00:00Z',
+    });
+
+    await expect(adapter.marketData.fetchVenueStatus()).rejects.toEqual(
+      expect.objectContaining({ code: PredictErrorCode.UNKNOWN }),
+    );
+  });
+
+  it('maps HTTP 429 to RATE_LIMITED without response data', async () => {
+    client.fetchEvents.mockRejectedValue(new PredictHttpError(429));
+
+    await expect(adapter.marketData.fetchEvents({})).rejects.toEqual(
+      expect.objectContaining({
+        code: PredictErrorCode.RATE_LIMITED,
+        metadata: undefined,
+      }),
+    );
+  });
+
+  it('maps HTTP 503 to VENUE_UNAVAILABLE', async () => {
+    client.fetchEvents.mockRejectedValue(new PredictHttpError(503));
+
+    await expect(adapter.marketData.fetchEvents({})).rejects.toEqual(
+      expect.objectContaining({
+        code: PredictErrorCode.VENUE_UNAVAILABLE,
+      }),
+    );
+  });
+
+  it('maps other transport failures to UNKNOWN', async () => {
+    client.fetchEvents.mockRejectedValue(new Error('network detail'));
+
+    await expect(adapter.marketData.fetchEvents({})).rejects.toEqual(
+      expect.objectContaining({ code: PredictErrorCode.UNKNOWN }),
+    );
+  });
+
+  it('preserves AbortError', async () => {
+    const abortError = new Error('aborted');
+    abortError.name = 'AbortError';
+    client.fetchEvents.mockRejectedValue(abortError);
+
+    await expect(adapter.marketData.fetchEvents({})).rejects.toBe(abortError);
+  });
+});

--- a/app/components/UI/PredictNext/adapters/remote/KalshiRemoteAdapter.ts
+++ b/app/components/UI/PredictNext/adapters/remote/KalshiRemoteAdapter.ts
@@ -1,0 +1,78 @@
+import {
+  parsePredictEvent,
+  parsePredictEventsPage,
+  parsePredictVenueStatus,
+} from '../../contracts/v1/marketData';
+import { PredictError, PredictErrorCode } from '../../errors';
+import { KALSHI_VENUE_ID } from '../../types';
+import type { VenueMarketDataAdapter } from '../types';
+import {
+  type PredictApiReadTransport,
+  PredictHttpError,
+} from './PredictApiReadClient';
+
+const isAbortError = (error: unknown): error is Error =>
+  error instanceof Error && error.name === 'AbortError';
+
+const mapError = (error: unknown): never => {
+  if (isAbortError(error) || error instanceof PredictError) {
+    throw error;
+  }
+
+  if (error instanceof PredictHttpError) {
+    if (error.status === 429) {
+      throw PredictError.from(PredictErrorCode.RATE_LIMITED);
+    }
+    if (error.status === 503) {
+      throw PredictError.from(PredictErrorCode.VENUE_UNAVAILABLE);
+    }
+  }
+
+  throw PredictError.from(PredictErrorCode.UNKNOWN);
+};
+
+export class KalshiRemoteAdapter {
+  readonly venueId = KALSHI_VENUE_ID;
+  readonly marketData: VenueMarketDataAdapter;
+
+  constructor(client: PredictApiReadTransport) {
+    this.marketData = {
+      fetchVenueStatus: async (options) => {
+        try {
+          const value = await client.fetchVenueStatus(this.venueId, options);
+          const result = parsePredictVenueStatus(value);
+          if (result.venueId !== this.venueId) {
+            throw PredictError.from(PredictErrorCode.UNKNOWN);
+          }
+          return result;
+        } catch (error) {
+          return mapError(error);
+        }
+      },
+      fetchEvents: async (params, options) => {
+        try {
+          const value = await client.fetchEvents(this.venueId, params, options);
+          const result = parsePredictEventsPage(value);
+          if (result.items.some((event) => event.venueId !== this.venueId)) {
+            throw PredictError.from(PredictErrorCode.UNKNOWN);
+          }
+          return result;
+        } catch (error) {
+          return mapError(error);
+        }
+      },
+      fetchEvent: async (eventId, options) => {
+        try {
+          const value = await client.fetchEvent(this.venueId, eventId, options);
+          const result = parsePredictEvent(value);
+          if (result.venueId !== this.venueId || result.id !== eventId) {
+            throw PredictError.from(PredictErrorCode.UNKNOWN);
+          }
+          return result;
+        } catch (error) {
+          return mapError(error);
+        }
+      },
+    };
+  }
+}

--- a/app/components/UI/PredictNext/adapters/remote/PredictApiReadClient.test.ts
+++ b/app/components/UI/PredictNext/adapters/remote/PredictApiReadClient.test.ts
@@ -36,7 +36,7 @@ describe('PredictApiReadClient', () => {
     await client.fetchVenueStatus(venueId);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://predict.example/api/predict/v1/venues/kalshi/status',
+      'https://predict.example/api/v1/venues/kalshi/status',
       {
         method: 'GET',
         headers: {
@@ -55,7 +55,7 @@ describe('PredictApiReadClient', () => {
     await client.fetchEvents(venueId, { cursor: 'next page', limit: 20 });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://predict.example/api/predict/v1/venues/kalshi/events?cursor=next+page&limit=20',
+      'https://predict.example/api/v1/venues/kalshi/events?cursor=next+page&limit=20',
       expect.any(Object),
     );
   });
@@ -66,7 +66,7 @@ describe('PredictApiReadClient', () => {
     await client.fetchEvent(venueId, eventId);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://predict.example/api/predict/v1/venues/kalshi/events/event%2Fone',
+      'https://predict.example/api/v1/venues/kalshi/events/event%2Fone',
       expect.any(Object),
     );
   });

--- a/app/components/UI/PredictNext/adapters/remote/PredictApiReadClient.test.ts
+++ b/app/components/UI/PredictNext/adapters/remote/PredictApiReadClient.test.ts
@@ -1,0 +1,125 @@
+import type { PredictEntityId, PredictVenueId } from '../../types';
+import { PredictApiReadClient, PredictHttpError } from './PredictApiReadClient';
+
+const venueId = 'kalshi' as PredictVenueId;
+const eventId = 'event/one' as PredictEntityId;
+
+const createResponse = ({
+  status = 200,
+  json = { ok: true },
+}: {
+  status?: number;
+  json?: unknown;
+} = {}): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(json),
+  }) as unknown as Response;
+
+describe('PredictApiReadClient', () => {
+  let fetchMock: jest.MockedFunction<typeof fetch>;
+  let client: PredictApiReadClient;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    client = new PredictApiReadClient({
+      baseUrl: 'https://predict.example/api/',
+      clientVersion: '7.0.0',
+      fetch: fetchMock,
+    });
+  });
+
+  it('requests Venue Status without authorization or content type headers', async () => {
+    fetchMock.mockResolvedValue(createResponse());
+
+    await client.fetchVenueStatus(venueId);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://predict.example/api/predict/v1/venues/kalshi/status',
+      {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          'x-metamask-clientproduct': 'metamask-mobile',
+          'x-metamask-clientversion': '7.0.0',
+        },
+        signal: undefined,
+      },
+    );
+  });
+
+  it('encodes event-list query parameters', async () => {
+    fetchMock.mockResolvedValue(createResponse());
+
+    await client.fetchEvents(venueId, { cursor: 'next page', limit: 20 });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://predict.example/api/predict/v1/venues/kalshi/events?cursor=next+page&limit=20',
+      expect.any(Object),
+    );
+  });
+
+  it('encodes an Event ID as one path segment', async () => {
+    fetchMock.mockResolvedValue(createResponse());
+
+    await client.fetchEvent(venueId, eventId);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://predict.example/api/predict/v1/venues/kalshi/events/event%2Fone',
+      expect.any(Object),
+    );
+  });
+
+  it('forwards an AbortSignal', async () => {
+    fetchMock.mockResolvedValue(createResponse());
+    const signal = new AbortController().signal;
+
+    await client.fetchEvents(venueId, {}, { signal });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ signal }),
+    );
+  });
+
+  it('throws a status-only error for non-2xx responses', async () => {
+    fetchMock.mockResolvedValue(
+      createResponse({ status: 429, json: { secret: 'discard' } }),
+    );
+
+    await expect(client.fetchEvents(venueId, {})).rejects.toEqual(
+      expect.objectContaining({ status: 429 }),
+    );
+  });
+
+  it('throws a status-only error when a success body is not JSON', async () => {
+    const response = createResponse();
+    jest.mocked(response.json).mockRejectedValue(new SyntaxError('payload'));
+    fetchMock.mockResolvedValue(response);
+
+    await expect(client.fetchEvents(venueId, {})).rejects.toEqual(
+      expect.objectContaining({ status: 200 }),
+    );
+  });
+
+  it('preserves AbortError from response parsing', async () => {
+    const abortError = new Error('aborted');
+    abortError.name = 'AbortError';
+    const response = createResponse();
+    jest.mocked(response.json).mockRejectedValue(abortError);
+    fetchMock.mockResolvedValue(response);
+
+    await expect(client.fetchEvents(venueId, {})).rejects.toBe(abortError);
+  });
+
+  it('performs one request when a request fails', async () => {
+    fetchMock.mockResolvedValue(createResponse({ status: 503 }));
+
+    await expect(client.fetchEvents(venueId, {})).rejects.toBeInstanceOf(
+      PredictHttpError,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/UI/PredictNext/adapters/remote/PredictApiReadClient.ts
+++ b/app/components/UI/PredictNext/adapters/remote/PredictApiReadClient.ts
@@ -1,0 +1,137 @@
+import type {
+  FetchEventsParams,
+  PredictEntityId,
+  PredictReadOptions,
+  PredictVenueId,
+} from '../../types';
+
+export interface PredictApiReadTransport {
+  fetchVenueStatus(
+    venueId: PredictVenueId,
+    options?: PredictReadOptions,
+  ): Promise<unknown>;
+  fetchEvents(
+    venueId: PredictVenueId,
+    params: FetchEventsParams,
+    options?: PredictReadOptions,
+  ): Promise<unknown>;
+  fetchEvent(
+    venueId: PredictVenueId,
+    eventId: PredictEntityId,
+    options?: PredictReadOptions,
+  ): Promise<unknown>;
+}
+
+export interface PredictApiReadClientOptions {
+  baseUrl: string;
+  clientVersion: string;
+  fetch?: typeof fetch;
+}
+
+export class PredictHttpError extends Error {
+  readonly status: number;
+
+  constructor(status: number) {
+    super(`Predict API request failed with status ${status}.`);
+    this.name = 'PredictHttpError';
+    this.status = status;
+  }
+}
+
+export class PredictApiReadClient implements PredictApiReadTransport {
+  readonly #baseUrl: URL;
+  readonly #clientVersion: string;
+  readonly #fetch: typeof fetch;
+
+  constructor({
+    baseUrl,
+    clientVersion,
+    fetch: fetchFn = global.fetch,
+  }: PredictApiReadClientOptions) {
+    this.#baseUrl = new URL(baseUrl);
+    this.#clientVersion = clientVersion;
+    this.#fetch = fetchFn;
+  }
+
+  fetchVenueStatus(
+    venueId: PredictVenueId,
+    options?: PredictReadOptions,
+  ): Promise<unknown> {
+    return this.#get(
+      ['predict', 'v1', 'venues', venueId, 'status'],
+      undefined,
+      options,
+    );
+  }
+
+  fetchEvents(
+    venueId: PredictVenueId,
+    params: FetchEventsParams,
+    options?: PredictReadOptions,
+  ): Promise<unknown> {
+    return this.#get(
+      ['predict', 'v1', 'venues', venueId, 'events'],
+      params,
+      options,
+    );
+  }
+
+  fetchEvent(
+    venueId: PredictVenueId,
+    eventId: PredictEntityId,
+    options?: PredictReadOptions,
+  ): Promise<unknown> {
+    return this.#get(
+      ['predict', 'v1', 'venues', venueId, 'events', eventId],
+      undefined,
+      options,
+    );
+  }
+
+  async #get(
+    segments: readonly string[],
+    params?: FetchEventsParams,
+    options?: PredictReadOptions,
+  ): Promise<unknown> {
+    const url = new URL(
+      segments.map(encodeURIComponent).join('/'),
+      this.#baseUrlWithTrailingSlash(),
+    );
+
+    if (params?.cursor !== undefined) {
+      url.searchParams.set('cursor', params.cursor);
+    }
+    if (params?.limit !== undefined) {
+      url.searchParams.set('limit', String(params.limit));
+    }
+
+    const response = await this.#fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'x-metamask-clientproduct': 'metamask-mobile',
+        'x-metamask-clientversion': this.#clientVersion,
+      },
+      signal: options?.signal,
+    });
+
+    if (!response.ok) {
+      throw new PredictHttpError(response.status);
+    }
+
+    try {
+      return await response.json();
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw error;
+      }
+      throw new PredictHttpError(response.status);
+    }
+  }
+
+  #baseUrlWithTrailingSlash(): URL {
+    const url = new URL(this.#baseUrl.toString());
+    url.pathname = `${url.pathname.replace(/\/$/u, '')}/`;
+    return url;
+  }
+}

--- a/app/components/UI/PredictNext/adapters/remote/PredictApiReadClient.ts
+++ b/app/components/UI/PredictNext/adapters/remote/PredictApiReadClient.ts
@@ -57,11 +57,7 @@ export class PredictApiReadClient implements PredictApiReadTransport {
     venueId: PredictVenueId,
     options?: PredictReadOptions,
   ): Promise<unknown> {
-    return this.#get(
-      ['predict', 'v1', 'venues', venueId, 'status'],
-      undefined,
-      options,
-    );
+    return this.#get(['v1', 'venues', venueId, 'status'], undefined, options);
   }
 
   fetchEvents(
@@ -69,11 +65,7 @@ export class PredictApiReadClient implements PredictApiReadTransport {
     params: FetchEventsParams,
     options?: PredictReadOptions,
   ): Promise<unknown> {
-    return this.#get(
-      ['predict', 'v1', 'venues', venueId, 'events'],
-      params,
-      options,
-    );
+    return this.#get(['v1', 'venues', venueId, 'events'], params, options);
   }
 
   fetchEvent(
@@ -82,7 +74,7 @@ export class PredictApiReadClient implements PredictApiReadTransport {
     options?: PredictReadOptions,
   ): Promise<unknown> {
     return this.#get(
-      ['predict', 'v1', 'venues', venueId, 'events', eventId],
+      ['v1', 'venues', venueId, 'events', eventId],
       undefined,
       options,
     );

--- a/app/components/UI/PredictNext/adapters/types.ts
+++ b/app/components/UI/PredictNext/adapters/types.ts
@@ -1,0 +1,20 @@
+import type {
+  FetchEventsParams,
+  PaginatedResult,
+  PredictEntityId,
+  PredictEvent,
+  PredictReadOptions,
+  PredictVenueStatus,
+} from '../types';
+
+export interface VenueMarketDataAdapter {
+  fetchVenueStatus(options?: PredictReadOptions): Promise<PredictVenueStatus>;
+  fetchEvents(
+    params: FetchEventsParams,
+    options?: PredictReadOptions,
+  ): Promise<PaginatedResult<PredictEvent>>;
+  fetchEvent(
+    eventId: PredictEntityId,
+    options?: PredictReadOptions,
+  ): Promise<PredictEvent>;
+}

--- a/app/components/UI/PredictNext/contracts/v1/marketData.test.ts
+++ b/app/components/UI/PredictNext/contracts/v1/marketData.test.ts
@@ -1,101 +1,188 @@
 import { PredictError, PredictErrorCode } from '../../errors';
-import { parsePredictEvent, parsePredictEventSummary } from './marketData';
+import {
+  parsePredictEvent,
+  parsePredictEventsPage,
+  parsePredictVenueStatus,
+} from './marketData';
 
 const venueId = 'kalshi';
 
-const createOutcome = (side: 'yes' | 'no') => ({
-  venueId,
+const createOutcome = (side: 'yes' | 'no', overrides = {}) => ({
   id: `market-1-${side}`,
-  marketId: 'market-1',
   side,
   label: side === 'yes' ? 'Yes' : 'No',
+  askPrice: side === 'yes' ? '0.42' : '0.61',
+  bidPrice: side === 'yes' ? '0.40' : '0.58',
+  ...overrides,
 });
 
 const createMarket = (overrides = {}) => ({
-  venueId,
   id: 'market-1',
-  eventId: 'event-1',
   question: 'Will the team win?',
   outcomes: [createOutcome('yes'), createOutcome('no')],
   status: 'open' as const,
   ...overrides,
 });
 
-describe('Predict API canonical response parsers', () => {
-  it('parses an event summary without venue-specific fields', () => {
-    const input = {
-      venueId,
-      id: 'event-1',
-      title: 'Game outcome',
-      startsAt: '2026-02-13T12:00:00Z',
-    };
+const createEvent = (overrides = {}) => ({
+  venueId,
+  id: 'event-1',
+  title: 'Game outcome',
+  markets: [createMarket()],
+  ...overrides,
+});
 
-    const result = parsePredictEventSummary(input);
+describe('Predict API canonical response parsers', () => {
+  it('parses an event containing prices for each binary outcome', () => {
+    const input = createEvent();
+
+    const result = parsePredictEvent(input);
 
     expect(result).toEqual(input);
   });
 
-  it('parses an event containing a binary market', () => {
+  it('parses an event containing an ask without a bid', () => {
+    const input = createEvent({
+      markets: [
+        createMarket({
+          outcomes: [
+            createOutcome('yes', { bidPrice: undefined }),
+            createOutcome('no'),
+          ],
+        }),
+      ],
+    });
+
+    const result = parsePredictEvent(input);
+
+    expect(result.markets[0].outcomes[0]).toEqual(
+      expect.objectContaining({ askPrice: '0.42' }),
+    );
+    expect(result.markets[0].outcomes[0].bidPrice).toBeUndefined();
+  });
+
+  it.each(['0', '0.0', '0.42', '1', '1.000'])(
+    'parses the price %s in the inclusive unit interval',
+    (price) => {
+      const input = createEvent({
+        markets: [
+          createMarket({
+            outcomes: [
+              createOutcome('yes', { askPrice: price }),
+              createOutcome('no'),
+            ],
+          }),
+        ],
+      });
+
+      const result = parsePredictEvent(input);
+
+      expect(result.markets[0].outcomes[0].askPrice).toBe(price);
+    },
+  );
+
+  it.each(['-0.1', '+0.5', '0.5 ', '1.01', '5e-1', ''])(
+    'rejects the price representation %s',
+    (price) => {
+      const input = createEvent({
+        markets: [
+          createMarket({
+            outcomes: [
+              createOutcome('yes', { askPrice: price }),
+              createOutcome('no'),
+            ],
+          }),
+        ],
+      });
+
+      expect(() => parsePredictEvent(input)).toThrow(
+        'Invalid Predict API response.',
+      );
+    },
+  );
+
+  it('discards unknown fields throughout an event', () => {
     const input = {
-      venueId,
-      id: 'event-1',
-      title: 'Game outcome',
-      markets: [createMarket()],
+      ...createEvent(),
+      venuePayload: 'discard',
+      markets: [
+        {
+          ...createMarket(),
+          venueMarketPayload: 'discard',
+          outcomes: [
+            { ...createOutcome('yes'), venueOutcomePayload: 'discard' },
+            createOutcome('no'),
+          ],
+        },
+      ],
     };
 
     const result = parsePredictEvent(input);
 
-    expect(result.markets[0].outcomes).toHaveLength(2);
-    expect(result.markets[0].outcomes.map(({ side }) => side)).toEqual([
-      'yes',
-      'no',
-    ]);
+    expect(result).not.toHaveProperty('venuePayload');
+    expect(result.markets[0]).not.toHaveProperty('venueMarketPayload');
+    expect(result.markets[0].outcomes[0]).not.toHaveProperty(
+      'venueOutcomePayload',
+    );
   });
 
   it('rejects an event without markets', () => {
-    const input = {
-      venueId,
-      id: 'event-1',
-      title: 'Game outcome',
-      markets: [],
-    };
+    const input = createEvent({ markets: [] });
 
     expect(() => parsePredictEvent(input)).toThrow(
-      'Invalid Predict API response',
+      'Invalid Predict API response.',
     );
   });
 
   it('rejects a market with two outcomes on the same side', () => {
-    const input = {
-      venueId,
-      id: 'event-1',
-      title: 'Game outcome',
+    const input = createEvent({
       markets: [
         createMarket({
           outcomes: [createOutcome('yes'), createOutcome('yes')],
         }),
       ],
-    };
+    });
 
     expect(() => parsePredictEvent(input)).toThrow(
-      'Invalid Predict API response',
+      'Invalid Predict API response.',
     );
   });
 
   it('rejects an event with a malformed timestamp', () => {
-    const input = {
-      venueId,
-      id: 'event-1',
-      title: 'Game outcome',
-      startsAt: 'not-a-timestamp',
-    };
+    const input = createEvent({ startsAt: 'not-a-timestamp' });
 
     try {
-      parsePredictEventSummary(input);
+      parsePredictEvent(input);
       throw new Error('Expected parser to throw');
     } catch (error) {
       expect(error).toBeInstanceOf(PredictError);
       expect((error as PredictError).code).toBe(PredictErrorCode.UNKNOWN);
     }
+  });
+
+  it('parses a paginated event response', () => {
+    const input = { items: [createEvent()], nextCursor: 'next-page' };
+
+    const result = parsePredictEventsPage(input);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.nextCursor).toBe('next-page');
+  });
+
+  it('parses an available Venue Status observation', () => {
+    const input = {
+      venueId,
+      status: 'available',
+      checkedAt: '2026-08-07T12:00:00Z',
+      addition: 'discard',
+    };
+
+    const result = parsePredictVenueStatus(input);
+
+    expect(result).toEqual({
+      venueId,
+      status: 'available',
+      checkedAt: '2026-08-07T12:00:00Z',
+    });
   });
 });

--- a/app/components/UI/PredictNext/contracts/v1/marketData.ts
+++ b/app/components/UI/PredictNext/contracts/v1/marketData.ts
@@ -1,6 +1,7 @@
 import {
   array,
   enums,
+  mask,
   number,
   object,
   optional,
@@ -8,13 +9,14 @@ import {
   string,
   tuple,
   type Struct,
-  create,
 } from '@metamask/superstruct';
 import { PredictError, PredictErrorCode } from '../../errors';
 import type {
+  FetchEventsParams,
+  PaginatedResult,
   PredictEvent,
-  PredictEventSummary,
   PredictMarket,
+  PredictVenueStatus,
 } from '../../types';
 
 const timestamp = refine(
@@ -31,6 +33,11 @@ const entityId = refine(
   'PredictEntityId',
   (value) => value.length > 0,
 );
+const decimal = refine(
+  string(),
+  'PredictDecimal',
+  (value) => /^(?:0(?:\.\d+)?|1(?:\.0+)?)$/.test(value) && Number(value) <= 1,
+);
 const status = enums([
   'upcoming',
   'open',
@@ -38,14 +45,15 @@ const status = enums([
   'resolved',
   'unavailable',
 ] as const);
+const venueStatus = enums(['available', 'degraded', 'unavailable'] as const);
 const side = enums(['yes', 'no'] as const);
 
 const outcomeSchema = object({
-  venueId,
   id: entityId,
-  marketId: entityId,
   side,
   label: string(),
+  askPrice: optional(decimal),
+  bidPrice: optional(decimal),
 });
 
 const binaryOutcomes = refine(
@@ -55,9 +63,7 @@ const binaryOutcomes = refine(
 );
 
 const marketSchema = object({
-  venueId,
   id: entityId,
-  eventId: entityId,
   question: string(),
   outcomes: binaryOutcomes,
   status,
@@ -66,16 +72,6 @@ const marketSchema = object({
   opensAt: optional(timestamp),
   closesAt: optional(timestamp),
   resolvesAt: optional(timestamp),
-});
-
-const eventSummarySchema = object({
-  venueId,
-  id: entityId,
-  title: string(),
-  subtitle: optional(string()),
-  startsAt: optional(timestamp),
-  closesAt: optional(timestamp),
-  updatedAt: optional(timestamp),
 });
 
 const nonEmptyMarkets = refine(
@@ -96,6 +92,17 @@ const eventSchema = object({
   markets: nonEmptyMarkets,
 });
 
+const eventsPageSchema = object({
+  items: array(eventSchema),
+  nextCursor: optional(string()),
+});
+
+const venueStatusSchema = object({
+  venueId,
+  status: venueStatus,
+  checkedAt: timestamp,
+});
+
 const eventsParamsSchema = object({
   cursor: optional(string()),
   limit: optional(refine(number(), 'PositiveLimit', (value) => value > 0)),
@@ -103,24 +110,27 @@ const eventsParamsSchema = object({
 
 function parse<T>(value: unknown, schema: Struct<T, unknown>): T {
   try {
-    return create(value, schema);
-  } catch (error) {
+    return mask(value, schema);
+  } catch {
     throw PredictError.from(PredictErrorCode.UNKNOWN, {
-      message: `Invalid Predict API response: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
+      message: 'Invalid Predict API response.',
     });
   }
 }
 
-export const parsePredictEventSummary = (value: unknown): PredictEventSummary =>
-  parse(value, eventSummarySchema) as unknown as PredictEventSummary;
-
 export const parsePredictEvent = (value: unknown): PredictEvent =>
   parse(value, eventSchema) as unknown as PredictEvent;
+
+export const parsePredictEventsPage = (
+  value: unknown,
+): PaginatedResult<PredictEvent> =>
+  parse(value, eventsPageSchema) as unknown as PaginatedResult<PredictEvent>;
 
 export const parsePredictMarket = (value: unknown): PredictMarket =>
   parse(value, marketSchema) as unknown as PredictMarket;
 
-export const parseFetchEventsParams = (value: unknown) =>
+export const parsePredictVenueStatus = (value: unknown): PredictVenueStatus =>
+  parse(value, venueStatusSchema) as unknown as PredictVenueStatus;
+
+export const parseFetchEventsParams = (value: unknown): FetchEventsParams =>
   parse(value, eventsParamsSchema);

--- a/app/components/UI/PredictNext/docs/architecture.md
+++ b/app/components/UI/PredictNext/docs/architecture.md
@@ -40,7 +40,7 @@ Do not add a forwarding layer that only repeats another module's interface. Do n
 
 Product-facing modules use the language in [`../CONTEXT.md`](../CONTEXT.md): Event, Market, Outcome, Order, Position, Predict User, Funding Wallet, and Venue Account. Kalshi DTO names and protocol mechanics remain inside the adapter/backend boundary.
 
-Every domain entity and query is Venue-qualified. Raw Venue identifiers are not globally unique.
+Every root Event, query, route, and operation is Venue-qualified. Nested Markets and Outcomes carry their own opaque identifiers and inherit Venue and parent scope through containment; raw Venue identifiers are not globally unique.
 
 ### Identity is not a wallet
 
@@ -77,7 +77,7 @@ See [`venue-adapters.md`](./venue-adapters.md).
 
 ### 2. Product services
 
-A service exists when a vertical slice needs a deep module for shared behavior. Depending on the concern, it may own:
+A service exists when a vertical slice needs a deep module for shared behavior. The first Kalshi-only read slice receives its `marketData` capability directly from the composition root; add a Venue registry only when runtime resolution among multiple Venues is required. Depending on the concern, a service may own:
 
 - server-read caching and request deduplication,
 - bounded read retry,
@@ -110,7 +110,7 @@ Reusable primitives, widgets, and views are extracted when real callers prove re
 View
   -> one query hook(venueId, params)
     -> market-data service
-      -> adapter registry.get(venueId).marketData
+      -> injected Kalshi marketData capability
         -> MetaMask Predict backend
           -> Kalshi market API
 ```
@@ -118,10 +118,11 @@ View
 Properties:
 
 - `venueId` is explicit and part of every cache key,
-- no selected wallet or account session is required,
+- no selected wallet, bearer token, or account session is required,
+- Event list and detail responses include the initial Outcome Bid Price and Ask Price snapshot,
 - transport and DTO normalization stay below the service,
-- responses are runtime-validated,
-- bounded retry applies only to safe reads.
+- responses are runtime-validated and unknown fields are discarded,
+- the service alone owns response caching, deduplication, and bounded retry for safe reads.
 
 ### Account-scoped read
 
@@ -184,7 +185,7 @@ Credentials, bearer tokens, OTPs, raw Venue sessions, PII/KYC values, and transf
 
 Each vertical slice leaves the smallest meaningful coverage at its deep interfaces:
 
-- shared mobile/backend contract fixtures and runtime parser tests,
+- runtime parser tests against synthetic canonical values,
 - adapter transformation tests against sanitized Venue payloads,
 - service tests for retry, state transitions, and reconciliation,
 - component-view tests for user-visible behavior,

--- a/app/components/UI/PredictNext/docs/interface-ledger.md
+++ b/app/components/UI/PredictNext/docs/interface-ledger.md
@@ -1,31 +1,35 @@
 # PredictNext Interface Ledger
 
-This ledger records the mobile canonical read contract stabilized by PRED-1168. Venue DTO mapping belongs to the Predict API backend; mobile validates canonical Predict API responses only.
+This ledger records the mobile canonical read contract stabilized by PRED-1168 and refined by PRED-1169. Venue DTO mapping belongs to the Predict API backend; mobile validates canonical Predict API responses only.
 
 ## Canonical read models
 
-- `PredictEventSummary` is returned by `getEvents`.
-- `PredictEvent` is returned by `getEvent` and contains one or more `PredictMarket` values.
+- `PredictEvent` is returned by both `getEvents` and `getEvent` and contains one or more `PredictMarket` values.
+- Event list pagination uses `{ items, nextCursor? }`; cursors are opaque.
 - `PredictMarket` contains exactly two `PredictOutcome` values: one `yes` and one `no`.
+- Each Event, Market, and Outcome retains its own opaque ID. Only the root Event carries `venueId`; nested scope and parent relationships come from containment.
+- Each Outcome may contain independent `askPrice` and `bidPrice` decimal strings in the inclusive range `[0, 1]`. Missing means no current quote, not zero.
+- Event responses provide the initial price snapshot. A separate price read is not part of this slice; future Live Updates may patch cached Outcomes.
 - Market status is a small browse projection, not a lossless Venue lifecycle.
 - Event status is intentionally absent.
-- Prices and order-book data are separate volatile read models and are not included here.
+- `PredictVenueStatus` contains the root `venueId`, an `available | degraded | unavailable` status, and the backend observation time as `PredictTimestamp`.
 - `PredictEntityId` is venue-local and opaque. An Outcome ID may be native or adapter-derived.
 - `PredictTimestamp` is an RFC 3339/ISO-8601 UTC string.
 
 ## Query descriptors
 
 ```ts
+marketDataQueries.getVenueStatus(venueId);
 marketDataQueries.getEvents(venueId, params);
 marketDataQueries.getEvent(venueId, eventId);
 ```
 
-Both descriptors have Venue-qualified keys, semantic invalidation families, explicit `venue` scope, and centralized stale-time policy. Cursors are opaque.
+All descriptors have Venue-qualified keys, semantic invalidation families, explicit `venue` scope, and centralized stale-time policy. The first price-bearing Event list/detail and Venue Status policy is one minute, with no background polling.
 
 ## Runtime boundary
 
-Mobile parsers in `contracts/v1/marketData.ts` validate canonical Predict API responses using `@metamask/superstruct`. Kalshi and Polymarket DTOs, status mapping, and identifier derivation are backend adapter responsibilities and must not enter this module.
+Mobile parsers in `contracts/v1/marketData.ts` validate canonical Predict API responses using `@metamask/superstruct`. Parsers discard unknown fields, reject malformed known fields, and return generic errors that do not retain received payload values. Kalshi and Polymarket DTOs, status mapping, price-field mapping, and identifier derivation are backend adapter responsibilities and must not enter this module. Contract-version header enforcement and cross-repository fixture tooling are deferred.
 
 ## Testing boundary
 
-Contract tests should validate canonical response parsing, binary outcome invariants, malformed responses failing closed, and descriptor behavior. Adapter mapping and service/controller integration tests belong to their respective delivery slices.
+Contract tests should validate canonical response parsing, binary outcome invariants, decimal price bounds, one-sided or missing quotes, recursive removal of unknown fields, malformed known fields failing closed, the complete pagination envelope, Venue Status, and descriptor behavior. Duplicate-ID validation is intentionally left to the backend. Adapter mapping and service/controller integration tests belong to their respective delivery slices.

--- a/app/components/UI/PredictNext/docs/remote-adapters.md
+++ b/app/components/UI/PredictNext/docs/remote-adapters.md
@@ -9,7 +9,7 @@ The governing Kalshi ADR set is currently proposed in [MetaMask/decisions PR #24
 ```text
 Mobile product intent
   -> KalshiRemoteAdapter
-    -> authenticated MetaMask platform API client
+    -> narrow Predict API transport
       -> MetaMask Predict backend
         -> Kalshi credentials + protocol adapter
           -> Kalshi
@@ -52,24 +52,24 @@ A privileged backend route never authorizes from a client-supplied wallet addres
 
 ## Mobile transport
 
-Use the repository's authenticated MetaMask platform API infrastructure rather than a feature-specific fetch wrapper. A concrete `KalshiRemoteAdapter` is preferable to a configurable remote-adapter factory while Kalshi is the only consumer.
+The installed MetaMask platform client has no supported generic request API. The first public-read slice therefore uses one narrow, injected Predict API GET transport. It is deliberately unauthenticated, forwards cancellation, retains no response bodies in errors, and performs no response caching or retry. The MarketDataService alone owns response caching, deduplication, and bounded retry.
 
-Extract shared remote transport only after a second Venue proves the same behavior.
+Base URL and client version come from composition/configuration; environment differences do not create different Venue adapters. A concrete `KalshiRemoteAdapter` is preferable to a configurable remote-adapter factory while Kalshi is the only consumer.
+
+Before account-scoped routes or writes, adopt an explicit required-auth, method-capable transport. Prefer a shared uncached platform request primitive when available; do not silently reuse the public-read client's unauthenticated behavior.
 
 ## Canonical backend contract
 
 The mobile/backend API exposes product capabilities, not raw Kalshi endpoints. Route names and schemas are defined by the implementing slice, but follow these rules:
 
 - routes are Venue-qualified,
-- mobile and backend validate the same versioned schema or fixture corpus,
-- mobile performs runtime response validation,
-- unknown or malformed write responses fail closed,
-- raw Venue errors map to canonical Predict errors,
+- mobile performs runtime response validation using canonical Superstruct parsers,
+- unknown response fields are discarded while malformed known fields fail closed,
+- raw Venue errors map to canonical Predict errors without retaining raw response bodies,
 - every response contains canonical Venue context where relevant,
-- credentials, PII, and raw KYC payloads never appear in canonical responses,
-- unsupported client/contract versions produce an explicit upgrade error.
+- credentials, PII, and raw KYC payloads never appear in canonical responses.
 
-The first read-only slice needs only Venue status, Event list/detail, and required price reads. Do not define account or write routes until their slices begin.
+Contract-version header enforcement and cross-repository fixture tooling are deferred until their semantics and value are proven. The first read-only slice needs only Venue Status and Event list/detail; Event responses embed the initial optional Outcome Bid Price and Ask Price snapshot. Do not define a separate price, account, or write route until a slice requires it.
 
 ## Sensitive-data rule
 
@@ -86,13 +86,15 @@ Sanitized fixtures must be demonstrably synthetic or redacted. Query/cache keys 
 
 ## Reads
 
-Safe reads may use:
+The MarketDataService may apply to safe reads:
 
 - bounded retry with backoff,
 - request deduplication,
 - cache stale times,
 - circuit breaking,
 - explicit degraded/unavailable states.
+
+The adapter and transport perform one network attempt per invocation so these policies are not nested.
 
 Rate limits and upstream outages are normalized below the UI. Browsing eligibility and Venue availability remain separate: an ineligible user may browse when policy permits, while an unavailable Venue cannot serve the surface.
 
@@ -125,8 +127,8 @@ Kalshi has Venue-specific feature flags and a kill switch. Rollback can disable 
 
 Each capability includes:
 
-- contract fixtures consumed by mobile and backend,
-- runtime parser tests,
+- runtime parser tests with synthetic canonical values,
+- adapter and transport tests that verify one uncached, non-retried request per invocation,
 - cross-user authorization tests for account routes,
 - secret/PII redaction tests,
 - lost-response and duplicate-request tests for writes,

--- a/app/components/UI/PredictNext/docs/venue-adapters.md
+++ b/app/components/UI/PredictNext/docs/venue-adapters.md
@@ -4,7 +4,7 @@ A Venue adapter is PredictNext's translation boundary for one prediction-market 
 
 ## Capability shape
 
-One registered adapter exposes focused capabilities that vary independently:
+One adapter exposes focused capabilities that vary independently:
 
 ```typescript
 interface VenueAdapter {
@@ -26,9 +26,9 @@ Structural presence is executable truth. Product capability metadata may control
 
 ## Public and account-scoped data
 
-Public Event, Market, Outcome, price, and Venue-status reads are scoped by `venueId`. They do not require a selected wallet or fake Venue Session.
+Public Event, Market, Outcome, Bid Price, Ask Price, and Venue Status reads are scoped by `venueId`. The first Kalshi browse slice is deliberately unauthenticated and does not require a selected wallet or fake Venue Session.
 
-If transport authentication is required for a nominally public endpoint, the remote adapter handles it internally. The visible query remains Venue-scoped unless its result is personalized.
+A later account-scoped route must use explicit required authentication. Do not opportunistically attach identity to public reads unless the contract and cache scope are intentionally personalized.
 
 Account Readiness, Account Setup, portfolio, trading, and funding are account-scoped. Product modules use a session-bound client or equivalent narrow handle; they never receive credentials or raw Venue sessions.
 
@@ -36,8 +36,9 @@ Account Readiness, Account Setup, portfolio, trading, and funding are account-sc
 
 - Predict User identity is distinct from Funding Wallet and Venue Account.
 - The backend authorizes account-scoped requests from authenticated MetaMask identity, not client-supplied identity fields.
-- Every Event, Market, Outcome, Order, Position, query key, route, and durable Venue Operation is Venue-qualified.
-- A raw Venue identifier is meaningful only with `venueId`.
+- Every root Event, query key, route, and durable Venue Operation is Venue-qualified.
+- Nested Markets and Outcomes carry their own opaque identifiers and inherit Venue and parent scope through containment.
+- A raw Venue identifier is meaningful only with its containing `venueId`.
 - Canonical entities contain no raw credentials, PII/KYC values, or authentication subjects.
 
 See [`../CONTEXT.md`](../CONTEXT.md) for terminology.
@@ -69,26 +70,37 @@ Services orchestrate product workflows above this boundary.
 The first walking-skeleton adapter should implement only the reads required by [PRED-1158](https://consensyssoftware.atlassian.net/browse/PRED-1158). A minimal shape is:
 
 ```typescript
+interface PredictReadOptions {
+  signal?: AbortSignal;
+}
+
 interface VenueMarketDataAdapter {
-  fetchVenueStatus(): Promise<PredictVenueStatus>;
+  fetchVenueStatus(options?: PredictReadOptions): Promise<PredictVenueStatus>;
   fetchEvents(
     params: FetchEventsParams,
+    options?: PredictReadOptions,
   ): Promise<PaginatedResult<PredictEvent>>;
-  fetchEvent(eventId: string): Promise<PredictEvent>;
-  fetchPrices(params: PriceQuery[]): Promise<MarketPrices>;
+  fetchEvent(
+    eventId: PredictEntityId,
+    options?: PredictReadOptions,
+  ): Promise<PredictEvent>;
 }
 ```
 
-Only add price history, search, carousel, account, portfolio, trading, funding, or live-data operations when an active product slice requires them.
+Event list and detail include the initial optional `bidPrice` and `askPrice` snapshot on each Outcome. There is no separate price operation in the first slice. Future live data may identify an Event, Market, and Outcome and patch these prices in cached Events.
 
-The market-data service resolves this capability by `venueId`:
+Only add price history, batch price reads, search, carousel, account, portfolio, trading, funding, or live-data operations when an active product slice requires them.
+
+The first Kalshi-only market-data service receives the capability directly from the composition root:
 
 ```text
 market-data service
-  -> adapter registry.get(venueId).marketData
+  -> injected Kalshi marketData capability
     -> Kalshi remote adapter
       -> MetaMask Predict backend
 ```
+
+Add a Venue registry only when the product must resolve multiple Venue adapters by `venueId` at runtime. Environment selection belongs in injected transport configuration, and tests inject doubles.
 
 ## Session-bound account capabilities
 

--- a/app/components/UI/PredictNext/queries/marketDataQueries.ts
+++ b/app/components/UI/PredictNext/queries/marketDataQueries.ts
@@ -2,14 +2,13 @@ import type {
   FetchEventsParams,
   PredictEntityId,
   PredictEvent,
-  PredictEventSummary,
   PredictQueryDescriptor,
   PredictVenueId,
   PaginatedResult,
 } from '../types';
 
 export const MARKET_DATA_EVENTS_STALE_TIME = 60_000;
-export const MARKET_DATA_EVENT_STALE_TIME = 5 * 60_000;
+export const MARKET_DATA_EVENT_STALE_TIME = 60_000;
 
 export interface MarketDataQueries {
   getEvents(
@@ -26,7 +25,7 @@ export interface MarketDataQueries {
   >;
 }
 
-export type GetEventsResult = PaginatedResult<PredictEventSummary>;
+export type GetEventsResult = PaginatedResult<PredictEvent>;
 export type GetEventResult = PredictEvent;
 
 export const marketDataQueries: MarketDataQueries = {

--- a/app/components/UI/PredictNext/types/index.ts
+++ b/app/components/UI/PredictNext/types/index.ts
@@ -1,10 +1,9 @@
-import type { PredictErrorCode } from '../errors';
-
 export type PredictVenueId = string & { readonly __brand: 'PredictVenueId' };
 export type PredictEntityId = string & { readonly __brand: 'PredictEntityId' };
 export type PredictTimestamp = string & {
   readonly __brand: 'PredictTimestamp';
 };
+export type PredictDecimal = string & { readonly __brand: 'PredictDecimal' };
 
 export const KALSHI_VENUE_ID = 'kalshi' as PredictVenueId;
 
@@ -18,17 +17,15 @@ export type PredictEntityStatus =
 export type PredictOutcomeSide = 'yes' | 'no';
 
 export interface PredictOutcome {
-  venueId: PredictVenueId;
   id: PredictEntityId;
-  marketId: PredictEntityId;
   side: PredictOutcomeSide;
   label: string;
+  askPrice?: PredictDecimal;
+  bidPrice?: PredictDecimal;
 }
 
 export interface PredictMarket {
-  venueId: PredictVenueId;
   id: PredictEntityId;
-  eventId: PredictEntityId;
   question: string;
   outcomes: readonly [PredictOutcome, PredictOutcome];
   status: PredictEntityStatus;
@@ -39,7 +36,7 @@ export interface PredictMarket {
   resolvesAt?: PredictTimestamp;
 }
 
-export interface PredictEventSummary {
+export interface PredictEvent {
   venueId: PredictVenueId;
   id: PredictEntityId;
   title: string;
@@ -47,9 +44,6 @@ export interface PredictEventSummary {
   startsAt?: PredictTimestamp;
   closesAt?: PredictTimestamp;
   updatedAt?: PredictTimestamp;
-}
-
-export interface PredictEvent extends PredictEventSummary {
   description?: string;
   markets: readonly PredictMarket[];
 }
@@ -67,8 +61,11 @@ export interface PaginatedResult<T> {
 export interface PredictVenueStatus {
   venueId: PredictVenueId;
   status: 'available' | 'degraded' | 'unavailable';
-  checkedAt: number;
-  reason?: PredictErrorCode;
+  checkedAt: PredictTimestamp;
+}
+
+export interface PredictReadOptions {
+  signal?: AbortSignal;
 }
 
 export interface PredictQueryDescriptor<TKey extends readonly unknown[]> {


### PR DESCRIPTION
## **Description**

Adds the Kalshi market-data remote adapter and narrow Predict API read client for PRED-1169.

The change:
- refines the canonical Event, Market, Outcome, pagination, and Venue Status contracts;
- embeds optional bid/ask quote snapshots in Outcomes;
- validates and masks canonical API payloads without retaining backend response data in errors;
- adds unauthenticated GET operations for Venue Status, Event list, and Event detail;
- forwards cancellation and maps transport failures to canonical Predict errors; and
- updates the PredictNext architecture and interface documentation.

The adapter intentionally performs no caching, request deduplication, or retries. Those policies remain owned by the market-data service in PRED-1170.

Final dev API integration remains dependent on PRED-1165 and PRED-1166 publishing the deployed base URL, routes, headers, and canonical envelopes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/PRED-1169

## **Manual testing steps**

```gherkin
Feature: Kalshi canonical market-data boundary

  Scenario: parse canonical Kalshi market data
    Given the Predict API returns canonical Venue Status, Event list, or Event detail data

    When the Kalshi remote adapter receives the response
    Then it returns validated canonical Predict models
    And unknown response fields are discarded
    And cancellation and HTTP failures retain their defined semantics
```

Automated verification:

```bash
CI=1 NODE_OPTIONS=--max-old-space-size=8192 yarn jest app/components/UI/PredictNext/contracts/v1/marketData.test.ts app/components/UI/PredictNext/queries/marketDataQueries.test.ts app/components/UI/PredictNext/adapters/remote/PredictApiReadClient.test.ts app/components/UI/PredictNext/adapters/remote/KalshiRemoteAdapter.test.ts --runInBand --forceExit --coverage=false --watchman=false
yarn lint:tsc
```

Live device/API verification is pending the PRED-1165/PRED-1166 dependencies described above.

## **Screenshots/Recordings**

N/A — this PR adds a non-visual API and domain boundary.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - N/A — no UI or device behavior is introduced.
- [ ] I've tested with a power user scenario
  - N/A — no account, token, or list rendering behavior is introduced.
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A — this single-attempt transport boundary does not own service observability.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New read-only API boundary with strict parsing and no auth, caching, or writes; limited blast radius until wired to live backend and market-data service.
> 
> **Overview**
> Introduces the **Kalshi remote market-data path**: a narrow `PredictApiReadClient` performs single-attempt unauthenticated GETs for venue status, paginated events, and event detail (MetaMask client headers, `AbortSignal`, path/query encoding), surfacing status-only `PredictHttpError` without response bodies. **`KalshiRemoteAdapter`** parses canonical payloads, enforces Kalshi `venueId`/event ID consistency, and maps HTTP 429/503 and other failures to `PredictError` while preserving abort semantics.
> 
> **Canonical contracts** are tightened for PRED-1169: `PredictEventSummary` is folded into full `PredictEvent` for list and detail; nested markets/outcomes drop redundant venue/parent IDs; outcomes gain optional `askPrice`/`bidPrice` decimals; venue status uses RFC3339 `checkedAt`; parsers switch to `mask` with generic validation errors. Query descriptors now return paginated full events with aligned 60s stale times. **`VenueMarketDataAdapter`** types the adapter surface; CONTEXT and architecture/interface docs describe ask/bid terminology, injected Kalshi capability (no registry yet), and service-owned cache/retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e66213900d54a6fd288d4aaee0f34f5cacaea30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->