### PR TITLE
perf(ramps): clear React Compiler bailouts under UI/Ramp (TRAM-3858)

### DIFF
--- a/app/components/UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails.tsx
@@ -178,17 +178,18 @@ const OrderDetails = () => {
     [dispatchThunk, dispatchUpdateFiatOrder, order],
   );
 
-  const hasRefreshedCreatedOrderRef = useRef(false);
+  // Preserve prior mount-only semantics: evaluate once on first effect run so
+  // a later transition into CREATED cannot trigger a second auto-refresh.
+  const hasAttemptedInitialCreatedRefreshRef = useRef(false);
 
   useEffect(() => {
-    if (hasRefreshedCreatedOrderRef.current) {
+    if (hasAttemptedInitialCreatedRefreshRef.current) {
       return;
     }
-    if (order?.state !== FIAT_ORDER_STATES.CREATED) {
-      return;
+    hasAttemptedInitialCreatedRefreshRef.current = true;
+    if (order?.state === FIAT_ORDER_STATES.CREATED) {
+      handleOnRefresh();
     }
-    hasRefreshedCreatedOrderRef.current = true;
-    handleOnRefresh();
   }, [order?.state, handleOnRefresh]);
 
   const handleMakeAnotherPurchase = useCallback(() => {

--- a/app/components/UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails.tsx
@@ -2,6 +2,7 @@ import React, {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useRef,
   useState,
 } from 'react';
 import { HeaderStandard } from '@metamask/design-system-react-native';
@@ -96,44 +97,48 @@ const OrderDetails = () => {
     order?.sellTxHash,
   ]);
 
+  const hasTrackedDetailsViewRef = useRef(false);
+
   useEffect(() => {
-    if (order) {
-      const { data, state, cryptocurrency, orderType, currency, network } =
-        order;
-
-      const providerName = (data as Order).provider?.name;
-
-      const payload = {
-        status: state,
-        payment_method_id: (data as Order).paymentMethod?.id,
-        order_type: orderType,
-      };
-      if (order.orderType === OrderOrderTypeEnum.Buy) {
-        trackEvent('ONRAMP_PURCHASE_DETAILS_VIEWED', {
-          ...payload,
-          currency_destination: cryptocurrency,
-          currency_destination_symbol: cryptocurrency,
-          currency_destination_network: getAggregatorOrderNetworkName(
-            data as Order,
-          ),
-          currency_source: currency,
-          provider_onramp: providerName,
-          chain_id_destination: network,
-        });
-      } else {
-        trackEvent('OFFRAMP_PURCHASE_DETAILS_VIEWED', {
-          ...payload,
-          currency_source: cryptocurrency,
-          currency_source_symbol: cryptocurrency,
-          currency_source_network: getAggregatorOrderNetworkName(data as Order),
-          currency_destination: currency,
-          provider_offramp: providerName,
-          chain_id_source: network,
-        });
-      }
+    if (!order || hasTrackedDetailsViewRef.current) {
+      return;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [trackEvent]);
+    hasTrackedDetailsViewRef.current = true;
+
+    const { data, state, cryptocurrency, orderType, currency, network } =
+      order;
+
+    const providerName = (data as Order).provider?.name;
+
+    const payload = {
+      status: state,
+      payment_method_id: (data as Order).paymentMethod?.id,
+      order_type: orderType,
+    };
+    if (order.orderType === OrderOrderTypeEnum.Buy) {
+      trackEvent('ONRAMP_PURCHASE_DETAILS_VIEWED', {
+        ...payload,
+        currency_destination: cryptocurrency,
+        currency_destination_symbol: cryptocurrency,
+        currency_destination_network: getAggregatorOrderNetworkName(
+          data as Order,
+        ),
+        currency_source: currency,
+        provider_onramp: providerName,
+        chain_id_destination: network,
+      });
+    } else {
+      trackEvent('OFFRAMP_PURCHASE_DETAILS_VIEWED', {
+        ...payload,
+        currency_source: cryptocurrency,
+        currency_source_symbol: cryptocurrency,
+        currency_source_network: getAggregatorOrderNetworkName(data as Order),
+        currency_destination: currency,
+        provider_offramp: providerName,
+        chain_id_source: network,
+      });
+    }
+  }, [order, trackEvent, getAggregatorOrderNetworkName]);
 
   const dispatchUpdateFiatOrder = useCallback(
     (updatedOrder: FiatOrder) => {
@@ -173,13 +178,18 @@ const OrderDetails = () => {
     [dispatchThunk, dispatchUpdateFiatOrder, order],
   );
 
+  const hasRefreshedCreatedOrderRef = useRef(false);
+
   useEffect(() => {
-    if (order?.state === FIAT_ORDER_STATES.CREATED) {
-      handleOnRefresh();
+    if (hasRefreshedCreatedOrderRef.current) {
+      return;
     }
-    // only run on mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (order?.state !== FIAT_ORDER_STATES.CREATED) {
+      return;
+    }
+    hasRefreshedCreatedOrderRef.current = true;
+    handleOnRefresh();
+  }, [order?.state, handleOnRefresh]);
 
   const handleMakeAnotherPurchase = useCallback(() => {
     navigation.goBack();

--- a/app/components/UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails.tsx
@@ -105,8 +105,7 @@ const OrderDetails = () => {
     }
     hasTrackedDetailsViewRef.current = true;
 
-    const { data, state, cryptocurrency, orderType, currency, network } =
-      order;
+    const { data, state, cryptocurrency, orderType, currency, network } = order;
 
     const providerName = (data as Order).provider?.name;
 

--- a/app/components/UI/Ramp/Aggregator/components/ErrorView.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/ErrorView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useTheme } from '../../../../../util/theme';
@@ -123,23 +123,39 @@ function ErrorView({
   // error is shown; the ref guard keeps analytics from firing repeatedly when
   // those values change.
   const hasTrackedErrorRef = useRef(false);
+  // One-frame grace so selectedRegion / selectedAsset / fiat can hydrate after
+  // sdk/isBuy are ready before we permanently lock the analytics snapshot.
+  const [hydrationGraceElapsed, setHydrationGraceElapsed] = useState(false);
+
+  useEffect(() => {
+    setHydrationGraceElapsed(true);
+  }, []);
 
   useEffect(() => {
     if (!sdk || isBuy === undefined || hasTrackedErrorRef.current) {
       return;
     }
+
+    const regionId = selectedRegion?.id;
+    const assetSymbol = selectedAsset?.symbol;
+    const fiatCurrencyId = selectedFiatCurrencyId;
+    const hasHydratedAnalyticsFields =
+      Boolean(regionId) && (Boolean(assetSymbol) || Boolean(fiatCurrencyId));
+
+    // Prefer a complete payload when selections hydrate shortly after mount.
+    // If they never arrive (pre-selection errors), track once the grace ends.
+    if (!hasHydratedAnalyticsFields && !hydrationGraceElapsed) {
+      return;
+    }
+
     hasTrackedErrorRef.current = true;
     trackEvent(isBuy ? 'ONRAMP_ERROR' : 'OFFRAMP_ERROR', {
       location,
       message: description,
       payment_method_id: selectedPaymentMethodId as string,
-      region: selectedRegion?.id,
-      currency_source: isBuy
-        ? (selectedFiatCurrencyId as string)
-        : selectedAsset?.symbol,
-      currency_destination: isBuy
-        ? selectedAsset?.symbol
-        : (selectedFiatCurrencyId as string),
+      region: regionId,
+      currency_source: isBuy ? (fiatCurrencyId as string) : assetSymbol,
+      currency_destination: isBuy ? assetSymbol : (fiatCurrencyId as string),
     });
   }, [
     sdk,
@@ -151,6 +167,7 @@ function ErrorView({
     selectedRegion?.id,
     selectedFiatCurrencyId,
     selectedAsset?.symbol,
+    hydrationGraceElapsed,
   ]);
 
   return (

--- a/app/components/UI/Ramp/Aggregator/components/ErrorView.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/ErrorView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { View, StyleSheet } from 'react-native';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useTheme } from '../../../../../util/theme';
@@ -119,10 +119,16 @@ function ErrorView({
     ctaOnPress?.();
   }, [ctaOnPress]);
 
+  // Track each ErrorView instance once. Extra SDK fields can mutate after the
+  // error is shown; the ref guard keeps analytics from firing repeatedly when
+  // those values change.
+  const hasTrackedErrorRef = useRef(false);
+
   useEffect(() => {
-    if (!sdk || isBuy === undefined) {
+    if (!sdk || isBuy === undefined || hasTrackedErrorRef.current) {
       return;
     }
+    hasTrackedErrorRef.current = true;
     trackEvent(isBuy ? 'ONRAMP_ERROR' : 'OFFRAMP_ERROR', {
       location,
       message: description,
@@ -135,11 +141,17 @@ function ErrorView({
         ? selectedAsset?.symbol
         : (selectedFiatCurrencyId as string),
     });
-    // Dependency array does not include extra data since it can mutate after the error
-    // is displayed. This is a safe guard to prevent the error from being tracked multiple
-    // times.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [description, location, trackEvent]);
+  }, [
+    sdk,
+    isBuy,
+    description,
+    location,
+    trackEvent,
+    selectedPaymentMethodId,
+    selectedRegion?.id,
+    selectedFiatCurrencyId,
+    selectedAsset?.symbol,
+  ]);
 
   return (
     <View style={styles.screen}>

--- a/app/components/UI/Ramp/Aggregator/hooks/useSDKMethod.test.ts
+++ b/app/components/UI/Ramp/Aggregator/hooks/useSDKMethod.test.ts
@@ -81,30 +81,8 @@ describe('useSDKMethod', () => {
     });
   });
 
-  describe('JSON.stringify memoization', () => {
-    it('does not call JSON.stringify on every render when params do not change', () => {
-      const jsonStringifySpy = jest.spyOn(JSON, 'stringify');
-
-      const { rerender } = renderHookWithProvider(() =>
-        useSDKMethod('getCountries'),
-      );
-
-      const callsAfterMount = jsonStringifySpy.mock.calls.length;
-
-      rerender(() => useSDKMethod('getCountries'));
-      rerender(() => useSDKMethod('getCountries'));
-      rerender(() => useSDKMethod('getCountries'));
-      rerender(() => useSDKMethod('getCountries'));
-
-      // JSON.stringify should not be called again after re-renders with unchanged params
-      expect(jsonStringifySpy.mock.calls.length).toBe(callsAfterMount);
-
-      jsonStringifySpy.mockRestore();
-    });
-
-    it('calls JSON.stringify when params change', () => {
-      const jsonStringifySpy = jest.spyOn(JSON, 'stringify');
-
+  describe('param content stability', () => {
+    it('keeps query stable when param values are unchanged across re-renders', () => {
       const mockGetDefaultFiatCurrency = jest
         .fn()
         .mockResolvedValue({ id: 'usd' });
@@ -115,28 +93,27 @@ describe('useSDKMethod', () => {
       };
 
       let regionId = 'region-1';
-      const { rerender } = renderHookWithProvider(() =>
+      const { result, rerender } = renderHookWithProvider(() =>
         useSDKMethod('getDefaultFiatCurrency', regionId as '/regions/cl'),
       );
 
-      const callsAfterMount = jsonStringifySpy.mock.calls.length;
+      const queryFirstRender = result.current[1];
 
-      // Re-render with same params - no new stringify call
       rerender(() =>
         useSDKMethod('getDefaultFiatCurrency', regionId as '/regions/cl'),
       );
-      expect(jsonStringifySpy.mock.calls.length).toBe(callsAfterMount);
+      rerender(() =>
+        useSDKMethod('getDefaultFiatCurrency', regionId as '/regions/cl'),
+      );
 
-      // Re-render with different params - stringify should be called again
+      expect(result.current[1]).toBe(queryFirstRender);
+
       regionId = 'region-2';
       rerender(() =>
         useSDKMethod('getDefaultFiatCurrency', regionId as '/regions/cl'),
       );
-      expect(jsonStringifySpy.mock.calls.length).toBeGreaterThan(
-        callsAfterMount,
-      );
 
-      jsonStringifySpy.mockRestore();
+      expect(result.current[1]).not.toBe(queryFirstRender);
     });
   });
 

--- a/app/components/UI/Ramp/Aggregator/hooks/useSDKMethod.ts
+++ b/app/components/UI/Ramp/Aggregator/hooks/useSDKMethod.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { RegionsService, ServicesSignatures } from '@consensys/on-ramp-sdk';
 import { useRampSDK, SDK } from '../sdk';
 import Logger from '../../../../../util/Logger';
@@ -98,17 +98,20 @@ export default function useSDKMethod<T extends keyof RegionsService>(
   > | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isFetching, setIsFetching] = useState<boolean>(onMount);
-  const stringifiedParams = useMemo(
-    () => JSON.stringify(params),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [...params],
-  );
+  // Rest-param arrays are a new reference every render; stringify for a
+  // content-stable dependency so `query` stays referentially equal when
+  // argument values are unchanged. Parse inside the callback (instead of
+  // closing over `params`) so the dependency is actually used and we avoid
+  // an exhaustive-deps suppression that would bail out React Compiler.
+  const stringifiedParams = JSON.stringify(params);
   const abortControllerRef = useRef<AbortController | undefined>(undefined);
 
   const query = useCallback(
     async (...customParams: PartialParameters<RegionsService[T]> | []) => {
       const hasCustomParams = customParams.length > 0;
-      const queryParams = hasCustomParams ? customParams : params;
+      const queryParams = (
+        hasCustomParams ? customParams : JSON.parse(stringifiedParams)
+      ) as PartialParameters<RegionsService[T]>;
 
       if (!validMethodParams(method, queryParams)) {
         return;
@@ -152,7 +155,6 @@ export default function useSDKMethod<T extends keyof RegionsService>(
         setIsFetching(false);
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [method, stringifiedParams, sdk],
   );
 

--- a/app/components/UI/Ramp/Aggregator/sdk/index.test.tsx
+++ b/app/components/UI/Ramp/Aggregator/sdk/index.test.tsx
@@ -53,10 +53,15 @@ describe('RampSDKProvider', () => {
   });
 
   it('provides default ramp type as BUY', () => {
-    let contextValue: ReturnType<typeof useRampSDK> | undefined;
     const TestComponent = () => {
-      contextValue = useRampSDK();
-      return <Text>Test Component</Text>;
+      const { rampType, isBuy, isSell } = useRampSDK();
+      return (
+        <>
+          <Text>{`Ramp Type: ${rampType}`}</Text>
+          <Text>{`isBuy: ${String(isBuy)}`}</Text>
+          <Text>{`isSell: ${String(isSell)}`}</Text>
+        </>
+      );
     };
 
     renderWithProvider(
@@ -68,16 +73,21 @@ describe('RampSDKProvider', () => {
       },
     );
 
-    expect(contextValue?.rampType).toBe(RampType.BUY);
-    expect(contextValue?.isBuy).toBe(true);
-    expect(contextValue?.isSell).toBe(false);
+    expect(screen.getByText('Ramp Type: buy')).toBeOnTheScreen();
+    expect(screen.getByText('isBuy: true')).toBeOnTheScreen();
+    expect(screen.getByText('isSell: false')).toBeOnTheScreen();
   });
 
   it('accepts custom ramp type', () => {
-    let contextValue: ReturnType<typeof useRampSDK> | undefined;
     const TestComponent = () => {
-      contextValue = useRampSDK();
-      return <Text>Test Component</Text>;
+      const { rampType, isBuy, isSell } = useRampSDK();
+      return (
+        <>
+          <Text>{`Ramp Type: ${rampType}`}</Text>
+          <Text>{`isBuy: ${String(isBuy)}`}</Text>
+          <Text>{`isSell: ${String(isSell)}`}</Text>
+        </>
+      );
     };
 
     renderWithProvider(
@@ -89,9 +99,9 @@ describe('RampSDKProvider', () => {
       },
     );
 
-    expect(contextValue?.rampType).toBe(RampType.SELL);
-    expect(contextValue?.isBuy).toBe(false);
-    expect(contextValue?.isSell).toBe(true);
+    expect(screen.getByText('Ramp Type: sell')).toBeOnTheScreen();
+    expect(screen.getByText('isBuy: false')).toBeOnTheScreen();
+    expect(screen.getByText('isSell: true')).toBeOnTheScreen();
   });
 
   it('syncs SDK locale on mount', () => {

--- a/app/components/UI/Ramp/Views/NativeFlow/BankDetails.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/BankDetails.tsx
@@ -141,17 +141,18 @@ const V2BankDetails = () => {
     }
   }, [order, getDepositOrder, refreshOrder, handleLogoutError]);
 
-  const hasRefreshedCreatedOrderRef = useRef(false);
+  // Preserve prior mount-only semantics: evaluate once on first effect run so
+  // later status/shouldUpdate changes cannot trigger a second auto-refresh.
+  const hasAttemptedInitialCreatedRefreshRef = useRef(false);
 
   useEffect(() => {
-    if (hasRefreshedCreatedOrderRef.current) {
+    if (hasAttemptedInitialCreatedRefreshRef.current) {
       return;
     }
-    if (order?.status !== RampsOrderStatus.Created || !shouldUpdate) {
-      return;
+    hasAttemptedInitialCreatedRefreshRef.current = true;
+    if (order?.status === RampsOrderStatus.Created && shouldUpdate) {
+      handleOnRefresh();
     }
-    hasRefreshedCreatedOrderRef.current = true;
-    handleOnRefresh();
   }, [order?.status, shouldUpdate, handleOnRefresh]);
 
   useEffect(() => {

--- a/app/components/UI/Ramp/Views/NativeFlow/BankDetails.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/BankDetails.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   HeaderStandard,
   Text,
@@ -135,12 +141,18 @@ const V2BankDetails = () => {
     }
   }, [order, getDepositOrder, refreshOrder, handleLogoutError]);
 
+  const hasRefreshedCreatedOrderRef = useRef(false);
+
   useEffect(() => {
-    if (order?.status === RampsOrderStatus.Created && shouldUpdate) {
-      handleOnRefresh();
+    if (hasRefreshedCreatedOrderRef.current) {
+      return;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (order?.status !== RampsOrderStatus.Created || !shouldUpdate) {
+      return;
+    }
+    hasRefreshedCreatedOrderRef.current = true;
+    handleOnRefresh();
+  }, [order?.status, shouldUpdate, handleOnRefresh]);
 
   useEffect(() => {
     if (!order?.status) return;

--- a/app/components/UI/Ramp/Views/NativeFlow/BasicInfo.tsx
+++ b/app/components/UI/Ramp/Views/NativeFlow/BasicInfo.tsx
@@ -179,10 +179,15 @@ const V2BasicInfo = (): React.JSX.Element => {
     navigation.goBack();
   }, [navigation]);
 
+  const hasClearedSsnRef = useRef(false);
+
   useEffect(() => {
+    if (hasClearedSsnRef.current) {
+      return;
+    }
+    hasClearedSsnRef.current = true;
     handleFormDataChange('ssn')('');
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [handleFormDataChange]);
 
   const handleOnPressContinue = useCallback(async () => {
     if (!validateFormData()) return;

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
@@ -165,6 +165,64 @@ describe('OrderDetails', () => {
     expect(mockEmitTerminalOrderAnalyticsFromCallback).not.toHaveBeenCalled();
   });
 
+  it('does not refresh after callback params clear for a still-pending order', async () => {
+    const pendingOrder = {
+      providerOrderId: 'ord-pending-cb',
+      status: RampsOrderStatus.Pending,
+      cryptoCurrency: { symbol: 'ETH' },
+      cryptoAmount: '0.1',
+      provider: { id: 'moonpay' },
+      walletAddress: '0x123',
+    };
+
+    let routeParams: Record<string, string | undefined> = {
+      callbackUrl: 'https://callback.example?x=1',
+      providerCode: 'moonpay',
+      walletAddress: '0x123',
+    };
+    mockUseParams.mockImplementation(() => routeParams);
+    mockGetOrderById.mockReturnValue(undefined);
+    mockGetOrderFromCallback.mockResolvedValue(pendingOrder);
+    mockRefreshOrder.mockResolvedValue(undefined);
+
+    const OrderDetailsHarness = () => {
+      const [, setVersion] = React.useState(0);
+
+      React.useEffect(() => {
+        mockSetParams.mockImplementation(
+          (next: Record<string, string | undefined>) => {
+            routeParams = { ...routeParams, ...next };
+            mockGetOrderById.mockReturnValue(pendingOrder);
+            setVersion((version) => version + 1);
+          },
+        );
+      }, []);
+
+      return <OrderDetails />;
+    };
+
+    renderScreen(OrderDetailsHarness, {
+      name: Routes.RAMP.RAMPS_ORDER_DETAILS,
+    });
+
+    await waitFor(() => {
+      expect(mockSetParams).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderId: 'ord-pending-cb',
+          callbackUrl: undefined,
+          providerCode: undefined,
+          walletAddress: undefined,
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockGetOrderById).toHaveBeenCalled();
+    });
+
+    expect(mockRefreshOrder).not.toHaveBeenCalled();
+  });
+
   it('emits terminal analytics instead of confirmed for a completed callback order', async () => {
     const completedOrder = {
       providerOrderId: 'ord-cb-1',

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.test.tsx
@@ -347,7 +347,9 @@ describe('OrderDetails', () => {
       expect(getByTestId('order-content')).toBeOnTheScreen();
     });
 
-    fireEvent.press(getByTestId('ramps-order-details-back-navbar-button'));
+    await act(async () => {
+      fireEvent.press(getByTestId('ramps-order-details-back-navbar-button'));
+    });
 
     expect(mockGoBack).toHaveBeenCalled();
     expect(mockTrackEvent).toHaveBeenCalled();

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
@@ -263,17 +263,21 @@ const OrderDetails = () => {
     }
   }, [order, refreshOrder]);
 
-  const hasRefreshedPendingOrderRef = useRef(false);
+  // Preserve prior mount-only semantics: evaluate once on first effect run.
+  // Marking the ref before the condition matters — callback success clears
+  // callback params via setParams while the order may still be pending; if we
+  // only marked the ref when refreshing, that transition would spuriously
+  // call handleOnRefresh.
+  const hasAttemptedInitialPendingRefreshRef = useRef(false);
 
   useEffect(() => {
-    if (hasRefreshedPendingOrderRef.current) {
+    if (hasAttemptedInitialPendingRefreshRef.current) {
       return;
     }
-    if (!isPending || hasCallbackParams) {
-      return;
+    hasAttemptedInitialPendingRefreshRef.current = true;
+    if (isPending && !hasCallbackParams) {
+      handleOnRefresh();
     }
-    hasRefreshedPendingOrderRef.current = true;
-    handleOnRefresh();
   }, [isPending, hasCallbackParams, handleOnRefresh]);
 
   useEffect(() => {

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx
@@ -263,12 +263,18 @@ const OrderDetails = () => {
     }
   }, [order, refreshOrder]);
 
+  const hasRefreshedPendingOrderRef = useRef(false);
+
   useEffect(() => {
-    if (isPending && !hasCallbackParams) {
-      handleOnRefresh();
+    if (hasRefreshedPendingOrderRef.current) {
+      return;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (!isPending || hasCallbackParams) {
+      return;
+    }
+    hasRefreshedPendingOrderRef.current = true;
+    handleOnRefresh();
+  }, [isPending, hasCallbackParams, handleOnRefresh]);
 
   useEffect(() => {
     if (

--- a/docs/performance/react-compiler.md
+++ b/docs/performance/react-compiler.md
@@ -1,41 +1,45 @@
 # React Compiler
 
-[React Compiler](https://react.dev/learn/react-compiler) is a build-time tool that automatically memoizes components, callbacks, and computed values per the [Rules of React](https://react.dev/reference/rules) — removing most hand-written `React.memo`/`useMemo`/`useCallback`. It's **already installed and enabled app-wide** in this repo.
+[React Compiler](https://react.dev/learn/react-compiler) is a build-time tool that automatically memoizes components, callbacks, and computed values per the [Rules of React](https://react.dev/reference/rules) — removing most hand-written `React.memo`/`useMemo`/`useCallback`. It's **already installed and configured** in this repo and adopted **incrementally**, directory by directory.
 
 ## Current setup
 
-- `babel-plugin-react-compiler` + the ESLint plugin are installed.
+- `babel-plugin-react-compiler` + `react-compiler-runtime` + the ESLint plugin are installed.
 - ESLint: `react-compiler/react-compiler` runs as a **warning**.
-- Babel wiring lives in `scripts/react-compiler.js` and is spread into `babel.config.js` via `reactCompilerBabelConfig`.
-- Plugin order in `babel.config.js`: React Compiler runs **first**; `react-native-reanimated/plugin` must remain **last** (required for `'worklet'`).
-- The compiler is disabled under Jest (`NODE_ENV === 'test'`) to avoid conflicts with `jest.mock` hoisting.
-- Optional bailout logging: set `REACT_COMPILER_LOG_FAILURES=true` to append skip/error events to the git-ignored `react-compiler.log`.
+- `babel.config.js`: `target: '18'`, the plugin runs **first**, and `react-native-reanimated/plugin` runs **last** (required for `'worklet'`).
+- Opted-in paths so far live in the plugin's `sources` `pathsToInclude` list.
 
-## Clearing bailouts for a feature
-
-The compiler silently skips components that violate the Rules of React. Use the already-installed ESLint plugin to find them:
-
-```bash
-yarn eslint <path>   # react-compiler/react-compiler warnings = what the compiler would skip
+```js
+// babel.config.js — react-compiler plugin
+[
+  'react-compiler',
+  {
+    target: '18',
+    sources: (filename) => {
+      const pathsToInclude = [
+        'app/components/Nav',
+        'app/components/UI/DeepLinkModal',
+        // add your feature path here to opt in
+      ];
+      return pathsToInclude.some((path) => filename.includes(path));
+    },
+  },
+],
 ```
 
-(The standalone `react-compiler-healthcheck` CLI gives a repo-wide count but isn't installed.)
+## Opting a feature in
 
-Common fixes:
-
-- Restructure `try`/`finally` and value-blocks-inside-try
-- Remove `eslint-disable` comments that force skips (especially `react-hooks/exhaustive-deps`)
-- Move ref reads/writes out of render when needed (e.g. sync in `useEffect`)
-- Remove/adjust manual memoization the compiler can't preserve
-- Replace mount-only `useEffect(..., [])` + exhaustive-deps suppressions with a once-guard ref and real dependencies
-
-After fixing, clear Metro's cache and verify in React DevTools:
-
-```bash
-yarn watch:clean
-```
-
-Optimized components show a `Memo ✨` badge in React DevTools.
+1. **Check Rules-of-React first** — the compiler silently skips components that violate them. Use the already-installed ESLint plugin:
+   ```bash
+   yarn eslint <path>   # react-compiler/react-compiler warnings = what the compiler would skip
+   ```
+   (The standalone `react-compiler-healthcheck` CLI gives a repo-wide count but isn't installed.)
+2. **Add the path** to `pathsToInclude` in `babel.config.js`.
+3. **Clear Metro's cache** — it caches compiled output aggressively:
+   ```bash
+   yarn watch:clean
+   ```
+4. **Verify** — optimized components show a `Memo ✨` badge in React DevTools.
 
 ## What it does / doesn't do
 
@@ -46,5 +50,5 @@ Optimized components show a `Memo ✨` badge in React DevTools.
 
 ## Don't
 
-- Don't reintroduce a `sources` / `pathsToInclude` allowlist unless you intentionally want to roll back to incremental opt-in — the compiler is already applied app-wide.
-- Don't change `target` away from the plugin default used by the installed Expo/RN toolchain, or reorder the reanimated plugin off last.
+- Don't hardcode the current path list as permanent — read `babel.config.js`.
+- Don't change `target` away from `'18'` or reorder the reanimated plugin off last.

--- a/docs/performance/react-compiler.md
+++ b/docs/performance/react-compiler.md
@@ -1,45 +1,41 @@
 # React Compiler
 
-[React Compiler](https://react.dev/learn/react-compiler) is a build-time tool that automatically memoizes components, callbacks, and computed values per the [Rules of React](https://react.dev/reference/rules) — removing most hand-written `React.memo`/`useMemo`/`useCallback`. It's **already installed and configured** in this repo and adopted **incrementally**, directory by directory.
+[React Compiler](https://react.dev/learn/react-compiler) is a build-time tool that automatically memoizes components, callbacks, and computed values per the [Rules of React](https://react.dev/reference/rules) — removing most hand-written `React.memo`/`useMemo`/`useCallback`. It's **already installed and enabled app-wide** in this repo.
 
 ## Current setup
 
-- `babel-plugin-react-compiler` + `react-compiler-runtime` + the ESLint plugin are installed.
+- `babel-plugin-react-compiler` + the ESLint plugin are installed.
 - ESLint: `react-compiler/react-compiler` runs as a **warning**.
-- `babel.config.js`: `target: '18'`, the plugin runs **first**, and `react-native-reanimated/plugin` runs **last** (required for `'worklet'`).
-- Opted-in paths so far live in the plugin's `sources` `pathsToInclude` list.
+- Babel wiring lives in `scripts/react-compiler.js` and is spread into `babel.config.js` via `reactCompilerBabelConfig`.
+- Plugin order in `babel.config.js`: React Compiler runs **first**; `react-native-reanimated/plugin` must remain **last** (required for `'worklet'`).
+- The compiler is disabled under Jest (`NODE_ENV === 'test'`) to avoid conflicts with `jest.mock` hoisting.
+- Optional bailout logging: set `REACT_COMPILER_LOG_FAILURES=true` to append skip/error events to the git-ignored `react-compiler.log`.
 
-```js
-// babel.config.js — react-compiler plugin
-[
-  'react-compiler',
-  {
-    target: '18',
-    sources: (filename) => {
-      const pathsToInclude = [
-        'app/components/Nav',
-        'app/components/UI/DeepLinkModal',
-        // add your feature path here to opt in
-      ];
-      return pathsToInclude.some((path) => filename.includes(path));
-    },
-  },
-],
+## Clearing bailouts for a feature
+
+The compiler silently skips components that violate the Rules of React. Use the already-installed ESLint plugin to find them:
+
+```bash
+yarn eslint <path>   # react-compiler/react-compiler warnings = what the compiler would skip
 ```
 
-## Opting a feature in
+(The standalone `react-compiler-healthcheck` CLI gives a repo-wide count but isn't installed.)
 
-1. **Check Rules-of-React first** — the compiler silently skips components that violate them. Use the already-installed ESLint plugin:
-   ```bash
-   yarn eslint <path>   # react-compiler/react-compiler warnings = what the compiler would skip
-   ```
-   (The standalone `react-compiler-healthcheck` CLI gives a repo-wide count but isn't installed.)
-2. **Add the path** to `pathsToInclude` in `babel.config.js`.
-3. **Clear Metro's cache** — it caches compiled output aggressively:
-   ```bash
-   yarn watch:clean
-   ```
-4. **Verify** — optimized components show a `Memo ✨` badge in React DevTools.
+Common fixes:
+
+- Restructure `try`/`finally` and value-blocks-inside-try
+- Remove `eslint-disable` comments that force skips (especially `react-hooks/exhaustive-deps`)
+- Move ref reads/writes out of render when needed (e.g. sync in `useEffect`)
+- Remove/adjust manual memoization the compiler can't preserve
+- Replace mount-only `useEffect(..., [])` + exhaustive-deps suppressions with a once-guard ref and real dependencies
+
+After fixing, clear Metro's cache and verify in React DevTools:
+
+```bash
+yarn watch:clean
+```
+
+Optimized components show a `Memo ✨` badge in React DevTools.
 
 ## What it does / doesn't do
 
@@ -50,5 +46,5 @@
 
 ## Don't
 
-- Don't hardcode the current path list as permanent — read `babel.config.js`.
-- Don't change `target` away from `'18'` or reorder the reanimated plugin off last.
+- Don't reintroduce a `sources` / `pathsToInclude` allowlist unless you intentionally want to roll back to incremental opt-in — the compiler is already applied app-wide.
+- Don't change `target` away from the plugin default used by the installed Expo/RN toolchain, or reorder the reanimated plugin off last.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

Clears React Compiler bailouts under `app/components/UI/Ramp/**` so Money Movement Ramp components can be optimized by `babel-plugin-react-compiler`.

React Compiler is already enabled app-wide (no `pathsToInclude` allowlist remains in `babel.config.js` / `scripts/react-compiler.js`). This PR focuses on the remaining Rules-of-React violations that made the compiler skip Ramp files:

- Removed `react-hooks/exhaustive-deps` suppressions that forced compiler skips
- Guarded one-shot analytics / refresh / SSN-clear effects with once-refs and real dependency arrays
- Stabilized `useSDKMethod` query identity via content-stable `JSON.stringify(params)` (parsed inside the callback) without an eslint-disable
- Updated SDK provider tests to avoid assigning outer variables during render
- Follow-up: preserve true mount-only semantics for pending/created auto-refresh effects so clearing callback params after a successful callback fetch cannot spuriously call `handleOnRefresh`

**Verification**
- `yarn eslint app/components/UI/Ramp` → **0** `react-compiler/react-compiler` warnings
- Unit tests for affected files: useSDKMethod, sdk provider, Aggregator OrderDetails, V2 OrderDetails, BankDetails, BasicInfo — all passing
- Added regression coverage for the callback-params-clear refresh bug

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3858

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

### React Compiler bailout validation (perf team)

Target bailouts for this work are tracked in the perf spreadsheet:

https://docs.google.com/spreadsheets/d/1w62YHs70AHE6_FGrnp2MBKqAtIQaC-j59C5je1B6yak/edit?gid=409796633#gid=409796633

Confirm there are **0** `react-compiler/react-compiler` warnings under Ramp:

```bash
yarn eslint app/components/UI/Ramp
```

To filter only compiler warnings:

```bash
yarn eslint app/components/UI/Ramp 2>&1 | grep 'react-compiler'
```

(Those ESLint warnings are what the compiler would skip — see `docs/performance/react-compiler.md`.)

### Manual flow checks

```gherkin
Feature: Ramp React Compiler cleanup

  Scenario: Aggregator order details still tracks and refreshes
    Given a user opens an aggregator order details screen for a created order
    When the screen mounts
    Then purchase-details analytics fire once
    And a forced order refresh runs once for CREATED orders

  Scenario: Native bank details still refreshes created orders
    Given a user lands on BankDetails with shouldUpdate for a Created order
    When the screen mounts
    Then the order refresh runs once

  Scenario: Callback order details does not double-refresh
    Given a user returns from an external browser with callback params
    When the callback fetch succeeds for a still-pending order and params are cleared
    Then handleOnRefresh is not invoked as a side effect of that param clear

  Scenario: Basic info clears SSN once on mount
    Given a user opens the BasicInfo KYC form
    When the screen mounts
    Then the SSN field is cleared once and the form remains usable

  Scenario: Error view tracks once
    Given an ErrorView is shown in the aggregator flow
    When SDK context is available
    Then ONRAMP_ERROR / OFFRAMP_ERROR is tracked once
```

Optional DevTools check after `yarn watch:clean`: optimized Ramp components show the `Memo ✨` badge.

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/3a8b7295-f1f3-4f55-804b-32242ac7f90e

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d7b0376-8644-4b46-bf82-a2d38df17fff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d7b0376-8644-4b46-bf82-a2d38df17fff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

