### PR TITLE
fix(perps): preserve stream cache across Android background teardown

### DIFF
--- a/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
@@ -4639,6 +4639,8 @@ describe('PerpsStreamManager', () => {
         size: '1',
         entryPrice: '50000',
         markPrice: '51000',
+        positionValue: '51000',
+        marginUsed: '5100',
         unrealizedPnl: '1000',
         leverage: { type: 'cross', value: 10 },
         liquidationPrice: '45000',

--- a/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
@@ -4499,6 +4499,30 @@ describe('PerpsStreamManager', () => {
       pricesDisconnect.mockRestore();
     });
 
+    it('delivers the first fresh positions update immediately after reconnect', () => {
+      const controllerCallbacks: ((positions: Position[]) => void)[] = [];
+      mockSubscribeToPositions.mockImplementation(
+        (params: { callback: (positions: Position[]) => void }) => {
+          controllerCallbacks.push(params.callback);
+          return jest.fn();
+        },
+      );
+      const callback = jest.fn();
+
+      testStreamManager.positions.subscribe({ callback, throttleMs: 100 });
+
+      act(() => controllerCallbacks[0]([]));
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      act(() => controllerCallbacks[0]([]));
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      testStreamManager.clearAllChannels();
+
+      act(() => controllerCallbacks[controllerCallbacks.length - 1]([]));
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+
     it('recreates prewarmed price subscription when no direct price subscribers are active', async () => {
       const firstUnsubscribe = jest.fn();
       const secondUnsubscribe = jest.fn();
@@ -4700,6 +4724,39 @@ describe('PerpsStreamManager', () => {
       // Should receive cached positions immediately via getCachedData()
       expect(callback).toHaveBeenCalledWith(mockPositions);
       expect(mockSubscribeToPositions).not.toHaveBeenCalled();
+    });
+
+    it('delivers the first fresh positions update immediately after cached data', () => {
+      let controllerCallback: ((positions: Position[]) => void) | null = null;
+      mockSubscribeToPositions.mockImplementation(
+        (params: { callback: (positions: Position[]) => void }) => {
+          controllerCallback = params.callback;
+          return jest.fn();
+        },
+      );
+      (
+        mockEngine.context.PerpsController as unknown as Record<string, unknown>
+      ).getCachedUserDataForActiveProvider = jest.fn().mockReturnValue({
+        positions: mockPositions,
+        orders: [],
+        accountState: null,
+      });
+      const streamManager = new PerpsStreamManager();
+      const callback = jest.fn();
+
+      streamManager.positions.subscribe({ callback, throttleMs: 100 });
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenLastCalledWith(mockPositions);
+
+      act(() => controllerCallback?.([]));
+      expect(callback).toHaveBeenCalledTimes(2);
+
+      act(() => controllerCallback?.(mockPositions as Position[]));
+      expect(callback).toHaveBeenCalledTimes(2);
+
+      act(() => jest.advanceTimersByTime(100));
+      expect(callback).toHaveBeenCalledTimes(3);
+      expect(callback).toHaveBeenLastCalledWith(mockPositions);
     });
 
     it('serves cached account state instantly via getCachedData before isInitialized', () => {

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -305,8 +305,8 @@ abstract class StreamChannel<T> {
     const cached = this.getCachedData();
     if (cached != null) {
       params.callback(cached);
-      // Mark as having received first update since we provided cached data
-      subscription.hasReceivedFirstUpdate = true;
+      // Cached data renders immediately but must not consume the first fresh
+      // update exemption. The first live snapshot should also bypass throttling.
     }
 
     // Ensure WebSocket connected
@@ -439,6 +439,11 @@ abstract class StreamChannel<T> {
    */
   public reconnect() {
     this.disconnect();
+    // Subscribers survive reconnect(). Rearm their first-update exemption so
+    // the first fresh snapshot from the new socket is delivered immediately.
+    this.subscribers.forEach((subscriber) => {
+      subscriber.hasReceivedFirstUpdate = false;
+    });
     // Re-establish connection if there are active subscribers
     if (this.subscribers.size > 0) {
       this.connect();

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -1442,6 +1442,78 @@ describe('PerpsConnectionManager', () => {
     });
   });
 
+  describe('scheduleGracePeriodDisconnection — Android cache continuity', () => {
+    interface SchedulableManager {
+      connectionRefCount: number;
+      scheduleGracePeriodDisconnection: () => void;
+    }
+
+    const fireAndroidGracePeriod = async (
+      appState: 'active' | 'background',
+    ) => {
+      const manager = PerpsConnectionManager as unknown as SchedulableManager;
+      manager.connectionRefCount = 0;
+      AppState.currentState = appState;
+      manager.scheduleGracePeriodDisconnection();
+      const backgroundTimer = jest.requireMock(
+        'react-native-background-timer',
+      ) as { setTimeout: jest.Mock };
+      const callback = backgroundTimer.setTimeout.mock.calls.at(-1)?.[0] as
+        | (() => void)
+        | undefined;
+      expect(callback).toBeDefined();
+      callback?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    };
+
+    beforeEach(async () => {
+      mockPerpsController.init.mockResolvedValue();
+      mockPerpsController.disconnect.mockResolvedValue();
+      await PerpsConnectionManager.connect();
+      mockPerpsController.disconnect.mockClear();
+      Object.values(mockStreamManagerInstance).forEach((channel) => {
+        if (typeof channel === 'object' && channel?.clearCache) {
+          channel.clearCache.mockClear();
+        }
+      });
+      jest.mocked(Device.isIos).mockReturnValue(false);
+      jest.mocked(Device.isAndroid).mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      jest.mocked(Device.isIos).mockReset();
+      jest.mocked(Device.isAndroid).mockReset();
+      AppState.currentState = 'active';
+    });
+
+    it('disconnects transport but preserves same-session caches after background expiry', async () => {
+      await fireAndroidGracePeriod('background');
+
+      expect(mockPerpsController.disconnect).toHaveBeenCalledTimes(1);
+      expect(
+        mockStreamManagerInstance.positions.clearCache,
+      ).not.toHaveBeenCalled();
+      expect(
+        mockStreamManagerInstance.orders.clearCache,
+      ).not.toHaveBeenCalled();
+      expect(
+        mockStreamManagerInstance.marketData.clearCache,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('still clears caches when an active in-app grace period expires', async () => {
+      await fireAndroidGracePeriod('active');
+
+      expect(mockPerpsController.disconnect).toHaveBeenCalledTimes(1);
+      expect(mockStreamManagerInstance.positions.clearCache).toHaveBeenCalled();
+      expect(mockStreamManagerInstance.orders.clearCache).toHaveBeenCalled();
+      expect(
+        mockStreamManagerInstance.marketData.clearCache,
+      ).toHaveBeenCalled();
+    });
+  });
+
   describe('NetInfo isInternetReachable null handling', () => {
     type NetInfoCallback = (state: {
       isInternetReachable: boolean | null;

--- a/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.test.ts
@@ -17,6 +17,9 @@ jest.mock('@metamask/perps-controller', () => {
 });
 
 jest.mock('../../../../core/SDKConnect/utils/DevLogger');
+const mockActiveProvider = {
+  ping: jest.fn().mockResolvedValue(undefined),
+};
 jest.mock('../../../../core/Engine', () => ({
   context: {
     PerpsController: {
@@ -24,9 +27,7 @@ jest.mock('../../../../core/Engine', () => ({
       getAccountState: jest.fn(),
       disconnect: jest.fn(),
       reconnectWithNewContext: jest.fn(),
-      getActiveProvider: jest.fn(() => ({
-        ping: jest.fn().mockResolvedValue(undefined),
-      })),
+      getActiveProvider: jest.fn(() => mockActiveProvider),
       isCurrentlyReinitializing: jest.fn(() => false),
     },
   },
@@ -1500,6 +1501,27 @@ describe('PerpsConnectionManager', () => {
 
       // Assert
       expect(m.wasOffline).toBe(true);
+    });
+
+    it('validates only once for duplicate online notifications', async () => {
+      const m = PerpsConnectionManager as unknown as { wasOffline: boolean };
+      m.wasOffline = true;
+      const reconnect = jest
+        .spyOn(PerpsConnectionManager, 'reconnectWithNewContext')
+        .mockResolvedValue();
+      mockActiveProvider.ping.mockClear();
+      mockStreamManagerInstance.clearAllChannels.mockClear();
+
+      capturedCallback?.({ isInternetReachable: true, isConnected: true });
+      capturedCallback?.({ isInternetReachable: true, isConnected: true });
+      await Promise.resolve();
+
+      expect(m.wasOffline).toBe(false);
+      expect(mockActiveProvider.ping).toHaveBeenCalledTimes(1);
+      expect(mockStreamManagerInstance.clearAllChannels).toHaveBeenCalledTimes(
+        1,
+      );
+      expect(reconnect).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -279,6 +279,9 @@ class PerpsConnectionManagerClass {
             netState.isInternetReachable ?? netState.isConnected ?? false;
 
           if (isOnline && this.wasOffline) {
+            // Claim the transition synchronously. NetInfo may emit duplicate
+            // online notifications before asynchronous validation completes.
+            this.wasOffline = false;
             DevLogger.log(
               'PerpsConnectionManager: Network restored - validating connection',
             );
@@ -319,6 +322,7 @@ class PerpsConnectionManagerClass {
         DevLogger.log(
           `PerpsConnectionManager: ${context} - connection healthy`,
         );
+        this.resubscribeActiveStreamChannels();
         return;
       } catch {
         DevLogger.log(
@@ -337,7 +341,8 @@ class PerpsConnectionManagerClass {
   }
 
   /**
-   * Attempt reconnection after network restore with exponential backoff.
+   * Validate and restore stream subscriptions after network restore with
+   * exponential backoff.
    * WebSocket endpoints may not be reachable immediately even though
    * NetInfo reports isInternetReachable: true.
    */
@@ -348,7 +353,7 @@ class PerpsConnectionManagerClass {
   }
 
   private attemptNetworkRestoreReconnect(): void {
-    this.validateAndReconnect('PerpsConnectionManager.netInfoListener', true)
+    this.validateAndReconnect('PerpsConnectionManager.netInfoListener')
       .then(() => {
         this.wasOffline = false;
         this.networkRestoreRetryCount = 0;
@@ -370,6 +375,7 @@ class PerpsConnectionManagerClass {
             this.attemptNetworkRestoreReconnect();
           }, delay);
         } else {
+          this.wasOffline = true;
           Logger.error(
             ensureError(error, 'PerpsConnectionManager.netInfoListener'),
             {

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -639,9 +639,15 @@ class PerpsConnectionManagerClass {
       // Stop immediately after scheduling (not in the callback)
       BackgroundTimer.stop();
     } else if (Device.isAndroid()) {
+      // A timer armed by the wallet-root AppState transition belongs to the
+      // same account/provider session. Keep its last visible data while the
+      // transport disconnects so foreground recovery can paint cache first and
+      // converge to the fresh snapshot. Active in-app reference-count teardown
+      // remains a hard clear, and identity changes clear caches separately.
+      const preserveCaches = AppState.currentState !== 'active';
       // Android uses BackgroundTimer.setTimeout directly
       this.gracePeriodTimer = BackgroundTimer.setTimeout(() => {
-        this.performActualDisconnection().catch((error) => {
+        this.performActualDisconnection({ preserveCaches }).catch((error) => {
           Logger.error(
             ensureError(
               error,


### PR DESCRIPTION
## Description

Preserves same-session Perps stream caches when Android's background grace-period timer disconnects the transport. Active in-app teardown and account/provider/network changes keep their existing hard-clear behavior.

Stacked on #34474. Review only the two-file diff against `fix/perps-stream-recovery`.

## Why

On a physical Pixel 6, a 25-second background interval expired the Android grace timer and cleared the last visible positions/orders. Foreground recovery therefore had no resident order to paint even though the account/provider session had not changed.

With this change, the identical recipe restored the resident ETH order in `958.624 ms`. That run separately exposed the Homepage orders throttle; it is intentionally not fixed here and will be the next stacked PR.

## Test scenarios

```gherkin
Scenario: Resume after Android background grace-period expiry
  Given Perps has a visible order in the current account and provider session
  When the app remains backgrounded beyond the disconnect grace period
  Then the transport disconnects
  And the same-session positions and orders caches remain available for foreground paint

Scenario: Expire an active in-app disconnect grace period
  Given the app is active and no Perps consumer retains the connection
  When the disconnect grace period expires
  Then the transport disconnects
  And all stream caches are cleared as before
```

## Validation

- `PerpsConnectionManager.test.ts`: 78/78 pass on this exact branch.
- Physical Android before: `android-homepage-background-reconnect-v1` lost resident cache after 25 seconds backgrounded.
- Physical Android after: `android-homepage-background-reconnect-v2` rendered the resident order at `958.624 ms`.
- Full-run videos, traces, logs, summaries, manifests, and screenshots are retained locally; no public artifact upload was performed.

## Risk

The preservation condition is limited to an Android timer armed while the app is not active. Identity changes and explicit/active teardown continue to clear caches.
