### PR TITLE
fix(perps): deliver homepage orders without throttle

### DIFF
--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -693,7 +693,7 @@ describe('PerpsSection', () => {
     expect(screen.queryByTestId('skeleton-placeholder')).not.toBeOnTheScreen();
   });
 
-  it('uses 5000ms throttle for WebSocket subscriptions', () => {
+  it('throttles positions but delivers orders immediately', () => {
     renderWithProvider(
       <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
     );
@@ -706,7 +706,7 @@ describe('PerpsSection', () => {
     expect(usePerpsLiveOrders).toHaveBeenCalledWith(
       expect.objectContaining({
         hideTpSl: true,
-        throttleMs: 5000,
+        throttleMs: 0,
       }),
     );
   });

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
@@ -97,7 +97,8 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
 
     const { orders, isInitialLoading: ordersLoading } = usePerpsLiveOrders({
       hideTpSl: true,
-      throttleMs: HOMEPAGE_THROTTLE_MS,
+      // Orders are low-frequency user state and should render immediately.
+      throttleMs: 0,
     });
 
     const hookLoading = positionsLoading || ordersLoading;


### PR DESCRIPTION
## **Description**

Homepage Perps order updates were delayed by the shared five-second throttle even after the controller had confirmed the order. This change delivers the first order update immediately on Homepage while retaining the existing throttle for positions and account data.

| Physical Pixel 6a result | Before | After |
| --- | --- | --- |
| Controller assertion | One matching order | One matching order |
| First requested capture | Order absent | Order visible |
| Capture requested after confirmation | 148 ms | 296 ms |
| Capture after six seconds | Order visible | Order visible |

Scope is limited to `usePerpsLiveOrders` using `throttleMs: 0` on Homepage and its existing contract test. There are no controller, connection, cache, or dependency changes. Positions and account data remain throttled at `5000 ms`.

Physical Android validation used the same 12-node recipe before and after on an unlocked Pixel 6a with HyperLiquid testnet. Both runs completed and removed the test order. Evidence artifacts: `pr34505-on-final-34474-live-order-02` and `pr34505-after-minimal-throttle-01`.

## **Changelog**

CHANGELOG entry: Fixed delayed Perps order updates on the wallet homepage

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/TAT-3662

## **Manual testing steps**

```gherkin
Feature: Homepage Perps order updates

  Scenario: A new Perps order is confirmed while Homepage remains visible
    Given the wallet is unlocked on HyperLiquid testnet
    And the Perpetuals section is visible on Homepage

    When a limit order is created for the selected account
    Then the order appears in the Perpetuals section without waiting five seconds
    And position and account streams retain their existing throttle
```

## **Screenshots/Recordings**

### **Before**

N/A — the reproducible recipe artifact is `pr34505-on-final-34474-live-order-02`.

### **After**

N/A — the reproducible recipe artifact is `pr34505-after-minimal-throttle-01`.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Follow-up: order fills can transition from an order to a position across different subscriber cadences. That pre-existing cross-stream transition requires separate live-fill proof and is intentionally outside this focused PR.
