### PR TITLE
test(dev-tools): support Android lifecycle performance recipes

### DIFF
--- a/app/dev-tools/AgenticService/AgentStepHud.test.tsx
+++ b/app/dev-tools/AgenticService/AgentStepHud.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, act } from '@testing-library/react-native';
+import { Platform } from 'react-native';
 import AgentStepHud, { emitStepHud } from './AgentStepHud';
 
 describe('AgentStepHud', () => {
@@ -113,5 +114,28 @@ describe('AgentStepHud', () => {
     });
 
     expect(toJSON()).toBeNull();
+  });
+
+  it('does not mount the iOS FullWindowOverlay on Android', () => {
+    const originalOs = Platform.OS;
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      value: 'android',
+    });
+    try {
+      const { getByTestId, queryByTestId } = render(<AgentStepHud />);
+
+      act(() => {
+        emitStepHud({ id: 'run 1/1', intent: 'Android lifecycle proof' });
+      });
+
+      expect(getByTestId('agent-step-hud')).toBeOnTheScreen();
+      expect(queryByTestId('agent-step-hud-ios-overlay')).toBeNull();
+    } finally {
+      Object.defineProperty(Platform, 'OS', {
+        configurable: true,
+        value: originalOs,
+      });
+    }
   });
 });

--- a/app/dev-tools/AgenticService/AgentStepHud.tsx
+++ b/app/dev-tools/AgenticService/AgentStepHud.tsx
@@ -172,11 +172,7 @@ const AgentStepHudInner = () => {
   // FullWindowOverlay is an iOS-only UIWindow bridge. Rendering it on Android
   // warns on every step and can abort Fabric while the runtime is restarting.
   if (Platform.OS === 'ios') {
-    return (
-      <FullWindowOverlay testID="agent-step-hud-ios-overlay">
-        {content}
-      </FullWindowOverlay>
-    );
+    return <FullWindowOverlay>{content}</FullWindowOverlay>;
   }
   return content;
 };

--- a/app/dev-tools/AgenticService/AgentStepHud.tsx
+++ b/app/dev-tools/AgenticService/AgentStepHud.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { Platform, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { FullWindowOverlay } from 'react-native-screens';
 
@@ -155,25 +155,30 @@ const AgentStepHudInner = () => {
         ? styles.badgeTextPass
         : styles.badgeTextRunning;
 
-  // FullWindowOverlay (iOS) renders the HUD in a UIWindow above every native
-  // layer — including native-stack modal screens (perps close-position/TPSL,
-  // etc.), which a plain absolute/zIndex View in the JS root cannot reach. On
-  // Android it is a passthrough, so root-level rendering is preserved.
-  return (
-    <FullWindowOverlay>
-      <View style={containerStyle} pointerEvents="none">
-        <Text style={styles.line}>
-          <Text style={[styles.badgeText, badgeTextStyle]}>{badge}</Text>
-          {intent ? `  ${intent}` : ''}
+  const content = (
+    <View testID="agent-step-hud" style={containerStyle} pointerEvents="none">
+      <Text style={styles.line}>
+        <Text style={[styles.badgeText, badgeTextStyle]}>{badge}</Text>
+        {intent ? `  ${intent}` : ''}
+      </Text>
+      {secondary.map((detail) => (
+        <Text key={detail} style={styles.secondary}>
+          {detail}
         </Text>
-        {secondary.map((detail) => (
-          <Text key={detail} style={styles.secondary}>
-            {detail}
-          </Text>
-        ))}
-      </View>
-    </FullWindowOverlay>
+      ))}
+    </View>
   );
+
+  // FullWindowOverlay is an iOS-only UIWindow bridge. Rendering it on Android
+  // warns on every step and can abort Fabric while the runtime is restarting.
+  if (Platform.OS === 'ios') {
+    return (
+      <FullWindowOverlay testID="agent-step-hud-ios-overlay">
+        {content}
+      </FullWindowOverlay>
+    );
+  }
+  return content;
 };
 
 // Outer guard — never calls hooks, so the __DEV__ early return is fine.

--- a/app/dev-tools/AgenticService/AgenticService.test.ts
+++ b/app/dev-tools/AgenticService/AgenticService.test.ts
@@ -690,10 +690,16 @@ describe('AgenticService.install', () => {
     const StorageWrapper = jest.requireMock('../../store/storage-wrapper');
     StorageWrapper.removeItem.mockClear();
     MockEngine.context.PerpsController.state.cachedMarketDataByProvider = {
-      market: {},
+      market: { data: [], timestamp: 0 },
     };
     MockEngine.context.PerpsController.state.cachedUserDataByProvider = {
-      user: {},
+      user: {
+        positions: [],
+        orders: [],
+        accountState: null,
+        timestamp: 0,
+        address: '0x0000000000000000000000000000000000000000',
+      },
     };
 
     await expect(bridge().clearPerpsPerformanceCaches()).resolves.toEqual({

--- a/app/dev-tools/AgenticService/AgenticService.test.ts
+++ b/app/dev-tools/AgenticService/AgenticService.test.ts
@@ -1,6 +1,7 @@
 import AgenticService, {
   walkFiber,
   findFiberByTestId,
+  findMeasurableStateNode,
   walkFiberRoots,
   tryScroll,
   toAccountSummary,
@@ -337,6 +338,20 @@ describe('findFiberByTestId', () => {
   it('returns null when testID not found', () => {
     const root = makeFiber({ child: makeFiber({ testID: 'other' }) });
     expect(findFiberByTestId(root, 'missing')).toBeNull();
+  });
+});
+
+describe('findMeasurableStateNode', () => {
+  it('resolves a Fabric public instance from the canonical host state node', () => {
+    const measureInWindow = jest.fn();
+    const publicInstance = { measureInWindow };
+    const fiber = makeFiber({
+      stateNode: {
+        canonical: { publicInstance },
+      } as FiberNode['stateNode'],
+    });
+
+    expect(findMeasurableStateNode(fiber)).toBe(publicInstance);
   });
 });
 

--- a/app/dev-tools/AgenticService/AgenticService.test.ts
+++ b/app/dev-tools/AgenticService/AgenticService.test.ts
@@ -4,6 +4,7 @@ import AgenticService, {
   findMeasurableStateNode,
   walkFiberRoots,
   tryScroll,
+  tryScrollNear,
   toAccountSummary,
   getFixtureMnemonicCount,
   getFixtureAccountNames,
@@ -119,6 +120,32 @@ jest.mock('../../core/Engine', () => ({
     PerpsController: {
       markTutorialCompleted: jest.fn(),
       getPositions: jest.fn().mockResolvedValue([]),
+      state: {
+        cachedMarketDataByProvider: { market: {} },
+        cachedUserDataByProvider: { user: {} },
+      },
+      update: jest.fn(
+        (
+          updater: (state: {
+            cachedMarketDataByProvider: Record<string, unknown>;
+            cachedUserDataByProvider: Record<string, unknown>;
+          }) => void,
+        ) =>
+          updater(
+            (
+              jest.requireMock('../../core/Engine') as {
+                context: {
+                  PerpsController: {
+                    state: {
+                      cachedMarketDataByProvider: Record<string, unknown>;
+                      cachedUserDataByProvider: Record<string, unknown>;
+                    };
+                  };
+                };
+              }
+            ).context.PerpsController.state,
+          ),
+      ),
     },
   },
   setSelectedAddress: jest.fn(),
@@ -148,6 +175,11 @@ jest.mock('../../components/UI/Perps/providers/PerpsStreamManager', () => ({
   getStreamManagerInstance: () => ({
     clearAllChannels: (...args: unknown[]) => mockClearAllChannels(...args),
   }),
+}));
+
+jest.mock('../../components/UI/Perps/constants/perpsConfig', () => ({
+  PERPS_DISK_CACHE_MARKETS: 'PERPS_DISK_CACHE_MARKETS',
+  PERPS_DISK_CACHE_USER_DATA: 'PERPS_DISK_CACHE_USER_DATA_V2',
 }));
 
 // Authentication pulls in the full auth/keychain stack; stub the singleton.
@@ -208,12 +240,14 @@ jest.mock('../../store/storage-wrapper', () => {
   const storageWrapper = {
     getItem: jest.fn().mockResolvedValue(null),
     setItem: jest.fn().mockResolvedValue(undefined),
+    removeItem: jest.fn().mockResolvedValue(undefined),
   };
   return {
     __esModule: true,
     default: storageWrapper,
     getItem: storageWrapper.getItem,
     setItem: storageWrapper.setItem,
+    removeItem: storageWrapper.removeItem,
   };
 });
 jest.mock('../../constants/storage', () => ({
@@ -518,6 +552,55 @@ describe('tryScroll', () => {
   });
 });
 
+describe('tryScrollNear', () => {
+  it('walks from a list item to its scrollable ancestor', () => {
+    const scrollTo = jest.fn();
+    const scrollView = makeFiber({
+      stateNode: { scrollTo } as FiberNode['stateNode'],
+    });
+    const item = makeFiber({ testID: 'offscreen-item', return: scrollView });
+    scrollView.child = item;
+
+    expect(tryScrollNear(item, 600, true)).toBe(true);
+    expect(scrollTo).toHaveBeenCalledWith({ y: 600, animated: true });
+  });
+
+  it('still supports a testID placed directly on a scrollable subtree', () => {
+    const scrollToOffset = jest.fn();
+    const nativeList = makeFiber({
+      stateNode: { scrollToOffset } as FiberNode['stateNode'],
+    });
+    const anchor = makeFiber({ testID: 'list', child: nativeList });
+
+    expect(tryScrollNear(anchor, 300, false)).toBe(true);
+    expect(scrollToOffset).toHaveBeenCalledWith({
+      offset: 300,
+      animated: false,
+    });
+  });
+
+  it('prefers a vertical ancestor over a scrollable target subtree for into-view', () => {
+    const parentScrollTo = jest.fn();
+    const childScrollTo = jest.fn();
+    const scrollView = makeFiber({
+      stateNode: { scrollTo: parentScrollTo } as FiberNode['stateNode'],
+    });
+    const carousel = makeFiber({
+      stateNode: { scrollTo: childScrollTo } as FiberNode['stateNode'],
+    });
+    const item = makeFiber({
+      testID: 'products',
+      child: carousel,
+      return: scrollView,
+    });
+    scrollView.child = item;
+
+    expect(tryScrollNear(item, 600, true, true)).toBe(true);
+    expect(parentScrollTo).toHaveBeenCalledWith({ y: 600, animated: true });
+    expect(childScrollTo).not.toHaveBeenCalled();
+  });
+});
+
 // ─── AgenticService.install / __AGENTIC__ bridge tests ──────────────────────
 
 describe('AgenticService.install', () => {
@@ -601,6 +684,37 @@ describe('AgenticService.install', () => {
       suppressError: true,
     });
     expect(mockClearAllChannels).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears only Perps persistent performance caches', async () => {
+    const StorageWrapper = jest.requireMock('../../store/storage-wrapper');
+    StorageWrapper.removeItem.mockClear();
+    MockEngine.context.PerpsController.state.cachedMarketDataByProvider = {
+      market: {},
+    };
+    MockEngine.context.PerpsController.state.cachedUserDataByProvider = {
+      user: {},
+    };
+
+    await expect(bridge().clearPerpsPerformanceCaches()).resolves.toEqual({
+      ok: true,
+      clearedStorageKeys: [
+        'PERPS_DISK_CACHE_MARKETS',
+        'PERPS_DISK_CACHE_USER_DATA_V2',
+      ],
+      clearedControllerMarketEntries: 1,
+      clearedControllerUserEntries: 1,
+    });
+    expect(StorageWrapper.removeItem.mock.calls).toEqual([
+      ['PERPS_DISK_CACHE_MARKETS'],
+      ['PERPS_DISK_CACHE_USER_DATA_V2'],
+    ]);
+    expect(
+      MockEngine.context.PerpsController.state.cachedMarketDataByProvider,
+    ).toEqual({});
+    expect(
+      MockEngine.context.PerpsController.state.cachedUserDataByProvider,
+    ).toEqual({});
   });
 
   it('listAccounts returns mapped accounts', () => {
@@ -793,6 +907,29 @@ describe('AgenticService.install', () => {
 
       expect(result.ok).toBe(true);
       expect(scrollTo).toHaveBeenCalledWith({ y: 100, animated: false });
+    });
+
+    it('scrolls a testID child through its scrollable ancestor', () => {
+      const scrollTo = jest.fn();
+      const scrollView = makeFiber({
+        stateNode: { scrollTo } as FiberNode['stateNode'],
+      });
+      const anchor = makeFiber({
+        testID: 'offscreen-item',
+        return: scrollView,
+      });
+      scrollView.child = anchor;
+      installFiberHook(scrollView);
+
+      const result = bridge().scrollView({
+        testId: 'offscreen-item',
+        offset: 600,
+        animated: true,
+        intoView: true,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(scrollTo).toHaveBeenCalledWith({ y: 600, animated: true });
     });
 
     it('returns error when no scrollable found', () => {

--- a/app/dev-tools/AgenticService/AgenticService.ts
+++ b/app/dev-tools/AgenticService/AgenticService.ts
@@ -58,6 +58,23 @@ import { getStreamManagerInstance } from '../../components/UI/Perps/providers/Pe
  * Minimal React fiber node shape used to walk the component tree
  * via __REACT_DEVTOOLS_GLOBAL_HOOK__.
  */
+interface MeasurableStateNode {
+  measure?: (
+    callback: (
+      x: number,
+      y: number,
+      width: number,
+      height: number,
+      pageX: number,
+      pageY: number,
+    ) => void,
+  ) => void;
+  measureInWindow?: (
+    callback: (x: number, y: number, width: number, height: number) => void,
+  ) => void;
+  [key: string]: unknown;
+}
+
 interface FiberNode {
   child: FiberNode | null;
   sibling: FiberNode | null;
@@ -68,24 +85,15 @@ interface FiberNode {
     onChangeText?: (text: string) => void;
     [key: string]: unknown;
   } | null;
-  stateNode: {
-    scrollTo?: (opts: { y: number; animated: boolean }) => void;
-    scrollToOffset?: (opts: { offset: number; animated: boolean }) => void;
-    measure?: (
-      callback: (
-        x: number,
-        y: number,
-        width: number,
-        height: number,
-        pageX: number,
-        pageY: number,
-      ) => void,
-    ) => void;
-    measureInWindow?: (
-      callback: (x: number, y: number, width: number, height: number) => void,
-    ) => void;
-    [key: string]: unknown;
-  } | null;
+  stateNode:
+    | (MeasurableStateNode & {
+        scrollTo?: (opts: { y: number; animated: boolean }) => void;
+        scrollToOffset?: (opts: { offset: number; animated: boolean }) => void;
+        canonical?: {
+          publicInstance?: MeasurableStateNode | null;
+        };
+      })
+    | null;
 }
 
 interface FiberRoot {
@@ -826,18 +834,37 @@ function findUiTargetFiber(
   return result;
 }
 
+function measurablePublicInstance(
+  stateNode: FiberNode['stateNode'],
+): MeasurableStateNode | null {
+  if (!stateNode) {
+    return null;
+  }
+  if (
+    typeof stateNode.measureInWindow === 'function' ||
+    typeof stateNode.measure === 'function'
+  ) {
+    return stateNode;
+  }
+  const fabricPublicInstance = stateNode.canonical?.publicInstance;
+  if (
+    fabricPublicInstance &&
+    (typeof fabricPublicInstance.measureInWindow === 'function' ||
+      typeof fabricPublicInstance.measure === 'function')
+  ) {
+    return fabricPublicInstance;
+  }
+  return null;
+}
+
 function findMeasurableStateNode(
   fiber: FiberNode | null,
-): FiberNode['stateNode'] | null {
-  let result: FiberNode['stateNode'] | null = null;
+): MeasurableStateNode | null {
+  let result: MeasurableStateNode | null = null;
   walkFiber(fiber, (node) => {
-    const sn = node.stateNode;
-    if (
-      sn &&
-      (typeof sn.measureInWindow === 'function' ||
-        typeof sn.measure === 'function')
-    ) {
-      result = sn;
+    const measurable = measurablePublicInstance(node.stateNode);
+    if (measurable) {
+      result = measurable;
       return true;
     }
     return false;
@@ -846,7 +873,7 @@ function findMeasurableStateNode(
 }
 
 function measureStateNode(
-  stateNode: FiberNode['stateNode'],
+  stateNode: MeasurableStateNode | null,
 ): Promise<{ x: number; y: number; width: number; height: number } | null> {
   return new Promise((resolve) => {
     if (!stateNode) {
@@ -1655,6 +1682,7 @@ export default AgenticService;
 export {
   walkFiber,
   findFiberByTestId,
+  findMeasurableStateNode,
   walkFiberRoots,
   tryScroll,
   toAccountSummary,

--- a/app/dev-tools/AgenticService/AgenticService.ts
+++ b/app/dev-tools/AgenticService/AgenticService.ts
@@ -51,6 +51,10 @@ import { emitStepHud } from './AgentStepHud';
 import { Wallet as EthersWallet } from 'ethers';
 import PerpsConnectionManager from '../../components/UI/Perps/services/PerpsConnectionManager';
 import { getStreamManagerInstance } from '../../components/UI/Perps/providers/PerpsStreamManager';
+import {
+  PERPS_DISK_CACHE_MARKETS,
+  PERPS_DISK_CACHE_USER_DATA,
+} from '../../components/UI/Perps/constants/perpsConfig';
 
 // ─── Fiber tree types ──────────────────────────────────────────────────────
 
@@ -140,6 +144,7 @@ interface AgenticBridge {
     testId?: string;
     offset?: number;
     animated?: boolean;
+    intoView?: boolean;
   }) => {
     ok: boolean;
     error?: string;
@@ -212,6 +217,12 @@ interface AgenticBridge {
   showStep: (step: AgenticHudStep) => void;
   hideStep: () => void;
   refreshPerpsStreams: () => Promise<{ ok: boolean; positions: number }>;
+  clearPerpsPerformanceCaches: () => Promise<{
+    ok: boolean;
+    clearedStorageKeys: string[];
+    clearedControllerMarketEntries: number;
+    clearedControllerUserEntries: number;
+  }>;
   findFiberByTestId: (testId: string) => boolean;
   queryUiTarget: (options: {
     testId?: string;
@@ -802,6 +813,38 @@ function tryScroll(
   return false;
 }
 
+/**
+ * Scroll from a testID anchor without assuming the scrollable is rendered
+ * below that anchor. React Native list items are normally descendants of the
+ * ScrollView, so their nearest scrollable is on the fiber return path.
+ */
+function tryScrollNear(
+  anchor: FiberNode,
+  offset: number,
+  animated: boolean,
+  preferAncestor = false,
+): boolean {
+  if (!preferAncestor && tryScroll(anchor, offset, animated, false)) {
+    return true;
+  }
+
+  let current = anchor.return;
+  while (current) {
+    const stateNode = current.stateNode;
+    if (typeof stateNode?.scrollTo === 'function') {
+      stateNode.scrollTo({ y: offset, animated });
+      return true;
+    }
+    if (typeof stateNode?.scrollToOffset === 'function') {
+      stateNode.scrollToOffset({ offset, animated });
+      return true;
+    }
+    current = current.return;
+  }
+
+  return preferAncestor && tryScroll(anchor, offset, animated, false);
+}
+
 function targetMatches(
   fiber: FiberNode,
   options: { testId?: string; textContains?: string },
@@ -1241,24 +1284,32 @@ const AgenticService = {
           testId?: string;
           offset?: number;
           animated?: boolean;
+          intoView?: boolean;
         } = {},
       ) => {
         const {
           testId: scrollTestId,
           offset = 300,
           animated = false,
+          intoView = false,
         } = options;
         try {
           const found = walkFiberRoots((rootFiber) => {
             if (scrollTestId) {
               const anchor = findFiberByTestId(rootFiber, scrollTestId);
               if (!anchor) return false;
-              return tryScroll(anchor, offset, animated, false);
+              return tryScrollNear(anchor, offset, animated, intoView);
             }
             return tryScroll(rootFiber, offset, animated);
           });
           if (found)
-            return { ok: true, testId: scrollTestId, offset, animated };
+            return {
+              ok: true,
+              testId: scrollTestId,
+              offset,
+              animated,
+              intoView,
+            };
           return {
             ok: false,
             error: scrollTestId
@@ -1379,6 +1430,45 @@ const AgenticService = {
         return {
           ok: true,
           positions: Array.isArray(positions) ? positions.length : 0,
+        };
+      },
+      clearPerpsPerformanceCaches: async () => {
+        const controller = Engine.context.PerpsController as unknown as {
+          state: {
+            cachedMarketDataByProvider: Record<string, unknown>;
+            cachedUserDataByProvider: Record<string, unknown>;
+          };
+          update: (
+            updater: (state: {
+              cachedMarketDataByProvider: Record<string, unknown>;
+              cachedUserDataByProvider: Record<string, unknown>;
+            }) => void,
+          ) => void;
+        };
+        const clearedControllerMarketEntries = Object.keys(
+          controller.state.cachedMarketDataByProvider,
+        ).length;
+        const clearedControllerUserEntries = Object.keys(
+          controller.state.cachedUserDataByProvider,
+        ).length;
+        const clearedStorageKeys = [
+          PERPS_DISK_CACHE_MARKETS,
+          PERPS_DISK_CACHE_USER_DATA,
+        ];
+
+        await Promise.all(
+          clearedStorageKeys.map((key) => StorageWrapper.removeItem(key)),
+        );
+        controller.update((state) => {
+          state.cachedMarketDataByProvider = {};
+          state.cachedUserDataByProvider = {};
+        });
+
+        return {
+          ok: true,
+          clearedStorageKeys,
+          clearedControllerMarketEntries,
+          clearedControllerUserEntries,
         };
       },
       findFiberByTestId: (testId: string): boolean => {
@@ -1685,6 +1775,7 @@ export {
   findMeasurableStateNode,
   walkFiberRoots,
   tryScroll,
+  tryScrollNear,
   toAccountSummary,
 };
 export type { FiberNode, FiberRoot, ReactDevToolsHook, AgenticBridge };

--- a/shim.js
+++ b/shim.js
@@ -213,6 +213,24 @@ if (typeof global.MessageEvent === 'undefined') {
     require('react-native/src/private/webapis/html/events/MessageEvent').default;
 }
 
+// @metamask/post-message-stream captures the browser-standard `source` getter
+// when its window transport module is evaluated. React Native's MessageEvent
+// implements data/origin/lastEventId but not source, which otherwise prevents
+// Engine initialization before the window transport is even instantiated.
+if (
+  typeof Object.getOwnPropertyDescriptor(
+    global.MessageEvent.prototype,
+    'source',
+  )?.get !== 'function'
+) {
+  Object.defineProperty(global.MessageEvent.prototype, 'source', {
+    configurable: true,
+    get() {
+      return global.window ?? null;
+    },
+  });
+}
+
 class AbortError extends Error {
   constructor(message) {
     super(message);


### PR DESCRIPTION
## Description

Extends the dev-only Mobile recipe bridge for deterministic Android lifecycle/performance validation:

- restores fixture-backed Android recipe setup;
- scrolls an offscreen testID through its actual ancestor ScrollView;
- clears only Perps disk/controller performance caches for cold-no-cache proof;
- renders the step HUD through `FullWindowOverlay` only on iOS, preventing an Android Fabric restart crash.

Stacked on #34506 for review and current validation. None of these helpers are part of release behavior.

## Proven defects

1. `ui.scroll` searched below an item for a scrollable, but React Native list items normally have the ScrollView on their fiber return path.
2. Cold-no-cache recipes could not remove only Perps caches without deleting the wallet/app fixture.
3. Android mounted the iOS-only `FullWindowOverlay`; terminate→foreground emitted platform warnings and then SIGABRT with a pending `FabricUIManager` null-cast exception.

## Before / after

- Android lifecycle before: app crashed to launcher; no Hermes target remained.
- Android lifecycle after: terminate→foreground recipe passed 5/5 in `32 s`, verified Wallet Home, and emitted no overlay/Fabric/fatal-signal evidence.
- Cold no-cache after: 13/13, exactly two Perps storage keys and controller snapshots cleared, ETH order visibly restored from fresh socket data.
- Scroll after: exact Homepage order/position rows can be brought into the physical viewport with declarative `ui.scroll`.

## Validation

- `AgenticService.test.ts`: 79/79 pass.
- `AgentStepHud.test.tsx`: 8/8 pass, including Android overlay exclusion.
- Physical Pixel 6 recipes use healing off and full-run video.
- Failed and passing lifecycle artifacts are retained locally; no public upload was performed.

## Risk

All bridge installation remains guarded by `__DEV__`. Cache removal is explicit and limited to Perps validation keys/state; it does not clear wallet or app data.
