### PR TITLE
fix(sentry): persist trace tags as span attributes

### DIFF
--- a/app/util/trace.test.ts
+++ b/app/util/trace.test.ts
@@ -175,7 +175,7 @@ describe('Trace', () => {
         {
           name: NAME_MOCK,
           parentSpan: PARENT_CONTEXT_MOCK,
-          attributes: DATA_MOCK,
+          attributes: { ...TAGS_MOCK, ...DATA_MOCK },
           op: 'custom',
         },
         expect.any(Function),
@@ -209,7 +209,7 @@ describe('Trace', () => {
         {
           name: NAME_MOCK,
           parentSpan: PARENT_CONTEXT_MOCK,
-          attributes: DATA_MOCK,
+          attributes: { ...TAGS_MOCK, ...DATA_MOCK },
           op: 'custom',
         },
         expect.any(Function),
@@ -221,6 +221,25 @@ describe('Trace', () => {
 
       expect(setMeasurementMock).toHaveBeenCalledTimes(1);
       expect(setMeasurementMock).toHaveBeenCalledWith('tag3', 123, 'none');
+    });
+
+    it('uses data when tags and data contain the same attribute', () => {
+      updateCachedConsent(true);
+
+      trace(
+        {
+          name: NAME_MOCK,
+          tags: { shared: 'tag' },
+          data: { shared: 'data' },
+        },
+        () => true,
+      );
+
+      expect(startSpanMock).toHaveBeenCalledWith(
+        expect.objectContaining({ attributes: { shared: 'data' } }),
+        expect.any(Function),
+      );
+      expect(setTagMock).toHaveBeenCalledWith('shared', 'tag');
     });
 
     it('buffers traces when consent is not given', () => {
@@ -263,7 +282,7 @@ describe('Trace', () => {
         {
           name: NAME_MOCK,
           parentSpan: PARENT_CONTEXT_MOCK,
-          attributes: DATA_MOCK,
+          attributes: { ...TAGS_MOCK, ...DATA_MOCK },
           op: 'custom',
           startTime: 123,
         },

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -394,8 +394,9 @@ function rememberOnboardingAccountType(
 }
 
 /**
- * Resolve the attributes a span starts with, adding the journey's account type to
- * onboarding spans that do not already set one of their own.
+ * Resolve the attributes a span starts with. Tags are mirrored into attributes,
+ * with data taking precedence, and onboarding spans inherit the journey's account
+ * type when they do not set one of their own.
  *
  * @param request - The trace request being started.
  * @returns The attributes to open the span with.

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -403,17 +403,27 @@ function rememberOnboardingAccountType(
 function getSpanAttributes(
   request: TraceRequest,
 ): Record<string, TraceValue> | undefined {
-  const { data, op } = request;
+  const { data, op, tags } = request;
+  const attributes =
+    data || tags
+      ? {
+          ...tags,
+          ...data,
+        }
+      : undefined;
 
   if (
     !op?.startsWith(ONBOARDING_OP_PREFIX) ||
     onboardingAccountType === undefined ||
-    data?.[ACCOUNT_TYPE_ATTRIBUTE] !== undefined
+    attributes?.[ACCOUNT_TYPE_ATTRIBUTE] !== undefined
   ) {
-    return data;
+    return attributes;
   }
 
-  return { ...data, [ACCOUNT_TYPE_ATTRIBUTE]: onboardingAccountType };
+  return {
+    ...attributes,
+    [ACCOUNT_TYPE_ATTRIBUTE]: onboardingAccountType,
+  };
 }
 
 export interface PendingTrace {


### PR DESCRIPTION
## **Description**

Persists `TraceRequest.tags` as Sentry span attributes while retaining the existing scope tags and numeric measurements for compatibility.

This independently enables lifecycle, content, and delivery-source filtering for the Perps CUF and Homepage visible-performance spans. It does not change measured boundaries or product behavior.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/TAT-3662

## **Manual testing steps**

```gherkin
Feature: Queryable performance dimensions

  Scenario: A trace starts with typed tags
    Given a trace starts with string, boolean, or numeric tags
    When the trace is sent to Sentry
    Then those values are stored as span attributes
    And dashboards can filter and group the span by those values
```

Before the fix, 92 development `perps.homepage.performance` spans existed while `has:lifecycle` returned zero and lifecycle/content/source fields were null. After the fix, the same iOS recipe and Sentry cohort reconciled TTC, DFD, and socket-to-visible values within milliseconds, and the expected dimensions were queryable.

## **Screenshots/Recordings**

### **Before**

N/A — the defect is missing Sentry span attributes rather than a visual UI difference. The authenticated development query and span counts are preserved in the task evidence.

### **After**

N/A — the same recipe was reconciled against authenticated Sentry results. The development dashboard is https://metamask.sentry.io/dashboard/9338822/?environment=development&project=2651591&statsPeriod=24h.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## Validation details

- `app/util/trace.test.ts`: 50/50 focused tests passed.
- iOS development recipe: 13/13 with healing disabled and a full native recording.
- Authenticated Sentry CDP `9331` read-only queries reconciled all emitted spans.
- The PR is based directly on `main` and has no dependency on another draft.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change in the trace helper with updated unit tests; no product or auth/data-path behavior changes.
> 
> **Overview**
> **`getSpanAttributes`** now builds span **`attributes`** from **`tags`** and **`data`** (`{ ...tags, ...data }`), so dimensions like lifecycle and content source are queryable in Sentry. Previously only **`data`** was attached to spans; tags still go to scope tags and numeric tags to measurements.
> 
> Onboarding **`account_type`** inheritance uses the merged attributes object, so journey account type is still applied when child spans do not set their own. A test covers the tag-vs-data precedence when keys overlap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1666fb346362867900dc454d87f5991f6d8f9e1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->