### PR TITLE
feat(perps): add homepage performance measurement pipeline

### DIFF
--- a/app/components/UI/Perps/adapters/mobileInfrastructure.test.ts
+++ b/app/components/UI/Perps/adapters/mobileInfrastructure.test.ts
@@ -9,6 +9,7 @@ import {
   getTerminalApiUrl,
 } from './mobileInfrastructure';
 import { TERMINAL_API_URLS } from '../constants/terminalApi';
+import { PERPS_DISK_CACHE_USER_DATA } from '../constants/perpsConfig';
 import Engine from '../../../../core/Engine';
 
 jest.mock('../../../../util/analytics/analytics', () => ({
@@ -60,6 +61,10 @@ jest.mock('react-native-performance', () => ({
 
 jest.mock('../providers/PerpsStreamManager', () => ({
   getStreamManagerInstance: jest.fn(),
+}));
+
+jest.mock('../utils/homepagePerformanceProbe', () => ({
+  markHomepagePerpsDiskCacheHydrated: jest.fn(),
 }));
 
 jest.mock('../../../../store/storage-wrapper', () => ({
@@ -282,6 +287,19 @@ describe('createMobileInfrastructure', () => {
 
       expect(StorageWrapper.getItemSync).toHaveBeenCalledWith('test-key');
       expect(value).toBe('cached-sync-value');
+    });
+
+    it('marks synchronous user-cache hydration for provenance', () => {
+      const { markHomepagePerpsDiskCacheHydrated } = jest.requireMock(
+        '../utils/homepagePerformanceProbe',
+      );
+      const infra = createMobileInfrastructure();
+
+      infra.diskCache.getItemSync?.(PERPS_DISK_CACHE_USER_DATA);
+
+      expect(markHomepagePerpsDiskCacheHydrated).toHaveBeenCalledWith(
+        'cached-sync-value',
+      );
     });
 
     it('delegates setItem to StorageWrapper.setItem', async () => {

--- a/app/components/UI/Perps/adapters/mobileInfrastructure.ts
+++ b/app/components/UI/Perps/adapters/mobileInfrastructure.ts
@@ -46,6 +46,8 @@ import {
 import { getIntlNumberFormatter } from '../../../../util/intl';
 
 import { TERMINAL_API_URLS } from '../constants/terminalApi';
+import { PERPS_DISK_CACHE_USER_DATA } from '../constants/perpsConfig';
+import { markHomepagePerpsDiskCacheHydrated } from '../utils/homepagePerformanceProbe';
 
 /**
  * Resolves the Terminal API base URL based on build environment.
@@ -323,7 +325,13 @@ export function createMobileInfrastructure(): PerpsPlatformDependencies {
     // === Disk Cache (cold-start persistence via MMKV) ===
     diskCache: {
       getItem: (key: string) => StorageWrapper.getItem(key),
-      getItemSync: (key: string) => StorageWrapper.getItemSync(key),
+      getItemSync: (key: string) => {
+        const value = StorageWrapper.getItemSync(key);
+        if (key === PERPS_DISK_CACHE_USER_DATA && value !== null) {
+          markHomepagePerpsDiskCacheHydrated(value);
+        }
+        return value;
+      },
       setItem: (key: string, value: string) =>
         StorageWrapper.setItem(key, value),
       removeItem: (key: string) =>

--- a/app/components/UI/Perps/constants/perpsCufTags.ts
+++ b/app/components/UI/Perps/constants/perpsCufTags.ts
@@ -2,6 +2,7 @@
 export const PERPS_CUF_TAG = {
   FEATURE: 'feature',
   LIFECYCLE_CONTEXT: 'lifecycle_context',
+  LIFECYCLE_DETAIL: 'lifecycle_detail',
   VARIANT: 'variant',
   DIRECTION: 'direction',
   ORDER_TYPE: 'order_type',

--- a/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
@@ -21,6 +21,7 @@ import { trace, TraceName, TraceOperation } from '../../../../util/trace';
 import { PERPS_CUF_TAG } from '../constants/perpsCufTags';
 import {
   PERPS_LIFECYCLE_CONTEXT,
+  PERPS_LIFECYCLE_DETAIL,
   resetPerpsLifecycleContextForTests,
 } from '../utils/perpsLifecycleContext';
 import { PerpsConnectionManager } from '../services/PerpsConnectionManager';
@@ -1186,7 +1187,7 @@ describe('PerpsStreamManager', () => {
     const expectedSharedTags = {
       [PERPS_CUF_TAG.FEATURE]: PERPS_CONSTANTS.FeatureName,
       [PERPS_CUF_TAG.LIFECYCLE_CONTEXT]: PERPS_LIFECYCLE_CONTEXT.COLD_PROCESS,
-      [PERPS_CUF_TAG.LIFECYCLE_DETAIL]: PERPS_LIFECYCLE_CONTEXT.COLD_PROCESS,
+      [PERPS_CUF_TAG.LIFECYCLE_DETAIL]: PERPS_LIFECYCLE_DETAIL.COLD_PROCESS,
     };
 
     it('starts the first-price trace with shared CUF tags', () => {

--- a/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
@@ -1186,6 +1186,7 @@ describe('PerpsStreamManager', () => {
     const expectedSharedTags = {
       [PERPS_CUF_TAG.FEATURE]: PERPS_CONSTANTS.FeatureName,
       [PERPS_CUF_TAG.LIFECYCLE_CONTEXT]: PERPS_LIFECYCLE_CONTEXT.COLD_PROCESS,
+      [PERPS_CUF_TAG.LIFECYCLE_DETAIL]: PERPS_LIFECYCLE_CONTEXT.COLD_PROCESS,
     };
 
     it('starts the first-price trace with shared CUF tags', () => {

--- a/app/components/UI/Perps/utils/homepagePerformanceProbe.test.ts
+++ b/app/components/UI/Perps/utils/homepagePerformanceProbe.test.ts
@@ -1,0 +1,372 @@
+import {
+  createHomepagePerformanceDemand,
+  getHomepagePerpsDiskCacheAgeMs,
+  handleHomepagePerformanceAppStateChange,
+  isHomepagePerpsDeliveryFreshForDemand,
+  markHomepagePerpsAccountSwitch,
+  markHomepagePerpsDiskCacheHydrated,
+  markHomepagePerpsNavigateReturn,
+  markHomepagePerpsNetworkRecovery,
+  recordHomepagePerpsErrorFrame,
+  recordHomepagePerpsVisibleFrame,
+  resetHomepagePerformanceProbeForTests,
+  type HomepagePerformanceDemand,
+  type HomepagePerpsDeliveryMetadata,
+} from './homepagePerformanceProbe';
+
+jest.mock('react-native', () => ({
+  AppState: { addEventListener: jest.fn() },
+}));
+
+jest.mock('react-native-performance', () => ({
+  __esModule: true,
+  default: { now: jest.fn(() => 0) },
+}));
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => `trace-${Math.random()}`),
+}));
+
+jest.mock('@metamask/perps-controller', () => ({
+  PERPS_CONSTANTS: { ConnectionGracePeriodMs: 20_000 },
+}));
+
+jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
+  DevLogger: { log: jest.fn() },
+}));
+
+jest.mock('../../../../util/trace', () => ({
+  trace: jest.fn(),
+  endTrace: jest.fn(),
+  TraceName: {
+    HomepagePerpsTimeToFirstVisibleContent:
+      'Homepage Perps Time To First Visible Content',
+    HomepagePerpsTimeToFreshVisibleData:
+      'Homepage Perps Time To Fresh Visible Data',
+    HomepagePerpsSocketToVisible: 'Homepage Perps Socket To Visible',
+    HomepagePerpsCachedToFreshVisible: 'Homepage Perps Cached To Fresh Visible',
+  },
+  TraceOperation: {
+    PerpsHomepagePerformance: 'perps.homepage.performance',
+  },
+}));
+
+const { trace: mockTrace, endTrace: mockEndTrace } = jest.requireMock(
+  '../../../../util/trace',
+);
+const mockPerformanceNow = jest.requireMock('react-native-performance').default
+  .now as jest.Mock;
+
+const createDemand = (): HomepagePerformanceDemand => ({
+  demandId: 'demand-1',
+  startedAtMonotonicMs: 100,
+  lifecycleStartedAtMonotonicMs: 50,
+  lifecycle: 'cold_disk_cache',
+  firstVisibleRecorded: false,
+  firstFreshVisibleRecorded: false,
+  recordedFreshPipelineStreams: new Set(),
+});
+
+const createDelivery = (
+  stream: 'positions' | 'orders',
+  source: 'disk_cache' | 'fresh_socket',
+  receivedAtMonotonicMs: number,
+): HomepagePerpsDeliveryMetadata => ({
+  deliveryId: `${stream}-${source}-${receivedAtMonotonicMs}`,
+  stream,
+  source,
+  itemCount: stream === 'positions' ? 1 : 0,
+  receivedAtMonotonicMs,
+  subscriberDeliveredAtMonotonicMs: receivedAtMonotonicMs + 10,
+  dataAgeMs: source === 'disk_cache' ? 5_000 : 0,
+  lifecycle: 'cold_disk_cache',
+  accountGeneration: 0,
+});
+
+describe('homepage visible performance telemetry', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetHomepagePerformanceProbeForTests();
+    mockPerformanceNow.mockReturnValue(0);
+    jest.spyOn(Date, 'now').mockReturnValue(100_000);
+  });
+
+  it('classifies disk cache from the oldest aggregated entry', () => {
+    markHomepagePerpsDiskCacheHydrated(
+      JSON.stringify({
+        entries: [
+          { timestamp: 95_000, positions: [], orders: [] },
+          { timestamp: 90_000, positions: [], orders: [] },
+        ],
+      }),
+    );
+
+    expect(getHomepagePerpsDiskCacheAgeMs()).toBe(10_000);
+    expect(createHomepagePerformanceDemand().lifecycle).toBe('cold_disk_cache');
+  });
+
+  it('uses a newer navigation lifecycle when it occurs before the first demand', () => {
+    markHomepagePerpsDiskCacheHydrated(
+      JSON.stringify({ entries: [{ timestamp: 95_000 }] }),
+    );
+    markHomepagePerpsNavigateReturn();
+
+    expect(createHomepagePerformanceDemand().lifecycle).toBe('navigate_return');
+  });
+
+  it.each([
+    [5_000, 'background_short'],
+    [25_000, 'background_reconnect'],
+  ] as const)(
+    'classifies a %i ms background interval as %s',
+    (foregroundAt, expectedLifecycle) => {
+      mockPerformanceNow.mockReturnValueOnce(0);
+      handleHomepagePerformanceAppStateChange('background');
+      mockPerformanceNow.mockReturnValue(foregroundAt);
+      handleHomepagePerformanceAppStateChange('active');
+
+      expect(createHomepagePerformanceDemand().lifecycle).toBe(
+        expectedLifecycle,
+      );
+    },
+  );
+
+  it('labels account switch and network recovery demands independently', () => {
+    markHomepagePerpsAccountSwitch();
+    expect(createHomepagePerformanceDemand().lifecycle).toBe('account_switch');
+
+    markHomepagePerpsNetworkRecovery();
+    expect(createHomepagePerformanceDemand().lifecycle).toBe(
+      'network_recovery',
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('records cache visibility, fresh visibility, and convergence at frame checkpoints', () => {
+    const demand = createDemand();
+
+    recordHomepagePerpsVisibleFrame({
+      demand,
+      deliveries: [
+        createDelivery('positions', 'disk_cache', 120),
+        createDelivery('orders', 'disk_cache', 130),
+      ],
+      contentVariant: 'positions',
+      reactCommitAtMonotonicMs: 180,
+      frameCheckpointAtMonotonicMs: 200,
+    });
+
+    expect(mockTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Homepage Perps Time To First Visible Content',
+        op: 'perps.homepage.performance',
+        startTime: 99_900,
+        tags: expect.objectContaining({
+          lifecycle: 'cold_disk_cache',
+          delivery_source: 'disk_cache',
+          frame_boundary: 'next_frame_checkpoint',
+          data_ready_at_demand: false,
+        }),
+      }),
+    );
+    expect(mockTrace).toHaveBeenCalledTimes(1);
+
+    recordHomepagePerpsVisibleFrame({
+      demand,
+      deliveries: [
+        createDelivery('positions', 'fresh_socket', 250),
+        createDelivery('orders', 'fresh_socket', 260),
+      ],
+      contentVariant: 'positions',
+      reactCommitAtMonotonicMs: 350,
+      frameCheckpointAtMonotonicMs: 400,
+    });
+
+    const traceNames = mockTrace.mock.calls.map(
+      (call: [{ name: string }]) => call[0].name,
+    );
+    expect(traceNames).toEqual(
+      expect.arrayContaining([
+        'Homepage Perps Time To Fresh Visible Data',
+        'Homepage Perps Socket To Visible',
+        'Homepage Perps Cached To Fresh Visible',
+      ]),
+    );
+    expect(mockTrace).toHaveBeenCalledTimes(5);
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Homepage Perps Cached To Fresh Visible',
+        data: expect.objectContaining({ success: true }),
+      }),
+    );
+  });
+
+  it('records each fresh stream pipeline at most once per demand', () => {
+    const demand = createDemand();
+    const positions = createDelivery('positions', 'fresh_socket', 120);
+    const orders = createDelivery('orders', 'disk_cache', 130);
+
+    recordHomepagePerpsVisibleFrame({
+      demand,
+      deliveries: [positions, orders],
+      contentVariant: 'positions',
+      reactCommitAtMonotonicMs: 180,
+      frameCheckpointAtMonotonicMs: 200,
+    });
+    recordHomepagePerpsVisibleFrame({
+      demand,
+      deliveries: [createDelivery('positions', 'fresh_socket', 220), orders],
+      contentVariant: 'positions',
+      reactCommitAtMonotonicMs: 280,
+      frameCheckpointAtMonotonicMs: 300,
+    });
+
+    const socketCalls = mockTrace.mock.calls.filter(
+      (call: [{ name: string }]) =>
+        call[0].name === 'Homepage Perps Socket To Visible',
+    );
+    expect(socketCalls).toHaveLength(1);
+  });
+
+  it('does not report offscreen-ready data as socket or cache pipeline latency', () => {
+    const demand = createDemand();
+
+    recordHomepagePerpsVisibleFrame({
+      demand,
+      deliveries: [
+        createDelivery('positions', 'fresh_socket', 80),
+        createDelivery('orders', 'fresh_socket', 90),
+      ],
+      contentVariant: 'empty',
+      reactCommitAtMonotonicMs: 120,
+      frameCheckpointAtMonotonicMs: 140,
+    });
+
+    const traceNames = mockTrace.mock.calls.map(
+      (call: [{ name: string }]) => call[0].name,
+    );
+    expect(traceNames).toContain(
+      'Homepage Perps Time To First Visible Content',
+    );
+    expect(traceNames).toContain('Homepage Perps Time To Fresh Visible Data');
+    expect(traceNames).not.toContain('Homepage Perps Socket To Visible');
+  });
+
+  it('records resident fresh data as ready at demand without socket latency', () => {
+    const demand = createDemand();
+    const resident = (stream: 'positions' | 'orders') => ({
+      ...createDelivery(stream, 'fresh_socket', 80),
+      source: 'resident_state' as const,
+      originSource: 'fresh_socket' as const,
+    });
+
+    recordHomepagePerpsVisibleFrame({
+      demand,
+      deliveries: [resident('positions'), resident('orders')],
+      contentVariant: 'orders',
+      reactCommitAtMonotonicMs: 120,
+      frameCheckpointAtMonotonicMs: 140,
+    });
+
+    const freshCall = mockTrace.mock.calls.find(
+      (call: [{ name: string }]) =>
+        call[0].name === 'Homepage Perps Time To Fresh Visible Data',
+    );
+    expect(freshCall?.[0]).toEqual(
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          delivery_source: 'resident_state',
+          freshness_source: 'fresh_socket',
+          data_ready_at_demand: true,
+        }),
+      }),
+    );
+    expect(
+      mockTrace.mock.calls.some(
+        (call: [{ name: string }]) =>
+          call[0].name === 'Homepage Perps Socket To Visible',
+      ),
+    ).toBe(false);
+  });
+
+  it('waits for post-lifecycle socket data when resident state predates recovery', () => {
+    const demand = {
+      ...createDemand(),
+      lifecycle: 'network_recovery' as const,
+      lifecycleStartedAtMonotonicMs: 90,
+    };
+    const staleResident = (stream: 'positions' | 'orders') => ({
+      ...createDelivery(stream, 'fresh_socket', 80),
+      source: 'resident_state' as const,
+      originSource: 'fresh_socket' as const,
+      dataAgeMs: 216_000,
+    });
+
+    expect(
+      isHomepagePerpsDeliveryFreshForDemand(staleResident('orders'), demand),
+    ).toBe(false);
+    recordHomepagePerpsVisibleFrame({
+      demand,
+      deliveries: [staleResident('positions'), staleResident('orders')],
+      contentVariant: 'orders',
+      reactCommitAtMonotonicMs: 120,
+      frameCheckpointAtMonotonicMs: 140,
+    });
+
+    expect(
+      mockTrace.mock.calls.some(
+        (call: [{ name: string }]) =>
+          call[0].name === 'Homepage Perps Time To Fresh Visible Data',
+      ),
+    ).toBe(false);
+
+    recordHomepagePerpsVisibleFrame({
+      demand,
+      deliveries: [
+        createDelivery('positions', 'fresh_socket', 150),
+        createDelivery('orders', 'fresh_socket', 160),
+      ],
+      contentVariant: 'orders',
+      reactCommitAtMonotonicMs: 180,
+      frameCheckpointAtMonotonicMs: 200,
+    });
+
+    expect(
+      mockTrace.mock.calls.some(
+        (call: [{ name: string }]) =>
+          call[0].name === 'Homepage Perps Time To Fresh Visible Data',
+      ),
+    ).toBe(true);
+  });
+
+  it('records a visible connection error as an unsuccessful first-visible outcome', () => {
+    const demand = createDemand();
+
+    recordHomepagePerpsErrorFrame({
+      demand,
+      frameCheckpointAtMonotonicMs: 175,
+    });
+
+    expect(mockTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Homepage Perps Time To First Visible Content',
+        tags: expect.objectContaining({
+          content_variant: 'error',
+          delivery_source: 'none',
+          success: false,
+        }),
+      }),
+    );
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          success: false,
+          reason: 'connection_error_visible',
+        }),
+      }),
+    );
+  });
+});

--- a/app/components/UI/Perps/utils/homepagePerformanceProbe.ts
+++ b/app/components/UI/Perps/utils/homepagePerformanceProbe.ts
@@ -1,0 +1,458 @@
+import type { AppStateStatus } from 'react-native';
+import performance from 'react-native-performance';
+import { v4 as uuidv4 } from 'uuid';
+import { PERPS_CONSTANTS } from '@metamask/perps-controller';
+import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../../util/trace';
+
+export type HomepagePerpsStream = 'positions' | 'orders';
+export type HomepagePerpsDeliverySource =
+  | 'memory_cache'
+  | 'disk_cache'
+  | 'resident_state'
+  | 'fresh_socket';
+export type HomepagePerformanceLifecycle =
+  | 'cold_no_cache'
+  | 'cold_disk_cache'
+  | 'warm_foreground'
+  | 'navigate_return'
+  | 'background_short'
+  | 'background_reconnect'
+  | 'network_recovery'
+  | 'account_switch';
+export type HomepagePerpsContentVariant =
+  | 'empty'
+  | 'positions'
+  | 'orders'
+  | 'positions_and_orders'
+  | 'trending'
+  | 'pills'
+  | 'error';
+
+export interface HomepagePerpsDeliveryMetadata {
+  deliveryId: string;
+  stream: HomepagePerpsStream;
+  source: HomepagePerpsDeliverySource;
+  /** Original source when this delivery wraps state already resident at demand. */
+  originSource?: HomepagePerpsDeliverySource;
+  itemCount: number;
+  receivedAtMonotonicMs: number;
+  subscriberDeliveredAtMonotonicMs?: number;
+  dataAgeMs: number;
+  lifecycle: HomepagePerformanceLifecycle;
+  accountGeneration: number;
+}
+
+export interface HomepagePerformanceDemand {
+  demandId: string;
+  startedAtMonotonicMs: number;
+  lifecycleStartedAtMonotonicMs: number;
+  lifecycle: HomepagePerformanceLifecycle;
+  firstVisibleRecorded: boolean;
+  firstFreshVisibleRecorded: boolean;
+  cachedVisibleAtMonotonicMs?: number;
+  cachedVisibleSource?: string;
+  recordedFreshPipelineStreams: Set<HomepagePerpsStream>;
+}
+
+type HomepagePerformanceStage =
+  | 'disk_cache_hydrated'
+  | 'viewport_demand'
+  | 'socket_received'
+  | 'cache_write'
+  | 'subscriber_delivery'
+  | 'react_commit'
+  | 'next_frame_checkpoint';
+
+let diskCacheTimestampMs: number | null = null;
+let firstDemand = true;
+let accountGeneration = 0;
+let lifecycle: HomepagePerformanceLifecycle = 'cold_no_cache';
+let lifecycleStartedAtMonotonicMs = performance.now();
+let backgroundStartedAt: number | null = null;
+const lifecycleListeners = new Set<() => void>();
+
+const log = (payload: Record<string, unknown>) => {
+  if (__DEV__) {
+    DevLogger.log(`[HomepagePerf] ${JSON.stringify(payload)}`);
+  }
+};
+
+export const logHomepagePerformanceStage = (
+  stage: HomepagePerformanceStage,
+  delivery?: HomepagePerpsDeliveryMetadata,
+  detail: Record<string, unknown> = {},
+) => {
+  log({
+    stage,
+    monotonic_ms: Number(performance.now().toFixed(3)),
+    ...(delivery && {
+      delivery_id: delivery.deliveryId,
+      stream: delivery.stream,
+      source: delivery.source,
+      ...(delivery.originSource && { origin_source: delivery.originSource }),
+      item_count: delivery.itemCount,
+      data_age_ms: Math.round(delivery.dataAgeMs),
+      lifecycle: delivery.lifecycle,
+      account_generation: delivery.accountGeneration,
+    }),
+    ...detail,
+  });
+};
+
+const notifyLifecycleChange = () =>
+  lifecycleListeners.forEach((listener) => listener());
+
+export const subscribeHomepagePerformanceLifecycleChange = (
+  listener: () => void,
+) => {
+  lifecycleListeners.add(listener);
+  return () => {
+    lifecycleListeners.delete(listener);
+  };
+};
+
+export const handleHomepagePerformanceAppStateChange = (
+  nextState: AppStateStatus,
+) => {
+  if (nextState === 'background' || nextState === 'inactive') {
+    backgroundStartedAt ??= performance.now();
+    return;
+  }
+  if (nextState !== 'active' || backgroundStartedAt === null) return;
+
+  const foregroundedAt = performance.now();
+  lifecycle =
+    foregroundedAt - backgroundStartedAt <
+    PERPS_CONSTANTS.ConnectionGracePeriodMs
+      ? 'background_short'
+      : 'background_reconnect';
+  lifecycleStartedAtMonotonicMs = foregroundedAt;
+  backgroundStartedAt = null;
+  notifyLifecycleChange();
+};
+
+export const wasHomepagePerpsDiskCacheHydrated = () =>
+  diskCacheTimestampMs !== null;
+export const getHomepagePerpsDiskCacheAgeMs = () =>
+  diskCacheTimestampMs === null
+    ? 0
+    : Math.max(0, Date.now() - diskCacheTimestampMs);
+
+export const markHomepagePerpsDiskCacheHydrated = (rawValue: string) => {
+  try {
+    const parsed = JSON.parse(rawValue) as {
+      timestamp?: number;
+      entries?: { timestamp?: number }[];
+    };
+    const timestamps = [
+      parsed.timestamp,
+      ...(parsed.entries?.map((entry) => entry.timestamp) ?? []),
+    ].filter((value): value is number => typeof value === 'number');
+    diskCacheTimestampMs =
+      timestamps.length > 0 ? Math.min(...timestamps) : null;
+  } catch {
+    diskCacheTimestampMs = null;
+  }
+  if (firstDemand) {
+    lifecycle = 'cold_disk_cache';
+    lifecycleStartedAtMonotonicMs = performance.now();
+  }
+  logHomepagePerformanceStage('disk_cache_hydrated', undefined, {
+    cache_age_ms: getHomepagePerpsDiskCacheAgeMs(),
+  });
+};
+
+const setLifecycle = (next: HomepagePerformanceLifecycle) => {
+  lifecycle = next;
+  lifecycleStartedAtMonotonicMs = performance.now();
+  notifyLifecycleChange();
+};
+
+export const markHomepagePerpsNavigateReturn = () =>
+  setLifecycle('navigate_return');
+export const markHomepagePerpsNetworkRecovery = () =>
+  setLifecycle('network_recovery');
+export const markHomepagePerpsAccountSwitch = () => {
+  accountGeneration += 1;
+  setLifecycle('account_switch');
+};
+
+export const createHomepagePerpsDelivery = ({
+  stream,
+  source,
+  itemCount,
+  dataAgeMs = 0,
+}: {
+  stream: HomepagePerpsStream;
+  source: HomepagePerpsDeliverySource;
+  itemCount: number;
+  dataAgeMs?: number;
+}): HomepagePerpsDeliveryMetadata => ({
+  deliveryId: uuidv4(),
+  stream,
+  source,
+  itemCount,
+  receivedAtMonotonicMs: performance.now(),
+  dataAgeMs,
+  lifecycle,
+  accountGeneration,
+});
+
+export const createHomepagePerpsResidentDelivery = ({
+  stream,
+  itemCount,
+  previousDelivery,
+}: {
+  stream: HomepagePerpsStream;
+  itemCount: number;
+  previousDelivery?: HomepagePerpsDeliveryMetadata;
+}): HomepagePerpsDeliveryMetadata => {
+  const now = performance.now();
+  return {
+    deliveryId: uuidv4(),
+    stream,
+    source: 'resident_state',
+    originSource: previousDelivery?.originSource ?? previousDelivery?.source,
+    itemCount,
+    receivedAtMonotonicMs: previousDelivery?.receivedAtMonotonicMs ?? now,
+    dataAgeMs: previousDelivery
+      ? previousDelivery.dataAgeMs +
+        now -
+        previousDelivery.receivedAtMonotonicMs
+      : 0,
+    lifecycle,
+    accountGeneration,
+  };
+};
+
+export const createHomepagePerformanceDemand =
+  (): HomepagePerformanceDemand => {
+    const demand = {
+      demandId: uuidv4(),
+      startedAtMonotonicMs: performance.now(),
+      lifecycleStartedAtMonotonicMs,
+      lifecycle,
+      firstVisibleRecorded: false,
+      firstFreshVisibleRecorded: false,
+      recordedFreshPipelineStreams: new Set<HomepagePerpsStream>(),
+    };
+    firstDemand = false;
+    logHomepagePerformanceStage('viewport_demand', undefined, {
+      demand_id: demand.demandId,
+      lifecycle: demand.lifecycle,
+    });
+    return demand;
+  };
+
+const recordTrace = ({
+  name,
+  start,
+  end,
+  tags,
+  data,
+}: {
+  name: TraceName;
+  start: number;
+  end: number;
+  tags: Record<string, string | boolean>;
+  data: Record<string, string | number | boolean>;
+}) => {
+  const id = uuidv4();
+  const endEpochMs = Date.now();
+  const startEpochMs = endEpochMs - Math.max(0, end - start);
+  trace({
+    name,
+    op: TraceOperation.PerpsHomepagePerformance,
+    id,
+    startTime: startEpochMs,
+    tags,
+  });
+  endTrace({ name, id, timestamp: endEpochMs, data });
+};
+
+const hasBothStreams = (deliveries: HomepagePerpsDeliveryMetadata[]) => {
+  const streams = new Set(deliveries.map(({ stream }) => stream));
+  return streams.has('positions') && streams.has('orders');
+};
+
+export const isHomepagePerpsDeliveryFreshForDemand = (
+  delivery: HomepagePerpsDeliveryMetadata,
+  demand: HomepagePerformanceDemand,
+) =>
+  delivery.receivedAtMonotonicMs >= demand.lifecycleStartedAtMonotonicMs &&
+  (delivery.source === 'fresh_socket' ||
+    (delivery.source === 'resident_state' &&
+      delivery.originSource === 'fresh_socket'));
+
+export const recordHomepagePerpsVisibleFrame = ({
+  demand,
+  deliveries,
+  contentVariant,
+  reactCommitAtMonotonicMs,
+  frameCheckpointAtMonotonicMs,
+}: {
+  demand: HomepagePerformanceDemand;
+  deliveries: HomepagePerpsDeliveryMetadata[];
+  contentVariant: HomepagePerpsContentVariant;
+  reactCommitAtMonotonicMs: number;
+  frameCheckpointAtMonotonicMs: number;
+}) => {
+  if (!hasBothStreams(deliveries)) return;
+
+  const sources = new Set(deliveries.map(({ source }) => source));
+  const deliverySource = sources.size === 1 ? deliveries[0].source : 'mixed';
+  const dataReadyAtDemand = deliveries.every(
+    ({ receivedAtMonotonicMs }) =>
+      receivedAtMonotonicMs <= demand.startedAtMonotonicMs,
+  );
+  const tags = {
+    lifecycle: demand.lifecycle,
+    content_variant: contentVariant,
+    delivery_source: deliverySource,
+    data_ready_at_demand: dataReadyAtDemand,
+    frame_boundary: 'next_frame_checkpoint',
+    success: true,
+  };
+
+  if (!demand.firstVisibleRecorded) {
+    recordTrace({
+      name: TraceName.HomepagePerpsTimeToFirstVisibleContent,
+      start: demand.startedAtMonotonicMs,
+      end: frameCheckpointAtMonotonicMs,
+      tags,
+      data: {
+        success: true,
+        max_data_age_ms: Math.round(
+          Math.max(...deliveries.map(({ dataAgeMs }) => dataAgeMs)),
+        ),
+      },
+    });
+    demand.firstVisibleRecorded = true;
+    if (
+      deliveries.some(
+        (delivery) => !isHomepagePerpsDeliveryFreshForDemand(delivery, demand),
+      )
+    ) {
+      demand.cachedVisibleAtMonotonicMs = frameCheckpointAtMonotonicMs;
+      demand.cachedVisibleSource = deliverySource;
+    }
+  }
+
+  deliveries.forEach((delivery) => {
+    if (
+      delivery.source !== 'fresh_socket' ||
+      delivery.receivedAtMonotonicMs <= demand.startedAtMonotonicMs ||
+      demand.recordedFreshPipelineStreams.has(delivery.stream)
+    ) {
+      return;
+    }
+    demand.recordedFreshPipelineStreams.add(delivery.stream);
+    const subscriberAt =
+      delivery.subscriberDeliveredAtMonotonicMs ??
+      delivery.receivedAtMonotonicMs;
+    recordTrace({
+      name: TraceName.HomepagePerpsSocketToVisible,
+      start: delivery.receivedAtMonotonicMs,
+      end: frameCheckpointAtMonotonicMs,
+      tags: {
+        ...tags,
+        delivery_source: 'fresh_socket',
+        stream: delivery.stream,
+      },
+      data: {
+        success: true,
+        receipt_to_subscriber_ms: subscriberAt - delivery.receivedAtMonotonicMs,
+        subscriber_to_react_commit_ms: reactCommitAtMonotonicMs - subscriberAt,
+        react_commit_to_frame_checkpoint_ms:
+          frameCheckpointAtMonotonicMs - reactCommitAtMonotonicMs,
+      },
+    });
+  });
+
+  const allFresh = deliveries.every((delivery) =>
+    isHomepagePerpsDeliveryFreshForDemand(delivery, demand),
+  );
+  if (!allFresh || demand.firstFreshVisibleRecorded) return;
+
+  const allFreshFromCurrentDelivery = deliveries.every(
+    ({ source }) => source === 'fresh_socket',
+  );
+
+  recordTrace({
+    name: TraceName.HomepagePerpsTimeToFreshVisibleData,
+    start: demand.startedAtMonotonicMs,
+    end: frameCheckpointAtMonotonicMs,
+    tags: {
+      ...tags,
+      delivery_source: allFreshFromCurrentDelivery
+        ? 'fresh_socket'
+        : deliverySource,
+      freshness_source: 'fresh_socket',
+    },
+    data: { success: true },
+  });
+  demand.firstFreshVisibleRecorded = true;
+
+  if (demand.cachedVisibleAtMonotonicMs !== undefined) {
+    recordTrace({
+      name: TraceName.HomepagePerpsCachedToFreshVisible,
+      start: demand.cachedVisibleAtMonotonicMs,
+      end: frameCheckpointAtMonotonicMs,
+      tags: {
+        ...tags,
+        delivery_source: 'fresh_socket',
+        cached_source: demand.cachedVisibleSource ?? 'mixed',
+      },
+      data: { success: true },
+    });
+  }
+};
+
+export const recordHomepagePerpsErrorFrame = ({
+  demand,
+  frameCheckpointAtMonotonicMs,
+}: {
+  demand: HomepagePerformanceDemand;
+  frameCheckpointAtMonotonicMs: number;
+}) => {
+  if (demand.firstVisibleRecorded) return;
+  recordTrace({
+    name: TraceName.HomepagePerpsTimeToFirstVisibleContent,
+    start: demand.startedAtMonotonicMs,
+    end: frameCheckpointAtMonotonicMs,
+    tags: {
+      lifecycle: demand.lifecycle,
+      content_variant: 'error',
+      delivery_source: 'none',
+      frame_boundary: 'next_frame_checkpoint',
+      success: false,
+    },
+    data: { success: false, reason: 'connection_error_visible' },
+  });
+  demand.firstVisibleRecorded = true;
+};
+
+export const markHomepagePerformanceFrameComplete = (
+  delivery: HomepagePerpsDeliveryMetadata,
+) => {
+  if (delivery.lifecycle === lifecycle) {
+    lifecycle = 'warm_foreground';
+    lifecycleStartedAtMonotonicMs = performance.now();
+  }
+};
+
+export const resetHomepagePerformanceProbeForTests = () => {
+  diskCacheTimestampMs = null;
+  firstDemand = true;
+  accountGeneration = 0;
+  lifecycle = 'cold_no_cache';
+  lifecycleStartedAtMonotonicMs = performance.now();
+  backgroundStartedAt = null;
+  lifecycleListeners.clear();
+};

--- a/app/components/UI/Perps/utils/perpsCufTrace.test.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.test.ts
@@ -38,6 +38,7 @@ import {
   markPerpsForegroundSettled,
   resetPerpsLifecycleContextForTests,
   PERPS_LIFECYCLE_CONTEXT,
+  PERPS_LIFECYCLE_DETAIL,
 } from './perpsLifecycleContext';
 
 jest.mock('../../../../util/trace', () => ({
@@ -99,6 +100,7 @@ describe('perpsCufTrace', () => {
           [PERPS_CUF_TAG.FEATURE]: PERPS_CONSTANTS.FeatureName,
           [PERPS_CUF_TAG.LIFECYCLE_CONTEXT]:
             PERPS_LIFECYCLE_CONTEXT.COLD_PROCESS,
+          [PERPS_CUF_TAG.LIFECYCLE_DETAIL]: PERPS_LIFECYCLE_DETAIL.COLD_PROCESS,
         }),
       }),
     );
@@ -127,6 +129,8 @@ describe('perpsCufTrace', () => {
         tags: {
           [PERPS_CUF_TAG.FEATURE]: PERPS_CONSTANTS.FeatureName,
           [PERPS_CUF_TAG.LIFECYCLE_CONTEXT]: PERPS_LIFECYCLE_CONTEXT.WARM,
+          [PERPS_CUF_TAG.LIFECYCLE_DETAIL]:
+            PERPS_LIFECYCLE_DETAIL.WARM_FOREGROUND,
           [PERPS_CUF_TAG.VARIANT]: PERPS_CUF_VARIANT.EMPTY,
         },
       }),

--- a/app/components/UI/Perps/utils/perpsCufTrace.ts
+++ b/app/components/UI/Perps/utils/perpsCufTrace.ts
@@ -18,6 +18,7 @@ import {
 } from '../constants/perpsCufTags';
 import {
   getPerpsLifecycleContext,
+  getPerpsLifecycleDetail,
   settlePerpsForegroundOnSpan,
 } from './perpsLifecycleContext';
 
@@ -120,6 +121,7 @@ export function buildPerpsCufStartTags(
   return {
     [PERPS_CUF_TAG.FEATURE]: PERPS_CONSTANTS.FeatureName,
     [PERPS_CUF_TAG.LIFECYCLE_CONTEXT]: getPerpsLifecycleContext(),
+    [PERPS_CUF_TAG.LIFECYCLE_DETAIL]: getPerpsLifecycleDetail(),
     ...extra,
   };
 }

--- a/app/components/UI/Perps/utils/perpsLifecycleContext.test.ts
+++ b/app/components/UI/Perps/utils/perpsLifecycleContext.test.ts
@@ -1,11 +1,15 @@
 import {
   getPerpsLifecycleContext,
+  getPerpsLifecycleDetail,
   handlePerpsAppStateChange,
   initPerpsLifecycleTracking,
   markPerpsForegroundSettled,
+  markPerpsNetworkRecovery,
+  markPerpsAccountSwitch,
   settlePerpsForegroundOnSpan,
   resetPerpsLifecycleContextForTests,
   PERPS_LIFECYCLE_CONTEXT,
+  PERPS_LIFECYCLE_DETAIL,
 } from './perpsLifecycleContext';
 import { TraceName } from '../../../../util/trace';
 import { AppState } from 'react-native';
@@ -19,12 +23,45 @@ describe('perpsLifecycleContext', () => {
     expect(getPerpsLifecycleContext()).toBe(
       PERPS_LIFECYCLE_CONTEXT.COLD_PROCESS,
     );
+    expect(getPerpsLifecycleDetail()).toBe(PERPS_LIFECYCLE_DETAIL.COLD_PROCESS);
   });
 
   it('becomes warm once the first foreground flow settles', () => {
     markPerpsForegroundSettled();
 
     expect(getPerpsLifecycleContext()).toBe(PERPS_LIFECYCLE_CONTEXT.WARM);
+    expect(getPerpsLifecycleDetail()).toBe(
+      PERPS_LIFECYCLE_DETAIL.WARM_FOREGROUND,
+    );
+  });
+
+  it.each([
+    [5_000, PERPS_LIFECYCLE_DETAIL.BACKGROUND_SHORT],
+    [25_000, PERPS_LIFECYCLE_DETAIL.BACKGROUND_RECONNECT],
+  ] as const)(
+    'records detailed lifecycle for a %i ms background interval',
+    (foregroundAt, expectedDetail) => {
+      handlePerpsAppStateChange('active', 'unknown', 0);
+      handlePerpsAppStateChange('background', 'active', 1_000);
+      handlePerpsAppStateChange('active', 'background', 1_000 + foregroundAt);
+
+      expect(getPerpsLifecycleContext()).toBe(
+        PERPS_LIFECYCLE_CONTEXT.BACKGROUND_RESUME,
+      );
+      expect(getPerpsLifecycleDetail()).toBe(expectedDetail);
+    },
+  );
+
+  it('records network recovery and account switch detail', () => {
+    markPerpsNetworkRecovery();
+    expect(getPerpsLifecycleDetail()).toBe(
+      PERPS_LIFECYCLE_DETAIL.NETWORK_RECOVERY,
+    );
+
+    markPerpsAccountSwitch();
+    expect(getPerpsLifecycleDetail()).toBe(
+      PERPS_LIFECYCLE_DETAIL.ACCOUNT_SWITCH,
+    );
   });
 
   it('tags background_resume when returning to active from background', () => {

--- a/app/components/UI/Perps/utils/perpsLifecycleContext.ts
+++ b/app/components/UI/Perps/utils/perpsLifecycleContext.ts
@@ -1,4 +1,6 @@
 import { AppState, type AppStateStatus } from 'react-native';
+import performance from 'react-native-performance';
+import { PERPS_CONSTANTS } from '@metamask/perps-controller';
 import { TraceName } from '../../../../util/trace';
 
 /**
@@ -15,16 +17,36 @@ export const PERPS_LIFECYCLE_CONTEXT = {
 export type PerpsLifecycleContext =
   (typeof PERPS_LIFECYCLE_CONTEXT)[keyof typeof PERPS_LIFECYCLE_CONTEXT];
 
+export const PERPS_LIFECYCLE_DETAIL = {
+  COLD_PROCESS: 'cold_process',
+  WARM_FOREGROUND: 'warm_foreground',
+  BACKGROUND_SHORT: 'background_short',
+  BACKGROUND_RECONNECT: 'background_reconnect',
+  NETWORK_RECOVERY: 'network_recovery',
+  ACCOUNT_SWITCH: 'account_switch',
+} as const;
+
+export type PerpsLifecycleDetail =
+  (typeof PERPS_LIFECYCLE_DETAIL)[keyof typeof PERPS_LIFECYCLE_DETAIL];
+
 // Module load == process start.
 let currentContext: PerpsLifecycleContext =
   PERPS_LIFECYCLE_CONTEXT.COLD_PROCESS;
+let currentDetail: PerpsLifecycleDetail = PERPS_LIFECYCLE_DETAIL.COLD_PROCESS;
 let hasEnteredForegroundOnce = false;
+let backgroundStartedAt: number | null = null;
 
 /** Update context from an AppState transition. Exported for tests. */
 export function handlePerpsAppStateChange(
   nextState: AppStateStatus,
   previousState: AppStateStatus,
+  now = performance.now(),
 ): void {
+  if (nextState === 'background' || nextState === 'inactive') {
+    backgroundStartedAt ??= now;
+    return;
+  }
+
   if (nextState !== 'active') {
     return;
   }
@@ -33,13 +55,31 @@ export function handlePerpsAppStateChange(
     (previousState === 'background' || previousState === 'inactive')
   ) {
     currentContext = PERPS_LIFECYCLE_CONTEXT.BACKGROUND_RESUME;
+    const backgroundDurationMs =
+      backgroundStartedAt === null
+        ? PERPS_CONSTANTS.ConnectionGracePeriodMs
+        : Math.max(0, now - backgroundStartedAt);
+    currentDetail =
+      backgroundDurationMs < PERPS_CONSTANTS.ConnectionGracePeriodMs
+        ? PERPS_LIFECYCLE_DETAIL.BACKGROUND_SHORT
+        : PERPS_LIFECYCLE_DETAIL.BACKGROUND_RECONNECT;
   }
+  backgroundStartedAt = null;
   hasEnteredForegroundOnce = true;
 }
 
 /** Mark the current foreground's first flow done; later flows read as warm. */
 export function markPerpsForegroundSettled(): void {
   currentContext = PERPS_LIFECYCLE_CONTEXT.WARM;
+  currentDetail = PERPS_LIFECYCLE_DETAIL.WARM_FOREGROUND;
+}
+
+export function markPerpsNetworkRecovery(): void {
+  currentDetail = PERPS_LIFECYCLE_DETAIL.NETWORK_RECOVERY;
+}
+
+export function markPerpsAccountSwitch(): void {
+  currentDetail = PERPS_LIFECYCLE_DETAIL.ACCOUNT_SWITCH;
 }
 
 /**
@@ -78,6 +118,10 @@ export function getPerpsLifecycleContext(): PerpsLifecycleContext {
   return currentContext;
 }
 
+export function getPerpsLifecycleDetail(): PerpsLifecycleDetail {
+  return currentDetail;
+}
+
 let subscription: { remove: () => void } | undefined;
 
 /** Subscribe to AppState so background_resume is detected. Idempotent. */
@@ -105,7 +149,9 @@ export function initPerpsLifecycleTracking(): () => void {
 /** Test-only reset. */
 export function resetPerpsLifecycleContextForTests(): void {
   currentContext = PERPS_LIFECYCLE_CONTEXT.COLD_PROCESS;
+  currentDetail = PERPS_LIFECYCLE_DETAIL.COLD_PROCESS;
   hasEnteredForegroundOnce = false;
+  backgroundStartedAt = null;
   subscription?.remove();
   subscription = undefined;
 }

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -264,6 +264,10 @@ export enum TraceName {
   // Homepage Section Performance
   HomepageSectionTimeToContent = 'Homepage Section Time To Content',
   HomepageSectionDataFetch = 'Homepage Section Data Fetch',
+  HomepagePerpsTimeToFirstVisibleContent = 'Homepage Perps Time To First Visible Content',
+  HomepagePerpsTimeToFreshVisibleData = 'Homepage Perps Time To Fresh Visible Data',
+  HomepagePerpsSocketToVisible = 'Homepage Perps Socket To Visible',
+  HomepagePerpsCachedToFreshVisible = 'Homepage Perps Cached To Fresh Visible',
   // Money Home Performance
   MoneyHomeTimeToContent = 'Money Home Time To Content',
   MoneyHomeBalanceTimeToContent = 'Money Home Balance Time To Content',
@@ -330,6 +334,7 @@ export enum TraceOperation {
   MarketInsightsViewportTracking = 'market_insights.viewport_tracking',
   // Homepage Section Performance
   HomepageSectionPerformance = 'homepage.section.performance',
+  PerpsHomepagePerformance = 'perps.homepage.performance',
   // Money Home Performance
   MoneyHomePerformance = 'money.home.performance',
   MoneyAccountDataFetch = 'money.account.data_fetch',


### PR DESCRIPTION
## Summary

Adds the reusable measurement pipeline for Perps Homepage visible performance:

- lifecycle/source/content classification;
- correlated demand, delivery, commit, and next-frame checkpoints;
- TTC, DFD, socket-to-visible, and cached-to-fresh span construction;
- bounded development markers used by the device recipe validator.

This is instrumentation only. It does not change stream delivery, Homepage rendering, or the shared Homepage Sentry dashboard.

## Stack

- Base: #34505 (`fix/perps-homepage-order-continuity`)
- This PR: measurement contract and probe
- Next: #34506, reduced to stream/UI integration after this PR

## Why split

The original #34506 diff exceeded the repository's 1,000-line gate. This extraction is 954 additions / 1 deletion and leaves the existing behavior/evidence unchanged while giving the measurement state machine an independent review boundary.

## Validation

- `homepagePerformanceProbe`, lifecycle-context, CUF-trace, mobile-infrastructure, and first WebSocket trace-tag tests pass.
- Physical Android and iOS lifecycle recipes correlate socket/cache/subscriber/commit/frame markers.
- iOS short background, long reconnect, cold/no-cache, and cold/disk-cache recipe values match project `2651591` development Sentry rows within `0.007 ms` once the stacked UI integration and span-attribute fix are present.

## Test scenario

```gherkin
Given a Perps Homepage demand with lifecycle and delivery metadata
When cached or fresh stream data reaches React commit and the next visible frame
Then the probe emits only the correlated TTC/DFD and pipeline measurements
And success, lifecycle, source, content, stream, and release dimensions remain explicit
```
