### PR TITLE
fix(perps): use recorded fees for historical orders

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -193,6 +193,8 @@ jest.mock('../../hooks/usePerpsMarketFills', () => ({
   usePerpsMarketFills: jest.fn(() => ({
     fills: [],
     isInitialLoading: false,
+    isHistoryLoading: false,
+    historyError: null,
     refresh: jest.fn(),
     isRefreshing: false,
   })),

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -193,8 +193,7 @@ jest.mock('../../hooks/usePerpsMarketFills', () => ({
   usePerpsMarketFills: jest.fn(() => ({
     fills: [],
     isInitialLoading: false,
-    isHistoryLoading: false,
-    historyError: null,
+    restHistoryStatus: 'ready',
     refresh: jest.fn(),
     isRefreshing: false,
   })),

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.test.tsx
@@ -6,7 +6,7 @@ import PerpsOrderTransactionView from './PerpsOrderTransactionView';
 import {
   usePerpsBlockExplorerUrl,
   usePerpsNetwork,
-  usePerpsOrderFees,
+  usePerpsRecordedOrderFees,
 } from '../../hooks';
 import { PerpsTransactionSelectorsIDs } from '../../Perps.testIds';
 
@@ -19,6 +19,7 @@ const mockTransaction = {
   timestamp: 1640995200000,
   asset: 'ETH',
   order: {
+    orderId: 'order-123',
     text: 'Filled',
     statusType: 'filled' as const,
     type: 'limit',
@@ -48,7 +49,7 @@ jest.mock('../../../../../selectors/multichainAccounts/accounts', () => ({
 
 jest.mock('../../hooks', () => ({
   usePerpsNetwork: jest.fn(),
-  usePerpsOrderFees: jest.fn(),
+  usePerpsRecordedOrderFees: jest.fn(),
   usePerpsBlockExplorerUrl: jest.fn(),
 }));
 
@@ -56,9 +57,10 @@ describe('PerpsOrderTransactionView', () => {
   const mockUsePerpsNetwork = usePerpsNetwork as jest.MockedFunction<
     typeof usePerpsNetwork
   >;
-  const mockUsePerpsOrderFees = usePerpsOrderFees as jest.MockedFunction<
-    typeof usePerpsOrderFees
-  >;
+  const mockUsePerpsRecordedOrderFees =
+    usePerpsRecordedOrderFees as jest.MockedFunction<
+      typeof usePerpsRecordedOrderFees
+    >;
   const mockUsePerpsBlockExplorerUrl =
     usePerpsBlockExplorerUrl as jest.MockedFunction<
       typeof usePerpsBlockExplorerUrl
@@ -86,15 +88,10 @@ describe('PerpsOrderTransactionView', () => {
       }),
       baseExplorerUrl: 'https://app.hyperliquid.xyz/explorer',
     });
-    mockUsePerpsOrderFees.mockReturnValue({
+    mockUsePerpsRecordedOrderFees.mockReturnValue({
       totalFee: 10.5,
-      undiscountedTotalFee: 10.5,
-      protocolFee: 7.5,
-      metamaskFee: 3,
-      protocolFeeRate: 0.1,
-      metamaskFeeRate: 0.05,
-      isLoadingMetamaskFee: false,
-      error: null,
+      isLoading: false,
+      hasError: false,
     });
 
     // Mock the route params
@@ -127,189 +124,64 @@ describe('PerpsOrderTransactionView', () => {
     expect(getByText('100%')).toBeTruthy();
   });
 
-  it('renders fee breakdown correctly', () => {
+  it('renders one total fee row from recorded fills', () => {
+    const { getByText, queryByText } = render(<PerpsOrderTransactionView />);
+
+    expect(getByText('Total fee')).toBeTruthy();
+    expect(getByText('$10.5')).toBeTruthy();
+    expect(queryByText('MetaMask fee')).toBeNull();
+    expect(queryByText('Hyperliquid fee')).toBeNull();
+  });
+
+  it('renders zero after a completed lookup finds no fills', () => {
+    mockUsePerpsRecordedOrderFees.mockReturnValue({
+      totalFee: 0,
+      isLoading: false,
+      hasError: false,
+    });
+
     const { getByText } = render(<PerpsOrderTransactionView />);
 
-    expect(getByText('MetaMask fee')).toBeTruthy();
-    expect(getByText('Hyperliquid fee')).toBeTruthy();
-    expect(getByText('Total fee')).toBeTruthy();
-    expect(getByText('$3')).toBeTruthy();
-    expect(getByText('$7.5')).toBeTruthy(); // Trailing zero stripped
-    expect(getByText('$10.5')).toBeTruthy(); // Trailing zero stripped
+    expect(getByText('$0')).toBeTruthy();
   });
 
-  it('shows zero fees when order is not filled', () => {
-    const unfilledTransaction = {
-      ...mockTransaction,
-      order: {
-        ...mockTransaction.order,
-        text: 'Canceled',
-        statusType: 'canceled' as const,
-      },
-    };
-
-    mockUseRoute.mockReturnValue({
-      params: { transaction: unfilledTransaction },
+  it('renders a placeholder while recorded fills are loading', () => {
+    mockUsePerpsRecordedOrderFees.mockReturnValue({
+      totalFee: undefined,
+      isLoading: true,
+      hasError: false,
     });
 
-    const { getAllByText } = render(<PerpsOrderTransactionView />);
+    const { getByText, queryByText } = render(<PerpsOrderTransactionView />);
 
-    const zeroFees = getAllByText('$0');
-    expect(zeroFees).toHaveLength(3); // All three fees should be $0
+    expect(getByText('—')).toBeTruthy();
+    expect(queryByText('$0')).toBeNull();
   });
 
-  it('shows exact fee values for fees less than 0.01', () => {
-    mockUsePerpsOrderFees.mockReturnValue({
+  it('renders a placeholder when recorded fills are unavailable', () => {
+    mockUsePerpsRecordedOrderFees.mockReturnValue({
+      totalFee: undefined,
+      isLoading: false,
+      hasError: true,
+    });
+
+    const { getByText, queryByText } = render(<PerpsOrderTransactionView />);
+
+    expect(getByText('—')).toBeTruthy();
+    expect(queryByText('$0')).toBeNull();
+  });
+
+  it('shows exact recorded fee values below 0.01', () => {
+    mockUsePerpsRecordedOrderFees.mockReturnValue({
       totalFee: 0.005,
-      undiscountedTotalFee: 0.005,
-      protocolFee: 0.003,
-      metamaskFee: 0.002,
-      protocolFeeRate: 0.1,
-      metamaskFeeRate: 0.05,
-      isLoadingMetamaskFee: false,
-      error: null,
+      isLoading: false,
+      hasError: false,
     });
 
     const { getByText, queryByText } = render(<PerpsOrderTransactionView />);
 
-    // All three fees should show exact values, not "< $0.01"
     expect(queryByText('< $0.01')).toBeNull();
-    expect(getByText('$0.005')).toBeTruthy(); // Total fee
-    expect(getByText('$0.003')).toBeTruthy(); // Protocol fee
-    expect(getByText('$0.002')).toBeTruthy(); // MetaMask fee
-  });
-
-  it('formats fees normally when they are exactly 0.01', () => {
-    mockUsePerpsOrderFees.mockReturnValue({
-      totalFee: 0.03,
-      undiscountedTotalFee: 0.03,
-      protocolFee: 0.01,
-      metamaskFee: 0.01,
-      protocolFeeRate: 0.1,
-      metamaskFeeRate: 0.05,
-      isLoadingMetamaskFee: false,
-      error: null,
-    });
-
-    const { getAllByText, queryByText, getByText } = render(
-      <PerpsOrderTransactionView />,
-    );
-
-    // Fees at exactly 0.01 should be formatted normally, not show "< $0.01"
-    expect(queryByText('< $0.01')).toBeNull();
-    // Both metamask and protocol fees are 0.01
-    const fee01Labels = getAllByText('$0.01');
-    expect(fee01Labels.length).toBeGreaterThanOrEqual(2);
-    expect(getByText('$0.03')).toBeTruthy(); // Total fee
-  });
-
-  it('formats fees with exact values regardless of size', () => {
-    mockUsePerpsOrderFees.mockReturnValue({
-      totalFee: 0.015,
-      undiscountedTotalFee: 0.015,
-      protocolFee: 0.012,
-      metamaskFee: 0.003,
-      protocolFeeRate: 0.1,
-      metamaskFeeRate: 0.05,
-      isLoadingMetamaskFee: false,
-      error: null,
-    });
-
-    const { getByText, queryByText } = render(<PerpsOrderTransactionView />);
-
-    // All fees should show exact values, not "< $0.01"
-    expect(queryByText('< $0.01')).toBeNull();
-    expect(getByText('$0.003')).toBeTruthy(); // MetaMask fee (exact)
-    expect(getByText('$0.012')).toBeTruthy(); // Protocol fee (exact)
-    expect(getByText('$0.015')).toBeTruthy(); // Total fee (exact)
-  });
-
-  it('handles mixed small and large fees correctly with exact values', () => {
-    mockUsePerpsOrderFees.mockReturnValue({
-      totalFee: 0.025,
-      undiscountedTotalFee: 0.025,
-      protocolFee: 0.02,
-      metamaskFee: 0.005,
-      protocolFeeRate: 0.1,
-      metamaskFeeRate: 0.05,
-      isLoadingMetamaskFee: false,
-      error: null,
-    });
-
-    const { getByText, queryByText } = render(<PerpsOrderTransactionView />);
-
-    // All fees should show exact values
-    expect(queryByText('< $0.01')).toBeNull();
-    expect(getByText('$0.005')).toBeTruthy(); // MetaMask fee (exact)
-    expect(getByText('$0.02')).toBeTruthy(); // Protocol fee
-    expect(getByText('$0.025')).toBeTruthy(); // Total fee (exact)
-  });
-
-  it('handles edge case: fee just below 0.01 threshold with exact values', () => {
-    mockUsePerpsOrderFees.mockReturnValue({
-      totalFee: 0.029,
-      undiscountedTotalFee: 0.029,
-      protocolFee: 0.0099,
-      metamaskFee: 0.0099,
-      protocolFeeRate: 0.1,
-      metamaskFeeRate: 0.05,
-      isLoadingMetamaskFee: false,
-      error: null,
-    });
-
-    const { getByText, getAllByText, queryByText } = render(
-      <PerpsOrderTransactionView />,
-    );
-
-    // All fees should show exact values, not "< $0.01"
-    expect(queryByText('< $0.01')).toBeNull();
-    // Both metamask and protocol fees show exact value
-    const fee0099Labels = getAllByText('$0.0099');
-    expect(fee0099Labels).toHaveLength(2);
-    // Total fee shows exact value
-    expect(getByText('$0.029')).toBeTruthy();
-  });
-
-  it('handles edge case: fee just above 0.01 threshold with exact values', () => {
-    mockUsePerpsOrderFees.mockReturnValue({
-      totalFee: 0.0201,
-      undiscountedTotalFee: 0.0201,
-      protocolFee: 0.0101,
-      metamaskFee: 0.01,
-      protocolFeeRate: 0.1,
-      metamaskFeeRate: 0.05,
-      isLoadingMetamaskFee: false,
-      error: null,
-    });
-
-    const { queryByText, getByText } = render(<PerpsOrderTransactionView />);
-
-    // All fees should show exact values, not "< $0.01"
-    expect(queryByText('< $0.01')).toBeNull();
-    expect(getByText('$0.01')).toBeTruthy(); // MetaMask fee (exact)
-    expect(getByText('$0.0101')).toBeTruthy(); // Protocol fee (exact)
-    expect(getByText('$0.0201')).toBeTruthy(); // Total fee (exact)
-  });
-
-  it('shows exact values for all fees when all are below 0.01', () => {
-    mockUsePerpsOrderFees.mockReturnValue({
-      totalFee: 0.008,
-      undiscountedTotalFee: 0.008,
-      protocolFee: 0.005,
-      metamaskFee: 0.003,
-      protocolFeeRate: 0.1,
-      metamaskFeeRate: 0.05,
-      isLoadingMetamaskFee: false,
-      error: null,
-    });
-
-    const { getByText, queryByText } = render(<PerpsOrderTransactionView />);
-
-    // All three fees should show exact values, not "< $0.01"
-    expect(queryByText('< $0.01')).toBeNull();
-    expect(getByText('$0.008')).toBeTruthy(); // Total fee
-    expect(getByText('$0.005')).toBeTruthy(); // Protocol fee
-    expect(getByText('$0.003')).toBeTruthy(); // MetaMask fee
+    expect(getByText('$0.005')).toBeTruthy();
   });
 
   it('navigates to block explorer in browser tab when button is pressed', () => {
@@ -413,11 +285,10 @@ describe('PerpsOrderTransactionView', () => {
 
     render(<PerpsOrderTransactionView />);
 
-    // Should still render without errors for market orders
-    expect(mockUsePerpsOrderFees).toHaveBeenCalledWith({
-      orderType: 'market',
-      amount: '3000',
-    });
+    expect(mockUsePerpsRecordedOrderFees).toHaveBeenCalledWith(
+      'order-123',
+      'ETH',
+    );
   });
 
   it('handles missing order data gracefully', () => {
@@ -432,10 +303,10 @@ describe('PerpsOrderTransactionView', () => {
 
     render(<PerpsOrderTransactionView />);
 
-    expect(mockUsePerpsOrderFees).toHaveBeenCalledWith({
-      orderType: 'market',
-      amount: '0',
-    });
+    expect(mockUsePerpsRecordedOrderFees).toHaveBeenCalledWith(
+      undefined,
+      'ETH',
+    );
   });
 
   it('displays exact price for low-priced assets like PUMP instead of "< $0.01"', () => {
@@ -465,13 +336,13 @@ describe('PerpsOrderTransactionView', () => {
     expect(getByText('$0.00234')).toBeTruthy();
   });
 
-  it('calls usePerpsOrderFees with correct parameters', () => {
+  it('looks up recorded fees with the order ID and asset', () => {
     render(<PerpsOrderTransactionView />);
 
-    expect(mockUsePerpsOrderFees).toHaveBeenCalledWith({
-      orderType: 'limit',
-      amount: '3000',
-    });
+    expect(mockUsePerpsRecordedOrderFees).toHaveBeenCalledWith(
+      'order-123',
+      'ETH',
+    );
   });
 
   it('sets correct navigation options', () => {

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.test.tsx
@@ -288,6 +288,7 @@ describe('PerpsOrderTransactionView', () => {
     expect(mockUsePerpsRecordedOrderFees).toHaveBeenCalledWith(
       'order-123',
       'ETH',
+      1640995200000,
     );
   });
 
@@ -306,6 +307,7 @@ describe('PerpsOrderTransactionView', () => {
     expect(mockUsePerpsRecordedOrderFees).toHaveBeenCalledWith(
       undefined,
       'ETH',
+      1640995200000,
     );
   });
 
@@ -342,6 +344,7 @@ describe('PerpsOrderTransactionView', () => {
     expect(mockUsePerpsRecordedOrderFees).toHaveBeenCalledWith(
       'order-123',
       'ETH',
+      1640995200000,
     );
   });
 

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.test.tsx
@@ -31,6 +31,12 @@ const mockTransaction = {
 
 const mockUseNavigation = jest.fn();
 const mockUseRoute = jest.fn();
+const mockPerpsConnectionProvider = jest.fn(
+  ({ children }: { children: React.ReactNode }) => <>{children}</>,
+);
+const mockPerpsStreamProvider = jest.fn(
+  ({ children }: { children: React.ReactNode }) => <>{children}</>,
+);
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => mockUseNavigation(),
@@ -51,6 +57,16 @@ jest.mock('../../hooks', () => ({
   usePerpsNetwork: jest.fn(),
   usePerpsRecordedOrderFees: jest.fn(),
   usePerpsBlockExplorerUrl: jest.fn(),
+}));
+
+jest.mock('../../providers/PerpsConnectionProvider', () => ({
+  PerpsConnectionProvider: ({ children }: { children: React.ReactNode }) =>
+    mockPerpsConnectionProvider({ children }),
+}));
+
+jest.mock('../../providers/PerpsStreamManager', () => ({
+  PerpsStreamProvider: ({ children }: { children: React.ReactNode }) =>
+    mockPerpsStreamProvider({ children }),
 }));
 
 describe('PerpsOrderTransactionView', () => {
@@ -122,6 +138,13 @@ describe('PerpsOrderTransactionView', () => {
     expect(getByText('Limit price')).toBeTruthy();
     expect(getByText('Filled')).toBeTruthy();
     expect(getByText('100%')).toBeTruthy();
+  });
+
+  it('provides connection and stream contexts without an external wrapper', () => {
+    render(<PerpsOrderTransactionView />);
+
+    expect(mockPerpsConnectionProvider).toHaveBeenCalledTimes(1);
+    expect(mockPerpsStreamProvider).toHaveBeenCalledTimes(1);
   });
 
   it('renders one total fee row from recorded fills', () => {

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.tsx
@@ -54,6 +54,7 @@ const PerpsOrderTransactionView: React.FC = () => {
   } = usePerpsRecordedOrderFees(
     transaction?.order?.orderId,
     transaction?.asset ?? '',
+    transaction?.timestamp,
   );
 
   useLayoutEffect(() => {

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.tsx
@@ -20,7 +20,10 @@ import { useStyles } from '../../../../../component-library/hooks';
 import { selectSelectedInternalAccountByScope } from '../../../../../selectors/multichainAccounts/accounts';
 import ScreenView from '../../../../Base/ScreenView';
 import PerpsTransactionDetailAssetHero from '../../components/PerpsTransactionDetailAssetHero';
-import { usePerpsBlockExplorerUrl, usePerpsOrderFees } from '../../hooks';
+import {
+  usePerpsBlockExplorerUrl,
+  usePerpsRecordedOrderFees,
+} from '../../hooks';
 import { PerpsOrderTransactionRouteProp } from '../../types/transactionHistory';
 import {
   formatPerpsFiat,
@@ -44,10 +47,14 @@ const PerpsOrderTransactionView: React.FC = () => {
   const transaction = route.params?.transaction;
 
   // Call hooks before conditional return
-  const { totalFee, protocolFee, metamaskFee } = usePerpsOrderFees({
-    orderType: transaction?.order?.type ?? 'market',
-    amount: transaction?.order?.size ?? '0',
-  });
+  const {
+    totalFee,
+    isLoading: isFeeLoading,
+    hasError: hasFeeError,
+  } = usePerpsRecordedOrderFees(
+    transaction?.order?.orderId,
+    transaction?.asset ?? '',
+  );
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -110,24 +117,19 @@ const PerpsOrderTransactionView: React.FC = () => {
     },
   ];
 
-  const isFilled = transaction.order?.text === 'Filled';
-
-  // Fee breakdown - use PRICE_RANGES_UNIVERSAL to show exact values instead of "< $0.01"
+  // Use universal ranges to show the exact recorded fee instead of "< $0.01".
   const formatFee = (fee: number) =>
     formatPerpsFiat(fee, { ranges: PRICE_RANGES_UNIVERSAL });
 
+  const feeValue =
+    isFeeLoading || hasFeeError || totalFee === undefined
+      ? '—'
+      : formatFee(totalFee);
+
   const feeRows = [
     {
-      label: strings('perps.transactions.order.metamask_fee'),
-      value: formatFee(isFilled ? metamaskFee : 0),
-    },
-    {
-      label: strings('perps.transactions.order.hyperliquid_fee'),
-      value: formatFee(isFilled ? protocolFee : 0),
-    },
-    {
       label: strings('perps.transactions.order.total_fee'),
-      value: formatFee(isFilled ? totalFee : 0),
+      value: feeValue,
     },
   ];
 
@@ -176,7 +178,7 @@ const PerpsOrderTransactionView: React.FC = () => {
             {/* Separator between sections */}
             <View style={styles.sectionSeparator} />
 
-            {/* Fee breakdown */}
+            {/* Recorded execution fee */}
             {feeRows.map((detail, index) => (
               <View
                 key={`fee-${index}`}

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.tsx
@@ -33,8 +33,10 @@ import {
 import { styleSheet } from './PerpsOrderTransactionView.styles';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { trackBlockExplorerLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
+import { PerpsConnectionProvider } from '../../providers/PerpsConnectionProvider';
+import { PerpsStreamProvider } from '../../providers/PerpsStreamManager';
 
-const PerpsOrderTransactionView: React.FC = () => {
+const PerpsOrderTransactionViewContent: React.FC = () => {
   const { styles } = useStyles(styleSheet, {});
   const navigation = useNavigation<AppNavigationProp>();
   const { trackEvent, createEventBuilder } = useAnalytics();
@@ -220,5 +222,13 @@ const PerpsOrderTransactionView: React.FC = () => {
     </ScreenView>
   );
 };
+
+const PerpsOrderTransactionView: React.FC = () => (
+  <PerpsConnectionProvider suppressErrorView>
+    <PerpsStreamProvider>
+      <PerpsOrderTransactionViewContent />
+    </PerpsStreamProvider>
+  </PerpsConnectionProvider>
+);
 
 export default PerpsOrderTransactionView;

--- a/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.test.tsx
@@ -24,6 +24,8 @@ jest.mock('../../hooks/usePerpsMarketFills', () => ({
   usePerpsMarketFills: jest.fn(() => ({
     fills: [],
     isInitialLoading: false,
+    isHistoryLoading: false,
+    historyError: null,
     refresh: jest.fn(),
     isRefreshing: false,
   })),
@@ -173,6 +175,8 @@ describe('PerpsMarketTradesList', () => {
   ) => ({
     fills,
     isInitialLoading,
+    isHistoryLoading: false,
+    historyError: null,
     refresh: jest.fn(),
     isRefreshing: false,
   });

--- a/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.test.tsx
@@ -24,8 +24,7 @@ jest.mock('../../hooks/usePerpsMarketFills', () => ({
   usePerpsMarketFills: jest.fn(() => ({
     fills: [],
     isInitialLoading: false,
-    isHistoryLoading: false,
-    historyError: null,
+    restHistoryStatus: 'ready',
     refresh: jest.fn(),
     isRefreshing: false,
   })),
@@ -175,8 +174,7 @@ describe('PerpsMarketTradesList', () => {
   ) => ({
     fills,
     isInitialLoading,
-    isHistoryLoading: false,
-    historyError: null,
+    restHistoryStatus: 'ready' as const,
     refresh: jest.fn(),
     isRefreshing: false,
   });

--- a/app/components/UI/Perps/hooks/index.ts
+++ b/app/components/UI/Perps/hooks/index.ts
@@ -90,6 +90,7 @@ export { default as usePerpsToasts } from './usePerpsToasts';
 // Transaction data hooks
 export { usePerpsOrderFills } from './usePerpsOrderFills';
 export { usePerpsMarketFills } from './usePerpsMarketFills';
+export { usePerpsRecordedOrderFees } from './usePerpsRecordedOrderFees';
 export { usePerpsOrders } from './usePerpsOrders';
 export { usePerpsFunding } from './usePerpsFunding';
 export { useWithdrawalRequests } from './useWithdrawalRequests';

--- a/app/components/UI/Perps/hooks/usePerpsMarketFills.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketFills.test.ts
@@ -135,6 +135,8 @@ describe('usePerpsMarketFills', () => {
       // Assert
       expect(result.current.fills).toEqual([]);
       expect(result.current.isInitialLoading).toBe(false);
+      expect(result.current.isHistoryLoading).toBe(true);
+      expect(result.current.historyError).toBeNull();
       expect(result.current.isRefreshing).toBe(false);
     });
 
@@ -152,6 +154,22 @@ describe('usePerpsMarketFills', () => {
 
       // Assert
       expect(result.current.isInitialLoading).toBe(true);
+    });
+
+    it('clears historical loading after the REST backfill completes', async () => {
+      // Arrange
+      mockProvider.getOrderFills.mockResolvedValue([]);
+
+      // Act
+      const { result } = renderHook(() =>
+        usePerpsMarketFills({ symbol: 'BTC' }),
+      );
+
+      // Assert
+      await waitFor(() => {
+        expect(result.current.isHistoryLoading).toBe(false);
+      });
+      expect(result.current.historyError).toBeNull();
     });
   });
 
@@ -467,6 +485,8 @@ describe('usePerpsMarketFills', () => {
         );
       });
       expect(result.current.fills).toHaveLength(1);
+      expect(result.current.isHistoryLoading).toBe(false);
+      expect(result.current.historyError).toBe('API Error');
     });
 
     it('handles missing provider gracefully', async () => {
@@ -486,8 +506,12 @@ describe('usePerpsMarketFills', () => {
         usePerpsMarketFills({ symbol: 'BTC' }),
       );
 
-      // Assert - should work with just WebSocket fills
+      // Assert - should work with just WebSocket fills and report unavailable history
       expect(result.current.fills).toHaveLength(1);
+      await waitFor(() => {
+        expect(result.current.isHistoryLoading).toBe(false);
+      });
+      expect(result.current.historyError).toBe('No active Perps provider');
     });
   });
 

--- a/app/components/UI/Perps/hooks/usePerpsMarketFills.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketFills.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import { usePerpsMarketFills } from './usePerpsMarketFills';
 import { usePerpsLiveFills } from './stream';
+import { usePerpsConnection } from './usePerpsConnection';
 import Engine from '../../../../core/Engine';
 import { PERPS_CONSTANTS, type OrderFill } from '@metamask/perps-controller';
 
@@ -16,6 +17,18 @@ jest.mock('react-redux', () => ({
 
 jest.mock('./stream', () => ({
   usePerpsLiveFills: jest.fn(),
+}));
+
+jest.mock('./usePerpsConnection', () => ({
+  usePerpsConnection: jest.fn(() => ({
+    isConnected: true,
+    isInitialized: true,
+    isConnecting: false,
+    error: null,
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    resetError: jest.fn(),
+  })),
 }));
 
 jest.mock('../../../../core/Engine', () => ({
@@ -38,6 +51,10 @@ const mockUsePerpsLiveFills = usePerpsLiveFills as jest.MockedFunction<
 >;
 
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+
+const mockUsePerpsConnection = usePerpsConnection as jest.MockedFunction<
+  typeof usePerpsConnection
+>;
 
 const mockGetActiveProviderOrNull = Engine.context.PerpsController
   .getActiveProviderOrNull as jest.MockedFunction<
@@ -103,6 +120,15 @@ describe('usePerpsMarketFills', () => {
     jest.clearAllMocks();
     mockSelectedAccountByScope.mockReturnValue({ address: '0xAccount1' });
     mockUseSelector.mockImplementation(() => mockSelectedAccountByScope);
+    mockUsePerpsConnection.mockReturnValue({
+      isConnected: true,
+      isInitialized: true,
+      isConnecting: false,
+      error: null,
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+      resetError: jest.fn(),
+    } as never);
 
     // Set up mock provider
     mockProvider = {
@@ -515,12 +541,92 @@ describe('usePerpsMarketFills', () => {
         usePerpsMarketFills({ symbol: 'BTC' }),
       );
 
-      // Assert - should work with just WebSocket fills and report unavailable history
+      // Assert - WebSocket fills still work and missing provider is not terminal
       expect(result.current.fills).toHaveLength(1);
       await waitFor(() => {
         expect(result.current.isHistoryLoading).toBe(false);
       });
-      expect(result.current.historyError).toBe('No active Perps provider');
+      expect(result.current.historyError).toBeNull();
+    });
+  });
+
+  describe('connection readiness', () => {
+    it('waits for connection without history error while reconnecting', () => {
+      // Arrange
+      mockUsePerpsConnection.mockReturnValue({
+        isConnected: true,
+        isInitialized: true,
+        isConnecting: true,
+        error: null,
+        connect: jest.fn(),
+        disconnect: jest.fn(),
+        resetError: jest.fn(),
+      } as never);
+      mockUsePerpsLiveFills.mockReturnValue({
+        fills: [mockBtcFill1],
+        isInitialLoading: false,
+      });
+
+      // Act
+      const { result } = renderHook(() =>
+        usePerpsMarketFills({ symbol: 'BTC' }),
+      );
+
+      // Assert
+      expect(mockProvider.getOrderFills).not.toHaveBeenCalled();
+      expect(result.current.isHistoryLoading).toBe(true);
+      expect(result.current.historyError).toBeNull();
+      expect(result.current.fills).toHaveLength(1);
+    });
+
+    it('refetches REST fills when connection becomes ready', async () => {
+      // Arrange
+      mockUsePerpsConnection.mockReturnValue({
+        isConnected: false,
+        isInitialized: false,
+        isConnecting: false,
+        error: null,
+        connect: jest.fn(),
+        disconnect: jest.fn(),
+        resetError: jest.fn(),
+      } as never);
+      mockUsePerpsLiveFills.mockReturnValue({
+        fills: [],
+        isInitialLoading: false,
+      });
+      mockProvider.getOrderFills.mockResolvedValue([mockBtcFill1]);
+
+      const { result, rerender } = renderHook(
+        ({ symbol }: { symbol: string }) => usePerpsMarketFills({ symbol }),
+        { initialProps: { symbol: 'BTC' } },
+      );
+
+      expect(mockProvider.getOrderFills).not.toHaveBeenCalled();
+      expect(result.current.historyError).toBeNull();
+
+      mockUsePerpsConnection.mockReturnValue({
+        isConnected: true,
+        isInitialized: true,
+        isConnecting: false,
+        error: null,
+        connect: jest.fn(),
+        disconnect: jest.fn(),
+        resetError: jest.fn(),
+      } as never);
+
+      // Act
+      await act(async () => {
+        rerender({ symbol: 'BTC' });
+      });
+
+      // Assert
+      await waitFor(() => {
+        expect(mockProvider.getOrderFills).toHaveBeenCalledTimes(1);
+      });
+      await waitFor(() => {
+        expect(result.current.fills).toHaveLength(1);
+      });
+      expect(result.current.historyError).toBeNull();
     });
   });
 

--- a/app/components/UI/Perps/hooks/usePerpsMarketFills.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketFills.test.ts
@@ -170,8 +170,7 @@ describe('usePerpsMarketFills', () => {
       // Assert
       expect(result.current.fills).toEqual([]);
       expect(result.current.isInitialLoading).toBe(false);
-      expect(result.current.isHistoryLoading).toBe(true);
-      expect(result.current.historyError).toBeNull();
+      expect(result.current.restHistoryStatus).toBe('loading');
       expect(result.current.isRefreshing).toBe(false);
     });
 
@@ -202,9 +201,8 @@ describe('usePerpsMarketFills', () => {
 
       // Assert
       await waitFor(() => {
-        expect(result.current.isHistoryLoading).toBe(false);
+        expect(result.current.restHistoryStatus).toBe('ready');
       });
-      expect(result.current.historyError).toBeNull();
     });
   });
 
@@ -520,8 +518,7 @@ describe('usePerpsMarketFills', () => {
         );
       });
       expect(result.current.fills).toHaveLength(1);
-      expect(result.current.isHistoryLoading).toBe(false);
-      expect(result.current.historyError).toBe('API Error');
+      expect(result.current.restHistoryStatus).toBe('error');
     });
 
     it('handles missing provider gracefully', async () => {
@@ -544,9 +541,27 @@ describe('usePerpsMarketFills', () => {
       // Assert - WebSocket fills still work and missing provider is not terminal
       expect(result.current.fills).toHaveLength(1);
       await waitFor(() => {
-        expect(result.current.isHistoryLoading).toBe(false);
+        expect(result.current.restHistoryStatus).toBe('pending');
       });
-      expect(result.current.historyError).toBeNull();
+    });
+
+    it('marks REST history complete after a successful backfill', async () => {
+      // Arrange
+      mockUsePerpsLiveFills.mockReturnValue({
+        fills: [],
+        isInitialLoading: false,
+      });
+      mockProvider.getOrderFills.mockResolvedValue([mockBtcFill1]);
+
+      // Act
+      const { result } = renderHook(() =>
+        usePerpsMarketFills({ symbol: 'BTC' }),
+      );
+
+      // Assert
+      await waitFor(() => {
+        expect(result.current.restHistoryStatus).toBe('ready');
+      });
     });
   });
 
@@ -574,8 +589,7 @@ describe('usePerpsMarketFills', () => {
 
       // Assert
       expect(mockProvider.getOrderFills).not.toHaveBeenCalled();
-      expect(result.current.isHistoryLoading).toBe(true);
-      expect(result.current.historyError).toBeNull();
+      expect(result.current.restHistoryStatus).toBe('pending');
       expect(result.current.fills).toHaveLength(1);
     });
 
@@ -602,7 +616,7 @@ describe('usePerpsMarketFills', () => {
       );
 
       expect(mockProvider.getOrderFills).not.toHaveBeenCalled();
-      expect(result.current.historyError).toBeNull();
+      expect(result.current.restHistoryStatus).toBe('pending');
 
       mockUsePerpsConnection.mockReturnValue({
         isConnected: true,
@@ -626,7 +640,46 @@ describe('usePerpsMarketFills', () => {
       await waitFor(() => {
         expect(result.current.fills).toHaveLength(1);
       });
-      expect(result.current.historyError).toBeNull();
+      expect(result.current.restHistoryStatus).toBe('ready');
+    });
+
+    it('discards an in-flight fetch when the connection becomes unavailable', async () => {
+      // Arrange
+      let resolveFetch: ((value: OrderFill[]) => void) | undefined;
+      mockProvider.getOrderFills.mockReturnValue(
+        new Promise<OrderFill[]>((resolve) => {
+          resolveFetch = resolve;
+        }),
+      );
+      mockUsePerpsLiveFills.mockReturnValue({
+        fills: [],
+        isInitialLoading: false,
+      });
+
+      const { result, rerender } = renderHook(() =>
+        usePerpsMarketFills({ symbol: 'BTC' }),
+      );
+
+      mockUsePerpsConnection.mockReturnValue({
+        isConnected: false,
+        isInitialized: false,
+        isConnecting: false,
+        error: null,
+        connect: jest.fn(),
+        disconnect: jest.fn(),
+        resetError: jest.fn(),
+      } as never);
+
+      // Act
+      rerender({ symbol: 'BTC' });
+      await act(async () => {
+        resolveFetch?.([mockBtcFill1]);
+        await Promise.resolve();
+      });
+
+      // Assert
+      expect(result.current.restHistoryStatus).toBe('pending');
+      expect(result.current.fills).toEqual([]);
     });
   });
 
@@ -728,11 +781,12 @@ describe('usePerpsMarketFills', () => {
 
       // Assert
       expect(result.current.isRefreshing).toBe(false);
+      expect(result.current.restHistoryStatus).toBe('error');
 
       consoleError.mockRestore();
     });
 
-    it('clears history loading when refresh supersedes initial fetch', async () => {
+    it('marks history ready when refresh supersedes initial fetch', async () => {
       // Arrange
       mockUsePerpsLiveFills.mockReturnValue({
         fills: [],
@@ -756,7 +810,7 @@ describe('usePerpsMarketFills', () => {
         usePerpsMarketFills({ symbol: 'BTC' }),
       );
 
-      expect(result.current.isHistoryLoading).toBe(true);
+      expect(result.current.restHistoryStatus).toBe('loading');
 
       let refreshPromise: Promise<void> | undefined;
       await act(async () => {
@@ -768,8 +822,7 @@ describe('usePerpsMarketFills', () => {
         await refreshPromise;
       });
 
-      expect(result.current.isHistoryLoading).toBe(false);
-      expect(result.current.historyError).toBeNull();
+      expect(result.current.restHistoryStatus).toBe('ready');
       expect(result.current.fills).toHaveLength(1);
 
       await act(async () => {
@@ -779,7 +832,7 @@ describe('usePerpsMarketFills', () => {
         await Promise.resolve();
       });
 
-      expect(result.current.isHistoryLoading).toBe(false);
+      expect(result.current.restHistoryStatus).toBe('ready');
       expect(result.current.fills).toHaveLength(1);
       expect(result.current.fills[0].orderId).toBe('btc-1');
     });
@@ -860,14 +913,14 @@ describe('usePerpsMarketFills', () => {
       await waitFor(() => {
         expect(result.current.fills).toHaveLength(1);
       });
-      expect(result.current.historyError).toBeNull();
+      expect(result.current.restHistoryStatus).toBe('ready');
 
       await act(async () => {
         rejectFirstFetch?.(new Error('Stale error'));
         await Promise.resolve();
       });
 
-      expect(result.current.historyError).toBeNull();
+      expect(result.current.restHistoryStatus).toBe('ready');
       expect(result.current.fills[0].orderId).toBe('current-account-fill');
       expect(mockLoggerError).not.toHaveBeenCalled();
     });
@@ -944,21 +997,21 @@ describe('usePerpsMarketFills', () => {
       mockSelectedAccountByScope.mockReturnValue({ address: '0xAccount2' });
       rerender({ symbol: 'BTC' });
 
-      expect(result.current.isHistoryLoading).toBe(true);
+      expect(result.current.restHistoryStatus).toBe('loading');
 
       await act(async () => {
         resolveFirstFetch?.([]);
         await Promise.resolve();
       });
 
-      expect(result.current.isHistoryLoading).toBe(true);
+      expect(result.current.restHistoryStatus).toBe('loading');
 
       await act(async () => {
         resolveSecondFetch?.([mockBtcFill1]);
         await Promise.resolve();
       });
 
-      expect(result.current.isHistoryLoading).toBe(false);
+      expect(result.current.restHistoryStatus).toBe('ready');
       expect(result.current.fills).toHaveLength(1);
     });
   });

--- a/app/components/UI/Perps/hooks/usePerpsMarketFills.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketFills.test.ts
@@ -731,6 +731,58 @@ describe('usePerpsMarketFills', () => {
 
       consoleError.mockRestore();
     });
+
+    it('clears history loading when refresh supersedes initial fetch', async () => {
+      // Arrange
+      mockUsePerpsLiveFills.mockReturnValue({
+        fills: [],
+        isInitialLoading: false,
+      });
+
+      let resolveInitialFetch: ((value: OrderFill[]) => void) | undefined;
+      let resolveRefreshFetch: ((value: OrderFill[]) => void) | undefined;
+      const initialFetch = new Promise<OrderFill[]>((resolve) => {
+        resolveInitialFetch = resolve;
+      });
+      const refreshFetch = new Promise<OrderFill[]>((resolve) => {
+        resolveRefreshFetch = resolve;
+      });
+
+      mockProvider.getOrderFills
+        .mockReturnValueOnce(initialFetch)
+        .mockReturnValueOnce(refreshFetch);
+
+      const { result } = renderHook(() =>
+        usePerpsMarketFills({ symbol: 'BTC' }),
+      );
+
+      expect(result.current.isHistoryLoading).toBe(true);
+
+      let refreshPromise: Promise<void> | undefined;
+      await act(async () => {
+        refreshPromise = result.current.refresh();
+      });
+
+      await act(async () => {
+        resolveRefreshFetch?.([mockBtcFill1]);
+        await refreshPromise;
+      });
+
+      expect(result.current.isHistoryLoading).toBe(false);
+      expect(result.current.historyError).toBeNull();
+      expect(result.current.fills).toHaveLength(1);
+
+      await act(async () => {
+        resolveInitialFetch?.([
+          createMockFill({ orderId: 'stale-initial-fill', symbol: 'BTC' }),
+        ]);
+        await Promise.resolve();
+      });
+
+      expect(result.current.isHistoryLoading).toBe(false);
+      expect(result.current.fills).toHaveLength(1);
+      expect(result.current.fills[0].orderId).toBe('btc-1');
+    });
   });
 
   describe('throttleMs option', () => {

--- a/app/components/UI/Perps/hooks/usePerpsMarketFills.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketFills.test.ts
@@ -1,12 +1,17 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
 import { usePerpsMarketFills } from './usePerpsMarketFills';
 import { usePerpsLiveFills } from './stream';
 import Engine from '../../../../core/Engine';
 import { PERPS_CONSTANTS, type OrderFill } from '@metamask/perps-controller';
 
+const mockSelectedAccountByScope = jest.fn(() => ({
+  address: '0xAccount1',
+}));
+
 // Mock dependencies
 jest.mock('react-redux', () => ({
-  useSelector: jest.fn(() => () => ({ address: '0xMockAddress' })),
+  useSelector: jest.fn(() => mockSelectedAccountByScope),
 }));
 
 jest.mock('./stream', () => ({
@@ -31,6 +36,8 @@ jest.mock('../../../../util/Logger', () => ({
 const mockUsePerpsLiveFills = usePerpsLiveFills as jest.MockedFunction<
   typeof usePerpsLiveFills
 >;
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 
 const mockGetActiveProviderOrNull = Engine.context.PerpsController
   .getActiveProviderOrNull as jest.MockedFunction<
@@ -94,6 +101,8 @@ describe('usePerpsMarketFills', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSelectedAccountByScope.mockReturnValue({ address: '0xAccount1' });
+    mockUseSelector.mockImplementation(() => mockSelectedAccountByScope);
 
     // Set up mock provider
     mockProvider = {
@@ -659,6 +668,140 @@ describe('usePerpsMarketFills', () => {
       // Assert
       expect(result.current.fills).toHaveLength(1);
       expect(result.current.fills[0].symbol).toBe('ETH');
+    });
+  });
+
+  describe('stale in-flight REST fetches', () => {
+    it('ignores stale fetch errors when a newer fetch succeeds', async () => {
+      // Arrange
+      mockUsePerpsLiveFills.mockReturnValue({
+        fills: [],
+        isInitialLoading: false,
+      });
+
+      let rejectFirstFetch: ((error: Error) => void) | undefined;
+      const staleFetch = new Promise<OrderFill[]>((_resolve, reject) => {
+        rejectFirstFetch = reject;
+      });
+      const currentAccountFill = createMockFill({
+        orderId: 'current-account-fill',
+        symbol: 'BTC',
+      });
+
+      mockProvider.getOrderFills
+        .mockReturnValueOnce(staleFetch)
+        .mockResolvedValueOnce([currentAccountFill]);
+
+      const { result, rerender } = renderHook(() =>
+        usePerpsMarketFills({ symbol: 'BTC' }),
+      );
+
+      mockSelectedAccountByScope.mockReturnValue({ address: '0xAccount2' });
+      rerender({ symbol: 'BTC' });
+
+      await waitFor(() => {
+        expect(result.current.fills).toHaveLength(1);
+      });
+      expect(result.current.historyError).toBeNull();
+
+      await act(async () => {
+        rejectFirstFetch?.(new Error('Stale error'));
+        await Promise.resolve();
+      });
+
+      expect(result.current.historyError).toBeNull();
+      expect(result.current.fills[0].orderId).toBe('current-account-fill');
+      expect(mockLoggerError).not.toHaveBeenCalled();
+    });
+
+    it('ignores stale fetch fills when the account changes', async () => {
+      // Arrange
+      mockUsePerpsLiveFills.mockReturnValue({
+        fills: [],
+        isInitialLoading: false,
+      });
+
+      let resolveFirstFetch: ((value: OrderFill[]) => void) | undefined;
+      const staleFetch = new Promise<OrderFill[]>((resolve) => {
+        resolveFirstFetch = resolve;
+      });
+      const staleAccountFill = createMockFill({
+        orderId: 'stale-account-fill',
+        symbol: 'BTC',
+      });
+      const currentAccountFill = createMockFill({
+        orderId: 'current-account-fill',
+        symbol: 'BTC',
+      });
+
+      mockProvider.getOrderFills
+        .mockReturnValueOnce(staleFetch)
+        .mockResolvedValueOnce([currentAccountFill]);
+
+      const { result, rerender } = renderHook(() =>
+        usePerpsMarketFills({ symbol: 'BTC' }),
+      );
+
+      mockSelectedAccountByScope.mockReturnValue({ address: '0xAccount2' });
+      rerender({ symbol: 'BTC' });
+
+      await waitFor(() => {
+        expect(result.current.fills).toHaveLength(1);
+      });
+      expect(result.current.fills[0].orderId).toBe('current-account-fill');
+
+      await act(async () => {
+        resolveFirstFetch?.([staleAccountFill]);
+        await Promise.resolve();
+      });
+
+      expect(result.current.fills).toHaveLength(1);
+      expect(result.current.fills[0].orderId).toBe('current-account-fill');
+    });
+
+    it('preserves loading while a superseding fetch is in flight', async () => {
+      // Arrange
+      mockUsePerpsLiveFills.mockReturnValue({
+        fills: [],
+        isInitialLoading: false,
+      });
+
+      let resolveFirstFetch: ((value: OrderFill[]) => void) | undefined;
+      let resolveSecondFetch: ((value: OrderFill[]) => void) | undefined;
+      const firstFetch = new Promise<OrderFill[]>((resolve) => {
+        resolveFirstFetch = resolve;
+      });
+      const secondFetch = new Promise<OrderFill[]>((resolve) => {
+        resolveSecondFetch = resolve;
+      });
+
+      mockProvider.getOrderFills
+        .mockReturnValueOnce(firstFetch)
+        .mockReturnValueOnce(secondFetch);
+
+      const { result, rerender } = renderHook(() =>
+        usePerpsMarketFills({ symbol: 'BTC' }),
+      );
+
+      mockSelectedAccountByScope.mockReturnValue({ address: '0xAccount2' });
+      rerender({ symbol: 'BTC' });
+
+      expect(result.current.isHistoryLoading).toBe(true);
+
+      await act(async () => {
+        resolveFirstFetch?.([]);
+        await Promise.resolve();
+      });
+
+      expect(result.current.isHistoryLoading).toBe(true);
+
+      await act(async () => {
+        resolveSecondFetch?.([mockBtcFill1]);
+        await Promise.resolve();
+      });
+
+      expect(result.current.isHistoryLoading).toBe(false);
+      expect(result.current.fills).toHaveLength(1);
     });
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsMarketFills.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketFills.ts
@@ -30,6 +30,14 @@ interface UsePerpsMarketFillsReturn {
    */
   isInitialLoading: boolean;
   /**
+   * True while the initial historical REST backfill is loading
+   */
+  isHistoryLoading: boolean;
+  /**
+   * Error from the historical REST backfill, if it failed
+   */
+  historyError: string | null;
+  /**
    * Refresh function to manually refetch REST data
    */
   refresh: () => Promise<void>;
@@ -73,17 +81,27 @@ export const usePerpsMarketFills = ({
 
   // REST API fills state for complete history
   const [restFills, setRestFills] = useState<OrderFill[]>([]);
+  const [isHistoryLoading, setIsHistoryLoading] = useState(true);
+  const [historyError, setHistoryError] = useState<string | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   // Fetch historical fills via REST API (limited to last 3 months for performance)
   const fetchRestFills = useCallback(async (isRefresh = false) => {
     const controller = Engine.context.PerpsController;
     if (!controller) {
+      setIsHistoryLoading(false);
+      setHistoryError('Perps controller is unavailable');
       return;
     }
 
+    if (!isRefresh) {
+      setIsHistoryLoading(true);
+    }
+    setHistoryError(null);
+
     try {
       if (!controller.getActiveProviderOrNull()) {
+        setHistoryError('No active Perps provider');
         return;
       }
 
@@ -102,11 +120,14 @@ export const usePerpsMarketFills = ({
       );
       setRestFills(fills);
     } catch (err) {
+      const error = ensureError(err, 'usePerpsMarketFills.fetchFills');
+      setHistoryError(error.message);
+
       // Get the current account for debugging context
       const accountAddress = addressRef.current ?? 'unknown';
 
       // Log error to Sentry but don't fail - WebSocket fills still work
-      Logger.error(ensureError(err, 'usePerpsMarketFills.fetchFills'), {
+      Logger.error(error, {
         tags: {
           feature: PERPS_CONSTANTS.FeatureName,
         },
@@ -116,6 +137,10 @@ export const usePerpsMarketFills = ({
           message: `[usePerpsMarketFills] Failed to fetch REST fills for account ${accountAddress}: ${err}`,
         },
       });
+    } finally {
+      if (!isRefresh) {
+        setIsHistoryLoading(false);
+      }
     }
   }, []);
 
@@ -151,6 +176,8 @@ export const usePerpsMarketFills = ({
   return {
     fills,
     isInitialLoading,
+    isHistoryLoading,
+    historyError,
     refresh,
     isRefreshing,
   };

--- a/app/components/UI/Perps/hooks/usePerpsMarketFills.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketFills.ts
@@ -85,22 +85,44 @@ export const usePerpsMarketFills = ({
   const [historyError, setHistoryError] = useState<string | null>(null);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
+  // Account switches and refresh can overlap in-flight REST fetches. Track the
+  // latest request so only the current one may write state — same pattern as
+  // usePerpsMarketData and usePerpsMarketForAsset.
+  const isMountedRef = useRef(true);
+  const requestIdRef = useRef(0);
+
   // Fetch historical fills via REST API (limited to last 3 months for performance)
   const fetchRestFills = useCallback(async (isRefresh = false) => {
+    const requestId = ++requestIdRef.current;
+    const isCurrentRequest = () =>
+      requestIdRef.current === requestId && isMountedRef.current;
+
     const controller = Engine.context.PerpsController;
     if (!controller) {
+      if (!isCurrentRequest()) {
+        return;
+      }
       setIsHistoryLoading(false);
       setHistoryError('Perps controller is unavailable');
       return;
     }
 
     if (!isRefresh) {
+      if (!isCurrentRequest()) {
+        return;
+      }
       setIsHistoryLoading(true);
+    }
+    if (!isCurrentRequest()) {
+      return;
     }
     setHistoryError(null);
 
     try {
       if (!controller.getActiveProviderOrNull()) {
+        if (!isCurrentRequest()) {
+          return;
+        }
         setHistoryError('No active Perps provider');
         return;
       }
@@ -118,8 +140,14 @@ export const usePerpsMarketFills = ({
         },
         { forceRefresh: isRefresh },
       );
+      if (!isCurrentRequest()) {
+        return;
+      }
       setRestFills(fills);
     } catch (err) {
+      if (!isCurrentRequest()) {
+        return;
+      }
       const error = ensureError(err, 'usePerpsMarketFills.fetchFills');
       setHistoryError(error.message);
 
@@ -138,10 +166,18 @@ export const usePerpsMarketFills = ({
         },
       });
     } finally {
-      if (!isRefresh) {
+      if (!isRefresh && isCurrentRequest()) {
         setIsHistoryLoading(false);
       }
     }
+  }, []);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
   }, []);
 
   // Fetch historical fills on mount and when account changes (background, non-blocking)

--- a/app/components/UI/Perps/hooks/usePerpsMarketFills.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketFills.ts
@@ -6,6 +6,7 @@ import { mergeOrderFills } from '../utils/transactionTransforms';
 import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
 import { ensureError } from '../../../../util/errorUtils';
+import { usePerpsConnection } from './usePerpsConnection';
 import { selectSelectedInternalAccountByScope } from '../../../../selectors/multichainAccounts/accounts';
 
 interface UsePerpsMarketFillsParams {
@@ -74,6 +75,8 @@ export const usePerpsMarketFills = ({
   const addressRef = useRef(selectedAddress);
   addressRef.current = selectedAddress;
 
+  const { isConnected, isInitialized, isConnecting } = usePerpsConnection();
+
   // WebSocket fills for real-time updates
   const { fills: liveFills, isInitialLoading } = usePerpsLiveFills({
     throttleMs,
@@ -123,7 +126,6 @@ export const usePerpsMarketFills = ({
         if (!isCurrentRequest()) {
           return;
         }
-        setHistoryError('No active Perps provider');
         return;
       }
 
@@ -180,14 +182,26 @@ export const usePerpsMarketFills = ({
     };
   }, []);
 
-  // Fetch historical fills on mount and when account changes (background, non-blocking)
-  // This ensures we have complete fill history, not just WebSocket snapshot
-  // Clear stale fills and refetch when account changes to prevent data leakage
+  // Fetch historical fills on mount, when account changes, and when the Perps
+  // connection becomes ready (background, non-blocking).
+  // Clear stale fills and refetch when account changes to prevent data leakage.
   useEffect(() => {
-    // Clear stale REST fills from previous account before fetching new ones
+    if (!isConnected || !isInitialized || isConnecting) {
+      setRestFills([]);
+      setHistoryError(null);
+      setIsHistoryLoading(true);
+      return;
+    }
+
     setRestFills([]);
     fetchRestFills();
-  }, [fetchRestFills, selectedAddress]);
+  }, [
+    fetchRestFills,
+    selectedAddress,
+    isConnected,
+    isInitialized,
+    isConnecting,
+  ]);
 
   // Refresh function for manual refetch
   const refresh = useCallback(async () => {

--- a/app/components/UI/Perps/hooks/usePerpsMarketFills.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketFills.ts
@@ -168,7 +168,7 @@ export const usePerpsMarketFills = ({
         },
       });
     } finally {
-      if (!isRefresh && isCurrentRequest()) {
+      if (isCurrentRequest()) {
         setIsHistoryLoading(false);
       }
     }

--- a/app/components/UI/Perps/hooks/usePerpsMarketFills.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketFills.ts
@@ -21,6 +21,8 @@ interface UsePerpsMarketFillsParams {
   throttleMs?: number;
 }
 
+type RestHistoryStatus = 'pending' | 'loading' | 'ready' | 'error';
+
 interface UsePerpsMarketFillsReturn {
   /**
    * Array of fills for the specified market, sorted by timestamp descending
@@ -30,14 +32,8 @@ interface UsePerpsMarketFillsReturn {
    * True while waiting for initial WebSocket data
    */
   isInitialLoading: boolean;
-  /**
-   * True while the initial historical REST backfill is loading
-   */
-  isHistoryLoading: boolean;
-  /**
-   * Error from the historical REST backfill, if it failed
-   */
-  historyError: string | null;
+  /** Current state of the historical REST backfill. */
+  restHistoryStatus: RestHistoryStatus;
   /**
    * Refresh function to manually refetch REST data
    */
@@ -84,8 +80,8 @@ export const usePerpsMarketFills = ({
 
   // REST API fills state for complete history
   const [restFills, setRestFills] = useState<OrderFill[]>([]);
-  const [isHistoryLoading, setIsHistoryLoading] = useState(true);
-  const [historyError, setHistoryError] = useState<string | null>(null);
+  const [restHistoryStatus, setRestHistoryStatus] =
+    useState<RestHistoryStatus>('pending');
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   // Account switches and refresh can overlap in-flight REST fetches. Track the
@@ -105,8 +101,7 @@ export const usePerpsMarketFills = ({
       if (!isCurrentRequest()) {
         return;
       }
-      setIsHistoryLoading(false);
-      setHistoryError('Perps controller is unavailable');
+      setRestHistoryStatus('error');
       return;
     }
 
@@ -114,18 +109,15 @@ export const usePerpsMarketFills = ({
       if (!isCurrentRequest()) {
         return;
       }
-      setIsHistoryLoading(true);
+      setRestHistoryStatus('loading');
     }
-    if (!isCurrentRequest()) {
-      return;
-    }
-    setHistoryError(null);
 
     try {
       if (!controller.getActiveProviderOrNull()) {
         if (!isCurrentRequest()) {
           return;
         }
+        setRestHistoryStatus('pending');
         return;
       }
 
@@ -146,12 +138,13 @@ export const usePerpsMarketFills = ({
         return;
       }
       setRestFills(fills);
+      setRestHistoryStatus('ready');
     } catch (err) {
       if (!isCurrentRequest()) {
         return;
       }
       const error = ensureError(err, 'usePerpsMarketFills.fetchFills');
-      setHistoryError(error.message);
+      setRestHistoryStatus('error');
 
       // Get the current account for debugging context
       const accountAddress = addressRef.current ?? 'unknown';
@@ -167,10 +160,6 @@ export const usePerpsMarketFills = ({
           message: `[usePerpsMarketFills] Failed to fetch REST fills for account ${accountAddress}: ${err}`,
         },
       });
-    } finally {
-      if (isCurrentRequest()) {
-        setIsHistoryLoading(false);
-      }
     }
   }, []);
 
@@ -187,9 +176,11 @@ export const usePerpsMarketFills = ({
   // Clear stale fills and refetch when account changes to prevent data leakage.
   useEffect(() => {
     if (!isConnected || !isInitialized || isConnecting) {
+      // Invalidate any request from the previous connection context before
+      // clearing its data.
+      requestIdRef.current += 1;
       setRestFills([]);
-      setHistoryError(null);
-      setIsHistoryLoading(true);
+      setRestHistoryStatus('pending');
       return;
     }
 
@@ -226,8 +217,7 @@ export const usePerpsMarketFills = ({
   return {
     fills,
     isInitialLoading,
-    isHistoryLoading,
-    historyError,
+    restHistoryStatus,
     refresh,
     isRefreshing,
   };

--- a/app/components/UI/Perps/hooks/usePerpsRecordedOrderFees.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsRecordedOrderFees.test.ts
@@ -1,0 +1,163 @@
+import { renderHook } from '@testing-library/react-native';
+import type { OrderFill } from '@metamask/perps-controller';
+import { usePerpsMarketFills } from './usePerpsMarketFills';
+import { usePerpsRecordedOrderFees } from './usePerpsRecordedOrderFees';
+
+jest.mock('./usePerpsMarketFills', () => ({
+  usePerpsMarketFills: jest.fn(),
+}));
+
+const mockUsePerpsMarketFills = usePerpsMarketFills as jest.MockedFunction<
+  typeof usePerpsMarketFills
+>;
+
+const createFill = (overrides: Partial<OrderFill> = {}): OrderFill => ({
+  orderId: 'order-1',
+  symbol: 'BTC',
+  side: 'buy',
+  size: '0.5',
+  price: '50000',
+  pnl: '0',
+  direction: 'Open Long',
+  fee: '1.25',
+  feeToken: 'USDC',
+  timestamp: 1640995200000,
+  startPosition: '0',
+  success: true,
+  ...overrides,
+});
+
+const setMarketFills = ({
+  fills = [],
+  isInitialLoading = false,
+  isHistoryLoading = false,
+  historyError = null,
+}: {
+  fills?: OrderFill[];
+  isInitialLoading?: boolean;
+  isHistoryLoading?: boolean;
+  historyError?: string | null;
+} = {}) => {
+  mockUsePerpsMarketFills.mockReturnValue({
+    fills,
+    isInitialLoading,
+    isHistoryLoading,
+    historyError,
+    refresh: jest.fn(),
+    isRefreshing: false,
+  });
+};
+
+describe('usePerpsRecordedOrderFees', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setMarketFills();
+  });
+
+  it('returns the recorded fee for one matching fill', () => {
+    setMarketFills({ fills: [createFill({ fee: '1.25' })] });
+
+    const { result } = renderHook(() =>
+      usePerpsRecordedOrderFees('order-1', 'BTC'),
+    );
+
+    expect(result.current).toEqual({
+      totalFee: 1.25,
+      isLoading: false,
+      hasError: false,
+    });
+  });
+
+  it('sums recorded fees from multiple partial fills', () => {
+    setMarketFills({
+      fills: [
+        createFill({ fee: '0.1', timestamp: 1 }),
+        createFill({ fee: '0.2', timestamp: 2 }),
+        createFill({ fee: '0.3', timestamp: 3 }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      usePerpsRecordedOrderFees('order-1', 'BTC'),
+    );
+
+    expect(result.current.totalFee).toBe(0.6);
+  });
+
+  it('excludes fills belonging to other orders', () => {
+    setMarketFills({
+      fills: [
+        createFill({ orderId: 'order-1', fee: '1.25' }),
+        createFill({ orderId: 'order-2', fee: '9.75' }),
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      usePerpsRecordedOrderFees('order-1', 'BTC'),
+    );
+
+    expect(result.current.totalFee).toBe(1.25);
+  });
+
+  it('returns undefined when the order ID is absent', () => {
+    setMarketFills({
+      fills: [createFill()],
+      isInitialLoading: true,
+      isHistoryLoading: true,
+    });
+
+    const { result } = renderHook(() =>
+      usePerpsRecordedOrderFees(undefined, 'BTC'),
+    );
+
+    expect(result.current).toEqual({
+      totalFee: undefined,
+      isLoading: false,
+      hasError: false,
+    });
+  });
+
+  it('returns zero after fill history loads without matching fills', () => {
+    setMarketFills({ fills: [createFill({ orderId: 'other-order' })] });
+
+    const { result } = renderHook(() =>
+      usePerpsRecordedOrderFees('order-1', 'BTC'),
+    );
+
+    expect(result.current.totalFee).toBe(0);
+  });
+
+  it('withholds the total while fill history is loading', () => {
+    setMarketFills({
+      fills: [createFill()],
+      isHistoryLoading: true,
+    });
+
+    const { result } = renderHook(() =>
+      usePerpsRecordedOrderFees('order-1', 'BTC'),
+    );
+
+    expect(result.current).toEqual({
+      totalFee: undefined,
+      isLoading: true,
+      hasError: false,
+    });
+  });
+
+  it('withholds the total when historical fill loading fails', () => {
+    setMarketFills({
+      fills: [createFill()],
+      historyError: 'API unavailable',
+    });
+
+    const { result } = renderHook(() =>
+      usePerpsRecordedOrderFees('order-1', 'BTC'),
+    );
+
+    expect(result.current).toEqual({
+      totalFee: undefined,
+      isLoading: false,
+      hasError: true,
+    });
+  });
+});

--- a/app/components/UI/Perps/hooks/usePerpsRecordedOrderFees.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsRecordedOrderFees.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react-native';
-import type { OrderFill } from '@metamask/perps-controller';
+import { PERPS_CONSTANTS, type OrderFill } from '@metamask/perps-controller';
 import { usePerpsMarketFills } from './usePerpsMarketFills';
 import { usePerpsRecordedOrderFees } from './usePerpsRecordedOrderFees';
 
@@ -10,6 +10,8 @@ jest.mock('./usePerpsMarketFills', () => ({
 const mockUsePerpsMarketFills = usePerpsMarketFills as jest.MockedFunction<
   typeof usePerpsMarketFills
 >;
+
+const NOW = new Date('2026-08-07T12:00:00.000Z').getTime();
 
 const createFill = (overrides: Partial<OrderFill> = {}): OrderFill => ({
   orderId: 'order-1',
@@ -51,14 +53,23 @@ const setMarketFills = ({
 describe('usePerpsRecordedOrderFees', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
     setMarketFills();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('returns the recorded fee for one matching fill', () => {
     setMarketFills({ fills: [createFill({ fee: '1.25' })] });
 
     const { result } = renderHook(() =>
-      usePerpsRecordedOrderFees('order-1', 'BTC'),
+      usePerpsRecordedOrderFees(
+        'order-1',
+        'BTC',
+        NOW - PERPS_CONSTANTS.FillsLookbackMs - 1,
+      ),
     );
 
     expect(result.current).toEqual({
@@ -78,7 +89,7 @@ describe('usePerpsRecordedOrderFees', () => {
     });
 
     const { result } = renderHook(() =>
-      usePerpsRecordedOrderFees('order-1', 'BTC'),
+      usePerpsRecordedOrderFees('order-1', 'BTC', NOW),
     );
 
     expect(result.current.totalFee).toBe(0.6);
@@ -93,7 +104,7 @@ describe('usePerpsRecordedOrderFees', () => {
     });
 
     const { result } = renderHook(() =>
-      usePerpsRecordedOrderFees('order-1', 'BTC'),
+      usePerpsRecordedOrderFees('order-1', 'BTC', NOW),
     );
 
     expect(result.current.totalFee).toBe(1.25);
@@ -107,7 +118,7 @@ describe('usePerpsRecordedOrderFees', () => {
     });
 
     const { result } = renderHook(() =>
-      usePerpsRecordedOrderFees(undefined, 'BTC'),
+      usePerpsRecordedOrderFees(undefined, 'BTC', NOW),
     );
 
     expect(result.current).toEqual({
@@ -117,11 +128,39 @@ describe('usePerpsRecordedOrderFees', () => {
     });
   });
 
-  it('returns zero after fill history loads without matching fills', () => {
+  it('returns zero for a covered order without matching fills', () => {
     setMarketFills({ fills: [createFill({ orderId: 'other-order' })] });
 
     const { result } = renderHook(() =>
-      usePerpsRecordedOrderFees('order-1', 'BTC'),
+      usePerpsRecordedOrderFees(
+        'order-1',
+        'BTC',
+        NOW - PERPS_CONSTANTS.FillsLookbackMs + 1,
+      ),
+    );
+
+    expect(result.current.totalFee).toBe(0);
+  });
+
+  it('withholds the total for an order older than fill history', () => {
+    const { result } = renderHook(() =>
+      usePerpsRecordedOrderFees(
+        'order-1',
+        'BTC',
+        NOW - PERPS_CONSTANTS.FillsLookbackMs - 1,
+      ),
+    );
+
+    expect(result.current.totalFee).toBeUndefined();
+  });
+
+  it('returns zero at the fill-history boundary without matching fills', () => {
+    const { result } = renderHook(() =>
+      usePerpsRecordedOrderFees(
+        'order-1',
+        'BTC',
+        NOW - PERPS_CONSTANTS.FillsLookbackMs,
+      ),
     );
 
     expect(result.current.totalFee).toBe(0);
@@ -134,7 +173,7 @@ describe('usePerpsRecordedOrderFees', () => {
     });
 
     const { result } = renderHook(() =>
-      usePerpsRecordedOrderFees('order-1', 'BTC'),
+      usePerpsRecordedOrderFees('order-1', 'BTC', NOW),
     );
 
     expect(result.current).toEqual({
@@ -151,7 +190,7 @@ describe('usePerpsRecordedOrderFees', () => {
     });
 
     const { result } = renderHook(() =>
-      usePerpsRecordedOrderFees('order-1', 'BTC'),
+      usePerpsRecordedOrderFees('order-1', 'BTC', NOW),
     );
 
     expect(result.current).toEqual({

--- a/app/components/UI/Perps/hooks/usePerpsRecordedOrderFees.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsRecordedOrderFees.test.ts
@@ -32,19 +32,16 @@ const createFill = (overrides: Partial<OrderFill> = {}): OrderFill => ({
 const setMarketFills = ({
   fills = [],
   isInitialLoading = false,
-  isHistoryLoading = false,
-  historyError = null,
+  restHistoryStatus = 'ready',
 }: {
   fills?: OrderFill[];
   isInitialLoading?: boolean;
-  isHistoryLoading?: boolean;
-  historyError?: string | null;
+  restHistoryStatus?: 'pending' | 'loading' | 'ready' | 'error';
 } = {}) => {
   mockUsePerpsMarketFills.mockReturnValue({
     fills,
     isInitialLoading,
-    isHistoryLoading,
-    historyError,
+    restHistoryStatus,
     refresh: jest.fn(),
     isRefreshing: false,
   });
@@ -114,7 +111,7 @@ describe('usePerpsRecordedOrderFees', () => {
     setMarketFills({
       fills: [createFill()],
       isInitialLoading: true,
-      isHistoryLoading: true,
+      restHistoryStatus: 'loading',
     });
 
     const { result } = renderHook(() =>
@@ -169,7 +166,7 @@ describe('usePerpsRecordedOrderFees', () => {
   it('withholds the total while fill history is loading', () => {
     setMarketFills({
       fills: [createFill()],
-      isHistoryLoading: true,
+      restHistoryStatus: 'loading',
     });
 
     const { result } = renderHook(() =>
@@ -186,7 +183,7 @@ describe('usePerpsRecordedOrderFees', () => {
   it('withholds the total when historical fill loading fails', () => {
     setMarketFills({
       fills: [createFill()],
-      historyError: 'API unavailable',
+      restHistoryStatus: 'error',
     });
 
     const { result } = renderHook(() =>
@@ -198,5 +195,35 @@ describe('usePerpsRecordedOrderFees', () => {
       isLoading: false,
       hasError: true,
     });
+  });
+
+  it('withholds zero for an in-window order without REST history', () => {
+    setMarketFills({
+      fills: [createFill({ orderId: 'other-order' })],
+      restHistoryStatus: 'pending',
+    });
+
+    const { result } = renderHook(() =>
+      usePerpsRecordedOrderFees(
+        'order-1',
+        'BTC',
+        NOW - PERPS_CONSTANTS.FillsLookbackMs + 1,
+      ),
+    );
+
+    expect(result.current.totalFee).toBeUndefined();
+  });
+
+  it('returns the live fill fee before REST history completes', () => {
+    setMarketFills({
+      fills: [createFill({ fee: '2.5' })],
+      restHistoryStatus: 'pending',
+    });
+
+    const { result } = renderHook(() =>
+      usePerpsRecordedOrderFees('order-1', 'BTC', NOW),
+    );
+
+    expect(result.current.totalFee).toBe(2.5);
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsRecordedOrderFees.ts
+++ b/app/components/UI/Perps/hooks/usePerpsRecordedOrderFees.ts
@@ -1,0 +1,51 @@
+import { useMemo } from 'react';
+import { BigNumber } from 'bignumber.js';
+import { usePerpsMarketFills } from './usePerpsMarketFills';
+
+interface UsePerpsRecordedOrderFeesResult {
+  /** Sum of execution-time fees for fills matched to the order. */
+  totalFee: number | undefined;
+  /** True until both live and historical fill sources finish initial loading. */
+  isLoading: boolean;
+  /** True when historical fills could not be loaded. */
+  hasError: boolean;
+}
+
+/**
+ * Returns the cumulative fee recorded for a historical order.
+ *
+ * All fills sharing the order ID contribute to the total, including partial
+ * fills that executed before an order was canceled. The value remains
+ * undefined while fill history is loading or unavailable so callers do not
+ * present an incomplete lookup as a confirmed zero fee.
+ *
+ * @param orderId - Hyperliquid order ID to correlate with execution fills.
+ * @param symbol - Market symbol used to scope the fill history.
+ * @returns Recorded total fee and lookup state.
+ */
+export function usePerpsRecordedOrderFees(
+  orderId: string | undefined,
+  symbol: string,
+): UsePerpsRecordedOrderFeesResult {
+  const { fills, isInitialLoading, isHistoryLoading, historyError } =
+    usePerpsMarketFills({ symbol });
+
+  const isLoading = Boolean(orderId && (isInitialLoading || isHistoryLoading));
+  const hasError = Boolean(orderId && historyError);
+
+  const totalFee = useMemo(() => {
+    if (!orderId || isLoading || hasError) {
+      return undefined;
+    }
+
+    return fills
+      .filter((fill) => fill.orderId === orderId)
+      .reduce(
+        (sum, fill) => sum.plus(new BigNumber(fill.fee || '0')),
+        new BigNumber(0),
+      )
+      .toNumber();
+  }, [fills, hasError, isLoading, orderId]);
+
+  return { totalFee, isLoading, hasError };
+}

--- a/app/components/UI/Perps/hooks/usePerpsRecordedOrderFees.ts
+++ b/app/components/UI/Perps/hooks/usePerpsRecordedOrderFees.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { BigNumber } from 'bignumber.js';
+import { PERPS_CONSTANTS } from '@metamask/perps-controller';
 import { usePerpsMarketFills } from './usePerpsMarketFills';
 
 interface UsePerpsRecordedOrderFeesResult {
@@ -21,11 +22,13 @@ interface UsePerpsRecordedOrderFeesResult {
  *
  * @param orderId - Hyperliquid order ID to correlate with execution fills.
  * @param symbol - Market symbol used to scope the fill history.
+ * @param orderTimestamp - Order timestamp used to verify fill-history coverage.
  * @returns Recorded total fee and lookup state.
  */
 export function usePerpsRecordedOrderFees(
   orderId: string | undefined,
   symbol: string,
+  orderTimestamp: number | undefined,
 ): UsePerpsRecordedOrderFeesResult {
   const { fills, isInitialLoading, isHistoryLoading, historyError } =
     usePerpsMarketFills({ symbol });
@@ -38,14 +41,22 @@ export function usePerpsRecordedOrderFees(
       return undefined;
     }
 
-    return fills
-      .filter((fill) => fill.orderId === orderId)
+    const matchingFills = fills.filter((fill) => fill.orderId === orderId);
+
+    if (matchingFills.length === 0) {
+      const historyStartTime = Date.now() - PERPS_CONSTANTS.FillsLookbackMs;
+      if (orderTimestamp === undefined || orderTimestamp < historyStartTime) {
+        return undefined;
+      }
+    }
+
+    return matchingFills
       .reduce(
         (sum, fill) => sum.plus(new BigNumber(fill.fee || '0')),
         new BigNumber(0),
       )
       .toNumber();
-  }, [fills, hasError, isLoading, orderId]);
+  }, [fills, hasError, isLoading, orderId, orderTimestamp]);
 
   return { totalFee, isLoading, hasError };
 }

--- a/app/components/UI/Perps/hooks/usePerpsRecordedOrderFees.ts
+++ b/app/components/UI/Perps/hooks/usePerpsRecordedOrderFees.ts
@@ -6,7 +6,7 @@ import { usePerpsMarketFills } from './usePerpsMarketFills';
 interface UsePerpsRecordedOrderFeesResult {
   /** Sum of execution-time fees for fills matched to the order. */
   totalFee: number | undefined;
-  /** True until both live and historical fill sources finish initial loading. */
+  /** True while the live snapshot or historical REST request is loading. */
   isLoading: boolean;
   /** True when historical fills could not be loaded. */
   hasError: boolean;
@@ -30,11 +30,14 @@ export function usePerpsRecordedOrderFees(
   symbol: string,
   orderTimestamp: number | undefined,
 ): UsePerpsRecordedOrderFeesResult {
-  const { fills, isInitialLoading, isHistoryLoading, historyError } =
-    usePerpsMarketFills({ symbol });
+  const { fills, isInitialLoading, restHistoryStatus } = usePerpsMarketFills({
+    symbol,
+  });
 
-  const isLoading = Boolean(orderId && (isInitialLoading || isHistoryLoading));
-  const hasError = Boolean(orderId && historyError);
+  const isLoading = Boolean(
+    orderId && (isInitialLoading || restHistoryStatus === 'loading'),
+  );
+  const hasError = Boolean(orderId && restHistoryStatus === 'error');
 
   const totalFee = useMemo(() => {
     if (!orderId || isLoading || hasError) {
@@ -45,7 +48,11 @@ export function usePerpsRecordedOrderFees(
 
     if (matchingFills.length === 0) {
       const historyStartTime = Date.now() - PERPS_CONSTANTS.FillsLookbackMs;
-      if (orderTimestamp === undefined || orderTimestamp < historyStartTime) {
+      if (
+        restHistoryStatus !== 'ready' ||
+        orderTimestamp === undefined ||
+        orderTimestamp < historyStartTime
+      ) {
         return undefined;
       }
     }
@@ -56,7 +63,7 @@ export function usePerpsRecordedOrderFees(
         new BigNumber(0),
       )
       .toNumber();
-  }, [fills, hasError, isLoading, orderId, orderTimestamp]);
+  }, [fills, hasError, isLoading, orderId, orderTimestamp, restHistoryStatus]);
 
   return { totalFee, isLoading, hasError };
 }

--- a/app/components/UI/Perps/types/transactionHistory.ts
+++ b/app/components/UI/Perps/types/transactionHistory.ts
@@ -68,6 +68,8 @@ export interface PerpsTransaction {
   };
   // For orders: order info
   order?: {
+    /** Hyperliquid order ID used to correlate recorded execution fills. */
+    orderId?: string;
     text: PerpsOrderTransactionStatus;
     statusType: PerpsOrderTransactionStatusType;
     type: 'limit' | 'market';

--- a/app/components/UI/Perps/utils/transactionTransforms.test.ts
+++ b/app/components/UI/Perps/utils/transactionTransforms.test.ts
@@ -1039,6 +1039,7 @@ describe('transactionTransforms', () => {
         timestamp: 1640995200000,
         asset: 'BTC',
         order: {
+          orderId: 'order1',
           text: PerpsOrderTransactionStatus.Filled,
           statusType: PerpsOrderTransactionStatusType.Filled,
           type: 'limit',

--- a/app/components/UI/Perps/utils/transactionTransforms.ts
+++ b/app/components/UI/Perps/utils/transactionTransforms.ts
@@ -546,6 +546,7 @@ export function transformOrdersToTransactions(
       timestamp,
       asset: symbol,
       order: {
+        orderId,
         text: statusText,
         statusType: orderStatusType,
         type: orderTypeSlug.includes('limit') ? 'limit' : 'market',

--- a/app/components/Views/ActivityDetails/components/ActivityDetailsPerps.utils.test.ts
+++ b/app/components/Views/ActivityDetails/components/ActivityDetailsPerps.utils.test.ts
@@ -113,9 +113,9 @@ describe('ActivityDetailsPerps.utils', () => {
   });
 
   describe('formatPerpsOrderFee', () => {
-    it('formats the fee when filled and $0 when not', () => {
-      expect(formatPerpsOrderFee(2, true)).toBe('$2');
-      expect(formatPerpsOrderFee(2, false)).toBe('$0');
+    it('formats the recorded fee with universal price ranges', () => {
+      expect(formatPerpsOrderFee(2)).toBe('$2');
+      expect(formatPerpsOrderFee(0.005)).toBe('$0.005');
     });
   });
 

--- a/app/components/Views/ActivityDetails/components/ActivityDetailsPerps.utils.ts
+++ b/app/components/Views/ActivityDetails/components/ActivityDetailsPerps.utils.ts
@@ -112,8 +112,8 @@ export function shouldShowPerpsPnl(fill: PerpsTransaction['fill']): boolean {
   );
 }
 
-export function formatPerpsOrderFee(fee: number, isFilled: boolean): string {
-  return formatPerpsFiat(isFilled ? fee : 0, {
+export function formatPerpsOrderFee(fee: number): string {
+  return formatPerpsFiat(fee, {
     ranges: PRICE_RANGES_UNIVERSAL,
   });
 }

--- a/app/components/Views/ActivityDetails/templates/PerpsDetails.test.tsx
+++ b/app/components/Views/ActivityDetails/templates/PerpsDetails.test.tsx
@@ -9,6 +9,7 @@ import {
   PerpsOrderTransactionStatusType,
   type PerpsTransaction,
 } from '../../../UI/Perps/types/transactionHistory';
+import { usePerpsRecordedOrderFees } from '../../../UI/Perps/hooks';
 import { ActivityDetailsSelectorsIDs } from '../ActivityDetails.testIds';
 import { PerpsDetails } from './PerpsDetails';
 
@@ -32,12 +33,17 @@ jest.mock('../../../UI/Perps/hooks', () => ({
   usePerpsBlockExplorerUrl: () => ({
     getExplorerUrl: () => 'https://app.hyperliquid.xyz/explorer/address/0x1',
   }),
-  usePerpsRecordedOrderFees: () => ({
+  usePerpsRecordedOrderFees: jest.fn(() => ({
     totalFee: 2.345,
     isLoading: false,
     hasError: false,
-  }),
+  })),
 }));
+
+const mockUsePerpsRecordedOrderFees =
+  usePerpsRecordedOrderFees as jest.MockedFunction<
+    typeof usePerpsRecordedOrderFees
+  >;
 
 const baseTransaction: Pick<
   PerpsTransaction,
@@ -244,6 +250,11 @@ describe('PerpsDetails', () => {
     expect(getByText('45%')).toBeOnTheScreen();
     expect(getByText('Total fee')).toBeOnTheScreen();
     expect(getByText('$2.345')).toBeOnTheScreen();
+    expect(mockUsePerpsRecordedOrderFees).toHaveBeenLastCalledWith(
+      'order-partially-filled',
+      'BTC',
+      1_765_361_640_000,
+    );
   });
 
   it('renders funding rate and signed funding fee', () => {

--- a/app/components/Views/ActivityDetails/templates/PerpsDetails.test.tsx
+++ b/app/components/Views/ActivityDetails/templates/PerpsDetails.test.tsx
@@ -32,10 +32,10 @@ jest.mock('../../../UI/Perps/hooks', () => ({
   usePerpsBlockExplorerUrl: () => ({
     getExplorerUrl: () => 'https://app.hyperliquid.xyz/explorer/address/0x1',
   }),
-  usePerpsOrderFees: () => ({
+  usePerpsRecordedOrderFees: () => ({
     totalFee: 2.345,
-    protocolFee: 0.005,
-    metamaskFee: 1.229,
+    isLoading: false,
+    hasError: false,
   }),
 }));
 
@@ -186,7 +186,7 @@ describe('PerpsDetails', () => {
     ).toHaveTextContent('Confirmed');
   });
 
-  it('renders canceled order rows and try-again CTA', () => {
+  it('renders the recorded fee for a partially filled canceled order', () => {
     const transaction: PerpsTransaction = {
       ...baseTransaction,
       id: 'order-1',
@@ -194,12 +194,13 @@ describe('PerpsDetails', () => {
       category: 'limit_order',
       title: 'Take profit close short',
       order: {
+        orderId: 'order-1',
         text: PerpsOrderTransactionStatus.Canceled,
         statusType: PerpsOrderTransactionStatusType.Canceled,
         type: 'limit',
         size: '10.23',
         limitPrice: '98023',
-        filled: '0%',
+        filled: '45%',
       },
     };
 
@@ -210,7 +211,9 @@ describe('PerpsDetails', () => {
     );
 
     expect(getByText('Limit price')).toBeOnTheScreen();
-    expect(getByText('MetaMask fee')).toBeOnTheScreen();
+    expect(getByText('45%')).toBeOnTheScreen();
+    expect(getByText('Total fee')).toBeOnTheScreen();
+    expect(getByText('$2.345')).toBeOnTheScreen();
     expect(
       getByTestId(ActivityDetailsSelectorsIDs.DO_IT_AGAIN_BUTTON),
     ).toBeOnTheScreen();
@@ -250,6 +253,7 @@ describe('PerpsDetails', () => {
       category: 'limit_order',
       title: 'Market short',
       order: {
+        orderId: 'order-2',
         text: PerpsOrderTransactionStatus.Filled,
         statusType: PerpsOrderTransactionStatusType.Filled,
         type: 'limit',
@@ -259,15 +263,15 @@ describe('PerpsDetails', () => {
       },
     };
 
-    const { getByText } = renderWithProvider(
+    const { getByText, queryByText } = renderWithProvider(
       <PerpsDetails item={perpsItem('marketShort', transaction)} />,
     );
 
     expect(getByText('$10.239')).toBeOnTheScreen();
     expect(getByText('$98,023')).toBeOnTheScreen();
-    expect(getByText('$1.229')).toBeOnTheScreen();
     expect(getByText('$2.345')).toBeOnTheScreen();
-    expect(getByText('$0.005')).toBeOnTheScreen();
+    expect(queryByText('MetaMask fee')).toBeNull();
+    expect(queryByText('Hyperliquid fee')).toBeNull();
   });
 
   it('shows a filled order as "Filled" in the status row, not "Confirmed"', () => {
@@ -278,6 +282,7 @@ describe('PerpsDetails', () => {
       category: 'limit_order',
       title: 'Market short',
       order: {
+        orderId: 'order-filled',
         text: PerpsOrderTransactionStatus.Filled,
         statusType: PerpsOrderTransactionStatusType.Filled,
         type: 'market',
@@ -296,6 +301,32 @@ describe('PerpsDetails', () => {
     expect(statusPill).not.toHaveTextContent('Confirmed');
   });
 
+  it('renders the recorded fee for a triggered order', () => {
+    const transaction: PerpsTransaction = {
+      ...baseTransaction,
+      id: 'order-triggered',
+      type: 'order',
+      category: 'limit_order',
+      title: 'Stop market close short',
+      order: {
+        orderId: 'order-triggered',
+        text: PerpsOrderTransactionStatus.Triggered,
+        statusType: PerpsOrderTransactionStatusType.Filled,
+        type: 'market',
+        size: '10',
+        limitPrice: '90000',
+        filled: '100%',
+      },
+    };
+
+    const { getByText } = renderWithProvider(
+      <PerpsDetails item={perpsItem('marketCloseShort', transaction)} />,
+    );
+
+    expect(getByText('Total fee')).toBeOnTheScreen();
+    expect(getByText('$2.345')).toBeOnTheScreen();
+  });
+
   it('labels a rejected order "Rejected" in the status row (not "Failed")', () => {
     const transaction: PerpsTransaction = {
       ...baseTransaction,
@@ -304,6 +335,7 @@ describe('PerpsDetails', () => {
       category: 'limit_order',
       title: 'Market short',
       order: {
+        orderId: 'order-rejected',
         text: PerpsOrderTransactionStatus.Rejected,
         statusType: PerpsOrderTransactionStatusType.Canceled,
         type: 'market',

--- a/app/components/Views/ActivityDetails/templates/PerpsDetails.test.tsx
+++ b/app/components/Views/ActivityDetails/templates/PerpsDetails.test.tsx
@@ -186,7 +186,7 @@ describe('PerpsDetails', () => {
     ).toHaveTextContent('Confirmed');
   });
 
-  it('renders the recorded fee for a partially filled canceled order', () => {
+  it('renders canceled order rows and try-again CTA', () => {
     const transaction: PerpsTransaction = {
       ...baseTransaction,
       id: 'order-1',
@@ -200,7 +200,7 @@ describe('PerpsDetails', () => {
         type: 'limit',
         size: '10.23',
         limitPrice: '98023',
-        filled: '45%',
+        filled: '0%',
       },
     };
 
@@ -211,12 +211,39 @@ describe('PerpsDetails', () => {
     );
 
     expect(getByText('Limit price')).toBeOnTheScreen();
-    expect(getByText('45%')).toBeOnTheScreen();
-    expect(getByText('Total fee')).toBeOnTheScreen();
-    expect(getByText('$2.345')).toBeOnTheScreen();
+    expect(getByText('0%')).toBeOnTheScreen();
     expect(
       getByTestId(ActivityDetailsSelectorsIDs.DO_IT_AGAIN_BUTTON),
     ).toBeOnTheScreen();
+  });
+
+  it('renders the recorded fee for a partially filled canceled order', () => {
+    const transaction: PerpsTransaction = {
+      ...baseTransaction,
+      id: 'order-partially-filled',
+      type: 'order',
+      category: 'limit_order',
+      title: 'Take profit close short',
+      order: {
+        orderId: 'order-partially-filled',
+        text: PerpsOrderTransactionStatus.Canceled,
+        statusType: PerpsOrderTransactionStatusType.Canceled,
+        type: 'limit',
+        size: '10.23',
+        limitPrice: '98023',
+        filled: '45%',
+      },
+    };
+
+    const { getByText } = renderWithProvider(
+      <PerpsDetails
+        item={perpsItem('marketCloseShort', transaction, 'cancelled')}
+      />,
+    );
+
+    expect(getByText('45%')).toBeOnTheScreen();
+    expect(getByText('Total fee')).toBeOnTheScreen();
+    expect(getByText('$2.345')).toBeOnTheScreen();
   });
 
   it('renders funding rate and signed funding fee', () => {

--- a/app/components/Views/ActivityDetails/templates/PerpsDetails.test.tsx
+++ b/app/components/Views/ActivityDetails/templates/PerpsDetails.test.tsx
@@ -13,6 +13,13 @@ import { usePerpsRecordedOrderFees } from '../../../UI/Perps/hooks';
 import { ActivityDetailsSelectorsIDs } from '../ActivityDetails.testIds';
 import { PerpsDetails } from './PerpsDetails';
 
+const mockPerpsConnectionProvider = jest.fn(
+  ({ children }: { children: React.ReactNode }) => <>{children}</>,
+);
+const mockPerpsStreamProvider = jest.fn(
+  ({ children }: { children: React.ReactNode }) => <>{children}</>,
+);
+
 jest.mock(
   '../../../../selectors/multichainAccounts/accountTreeController',
   () => {
@@ -28,6 +35,16 @@ jest.mock(
     };
   },
 );
+
+jest.mock('../../../UI/Perps/providers/PerpsConnectionProvider', () => ({
+  PerpsConnectionProvider: ({ children }: { children: React.ReactNode }) =>
+    mockPerpsConnectionProvider({ children }),
+}));
+
+jest.mock('../../../UI/Perps/providers/PerpsStreamManager', () => ({
+  PerpsStreamProvider: ({ children }: { children: React.ReactNode }) =>
+    mockPerpsStreamProvider({ children }),
+}));
 
 jest.mock('../../../UI/Perps/hooks', () => ({
   usePerpsBlockExplorerUrl: () => ({
@@ -156,6 +173,10 @@ function localPerpsFundsItem(
 }
 
 describe('PerpsDetails', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders trade rows and trade-again CTA', () => {
     const transaction: PerpsTransaction = {
       ...baseTransaction,
@@ -192,6 +213,34 @@ describe('PerpsDetails', () => {
     ).toHaveTextContent('Confirmed');
   });
 
+  it('renders trade details without Perps provider contexts', () => {
+    const transaction: PerpsTransaction = {
+      ...baseTransaction,
+      type: 'trade',
+      fill: {
+        shortTitle: 'Closed short',
+        amount: '-$0.02',
+        amountNumber: -0.02,
+        isPositive: false,
+        size: '0.0001',
+        entryPrice: '92113',
+        points: '0',
+        pnl: '-$0.02',
+        fee: '0.02',
+        action: 'Closed',
+        feeToken: 'USDC',
+        fillType: FillType.Standard,
+      },
+    };
+
+    renderWithProvider(
+      <PerpsDetails item={perpsItem('perpsCloseShort', transaction)} />,
+    );
+
+    expect(mockPerpsConnectionProvider).not.toHaveBeenCalled();
+    expect(mockPerpsStreamProvider).not.toHaveBeenCalled();
+  });
+
   it('renders canceled order rows and try-again CTA', () => {
     const transaction: PerpsTransaction = {
       ...baseTransaction,
@@ -221,6 +270,32 @@ describe('PerpsDetails', () => {
     expect(
       getByTestId(ActivityDetailsSelectorsIDs.DO_IT_AGAIN_BUTTON),
     ).toBeOnTheScreen();
+  });
+
+  it('provides connection and stream contexts for order details', () => {
+    const transaction: PerpsTransaction = {
+      ...baseTransaction,
+      id: 'provider-backed-order',
+      type: 'order',
+      category: 'limit_order',
+      title: 'Limit order',
+      order: {
+        orderId: 'provider-backed-order',
+        text: PerpsOrderTransactionStatus.Filled,
+        statusType: PerpsOrderTransactionStatusType.Filled,
+        type: 'limit',
+        size: '10',
+        limitPrice: '98023',
+        filled: '100%',
+      },
+    };
+
+    renderWithProvider(
+      <PerpsDetails item={perpsItem('marketShort', transaction)} />,
+    );
+
+    expect(mockPerpsConnectionProvider).toHaveBeenCalledTimes(1);
+    expect(mockPerpsStreamProvider).toHaveBeenCalledTimes(1);
   });
 
   it('renders the recorded fee for a partially filled canceled order', () => {

--- a/app/components/Views/ActivityDetails/templates/PerpsDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/PerpsDetails.tsx
@@ -204,7 +204,11 @@ function OrderDetails({
     totalFee,
     isLoading: isFeeLoading,
     hasError: hasFeeError,
-  } = usePerpsRecordedOrderFees(order?.orderId, transaction.asset);
+  } = usePerpsRecordedOrderFees(
+    order?.orderId,
+    transaction.asset,
+    transaction.timestamp,
+  );
   const totalFeeValue =
     isFeeLoading || hasFeeError || totalFee === undefined
       ? '—'

--- a/app/components/Views/ActivityDetails/templates/PerpsDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/PerpsDetails.tsx
@@ -51,7 +51,7 @@ import {
   type PerpsTransaction,
 } from '../components/ActivityDetailsPerps.utils';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
-import { usePerpsOrderFees } from '../../../UI/Perps/hooks';
+import { usePerpsRecordedOrderFees } from '../../../UI/Perps/hooks';
 import { resolvePerpsOrderStatusLabel } from '../../../UI/ActivityListItemRow/titleLabels';
 
 /**
@@ -200,11 +200,15 @@ function OrderDetails({
   const handleTryAgain = useTradeAgain(transaction.asset);
   const shouldShowTryAgain =
     item.status === 'cancelled' || item.status === 'failed';
-  const isFilled = item.status === 'success';
-  const { totalFee, protocolFee, metamaskFee } = usePerpsOrderFees({
-    orderType: order?.type ?? 'market',
-    amount: isFilled ? (order?.size ?? '0') : '0',
-  });
+  const {
+    totalFee,
+    isLoading: isFeeLoading,
+    hasError: hasFeeError,
+  } = usePerpsRecordedOrderFees(order?.orderId, transaction.asset);
+  const totalFeeValue =
+    isFeeLoading || hasFeeError || totalFee === undefined
+      ? '—'
+      : formatPerpsOrderFee(totalFee);
 
   return (
     <ActivityDetailsTemplateFrame
@@ -238,16 +242,8 @@ function OrderDetails({
       details={
         <ActivityDetailSection>
           <ActivityDetailRow
-            label={strings('perps.transactions.order.metamask_fee')}
-            value={formatPerpsOrderFee(metamaskFee, isFilled)}
-          />
-          <ActivityDetailRow
-            label={strings('perps.transactions.order.hyperliquid_fee')}
-            value={formatPerpsOrderFee(protocolFee, isFilled)}
-          />
-          <ActivityDetailRow
             label={strings('perps.transactions.order.total_fee')}
-            value={formatPerpsOrderFee(totalFee, isFilled)}
+            value={totalFeeValue}
           />
         </ActivityDetailSection>
       }

--- a/app/components/Views/ActivityDetails/templates/PerpsDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/PerpsDetails.tsx
@@ -53,6 +53,8 @@ import {
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { usePerpsRecordedOrderFees } from '../../../UI/Perps/hooks';
 import { resolvePerpsOrderStatusLabel } from '../../../UI/ActivityListItemRow/titleLabels';
+import { PerpsConnectionProvider } from '../../../UI/Perps/providers/PerpsConnectionProvider';
+import { PerpsStreamProvider } from '../../../UI/Perps/providers/PerpsStreamManager';
 
 /**
  * The local row's activity status in the terms the step timeline speaks. A
@@ -476,7 +478,13 @@ export function PerpsDetails({ item }: { item: ActivityListItem }) {
   }
 
   if (transaction.type === 'order') {
-    return <OrderDetails item={perpsItem} transaction={transaction} />;
+    return (
+      <PerpsConnectionProvider suppressErrorView>
+        <PerpsStreamProvider>
+          <OrderDetails item={perpsItem} transaction={transaction} />
+        </PerpsStreamProvider>
+      </PerpsConnectionProvider>
+    );
   }
 
   if (transaction.type === 'funding') {

--- a/app/components/Views/ActivityDetails/templates/TemplateLoader.test.tsx
+++ b/app/components/Views/ActivityDetails/templates/TemplateLoader.test.tsx
@@ -58,10 +58,10 @@ jest.mock('../../../UI/Perps/hooks', () => ({
   usePerpsBlockExplorerUrl: () => ({
     getExplorerUrl: () => 'https://app.hyperliquid.xyz/explorer/address/0x1',
   }),
-  usePerpsOrderFees: () => ({
+  usePerpsRecordedOrderFees: () => ({
     totalFee: 0,
-    protocolFee: 0,
-    metamaskFee: 0,
+    isLoading: false,
+    hasError: false,
   }),
 }));
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Historical Perps order details recalculated fees using the current fee schedule, which could differ from the fees charged when the order executed.

This change associates orders with their execution fills and displays the summed recorded fee. It also replaces the estimated MetaMask/Hyperliquid breakdown with one accurate Total fee row and prevents loading failures from appearing as $0.

Fees are derived from matching fills rather than order status because canceled orders may have partial fills that incurred fees, while triggered orders may not use the literal Filled status.

**Expected QA behavior:** Recent fully filled orders may show the same total as main — that is expected when current rates match execution-time rates. The clearest regression to verify is a partially filled, then canceled order: main showed $0 fees; this branch should show the sum of fees from those partial fills. Larger divergence is more likely on older orders or after VIP/builder fee tier changes.

- Orders outside the 90-day fill window now show — when no fills match.
- Covered orders without fills still show $0.
- Matching recorded fills are summed regardless of age.
- Both detail views now pass the transaction timestamp.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed historical Perps orders displaying fees calculated from current rates.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3693

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Historical Perps order fees

  Scenario: user views a historical Perps order
    Given the order has one or more recorded execution fills

    When user opens the order details
    Then the total fee equals the sum of the recorded fill fees
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-07 at 19 50 13" src="https://github.com/user-attachments/assets/61820504-5f9f-45b7-9c76-81eea3bc287b" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-07 at 19 50 49" src="https://github.com/user-attachments/assets/79cb68d8-097a-40db-99de-b8dc86ff7fc5" />


<!-- [screenshots/recordings] -->

### **After**
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-07 at 19 50 13" src="https://github.com/user-attachments/assets/2987fd56-abb8-484e-ad1f-acfb99583641" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-07 at 19 50 49" src="https://github.com/user-attachments/assets/dcc40bdd-37f1-493d-b8d6-11953452fe7c" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing fee amounts change for historical orders and depend on fill history coverage (90-day lookback) and async loading; incorrect handling could misstate fees, but the change moves toward recorded execution data rather than estimates.
> 
> **Overview**
> Fixes historical Perps order fees that were **recalculated from today’s fee schedule** instead of what was charged at execution.
> 
> Order details (transaction view and Activity **PerpsDetails**) now use **`usePerpsRecordedOrderFees`**, which matches fills by **`orderId`** (added on order transactions in **`transactionTransforms`**) and sums **`fill.fee`**, including partial fills on canceled orders. The MetaMask/Hyperliquid fee breakdown is removed in favor of one **Total fee** row; loading and errors show **—** rather than **$0**.
> 
> **`usePerpsMarketFills`** gains **`restHistoryStatus`**, waits for Perps connection before REST backfill, and ignores stale in-flight fetches on account or connection changes. Order screens wrap content in **`PerpsConnectionProvider`** and **`PerpsStreamProvider`** so fill history can load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 878bb9f1fafdfc714acb12ab1a03a2463564ebea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->