### PR TITLE
feat(perps): add catalog haptics to Pro-mode trading interactions

### DIFF
--- a/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.test.tsx
@@ -201,13 +201,18 @@ jest.mock('@metamask/design-system-react-native', () => {
   };
 });
 
-jest.mock('../../../../../util/haptics', () => ({
-  playImpact: jest.fn(),
-  ImpactMoment: {
-    SliderGrip: 'SliderGrip',
-    SliderTick: 'SliderTick',
-  },
-}));
+jest.mock('../../../../../util/haptics', () => {
+  const mockPlayImpact = jest.fn().mockResolvedValue(undefined);
+  return {
+    playImpact: mockPlayImpact,
+    useHaptics: () => ({ playImpact: mockPlayImpact }),
+    ImpactMoment: {
+      PrimaryCTA: 'PrimaryCTA',
+      SliderGrip: 'SliderGrip',
+      SliderTick: 'SliderTick',
+    },
+  };
+});
 
 describe('PerpsAdjustMarginView', () => {
   const mockPosition: Position = {
@@ -265,6 +270,7 @@ describe('PerpsAdjustMarginView', () => {
       mockRouteParams = {
         position: mockPosition,
         mode: 'add',
+        enableHaptics: true,
       };
     });
 
@@ -681,12 +687,14 @@ describe('PerpsAdjustMarginView', () => {
       });
 
       expect(mockHandleAddMargin).toHaveBeenCalledWith('ETH', 250);
+      expect(playImpact).not.toHaveBeenCalled();
     });
 
     it('removes margin on confirm in remove mode', async () => {
       mockRouteParams = {
         position: mockPosition,
         mode: 'remove',
+        enableHaptics: true,
       };
       mockUsePerpsAdjustMarginData.mockReturnValue({
         position: mockPosition,
@@ -724,6 +732,8 @@ describe('PerpsAdjustMarginView', () => {
       });
 
       expect(mockHandleRemoveMargin).toHaveBeenCalledWith('ETH', 100);
+      expect(playImpact).toHaveBeenCalledTimes(1);
+      expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
     });
 
     it('does not submit when amount is zero', () => {
@@ -740,6 +750,7 @@ describe('PerpsAdjustMarginView', () => {
 
       expect(mockHandleAddMargin).not.toHaveBeenCalled();
       expect(mockHandleRemoveMargin).not.toHaveBeenCalled();
+      expect(playImpact).not.toHaveBeenCalled();
     });
 
     it('does not remove margin when amount exceeds max removable', async () => {

--- a/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx
+++ b/app/components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx
@@ -48,11 +48,16 @@ import {
   PRICE_RANGES_UNIVERSAL,
   PRICE_RANGES_MINIMAL_VIEW,
 } from '../../utils/formatUtils';
-import { ImpactMoment, playImpact } from '../../../../../util/haptics';
+import {
+  ImpactMoment,
+  playImpact,
+  useHaptics,
+} from '../../../../../util/haptics';
 
 interface AdjustMarginRouteParams {
   position: Position;
   mode: 'add' | 'remove';
+  enableHaptics?: boolean;
 }
 
 const floorUsd = (value: number) => Math.floor(value * 100) / 100;
@@ -62,7 +67,12 @@ const PerpsAdjustMarginView: React.FC = () => {
   const navigation = useNavigation<AppNavigationProp>();
   const route =
     useRoute<RouteProp<{ params: AdjustMarginRouteParams }, 'params'>>();
-  const { position: routePosition, mode } = route.params || {};
+  const {
+    position: routePosition,
+    mode,
+    enableHaptics = false,
+  } = route.params || {};
+  const { playImpact: playHapticImpact } = useHaptics();
 
   const [marginAmountString, setMarginAmountString] = useState('0');
   const [isInputFocused, setIsInputFocused] = useState(false);
@@ -237,11 +247,22 @@ const PerpsAdjustMarginView: React.FC = () => {
   );
 
   const handleConfirm = useCallback(async () => {
-    if (marginAmount <= 0 || !position) return;
+    if (
+      marginAmount <= 0 ||
+      !position ||
+      isAdjusting ||
+      validationErrors.length
+    ) {
+      return;
+    }
 
     // Prevent submission if amount exceeds max removable (extra safety for remove mode)
     if (!isAddMode && marginAmount > flooredMaxAmount) {
       return;
+    }
+
+    if (enableHaptics) {
+      playHapticImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
     }
 
     // Capture estimates at submission - displayed during exit animation
@@ -258,12 +279,16 @@ const PerpsAdjustMarginView: React.FC = () => {
   }, [
     marginAmount,
     position,
+    enableHaptics,
     isAddMode,
+    isAdjusting,
+    validationErrors.length,
     flooredMaxAmount,
     newLiquidationPrice,
     newLiquidationDistance,
     handleAddMargin,
     handleRemoveMargin,
+    playHapticImpact,
   ]);
 
   const buttonLabel = isAddMode

--- a/app/components/UI/Perps/Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { fireEvent, render } from '@testing-library/react-native';
 import PerpsCloseAllPositionsView from './PerpsCloseAllPositionsView';
 import { strings } from '../../../../../../locales/i18n';
 import {
@@ -10,11 +10,13 @@ import {
 } from '../../hooks';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { PerpsCloseAllPositionsViewSelectorsIDs } from '../../Perps.testIds';
+import { ImpactMoment, playImpact } from '../../../../../util/haptics';
 
 // Mock all dependencies
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(() => ({ navigate: jest.fn(), goBack: jest.fn() })),
 }));
+jest.mock('../../../../../util/haptics');
 
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => key),
@@ -145,6 +147,31 @@ describe('PerpsCloseAllPositionsView', () => {
       accountOptedIn: true,
       account: mockRewardAccountOptedIn as unknown as InternalAccount,
     });
+  });
+
+  it('keeps close-all confirmation haptics off by default', () => {
+    const { getByTestId } = render(<PerpsCloseAllPositionsView />);
+
+    fireEvent.press(
+      getByTestId(PerpsCloseAllPositionsViewSelectorsIDs.CLOSE_ALL_BUTTON),
+    );
+
+    expect(mockCloseAllHook.handleCloseAll).toHaveBeenCalledTimes(1);
+    expect(playImpact).not.toHaveBeenCalled();
+  });
+
+  it('plays PrimaryCTA once for opted-in close-all confirmation', () => {
+    const { getByTestId } = render(
+      <PerpsCloseAllPositionsView enableHaptics />,
+    );
+
+    fireEvent.press(
+      getByTestId(PerpsCloseAllPositionsViewSelectorsIDs.CLOSE_ALL_BUTTON),
+    );
+
+    expect(mockCloseAllHook.handleCloseAll).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
   });
 
   it('renders loading state when initially loading positions', () => {

--- a/app/components/UI/Perps/Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView.tsx
@@ -15,7 +15,11 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import { NotificationMoment } from '../../../../../util/haptics';
+import {
+  ImpactMoment,
+  NotificationMoment,
+  useHaptics,
+} from '../../../../../util/haptics';
 import { strings } from '../../../../../../locales/i18n';
 import { IconName } from '../../../../../component-library/components/Icons/Icon';
 import { ToastVariants } from '../../../../../component-library/components/Toast/Toast.types';
@@ -49,6 +53,7 @@ interface PerpsCloseAllPositionsViewProps {
   positions?: Position[];
   /** Drops "all" from the title, which would misdescribe a filtered subset. */
   isFiltered?: boolean;
+  enableHaptics?: boolean;
 }
 
 const PerpsCloseAllPositionsView: React.FC<PerpsCloseAllPositionsViewProps> = ({
@@ -56,6 +61,7 @@ const PerpsCloseAllPositionsView: React.FC<PerpsCloseAllPositionsViewProps> = ({
   onClose: onExternalClose,
   positions: propPositions,
   isFiltered = false,
+  enableHaptics = false,
 }) => {
   const theme = useTheme();
   const styles = createStyles(theme);
@@ -63,6 +69,7 @@ const PerpsCloseAllPositionsView: React.FC<PerpsCloseAllPositionsViewProps> = ({
   const internalSheetRef = useRef<BottomSheetRef>(null);
   const sheetRef = externalSheetRef || internalSheetRef;
   const { showToast } = usePerpsToasts();
+  const { playImpact } = useHaptics();
 
   // Fetch positions from live stream (used only when no positions prop is passed)
   const liveResult = usePerpsLivePositions({
@@ -210,6 +217,16 @@ const PerpsCloseAllPositionsView: React.FC<PerpsCloseAllPositionsViewProps> = ({
       },
     });
 
+  const handleCloseAllPress = useCallback(() => {
+    if (isClosing) {
+      return;
+    }
+    if (enableHaptics) {
+      playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
+    }
+    handleCloseAll();
+  }, [enableHaptics, handleCloseAll, isClosing, playImpact]);
+
   const handleClose = useCallback(() => {
     if (externalSheetRef) {
       sheetRef.current?.onCloseBottomSheet(() => {
@@ -249,13 +266,13 @@ const PerpsCloseAllPositionsView: React.FC<PerpsCloseAllPositionsViewProps> = ({
       children: isClosing
         ? strings('perps.close_all_modal.closing')
         : strings('perps.close_all_modal.close_count', { count: closeCount }),
-      onPress: handleCloseAll,
+      onPress: handleCloseAllPress,
       size: ButtonSize.Lg,
       isDisabled: isClosing,
       isDanger: true,
       testID: PerpsCloseAllPositionsViewSelectorsIDs.CLOSE_ALL_BUTTON,
     }),
-    [closeCount, handleCloseAll, isClosing],
+    [closeCount, handleCloseAllPress, isClosing],
   );
 
   const title = isFiltered

--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.test.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../Perps.testIds';
 import { strings } from '../../../../../../locales/i18n';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import { ImpactMoment, playImpact } from '../../../../../util/haptics';
 import {
   defaultMinimumOrderAmountMock,
   defaultPerpsClosePositionMock,
@@ -38,6 +39,7 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
   useRoute: jest.fn(),
 }));
+jest.mock('../../../../../util/haptics');
 
 // Mock React Native Linking specifically for this test to prevent NavigationContainer errors
 jest.mock('react-native/Libraries/Linking/Linking', () => ({
@@ -393,13 +395,55 @@ describe('PerpsClosePositionView', () => {
       await waitFor(() => {
         expect(handleClosePosition).toHaveBeenCalled();
       });
+      expect(playImpact).not.toHaveBeenCalled();
+    });
+
+    it('plays PrimaryCTA once for an opted-in close confirmation', async () => {
+      const handleClosePosition = jest.fn();
+      usePerpsClosePositionMock.mockReturnValue({
+        handleClosePosition,
+        isClosing: false,
+      });
+      useRouteMock.mockReturnValue({
+        params: {
+          position: defaultPerpsPositionMock,
+          enableHaptics: true,
+        },
+      });
+
+      const { getByTestId } = renderWithProvider(
+        <PerpsClosePositionView />,
+        {
+          state: STATE_MOCK,
+        },
+        true,
+      );
+
+      fireEvent.press(
+        getByTestId(
+          PerpsClosePositionViewSelectorsIDs.CLOSE_POSITION_CONFIRM_BUTTON,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(handleClosePosition).toHaveBeenCalled();
+      });
+      expect(playImpact).toHaveBeenCalledTimes(1);
+      expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
     });
 
     it('disables confirm button when closing is in progress', () => {
       // Arrange
+      const handleClosePosition = jest.fn();
       usePerpsClosePositionMock.mockReturnValue({
-        handleClosePosition: jest.fn(),
+        handleClosePosition,
         isClosing: true,
+      });
+      useRouteMock.mockReturnValue({
+        params: {
+          position: defaultPerpsPositionMock,
+          enableHaptics: true,
+        },
       });
 
       const { getByTestId } = renderWithProvider(
@@ -420,6 +464,9 @@ describe('PerpsClosePositionView', () => {
         confirmButton.props.disabled ||
           confirmButton.props.accessibilityState?.disabled,
       ).toBe(true);
+      fireEvent.press(confirmButton);
+      expect(handleClosePosition).not.toHaveBeenCalled();
+      expect(playImpact).not.toHaveBeenCalled();
     });
 
     it('shows loading state on confirm button when closing', () => {

--- a/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx
@@ -33,7 +33,11 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTheme } from '../../../../../util/theme';
-import { ImpactMoment, playImpact } from '../../../../../util/haptics';
+import {
+  ImpactMoment,
+  playImpact,
+  useHaptics,
+} from '../../../../../util/haptics';
 import Keypad from '../../../../Base/Keypad';
 import {
   DECIMAL_PRECISION_CONFIG,
@@ -97,12 +101,15 @@ const PerpsClosePositionView: React.FC = () => {
     source: routeSource,
     buttonClicked: entryButtonClicked,
     buttonLocation: entryButtonLocation,
+    enableHaptics = false,
   } = route.params as {
     position: Position;
     source?: string;
     buttonClicked?: string;
     buttonLocation?: string;
+    enableHaptics?: boolean;
   };
+  const { playImpact: playHapticImpact } = useHaptics();
 
   const inputMethodRef = useRef<InputMethod>('default');
   const isAmountInitializedRef = useRef(false);
@@ -564,6 +571,10 @@ const PerpsClosePositionView: React.FC = () => {
   }, [effectiveOrderType, limitPrice]);
 
   const handleConfirm = useCallback(async () => {
+    if (isClosing) {
+      return;
+    }
+
     // Guard against submitting a stale committed `closePercentage` while
     // `isDraggingSlider` is (or is stuck) true — e.g. a cancelled gesture
     // that never reached commitClosePercentage (see handleSliderDragCancel
@@ -583,6 +594,9 @@ const PerpsClosePositionView: React.FC = () => {
     // For limit orders, validate price
     if (effectiveOrderType === 'limit' && !limitPrice) {
       return;
+    }
+    if (enableHaptics) {
+      playHapticImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
     }
     // Mark confirmed so the focus-effect cleanup does not emit an abandon event
     hasConfirmedCloseRef.current = true;
@@ -629,6 +643,8 @@ const PerpsClosePositionView: React.FC = () => {
     closePercentage,
     closeAmount,
     effectiveOrderType,
+    enableHaptics,
+    isClosing,
     limitPrice,
     navigation,
     handleClosePosition,
@@ -648,6 +664,7 @@ const PerpsClosePositionView: React.FC = () => {
     position.symbol,
     closingValueString,
     effectivePrice,
+    playHapticImpact,
     isDraggingSlider,
     commitClosePercentage,
     liveDragClosePercentage,

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
@@ -610,7 +610,7 @@ describe('PerpsHomeView', () => {
     expect(getByTestId(PerpsHomeViewSelectorsIDs.SEARCH_TOGGLE)).toBeTruthy();
   });
 
-  it('renders the active-mode pill in the header when the Pro mode flag is enabled', () => {
+  it('enables mode-toggle haptics for the Lite mode header', () => {
     // Arrange
     mockUseSelector.mockImplementation(
       (selector: unknown) => selector === selectPerpsProModeEnabledFlag,
@@ -629,7 +629,7 @@ describe('PerpsHomeView', () => {
     ).toBeOnTheScreen();
     expect(mockPerpsModeToggle).toHaveBeenCalledWith({
       variant: 'active',
-      enableHaptics: false,
+      enableHaptics: true,
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act, render, fireEvent, waitFor } from '@testing-library/react-native';
 import PerpsHomeView from './PerpsHomeView';
-import { PERPS_EVENT_VALUE } from '@metamask/perps-controller';
+import { PERPS_EVENT_VALUE, PerpsMode } from '@metamask/perps-controller';
 import {
   selectPerpsFeedbackEnabledFlag,
   selectPerpsProductsEnabledFlag,
@@ -70,6 +70,7 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 const mockPerpsModeToggle = jest.fn();
+let mockPerpsModeValue = PerpsMode.Lite;
 
 // Stub the reusable Lite/Pro toggle so this view test focuses on header wiring
 // (its analytics/design-system internals are covered by its own unit tests).
@@ -84,11 +85,13 @@ jest.mock('../../components/PerpsModeToggle', () => {
     default: ({
       onChange,
       variant,
+      enableHaptics,
     }: {
       onChange?: (mode: string) => void;
       variant?: string;
+      enableHaptics?: boolean;
     }) => {
-      mockPerpsModeToggle({ variant });
+      mockPerpsModeToggle({ variant, enableHaptics });
       return ReactActual.createElement(TouchableOpacity, {
         testID: SelectorsIDs.CONTAINER,
         // Simulate the user switching to Pro from the stubbed toggle.
@@ -155,7 +158,7 @@ jest.mock('../../hooks', () => ({
   })),
   usePerpsHomeSectionTracking: () => mockUsePerpsHomeSectionTracking(),
   usePerpsMode: jest.fn(() => ({
-    mode: 'lite',
+    mode: mockPerpsModeValue,
     setMode: mockSetPerpsMode,
   })),
 }));
@@ -558,6 +561,7 @@ describe('PerpsHomeView', () => {
     mockNavigateToWallet.mockClear();
     mockNavigateToMarketList.mockClear();
     mockRouteParams = { source: 'main_action_button' };
+    mockPerpsModeValue = PerpsMode.Lite;
     mockUsePerpsHomeData.mockReturnValue(mockDefaultData);
     mockUsePerpsHomeSectionTracking.mockReturnValue(mockScrollTracking());
     mockUsePerpsTopMovers.mockReturnValue({
@@ -623,7 +627,27 @@ describe('PerpsHomeView', () => {
     expect(
       getByTestId(PerpsModeToggleSelectorsIDs.CONTAINER),
     ).toBeOnTheScreen();
-    expect(mockPerpsModeToggle).toHaveBeenCalledWith({ variant: 'active' });
+    expect(mockPerpsModeToggle).toHaveBeenCalledWith({
+      variant: 'active',
+      enableHaptics: false,
+    });
+  });
+
+  it('enables mode-toggle haptics for the Pro mode header', () => {
+    // Arrange
+    mockPerpsModeValue = PerpsMode.Pro;
+    mockUseSelector.mockImplementation(
+      (selector: unknown) => selector === selectPerpsProModeEnabledFlag,
+    );
+
+    // Act
+    render(<PerpsHomeView />);
+
+    // Assert
+    expect(mockPerpsModeToggle).toHaveBeenCalledWith({
+      variant: 'active',
+      enableHaptics: true,
+    });
   });
 
   it('does not render the Lite/Pro toggle when the Pro mode flag is disabled', () => {

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -1098,6 +1098,7 @@ const PerpsHomeView = () => {
                 mode={perpsMode}
                 onChange={handleModeChange}
                 variant="active"
+                enableHaptics
                 source={PERPS_EVENT_VALUE.SOURCE.PERPS_HOME}
               />
             ) : null}

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -1098,7 +1098,7 @@ const PerpsHomeView = () => {
                 mode={perpsMode}
                 onChange={handleModeChange}
                 variant="active"
-                enableHaptics={perpsMode === PerpsMode.Pro}
+                enableHaptics
                 source={PERPS_EVENT_VALUE.SOURCE.PERPS_HOME}
               />
             ) : null}

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -1098,7 +1098,7 @@ const PerpsHomeView = () => {
                 mode={perpsMode}
                 onChange={handleModeChange}
                 variant="active"
-                enableHaptics
+                enableHaptics={perpsMode === PerpsMode.Pro}
                 source={PERPS_EVENT_VALUE.SOURCE.PERPS_HOME}
               />
             ) : null}

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -1118,9 +1118,11 @@ describe('PerpsMarketDetailsView', () => {
     expect(mockSetPerpsMode).not.toHaveBeenCalled();
     await act(async () => {
       jest.advanceTimersByTime(GLOW_TOTAL_MS);
+      await Promise.resolve();
     });
 
     expect(mockSetPerpsMode).toHaveBeenCalledWith(PerpsMode.Pro);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.TabChange);
     expect(mockNavigate).not.toHaveBeenCalledWith(
       Routes.PERPS.MODALS.ROOT,
       expect.objectContaining({
@@ -1148,10 +1150,12 @@ describe('PerpsMarketDetailsView', () => {
     expect(mockSetPerpsMode).not.toHaveBeenCalled();
     await act(async () => {
       jest.advanceTimersByTime(GLOW_TOTAL_MS);
+      await Promise.resolve();
     });
 
     expect(mockSetPerpsMode).toHaveBeenCalledWith(PerpsMode.Lite);
     expect(mockReset).not.toHaveBeenCalled();
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.TabChange);
   });
 
   it('opens the mode chooser from the pill when the chooser has not been completed', async () => {
@@ -1172,6 +1176,7 @@ describe('PerpsMarketDetailsView', () => {
 
     await act(async () => {
       jest.advanceTimersByTime(GLOW_TOTAL_MS);
+      await Promise.resolve();
     });
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.MODALS.ROOT, {
@@ -1182,6 +1187,7 @@ describe('PerpsMarketDetailsView', () => {
       },
     });
     expect(mockSetPerpsMode).not.toHaveBeenCalled();
+    expect(playImpact).not.toHaveBeenCalled();
   });
 
   it('does not show the active-mode pill when the Pro mode flag is disabled', () => {

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -16,6 +16,7 @@ import { GLOW_TOTAL_MS } from '../../components/PerpsModeToggle/PerpsModeSwitchP
 import { useDefaultPayWithTokenWhenNoPerpsBalance } from '../../hooks/useDefaultPayWithTokenWhenNoPerpsBalance';
 import { Linking, Platform } from 'react-native';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { ImpactMoment, playImpact } from '../../../../../util/haptics';
 import Routes from '../../../../../constants/navigation/Routes';
 import {
   selectPerpsAdvancedChartEnabledFlag,
@@ -38,6 +39,8 @@ import {
 const mockPerpsAdvancedChartMount = jest.fn();
 const mockPerpsAdvancedChartUnmount = jest.fn();
 const mockTradingViewResetToDefault = jest.fn();
+
+jest.mock('../../../../../util/haptics');
 
 jest.mock('react-native-modal', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
@@ -3919,6 +3922,7 @@ describe('PerpsMarketDetailsView', () => {
         source: 'perp_asset_screen',
         enableHaptics: false,
       });
+      expect(playImpact).not.toHaveBeenCalled();
     });
 
     it('enables market list haptics in Pro mode', () => {
@@ -3941,6 +3945,7 @@ describe('PerpsMarketDetailsView', () => {
         source: 'perp_asset_screen',
         enableHaptics: true,
       });
+      expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
     });
 
     it('tracks the market list button click with the correct analytics values', () => {

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -3917,6 +3917,29 @@ describe('PerpsMarketDetailsView', () => {
 
       expect(mockNavigateToMarketListFromHeader).toHaveBeenCalledWith({
         source: 'perp_asset_screen',
+        enableHaptics: false,
+      });
+    });
+
+    it('enables market list haptics in Pro mode', () => {
+      mockPerpsModeValue = PerpsMode.Pro;
+
+      const { getByTestId } = renderWithProvider(
+        <PerpsConnectionProvider>
+          <PerpsMarketDetailsView />
+        </PerpsConnectionProvider>,
+        {
+          state: initialState,
+        },
+      );
+
+      fireEvent.press(
+        getByTestId(PerpsMarketHeaderSelectorsIDs.MARKET_LIST_BUTTON),
+      );
+
+      expect(mockNavigateToMarketListFromHeader).toHaveBeenCalledWith({
+        source: 'perp_asset_screen',
+        enableHaptics: true,
       });
     });
 

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -40,6 +40,7 @@ import Animated, { useAnimatedScrollHandler } from 'react-native-reanimated';
 import { scheduleOnRN } from 'react-native-worklets';
 import {
   CandlePeriod,
+  PerpsMode,
   TimeDuration,
   PERPS_CONSTANTS,
   type Position,
@@ -1531,7 +1532,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
         isFavorite={isWatchlist}
         mode={isPerpsProModeEnabled ? perpsMode : undefined}
         onModeChange={isPerpsProModeEnabled ? handlePerpsModeChange : undefined}
-        enableHaptics
+        enableHaptics={perpsMode === PerpsMode.Pro}
         scrollY={scrollYShared}
         priceSectionHeight={titleSectionHeightSv}
         currentPrice={syncedChartCurrentPrice}

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -1531,6 +1531,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
         isFavorite={isWatchlist}
         mode={isPerpsProModeEnabled ? perpsMode : undefined}
         onModeChange={isPerpsProModeEnabled ? handlePerpsModeChange : undefined}
+        enableHaptics
         scrollY={scrollYShared}
         priceSectionHeight={titleSectionHeightSv}
         currentPrice={syncedChartCurrentPrice}

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -1533,6 +1533,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
         mode={isPerpsProModeEnabled ? perpsMode : undefined}
         onModeChange={isPerpsProModeEnabled ? handlePerpsModeChange : undefined}
         enableHaptics={perpsMode === PerpsMode.Pro}
+        enableModeHaptics={isPerpsProModeEnabled}
         scrollY={scrollYShared}
         priceSectionHeight={titleSectionHeightSv}
         currentPrice={syncedChartCurrentPrice}

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.test.tsx
@@ -15,6 +15,9 @@ import Routes from '../../../../../constants/navigation/Routes';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { createActiveABTestAssignment } from '../../../../../util/analytics/activeABTestAssignments';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { playSelection } from '../../../../../util/haptics';
+
+jest.mock('../../../../../util/haptics');
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -734,6 +737,7 @@ describe('PerpsMarketListView', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(playSelection).mockClear();
 
     // Reset watchlist flag so each test starts with it off
     mockWatchlistFlagEnabled = false;
@@ -1613,6 +1617,37 @@ describe('PerpsMarketListView', () => {
           }),
         }),
       );
+    });
+
+    it('plays selection haptics when enableHaptics is opted in', () => {
+      mockUseRoute.mockReturnValue({
+        key: 'PerpsMarketListView-picker',
+        name: 'PerpsMarketListView',
+        params: {
+          replaceOnSelect: true,
+          enableHaptics: true,
+        },
+      });
+
+      renderWithProvider(<PerpsMarketListView />, { state: mockState });
+
+      fireEvent.press(screen.getAllByTestId('market-row-ETH')[0]);
+
+      expect(playSelection).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not play selection haptics when enableHaptics is omitted', () => {
+      mockUseRoute.mockReturnValue({
+        key: 'PerpsMarketListView-123',
+        name: 'PerpsMarketListView',
+        params: {},
+      });
+
+      renderWithProvider(<PerpsMarketListView />, { state: mockState });
+
+      fireEvent.press(screen.getAllByTestId('market-row-ETH')[0]);
+
+      expect(playSelection).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx
@@ -65,6 +65,7 @@ import { useSelector } from 'react-redux';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { TraceName } from '../../../../../util/trace';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { useHaptics } from '../../../../../util/haptics';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { PerpsNavigationParamList } from '../../types/navigation';
 import { normalizeFilterKey } from '../../utils/marketCategoryMapping';
@@ -91,6 +92,7 @@ const PerpsMarketListView = ({
   );
   const route =
     useRoute<RouteProp<PerpsNavigationParamList, 'PerpsMarketListView'>>();
+  const { playSelection } = useHaptics();
 
   const perpsNavigation = usePerpsNavigation();
   const navigation = useNavigation<AppNavigationProp>();
@@ -107,6 +109,7 @@ const PerpsMarketListView = ({
   const defaultSortDirection = route.params?.defaultSortDirection;
   const transactionActiveAbTests = route.params?.transactionActiveAbTests;
   const replaceOnSelect = route.params?.replaceOnSelect === true;
+  const enableHaptics = route.params?.enableHaptics === true;
 
   const isWatchlistEnabled = useSelector(selectPerpsWatchlistEnabledFlag);
   const isRecentlyViewedEnabled = useSelector(
@@ -246,9 +249,14 @@ const PerpsMarketListView = ({
     ],
   );
 
-  // Handler for market press (defined early to avoid use-before-define)
+  // Handler for market press (defined early to avoid use-before-define).
+  // Covers FlashList rows, watchlist rows, and recently-viewed tiles.
   const handleMarketPress = useCallback(
     (market: PerpsMarketData, sourceSectionOverride?: string) => {
+      if (enableHaptics) {
+        playSelection().catch(() => undefined);
+      }
+
       if (onMarketSelect) {
         onMarketSelect(market);
       } else {
@@ -340,6 +348,8 @@ const PerpsMarketListView = ({
       }
     },
     [
+      enableHaptics,
+      playSelection,
       onMarketSelect,
       navigation,
       replaceOnSelect,

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
@@ -23,6 +23,9 @@ import {
 } from '../../Perps.testIds';
 import type { UsePerpsMarketsOptions } from '../../hooks/usePerpsMarkets';
 import type { OrderBookData } from '../../hooks/stream/usePerpsLiveOrderBook';
+import { playSelection } from '../../../../../util/haptics';
+
+jest.mock('../../../../../util/haptics');
 
 interface MockLiveOrderBookResult {
   orderBook: OrderBookData | null;
@@ -406,6 +409,7 @@ describe('PerpsProMarketView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockOrderFormType = 'market';
+    jest.mocked(playSelection).mockClear();
     mockRouteParams = {
       market: {
         symbol: 'BTC',
@@ -471,6 +475,7 @@ describe('PerpsProMarketView', () => {
       source_section: PERPS_EVENT_VALUE.SOURCE_SECTION.POSITIONS,
       direction: undefined,
     });
+    expect(playSelection).toHaveBeenCalledTimes(1);
   });
 
   it('attributes order-row market switches with the orders source section', () => {
@@ -554,6 +559,7 @@ describe('PerpsProMarketView', () => {
     fireEvent.press(getByTestId(getPerpsProPositionRowSelector('BTC')));
 
     expect(mockSetParams).not.toHaveBeenCalled();
+    expect(playSelection).not.toHaveBeenCalled();
   });
 
   it('scrolls to the top when the active market symbol changes', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
@@ -50,6 +50,7 @@ interface MockRouteParams {
 interface MockChartPanelProps {
   symbol: string;
   selectedCandlePeriod: CandlePeriod;
+  onCandlePeriodChange: (period: CandlePeriod) => void;
   onMorePress: () => void;
   currentPrice?: number;
   onLatestPriceChange?: (price: number | undefined) => void;
@@ -111,7 +112,12 @@ const mockHandlePerpsModeChange = jest.fn();
 const mockHeaderPerpsMode = PerpsMode.Pro;
 
 const mockPerpsProChartPanel = jest.fn(
-  ({ symbol, onMorePress }: MockChartPanelProps) => (
+  ({
+    symbol,
+    selectedCandlePeriod,
+    onCandlePeriodChange,
+    onMorePress,
+  }: MockChartPanelProps) => (
     <>
       <Box
         testID={PerpsProMarketViewSelectorsIDs.MARKET_SUMMARY}
@@ -126,6 +132,18 @@ const mockPerpsProChartPanel = jest.fn(
           twClassName="h-[344px]"
         />
         <ButtonBase testID="mock-pro-chart-more-button" onPress={onMorePress}>
+          <Box />
+        </ButtonBase>
+        <ButtonBase
+          testID="mock-pro-chart-period-option"
+          onPress={() => onCandlePeriodChange(CandlePeriod.FiveMinutes)}
+        >
+          <Box />
+        </ButtonBase>
+        <ButtonBase
+          testID="mock-pro-chart-current-period"
+          onPress={() => onCandlePeriodChange(selectedCandlePeriod)}
+        >
           <Box />
         </ButtonBase>
       </Box>
@@ -182,7 +200,7 @@ jest.mock('../../components/PerpsBalanceBottomSheet', () => ({
 // need a lightweight placeholder so the layout scaffold assertions still pass.
 jest.mock('./components/PerpsProOrderFormPanel', () => {
   const ReactActual = jest.requireActual('react');
-  const { Box, ButtonBase } = jest.requireActual(
+  const { Box: MockBox, ButtonBase: MockButtonBase } = jest.requireActual(
     '@metamask/design-system-react-native',
   );
   const { PerpsProMarketViewSelectorsIDs: ids } = jest.requireActual(
@@ -195,16 +213,16 @@ jest.mock('./components/PerpsProOrderFormPanel', () => {
       onExpandOrderBook,
     }: MockOrderFormPanelProps) =>
       ReactActual.createElement(
-        Box,
+        MockBox,
         { testID: ids.ORDER_FORM_PANEL },
         isOrderBookCollapsed
           ? ReactActual.createElement(
-              ButtonBase,
+              MockButtonBase,
               {
                 testID: ids.ORDER_BOOK_EXPAND_BUTTON,
                 onPress: onExpandOrderBook,
               },
-              ReactActual.createElement(Box, null),
+              ReactActual.createElement(MockBox, null),
             )
           : null,
       ),
@@ -703,6 +721,23 @@ describe('PerpsProMarketView', () => {
         selectedCandlePeriod: CandlePeriod.FourHours,
       }),
     );
+    expect(playSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it('plays selection when a visible candle period changes', () => {
+    const { getByTestId } = renderView();
+
+    fireEvent.press(getByTestId('mock-pro-chart-period-option'));
+
+    expect(playSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps haptics silent when the current candle period is selected', () => {
+    const { getByTestId } = renderView();
+
+    fireEvent.press(getByTestId('mock-pro-chart-current-period'));
+
+    expect(playSelection).not.toHaveBeenCalled();
   });
 
   it('closes the More candle periods sheet', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
@@ -10,6 +10,7 @@ import {
   isLimitExecutionOrderType,
   isTriggerOrderType,
   TimeDuration,
+  type CandlePeriod,
   type PerpsMarketData,
 } from '@metamask/perps-controller';
 import {
@@ -324,6 +325,17 @@ const PerpsProMarketView = () => {
       onAdvancedChartError: handleAdvancedChartError,
     });
 
+  const handleProCandlePeriodChange = useCallback(
+    (period: CandlePeriod) => {
+      if (period === selectedCandlePeriod) {
+        return;
+      }
+      playSelection().catch(() => undefined);
+      handleCandlePeriodChange(period);
+    },
+    [handleCandlePeriodChange, playSelection, selectedCandlePeriod],
+  );
+
   const {
     perpsMode,
     isWatchlist,
@@ -393,7 +405,7 @@ const PerpsProMarketView = () => {
           selectedCandlePeriod={selectedCandlePeriod}
           isAdvancedChartEnabled={isAdvancedChartEnabled}
           effectiveChartLibrary={effectiveChartLibrary}
-          onCandlePeriodChange={handleCandlePeriodChange}
+          onCandlePeriodChange={handleProCandlePeriodChange}
           onMorePress={() => setIsMoreCandlePeriodsVisible(true)}
           onChartError={handleChartError}
           currentPrice={syncedChartCurrentPrice}
@@ -459,7 +471,7 @@ const PerpsProMarketView = () => {
         onClose={() => setIsMoreCandlePeriodsVisible(false)}
         selectedPeriod={selectedCandlePeriod}
         selectedDuration={TimeDuration.YearToDate}
-        onPeriodChange={handleCandlePeriodChange}
+        onPeriodChange={handleProCandlePeriodChange}
         showAllPeriods
         asset={market.symbol}
         testID={PerpsProMarketViewSelectorsIDs.CHART_MORE_PERIODS_SHEET}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
@@ -368,6 +368,7 @@ const PerpsProMarketView = () => {
         onFavoritePress={handleFavoritePress}
         isFavorite={isWatchlist}
         onModeChange={handlePerpsModeChange}
+        enableHaptics
         scrollY={scrollY}
         priceSectionHeight={titleSectionHeightSv}
         currentPrice={syncedChartCurrentPrice}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
@@ -38,6 +38,7 @@ import { useStyles } from '../../../../../component-library/hooks';
 import Routes from '../../../../../constants/navigation/Routes';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
+import { useHaptics } from '../../../../../util/haptics';
 import { PerpsProMarketViewSelectorsIDs } from '../../Perps.testIds';
 import PerpsBalanceBottomSheet from '../../components/PerpsBalanceBottomSheet';
 import PerpsCandlePeriodBottomSheet from '../../components/PerpsCandlePeriodBottomSheet';
@@ -144,6 +145,7 @@ const PerpsProOrderBookColumn = ({
  */
 const PerpsProMarketView = () => {
   const { styles } = useStyles(createStyles, {});
+  const { playSelection } = useHaptics();
   const navigation =
     useNavigation<NavigationProp<PerpsStackParamList, 'PerpsMarketDetails'>>();
   const route =
@@ -186,6 +188,8 @@ const PerpsProMarketView = () => {
         return;
       }
 
+      playSelection().catch(() => undefined);
+
       // POSITION_TAB is the panel-level source; source_section distinguishes
       // which tab the row came from (same pattern as Perps home).
       // `direction` is cleared because `setParams` merges: the side belongs to
@@ -198,7 +202,7 @@ const PerpsProMarketView = () => {
         direction: undefined,
       });
     },
-    [navigation, routeMarket?.symbol],
+    [navigation, playSelection, routeMarket?.symbol],
   );
 
   // Bring the chart back into view when the active market changes (e.g. the

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.test.tsx
@@ -19,7 +19,10 @@ import PerpsCandlePeriodSelector from '../../../components/PerpsCandlePeriodSele
 import type { PerpsChartFullscreenModalProps } from '../../../components/PerpsChartFullscreenModal/PerpsChartFullscreenModal';
 import type { OhlcData } from '../../../components/TradingViewChart';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
+import { playSelection } from '../../../../../../util/haptics';
 import PerpsProChartPanel from './PerpsProChartPanel';
+
+jest.mock('../../../../../../util/haptics');
 
 interface MockLivePriceHeaderProps {
   currentPrice: number;
@@ -213,6 +216,7 @@ const renderChartPanel = (overrides: Partial<PerpsProChartPanelProps> = {}) =>
 describe('PerpsProChartPanel', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(playSelection).mockClear();
     mockUsePerpsLiveCandles.mockReturnValue({
       candleData: MOCK_CANDLE_DATA,
       isLoading: false,
@@ -551,6 +555,7 @@ describe('PerpsProChartPanel', () => {
       );
 
       expect(mockSetChartExpanded).toHaveBeenCalledWith(true);
+      expect(playSelection).toHaveBeenCalledTimes(1);
       expect(mockTrack).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
@@ -572,6 +577,7 @@ describe('PerpsProChartPanel', () => {
       );
 
       expect(mockSetChartExpanded).toHaveBeenCalledWith(false);
+      expect(playSelection).toHaveBeenCalledTimes(1);
       expect(mockTrack).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.tsx
@@ -26,6 +26,7 @@ import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import { strings } from '../../../../../../../locales/i18n';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
 import { Skeleton } from '../../../../../../component-library/components-temp/Skeleton';
+import { useHaptics } from '../../../../../../util/haptics';
 import ComponentErrorBoundary from '../../../../ComponentErrorBoundary';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
 import { PERPS_CHART_CONFIG } from '../../../constants/chartConfig';
@@ -101,6 +102,7 @@ const PerpsProChartPanel = ({
   onLatestPriceChange,
 }: PerpsProChartPanelProps) => {
   const { track } = usePerpsEventTracking();
+  const { playSelection } = useHaptics();
   const { isChartExpanded, setChartExpanded } = usePerpsProChartExpanded();
   const [isFullscreenChartVisible, setIsFullscreenChartVisible] =
     useState(false);
@@ -169,6 +171,7 @@ const PerpsProChartPanel = ({
 
   const handleToggleChartExpanded = useCallback(
     (expanded: boolean) => {
+      playSelection().catch(() => undefined);
       setChartExpanded(expanded);
       track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
         [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
@@ -180,7 +183,7 @@ const PerpsProChartPanel = ({
         ...chartAnalyticsProperties,
       });
     },
-    [chartAnalyticsProperties, setChartExpanded, symbol, track],
+    [chartAnalyticsProperties, playSelection, setChartExpanded, symbol, track],
   );
 
   const handleFullscreenChartOpen = useCallback(() => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookConfigSheet.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookConfigSheet.test.tsx
@@ -5,7 +5,11 @@ import PerpsProOrderBookConfigSheet from './PerpsProOrderBookConfigSheet';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
 import { PERPS_PRO_MODAL_GESTURE_ROOT_TEST_ID } from './PerpsProModalPortal';
-import { playSelection } from '../../../../../../util/haptics';
+import {
+  ImpactMoment,
+  playImpact,
+  playSelection,
+} from '../../../../../../util/haptics';
 
 const mockOnOpenBottomSheet = jest.fn();
 const mockOnCloseBottomSheet = jest.fn();
@@ -185,8 +189,10 @@ describe('PerpsProOrderBookConfigSheet', () => {
       grouping: 10,
     });
     expect(onClose).toHaveBeenCalled();
-    // Three changed chip picks + save.
-    expect(playSelection).toHaveBeenCalledTimes(4);
+    // Three changed chip picks + the primary save commit.
+    expect(playSelection).toHaveBeenCalledTimes(3);
+    expect(playImpact).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
   });
 
   it('does not play a haptic when an already-selected chip is pressed', () => {
@@ -205,6 +211,7 @@ describe('PerpsProOrderBookConfigSheet', () => {
 
     expect(onApply).not.toHaveBeenCalled();
     expect(playSelection).not.toHaveBeenCalled();
+    expect(playImpact).not.toHaveBeenCalled();
   });
 
   it('closes via the header close control', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookConfigSheet.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookConfigSheet.test.tsx
@@ -5,9 +5,12 @@ import PerpsProOrderBookConfigSheet from './PerpsProOrderBookConfigSheet';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
 import { PERPS_PRO_MODAL_GESTURE_ROOT_TEST_ID } from './PerpsProModalPortal';
+import { playSelection } from '../../../../../../util/haptics';
 
 const mockOnOpenBottomSheet = jest.fn();
 const mockOnCloseBottomSheet = jest.fn();
+
+jest.mock('../../../../../../util/haptics');
 
 jest.mock('@metamask/design-system-react-native', () => {
   const ReactActual = jest.requireActual('react');
@@ -182,6 +185,16 @@ describe('PerpsProOrderBookConfigSheet', () => {
       grouping: 10,
     });
     expect(onClose).toHaveBeenCalled();
+    // Three changed chip picks + save.
+    expect(playSelection).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not play a haptic when an already-selected chip is pressed', () => {
+    const { getByTestId } = renderSheet({ currency: 'usd' });
+
+    fireEvent.press(getByTestId('config-sheet-currency-usd'));
+
+    expect(playSelection).not.toHaveBeenCalled();
   });
 
   it('does not apply when grouping is null', () => {
@@ -191,6 +204,7 @@ describe('PerpsProOrderBookConfigSheet', () => {
     fireEvent.press(getByTestId('config-sheet-apply'));
 
     expect(onApply).not.toHaveBeenCalled();
+    expect(playSelection).not.toHaveBeenCalled();
   });
 
   it('closes via the header close control', () => {
@@ -201,6 +215,7 @@ describe('PerpsProOrderBookConfigSheet', () => {
 
     expect(mockOnCloseBottomSheet).toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();
+    expect(playSelection).not.toHaveBeenCalled();
   });
 
   it('closes via Modal onRequestClose for Android back', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookConfigSheet.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookConfigSheet.tsx
@@ -19,7 +19,7 @@ import React, {
 } from 'react';
 import { Pressable, StyleSheet } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
-import { useHaptics } from '../../../../../../util/haptics';
+import { ImpactMoment, useHaptics } from '../../../../../../util/haptics';
 import { useTheme } from '../../../../../../util/theme';
 import type { Colors } from '../../../../../../util/theme/models';
 import {
@@ -138,7 +138,7 @@ const PerpsProOrderBookConfigSheet = ({
   onClose,
   testID = 'perps-pro-order-book-config-sheet',
 }: PerpsProOrderBookConfigSheetProps) => {
-  const { playSelection } = useHaptics();
+  const { playImpact, playSelection } = useHaptics();
   const sheetRef = useRef<BottomSheetRef>(null);
   const wasVisibleRef = useRef(false);
   const [draftCurrency, setDraftCurrency] =
@@ -203,7 +203,7 @@ const PerpsProOrderBookConfigSheet = ({
     if (draftGrouping === null) {
       return;
     }
-    playSelection().catch(() => undefined);
+    playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
     onApply({
       currency: draftCurrency,
       metric: draftMetric,
@@ -216,7 +216,7 @@ const PerpsProOrderBookConfigSheet = ({
     draftGrouping,
     onApply,
     handleClose,
-    playSelection,
+    playImpact,
   ]);
 
   const primaryButtonProps = useMemo(

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookConfigSheet.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookConfigSheet.tsx
@@ -19,6 +19,7 @@ import React, {
 } from 'react';
 import { Pressable, StyleSheet } from 'react-native';
 import { strings } from '../../../../../../../locales/i18n';
+import { useHaptics } from '../../../../../../util/haptics';
 import { useTheme } from '../../../../../../util/theme';
 import type { Colors } from '../../../../../../util/theme/models';
 import {
@@ -137,6 +138,7 @@ const PerpsProOrderBookConfigSheet = ({
   onClose,
   testID = 'perps-pro-order-book-config-sheet',
 }: PerpsProOrderBookConfigSheetProps) => {
+  const { playSelection } = useHaptics();
   const sheetRef = useRef<BottomSheetRef>(null);
   const wasVisibleRef = useRef(false);
   const [draftCurrency, setDraftCurrency] =
@@ -164,17 +166,58 @@ const PerpsProOrderBookConfigSheet = ({
     sheetRef.current?.onCloseBottomSheet(onClose);
   }, [onClose]);
 
+  const handleCurrencySelect = useCallback(
+    (next: OrderBookListCurrency) => {
+      if (draftCurrency === next) {
+        return;
+      }
+      playSelection().catch(() => undefined);
+      setDraftCurrency(next);
+    },
+    [draftCurrency, playSelection],
+  );
+
+  const handleMetricSelect = useCallback(
+    (next: OrderBookListMetric) => {
+      if (draftMetric === next) {
+        return;
+      }
+      playSelection().catch(() => undefined);
+      setDraftMetric(next);
+    },
+    [draftMetric, playSelection],
+  );
+
+  const handleGroupingSelect = useCallback(
+    (next: number) => {
+      if (draftGrouping === next) {
+        return;
+      }
+      playSelection().catch(() => undefined);
+      setDraftGrouping(next);
+    },
+    [draftGrouping, playSelection],
+  );
+
   const handleSave = useCallback(() => {
     if (draftGrouping === null) {
       return;
     }
+    playSelection().catch(() => undefined);
     onApply({
       currency: draftCurrency,
       metric: draftMetric,
       grouping: draftGrouping,
     });
     handleClose();
-  }, [draftCurrency, draftMetric, draftGrouping, onApply, handleClose]);
+  }, [
+    draftCurrency,
+    draftMetric,
+    draftGrouping,
+    onApply,
+    handleClose,
+    playSelection,
+  ]);
 
   const primaryButtonProps = useMemo(
     () => ({
@@ -225,13 +268,13 @@ const PerpsProOrderBookConfigSheet = ({
                 <OptionChip
                   label={baseSymbol}
                   isSelected={draftCurrency === 'base'}
-                  onPress={() => setDraftCurrency('base')}
+                  onPress={() => handleCurrencySelect('base')}
                   testID={`${testID}-currency-base`}
                 />
                 <OptionChip
                   label="USD"
                   isSelected={draftCurrency === 'usd'}
-                  onPress={() => setDraftCurrency('usd')}
+                  onPress={() => handleCurrencySelect('usd')}
                   testID={`${testID}-currency-usd`}
                 />
               </Box>
@@ -243,13 +286,13 @@ const PerpsProOrderBookConfigSheet = ({
                 <OptionChip
                   label={strings('perps.order_book.size')}
                   isSelected={draftMetric === 'size'}
-                  onPress={() => setDraftMetric('size')}
+                  onPress={() => handleMetricSelect('size')}
                   testID={`${testID}-metric-size`}
                 />
                 <OptionChip
                   label={strings('perps.order_book.total')}
                   isSelected={draftMetric === 'total'}
-                  onPress={() => setDraftMetric('total')}
+                  onPress={() => handleMetricSelect('total')}
                   testID={`${testID}-metric-total`}
                 />
               </Box>
@@ -278,7 +321,7 @@ const PerpsProOrderBookConfigSheet = ({
                       key={value}
                       label={formatGroupingLabel(value)}
                       isSelected={draftGrouping === value}
-                      onPress={() => setDraftGrouping(value)}
+                      onPress={() => handleGroupingSelect(value)}
                       testID={`${testID}-grouping-${value}`}
                     />
                   ))}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.test.tsx
@@ -7,11 +7,18 @@ import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
 import type { OrderBookData } from '../../../hooks/stream/usePerpsLiveOrderBook';
+import {
+  ImpactMoment,
+  playImpact,
+  playSelection,
+} from '../../../../../../util/haptics';
 
 const mockUsePerpsLiveOrderBook = jest.fn();
 const mockReconnect = jest.fn();
 const mockSaveGrouping = jest.fn();
 const mockSavedGroupingBySymbol: Record<string, number | undefined> = {};
+
+jest.mock('../../../../../../util/haptics');
 
 jest.mock('../../../hooks/stream/usePerpsLiveOrderBook', () => ({
   usePerpsLiveOrderBook: (params: unknown) => mockUsePerpsLiveOrderBook(params),
@@ -255,10 +262,12 @@ describe('PerpsProOrderBookPanel', () => {
 
     fireEvent.press(getByTestId(`${testID}-bid-row-0`));
     expect(onSelectPrice).toHaveBeenCalledWith('50000');
+    expect(playSelection).toHaveBeenCalledTimes(1);
 
     fireEvent.press(getByTestId(`${testID}-ask-row-0`));
     // Asks render farthest-to-closest, so ask-row-0 is the deepest ask (50200).
     expect(onSelectPrice).toHaveBeenLastCalledWith('50200');
+    expect(playSelection).toHaveBeenCalledTimes(2);
   });
 
   it('renders static, non-interactive rows when onSelectPrice is omitted', () => {
@@ -288,6 +297,18 @@ describe('PerpsProOrderBookPanel', () => {
       getByTestId(PerpsProMarketViewSelectorsIDs.ORDER_BOOK_COLLAPSE_BUTTON),
     );
     expect(onCollapse).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
+  });
+
+  it('plays selection when the settings icon opens the config sheet', () => {
+    const { getByTestId } = renderWithProvider(
+      <PerpsProOrderBookPanel symbol="BTC" marketPrice={50000} />,
+      { state: { engine: { backgroundState } } },
+    );
+
+    fireEvent.press(getByTestId(`${testID}-grouping-trigger`));
+
+    expect(playSelection).toHaveBeenCalledTimes(1);
   });
 
   it('positions collapse at the leading edge and settings at the trailing edge', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.test.tsx
@@ -7,11 +7,7 @@ import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
 import type { OrderBookData } from '../../../hooks/stream/usePerpsLiveOrderBook';
-import {
-  ImpactMoment,
-  playImpact,
-  playSelection,
-} from '../../../../../../util/haptics';
+import { playSelection } from '../../../../../../util/haptics';
 
 const mockUsePerpsLiveOrderBook = jest.fn();
 const mockReconnect = jest.fn();
@@ -297,7 +293,7 @@ describe('PerpsProOrderBookPanel', () => {
       getByTestId(PerpsProMarketViewSelectorsIDs.ORDER_BOOK_COLLAPSE_BUTTON),
     );
     expect(onCollapse).toHaveBeenCalledTimes(1);
-    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
+    expect(playSelection).toHaveBeenCalledTimes(1);
   });
 
   it('plays selection when the settings icon opens the config sheet', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.tsx
@@ -28,6 +28,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { strings } from '../../../../../../../locales/i18n';
+import { ImpactMoment, useHaptics } from '../../../../../../util/haptics';
 import { useTheme } from '../../../../../../util/theme';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
 import {
@@ -120,6 +121,7 @@ const OrderBookRow = ({
   onSelectPrice,
   testID,
 }: OrderBookRowProps) => {
+  const { playSelection } = useHaptics();
   const depthWidth = getDepthWidth(level, maxTotal);
   const isBid = side === 'bid';
   const sideColor = isBid ? TextColor.SuccessDefault : TextColor.ErrorDefault;
@@ -178,7 +180,10 @@ const OrderBookRow = ({
   if (onSelectPrice) {
     return (
       <Pressable
-        onPress={() => onSelectPrice(level.price)}
+        onPress={() => {
+          playSelection().catch(() => undefined);
+          onSelectPrice(level.price);
+        }}
         accessibilityRole="button"
         accessibilityLabel={strings('perps.order_book.use_price', {
           price: priceLabel,
@@ -385,6 +390,7 @@ const PerpsProOrderBookPanel = ({
   const testID = PerpsProMarketViewSelectorsIDs.ORDER_BOOK_PANEL;
   const displaySymbol = getPerpsDisplaySymbol(symbol);
   const { colors } = useTheme();
+  const { playImpact, playSelection } = useHaptics();
   const buyColor = colors.success.default;
   const sellColor = colors.error.default;
 
@@ -392,6 +398,19 @@ const PerpsProOrderBookPanel = ({
   const [metric, setMetric] = useState<OrderBookListMetric>('total');
   const [viewMode, setViewMode] = useState<OrderBookViewMode>('default');
   const [isConfigOpen, setIsConfigOpen] = useState(false);
+
+  const handleCollapse = useCallback(() => {
+    if (!onCollapse) {
+      return;
+    }
+    playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
+    onCollapse();
+  }, [onCollapse, playImpact]);
+
+  const handleOpenConfig = useCallback(() => {
+    playSelection().catch(() => undefined);
+    setIsConfigOpen(true);
+  }, [playSelection]);
 
   const { savedGrouping, saveGrouping } = usePerpsOrderBookGrouping(symbol);
   const [selectedGrouping, setSelectedGrouping] = useState<number | null>(
@@ -622,7 +641,7 @@ const PerpsProOrderBookPanel = ({
               iconName={IconName.Collapse}
               accessibilityLabel={strings('perps.order_book.collapse')}
               size={ButtonIconSize.Md}
-              onPress={onCollapse}
+              onPress={handleCollapse}
               testID={PerpsProMarketViewSelectorsIDs.ORDER_BOOK_COLLAPSE_BUTTON}
             />
           ) : null}
@@ -636,7 +655,7 @@ const PerpsProOrderBookPanel = ({
             iconName={IconName.Setting}
             accessibilityLabel={strings('perps.order_book.config_title')}
             size={ButtonIconSize.Md}
-            onPress={() => setIsConfigOpen(true)}
+            onPress={handleOpenConfig}
             testID={`${testID}-grouping-trigger`}
           />
         </Box>

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.tsx
@@ -121,7 +121,6 @@ const OrderBookRow = ({
   onSelectPrice,
   testID,
 }: OrderBookRowProps) => {
-  const { playSelection } = useHaptics();
   const depthWidth = getDepthWidth(level, maxTotal);
   const isBid = side === 'bid';
   const sideColor = isBid ? TextColor.SuccessDefault : TextColor.ErrorDefault;
@@ -180,10 +179,7 @@ const OrderBookRow = ({
   if (onSelectPrice) {
     return (
       <Pressable
-        onPress={() => {
-          playSelection().catch(() => undefined);
-          onSelectPrice(level.price);
-        }}
+        onPress={() => onSelectPrice(level.price)}
         accessibilityRole="button"
         accessibilityLabel={strings('perps.order_book.use_price', {
           price: priceLabel,
@@ -411,6 +407,18 @@ const PerpsProOrderBookPanel = ({
     playSelection().catch(() => undefined);
     setIsConfigOpen(true);
   }, [playSelection]);
+
+  const handleSelectPrice = useCallback(
+    (price: string) => {
+      if (!onSelectPrice) {
+        return;
+      }
+      playSelection().catch(() => undefined);
+      onSelectPrice(price);
+    },
+    [onSelectPrice, playSelection],
+  );
+  const rowSelectPrice = onSelectPrice ? handleSelectPrice : undefined;
 
   const { savedGrouping, saveGrouping } = usePerpsOrderBookGrouping(symbol);
   const [selectedGrouping, setSelectedGrouping] = useState<number | null>(
@@ -732,7 +740,7 @@ const PerpsProOrderBookPanel = ({
                   depthBarColor={sellColor}
                   szDecimals={szDecimals}
                   priceFormat={priceFormat}
-                  onSelectPrice={onSelectPrice}
+                  onSelectPrice={rowSelectPrice}
                   testID={`${testID}-ask-row-${index}`}
                 />
               ))}
@@ -779,7 +787,7 @@ const PerpsProOrderBookPanel = ({
                   depthBarColor={buyColor}
                   szDecimals={szDecimals}
                   priceFormat={priceFormat}
-                  onSelectPrice={onSelectPrice}
+                  onSelectPrice={rowSelectPrice}
                   testID={`${testID}-bid-row-${index}`}
                 />
               ))}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.tsx
@@ -28,7 +28,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { strings } from '../../../../../../../locales/i18n';
-import { ImpactMoment, useHaptics } from '../../../../../../util/haptics';
+import { useHaptics } from '../../../../../../util/haptics';
 import { useTheme } from '../../../../../../util/theme';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
 import {
@@ -386,7 +386,7 @@ const PerpsProOrderBookPanel = ({
   const testID = PerpsProMarketViewSelectorsIDs.ORDER_BOOK_PANEL;
   const displaySymbol = getPerpsDisplaySymbol(symbol);
   const { colors } = useTheme();
-  const { playImpact, playSelection } = useHaptics();
+  const { playSelection } = useHaptics();
   const buyColor = colors.success.default;
   const sellColor = colors.error.default;
 
@@ -399,9 +399,9 @@ const PerpsProOrderBookPanel = ({
     if (!onCollapse) {
       return;
     }
-    playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
+    playSelection().catch(() => undefined);
     onCollapse();
-  }, [onCollapse, playImpact]);
+  }, [onCollapse, playSelection]);
 
   const handleOpenConfig = useCallback(() => {
     playSelection().catch(() => undefined);

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -729,7 +729,7 @@ describe('PerpsProOrderForm', () => {
       );
 
       expect(onExpandOrderBook).toHaveBeenCalledTimes(1);
-      expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
+      expect(playSelection).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -610,7 +610,7 @@ describe('PerpsProOrderForm', () => {
       expect(playSelection).toHaveBeenCalledTimes(1);
     });
 
-    it('calls onSlippagePress when the slippage value is pressed', () => {
+    it('plays selection when the slippage summary value opens the sheet', () => {
       const onSlippagePress = jest.fn();
       renderForm({
         summary: {
@@ -624,6 +624,21 @@ describe('PerpsProOrderForm', () => {
       fireEvent.press(screen.getByTestId(ids.SUMMARY_SLIPPAGE_BUTTON));
 
       expect(onSlippagePress).toHaveBeenCalledTimes(1);
+      expect(playSelection).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps haptics silent when the slippage summary action is disabled', () => {
+      renderForm({
+        summary: {
+          margin: '--',
+          liquidationPrice: '--',
+          slippage: '0.50% / 1%',
+        },
+      });
+
+      fireEvent.press(screen.getByTestId(ids.SUMMARY_SLIPPAGE_BUTTON));
+
+      expect(playSelection).not.toHaveBeenCalled();
     });
 
     it('disables Place Order when requested', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -9,9 +9,16 @@ import {
 import { getPerpsProInputAccessoryID } from './PerpsProCompactInput';
 import PerpsProOrderForm from './PerpsProOrderForm';
 import type { PerpsProOrderFormProps } from './PerpsProOrderForm.types';
+import {
+  ImpactMoment,
+  playImpact,
+  playSelection,
+} from '../../../../../../../util/haptics';
 
 jest.mock('../../../../components/PerpsSlider', () => 'PerpsSlider');
 jest.mock('../../../../components/PerpsFeesDisplay', () => 'PerpsFeesDisplay');
+
+jest.mock('../../../../../../../util/haptics');
 
 const host = (name: string) => name as unknown as React.ComponentType<unknown>;
 
@@ -74,6 +81,11 @@ const renderForm = (overrides: Partial<PerpsProOrderFormProps> = {}) =>
   render(<PerpsProOrderForm {...createProps(overrides)} />);
 
 describe('PerpsProOrderForm', () => {
+  beforeEach(() => {
+    jest.mocked(playImpact).mockClear();
+    jest.mocked(playSelection).mockClear();
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
   });
@@ -483,6 +495,17 @@ describe('PerpsProOrderForm', () => {
       fireEvent.press(screen.getByTestId(ids.DIRECTION_SHORT));
 
       expect(onDirectionChange).toHaveBeenCalledWith('short');
+      expect(playSelection).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not play a haptic when the current direction is re-selected', () => {
+      const onDirectionChange = jest.fn();
+      renderForm({ onDirectionChange, direction: 'long' });
+
+      fireEvent.press(screen.getByTestId(ids.DIRECTION_LONG));
+
+      expect(onDirectionChange).not.toHaveBeenCalled();
+      expect(playSelection).not.toHaveBeenCalled();
     });
 
     it('calls onOrderTypeButtonPress when order type is pressed', () => {
@@ -492,6 +515,7 @@ describe('PerpsProOrderForm', () => {
       fireEvent.press(screen.getByTestId(ids.ORDER_TYPE_BUTTON));
 
       expect(onOrderTypeButtonPress).toHaveBeenCalledTimes(1);
+      expect(playSelection).toHaveBeenCalledTimes(1);
     });
 
     it('exposes Reduce only with checked checkbox semantics', () => {
@@ -514,6 +538,22 @@ describe('PerpsProOrderForm', () => {
       fireEvent.press(screen.getByTestId(ids.REDUCE_ONLY));
 
       expect(onReduceOnlyChange).toHaveBeenCalledWith(true);
+      expect(playSelection).toHaveBeenCalledTimes(1);
+    });
+
+    it('plays selection when the size denomination toggle is pressed', () => {
+      const onToggleDenomination = jest.fn();
+      renderForm({
+        sizeInput: createSizeInput({
+          canToggleDenomination: true,
+          onToggleDenomination,
+        }),
+      });
+
+      fireEvent.press(screen.getByTestId(ids.SIZE_UNIT_BUTTON));
+
+      expect(onToggleDenomination).toHaveBeenCalledTimes(1);
+      expect(playSelection).toHaveBeenCalledTimes(1);
     });
 
     it('hides the TP/SL row when Reduce Only is on', () => {
@@ -539,6 +579,7 @@ describe('PerpsProOrderForm', () => {
       fireEvent.press(screen.getByTestId(ids.TPSL));
 
       expect(onTPSLPress).toHaveBeenCalledTimes(1);
+      expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
     });
 
     it('calls onPlaceOrderPress when Place Order is pressed', () => {
@@ -548,6 +589,17 @@ describe('PerpsProOrderForm', () => {
       fireEvent.press(screen.getByTestId(ids.PLACE_ORDER_BUTTON));
 
       expect(onPlaceOrderPress).toHaveBeenCalledTimes(1);
+      expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
+    });
+
+    it('plays selection when leverage is opened', () => {
+      const onLeveragePress = jest.fn();
+      renderForm({ onLeveragePress });
+
+      fireEvent.press(screen.getByTestId(ids.LEVERAGE_BUTTON));
+
+      expect(onLeveragePress).toHaveBeenCalledTimes(1);
+      expect(playSelection).toHaveBeenCalledTimes(1);
     });
 
     it('calls onSlippagePress when the slippage value is pressed', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -587,7 +587,6 @@ describe('PerpsProOrderForm', () => {
       fireEvent.press(screen.getByTestId(ids.TPSL));
 
       expect(onTPSLPress).toHaveBeenCalledTimes(1);
-      expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
     });
 
     it('calls onPlaceOrderPress when Place Order is pressed', () => {
@@ -597,7 +596,6 @@ describe('PerpsProOrderForm', () => {
       fireEvent.press(screen.getByTestId(ids.PLACE_ORDER_BUTTON));
 
       expect(onPlaceOrderPress).toHaveBeenCalledTimes(1);
-      expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
     });
 
     it('plays selection when leverage is opened', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -334,6 +334,14 @@ describe('PerpsProOrderForm', () => {
       fireEvent.press(screen.getByTestId(ids.AVAILABLE_BALANCE));
 
       expect(onAddFundsPress).toHaveBeenCalledTimes(1);
+      expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
+    });
+
+    it('does not play Add funds haptics when the action is disabled', () => {
+      renderForm({ onAddFundsPress: undefined });
+
+      expect(screen.getByTestId(ids.ADD_FUNDS_BUTTON)).toBeDisabled();
+      expect(playImpact).not.toHaveBeenCalled();
     });
 
     const sizeAccessoryID = getPerpsProInputAccessoryID(ids.SIZE_INPUT);

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -716,6 +716,7 @@ describe('PerpsProOrderForm', () => {
       );
 
       expect(onExpandOrderBook).toHaveBeenCalledTimes(1);
+      expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -433,14 +433,6 @@ const PerpsProOrderForm = ({
     [onReduceOnlyChange, playSelection],
   );
 
-  const handleTPSLPress = useCallback(() => {
-    if (!onTPSLPress) {
-      return;
-    }
-    playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
-    onTPSLPress();
-  }, [onTPSLPress, playImpact]);
-
   const handleExpandOrderBook = useCallback(() => {
     if (!onExpandOrderBook) {
       return;
@@ -448,11 +440,6 @@ const PerpsProOrderForm = ({
     playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
     onExpandOrderBook();
   }, [onExpandOrderBook, playImpact]);
-
-  const handlePlaceOrderPress = useCallback(() => {
-    playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
-    onPlaceOrderPress();
-  }, [onPlaceOrderPress, playImpact]);
 
   return (
     <>
@@ -627,7 +614,7 @@ const PerpsProOrderForm = ({
           {showsTpSl ? (
             <TPSLRow
               label={strings('perps.pro_order_form.tpsl')}
-              onPress={onTPSLPress ? handleTPSLPress : undefined}
+              onPress={onTPSLPress}
               testID={ids.TPSL}
             />
           ) : null}
@@ -642,7 +629,7 @@ const PerpsProOrderForm = ({
             isFullWidth
             isDisabled={isPlaceOrderDisabled}
             isLoading={isPlaceOrderLoading}
-            onPress={handlePlaceOrderPress}
+            onPress={onPlaceOrderPress}
             testID={ids.PLACE_ORDER_BUTTON}
           >
             {placeOrderLabel}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -29,7 +29,7 @@ import {
   isLimitExecutionOrderType,
   isTriggerOrderType,
 } from '@metamask/perps-controller';
-import React from 'react';
+import React, { useCallback } from 'react';
 import {
   InputAccessoryView,
   Keyboard,
@@ -37,6 +37,7 @@ import {
   Pressable,
 } from 'react-native';
 import { strings } from '../../../../../../../../locales/i18n';
+import { ImpactMoment, useHaptics } from '../../../../../../../util/haptics';
 import {
   PerpsProMarketViewSelectorsIDs,
   PerpsProOrderFormSelectorsIDs,
@@ -367,11 +368,74 @@ const PerpsProOrderForm = ({
   isPlaceOrderLoading = false,
   onPlaceOrderPress,
 }: PerpsProOrderFormProps) => {
+  const { playImpact, playSelection } = useHaptics();
   const isLong = direction === 'long';
   const showsTriggerPrice = isTriggerOrderType(orderType);
   const showsLimitPrice = isLimitExecutionOrderType(orderType);
   const showsTpSl = !reduceOnly && !showsTriggerPrice;
   const orderTypeTitle = strings(`perps.order.type.${orderType}.title`);
+
+  const handleDirectionChange = useCallback(
+    (value: string) => {
+      const nextDirection = value as PerpsProOrderDirection;
+      if (nextDirection === direction) {
+        return;
+      }
+      playSelection().catch(() => undefined);
+      onDirectionChange(nextDirection);
+    },
+    [direction, onDirectionChange, playSelection],
+  );
+
+  const handleMarginModePress = useCallback(() => {
+    if (!onMarginModePress) {
+      return;
+    }
+    playSelection().catch(() => undefined);
+    onMarginModePress();
+  }, [onMarginModePress, playSelection]);
+
+  const handleLeveragePress = useCallback(() => {
+    if (!onLeveragePress) {
+      return;
+    }
+    playSelection().catch(() => undefined);
+    onLeveragePress();
+  }, [onLeveragePress, playSelection]);
+
+  const handleOrderTypeButtonPress = useCallback(() => {
+    playSelection().catch(() => undefined);
+    onOrderTypeButtonPress();
+  }, [onOrderTypeButtonPress, playSelection]);
+
+  const handleUseMidPricePress = useCallback(() => {
+    if (!onUseMidPricePress) {
+      return;
+    }
+    playSelection().catch(() => undefined);
+    onUseMidPricePress();
+  }, [onUseMidPricePress, playSelection]);
+
+  const handleReduceOnlyChange = useCallback(
+    (value: boolean) => {
+      playSelection().catch(() => undefined);
+      onReduceOnlyChange(value);
+    },
+    [onReduceOnlyChange, playSelection],
+  );
+
+  const handleTPSLPress = useCallback(() => {
+    if (!onTPSLPress) {
+      return;
+    }
+    playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
+    onTPSLPress();
+  }, [onTPSLPress, playImpact]);
+
+  const handlePlaceOrderPress = useCallback(() => {
+    playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
+    onPlaceOrderPress();
+  }, [onPlaceOrderPress, playImpact]);
 
   return (
     <>
@@ -388,9 +452,7 @@ const PerpsProOrderForm = ({
           >
             <SegmentedControl
               value={direction}
-              onChange={(value) =>
-                onDirectionChange(value as PerpsProOrderDirection)
-              }
+              onChange={handleDirectionChange}
               isFullWidth
               twClassName="flex-1"
               size={ButtonBaseSize.Sm}
@@ -445,7 +507,7 @@ const PerpsProOrderForm = ({
           >
             <ButtonBase
               size={ButtonBaseSize.Sm}
-              onPress={onMarginModePress}
+              onPress={handleMarginModePress}
               isDisabled={!onMarginModePress}
               twClassName="h-8 rounded-lg bg-muted px-2"
               testID={ids.MARGIN_MODE_BUTTON}
@@ -454,7 +516,7 @@ const PerpsProOrderForm = ({
             </ButtonBase>
             <ButtonBase
               size={ButtonBaseSize.Sm}
-              onPress={onLeveragePress}
+              onPress={handleLeveragePress}
               isDisabled={!onLeveragePress}
               twClassName="rounded-lg bg-muted px-2"
               testID={ids.LEVERAGE_BUTTON}
@@ -467,7 +529,7 @@ const PerpsProOrderForm = ({
             twClassName="overflow-hidden rounded-xl border border-muted bg-muted"
           >
             <ButtonBase
-              onPress={onOrderTypeButtonPress}
+              onPress={handleOrderTypeButtonPress}
               twClassName="h-12 w-full bg-transparent px-3"
               contentWrapperProps={{ twClassName: 'w-full justify-between' }}
               textProps={{ variant: TextVariant.BodySm }}
@@ -540,7 +602,7 @@ const PerpsProOrderForm = ({
                 style: { marginLeft: 0, flex: 1 },
               }}
               isSelected={reduceOnly}
-              onChange={onReduceOnlyChange}
+              onChange={handleReduceOnlyChange}
               testID={ids.REDUCE_ONLY}
               twClassName="w-full flex-row-reverse justify-between"
             />
@@ -548,7 +610,7 @@ const PerpsProOrderForm = ({
           {showsTpSl ? (
             <TPSLRow
               label={strings('perps.pro_order_form.tpsl')}
-              onPress={onTPSLPress}
+              onPress={onTPSLPress ? handleTPSLPress : undefined}
               testID={ids.TPSL}
             />
           ) : null}
@@ -563,7 +625,7 @@ const PerpsProOrderForm = ({
             isFullWidth
             isDisabled={isPlaceOrderDisabled}
             isLoading={isPlaceOrderLoading}
-            onPress={onPlaceOrderPress}
+            onPress={handlePlaceOrderPress}
             testID={ids.PLACE_ORDER_BUTTON}
           >
             {placeOrderLabel}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -374,6 +374,7 @@ const PerpsProOrderForm = ({
   const showsLimitPrice = isLimitExecutionOrderType(orderType);
   const showsTpSl = !reduceOnly && !showsTriggerPrice;
   const orderTypeTitle = strings(`perps.order.type.${orderType}.title`);
+  const summaryOnSlippagePress = summary.onSlippagePress;
 
   const handleDirectionChange = useCallback(
     (value: string) => {
@@ -402,6 +403,14 @@ const PerpsProOrderForm = ({
     playSelection().catch(() => undefined);
     onLeveragePress();
   }, [onLeveragePress, playSelection]);
+
+  const handleSlippagePress = useCallback(() => {
+    if (!summaryOnSlippagePress) {
+      return;
+    }
+    playSelection().catch(() => undefined);
+    summaryOnSlippagePress();
+  }, [playSelection, summaryOnSlippagePress]);
 
   const handleOrderTypeButtonPress = useCallback(() => {
     playSelection().catch(() => undefined);
@@ -639,7 +648,12 @@ const PerpsProOrderForm = ({
             {placeOrderLabel}
           </ButtonSemantic>
         </Box>
-        <OrderSummary {...summary} />
+        <OrderSummary
+          {...summary}
+          onSlippagePress={
+            summaryOnSlippagePress ? handleSlippagePress : undefined
+          }
+        />
       </Box>
       {Platform.OS === 'ios' ? (
         <>

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -432,6 +432,14 @@ const PerpsProOrderForm = ({
     onTPSLPress();
   }, [onTPSLPress, playImpact]);
 
+  const handleExpandOrderBook = useCallback(() => {
+    if (!onExpandOrderBook) {
+      return;
+    }
+    playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
+    onExpandOrderBook();
+  }, [onExpandOrderBook, playImpact]);
+
   const handlePlaceOrderPress = useCallback(() => {
     playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
     onPlaceOrderPress();
@@ -496,7 +504,7 @@ const PerpsProOrderForm = ({
                 iconName={IconName.Book}
                 accessibilityLabel={strings('perps.order_book.expand')}
                 size={ButtonIconSize.Md}
-                onPress={onExpandOrderBook}
+                onPress={handleExpandOrderBook}
                 testID={PerpsProMarketViewSelectorsIDs.ORDER_BOOK_EXPAND_BUTTON}
               />
             ) : null}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -37,7 +37,7 @@ import {
   Pressable,
 } from 'react-native';
 import { strings } from '../../../../../../../../locales/i18n';
-import { ImpactMoment, useHaptics } from '../../../../../../../util/haptics';
+import { useHaptics } from '../../../../../../../util/haptics';
 import {
   PerpsProMarketViewSelectorsIDs,
   PerpsProOrderFormSelectorsIDs,
@@ -368,7 +368,7 @@ const PerpsProOrderForm = ({
   isPlaceOrderLoading = false,
   onPlaceOrderPress,
 }: PerpsProOrderFormProps) => {
-  const { playImpact, playSelection } = useHaptics();
+  const { playSelection } = useHaptics();
   const isLong = direction === 'long';
   const showsTriggerPrice = isTriggerOrderType(orderType);
   const showsLimitPrice = isLimitExecutionOrderType(orderType);
@@ -437,9 +437,9 @@ const PerpsProOrderForm = ({
     if (!onExpandOrderBook) {
       return;
     }
-    playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
+    playSelection().catch(() => undefined);
     onExpandOrderBook();
-  }, [onExpandOrderBook, playImpact]);
+  }, [onExpandOrderBook, playSelection]);
 
   return (
     <>

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProSizeInput.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProSizeInput.test.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import { TextVariant } from '@metamask/design-system-react-native';
+import {
+  ImpactMoment,
+  playImpact,
+  playSelection,
+} from '../../../../../../../util/haptics';
 import { PerpsProOrderFormSelectorsIDs } from '../../../../Perps.testIds';
 import { getPerpsProInputAccessoryID } from './PerpsProCompactInput';
 import PerpsProSizeInput, {
   type PerpsProSizeInputProps,
 } from './PerpsProSizeInput';
+
+jest.mock('../../../../../../../util/haptics');
 
 const mockInputFocus = jest.fn();
 
@@ -64,6 +71,8 @@ const renderInput = (overrides: Partial<PerpsProSizeInputProps> = {}) =>
 describe('PerpsProSizeInput', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(playImpact).mockClear();
+    jest.mocked(playSelection).mockClear();
   });
 
   it('focuses the input when the upper field is pressed', () => {
@@ -82,6 +91,24 @@ describe('PerpsProSizeInput', () => {
 
     expect(onToggleDenomination).toHaveBeenCalledTimes(1);
     expect(mockInputFocus).toHaveBeenCalledTimes(1);
+    expect(playSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it('plays PrimaryCTA when Add funds is pressed', () => {
+    const onAddFundsPress = jest.fn();
+    renderInput({ onAddFundsPress });
+
+    fireEvent.press(screen.getByTestId(ids.ADD_FUNDS_BUTTON));
+
+    expect(onAddFundsPress).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
+  });
+
+  it('does not play Add funds haptics when the action is disabled', () => {
+    renderInput({ onAddFundsPress: undefined });
+
+    expect(screen.getByTestId(ids.ADD_FUNDS_BUTTON)).toBeDisabled();
+    expect(playImpact).not.toHaveBeenCalled();
   });
 
   it('disables the denomination toggle when conversion is unavailable', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProSizeInput.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProSizeInput.tsx
@@ -17,6 +17,7 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React, { useCallback, useRef } from 'react';
 import { Platform, type TextInput, type View } from 'react-native';
 import { strings } from '../../../../../../../../locales/i18n';
+import { useHaptics } from '../../../../../../../util/haptics';
 import { PerpsProOrderFormSelectorsIDs } from '../../../../Perps.testIds';
 import PerpsSlider from '../../../../components/PerpsSlider';
 import { getPerpsProInputAccessoryID } from './PerpsProCompactInput';
@@ -65,6 +66,7 @@ const PerpsProSizeInput = ({
   onFieldPress,
 }: PerpsProSizeInputProps) => {
   const tw = useTailwind();
+  const { playSelection } = useHaptics();
   const inputRef = useRef<TextInput>(null);
   const unitLabel = getUnitLabel(denomination);
   const showUsdPrefix = denomination.unit === 'usd';
@@ -88,9 +90,15 @@ const PerpsProSizeInput = ({
       return;
     }
 
+    playSelection().catch(() => undefined);
     onToggleDenomination?.();
     focusInput();
-  }, [canPressDenominationToggle, focusInput, onToggleDenomination]);
+  }, [
+    canPressDenominationToggle,
+    focusInput,
+    onToggleDenomination,
+    playSelection,
+  ]);
 
   return (
     <Box

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProSizeInput.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProSizeInput.tsx
@@ -17,7 +17,7 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import React, { useCallback, useRef } from 'react';
 import { Platform, type TextInput, type View } from 'react-native';
 import { strings } from '../../../../../../../../locales/i18n';
-import { useHaptics } from '../../../../../../../util/haptics';
+import { ImpactMoment, useHaptics } from '../../../../../../../util/haptics';
 import { PerpsProOrderFormSelectorsIDs } from '../../../../Perps.testIds';
 import PerpsSlider from '../../../../components/PerpsSlider';
 import { getPerpsProInputAccessoryID } from './PerpsProCompactInput';
@@ -66,7 +66,7 @@ const PerpsProSizeInput = ({
   onFieldPress,
 }: PerpsProSizeInputProps) => {
   const tw = useTailwind();
-  const { playSelection } = useHaptics();
+  const { playImpact, playSelection } = useHaptics();
   const inputRef = useRef<TextInput>(null);
   const unitLabel = getUnitLabel(denomination);
   const showUsdPrefix = denomination.unit === 'usd';
@@ -99,6 +99,15 @@ const PerpsProSizeInput = ({
     onToggleDenomination,
     playSelection,
   ]);
+
+  const handleAddFundsPress = useCallback(() => {
+    if (!onAddFundsPress) {
+      return;
+    }
+
+    playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
+    onAddFundsPress();
+  }, [onAddFundsPress, playImpact]);
 
   return (
     <Box
@@ -208,7 +217,7 @@ const PerpsProSizeInput = ({
       </Box>
       <Box twClassName="w-full border-t border-muted" />
       <ButtonBase
-        onPress={onAddFundsPress}
+        onPress={handleAddFundsPress}
         isDisabled={!onAddFundsPress}
         twClassName="h-[46px] w-full rounded-b-2xl bg-transparent px-3"
         contentWrapperProps={{

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
@@ -7,6 +7,7 @@ import {
 import { MetaMetricsEvents } from '../../../../../../../core/Analytics';
 import { PERPS_ANALYTICS_PREVIOUS_LEVERAGE } from '../../../../constants/perpsAnalytics';
 import type { OrderFormFieldIssue } from '../../../../utils/triggerOrderValidation';
+import { ImpactMoment, playImpact } from '../../../../../../../util/haptics';
 import { usePerpsProOrderForm } from './usePerpsProOrderForm';
 
 // ---------------------------------------------------------------------------
@@ -240,6 +241,8 @@ jest.mock('react-redux', () => ({
 jest.mock('../../../../../../../selectors/accountsController', () => ({
   selectSelectedInternalAccountAddress: jest.fn(),
 }));
+
+jest.mock('../../../../../../../util/haptics');
 
 jest.mock('../../../../../../../core/Engine', () => ({
   context: {
@@ -487,6 +490,36 @@ describe('usePerpsProOrderForm', () => {
       expect(mockComplianceGate).toHaveBeenCalledTimes(1);
       expect(mockShowEligibilityModal).not.toHaveBeenCalled();
       expect(mockExecuteOrder).toHaveBeenCalledTimes(1);
+      expect(playImpact).toHaveBeenCalledTimes(1);
+      expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
+    });
+
+    it('keeps haptics silent for a duplicate submit', async () => {
+      let resolveOrder:
+        | ((value: { success: boolean; error?: string }) => void)
+        | undefined;
+      mockExecuteOrder.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveOrder = resolve;
+        }),
+      );
+      const { result } = renderProForm();
+
+      let firstSubmission: Promise<unknown> | undefined;
+      await act(async () => {
+        firstSubmission = result.current.onPlaceOrderPress();
+        await Promise.resolve();
+        await result.current.onPlaceOrderPress();
+      });
+
+      expect(mockExecuteOrder).toHaveBeenCalledTimes(1);
+      expect(playImpact).toHaveBeenCalledTimes(1);
+      expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
+
+      await act(async () => {
+        resolveOrder?.({ success: false, error: 'rejected' });
+        await firstSubmission;
+      });
     });
 
     it('opens geo-block modal and skips execution for an ineligible user', async () => {
@@ -502,6 +535,7 @@ describe('usePerpsProOrderForm', () => {
         PERPS_EVENT_VALUE.SOURCE.TRADE_ACTION,
       );
       expect(mockExecuteOrder).not.toHaveBeenCalled();
+      expect(playImpact).not.toHaveBeenCalled();
     });
 
     it('skips geo handling and execution when compliance gate blocks', async () => {
@@ -516,6 +550,7 @@ describe('usePerpsProOrderForm', () => {
       expect(mockComplianceGate).toHaveBeenCalledTimes(1);
       expect(mockShowEligibilityModal).not.toHaveBeenCalled();
       expect(mockExecuteOrder).not.toHaveBeenCalled();
+      expect(playImpact).not.toHaveBeenCalled();
     });
 
     it('commits pending slider preview without invoking compliance or submitting', async () => {
@@ -531,6 +566,7 @@ describe('usePerpsProOrderForm', () => {
       expect(mockSetAmount).toHaveBeenCalledWith('250');
       expect(mockComplianceGate).not.toHaveBeenCalled();
       expect(mockExecuteOrder).not.toHaveBeenCalled();
+      expect(playImpact).not.toHaveBeenCalled();
 
       mockOrderForm.amount = '250';
       mockIsEligible = false;
@@ -545,6 +581,7 @@ describe('usePerpsProOrderForm', () => {
         PERPS_EVENT_VALUE.SOURCE.TRADE_ACTION,
       );
       expect(mockExecuteOrder).not.toHaveBeenCalled();
+      expect(playImpact).not.toHaveBeenCalled();
     });
 
     it('builds OrderParams including reduceOnly and calls executeOrder', async () => {
@@ -768,6 +805,7 @@ describe('usePerpsProOrderForm', () => {
 
       expect(mockExecuteOrder).not.toHaveBeenCalled();
       expect(result.current.isPlaceOrderDisabled).toBe(true);
+      expect(playImpact).not.toHaveBeenCalled();
     });
 
     it('blocks reduce-only submit when size exceeds the open position', async () => {
@@ -788,6 +826,7 @@ describe('usePerpsProOrderForm', () => {
 
       expect(mockExecuteOrder).not.toHaveBeenCalled();
       expect(result.current.isPlaceOrderDisabled).toBe(true);
+      expect(playImpact).not.toHaveBeenCalled();
     });
 
     it('blocks submit and shows a toast when validation is invalid', async () => {
@@ -804,6 +843,7 @@ describe('usePerpsProOrderForm', () => {
       // Assert
       expect(mockExecuteOrder).not.toHaveBeenCalled();
       expect(validationError).toHaveBeenCalledWith('Bad order');
+      expect(playImpact).not.toHaveBeenCalled();
     });
 
     it('blocks submit and exposes loading while validation is pending', async () => {
@@ -841,6 +881,7 @@ describe('usePerpsProOrderForm', () => {
       // Assert
       expect(mockNavigate).toHaveBeenCalledTimes(1);
       expect(mockExecuteOrder).not.toHaveBeenCalled();
+      expect(playImpact).not.toHaveBeenCalled();
     });
 
     it('aborts and tracks when the estimated slippage exceeds the max', async () => {
@@ -856,6 +897,7 @@ describe('usePerpsProOrderForm', () => {
       // Assert
       expect(mockExecuteOrder).not.toHaveBeenCalled();
       expect(validationError).toHaveBeenCalled();
+      expect(playImpact).not.toHaveBeenCalled();
     });
 
     it('aborts submit when the stop loss risks liquidation (doesStopLossRiskLiquidation guard)', async () => {
@@ -870,6 +912,7 @@ describe('usePerpsProOrderForm', () => {
 
       // Assert
       expect(mockExecuteOrder).not.toHaveBeenCalled();
+      expect(playImpact).not.toHaveBeenCalled();
     });
 
     it('skips updatePositionTPSL and clearPendingConfig when the order fails (shouldHandleTPSLSeparately path)', async () => {
@@ -1713,6 +1756,8 @@ describe('usePerpsProOrderForm', () => {
 
       // Assert
       expect(mockNavigate).toHaveBeenCalledTimes(1);
+      expect(playImpact).toHaveBeenCalledTimes(1);
+      expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
       const onConfirm = mockNavigate.mock.calls[0][1].onConfirm;
       await act(async () => {
         await onConfirm(undefined, '95000', '80000');
@@ -1735,6 +1780,7 @@ describe('usePerpsProOrderForm', () => {
       // Assert
       expect(mockShowToast).toHaveBeenCalledWith(limitPriceRequired);
       expect(mockNavigate).not.toHaveBeenCalled();
+      expect(playImpact).not.toHaveBeenCalled();
     });
 
     it('confirms leverage, clamps an over-max amount, and tracks the change', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
@@ -507,7 +507,7 @@ describe('usePerpsProOrderForm', () => {
 
       let firstSubmission: Promise<unknown> | undefined;
       await act(async () => {
-        firstSubmission = result.current.onPlaceOrderPress();
+        firstSubmission = Promise.resolve(result.current.onPlaceOrderPress());
         await Promise.resolve();
         await result.current.onPlaceOrderPress();
       });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
@@ -1037,6 +1037,7 @@ export const usePerpsProOrderForm = ({
       initialStopLossPrice: orderForm.stopLossPrice,
       amount: effectiveUsdAmount,
       szDecimals,
+      enableHaptics: true,
       onConfirm: async (
         _position?: Position,
         takeProfitPrice?: string,

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
@@ -27,6 +27,7 @@ import { MetaMetricsEvents } from '../../../../../../../core/Analytics';
 import Routes from '../../../../../../../constants/navigation/Routes';
 import type { AppNavigationProp } from '../../../../../../../core/NavigationService/types';
 import { selectSelectedInternalAccountAddress } from '../../../../../../../selectors/accountsController';
+import { ImpactMoment, useHaptics } from '../../../../../../../util/haptics';
 import { useVipTier } from '../../../../../Rewards/hooks/useVipTier';
 import { useComplianceGate } from '../../../../../Compliance';
 import type { PerpsTooltipContentKey } from '../../../../components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.types';
@@ -338,6 +339,7 @@ export const usePerpsProOrderForm = ({
 
   const { isInitialized } = usePerpsConnection();
   const { track } = usePerpsEventTracking();
+  const { playImpact } = useHaptics();
   const { showToast, PerpsToastOptions } = usePerpsToasts();
   const { updatePositionTPSL } = usePerpsTrading();
 
@@ -903,6 +905,7 @@ export const usePerpsProOrderForm = ({
         }),
       });
 
+      playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
       showToast(
         PerpsToastOptions.orderManagement[
           getOrderManagementToastKey(orderForm.type)
@@ -1010,6 +1013,7 @@ export const usePerpsProOrderForm = ({
     sourceSection,
     chartLibrary,
     vipTier,
+    playImpact,
     executeOrder,
     updateOrderForm,
     setLimitPrice,
@@ -1026,6 +1030,7 @@ export const usePerpsProOrderForm = ({
       showToast(PerpsToastOptions.formValidation.orderForm.limitPriceRequired);
       return;
     }
+    playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
     navigation.navigate(Routes.PERPS.TPSL, {
       asset: orderForm.asset,
       currentPrice: assetData.price,
@@ -1061,6 +1066,7 @@ export const usePerpsProOrderForm = ({
     assetData.price,
     showToast,
     navigation,
+    playImpact,
     setTakeProfitPrice,
     setStopLossPrice,
     szDecimals,

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.test.tsx
@@ -147,13 +147,18 @@ jest.mock('../../../components/PerpsLeverageBottomSheet', () => {
     default: ({
       isVisible,
       onConfirm,
+      enableConfirmHaptics,
     }: {
       isVisible: boolean;
       onConfirm: (leverage: number) => void;
+      enableConfirmHaptics?: boolean;
     }) =>
       isVisible
         ? ReactActual.createElement(P, {
             testID: 'mock-leverage-confirm',
+            accessibilityLabel: enableConfirmHaptics
+              ? 'confirm-haptics-enabled'
+              : 'confirm-haptics-off',
             onPress: () => onConfirm(10),
           })
         : null,
@@ -351,6 +356,10 @@ describe('PerpsProOrderFormPanel', () => {
 
     // Assert
     expect(mockHookResult.onLeverageConfirm).toHaveBeenCalledWith(10);
+    expect(screen.getByTestId('mock-leverage-confirm')).toHaveProp(
+      'accessibilityLabel',
+      'confirm-haptics-enabled',
+    );
   });
 
   it('renders the leverage sheet inside the Android modal gesture root', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.test.tsx
@@ -30,6 +30,7 @@ jest.mock('../../../utils/perpsModeSwitch', () => ({
 
 jest.mock('../../../components/PerpsSlider', () => 'PerpsSlider');
 jest.mock('../../../components/PerpsFeesDisplay', () => 'PerpsFeesDisplay');
+jest.mock('../../../../../../util/haptics');
 
 const host = (name: string) => name as unknown as React.ComponentType<unknown>;
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.tsx
@@ -246,6 +246,7 @@ const PerpsProOrderFormPanel = ({
             limitPrice={limitPrice}
             triggerPrice={triggerPrice}
             orderType={orderType}
+            enableConfirmHaptics
           />
         </PerpsProModalPortal>
       )}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrdersSortSheet.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrdersSortSheet.test.tsx
@@ -1,7 +1,10 @@
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import React from 'react';
 import { DEFAULT_PRO_ORDER_SORT } from '../utils/proOrderSort';
+import { playSelection } from '../../../../../../util/haptics';
 import PerpsProOrdersSortSheet from './PerpsProOrdersSortSheet';
+
+jest.mock('../../../../../../util/haptics');
 
 jest.mock('../../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
@@ -65,5 +68,6 @@ describe('PerpsProOrdersSortSheet', () => {
       direction: 'desc',
     });
     expect(mockOnClose).toHaveBeenCalled();
+    expect(playSelection).toHaveBeenCalledTimes(2);
   });
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrdersSortSheet.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrdersSortSheet.test.tsx
@@ -1,7 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import React from 'react';
 import { DEFAULT_PRO_ORDER_SORT } from '../utils/proOrderSort';
-import { playSelection } from '../../../../../../util/haptics';
+import {
+  ImpactMoment,
+  playImpact,
+  playSelection,
+} from '../../../../../../util/haptics';
 import PerpsProOrdersSortSheet from './PerpsProOrdersSortSheet';
 
 jest.mock('../../../../../../util/haptics');
@@ -68,6 +72,8 @@ describe('PerpsProOrdersSortSheet', () => {
       direction: 'desc',
     });
     expect(mockOnClose).toHaveBeenCalled();
-    expect(playSelection).toHaveBeenCalledTimes(2);
+    expect(playSelection).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
   });
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsOptionSheet.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsOptionSheet.test.tsx
@@ -3,7 +3,11 @@ import { fireEvent, render, screen } from '@testing-library/react-native';
 import { Text } from '@metamask/design-system-react-native';
 import PerpsProPositionsOptionSheet from './PerpsProPositionsOptionSheet';
 import { PERPS_PRO_MODAL_GESTURE_ROOT_TEST_ID } from './PerpsProModalPortal';
-import { playSelection } from '../../../../../../util/haptics';
+import {
+  ImpactMoment,
+  playImpact,
+  playSelection,
+} from '../../../../../../util/haptics';
 
 jest.mock('../../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
@@ -63,7 +67,9 @@ describe('PerpsProPositionsOptionSheet', () => {
 
     expect(mockOnApply).toHaveBeenCalled();
     expect(mockOnClose).toHaveBeenCalled();
-    expect(playSelection).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
+    expect(playSelection).not.toHaveBeenCalled();
   });
 
   it('plays selection when Clear is pressed', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsOptionSheet.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsOptionSheet.test.tsx
@@ -3,15 +3,19 @@ import { fireEvent, render, screen } from '@testing-library/react-native';
 import { Text } from '@metamask/design-system-react-native';
 import PerpsProPositionsOptionSheet from './PerpsProPositionsOptionSheet';
 import { PERPS_PRO_MODAL_GESTURE_ROOT_TEST_ID } from './PerpsProModalPortal';
+import { playSelection } from '../../../../../../util/haptics';
 
 jest.mock('../../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
     const translations: Record<string, string> = {
       'perps.sort.apply': 'Apply',
+      'perps.sort.clear': 'Clear',
     };
     return translations[key] || key;
   }),
 }));
+
+jest.mock('../../../../../../util/haptics');
 
 describe('PerpsProPositionsOptionSheet', () => {
   const mockOnClose = jest.fn();
@@ -59,6 +63,29 @@ describe('PerpsProPositionsOptionSheet', () => {
 
     expect(mockOnApply).toHaveBeenCalled();
     expect(mockOnClose).toHaveBeenCalled();
+    expect(playSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it('plays selection when Clear is pressed', () => {
+    const onClear = jest.fn();
+    render(
+      <PerpsProPositionsOptionSheet
+        isVisible
+        title="Options"
+        onClose={mockOnClose}
+        onApply={mockOnApply}
+        onClear={onClear}
+        testID="option-sheet"
+      >
+        <Text>Option</Text>
+      </PerpsProPositionsOptionSheet>,
+    );
+
+    fireEvent.press(screen.getByTestId('option-sheet-clear'));
+
+    expect(onClear).toHaveBeenCalledTimes(1);
+    expect(mockOnClose).toHaveBeenCalled();
+    expect(playSelection).toHaveBeenCalledTimes(1);
   });
 
   it('renders options inside the Android modal gesture root', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsOptionSheet.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsOptionSheet.tsx
@@ -8,7 +8,7 @@ import {
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { strings } from '../../../../../../../locales/i18n';
 import PerpsProModalPortal from './PerpsProModalPortal';
-import { useHaptics } from '../../../../../../util/haptics';
+import { ImpactMoment, useHaptics } from '../../../../../../util/haptics';
 
 export interface PerpsProPositionsOptionSheetProps {
   isVisible: boolean;
@@ -34,7 +34,7 @@ const PerpsProPositionsOptionSheet = ({
   testID = 'perps-pro-positions-option-sheet',
   children,
 }: PerpsProPositionsOptionSheetProps) => {
-  const { playSelection } = useHaptics();
+  const { playImpact, playSelection } = useHaptics();
   const sheetRef = useRef<BottomSheetRef>(null);
   const wasVisibleRef = useRef(false);
 
@@ -55,10 +55,10 @@ const PerpsProPositionsOptionSheet = ({
   }, [onClose]);
 
   const handleApply = useCallback(() => {
-    playSelection().catch(() => undefined);
+    playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
     onApply();
     handleClose();
-  }, [handleClose, onApply, playSelection]);
+  }, [handleClose, onApply, playImpact]);
 
   const handleClear = useCallback(() => {
     if (!onClear) {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsOptionSheet.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsOptionSheet.tsx
@@ -8,6 +8,7 @@ import {
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { strings } from '../../../../../../../locales/i18n';
 import PerpsProModalPortal from './PerpsProModalPortal';
+import { useHaptics } from '../../../../../../util/haptics';
 
 export interface PerpsProPositionsOptionSheetProps {
   isVisible: boolean;
@@ -33,6 +34,7 @@ const PerpsProPositionsOptionSheet = ({
   testID = 'perps-pro-positions-option-sheet',
   children,
 }: PerpsProPositionsOptionSheetProps) => {
+  const { playSelection } = useHaptics();
   const sheetRef = useRef<BottomSheetRef>(null);
   const wasVisibleRef = useRef(false);
 
@@ -53,9 +55,19 @@ const PerpsProPositionsOptionSheet = ({
   }, [onClose]);
 
   const handleApply = useCallback(() => {
+    playSelection().catch(() => undefined);
     onApply();
     handleClose();
-  }, [handleClose, onApply]);
+  }, [handleClose, onApply, playSelection]);
+
+  const handleClear = useCallback(() => {
+    if (!onClear) {
+      return;
+    }
+    playSelection().catch(() => undefined);
+    onClear();
+    handleClose();
+  }, [handleClose, onClear, playSelection]);
 
   const primaryButtonProps = useMemo(
     () => ({
@@ -71,14 +83,11 @@ const PerpsProPositionsOptionSheet = ({
       onClear
         ? {
             children: strings('perps.sort.clear'),
-            onPress: () => {
-              onClear();
-              handleClose();
-            },
+            onPress: handleClear,
             testID: `${testID}-clear`,
           }
         : undefined,
-    [handleClose, onClear, testID],
+    [handleClear, onClear, testID],
   );
 
   if (!isVisible) {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.test.tsx
@@ -19,7 +19,10 @@ import {
   getPerpsProPositionRowSelector,
   PerpsProMarketViewSelectorsIDs,
 } from '../../../Perps.testIds';
+import { playSelection } from '../../../../../../util/haptics';
 import PerpsProPositionsPanel from './PerpsProPositionsPanel';
+
+jest.mock('../../../../../../util/haptics');
 
 jest.mock('../../../components/PerpsTokenLogo', () => 'PerpsTokenLogo');
 
@@ -363,6 +366,31 @@ describe('PerpsProPositionsPanel', () => {
     expectTabLabel('Orders (1)');
     expect(screen.getByText('SOL')).toBeOnTheScreen();
     expect(screen.queryByText('BTC')).toBeNull();
+  });
+
+  it('plays selection when the ticker-only checkbox changes', () => {
+    renderPanel('SOL');
+    const tickerOnlyCheckbox = screen.getByTestId(
+      PerpsProMarketViewSelectorsIDs.POSITIONS_TICKER_ONLY,
+    );
+
+    fireEvent.press(tickerOnlyCheckbox);
+    fireEvent.press(
+      screen.getByTestId(PerpsProMarketViewSelectorsIDs.POSITIONS_TICKER_ONLY),
+    );
+
+    expect(playSelection).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps haptics silent when the ticker-only value does not change', () => {
+    renderPanel('SOL');
+    const tickerOnlyCheckbox = screen.getByTestId(
+      PerpsProMarketViewSelectorsIDs.POSITIONS_TICKER_ONLY,
+    );
+
+    fireEvent(tickerOnlyCheckbox, 'onChange', false);
+
+    expect(playSelection).not.toHaveBeenCalled();
   });
 
   it('uses filtered count and filtered empty copy for ticker-only orders with no match', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.tsx
@@ -21,6 +21,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { strings } from '../../../../../../../locales/i18n';
 import TabsBar from '../../../../../../component-library/components-temp/Tabs/TabsBar';
 import type { TabItem } from '../../../../../../component-library/components-temp/Tabs/TabsBar/TabsBar.types';
+import { useHaptics } from '../../../../../../util/haptics';
 import { usePerpsProPositionsPanelActions } from '../../../hooks/usePerpsProPositionsPanelActions';
 import { usePerpsProOrdersPreferences } from '../../../hooks/usePerpsProOrdersPreferences';
 import { usePerpsProPositionsPreferences } from '../../../hooks/usePerpsProPositionsPreferences';
@@ -93,6 +94,7 @@ const PerpsProPositionsPanel = ({
   onSelectMarket,
   onHistoryPress,
 }: PerpsProPositionsPanelProps) => {
+  const { playSelection } = useHaptics();
   const [activeIndex, setActiveIndex] = useState(POSITIONS_TAB_INDEX);
   const [isTickerOnly, setIsTickerOnly] = useState(false);
   const [isSortSheetOpen, setIsSortSheetOpen] = useState(false);
@@ -109,6 +111,16 @@ const PerpsProPositionsPanel = ({
     setSideFilter: setOrdersSideFilter,
     setSortConfig: setOrderSortConfig,
   } = usePerpsProOrdersPreferences();
+  const handleTickerOnlyChange = useCallback(
+    (nextIsTickerOnly: boolean) => {
+      if (nextIsTickerOnly === isTickerOnly) {
+        return;
+      }
+      playSelection().catch(() => undefined);
+      setIsTickerOnly(nextIsTickerOnly);
+    },
+    [isTickerOnly, playSelection],
+  );
   const { positions, isInitialLoading } = usePerpsLivePositions({
     throttleMs: 1000,
     useLivePnl: true,
@@ -388,7 +400,7 @@ const PerpsProPositionsPanel = ({
         ticker: displaySymbol,
       })}
       isSelected={isTickerOnly}
-      onChange={setIsTickerOnly}
+      onChange={handleTickerOnlyChange}
       testID={PerpsProMarketViewSelectorsIDs.POSITIONS_TICKER_ONLY}
     />
   );

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanelActions.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanelActions.test.tsx
@@ -9,6 +9,7 @@ import type { Order, Position } from '@metamask/perps-controller';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import Routes from '../../../../../../constants/navigation/Routes';
+import { ImpactMoment, playImpact } from '../../../../../../util/haptics';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
 import { usePerpsProPositionsPanelActions } from '../../../hooks/usePerpsProPositionsPanelActions';
 import PerpsProPositionCard from './PerpsProPositionCard';
@@ -16,6 +17,7 @@ import PerpsProOrderCard from './PerpsProOrderCard';
 import PerpsProUnrealizedPnl from './PerpsProUnrealizedPnl';
 
 jest.mock('../../../components/PerpsTokenLogo', () => 'PerpsTokenLogo');
+jest.mock('../../../../../../util/haptics');
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
@@ -125,8 +127,17 @@ jest.mock(
   '../../../Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView',
   () => {
     const { View } = jest.requireActual('react-native');
-    return function PerpsCloseAllPositionsView() {
-      return <View testID="perps-close-all-positions-view" />;
+    return function PerpsCloseAllPositionsView({
+      enableHaptics,
+    }: {
+      enableHaptics?: boolean;
+    }) {
+      return (
+        <View
+          testID="perps-close-all-positions-view"
+          accessibilityLabel={enableHaptics ? 'haptics-enabled' : 'haptics-off'}
+        />
+      );
     };
   },
 );
@@ -135,8 +146,17 @@ jest.mock(
   '../../../components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet',
   () => {
     const { View } = jest.requireActual('react-native');
-    return function PerpsFlipPositionConfirmSheet() {
-      return <View testID="perps-flip-position-confirm-sheet" />;
+    return function PerpsFlipPositionConfirmSheet({
+      enableHaptics,
+    }: {
+      enableHaptics?: boolean;
+    }) {
+      return (
+        <View
+          testID="perps-flip-position-confirm-sheet"
+          accessibilityLabel={enableHaptics ? 'haptics-enabled' : 'haptics-off'}
+        />
+      );
     };
   },
 );
@@ -145,8 +165,17 @@ jest.mock(
   '../../../Views/PerpsSelectAdjustMarginActionView/PerpsSelectAdjustMarginActionView',
   () => {
     const { View } = jest.requireActual('react-native');
-    return function PerpsSelectAdjustMarginActionView() {
-      return <View testID="perps-select-adjust-margin-action-view" />;
+    return function PerpsSelectAdjustMarginActionView({
+      enableHaptics,
+    }: {
+      enableHaptics?: boolean;
+    }) {
+      return (
+        <View
+          testID="perps-select-adjust-margin-action-view"
+          accessibilityLabel={enableHaptics ? 'haptics-enabled' : 'haptics-off'}
+        />
+      );
     };
   },
 );
@@ -283,8 +312,34 @@ describe('usePerpsProPositionsPanelActions', () => {
       expect.objectContaining({
         buttonClicked: 'close',
         buttonLocation: 'perp_market_details',
+        enableHaptics: true,
       }),
     );
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
+  });
+
+  it('keeps haptics silent when eligibility blocks an action', async () => {
+    (useSelector as jest.Mock)
+      .mockReset()
+      .mockReturnValueOnce(false)
+      .mockReturnValue('0x123');
+    let actions:
+      | ReturnType<typeof usePerpsProPositionsPanelActions>
+      | undefined;
+    render(
+      <ActionHarness
+        onReady={(readyActions) => {
+          actions = readyActions;
+        }}
+      />,
+    );
+
+    await act(async () => {
+      actions?.handleClosePosition(position);
+    });
+
+    expect(mockNavigateToClosePosition).not.toHaveBeenCalled();
+    expect(playImpact).not.toHaveBeenCalled();
   });
 
   it('opens reverse confirmation sheet for the selected position', async () => {
@@ -307,8 +362,9 @@ describe('usePerpsProPositionsPanelActions', () => {
     await waitFor(() => {
       expect(
         screen.getByTestId('perps-flip-position-confirm-sheet'),
-      ).toBeOnTheScreen();
+      ).toHaveProp('accessibilityLabel', 'haptics-enabled');
     });
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
   });
 
   it('navigates to share PnL with derived mark price', async () => {
@@ -332,6 +388,7 @@ describe('usePerpsProPositionsPanelActions', () => {
       position,
       marketPrice: '2900',
     });
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
   });
 
   it('cancels an order using the existing trading flow', async () => {
@@ -361,6 +418,32 @@ describe('usePerpsProPositionsPanelActions', () => {
       }),
     );
     expect(mockShowToast).toHaveBeenCalled();
+    expect(playImpact).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
+  });
+
+  it('keeps haptics silent for a non-cancelable order', async () => {
+    let actions:
+      | ReturnType<typeof usePerpsProPositionsPanelActions>
+      | undefined;
+    render(
+      <ActionHarness
+        onReady={(readyActions) => {
+          actions = readyActions;
+        }}
+      />,
+    );
+
+    await act(async () => {
+      await actions?.handleCancelOrder({
+        ...order,
+        orderId: 'order-1-synthetic-tp',
+        isSynthetic: true,
+      });
+    });
+
+    expect(mockCancelOrder).not.toHaveBeenCalled();
+    expect(playImpact).not.toHaveBeenCalled();
   });
 
   it('edits an order price through the limit price sheet', async () => {
@@ -419,6 +502,8 @@ describe('usePerpsProPositionsPanelActions', () => {
     });
 
     expect(mockShowToast).toHaveBeenCalled();
+    expect(playImpact).toHaveBeenNthCalledWith(1, ImpactMoment.PageNavigation);
+    expect(playImpact).toHaveBeenNthCalledWith(2, ImpactMoment.PrimaryCTA);
   });
 
   it('edits an order size through the size bottom sheet', async () => {
@@ -450,6 +535,7 @@ describe('usePerpsProPositionsPanelActions', () => {
         screen.getByTestId('perps-order-size-bottom-sheet'),
       ).toBeOnTheScreen();
     });
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
 
     await act(async () => {
       fireEvent.press(screen.getByTestId('perps-order-size-confirm'));
@@ -498,10 +584,12 @@ describe('usePerpsProPositionsPanelActions', () => {
 
     expect(mockGate).toHaveBeenCalled();
     await waitFor(() => {
-      expect(
-        screen.getByTestId('perps-close-all-positions-view'),
-      ).toBeOnTheScreen();
+      expect(screen.getByTestId('perps-close-all-positions-view')).toHaveProp(
+        'accessibilityLabel',
+        'haptics-enabled',
+      );
     });
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
   });
 });
 
@@ -562,8 +650,31 @@ describe('PerpsProPositionsPanel action callbacks', () => {
     await waitFor(() => {
       expect(
         screen.getByTestId('perps-select-adjust-margin-action-view'),
-      ).toBeOnTheScreen();
+      ).toHaveProp('accessibilityLabel', 'haptics-enabled');
     });
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
+  });
+
+  it('keeps haptics silent for a non-editable cross-margin position', async () => {
+    let actions:
+      | ReturnType<typeof usePerpsProPositionsPanelActions>
+      | undefined;
+    render(
+      <ActionHarness
+        onReady={(readyActions) => {
+          actions = readyActions;
+        }}
+      />,
+    );
+
+    await act(async () => {
+      actions?.handleEditPositionMargin({
+        ...position,
+        leverage: { ...position.leverage, type: 'cross' },
+      });
+    });
+
+    expect(playImpact).not.toHaveBeenCalled();
   });
 
   it('navigates to TP/SL screen when edit control is pressed', () => {
@@ -590,8 +701,10 @@ describe('PerpsProPositionsPanel action callbacks', () => {
         initialTakeProfitPrice: position.takeProfitPrice,
         initialStopLossPrice: position.stopLossPrice,
         leverage: position.leverage.value,
+        enableHaptics: true,
       }),
     );
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
   });
 
   it('invokes edit TP/SL callback from position card control', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsSideFilterSheet.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsSideFilterSheet.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react-native';
 import PerpsProPositionsSideFilterSheet from './PerpsProPositionsSideFilterSheet';
 import { DEFAULT_PRO_POSITION_SIDE_FILTER } from '../utils/proPositionSideFilter';
 import { PERPS_PRO_MODAL_GESTURE_ROOT_TEST_ID } from './PerpsProModalPortal';
+import { playSelection } from '../../../../../../util/haptics';
 
 jest.mock('./ProPositionSideFilterIcon', () => 'ProPositionSideFilterIcon');
 
@@ -18,6 +19,8 @@ jest.mock('../../../../../../../locales/i18n', () => ({
     return translations[key] || key;
   }),
 }));
+
+jest.mock('../../../../../../util/haptics');
 
 describe('PerpsProPositionsSideFilterSheet', () => {
   const mockOnClose = jest.fn();
@@ -89,5 +92,26 @@ describe('PerpsProPositionsSideFilterSheet', () => {
 
     expect(mockOnApply).toHaveBeenCalledWith('long');
     expect(mockOnClose).toHaveBeenCalled();
+    expect(playSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes without haptic or apply when the current filter is re-selected', () => {
+    render(
+      <PerpsProPositionsSideFilterSheet
+        isVisible
+        sideFilter="long"
+        onClose={mockOnClose}
+        onApply={mockOnApply}
+        testID="positions-side-filter-sheet"
+      />,
+    );
+
+    fireEvent.press(
+      screen.getByTestId('positions-side-filter-sheet-option-long'),
+    );
+
+    expect(mockOnApply).not.toHaveBeenCalled();
+    expect(mockOnClose).toHaveBeenCalled();
+    expect(playSelection).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsSideFilterSheet.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsSideFilterSheet.tsx
@@ -6,6 +6,7 @@ import {
 } from '@metamask/design-system-react-native';
 import React, { useCallback, useEffect, useRef } from 'react';
 import { strings } from '../../../../../../../locales/i18n';
+import { useHaptics } from '../../../../../../util/haptics';
 import ProPositionSideFilterIcon from './ProPositionSideFilterIcon';
 import PerpsProModalPortal from './PerpsProModalPortal';
 import {
@@ -32,6 +33,7 @@ const PerpsProPositionsSideFilterSheet = ({
   onClose,
   testID = 'perps-pro-positions-side-filter-sheet',
 }: PerpsProPositionsSideFilterSheetProps) => {
+  const { playSelection } = useHaptics();
   const sheetRef = useRef<BottomSheetRef>(null);
 
   useEffect(() => {
@@ -46,10 +48,13 @@ const PerpsProPositionsSideFilterSheet = ({
 
   const handleSelect = useCallback(
     (option: ProPositionSideFilter) => {
-      onApply(option);
+      if (option !== sideFilter) {
+        playSelection().catch(() => undefined);
+        onApply(option);
+      }
       handleClose();
     },
-    [onApply, handleClose],
+    [onApply, handleClose, playSelection, sideFilter],
   );
 
   if (!isVisible) {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsSortSheet.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsSortSheet.test.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import PerpsProPositionsSortSheet from './PerpsProPositionsSortSheet';
 import { DEFAULT_PRO_POSITION_SORT } from '../utils/proPositionSort';
+import { playSelection } from '../../../../../../util/haptics';
 
 jest.mock('../../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
     const translations: Record<string, string> = {
       'perps.sort.sort_by': 'Sort by',
       'perps.sort.apply': 'Apply',
+      'perps.sort.clear': 'Clear',
       'perps.sort.high_to_low': 'High to low',
       'perps.sort.low_to_high': 'Low to high',
       'perps.pro_positions_panel.sort.position_value': 'Position value',
@@ -17,6 +19,8 @@ jest.mock('../../../../../../../locales/i18n', () => ({
     return translations[key] || key;
   }),
 }));
+
+jest.mock('../../../../../../util/haptics');
 
 describe('PerpsProPositionsSortSheet', () => {
   const mockOnClose = jest.fn();
@@ -76,6 +80,7 @@ describe('PerpsProPositionsSortSheet', () => {
     expect(
       screen.getByTestId('positions-sort-sheet-direction-text-positionValue'),
     ).toHaveTextContent('Low to high');
+    expect(playSelection).toHaveBeenCalledTimes(1);
 
     fireEvent.press(screen.getByTestId('positions-sort-sheet-apply'));
 
@@ -84,6 +89,7 @@ describe('PerpsProPositionsSortSheet', () => {
       direction: 'asc',
     });
     expect(mockOnClose).toHaveBeenCalled();
+    expect(playSelection).toHaveBeenCalledTimes(2);
   });
 
   it('selects a new field with high-to-low default when pressing another option', () => {
@@ -106,5 +112,23 @@ describe('PerpsProPositionsSortSheet', () => {
       field: 'unrealizedPnl',
       direction: 'desc',
     });
+    expect(playSelection).toHaveBeenCalledTimes(2);
+  });
+
+  it('plays selection when Clear resets the sort', () => {
+    render(
+      <PerpsProPositionsSortSheet
+        isVisible
+        sortConfig={{ field: 'unrealizedPnl', direction: 'asc' }}
+        onClose={mockOnClose}
+        onApply={mockOnApply}
+        testID="positions-sort-sheet"
+      />,
+    );
+
+    fireEvent.press(screen.getByTestId('positions-sort-sheet-clear'));
+
+    expect(mockOnApply).toHaveBeenCalledWith(DEFAULT_PRO_POSITION_SORT);
+    expect(playSelection).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsSortSheet.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsSortSheet.test.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import PerpsProPositionsSortSheet from './PerpsProPositionsSortSheet';
 import { DEFAULT_PRO_POSITION_SORT } from '../utils/proPositionSort';
-import { playSelection } from '../../../../../../util/haptics';
+import {
+  ImpactMoment,
+  playImpact,
+  playSelection,
+} from '../../../../../../util/haptics';
 
 jest.mock('../../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
@@ -89,7 +93,9 @@ describe('PerpsProPositionsSortSheet', () => {
       direction: 'asc',
     });
     expect(mockOnClose).toHaveBeenCalled();
-    expect(playSelection).toHaveBeenCalledTimes(2);
+    expect(playSelection).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
   });
 
   it('selects a new field with high-to-low default when pressing another option', () => {
@@ -112,7 +118,9 @@ describe('PerpsProPositionsSortSheet', () => {
       field: 'unrealizedPnl',
       direction: 'desc',
     });
-    expect(playSelection).toHaveBeenCalledTimes(2);
+    expect(playSelection).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
   });
 
   it('plays selection when Clear resets the sort', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProSortSheet.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProSortSheet.tsx
@@ -12,6 +12,7 @@ import {
 } from '@metamask/design-system-react-native';
 import React, { useCallback, useState } from 'react';
 import { strings } from '../../../../../../../locales/i18n';
+import { useHaptics } from '../../../../../../util/haptics';
 import type { ProSortDirection } from '../utils/proSortCompare';
 import PerpsProPositionsOptionSheet from './PerpsProPositionsOptionSheet';
 
@@ -48,6 +49,7 @@ const PerpsProSortSheet = <TField extends string>({
   onClear,
   testID = 'perps-pro-sort-sheet',
 }: PerpsProSortSheetProps<TField>) => {
+  const { playSelection } = useHaptics();
   const [draftField, setDraftField] = useState<TField>(sortConfig.field);
   const [draftDirection, setDraftDirection] = useState<ProSortDirection>(
     sortConfig.direction,
@@ -60,6 +62,7 @@ const PerpsProSortSheet = <TField extends string>({
 
   const handleOptionPress = useCallback(
     (field: TField) => {
+      playSelection().catch(() => undefined);
       if (draftField === field) {
         setDraftDirection((current) => (current === 'asc' ? 'desc' : 'asc'));
         return;
@@ -68,7 +71,7 @@ const PerpsProSortSheet = <TField extends string>({
       setDraftField(field);
       setDraftDirection('desc');
     },
-    [draftField],
+    [draftField, playSelection],
   );
 
   const handleApply = useCallback(() => {

--- a/app/components/UI/Perps/Views/PerpsSelectAdjustMarginActionView/PerpsSelectAdjustMarginActionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsSelectAdjustMarginActionView/PerpsSelectAdjustMarginActionView.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react-native';
 import PerpsSelectAdjustMarginActionView from './PerpsSelectAdjustMarginActionView';
 import { type Position } from '@metamask/perps-controller';
+import { ImpactMoment, playImpact } from '../../../../../util/haptics';
 
 let mockRouteParams: { position?: Position } = {};
 const mockGoBack = jest.fn();
@@ -21,6 +22,7 @@ jest.mock('@react-navigation/native', () => ({
     name: 'SELECT_ADJUST_MARGIN_ACTION',
   }),
 }));
+jest.mock('../../../../../util/haptics');
 
 jest.mock('../../hooks/usePerpsNavigation', () => ({
   usePerpsNavigation: () => ({
@@ -141,7 +143,9 @@ describe('PerpsSelectAdjustMarginActionView', () => {
     expect(mockNavigateToAdjustMargin).toHaveBeenCalledWith(
       mockPosition,
       'add',
+      { enableHaptics: false },
     );
+    expect(playImpact).not.toHaveBeenCalled();
   });
 
   it('calls goBack after add_margin action is selected without external sheetRef', () => {
@@ -153,14 +157,22 @@ describe('PerpsSelectAdjustMarginActionView', () => {
   });
 
   it('navigates to reduce margin when reduce_margin action is selected', () => {
-    render(<PerpsSelectAdjustMarginActionView position={mockPosition} />);
+    render(
+      <PerpsSelectAdjustMarginActionView
+        position={mockPosition}
+        enableHaptics
+      />,
+    );
 
     fireEvent.press(screen.getByTestId('reduce-margin'));
 
     expect(mockNavigateToAdjustMargin).toHaveBeenCalledWith(
       mockPosition,
       'remove',
+      { enableHaptics: true },
     );
+    expect(playImpact).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
   });
 
   it('does not navigate when position is not available', () => {
@@ -170,6 +182,7 @@ describe('PerpsSelectAdjustMarginActionView', () => {
     fireEvent.press(screen.getByTestId('add-margin'));
 
     expect(mockNavigateToAdjustMargin).not.toHaveBeenCalled();
+    expect(playImpact).not.toHaveBeenCalled();
   });
 
   it('calls goBack when close button is pressed without external sheetRef', () => {
@@ -229,6 +242,7 @@ describe('PerpsSelectAdjustMarginActionView', () => {
     expect(mockNavigateToAdjustMargin).toHaveBeenCalledWith(
       mockPosition,
       'add',
+      { enableHaptics: false },
     );
   });
 });

--- a/app/components/UI/Perps/Views/PerpsSelectAdjustMarginActionView/PerpsSelectAdjustMarginActionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsSelectAdjustMarginActionView/PerpsSelectAdjustMarginActionView.tsx
@@ -19,11 +19,13 @@ import { usePerpsNavigation } from '../../hooks/usePerpsNavigation';
 import { type BottomSheetRef } from '@metamask/design-system-react-native';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { ImpactMoment, useHaptics } from '../../../../../util/haptics';
 
 interface PerpsSelectAdjustMarginActionViewProps {
   sheetRef?: React.RefObject<BottomSheetRef | null>;
   position?: Position;
   onClose?: () => void;
+  enableHaptics?: boolean;
 }
 
 const PerpsSelectAdjustMarginActionView: React.FC<
@@ -32,6 +34,7 @@ const PerpsSelectAdjustMarginActionView: React.FC<
   sheetRef: externalSheetRef,
   position: positionProp,
   onClose: onExternalClose,
+  enableHaptics = false,
 }) => {
   const navigation = useNavigation<AppNavigationProp>();
   const route =
@@ -45,6 +48,7 @@ const PerpsSelectAdjustMarginActionView: React.FC<
   const internalSheetRef = useRef<BottomSheetRef>(null);
   const sheetRef = externalSheetRef || internalSheetRef;
   const { navigateToAdjustMargin } = usePerpsNavigation();
+  const { playImpact } = useHaptics();
 
   const handleClose = useCallback(() => {
     if (externalSheetRef) {
@@ -57,6 +61,10 @@ const PerpsSelectAdjustMarginActionView: React.FC<
   const handleActionSelect = useCallback(
     (action: AdjustMarginAction) => {
       if (!position) return;
+
+      if (enableHaptics) {
+        playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
+      }
 
       // Track UI interaction for add/remove margin selection
       const interactionType = {
@@ -78,10 +86,10 @@ const PerpsSelectAdjustMarginActionView: React.FC<
       // Navigate BEFORE closing (prevents navigation loss from component unmounting)
       switch (action) {
         case 'add_margin':
-          navigateToAdjustMargin(position, 'add');
+          navigateToAdjustMargin(position, 'add', { enableHaptics });
           break;
         case 'reduce_margin':
-          navigateToAdjustMargin(position, 'remove');
+          navigateToAdjustMargin(position, 'remove', { enableHaptics });
           break;
       }
 
@@ -90,6 +98,8 @@ const PerpsSelectAdjustMarginActionView: React.FC<
     },
     [
       position,
+      enableHaptics,
+      playImpact,
       sheetRef,
       handleClose,
       navigateToAdjustMargin,

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.test.tsx
@@ -2,9 +2,19 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react-native';
 import PerpsTPSLView from './PerpsTPSLView';
 import { PERPS_EVENT_VALUE, type Position } from '@metamask/perps-controller';
-import { PerpsTPSLViewSelectorsIDs } from '../../Perps.testIds';
+import {
+  getPerpsTPSLViewSelector,
+  PerpsTPSLViewSelectorsIDs,
+} from '../../Perps.testIds';
+import {
+  ImpactMoment,
+  playImpact,
+  playSelection,
+} from '../../../../../util/haptics';
 
 // react-native-reanimated is already mocked globally via setUpTests() in testSetup.js
+
+jest.mock('../../../../../util/haptics');
 
 jest.mock('../../utils/perpsAnalyticsAttribution', () => ({
   ...jest.requireActual('../../utils/perpsAnalyticsAttribution'),
@@ -546,6 +556,80 @@ describe('PerpsTPSLView', () => {
       expect(mockNavigation.goBack).toHaveBeenCalled();
     });
 
+    it('plays PageNavigation on back when enableHaptics is true', async () => {
+      mockRouteParams = { ...defaultRouteParams, enableHaptics: true };
+      renderView();
+
+      await act(async () => {
+        fireEvent.press(
+          screen.getByTestId(PerpsTPSLViewSelectorsIDs.BACK_BUTTON),
+        );
+      });
+
+      expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
+      expect(mockNavigation.goBack).toHaveBeenCalled();
+    });
+
+    it('does not play a haptic on back when enableHaptics is omitted', async () => {
+      renderView();
+
+      await act(async () => {
+        fireEvent.press(
+          screen.getByTestId(PerpsTPSLViewSelectorsIDs.BACK_BUTTON),
+        );
+      });
+
+      expect(playImpact).not.toHaveBeenCalled();
+      expect(playSelection).not.toHaveBeenCalled();
+    });
+
+    it('plays selection when a take-profit preset is pressed with enableHaptics', async () => {
+      mockRouteParams = { ...defaultRouteParams, enableHaptics: true };
+      renderView();
+
+      await act(async () => {
+        fireEvent.press(
+          screen.getByTestId(
+            getPerpsTPSLViewSelector.takeProfitPercentageButton(10),
+          ),
+        );
+      });
+
+      expect(playSelection).toHaveBeenCalledTimes(1);
+      expect(
+        defaultMockReturn.buttons.handleTakeProfitPercentageButton,
+      ).toHaveBeenCalledWith(10);
+    });
+
+    it('plays PrimaryCTA on Set when enableHaptics is true', async () => {
+      const mockOnConfirm = jest.fn().mockResolvedValue(undefined);
+      mockRouteParams = {
+        ...defaultRouteParams,
+        onConfirm: mockOnConfirm,
+        enableHaptics: true,
+      };
+      renderView({
+        formState: {
+          ...defaultMockReturn.formState,
+          takeProfitPrice: '$3,150.00',
+          stopLossPrice: '$2,850.00',
+        },
+        validation: {
+          ...defaultMockReturn.validation,
+          hasChanges: true,
+        },
+      });
+
+      await act(async () => {
+        fireEvent.press(
+          screen.getByTestId(PerpsTPSLViewSelectorsIDs.SET_BUTTON),
+        );
+      });
+
+      expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
+      expect(mockOnConfirm).toHaveBeenCalled();
+    });
+
     it('calls onConfirm with hook values when Set button pressed', async () => {
       const mockOnConfirm = jest.fn().mockResolvedValue(undefined);
       mockRouteParams = { ...defaultRouteParams, onConfirm: mockOnConfirm };
@@ -582,6 +666,7 @@ describe('PerpsTPSLView', () => {
           entryPrice: 3000,
         }),
       );
+      expect(playImpact).not.toHaveBeenCalled();
     });
 
     it('calls onConfirm with undefined when values are empty', async () => {

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.test.tsx
@@ -630,6 +630,42 @@ describe('PerpsTPSLView', () => {
       expect(mockOnConfirm).toHaveBeenCalled();
     });
 
+    it.each([
+      {
+        state: 'there are no changes',
+        validation: { isValid: true, hasChanges: false },
+      },
+      {
+        state: 'the form is invalid',
+        validation: { isValid: false, hasChanges: true },
+      },
+    ])(
+      'does not confirm or play PrimaryCTA when $state',
+      async ({ validation }) => {
+        const mockOnConfirm = jest.fn().mockResolvedValue(undefined);
+        mockRouteParams = {
+          ...defaultRouteParams,
+          onConfirm: mockOnConfirm,
+          enableHaptics: true,
+        };
+        renderView({
+          validation: {
+            ...defaultMockReturn.validation,
+            ...validation,
+          },
+        });
+
+        await act(async () => {
+          fireEvent.press(
+            screen.getByTestId(PerpsTPSLViewSelectorsIDs.SET_BUTTON),
+          );
+        });
+
+        expect(playImpact).not.toHaveBeenCalled();
+        expect(mockOnConfirm).not.toHaveBeenCalled();
+      },
+    );
+
     it('calls onConfirm with hook values when Set button pressed', async () => {
       const mockOnConfirm = jest.fn().mockResolvedValue(undefined);
       mockRouteParams = { ...defaultRouteParams, onConfirm: mockOnConfirm };

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
@@ -41,6 +41,7 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import Keypad from '../../../../../components/Base/Keypad';
+import { ImpactMoment, useHaptics } from '../../../../../util/haptics';
 
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import {
@@ -113,6 +114,7 @@ const PerpsTPSLView: React.FC = () => {
   const navigation = useNavigation<AppNavigationProp>();
   const route = useRoute<RouteProp<PerpsNavigationParamList, 'PerpsTPSL'>>();
   const tw = useTailwind();
+  const { playImpact, playSelection } = useHaptics();
 
   // Extract params from navigation route
   const {
@@ -127,6 +129,7 @@ const PerpsTPSLView: React.FC = () => {
     limitPrice,
     amount,
     szDecimals,
+    enableHaptics = false,
     onConfirm,
   } = route.params;
 
@@ -309,8 +312,11 @@ const PerpsTPSLView: React.FC = () => {
 
   // Handle back button press
   const handleBack = useCallback(() => {
+    if (enableHaptics) {
+      playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
+    }
     navigation.goBack();
-  }, [navigation]);
+  }, [enableHaptics, navigation, playImpact]);
 
   const scrollFocusedSectionIntoView = useCallback((inputType: string) => {
     const sectionRef =
@@ -497,6 +503,10 @@ const PerpsTPSLView: React.FC = () => {
       ? stopLossPrice.replace(/[$,]/g, '')
       : undefined;
 
+    if (enableHaptics) {
+      playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
+    }
+
     setIsUpdating(true);
     try {
       // Pass tracking data to avoid duplicate position fetch in controller
@@ -544,25 +554,81 @@ const PerpsTPSLView: React.FC = () => {
     formattedStopLossPercentage,
     isEditingExistingPosition,
     effectiveEntryPrice,
+    enableHaptics,
+    playImpact,
   ]);
 
   const confirmDisabled = !hasChanges || !isValid || isUpdating;
   const inputsDisabled = isUpdating;
+
+  const handleTakeProfitPresetPress = useCallback(
+    (percentage: number) => {
+      if (inputsDisabled) {
+        return;
+      }
+      if (enableHaptics) {
+        playSelection().catch(() => undefined);
+      }
+      handleTakeProfitPercentageButton(percentage);
+    },
+    [
+      enableHaptics,
+      handleTakeProfitPercentageButton,
+      inputsDisabled,
+      playSelection,
+    ],
+  );
+
+  const handleStopLossPresetPress = useCallback(
+    (percentage: number) => {
+      if (inputsDisabled) {
+        return;
+      }
+      if (enableHaptics) {
+        playSelection().catch(() => undefined);
+      }
+      handleStopLossPercentageButton(percentage);
+    },
+    [
+      enableHaptics,
+      handleStopLossPercentageButton,
+      inputsDisabled,
+      playSelection,
+    ],
+  );
 
   // Wrapper handlers to dismiss keyboard before clearing
   const handleTakeProfitClear = useCallback(() => {
     if (focusedInput) {
       dismissKeypad();
     }
+    if (enableHaptics) {
+      playSelection().catch(() => undefined);
+    }
     handleTakeProfitOff();
-  }, [focusedInput, dismissKeypad, handleTakeProfitOff]);
+  }, [
+    focusedInput,
+    dismissKeypad,
+    enableHaptics,
+    handleTakeProfitOff,
+    playSelection,
+  ]);
 
   const handleStopLossClear = useCallback(() => {
     if (focusedInput) {
       dismissKeypad();
     }
+    if (enableHaptics) {
+      playSelection().catch(() => undefined);
+    }
     handleStopLossOff();
-  }, [focusedInput, dismissKeypad, handleStopLossOff]);
+  }, [
+    focusedInput,
+    dismissKeypad,
+    enableHaptics,
+    handleStopLossOff,
+    playSelection,
+  ]);
 
   const cancelButtonProps = useMemo(
     () => ({
@@ -736,7 +802,7 @@ const PerpsTPSLView: React.FC = () => {
                     variant={ButtonVariant.Secondary}
                     size={ButtonSize.Md}
                     twClassName="flex-1"
-                    onPress={() => handleTakeProfitPercentageButton(percentage)}
+                    onPress={() => handleTakeProfitPresetPress(percentage)}
                     testID={getPerpsTPSLViewSelector.takeProfitPercentageButton(
                       percentage,
                     )}
@@ -864,7 +930,7 @@ const PerpsTPSLView: React.FC = () => {
                     variant={ButtonVariant.Secondary}
                     size={ButtonSize.Md}
                     twClassName="flex-1"
-                    onPress={() => handleStopLossPercentageButton(percentage)}
+                    onPress={() => handleStopLossPresetPress(percentage)}
                     testID={getPerpsTPSLViewSelector.stopLossPercentageButton(
                       percentage,
                     )}

--- a/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx
@@ -490,6 +490,10 @@ const PerpsTPSLView: React.FC = () => {
   }, [focusedInput]);
 
   const handleConfirm = useCallback(async () => {
+    if (!hasChanges || !isValid || isUpdating) {
+      return;
+    }
+
     if (focusedInput) {
       dismissKeypad();
     }
@@ -556,6 +560,9 @@ const PerpsTPSLView: React.FC = () => {
     effectiveEntryPrice,
     enableHaptics,
     playImpact,
+    hasChanges,
+    isValid,
+    isUpdating,
   ]);
 
   const confirmDisabled = !hasChanges || !isValid || isUpdating;

--- a/app/components/UI/Perps/__mocks__/perpsMocks.ts
+++ b/app/components/UI/Perps/__mocks__/perpsMocks.ts
@@ -8,7 +8,7 @@
  *   createMockHyperLiquidProvider,
  *   createMockEngineContext,
  *   setupMockDiscountSuccess
- * } from '../__mocks__';
+ * } from '../__mocks__/perpsMocks';
  * ```
  */
 

--- a/app/components/UI/Perps/components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet.test.tsx
@@ -8,6 +8,7 @@ import {
 import PerpsFlipPositionConfirmSheet from './PerpsFlipPositionConfirmSheet';
 import { type Position } from '@metamask/perps-controller';
 import { usePerpsOrderFees } from '../../hooks';
+import { ImpactMoment, playImpact } from '../../../../../util/haptics';
 
 const mockHandleFlipPosition = jest.fn();
 let mockIsFlipping = false;
@@ -19,6 +20,7 @@ jest.mock('../../../../../util/theme', () => {
     useTheme: jest.fn(() => mockTheme),
   };
 });
+jest.mock('../../../../../util/haptics');
 
 jest.mock('./PerpsFlipPositionConfirmSheet.styles', () => () => ({
   contentContainer: {},
@@ -339,6 +341,24 @@ describe('PerpsFlipPositionConfirmSheet', () => {
         }),
       );
     });
+    expect(playImpact).not.toHaveBeenCalled();
+  });
+
+  it('plays PrimaryCTA once for an opted-in flip confirmation', async () => {
+    render(
+      <PerpsFlipPositionConfirmSheet
+        position={mockLongPosition}
+        enableHaptics
+      />,
+    );
+
+    fireEvent.press(screen.getByText('Flip'));
+
+    await waitFor(() => {
+      expect(mockHandleFlipPosition).toHaveBeenCalled();
+    });
+    expect(playImpact).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PrimaryCTA);
   });
 
   it('calls onClose when cancel button is pressed', () => {

--- a/app/components/UI/Perps/components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet.tsx
@@ -43,14 +43,22 @@ import {
   IconSize,
   IconColor,
 } from '@metamask/design-system-react-native';
+import { ImpactMoment, useHaptics } from '../../../../../util/haptics';
 
 const PerpsFlipPositionConfirmSheet: React.FC<
   PerpsFlipPositionConfirmSheetProps
-> = ({ position, sheetRef: externalSheetRef, onClose, onConfirm }) => {
+> = ({
+  position,
+  sheetRef: externalSheetRef,
+  onClose,
+  onConfirm,
+  enableHaptics = false,
+}) => {
   const theme = useTheme();
   const styles = createStyles(theme);
   const internalSheetRef = useRef<BottomSheetRef>(null);
   const sheetRef = externalSheetRef || internalSheetRef;
+  const { playImpact } = useHaptics();
 
   // Measure bottom sheet display
   usePerpsMeasurement({ traceName: TraceName.PerpsFlipPositionSheet });
@@ -135,6 +143,12 @@ const PerpsFlipPositionConfirmSheet: React.FC<
   const vipTier = useVipTier();
 
   const handleReverse = useCallback(async () => {
+    if (isFlipping || !hasValidAmount) {
+      return;
+    }
+    if (enableHaptics) {
+      playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
+    }
     await handleFlipPosition(position, {
       totalFee: feeResults.totalFee,
       metamaskFee: feeResults.metamaskFee,
@@ -152,7 +166,11 @@ const PerpsFlipPositionConfirmSheet: React.FC<
     });
   }, [
     position,
+    enableHaptics,
     handleFlipPosition,
+    hasValidAmount,
+    isFlipping,
+    playImpact,
     feeResults.totalFee,
     feeResults.metamaskFee,
     feeResults.metamaskFeeRate,

--- a/app/components/UI/Perps/components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet.types.ts
+++ b/app/components/UI/Perps/components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet.types.ts
@@ -6,4 +6,5 @@ export interface PerpsFlipPositionConfirmSheetProps {
   sheetRef?: React.RefObject<BottomSheetRef | null>;
   onClose?: () => void;
   onConfirm?: () => void;
+  enableHaptics?: boolean;
 }

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen } from '@testing-library/react-native';
 import React from 'react';
+import { playSelection } from '../../../../../util/haptics';
 import { PerpsLeverageBottomSheetSelectorsIDs } from '../../Perps.testIds';
 import PerpsLeverageBottomSheet from './PerpsLeverageBottomSheet';
 
@@ -602,6 +603,28 @@ describe('PerpsLeverageBottomSheet', () => {
       fireEvent.press(screen.getByText('Set 5x'));
 
       expect(mockOnConfirm).toHaveBeenCalledWith(5, 'slider');
+      expect(playSelection).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not play a haptic when confirm only flushes a stuck drag', () => {
+      const mockOnConfirm = jest.fn();
+      render(
+        <PerpsLeverageBottomSheet
+          {...defaultProps}
+          onConfirm={mockOnConfirm}
+        />,
+      );
+
+      const slider = screen.getByTestId(
+        PerpsLeverageBottomSheetSelectorsIDs.SLIDER,
+      );
+      fireEvent(slider, 'valueChange', 12);
+      jest.mocked(playSelection).mockClear();
+
+      fireEvent.press(screen.getByText('Set 12x'));
+
+      expect(mockOnConfirm).not.toHaveBeenCalled();
+      expect(playSelection).not.toHaveBeenCalled();
     });
 
     it('flushes a stuck live drag value instead of confirming a stale leverage', () => {

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.test.tsx
@@ -591,12 +591,28 @@ describe('PerpsLeverageBottomSheet', () => {
   });
 
   describe('Confirm and Close Actions', () => {
-    it('calls onConfirm with current leverage when confirmed', () => {
+    it('confirms without new haptics by default', () => {
       const mockOnConfirm = jest.fn();
       render(
         <PerpsLeverageBottomSheet
           {...defaultProps}
           onConfirm={mockOnConfirm}
+        />,
+      );
+
+      fireEvent.press(screen.getByText('Set 5x'));
+
+      expect(mockOnConfirm).toHaveBeenCalledWith(5, 'slider');
+      expect(playSelection).not.toHaveBeenCalled();
+    });
+
+    it('plays selection when confirm haptics are enabled', () => {
+      const mockOnConfirm = jest.fn();
+      render(
+        <PerpsLeverageBottomSheet
+          {...defaultProps}
+          onConfirm={mockOnConfirm}
+          enableConfirmHaptics
         />,
       );
 

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
@@ -408,6 +408,7 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
       `Confirming leverage: ${tempLeverage}, method: ${inputMethod}`,
     );
 
+    playSelection();
     onConfirm(tempLeverage, inputMethod);
     onClose();
   }, [

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx
@@ -65,6 +65,7 @@ interface PerpsLeverageBottomSheetProps {
   limitPrice?: string;
   triggerPrice?: string;
   orderType?: OrderType;
+  enableConfirmHaptics?: boolean;
 }
 
 interface LeverageSliderEntry {
@@ -96,6 +97,7 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
   limitPrice,
   triggerPrice,
   orderType = 'market',
+  enableConfirmHaptics = false,
 }) => {
   const styles = createStyles();
   const bottomSheetRef = useRef<BottomSheetRef>(null);
@@ -408,10 +410,13 @@ const PerpsLeverageBottomSheet: React.FC<PerpsLeverageBottomSheetProps> = ({
       `Confirming leverage: ${tempLeverage}, method: ${inputMethod}`,
     );
 
-    playSelection();
+    if (enableConfirmHaptics) {
+      playSelection().catch(() => undefined);
+    }
     onConfirm(tempLeverage, inputMethod);
     onClose();
   }, [
+    enableConfirmHaptics,
     handleSliderDragCancel,
     inputMethod,
     isDragging,

--- a/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.test.tsx
@@ -247,7 +247,7 @@ describe('PerpsMarketHeader', () => {
     expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
   });
 
-  it('plays selection immediately on mode-pill press when enableHaptics is true', () => {
+  it('plays TabChange immediately on mode-pill press when haptics are enabled', () => {
     jest.useFakeTimers();
     const onModeChange = jest.fn();
     const { getByTestId } = renderHeader({
@@ -257,7 +257,7 @@ describe('PerpsMarketHeader', () => {
 
     fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.PRO_SEGMENT));
 
-    expect(playSelection).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.TabChange);
     expect(onModeChange).not.toHaveBeenCalled();
 
     act(() => {
@@ -265,7 +265,7 @@ describe('PerpsMarketHeader', () => {
     });
 
     expect(onModeChange).toHaveBeenCalledWith(PerpsMode.Lite);
-    expect(playSelection).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledTimes(1);
   });
 
   it('renders the filled star when the market is favorited', () => {

--- a/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.test.tsx
@@ -247,7 +247,7 @@ describe('PerpsMarketHeader', () => {
     expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
   });
 
-  it('plays TabChange immediately on mode-pill press when haptics are enabled', () => {
+  it('plays TabChange after an accepted mode-pill switch', async () => {
     jest.useFakeTimers();
     const onModeChange = jest.fn();
     const { getByTestId } = renderHeader({
@@ -257,15 +257,45 @@ describe('PerpsMarketHeader', () => {
 
     fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.PRO_SEGMENT));
 
-    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.TabChange);
+    expect(playImpact).not.toHaveBeenCalled();
     expect(onModeChange).not.toHaveBeenCalled();
 
-    act(() => {
+    await act(async () => {
       jest.advanceTimersByTime(GLOW_TOTAL_MS);
+      await Promise.resolve();
     });
 
     expect(onModeChange).toHaveBeenCalledWith(PerpsMode.Lite);
     expect(playImpact).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.TabChange);
+  });
+
+  it('keeps other Lite header actions silent when mode haptics are enabled', async () => {
+    jest.useFakeTimers();
+    const onBackPress = jest.fn();
+    const onModeChange = jest.fn();
+    const { getByTestId } = renderHeader({
+      mode: PerpsMode.Lite,
+      onBackPress,
+      onModeChange,
+      enableModeHaptics: true,
+    });
+
+    fireEvent.press(
+      getByTestId(PerpsProMarketViewSelectorsIDs.HEADER_BACK_BUTTON),
+    );
+    expect(playImpact).not.toHaveBeenCalled();
+
+    fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.LITE_SEGMENT));
+
+    await act(async () => {
+      jest.advanceTimersByTime(GLOW_TOTAL_MS);
+      await Promise.resolve();
+    });
+
+    expect(onModeChange).toHaveBeenCalledWith(PerpsMode.Pro);
+    expect(playImpact).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.TabChange);
   });
 
   it('renders the filled star when the market is favorited', () => {

--- a/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.test.tsx
@@ -12,6 +12,11 @@ import {
 import PerpsMarketHeader from './PerpsMarketHeader';
 import { createProMarketHeaderTestIDs } from './perpsMarketHeaderTestIds';
 import { GLOW_TOTAL_MS } from '../PerpsModeToggle/PerpsModeSwitchPill';
+import {
+  ImpactMoment,
+  playImpact,
+  playSelection,
+} from '../../../../../util/haptics';
 
 jest.mock('../../providers/PerpsStreamManager');
 
@@ -26,6 +31,7 @@ jest.mock('../../hooks/stream', () => ({
     },
   })),
 }));
+jest.mock('../../../../../util/haptics');
 
 const mockMarket: PerpsMarketData = {
   symbol: 'BTC',
@@ -57,6 +63,11 @@ const renderHeader = (
   );
 
 describe('PerpsMarketHeader', () => {
+  beforeEach(() => {
+    jest.mocked(playImpact).mockClear();
+    jest.mocked(playSelection).mockClear();
+  });
+
   afterEach(() => {
     jest.useRealTimers();
   });
@@ -117,6 +128,30 @@ describe('PerpsMarketHeader', () => {
     );
 
     expect(onBackPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('plays PageNavigation when back is pressed with enableHaptics', () => {
+    const onBackPress = jest.fn();
+    const { getByTestId } = renderHeader({ onBackPress, enableHaptics: true });
+
+    fireEvent.press(
+      getByTestId(PerpsProMarketViewSelectorsIDs.HEADER_BACK_BUTTON),
+    );
+
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
+    expect(onBackPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not play a haptic on back press when enableHaptics is omitted', () => {
+    const onBackPress = jest.fn();
+    const { getByTestId } = renderHeader({ onBackPress });
+
+    fireEvent.press(
+      getByTestId(PerpsProMarketViewSelectorsIDs.HEADER_BACK_BUTTON),
+    );
+
+    expect(playImpact).not.toHaveBeenCalled();
+    expect(playSelection).not.toHaveBeenCalled();
   });
 
   it('omits the back button when onBackPress is not provided', () => {
@@ -182,6 +217,55 @@ describe('PerpsMarketHeader', () => {
     );
 
     expect(onFavoritePress).toHaveBeenCalledTimes(1);
+  });
+
+  it('plays selection when favorite is pressed with enableHaptics', () => {
+    const onFavoritePress = jest.fn();
+    const { getByTestId } = renderHeader({
+      onFavoritePress,
+      enableHaptics: true,
+    });
+
+    fireEvent.press(
+      getByTestId(PerpsProMarketViewSelectorsIDs.HEADER_FAVORITE_BUTTON),
+    );
+
+    expect(playSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it('plays PageNavigation when wallet is pressed with enableHaptics', () => {
+    const onWalletPress = jest.fn();
+    const { getByTestId } = renderHeader({
+      onWalletPress,
+      enableHaptics: true,
+    });
+
+    fireEvent.press(
+      getByTestId(PerpsProMarketViewSelectorsIDs.HEADER_WALLET_BUTTON),
+    );
+
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
+  });
+
+  it('plays selection immediately on mode-pill press when enableHaptics is true', () => {
+    jest.useFakeTimers();
+    const onModeChange = jest.fn();
+    const { getByTestId } = renderHeader({
+      onModeChange,
+      enableHaptics: true,
+    });
+
+    fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.PRO_SEGMENT));
+
+    expect(playSelection).toHaveBeenCalledTimes(1);
+    expect(onModeChange).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(GLOW_TOTAL_MS);
+    });
+
+    expect(onModeChange).toHaveBeenCalledWith(PerpsMode.Lite);
+    expect(playSelection).toHaveBeenCalledTimes(1);
   });
 
   it('renders the filled star when the market is favorited', () => {

--- a/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.tsx
@@ -14,7 +14,7 @@ import {
 import { AnimationDuration } from '@metamask/design-tokens';
 import { getPerpsDisplaySymbol } from '@metamask/perps-controller';
 import { PERPS_EVENT_VALUE } from '@metamask/perps-controller/constants';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { StyleSheet } from 'react-native';
 import Animated, {
   useAnimatedReaction,
@@ -23,6 +23,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { strings } from '../../../../../../locales/i18n';
+import { ImpactMoment, useHaptics } from '../../../../../util/haptics';
 import { PERPS_COLLATERAL_SYMBOL } from '../../constants/perpsConfig';
 import LivePriceHeader from '../LivePriceDisplay/LivePriceHeader';
 import PerpsMarketIdentity from '../PerpsMarketIdentity';
@@ -117,14 +118,56 @@ const PerpsMarketHeader = ({
   isFavorite = false,
   mode,
   onModeChange,
+  enableHaptics = false,
   scrollY,
   priceSectionHeight,
   currentPrice: currentPriceOverride,
 }: PerpsMarketHeaderProps) => {
+  const { playImpact, playSelection } = useHaptics();
   const fallbackScrollY = useSharedValue(0);
   const fallbackPriceSectionHeight = useSharedValue(0);
   const scrollYSv = scrollY ?? fallbackScrollY;
   const priceSectionHeightSv = priceSectionHeight ?? fallbackPriceSectionHeight;
+
+  const handleBackPress = useCallback(() => {
+    if (!onBackPress) {
+      return;
+    }
+    if (enableHaptics) {
+      playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
+    }
+    onBackPress();
+  }, [enableHaptics, onBackPress, playImpact]);
+
+  const handleIdentityPress = useCallback(() => {
+    if (!onIdentityPress) {
+      return;
+    }
+    if (enableHaptics) {
+      playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
+    }
+    onIdentityPress();
+  }, [enableHaptics, onIdentityPress, playImpact]);
+
+  const handleWalletPress = useCallback(() => {
+    if (!onWalletPress) {
+      return;
+    }
+    if (enableHaptics) {
+      playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
+    }
+    onWalletPress();
+  }, [enableHaptics, onWalletPress, playImpact]);
+
+  const handleFavoritePress = useCallback(() => {
+    if (!onFavoritePress) {
+      return;
+    }
+    if (enableHaptics) {
+      playSelection().catch(() => undefined);
+    }
+    onFavoritePress();
+  }, [enableHaptics, onFavoritePress, playSelection]);
 
   const compactProgress = useSharedValue(0);
 
@@ -225,7 +268,7 @@ const PerpsMarketHeader = ({
             <ButtonIcon
               iconName={IconName.Wallet}
               size={ButtonIconSize.Md}
-              onPress={onWalletPress}
+              onPress={handleWalletPress}
               accessibilityLabel={strings('perps.market_details.wallet')}
               testID={testIDs.walletButton}
             />
@@ -240,7 +283,7 @@ const PerpsMarketHeader = ({
             <ButtonIcon
               iconName={isFavorite ? IconName.StarFilled : IconName.Star}
               size={ButtonIconSize.Md}
-              onPress={onFavoritePress}
+              onPress={handleFavoritePress}
               accessibilityLabel={strings(
                 isFavorite
                   ? 'perps.market_details.remove_from_watchlist'
@@ -256,6 +299,7 @@ const PerpsMarketHeader = ({
               mode={mode}
               variant="active"
               onChange={onModeChange}
+              enableHaptics={enableHaptics}
               source={PERPS_EVENT_VALUE.SOURCE.PERP_ASSET_SCREEN}
             />
           </Box>
@@ -276,7 +320,7 @@ const PerpsMarketHeader = ({
         <ButtonIcon
           iconName={IconName.ArrowLeft}
           size={ButtonIconSize.Sm}
-          onPress={onBackPress}
+          onPress={handleBackPress}
           accessibilityLabel={strings('perps.market_details.back')}
           testID={testIDs.backButton}
         />
@@ -290,7 +334,7 @@ const PerpsMarketHeader = ({
             maxLeverage={market.maxLeverage}
             size={32}
             gap={2}
-            onPress={onIdentityPress}
+            onPress={onIdentityPress ? handleIdentityPress : undefined}
             subtitleContent={displaySubtitleAndPrice}
             testIDs={{
               assetIcon: testIDs.assetIcon,

--- a/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.tsx
@@ -119,24 +119,23 @@ const PerpsMarketHeader = ({
   mode,
   onModeChange,
   enableHaptics = false,
+  enableModeHaptics = false,
   scrollY,
   priceSectionHeight,
   currentPrice: currentPriceOverride,
 }: PerpsMarketHeaderProps) => {
   const { playImpact, playSelection } = useHaptics();
+  const shouldEnableModeHaptics = enableModeHaptics || enableHaptics;
   const fallbackScrollY = useSharedValue(0);
   const fallbackPriceSectionHeight = useSharedValue(0);
   const scrollYSv = scrollY ?? fallbackScrollY;
   const priceSectionHeightSv = priceSectionHeight ?? fallbackPriceSectionHeight;
 
   const handleBackPress = useCallback(() => {
-    if (!onBackPress) {
-      return;
-    }
     if (enableHaptics) {
       playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
     }
-    onBackPress();
+    onBackPress?.();
   }, [enableHaptics, onBackPress, playImpact]);
 
   const handleIdentityPress = useCallback(() => {
@@ -150,23 +149,17 @@ const PerpsMarketHeader = ({
   }, [enableHaptics, onIdentityPress, playImpact]);
 
   const handleWalletPress = useCallback(() => {
-    if (!onWalletPress) {
-      return;
-    }
     if (enableHaptics) {
       playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
     }
-    onWalletPress();
+    onWalletPress?.();
   }, [enableHaptics, onWalletPress, playImpact]);
 
   const handleFavoritePress = useCallback(() => {
-    if (!onFavoritePress) {
-      return;
-    }
     if (enableHaptics) {
       playSelection().catch(() => undefined);
     }
-    onFavoritePress();
+    onFavoritePress?.();
   }, [enableHaptics, onFavoritePress, playSelection]);
 
   const compactProgress = useSharedValue(0);
@@ -299,7 +292,7 @@ const PerpsMarketHeader = ({
               mode={mode}
               variant="active"
               onChange={onModeChange}
-              enableHaptics={enableHaptics}
+              enableHaptics={shouldEnableModeHaptics}
               source={PERPS_EVENT_VALUE.SOURCE.PERP_ASSET_SCREEN}
             />
           </Box>

--- a/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.types.ts
+++ b/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.types.ts
@@ -38,6 +38,11 @@ export interface PerpsMarketHeaderProps {
   mode?: PerpsMode;
   onModeChange?: (mode: PerpsMode) => void;
   /**
+   * When true, fires catalog haptics for header gestures and the mode pill.
+   * Defaults off so Lite market headers stay silent.
+   */
+  enableHaptics?: boolean;
+  /**
    * Scroll offset from the parent's `Animated.ScrollView`, shared via
    * `useHeaderStandardAnimated()`. Drives the subtitle/price crossfade.
    */

--- a/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.types.ts
+++ b/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.types.ts
@@ -43,6 +43,12 @@ export interface PerpsMarketHeaderProps {
    */
   enableHaptics?: boolean;
   /**
+   * When true, fires the mode-toggle haptic independently of other header
+   * gestures. This allows Lite/Pro switching feedback while Lite header
+   * navigation actions remain silent.
+   */
+  enableModeHaptics?: boolean;
+  /**
    * Scroll offset from the parent's `Animated.ScrollView`, shared via
    * `useHeaderStandardAnimated()`. Drives the subtitle/price crossfade.
    */

--- a/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeSwitchPill.tsx
+++ b/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeSwitchPill.tsx
@@ -17,6 +17,7 @@ import Animated, {
   withSequence,
   withTiming,
 } from 'react-native-reanimated';
+import { useHaptics } from '../../../../../util/haptics';
 
 export const GLOW_TOTAL_MS = 750;
 const GLOW_SWEEP_MS = 700;
@@ -101,6 +102,7 @@ interface PerpsModeSwitchPillProps {
   currentModeLabel: string;
   isPro: boolean;
   onSwitchRequest: () => void;
+  enableHaptics?: boolean;
   accessibilityLabel: string;
   accessibilityHint: string;
   testID: string;
@@ -110,11 +112,13 @@ const PerpsModeSwitchPill = ({
   currentModeLabel,
   isPro,
   onSwitchRequest,
+  enableHaptics = false,
   accessibilityLabel,
   accessibilityHint,
   testID,
 }: PerpsModeSwitchPillProps) => {
   const tw = useTailwind();
+  const { playSelection } = useHaptics();
   const [width, setWidth] = useState(0);
   const [isShimmering, setIsShimmering] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -147,6 +151,10 @@ const PerpsModeSwitchPill = ({
       return;
     }
 
+    if (enableHaptics) {
+      playSelection().catch(() => undefined);
+    }
+
     setIsShimmering(true);
     sweepProgress.value = 0;
     overlayOpacity.value = 0;
@@ -164,7 +172,13 @@ const PerpsModeSwitchPill = ({
       setIsShimmering(false);
       onSwitchRequest();
     }, GLOW_TOTAL_MS);
-  }, [onSwitchRequest, overlayOpacity, sweepProgress]);
+  }, [
+    enableHaptics,
+    onSwitchRequest,
+    overlayOpacity,
+    playSelection,
+    sweepProgress,
+  ]);
 
   const gradient = (
     <LinearGradient

--- a/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeSwitchPill.tsx
+++ b/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeSwitchPill.tsx
@@ -101,7 +101,7 @@ const ModeLabel = ({ children, isPro, isMask = false }: ModeLabelProps) => {
 interface PerpsModeSwitchPillProps {
   currentModeLabel: string;
   isPro: boolean;
-  onSwitchRequest: () => void;
+  onSwitchRequest: () => void | Promise<boolean | void>;
   enableHaptics?: boolean;
   accessibilityLabel: string;
   accessibilityHint: string;
@@ -146,13 +146,19 @@ const PerpsModeSwitchPill = ({
     opacity: overlayOpacity.value,
   }));
 
+  const handleModeSwitch = useCallback(() => {
+    Promise.resolve(onSwitchRequest())
+      .then((applied) => {
+        if (applied !== false && enableHaptics) {
+          playImpact(ImpactMoment.TabChange).catch(() => undefined);
+        }
+      })
+      .catch(() => undefined);
+  }, [enableHaptics, onSwitchRequest, playImpact]);
+
   const handlePress = useCallback(() => {
     if (timerRef.current) {
       return;
-    }
-
-    if (enableHaptics) {
-      playImpact(ImpactMoment.TabChange).catch(() => undefined);
     }
 
     setIsShimmering(true);
@@ -170,15 +176,9 @@ const PerpsModeSwitchPill = ({
     timerRef.current = setTimeout(() => {
       timerRef.current = null;
       setIsShimmering(false);
-      onSwitchRequest();
+      handleModeSwitch();
     }, GLOW_TOTAL_MS);
-  }, [
-    enableHaptics,
-    onSwitchRequest,
-    overlayOpacity,
-    playImpact,
-    sweepProgress,
-  ]);
+  }, [handleModeSwitch, overlayOpacity, sweepProgress]);
 
   const gradient = (
     <LinearGradient

--- a/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeSwitchPill.tsx
+++ b/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeSwitchPill.tsx
@@ -17,7 +17,7 @@ import Animated, {
   withSequence,
   withTiming,
 } from 'react-native-reanimated';
-import { useHaptics } from '../../../../../util/haptics';
+import { ImpactMoment, useHaptics } from '../../../../../util/haptics';
 
 export const GLOW_TOTAL_MS = 750;
 const GLOW_SWEEP_MS = 700;
@@ -118,7 +118,7 @@ const PerpsModeSwitchPill = ({
   testID,
 }: PerpsModeSwitchPillProps) => {
   const tw = useTailwind();
-  const { playSelection } = useHaptics();
+  const { playImpact } = useHaptics();
   const [width, setWidth] = useState(0);
   const [isShimmering, setIsShimmering] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -152,7 +152,7 @@ const PerpsModeSwitchPill = ({
     }
 
     if (enableHaptics) {
-      playSelection().catch(() => undefined);
+      playImpact(ImpactMoment.TabChange).catch(() => undefined);
     }
 
     setIsShimmering(true);
@@ -176,7 +176,7 @@ const PerpsModeSwitchPill = ({
     enableHaptics,
     onSwitchRequest,
     overlayOpacity,
-    playSelection,
+    playImpact,
     sweepProgress,
   ]);
 

--- a/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeToggle.test.tsx
+++ b/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeToggle.test.tsx
@@ -8,6 +8,7 @@ import {
 import PerpsModeToggle from './PerpsModeToggle';
 import { PerpsModeToggleSelectorsIDs } from '../../Perps.testIds';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { playSelection } from '../../../../../util/haptics';
 import { GLOW_TOTAL_MS } from './PerpsModeSwitchPill';
 import { PERPS_MODE_ANALYTICS_PROPERTY } from '../../utils/perpsModeAnalytics';
 
@@ -15,6 +16,8 @@ const mockTrack = jest.fn();
 jest.mock('../../hooks/usePerpsEventTracking', () => ({
   usePerpsEventTracking: () => ({ track: mockTrack }),
 }));
+
+jest.mock('../../../../../util/haptics');
 
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string, params?: { mode?: string }) => {
@@ -146,6 +149,7 @@ jest.mock('react-native-linear-gradient', () => {
 describe('PerpsModeToggle', () => {
   beforeEach(() => {
     mockTrack.mockClear();
+    jest.mocked(playSelection).mockClear();
   });
 
   afterEach(() => {
@@ -262,6 +266,44 @@ describe('PerpsModeToggle', () => {
     expect(mockTrack).not.toHaveBeenCalled();
   });
 
+  it('plays a selection haptic when enableHaptics is true and mode changes', () => {
+    const { getByTestId } = render(
+      <PerpsModeToggle
+        mode={PerpsMode.Lite}
+        onChange={jest.fn()}
+        enableHaptics
+      />,
+    );
+
+    fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.PRO_SEGMENT));
+
+    expect(playSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not play a haptic when enableHaptics is omitted', () => {
+    const { getByTestId } = render(
+      <PerpsModeToggle mode={PerpsMode.Lite} onChange={jest.fn()} />,
+    );
+
+    fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.PRO_SEGMENT));
+
+    expect(playSelection).not.toHaveBeenCalled();
+  });
+
+  it('does not play a haptic when re-selecting the already active mode with enableHaptics', () => {
+    const { getByTestId } = render(
+      <PerpsModeToggle
+        mode={PerpsMode.Lite}
+        onChange={jest.fn()}
+        enableHaptics
+      />,
+    );
+
+    fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.LITE_SEGMENT));
+
+    expect(playSelection).not.toHaveBeenCalled();
+  });
+
   it('renders only the active mode as a single pill in the active variant', () => {
     const { getByTestId, queryByTestId, getAllByText } = render(
       <PerpsModeToggle
@@ -311,6 +353,31 @@ describe('PerpsModeToggle', () => {
           PERPS_EVENT_VALUE.SOURCE.PERP_ASSET_SCREEN,
       },
     );
+  });
+
+  it('plays a selection haptic immediately on active-pill press when enableHaptics is true', () => {
+    jest.useFakeTimers();
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <PerpsModeToggle
+        mode={PerpsMode.Pro}
+        onChange={onChange}
+        variant="active"
+        enableHaptics
+      />,
+    );
+
+    fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.PRO_SEGMENT));
+
+    expect(playSelection).toHaveBeenCalledTimes(1);
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(GLOW_TOTAL_MS);
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(playSelection).toHaveBeenCalledTimes(1);
   });
 
   it('exposes VoiceOver label and hint for the active Pro pill', () => {

--- a/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeToggle.test.tsx
+++ b/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeToggle.test.tsx
@@ -266,7 +266,7 @@ describe('PerpsModeToggle', () => {
     expect(mockTrack).not.toHaveBeenCalled();
   });
 
-  it('plays a selection haptic when enableHaptics is true and mode changes', () => {
+  it('plays a selection haptic when enableHaptics is true and mode changes', async () => {
     const { getByTestId } = render(
       <PerpsModeToggle
         mode={PerpsMode.Lite}
@@ -275,22 +275,26 @@ describe('PerpsModeToggle', () => {
       />,
     );
 
-    fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.PRO_SEGMENT));
+    await act(async () => {
+      fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.PRO_SEGMENT));
+    });
 
     expect(playSelection).toHaveBeenCalledTimes(1);
   });
 
-  it('does not play a haptic when enableHaptics is omitted', () => {
+  it('does not play a haptic when enableHaptics is omitted', async () => {
     const { getByTestId } = render(
       <PerpsModeToggle mode={PerpsMode.Lite} onChange={jest.fn()} />,
     );
 
-    fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.PRO_SEGMENT));
+    await act(async () => {
+      fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.PRO_SEGMENT));
+    });
 
     expect(playSelection).not.toHaveBeenCalled();
   });
 
-  it('does not play a haptic when re-selecting the already active mode with enableHaptics', () => {
+  it('does not play a haptic when re-selecting the already active mode with enableHaptics', async () => {
     const { getByTestId } = render(
       <PerpsModeToggle
         mode={PerpsMode.Lite}
@@ -299,7 +303,9 @@ describe('PerpsModeToggle', () => {
       />,
     );
 
-    fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.LITE_SEGMENT));
+    await act(async () => {
+      fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.LITE_SEGMENT));
+    });
 
     expect(playSelection).not.toHaveBeenCalled();
   });

--- a/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeToggle.test.tsx
+++ b/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeToggle.test.tsx
@@ -394,7 +394,7 @@ describe('PerpsModeToggle', () => {
     );
   });
 
-  it('plays TabChange immediately on active-pill press when haptics are enabled', () => {
+  it('plays TabChange after an active-pill switch is applied', async () => {
     jest.useFakeTimers();
     const onChange = jest.fn();
     const { getByTestId } = render(
@@ -408,15 +408,40 @@ describe('PerpsModeToggle', () => {
 
     fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.PRO_SEGMENT));
 
-    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.TabChange);
+    expect(playImpact).not.toHaveBeenCalled();
     expect(onChange).not.toHaveBeenCalled();
 
-    act(() => {
+    await act(async () => {
       jest.advanceTimersByTime(GLOW_TOTAL_MS);
+      await Promise.resolve();
     });
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(playImpact).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.TabChange);
+  });
+
+  it('keeps active-pill haptics silent when the mode switch is not applied', async () => {
+    jest.useFakeTimers();
+    const onChange = jest.fn().mockResolvedValue(false);
+    const { getByTestId } = render(
+      <PerpsModeToggle
+        mode={PerpsMode.Pro}
+        onChange={onChange}
+        variant="active"
+        enableHaptics
+      />,
+    );
+
+    fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.PRO_SEGMENT));
+
+    await act(async () => {
+      jest.advanceTimersByTime(GLOW_TOTAL_MS);
+      await Promise.resolve();
+    });
+
+    expect(onChange).toHaveBeenCalledWith(PerpsMode.Lite);
+    expect(playImpact).not.toHaveBeenCalled();
   });
 
   it('exposes VoiceOver label and hint for the active Pro pill', () => {

--- a/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeToggle.test.tsx
+++ b/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeToggle.test.tsx
@@ -8,7 +8,7 @@ import {
 import PerpsModeToggle from './PerpsModeToggle';
 import { PerpsModeToggleSelectorsIDs } from '../../Perps.testIds';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
-import { playSelection } from '../../../../../util/haptics';
+import { ImpactMoment, playImpact } from '../../../../../util/haptics';
 import { GLOW_TOTAL_MS } from './PerpsModeSwitchPill';
 import { PERPS_MODE_ANALYTICS_PROPERTY } from '../../utils/perpsModeAnalytics';
 
@@ -149,7 +149,7 @@ jest.mock('react-native-linear-gradient', () => {
 describe('PerpsModeToggle', () => {
   beforeEach(() => {
     mockTrack.mockClear();
-    jest.mocked(playSelection).mockClear();
+    jest.mocked(playImpact).mockClear();
   });
 
   afterEach(() => {
@@ -233,6 +233,23 @@ describe('PerpsModeToggle', () => {
     expect(mockTrack).not.toHaveBeenCalled();
   });
 
+  it('keeps haptics silent when onChange reports the mode was not applied', async () => {
+    const onChange = jest.fn().mockResolvedValue(false);
+    const { getByTestId } = render(
+      <PerpsModeToggle
+        mode={PerpsMode.Lite}
+        onChange={onChange}
+        enableHaptics
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.PRO_SEGMENT));
+    });
+
+    expect(playImpact).not.toHaveBeenCalled();
+  });
+
   it('omits the source property when no source is provided', async () => {
     const { getByTestId } = render(
       <PerpsModeToggle mode={PerpsMode.Lite} onChange={jest.fn()} />,
@@ -266,7 +283,7 @@ describe('PerpsModeToggle', () => {
     expect(mockTrack).not.toHaveBeenCalled();
   });
 
-  it('plays a selection haptic when enableHaptics is true and mode changes', async () => {
+  it('plays TabChange when switching from Lite to Pro with haptics enabled', async () => {
     const { getByTestId } = render(
       <PerpsModeToggle
         mode={PerpsMode.Lite}
@@ -279,7 +296,23 @@ describe('PerpsModeToggle', () => {
       fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.PRO_SEGMENT));
     });
 
-    expect(playSelection).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.TabChange);
+  });
+
+  it('plays TabChange when switching from Pro to Lite with haptics enabled', async () => {
+    const { getByTestId } = render(
+      <PerpsModeToggle
+        mode={PerpsMode.Pro}
+        onChange={jest.fn()}
+        enableHaptics
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.LITE_SEGMENT));
+    });
+
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.TabChange);
   });
 
   it('does not play a haptic when enableHaptics is omitted', async () => {
@@ -291,7 +324,7 @@ describe('PerpsModeToggle', () => {
       fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.PRO_SEGMENT));
     });
 
-    expect(playSelection).not.toHaveBeenCalled();
+    expect(playImpact).not.toHaveBeenCalled();
   });
 
   it('does not play a haptic when re-selecting the already active mode with enableHaptics', async () => {
@@ -307,7 +340,7 @@ describe('PerpsModeToggle', () => {
       fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.LITE_SEGMENT));
     });
 
-    expect(playSelection).not.toHaveBeenCalled();
+    expect(playImpact).not.toHaveBeenCalled();
   });
 
   it('renders only the active mode as a single pill in the active variant', () => {
@@ -361,7 +394,7 @@ describe('PerpsModeToggle', () => {
     );
   });
 
-  it('plays a selection haptic immediately on active-pill press when enableHaptics is true', () => {
+  it('plays TabChange immediately on active-pill press when haptics are enabled', () => {
     jest.useFakeTimers();
     const onChange = jest.fn();
     const { getByTestId } = render(
@@ -375,7 +408,7 @@ describe('PerpsModeToggle', () => {
 
     fireEvent.press(getByTestId(PerpsModeToggleSelectorsIDs.PRO_SEGMENT));
 
-    expect(playSelection).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.TabChange);
     expect(onChange).not.toHaveBeenCalled();
 
     act(() => {
@@ -383,7 +416,7 @@ describe('PerpsModeToggle', () => {
     });
 
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(playSelection).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledTimes(1);
   });
 
   it('exposes VoiceOver label and hint for the active Pro pill', () => {

--- a/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeToggle.tsx
+++ b/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeToggle.tsx
@@ -48,10 +48,10 @@ const PerpsModeToggle: React.FC<PerpsModeToggleProps> = ({
   const { playImpact } = useHaptics();
 
   const handleChange = useCallback(
-    async (value: string) => {
+    async (value: string): Promise<boolean> => {
       const nextMode = value as PerpsMode;
       if (nextMode === mode) {
-        return;
+        return false;
       }
 
       // Defer analytics until the parent confirms the mode was applied.
@@ -59,11 +59,11 @@ const PerpsModeToggle: React.FC<PerpsModeToggleProps> = ({
       // switching — otherwise we would count dismissals as mode switches.
       const applied = await onChange?.(nextMode);
       if (applied === false) {
-        return;
+        return false;
       }
 
-      // Active pill fires TabChange immediately on press; the delayed
-      // onSwitchRequest path must not double-fire after the shimmer.
+      // The active pill fires TabChange after its delayed switch request
+      // confirms the mode was applied; the default variant fires here.
       if (enableHaptics && variant !== 'active') {
         playImpact(ImpactMoment.TabChange).catch(() => undefined);
       }
@@ -74,6 +74,7 @@ const PerpsModeToggle: React.FC<PerpsModeToggleProps> = ({
         [PERPS_MODE_ANALYTICS_PROPERTY]: nextMode,
         ...(source ? { [PERPS_EVENT_PROPERTY.SOURCE]: source } : {}),
       });
+      return true;
     },
     [enableHaptics, mode, onChange, playImpact, source, track, variant],
   );

--- a/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeToggle.tsx
+++ b/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeToggle.tsx
@@ -11,6 +11,7 @@ import {
 } from '@metamask/perps-controller';
 import { strings } from '../../../../../../locales/i18n';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { useHaptics } from '../../../../../util/haptics';
 import { PerpsModeToggleSelectorsIDs } from '../../Perps.testIds';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { PERPS_MODE_ANALYTICS_PROPERTY } from '../../utils/perpsModeAnalytics';
@@ -40,9 +41,11 @@ const PerpsModeToggle: React.FC<PerpsModeToggleProps> = ({
   size = SegmentedControlSize.Sm,
   isFullWidth = false,
   source,
+  enableHaptics = false,
   testID = PerpsModeToggleSelectorsIDs.CONTAINER,
 }) => {
   const { track } = usePerpsEventTracking();
+  const { playSelection } = useHaptics();
 
   const handleChange = useCallback(
     async (value: string) => {
@@ -59,6 +62,12 @@ const PerpsModeToggle: React.FC<PerpsModeToggleProps> = ({
         return;
       }
 
+      // Active pill fires selection immediately on press; the delayed
+      // onSwitchRequest path must not double-fire after the shimmer.
+      if (enableHaptics && variant !== 'active') {
+        playSelection().catch(() => undefined);
+      }
+
       track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
         [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
           PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
@@ -66,7 +75,7 @@ const PerpsModeToggle: React.FC<PerpsModeToggleProps> = ({
         ...(source ? { [PERPS_EVENT_PROPERTY.SOURCE]: source } : {}),
       });
     },
-    [mode, onChange, source, track],
+    [enableHaptics, mode, onChange, playSelection, source, track, variant],
   );
 
   const liteLabel = strings('perps.mode.lite');
@@ -85,6 +94,7 @@ const PerpsModeToggle: React.FC<PerpsModeToggleProps> = ({
       <PerpsModeSwitchPill
         currentModeLabel={currentModeLabel}
         isPro={isPro}
+        enableHaptics={enableHaptics}
         onSwitchRequest={() =>
           handleChange(isPro ? PerpsMode.Lite : PerpsMode.Pro)
         }

--- a/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeToggle.tsx
+++ b/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeToggle.tsx
@@ -11,7 +11,7 @@ import {
 } from '@metamask/perps-controller';
 import { strings } from '../../../../../../locales/i18n';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
-import { useHaptics } from '../../../../../util/haptics';
+import { ImpactMoment, useHaptics } from '../../../../../util/haptics';
 import { PerpsModeToggleSelectorsIDs } from '../../Perps.testIds';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { PERPS_MODE_ANALYTICS_PROPERTY } from '../../utils/perpsModeAnalytics';
@@ -45,7 +45,7 @@ const PerpsModeToggle: React.FC<PerpsModeToggleProps> = ({
   testID = PerpsModeToggleSelectorsIDs.CONTAINER,
 }) => {
   const { track } = usePerpsEventTracking();
-  const { playSelection } = useHaptics();
+  const { playImpact } = useHaptics();
 
   const handleChange = useCallback(
     async (value: string) => {
@@ -62,10 +62,10 @@ const PerpsModeToggle: React.FC<PerpsModeToggleProps> = ({
         return;
       }
 
-      // Active pill fires selection immediately on press; the delayed
+      // Active pill fires TabChange immediately on press; the delayed
       // onSwitchRequest path must not double-fire after the shimmer.
       if (enableHaptics && variant !== 'active') {
-        playSelection().catch(() => undefined);
+        playImpact(ImpactMoment.TabChange).catch(() => undefined);
       }
 
       track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
@@ -75,7 +75,7 @@ const PerpsModeToggle: React.FC<PerpsModeToggleProps> = ({
         ...(source ? { [PERPS_EVENT_PROPERTY.SOURCE]: source } : {}),
       });
     },
-    [enableHaptics, mode, onChange, playSelection, source, track, variant],
+    [enableHaptics, mode, onChange, playImpact, source, track, variant],
   );
 
   const liteLabel = strings('perps.mode.lite');

--- a/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeToggle.types.ts
+++ b/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeToggle.types.ts
@@ -56,8 +56,8 @@ export interface PerpsModeToggleProps {
   source?: string;
 
   /**
-   * When true, fires selection haptics on a meaningful mode change.
-   * Defaults off so Lite entry points stay silent.
+   * When true, fires the medium TabChange haptic on a meaningful mode change.
+   * Defaults off for callers that do not opt into mode feedback.
    */
   enableHaptics?: boolean;
 

--- a/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeToggle.types.ts
+++ b/app/components/UI/Perps/components/PerpsModeToggle/PerpsModeToggle.types.ts
@@ -55,5 +55,11 @@ export interface PerpsModeToggleProps {
    */
   source?: string;
 
+  /**
+   * When true, fires selection haptics on a meaningful mode change.
+   * Defaults off so Lite entry points stay silent.
+   */
+  enableHaptics?: boolean;
+
   testID?: string;
 }

--- a/app/components/UI/Perps/hooks/usePerpsMarketHeaderActions.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketHeaderActions.ts
@@ -108,8 +108,10 @@ export const usePerpsMarketHeaderActions = ({
 
     navigateToMarketListFromHeader({
       source: PERPS_EVENT_VALUE.SOURCE.PERP_ASSET_SCREEN,
+      // Selection haptics on list rows are Pro-only; Lite stays silent.
+      enableHaptics: perpsMode === PerpsMode.Pro,
     });
-  }, [symbol, track, navigateToMarketListFromHeader]);
+  }, [symbol, track, navigateToMarketListFromHeader, perpsMode]);
 
   const handleFavoritePress = useCallback(() => {
     if (!symbol) {

--- a/app/components/UI/Perps/hooks/usePerpsNavigation.ts
+++ b/app/components/UI/Perps/hooks/usePerpsNavigation.ts
@@ -56,11 +56,19 @@ export interface PerpsNavigationHandlers {
   navigateToTutorial: (
     params?: PerpsNavigationParamList['PerpsTutorial'],
   ) => void;
-  navigateToAdjustMargin: (position: Position, mode: 'add' | 'remove') => void;
+  navigateToAdjustMargin: (
+    position: Position,
+    mode: 'add' | 'remove',
+    options?: { enableHaptics?: boolean },
+  ) => void;
   navigateToClosePosition: (
     position: Position,
     source?: string,
-    entry?: { buttonClicked?: string; buttonLocation?: string },
+    entry?: {
+      buttonClicked?: string;
+      buttonLocation?: string;
+      enableHaptics?: boolean;
+    },
   ) => void;
   navigateToOrderDetails: (order: Order) => void;
 
@@ -262,8 +270,16 @@ export const usePerpsNavigation = (): PerpsNavigationHandlers => {
   );
 
   const navigateToAdjustMargin = useCallback(
-    (position: Position, mode: 'add' | 'remove') => {
-      navigation.navigate(Routes.PERPS.ADJUST_MARGIN, { position, mode });
+    (
+      position: Position,
+      mode: 'add' | 'remove',
+      options?: { enableHaptics?: boolean },
+    ) => {
+      navigation.navigate(Routes.PERPS.ADJUST_MARGIN, {
+        position,
+        mode,
+        enableHaptics: options?.enableHaptics,
+      });
     },
     [navigation],
   );
@@ -272,13 +288,18 @@ export const usePerpsNavigation = (): PerpsNavigationHandlers => {
     (
       position: Position,
       source?: string,
-      entry?: { buttonClicked?: string; buttonLocation?: string },
+      entry?: {
+        buttonClicked?: string;
+        buttonLocation?: string;
+        enableHaptics?: boolean;
+      },
     ) => {
       navigation.navigate(Routes.PERPS.CLOSE_POSITION, {
         position,
         source,
         buttonClicked: entry?.buttonClicked,
         buttonLocation: entry?.buttonLocation,
+        enableHaptics: entry?.enableHaptics,
       });
     },
     [navigation],

--- a/app/components/UI/Perps/hooks/usePerpsOrderFees.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderFees.test.ts
@@ -17,7 +17,10 @@ import {
 jest.mock('./usePerpsTrading');
 
 // Import existing mocks
-import { createMockEngineContext, TEST_CONSTANTS } from '../__mocks__';
+import {
+  createMockEngineContext,
+  TEST_CONSTANTS,
+} from '../__mocks__/perpsMocks';
 
 // Use shared Engine context mock
 const mockEngineContext = createMockEngineContext();

--- a/app/components/UI/Perps/hooks/usePerpsProMarketHeaderActions.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsProMarketHeaderActions.test.ts
@@ -28,10 +28,12 @@ jest.mock('./usePerpsNavigation', () => ({
 }));
 
 const mockSetPerpsMode = jest.fn();
-const mockPerpsModeValue = PerpsMode.Pro;
+let mockPerpsModeValue = PerpsMode.Pro;
 jest.mock('./usePerpsMode', () => ({
   usePerpsMode: jest.fn(() => ({
-    mode: mockPerpsModeValue,
+    get mode() {
+      return mockPerpsModeValue;
+    },
     setMode: mockSetPerpsMode,
   })),
 }));
@@ -80,6 +82,7 @@ describe('usePerpsProMarketHeaderActions', () => {
     jest.clearAllMocks();
     mockCanGoBack = true;
     mockIsWatchlist = false;
+    mockPerpsModeValue = PerpsMode.Pro;
     mockOpenPerpsModeSelectionIfNeeded.mockResolvedValue(false);
   });
 
@@ -142,6 +145,7 @@ describe('usePerpsProMarketHeaderActions', () => {
 
     expect(mockNavigateToMarketListFromHeader).toHaveBeenCalledWith({
       source: PERPS_EVENT_VALUE.SOURCE.PERP_ASSET_SCREEN,
+      enableHaptics: true,
     });
     expect(mockTrack).toHaveBeenCalledWith(
       MetaMetricsEvents.PERPS_UI_INTERACTION,
@@ -151,6 +155,23 @@ describe('usePerpsProMarketHeaderActions', () => {
         [PERPS_EVENT_PROPERTY.ASSET]: 'BTC',
       }),
     );
+  });
+
+  it('omits market-list selection haptics when the header is in Lite mode', () => {
+    mockPerpsModeValue = PerpsMode.Lite;
+
+    const { result } = renderHook(() =>
+      usePerpsProMarketHeaderActions({ symbol: 'BTC' }),
+    );
+
+    act(() => {
+      result.current.handleMarketListPress();
+    });
+
+    expect(mockNavigateToMarketListFromHeader).toHaveBeenCalledWith({
+      source: PERPS_EVENT_VALUE.SOURCE.PERP_ASSET_SCREEN,
+      enableHaptics: false,
+    });
   });
 
   it('no-ops market list press when symbol is missing', () => {

--- a/app/components/UI/Perps/hooks/usePerpsProOrderEdit.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsProOrderEdit.test.tsx
@@ -8,7 +8,10 @@ import {
 import type { Order, OrderResult } from '@metamask/perps-controller';
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { ImpactMoment, playImpact } from '../../../../util/haptics';
 import { usePerpsProOrderEdit } from './usePerpsProOrderEdit';
+
+jest.mock('../../../../util/haptics');
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
@@ -252,6 +255,12 @@ describe('usePerpsProOrderEdit', () => {
       expect(mockEditSubmittingToast).toHaveBeenCalled();
       expect(mockEditConfirmedToast).toHaveBeenCalled();
       expect(mockEditFailedToast).not.toHaveBeenCalled();
+      expect(playImpact).toHaveBeenNthCalledWith(
+        1,
+        ImpactMoment.PageNavigation,
+      );
+      expect(playImpact).toHaveBeenNthCalledWith(2, ImpactMoment.PrimaryCTA);
+      expect(playImpact).toHaveBeenCalledTimes(2);
     },
   );
 
@@ -331,6 +340,7 @@ describe('usePerpsProOrderEdit', () => {
     });
 
     expect(mockEditOrder).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledTimes(2);
 
     await act(async () => {
       resolveEdit({ success: true, orderId: order.orderId });
@@ -349,6 +359,8 @@ describe('usePerpsProOrderEdit', () => {
 
     expect(mockEditOrder).not.toHaveBeenCalled();
     expect(mockUpdateOrderOptimistic).not.toHaveBeenCalled();
+    expect(playImpact).toHaveBeenCalledTimes(1);
+    expect(playImpact).toHaveBeenCalledWith(ImpactMoment.PageNavigation);
     await waitFor(() => {
       expect(
         screen.queryByTestId('perps-order-edit-sheet-price'),
@@ -367,6 +379,21 @@ describe('usePerpsProOrderEdit', () => {
       screen.queryByTestId('perps-order-edit-sheet-price'),
     ).not.toBeOnTheScreen();
     expect(mockRunGatedEligibleAction).not.toHaveBeenCalled();
+    expect(playImpact).not.toHaveBeenCalled();
+  });
+
+  it('keeps haptics silent when the eligibility gate blocks editing', async () => {
+    mockRunGatedEligibleAction.mockImplementationOnce(() => undefined);
+    const orderEdit = await renderOrderEditHarness();
+
+    await act(async () => {
+      orderEdit.handleEditOrderPrice(order);
+    });
+
+    expect(
+      screen.queryByTestId('perps-order-edit-sheet-price'),
+    ).not.toBeOnTheScreen();
+    expect(playImpact).not.toHaveBeenCalled();
   });
 
   it('aborts confirm when a mutation becomes blocked while the sheet is open', async () => {

--- a/app/components/UI/Perps/hooks/usePerpsProOrderEdit.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsProOrderEdit.tsx
@@ -22,6 +22,7 @@ import {
   isLimitOrderEditable,
   isLimitOrderSizeEditable,
 } from '../utils/orderUtils';
+import { ImpactMoment, useHaptics } from '../../../../util/haptics';
 import { usePerpsLivePositions } from './stream';
 import { usePerpsMarketData } from './usePerpsMarketData';
 import { usePerpsSelector } from './usePerpsSelector';
@@ -62,6 +63,7 @@ export const usePerpsProOrderEdit = ({
   const { editOrder } = usePerpsTrading();
   const stream = usePerpsStream();
   const { showToast, PerpsToastOptions } = usePerpsToasts();
+  const { playImpact } = useHaptics();
 
   const [editingOrder, setEditingOrder] = useState<Order | null>(null);
   const [editingOrderSheet, setEditingOrderSheet] =
@@ -146,12 +148,13 @@ export const usePerpsProOrderEdit = ({
       runGatedEligibleAction(
         PERPS_EVENT_VALUE.SOURCE.MODIFY_POSITION_ACTION,
         () => {
+          playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
           setEditingOrder(order);
           setEditingOrderSheet(field);
         },
       );
     },
-    [editingOrderId, isMutationBlocked, runGatedEligibleAction],
+    [editingOrderId, isMutationBlocked, playImpact, runGatedEligibleAction],
   );
 
   const handleEditOrderPrice = useCallback(
@@ -208,6 +211,7 @@ export const usePerpsProOrderEdit = ({
       const previousValue = getOrderEditPreviousValue(orderToEdit, field);
       const optimisticEdit = buildOrderOptimisticEdit(field, newValue);
 
+      playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
       isSubmittingEditRef.current = true;
       closeEditSheet();
       setEditingOrderId(orderToEdit.orderId);
@@ -278,6 +282,7 @@ export const usePerpsProOrderEdit = ({
       editingOrderLeverage,
       isMutationBlocked,
       PerpsToastOptions,
+      playImpact,
       showToast,
       stream,
     ],

--- a/app/components/UI/Perps/hooks/usePerpsProPositionsPanelActions.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsProPositionsPanelActions.tsx
@@ -14,6 +14,7 @@ import Routes from '../../../../constants/navigation/Routes';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import type { AppNavigationProp } from '../../../../core/NavigationService/types';
 import { selectSelectedInternalAccountAddress } from '../../../../selectors/accountsController';
+import { ImpactMoment, useHaptics } from '../../../../util/haptics';
 import { useComplianceGate } from '../../Compliance';
 import PerpsBottomSheetTooltip from '../components/PerpsBottomSheetTooltip';
 import PerpsFlipPositionConfirmSheet from '../components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet';
@@ -84,6 +85,7 @@ export const usePerpsProPositionsPanelActions =
     const { cancelOrder } = usePerpsTrading();
     const { handleUpdateTPSL } = usePerpsTPSLUpdate();
     const { showToast, PerpsToastOptions } = usePerpsToasts();
+    const { playImpact } = useHaptics();
 
     const [showCloseAllSheet, setShowCloseAllSheet] = useState(false);
     const [reversePosition, setReversePosition] = useState<Position | null>(
@@ -176,34 +178,41 @@ export const usePerpsProPositionsPanelActions =
       (position: Position) => {
         runGatedEligibleAction(
           PERPS_EVENT_VALUE.SOURCE.CLOSE_POSITION_ACTION,
-          () =>
+          () => {
+            playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
             navigateToClosePosition(position, PRO_MARKET_SOURCE, {
               buttonClicked: PERPS_EVENT_VALUE.BUTTON_CLICKED.CLOSE,
               buttonLocation: PRO_MARKET_BUTTON_LOCATION,
-            }),
+              enableHaptics: true,
+            });
+          },
         );
       },
-      [navigateToClosePosition, runGatedEligibleAction],
+      [navigateToClosePosition, playImpact, runGatedEligibleAction],
     );
 
     const handleReversePosition = useCallback(
       (position: Position) => {
         runGatedEligibleAction(
           PERPS_EVENT_VALUE.SOURCE.MODIFY_POSITION_ACTION,
-          () => setReversePosition(position),
+          () => {
+            playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
+            setReversePosition(position);
+          },
         );
       },
-      [runGatedEligibleAction],
+      [playImpact, runGatedEligibleAction],
     );
 
     const handleSharePosition = useCallback(
       (position: Position) => {
+        playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
         navigation.navigate(Routes.PERPS.PNL_HERO_CARD, {
           position,
           marketPrice: getPositionMarkPrice(position),
         });
       },
-      [navigation],
+      [navigation, playImpact],
     );
 
     const handleEditPositionTpSl = useCallback(
@@ -211,6 +220,7 @@ export const usePerpsProPositionsPanelActions =
         runGatedEligibleAction(
           PERPS_EVENT_VALUE.SOURCE.AUTO_CLOSE_ACTION,
           () => {
+            playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
             const markPrice = parseFloat(getPositionMarkPrice(position));
             const currentPrice =
               Number.isFinite(markPrice) && markPrice > 0
@@ -243,7 +253,7 @@ export const usePerpsProPositionsPanelActions =
           },
         );
       },
-      [handleUpdateTPSL, navigation, runGatedEligibleAction],
+      [handleUpdateTPSL, navigation, playImpact, runGatedEligibleAction],
     );
 
     const isPositionMarginEditable = useCallback(
@@ -259,10 +269,13 @@ export const usePerpsProPositionsPanelActions =
 
         runGatedEligibleAction(
           PERPS_EVENT_VALUE.SOURCE.ADJUST_MARGIN_ACTION,
-          () => setAdjustMarginPosition(position),
+          () => {
+            playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
+            setAdjustMarginPosition(position);
+          },
         );
       },
-      [isPositionMarginEditable, runGatedEligibleAction],
+      [isPositionMarginEditable, playImpact, runGatedEligibleAction],
     );
 
     const isOrderCancelable = useCallback(
@@ -277,6 +290,7 @@ export const usePerpsProPositionsPanelActions =
           return;
         }
 
+        playImpact(ImpactMoment.PrimaryCTA).catch(() => undefined);
         setCancelingOrderId(order.orderId);
 
         const orderDirection = getOrderPositionDirection(order);
@@ -335,6 +349,7 @@ export const usePerpsProPositionsPanelActions =
         cancelingOrderId,
         editingOrderId,
         isOrderCancelable,
+        playImpact,
         showToast,
       ],
     );
@@ -342,9 +357,12 @@ export const usePerpsProPositionsPanelActions =
     const handleCloseAllPress = useCallback(() => {
       runGatedEligibleAction(
         PERPS_EVENT_VALUE.SOURCE.CLOSE_ALL_POSITIONS_BUTTON,
-        () => setShowCloseAllSheet(true),
+        () => {
+          playImpact(ImpactMoment.PageNavigation).catch(() => undefined);
+          setShowCloseAllSheet(true);
+        },
       );
-    }, [runGatedEligibleAction]);
+    }, [playImpact, runGatedEligibleAction]);
 
     const renderActionSheets = useCallback(
       (filteredPositions?: Position[], isFiltered?: boolean) => (
@@ -356,6 +374,7 @@ export const usePerpsProPositionsPanelActions =
                 onClose={handleCloseAllSheetClose}
                 positions={filteredPositions}
                 isFiltered={isFiltered}
+                enableHaptics
               />
             </PerpsProModalPortal>
           )}
@@ -367,6 +386,7 @@ export const usePerpsProPositionsPanelActions =
                 sheetRef={reversePositionSheetRef}
                 onClose={handleReverseSheetClose}
                 onConfirm={handleReverseSheetClose}
+                enableHaptics
               />
             </PerpsProModalPortal>
           )}
@@ -377,6 +397,7 @@ export const usePerpsProPositionsPanelActions =
                 sheetRef={adjustMarginSheetRef}
                 position={adjustMarginPosition}
                 onClose={handleAdjustMarginSheetClose}
+                enableHaptics
               />
             </PerpsProModalPortal>
           )}

--- a/app/components/UI/Perps/hooks/usePerpsProPositionsPanelActions.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsProPositionsPanelActions.tsx
@@ -224,6 +224,7 @@ export const usePerpsProPositionsPanelActions =
               initialTakeProfitPrice: position.takeProfitPrice,
               initialStopLossPrice: position.stopLossPrice,
               leverage: position.leverage.value,
+              enableHaptics: true,
               onConfirm: async (
                 positionFromRoute?: Position,
                 takeProfitPrice?: string,

--- a/app/components/UI/Perps/types/navigation.ts
+++ b/app/components/UI/Perps/types/navigation.ts
@@ -252,6 +252,11 @@ export type PerpsStackParamList = {
     amount?: string; // For new orders - USD amount to calculate position size for P&L
     szDecimals?: number; // For new orders - asset decimal precision for P&L
     /**
+     * When true, fires catalog haptics for meaningful TP/SL gestures.
+     * Defaults off so Lite entry points stay silent.
+     */
+    enableHaptics?: boolean;
+    /**
      * Called when user confirms TP/SL. First arg is position when editing existing position (avoids "No position found" from stale ref).
      * Signature: (position?, takeProfitPrice?, stopLossPrice?, trackingData?) so both edit-flow and order-flow can use it.
      */

--- a/app/components/UI/Perps/types/navigation.ts
+++ b/app/components/UI/Perps/types/navigation.ts
@@ -147,6 +147,11 @@ export type PerpsStackParamList = {
          * Used by the header slide-up picker.
          */
         replaceOnSelect?: boolean;
+        /**
+         * When true, fires selection haptics on market row taps.
+         * Defaults off so Lite entry points stay silent.
+         */
+        enableHaptics?: boolean;
       }
     | undefined;
 

--- a/app/components/UI/Perps/types/navigation.ts
+++ b/app/components/UI/Perps/types/navigation.ts
@@ -185,11 +185,13 @@ export type PerpsStackParamList = {
     source?: string;
     buttonClicked?: string;
     buttonLocation?: string;
+    enableHaptics?: boolean;
   };
 
   PerpsAdjustMargin: {
     position: Position;
     mode: 'add' | 'remove';
+    enableHaptics?: boolean;
   };
 
   // Action selection routes

--- a/app/util/haptics/__mocks__/index.ts
+++ b/app/util/haptics/__mocks__/index.ts
@@ -1,0 +1,3 @@
+import { createHapticsJestMock } from '../testing/createHapticsJestMock';
+
+export = createHapticsJestMock();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Pro-mode interactive surfaces were largely silent tactilely, so high-frequency trading gestures lacked the same feedback already used elsewhere in the app.

This PR wires the shared app/util/haptics catalog into the named Pro surfaces (order book, market header, mode toggle, order form, TP/SL, selection sheets, and leverage confirm). Feedback uses useHaptics() in gesture handlers, is Pro-opt-in for shared navigation and confirmation surfaces, and has an explicit mode-toggle opt-in so Lite ↔ Pro switching gets the designer-approved medium TabChange haptic in both directions. Haptics respect existing gates and fire only on meaningful user actions (not re-renders, disabled controls, or unchanged selections). Order lifecycle toast notifications are preserved alongside Place Order PrimaryCTA.

Notes from review:

- Leverage sheet exception: PerpsLeverageBottomSheet already had ungated slider/chip haptics on main (Lite included). This PR only gates the new confirm haptic behind enableConfirmHaptics (Pro passes it; Lite does not).
- T1 tabChange omitted: The order-book view-toggle control is dead-gated behind {false && …} and isn't user-reachable, so tabChange wasn't wired.
- Designer moment mapping: mode switching uses medium TabChange; slippage summary opening, candle interval changes, ticker-only, and panel expand/collapse use light Selection; bottom-sheet Save/Apply uses PrimaryCTA.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Added haptic feedback to Perps Pro trading interactions

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3641

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps Pro haptic feedback
  Scenario: user receives selection feedback on Pro order-form controls
    Given the user is on a Pro market screen
    And app haptics are enabled
    When the user changes Long/Short, opens leverage or order type, toggles size unit or reduce-only
    Then a selection haptic plays for each meaningful change
    And re-selecting the already-active direction produces no haptic
  Scenario: user receives PrimaryCTA feedback when placing an order
    Given the user is on a Pro market screen with a valid order ready
    And app haptics are enabled
    When the user presses Place Order
    Then a PrimaryCTA haptic plays after the order passes its validation and submission guards
    And any order lifecycle toast haptics still play as before
  Scenario: user receives navigation and selection feedback in the Pro header
    Given the user is on a Pro market screen
    And app haptics are enabled
    When the user presses back, identity, or wallet
    Then a PageNavigation haptic plays
    When the user toggles favorite
    Then a selection haptic plays
    When the user presses the active mode pill
    Then one medium TabChange haptic plays after the mode switch is accepted
  Scenario: user receives feedback from the order book and selection sheets
    Given the user is on a Pro market screen
    And app haptics are enabled
    When the user taps an order-book price row
    Then a selection haptic plays and the limit price updates
    When the user expands or collapses the chart or order book
    Then one selection haptic plays for the panel toggle
    When the user opens settings, changes chips, and saves
    Then selection haptics play for changed picks and one PrimaryCTA haptic plays for Save
    And dismissing the sheet without Save produces no haptic
    When the user changes positions sort or side filter and applies
    Then selection haptics play for meaningful picks and Clear, and one PrimaryCTA haptic plays for Apply
  Scenario: user receives feedback on the Pro TP/SL screen
    Given the user opened TP/SL from Pro order form or Pro positions
    And app haptics are enabled
    When the user taps a percentage preset or Clear
    Then a selection haptic plays
    When the user presses Set
    Then a PrimaryCTA haptic plays
    When the user presses back or Cancel
    Then a PageNavigation haptic plays
  Scenario: Lite mode switching and shared Lite actions
    Given the user is on Perps Home or a Lite market screen
    And app haptics are enabled
    When the user switches between Lite and Pro
    Then one medium TabChange haptic plays after the switch is accepted
    When the user uses Lite market header navigation, market-list, wallet, or favorite actions
    Then no Pro navigation or selection haptics play
  Scenario: system and app haptic settings are respected
    Given the user is on a Pro market screen
    When app-level haptics are disabled
    Then Pro interactions produce no haptics
    When OS-level haptics are disabled
    Then Pro interactions produce no haptics
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
N/A — tactile-only change; validate on a physical iOS device plus Android smoke.

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only tactile feedback using existing haptic gates. Shared confirm/navigation screens stay off unless Pro passes enableHaptics; extra early-return guards on a few submit handlers are defensive and well-tested.
> 
> **Overview**
> Wires the shared `useHaptics()` catalog into Perps Pro so trading gestures get tactile feedback. **Selection** covers chips, filters, chart/order-book toggles, and form controls; **PrimaryCTA** covers Place Order, Save/Apply, and other commits; **PageNavigation** covers header/back/wallet and sheet opens; **TabChange** plays after an accepted Lite↔Pro switch.
> 
> Shared Lite screens (close, TP/SL, margin, flip, market list, leverage confirm) stay silent by default. Pro passes `enableHaptics` / `enableConfirmHaptics` through navigation and sheets. Haptics fire only after existing guards (disabled, in-flight, invalid, unchanged selection). Lite header nav remains silent; Home and market headers enable mode-toggle haptics in both directions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d187ddcce854b569b9eeabc7db38abbcfcfda07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->