### PR TITLE
fix(walletconnect): always answer a session request that fails to be handled

### DIFF
--- a/app/core/WalletConnect/WalletConnect2Session.test.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.test.ts
@@ -16,6 +16,7 @@ import { Minimizer } from '../NativeModules';
 import DevLogger from '../SDKConnect/utils/DevLogger';
 import { getGlobalNetworkClientId } from '../../util/networks/global-network';
 import { Hex, CaipChainId } from '@metamask/utils';
+import { errorCodes } from '@metamask/rpc-errors';
 import WalletConnectPort from '../BackgroundBridge/WalletConnectPort';
 
 jest.mock('../AppConstants', () => ({
@@ -948,7 +949,7 @@ describe('WalletConnect2Session', () => {
       });
     });
 
-    it('handles personal_sign correctly with invalid chainId network config', async () => {
+    it('answers the dapp when the request chain is not permitted', async () => {
       const requestId = Math.floor(Math.random() * 1000000);
       const request: WalletKitTypes.SessionRequest = {
         id: requestId,
@@ -974,17 +975,81 @@ describe('WalletConnect2Session', () => {
           'getChainIdForCaipChainId',
         )
         .mockReturnValue('eip155:2');
+      const mockRespondSessionRequest = jest
+        .spyOn(mockClient, 'respondSessionRequest')
+        .mockResolvedValue(undefined);
 
-      // Test with an invalid chainId that should cause handleSwitchToChain to throw
+      // A non-permitted chain makes handleRequest throw internally. That throw
+      // must not escape: both callers only log it, which would leave the dapp
+      // waiting forever and the request pending in WalletKit's store.
+      // Regression test for https://github.com/MetaMask/metamask-mobile/issues/25150
       await expect(
         buildCase(
           request,
           '0x2',
           'eip155:1234567890abcdef1234567890abcdef12345678',
         ),
-      ).rejects.toThrow(
-        'Invalid parameters: active chainId is different than the one provided.',
-      );
+      ).resolves.toBeUndefined();
+
+      // Exact shape matters: only code and message may reach the dapp, never
+      // the wallet's stack trace or the raw thrown value.
+      expect(mockRespondSessionRequest).toHaveBeenCalledWith({
+        topic: mockSession.topic,
+        response: {
+          id: request.id,
+          jsonrpc: '2.0',
+          error: {
+            code: errorCodes.rpc.invalidParams,
+            message:
+              'Invalid parameters: active chainId is different than the one provided.',
+          },
+        },
+      });
+      expect(session.isHandlingRequest()).toBe(false);
+    });
+
+    it('clears the handling flag when a failed request cannot be answered', async () => {
+      const requestId = Math.floor(Math.random() * 1000000);
+      const request: WalletKitTypes.SessionRequest = {
+        id: requestId,
+        topic: mockSession.topic,
+        params: {
+          request: {
+            method: 'personal_sign',
+            params: [{ chainId: 'eip155:2', message: 'test' }],
+          },
+          chainId: 'eip155:2',
+        },
+        verifyContext: {
+          verified: {
+            origin: 'https://example.com',
+            validation: 'UNKNOWN',
+            verifyUrl: '',
+          },
+        },
+      };
+      jest
+        .spyOn(
+          jest.requireMock('./wc-utils') as any,
+          'getChainIdForCaipChainId',
+        )
+        .mockReturnValue('eip155:2');
+      // Relay is down: even the error response fails to go out.
+      jest
+        .spyOn(mockClient, 'respondSessionRequest')
+        .mockRejectedValue(new Error('relay unavailable'));
+
+      await expect(
+        buildCase(
+          request,
+          '0x2',
+          'eip155:1234567890abcdef1234567890abcdef12345678',
+        ),
+      ).resolves.toBeUndefined();
+
+      // A stuck flag makes connect() skip the loading sheet on every later
+      // deeplink for this session, so the wallet opens to a blank home screen.
+      expect(session.isHandlingRequest()).toBe(false);
     });
 
     it('handles personal_sign correctly with invalid chainId', async () => {

--- a/app/core/WalletConnect/WalletConnect2Session.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.ts
@@ -58,7 +58,12 @@ import {
 } from './multichain';
 
 import { selectPerOriginChainId } from '../../selectors/selectedNetworkController';
-import { errorCodes, providerErrors, rpcErrors } from '@metamask/rpc-errors';
+import {
+  errorCodes,
+  providerErrors,
+  rpcErrors,
+  serializeError,
+} from '@metamask/rpc-errors';
 import { switchToNetwork } from '../RPCMethods/lib/ethereum-chain-utils';
 import { updateWC2Metadata } from '../../actions/sdk';
 import AppConstants from '../AppConstants';
@@ -318,12 +323,15 @@ class WalletConnect2Session {
           result,
         },
       });
-      this._isHandlingRequest = false;
     } catch (err) {
       console.warn(
         `WC2::approveRequest error while approving request id=${id} topic=${topic}`,
         err,
       );
+    } finally {
+      // Must be cleared even when responding fails, otherwise the session stays
+      // wedged in "handling" state and never shows the loading sheet again.
+      this._isHandlingRequest = false;
     }
 
     const requests = this.web3Wallet.getPendingSessionRequests() || [];
@@ -361,12 +369,14 @@ class WalletConnect2Session {
           error: errorResponse,
         },
       });
-      this._isHandlingRequest = false;
     } catch (err) {
       console.warn(
         `WC2::rejectRequest error while rejecting request id=${id} topic=${topic}`,
         err,
       );
+    } finally {
+      // See the equivalent note in approveRequest.
+      this._isHandlingRequest = false;
     }
 
     this.needsRedirect(id);
@@ -566,7 +576,74 @@ class WalletConnect2Session {
     }
   };
 
+  /**
+   * Entry point for every incoming session request.
+   *
+   * Wraps {@link handleRequestInternal} so that a throw can never leave the
+   * request unanswered. Both callers (`WC2Manager.onSessionRequest` and
+   * `checkPendingRequests`) only log what escapes, so an uncaught throw used to
+   * mean: the dapp waited on a promise that never settled, `_isHandlingRequest`
+   * stayed `true` — which makes `connect()` skip the loading sheet for every
+   * later deeplink on this session — and WalletKit kept the request in its
+   * pending store, replaying it on a subsequent app launch.
+   *
+   * See https://github.com/MetaMask/metamask-mobile/issues/25150
+   */
   handleRequest = async (requestEvent: WalletKitTypes.SessionRequest) => {
+    try {
+      return await this.handleRequestInternal(requestEvent);
+    } catch (error) {
+      await this.failRequest(requestEvent, error);
+    }
+  };
+
+  /**
+   * Answer a request that could not be handled, so the dapp stops waiting and
+   * WalletKit drops it from its pending store.
+   */
+  private async failRequest(
+    requestEvent: WalletKitTypes.SessionRequest,
+    error: unknown,
+  ) {
+    Logger.error(
+      error as Error,
+      `WC2::handleRequest unhandled failure requestId=${requestEvent.id} topic=${requestEvent.topic}`,
+    );
+
+    this._isHandlingRequest = false;
+
+    // Only the code and message go back to the dapp. serializeError keeps the
+    // thrown value under `data.cause` — stack included — whenever it isn't
+    // already a JSON-RPC error, and wallet internals are not the dapp's
+    // business.
+    const { code, message } = serializeError(error, {
+      shouldIncludeStack: false,
+    });
+
+    try {
+      await this.web3Wallet.respondSessionRequest({
+        topic: requestEvent.topic,
+        response: {
+          id: requestEvent.id,
+          jsonrpc: '2.0',
+          error: { code, message },
+        },
+      });
+    } catch (respondError) {
+      Logger.error(
+        respondError as Error,
+        `WC2::handleRequest could not respond requestId=${requestEvent.id}`,
+      );
+    }
+
+    // Send the user back to the dapp instead of stranding them in the wallet,
+    // matching what rejectRequest does.
+    this.needsRedirect(requestEvent.id + '');
+  }
+
+  private handleRequestInternal = async (
+    requestEvent: WalletKitTypes.SessionRequest,
+  ) => {
     DevLogger.log(
       'WC2::handleRequest requestEvent',
       JSON.stringify(requestEvent, null, 2),


### PR DESCRIPTION
## **Description**

A WalletConnect session request that throws while being handled is never answered, and the failure is invisible to the dapp.

`WalletConnect2Session.handleRequest` has two paths that throw instead of responding:

- `app/core/WalletConnect/WalletConnect2Session.ts` — `await this.switchToChain(...)`, which propagates whatever `switchToNetwork` throws (for example when the user dismisses the "permit this chain" approval).
- The `if (!isAllowedChainId) throw rpcErrors.invalidParams(...)` guard immediately after it.

Every other early return in that method responds to the dapp and resets `_isHandlingRequest`. These two do neither, and both callers — `WC2Manager.onSessionRequest` and the `checkPendingRequests` loop in the constructor — only log what escapes. Three things follow:

1. **The dapp waits forever.** No JSON-RPC response is sent, so the request promise never settles.
2. **The session is wedged.** `_isHandlingRequest` stays `true` for the lifetime of the session object, so `WC2Manager.connect()` skips `showWCLoadingState()` on every later deeplink for that session. The wallet is brought to the foreground and sits on the home screen with no loading sheet and no modal. It recovers only when the app is restarted and the session object is rebuilt, which is why the symptom reads as intermittent.
3. **The request is replayed much later.** Because it was never answered, WalletKit keeps it in its pending store. On a subsequent launch `restoreSessions()` builds a new `WalletConnect2Session`, whose constructor calls `checkPendingRequests()` and replays it — a confirmation modal appearing long after the user gave up, which is exactly what #25150 describes.

### Fix

`handleRequest` is now a thin guard around the previous body (`handleRequestInternal`). Anything that escapes is logged via `Logger.error` for Sentry visibility, answered with a JSON-RPC error so the dapp and WalletKit both stop waiting, and the redirect back to the dapp is triggered as `rejectRequest` already does. Only `code` and `message` are sent: `serializeError` puts the raw thrown value — stack included — under `data.cause` whenever it is not already a JSON-RPC error, and the dapp has no business seeing wallet internals.

`approveRequest` and `rejectRequest` had a narrower version of the same leak — `_isHandlingRequest = false` sat inside the `try`, so a failing `respondSessionRequest` left the flag set. Both now clear it in a `finally`.

This is a catch-all rather than a patch of the two known throw sites, because the defect is structural: any future throw in request handling would fail the same way.

### Note on scope

This addresses the "opens to the home screen with no popup" and "popup appears days later" halves of #25150. The reporter also describes a 30+ second delay, which has a separate cause: MetaMask does not implement WalletConnect Link Mode (`AppConstants.WALLET_CONNECT.METADATA.redirect` has no `linkMode: true`, and there is no `wc_ev` envelope handling anywhere in the app), so Reown AppKit falls back to the relay socket, which Android tears down while the app is backgrounded. That is a feature gap rather than a bug and is out of scope here.

## **Changelog**

CHANGELOG entry: Fixed a bug where a WalletConnect transaction or signature request could silently fail to show its confirmation, leaving the dapp waiting and the request to resurface on a later app launch

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/issues/25150

## **Manual testing steps**

```gherkin
Feature: WalletConnect requests always get answered

  Scenario: request arrives for a chain the session does not permit
    Given a dapp is connected over WalletConnect with only Ethereum Mainnet permitted
    And the wallet is on a different network

    When the dapp sends eth_sendTransaction scoped to a non-permitted chain
    Then the dapp receives a JSON-RPC error instead of hanging
    And the wallet is not left in a state where later deeplinks open to the home screen

  Scenario: session is not wedged after a failed request
    Given a request for that session has just failed as above

    When the dapp sends a second, valid request and deeplinks into the wallet
    Then the loading sheet appears
    And the confirmation modal is shown

  Scenario: failed request is not replayed later
    Given a request for that session has just failed as above

    When the app is force-quit and relaunched
    Then no stale confirmation modal appears for that request
```

## **Screenshots/Recordings**

N/A — the change is in request-handling control flow and has no visual surface of its own. The user-visible effect is the absence of the failure modes described above; it is covered by the unit tests added in `WalletConnect2Session.test.ts`.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core WalletConnect request lifecycle and error surfacing to dapps; behavior is broader than two known throw sites but is covered by targeted regression tests.
> 
> **Overview**
> Fixes WalletConnect sessions where thrown errors during request handling left dapps hanging, wedged `_isHandlingRequest`, and kept stale requests in WalletKit (#25150).
> 
> **`handleRequest`** is now a wrapper around the former logic (`handleRequestInternal`). Any uncaught failure is logged, answered with a JSON-RPC error built from **`serializeError`** (only `code` and `message` to the dapp), and followed by the same redirect path as **`rejectRequest`**. **`failRequest`** clears the handling flag even when the relay rejects the error response.
> 
> **`approveRequest`** and **`rejectRequest`** always reset **`_isHandlingRequest`** in **`finally`**, so a failed **`respondSessionRequest`** no longer leaves later deeplinks opening to the home screen without the loading sheet.
> 
> Tests were updated to expect a proper error response (not a rejected promise) when the request chain is not permitted, and to assert the handling flag clears when responding fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fc12de663df7ca1252ac23aac2d085a96bdb54f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->