### PR TITLE
fix: remove bottom safe area cutoff on Follow Trading scroll screens

### DIFF
--- a/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.test.tsx
@@ -4,6 +4,8 @@ import renderWithProvider from '../../../../util/test/renderWithProvider';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import SocialTradersTabsView from './SocialTradersTabsView';
 import { SocialTradersTabsViewSelectorsIDs } from './SocialTradersTabsView.testIds';
+import { SCROLLABLE_SCREEN_SAFE_AREA_EDGES } from '../shared/scrollableScreenSafeArea';
+import { expectHeaderIncludesTopInset } from '../shared/scrollableScreenSafeArea.testUtils';
 
 const mockPlaySelection = jest.fn().mockResolvedValue(undefined);
 const mockTrack = jest.fn();
@@ -160,6 +162,25 @@ describe('SocialTradersTabsView', () => {
     ).toBeOnTheScreen();
     expect(screen.getByTestId('mock-top-traders')).toBeOnTheScreen();
     expect(screen.getByTestId('mock-feed')).toBeOnTheScreen();
+  });
+
+  describe('safe area layout', () => {
+    it('excludes bottom safe area so the scroll list extends to the screen edge', () => {
+      renderWithProvider(<SocialTradersTabsView />);
+
+      expect(
+        screen.getByTestId(SocialTradersTabsViewSelectorsIDs.CONTAINER).props
+          .edges,
+      ).toEqual(SCROLLABLE_SCREEN_SAFE_AREA_EDGES);
+    });
+
+    it('keeps the top inset on the header to prevent layout shift on push', () => {
+      renderWithProvider(<SocialTradersTabsView />);
+
+      expectHeaderIncludesTopInset(
+        screen.getByTestId(SocialTradersTabsViewSelectorsIDs.HEADER),
+      );
+    });
   });
 
   it('renders the tabbed screen title from the feed i18n key', () => {

--- a/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.tsx
+++ b/app/components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.tsx
@@ -43,6 +43,7 @@ import FeedSpotBuyAction, {
 } from '../FeedView/components/FeedSpotBuyAction';
 import TopTradersView from '../TopTradersView';
 import type { SocialTabPageHandle } from '../shared/tabPageScroll';
+import { SCROLLABLE_SCREEN_SAFE_AREA_EDGES } from '../shared/scrollableScreenSafeArea';
 import type { QuickBuyTarget } from '../TraderPositionView/components/QuickBuy';
 import {
   TabsBar,
@@ -349,13 +350,11 @@ const SocialTradersTabsView: React.FC = () => {
   ]);
 
   return (
-    // The top edge is deliberately off: a native SafeAreaView top padding is
-    // recalculated as the view is attached, which lands after this screen's
-    // `slide_from_right` push and visibly drops the header into place. The top
-    // inset comes from `includesTopInset` (JS `marginTop` off the already
-    // resolved provider) instead.
+    // Top and bottom edges are deliberately off — see
+    // `SCROLLABLE_SCREEN_SAFE_AREA_EDGES`. The top inset comes from
+    // `includesTopInset` (JS `marginTop` off the already resolved provider).
     <SafeAreaView
-      edges={['bottom', 'left', 'right']}
+      edges={SCROLLABLE_SCREEN_SAFE_AREA_EDGES}
       style={tw.style('flex-1 bg-default')}
       testID={SocialTradersTabsViewSelectorsIDs.CONTAINER}
     >

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
@@ -14,6 +14,8 @@ import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { ImpactMoment } from '../../../../util/haptics';
 import TopTradersView from './TopTradersView';
 import { TopTradersViewSelectorsIDs } from './TopTradersView.testIds';
+import { SCROLLABLE_SCREEN_SAFE_AREA_EDGES } from '../shared/scrollableScreenSafeArea';
+import { expectHeaderIncludesTopInset } from '../shared/scrollableScreenSafeArea.testUtils';
 import {
   getSortFilterOptionTestId,
   getTimeframeFilterOptionTestId,
@@ -343,6 +345,24 @@ describe('TopTradersView', () => {
     expect(
       screen.getByTestId(TopTradersViewSelectorsIDs.CONTAINER),
     ).toBeOnTheScreen();
+  });
+
+  describe('safe area layout', () => {
+    it('excludes bottom safe area so the scroll list extends to the screen edge', () => {
+      renderWithProvider(<TopTradersView />);
+
+      expect(
+        screen.getByTestId(TopTradersViewSelectorsIDs.CONTAINER).props.edges,
+      ).toEqual(SCROLLABLE_SCREEN_SAFE_AREA_EDGES);
+    });
+
+    it('keeps the top inset on the header to prevent layout shift on push', () => {
+      renderWithProvider(<TopTradersView />);
+
+      expectHeaderIncludesTopInset(
+        screen.getByTestId(TopTradersViewSelectorsIDs.HEADER),
+      );
+    });
   });
 
   it('renders the Weekly top traders title in the scrollable title section', () => {

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx
@@ -65,6 +65,7 @@ import { useNotificationStoragePreferences } from '../../Settings/NotificationsS
 import { useNotificationPreferences } from '../NotificationPreferences/hooks';
 import { areTradingSignalsChannelsDisabled } from '../NotificationPreferences/hooks/tradingSignalsChannels';
 import { useOpenTradingSignalsSetup } from '../hooks/useOpenTradingSignalsSetup';
+import { SCROLLABLE_SCREEN_SAFE_AREA_EDGES } from '../shared/scrollableScreenSafeArea';
 import {
   TraderRow,
   TraderRowSkeleton,
@@ -821,13 +822,11 @@ const TopTradersView: React.FC<TopTradersViewProps> = ({
   }
 
   return (
-    // The top edge is deliberately off: a native SafeAreaView top padding is
-    // recalculated as the view is attached, which lands after this screen's
-    // `slide_from_right` push and visibly drops the header into place. The top
-    // inset comes from `includesTopInset` (JS `marginTop` off the already
-    // resolved provider) instead.
+    // Top and bottom edges are deliberately off — see
+    // `SCROLLABLE_SCREEN_SAFE_AREA_EDGES`. The top inset comes from
+    // `includesTopInset` (JS `marginTop` off the already resolved provider).
     <SafeAreaView
-      edges={['bottom', 'left', 'right']}
+      edges={SCROLLABLE_SCREEN_SAFE_AREA_EDGES}
       style={tw.style('flex-1 bg-default')}
       testID={TopTradersViewSelectorsIDs.CONTAINER}
     >

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.test.tsx
@@ -13,6 +13,8 @@ import type { UseTraderPositionsResult } from './hooks/useTraderPositions';
 import type { UseTraderProfileResult } from './hooks/useTraderProfile';
 import TraderProfileView from './TraderProfileView';
 import { TraderProfileViewSelectorsIDs } from './TraderProfileView.testIds';
+import { SCROLLABLE_SCREEN_SAFE_AREA_EDGES } from '../shared/scrollableScreenSafeArea';
+import { expectHeaderIncludesTopInset } from '../shared/scrollableScreenSafeArea.testUtils';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 
 const mockGoBack = jest.fn();
@@ -423,6 +425,24 @@ describe('TraderProfileView', () => {
     expect(
       screen.getByTestId(TraderProfileViewSelectorsIDs.CONTAINER),
     ).toBeOnTheScreen();
+  });
+
+  describe('safe area layout', () => {
+    it('excludes bottom safe area so the scroll list extends to the screen edge', () => {
+      renderWithProvider(<TraderProfileView />);
+
+      expect(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.CONTAINER).props.edges,
+      ).toEqual(SCROLLABLE_SCREEN_SAFE_AREA_EDGES);
+    });
+
+    it('keeps the top inset on the header to prevent layout shift on push', () => {
+      renderWithProvider(<TraderProfileView />);
+
+      expectHeaderIncludesTopInset(
+        screen.getByTestId(TraderProfileViewSelectorsIDs.HEADER),
+      );
+    });
   });
 
   it('displays the trader name in the profile header and compact nav header', () => {

--- a/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx
@@ -54,6 +54,7 @@ import TraderHeaderIdentity from '../components/TraderHeaderIdentity';
 import TraderMuteChip from '../components/TraderMuteChip';
 import { useOpenTradingSignalsSetup } from '../hooks/useOpenTradingSignalsSetup';
 import { useTraderMute } from '../hooks/useTraderMute';
+import { SCROLLABLE_SCREEN_SAFE_AREA_EDGES } from '../shared/scrollableScreenSafeArea';
 import { HYPERLIQUID_CHAIN_NAME, isPerpPosition } from '../utils/perp';
 import { TraderProfileViewSelectorsIDs } from './TraderProfileView.testIds';
 import PositionRow from './components/PositionRow';
@@ -355,13 +356,11 @@ const TraderProfileView = () => {
   const headerTitle = profile?.profile.name;
 
   return (
-    // The top edge is deliberately off: a native SafeAreaView top padding is
-    // recalculated as the view is attached, which lands after this screen's
-    // `slide_from_right` push and visibly drops the header into place. The top
-    // inset comes from `includesTopInset` (JS `marginTop` off the already
-    // resolved provider) instead.
+    // Top and bottom edges are deliberately off — see
+    // `SCROLLABLE_SCREEN_SAFE_AREA_EDGES`. The top inset comes from
+    // `includesTopInset` (JS `marginTop` off the already resolved provider).
     <SafeAreaView
-      edges={['bottom', 'left', 'right']}
+      edges={SCROLLABLE_SCREEN_SAFE_AREA_EDGES}
       style={tw.style('flex-1 bg-default')}
       testID={TraderProfileViewSelectorsIDs.CONTAINER}
     >

--- a/app/components/Views/SocialLeaderboard/shared/scrollableScreenSafeArea.test.ts
+++ b/app/components/Views/SocialLeaderboard/shared/scrollableScreenSafeArea.test.ts
@@ -1,0 +1,9 @@
+import { SCROLLABLE_SCREEN_SAFE_AREA_EDGES } from './scrollableScreenSafeArea';
+
+describe('SCROLLABLE_SCREEN_SAFE_AREA_EDGES', () => {
+  it('excludes top and bottom edges so scroll content extends edge to edge', () => {
+    expect(SCROLLABLE_SCREEN_SAFE_AREA_EDGES).toEqual(['left', 'right']);
+    expect(SCROLLABLE_SCREEN_SAFE_AREA_EDGES).not.toContain('top');
+    expect(SCROLLABLE_SCREEN_SAFE_AREA_EDGES).not.toContain('bottom');
+  });
+});

--- a/app/components/Views/SocialLeaderboard/shared/scrollableScreenSafeArea.testUtils.ts
+++ b/app/components/Views/SocialLeaderboard/shared/scrollableScreenSafeArea.testUtils.ts
@@ -4,9 +4,9 @@ import { StyleSheet } from 'react-native';
  * Asserts the animated header still applies the JS top inset (TSA-970) without
  * relying on native SafeAreaView top padding.
  */
-export const expectHeaderIncludesTopInset = (
-  header: { props: { style?: unknown } },
-) => {
+export const expectHeaderIncludesTopInset = (header: {
+  props: { style?: unknown };
+}) => {
   const flattened = StyleSheet.flatten(header.props.style);
 
   expect(flattened).toEqual(

--- a/app/components/Views/SocialLeaderboard/shared/scrollableScreenSafeArea.testUtils.ts
+++ b/app/components/Views/SocialLeaderboard/shared/scrollableScreenSafeArea.testUtils.ts
@@ -1,0 +1,15 @@
+import { StyleSheet } from 'react-native';
+
+/**
+ * Asserts the animated header still applies the JS top inset (TSA-970) without
+ * relying on native SafeAreaView top padding.
+ */
+export const expectHeaderIncludesTopInset = (
+  header: { props: { style?: unknown } },
+) => {
+  const flattened = StyleSheet.flatten(header.props.style);
+
+  expect(flattened).toEqual(
+    expect.objectContaining({ marginTop: expect.any(Number) }),
+  );
+};

--- a/app/components/Views/SocialLeaderboard/shared/scrollableScreenSafeArea.ts
+++ b/app/components/Views/SocialLeaderboard/shared/scrollableScreenSafeArea.ts
@@ -2,8 +2,8 @@
  * Safe-area edges for Follow Trading scroll screens.
  *
  * - **Top** is off: native top padding recalculates mid push transition (TSA-970).
- *   Use `includesTopInset` on the header instead.
- * - **Bottom** is off: scrollable lists extend to the screen edge; bottom
- *   padding would leave dead space below the last row.
+ * Use `includesTopInset` on the header instead.
+ * - **Bottom** is off: scrollable lists extend to the screen edge; bottom padding
+ * would leave dead space below the last row.
  */
 export const SCROLLABLE_SCREEN_SAFE_AREA_EDGES = ['left', 'right'] as const;

--- a/app/components/Views/SocialLeaderboard/shared/scrollableScreenSafeArea.ts
+++ b/app/components/Views/SocialLeaderboard/shared/scrollableScreenSafeArea.ts
@@ -1,0 +1,9 @@
+/**
+ * Safe-area edges for Follow Trading scroll screens.
+ *
+ * - **Top** is off: native top padding recalculates mid push transition (TSA-970).
+ *   Use `includesTopInset` on the header instead.
+ * - **Bottom** is off: scrollable lists extend to the screen edge; bottom
+ *   padding would leave dead space below the last row.
+ */
+export const SCROLLABLE_SCREEN_SAFE_AREA_EDGES = ['left', 'right'] as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

#34278 (TSA-970) fixed a header layout shift on Follow Trading screens by turning off the native `SafeAreaView` top edge and applying the top inset via `includesTopInset` on `HeaderStandardAnimated`. That change also enabled the bottom `SafeAreaView` edge (`edges={['bottom', 'left', 'right']}`), which introduced a regression: scroll-only screens no longer extend to the bottom of the display, leaving dead space below the last row.

**Cause.** Bottom safe-area padding is appropriate when a CTA is pinned at the bottom of the screen. On scroll-only views (Top Traders leaderboard and Trader Profile), the list should reach the screen edge and scroll behind the home indicator.

**Fix.** Drop the bottom edge and keep `includesTopInset` on the animated header so the TSA-970 header fix is preserved. Centralize the edge list in `SCROLLABLE_SCREEN_SAFE_AREA_EDGES` (`['left', 'right']`) and add regression tests that guard both the bottom cutoff and the header top inset.

| Screen | SafeAreaView edges | Header top inset |
| --- | --- | --- |
| `TopTradersView` (standalone) | `left`, `right` | `includesTopInset` |
| `SocialTradersTabsView` (tabbed Top traders) | `left`, `right` | `includesTopInset` |
| `TraderProfileView` | `left`, `right` | `includesTopInset` |

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed dead space below the last row on Top Traders and Trader Profile scroll screens.

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/pull/34278

## **Manual testing steps**

```gherkin
Feature: Follow Trading scroll screen layout

  Scenario: Top Traders list extends to the bottom edge
    Given the user is in the app
    And the aiSocialFeedEnabled flag is on or off

    When user opens the Top Traders leaderboard
    And user scrolls to the last trader row
    Then the list content reaches the bottom of the screen
    And there is no dead space below the last row

  Scenario: Trader Profile list extends to the bottom edge
    Given the user is in the app

    When user opens a trader profile from the leaderboard
    And user scrolls to the last position row
    Then the list content reaches the bottom of the screen
    And there is no dead space below the last row

  Scenario: header placement is unchanged after the bottom-edge fix
    Given the user is in the app

    When user opens the Top Traders leaderboard or a trader profile
    Then the header title and back button are positioned below the notch / Dynamic Island for the whole push transition
    And they do not shift vertically once the transition ends
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="725" height="938" alt="image" src="https://github.com/user-attachments/assets/c2d07ddb-bc71-4c57-8fc3-969e22c01abd" />

### **After**

<img width="689" height="942" alt="image" src="https://github.com/user-attachments/assets/10b9ea7c-9e4c-458a-90e6-42eba08d8817" />

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C092MDPA0LU/p1785857076484199?thread_ts=1785857076.484199&cid=C092MDPA0LU)

<div><a href="https://cursor.com/agents/bc-e2f9547d-866c-57cd-80ae-750facb61b5b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2f9547d-866c-57cd-80ae-750facb61b5b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

