### PR TITLE
fix(market-insights): remove stale optional label on feedback field

### DIFF
--- a/app/components/UI/MarketInsights/components/MarketInsightsFeedbackBottomSheet.test.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsFeedbackBottomSheet.test.tsx
@@ -93,6 +93,32 @@ describe('MarketInsightsFeedbackBottomSheet', () => {
     });
   });
 
+  it('does not submit "something else" without additional feedback text', () => {
+    const onSubmit = jest.fn();
+
+    const { getByTestId } = renderWithProvider(
+      <MarketInsightsFeedbackBottomSheet
+        isVisible
+        onClose={jest.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.press(
+      getByTestId(MarketInsightsSelectorsIDs.FEEDBACK_OPTION_SOMETHING_ELSE),
+    );
+
+    expect(
+      getByTestId(MarketInsightsSelectorsIDs.FEEDBACK_SUBMIT_BUTTON),
+    ).toBeDisabled();
+
+    fireEvent.press(
+      getByTestId(MarketInsightsSelectorsIDs.FEEDBACK_SUBMIT_BUTTON),
+    );
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it('does not submit stale additional feedback after switching reason', () => {
     const onSubmit = jest.fn();
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2676,7 +2676,7 @@
       "hard_to_understand": "Hard to understand",
       "harmful_or_offensive": "Harmful or offensive",
       "something_else": "Something else",
-      "additional_feedback_label": "Additional feedback (optional)",
+      "additional_feedback_label": "Additional feedback",
       "additional_feedback_placeholder": "How can we improve?",
       "characters_remaining": "{{count}} characters remaining",
       "submit": "Submit"


### PR DESCRIPTION
## **Description**

The Market Insights thumbs-down feedback sheet shows an "Additional feedback" text field when users select "Something else". Since #27926, that field is required before submit is enabled, but the label still said "Additional feedback (optional)".

This PR updates the English copy to "Additional feedback" so the label matches the required validation behavior. A unit test is added to document that submit stays disabled until text is entered for the "Something else" option.

## **Changelog**

CHANGELOG entry: Fixed misleading "optional" label on Market Insights feedback text field

## **Related issues**

Fixes: TSA-982

## **Manual testing steps**

```gherkin
Feature: Market Insights negative feedback label

  Scenario: user selects "Something else" without entering text
    Given Market Insights is enabled and a report is loaded
    And the user taps thumbs down on the feedback row

    When the user selects "Something else"
    Then the additional feedback label reads "Additional feedback" (not "optional")
    And the Submit button remains disabled until text is entered

  Scenario: user submits "Something else" with feedback text
    Given the feedback bottom sheet is open with "Something else" selected

    When the user enters feedback text and taps Submit
    Then feedback is submitted successfully and the confirmation toast appears
```

## **Screenshots/Recordings**

N/A — copy-only change; behavior unchanged.

### **Before**

Label: "Additional feedback (optional)" while submit requires text.

### **After**

Label: "Additional feedback" with submit still required for "Something else".

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> English copy and a unit test only; no change to submission or validation logic.
> 
> **Overview**
> **Market Insights** negative feedback for **Something else** already blocks submit until the user enters text; the English label still said **Additional feedback (optional)**.
> 
> This PR updates `market_insights.feedback.additional_feedback_label` in `en.json` to **Additional feedback** so the UI matches that validation. A unit test asserts that with **Something else** selected and no text, Submit stays disabled and `onSubmit` is not called.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee84570cd57e74f81b82c4c3a70daf2c4ea8fa67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->