### PR TITLE
ci: use smart e2e selector for RC PRs. Run all E2E on push to RC bran…

### DIFF
--- a/.github/actions/smart-e2e-selection/action.yml
+++ b/.github/actions/smart-e2e-selection/action.yml
@@ -27,7 +27,7 @@ inputs:
     required: false
     default: 'false'
   base-ref:
-    description: 'PR base branch ref passed to the AI analysis script for diff comparison. When release/* or stable, AI selection is skipped and the full E2E suite is selected.'
+    description: 'PR base branch ref passed to the AI analysis script for diff comparison.'
     required: false
     default: ''
 outputs:
@@ -38,7 +38,7 @@ outputs:
     description: 'AI confidence score (0-100)'
     value: ${{ steps.final-outputs.outputs.ai_confidence }}
   ai_performance_test_tags:
-    description: "Performance test tags to run. Empty string '' = run all (conservative fallback). Literal '[]' = skip (AI found no relevant changes). '[\"@Tag\",...]' = run specific tags."
+    description: 'Performance test tags to run. Empty string '''' = run all (conservative fallback). Literal ''[]'' = skip (AI found no relevant changes). ''["@Tag",...]'' = run specific tags.'
     value: ${{ steps.final-outputs.outputs.ai_performance_test_tags }}
   ai_performance_test_reasoning:
     description: 'Reasoning for the performance test selection'
@@ -60,32 +60,21 @@ runs:
           echo "⏭️ SKIP=true due to 'skip-smart-e2e-selection' label on PR"
         fi
 
-    - name: Check release or stable target branch (full E2E, no AI selection)
-      id: check-release-target
-      shell: bash
-      run: |
-        echo "SKIP=false" >> "$GITHUB_OUTPUT"
-        BASE='${{ inputs.base-ref }}'
-        if [[ -n "$BASE" && ( "$BASE" == release/* || "$BASE" == "stable" ) ]]; then
-          echo "SKIP=true" >> "$GITHUB_OUTPUT"
-          echo "⏭️ Base branch is release/* or stable — skipping AI E2E selection; full E2E suite will run"
-        fi
-
     - name: Checkout for PR analysis
-      if: steps.check-skip-label.outputs.SKIP != 'true' && steps.check-release-target.outputs.SKIP != 'true'
+      if: steps.check-skip-label.outputs.SKIP != 'true'
       uses: actions/checkout@v6
       with:
         fetch-depth: 1 # Shallow clone for speed; unshallowed below for diff comparison
 
     - name: Disable sparse checkout and restore all files
-      if: steps.check-skip-label.outputs.SKIP != 'true' && steps.check-release-target.outputs.SKIP != 'true'
+      if: steps.check-skip-label.outputs.SKIP != 'true'
       shell: bash
       run: |
         git sparse-checkout disable
         git checkout HEAD -- .
 
     - name: Fetch base branch for comparison
-      if: steps.check-skip-label.outputs.SKIP != 'true' && steps.check-release-target.outputs.SKIP != 'true'
+      if: steps.check-skip-label.outputs.SKIP != 'true'
       shell: bash
       run: |
         # Unshallow the repository first (if it's shallow)
@@ -94,13 +83,13 @@ runs:
         git fetch origin "${{ inputs.base-ref || 'main' }}" 2>/dev/null || true
 
     - name: Setup Node.js
-      if: steps.check-skip-label.outputs.SKIP != 'true' && steps.check-release-target.outputs.SKIP != 'true'
+      if: steps.check-skip-label.outputs.SKIP != 'true'
       uses: actions/setup-node@v6
       with:
         node-version-file: '.nvmrc'
 
     - name: Install minimal dependencies for AI analysis
-      if: steps.check-skip-label.outputs.SKIP != 'true' && steps.check-release-target.outputs.SKIP != 'true'
+      if: steps.check-skip-label.outputs.SKIP != 'true'
       shell: bash
       run: |
         echo "📦 Installing only required packages for AI analysis..."
@@ -112,7 +101,7 @@ runs:
         echo "✅ AI analysis dependencies installed in /tmp/ai-deps"
 
     - name: Copy AI dependencies to workspace
-      if: steps.check-skip-label.outputs.SKIP != 'true' && steps.check-release-target.outputs.SKIP != 'true'
+      if: steps.check-skip-label.outputs.SKIP != 'true'
       shell: bash
       run: |
         echo "📋 Copying AI dependencies to workspace..."
@@ -149,14 +138,6 @@ runs:
           # Skip label → run all E2E (ALL) but do NOT launch the PR performance workflow.
           # Performance tests are expensive and the skip label only opts out of AI selection,
           # not into a full performance run. Use '[]' so run-performance-tests-pr is skipped.
-          echo "ai_performance_test_tags=[]" >> "$GITHUB_OUTPUT"
-        elif [[ "${{ steps.check-release-target.outputs.SKIP }}" == "true" ]]; then
-          echo "⏭️ Skipping AI analysis - PR targets a release or stable branch"
-          echo "SKIPPED=true" >> "$GITHUB_OUTPUT"
-          echo "SKIP_REASON=PR targets a release or stable branch (release/* or stable)" >> "$GITHUB_OUTPUT"
-          echo "ai_confidence=100" >> "$GITHUB_OUTPUT"
-          # Release/stable target → performance runs are label-only. Return []
-          # so AI output cannot automatically trigger the PR performance job.
           echo "ai_performance_test_tags=[]" >> "$GITHUB_OUTPUT"
         else
           echo "✅ Running AI analysis for PR #$PR_NUMBER"

--- a/.github/guidelines/E2E_DECISION_TREE.md
+++ b/.github/guidelines/E2E_DECISION_TREE.md
@@ -16,7 +16,8 @@ flowchart TD
     GR -->|PR has Android-only changes| Android[Android Build + Tests needed]
     GR -->|PR has iOS-only changes| iOS[iOS Build + Test needed]
     GR -->|PR other files changed| Both[Both Build + Tests needed]
-    GR -->|Scheduled and Push to main | Full[Run all E2E Suites for Both]
+    GR -->|PR targets stable| StableSync[No E2E - synchronization only]
+    GR -->|Scheduled or Push to main/release/*| Full[Run all E2E Suites for Both]
 
     Android & iOS & Both --> LABEL{{PR label: skip-smart-e2e-selection ?}}
     LABEL -->|yes| AllTags[Run all E2E needed]
@@ -50,18 +51,29 @@ To save infra resources while waiting for static analysis findings and potential
 
 Runs only when all of the following are true:
 
+- Event is a pull request
 - Not a fork
 - No hard E2E skip signal (label `skip-e2e`)
 - No `skip-smart-e2e-selection` label
+- PR does not target `stable`
+
+For PRs targeting `main` or `release/*`, Smart E2E selects the test tags. Release
+cherry-pick PRs use the same Android-first platform policy as main PRs: Android
+is selected by path filters and iOS is opt-in through the Appium iOS label or
+shared smoke/Appium infrastructure changes.
 
 ## (Exceptional) skip builds and all E2E tests
 
 - Label `skip-e2e` can be added to the PR to skip E2E tests (and builds) in case of infra issues.
 - Using this label should be exceptional in case of CI friction and urgencies. Verify new changes and regressions manually before merging.
 
-## (Exceptional) force Appium iOS smoke tests on PRs
+## Appium smoke platform policy
 
-Appium iOS smoke tests are skipped on PRs by default (they still run on every `main` push/schedule). They also run automatically on a PR when shared smoke infra or Appium specs change (`tests/page-objects/**`, `tests/selectors/**`, `tests/locators/**`, `tests/framework/**`, `tests/smoke-appium/**`). To force them on any other PR, add the `run-appium-ios-tests` label. Smart E2E Selection still controls which suites run. CI re-runs automatically when the label is added or removed.
+- Pull requests targeting `main` or `release/*` run Appium Android when Android E2E is required. Smart E2E controls the selected tags.
+- Appium iOS is skipped on PRs by default. It runs when `run-appium-ios-tests` is added or shared smoke/Appium infrastructure changes (`tests/page-objects/**`, `tests/selectors/**`, `tests/locators/**`, `tests/framework/**`, or `tests/smoke-appium/**`), provided an iOS build is required by path filters.
+- Pushes to `main` and `release/*` run Appium Android and Appium iOS with the full `ALL` tag set.
+- PRs targeting `stable` from `release/*` are synchronization-only and run no E2E, including Appium.
+- Stable branch synchronization automation remains active; stable is not the release-build source.
 
 ## E2E flakiness detection in PRs
 
@@ -73,7 +85,10 @@ Flakiness detection is applied to modified E2E test files in PRs:
 
 ## Release branches
 
-PRs to release branches (cherry-picks from main to release/\* branches and PRs to stable branch) are exempt from the following:
+`release/*` branches are release candidates. Their E2E policy is:
 
-- Label `pr-not-ready-for-e2e` is not applied
-- Smart AI E2E selection is skipped - all E2E suites are run (if changes are not ignorable-only, e.g. only docs)
+- Cherry-pick PRs from `main` use Smart E2E selection with the Android-first platform policy.
+- Release cherry-pick PRs do not automatically run iOS; use `run-appium-ios-tests` when an iOS build is required.
+- Every push to `release/*` runs Android and iOS Appium E2E with `ALL` tags.
+- PRs from `release/*` to `stable` are synchronization PRs and run no E2E.
+- The final release decision is based on the latest tested `release/*` SHA, which is also the source for the production build.

--- a/.github/guidelines/LABELING_GUIDELINES.md
+++ b/.github/guidelines/LABELING_GUIDELINES.md
@@ -45,7 +45,7 @@ Using any of these labels should be exceptional in case of CI friction and urgen
 
 ### Force Appium iOS Smoke Tests
 
-- **run-appium-ios-tests**: Also runs Appium iOS smoke tests on a PR (normally they run on `main` push/schedule, or automatically when `tests/smoke-appium/**` / shared smoke infra paths change). Uses the same Smart E2E Selection tags as Detox/Appium Android — it does not bypass path filters, build gates, or AI tag selection. Remove `pr-not-ready-for-e2e` when the PR is ready for E2E validation. Adding or removing this label re-triggers CI. Not honored on fork PRs.
+- **run-appium-ios-tests**: Also runs Appium iOS smoke tests on a PR targeting `main` or `release/*` (normally iOS is skipped, or it runs automatically when `tests/smoke-appium/**` / shared smoke infra paths change). Uses the same Smart E2E Selection tags as Appium Android — it does not bypass path filters or build gates, and it is ignored for synchronization PRs targeting `stable`. Pushes to `main` and `release/*` run iOS automatically with the full `ALL` tag set. Remove `pr-not-ready-for-e2e` when the PR is ready for E2E validation. Adding or removing this label re-triggers CI. Not honored on fork PRs.
 
 ### Block merge if any is present
 

--- a/.github/scripts/compute-e2e-platform-flags.cjs
+++ b/.github/scripts/compute-e2e-platform-flags.cjs
@@ -9,6 +9,7 @@
 function computeE2EPlatformFlags(input) {
   const {
     githubEventName,
+    prBaseRef = '',
     isFork,
     shouldSkipE2E,
     allChangesCount,
@@ -40,8 +41,14 @@ function computeE2EPlatformFlags(input) {
     e2eTestFilesCount > 0 &&
     e2eWorkflowsCount === 0;
 
-  if (githubEventName === 'schedule' || githubEventName === 'push') {
-    message = 'E2E for both platforms (scheduled or push to main)';
+  const isStableTarget =
+    githubEventName === 'pull_request' && prBaseRef === 'stable';
+
+  if (isStableTarget) {
+    message = 'Skipping E2E (stable branch synchronization PR)';
+  } else if (githubEventName === 'schedule' || githubEventName === 'push') {
+    message =
+      'E2E for both platforms (scheduled or push to main/release/*)';
     android = true;
     ios = true;
   } else if (githubEventName === 'merge_group') {

--- a/.github/scripts/compute-e2e-platform-flags.test.ts
+++ b/.github/scripts/compute-e2e-platform-flags.test.ts
@@ -68,4 +68,57 @@ describe('computeE2EPlatformFlags', () => {
 
     expect(result.nativeBuildNeeded).toBe(true);
   });
+
+  it('runs Smart E2E selection for cherry-pick PRs targeting release/*', () => {
+    const result = computeE2EPlatformFlags({
+      ...baseInput,
+      prBaseRef: 'release/1.0.0',
+    });
+
+    expect(result.runSmartE2ESelection).toBe(true);
+  });
+
+  it('keeps Android-only path selection for release cherry-pick PRs', () => {
+    const result = computeE2EPlatformFlags({
+      ...baseInput,
+      prBaseRef: 'release/1.0.0',
+      e2eTestFilesCount: 0,
+      e2eTestOrIgnorableCount: 0,
+      androidCount: 1,
+      androidOrIgnorableCount: 1,
+    });
+
+    expect(result.android).toBe(true);
+    expect(result.ios).toBe(false);
+    expect(result.runSmartE2ESelection).toBe(true);
+  });
+
+  it('skips all E2E for PRs synchronizing release/* into stable', () => {
+    const result = computeE2EPlatformFlags({
+      ...baseInput,
+      prBaseRef: 'stable',
+    });
+
+    expect(result).toMatchObject({
+      android: false,
+      ios: false,
+      e2eNeeded: false,
+      nativeBuildNeeded: false,
+      runSmartE2ESelection: false,
+      message: 'Skipping E2E (stable branch synchronization PR)',
+    });
+  });
+
+  it('runs both platforms on pushes to main and release/*', () => {
+    const result = computeE2EPlatformFlags({
+      ...baseInput,
+      githubEventName: 'push',
+    });
+
+    expect(result.android).toBe(true);
+    expect(result.ios).toBe(true);
+    expect(result.e2eNeeded).toBe(true);
+    expect(result.message).toContain('push to main/release/*');
+    expect(result.runSmartE2ESelection).toBe(false);
+  });
 });

--- a/.github/scripts/run-compute-e2e-platform-flags.cjs
+++ b/.github/scripts/run-compute-e2e-platform-flags.cjs
@@ -34,6 +34,7 @@ const ignorableOnly =
 
 const flags = computeE2EPlatformFlags({
   githubEventName: process.env.GITHUB_EVENT_NAME || '',
+  prBaseRef: process.env.PR_BASE_REF || '',
   isFork: readBool(process.env.IS_FORK),
   shouldSkipE2E: readBool(process.env.SHOULD_SKIP_E2E),
   allChangesCount,
@@ -51,6 +52,7 @@ const flags = computeE2EPlatformFlags({
 let runAppiumIos = false;
 if (
   process.env.GITHUB_EVENT_NAME === 'pull_request' &&
+  process.env.PR_BASE_REF !== 'stable' &&
   !readBool(process.env.IS_FORK)
 ) {
   if (readBool(process.env.RUN_APPIUM_IOS_LABEL)) {
@@ -78,6 +80,7 @@ if (readBool(process.env.LABEL_BLOCKS_MERGE) && !ignorableOnly) {
 let runPerformance = false;
 if (
   process.env.GITHUB_EVENT_NAME === 'pull_request' &&
+  process.env.PR_BASE_REF !== 'stable' &&
   !readBool(process.env.IS_FORK) &&
   readBool(process.env.RUN_PERFORMANCE_LABEL)
 ) {

--- a/.github/workflows/ci-namespace-shadow.yml
+++ b/.github/workflows/ci-namespace-shadow.yml
@@ -39,7 +39,7 @@ on:
       - "**/*.md"
       - ".github/CODEOWNERS"
   push:
-    branches: [main]
+    branches: [main, 'release/*']
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-namespace-shadow.yml
+++ b/.github/workflows/ci-namespace-shadow.yml
@@ -31,6 +31,9 @@ name: CI (Namespace shadow)
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+    # Stable sync PRs are release-only; do not dispatch advisory shadow CI.
+    branches-ignore:
+      - stable
     paths-ignore:
       - "docs/**"
       - "**/*.md"

--- a/.github/workflows/ci-namespace-shadow.yml
+++ b/.github/workflows/ci-namespace-shadow.yml
@@ -39,7 +39,7 @@ on:
       - "**/*.md"
       - ".github/CODEOWNERS"
   push:
-    branches: [main, 'release/*']
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ run-name: >-
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/*']
   pull_request:
     types:
       - opened
@@ -1427,7 +1427,7 @@ jobs:
 
   appium-smoke-tests-ios:
     name: 'Appium Smoke Tests (iOS)'
-    # Main push/schedule: always run when the iOS build succeeded.
+    # Main/release push and main schedule: always run when the iOS build succeeded.
     # PRs: skipped by default; add run-appium-ios-tests, or change
     # page-objects/selectors/locators/framework/smoke-appium
     # (same smart-selected tags as other E2E jobs).
@@ -1437,8 +1437,15 @@ jobs:
         needs.ios-tests-ready.result == 'success' &&
         (
           (
+            github.event_name == 'push' &&
+            (
+              github.ref == 'refs/heads/main' ||
+              startsWith(github.ref, 'refs/heads/release/')
+            )
+          ) ||
+          (
             github.ref == 'refs/heads/main' &&
-            (github.event_name == 'push' || github.event_name == 'schedule')
+            github.event_name == 'schedule'
           ) ||
           (
             github.event_name == 'pull_request' &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
       - opened
       - reopened
       - synchronize
+    branches-ignore:
+      - stable
   merge_group:
   schedule:
     # Run the full suite "overnight," once every hour from 2:00am UTC until 6:00am UTC.

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -24,13 +24,13 @@ on:
         description: 'Whether merge should be blocked for E2E readiness. True when "pr-not-ready-for-e2e" label is applied AND changes are not ignorable-only (i.e. E2E is actually relevant). Ignorable-only PRs (docs, assets, configs, test files) bypass the block automatically.'
         value: ${{ jobs.detect-changes.outputs.block_merge_for_e2e_readiness }}
       run_smart_e2e_selection:
-        description: 'Whether the smart-e2e-selection job should run. False for non-PR events, forks, or hard E2E skips.'
+        description: 'Whether the smart-e2e-selection job should run. False for non-PR events, forks, stable-target synchronization PRs, or hard E2E skips.'
         value: ${{ jobs.detect-changes.outputs.run_smart_e2e_selection }}
       run_performance:
         description: 'Whether performance E2E tests should be forced to run via the run-performance-tests PR label'
         value: ${{ jobs.detect-changes.outputs.run_performance }}
       run_appium_ios:
-        description: 'Whether Appium iOS smoke tests should also run on a PR via the run-appium-ios-tests label or e2e smoke infra / smoke-appium file changes'
+        description: 'Whether Appium iOS smoke tests should also run on an eligible PR via the run-appium-ios-tests label or e2e smoke infra / smoke-appium file changes'
         value: ${{ jobs.detect-changes.outputs.run_appium_ios }}
       native_build_needed:
         description: 'Whether fresh iOS/Android native E2E builds are required. False when only E2E/performance test files changed — CI reuses main branch builds instead.'
@@ -150,6 +150,7 @@ jobs:
         if: steps.skip-merge-queue.outputs.up-to-date != 'true'
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
           IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
           SHOULD_SKIP_E2E: ${{ steps.skip-e2e-tag.outputs.SKIP == 'true' || steps.check-labels.outputs.SKIP_E2E == 'true' }}
           LABEL_BLOCKS_MERGE: ${{ steps.check-labels.outputs.LABEL_BLOCKS_MERGE }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

- Enable Smart E2E selection for cherry-pick PRs targeting RC branches, i.e. `release/*` branches.
- Run full Android and iOS E2E on pushes to `release/*` branches.
- Skip all E2E for synchronization PRs targeting stable (PR from `release/*` -> `stable`).
- Keep iOS PR E2E runs on demand through the existing label `run-appium-ios-tests`.
- Update E2E decision-tree and labeling documentation.


<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MCRM-137

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when Android/iOS E2E and AI tag selection run on release and stable workflows—wrong gating could skip needed tests on RC PRs or overload CI on release pushes.
> 
> **Overview**
> **Reworks release-branch E2E policy** so cherry-pick PRs into `release/*` use **Smart AI E2E selection** (Android-first, iOS via label/infra paths) instead of always running the full suite. The composite `smart-e2e-selection` action drops the step that forced full E2E when the PR base was `release/*` or `stable`.
> 
> **Pushes and schedules** now treat `release/*` like `main` for breadth: `ci.yml` runs on push to `release/*`, Appium iOS smoke runs on push to `main` or `release/*`, and platform flags document full Android+iOS for scheduled/push events.
> 
> **PRs targeting `stable`** (release → stable sync) skip E2E entirely: `compute-e2e-platform-flags` takes `prBaseRef`, `get-requirements` passes the PR base, `ci.yml` ignores PRs to `stable`, and Appium iOS / forced performance labels are ignored for those PRs. Namespace shadow CI also ignores PRs to `stable`.
> 
> Guidelines (`E2E_DECISION_TREE`, `LABELING_GUIDELINES`) and unit tests for the new branches are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25e4d3bcdfb6376b355c2bd315de389650eb8bd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->