### PR TITLE
refactor: rename Perpetuals to Perps across components and tests and update balance breakdown component cp-8.7.0

### DIFF
--- a/app/components/UI/Bridge/components/PostTradeBottomSheet/usePostTradeTrendingTokens.test.ts
+++ b/app/components/UI/Bridge/components/PostTradeBottomSheet/usePostTradeTrendingTokens.test.ts
@@ -1,5 +1,10 @@
 import React from 'react';
-import { act, renderHook, waitFor } from '@testing-library/react-native';
+import {
+  act,
+  cleanup,
+  renderHook,
+  waitFor,
+} from '@testing-library/react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   getTrendingTokens,
@@ -24,6 +29,7 @@ jest.mock('../../../../../selectors/currencyRateController', () => ({
 }));
 
 const mockGetTrendingTokens = jest.mocked(getTrendingTokens);
+const queryClients = new Set<QueryClient>();
 
 const createWrapper = () => {
   const queryClient = new QueryClient({
@@ -34,6 +40,7 @@ const createWrapper = () => {
       error: () => undefined,
     },
   });
+  queryClients.add(queryClient);
 
   const Wrapper = ({ children }: { children: React.ReactNode }) =>
     React.createElement(QueryClientProvider, { client: queryClient }, children);
@@ -71,6 +78,15 @@ describe('usePostTradeTrendingTokens', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetTrendingTokens.mockResolvedValue([]);
+  });
+
+  afterEach(async () => {
+    cleanup();
+    await Promise.all(
+      Array.from(queryClients, (queryClient) => queryClient.cancelQueries()),
+    );
+    queryClients.forEach((queryClient) => queryClient.clear());
+    queryClients.clear();
   });
 
   it('fetches, sorts by market cap descending, and caps results', async () => {

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -354,7 +354,7 @@ describe('PerpsSection', () => {
       <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
     );
 
-    expect(screen.getByText('Perpetuals')).toBeOnTheScreen();
+    expect(screen.getByText('Perps')).toBeOnTheScreen();
   });
 
   it('renders live positions with leverage info', () => {
@@ -440,7 +440,7 @@ describe('PerpsSection', () => {
       <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
     );
 
-    fireEvent.press(screen.getByText('Perpetuals'));
+    fireEvent.press(screen.getByText('Perps'));
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.ROOT, {
       screen: Routes.PERPS.PERPS_HOME,
@@ -467,7 +467,7 @@ describe('PerpsSection', () => {
       mockUseHomepagePerpsPillsEmptyTransactionActiveAbTestsHook,
     ).toHaveBeenCalledWith(false);
 
-    fireEvent.press(screen.getByText('Perpetuals'));
+    fireEvent.press(screen.getByText('Perps'));
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.ROOT, {
       screen: Routes.PERPS.PERPS_HOME,
@@ -972,7 +972,7 @@ describe('PerpsSection', () => {
         />,
       );
 
-      expect(screen.getByText('Perpetuals')).toBeOnTheScreen();
+      expect(screen.getByText('Perps')).toBeOnTheScreen();
       expect(screen.queryByText('Perps movers')).toBeNull();
       expect(usePerpsMarkets).toHaveBeenCalledWith(
         expect.objectContaining({ skipInitialFetch: false }),
@@ -1204,7 +1204,7 @@ describe('PerpsSection', () => {
         />,
       );
 
-      expect(screen.getByText('Perpetuals')).toBeOnTheScreen();
+      expect(screen.getByText('Perps')).toBeOnTheScreen();
       expect(screen.queryByText('Perps movers')).toBeNull();
       expect(screen.getByTestId('homepage-perps-positions')).toBeOnTheScreen();
     });
@@ -1579,8 +1579,8 @@ describe('PerpsSection', () => {
         <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
       );
 
-      expect(screen.getByText('Perpetuals')).toBeOnTheScreen();
-      expect(screen.getByText('Unable to load perpetuals')).toBeOnTheScreen();
+      expect(screen.getByText('Perps')).toBeOnTheScreen();
+      expect(screen.getByText('Unable to load perps')).toBeOnTheScreen();
       expect(screen.getByText('Retry')).toBeOnTheScreen();
     });
 
@@ -1684,7 +1684,7 @@ describe('PerpsSection', () => {
         <PerpsSection sectionIndex={0} totalSectionsLoaded={1} />,
       );
 
-      fireEvent.press(screen.getByText('Perpetuals'));
+      fireEvent.press(screen.getByText('Perps'));
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.TUTORIAL, {
         source: 'home_section',

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
@@ -60,7 +60,7 @@ import { usePerpsFeed } from '../../../TrendingView/feeds/perps/usePerpsFeed';
 import { HOMEPAGE_THROTTLE_MS, MAX_ITEMS } from './constants';
 
 /**
- * PerpsSection — single "Perpetuals" section on the homepage.
+ * PerpsSection — single "Perps" section on the homepage.
  *
  * Shows open positions + limit orders when the user has any,
  * otherwise shows the configured empty state content.
@@ -78,7 +78,7 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
     ref,
   ) => {
     const sectionViewRef = useRef<View>(null);
-    const baseTitle = strings('homepage.sections.perpetuals');
+    const baseTitle = strings('homepage.sections.perps');
     const usesPillsEmptyState = emptyStateContent === 'pills';
     const { error: connectionError, reconnectWithNewContext } =
       usePerpsConnection();

--- a/app/components/Views/Homepage/components/HomepageBalanceBreakdown/HomepageBalanceBreakdown.test.tsx
+++ b/app/components/Views/Homepage/components/HomepageBalanceBreakdown/HomepageBalanceBreakdown.test.tsx
@@ -232,6 +232,17 @@ describe('HomepageBalanceBreakdown', () => {
       getByTestId(HomepageBalanceBreakdownTestIds.ROW('tokens')).props
         .accessibilityLabel,
     ).toBe('Tokens, USD 20.00, 20%');
+    expect(
+      getByTestId(HomepageBalanceBreakdownTestIds.ROW('tokens')),
+    ).toHaveStyle({
+      minHeight: 40,
+      paddingBottom: 0,
+      paddingTop: 0,
+    });
+    expect(
+      getByTestId(HomepageBalanceBreakdownTestIds.ROW('perps')).props
+        .accessibilityLabel,
+    ).toBe('Perps, USD 10.00, 20%');
   });
 
   it('localizes allocation percentages and APY numbers', () => {
@@ -417,6 +428,30 @@ describe('HomepageBalanceBreakdown', () => {
     expect(
       getByTestId(HomepageBalanceBreakdownTestIds.PERCENTAGE('tokens')),
     ).toHaveTextContent('<1%');
+  });
+
+  it('renders less than zero for a positive fiat value that rounds to zero', () => {
+    jest.mocked(useBalanceBreakdown).mockReturnValue({
+      ...breakdown,
+      slices: {
+        ...breakdown.slices,
+        tokens: makeSlice('tokens', {
+          valueFiat: 0.001,
+        }),
+      },
+    });
+
+    const { getByTestId } = render(
+      <HomepageBalanceBreakdown layout="allocation" />,
+    );
+
+    expect(
+      getByTestId(HomepageBalanceBreakdownTestIds.VALUE('tokens')),
+    ).toHaveTextContent('<USD 0.00');
+    expect(
+      getByTestId(HomepageBalanceBreakdownTestIds.ROW('tokens')).props
+        .accessibilityLabel,
+    ).toContain('<USD 0.00');
   });
 
   it('renders the Money APY loading slot', () => {

--- a/app/components/Views/Homepage/components/HomepageBalanceBreakdown/HomepageBalanceBreakdown.tsx
+++ b/app/components/Views/Homepage/components/HomepageBalanceBreakdown/HomepageBalanceBreakdown.tsx
@@ -43,7 +43,7 @@ const HomepageBalanceBreakdown = ({
       {!hideRows ? (
         <Box
           testID={HomepageBalanceBreakdownTestIds.ROWS}
-          twClassName="mt-3 px-4 pt-2"
+          twClassName="mt-3 pt-2"
         >
           {layout === 'allocation' ? (
             <HomepageBalanceBreakdownAllocationBar slices={slices} />

--- a/app/components/Views/Homepage/components/HomepageBalanceBreakdown/HomepageBalanceBreakdownAllocationBar.tsx
+++ b/app/components/Views/Homepage/components/HomepageBalanceBreakdown/HomepageBalanceBreakdownAllocationBar.tsx
@@ -31,7 +31,7 @@ const HomepageBalanceBreakdownAllocationBar = ({
   const privacyMode = useSelector(selectPrivacyMode);
 
   return (
-    <Box twClassName="mb-2 gap-3 pt-1">
+    <Box twClassName="mx-4 mb-2 gap-3 pt-1">
       <Text
         testID={HomepageBalanceBreakdownTestIds.ALLOCATION_TITLE}
         variant={TextVariant.HeadingMd}

--- a/app/components/Views/Homepage/components/HomepageBalanceBreakdown/HomepageBalanceBreakdownRow.tsx
+++ b/app/components/Views/Homepage/components/HomepageBalanceBreakdown/HomepageBalanceBreakdownRow.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Pressable, View, type ViewStyle } from 'react-native';
+import { View, type ViewStyle } from 'react-native';
 import { useSelector } from 'react-redux';
 import {
   Box,
@@ -10,13 +10,14 @@ import {
   Icon,
   IconColor,
   IconSize,
+  ListItem,
+  ListItemVariant,
   SensitiveText,
   SensitiveTextLength,
   Text,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import I18n, { strings } from '../../../../../../locales/i18n';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
@@ -36,6 +37,13 @@ const getAllocationColorStyle = (slice: SliceData): ViewStyle => ({
   backgroundColor: slice.color,
 });
 
+const allocationDotStyle: ViewStyle = {
+  width: 8,
+  height: 8,
+  borderRadius: 999,
+  marginRight: 4,
+};
+
 export interface HomepageBalanceBreakdownRowProps {
   slice: SliceData;
   userCurrency: string;
@@ -49,7 +57,6 @@ const HomepageBalanceBreakdownRow = ({
   onPress,
   layout,
 }: HomepageBalanceBreakdownRowProps) => {
-  const tw = useTailwind();
   const privacyMode = useSelector(selectPrivacyMode);
   const { formatCurrency } = useFormatters();
   const isLoading = slice.status === 'loading';
@@ -60,10 +67,14 @@ const HomepageBalanceBreakdownRow = ({
           style: 'percent',
           maximumFractionDigits: 0,
         });
+  const formattedValue = formatCurrency(slice.valueFiat, userCurrency);
+  const zeroValue = formatCurrency(0, userCurrency);
   const displayValue =
     slice.status === 'error' || slice.status === 'ineligible'
       ? '—'
-      : formatCurrency(slice.valueFiat, userCurrency);
+      : slice.valueFiat > 0 && formattedValue === zeroValue
+        ? `<${formattedValue}`
+        : formattedValue;
   const valueColor =
     slice.status === 'ready' && slice.valueFiat === 0
       ? TextColor.TextAlternative
@@ -94,139 +105,133 @@ const HomepageBalanceBreakdownRow = ({
   const iconName = SLICE_ICONS[slice.key];
   const iconSymbol = SLICE_ICON_SYMBOLS[slice.key];
 
-  return (
-    <Pressable
-      accessibilityLabel={accessibilityLabel}
-      accessibilityRole="button"
-      onPress={onPress}
-      testID={HomepageBalanceBreakdownTestIds.ROW(slice.key)}
-      style={({ pressed }) =>
-        tw.style('flex-row items-center', 'min-h-10', pressed && 'opacity-80')
-      }
+  const avatar = showIcon ? (
+    <Box
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Center}
+      twClassName="h-8 w-8 rounded-full bg-muted"
     >
-      {showIcon ? (
-        <Box
-          alignItems={BoxAlignItems.Center}
-          justifyContent={BoxJustifyContent.Center}
-          twClassName="h-8 w-8 rounded-full bg-muted"
+      {iconName ? (
+        <Icon
+          color={IconColor.IconDefault}
+          name={iconName}
+          size={IconSize.Md}
+          testID={HomepageBalanceBreakdownTestIds.ICON(slice.key)}
+        />
+      ) : (
+        <Text
+          color={TextColor.TextDefault}
+          fontWeight={FontWeight.Medium}
+          testID={HomepageBalanceBreakdownTestIds.ICON(slice.key)}
+          variant={TextVariant.HeadingSm}
         >
-          {iconName ? (
-            <Icon
-              color={IconColor.IconDefault}
-              name={iconName}
-              size={IconSize.Md}
-              testID={HomepageBalanceBreakdownTestIds.ICON(slice.key)}
-            />
-          ) : (
+          {iconSymbol}
+        </Text>
+      )}
+    </Box>
+  ) : undefined;
+
+  const title = (
+    <Box
+      alignItems={BoxAlignItems.Center}
+      flexDirection={BoxFlexDirection.Row}
+      twClassName="min-w-0 flex-1"
+      gap={2}
+    >
+      <Box
+        alignItems={BoxAlignItems.Center}
+        flexDirection={BoxFlexDirection.Row}
+        twClassName="min-w-0 shrink"
+        gap={1}
+      >
+        {showAllocationDot ? (
+          <View
+            testID={HomepageBalanceBreakdownTestIds.DOT(slice.key)}
+            style={[allocationDotStyle, getAllocationColorStyle(slice)]}
+          />
+        ) : null}
+        <Text
+          color={TextColor.TextDefault}
+          fontWeight={FontWeight.Medium}
+          numberOfLines={1}
+          twClassName="shrink"
+          variant={TextVariant.BodyMd}
+        >
+          {getSliceLabel(slice.key)}
+        </Text>
+        {percentageLabel ? (
+          <>
             <Text
-              color={TextColor.TextDefault}
-              fontWeight={FontWeight.Medium}
-              testID={HomepageBalanceBreakdownTestIds.ICON(slice.key)}
-              variant={TextVariant.HeadingSm}
-            >
-              {iconSymbol}
-            </Text>
-          )}
-        </Box>
-      ) : null}
-      <Box twClassName={showIcon ? 'ml-3 min-w-0 flex-1' : 'min-w-0 flex-1'}>
-        <Box
-          alignItems={BoxAlignItems.Center}
-          flexDirection={BoxFlexDirection.Row}
-          justifyContent={BoxJustifyContent.Between}
-          gap={3}
-        >
-          <Box
-            alignItems={BoxAlignItems.Center}
-            flexDirection={BoxFlexDirection.Row}
-            twClassName="min-w-0 flex-1"
-            gap={2}
-          >
-            <Box
-              alignItems={BoxAlignItems.Center}
-              flexDirection={BoxFlexDirection.Row}
-              twClassName="min-w-0 shrink"
-              gap={1}
-            >
-              {showAllocationDot ? (
-                <View
-                  testID={HomepageBalanceBreakdownTestIds.DOT(slice.key)}
-                  style={[
-                    tw.style('h-2 w-2 rounded-full mr-1'),
-                    getAllocationColorStyle(slice),
-                  ]}
-                />
-              ) : null}
-              <Text
-                color={TextColor.TextDefault}
-                fontWeight={FontWeight.Medium}
-                numberOfLines={1}
-                twClassName="shrink"
-                variant={TextVariant.BodyMd}
-              >
-                {getSliceLabel(slice.key)}
-              </Text>
-              {percentageLabel ? (
-                <>
-                  <Text
-                    color={TextColor.TextAlternative}
-                    variant={TextVariant.BodyMd}
-                  >
-                    •
-                  </Text>
-                  <SensitiveText
-                    color={TextColor.TextAlternative}
-                    isHidden={privacyMode}
-                    length={SensitiveTextLength.Short}
-                    testID={HomepageBalanceBreakdownTestIds.PERCENTAGE(
-                      slice.key,
-                    )}
-                    variant={TextVariant.BodyMd}
-                  >
-                    {percentageLabel}
-                  </SensitiveText>
-                </>
-              ) : null}
-            </Box>
-            {slice.key === 'money' && slice.apyLoading ? (
-              <Skeleton
-                height={20}
-                testID={HomepageBalanceBreakdownTestIds.APY_SKELETON}
-                twClassName="shrink-0"
-                width={60}
-              />
-            ) : moneyApy !== undefined ? (
-              <Box
-                testID={HomepageBalanceBreakdownTestIds.APY}
-                twClassName="shrink-0 rounded-md bg-success-muted px-1.5 py-0.5"
-              >
-                <Text
-                  color={TextColor.SuccessDefault}
-                  fontWeight={FontWeight.Medium}
-                  variant={TextVariant.BodySm}
-                >
-                  {apyLabel}
-                </Text>
-              </Box>
-            ) : null}
-          </Box>
-          <Skeleton
-            hideChildren={isLoading}
-            testID={HomepageBalanceBreakdownTestIds.SKELETON(slice.key)}
-          >
-            <SensitiveText
-              color={valueColor}
-              isHidden={privacyMode}
-              length={SensitiveTextLength.Medium}
-              testID={HomepageBalanceBreakdownTestIds.VALUE(slice.key)}
+              color={TextColor.TextAlternative}
               variant={TextVariant.BodyMd}
             >
-              {displayValue}
+              •
+            </Text>
+            <SensitiveText
+              color={TextColor.TextAlternative}
+              isHidden={privacyMode}
+              length={SensitiveTextLength.Short}
+              testID={HomepageBalanceBreakdownTestIds.PERCENTAGE(slice.key)}
+              variant={TextVariant.BodyMd}
+            >
+              {percentageLabel}
             </SensitiveText>
-          </Skeleton>
-        </Box>
+          </>
+        ) : null}
       </Box>
-    </Pressable>
+      {slice.key === 'money' && slice.apyLoading ? (
+        <Skeleton
+          height={20}
+          testID={HomepageBalanceBreakdownTestIds.APY_SKELETON}
+          twClassName="shrink-0"
+          width={60}
+        />
+      ) : moneyApy !== undefined ? (
+        <Box
+          testID={HomepageBalanceBreakdownTestIds.APY}
+          twClassName="shrink-0 rounded-md bg-success-muted px-1.5 py-0.5"
+        >
+          <Text
+            color={TextColor.SuccessDefault}
+            fontWeight={FontWeight.Medium}
+            variant={TextVariant.BodySm}
+          >
+            {apyLabel}
+          </Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+
+  const value = (
+    <Skeleton
+      hideChildren={isLoading}
+      testID={HomepageBalanceBreakdownTestIds.SKELETON(slice.key)}
+    >
+      <SensitiveText
+        color={valueColor}
+        isHidden={privacyMode}
+        length={SensitiveTextLength.Medium}
+        testID={HomepageBalanceBreakdownTestIds.VALUE(slice.key)}
+        variant={TextVariant.BodyMd}
+      >
+        {displayValue}
+      </SensitiveText>
+    </Skeleton>
+  );
+
+  return (
+    <ListItem
+      accessibilityLabel={accessibilityLabel}
+      avatar={avatar}
+      isInteractive
+      onPress={onPress}
+      testID={HomepageBalanceBreakdownTestIds.ROW(slice.key)}
+      title={title}
+      twClassName="min-h-10 py-0"
+      value={value}
+      variant={ListItemVariant.OneLine}
+    />
   );
 };
 

--- a/app/components/Views/Homepage/components/HomepageBalanceBreakdown/homepageBalanceBreakdown.constants.ts
+++ b/app/components/Views/Homepage/components/HomepageBalanceBreakdown/homepageBalanceBreakdown.constants.ts
@@ -16,7 +16,7 @@ export const SLICE_ICON_SYMBOLS: Partial<Record<SliceKey, string>> = {
 const SLICE_LABEL_KEYS = {
   money: 'homepage.sections.money',
   tokens: 'homepage.sections.tokens',
-  perps: 'homepage.sections.perpetuals',
+  perps: 'homepage.sections.perps',
   predict: 'homepage.sections.predictions',
   defi: 'homepage.sections.defi',
 } as const;

--- a/app/components/Views/Homepage/components/HomepageDiscoveryPills/HomepageDiscoveryPills.test.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryPills/HomepageDiscoveryPills.test.tsx
@@ -89,7 +89,9 @@ describe('HomepageDiscoveryPills', () => {
   });
 
   it('renders enabled discovery pills', () => {
-    const { getByTestId } = render(<HomepageDiscoveryPills iconStyle="gray" />);
+    const { getByLabelText, getByTestId } = render(
+      <HomepageDiscoveryPills iconStyle="gray" />,
+    );
 
     expect(
       getByTestId(HomepageDiscoveryPillsTestIds.CONTAINER),
@@ -106,6 +108,7 @@ describe('HomepageDiscoveryPills', () => {
     expect(
       getByTestId(HomepageDiscoveryPillsTestIds.pill('stocks')),
     ).toBeOnTheScreen();
+    expect(getByLabelText('Perps')).toBeOnTheScreen();
   });
 
   it('omits perps pill when perps flag is disabled', () => {

--- a/app/components/Views/Homepage/components/HomepageDiscoveryPills/HomepageDiscoveryPills.tsx
+++ b/app/components/Views/Homepage/components/HomepageDiscoveryPills/HomepageDiscoveryPills.tsx
@@ -28,12 +28,12 @@ import { useHomepageDiscoveryPillsNavigation } from './useHomepageDiscoveryPills
 
 const PILL_LABEL_KEYS: Record<
   HomepageDiscoveryPillId,
-  | 'homepage.sections.perpetuals'
+  | 'homepage.sections.perps'
   | 'homepage.sections.predictions'
   | 'trending.stocks'
   | 'trending.crypto'
 > = {
-  perpetuals: 'homepage.sections.perpetuals',
+  perpetuals: 'homepage.sections.perps',
   predictions: 'homepage.sections.predictions',
   stocks: 'trending.stocks',
   crypto: 'trending.crypto',

--- a/app/components/Views/Wallet/WalletView.testIds.ts
+++ b/app/components/Views/Wallet/WalletView.testIds.ts
@@ -128,7 +128,7 @@ export const WalletViewSelectorsText = {
   DEFI_TAB: enContent.wallet.defi,
   PREDICTIONS_TAB: enContent.wallet.predict,
   AVAILABLE_BALANCE: enContent.predict.available_balance,
-  PERPETUALS_SECTION: enContent.homepage.sections.perpetuals,
+  PERPETUALS_SECTION: enContent.homepage.sections.perps,
   TOKENS_SECTION: enContent.homepage.sections.tokens,
   DEFI_SECTION: enContent.homepage.sections.defi,
   NFTS_SECTION: enContent.homepage.sections.nfts,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Updates the Homepage balance breakdown presentation and Perps branding:

- Displays positive fiat balances that round to zero as `<$0.00` instead of `$0.00`, while exact zero remains unchanged.
- Replaces user-facing `Perpetuals` labels on the Homepage with the branded `Perps` name across the section header, discovery pill, balance row, error state, accessibility labels, and test selectors.
- Refactors balance breakdown rows to the MMDS `ListItem` OneLine variant with `isInteractive`, using the standard `bg-pressed` interaction state.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated the Homepage balance breakdown formatting, interaction state, and Perps branding

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
https://consensyssoftware.atlassian.net/browse/TMCU-1247
https://consensyssoftware.atlassian.net/browse/TMCU-1252
https://consensyssoftware.atlassian.net/browse/TMCU-1250

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Homepage balance breakdown presentation

  Scenario: Display a positive fiat balance that rounds to zero
    Given the Homepage balance breakdown is visible
    And a balance category has a fiat value greater than zero but below the displayed precision

    When the balance category is rendered
    Then its fiat value is displayed with a leading less-than sign
    And an exact zero balance is still displayed without a less-than sign

  Scenario: Use consistent Perps branding
    Given Perps is enabled

    When the Homepage is displayed
    Then the balance breakdown row is labeled "Perps"
    And the Perps section header is labeled "Perps"
    And the Perps discovery pill is labeled "Perps"
    And the Perps error state uses the "Perps" name

  Scenario: Press a balance breakdown row
    Given the Homepage balance breakdown is visible

    When a user presses a balance breakdown row
    Then the row uses the MMDS pressed background
    And selecting the row opens its existing destination
    And the row retains its previous 40px height and vertical spacing
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="377" height="551" alt="Screenshot 2026-08-10 at 13 31 54" src="https://github.com/user-attachments/assets/41d6d5dc-8613-4df1-aaba-ee823f898a1a" />

<!-- [screenshots/recordings] -->

### **After**
<img width="368" height="576" alt="Screenshot 2026-08-10 at 13 11 44" src="https://github.com/user-attachments/assets/846b80b9-6433-436b-9b12-17238f69a3c3" />

https://github.com/user-attachments/assets/b2c7eed0-c2e7-4b99-86c4-9db5efa23719


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Homepage UI, copy, and display formatting only; navigation and slice behavior are unchanged aside from row interaction styling.
> 
> **Overview**
> **Homepage balance breakdown** rows are rebuilt on the MMDS **`ListItem`** OneLine variant with **`isInteractive`** (replacing custom **`Pressable`** styling), and row container padding is adjusted so the allocation bar keeps horizontal inset via **`mx-4`**.
> 
> Positive fiat amounts that **round to zero** in the user’s currency now render as **`<{formattedValue}`** (exact zero is unchanged), with matching accessibility labels and tests.
> 
> User-facing **“Perpetuals”** strings on the homepage move to the **`homepage.sections.perps`** copy for the Perps section title, discovery pill, balance slice label, and related error/test expectations.
> 
> **`usePostTradeTrendingTokens`** tests register each **`QueryClient`**, run **`cleanup`**, cancel queries, and clear clients in **`afterEach`** to avoid leaky async state between cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df84154104f72d1cf35c3086a7c5386adbafef60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->