### PR TITLE
chore: bump `@metamask/tron-wallet-snap` to `^3.1.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -373,7 +373,7 @@
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/transaction-controller": "^69.5.1",
     "@metamask/transaction-pay-controller": "^26.2.2",
-    "@metamask/tron-wallet-snap": "^1.33.1",
+    "@metamask/tron-wallet-snap": "^3.1.0",
     "@metamask/utils": "^11.11.0",
     "@metamask/wallet": "^8.1.0",
     "@myx-trade/sdk": "^0.1.265",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10597,10 +10597,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/tron-wallet-snap@npm:^1.33.1":
-  version: 1.33.1
-  resolution: "@metamask/tron-wallet-snap@npm:1.33.1"
-  checksum: 10/cd1d5acb6ad4b7753aca0fd78bb2abec2dc1977d6e93fd6512e9536cf6af46ded04e83092b63a13ba6aac91e96b192a38aba959b96d42c025b13d3d7bfab5c79
+"@metamask/tron-wallet-snap@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@metamask/tron-wallet-snap@npm:3.1.0"
+  checksum: 10/9a91bd31746240c0be188b963c9c08749cacff1f0ab9a9b9d93f7e4f47719313f53c7ce953afcaa303cc3d997a8ea3f83f448087a1ddb98f2d2150766533b108
   languageName: node
   linkType: hard
 
@@ -35986,7 +35986,7 @@ __metadata:
     "@metamask/tooling-insight": "npm:^1.0.0"
     "@metamask/transaction-controller": "npm:^69.5.1"
     "@metamask/transaction-pay-controller": "npm:^26.2.2"
-    "@metamask/tron-wallet-snap": "npm:^1.33.1"
+    "@metamask/tron-wallet-snap": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
     "@metamask/wallet": "npm:^8.1.0"
     "@myx-trade/sdk": "npm:^0.1.265"


### PR DESCRIPTION
## Description

Bringing the following changes to the client:

    ## [3.1.0]

    ### Added

    - Add Core messenger plumbing (`coreMessenger`, `RemoteFeatureFlagsProvider`, `AssetsProvider`) for upcoming AssetsController migration ([#95](https://github.com/MetaMask/internal-snaps/pull/95))

    ### Fixed

    - Scope `bip44:discover` activity checks and account creation to the networks declared in the snap manifest, preventing unnecessary calls to testnet APIs during discovery ([#135](https://github.com/MetaMask/internal-snaps/pull/135))

## Changelog

CHANGELOG entry: null

## Related issues

n/a

## Manual testing steps

n/a

## Screenshots/Recordings

### Before

n/a

### After

n/a