### PR TITLE
fix(social): prevent feed audience toggle label clipping

### DIFF
--- a/app/components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.tsx
+++ b/app/components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.tsx
@@ -181,7 +181,7 @@ const FeedAudienceToggle: React.FC<FeedAudienceToggleProps> = ({
   return (
     <Box
       flexDirection={BoxFlexDirection.Row}
-      twClassName="border border-muted rounded-2xl p-1"
+      twClassName="shrink-0 border border-muted rounded-2xl p-1"
       testID={testID}
     >
       <Box flexDirection={BoxFlexDirection.Row} style={styles.row}>


### PR DESCRIPTION
## **Description**

The Following/All audience toggle in the Top Traders feed filter row was truncating the selected option label (e.g. "All" rendered as "Al", "Following" as "Followin"). The toggle sits in a flex row beside the type filter; without `flexShrink: 0`, React Native compressed the toggle to fit available space and clipped text on the right edge.

Added `shrink-0` to the toggle container so it keeps its natural width and labels render fully.

## **Changelog**

CHANGELOG entry: Fixed truncated labels on the Top Traders feed audience toggle

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Feed audience toggle labels

  Scenario: Following and All labels render fully when selected
    Given the user is on the Top Traders screen with the Feed tab selected

    When the user selects the "Following" audience option
    Then the full word "Following" is visible without truncation

    When the user selects the "All" audience option
    Then the full word "All" is visible without truncation
```

## **Screenshots/Recordings**

### **Before**

Labels truncated when selected (e.g. "Al" instead of "All") due to flex compression in the filter row.

<img width="425" height="450" alt="Screenshot 2026-08-10 at 14 18 18" src="https://github.com/user-attachments/assets/389025f8-f702-4f6f-b5b2-2a9c0d97d814" />

### **After**

"All" displays their full labels when selected.

<img width="405" height="414" alt="Screenshot 2026-08-10 at 14 20 00" src="https://github.com/user-attachments/assets/6b540d13-19c9-4d77-9f94-0e58739ad1c7" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class on a social feed UI control; no auth, data, or API changes.
> 
> **Overview**
> Fixes truncated **Following** / **All** labels on the Top Traders feed audience toggle by adding **`shrink-0`** to the outer `FeedAudienceToggle` container so it no longer shrinks in the filter row beside the type filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a65710855ef5a68e978aceae200ce89ba16b1a1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->