### PR TITLE
chore: reduce API calls to gamma API from 8 to 2 on wallet unlock

### DIFF
--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -373,6 +373,44 @@ describe('PredictionsSection', () => {
     expect(screen.getByText('Predictions')).toBeOnTheScreen();
   });
 
+  it('skips trending market fetches for treatment discovery', () => {
+    renderWithProvider(
+      <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
+    );
+
+    expect(mockUsePredictMarketsForHomepage).toHaveBeenCalledWith(5, {
+      enabled: false,
+    });
+    expect(mockUseHomepagePredictMarketSlots).toHaveBeenCalledWith({
+      enabled: true,
+    });
+  });
+
+  it('fetches trending markets for control discovery', () => {
+    mockUseABTest.mockReturnValue({
+      variant: { layout: 'carousel' as const },
+      variantName: 'control',
+      isActive: true,
+    });
+    mockUsePredictMarketsForHomepage.mockReturnValue({
+      markets: [HOMEPAGE_DISCOVERY_EPL_MARKET],
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    renderWithProvider(
+      <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,
+    );
+
+    expect(mockUsePredictMarketsForHomepage).toHaveBeenCalledWith(5, {
+      enabled: true,
+    });
+    expect(mockUseHomepagePredictMarketSlots).toHaveBeenCalledWith({
+      enabled: false,
+    });
+  });
+
   it('navigates with home_section entry_point when trending markets title is pressed', () => {
     renderWithProvider(
       <PredictionsSection sectionIndex={0} totalSectionsLoaded={1} />,

--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.tsx
@@ -287,14 +287,6 @@ const PredictionsSectionDefault = forwardRef<
       hasPositions,
       predictHomepageUnrealizedPnl,
     } = usePredictPositionsSectionData(isPredictEnabled);
-    const {
-      markets,
-      isLoading: isLoadingMarkets,
-      error: marketsError,
-      refetch: refetchMarkets,
-    } = usePredictMarketsForHomepage(MAX_MARKETS_DISPLAYED, {
-      enabled: isPredictEnabled,
-    });
 
     const {
       discoveryLayout,
@@ -303,6 +295,15 @@ const PredictionsSectionDefault = forwardRef<
       predictEmptyStateVariantName,
       isPredictEmptyStateAssignmentActive,
     } = usePredictHomepageDiscoveryExperiment();
+
+    const {
+      markets,
+      isLoading: isLoadingMarkets,
+      error: marketsError,
+      refetch: refetchMarkets,
+    } = usePredictMarketsForHomepage(MAX_MARKETS_DISPLAYED, {
+      enabled: isPredictEnabled && !isTreatmentDiscovery,
+    });
 
     const homepageMarketSlots = useHomepagePredictMarketSlots({
       enabled: isPredictEnabled && isTreatmentDiscovery,

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictMarketsForHomepage.test.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/usePredictMarketsForHomepage.test.ts
@@ -1,29 +1,13 @@
-import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { usePredictMarketData } from '../../../../../UI/Predict/hooks/usePredictMarketData';
 import { usePredictMarketsForHomepage } from './usePredictMarketsForHomepage';
 import type { PredictMarket } from '../../../../../UI/Predict/types';
 
-const mockRefetch = jest.fn().mockResolvedValue(undefined);
-let mockUsePredictMarketDataReturn: {
-  marketData: PredictMarket[];
-  isFetching: boolean;
-  isFetchingMore: boolean;
-  error: string | null;
-  hasMore: boolean;
-  refetch: jest.Mock;
-  fetchMore: jest.Mock;
-} = {
-  marketData: [],
-  isFetching: false,
-  isFetchingMore: false,
-  error: null,
-  hasMore: false,
-  refetch: mockRefetch,
-  fetchMore: jest.fn(),
-};
-
 jest.mock('../../../../../UI/Predict/hooks/usePredictMarketData', () => ({
-  usePredictMarketData: () => mockUsePredictMarketDataReturn,
+  usePredictMarketData: jest.fn(),
 }));
+
+const mockUsePredictMarketData = usePredictMarketData as jest.Mock;
 
 const createMockMarket = (id: string): PredictMarket =>
   ({
@@ -40,9 +24,11 @@ const createMockMarket = (id: string): PredictMarket =>
   }) as unknown as PredictMarket;
 
 describe('usePredictMarketsForHomepage', () => {
+  const mockRefetch = jest.fn().mockResolvedValue(undefined);
+
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUsePredictMarketDataReturn = {
+    mockUsePredictMarketData.mockReturnValue({
       marketData: [
         createMockMarket('1'),
         createMockMarket('2'),
@@ -54,12 +40,17 @@ describe('usePredictMarketsForHomepage', () => {
       hasMore: false,
       refetch: mockRefetch,
       fetchMore: jest.fn(),
-    };
+    });
   });
 
-  it('fetches markets on mount when predict is enabled', async () => {
+  it('fetches trending markets with the requested page size', async () => {
     const { result } = renderHook(() => usePredictMarketsForHomepage(5));
 
+    expect(mockUsePredictMarketData).toHaveBeenCalledWith({
+      category: 'trending',
+      pageSize: 5,
+      enabled: true,
+    });
     await waitFor(() => {
       expect(result.current.markets).toHaveLength(3);
     });
@@ -67,8 +58,26 @@ describe('usePredictMarketsForHomepage', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('forwards enabled: false to usePredictMarketData', () => {
+    renderHook(() => usePredictMarketsForHomepage(5, { enabled: false }));
+
+    expect(mockUsePredictMarketData).toHaveBeenCalledWith({
+      category: 'trending',
+      pageSize: 5,
+      enabled: false,
+    });
+  });
+
   it('forwards isFetching as isLoading', () => {
-    mockUsePredictMarketDataReturn.isFetching = true;
+    mockUsePredictMarketData.mockReturnValue({
+      marketData: [],
+      isFetching: true,
+      isFetchingMore: false,
+      error: null,
+      hasMore: false,
+      refetch: mockRefetch,
+      fetchMore: jest.fn(),
+    });
 
     const { result } = renderHook(() => usePredictMarketsForHomepage(5));
 
@@ -76,7 +85,15 @@ describe('usePredictMarketsForHomepage', () => {
   });
 
   it('forwards error from usePredictMarketData', () => {
-    mockUsePredictMarketDataReturn.error = 'Network error';
+    mockUsePredictMarketData.mockReturnValue({
+      marketData: [],
+      isFetching: false,
+      isFetchingMore: false,
+      error: 'Network error',
+      hasMore: false,
+      refetch: mockRefetch,
+      fetchMore: jest.fn(),
+    });
 
     const { result } = renderHook(() => usePredictMarketsForHomepage(5));
 


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

On wallet unlock, the homepage Predictions section always fetched trending markets from Gamma, even for the treatment discovery layout (championship slots + BTC row), which does not render that trending list.

Gate `usePredictMarketsForHomepage` with `enabled: isPredictEnabled && !isTreatmentDiscovery` so treatment unlocks skip the unused trending request and its follow-on work.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: reduce API calls to gamma API from 8 to 2 on wallet unlock

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3861

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Homepage Predictions discovery fetches

  Scenario: treatment discovery does not fetch trending on unlock
    Given Predict is enabled
    And the user is in the treatment discovery layout
    When the user unlocks the wallet and lands on the homepage
    Then championship slots and the BTC row still load
    And trending Gamma keyset requests are not made for the homepage section

  Scenario: control discovery still fetches trending
    Given Predict is enabled
    And the user is in the control discovery layout
    When the user unlocks the wallet and lands on the homepage
    Then the trending Predictions carousel loads as before
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

https://github.com/user-attachments/assets/b3d0af0d-b247-419c-8751-7fa9837d51fd


### **After**


https://github.com/user-attachments/assets/b07cd493-72ba-48ae-8fc0-8c85c9cea6ba



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to skipping an unused fetch for one AB variant; control path and refresh still call trending refetch.
> 
> **Overview**
> **Skips unused trending Gamma requests** when users see the treatment homepage Predict discovery layout (championship slots + BTC row), cutting redundant API work on wallet unlock (e.g. Gamma calls from 8 → 2 per PR description).
> 
> `PredictionsSection` now calls `usePredictMarketsForHomepage` with `enabled: isPredictEnabled && !isTreatmentDiscovery`, after resolving `usePredictHomepageDiscoveryExperiment()`, so treatment users only load `useHomepagePredictMarketSlots` while **control** (carousel) still fetches trending markets as before.
> 
> Tests assert the treatment vs control `enabled` wiring for both hooks, and `usePredictMarketsForHomepage` tests were tightened to mock `usePredictMarketData` and verify `enabled: false` is forwarded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9783f67b67784f3c1bf169f17fe51d4099cfee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->