### PR TITLE
test: validate check-diff CocoaPods specs cache fix (stacked on #34562)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
   check-diff:
     name: Check diff
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ios-build' || 'macos-latest' }}
+    # TEST-ONLY: no-op comment to force a fresh CI run (including a merge_group run once
+    # queued) to validate the CocoaPods specs cache fix in #34562. Safe to drop on merge.
     # NAMESPACE-SHADOW: macOS job — runs on Namespace shadow only when NAMESPACE_SHADOW_AUTO_DISPATCH=true (iOS pipeline)
     if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && (inputs.runner_provider != 'namespace' || vars.NAMESPACE_SHADOW_AUTO_DISPATCH == 'true') }}
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
     runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-ios-build' || 'macos-latest' }}
     # TEST-ONLY: no-op comment to force a fresh CI run (including a merge_group run once
     # queued) to validate the CocoaPods specs cache fix in #34562. Safe to drop on merge.
+    # Run 2: verifying an actual cache HIT restores quickly (prior runs were cache misses).
     # NAMESPACE-SHADOW: macOS job — runs on Namespace shadow only when NAMESPACE_SHADOW_AUTO_DISPATCH=true (iOS pipeline)
     if: ${{ needs.get_requirements.outputs.skip_everything != 'true' && (inputs.runner_provider != 'namespace' || vars.NAMESPACE_SHADOW_AUTO_DISPATCH == 'true') }}
     needs:


### PR DESCRIPTION
## **Description**

Test PR stacked on top of #34562, opened purely to exercise the `check-diff` CocoaPods specs-cache fix through real CI — both a normal PR run and, once queued/approved, a `merge_group` run — before considering #34562 fully validated.

No functional change: adds a single no-op comment to `.github/workflows/ci.yml` to force a fresh `check-diff` run distinct from #34562's own run.

Things to check once CI runs:
- "Restore CocoaPods specs cache" step stays fast (seconds, not tens of minutes) and only touches `~/.cocoapods/repos`.
- "Check diff" job overall stays well within the new 30-minute timeout, close to the pre-#33442 baseline (~15-25 min).
- Once this PR (or #34562) enters the merge queue, `check-diff` completes normally under `event_name == merge_group` without getting stuck in a re-basing loop.

Safe to close without merging once validated — it exists only to generate CI signal.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A — validation PR for #34562.

## **Manual testing steps**

```gherkin
Feature: Validate check-diff CocoaPods specs cache fix

  Scenario: PR run
    Given this PR is opened against fix/check-diff-cocoapods-specs-cache
    When the "Check diff" job runs
    Then it completes quickly with a small ~/.cocoapods/repos cache restore

  Scenario: Merge queue run
    Given this PR is added to the merge queue
    When the "ci" workflow runs with event_name == merge_group
    Then "Check diff" completes without the ~77-minute cache-restore regression seen in #33442
```

## **Screenshots/Recordings**

N/A — CI validation only, no UI impact.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
