### PR TITLE
feat(card): redesign Set Card PIN with keypad UI

### DIFF
--- a/app/components/UI/Card/Views/SetCardPin/ConfirmCardPin.test.tsx
+++ b/app/components/UI/Card/Views/SetCardPin/ConfirmCardPin.test.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { act, fireEvent, waitFor } from '@testing-library/react-native';
-import { AppState } from 'react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import Routes from '../../../../../constants/navigation/Routes';
+import {
+  CardProviderError,
+  CardProviderErrorCode,
+} from '../../../../../core/Engine/controllers/card-controller/provider-types';
 import { SetCardPinSelectors } from './SetCardPin.testIds';
-import { clearPinDraft, getPinDraft } from './pinDraftStore';
+import { clearPinDraft, setPinDraft } from './pinDraftStore';
 import { PIN_ERROR_RESET_DELAY_MS } from './constants';
 
 const mockNavigate = jest.fn();
@@ -14,14 +17,16 @@ const mockCreateEventBuilder = jest.fn(() => ({
   addProperties: jest.fn().mockReturnThis(),
   build: jest.fn().mockReturnValue({}),
 }));
+const mockSetCardPin = jest.fn();
+const mockLogout = jest.fn();
 
 jest.mock('../../../../../core/Engine', () => ({
   __esModule: true,
   default: {
     context: {
       CardController: {
-        setCardPin: jest.fn(),
-        logout: jest.fn(),
+        setCardPin: (...args: unknown[]) => mockSetCardPin(...args),
+        logout: (...args: unknown[]) => mockLogout(...args),
       },
     },
   },
@@ -45,6 +50,11 @@ jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
     trackEvent: mockTrackEvent,
     createEventBuilder: mockCreateEventBuilder,
   }),
+}));
+
+jest.mock('../../../../../util/Logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn(), log: jest.fn() },
 }));
 
 jest.mock(
@@ -72,7 +82,9 @@ jest.mock('react-native-safe-area-context', () => {
 });
 
 jest.mock('../../hooks/useCardHeaderHandlers', () => ({
-  useCardHeaderHandlers: () => ({ onBack: jest.fn() }),
+  useCardHeaderHandlers: jest.fn((mode: string) =>
+    mode === 'back' ? { onBack: jest.fn() } : {},
+  ),
 }));
 
 jest.mock('../../../../Base/Keypad', () => {
@@ -122,19 +134,6 @@ jest.mock('../../../../Base/Keypad', () => {
           ReactActual.createElement(Text, null, digit),
         ),
       ),
-      ReactActual.createElement(
-        Pressable,
-        {
-          testID: 'keypad-delete-button',
-          onPress: () =>
-            onChange({
-              value: '',
-              valueAsNumber: 0,
-              pressedKey: KeysEnum.Back,
-            }),
-        },
-        ReactActual.createElement(Text, null, 'Del'),
-      ),
     );
 
   return {
@@ -162,7 +161,11 @@ jest.mock('@metamask/design-system-react-native', () => {
     BoxFlexDirection: { Row: 'row' },
     BoxAlignItems: { Center: 'center' },
     BoxJustifyContent: { Center: 'center' },
-    HeaderStandard: () => <View testID="header-standard" />,
+    HeaderStandard: ({ onBack }: { onBack?: () => void }) => (
+      <Pressable testID="confirm-back" onPress={onBack}>
+        <Text>Back</Text>
+      </Pressable>
+    ),
     Button: ({
       children,
       onPress,
@@ -190,7 +193,7 @@ jest.mock('@metamask/design-system-react-native', () => {
   };
 });
 
-import SetCardPin from './SetCardPin';
+import ConfirmCardPin from './ConfirmCardPin';
 
 const enterPin = (pressKey: (testID: string) => void, digits: string) => {
   for (const digit of digits) {
@@ -198,21 +201,14 @@ const enterPin = (pressKey: (testID: string) => void, digits: string) => {
   }
 };
 
-describe('SetCardPin', () => {
-  let appStateHandler: ((state: string) => void) | undefined;
-
+describe('ConfirmCardPin', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
     clearPinDraft();
-    jest
-      .spyOn(AppState, 'addEventListener')
-      .mockImplementation((event, handler) => {
-        if (event === 'change') {
-          appStateHandler = handler as (state: string) => void;
-        }
-        return { remove: jest.fn() } as never;
-      });
+    setPinDraft('1337');
+    mockSetCardPin.mockResolvedValue(undefined);
+    mockLogout.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -222,56 +218,86 @@ describe('SetCardPin', () => {
     jest.useRealTimers();
   });
 
-  it('keeps continue disabled until four digits are entered', () => {
-    const { getByTestId } = renderWithProvider(<SetCardPin />);
-    expect(getByTestId(SetCardPinSelectors.CONTINUE_BUTTON)).toBeDisabled();
-
-    enterPin((id) => fireEvent.press(getByTestId(id)), '133');
-    expect(getByTestId(SetCardPinSelectors.CONTINUE_BUTTON)).toBeDisabled();
-
-    fireEvent.press(getByTestId('keypad-key-7'));
-    expect(getByTestId(SetCardPinSelectors.CONTINUE_BUTTON)).toBeEnabled();
+  it('navigates back when draft PIN is missing', () => {
+    clearPinDraft();
+    renderWithProvider(<ConfirmCardPin />);
+    expect(mockGoBack).toHaveBeenCalled();
   });
 
-  it('stores the PIN draft and navigates to confirm on continue', () => {
-    const { getByTestId } = renderWithProvider(<SetCardPin />);
-    enterPin((id) => fireEvent.press(getByTestId(id)), '1337');
-    fireEvent.press(getByTestId(SetCardPinSelectors.CONTINUE_BUTTON));
-
-    expect(getPinDraft()).toBe('1337');
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.CONFIRM_PIN, {
-      cardId: 'card-1',
-    });
-  });
-
-  it('shows repeating PIN error then resets after delay', async () => {
-    const { getByTestId, queryByTestId } = renderWithProvider(<SetCardPin />);
-    enterPin((id) => fireEvent.press(getByTestId(id)), '1111');
-    fireEvent.press(getByTestId(SetCardPinSelectors.CONTINUE_BUTTON));
+  it('shows mismatch error then returns to set PIN', async () => {
+    const { getByTestId } = renderWithProvider(<ConfirmCardPin />);
+    enterPin((id) => fireEvent.press(getByTestId(id)), '1338');
+    fireEvent.press(getByTestId(SetCardPinSelectors.SUBMIT_BUTTON));
 
     expect(getByTestId(SetCardPinSelectors.INLINE_ERROR)).toBeOnTheScreen();
-    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockSetCardPin).not.toHaveBeenCalled();
 
     await act(async () => {
       jest.advanceTimersByTime(PIN_ERROR_RESET_DELAY_MS);
     });
 
-    await waitFor(() => {
-      expect(queryByTestId(SetCardPinSelectors.INLINE_ERROR)).toBeNull();
-      expect(getByTestId(SetCardPinSelectors.CONTINUE_BUTTON)).toBeDisabled();
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.SET_PIN, {
+      cardId: 'card-1',
     });
   });
 
-  it('clears PIN state when the app backgrounds', async () => {
-    const { getByTestId } = renderWithProvider(<SetCardPin />);
+  it('submits matching PINs and navigates to success', async () => {
+    const { getByTestId } = renderWithProvider(<ConfirmCardPin />);
     enterPin((id) => fireEvent.press(getByTestId(id)), '1337');
-    expect(getByTestId(SetCardPinSelectors.CONTINUE_BUTTON)).toBeEnabled();
+    fireEvent.press(getByTestId(SetCardPinSelectors.SUBMIT_BUTTON));
 
-    await act(async () => {
-      appStateHandler?.('background');
+    await waitFor(() => {
+      expect(mockSetCardPin).toHaveBeenCalledWith('card-1', '1337');
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.SET_PIN_SUCCESS);
+    });
+  });
+
+  it('routes auth failures to CardAuthentication', async () => {
+    mockSetCardPin.mockRejectedValue(
+      new CardProviderError(
+        CardProviderErrorCode.Forbidden,
+        'Forbidden',
+        403,
+        'LIVENESS_MISMATCH',
+      ),
+    );
+    const { getByTestId } = renderWithProvider(<ConfirmCardPin />);
+    enterPin((id) => fireEvent.press(getByTestId(id)), '1337');
+    fireEvent.press(getByTestId(SetCardPinSelectors.SUBMIT_BUTTON));
+
+    await waitFor(() => {
+      expect(mockLogout).toHaveBeenCalled();
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.AUTHENTICATION, {
+        showAuthPrompt: true,
+      });
+    });
+  });
+
+  it('ignores back while submit is pending', async () => {
+    let resolveSetCardPin: (() => void) | undefined;
+    mockSetCardPin.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSetCardPin = resolve;
+        }),
+    );
+    const { getByTestId } = renderWithProvider(<ConfirmCardPin />);
+    enterPin((id) => fireEvent.press(getByTestId(id)), '1337');
+    fireEvent.press(getByTestId(SetCardPinSelectors.SUBMIT_BUTTON));
+
+    await waitFor(() => {
+      expect(mockSetCardPin).toHaveBeenCalled();
     });
 
-    expect(getByTestId(SetCardPinSelectors.CONTINUE_BUTTON)).toBeDisabled();
-    expect(getPinDraft()).toBeNull();
+    fireEvent.press(getByTestId('confirm-back'));
+    expect(mockGoBack).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveSetCardPin?.();
+    });
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.SET_PIN_SUCCESS);
+    });
   });
 });

--- a/app/components/UI/Card/Views/SetCardPin/ConfirmCardPin.test.tsx
+++ b/app/components/UI/Card/Views/SetCardPin/ConfirmCardPin.test.tsx
@@ -7,11 +7,12 @@ import {
   CardProviderErrorCode,
 } from '../../../../../core/Engine/controllers/card-controller/provider-types';
 import { SetCardPinSelectors } from './SetCardPin.testIds';
-import { clearPinDraft, setPinDraft } from './pinDraftStore';
+import { clearPinDraft, getPinDraft, setPinDraft } from './pinDraftStore';
 import { PIN_ERROR_RESET_DELAY_MS } from './constants';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
+const mockReset = jest.fn();
 const mockTrackEvent = jest.fn();
 const mockCreateEventBuilder = jest.fn(() => ({
   addProperties: jest.fn().mockReturnThis(),
@@ -37,7 +38,7 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({
     navigate: mockNavigate,
     goBack: mockGoBack,
-    reset: jest.fn(),
+    reset: mockReset,
   }),
 }));
 
@@ -241,15 +242,31 @@ describe('ConfirmCardPin', () => {
     });
   });
 
-  it('submits matching PINs and navigates to success', async () => {
+  it('submits matching PINs and resets stack to success', async () => {
     const { getByTestId } = renderWithProvider(<ConfirmCardPin />);
     enterPin((id) => fireEvent.press(getByTestId(id)), '1337');
     fireEvent.press(getByTestId(SetCardPinSelectors.SUBMIT_BUTTON));
 
     await waitFor(() => {
       expect(mockSetCardPin).toHaveBeenCalledWith('card-1', '1337');
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.SET_PIN_SUCCESS);
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 1,
+        routes: [
+          { name: Routes.CARD.HOME },
+          { name: Routes.CARD.SET_PIN_SUCCESS },
+        ],
+      });
     });
+  });
+
+  it('clears draft PIN when confirm header back is pressed', async () => {
+    const { getByTestId } = renderWithProvider(<ConfirmCardPin />);
+    expect(getPinDraft()).toBe('1337');
+
+    fireEvent.press(getByTestId('confirm-back'));
+
+    expect(getPinDraft()).toBeNull();
+    expect(mockGoBack).toHaveBeenCalled();
   });
 
   it('routes auth failures to CardAuthentication', async () => {
@@ -297,7 +314,13 @@ describe('ConfirmCardPin', () => {
     });
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.CARD.SET_PIN_SUCCESS);
+      expect(mockReset).toHaveBeenCalledWith({
+        index: 1,
+        routes: [
+          { name: Routes.CARD.HOME },
+          { name: Routes.CARD.SET_PIN_SUCCESS },
+        ],
+      });
     });
   });
 });

--- a/app/components/UI/Card/Views/SetCardPin/ConfirmCardPin.tsx
+++ b/app/components/UI/Card/Views/SetCardPin/ConfirmCardPin.tsx
@@ -87,6 +87,7 @@ const ConfirmCardPin: React.FC = () => {
     if (submittingRef.current || isPending) {
       return;
     }
+    clearPinDraft();
     setIsTerminalForbidden(false);
     resetToEmpty();
     navigation.goBack();
@@ -144,7 +145,14 @@ const ConfirmCardPin: React.FC = () => {
           })
           .build(),
       );
-      navigation.navigate(Routes.CARD.SET_PIN_SUCCESS);
+      // Replace the set/confirm stack so system back cannot return to Confirm.
+      navigation.reset({
+        index: 1,
+        routes: [
+          { name: Routes.CARD.HOME },
+          { name: Routes.CARD.SET_PIN_SUCCESS },
+        ],
+      });
     } catch (error) {
       const kind = classifySetCardPinError(error);
       const httpStatus =

--- a/app/components/UI/Card/Views/SetCardPin/ConfirmCardPin.tsx
+++ b/app/components/UI/Card/Views/SetCardPin/ConfirmCardPin.tsx
@@ -1,0 +1,252 @@
+import React, { useCallback, useEffect } from 'react';
+import { AppState, type AppStateStatus } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
+import Engine from '../../../../../core/Engine';
+import Routes from '../../../../../constants/navigation/Routes';
+import { strings } from '../../../../../../locales/i18n';
+import { useParams } from '../../../../../util/navigation/navUtils';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import Logger from '../../../../../util/Logger';
+import { CardProviderIds } from '../../../../../core/Engine/controllers/card-controller/provider-types';
+import CardScreenshotDeterrent from '../../components/CardScreenshotDeterrent/CardScreenshotDeterrent';
+import { CardActions, CardScreens } from '../../util/metrics';
+import { SetCardPinSelectors } from './SetCardPin.testIds';
+import { PIN_LENGTH, validateCardPin } from './validatePin';
+import { classifySetCardPinError } from './classifySetCardPinError';
+import { clearPinDraft, getPinDraft } from './pinDraftStore';
+import { usePinEntry } from './hooks/usePinEntry';
+import PinEntryLayout from './components/PinEntryLayout';
+
+const PROVIDER = CardProviderIds.Immersve;
+
+const ConfirmCardPin: React.FC = () => {
+  const navigation = useNavigation<AppNavigationProp>();
+  const { cardId } = useParams<{ cardId: string }>();
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const [isPending, setIsPending] = React.useState(false);
+  const [isTerminalForbidden, setIsTerminalForbidden] = React.useState(false);
+  const submittingRef = React.useRef(false);
+
+  const {
+    value: confirmPin,
+    revealedIndex,
+    isError,
+    errorMessage,
+    isInputLocked,
+    handleKeypadChange,
+    triggerError,
+    lockWithError,
+    resetToEmpty,
+  } = usePinEntry({
+    disabled: isPending || isTerminalForbidden,
+  });
+
+  useEffect(() => {
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.CARD_VIEWED)
+        .addProperties({
+          screen: CardScreens.CONFIRM_PIN,
+          provider: PROVIDER,
+        })
+        .build(),
+    );
+  }, [trackEvent, createEventBuilder]);
+
+  useEffect(() => {
+    if (!getPinDraft()) {
+      navigation.goBack();
+    }
+  }, [navigation]);
+
+  useEffect(() => {
+    const onAppStateChange = (nextState: AppStateStatus) => {
+      if (nextState === 'background' || nextState === 'inactive') {
+        clearPinDraft();
+        resetToEmpty();
+        navigation.navigate(Routes.CARD.SET_PIN, { cardId });
+      }
+    };
+    const subscription = AppState.addEventListener('change', onAppStateChange);
+    return () => subscription.remove();
+  }, [cardId, navigation, resetToEmpty]);
+
+  const handleAuthFailure = useCallback(async () => {
+    clearPinDraft();
+    resetToEmpty();
+    try {
+      await Engine.context.CardController.logout();
+    } catch {
+      // Continue to auth even if logout fails.
+    }
+    navigation.navigate(Routes.CARD.AUTHENTICATION, { showAuthPrompt: true });
+  }, [navigation, resetToEmpty]);
+
+  const handleBack = useCallback(() => {
+    if (submittingRef.current || isPending) {
+      return;
+    }
+    setIsTerminalForbidden(false);
+    resetToEmpty();
+    navigation.goBack();
+  }, [isPending, navigation, resetToEmpty]);
+
+  const handleSubmit = useCallback(async () => {
+    if (submittingRef.current || isPending || isInputLocked) {
+      return;
+    }
+
+    const draftPin = getPinDraft();
+    if (!draftPin) {
+      navigation.goBack();
+      return;
+    }
+
+    if (draftPin !== confirmPin) {
+      triggerError(strings('card.set_pin.mismatch_error'), () => {
+        clearPinDraft();
+        navigation.navigate(Routes.CARD.SET_PIN, { cardId });
+      });
+      return;
+    }
+
+    const validation = validateCardPin(draftPin);
+    if (!validation.valid) {
+      triggerError(strings('card.set_pin.invalid_pin_error'), () => {
+        clearPinDraft();
+        navigation.navigate(Routes.CARD.SET_PIN, { cardId });
+      });
+      return;
+    }
+
+    submittingRef.current = true;
+    setIsPending(true);
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
+        .addProperties({
+          action: CardActions.CONFIRM_PIN_SUBMIT,
+          provider: PROVIDER,
+        })
+        .build(),
+    );
+
+    try {
+      await Engine.context.CardController.setCardPin(cardId, draftPin);
+      clearPinDraft();
+      resetToEmpty();
+      trackEvent(
+        createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
+          .addProperties({
+            action: CardActions.CONFIRM_PIN_SUBMIT,
+            provider: PROVIDER,
+            status: 'succeeded',
+          })
+          .build(),
+      );
+      navigation.navigate(Routes.CARD.SET_PIN_SUCCESS);
+    } catch (error) {
+      const kind = classifySetCardPinError(error);
+      const httpStatus =
+        error && typeof error === 'object' && 'statusCode' in error
+          ? (error as { statusCode?: number }).statusCode
+          : undefined;
+      const errorCode =
+        error && typeof error === 'object' && 'errorCode' in error
+          ? (error as { errorCode?: string }).errorCode
+          : undefined;
+
+      trackEvent(
+        createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
+          .addProperties({
+            action: CardActions.CONFIRM_PIN_SUBMIT,
+            provider: PROVIDER,
+            status: 'failed',
+            httpStatus,
+            errorCode,
+          })
+          .build(),
+      );
+
+      if (kind === 'auth') {
+        await handleAuthFailure();
+        return;
+      }
+
+      if (kind === 'forbidden') {
+        clearPinDraft();
+        resetToEmpty();
+        setIsTerminalForbidden(true);
+        lockWithError(strings('card.set_pin.forbidden_error'));
+        return;
+      }
+
+      if (kind === 'invalid_pin') {
+        triggerError(strings('card.set_pin.invalid_pin_error'), () => {
+          clearPinDraft();
+          navigation.navigate(Routes.CARD.SET_PIN, { cardId });
+        });
+        return;
+      }
+
+      triggerError(strings('card.set_pin.network_error'));
+      Logger.error(error as Error, {
+        tags: { feature: 'card', provider: 'immersve' },
+        context: {
+          name: 'ConfirmCardPin',
+          data: { method: 'handleSubmit', httpStatus, errorCode },
+        },
+      });
+    } finally {
+      submittingRef.current = false;
+      setIsPending(false);
+    }
+  }, [
+    isPending,
+    isInputLocked,
+    confirmPin,
+    cardId,
+    navigation,
+    triggerError,
+    lockWithError,
+    resetToEmpty,
+    trackEvent,
+    createEventBuilder,
+    handleAuthFailure,
+  ]);
+
+  const canSubmit =
+    confirmPin.length === PIN_LENGTH &&
+    !isTerminalForbidden &&
+    !isInputLocked &&
+    !isPending;
+
+  return (
+    <>
+      <PinEntryLayout
+        testID={SetCardPinSelectors.CONFIRM_ROOT}
+        title={strings('card.set_pin.confirm_title')}
+        description={strings('card.set_pin.confirm_description')}
+        accessibilityLabel={strings('card.set_pin.confirm_label')}
+        value={confirmPin}
+        revealedIndex={revealedIndex}
+        isError={isError || isTerminalForbidden}
+        errorMessage={errorMessage}
+        headerMode="back"
+        onBackPress={handleBack}
+        ctaLabel={strings('card.set_pin.submit')}
+        ctaTestID={SetCardPinSelectors.SUBMIT_BUTTON}
+        ctaDisabled={!canSubmit}
+        ctaLoading={isPending}
+        onCtaPress={() => {
+          handleSubmit().catch(() => undefined);
+        }}
+        keypadDisabled={isPending || isInputLocked || isTerminalForbidden}
+        onKeypadChange={handleKeypadChange}
+      />
+      <CardScreenshotDeterrent enabled />
+    </>
+  );
+};
+
+export default ConfirmCardPin;

--- a/app/components/UI/Card/Views/SetCardPin/SetCardPin.testIds.ts
+++ b/app/components/UI/Card/Views/SetCardPin/SetCardPin.testIds.ts
@@ -1,10 +1,12 @@
 export const SetCardPinSelectors = {
   ROOT: 'set-card-pin-root',
-  PIN_FIELD: 'set-card-pin-field',
-  CONFIRM_PIN_FIELD: 'confirm-card-pin-field',
+  CONFIRM_ROOT: 'confirm-card-pin-root',
+  SUCCESS_ROOT: 'set-card-pin-success-root',
+  PIN_DOTS: 'set-card-pin-dots',
   CONTINUE_BUTTON: 'set-card-pin-continue-button',
   SUBMIT_BUTTON: 'confirm-card-pin-submit-button',
   DONE_BUTTON: 'set-card-pin-done-button',
   INLINE_ERROR: 'set-card-pin-inline-error',
   SUCCESS_TITLE: 'set-card-pin-success-title',
+  SUCCESS_ICON: 'set-card-pin-success-icon',
 };

--- a/app/components/UI/Card/Views/SetCardPin/SetCardPin.tsx
+++ b/app/components/UI/Card/Views/SetCardPin/SetCardPin.tsx
@@ -1,32 +1,20 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { AppState, type AppStateStatus } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
-import {
-  Box,
-  Button,
-  ButtonSize,
-  ButtonVariant,
-  Text,
-  TextField,
-  TextVariant,
-} from '@metamask/design-system-react-native';
-import Engine from '../../../../../core/Engine';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
 import { useParams } from '../../../../../util/navigation/navUtils';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
-import Logger from '../../../../../util/Logger';
 import { CardProviderIds } from '../../../../../core/Engine/controllers/card-controller/provider-types';
-import OnboardingStep from '../../components/Onboarding/OnboardingStep';
 import CardScreenshotDeterrent from '../../components/CardScreenshotDeterrent/CardScreenshotDeterrent';
 import { CardActions, CardScreens } from '../../util/metrics';
 import { SetCardPinSelectors } from './SetCardPin.testIds';
 import { PIN_LENGTH, validateCardPin } from './validatePin';
-import { classifySetCardPinError } from './classifySetCardPinError';
-
-type SetPinStep = 'set' | 'confirm' | 'success';
+import { clearPinDraft, setPinDraft } from './pinDraftStore';
+import { usePinEntry } from './hooks/usePinEntry';
+import PinEntryLayout from './components/PinEntryLayout';
 
 const PROVIDER = CardProviderIds.Immersve;
 
@@ -35,86 +23,51 @@ const SetCardPin: React.FC = () => {
   const { cardId } = useParams<{ cardId: string }>();
   const { trackEvent, createEventBuilder } = useAnalytics();
 
-  const [step, setStep] = useState<SetPinStep>('set');
-  const [pin, setPin] = useState('');
-  const [confirmPin, setConfirmPin] = useState('');
-  const [inlineError, setInlineError] = useState<string | null>(null);
-  const [isTerminalForbidden, setIsTerminalForbidden] = useState(false);
-  const [isPending, setIsPending] = useState(false);
-  const submittingRef = useRef(false);
-
-  const clearPins = useCallback(() => {
-    setPin('');
-    setConfirmPin('');
-  }, []);
+  const {
+    value: pin,
+    revealedIndex,
+    isError,
+    errorMessage,
+    isInputLocked,
+    handleKeypadChange,
+    triggerError,
+    resetToEmpty,
+  } = usePinEntry();
 
   useEffect(() => {
-    const screen =
-      step === 'set'
-        ? CardScreens.SET_PIN
-        : step === 'confirm'
-          ? CardScreens.CONFIRM_PIN
-          : CardScreens.SET_PIN_SUCCESS;
     trackEvent(
       createEventBuilder(MetaMetricsEvents.CARD_VIEWED)
-        .addProperties({ screen, provider: PROVIDER })
+        .addProperties({ screen: CardScreens.SET_PIN, provider: PROVIDER })
         .build(),
     );
-  }, [step, trackEvent, createEventBuilder]);
-
-  useEffect(
-    () => () => {
-      clearPins();
-    },
-    [clearPins],
-  );
+  }, [trackEvent, createEventBuilder]);
 
   useEffect(() => {
     const onAppStateChange = (nextState: AppStateStatus) => {
       if (nextState === 'background' || nextState === 'inactive') {
-        clearPins();
-        setInlineError(null);
-        if (step !== 'success') {
-          setStep('set');
-        }
+        clearPinDraft();
+        resetToEmpty();
       }
     };
     const subscription = AppState.addEventListener('change', onAppStateChange);
     return () => subscription.remove();
-  }, [clearPins, step]);
+  }, [resetToEmpty]);
 
-  const digitsOnly = useCallback(
-    (value: string) => value.replace(/\D/g, ''),
-    [],
-  );
-
-  const handlePinChange = useCallback(
-    (value: string) => {
-      const next = digitsOnly(value).slice(0, PIN_LENGTH);
-      setPin(next);
-      if (next.length === PIN_LENGTH && !validateCardPin(next).valid) {
-        setInlineError(strings('card.set_pin.repeating_pin_error'));
-      } else {
-        setInlineError(null);
-      }
-    },
-    [digitsOnly],
-  );
-
-  const handleConfirmPinChange = useCallback(
-    (value: string) => {
-      setInlineError(null);
-      setConfirmPin(digitsOnly(value).slice(0, PIN_LENGTH));
-    },
-    [digitsOnly],
-  );
-
-  const handleContinueFromSet = useCallback(() => {
-    const validation = validateCardPin(pin);
-    if (!validation.valid) {
-      setInlineError(strings('card.set_pin.repeating_pin_error'));
+  const handleContinue = useCallback(() => {
+    if (isInputLocked) {
       return;
     }
+
+    const validation = validateCardPin(pin);
+    if (!validation.valid) {
+      triggerError(
+        validation.reason === 'repeating'
+          ? strings('card.set_pin.repeating_pin_error')
+          : strings('card.set_pin.invalid_pin_error'),
+      );
+      return;
+    }
+
     trackEvent(
       createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
         .addProperties({
@@ -123,291 +76,43 @@ const SetCardPin: React.FC = () => {
         })
         .build(),
     );
-    setConfirmPin('');
-    setInlineError(null);
-    setStep('confirm');
-  }, [pin, trackEvent, createEventBuilder]);
-
-  const handleBackFromConfirm = useCallback(() => {
-    if (submittingRef.current || isPending) {
-      return;
-    }
-    setConfirmPin('');
-    setInlineError(null);
-    setIsTerminalForbidden(false);
-    setStep('set');
-  }, [isPending]);
-
-  const handleAuthFailure = useCallback(async () => {
-    clearPins();
-    try {
-      await Engine.context.CardController.logout();
-    } catch {
-      // Continue to auth even if logout fails.
-    }
-    navigation.navigate(Routes.CARD.AUTHENTICATION, { showAuthPrompt: true });
-  }, [clearPins, navigation]);
-
-  const handleSubmitConfirm = useCallback(async () => {
-    if (submittingRef.current || isPending) {
-      return;
-    }
-
-    if (pin !== confirmPin) {
-      setInlineError(strings('card.set_pin.mismatch_error'));
-      clearPins();
-      setStep('set');
-      return;
-    }
-
-    const validation = validateCardPin(pin);
-    if (!validation.valid) {
-      setInlineError(strings('card.set_pin.invalid_pin_error'));
-      clearPins();
-      setStep('set');
-      return;
-    }
-
-    submittingRef.current = true;
-    setIsPending(true);
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
-        .addProperties({
-          action: CardActions.CONFIRM_PIN_SUBMIT,
-          provider: PROVIDER,
-        })
-        .build(),
-    );
-
-    try {
-      await Engine.context.CardController.setCardPin(cardId, pin);
-      clearPins();
-      setInlineError(null);
-      setStep('success');
-      trackEvent(
-        createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
-          .addProperties({
-            action: CardActions.CONFIRM_PIN_SUBMIT,
-            provider: PROVIDER,
-            status: 'succeeded',
-          })
-          .build(),
-      );
-    } catch (error) {
-      const kind = classifySetCardPinError(error);
-      const httpStatus =
-        error && typeof error === 'object' && 'statusCode' in error
-          ? (error as { statusCode?: number }).statusCode
-          : undefined;
-      const errorCode =
-        error && typeof error === 'object' && 'errorCode' in error
-          ? (error as { errorCode?: string }).errorCode
-          : undefined;
-
-      trackEvent(
-        createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
-          .addProperties({
-            action: CardActions.CONFIRM_PIN_SUBMIT,
-            provider: PROVIDER,
-            status: 'failed',
-            httpStatus,
-            errorCode,
-          })
-          .build(),
-      );
-
-      if (kind === 'auth') {
-        await handleAuthFailure();
-        return;
-      }
-
-      if (kind === 'forbidden') {
-        clearPins();
-        setIsTerminalForbidden(true);
-        setInlineError(strings('card.set_pin.forbidden_error'));
-        return;
-      }
-
-      if (kind === 'invalid_pin') {
-        setInlineError(strings('card.set_pin.invalid_pin_error'));
-        clearPins();
-        setStep('set');
-        return;
-      }
-
-      setInlineError(strings('card.set_pin.network_error'));
-      Logger.error(error as Error, {
-        tags: { feature: 'card', provider: 'immersve' },
-        context: {
-          name: 'SetCardPin',
-          data: { method: 'handleSubmitConfirm', httpStatus, errorCode },
-        },
-      });
-    } finally {
-      submittingRef.current = false;
-      setIsPending(false);
-    }
+    setPinDraft(pin);
+    resetToEmpty();
+    navigation.navigate(Routes.CARD.CONFIRM_PIN, { cardId });
   }, [
     pin,
-    confirmPin,
-    isPending,
-    cardId,
-    clearPins,
+    isInputLocked,
+    triggerError,
     trackEvent,
     createEventBuilder,
-    handleAuthFailure,
+    resetToEmpty,
+    navigation,
+    cardId,
   ]);
 
-  const handleDone = useCallback(() => {
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
-        .addProperties({
-          action: CardActions.SET_PIN_SUCCESS_DONE,
-          provider: PROVIDER,
-        })
-        .build(),
-    );
-    navigation.reset({
-      index: 0,
-      routes: [{ name: Routes.CARD.HOME }],
-    });
-  }, [navigation, trackEvent, createEventBuilder]);
-
-  const canContinueFromSet =
-    pin.length === PIN_LENGTH && validateCardPin(pin).valid;
-  const canSubmitConfirm =
-    confirmPin.length === PIN_LENGTH && !isTerminalForbidden;
-
-  if (step === 'success') {
-    return (
-      <Box testID={SetCardPinSelectors.ROOT} twClassName="flex-1">
-        <OnboardingStep
-          title={strings('card.set_pin.success_title')}
-          description={strings('card.set_pin.success_description')}
-          headerMode="close-reset-home"
-          stickyActions
-          formFields={<Box testID={SetCardPinSelectors.SUCCESS_TITLE} />}
-          actions={
-            <Button
-              variant={ButtonVariant.Primary}
-              size={ButtonSize.Lg}
-              isFullWidth
-              onPress={handleDone}
-              testID={SetCardPinSelectors.DONE_BUTTON}
-            >
-              {strings('card.set_pin.success_done')}
-            </Button>
-          }
-        />
-      </Box>
-    );
-  }
-
-  if (step === 'confirm') {
-    return (
-      <Box testID={SetCardPinSelectors.ROOT} twClassName="flex-1">
-        <OnboardingStep
-          title={strings('card.set_pin.confirm_title')}
-          description={strings('card.set_pin.confirm_description')}
-          headerMode="back"
-          onBackPress={handleBackFromConfirm}
-          stickyActions
-          formFields={
-            <Box>
-              <TextField
-                onChangeText={handleConfirmPinChange}
-                value={confirmPin}
-                isError={!!inlineError}
-                isDisabled={isPending || isTerminalForbidden}
-                autoFocus
-                inputProps={{
-                  keyboardType: 'number-pad',
-                  maxLength: PIN_LENGTH,
-                  secureTextEntry: true,
-                  accessibilityLabel: strings('card.set_pin.confirm_label'),
-                  testID: SetCardPinSelectors.CONFIRM_PIN_FIELD,
-                }}
-              />
-              {inlineError ? (
-                <Text
-                  variant={TextVariant.BodySm}
-                  testID={SetCardPinSelectors.INLINE_ERROR}
-                  twClassName="text-error-default mt-2"
-                >
-                  {inlineError}
-                </Text>
-              ) : null}
-            </Box>
-          }
-          actions={
-            <Button
-              variant={ButtonVariant.Primary}
-              size={ButtonSize.Lg}
-              isFullWidth
-              isDisabled={!canSubmitConfirm || isPending}
-              isLoading={isPending}
-              onPress={() => {
-                handleSubmitConfirm().catch(() => undefined);
-              }}
-              testID={SetCardPinSelectors.SUBMIT_BUTTON}
-            >
-              {strings('card.set_pin.submit')}
-            </Button>
-          }
-        />
-        <CardScreenshotDeterrent enabled />
-      </Box>
-    );
-  }
+  const canContinue = pin.length === PIN_LENGTH && !isInputLocked;
 
   return (
-    <Box testID={SetCardPinSelectors.ROOT} twClassName="flex-1">
-      <OnboardingStep
+    <>
+      <PinEntryLayout
+        testID={SetCardPinSelectors.ROOT}
         title={strings('card.set_pin.set_title')}
         description={strings('card.set_pin.set_description')}
+        accessibilityLabel={strings('card.set_pin.set_label')}
+        value={pin}
+        revealedIndex={revealedIndex}
+        isError={isError}
+        errorMessage={errorMessage}
         headerMode="back"
-        stickyActions
-        formFields={
-          <Box>
-            <TextField
-              onChangeText={handlePinChange}
-              value={pin}
-              isError={!!inlineError}
-              autoFocus
-              inputProps={{
-                keyboardType: 'number-pad',
-                maxLength: PIN_LENGTH,
-                secureTextEntry: true,
-                accessibilityLabel: strings('card.set_pin.set_label'),
-                testID: SetCardPinSelectors.PIN_FIELD,
-              }}
-            />
-            {inlineError ? (
-              <Text
-                variant={TextVariant.BodySm}
-                testID={SetCardPinSelectors.INLINE_ERROR}
-                twClassName="text-error-default mt-2"
-              >
-                {inlineError}
-              </Text>
-            ) : null}
-          </Box>
-        }
-        actions={
-          <Button
-            variant={ButtonVariant.Primary}
-            size={ButtonSize.Lg}
-            isFullWidth
-            isDisabled={!canContinueFromSet}
-            onPress={handleContinueFromSet}
-            testID={SetCardPinSelectors.CONTINUE_BUTTON}
-          >
-            {strings('card.set_pin.continue')}
-          </Button>
-        }
+        ctaLabel={strings('card.set_pin.continue')}
+        ctaTestID={SetCardPinSelectors.CONTINUE_BUTTON}
+        ctaDisabled={!canContinue}
+        onCtaPress={handleContinue}
+        keypadDisabled={isInputLocked}
+        onKeypadChange={handleKeypadChange}
       />
       <CardScreenshotDeterrent enabled />
-    </Box>
+    </>
   );
 };
 

--- a/app/components/UI/Card/Views/SetCardPin/SetCardPinSuccess.test.tsx
+++ b/app/components/UI/Card/Views/SetCardPin/SetCardPinSuccess.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import Routes from '../../../../../constants/navigation/Routes';
+import { SetCardPinSelectors } from './SetCardPin.testIds';
+
+const mockReset = jest.fn();
+const mockTrackEvent = jest.fn();
+const mockCreateEventBuilder = jest.fn(() => ({
+  addProperties: jest.fn().mockReturnThis(),
+  build: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    reset: mockReset,
+  }),
+}));
+
+jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: mockCreateEventBuilder,
+  }),
+}));
+
+jest.mock('@metamask/design-system-twrnc-preset', () => {
+  const tw = Object.assign((..._args: unknown[]) => ({}), {
+    style: jest.fn(() => ({})),
+  });
+  return { useTailwind: () => tw };
+});
+
+jest.mock('react-native-safe-area-context', () => {
+  const { View } = jest.requireActual('react-native');
+  return {
+    SafeAreaView: ({ children, ...props }: { children?: React.ReactNode }) => (
+      <View {...props}>{children}</View>
+    ),
+  };
+});
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const { View, Text, Pressable } = jest.requireActual('react-native');
+  return {
+    Box: ({ children, ...props }: { children?: React.ReactNode }) => (
+      <View {...props}>{children}</View>
+    ),
+    Text: ({ children, ...props }: { children?: React.ReactNode }) => (
+      <Text {...props}>{children}</Text>
+    ),
+    TextVariant: { BodyMd: 'BodyMd', HeadingLg: 'HeadingLg' },
+    BoxAlignItems: { Center: 'center' },
+    BoxJustifyContent: { Center: 'center' },
+    Icon: () => <View testID="success-check-icon" />,
+    IconName: { Check: 'Check' },
+    IconColor: { SuccessInverse: 'SuccessInverse' },
+    IconSize: { Xl: 'Xl' },
+    Button: ({
+      children,
+      onPress,
+      testID,
+    }: {
+      children?: React.ReactNode;
+      onPress?: () => void;
+      testID?: string;
+    }) => (
+      <Pressable testID={testID} onPress={onPress}>
+        <Text>{children}</Text>
+      </Pressable>
+    ),
+    ButtonVariant: { Primary: 'Primary' },
+    ButtonSize: { Lg: 'Lg' },
+  };
+});
+
+import SetCardPinSuccess from './SetCardPinSuccess';
+
+describe('SetCardPinSuccess', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders success content and resets to Card Home on Done', () => {
+    const { getByTestId } = renderWithProvider(<SetCardPinSuccess />);
+
+    expect(getByTestId(SetCardPinSelectors.SUCCESS_ICON)).toBeOnTheScreen();
+    expect(getByTestId(SetCardPinSelectors.SUCCESS_TITLE)).toBeOnTheScreen();
+
+    fireEvent.press(getByTestId(SetCardPinSelectors.DONE_BUTTON));
+    expect(mockReset).toHaveBeenCalledWith({
+      index: 0,
+      routes: [{ name: Routes.CARD.HOME }],
+    });
+  });
+});

--- a/app/components/UI/Card/Views/SetCardPin/SetCardPinSuccess.tsx
+++ b/app/components/UI/Card/Views/SetCardPin/SetCardPinSuccess.tsx
@@ -1,0 +1,137 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { Animated } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
+import {
+  Box,
+  BoxAlignItems,
+  BoxJustifyContent,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import Routes from '../../../../../constants/navigation/Routes';
+import { strings } from '../../../../../../locales/i18n';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import { CardProviderIds } from '../../../../../core/Engine/controllers/card-controller/provider-types';
+import { CardActions, CardScreens } from '../../util/metrics';
+import { SetCardPinSelectors } from './SetCardPin.testIds';
+import { clearPinDraft } from './pinDraftStore';
+
+const PROVIDER = CardProviderIds.Immersve;
+const SUCCESS_ICON_SIZE = 64;
+
+const SetCardPinSuccess: React.FC = () => {
+  const tw = useTailwind();
+  const navigation = useNavigation<AppNavigationProp>();
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const iconScale = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    clearPinDraft();
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.CARD_VIEWED)
+        .addProperties({
+          screen: CardScreens.SET_PIN_SUCCESS,
+          provider: PROVIDER,
+        })
+        .build(),
+    );
+  }, [trackEvent, createEventBuilder]);
+
+  useEffect(() => {
+    Animated.spring(iconScale, {
+      toValue: 1,
+      friction: 4,
+      tension: 140,
+      useNativeDriver: true,
+    }).start();
+  }, [iconScale]);
+
+  const handleDone = useCallback(() => {
+    trackEvent(
+      createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
+        .addProperties({
+          action: CardActions.SET_PIN_SUCCESS_DONE,
+          provider: PROVIDER,
+        })
+        .build(),
+    );
+    navigation.reset({
+      index: 0,
+      routes: [{ name: Routes.CARD.HOME }],
+    });
+  }, [navigation, trackEvent, createEventBuilder]);
+
+  return (
+    <SafeAreaView
+      testID={SetCardPinSelectors.SUCCESS_ROOT}
+      style={tw.style('flex-1 bg-background-default')}
+      edges={['top', 'bottom']}
+    >
+      <Box
+        twClassName="flex-1 px-4"
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Center}
+        gap={4}
+      >
+        <Animated.View
+          testID={SetCardPinSelectors.SUCCESS_ICON}
+          style={{ transform: [{ scale: iconScale }] }}
+        >
+          <Box
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Center}
+            twClassName="rounded-full bg-success-default"
+            style={{ width: SUCCESS_ICON_SIZE, height: SUCCESS_ICON_SIZE }}
+          >
+            <Icon
+              name={IconName.Check}
+              color={IconColor.SuccessInverse}
+              size={IconSize.Xl}
+            />
+          </Box>
+        </Animated.View>
+
+        <Box twClassName="gap-2 px-2" alignItems={BoxAlignItems.Center}>
+          <Text
+            variant={TextVariant.HeadingLg}
+            twClassName="text-default text-center"
+            testID={SetCardPinSelectors.SUCCESS_TITLE}
+          >
+            {strings('card.set_pin.success_title')}
+          </Text>
+          <Text
+            variant={TextVariant.BodyMd}
+            twClassName="text-text-alternative text-center"
+          >
+            {strings('card.set_pin.success_description')}
+          </Text>
+        </Box>
+      </Box>
+
+      <Box twClassName="px-4 pb-2">
+        <Button
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          isFullWidth
+          onPress={handleDone}
+          testID={SetCardPinSelectors.DONE_BUTTON}
+        >
+          {strings('card.set_pin.success_done')}
+        </Button>
+      </Box>
+    </SafeAreaView>
+  );
+};
+
+export default SetCardPinSuccess;

--- a/app/components/UI/Card/Views/SetCardPin/components/PinDots.tsx
+++ b/app/components/UI/Card/Views/SetCardPin/components/PinDots.tsx
@@ -1,0 +1,205 @@
+import React, { useLayoutEffect, useRef, useState } from 'react';
+import { Animated, StyleSheet } from 'react-native';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { PIN_LENGTH } from '../validatePin';
+import { SetCardPinSelectors } from '../SetCardPin.testIds';
+
+interface PinDotsProps {
+  value: string;
+  revealedIndex: number | null;
+  isError?: boolean;
+}
+
+const DOT_SIZE = 16;
+const SLOT_SIZE = 24;
+const FILL_FADE_OUT_MS = 180;
+
+type FadeKind = 'fill' | 'digit';
+
+const styles = StyleSheet.create({
+  slot: {
+    width: SLOT_SIZE,
+    height: SLOT_SIZE,
+  },
+  dot: {
+    width: DOT_SIZE,
+    height: DOT_SIZE,
+  },
+  emptyOutlineAbsolute: {
+    position: 'absolute',
+    width: DOT_SIZE,
+    height: DOT_SIZE,
+    left: (SLOT_SIZE - DOT_SIZE) / 2,
+    top: (SLOT_SIZE - DOT_SIZE) / 2,
+  },
+  overlay: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: SLOT_SIZE,
+    height: SLOT_SIZE,
+  },
+});
+
+const PinDotSlot: React.FC<{
+  filled: boolean;
+  revealedDigit: string | null;
+  isError: boolean;
+}> = ({ filled, revealedDigit, isError }) => {
+  const occupied = filled || revealedDigit != null;
+
+  // Delete/clear animation only. Digit ↔ fill is derived from props (instant).
+  const [fading, setFading] = useState<FadeKind | null>(null);
+  const [fadeDigit, setFadeDigit] = useState<string | null>(null);
+  const fillOpacity = useRef(new Animated.Value(1)).current;
+  const wasOccupiedRef = useRef(occupied);
+  const lastDigitRef = useRef<string | null>(revealedDigit);
+  const lastKindRef = useRef<FadeKind | null>(
+    revealedDigit != null ? 'digit' : filled ? 'fill' : null,
+  );
+  const lastIsErrorRef = useRef(isError);
+  const fadeAnimationRef = useRef<Animated.CompositeAnimation | null>(null);
+
+  if (occupied) {
+    lastIsErrorRef.current = isError;
+  }
+  if (revealedDigit != null) {
+    lastDigitRef.current = revealedDigit;
+    lastKindRef.current = 'digit';
+  } else if (filled) {
+    lastKindRef.current = 'fill';
+  }
+
+  useLayoutEffect(() => {
+    if (occupied) {
+      fadeAnimationRef.current?.stop();
+      fadeAnimationRef.current = null;
+      setFading(null);
+      setFadeDigit(null);
+      fillOpacity.setValue(1);
+      wasOccupiedRef.current = true;
+      return;
+    }
+
+    if (!wasOccupiedRef.current || fading != null) {
+      return;
+    }
+
+    // Occupied → empty (single delete, long-press clear, or error reset):
+    // keep fill/digit over the empty ring and fade only that overlay.
+    wasOccupiedRef.current = false;
+    const kind = lastKindRef.current ?? 'fill';
+    setFadeDigit(kind === 'digit' ? lastDigitRef.current : null);
+    setFading(kind);
+    fillOpacity.setValue(1);
+
+    const animation = Animated.timing(fillOpacity, {
+      toValue: 0,
+      duration: FILL_FADE_OUT_MS,
+      useNativeDriver: true,
+    });
+    fadeAnimationRef.current = animation;
+    animation.start(({ finished }) => {
+      if (!finished) {
+        return;
+      }
+      setFading(null);
+      setFadeDigit(null);
+      fillOpacity.setValue(1);
+      fadeAnimationRef.current = null;
+    });
+  }, [occupied, fading, fillOpacity]);
+
+  // First render after a clear still has wasOccupiedRef=true before layout
+  // effect runs — treat that as an in-progress fade so we never paint empty-only.
+  const pendingFadeKind: FadeKind | null =
+    !occupied && wasOccupiedRef.current && fading == null
+      ? (lastKindRef.current ?? 'fill')
+      : null;
+  const activeFade = fading ?? pendingFadeKind;
+  const paintError = activeFade != null ? lastIsErrorRef.current : isError;
+
+  const colorClass = paintError ? 'bg-error-default' : 'bg-icon-default';
+  const borderClass = paintError
+    ? 'border-error-default'
+    : 'border-icon-default';
+  const digitColorClass = paintError ? 'text-error-default' : 'text-default';
+
+  const showDigit = revealedDigit != null || activeFade === 'digit';
+  const showFill = (filled && revealedDigit == null) || activeFade === 'fill';
+  const showEmptyOutline =
+    (!occupied && activeFade == null) || activeFade != null;
+
+  const digitOverlayStyle = [
+    styles.overlay,
+    { opacity: activeFade === 'digit' ? fillOpacity : 1 },
+  ];
+  const fillOverlayStyle = [
+    styles.overlay,
+    { opacity: activeFade === 'fill' ? fillOpacity : 1 },
+  ];
+
+  return (
+    <Box
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Center}
+      style={styles.slot}
+    >
+      {showEmptyOutline ? (
+        <Box
+          twClassName={`rounded-full border-2 ${borderClass}`}
+          style={activeFade == null ? styles.dot : styles.emptyOutlineAbsolute}
+        />
+      ) : null}
+
+      {showDigit ? (
+        <Animated.View style={digitOverlayStyle}>
+          <Text variant={TextVariant.HeadingMd} twClassName={digitColorClass}>
+            {revealedDigit ?? fadeDigit ?? lastDigitRef.current}
+          </Text>
+        </Animated.View>
+      ) : null}
+
+      {showFill ? (
+        <Animated.View style={fillOverlayStyle}>
+          <Box twClassName={`rounded-full ${colorClass}`} style={styles.dot} />
+        </Animated.View>
+      ) : null}
+    </Box>
+  );
+};
+
+const PinDots: React.FC<PinDotsProps> = ({
+  value,
+  revealedIndex,
+  isError = false,
+}) => (
+  <Box
+    testID={SetCardPinSelectors.PIN_DOTS}
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Center}
+    justifyContent={BoxJustifyContent.Center}
+    gap={4}
+  >
+    {Array.from({ length: PIN_LENGTH }, (_, index) => {
+      const digit = value[index] ?? null;
+      const isRevealed = revealedIndex === index && digit != null;
+      return (
+        <PinDotSlot
+          key={index}
+          filled={digit != null && !isRevealed}
+          revealedDigit={isRevealed ? digit : null}
+          isError={isError}
+        />
+      );
+    })}
+  </Box>
+);
+
+export default PinDots;

--- a/app/components/UI/Card/Views/SetCardPin/components/PinEntryLayout.tsx
+++ b/app/components/UI/Card/Views/SetCardPin/components/PinEntryLayout.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import {
+  Box,
+  BoxAlignItems,
+  BoxJustifyContent,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  HeaderStandard,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import Keypad, { type KeypadChangeData } from '../../../../../Base/Keypad';
+import {
+  useCardHeaderHandlers,
+  type CardHeaderMode,
+} from '../../../hooks/useCardHeaderHandlers';
+import PinDots from './PinDots';
+import { SetCardPinSelectors } from '../SetCardPin.testIds';
+
+interface PinEntryLayoutProps {
+  testID?: string;
+  title: string;
+  description: string;
+  accessibilityLabel: string;
+  value: string;
+  revealedIndex: number | null;
+  isError: boolean;
+  errorMessage: string | null;
+  headerMode?: CardHeaderMode;
+  onBackPress?: () => void;
+  ctaLabel: string;
+  ctaTestID: string;
+  ctaDisabled: boolean;
+  ctaLoading?: boolean;
+  onCtaPress: () => void;
+  keypadDisabled: boolean;
+  onKeypadChange: (data: KeypadChangeData) => void;
+}
+
+const styles = StyleSheet.create({
+  hiddenPeriod: {
+    opacity: 0,
+  },
+  keypadDisabled: {
+    opacity: 0.5,
+  },
+});
+
+const PinEntryLayout: React.FC<PinEntryLayoutProps> = ({
+  testID = SetCardPinSelectors.ROOT,
+  title,
+  description,
+  accessibilityLabel,
+  value,
+  revealedIndex,
+  isError,
+  errorMessage,
+  headerMode = 'back',
+  onBackPress,
+  ctaLabel,
+  ctaTestID,
+  ctaDisabled,
+  ctaLoading = false,
+  onCtaPress,
+  keypadDisabled,
+  onKeypadChange,
+}) => {
+  const tw = useTailwind();
+  const headerHandlers = useCardHeaderHandlers(headerMode);
+  const resolvedHeaderHandlers =
+    headerMode === 'back' && onBackPress
+      ? { ...headerHandlers, onBack: onBackPress }
+      : headerHandlers;
+
+  return (
+    <SafeAreaView
+      testID={testID}
+      style={tw.style('flex-1 bg-background-default')}
+      edges={['bottom']}
+      accessibilityLabel={accessibilityLabel}
+    >
+      <HeaderStandard
+        includesTopInset
+        twClassName="bg-background-default"
+        {...resolvedHeaderHandlers}
+      />
+      <Box twClassName="flex-1 px-4">
+        <Box twClassName="gap-2 mt-2">
+          <Text variant={TextVariant.HeadingLg} twClassName="text-default">
+            {title}
+          </Text>
+          <Text
+            variant={TextVariant.BodyMd}
+            twClassName="text-text-alternative"
+          >
+            {description}
+          </Text>
+        </Box>
+
+        <Box
+          twClassName="flex-1 mt-10"
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Start}
+          gap={4}
+        >
+          <PinDots
+            value={value}
+            revealedIndex={revealedIndex}
+            isError={isError}
+          />
+          {errorMessage ? (
+            <Text
+              variant={TextVariant.BodySm}
+              testID={SetCardPinSelectors.INLINE_ERROR}
+              twClassName="text-error-default text-center"
+            >
+              {errorMessage}
+            </Text>
+          ) : null}
+        </Box>
+      </Box>
+
+      <Box twClassName="px-4 pb-2 gap-4">
+        <Button
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          isFullWidth
+          isDisabled={ctaDisabled}
+          isLoading={ctaLoading}
+          onPress={onCtaPress}
+          testID={ctaTestID}
+        >
+          {ctaLabel}
+        </Button>
+        <Box
+          pointerEvents={keypadDisabled ? 'none' : 'auto'}
+          style={keypadDisabled ? styles.keypadDisabled : undefined}
+        >
+          <Keypad
+            value={value || '0'}
+            onChange={onKeypadChange}
+            periodButtonProps={{
+              isDisabled: true,
+              style: styles.hiddenPeriod,
+            }}
+          />
+        </Box>
+      </Box>
+    </SafeAreaView>
+  );
+};
+
+export default PinEntryLayout;

--- a/app/components/UI/Card/Views/SetCardPin/constants.ts
+++ b/app/components/UI/Card/Views/SetCardPin/constants.ts
@@ -1,0 +1,2 @@
+export const PIN_UNMASK_DURATION_MS = 300;
+export const PIN_ERROR_RESET_DELAY_MS = 1500;

--- a/app/components/UI/Card/Views/SetCardPin/hooks/usePinEntry.test.ts
+++ b/app/components/UI/Card/Views/SetCardPin/hooks/usePinEntry.test.ts
@@ -69,4 +69,33 @@ describe('usePinEntry', () => {
     expect(result.current.isInputLocked).toBe(false);
     expect(onAfterReset).toHaveBeenCalled();
   });
+
+  it('keeps all digits when keypad presses are batched before re-render', () => {
+    const { result } = renderHook(() => usePinEntry());
+
+    act(() => {
+      result.current.handleKeypadChange({
+        value: '1',
+        valueAsNumber: 1,
+        pressedKey: Keys.Digit1,
+      });
+      result.current.handleKeypadChange({
+        value: '3',
+        valueAsNumber: 3,
+        pressedKey: Keys.Digit3,
+      });
+      result.current.handleKeypadChange({
+        value: '3',
+        valueAsNumber: 3,
+        pressedKey: Keys.Digit3,
+      });
+      result.current.handleKeypadChange({
+        value: '7',
+        valueAsNumber: 7,
+        pressedKey: Keys.Digit7,
+      });
+    });
+
+    expect(result.current.value).toBe('1337');
+  });
 });

--- a/app/components/UI/Card/Views/SetCardPin/hooks/usePinEntry.test.ts
+++ b/app/components/UI/Card/Views/SetCardPin/hooks/usePinEntry.test.ts
@@ -1,0 +1,72 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { Keys } from '../../../../../Base/Keypad';
+import { usePinEntry } from './usePinEntry';
+import { PIN_ERROR_RESET_DELAY_MS, PIN_UNMASK_DURATION_MS } from '../constants';
+
+describe('usePinEntry', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('appends digits and temporarily reveals the last digit', () => {
+    const { result } = renderHook(() => usePinEntry());
+
+    act(() => {
+      result.current.handleKeypadChange({
+        value: '1',
+        valueAsNumber: 1,
+        pressedKey: Keys.Digit1,
+      });
+    });
+
+    expect(result.current.value).toBe('1');
+    expect(result.current.revealedIndex).toBe(0);
+
+    act(() => {
+      jest.advanceTimersByTime(PIN_UNMASK_DURATION_MS);
+    });
+
+    expect(result.current.revealedIndex).toBeNull();
+  });
+
+  it('locks input on error then resets after the delay', () => {
+    const { result } = renderHook(() => usePinEntry());
+    const onAfterReset = jest.fn();
+
+    act(() => {
+      result.current.handleKeypadChange({
+        value: '1',
+        valueAsNumber: 1,
+        pressedKey: Keys.Digit1,
+      });
+      result.current.triggerError('bad', onAfterReset);
+    });
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.isInputLocked).toBe(true);
+    expect(result.current.errorMessage).toBe('bad');
+
+    act(() => {
+      result.current.handleKeypadChange({
+        value: '2',
+        valueAsNumber: 2,
+        pressedKey: Keys.Digit2,
+      });
+    });
+    expect(result.current.value).toBe('1');
+
+    act(() => {
+      jest.advanceTimersByTime(PIN_ERROR_RESET_DELAY_MS);
+    });
+
+    expect(result.current.value).toBe('');
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isInputLocked).toBe(false);
+    expect(onAfterReset).toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Card/Views/SetCardPin/hooks/usePinEntry.ts
+++ b/app/components/UI/Card/Views/SetCardPin/hooks/usePinEntry.ts
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Keys, type KeypadChangeData } from '../../../../../Base/Keypad';
+import { PIN_LENGTH } from '../validatePin';
+import { PIN_ERROR_RESET_DELAY_MS, PIN_UNMASK_DURATION_MS } from '../constants';
+
+interface UsePinEntryOptions {
+  disabled?: boolean;
+}
+
+export function usePinEntry({ disabled = false }: UsePinEntryOptions = {}) {
+  const [value, setValue] = useState('');
+  const [revealedIndex, setRevealedIndex] = useState<number | null>(null);
+  const [isError, setIsError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isInputLocked, setIsInputLocked] = useState(false);
+
+  const unmaskTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimers = useCallback(() => {
+    if (unmaskTimerRef.current) {
+      clearTimeout(unmaskTimerRef.current);
+      unmaskTimerRef.current = null;
+    }
+    if (errorTimerRef.current) {
+      clearTimeout(errorTimerRef.current);
+      errorTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => clearTimers(), [clearTimers]);
+
+  const resetToEmpty = useCallback(() => {
+    clearTimers();
+    setValue('');
+    setRevealedIndex(null);
+    setIsError(false);
+    setErrorMessage(null);
+    setIsInputLocked(false);
+  }, [clearTimers]);
+
+  const revealLastDigit = useCallback((nextLength: number) => {
+    if (unmaskTimerRef.current) {
+      clearTimeout(unmaskTimerRef.current);
+    }
+    setRevealedIndex(nextLength - 1);
+    unmaskTimerRef.current = setTimeout(() => {
+      setRevealedIndex(null);
+      unmaskTimerRef.current = null;
+    }, PIN_UNMASK_DURATION_MS);
+  }, []);
+
+  const appendDigit = useCallback(
+    (digit: string) => {
+      if (disabled || isInputLocked || value.length >= PIN_LENGTH) {
+        return;
+      }
+      setIsError(false);
+      setErrorMessage(null);
+      const next = `${value}${digit}`;
+      setValue(next);
+      revealLastDigit(next.length);
+    },
+    [disabled, isInputLocked, value, revealLastDigit],
+  );
+
+  const deleteDigit = useCallback(() => {
+    if (disabled || isInputLocked || value.length === 0) {
+      return;
+    }
+    setIsError(false);
+    setErrorMessage(null);
+    if (unmaskTimerRef.current) {
+      clearTimeout(unmaskTimerRef.current);
+      unmaskTimerRef.current = null;
+    }
+    setRevealedIndex(null);
+    setValue((prev) => prev.slice(0, -1));
+  }, [disabled, isInputLocked, value.length]);
+
+  const lockWithError = useCallback(
+    (message: string) => {
+      clearTimers();
+      setIsError(true);
+      setErrorMessage(message);
+      setIsInputLocked(true);
+      setRevealedIndex(null);
+    },
+    [clearTimers],
+  );
+
+  const triggerError = useCallback(
+    (message: string, onAfterReset?: () => void) => {
+      lockWithError(message);
+      errorTimerRef.current = setTimeout(() => {
+        setValue('');
+        setIsError(false);
+        setErrorMessage(null);
+        setIsInputLocked(false);
+        setRevealedIndex(null);
+        errorTimerRef.current = null;
+        onAfterReset?.();
+      }, PIN_ERROR_RESET_DELAY_MS);
+    },
+    [lockWithError],
+  );
+
+  const handleKeypadChange = useCallback(
+    ({ pressedKey }: KeypadChangeData) => {
+      if (disabled || isInputLocked) {
+        return;
+      }
+      if (pressedKey === Keys.Back) {
+        deleteDigit();
+        return;
+      }
+      if (pressedKey === Keys.Initial) {
+        resetToEmpty();
+        return;
+      }
+      if (pressedKey === Keys.Period) {
+        return;
+      }
+      appendDigit(pressedKey);
+    },
+    [disabled, isInputLocked, deleteDigit, resetToEmpty, appendDigit],
+  );
+
+  return {
+    value,
+    revealedIndex,
+    isError,
+    errorMessage,
+    isInputLocked,
+    handleKeypadChange,
+    triggerError,
+    lockWithError,
+    resetToEmpty,
+  };
+}

--- a/app/components/UI/Card/Views/SetCardPin/hooks/usePinEntry.ts
+++ b/app/components/UI/Card/Views/SetCardPin/hooks/usePinEntry.ts
@@ -16,6 +16,8 @@ export function usePinEntry({ disabled = false }: UsePinEntryOptions = {}) {
 
   const unmaskTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const valueRef = useRef(value);
+  valueRef.current = value;
 
   const clearTimers = useCallback(() => {
     if (unmaskTimerRef.current) {
@@ -32,6 +34,7 @@ export function usePinEntry({ disabled = false }: UsePinEntryOptions = {}) {
 
   const resetToEmpty = useCallback(() => {
     clearTimers();
+    valueRef.current = '';
     setValue('');
     setRevealedIndex(null);
     setIsError(false);
@@ -52,20 +55,21 @@ export function usePinEntry({ disabled = false }: UsePinEntryOptions = {}) {
 
   const appendDigit = useCallback(
     (digit: string) => {
-      if (disabled || isInputLocked || value.length >= PIN_LENGTH) {
+      if (disabled || isInputLocked || valueRef.current.length >= PIN_LENGTH) {
         return;
       }
       setIsError(false);
       setErrorMessage(null);
-      const next = `${value}${digit}`;
+      const next = `${valueRef.current}${digit}`;
+      valueRef.current = next;
       setValue(next);
       revealLastDigit(next.length);
     },
-    [disabled, isInputLocked, value, revealLastDigit],
+    [disabled, isInputLocked, revealLastDigit],
   );
 
   const deleteDigit = useCallback(() => {
-    if (disabled || isInputLocked || value.length === 0) {
+    if (disabled || isInputLocked || valueRef.current.length === 0) {
       return;
     }
     setIsError(false);
@@ -75,8 +79,10 @@ export function usePinEntry({ disabled = false }: UsePinEntryOptions = {}) {
       unmaskTimerRef.current = null;
     }
     setRevealedIndex(null);
-    setValue((prev) => prev.slice(0, -1));
-  }, [disabled, isInputLocked, value.length]);
+    const next = valueRef.current.slice(0, -1);
+    valueRef.current = next;
+    setValue(next);
+  }, [disabled, isInputLocked]);
 
   const lockWithError = useCallback(
     (message: string) => {
@@ -93,6 +99,7 @@ export function usePinEntry({ disabled = false }: UsePinEntryOptions = {}) {
     (message: string, onAfterReset?: () => void) => {
       lockWithError(message);
       errorTimerRef.current = setTimeout(() => {
+        valueRef.current = '';
         setValue('');
         setIsError(false);
         setErrorMessage(null);

--- a/app/components/UI/Card/Views/SetCardPin/index.ts
+++ b/app/components/UI/Card/Views/SetCardPin/index.ts
@@ -1,4 +1,6 @@
 export { default } from './SetCardPin';
+export { default as ConfirmCardPin } from './ConfirmCardPin';
+export { default as SetCardPinSuccess } from './SetCardPinSuccess';
 export { validateCardPin, PIN_LENGTH } from './validatePin';
 export { classifySetCardPinError } from './classifySetCardPinError';
 export { SetCardPinSelectors } from './SetCardPin.testIds';

--- a/app/components/UI/Card/Views/SetCardPin/pinDraftStore.test.ts
+++ b/app/components/UI/Card/Views/SetCardPin/pinDraftStore.test.ts
@@ -1,0 +1,15 @@
+import { clearPinDraft, getPinDraft, setPinDraft } from './pinDraftStore';
+
+describe('pinDraftStore', () => {
+  afterEach(() => {
+    clearPinDraft();
+  });
+
+  it('stores and clears the draft PIN', () => {
+    expect(getPinDraft()).toBeNull();
+    setPinDraft('1337');
+    expect(getPinDraft()).toBe('1337');
+    clearPinDraft();
+    expect(getPinDraft()).toBeNull();
+  });
+});

--- a/app/components/UI/Card/Views/SetCardPin/pinDraftStore.ts
+++ b/app/components/UI/Card/Views/SetCardPin/pinDraftStore.ts
@@ -1,0 +1,17 @@
+/**
+ * Short-lived in-memory holder for the first PIN between Set and Confirm screens.
+ * Intentionally not route params — avoids nav persistence / logging of the PIN.
+ */
+let draftPin: string | null = null;
+
+export function setPinDraft(pin: string): void {
+  draftPin = pin;
+}
+
+export function getPinDraft(): string | null {
+  return draftPin;
+}
+
+export function clearPinDraft(): void {
+  draftPin = null;
+}

--- a/app/components/UI/Card/routes/index.test.tsx
+++ b/app/components/UI/Card/routes/index.test.tsx
@@ -184,6 +184,8 @@ jest.mock('../../../../constants/navigation/Routes', () => ({
     CASHBACK: 'Cashback',
     CREDIT_REDEEM: 'CreditRedeem',
     SET_PIN: 'CardSetPin',
+    CONFIRM_PIN: 'CardConfirmPin',
+    SET_PIN_SUCCESS: 'CardSetPinSuccess',
     AUTHENTICATION: 'CardAuthentication',
     SPENDING_LIMIT: 'SpendingLimit',
     ONBOARDING: {

--- a/app/components/UI/Card/routes/index.tsx
+++ b/app/components/UI/Card/routes/index.tsx
@@ -25,7 +25,10 @@ import ConfirmModal from '../components/Onboarding/ConfirmModal';
 import RecurringFeeModal from '../components/RecurringFeeModal/RecurringFeeModal';
 import DaimoPayModal from '../components/DaimoPayModal/DaimoPayModal';
 import ViewPinBottomSheet from '../components/ViewPinBottomSheet';
-import SetCardPin from '../Views/SetCardPin';
+import SetCardPin, {
+  ConfirmCardPin,
+  SetCardPinSuccess,
+} from '../Views/SetCardPin';
 import SpendingLimitOptionsSheet from '../Views/SpendingLimit/components/SpendingLimitOptionsSheet';
 import WaitlistFormModal from '../components/WaitlistFormModal/WaitlistFormModal';
 import ImmersveKYCModal from '../components/ImmersveKYCModal/ImmersveKYCModal';
@@ -102,6 +105,14 @@ const MainRoutes = () => {
         component={CreditRedeem}
       />
       <ScreensStack.Screen name={Routes.CARD.SET_PIN} component={SetCardPin} />
+      <ScreensStack.Screen
+        name={Routes.CARD.CONFIRM_PIN}
+        component={ConfirmCardPin}
+      />
+      <ScreensStack.Screen
+        name={Routes.CARD.SET_PIN_SUCCESS}
+        component={SetCardPinSuccess}
+      />
       <ScreensStack.Screen
         name={Routes.CARD.AUTHENTICATION}
         component={CardAuthentication}

--- a/app/components/UI/Card/routes/index.tsx
+++ b/app/components/UI/Card/routes/index.tsx
@@ -112,6 +112,7 @@ const MainRoutes = () => {
       <ScreensStack.Screen
         name={Routes.CARD.SET_PIN_SUCCESS}
         component={SetCardPinSuccess}
+        options={{ gestureEnabled: false }}
       />
       <ScreensStack.Screen
         name={Routes.CARD.AUTHENTICATION}

--- a/app/components/UI/Card/types/navigation.ts
+++ b/app/components/UI/Card/types/navigation.ts
@@ -48,6 +48,8 @@ export type CardScreensStackParamList = {
   CardCashback: undefined;
   CardCreditRedeem: undefined;
   CardSetPin: { cardId: string };
+  CardConfirmPin: { cardId: string };
+  CardSetPinSuccess: undefined;
   CardAuthentication:
     | {
         showAuthPrompt?: boolean;

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -546,6 +546,8 @@ const Routes = {
     CASHBACK: 'CardCashback',
     CREDIT_REDEEM: 'CardCreditRedeem',
     SET_PIN: 'CardSetPin',
+    CONFIRM_PIN: 'CardConfirmPin',
+    SET_PIN_SUCCESS: 'CardSetPinSuccess',
     ONBOARDING: {
       ROOT: 'CardOnboarding',
       SIGN_UP: 'CardOnboardingSignUp',

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -1113,6 +1113,8 @@ export type RootStackParamList = {
   CardCashback: CardScreensStackParamList['CardCashback'];
   CardCreditRedeem: CardScreensStackParamList['CardCreditRedeem'];
   CardSetPin: CardScreensStackParamList['CardSetPin'];
+  CardConfirmPin: CardScreensStackParamList['CardConfirmPin'];
+  CardSetPinSuccess: CardScreensStackParamList['CardSetPinSuccess'];
   ReviewOrder: CardScreensStackParamList['ReviewOrder'];
   OrderCompleted: CardScreensStackParamList['OrderCompleted'];
   CardOnboarding: CardScreensStackParamList['CardOnboarding'];


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Follow-up to #34420 that redesigns the Immersve Set Card PIN UX to match the product prototype.

1. **Why:** The initial Set PIN flow used a single screen with a system text field. Design requires separate stack screens, masked pin dots with a brief last-digit reveal, and the shared `Base/Keypad` with the CTA above it.
2. **What:** Splits set / confirm / success into `CardSetPin` → `CardConfirmPin` → `CardSetPinSuccess`, keeps the first PIN in a short-lived in-memory draft (not route params), adds Card-local `PinDots` + `PinEntryLayout`, and updates success to a centered green check with a spring bounce. Error states lock the keypad, show red dots, then clear after 1.5s (mismatch returns to set).

Stacked on `feature/card-435-set-card-pin` (#34420). Known follow-ups from local review (not blocking draft): success should replace/reset the stack so back cannot return to confirm; clear draft on Confirm back/unmount; functional `appendDigit` for rapid taps.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Updated MetaMask Card set PIN to use a keypad and multi-screen flow

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #34420

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Set Card PIN keypad flow

  Scenario: user sets a valid PIN
    Given the user is authenticated with Immersve Card and has an active card
    And Set card PIN is available from Manage card

    When the user opens Set card PIN and passes biometrics
    And the user enters a valid 4-digit PIN on the keypad
    And the user taps Continue
    And the user re-enters the same PIN
    And the user taps Set PIN
    Then the success screen shows a green check and PIN set copy
    When the user taps Done
    Then the user returns to Card Home

  Scenario: user sees invalid PIN error then can retry
    Given the user is on Set your card PIN

    When the user enters 1111 and taps Continue
    Then the dots show an error and the keypad is locked briefly
    And after about 1.5 seconds the dots clear to empty

  Scenario: user confirms a mismatched PIN
    Given the user continued from Set with PIN 1337

    When the user enters 1338 and taps Set PIN
    Then the confirm screen shows a match error
    And after about 1.5 seconds the user returns to Set your card PIN
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/b7624658-0402-4dea-85a8-933f2633e405





## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches card PIN entry and `setCardPin` submission with sensitive in-memory draft handling and auth-failure redirects; scope is mostly UI/navigation with existing controller APIs.
> 
> **Overview**
> **Redesigns MetaMask Card set PIN** from a single onboarding-style text field into a three-screen stack flow with a shared keypad UI.
> 
> `SetCardPin` now only collects the first PIN via `PinEntryLayout` (masked dots, brief last-digit reveal, `Base/Keypad` with CTA above), validates locally, then stores the value in an **in-memory `pinDraftStore`** and navigates to **`ConfirmCardPin`**. Confirm compares entry to the draft, calls `CardController.setCardPin`, and on success **`navigation.reset`s** to Card Home + **`SetCardPinSuccess`** so back cannot return to confirm. **`SetCardPinSuccess`** is a dedicated screen with animated success UI and Done → Card Home.
> 
> Shared pieces added: **`usePinEntry`** (rapid-tap-safe append, unmask timer, error lock + 1.5s clear with optional callback), **`PinDots`** animations, and draft clearing on confirm back, missing draft, and app background/inactive. Card routes and nav types gain `CONFIRM_PIN` and `SET_PIN_SUCCESS` (success gestures disabled). Tests are split/expanded for set, confirm, success, hook, and draft store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02297e908ab2ea066ad78f5d3a2f642a5011be9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->