### PR TITLE
fix(Rewards): Move company name in Benefits cards

### DIFF
--- a/app/components/UI/Rewards/Views/BenefitFullView.test.tsx
+++ b/app/components/UI/Rewards/Views/BenefitFullView.test.tsx
@@ -154,7 +154,7 @@ describe('BenefitFullView', () => {
     ).toBeOnTheScreen();
     expect(getByText('1mo 3d')).toBeOnTheScreen();
     expect(mockFormatDateRemaining).toHaveBeenCalledWith(
-      mockBenefit.actionDate,
+      mockBenefit.validTo,
       expect.any(Number),
     );
     expect(mockStrings).toHaveBeenCalledWith('rewards.benefits.title_claim');
@@ -375,10 +375,11 @@ describe('BenefitFullView', () => {
     expect(queryByText('1mo 3d')).toBeNull();
   });
 
-  it('uses validTo when actionDate is null', () => {
+  it('formats remaining time from validTo even when actionDate is present', () => {
     mockRouteBenefit = {
       ...mockBenefit,
-      actionDate: null as unknown as string,
+      actionDate: '2026-09-01T00:00:00Z',
+      validTo: '2026-12-31T23:59:59Z',
     };
 
     const { getByText } = render(<BenefitFullView />);

--- a/app/components/UI/Rewards/Views/BenefitFullView.test.tsx
+++ b/app/components/UI/Rewards/Views/BenefitFullView.test.tsx
@@ -375,16 +375,19 @@ describe('BenefitFullView', () => {
     expect(queryByText('1mo 3d')).toBeNull();
   });
 
-  it('does not format remaining time when actionDate is null', () => {
+  it('uses validTo when actionDate is null', () => {
     mockRouteBenefit = {
       ...mockBenefit,
       actionDate: null as unknown as string,
     };
 
-    const { queryByText } = render(<BenefitFullView />);
+    const { getByText } = render(<BenefitFullView />);
 
-    expect(mockFormatDateRemaining).not.toHaveBeenCalled();
-    expect(queryByText('1mo 3d')).toBeNull();
+    expect(mockFormatDateRemaining).toHaveBeenCalledWith(
+      mockRouteBenefit.validTo,
+      expect.any(Number),
+    );
+    expect(getByText('1mo 3d')).toBeOnTheScreen();
   });
 
   it('does not render company label when companyName is null', () => {

--- a/app/components/UI/Rewards/Views/BenefitFullView.test.tsx
+++ b/app/components/UI/Rewards/Views/BenefitFullView.test.tsx
@@ -391,6 +391,21 @@ describe('BenefitFullView', () => {
     expect(getByText('1mo 3d')).toBeOnTheScreen();
   });
 
+  it('falls back to actionDate when validTo is unavailable', () => {
+    mockRouteBenefit = {
+      ...mockBenefit,
+      validTo: null,
+    };
+
+    const { getByText } = render(<BenefitFullView />);
+
+    expect(mockFormatDateRemaining).toHaveBeenCalledWith(
+      mockRouteBenefit.actionDate,
+      expect.any(Number),
+    );
+    expect(getByText('1mo 3d')).toBeOnTheScreen();
+  });
+
   it('does not render company label when companyName is null', () => {
     mockRouteBenefit = {
       ...mockBenefit,

--- a/app/components/UI/Rewards/Views/BenefitFullView.tsx
+++ b/app/components/UI/Rewards/Views/BenefitFullView.tsx
@@ -24,7 +24,10 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { BenefitFullViewRouteProp } from './BenefitFullView.types.ts';
 import { REWARDS_VIEW_SELECTORS } from './RewardsView.constants.ts';
-import { formatDateRemaining } from '../utils/formatUtils.ts';
+import {
+  formatDateRemaining,
+  resolveBenefitEndDate,
+} from '../utils/formatUtils.ts';
 import { strings } from '../../../../../locales/i18n';
 import ErrorBoundary from '../../../Views/ErrorBoundary';
 import Routes from '../../../../constants/navigation/Routes.ts';
@@ -110,10 +113,10 @@ const BenefitFullView = () => {
     }
   };
 
-  const remainingTime = useMemo(
-    () => formatDateRemaining(benefit.validTo, Date.now()),
-    [benefit.validTo],
-  );
+  const remainingTime = useMemo(() => {
+    const endDate = resolveBenefitEndDate(benefit.validTo, benefit.actionDate);
+    return endDate == null ? null : formatDateRemaining(endDate, Date.now());
+  }, [benefit.actionDate, benefit.validTo]);
   const companyName = benefit.companyName?.trim();
 
   return (

--- a/app/components/UI/Rewards/Views/BenefitFullView.tsx
+++ b/app/components/UI/Rewards/Views/BenefitFullView.tsx
@@ -111,9 +111,8 @@ const BenefitFullView = () => {
   };
 
   const remainingTime = useMemo(
-    () =>
-      formatDateRemaining(benefit.actionDate ?? benefit.validTo, Date.now()),
-    [benefit.actionDate, benefit.validTo],
+    () => formatDateRemaining(benefit.validTo, Date.now()),
+    [benefit.validTo],
   );
   const companyName = benefit.companyName?.trim();
 
@@ -185,7 +184,7 @@ const BenefitFullView = () => {
                 )}
                 {companyName ? (
                   <Text
-                    variant={TextVariant.BodyMd}
+                    variant={TextVariant.BodySm}
                     color={TextColor.TextAlternative}
                     twClassName="max-w-[55%]"
                     numberOfLines={1}

--- a/app/components/UI/Rewards/Views/BenefitFullView.tsx
+++ b/app/components/UI/Rewards/Views/BenefitFullView.tsx
@@ -112,10 +112,8 @@ const BenefitFullView = () => {
 
   const remainingTime = useMemo(
     () =>
-      benefit.actionDate == null
-        ? null
-        : formatDateRemaining(benefit.actionDate, Date.now()),
-    [benefit.actionDate],
+      formatDateRemaining(benefit.actionDate ?? benefit.validTo, Date.now()),
+    [benefit.actionDate, benefit.validTo],
   );
   const companyName = benefit.companyName?.trim();
 

--- a/app/components/UI/Rewards/Views/RewardsView.constants.ts
+++ b/app/components/UI/Rewards/Views/RewardsView.constants.ts
@@ -55,6 +55,7 @@ export const REWARDS_VIEW_SELECTORS = {
   TOP_BENEFIT_SECTION: 'rewards-view-top-benefit-section',
   TOP_BENEFIT_DETAILS: 'rewards-view-top-benefit-details',
   TOP_BENEFIT_DETAILS_IMAGE: 'rewards-view-top-benefit-details-image',
+  BENEFIT_CARD_FOOTER: 'rewards-view-benefit-card-footer',
   LIST_BENEFIT_VIEW: 'rewards-view-list-benefit-view',
   DETAIL_BENEFIT_VIEW: 'rewards-view-detail-benefit-view',
   DETAIL_BENEFIT_ACTION: 'rewards-view-detail-benefit-action',

--- a/app/components/UI/Rewards/components/Benefits/BenefitCard.test.tsx
+++ b/app/components/UI/Rewards/components/Benefits/BenefitCard.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react-native';
+import { fireEvent, render, within } from '@testing-library/react-native';
 import { TouchableOpacity } from 'react-native';
 import BenefitCard from './BenefitCard';
 import Routes from '../../../../../constants/navigation/Routes';
@@ -93,11 +93,15 @@ describe('BenefitCard', () => {
 
     it('renders the company name in the remaining-time row', () => {
       const benefit = createBenefit({ companyName: 'Pudgy Penguins' });
-      const { getByText } = render(<BenefitCard benefit={benefit} />);
-
-      expect(getByText('Pudgy Penguins').parent).toBe(
-        getByText('1mo 3d').parent?.parent,
+      const { getByTestId } = render(<BenefitCard benefit={benefit} />);
+      const footer = within(
+        getByTestId(
+          `${REWARDS_VIEW_SELECTORS.BENEFIT_CARD_FOOTER}-${benefit.id}`,
+        ),
       );
+
+      expect(footer.getByText('Pudgy Penguins')).toBeOnTheScreen();
+      expect(footer.getByText('1mo 3d')).toBeOnTheScreen();
     });
 
     it('does not render an empty company label when companyName is null', () => {
@@ -168,16 +172,31 @@ describe('BenefitCard', () => {
   });
 
   describe('remaining time', () => {
-    it('formats and renders remaining time from validTo', () => {
+    it('prefers validTo when validTo and actionDate exist', () => {
       const benefit = createBenefit({
-        actionDate: '2026-09-01T00:00:00Z',
         validTo: '2026-12-31T23:59:59Z',
+        actionDate: '2026-09-01T00:00:00Z',
       });
       const { getByText } = render(<BenefitCard benefit={benefit} />);
 
       expect(mockFormatDateRemaining).toHaveBeenCalledTimes(1);
       expect(mockFormatDateRemaining).toHaveBeenCalledWith(
         benefit.validTo,
+        expect.any(Number),
+      );
+      expect(getByText('1mo 3d')).toBeOnTheScreen();
+    });
+
+    it('falls back to actionDate when validTo is unavailable', () => {
+      const benefit = createBenefit({
+        validTo: null,
+        actionDate: '2026-09-01T00:00:00Z',
+      });
+      const { getByText } = render(<BenefitCard benefit={benefit} />);
+
+      expect(mockFormatDateRemaining).toHaveBeenCalledTimes(1);
+      expect(mockFormatDateRemaining).toHaveBeenCalledWith(
+        benefit.actionDate,
         expect.any(Number),
       );
       expect(getByText('1mo 3d')).toBeOnTheScreen();

--- a/app/components/UI/Rewards/components/Benefits/BenefitCard.test.tsx
+++ b/app/components/UI/Rewards/components/Benefits/BenefitCard.test.tsx
@@ -91,6 +91,15 @@ describe('BenefitCard', () => {
       expect(getByText('Pudgy Penguins')).toBeOnTheScreen();
     });
 
+    it('renders the company name in the remaining-time row', () => {
+      const benefit = createBenefit({ companyName: 'Pudgy Penguins' });
+      const { getByText } = render(<BenefitCard benefit={benefit} />);
+
+      expect(getByText('Pudgy Penguins').parent).toBe(
+        getByText('1mo 3d').parent?.parent,
+      );
+    });
+
     it('does not render an empty company label when companyName is null', () => {
       const benefit = createBenefit({ companyName: null });
       const { queryByText } = render(<BenefitCard benefit={benefit} />);
@@ -171,14 +180,18 @@ describe('BenefitCard', () => {
       expect(getByText('1mo 3d')).toBeOnTheScreen();
     });
 
-    it('does not call formatter and hides remaining time when actionDate is null', () => {
+    it('uses validTo when actionDate is null', () => {
       const benefit = createBenefit({
         actionDate: null,
+        validTo: '2026-12-31T23:59:59Z',
       });
-      const { queryByText } = render(<BenefitCard benefit={benefit} />);
+      const { getByText } = render(<BenefitCard benefit={benefit} />);
 
-      expect(mockFormatDateRemaining).not.toHaveBeenCalled();
-      expect(queryByText('1mo 3d')).toBeNull();
+      expect(mockFormatDateRemaining).toHaveBeenCalledWith(
+        benefit.validTo,
+        expect.any(Number),
+      );
+      expect(getByText('1mo 3d')).toBeOnTheScreen();
     });
 
     it('hides remaining time when formatter returns null', () => {

--- a/app/components/UI/Rewards/components/Benefits/BenefitCard.test.tsx
+++ b/app/components/UI/Rewards/components/Benefits/BenefitCard.test.tsx
@@ -168,25 +168,14 @@ describe('BenefitCard', () => {
   });
 
   describe('remaining time', () => {
-    it('formats and renders remaining time when actionDate exists', () => {
-      const benefit = createBenefit({ actionDate: '2026-09-01T00:00:00Z' });
-      const { getByText } = render(<BenefitCard benefit={benefit} />);
-
-      expect(mockFormatDateRemaining).toHaveBeenCalledTimes(1);
-      expect(mockFormatDateRemaining).toHaveBeenCalledWith(
-        '2026-09-01T00:00:00Z',
-        expect.any(Number),
-      );
-      expect(getByText('1mo 3d')).toBeOnTheScreen();
-    });
-
-    it('uses validTo when actionDate is null', () => {
+    it('formats and renders remaining time from validTo', () => {
       const benefit = createBenefit({
-        actionDate: null,
+        actionDate: '2026-09-01T00:00:00Z',
         validTo: '2026-12-31T23:59:59Z',
       });
       const { getByText } = render(<BenefitCard benefit={benefit} />);
 
+      expect(mockFormatDateRemaining).toHaveBeenCalledTimes(1);
       expect(mockFormatDateRemaining).toHaveBeenCalledWith(
         benefit.validTo,
         expect.any(Number),

--- a/app/components/UI/Rewards/components/Benefits/BenefitCard.tsx
+++ b/app/components/UI/Rewards/components/Benefits/BenefitCard.tsx
@@ -28,10 +28,7 @@ const BenefitCard = ({ benefit }: Props) => {
   const tw = useTailwind();
   const benefitImageTestId = `${REWARDS_VIEW_SELECTORS.TOP_BENEFIT_DETAILS_IMAGE}-${benefit.id}`;
 
-  const remainingTime = formatDateRemaining(
-    benefit.actionDate ?? benefit.validTo,
-    Date.now(),
-  );
+  const remainingTime = formatDateRemaining(benefit.validTo, Date.now());
   const companyName = benefit.companyName?.trim();
 
   return (
@@ -65,7 +62,7 @@ const BenefitCard = ({ benefit }: Props) => {
             </Text>
           </Box>
           <Text
-            variant={TextVariant.BodyMd}
+            variant={TextVariant.BodySm}
             color={TextColor.TextAlternative}
             numberOfLines={3}
           >
@@ -86,11 +83,11 @@ const BenefitCard = ({ benefit }: Props) => {
                 >
                   <Icon
                     name={IconName.Clock}
-                    size={IconSize.Md}
+                    size={IconSize.Sm}
                     color={IconColor.IconAlternative}
                   />
                   <Text
-                    variant={TextVariant.BodyMd}
+                    variant={TextVariant.BodySm}
                     color={TextColor.TextAlternative}
                   >
                     {remainingTime}

--- a/app/components/UI/Rewards/components/Benefits/BenefitCard.tsx
+++ b/app/components/UI/Rewards/components/Benefits/BenefitCard.tsx
@@ -28,10 +28,10 @@ const BenefitCard = ({ benefit }: Props) => {
   const tw = useTailwind();
   const benefitImageTestId = `${REWARDS_VIEW_SELECTORS.TOP_BENEFIT_DETAILS_IMAGE}-${benefit.id}`;
 
-  const remainingTime =
-    benefit.actionDate == null
-      ? null
-      : formatDateRemaining(benefit.actionDate, Date.now());
+  const remainingTime = formatDateRemaining(
+    benefit.actionDate ?? benefit.validTo,
+    Date.now(),
+  );
   const companyName = benefit.companyName?.trim();
 
   return (
@@ -55,29 +55,14 @@ const BenefitCard = ({ benefit }: Props) => {
         </Box>
 
         <Box twClassName="flex-1 gap-1">
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            justifyContent={BoxJustifyContent.Between}
-            twClassName="gap-2"
-          >
+          <Box>
             <Text
               variant={TextVariant.HeadingSm}
-              twClassName="text-default flex-1"
+              twClassName="text-default"
               numberOfLines={1}
             >
               {benefit.longTitle}
             </Text>
-            {companyName ? (
-              <Text
-                variant={TextVariant.BodySm}
-                color={TextColor.TextAlternative}
-                twClassName="max-w-[40%]"
-                numberOfLines={1}
-              >
-                {companyName}
-              </Text>
-            ) : null}
           </Box>
           <Text
             variant={TextVariant.BodyMd}
@@ -86,23 +71,42 @@ const BenefitCard = ({ benefit }: Props) => {
           >
             {benefit.shortDescription}
           </Text>
-          {remainingTime != null && (
+          {(remainingTime != null || companyName) && (
             <Box
               gap={1}
               flexDirection={BoxFlexDirection.Row}
               alignItems={BoxAlignItems.Center}
+              justifyContent={BoxJustifyContent.Between}
             >
-              <Icon
-                name={IconName.Clock}
-                size={IconSize.Md}
-                color={IconColor.IconAlternative}
-              />
-              <Text
-                variant={TextVariant.BodyMd}
-                color={TextColor.TextAlternative}
-              >
-                {remainingTime}
-              </Text>
+              {remainingTime != null && (
+                <Box
+                  gap={1}
+                  flexDirection={BoxFlexDirection.Row}
+                  alignItems={BoxAlignItems.Center}
+                >
+                  <Icon
+                    name={IconName.Clock}
+                    size={IconSize.Md}
+                    color={IconColor.IconAlternative}
+                  />
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    color={TextColor.TextAlternative}
+                  >
+                    {remainingTime}
+                  </Text>
+                </Box>
+              )}
+              {companyName ? (
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextAlternative}
+                  twClassName="max-w-[40%]"
+                  numberOfLines={1}
+                >
+                  {companyName}
+                </Text>
+              ) : null}
             </Box>
           )}
         </Box>

--- a/app/components/UI/Rewards/components/Benefits/BenefitCard.tsx
+++ b/app/components/UI/Rewards/components/Benefits/BenefitCard.tsx
@@ -18,7 +18,10 @@ import { REWARDS_VIEW_SELECTORS } from '../../Views/RewardsView.constants.ts';
 import React from 'react';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { SubscriptionBenefitDto } from '../../../../../core/Engine/controllers/rewards-controller/types.ts';
-import { formatDateRemaining } from '../../utils/formatUtils.ts';
+import {
+  formatDateRemaining,
+  resolveBenefitEndDate,
+} from '../../utils/formatUtils.ts';
 
 interface Props {
   benefit: SubscriptionBenefitDto;
@@ -28,7 +31,14 @@ const BenefitCard = ({ benefit }: Props) => {
   const tw = useTailwind();
   const benefitImageTestId = `${REWARDS_VIEW_SELECTORS.TOP_BENEFIT_DETAILS_IMAGE}-${benefit.id}`;
 
-  const remainingTime = formatDateRemaining(benefit.validTo, Date.now());
+  const remainingTimeEndDate = resolveBenefitEndDate(
+    benefit.validTo,
+    benefit.actionDate,
+  );
+  const remainingTime =
+    remainingTimeEndDate == null
+      ? null
+      : formatDateRemaining(remainingTimeEndDate, Date.now());
   const companyName = benefit.companyName?.trim();
 
   return (
@@ -74,12 +84,14 @@ const BenefitCard = ({ benefit }: Props) => {
               flexDirection={BoxFlexDirection.Row}
               alignItems={BoxAlignItems.Center}
               justifyContent={BoxJustifyContent.Between}
+              testID={`${REWARDS_VIEW_SELECTORS.BENEFIT_CARD_FOOTER}-${benefit.id}`}
             >
-              {remainingTime != null && (
+              {remainingTime != null ? (
                 <Box
                   gap={1}
                   flexDirection={BoxFlexDirection.Row}
                   alignItems={BoxAlignItems.Center}
+                  twClassName="flex-1"
                 >
                   <Icon
                     name={IconName.Clock}
@@ -93,6 +105,8 @@ const BenefitCard = ({ benefit }: Props) => {
                     {remainingTime}
                   </Text>
                 </Box>
+              ) : (
+                <Box twClassName="flex-1" />
               )}
               {companyName ? (
                 <Text

--- a/app/components/UI/Rewards/utils/formatUtils.test.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.test.ts
@@ -27,6 +27,7 @@ import {
   formatCompactValue,
   formatCompactUsd,
   formatOrdinalRank,
+  resolveBenefitEndDate,
 } from './formatUtils';
 import { IconName } from '@metamask/design-system-react-native';
 import { getTimeDifferenceFromNow } from '../../../../util/date';
@@ -396,6 +397,41 @@ describe('formatUtils', () => {
 
       // Then: should return days and hours format without trailing space
       expect(result).toBe('2d 3h');
+    });
+  });
+
+  describe('resolveBenefitEndDate', () => {
+    const validTo = '2026-12-31T23:59:59Z';
+    const actionDate = '2026-09-01T00:00:00Z';
+
+    it('prefers validTo when both dates are valid', () => {
+      const result = resolveBenefitEndDate(validTo, actionDate);
+
+      expect(result).toBe(validTo);
+    });
+
+    it('falls back to actionDate when validTo is null', () => {
+      const result = resolveBenefitEndDate(null, actionDate);
+
+      expect(result).toBe(actionDate);
+    });
+
+    it('falls back to actionDate when validTo is empty', () => {
+      const result = resolveBenefitEndDate('  ', actionDate);
+
+      expect(result).toBe(actionDate);
+    });
+
+    it('falls back to actionDate when validTo is malformed', () => {
+      const result = resolveBenefitEndDate('not-a-date', actionDate);
+
+      expect(result).toBe(actionDate);
+    });
+
+    it('returns null when neither date is valid', () => {
+      const result = resolveBenefitEndDate('not-a-date', null);
+
+      expect(result).toBeNull();
     });
   });
 

--- a/app/components/UI/Rewards/utils/formatUtils.ts
+++ b/app/components/UI/Rewards/utils/formatUtils.ts
@@ -150,6 +150,21 @@ export const formatTimeRemaining = (endDate: Date): string | null => {
 };
 
 /**
+ * Resolves the date used for a benefit countdown, preferring a valid `validTo`
+ * value and falling back to a valid `actionDate` value.
+ */
+export const resolveBenefitEndDate = (
+  validTo: string | null | undefined,
+  actionDate: string | null | undefined,
+): string | null =>
+  [validTo, actionDate].find(
+    (date): date is string =>
+      typeof date === 'string' &&
+      date.trim().length > 0 &&
+      !Number.isNaN(Date.parse(date)),
+  ) ?? null;
+
+/**
  * Formats remaining time until `endDate` (UTC, calendar months).
  * - Under 1 hour: minutes only (e.g. `45min`).
  * - Otherwise exactly two units: `y`+`mo`, `mo`+`d`, `d`+`h`, or `h`+`min`.

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -2043,7 +2043,7 @@ export type SubscriptionBenefitDto = {
   longDescription: string;
   thumbnail: string;
   validFrom: string;
-  validTo: string;
+  validTo: string | null;
   url: string;
   actionDate: string | null;
   chain: string;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Company name in Benefits cards was displayed on the same line as the title, overlapping and severely truncating the titles. This moves it to the bottom of the card alongside the time left. It also addresses other issues related to Benefits cards. Full list of changes: 

- Move the benefit company name from the title row to the footer row alongside the remaining-time countdown.
- Keep the company name right-aligned when no countdown is available.
- Use `validTo` as the preferred countdown date, falling back to `actionDate`.
- Treat empty or malformed dates as unavailable and try the fallback date.
- Allow both `validTo` and `actionDate` to be nullable.
- Apply the countdown logic consistently to benefit cards and the full benefit view.
- Update benefit card typography and clock sizing for the compact layout.
- Add stable footer test identifiers and replace the fragile React instance comparison.
- Add tests covering date priority, fallback behavior, malformed dates, missing dates, and company placement.

## Testing

- `yarn jest app/components/UI/Rewards/utils/formatUtils.test.ts app/components/UI/Rewards/components/Benefits/BenefitCard.test.tsx app/components/UI/Rewards/Views/BenefitFullView.test.tsx --runInBand`
- `yarn lint:tsc`
- ESLint on all modified files
- `git diff --check`

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Improved the readability of Benefits cards in Rewards

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: n/a

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Benefits card company name

  Scenario: user has mobile app
    Given user navigates to the Rewards tab

    When user views a Benefit card in the Benefits list
    Then time remaining is display cleanly at the bottom of the card
```

Note: it isn't possible to see company names right now because they had to be disabled at the API level. 

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

n/a

### **After**

<!-- [screenshots/recordings] -->
<img width="1179" height="2556" alt="Simulator Screenshot - E2E Test  - 2026-08-10 at 17 06 21" src="https://github.com/user-attachments/assets/ff889f7e-f60b-42b2-8e7a-04f4594f18da" />



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rewards benefits UI and display-only date selection; changes are localized with new unit tests and no auth or payment impact.
> 
> **Overview**
> Rewards benefit **list cards** no longer show the partner **company name** on the same row as the title (which was truncating titles). The name now sits in a **footer row** with the clock and **time remaining**, using a new `BENEFIT_CARD_FOOTER` test id and slightly smaller typography for description and footer text.
> 
> **Time left** on cards and the **benefit detail** screen now comes from a shared **`resolveBenefitEndDate`** helper: it uses **`validTo` when present and parseable**, otherwise **`actionDate`**. `SubscriptionBenefitDto.validTo` is typed as **`string | null`** to match nullable API data. Unit and component tests cover the date resolution and layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ee721e5528baa2302caf8dac18a17e59b38ba9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->