### PR TITLE
feat(predict): offer Add funds when PWAT payment fails

### DIFF
--- a/app/components/UI/Predict/Predict.testIds.ts
+++ b/app/components/UI/Predict/Predict.testIds.ts
@@ -305,6 +305,9 @@ export const PredictBuyPreviewSelectorsIDs = {
   // Inline error banners (sheet mode)
   PRICE_CHANGED_BANNER: 'predict-buy-preview-price-changed-banner',
   ORDER_FAILED_BANNER: 'predict-buy-preview-order-failed-banner',
+  PAYMENT_FAILED_BANNER: 'predict-buy-preview-payment-failed-banner',
+  PAYMENT_FAILED_ADD_FUNDS_BUTTON:
+    'predict-buy-preview-payment-failed-add-funds',
 } as const;
 
 // ========================================

--- a/app/components/UI/Predict/constants/errors.ts
+++ b/app/components/UI/Predict/constants/errors.ts
@@ -84,4 +84,10 @@ export const getPredictErrorMessages = () =>
     [PREDICT_ERROR_CODES.MARKET_BETTABLE_CHECK_FAILED]: strings(
       'predict.error_messages.market_bettable_check_failed',
     ),
+    [PREDICT_ERROR_CODES.DEPOSIT_FAILED]: strings(
+      'predict.error_messages.deposit_failed',
+    ),
+    [PREDICT_ERROR_CODES.WITHDRAW_FAILED]: strings(
+      'predict.error_messages.withdraw_failed',
+    ),
   }) as const;

--- a/app/components/UI/Predict/constants/eventNames.ts
+++ b/app/components/UI/Predict/constants/eventNames.ts
@@ -223,6 +223,8 @@ export const PredictTradeStatus = {
   SWAP_FAILED: 'swap_failed',
   RETRY_PROMPTED: 'retry_prompted',
   RETRY_SUBMITTED: 'retry_submitted',
+  PAYMENT_FAILURE_PROMPTED: 'payment_failure_prompted',
+  ADD_FUNDS_SUBMITTED: 'add_funds_submitted',
 } as const;
 
 export type PredictTradeStatusValue =

--- a/app/components/UI/Predict/contexts/PredictPreviewSheetContext.test.tsx
+++ b/app/components/UI/Predict/contexts/PredictPreviewSheetContext.test.tsx
@@ -791,6 +791,11 @@ describe('PredictPreviewSheetContext', () => {
       expect(mockToastShowToast).toHaveBeenCalledTimes(1);
       const toastCall = mockToastShowToast.mock.calls[0][0];
       expect(toastCall.closeButtonOptions.label).toBe('Add funds');
+      expect(mockTrackPredictOrderEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'payment_failure_prompted',
+        }),
+      );
 
       act(() => {
         jest.advanceTimersByTime(3000);

--- a/app/components/UI/Predict/contexts/PredictPreviewSheetContext.test.tsx
+++ b/app/components/UI/Predict/contexts/PredictPreviewSheetContext.test.tsx
@@ -16,12 +16,15 @@ import Routes from '../../../../constants/navigation/Routes';
 
 const mockNavigate = jest.fn();
 const mockTrackBetslipDismissed = jest.fn();
+const mockTrackPredictOrderEvent = jest.fn();
 
 jest.mock('../../../../core/Engine', () => ({
   context: {
     PredictController: {
       trackBetslipDismissed: (...args: unknown[]) =>
         mockTrackBetslipDismissed(...args),
+      trackPredictOrderEvent: (...args: unknown[]) =>
+        mockTrackPredictOrderEvent(...args),
     },
   },
 }));
@@ -59,7 +62,13 @@ jest.mock('react-redux', () => ({
 }));
 
 const mockClearOrderError = jest.fn();
-let mockActiveOrder: { error?: string; state?: string } | null = null;
+let mockActiveOrder: {
+  error?: string;
+  errorStage?: 'payment' | 'order';
+  state?: string;
+  paymentTokenAddress?: string;
+  paymentTokenSymbol?: string;
+} | null = null;
 
 jest.mock('../hooks/usePredictActiveOrder', () => ({
   usePredictActiveOrder: jest.fn(() => ({
@@ -754,6 +763,56 @@ describe('PredictPreviewSheetContext', () => {
       });
       expect(screen.getByTestId('predict-buy-preview-sheet')).toBeOnTheScreen();
       expect(mockToastCloseToast).not.toHaveBeenCalled();
+    });
+
+    it('offers Add funds for payment-stage failures and does not auto-clear the error', () => {
+      jest.useFakeTimers();
+      const { rerender } = render(
+        <PredictPreviewSheetProvider>
+          <TestConsumer />
+        </PredictPreviewSheetProvider>,
+      );
+
+      fireEvent.press(screen.getByTestId('open-buy'));
+      fireEvent.press(screen.getByTestId('dismiss-sheet'));
+      mockClearOrderError.mockClear();
+
+      mockActiveOrder = {
+        error: 'PREDICT_DEPOSIT_FAILED',
+        errorStage: 'payment',
+        paymentTokenSymbol: 'USDC',
+      };
+      rerender(
+        <PredictPreviewSheetProvider>
+          <TestConsumer />
+        </PredictPreviewSheetProvider>,
+      );
+
+      expect(mockToastShowToast).toHaveBeenCalledTimes(1);
+      const toastCall = mockToastShowToast.mock.calls[0][0];
+      expect(toastCall.closeButtonOptions.label).toBe('Add funds');
+
+      act(() => {
+        jest.advanceTimersByTime(3000);
+      });
+      expect(mockClearOrderError).not.toHaveBeenCalled();
+
+      act(() => {
+        toastCall.closeButtonOptions.onPress();
+      });
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.PREDICT.MODALS.ROOT,
+        expect.objectContaining({
+          screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
+          params: { autoDeposit: true },
+        }),
+      );
+      expect(mockTrackPredictOrderEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'add_funds_submitted',
+        }),
+      );
+      jest.useRealTimers();
     });
 
     it('does not fire the toast when the slip is open (banner handles it)', () => {

--- a/app/components/UI/Predict/contexts/PredictPreviewSheetContext.tsx
+++ b/app/components/UI/Predict/contexts/PredictPreviewSheetContext.tsx
@@ -28,6 +28,10 @@ import { ButtonVariants } from '../../../../component-library/components/Buttons
 import ToastService from '../../../../core/ToastService';
 import { useAppThemeFromContext } from '../../../../util/theme';
 import {
+  PredictEventValues,
+  PredictTradeStatus,
+ PredictDismissalMethod } from '../constants/eventNames';
+import {
   selectPredictWithAnyTokenEnabledFlag,
   selectPredictBottomSheetEnabledFlag,
 } from '../selectors/featureFlags';
@@ -49,7 +53,6 @@ import PredictBuyWithAnyToken from '../views/PredictBuyWithAnyToken/PredictBuyWi
 import PredictSellPreview from '../views/PredictSellPreview/PredictSellPreview';
 import { PredictMarketDetailsSelectorsIDs } from '../Predict.testIds';
 import { usePredictActiveOrder } from '../hooks/usePredictActiveOrder';
-import { PredictDismissalMethod } from '../constants/eventNames';
 import { parseAnalyticsProperties } from '../utils/analytics';
 import PredictRegTimeTag from '../components/PredictRegTimeTag';
 import { getBuyOutcomeImage } from '../utils/sports';
@@ -388,10 +391,11 @@ export const PredictPreviewSheetProvider: React.FC<
     }
 
     const lastParams = lastBuyParamsRef.current;
+    const isPaymentFailure = activeOrder?.errorStage === 'payment';
     // Use `closeButtonOptions` (with `ButtonVariants.Link`) rather than
-    // `linkButtonOptions` so the Retry sits inline on the right of the row
-    // (`[icon] [label] [Retry]`) instead of stacked below the label. This
-    // matches the deposit "Adding funds / Track" toast convention.
+    // `linkButtonOptions` so the Retry / Add funds sits inline on the right of
+    // the row (`[icon] [label] [action]`) instead of stacked below the label.
+    // This matches the deposit "Adding funds / Track" toast convention.
     ToastService.showToast({
       variant: ToastVariants.Icon,
       labelOptions: [
@@ -401,23 +405,47 @@ export const PredictPreviewSheetProvider: React.FC<
         },
       ],
       // The description provides useful context AND makes the labels
-      // container two lines tall — same height as the Retry Primary
+      // container two lines tall — same height as the action Primary
       // button — so the row's `alignItems: flex-start` produces a
       // visually-balanced layout (matches the deposit/Track toast).
       descriptionOptions: {
-        description: strings('predict.order.order_failed_generic'),
+        description: isPaymentFailure
+          ? strings('predict.order.payment_failed_body_generic')
+          : strings('predict.order.order_failed_generic'),
       },
       iconName: IconName.Error,
       iconColor: themeRef.current.colors.error.default,
       backgroundColor: themeRef.current.colors.error.muted,
       hasNoTimeout: false,
       closeButtonOptions: {
-        label: strings('predict.order.retry'),
+        label: isPaymentFailure
+          ? strings('predict.deposit.add_funds')
+          : strings('predict.order.retry'),
         variant: ButtonVariants.Link,
         onPress: () => {
           if (clearErrorTimerRef.current) {
             clearTimeout(clearErrorTimerRef.current);
             clearErrorTimerRef.current = null;
+          }
+          if (isPaymentFailure) {
+            Engine.context.PredictController.trackPredictOrderEvent({
+              status: PredictTradeStatus.ADD_FUNDS_SUBMITTED,
+              analyticsProperties: {
+                marketId: lastParams.market?.id,
+                marketTitle: lastParams.market?.title,
+                marketCategory: lastParams.market?.category,
+                entryPoint: lastParams.entryPoint,
+                transactionType:
+                  PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_BUY,
+              },
+              paymentTokenAddress: activeOrder?.paymentTokenAddress,
+              paymentTokenSymbol: activeOrder?.paymentTokenSymbol,
+            });
+            navigation.navigate(Routes.PREDICT.MODALS.ROOT, {
+              screen: Routes.PREDICT.MODALS.ADD_FUNDS_SHEET,
+              params: { autoDeposit: true },
+            });
+            return;
           }
           openBuySheet(lastParams);
         },
@@ -426,22 +454,29 @@ export const PredictPreviewSheetProvider: React.FC<
 
     // Toast auto-dismisses on the platform default (~2.75s visibility +
     // ~250ms exit anim). When that finishes without the user tapping
-    // Retry, clear the error so the next slip open is clean (no banner).
-    // Tapping Retry cancels this timer so the reopened slip can show the
-    // banner explaining what went wrong.
+    // Retry, clear order-stage errors so the next slip open is clean.
+    // Payment-stage errors persist so reopening the slip still explains
+    // what happened. Tapping Retry cancels this timer so the reopened
+    // slip can show the banner explaining what went wrong.
     if (clearErrorTimerRef.current) {
       clearTimeout(clearErrorTimerRef.current);
     }
-    clearErrorTimerRef.current = setTimeout(() => {
-      clearErrorTimerRef.current = null;
-      clearOrderError();
-    }, 3000);
+    if (!isPaymentFailure) {
+      clearErrorTimerRef.current = setTimeout(() => {
+        clearErrorTimerRef.current = null;
+        clearOrderError();
+      }, 3000);
+    }
   }, [
     activeOrder?.error,
+    activeOrder?.errorStage,
+    activeOrder?.paymentTokenAddress,
+    activeOrder?.paymentTokenSymbol,
     buyParams,
     bottomSheetEnabled,
     openBuySheet,
     clearOrderError,
+    navigation,
   ]);
 
   const BuyComponent = useMemo(

--- a/app/components/UI/Predict/contexts/PredictPreviewSheetContext.tsx
+++ b/app/components/UI/Predict/contexts/PredictPreviewSheetContext.tsx
@@ -30,7 +30,8 @@ import { useAppThemeFromContext } from '../../../../util/theme';
 import {
   PredictEventValues,
   PredictTradeStatus,
- PredictDismissalMethod } from '../constants/eventNames';
+  PredictDismissalMethod,
+} from '../constants/eventNames';
 import {
   selectPredictWithAnyTokenEnabledFlag,
   selectPredictBottomSheetEnabledFlag,
@@ -392,6 +393,23 @@ export const PredictPreviewSheetProvider: React.FC<
 
     const lastParams = lastBuyParamsRef.current;
     const isPaymentFailure = activeOrder?.errorStage === 'payment';
+    const toastAnalyticsProperties = {
+      marketId: lastParams.market?.id,
+      marketTitle: lastParams.market?.title,
+      marketCategory: lastParams.market?.category,
+      entryPoint: lastParams.entryPoint,
+      transactionType: PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_BUY,
+    };
+
+    if (isPaymentFailure) {
+      Engine.context.PredictController.trackPredictOrderEvent({
+        status: PredictTradeStatus.PAYMENT_FAILURE_PROMPTED,
+        analyticsProperties: toastAnalyticsProperties,
+        paymentTokenAddress: activeOrder?.paymentTokenAddress,
+        paymentTokenSymbol: activeOrder?.paymentTokenSymbol,
+      });
+    }
+
     // Use `closeButtonOptions` (with `ButtonVariants.Link`) rather than
     // `linkButtonOptions` so the Retry / Add funds sits inline on the right of
     // the row (`[icon] [label] [action]`) instead of stacked below the label.
@@ -430,14 +448,7 @@ export const PredictPreviewSheetProvider: React.FC<
           if (isPaymentFailure) {
             Engine.context.PredictController.trackPredictOrderEvent({
               status: PredictTradeStatus.ADD_FUNDS_SUBMITTED,
-              analyticsProperties: {
-                marketId: lastParams.market?.id,
-                marketTitle: lastParams.market?.title,
-                marketCategory: lastParams.market?.category,
-                entryPoint: lastParams.entryPoint,
-                transactionType:
-                  PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_BUY,
-              },
+              analyticsProperties: toastAnalyticsProperties,
               paymentTokenAddress: activeOrder?.paymentTokenAddress,
               paymentTokenSymbol: activeOrder?.paymentTokenSymbol,
             });

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -5950,6 +5950,46 @@ describe('PredictController', () => {
       });
     });
 
+    it('preserves payment-stage error after successful re-init', async () => {
+      await withController(async ({ controller }) => {
+        setActiveOrderForTest(controller, {
+          state: ActiveOrderState.PAY_WITH_ANY_TOKEN,
+          error: 'Deposit reverted',
+          errorStage: 'payment',
+        });
+
+        const result = await controller.initPayWithAnyToken();
+
+        expect(result.success).toBe(true);
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.error).toBe(
+          'Deposit reverted',
+        );
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.errorStage).toBe(
+          'payment',
+        );
+      });
+    });
+
+    it('clears non-payment error after successful re-init', async () => {
+      await withController(async ({ controller }) => {
+        setActiveOrderForTest(controller, {
+          state: ActiveOrderState.PAY_WITH_ANY_TOKEN,
+          error: 'Order placement failed',
+          errorStage: 'order',
+        });
+
+        const result = await controller.initPayWithAnyToken();
+
+        expect(result.success).toBe(true);
+        expect(
+          controller.state.activeBuyOrders[MOCK_ADDRESS]?.error,
+        ).toBeUndefined();
+        expect(
+          controller.state.activeBuyOrders[MOCK_ADDRESS]?.errorStage,
+        ).toBeUndefined();
+      });
+    });
+
     it('uses predict deposit transaction when setup transactions are present', async () => {
       const setupTransaction = {
         params: {

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -1762,6 +1762,7 @@ describe('PredictController', () => {
           expect(controller.state.activeBuyOrders[MOCK_ADDRESS]).toEqual({
             state: ActiveOrderState.PREVIEW,
             error: PREDICT_ERROR_CODES.MARKET_BETTABLE_CHECK_FAILED,
+            errorStage: 'order',
           });
           expect(mockPolymarketProvider.placeOrder).not.toHaveBeenCalled();
         },
@@ -1809,6 +1810,7 @@ describe('PredictController', () => {
           expect(controller.state.activeBuyOrders[MOCK_ADDRESS]).toEqual({
             state: ActiveOrderState.PREVIEW,
             error: PREDICT_ERROR_CODES.MARKET_PENDING_RESOLUTION,
+            errorStage: 'order',
           });
         },
         {

--- a/app/components/UI/Predict/controllers/PredictController.test.ts
+++ b/app/components/UI/Predict/controllers/PredictController.test.ts
@@ -5692,12 +5692,16 @@ describe('PredictController', () => {
         setActiveOrderForTest(controller, {
           state: ActiveOrderState.PREVIEW,
           error: 'some error',
+          errorStage: 'payment',
         });
 
         controller.clearOrderError();
 
         expect(
           controller.state.activeBuyOrders[MOCK_ADDRESS]?.error,
+        ).toBeUndefined();
+        expect(
+          controller.state.activeBuyOrders[MOCK_ADDRESS]?.errorStage,
         ).toBeUndefined();
       });
     });
@@ -12519,6 +12523,12 @@ describe('PredictController', () => {
         ).toMatchObject({
           payment_token_address: '0xpaytoken',
         });
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.errorStage).toBe(
+          'payment',
+        );
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.error).toBe(
+          'Deposit reverted',
+        );
       });
     });
 
@@ -12823,6 +12833,12 @@ describe('PredictController', () => {
           success: false,
           error: 'Deposit preparation returned undefined',
         });
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.errorStage).toBe(
+          'payment',
+        );
+        expect(controller.state.activeBuyOrders[MOCK_ADDRESS]?.error).toBe(
+          'Deposit preparation returned undefined',
+        );
       });
     });
 

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -103,6 +103,7 @@ import {
   PredictMarket,
   PredictMarketListParams,
   PredictMarketListResponse,
+  PredictOrderErrorStage,
   PredictPosition,
   PredictPositionStatus,
   PredictPriceHistoryPoint,
@@ -171,6 +172,11 @@ export type PredictControllerState = {
       transactionId?: string;
       state: ActiveOrderState;
       error?: string;
+      /**
+       * Which buy leg failed. `'payment'` = swap/deposit before order placement.
+       * `'order'` (default when omitted) = order placement / fill failure.
+       */
+      errorStage?: PredictOrderErrorStage;
       paymentTokenAddress?: string;
       paymentTokenSymbol?: string;
     };
@@ -1616,6 +1622,7 @@ export class PredictController extends BaseController<
           state.activeBuyOrders[activeOrderAddress].state =
             ActiveOrderState.PREVIEW;
           state.activeBuyOrders[activeOrderAddress].error = errorMessage;
+          state.activeBuyOrders[activeOrderAddress].errorStage = 'order';
         }
       });
 
@@ -1927,6 +1934,7 @@ export class PredictController extends BaseController<
           state.activeBuyOrders[activeOrderAddress].state =
             ActiveOrderState.PREVIEW;
           state.activeBuyOrders[activeOrderAddress].error = errorMessage;
+          state.activeBuyOrders[activeOrderAddress].errorStage = 'order';
         }
         if (isBuyWithAnyToken) {
           state.selectedPaymentToken = null;
@@ -2651,6 +2659,7 @@ export class PredictController extends BaseController<
     this.update((state) => {
       if (state.activeBuyOrders[address]) {
         delete state.activeBuyOrders[address].error;
+        delete state.activeBuyOrders[address].errorStage;
       }
     });
   }
@@ -2997,6 +3006,7 @@ export class PredictController extends BaseController<
       this.update((state) => {
         if (state.activeBuyOrders[address]) {
           delete state.activeBuyOrders[address].error;
+          delete state.activeBuyOrders[address].errorStage;
         }
       });
 
@@ -3019,10 +3029,17 @@ export class PredictController extends BaseController<
         };
       }
 
-      this.trackFlowSubmissionFailureMetric({
+      const isUserCancelled = this.trackFlowSubmissionFailureMetric({
         transactionType: PredictEventValues.TRANSACTION_TYPE.MM_PREDICT_DEPOSIT,
         error,
       });
+
+      if (isUserCancelled) {
+        return {
+          success: true,
+          response: { batchId: 'NA' },
+        };
+      }
 
       Logger.error(
         e,
@@ -3031,9 +3048,17 @@ export class PredictController extends BaseController<
         }),
       );
 
+      const errorMessage = e.message || PREDICT_ERROR_CODES.DEPOSIT_FAILED;
+      this.update((state) => {
+        if (state.activeBuyOrders[address]) {
+          state.activeBuyOrders[address].error = errorMessage;
+          state.activeBuyOrders[address].errorStage = 'payment';
+        }
+      });
+
       return {
         success: false,
-        error: e.message,
+        error: errorMessage,
       };
     }
   }
@@ -3352,6 +3377,7 @@ export class PredictController extends BaseController<
             state.activeBuyOrders[address].state =
               ActiveOrderState.PAY_WITH_ANY_TOKEN;
             state.activeBuyOrders[address].error = errorMessage;
+            state.activeBuyOrders[address].errorStage = 'payment';
             state.activeBuyOrders[address].transactionId = undefined;
           }
         });

--- a/app/components/UI/Predict/controllers/PredictController.ts
+++ b/app/components/UI/Predict/controllers/PredictController.ts
@@ -3003,8 +3003,13 @@ export class PredictController extends BaseController<
       });
       submittedBatchId = batchId;
 
+      // Keep payment-stage errors sticky so reopen still shows the Add funds
+      // banner after a depositAndOrder failure + successful re-init (PRED-1026).
       this.update((state) => {
-        if (state.activeBuyOrders[address]) {
+        if (
+          state.activeBuyOrders[address] &&
+          state.activeBuyOrders[address].errorStage !== 'payment'
+        ) {
           delete state.activeBuyOrders[address].error;
           delete state.activeBuyOrders[address].errorStage;
         }

--- a/app/components/UI/Predict/types/index.ts
+++ b/app/components/UI/Predict/types/index.ts
@@ -19,6 +19,12 @@ export enum ActiveOrderState {
   SUCCESS = 'success',
 }
 
+/**
+ * Which leg of a PWAT buy failed. Defaults to `'order'` when omitted so
+ * existing failure UX (Retry-only) is preserved for non-payment failures.
+ */
+export type PredictOrderErrorStage = 'payment' | 'order';
+
 export enum PredictPriceHistoryInterval {
   ONE_HOUR = '1h',
   SIX_HOUR = '6h',

--- a/app/components/UI/Predict/utils/predictErrorHandler.test.ts
+++ b/app/components/UI/Predict/utils/predictErrorHandler.test.ts
@@ -24,6 +24,8 @@ jest.mock('../constants/errors', () => ({
     PREDICT_UNKNOWN_ERROR: 'Something went wrong',
     PREDICT_BUY_ORDER_NOT_FULLY_FILLED: 'Buy order not fully filled',
     PREDICT_SELL_ORDER_NOT_FULLY_FILLED: 'Sell order not fully filled',
+    PREDICT_DEPOSIT_FAILED: 'Deposit failed mapped',
+    PREDICT_WITHDRAW_FAILED: 'Withdraw failed mapped',
   }),
 }));
 
@@ -199,6 +201,30 @@ describe('predictErrorHandler', () => {
       });
 
       expect(result).toBe('completely unknown');
+    });
+
+    it('maps deposit failed code to human-readable copy', () => {
+      const result = parseErrorMessage({
+        error: new Error(PREDICT_ERROR_CODES.DEPOSIT_FAILED),
+      });
+
+      expect(result).toBe('Deposit failed mapped');
+    });
+
+    it('maps withdraw failed code to human-readable copy', () => {
+      const result = parseErrorMessage({
+        error: new Error(PREDICT_ERROR_CODES.WITHDRAW_FAILED),
+      });
+
+      expect(result).toBe('Withdraw failed mapped');
+    });
+
+    it('falls back to unknown error for unmapped PREDICT_* codes', () => {
+      const result = parseErrorMessage({
+        error: new Error('PREDICT_SOME_NEW_CODE'),
+      });
+
+      expect(result).toBe('Something went wrong');
     });
 
     it('converts string error to message', () => {

--- a/app/components/UI/Predict/utils/predictErrorHandler.ts
+++ b/app/components/UI/Predict/utils/predictErrorHandler.ts
@@ -113,6 +113,10 @@ export function parseErrorMessage({
   if (parsedErrorMessage) {
     return parsedErrorMessage;
   }
+  // Never surface raw PREDICT_* codes to users.
+  if (typeof errorMessage === 'string' && errorMessage.startsWith('PREDICT_')) {
+    return errorMessages[PREDICT_ERROR_CODES.UNKNOWN_ERROR];
+  }
   return errorMessage;
 }
 

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.test.tsx
@@ -33,7 +33,7 @@ let mockErrorMessageSource:
   | 'order_error'
   | undefined;
 let mockBuyErrorBanner: {
-  variant: 'price_changed' | 'order_failed';
+  variant: 'price_changed' | 'order_failed' | 'payment_failed';
   title: string;
   description: string;
 } | null = null;
@@ -85,7 +85,16 @@ jest.mock('../../utils/format', () => ({
 jest.mock('../../hooks/usePredictActiveOrder', () => ({
   usePredictActiveOrder: () => ({
     isPlacingOrder: mockIsPlacingOrder,
+    activeOrder: null,
   }),
+}));
+
+jest.mock('../../../../../core/Engine', () => ({
+  context: {
+    PredictController: {
+      trackPredictOrderEvent: jest.fn(),
+    },
+  },
 }));
 
 const mockDeposit = jest.fn();
@@ -261,16 +270,22 @@ jest.mock('./components/PredictBuyError', () => {
 });
 
 jest.mock('./components/PredictBuyErrorBanner', () => {
-  const { View, Text } = jest.requireActual('react-native');
+  const { View, Text, Pressable } = jest.requireActual('react-native');
   return function MockPredictBuyErrorBanner({
     variant,
     title,
     description,
+    actionLabel,
+    onActionPress,
+    actionTestID,
     testID,
   }: {
     variant: string;
     title: string;
     description: string;
+    actionLabel?: string;
+    onActionPress?: () => void;
+    actionTestID?: string;
     testID?: string;
   }) {
     return (
@@ -278,6 +293,14 @@ jest.mock('./components/PredictBuyErrorBanner', () => {
         <Text testID={`${testID ?? 'banner'}-variant`}>{variant}</Text>
         <Text testID={`${testID ?? 'banner'}-title`}>{title}</Text>
         <Text testID={`${testID ?? 'banner'}-description`}>{description}</Text>
+        {actionLabel && onActionPress ? (
+          <Pressable
+            testID={actionTestID ?? `${testID ?? 'banner'}-action`}
+            onPress={onActionPress}
+          >
+            <Text>{actionLabel}</Text>
+          </Pressable>
+        ) : null}
       </View>
     );
   };
@@ -634,6 +657,37 @@ describe('PredictBuyWithAnyToken', () => {
       expect(
         screen.getByTestId('predict-buy-preview-order-failed-banner'),
       ).toBeOnTheScreen();
+    });
+
+    it('renders payment_failed banner with Add funds action and keeps Retry as main CTA', () => {
+      mockBuyErrorBanner = {
+        variant: 'payment_failed',
+        title: "Payment didn't go through",
+        description: "We couldn't convert your USDC.",
+      };
+
+      renderWithProvider(<PredictBuyWithAnyToken {...sheetProps} />);
+
+      expect(
+        screen.getByTestId('predict-buy-preview-payment-failed-banner'),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('predict-buy-preview-payment-failed-add-funds'),
+      ).toBeOnTheScreen();
+      expect(screen.getByTestId('predict-buy-action-button')).toHaveTextContent(
+        /mode-retry/,
+      );
+
+      fireEvent.press(
+        screen.getByTestId('predict-buy-preview-payment-failed-add-funds'),
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          params: { autoDeposit: true },
+        }),
+      );
     });
 
     it('routes the action button to handleRetryWithBestPrice when banner is active', () => {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
@@ -305,12 +305,14 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
       paymentTokenSymbol: activeOrder?.paymentTokenSymbol,
     });
     handleAddFunds();
+    onClose?.();
   }, [
     analyticsProperties,
     preview?.sharePrice,
     activeOrder?.paymentTokenAddress,
     activeOrder?.paymentTokenSymbol,
     handleAddFunds,
+    onClose,
   ]);
 
   const paymentFailurePromptedRef = useRef(false);

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/PredictBuyWithAnyToken.tsx
@@ -17,6 +17,7 @@ import React, {
 import { ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
+import { strings } from '../../../../../../locales/i18n';
 import { BottomSheetRef } from '../../../../../component-library/components/BottomSheets/BottomSheet';
 import { TraceName } from '../../../../../util/trace';
 import { PredictBuyPreviewSelectorsIDs } from '../../Predict.testIds';
@@ -54,6 +55,8 @@ import {
   PredictNavigationParamList,
 } from '../../types/navigation';
 import Routes from '../../../../../constants/navigation/Routes';
+import Engine from '../../../../../core/Engine';
+import { PredictTradeStatus } from '../../constants/eventNames';
 import { parseAnalyticsProperties } from '../../utils/analytics';
 import { formatPrice } from '../../utils/format';
 import { getDisplayBuyPrice } from '../../utils/prices';
@@ -131,7 +134,7 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
   } = isSheetMode ? props : route.params;
   const onClose = isSheetMode ? props.onClose : undefined;
 
-  const { isPlacingOrder } = usePredictActiveOrder();
+  const { isPlacingOrder, activeOrder } = usePredictActiveOrder();
   const { deposit } = usePredictDeposit();
 
   const [isFeeBreakdownVisible, setIsFeeBreakdownVisible] = useState(false);
@@ -292,6 +295,48 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
       deposit();
     }
   }, [deposit, isSheetMode, navigation]);
+
+  const handlePaymentFailureAddFunds = useCallback(() => {
+    Engine.context.PredictController.trackPredictOrderEvent({
+      status: PredictTradeStatus.ADD_FUNDS_SUBMITTED,
+      analyticsProperties,
+      sharePrice: preview?.sharePrice,
+      paymentTokenAddress: activeOrder?.paymentTokenAddress,
+      paymentTokenSymbol: activeOrder?.paymentTokenSymbol,
+    });
+    handleAddFunds();
+  }, [
+    analyticsProperties,
+    preview?.sharePrice,
+    activeOrder?.paymentTokenAddress,
+    activeOrder?.paymentTokenSymbol,
+    handleAddFunds,
+  ]);
+
+  const paymentFailurePromptedRef = useRef(false);
+  useEffect(() => {
+    if (buyErrorBanner?.variant !== 'payment_failed') {
+      paymentFailurePromptedRef.current = false;
+      return;
+    }
+    if (paymentFailurePromptedRef.current) {
+      return;
+    }
+    paymentFailurePromptedRef.current = true;
+    Engine.context.PredictController.trackPredictOrderEvent({
+      status: PredictTradeStatus.PAYMENT_FAILURE_PROMPTED,
+      analyticsProperties,
+      sharePrice: preview?.sharePrice,
+      paymentTokenAddress: activeOrder?.paymentTokenAddress,
+      paymentTokenSymbol: activeOrder?.paymentTokenSymbol,
+    });
+  }, [
+    buyErrorBanner?.variant,
+    analyticsProperties,
+    preview?.sharePrice,
+    activeOrder?.paymentTokenAddress,
+    activeOrder?.paymentTokenSymbol,
+  ]);
 
   const { handleConfirm, placeOrder } = usePredictBuyActions({
     analyticsProperties,
@@ -529,10 +574,25 @@ const PredictBuyWithAnyToken = (props: PredictBuyPreviewProps) => {
               variant={buyErrorBanner.variant}
               title={buyErrorBanner.title}
               description={buyErrorBanner.description}
+              actionLabel={
+                buyErrorBanner.variant === 'payment_failed'
+                  ? strings('predict.deposit.add_funds')
+                  : undefined
+              }
+              onActionPress={
+                buyErrorBanner.variant === 'payment_failed'
+                  ? handlePaymentFailureAddFunds
+                  : undefined
+              }
+              actionTestID={
+                PredictBuyPreviewSelectorsIDs.PAYMENT_FAILED_ADD_FUNDS_BUTTON
+              }
               testID={
                 buyErrorBanner.variant === 'price_changed'
                   ? PredictBuyPreviewSelectorsIDs.PRICE_CHANGED_BANNER
-                  : PredictBuyPreviewSelectorsIDs.ORDER_FAILED_BANNER
+                  : buyErrorBanner.variant === 'payment_failed'
+                    ? PredictBuyPreviewSelectorsIDs.PAYMENT_FAILED_BANNER
+                    : PredictBuyPreviewSelectorsIDs.ORDER_FAILED_BANNER
               }
             />
           )}

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyErrorBanner/PredictBuyErrorBanner.test.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyErrorBanner/PredictBuyErrorBanner.test.tsx
@@ -43,6 +43,42 @@ describe('PredictBuyErrorBanner', () => {
     ).toHaveTextContent('Try again');
   });
 
+  it('renders the payment_failed variant with an Add funds action', () => {
+    const onActionPress = jest.fn();
+    renderWithProvider(
+      <PredictBuyErrorBanner
+        variant="payment_failed"
+        title="Payment didn't go through"
+        description="We couldn't convert your USDC."
+        actionLabel="Add funds"
+        onActionPress={onActionPress}
+        actionTestID="payment-failed-add-funds"
+        testID="payment-failed-banner"
+      />,
+    );
+
+    expect(screen.getByTestId('payment-failed-banner')).toBeOnTheScreen();
+    expect(screen.getByTestId('payment-failed-banner-title')).toHaveTextContent(
+      "Payment didn't go through",
+    );
+    expect(screen.getByTestId('payment-failed-add-funds')).toBeOnTheScreen();
+  });
+
+  it('does not render an action button when action props are omitted', () => {
+    renderWithProvider(
+      <PredictBuyErrorBanner
+        variant="payment_failed"
+        title="Payment didn't go through"
+        description="Try again"
+        testID="payment-failed-banner"
+      />,
+    );
+
+    expect(
+      screen.queryByTestId('payment-failed-banner-action'),
+    ).not.toBeOnTheScreen();
+  });
+
   it('falls back to a default testID prefix when none is provided', () => {
     renderWithProvider(
       <PredictBuyErrorBanner

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyErrorBanner/PredictBuyErrorBanner.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyErrorBanner/PredictBuyErrorBanner.tsx
@@ -3,6 +3,8 @@ import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
+  Button,
+  ButtonBaseSize,
   Icon,
   IconColor,
   IconName,
@@ -12,12 +14,18 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 
-export type PredictBuyErrorBannerVariant = 'price_changed' | 'order_failed';
+export type PredictBuyErrorBannerVariant =
+  | 'price_changed'
+  | 'order_failed'
+  | 'payment_failed';
 
 interface PredictBuyErrorBannerProps {
   variant: PredictBuyErrorBannerVariant;
   title: string;
   description: string;
+  actionLabel?: string;
+  onActionPress?: () => void;
+  actionTestID?: string;
   testID?: string;
 }
 
@@ -42,15 +50,25 @@ const VARIANT_STYLES: Record<
     iconColor: IconColor.ErrorDefault,
     titleColor: TextColor.ErrorDefault,
   },
+  payment_failed: {
+    containerClass: 'bg-error-muted',
+    iconName: IconName.Danger,
+    iconColor: IconColor.ErrorDefault,
+    titleColor: TextColor.ErrorDefault,
+  },
 };
 
 const PredictBuyErrorBanner = ({
   variant,
   title,
   description,
+  actionLabel,
+  onActionPress,
+  actionTestID,
   testID,
 }: PredictBuyErrorBannerProps) => {
   const styles = VARIANT_STYLES[variant];
+  const showAction = Boolean(actionLabel && onActionPress);
 
   return (
     // `-mt-1` (-4px) trims the 24px gap left by the preceding PredictFeeSummary
@@ -69,7 +87,7 @@ const PredictBuyErrorBanner = ({
         size={IconSize.Md}
         testID={`${testID ?? 'predict-buy-error-banner'}-icon`}
       />
-      <Box twClassName="flex-1 min-w-0">
+      <Box twClassName="flex-1 min-w-0 gap-2">
         <Text
           variant={TextVariant.BodyMd}
           color={styles.titleColor}
@@ -85,6 +103,19 @@ const PredictBuyErrorBanner = ({
         >
           {description}
         </Text>
+        {showAction && (
+          <Button
+            size={ButtonBaseSize.Sm}
+            onPress={onActionPress}
+            testID={
+              actionTestID ?? `${testID ?? 'predict-buy-error-banner'}-action`
+            }
+          >
+            <Text variant={TextVariant.BodySm} twClassName="font-medium">
+              {actionLabel}
+            </Text>
+          </Button>
+        )}
       </Box>
     </Box>
   );

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyErrorBanner/PredictBuyErrorBanner.tsx
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyErrorBanner/PredictBuyErrorBanner.tsx
@@ -5,6 +5,7 @@ import {
   BoxFlexDirection,
   Button,
   ButtonBaseSize,
+  ButtonVariant,
   Icon,
   IconColor,
   IconName,
@@ -105,15 +106,15 @@ const PredictBuyErrorBanner = ({
         </Text>
         {showAction && (
           <Button
+            variant={ButtonVariant.Primary}
             size={ButtonBaseSize.Sm}
             onPress={onActionPress}
+            twClassName="self-start"
             testID={
               actionTestID ?? `${testID ?? 'predict-buy-error-banner'}-action`
             }
           >
-            <Text variant={TextVariant.BodySm} twClassName="font-medium">
-              {actionLabel}
-            </Text>
+            {actionLabel}
           </Button>
         )}
       </Box>

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.test.ts
@@ -200,6 +200,21 @@ describe('usePredictBuyActions', () => {
       expect(mockInitPayWithAnyToken).toHaveBeenCalledTimes(1);
     });
 
+    it('handles initPayWithAnyToken failure on mount without throwing', async () => {
+      mockInitPayWithAnyToken.mockResolvedValue({
+        success: false,
+        error: 'Deposit preparation returned undefined',
+      });
+
+      renderHook(() => usePredictBuyActions(createDefaultParams()));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockInitPayWithAnyToken).toHaveBeenCalledTimes(1);
+    });
+
     it('does not reset payment token during init', () => {
       renderHook(() => usePredictBuyActions(createDefaultParams()));
 
@@ -499,6 +514,35 @@ describe('usePredictBuyActions', () => {
 
       expect(mockPlaceOrder).not.toHaveBeenCalled();
       expect(mockInitPayWithAnyToken).toHaveBeenCalledTimes(1);
+      expect(mockSetIsConfirming).toHaveBeenCalledWith(false);
+    });
+
+    it('surfaces init failure when confirm re-init fails', async () => {
+      mockActiveOrder = { state: ActiveOrderState.PAY_WITH_ANY_TOKEN };
+      mockApprovalRequest = undefined;
+      mockInitPayWithAnyToken.mockResolvedValue({
+        success: false,
+        error: 'Deposit preparation returned undefined',
+      });
+      const { result } = renderHook(() =>
+        usePredictBuyActions(createDefaultParams()),
+      );
+
+      mockInitPayWithAnyToken.mockClear();
+      mockInitPayWithAnyToken.mockResolvedValue({
+        success: false,
+        error: 'Deposit preparation returned undefined',
+      });
+
+      let outcome;
+      await act(async () => {
+        outcome = await result.current.handleConfirm();
+      });
+
+      expect(outcome).toEqual({
+        status: 'error',
+        error: 'Deposit preparation returned undefined',
+      });
       expect(mockSetIsConfirming).toHaveBeenCalledWith(false);
     });
   });

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.ts
@@ -126,7 +126,14 @@ export const usePredictBuyActions = ({
       const result = await initPayWithAnyToken();
       if (result?.success && result.response?.batchId) {
         batchIdRef.current = result.response.batchId;
+        return;
       }
+      // Failure sets payment-stage error on the active order in the controller
+      // so the buy sheet can show a visible banner instead of an inert Confirm.
+      Logger.log(
+        'usePredictBuyActions: initPayWithAnyToken failed on mount',
+        result && 'error' in result ? result.error : 'unknown',
+      );
     };
 
     if (isSheetMode) {
@@ -256,11 +263,19 @@ export const usePredictBuyActions = ({
         const result = await initPayWithAnyToken();
         if (result?.success && result.response?.batchId) {
           batchIdRef.current = result.response.batchId;
+        } else {
+          Logger.log(
+            'usePredictBuyActions: initPayWithAnyToken failed on confirm re-init',
+            result && 'error' in result ? result.error : 'unknown',
+          );
         }
         resetImmediateConfirmFailure();
         return {
           status: 'error',
-          error: PREDICT_ERROR_CODES.PLACE_ORDER_FAILED,
+          error:
+            result && 'error' in result && result.error
+              ? result.error
+              : PREDICT_ERROR_CODES.PLACE_ORDER_FAILED,
         };
       }
     }

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.test.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.test.ts
@@ -6,11 +6,18 @@ import { usePredictBuyError } from './usePredictBuyError';
 const mockClearOrderError = jest.fn();
 const mockDevLoggerLog = jest.fn();
 
-let mockActiveOrder: { error?: string } | null = null;
+let mockActiveOrder: {
+  error?: string;
+  errorStage?: 'payment' | 'order';
+  paymentTokenSymbol?: string;
+} | null = null;
 let mockIsBalanceLoading = false;
 let mockIsPredictBalanceSelected = true;
-let mockSelectedPaymentToken: { address: string; chainId: string } | null =
-  null;
+let mockSelectedPaymentToken: {
+  address: string;
+  chainId: string;
+  symbol?: string;
+} | null = null;
 
 jest.mock('../../../hooks/usePredictActiveOrder', () => ({
   usePredictActiveOrder: () => ({
@@ -50,6 +57,12 @@ jest.mock('../../../../../../../locales/i18n', () => ({
     }
     if (key === 'predict.order.no_funds_enough_try_token') {
       return 'Not enough funds. Try a different token.';
+    }
+    if (key === 'predict.order.payment_failed_body') {
+      return `We couldn't convert your ${options?.token}.`;
+    }
+    if (key === 'predict.order.payment_failed_body_generic') {
+      return "We couldn't convert your token.";
     }
     return key;
   }),
@@ -519,6 +532,45 @@ describe('usePredictBuyError', () => {
           errorMessage: 'parsed message',
         },
       );
+    });
+
+    it('returns payment_failed variant when errorStage is payment', () => {
+      mockActiveOrder = {
+        error: 'PREDICT_DEPOSIT_FAILED',
+        errorStage: 'payment',
+        paymentTokenSymbol: 'USDC',
+      };
+      mockGetPlaceOrderErrorOutcome.mockReturnValue({
+        status: 'error',
+        error: 'Deposit failed',
+      });
+
+      const { result } = renderHook(() => usePredictBuyError(defaultParams));
+
+      expect(result.current.buyErrorBanner).toEqual({
+        variant: 'payment_failed',
+        title: 'predict.order.payment_failed_title',
+        description: "We couldn't convert your USDC.",
+      });
+    });
+
+    it('uses generic payment copy when payment token symbol is missing', () => {
+      mockActiveOrder = {
+        error: 'PREDICT_DEPOSIT_FAILED',
+        errorStage: 'payment',
+      };
+      mockGetPlaceOrderErrorOutcome.mockReturnValue({
+        status: 'error',
+        error: 'Deposit failed',
+      });
+
+      const { result } = renderHook(() => usePredictBuyError(defaultParams));
+
+      expect(result.current.buyErrorBanner).toEqual({
+        variant: 'payment_failed',
+        title: 'predict.order.payment_failed_title',
+        description: "We couldn't convert your token.",
+      });
     });
 
     it('falls back to generic order failed body when parsed order error is missing', () => {

--- a/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.ts
+++ b/app/components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.ts
@@ -272,6 +272,29 @@ export const usePredictBuyError = ({
       }
 
       if (orderError.status === 'error') {
+        if (activeOrder.errorStage === 'payment') {
+          const tokenSymbol =
+            activeOrder.paymentTokenSymbol ??
+            selectedPaymentToken?.symbol ??
+            undefined;
+          const description = tokenSymbol
+            ? strings('predict.order.payment_failed_body', {
+                token: tokenSymbol,
+              })
+            : strings('predict.order.payment_failed_body_generic');
+
+          DevLogger.log('usePredictBuyError: Showing payment error banner', {
+            rawError: activeOrder.error,
+            tokenSymbol,
+          });
+
+          return {
+            variant: 'payment_failed',
+            title: strings('predict.order.payment_failed_title'),
+            description,
+          };
+        }
+
         const errorMessage =
           orderError.error ?? strings('predict.order.order_failed_body');
 
@@ -290,6 +313,9 @@ export const usePredictBuyError = ({
       return null;
     }, [
       activeOrder?.error,
+      activeOrder?.errorStage,
+      activeOrder?.paymentTokenSymbol,
+      selectedPaymentToken?.symbol,
       preview,
       outcomeTokenPrice,
       isPlacingOrder,

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3133,6 +3133,9 @@
       "market_busy_body_sell": "The market is moving fast, so we couldn't sell at {{price}}. Try again at the best available price?",
       "order_failed_title": "Order failed",
       "order_failed_body": "Your order couldn't be filled. Try again?",
+      "payment_failed_title": "Payment didn't go through",
+      "payment_failed_body": "We couldn't convert your {{token}}. Add funds to your Predict balance instead.",
+      "payment_failed_body_generic": "We couldn't convert your token. Add funds to your Predict balance instead.",
       "price_changed_title": "Price changed",
       "price_changed_body": "Couldn't buy at {{price}}. Try at market price?",
       "retry": "Retry",
@@ -3203,7 +3206,9 @@
       "preview_not_available": "No preview available",
       "market_pending_resolution": "This market is pending resolution.",
       "market_not_accepting_bets": "This market is no longer accepting bets.",
-      "market_bettable_check_failed": "We couldn't confirm this market is accepting bets. Try again."
+      "market_bettable_check_failed": "We couldn't confirm this market is accepting bets. Try again.",
+      "deposit_failed": "We couldn't add funds to your Predict balance. Try again.",
+      "withdraw_failed": "We couldn't complete your withdrawal. Try again."
     },
     "game_details_footer": {
       "pick_a_winner": "Pick a winner",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.
In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.
  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.
Sections without a directive are checked for structural presence only.
-->
## **Description**
<!-- mms-check: type=text required=true -->
When Pay with Any Token (PWAT) fails on the payment/swap leg, users previously only got **Retry**. Retrying the same path is a weak recovery option, especially when the Predict balance itself is the clearer next step.
This change marks payment failures separately from order-fill failures (`errorStage: 'payment' | 'order'` on active buy orders), then:
- Shows a `payment_failed` banner on the buy sheet with an **Add funds** action next to the existing **Retry** CTA
- Uses **Add funds** on the dismissed-sheet failure toast for payment-stage errors (and keeps those errors until the user acts, instead of auto-clearing after 3s)
- Maps `PREDICT_DEPOSIT_FAILED` / `PREDICT_WITHDRAW_FAILED` to human-readable copy, and falls unknown `PREDICT_*` codes back to a generic message so raw codes do not appear in the UI
- Surfaces `initPayWithAnyToken()` failures instead of leaving Confirm looking live but doing nothing
- Tracks `PAYMENT_FAILURE_PROMPTED` and `ADD_FUNDS_SUBMITTED` analytics statuses
Also fixes the banner **Add funds** button contrast and dismisses the bet slip when that action is pressed.
## **Changelog**
<!-- mms-check: type=changelog required=true blocking=true -->
CHANGELOG entry: Offered Add funds when Pay with Any Token payment fails, instead of Retry only
## **Related issues**
<!-- mms-check: type=issue-link required=true -->
Fixes: https://consensyssoftware.atlassian.net/browse/PRED-1026
## **Manual testing steps**
<!-- mms-check: type=manual-testing required=true -->
```gherkin
Feature: PWAT payment failure recovery
  Scenario: user sees Add funds on the buy sheet after a payment failure
    Given the user has opened a Predict buy sheet with Pay with Any Token enabled
    And a payment/swap failure occurs before the order is placed
    When the buy sheet is still open
    Then the user sees a "Payment didn't go through" banner
    And the banner includes a readable "Add funds" button
    And the primary CTA remains "Retry"
  Scenario: user taps Add funds from the payment failure banner
    Given the payment_failed banner is visible on the buy sheet
    When the user taps "Add funds"
    Then the bet slip is dismissed
    And the Add funds / deposit flow opens
  Scenario: user sees Add funds on the toast after the sheet already closed
    Given a PWAT deposit starts and the buy sheet dismisses
    And the deposit/payment leg then fails
    When the failure toast appears
    Then the toast action is "Add funds" (not "Retry")
    And reopening the slip still shows the payment failure banner
    And the payment error does not auto-clear after 3 seconds
  Scenario: order-fill failures keep Retry-only behavior
    Given an order placement/fill failure (errorStage is order, not payment)
    When the failure UI appears
    Then the user sees Retry recovery as before
    And no payment_failed Add funds path is shown
  Scenario: initPayWithAnyToken failure is visible
    Given initPayWithAnyToken fails while opening or confirming the buy flow
    When the failure is returned
    Then the user sees a payment failure state
    And Confirm is not left in a silent dead state
```
## **Screenshots/Recordings**
<!-- mms-check: type=screenshot required=true -->
<!-- Attach screenshots/recordings from device testing when opening the PR. -->
### **Before**
<!-- Retry-only recovery after PWAT payment failure; no Add funds path on banner/toast -->
### **After**

https://github.com/user-attachments/assets/61aab00a-d17b-4c96-a20a-0e1ba17e61b7

<!-- payment_failed banner with readable Add funds CTA; toast offers Add funds; slip dismisses into Add funds flow -->
## **Pre-merge author checklist**
<!-- mms-check: type=checklist required=true -->
- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
#### Performance checks (if applicable)
- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example
For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).
## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Predict buy/deposit error state, navigation into add funds, and transaction cancellation handling—user-facing money flows but scoped to PWAT failure recovery with broad test coverage.
> 
> **Overview**
> **Pay with Any Token** buy failures are split into **`errorStage: 'payment' | 'order'`** on active buy orders so swap/deposit failures are handled separately from order-fill failures.
> 
> For **payment** failures, the buy sheet shows a **`payment_failed`** banner with an **Add funds** action (primary CTA stays **Retry**), and the dismissed-sheet toast uses **Add funds** instead of **Retry**, opens the add-funds modal with `autoDeposit`, and **does not** auto-clear the error after 3s. Order-stage failures keep the existing Retry-only toast behavior.
> 
> **`PredictController`** sets `errorStage: 'payment'` on deposit/swap/`initPayWithAnyToken` failures, preserves payment errors across successful re-init, treats user-cancelled deposit init as success, and surfaces init errors on the active order. **`usePredictBuyActions`** propagates real init failure messages instead of a generic place-order error.
> 
> Copy/analytics: new i18n for payment/deposit/withdraw failures, **`PREDICT_*` codes** no longer shown raw in the UI, and **`PAYMENT_FAILURE_PROMPTED`** / **`ADD_FUNDS_SUBMITTED`** trade statuses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e8d9f2c8f205d04fb9219ba90e228e23b56dc30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->