### PR TITLE
fix: treat remote-transport dapp origins as unverified in confirmations and security scans

### DIFF
--- a/app/components/Views/confirmations/components/rows/origin-row/origin-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/origin-row/origin-row.test.tsx
@@ -76,4 +76,73 @@ describe('InfoRowOrigin', () => {
       expect(queryByText(origin)).not.toBeOnTheScreen();
     },
   );
+
+  // WalletConnect / SDK v1 / MetaMask Connect transactions carry the dapp's
+  // self-reported domain as `origin`, which is unverifiable and must not be
+  // presented as if the wallet had verified it. The transport is stored in
+  // the confirmationMetrics slice keyed by transaction id (transactions
+  // cannot carry client-only fields on TransactionMeta), and the row must
+  // read it and render "External app" instead of the self-reported domain.
+  it.each([
+    ['WalletConnect', 'WalletConnect'],
+    ['SDK v1', 'MetaMask-SDK-Remote-Conn'],
+    ['MetaMask Connect', 'MetaMask-Connect'],
+  ])(
+    'renders "External app" for %s transactions with a self-reported domain origin',
+    (_label, requestSource) => {
+      const selfReportedOrigin = 'https://innocent-looking.example';
+      const externalAppConfirmationState = merge(
+        {},
+        generateContractInteractionState,
+        {
+          engine: {
+            backgroundState: {
+              ApprovalController: {
+                pendingApprovals: {
+                  [mockTxId]: { origin: selfReportedOrigin },
+                },
+              },
+              TransactionController: {
+                transactions: [{ id: mockTxId, origin: selfReportedOrigin }],
+              },
+            },
+          },
+          confirmationMetrics: {
+            metricsById: {
+              [mockTxId]: {
+                properties: { request_source: requestSource },
+              },
+            },
+          },
+        },
+      );
+
+      const { getByText, queryByText } = renderWithProvider(<OriginRow />, {
+        state: externalAppConfirmationState,
+      });
+
+      expect(getByText('Request from')).toBeOnTheScreen();
+      expect(getByText('External app')).toBeOnTheScreen();
+      expect(queryByText(selfReportedOrigin)).not.toBeOnTheScreen();
+    },
+  );
+
+  it('keeps the verified origin when no external transport is recorded', () => {
+    const inAppBrowserState = merge({}, generateContractInteractionState, {
+      confirmationMetrics: {
+        metricsById: {
+          [mockTxId]: {
+            properties: { request_source: 'In-App-Browser' },
+          },
+        },
+      },
+    });
+
+    const { getByText } = renderWithProvider(<OriginRow />, {
+      state: inAppBrowserState,
+    });
+
+    expect(getByText('Request from')).toBeOnTheScreen();
+    expect(getByText('metamask.github.io')).toBeOnTheScreen();
+  });
 });

--- a/app/components/Views/confirmations/hooks/useIsExternalAppRequest.ts
+++ b/app/components/Views/confirmations/hooks/useIsExternalAppRequest.ts
@@ -1,3 +1,7 @@
+import { useSelector } from 'react-redux';
+
+import { selectConfirmationMetricsById } from '../../../../core/redux/slices/confirmationMetrics';
+import type { RootState } from '../../../../reducers';
 import { useSignatureRequest } from './signatures/useSignatureRequest';
 import { useTransactionBatchesMetadata } from './transactions/useTransactionBatchesMetadata';
 import { useTransactionMetadataRequest } from './transactions/useTransactionMetadataRequest';
@@ -15,8 +19,11 @@ import {
  * (signature, transaction, transaction batch): the origin itself
  * ({@link isExternalAppOrigin}: `'deeplink'` / `'qr-code'` constants, or a
  * bare SDK / MWP connection UUID), and the transport-derived `request_source`
- * ({@link isExternalAppRequestSource}: SDK v1 / MWP / WalletConnect), which
- * is only persisted on signature requests.
+ * ({@link isExternalAppRequestSource}: SDK v1 / MWP / WalletConnect). For
+ * signatures the transport rides on `messageParams.meta.analytics`; for
+ * transactions it is read from the `confirmationMetrics` slice, which the
+ * request entry points populate keyed by transaction id (see
+ * `eth_sendTransaction` and `WalletConnect2Session.handleSendTransaction`).
  *
  * This is the single source of truth for the "Request from" rows
  * (`OriginRow`, `NetworkAndOriginRow`, `InfoSectionOriginAndDetails`) so that
@@ -32,14 +39,28 @@ export function useIsExternalAppRequest(): boolean {
     signatureRequest?.messageParams?.origin ??
     transactionBatchesMetadata?.origin;
 
-  // `request_source` is the transport the request arrived on. It is only
-  // populated on signature requests; `meta` is not on the persisted
-  // MessageParams union type, hence the structural cast.
-  const requestSource = (
+  // `request_source` for signatures: the transport the request arrived on.
+  // `meta` is not on the persisted MessageParams union type, hence the
+  // structural cast.
+  const signatureRequestSource = (
     signatureRequest?.messageParams as
       | { meta?: { analytics?: { request_source?: string } } }
       | undefined
   )?.meta?.analytics?.request_source;
+
+  // `request_source` for transactions: transactions persist only `origin` on
+  // TransactionMeta (arbitrary fields cannot be added to controller state),
+  // so the transport is stored client-side in the confirmationMetrics slice
+  // keyed by transaction id.
+  const transactionId =
+    transactionMetadata?.id ?? transactionBatchesMetadata?.id;
+  const confirmationMetrics = useSelector((state: RootState) =>
+    selectConfirmationMetricsById(state, transactionId as string),
+  );
+  const transactionRequestSource = confirmationMetrics?.properties
+    ?.request_source as string | undefined;
+
+  const requestSource = signatureRequestSource ?? transactionRequestSource;
 
   return (
     isExternalAppOrigin(origin) || isExternalAppRequestSource(requestSource)

--- a/app/components/Views/confirmations/utils/origin.ts
+++ b/app/components/Views/confirmations/utils/origin.ts
@@ -39,11 +39,12 @@ function isExternalAppOrigin(origin?: string | null): boolean {
  * of whether the transport surfaced the origin as a placeholder, a connection
  * id, or a self-reported domain.
  *
- * Note: `request_source` is currently only populated on signature requests
- * (`messageParams.meta.analytics.request_source`). Transactions persist only
- * `origin`, so unverifiable WalletConnect / SDK v1 *transactions* (whose origin
- * is a self-reported domain) still rely on {@link isExternalAppOrigin} and are
- * tracked as a follow-up.
+ * Note: for signatures `request_source` rides on
+ * `messageParams.meta.analytics.request_source`; for transactions it is
+ * stored in the `confirmationMetrics` redux slice keyed by transaction id
+ * (TransactionMeta cannot carry arbitrary client-only fields), written by the
+ * request entry points (`eth_sendTransaction`,
+ * `WalletConnect2Session.handleSendTransaction`).
  */
 function isExternalAppRequestSource(requestSource?: string | null): boolean {
   const { REQUEST_SOURCES } = AppConstants;

--- a/app/core/BackgroundBridge/BackgroundBridge.js
+++ b/app/core/BackgroundBridge/BackgroundBridge.js
@@ -918,10 +918,18 @@ export class BackgroundBridge extends EventEmitter {
               Engine.context.TransactionController,
             ),
           validateSecurity: (securityAlertId, request, chainId) =>
-            PPOMUtil.validateRequest(request, {
-              transactionMeta: { chainId },
-              securityAlertId,
-            }),
+            PPOMUtil.validateRequest(
+              // For remote transports (WalletConnect / SDK v1 / MetaMask
+              // Connect) the request origin is self-reported by the dapp and
+              // unverifiable, so it must never influence the security scan.
+              this.isWalletConnect || this.isRemoteConn || this.isMMSDK
+                ? { ...request, origin: undefined }
+                : request,
+              {
+                transactionMeta: { chainId },
+                securityAlertId,
+              },
+            ),
           isAuxiliaryFundsSupported: (chainId) =>
             ALLOWED_BRIDGE_CHAIN_IDS.includes(chainId),
           getPermittedAccountsForOrigin: async () =>

--- a/app/core/OriginProvenance/index.test.ts
+++ b/app/core/OriginProvenance/index.test.ts
@@ -1,0 +1,86 @@
+import {
+  RemoteTransport,
+  getRequestSourceForTransport,
+  getOriginProvenance,
+  removeOriginProvenance,
+  stampOriginProvenance,
+} from './index';
+import AppConstants from '../AppConstants';
+
+describe('OriginProvenance', () => {
+  const CONNECTION_ID = 'a3b1c9d0-0000-4000-8000-123456789abc';
+
+  afterEach(() => {
+    removeOriginProvenance(CONNECTION_ID);
+  });
+
+  it('stamps and returns provenance keyed by the unspoofable connection id', () => {
+    const provenance = stampOriginProvenance({
+      connectionId: CONNECTION_ID,
+      transport: RemoteTransport.WalletConnect,
+      selfReported: {
+        url: 'https://claimed-by-dapp.example',
+        name: 'Claimed Dapp',
+        icon: 'https://claimed-by-dapp.example/icon.png',
+      },
+    });
+
+    expect(getOriginProvenance(CONNECTION_ID)).toBe(provenance);
+    expect(provenance).toStrictEqual({
+      connectionId: CONNECTION_ID,
+      transport: RemoteTransport.WalletConnect,
+      // Self-reported metadata is never verified on remote transports.
+      isVerified: false,
+      selfReported: {
+        url: 'https://claimed-by-dapp.example',
+        name: 'Claimed Dapp',
+        icon: 'https://claimed-by-dapp.example/icon.png',
+      },
+    });
+  });
+
+  it('overwrites the stamp when the same connection re-registers with fresh metadata', () => {
+    stampOriginProvenance({
+      connectionId: CONNECTION_ID,
+      transport: RemoteTransport.SDKv1,
+      selfReported: { url: 'https://old.example' },
+    });
+    stampOriginProvenance({
+      connectionId: CONNECTION_ID,
+      transport: RemoteTransport.SDKv1,
+      selfReported: { url: 'https://new.example' },
+    });
+
+    expect(getOriginProvenance(CONNECTION_ID)?.selfReported.url).toBe(
+      'https://new.example',
+    );
+  });
+
+  it('returns undefined for connection ids that were never stamped', () => {
+    expect(getOriginProvenance('never-stamped')).toBeUndefined();
+  });
+
+  it('removes the stamp when the connection closes', () => {
+    stampOriginProvenance({
+      connectionId: CONNECTION_ID,
+      transport: RemoteTransport.MMConnect,
+      selfReported: {},
+    });
+
+    removeOriginProvenance(CONNECTION_ID);
+
+    expect(getOriginProvenance(CONNECTION_ID)).toBeUndefined();
+  });
+
+  it('maps every remote transport to its request_source constant', () => {
+    expect(getRequestSourceForTransport(RemoteTransport.WalletConnect)).toBe(
+      AppConstants.REQUEST_SOURCES.WC,
+    );
+    expect(getRequestSourceForTransport(RemoteTransport.SDKv1)).toBe(
+      AppConstants.REQUEST_SOURCES.SDK_REMOTE_CONN,
+    );
+    expect(getRequestSourceForTransport(RemoteTransport.MMConnect)).toBe(
+      AppConstants.REQUEST_SOURCES.MM_CONNECT,
+    );
+  });
+});

--- a/app/core/OriginProvenance/index.ts
+++ b/app/core/OriginProvenance/index.ts
@@ -59,11 +59,13 @@ function exhaustiveCheck(transport: never): never {
  * (Blockaid, SIWS) or be presented as a verified origin.
  *
  * This is the mobile-internal shape for the provenance contract agreed in
- * the origin-spoofing thread (MCWP-771). Once the Snaps platform releases
- * the `OriginMetadata` keyring/snap request field (WPC-1194 / WPC-1195,
- * threaded through mobile in PR #34460), `selfReported.url` is what maps to
- * `originMetadata.selfReportedOrigin` at the Snap boundary, while
- * `connectionId` stays the request `origin`.
+ * the origin-spoofing thread (MCWP-771). At the Snap boundary the same
+ * split is expressed with the snaps-sdk `OriginMetadata` field
+ * (WPC-1194 / WPC-1195, threaded through mobile in PR #34460):
+ * `connectionId` stays the request `origin`, and `selfReported.url` is what
+ * `originMetadata.selfReportedOrigin` carries (see
+ * `WalletConnect2Session.handleRequest`, which builds it from the same
+ * session peer metadata this stamp records).
  */
 export interface OriginProvenance {
   /**

--- a/app/core/OriginProvenance/index.ts
+++ b/app/core/OriginProvenance/index.ts
@@ -1,0 +1,138 @@
+import AppConstants from '../AppConstants';
+
+/**
+ * Remote transports over which a dapp can connect without the wallet being
+ * able to verify its identity. In-app browser and extension contexts are
+ * intentionally absent: there the wallet loads the page itself, so the origin
+ * is verifiable and no provenance stamp is needed.
+ */
+export const RemoteTransport = {
+  WalletConnect: 'walletconnect',
+  /** MetaMask SDK v1 (socket relay / deeplink). */
+  SDKv1: 'sdk-v1',
+  /** MetaMask Connect / Mobile Wallet Protocol (SDK v2). */
+  MMConnect: 'mmconnect',
+} as const;
+
+export type RemoteTransport =
+  (typeof RemoteTransport)[keyof typeof RemoteTransport];
+
+/**
+ * Maps a remote transport to the `request_source` analytics constant used by
+ * the confirmation UI (`useIsExternalAppRequest` via the
+ * `confirmationMetrics` slice) and by `getSource()` in RPCMethodMiddleware.
+ */
+export function getRequestSourceForTransport(
+  transport: RemoteTransport,
+): string {
+  switch (transport) {
+    case RemoteTransport.WalletConnect:
+      return AppConstants.REQUEST_SOURCES.WC;
+    case RemoteTransport.SDKv1:
+      return AppConstants.REQUEST_SOURCES.SDK_REMOTE_CONN;
+    case RemoteTransport.MMConnect:
+      return AppConstants.REQUEST_SOURCES.MM_CONNECT;
+    default:
+      return exhaustiveCheck(transport);
+  }
+}
+
+function exhaustiveCheck(transport: never): never {
+  throw new Error(`Unknown remote transport: ${transport as string}`);
+}
+
+/**
+ * Provenance of a remote connection, stamped once at the entry point where
+ * the connection enters the app (WalletConnect session creation, SDK v1
+ * bridge setup, MetaMask Connect bridge adapter).
+ *
+ * It separates the two identities that were historically conflated in a
+ * single `origin` string:
+ *
+ * - `connectionId` is the wallet-side connection/channel id. It is the only
+ * unspoofable identifier the connection has and the only value that may be
+ * used as `origin` for permissions, session identity, or anything
+ * security-relevant.
+ * - `selfReported` is whatever the dapp claimed about itself over the
+ * transport (URL, name, icon). It is unverifiable, display-only, and must
+ * always be framed as unverified. It must never reach security logic
+ * (Blockaid, SIWS) or be presented as a verified origin.
+ *
+ * This is the mobile-internal shape for the provenance contract agreed in
+ * the origin-spoofing thread (MCWP-771). Once the Snaps platform releases
+ * the `OriginMetadata` keyring/snap request field (WPC-1194 / WPC-1195,
+ * threaded through mobile in PR #34460), `selfReported.url` is what maps to
+ * `originMetadata.selfReportedOrigin` at the Snap boundary, while
+ * `connectionId` stays the request `origin`.
+ */
+export interface OriginProvenance {
+  /**
+   * Unspoofable wallet-side connection/channel id: the WalletConnect
+   * channelId, the SDK v1 channelId, or the MetaMask Connect connection id.
+   */
+  connectionId: string;
+  /** Transport the connection arrived on. */
+  transport: RemoteTransport;
+  /**
+   * Always `false`: every field in {@link selfReported} was provided by the
+   * remote dapp and cannot be verified by the wallet. Present so future
+   * verifiable transports can share the shape without weakening the framing
+   * of existing ones.
+   */
+  isVerified: false;
+  /**
+   * Self-reported (unverified) dapp metadata. Display-only; never a
+   * security input.
+   */
+  selfReported: {
+    url?: string;
+    name?: string;
+    icon?: string;
+  };
+}
+
+const provenanceByConnectionId = new Map<string, OriginProvenance>();
+
+/**
+ * Record the provenance of a remote connection, keyed by its unspoofable
+ * connection id. Call this exactly where the connection enters the app.
+ * Re-stamping the same connection id overwrites the previous entry, so
+ * reconnects with refreshed metadata stay current.
+ */
+export function stampOriginProvenance({
+  connectionId,
+  transport,
+  selfReported,
+}: {
+  connectionId: string;
+  transport: RemoteTransport;
+  selfReported: OriginProvenance['selfReported'];
+}): OriginProvenance {
+  const provenance: OriginProvenance = {
+    connectionId,
+    transport,
+    isVerified: false,
+    selfReported,
+  };
+  provenanceByConnectionId.set(connectionId, provenance);
+  return provenance;
+}
+
+/**
+ * Look up the provenance of a remote connection by its unspoofable
+ * connection id. Returns `undefined` for ids that were never stamped, which
+ * includes every verifiable context (in-app browser tabs are keyed by
+ * hostname, not connection id).
+ */
+export function getOriginProvenance(
+  connectionId: string,
+): OriginProvenance | undefined {
+  return provenanceByConnectionId.get(connectionId);
+}
+
+/**
+ * Drop the provenance for a closed connection.
+ */
+export function removeOriginProvenance(connectionId: string): void {
+  provenanceByConnectionId.delete(connectionId);
+}

--- a/app/core/OriginProvenance/index.ts
+++ b/app/core/OriginProvenance/index.ts
@@ -58,14 +58,12 @@ function exhaustiveCheck(transport: never): never {
  * always be framed as unverified. It must never reach security logic
  * (Blockaid, SIWS) or be presented as a verified origin.
  *
- * This is the mobile-internal shape for the provenance contract agreed in
- * the origin-spoofing thread (MCWP-771). At the Snap boundary the same
- * split is expressed with the snaps-sdk `OriginMetadata` field
- * (WPC-1194 / WPC-1195, threaded through mobile in PR #34460):
- * `connectionId` stays the request `origin`, and `selfReported.url` is what
- * `originMetadata.selfReportedOrigin` carries (see
- * `WalletConnect2Session.handleRequest`, which builds it from the same
- * session peer metadata this stamp records).
+ * This is the mobile-internal shape for the provenance contract. At the
+ * Snap boundary the same split is expressed with the snaps-sdk
+ * `OriginMetadata` field: `connectionId` stays the request `origin`, and
+ * `selfReported.url` is what `originMetadata.selfReportedOrigin` carries
+ * (see `WalletConnect2Session.handleRequest`, which builds it from the
+ * same session peer metadata this stamp records).
  */
 export interface OriginProvenance {
   /**

--- a/app/core/RPCMethods/RPCMethodMiddleware.test.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.test.ts
@@ -1707,6 +1707,70 @@ describe('getRpcMethodMiddleware', () => {
     });
   });
 
+  describe('PPOM origin sanitization for signature requests', () => {
+    async function sendPersonalSignRequest(
+      middlewareOptions: Partial<Parameters<typeof getRpcMethodMiddleware>[0]>,
+    ) {
+      setupSignature();
+      const middleware = getRpcMethodMiddleware({
+        ...getMinimalOptions(),
+        hostname: hostMock,
+        ...middlewareOptions,
+      });
+
+      // `origin` is normally stamped on the request by the bridge's origin
+      // middleware; simulate it explicitly here.
+      const request = {
+        jsonrpc,
+        id: 1,
+        method: 'personal_sign',
+        params: [dataMock, addressMock],
+        origin: 'https://self-reported.example',
+      };
+
+      MockEngine.context.SignatureController.newUnsignedPersonalMessage.mockResolvedValue(
+        signatureMock,
+      );
+
+      return await callMiddleware({
+        middleware,
+        request: request as unknown as JsonRpcRequest<JsonRpcParams>,
+      });
+    }
+
+    // Security invariant: for remote transports the request origin is
+    // self-reported by the dapp and unverifiable, so it must never reach the
+    // security scan, where Blockaid treats the URL as a core heuristic that
+    // can flip a verdict between malicious and benign.
+    it.each([
+      ['WalletConnect', { isWalletConnect: true }],
+      ['SDK v1', { analytics: { isRemoteConn: true } }],
+      [
+        'MetaMask Connect (MWP)',
+        { analytics: { isRemoteConn: true, transport: 'mwp' } },
+      ],
+    ])(
+      'drops the self-reported origin from PPOM validation for %s requests',
+      async (_label, middlewareOptions) => {
+        const spy = jest.spyOn(PPOMUtil, 'validateRequest');
+
+        await sendPersonalSignRequest(middlewareOptions);
+
+        expect(spy).toBeCalledTimes(1);
+        expect(spy.mock.calls[0][0].origin).toBeUndefined();
+      },
+    );
+
+    it('keeps the origin on PPOM validation for in-app browser requests', async () => {
+      const spy = jest.spyOn(PPOMUtil, 'validateRequest');
+
+      await sendPersonalSignRequest({});
+
+      expect(spy).toBeCalledTimes(1);
+      expect(spy.mock.calls[0][0].origin).toBe('https://self-reported.example');
+    });
+  });
+
   describe.each([
     ['eth_signTypedData_v3', 'V3'],
     ['eth_signTypedData_v4', 'V4'],

--- a/app/core/RPCMethods/RPCMethodMiddleware.test.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.test.ts
@@ -1771,6 +1771,115 @@ describe('getRpcMethodMiddleware', () => {
     });
   });
 
+  describe('PPOM origin sanitization for transaction requests', () => {
+    const mockAddress = '0x0000000000000000000000000000000000000001';
+    const mockTransactionParameters = { from: mockAddress, chainId: '0x1' };
+    const mockChannelId = '70a863a4-a756-4660-8c72-dc367d02f625';
+
+    async function sendTransactionRequest(
+      middlewareOptions: Partial<Parameters<typeof getRpcMethodMiddleware>[0]>,
+      permittedOrigin: string,
+    ) {
+      setupGlobalState({
+        addTransactionResult: Promise.resolve('fake-hash'),
+        permittedAccounts: { [permittedOrigin]: [mockAddress] },
+        selectedNetworkClientId: 'mainnet',
+        networksMetadata: {},
+        networkConfigurationsByChainId: {
+          '0x1': {
+            blockExplorerUrls: ['https://etherscan.com'],
+            chainId: '0x1',
+            defaultRpcEndpointIndex: 0,
+            name: 'Ethereum Mainnet',
+            nativeCurrency: 'ETH',
+            rpcEndpoints: [
+              {
+                networkClientId: 'mainnet',
+                type: 'Custom',
+                url: 'https://mainnet.infura.io/v3',
+              },
+            ],
+          },
+        },
+      });
+      const middleware = getRpcMethodMiddleware({
+        ...getMinimalOptions(),
+        hostname: 'example.metamask.io',
+        ...middlewareOptions,
+      });
+
+      // `origin` is normally stamped on the request by the bridge's origin
+      // middleware; simulate it explicitly here. ppom-util's own sanitization
+      // cannot recognize this value as unverifiable (no transport prefix, not
+      // a UUID), which is exactly the case the middleware-level drop covers:
+      // SDK v1 channel ids arrive via deeplink params unvalidated, so a
+      // malicious sender can make the request origin look like a domain.
+      const request = {
+        jsonrpc,
+        id: 1,
+        method: 'eth_sendTransaction',
+        params: [mockTransactionParameters],
+        origin: 'https://self-reported.example',
+      };
+
+      return await callMiddleware({
+        middleware,
+        request: request as unknown as JsonRpcRequest<JsonRpcParams>,
+      });
+    }
+
+    // Security invariant: for remote transports the request origin is
+    // self-reported by the dapp (or attacker-chosen, for SDK v1 channel ids)
+    // and unverifiable, so it must never reach the security scan, where
+    // Blockaid treats the URL as a core heuristic that can flip a verdict
+    // between malicious and benign.
+    it.each([
+      ['WalletConnect', { isWalletConnect: true }, 'example.metamask.io'],
+      [
+        'SDK v1',
+        {
+          isMMSDK: true,
+          channelId: mockChannelId,
+          analytics: { isRemoteConn: true },
+        },
+        mockChannelId,
+      ],
+      [
+        'MetaMask Connect (MWP)',
+        {
+          isMMSDK: true,
+          channelId: mockChannelId,
+          analytics: { isRemoteConn: true, transport: 'mwp' },
+        },
+        mockChannelId,
+      ],
+    ])(
+      'drops the self-reported origin from PPOM validation for %s transactions',
+      async (_label, middlewareOptions, permittedOrigin) => {
+        const spy = jest.spyOn(PPOMUtil, 'validateRequest');
+
+        const response = await sendTransactionRequest(
+          middlewareOptions,
+          permittedOrigin,
+        );
+
+        expect((response as JsonRpcFailure).error).toBeUndefined();
+        expect(spy).toBeCalledTimes(1);
+        expect(spy.mock.calls[0][0].origin).toBeUndefined();
+      },
+    );
+
+    it('keeps the origin on PPOM validation for in-app browser transactions', async () => {
+      const spy = jest.spyOn(PPOMUtil, 'validateRequest');
+
+      const response = await sendTransactionRequest({}, 'example.metamask.io');
+
+      expect((response as JsonRpcFailure).error).toBeUndefined();
+      expect(spy).toBeCalledTimes(1);
+      expect(spy.mock.calls[0][0].origin).toBe('https://self-reported.example');
+    });
+  });
+
   describe.each([
     ['eth_signTypedData_v3', 'V3'],
     ['eth_signTypedData_v4', 'V4'],

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -440,6 +440,25 @@ export const getRpcMethodMiddleware = ({
     return AppConstants.REQUEST_SOURCES.IN_APP_BROWSER;
   };
 
+  /**
+   * Validate a request with PPOM, dropping `req.origin` when the request
+   * arrived over a remote transport (WalletConnect / SDK v1 / MetaMask
+   * Connect). On those paths the origin is self-reported by the dapp and
+   * unverifiable, so it must never influence the security scan: Blockaid
+   * treats the URL as a core heuristic that can flip a verdict between
+   * malicious and benign. In-app browser requests keep their origin, which
+   * the wallet itself verified by loading the page.
+   */
+  // TODO: Replace "any" with type
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const validateRequestWithPPOM = (req: any) => {
+    const isVerifiableOrigin =
+      getSource() === AppConstants.REQUEST_SOURCES.IN_APP_BROWSER;
+    return PPOMUtil.validateRequest(
+      isVerifiableOrigin ? req : { ...req, origin: undefined },
+    );
+  };
+
   const hooks = getRpcMethodMiddlewareHooks({
     origin,
     url,
@@ -769,7 +788,7 @@ export const getRpcMethodMiddleware = ({
 
         trace(
           { name: TraceName.PPOMValidation, parentContext: req.traceContext },
-          () => PPOMUtil.validateRequest(req),
+          () => validateRequestWithPPOM(req),
         );
 
         const rawSig = await signatureController.newUnsignedPersonalMessage(
@@ -832,7 +851,7 @@ export const getRpcMethodMiddleware = ({
 
         trace(
           { name: TraceName.PPOMValidation, parentContext: req.traceContext },
-          () => PPOMUtil.validateRequest(req),
+          () => validateRequestWithPPOM(req),
         );
 
         const rawSig = await signatureController.newUnsignedTypedMessage(
@@ -863,7 +882,7 @@ export const getRpcMethodMiddleware = ({
 
         trace(
           { name: TraceName.PPOMValidation, parentContext: req.traceContext },
-          () => PPOMUtil.validateRequest(req),
+          () => validateRequestWithPPOM(req),
         );
 
         res.result = await generateRawSignature({
@@ -892,7 +911,7 @@ export const getRpcMethodMiddleware = ({
 
         trace(
           { name: TraceName.PPOMValidation, parentContext: req.traceContext },
-          () => PPOMUtil.validateRequest(req),
+          () => validateRequestWithPPOM(req),
         );
 
         res.result = await generateRawSignature({

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -441,23 +441,30 @@ export const getRpcMethodMiddleware = ({
   };
 
   /**
-   * Validate a request with PPOM, dropping `req.origin` when the request
-   * arrived over a remote transport (WalletConnect / SDK v1 / MetaMask
-   * Connect). On those paths the origin is self-reported by the dapp and
-   * unverifiable, so it must never influence the security scan: Blockaid
-   * treats the URL as a core heuristic that can flip a verdict between
-   * malicious and benign. In-app browser requests keep their origin, which
-   * the wallet itself verified by loading the page.
+   * Drop `req.origin` when the request arrived over a remote transport
+   * (WalletConnect / SDK v1 / MetaMask Connect), so it never influences the
+   * PPOM security scan. On those paths the origin is self-reported by the
+   * dapp and unverifiable, and Blockaid treats the URL as a core heuristic
+   * that can flip a verdict between malicious and benign. In-app browser
+   * requests keep their origin, which the wallet itself verified by loading
+   * the page.
    */
   // TODO: Replace "any" with type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const validateRequestWithPPOM = (req: any) => {
+  const sanitizeRequestForPPOM = (req: any) => {
     const isVerifiableOrigin =
       getSource() === AppConstants.REQUEST_SOURCES.IN_APP_BROWSER;
-    return PPOMUtil.validateRequest(
-      isVerifiableOrigin ? req : { ...req, origin: undefined },
-    );
+    return isVerifiableOrigin ? req : { ...req, origin: undefined };
   };
+
+  /**
+   * Validate a request with PPOM, dropping `req.origin` for remote
+   * transports (see {@link sanitizeRequestForPPOM}).
+   */
+  // TODO: Replace "any" with type
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const validateRequestWithPPOM = (req: any) =>
+    PPOMUtil.validateRequest(sanitizeRequestForPPOM(req));
 
   const hooks = getRpcMethodMiddlewareHooks({
     origin,
@@ -722,7 +729,17 @@ export const getRpcMethodMiddleware = ({
         };
         return RPCMethods.eth_sendTransaction({
           hostname,
-          req,
+          // eth_sendTransaction forwards this request to the PPOM security
+          // scan. ppom-util already drops origins it can recognize as
+          // unverifiable (transport prefixes, bare connection UUIDs,
+          // deeplink/qr-code placeholders), but that net has a hole: SDK v1
+          // channel ids arrive via deeplink params unvalidated, so a
+          // malicious sender could pick a domain-looking channel id that
+          // slips through and reaches Blockaid as a plausible origin. The
+          // transport is known here, so drop the origin at the source for
+          // anything that is not the in-app browser, mirroring the signature
+          // handlers (validateRequestWithPPOM).
+          req: sanitizeRequestForPPOM(req),
           res,
           sendTransaction: addTransaction,
           validateAccountAndChainId: async ({

--- a/app/core/RPCMethods/RPCMethodMiddleware.ts
+++ b/app/core/RPCMethods/RPCMethodMiddleware.ts
@@ -28,7 +28,7 @@ import { v1 as random } from 'uuid';
 import { getPermittedAccounts } from '../Permissions';
 import AppConstants from '../AppConstants';
 import { TransportType } from '../../components/hooks/useAnalytics/useAnalytics.types';
-import PPOMUtil from '../../lib/ppom/ppom-util';
+import PPOMUtil, { type PPOMRequest } from '../../lib/ppom/ppom-util';
 import { setEventStageError, setEventStage } from '../../actions/rpcEvents';
 import { isWhitelistedRPC, RPCStageTypes } from '../../reducers/rpcEvents';
 import { regex } from '../../../app/util/regex';
@@ -449,9 +449,9 @@ export const getRpcMethodMiddleware = ({
    * requests keep their origin, which the wallet itself verified by loading
    * the page.
    */
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const sanitizeRequestForPPOM = (req: any) => {
+  const sanitizeRequestForPPOM = <Request extends PPOMRequest>(
+    req: Request,
+  ) => {
     const isVerifiableOrigin =
       getSource() === AppConstants.REQUEST_SOURCES.IN_APP_BROWSER;
     return isVerifiableOrigin ? req : { ...req, origin: undefined };
@@ -461,9 +461,7 @@ export const getRpcMethodMiddleware = ({
    * Validate a request with PPOM, dropping `req.origin` for remote
    * transports (see {@link sanitizeRequestForPPOM}).
    */
-  // TODO: Replace "any" with type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const validateRequestWithPPOM = (req: any) =>
+  const validateRequestWithPPOM = (req: PPOMRequest) =>
     PPOMUtil.validateRequest(sanitizeRequestForPPOM(req));
 
   const hooks = getRpcMethodMiddlewareHooks({

--- a/app/core/SDKConnect/Connection/ConnectionLifecycle/disconnect.test.ts
+++ b/app/core/SDKConnect/Connection/ConnectionLifecycle/disconnect.test.ts
@@ -1,4 +1,10 @@
 import { MessageType } from '@metamask/sdk-communication-layer';
+import {
+  getOriginProvenance,
+  removeOriginProvenance,
+  RemoteTransport,
+  stampOriginProvenance,
+} from '../../../OriginProvenance';
 import DevLogger from '../../utils/DevLogger';
 import { Connection } from '../Connection';
 import disconnect from './disconnect';
@@ -92,6 +98,44 @@ describe('disconnect', () => {
       await disconnect({ instance: mockConnection, terminate: false });
 
       expect(mockRemoteDisconnect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('origin provenance', () => {
+    const stampTestProvenance = () =>
+      stampOriginProvenance({
+        connectionId: 'testChannelId',
+        transport: RemoteTransport.SDKv1,
+        selfReported: { url: 'https://example.com' },
+      });
+
+    afterEach(() => {
+      removeOriginProvenance('testChannelId');
+    });
+
+    it('drops the provenance stamped in setupBridge when the connection terminates', async () => {
+      stampTestProvenance();
+
+      await disconnect({ instance: mockConnection, terminate: true });
+
+      expect(getOriginProvenance('testChannelId')).toBeUndefined();
+    });
+
+    it('keeps the provenance when termination fails so a retry can still find it', async () => {
+      stampTestProvenance();
+      mockRemoteSendMessage.mockResolvedValue(false);
+
+      await disconnect({ instance: mockConnection, terminate: true });
+
+      expect(getOriginProvenance('testChannelId')).toBeDefined();
+    });
+
+    it('keeps the provenance on non-terminal disconnects because the connection can resume', async () => {
+      stampTestProvenance();
+
+      await disconnect({ instance: mockConnection, terminate: false });
+
+      expect(getOriginProvenance('testChannelId')).toBeDefined();
     });
   });
 

--- a/app/core/SDKConnect/Connection/ConnectionLifecycle/disconnect.ts
+++ b/app/core/SDKConnect/Connection/ConnectionLifecycle/disconnect.ts
@@ -1,4 +1,5 @@
 import { MessageType } from '@metamask/sdk-communication-layer';
+import { removeOriginProvenance } from '../../../OriginProvenance';
 import DevLogger from '../../utils/DevLogger';
 import { Connection } from '../Connection';
 
@@ -29,6 +30,11 @@ async function disconnect({
   }
   if (terminated) {
     instance.remote.disconnect();
+    // The connection is permanently closed: drop the provenance stamped in
+    // setupBridge (mirrors WalletConnect2Session.removeListeners and
+    // RPCBridgeAdapter.dispose). Non-terminal disconnects keep the stamp
+    // because the connection can resume.
+    removeOriginProvenance(instance.channelId);
   }
   return terminated;
 }

--- a/app/core/SDKConnect/handlers/setupBridge.test.ts
+++ b/app/core/SDKConnect/handlers/setupBridge.test.ts
@@ -1,6 +1,11 @@
 import { OriginatorInfo } from '@metamask/sdk-communication-layer';
 import BackgroundBridge from '../../BackgroundBridge/BackgroundBridge';
 import { Connection } from '../Connection';
+import {
+  getOriginProvenance,
+  removeOriginProvenance,
+  RemoteTransport,
+} from '../../OriginProvenance';
 import DevLogger from '../utils/DevLogger';
 import getRpcMethodMiddleware from '../../RPCMethods/RPCMethodMiddleware';
 import setupBridge from './setupBridge';
@@ -105,6 +110,41 @@ describe('setupBridge', () => {
         getRpcMethodMiddleware: expect.any(Function),
       }),
     );
+  });
+
+  describe('origin provenance', () => {
+    afterEach(() => {
+      removeOriginProvenance('sdk-channel-1');
+    });
+
+    it('stamps the connection provenance keyed by the unspoofable channel id', () => {
+      connection.backgroundBridge = undefined;
+      (connection as { channelId?: string }).channelId = 'sdk-channel-1';
+
+      setupBridge({ originatorInfo, connection });
+
+      expect(getOriginProvenance('sdk-channel-1')).toStrictEqual({
+        connectionId: 'sdk-channel-1',
+        transport: RemoteTransport.SDKv1,
+        isVerified: false,
+        selfReported: {
+          url: 'https://example.com',
+          name: 'Test Title',
+          icon: undefined,
+        },
+      });
+    });
+
+    it('does not stamp provenance when the connection is rejected', () => {
+      connection.backgroundBridge = undefined;
+      (connection as { channelId?: string }).channelId = 'sdk-channel-1';
+      originatorInfo.url = 'metamask';
+
+      expect(() => setupBridge({ originatorInfo, connection })).toThrow(
+        'Connections from metamask origin are not allowed',
+      );
+      expect(getOriginProvenance('sdk-channel-1')).toBeUndefined();
+    });
   });
 
   it('should setup backgroundBridge with correct params', () => {

--- a/app/core/SDKConnect/handlers/setupBridge.ts
+++ b/app/core/SDKConnect/handlers/setupBridge.ts
@@ -9,6 +9,7 @@ import { OriginatorInfo } from '@metamask/sdk-communication-layer';
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 import Logger from '../../../util/Logger';
 import { Connection } from '../Connection';
+import { RemoteTransport, stampOriginProvenance } from '../../OriginProvenance';
 import DevLogger from '../utils/DevLogger';
 import handleSendMessage from './handleSendMessage';
 import { ImageSourcePropType } from 'react-native';
@@ -52,6 +53,19 @@ export const setupBridge = ({
   ) {
     throw new Error('Connections from metamask origin are not allowed');
   }
+
+  // Stamp the connection's provenance at the entry point: the SDK channelId
+  // is the unspoofable connection identity; originatorInfo is self-reported
+  // by the dapp and display-only (MCWP-771).
+  stampOriginProvenance({
+    connectionId: connection.channelId,
+    transport: RemoteTransport.SDKv1,
+    selfReported: {
+      url: selfReportedUrl,
+      name: selfReportedTitle,
+      icon: selfReportedIcon,
+    },
+  });
 
   const backgroundBridge = new BackgroundBridge({
     webview: null,

--- a/app/core/SDKConnect/handlers/setupBridge.ts
+++ b/app/core/SDKConnect/handlers/setupBridge.ts
@@ -56,7 +56,7 @@ export const setupBridge = ({
 
   // Stamp the connection's provenance at the entry point: the SDK channelId
   // is the unspoofable connection identity; originatorInfo is self-reported
-  // by the dapp and display-only (MCWP-771).
+  // by the dapp and display-only.
   stampOriginProvenance({
     connectionId: connection.channelId,
     transport: RemoteTransport.SDKv1,

--- a/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.test.ts
+++ b/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.test.ts
@@ -2,6 +2,7 @@
 import Engine from '../../Engine';
 import BackgroundBridge from '../../BackgroundBridge/BackgroundBridge';
 import { ConnectionInfo } from '../types/connection-info';
+import { getOriginProvenance, RemoteTransport } from '../../OriginProvenance';
 import { RPCBridgeAdapter } from './rpc-bridge-adapter';
 import { whenEngineReady } from '../utils/when-engine-ready';
 import { whenOnboardingComplete } from '../utils/when-onboarding-complete';
@@ -195,6 +196,27 @@ describe('RPCBridgeAdapter', () => {
       await new Promise(process.nextTick);
 
       expect(backgroundBridgeInstance.onMessage).toHaveBeenCalledWith(request);
+    });
+  });
+
+  describe('Origin Provenance', () => {
+    it('stamps the connection provenance on construction and drops it on dispose', () => {
+      // The MWP connection id is the unspoofable connection identity; the
+      // dapp metadata is self-reported and display-only (MCWP-771).
+      expect(getOriginProvenance('mock-connection-id')).toStrictEqual({
+        connectionId: 'mock-connection-id',
+        transport: RemoteTransport.MMConnect,
+        isVerified: false,
+        selfReported: {
+          url: 'https://mockdapp.com',
+          name: 'MockDApp',
+          icon: undefined,
+        },
+      });
+
+      adapter.dispose();
+
+      expect(getOriginProvenance('mock-connection-id')).toBeUndefined();
     });
   });
 

--- a/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.test.ts
+++ b/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.test.ts
@@ -202,7 +202,7 @@ describe('RPCBridgeAdapter', () => {
   describe('Origin Provenance', () => {
     it('stamps the connection provenance on construction and drops it on dispose', () => {
       // The MWP connection id is the unspoofable connection identity; the
-      // dapp metadata is self-reported and display-only (MCWP-771).
+      // dapp metadata is self-reported and display-only.
       expect(getOriginProvenance('mock-connection-id')).toStrictEqual({
         connectionId: 'mock-connection-id',
         transport: RemoteTransport.MMConnect,

--- a/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts
+++ b/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts
@@ -7,6 +7,11 @@ import getRpcMethodMiddleware from '../../RPCMethods/RPCMethodMiddleware';
 import { TransportType } from '../../../components/hooks/useAnalytics/useAnalytics.types';
 import { ImageSourcePropType } from 'react-native';
 import { ConnectionInfo } from '../types/connection-info';
+import {
+  RemoteTransport,
+  stampOriginProvenance,
+  removeOriginProvenance,
+} from '../../OriginProvenance';
 import { whenEngineReady } from '../utils/when-engine-ready';
 import { whenOnboardingComplete } from '../utils/when-onboarding-complete';
 import { whenStoreReady } from '../utils/when-store-ready';
@@ -25,6 +30,19 @@ export class RPCBridgeAdapter
   constructor(connInfo: ConnectionInfo) {
     super();
     this.connInfo = connInfo;
+    // Stamp the connection's provenance at the entry point: the MWP
+    // connection id is the unspoofable connection identity; the dapp
+    // metadata in the connection request is self-reported and display-only
+    // (MCWP-771).
+    stampOriginProvenance({
+      connectionId: connInfo.id,
+      transport: RemoteTransport.MMConnect,
+      selfReported: {
+        url: connInfo.metadata.dapp.url,
+        name: connInfo.metadata.dapp.name,
+        icon: connInfo.metadata.dapp.icon,
+      },
+    });
     this.processQueue = this.processQueue.bind(this);
     this.ensureInitialized();
   }
@@ -41,6 +59,7 @@ export class RPCBridgeAdapter
    * Disposes of the adapter, cleaning up listeners and connections.
    */
   public dispose(): void {
+    removeOriginProvenance(this.connInfo.id);
     this.messenger?.tryUnsubscribe(
       'KeyringController:unlock',
       this.processQueue,

--- a/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts
+++ b/app/core/SDKConnectV2/adapters/rpc-bridge-adapter.ts
@@ -32,8 +32,7 @@ export class RPCBridgeAdapter
     this.connInfo = connInfo;
     // Stamp the connection's provenance at the entry point: the MWP
     // connection id is the unspoofable connection identity; the dapp
-    // metadata in the connection request is self-reported and display-only
-    // (MCWP-771).
+    // metadata in the connection request is self-reported and display-only.
     stampOriginProvenance({
       connectionId: connInfo.id,
       transport: RemoteTransport.MMConnect,

--- a/app/core/WalletConnect/WalletConnect2Session.test.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.test.ts
@@ -17,6 +17,14 @@ import DevLogger from '../SDKConnect/utils/DevLogger';
 import { getGlobalNetworkClientId } from '../../util/networks/global-network';
 import { Hex, CaipChainId } from '@metamask/utils';
 import WalletConnectPort from '../BackgroundBridge/WalletConnectPort';
+import { addTransaction } from '../../util/transaction-controller';
+import ppomUtil from '../../../app/lib/ppom/ppom-util';
+import { updateConfirmationMetric } from '../redux/slices/confirmationMetrics';
+
+jest.mock('../../util/transaction-controller', () => ({
+  ...jest.requireActual('../../util/transaction-controller'),
+  addTransaction: jest.fn().mockRejectedValue(new Error('not mocked')),
+}));
 
 jest.mock('../AppConstants', () => ({
   WALLET_CONNECT: {
@@ -35,6 +43,13 @@ jest.mock('../AppConstants', () => ({
     chainChanged: 'metamask_chainChanged',
     accountsChanged: 'metamask_accountsChanged',
     unlockStateChanged: 'metamask_unlockStateChanged',
+  },
+  REQUEST_SOURCES: {
+    SDK_REMOTE_CONN: 'MetaMask-SDK-Remote-Conn',
+    MM_CONNECT: 'MetaMask-Connect',
+    WC: 'WalletConnect',
+    WC2: 'WalletConnectV2',
+    IN_APP_BROWSER: 'In-App-Browser',
   },
 }));
 
@@ -1099,6 +1114,79 @@ describe('WalletConnect2Session', () => {
 
       // Verify that handleSwitchToChain was called
       expect(handleSwitchToChainSpy).toHaveBeenCalled();
+    });
+
+    it('omits the self-reported origin from the security scan and records the WC transport for eth_sendTransaction', async () => {
+      jest.mock('./wc-utils', () => jest.requireActual('./wc-utils'));
+
+      const addTransactionMock = addTransaction as jest.MockedFunction<
+        typeof addTransaction
+      >;
+      addTransactionMock.mockClear();
+      addTransactionMock.mockResolvedValueOnce({
+        result: Promise.resolve('0xhash'),
+        transactionMeta: { id: 'wc-tx-id-1' },
+      } as unknown as Awaited<ReturnType<typeof addTransaction>>);
+      const validateRequestSpy = jest
+        .spyOn(ppomUtil, 'validateRequest')
+        .mockResolvedValue(undefined);
+
+      const requestId = 333333;
+      const request: WalletKitTypes.SessionRequest = {
+        id: requestId,
+        topic: mockSession.topic,
+        params: {
+          request: {
+            method: 'eth_sendTransaction',
+            params: [
+              {
+                from: '0x1234567890abcdef1234567890abcdef12345678',
+                to: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef',
+                value: '0x16345785d8a0000',
+                gas: '0x5208',
+                gasPrice: '0x4a817c800',
+                data: '0x',
+              },
+            ],
+          },
+          chainId: testChainCaip,
+        },
+        verifyContext: {
+          verified: {
+            origin: 'https://example.com',
+            validation: 'UNKNOWN',
+            verifyUrl: '',
+          },
+        },
+      };
+
+      await buildCase(request, testChainId, testChainCaip);
+
+      // The transaction itself keeps the (unverified) origin for display and
+      // analytics purposes.
+      expect(addTransactionMock).toHaveBeenCalledTimes(1);
+
+      // Security invariant: the request sent to PPOM/Blockaid must not carry
+      // the dapp's self-reported origin. It is unverifiable over
+      // WalletConnect and the URL is a core Blockaid heuristic that can flip
+      // a scan verdict between malicious and benign.
+      expect(validateRequestSpy).toHaveBeenCalledTimes(1);
+      const [ppomRequest] = validateRequestSpy.mock.calls[0];
+      expect(ppomRequest).not.toHaveProperty('origin');
+
+      // The transport is recorded keyed by transaction id so the
+      // confirmation UI shows "External app" instead of the self-reported
+      // domain (useIsExternalAppRequest).
+      expect(store.dispatch).toHaveBeenCalledWith(
+        updateConfirmationMetric({
+          id: 'wc-tx-id-1',
+          params: {
+            properties: { request_source: 'WalletConnect' },
+          },
+        }),
+      );
+
+      validateRequestSpy.mockRestore();
     });
 
     it('rejects eth_sendTransaction with extraneous top-level param key', async () => {

--- a/app/core/WalletConnect/WalletConnect2Session.test.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.test.ts
@@ -20,6 +20,7 @@ import WalletConnectPort from '../BackgroundBridge/WalletConnectPort';
 import { addTransaction } from '../../util/transaction-controller';
 import ppomUtil from '../../../app/lib/ppom/ppom-util';
 import { updateConfirmationMetric } from '../redux/slices/confirmationMetrics';
+import { getOriginProvenance, RemoteTransport } from '../OriginProvenance';
 
 jest.mock('../../util/transaction-controller', () => ({
   ...jest.requireActual('../../util/transaction-controller'),
@@ -344,6 +345,25 @@ describe('WalletConnect2Session', () => {
     expect((session as any).topicByRequestId).toEqual({
       '1': mockSession.topic,
     });
+  });
+
+  it('stamps the connection provenance on construction and drops it on removeListeners', async () => {
+    // The channelId is the unspoofable connection identity; the peer
+    // metadata is self-reported by the dapp and display-only (MCWP-771).
+    expect(getOriginProvenance('test-channel')).toStrictEqual({
+      connectionId: 'test-channel',
+      transport: RemoteTransport.WalletConnect,
+      isVerified: false,
+      selfReported: {
+        url: 'https://example.com',
+        name: 'Test App',
+        icon: undefined,
+      },
+    });
+
+    await session.removeListeners();
+
+    expect(getOriginProvenance('test-channel')).toBeUndefined();
   });
 
   it('normalizes URLs without protocol for legacy session compatibility', () => {

--- a/app/core/WalletConnect/WalletConnect2Session.test.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.test.ts
@@ -349,7 +349,7 @@ describe('WalletConnect2Session', () => {
 
   it('stamps the connection provenance on construction and drops it on removeListeners', async () => {
     // The channelId is the unspoofable connection identity; the peer
-    // metadata is self-reported by the dapp and display-only (MCWP-771).
+    // metadata is self-reported by the dapp and display-only.
     expect(getOriginProvenance('test-channel')).toStrictEqual({
       connectionId: 'test-channel',
       transport: RemoteTransport.WalletConnect,

--- a/app/core/WalletConnect/WalletConnect2Session.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.ts
@@ -21,6 +21,12 @@ import Routes from '../../../app/constants/navigation/Routes';
 import ppomUtil from '../../../app/lib/ppom/ppom-util';
 import { updateConfirmationMetric } from '../redux/slices/confirmationMetrics';
 import {
+  RemoteTransport,
+  getRequestSourceForTransport,
+  stampOriginProvenance,
+  removeOriginProvenance,
+} from '../OriginProvenance';
+import {
   selectEvmChainId,
   selectEvmNetworkConfigurationsByChainId,
 } from '../../selectors/networkController';
@@ -133,6 +139,15 @@ class WalletConnect2Session {
     DevLogger.log(
       `WalletConnect2Session::constructor topic=${session.topic} pairingTopic=${session.pairingTopic} url=${url} name=${name} icons=${icons}`,
     );
+
+    // Stamp the connection's provenance at the entry point: the channelId is
+    // the unspoofable connection identity; the session peer metadata is
+    // self-reported by the dapp and display-only (MCWP-771).
+    stampOriginProvenance({
+      connectionId: channelId,
+      transport: RemoteTransport.WalletConnect,
+      selfReported: { url, name, icon: icons?.[0] },
+    });
 
     this.backgroundBridge = backgroundBridgeFactory.create({
       webview: null,
@@ -838,6 +853,7 @@ class WalletConnect2Session {
   };
 
   removeListeners = async () => {
+    removeOriginProvenance(this.channelId);
     this.backgroundBridge.onDisconnect();
   };
 
@@ -868,7 +884,9 @@ class WalletConnect2Session {
           id: trx.transactionMeta.id,
           params: {
             properties: {
-              request_source: AppConstants.REQUEST_SOURCES.WC,
+              request_source: getRequestSourceForTransport(
+                RemoteTransport.WalletConnect,
+              ),
             },
           },
         }),

--- a/app/core/WalletConnect/WalletConnect2Session.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.ts
@@ -19,6 +19,7 @@ import {
 } from '@metamask/utils';
 import Routes from '../../../app/constants/navigation/Routes';
 import ppomUtil from '../../../app/lib/ppom/ppom-util';
+import { updateConfirmationMetric } from '../redux/slices/confirmationMetrics';
 import {
   selectEvmChainId,
   selectEvmNetworkConfigurationsByChainId,
@@ -858,11 +859,29 @@ class WalletConnect2Session {
         securityAlertResponse: undefined,
       });
 
+      // Record the transport keyed by transaction id so the confirmation UI
+      // (useIsExternalAppRequest) can render the "External app" treatment:
+      // `unverifiedOrigin` is a self-reported domain the UI must not present
+      // as verified, and TransactionMeta cannot carry client-only fields.
+      store.dispatch(
+        updateConfirmationMetric({
+          id: trx.transactionMeta.id,
+          params: {
+            properties: {
+              request_source: AppConstants.REQUEST_SOURCES.WC,
+            },
+          },
+        }),
+      );
+
       const reqObject = {
         id: requestEvent.id,
         jsonrpc: '2.0',
         method: 'eth_sendTransaction',
-        origin: unverifiedOrigin,
+        // No `origin`: it would be the dapp's self-reported URL, which is
+        // unverifiable over WalletConnect and must never influence the
+        // security scan (Blockaid treats the URL as a core heuristic that
+        // can flip a verdict between malicious and benign).
         params: [
           {
             from: methodParams[0].from,

--- a/app/core/WalletConnect/WalletConnect2Session.ts
+++ b/app/core/WalletConnect/WalletConnect2Session.ts
@@ -142,7 +142,7 @@ class WalletConnect2Session {
 
     // Stamp the connection's provenance at the entry point: the channelId is
     // the unspoofable connection identity; the session peer metadata is
-    // self-reported by the dapp and display-only (MCWP-771).
+    // self-reported by the dapp and display-only.
     stampOriginProvenance({
       connectionId: channelId,
       transport: RemoteTransport.WalletConnect,

--- a/app/lib/ppom/ppom-util.test.ts
+++ b/app/lib/ppom/ppom-util.test.ts
@@ -368,14 +368,41 @@ describe('PPOM Utils', () => {
       );
     });
 
-    it('normalizes transaction request origin before validation', async () => {
-      await PPOMUtil.validateRequest(
-        {
-          ...mockRequest,
-          origin: 'wc::metamask.github.io',
-        },
-        { transactionMeta: mockTransactionMeta },
-      );
+    it.each([
+      ['WalletConnect-prefixed', 'wc::https://malicious.example'],
+      ['SDK v1-prefixed', 'MMSDKREMOTE::https://malicious.example'],
+      [
+        'MetaMask Connect-prefixed',
+        'MMSDKCONNECTV2::https://malicious.example',
+      ],
+      ['deeplink placeholder', 'deeplink'],
+      ['qr-code placeholder', 'qr-code'],
+      ['bare connection UUID', 'f8b7f6f6-a086-4b6e-8f0e-2b6c9d4a1e5b'],
+    ])(
+      'drops %s origin from the scan request instead of forwarding it',
+      async (_label, origin) => {
+        // Security invariant: origins from unverifiable paths are
+        // self-reported (or meaningless connection ids / placeholders) and
+        // must never reach Blockaid, where the URL is a core heuristic that
+        // can flip a scan verdict between malicious and benign.
+        await PPOMUtil.validateRequest(
+          {
+            ...mockRequest,
+            origin,
+          },
+          { transactionMeta: mockTransactionMeta },
+        );
+
+        expect(validateWithSecurityAlertsAPIMock).toHaveBeenCalledTimes(1);
+        const sentRequest = validateWithSecurityAlertsAPIMock.mock.calls[0][1];
+        expect(sentRequest).not.toHaveProperty('origin');
+      },
+    );
+
+    it('keeps the verified in-app browser origin on the scan request', async () => {
+      await PPOMUtil.validateRequest(mockRequest, {
+        transactionMeta: mockTransactionMeta,
+      });
 
       expect(normalizeTransactionParamsMock).toHaveBeenCalledTimes(1);
       expect(validateWithSecurityAlertsAPIMock).toHaveBeenCalledTimes(1);
@@ -383,6 +410,17 @@ describe('PPOM Utils', () => {
         expect.any(String),
         mockTransactionNormalizedWithGasAndGasPrice,
       );
+    });
+
+    it('drops unverifiable origins from signature scan requests too', async () => {
+      await PPOMUtil.validateRequest({
+        ...mockSignatureRequest,
+        origin: 'wc::https://malicious.example',
+      });
+
+      expect(validateWithSecurityAlertsAPIMock).toHaveBeenCalledTimes(1);
+      const sentRequest = validateWithSecurityAlertsAPIMock.mock.calls[0][1];
+      expect(sentRequest).not.toHaveProperty('origin');
     });
 
     it('uses chain ID from transaction if provided', async () => {

--- a/app/lib/ppom/ppom-util.ts
+++ b/app/lib/ppom/ppom-util.ts
@@ -22,6 +22,7 @@ import {
 } from '@metamask/transaction-controller';
 import { WALLET_CONNECT_ORIGIN } from '../../util/walletconnect';
 import AppConstants from '../../core/AppConstants';
+import { isUUID } from '../../core/SDKConnect/utils/isUUID';
 import { validateWithSecurityAlertsAPI } from './security-alerts-api';
 import { Messenger } from '@metamask/messenger';
 import { SignatureStateChange } from '@metamask/signature-controller';
@@ -300,11 +301,56 @@ function normalizeSignatureRequest(request: PPOMRequest): PPOMRequest {
   };
 }
 
+/**
+ * Whether a request origin identifies a path where the wallet cannot verify
+ * the dapp's identity: a remote transport prefix (WalletConnect `wc::`,
+ * MetaMask SDK v1 `MMSDKREMOTE::`, MetaMask Connect / MWP `MMSDKCONNECTV2::`),
+ * a bare connection/channel UUID (the SDK v1 / MWP request origin once the
+ * transport prefix is stripped), or the `deeplink` / `qr-code` placeholders.
+ *
+ * On these paths any URL accompanying the origin is self-reported by the
+ * sender, and the rest of the value (connection ids, placeholders) is
+ * meaningless to the scan.
+ */
+function isUnverifiableOrigin(origin: string): boolean {
+  return (
+    origin.startsWith(WALLET_CONNECT_ORIGIN) ||
+    origin.startsWith(AppConstants.MM_SDK.SDK_REMOTE_ORIGIN) ||
+    origin.startsWith(AppConstants.MM_SDK.SDK_CONNECT_V2_ORIGIN) ||
+    origin === AppConstants.DEEPLINKS.ORIGIN_DEEPLINK ||
+    origin === AppConstants.DEEPLINKS.ORIGIN_QR_CODE ||
+    isUUID(origin)
+  );
+}
+
+/**
+ * Remove the origin from the scan request when it comes from an unverifiable
+ * path. Blockaid treats the URL as a core heuristic that can flip a scan
+ * verdict between malicious and benign, so a self-reported (spoofable) origin
+ * must never reach it. Previously the transport prefix was stripped and the
+ * remaining self-reported domain was still sent.
+ *
+ * This is a defense-in-depth net for origins that carry a transport marker.
+ * Call sites where the transport is known but the origin is a bare
+ * self-reported URL (indistinguishable from a verified hostname here) must
+ * drop the origin themselves: see `WalletConnect2Session.handleSendTransaction`,
+ * the signature handlers in `RPCMethodMiddleware`, and
+ * `BackgroundBridge.validateSecurity`.
+ */
+function sanitizeRequestOrigin(request: PPOMRequest): PPOMRequest {
+  if (request.origin && isUnverifiableOrigin(request.origin)) {
+    delete request.origin;
+  }
+  return request;
+}
+
 function normalizeRequest(
   request: PPOMRequest,
   transactionMeta?: TransactionMeta,
 ): PPOMRequest {
   let normalizedRequest = cloneDeep(request);
+
+  normalizedRequest = sanitizeRequestOrigin(normalizedRequest);
 
   normalizedRequest = normalizeSignatureRequest(normalizedRequest);
 
@@ -323,11 +369,6 @@ function normalizeTransactionRequest(
   if (request.method !== METHOD_SEND_TRANSACTION) {
     return request;
   }
-
-  request.origin = request.origin
-    ?.replace(WALLET_CONNECT_ORIGIN, '')
-    ?.replace(AppConstants.MM_SDK.SDK_REMOTE_ORIGIN, '')
-    ?.replace(AppConstants.MM_SDK.SDK_CONNECT_V2_ORIGIN, '');
 
   const txParams = (
     Array.isArray(request.params) ? request.params[0] : {}


### PR DESCRIPTION
## **Description**

For every remote transport (WalletConnect, SDK v1, MetaMask Connect / MWP) the dapp origin (URL, name, icon) is self-reported by the sender and unverifiable. Two sensitive consumers were still trusting that value; this PR closes both gaps and stamps a canonical provenance record at every remote entry point (scope items 1, 3, and 4 of [MCWP-771](https://consensyssoftware.atlassian.net/browse/MCWP-771)):

**Manual validation I completed.** Debugger-stepped the WalletConnect Tron and EVM remote paths + MMConnect EVM + Solana transactions and confirmed the provenance stamp, Snap `origin` / `originMetadata`, and EVM `request_source` are correct at every hop before the confirmation UI. The Tron Snap confirmation still shows the channel-id UUID in "Request from"; that is Snap display of `origin`, not a miss on this PR.

**1. Confirmation UI: "External app" treatment now covers transactions, not just signatures (interim treatment until the unverified-origin designs land).**

[perf(confirmations): stop leaking unverifiable origins into confirmation UI](https://github.com/MetaMask/metamask-mobile/pull/30547) introduced the generic "External app" label for unverifiable requests, but the detection signal (`request_source`) only rode on signature requests. WalletConnect and SDK transactions carry a self-reported domain as `origin`, so the "Request from" row presented it as if the wallet had verified it.

Following the approach agreed for [WAPI-1551](https://consensyssoftware.atlassian.net/browse/WAPI-1551) (no controller changes; the extension reviewers rejected bolting client-only fields onto `TransactionMeta` in [Add security data to token in state](https://github.com/MetaMask/metamask-extension/pull/42224)):

- The transport is recorded client-side in the existing `confirmationMetrics` redux slice keyed by transaction id. `eth_sendTransaction` already did this; `WalletConnect2Session.handleSendTransaction` (the WC transaction path, which bypasses `eth_sendTransaction`) now does it too.
- `useIsExternalAppRequest`, the single source of truth for the "Request from" rows, reads that stored `request_source` for transactions and transaction batches, in addition to the existing signature signal.

**Note: the generic "External app" label is a stop gap, not the end state.** The aligned direction (per the thread and MCWP-771's "External app or successor treatment") is to show the self-reported origin with explicit unverified framing; the uniform UI/UX designs for that treatment are still pending. When they land, the swap should be mostly presentational: the `request_source` signal wired up here already tells the UI the transport is unverifiable, and the provenance stamps in item 3 carry the self-reported URL/name/icon that the successor treatment will display.

**2. Security scans: self-reported origins never reach Blockaid.**

Product Safety confirmed Blockaid treats the request URL as a core heuristic; a spoofed origin can flip a transaction scan between `malicious` and `benign` ([Martin's confirmation](https://consensys.slack.com/archives/C09AM4DJAUR/p1781724880723799?thread_ts=1779213884.226009&cid=C09AM4DJAUR)). Previously `ppom-util` stripped the transport prefix (`wc::`, `MMSDKREMOTE::`, `MMSDKCONNECTV2::`) and forwarded the remaining self-reported domain to the security alerts API.

The origin is now dropped from the scan request at every call site where the transport is known, because a bare self-reported URL is indistinguishable from a verified in-app browser hostname once it reaches `ppom-util`:

- `RPCMethodMiddleware` signature handlers (`personal_sign`, `eth_signTypedData` v1/v3/v4): origin dropped whenever `getSource()` is not the in-app browser.
- `WalletConnect2Session.handleSendTransaction`: origin omitted from the PPOM request object.
- `BackgroundBridge.validateSecurity` (EIP-5792 / `wallet_sendCalls` path): origin dropped for WC / SDK / remote bridges.
- `ppom-util.sanitizeRequestOrigin` (defense in depth, all confirmation methods): drops origins carrying a transport prefix, bare connection UUIDs, and the `deeplink` / `qr-code` placeholders instead of prefix-stripping.

In-app browser origins are untouched: the wallet loaded the page itself, so the hostname is verifiable and stays on the scan request. `TransactionMeta.origin` / `messageParams.origin`, permissions, and analytics are all unchanged; this only affects what the confirmation row displays and what the scan API receives.

**3. Connection provenance stamped at every remote entry point.**

A new `app/core/OriginProvenance` module records, per remote connection and keyed by its unspoofable connection id, an `OriginProvenance`: the connection/channel id (the only value that may serve as `origin` for anything security-relevant), the transport, and the dapp's self-reported metadata (URL, name, icon), explicitly typed as unverified and display-only. It is stamped at the three places a remote connection enters the app and removed when the connection closes:

- `WalletConnect2Session` (constructor / `removeListeners`)
- `setupBridge` for SDK v1 (after the internal-origin rejection check, so rejected connections are never stamped)
- `RPCBridgeAdapter` for MetaMask Connect / MWP (constructor / `dispose`)

This is the mobile-side substrate for the provenance contract agreed in [this thread about origin spoofing](https://consensys.slack.com/archives/C09AM4DJAUR/p1779213884226009). The snaps `originMetadata` field has now shipped (snaps-sdk 12, threaded through the WC multichain path by [feat: Pass `originMetadata` to non-EVM Snaps](https://github.com/MetaMask/metamask-mobile/pull/34460), merged): at the Snap boundary the connection id stays the request `origin` and the self-reported URL rides in `originMetadata.selfReportedOrigin`, the same split this module stamps. The branch is rebased on top of that change. The WC transaction path derives its `request_source` via the module's transport mapping (`getRequestSourceForTransport`); the stamped records themselves are not read anywhere yet. Their consumers (the confirmation and connection-flow surfaces that will present the self-reported URL, name, and icon with explicit unverified framing) already exist, but don't yet have the uniform UI/UX designs for that treatment discussed in the thread.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed transaction confirmations from WalletConnect and MetaMask SDK connections displaying the dapp's self-reported domain as if verified; they now show "External app" like signature confirmations do.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MCWP-771 (scope items 1, 3, and 4), https://consensyssoftware.atlassian.net/browse/WAPI-1551

## **Manual testing steps**

Feature: External app treatment for remote-transport transactions

  Scenario: user sends a transaction from a WalletConnect dapp
    Given the user has connected a dapp via WalletConnect (e.g. https://metamask.github.io/test-dapp/ via the WC modal)

    When the dapp requests eth_sendTransaction
    Then the confirmation "Request from" row shows "External app" instead of the dapp's self-reported domain

  Scenario: user signs a message from a WalletConnect dapp
    Given the same WalletConnect connection

    When the dapp requests personal_sign
    Then the confirmation shows "External app" (unchanged behavior) and the request sent to the security alerts API carries no origin field (verify via Charles/proxy or debugger on validateWithSecurityAlertsAPI)

  Scenario: user sends a transaction from the in-app browser
    Given the user opens a dapp in the MetaMask in-app browser

    When the dapp requests eth_sendTransaction
    Then the confirmation shows the dapp's domain as before, and the scan request still carries the origin

## **Screenshots/Recordings**

### **Before**

WalletConnect transaction confirmation showing the dapp's self-reported domain in "Request from".

### **After**

WalletConnect transaction confirmation showing "External app" in "Request from".

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MCWP-771]: https://consensyssoftware.atlassian.net/browse/MCWP-771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WAPI-1551]: https://consensyssoftware.atlassian.net/browse/WAPI-1551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes security scan inputs and confirmation origin presentation for WalletConnect/SDK paths; incorrect sanitization could hide real threats or mislabel verified in-app browser traffic.
> 
> **Overview**
> Remote transports (WalletConnect, SDK v1, MetaMask Connect) can spoof dapp URLs; this PR stops treating those values as trusted in confirmations and Blockaid/PPOM scans, and records connection provenance at entry points.
> 
> **Confirmation UI:** `useIsExternalAppRequest` now reads `request_source` from the `confirmationMetrics` slice for transactions and batches (not only signatures). WalletConnect’s `handleSendTransaction` writes that metric so **Request from** shows **External app** instead of a self-reported domain.
> 
> **Security scans:** Self-reported `origin` is stripped before PPOM/Blockaid in `RPCMethodMiddleware` (signatures and `eth_sendTransaction`), `BackgroundBridge.validateSecurity`, `WalletConnect2Session.handleSendTransaction`, and in `ppom-util` via `sanitizeRequestOrigin` (drops transport prefixes, UUIDs, deeplink/qr placeholders) instead of forwarding the domain after prefix stripping.
> 
> **Provenance:** New `OriginProvenance` module stamps unverified self-reported metadata per connection id at WC, SDK v1 `setupBridge`, and MWP `RPCBridgeAdapter`, and clears it on disconnect/dispose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d51de6b048674373570d788ab623de66c8a3323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->