### PR TITLE
chore: skip release-team approval for rc/exp OTA pushes

### DIFF
--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -418,7 +418,15 @@ jobs:
       - verify-release-branch
       - setup-dependencies
       - prepare
+    # approval is intentionally skipped for non-production channels, so the default implicit
+    # success() (which treats a skipped dependency as failing) must be overridden here.
     if: >
+      always() && !cancelled() &&
+      needs.fingerprint-comparison.result == 'success' &&
+      needs.validate-pr.result == 'success' &&
+      needs.verify-release-branch.result == 'success' &&
+      needs.setup-dependencies.result == 'success' &&
+      needs.prepare.result == 'success' &&
       needs.fingerprint-comparison.outputs.fingerprints_equal == 'true' &&
       (needs.approval.result == 'success' || (needs.approval.result == 'skipped' && inputs.channel != 'production')) &&
       (inputs.platform == 'all' || inputs.platform == 'ios')
@@ -442,7 +450,14 @@ jobs:
       - validate-pr
       - setup-dependencies
       - prepare
+    # approval is intentionally skipped for non-production channels, so the default implicit
+    # success() (which treats a skipped dependency as failing) must be overridden here.
     if: >
+      always() && !cancelled() &&
+      needs.fingerprint-comparison.result == 'success' &&
+      needs.validate-pr.result == 'success' &&
+      needs.setup-dependencies.result == 'success' &&
+      needs.prepare.result == 'success' &&
       needs.fingerprint-comparison.outputs.fingerprints_equal == 'true' &&
       (needs.approval.result == 'success' || (needs.approval.result == 'skipped' && inputs.channel != 'production')) &&
       (inputs.platform == 'all' || inputs.platform == 'android')

--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -389,7 +389,9 @@ jobs:
     needs:
       - fingerprint-comparison
       - validate-pr
-    if: ${{ needs.fingerprint-comparison.outputs.fingerprints_equal == 'true' }}
+    if: >
+      needs.fingerprint-comparison.outputs.fingerprints_equal == 'true' &&
+      inputs.channel == 'production'
     runs-on: ubuntu-latest
     steps:
       - name: Get token
@@ -418,7 +420,7 @@ jobs:
       - prepare
     if: >
       needs.fingerprint-comparison.outputs.fingerprints_equal == 'true' &&
-      needs.approval.result == 'success' &&
+      (needs.approval.result == 'success' || (needs.approval.result == 'skipped' && inputs.channel != 'production')) &&
       (inputs.platform == 'all' || inputs.platform == 'ios')
     uses: ./.github/workflows/eas-update-platform.yml
     with:
@@ -442,7 +444,7 @@ jobs:
       - prepare
     if: >
       needs.fingerprint-comparison.outputs.fingerprints_equal == 'true' &&
-      needs.approval.result == 'success' &&
+      (needs.approval.result == 'success' || (needs.approval.result == 'skipped' && inputs.channel != 'production')) &&
       (inputs.platform == 'all' || inputs.platform == 'android')
     uses: ./.github/workflows/eas-update-platform.yml
     with:


### PR DESCRIPTION
## Summary
- Skips the release-team approval gate (`require-team-approval`) in `push-eas-update.yml` for the `rc` and `exp` OTA channels; `production` still requires it.
- Updates the `push-update-ios`/`push-update-android` job conditions to proceed when the approval job was skipped for non-production channels (previously they only proceeded on `needs.approval.result == 'success'`).

JIRA ticket: https://consensyssoftware.atlassian.net/browse/MCWP-775

## Test plan
- [ ] Trigger `Runway OTA RC` (`.github/workflows/runway-ota-rc.yml`) on a test release branch and confirm the OTA update publishes to the `rc` channel without waiting on release-team approval.
- [ ] Trigger `Runway OTA Production` and confirm the release-team approval gate still runs and blocks publishing until approved.
- [ ] Manually dispatch `push-eas-update.yml` with `channel: exp` and confirm it publishes without approval.

Made with [Cursor](https://cursor.com)