### PR TITLE
fix: remove extra horizontal padding from perps rows in Explore search

### DIFF
--- a/app/components/Views/TrendingView/search/SearchFeedRow.test.tsx
+++ b/app/components/Views/TrendingView/search/SearchFeedRow.test.tsx
@@ -5,7 +5,10 @@ import type { TrendingAsset } from '@metamask/assets-controllers';
 import type { PerpsMarketData } from '@metamask/perps-controller';
 import type { PredictMarket as PredictMarketType } from '../../../UI/Predict/types';
 import type { SiteData } from '../../../UI/Sites/components/SiteRowItem/SiteRowItem';
-import SearchFeedRow, { SearchFeedSkeleton } from './SearchFeedRow';
+import SearchFeedRow, {
+  SearchFeedSkeleton,
+  PERPS_ROW_WRAPPER_TEST_ID,
+} from './SearchFeedRow';
 import { trackExploreSearchEvent } from './analytics';
 import { TokenDetailsSource } from '../../../UI/TokenDetails/constants/constants';
 
@@ -223,6 +226,55 @@ describe('SearchFeedRow', () => {
       expect.objectContaining({ search_query: 'second' }),
     );
   });
+});
+
+describe('perps row alignment', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('cancels the list container padding so perps rows align with other feeds', () => {
+    const perpsMarket = { symbol: 'ETH' } as PerpsMarketData;
+
+    const { getByTestId } = render(
+      <SearchFeedRow
+        feedId="perps"
+        item={perpsMarket}
+        index={0}
+        searchQuery="q"
+        tabName="perps"
+      />,
+    );
+
+    expect(getByTestId(PERPS_ROW_WRAPPER_TEST_ID)).toHaveStyle({
+      marginLeft: -16,
+      marginRight: -16,
+    });
+  });
+
+  it.each(['tokens', 'stocks', 'predictions', 'sites'] as const)(
+    'does not wrap %s rows, which rely on the container padding',
+    (feedId) => {
+      const itemByFeed = {
+        tokens: { assetId: 'asset-1' } as TrendingAsset,
+        stocks: { assetId: 'asset-2' } as TrendingAsset,
+        predictions: { id: 'pred-9' } as PredictMarketType,
+        sites: { url: 'https://example.com' } as SiteData,
+      }[feedId];
+
+      const { queryByTestId } = render(
+        <SearchFeedRow
+          feedId={feedId}
+          item={itemByFeed}
+          index={0}
+          searchQuery="q"
+          tabName={feedId}
+        />,
+      );
+
+      expect(queryByTestId(PERPS_ROW_WRAPPER_TEST_ID)).toBeNull();
+    },
+  );
 });
 
 describe('onQuickTrade prop', () => {

--- a/app/components/Views/TrendingView/search/SearchFeedRow.tsx
+++ b/app/components/Views/TrendingView/search/SearchFeedRow.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useRef } from 'react';
+import { Box } from '@metamask/design-system-react-native';
 import type { TrendingAsset } from '@metamask/assets-controllers';
 import type { PerpsMarketData } from '@metamask/perps-controller';
 import type { PredictMarket as PredictMarketType } from '../../../UI/Predict/types';
@@ -23,6 +24,8 @@ interface SearchFeedRowProps {
   resultCount?: number;
   onQuickTrade?: (token: TrendingAsset) => void;
 }
+
+export const PERPS_ROW_WRAPPER_TEST_ID = 'search-feed-row-perps-wrapper';
 
 export const getItemId = (feedId: SearchFeedId, item: unknown): string => {
   switch (feedId) {
@@ -78,7 +81,13 @@ const SearchFeedRow: React.FC<SearchFeedRowProps> = ({
           />
         );
       case 'perps':
-        return <PerpsRowItem market={item as PerpsMarketData} />;
+        // ListItem owns its own px-4 for the pressed state, so cancel the list
+        // container's px-4 to avoid indenting perps rows an extra 16px.
+        return (
+          <Box twClassName="-mx-4" testID={PERPS_ROW_WRAPPER_TEST_ID}>
+            <PerpsRowItem market={item as PerpsMarketData} />
+          </Box>
+        );
       case 'predictions':
         return <PredictionSearchRowItem market={item as PredictMarketType} />;
       case 'sites':


### PR DESCRIPTION
## **Description**

Perps rows in Explore search were indented 16px further than every other feed. `PerpsMarketRowItem` renders the design-system `ListItem`, which bakes in its own `px-4` so the pressed-state background bleeds to the screen edge. Both Explore search lists also pad their FlashList container with `px-4`, so perps rows landed at 32px while token, stock, prediction, and site rows (which carry no padding of their own) sat at 16px.

**What**

- **Cancel the container padding on the perps row wrapper** in [SearchFeedRow.tsx](app/components/Views/TrendingView/search/SearchFeedRow.tsx) with `-mx-4`.
- The `ListItem`'s own horizontal padding is **kept**, as the reporter asked, so the pressed state still bleeds to the screen edge.
- Fixes both the **Perps tab** and the **perps section of the All tab** — same root cause, one shared seam.

**Why**

The container padding is shared by all five feeds, so it can't just be deleted — the other feeds rely on it. Negating it for perps only is the smallest change that aligns all feeds.

<details>
<summary>More info: why the fix is scoped to the search path</summary>

`PerpsRowItem` is also used by `PerpsToggleBlock` on the Explore home tabs. That path renders through `PillToggleCardList`, which has **no** container horizontal padding — so those rows are already correctly aligned by the `ListItem`'s own `px-4`.

Changing `PerpsRowItem` or `PerpsMarketRowItem` would therefore have broken the home tabs. Scoping the change to `SearchFeedRow` (the single component both search lists use to render rows) fixes the search lists and leaves the home tabs untouched.

Verified `px-4 py-3` is baked into the DS `ListItem` at `node_modules/@metamask/design-system-react-native/dist/components/ListItem/ListItem.mjs`.

</details>

## **Changelog**

CHANGELOG entry: Fixed the extra indentation on perps results in Explore search

## **Related issues**

Fixes: [TMCU-1257](https://consensyssoftware.atlassian.net/browse/TMCU-1257)

## **Manual testing steps**

```gherkin
Feature: Explore search perps row alignment

  Scenario: user views the Perps tab in Explore search
    Given user is on the Explore tab
    And user taps the search bar
    And user has search results across multiple feeds

    When user selects the "Perps" pill
    Then perp rows are left-aligned with the rows in the "Crypto" and "Stocks" tabs
    And tapping and holding a perp row still shows the pressed background bleeding to the screen edges

  Scenario: user views the perps section on the All tab
    Given user is on Explore search with the "All" pill selected

    When user scrolls to the "Perps" section
    Then perp rows are left-aligned with the rows in the "Crypto" section above
```

## **Screenshots/Recordings**


https://github.com/user-attachments/assets/8431f23c-8ab2-4385-a75c-99b3c3d61c5a

### **Before**

Perps rows indented an extra 16px (see the ticket's attachments: the Perps tab and the Perps section of the All tab).

https://github.com/user-attachments/assets/309c37cb-60bf-4d1b-ada6-5ddd65a77f4c

### **After**

https://github.com/user-attachments/assets/8431f23c-8ab2-4385-a75c-99b3c3d61c5a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

N/A — CSS-only alignment change, no new work on any code path.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TMCU-1257]: https://consensyssoftware.atlassian.net/browse/TMCU-1257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped layout tweak in Explore search row rendering with unit tests; no auth, data, or shared perps component changes.
> 
> **Overview**
> Explore search **perps** rows were sitting **16px further in** than crypto, stocks, predictions, and sites because the list uses `px-4` while `PerpsRowItem`’s design-system `ListItem` already applies its own horizontal padding.
> 
> **`SearchFeedRow`** now wraps only the **perps** branch in a `Box` with **`-mx-4`** (and exports **`PERPS_ROW_WRAPPER_TEST_ID`** for tests), canceling the list container padding without touching other feeds or Explore home perps UI.
> 
> Tests assert the wrapper’s **±16px margins** and that **tokens, stocks, predictions, and sites** do not use that wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4dfe1054ee52837ebb078257e642ad4c67cde1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->