### PR TITLE
test(e2e): skip flaky token-approve Appium smokes until stabilized

### DIFF
--- a/tests/smoke-appium/confirmations/transactions/token-approve/approve.spec.ts
+++ b/tests/smoke-appium/confirmations/transactions/token-approve/approve.spec.ts
@@ -64,7 +64,8 @@ const testSpecificMock = async (mockServer: Mockttp) => {
   );
 };
 
-appiumTest.describe(
+// Skipped: flaky on main, confirm-button not in hierarchy. See #34581.
+appiumTest.describe.skip(
   SmokeConfirmations('Token Approve - approve method'),
   () => {
     appiumTest.describe.configure({ timeout: 2500000 });

--- a/tests/smoke-appium/confirmations/transactions/token-approve/increase-allowance.spec.ts
+++ b/tests/smoke-appium/confirmations/transactions/token-approve/increase-allowance.spec.ts
@@ -67,7 +67,8 @@ const testSpecificMock = async (mockServer: Mockttp) => {
   );
 };
 
-appiumTest.describe(
+// Skipped: flaky on main, confirm-button not in hierarchy. See #34581.
+appiumTest.describe.skip(
   SmokeConfirmations('Token Approve - increaseAllowance method'),
   () => {
     appiumTest.describe.configure({ timeout: 2500000 });

--- a/tests/smoke-appium/confirmations/transactions/token-approve/set-approval-for-all.spec.ts
+++ b/tests/smoke-appium/confirmations/transactions/token-approve/set-approval-for-all.spec.ts
@@ -64,7 +64,8 @@ const testSpecificMock = async (mockServer: Mockttp) => {
   );
 };
 
-appiumTest.describe(
+// Skipped: flaky on main, confirm-button not in hierarchy. See #34581.
+appiumTest.describe.skip(
   SmokeConfirmations('Token Approve - setApprovalForAll method'),
   () => {
     appiumTest.describe.configure({ timeout: 2500000 });


### PR DESCRIPTION
## **Description**

The token-approve Appium smoke suite fails consistently on `main` with `Element "confirm-button" not in hierarchy after 3000ms`. The approve confirmation does not open reliably in CI, so `appium-confirmations-android-smoke` has been red on `main` and is blocking confirmations CI for every PR.

This re-skips the three token-approve smoke suites (mirroring #34387) so they stop blocking CI while the flakiness is investigated. No product code changes. Tracked in #34581.

Suites skipped:
- `token-approve/approve.spec.ts`
- `token-approve/increase-allowance.spec.ts`
- `token-approve/set-approval-for-all.spec.ts`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #34581

## **Manual testing steps**

N/A. Test-only change that skips flaky E2E suites. CI confirms `appium-confirmations-android-smoke` no longer fails on these specs.

## **Screenshots/Recordings**

N/A. No UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that disables flaky E2E coverage; no application or release behavior is modified.
> 
> **Overview**
> Unblocks **confirmations CI** by skipping three flaky **token-approve** Appium smoke suites that fail on `main` when **`confirm-button`** never appears in the view hierarchy.
> 
> Each suite (`approve`, `increase-allowance`, `set-approval-for-all`) switches from `appiumTest.describe` to **`appiumTest.describe.skip`**, with an inline note pointing to **#34581**. Test bodies are unchanged; this mirrors the earlier temporary skip in **#34387**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1142945530cdd7d6fd02a85c793905e8ef7d8e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->