### PR TITLE
feat(perf): add real-network unlock HTTP call budget meter

### DIFF
--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -27,6 +27,10 @@ import { selectSocialLeaderboardEnabled } from '../../../selectors/featureFlagCo
 import { selectTokenWatchlistEnabled } from '../../UI/Assets/selectors/featureFlags';
 import { HomeSectionNames, HomeSectionName } from './hooks/useHomeViewedEvent';
 import useHomeSessionSummary from './hooks/useHomeSessionSummary';
+import {
+  UnlockNetworkMeterProbe,
+  useUnlockNetworkMeterEnd,
+} from './hooks/useUnlockNetworkMeterEnd';
 import { useNetworkEnablement } from '../../hooks/useNetworkEnablement/useNetworkEnablement';
 import { PerpsConnectionProvider } from '../../UI/Perps/providers/PerpsConnectionProvider';
 import { PerpsStreamProvider } from '../../UI/Perps/providers/PerpsStreamManager';
@@ -118,6 +122,7 @@ const Homepage = forwardRef<SectionRefreshHandle, HomepageProps>(
     const totalSectionsLoaded = enabledSections.length;
 
     useHomeSessionSummary({ totalSectionsLoaded });
+    useUnlockNetworkMeterEnd();
 
     const getSectionIndex = useCallback(
       (name: HomeSectionName) =>
@@ -194,6 +199,7 @@ const Homepage = forwardRef<SectionRefreshHandle, HomepageProps>(
               totalSectionsLoaded={totalSectionsLoaded}
             />
             <MoreSection />
+            <UnlockNetworkMeterProbe />
           </Box>
         </PerpsStreamProvider>
       </PerpsConnectionProvider>

--- a/app/components/Views/Homepage/hooks/useUnlockNetworkMeterEnd.tsx
+++ b/app/components/Views/Homepage/hooks/useUnlockNetworkMeterEnd.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import {
+  getLastUnlockSummary,
+  signalHomepageReadyForUnlockMeter,
+  subscribeUnlockNetworkMeter,
+  UNLOCK_NETWORK_METER_SUMMARY_TEST_ID,
+  type UnlockNetworkSummary,
+} from '../../../../core/UnlockNetworkMeter';
+
+const styles = StyleSheet.create({
+  probe: {
+    width: 1,
+    height: 1,
+    opacity: 0,
+    position: 'absolute',
+  },
+});
+
+/**
+ * Signals unlock-window end conditions once Homepage chrome mounts, and exposes
+ * the last unlock HTTP summary for Developer Options / real-network performance
+ * E2E via accessibility (no Mockttp).
+ */
+export function useUnlockNetworkMeterEnd(): void {
+  useEffect(() => {
+    signalHomepageReadyForUnlockMeter();
+  }, []);
+}
+
+function summaryAccessibilityLabel(summary: UnlockNetworkSummary): string {
+  return JSON.stringify({
+    total: summary.total,
+    byHost: summary.byHost,
+    endReason: summary.endReason,
+    startedAt: summary.startedAt,
+    endedAt: summary.endedAt,
+  });
+}
+
+/**
+ * Invisible probe so performance E2E can read the in-app unlock HTTP summary
+ * without mocks.
+ */
+export function UnlockNetworkMeterProbe() {
+  const [summary, setSummary] = useState<UnlockNetworkSummary | null>(
+    getLastUnlockSummary,
+  );
+
+  useEffect(
+    () =>
+      subscribeUnlockNetworkMeter(() => {
+        setSummary(getLastUnlockSummary());
+      }),
+    [],
+  );
+
+  if (!summary) {
+    return null;
+  }
+
+  return (
+    <View
+      testID={UNLOCK_NETWORK_METER_SUMMARY_TEST_ID}
+      accessibilityLabel={summaryAccessibilityLabel(summary)}
+      accessible
+      // Keep out of layout while remaining queryable by automation.
+      collapsable={false}
+      style={styles.probe}
+    />
+  );
+}

--- a/app/components/Views/Settings/DeveloperOptions/UnlockNetworkMeterDeveloperOptionsSection.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/UnlockNetworkMeterDeveloperOptionsSection.tsx
@@ -1,0 +1,137 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import Clipboard from '@react-native-clipboard/clipboard';
+import {
+  Button,
+  ButtonVariant,
+  ButtonSize,
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../locales/i18n';
+import { useTheme } from '../../../../util/theme';
+import { useStyles } from '../../../../component-library/hooks';
+import {
+  getLastUnlockSummary,
+  getUnlockWindowLiveCount,
+  isUnlockWindowActive,
+  subscribeUnlockNetworkMeter,
+  type UnlockNetworkSummary,
+} from '../../../../core/UnlockNetworkMeter';
+import styleSheet from './DeveloperOptions.styles';
+
+const UnlockNetworkMeterDeveloperOptionsSection = () => {
+  const theme = useTheme();
+  const { styles } = useStyles(styleSheet, { theme });
+  const [summary, setSummary] = useState<UnlockNetworkSummary | null>(
+    getLastUnlockSummary,
+  );
+  const [active, setActive] = useState(isUnlockWindowActive);
+  const [liveCount, setLiveCount] = useState(getUnlockWindowLiveCount);
+
+  useEffect(
+    () =>
+      subscribeUnlockNetworkMeter(() => {
+        setSummary(getLastUnlockSummary());
+        setActive(isUnlockWindowActive());
+        setLiveCount(getUnlockWindowLiveCount());
+      }),
+    [],
+  );
+
+  const handleCopyJson = useCallback(() => {
+    if (!summary) {
+      return;
+    }
+    Clipboard.setString(
+      JSON.stringify(
+        {
+          total: summary.total,
+          byHost: summary.byHost,
+          endReason: summary.endReason,
+          startedAt: summary.startedAt,
+          endedAt: summary.endedAt,
+          requests: summary.requests,
+        },
+        null,
+        2,
+      ),
+    );
+  }, [summary]);
+
+  const hostLines = summary
+    ? Object.entries(summary.byHost)
+        .sort((a, b) => b[1] - a[1])
+        .map(([host, count]) => `${host}: ${count}`)
+        .join('\n')
+    : '';
+
+  return (
+    <>
+      <Text
+        color={TextColor.TextDefault}
+        variant={TextVariant.HeadingLg}
+        style={styles.heading}
+      >
+        {strings('app_settings.developer_options.unlock_network_meter.title')}
+      </Text>
+      <Text
+        color={TextColor.TextAlternative}
+        variant={TextVariant.BodyMd}
+        style={styles.desc}
+      >
+        {strings(
+          'app_settings.developer_options.unlock_network_meter.description',
+        )}
+      </Text>
+      <Text
+        color={TextColor.TextDefault}
+        variant={TextVariant.BodyMd}
+        style={styles.desc}
+        testID="unlock-network-meter-status"
+      >
+        {active
+          ? strings(
+              'app_settings.developer_options.unlock_network_meter.status_active',
+              { count: liveCount },
+            )
+          : summary
+            ? strings(
+                'app_settings.developer_options.unlock_network_meter.status_last',
+                {
+                  total: summary.total,
+                  reason: summary.endReason,
+                },
+              )
+            : strings(
+                'app_settings.developer_options.unlock_network_meter.status_empty',
+              )}
+      </Text>
+      {hostLines ? (
+        <Text
+          color={TextColor.TextAlternative}
+          variant={TextVariant.BodySm}
+          style={styles.desc}
+          testID="unlock-network-meter-hosts"
+        >
+          {hostLines}
+        </Text>
+      ) : null}
+      <Button
+        variant={ButtonVariant.Secondary}
+        size={ButtonSize.Lg}
+        onPress={handleCopyJson}
+        isFullWidth
+        isDisabled={!summary}
+        style={styles.accessory}
+        testID="unlock-network-meter-copy-json"
+      >
+        {strings(
+          'app_settings.developer_options.unlock_network_meter.copy_json_button',
+        )}
+      </Button>
+    </>
+  );
+};
+
+export default UnlockNetworkMeterDeveloperOptionsSection;

--- a/app/components/Views/Settings/DeveloperOptions/index.tsx
+++ b/app/components/Views/Settings/DeveloperOptions/index.tsx
@@ -16,6 +16,7 @@ import styleSheet from './DeveloperOptions.styles';
 import SentryTest from './SentryTest';
 import HapticsDeveloperOptionsSection from './HapticsDeveloperOptionsSection';
 import IdentityDeveloperOptionsSection from './IdentityDeveloperOptionsSection';
+import UnlockNetworkMeterDeveloperOptionsSection from './UnlockNetworkMeterDeveloperOptionsSection';
 ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
 import SampleFeatureDevSettingsEntryPoint from '../../../../features/SampleFeature/components/views/SampleFeatureDevSettingsEntryPoint/SampleFeatureDevSettingsEntryPoint';
 ///: END:ONLY_INCLUDE_IF
@@ -82,6 +83,7 @@ const DeveloperOptions = () => {
       />
       <ScrollView contentContainerStyle={styles.contentContainer}>
         <SentryTest />
+        <UnlockNetworkMeterDeveloperOptionsSection />
         {
           ///: BEGIN:ONLY_INCLUDE_IF(sample-feature)
         }

--- a/app/core/Authentication/Authentication.test.ts
+++ b/app/core/Authentication/Authentication.test.ts
@@ -319,6 +319,11 @@ jest.mock('../../util/analytics/analyticsDataDeletion', () => ({
 const mockCaptureException = jest.fn();
 jest.mock('@sentry/react-native', () => ({
   captureException: (...args: unknown[]) => mockCaptureException(...args),
+  setMeasurement: jest.fn(),
+}));
+
+jest.mock('../UnlockNetworkMeter', () => ({
+  startUnlockWindow: jest.fn(),
 }));
 
 jest.mock('../../components/UI/Ramp/utils/ProviderTokenVault', () => ({

--- a/app/core/Authentication/Authentication.ts
+++ b/app/core/Authentication/Authentication.ts
@@ -23,6 +23,7 @@ import {
 import AUTHENTICATION_TYPE from '../../constants/userProperties';
 import AuthenticationError from './AuthenticationError';
 import { UNLOCK_WALLET_ERROR_MESSAGES } from './constants';
+import { startUnlockWindow } from '../UnlockNetworkMeter';
 import { UserCredentials, BIOMETRY_TYPE } from 'react-native-keychain';
 import {
   AUTHENTICATION_FAILED_WALLET_CREATION,
@@ -799,6 +800,10 @@ class AuthenticationService {
   ) => {
     let passwordToUse: string | undefined;
     try {
+      // Arm in-app unlock HTTP meter (fetch/XHR) for Developer Options + real-network
+      // performance gates. Ends on homepage ready + network quiescence.
+      startUnlockWindow();
+
       const existingUser = selectExistingUser(ReduxService.store.getState());
 
       if (existingUser || authPreference?.oauth2Login) {

--- a/app/core/NitroFetchSetup.ts
+++ b/app/core/NitroFetchSetup.ts
@@ -34,6 +34,7 @@ import {
   getFeatureFlagAppDistribution,
   getFeatureFlagAppEnvironment,
 } from './Engine/controllers/remote-feature-flag-controller/utils';
+import { installUnlockNetworkMeterTransport } from './UnlockNetworkMeter';
 
 /**
  * Single source of truth for startup prefetches.
@@ -147,6 +148,10 @@ function installProductionNitroFetch(): void {
     // not that the request fails — swallow so it never becomes an unhandled rejection.
     prefetchOnAppStart(url, { prefetchKey: key }).catch(() => undefined);
   }
+
+  // Wrap the live nitro fetch (and XHR) so unlock → homepage HTTP volume can be
+  // measured on real builds without Mockttp.
+  installUnlockNetworkMeterTransport();
 }
 
 if (!hasTestOverrides) {

--- a/app/core/UnlockNetworkMeter.test.ts
+++ b/app/core/UnlockNetworkMeter.test.ts
@@ -1,0 +1,122 @@
+import { setMeasurement } from '@sentry/react-native';
+import {
+  __resetUnlockNetworkMeterForTests,
+  endUnlockWindow,
+  getLastUnlockSummary,
+  getUnlockWindowLiveCount,
+  isUnlockWindowActive,
+  recordUnlockNetworkRequest,
+  signalHomepageReadyForUnlockMeter,
+  startUnlockWindow,
+  UNLOCK_HTTP_REQUEST_COUNT_MEASUREMENT,
+  UNLOCK_NETWORK_METER_MAX_WINDOW_MS,
+  UNLOCK_NETWORK_METER_QUIET_MS,
+} from './UnlockNetworkMeter';
+
+jest.mock('@sentry/react-native', () => ({
+  setMeasurement: jest.fn(),
+}));
+
+const mockSetMeasurement = jest.mocked(setMeasurement);
+
+describe('UnlockNetworkMeter', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    __resetUnlockNetworkMeterForTests();
+    mockSetMeasurement.mockClear();
+  });
+
+  afterEach(() => {
+    __resetUnlockNetworkMeterForTests();
+    jest.useRealTimers();
+  });
+
+  it('ignores record calls when the unlock window is inactive', () => {
+    recordUnlockNetworkRequest('GET', 'https://api.example.com/v1');
+
+    expect(isUnlockWindowActive()).toBe(false);
+    expect(getLastUnlockSummary()).toBeNull();
+    expect(getUnlockWindowLiveCount()).toBe(0);
+  });
+
+  it('records method/host/url while the window is active', () => {
+    startUnlockWindow();
+    recordUnlockNetworkRequest('post', 'https://api.example.com/a');
+    recordUnlockNetworkRequest('GET', 'https://cdn.example.com/b');
+
+    expect(isUnlockWindowActive()).toBe(true);
+    expect(getUnlockWindowLiveCount()).toBe(2);
+
+    signalHomepageReadyForUnlockMeter();
+    jest.advanceTimersByTime(UNLOCK_NETWORK_METER_QUIET_MS);
+
+    const summary = getLastUnlockSummary();
+    expect(summary).toMatchObject({
+      total: 2,
+      byHost: {
+        'api.example.com': 1,
+        'cdn.example.com': 1,
+      },
+      endReason: 'quiescence',
+    });
+    expect(summary?.requests[0]).toMatchObject({
+      method: 'POST',
+      host: 'api.example.com',
+      url: 'https://api.example.com/a',
+    });
+    expect(mockSetMeasurement).toHaveBeenCalledWith(
+      UNLOCK_HTTP_REQUEST_COUNT_MEASUREMENT,
+      2,
+      'none',
+    );
+  });
+
+  it('does not end on quiescence until homepage is ready', () => {
+    startUnlockWindow();
+    recordUnlockNetworkRequest('GET', 'https://api.example.com/a');
+
+    jest.advanceTimersByTime(UNLOCK_NETWORK_METER_QUIET_MS * 3);
+
+    expect(isUnlockWindowActive()).toBe(true);
+    expect(getLastUnlockSummary()).toBeNull();
+  });
+
+  it('ends via max window fallback', () => {
+    startUnlockWindow();
+    recordUnlockNetworkRequest('GET', 'https://api.example.com/a');
+    // Do not signal homepage ready — quiescence must not fire first.
+
+    jest.advanceTimersByTime(UNLOCK_NETWORK_METER_MAX_WINDOW_MS);
+
+    expect(getLastUnlockSummary()?.endReason).toBe('max_window');
+    expect(isUnlockWindowActive()).toBe(false);
+  });
+
+  it('ends manually and emits the Sentry measurement', () => {
+    startUnlockWindow();
+    recordUnlockNetworkRequest('GET', 'https://api.example.com/a');
+
+    const summary = endUnlockWindow('manual');
+
+    expect(summary?.total).toBe(1);
+    expect(summary?.endReason).toBe('manual');
+    expect(mockSetMeasurement).toHaveBeenCalledWith(
+      UNLOCK_HTTP_REQUEST_COUNT_MEASUREMENT,
+      1,
+      'none',
+    );
+  });
+
+  it('resets an in-flight window when startUnlockWindow is called again', () => {
+    startUnlockWindow();
+    recordUnlockNetworkRequest('GET', 'https://api.example.com/old');
+    startUnlockWindow();
+    recordUnlockNetworkRequest('GET', 'https://api.example.com/new');
+    endUnlockWindow('manual');
+
+    expect(getLastUnlockSummary()?.total).toBe(1);
+    expect(getLastUnlockSummary()?.requests[0]?.url).toBe(
+      'https://api.example.com/new',
+    );
+  });
+});

--- a/app/core/UnlockNetworkMeter.ts
+++ b/app/core/UnlockNetworkMeter.ts
@@ -1,0 +1,308 @@
+/**
+ * In-app unlock HTTP call meter (fetch + XHR).
+ *
+ * Counts real-network requests during an unlock → homepage window.
+ * No Mockttp / canned mocks — intended for local Developer Options dumps and
+ * real-network performance E2E reading the same summary.
+ *
+ * Records method/host/url/ts only (no bodies or headers).
+ * Inactive window = no-op.
+ */
+
+import { setMeasurement } from '@sentry/react-native';
+
+export const UNLOCK_NETWORK_METER_SUMMARY_TEST_ID =
+  'unlock-network-meter-summary';
+
+/** Quiet period after homepage ready with no new HTTP before ending the window. */
+export const UNLOCK_NETWORK_METER_QUIET_MS = 2500;
+
+/** Hard ceiling for an unlock measurement window. */
+export const UNLOCK_NETWORK_METER_MAX_WINDOW_MS = 45_000;
+
+export const UNLOCK_HTTP_REQUEST_COUNT_MEASUREMENT =
+  'unlock_http_request_count';
+
+export interface UnlockNetworkRequest {
+  method: string;
+  host: string;
+  url: string;
+  ts: number;
+}
+
+export type UnlockNetworkEndReason = 'quiescence' | 'max_window' | 'manual';
+
+export interface UnlockNetworkSummary {
+  total: number;
+  byHost: Record<string, number>;
+  requests: UnlockNetworkRequest[];
+  startedAt: number;
+  endedAt: number;
+  endReason: UnlockNetworkEndReason;
+}
+
+type UnlockMeterXhr = XMLHttpRequest & {
+  __unlockMeterMethod?: string;
+  __unlockMeterUrl?: string;
+};
+
+let active = false;
+let homepageReady = false;
+let requests: UnlockNetworkRequest[] = [];
+let startedAt = 0;
+let lastRequestAt = 0;
+let lastSummary: UnlockNetworkSummary | null = null;
+let quietTimer: ReturnType<typeof setTimeout> | null = null;
+let maxTimer: ReturnType<typeof setTimeout> | null = null;
+let transportInstalled = false;
+const listeners = new Set<() => void>();
+
+function notifyListeners(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function clearTimers(): void {
+  if (quietTimer) {
+    clearTimeout(quietTimer);
+    quietTimer = null;
+  }
+  if (maxTimer) {
+    clearTimeout(maxTimer);
+    maxTimer = null;
+  }
+}
+
+function parseHost(url: string): string {
+  try {
+    return new URL(url).host || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function getUrlFromFetchInput(input: RequestInfo | URL): string {
+  if (typeof input === 'string') {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
+  return (input as Request).url ?? '';
+}
+
+function getMethodFromFetchInit(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): string {
+  if (init?.method) {
+    return init.method.toUpperCase();
+  }
+  if (typeof input === 'object' && input !== null && 'method' in input) {
+    const method = (input as Request).method;
+    if (method) {
+      return method.toUpperCase();
+    }
+  }
+  return 'GET';
+}
+
+function buildSummary(endReason: UnlockNetworkEndReason): UnlockNetworkSummary {
+  const byHost: Record<string, number> = {};
+  for (const request of requests) {
+    byHost[request.host] = (byHost[request.host] ?? 0) + 1;
+  }
+  return {
+    total: requests.length,
+    byHost,
+    requests: [...requests],
+    startedAt,
+    endedAt: Date.now(),
+    endReason,
+  };
+}
+
+function scheduleQuietCheck(): void {
+  if (quietTimer) {
+    clearTimeout(quietTimer);
+    quietTimer = null;
+  }
+  if (!active || !homepageReady) {
+    return;
+  }
+  quietTimer = setTimeout(() => {
+    if (!active || !homepageReady) {
+      return;
+    }
+    if (Date.now() - lastRequestAt >= UNLOCK_NETWORK_METER_QUIET_MS) {
+      endUnlockWindow('quiescence');
+      return;
+    }
+    scheduleQuietCheck();
+  }, UNLOCK_NETWORK_METER_QUIET_MS);
+}
+
+/**
+ * Record one outbound HTTP request while the unlock window is active.
+ */
+export function recordUnlockNetworkRequest(method: string, url: string): void {
+  if (!active) {
+    return;
+  }
+  const ts = Date.now();
+  lastRequestAt = ts;
+  requests.push({
+    method: method.toUpperCase() || 'GET',
+    host: parseHost(url),
+    url,
+    ts,
+  });
+  if (homepageReady) {
+    scheduleQuietCheck();
+  }
+}
+
+/**
+ * Start measuring unlock → homepage HTTP traffic.
+ * Resets any in-flight window without publishing a summary.
+ */
+export function startUnlockWindow(): void {
+  installUnlockNetworkMeterTransport();
+  clearTimers();
+  active = true;
+  homepageReady = false;
+  requests = [];
+  startedAt = Date.now();
+  lastRequestAt = startedAt;
+  maxTimer = setTimeout(() => {
+    endUnlockWindow('max_window');
+  }, UNLOCK_NETWORK_METER_MAX_WINDOW_MS);
+  notifyListeners();
+}
+
+/**
+ * Homepage chrome is visible; begin quiescence countdown once requests quiet.
+ */
+export function signalHomepageReadyForUnlockMeter(): void {
+  if (!active) {
+    return;
+  }
+  homepageReady = true;
+  scheduleQuietCheck();
+  notifyListeners();
+}
+
+/**
+ * End the unlock window and publish the last summary + Sentry measurement.
+ */
+export function endUnlockWindow(
+  endReason: UnlockNetworkEndReason = 'manual',
+): UnlockNetworkSummary | null {
+  if (!active) {
+    return lastSummary;
+  }
+  clearTimers();
+  active = false;
+  homepageReady = false;
+  lastSummary = buildSummary(endReason);
+  setMeasurement(
+    UNLOCK_HTTP_REQUEST_COUNT_MEASUREMENT,
+    lastSummary.total,
+    'none',
+  );
+  notifyListeners();
+  return lastSummary;
+}
+
+export function getLastUnlockSummary(): UnlockNetworkSummary | null {
+  return lastSummary;
+}
+
+export function isUnlockWindowActive(): boolean {
+  return active;
+}
+
+export function getUnlockWindowLiveCount(): number {
+  return active ? requests.length : (lastSummary?.total ?? 0);
+}
+
+/**
+ * Subscribe to meter state changes (window start/end, homepage ready).
+ * Returns an unsubscribe function.
+ */
+export function subscribeUnlockNetworkMeter(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Wrap `global.fetch` and `XMLHttpRequest` so unlock-window traffic is counted.
+ * Idempotent. Safe when the window is inactive (record is a no-op).
+ */
+export function installUnlockNetworkMeterTransport(): void {
+  if (transportInstalled) {
+    return;
+  }
+  transportInstalled = true;
+
+  const originalFetch = global.fetch.bind(global);
+  global.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+    recordUnlockNetworkRequest(
+      getMethodFromFetchInit(input, init),
+      getUrlFromFetchInput(input),
+    );
+    return originalFetch(input, init);
+  };
+
+  const xhrProto = global.XMLHttpRequest?.prototype;
+  if (!xhrProto) {
+    return;
+  }
+
+  const originalOpen = xhrProto.open;
+  xhrProto.open = function unlockMeterOpen(
+    this: UnlockMeterXhr,
+    method: string,
+    url: string | URL,
+    ...rest: unknown[]
+  ) {
+    this.__unlockMeterMethod = String(method);
+    this.__unlockMeterUrl = String(url);
+    return originalOpen.apply(this, [
+      method,
+      url,
+      ...rest,
+    ] as unknown as Parameters<typeof originalOpen>);
+  };
+
+  const originalSend = xhrProto.send;
+  xhrProto.send = function unlockMeterSend(
+    this: UnlockMeterXhr,
+    body?: Document | XMLHttpRequestBodyInit | null,
+  ) {
+    if (this.__unlockMeterUrl) {
+      recordUnlockNetworkRequest(
+        this.__unlockMeterMethod ?? 'GET',
+        this.__unlockMeterUrl,
+      );
+    }
+    return originalSend.call(this, body);
+  };
+}
+
+/**
+ * Test-only reset. Do not call from product code.
+ */
+export function __resetUnlockNetworkMeterForTests(): void {
+  clearTimers();
+  active = false;
+  homepageReady = false;
+  requests = [];
+  startedAt = 0;
+  lastRequestAt = 0;
+  lastSummary = null;
+  listeners.clear();
+}

--- a/app/core/UnlockNetworkMeter.ts
+++ b/app/core/UnlockNetworkMeter.ts
@@ -206,11 +206,14 @@ export function endUnlockWindow(
   active = false;
   homepageReady = false;
   lastSummary = buildSummary(endReason);
-  setMeasurement(
-    UNLOCK_HTTP_REQUEST_COUNT_MEASUREMENT,
-    lastSummary.total,
-    'none',
-  );
+  // Sentry may be partially mocked in unit tests (no setMeasurement).
+  if (typeof setMeasurement === 'function') {
+    setMeasurement(
+      UNLOCK_HTTP_REQUEST_COUNT_MEASUREMENT,
+      lastSummary.total,
+      'none',
+    );
+  }
   notifyListeners();
   return lastSummary;
 }

--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -47,6 +47,7 @@ Always measure on **Android** (more sensitive, more representative) with the **p
 - **[anti-patterns.md](./anti-patterns.md)** — the catalogue: selectors, Redux/`useSelector`, Context, hook deps, unstable hook returns, lists, layout animations, eager-work-on-mount, streaming, bundle/barrel, memory.
 - **[tools.md](./tools.md)** — symptom-first decision tree + when/how to use each tool (Perf Monitor, RN DevTools, Flashlight, `trace()`, Reassure, E2E gates, Release Profiler, Sentry).
 - **[measuring.md](./measuring.md)** — the power-user scenario, TTI via `trace()`, render-regression tests, FPS benchmarking, CI gates.
+- **[unlock-api-call-budget.md](./unlock-api-call-budget.md)** — In-app unlock → homepage HTTP call-volume meter (real network, zero mocks).
 - **[react-compiler.md](./react-compiler.md)** — automatic memoization: how it's set up here and how to opt a feature in.
 
 ## Deep dives & references

--- a/docs/performance/measuring.md
+++ b/docs/performance/measuring.md
@@ -78,6 +78,15 @@ For day-to-day FPS checks without it, use the in-app Perf Monitor and the RN Dev
 
 Core flows have timing budgets enforced in CI. The framework lives in `tests/performance/` (specs grouped by `login` / `onboarding`; MMConnect Appium smoke lives under `tests/smoke-appium/mm-connect/`) on top of `tests/framework/TimerHelper.ts` (platform-specific thresholds with a 10% margin). Add a gate for your flow following the **`mms-performance-testing`** skill.
 
+## Unlock API call-volume meter
+
+Separately from latency timers, unlock HTTP volume is measured **in-app on real network** (no Mockttp):
+
+- Meter: `app/core/UnlockNetworkMeter.ts`
+- Local dump: Developer Options → Unlock HTTP meter
+- Perf budget: `tests/performance/budgets/wallet-unlock-api-calls.json`
+- Runbook: [unlock-api-call-budget.md](./unlock-api-call-budget.md)
+
 ## Production — Sentry & Release Profiler
 
 - **Sentry** surfaces real-device metrics and alerts (`#metamask-mobile-release-monitoring`); `trace()` spans/measurements flow here.

--- a/docs/performance/unlock-api-call-budget.md
+++ b/docs/performance/unlock-api-call-budget.md
@@ -1,0 +1,84 @@
+# Unlock API-call measurement (zero mocks)
+
+Measures **how many real HTTP calls** (`fetch` / `XHR`) happen in the wallet unlock → homepage window on a **live** app build.
+
+**Hard rule:** no Mockttp and no canned API mocks for unlock call-volume measurement or gating. If a gate needs mocks to stay green, it is the wrong tool for this problem.
+
+This is a **call-volume** meter (in-app), not a latency gate (`TimerHelper`) and not a render gate (Reassure).
+
+## Why in-app (not Mockttp smoke)
+
+Mocked Appium smoke undercounts badly vs a real unlock (e.g. ~44 proxied calls vs ~140 in RN DevTools under local/dev FFs). Forced feature flags, light fixtures, and canned responses create a different measurement world. New unlock-time fetches under real FFs/data can miss that gate.
+
+The SSOT is the same meter you see after a normal unlock on a real backend.
+
+## What it measures
+
+1. `Authentication.unlockWallet` starts `UnlockNetworkMeter`.
+2. NitroFetch / XHR wrappers record `{ method, host, url, ts }` (no bodies/headers) while the window is active.
+3. Homepage mount signals ready; the window ends after ~2.5s with no new HTTP (or a 45s max-window fallback).
+4. On end: last summary is kept for Developer Options; Sentry gets `setMeasurement('unlock_http_request_count', total)`.
+
+WebSocket frames and some native image loads may still differ from DevTools’ total — document that when comparing.
+
+## Files
+
+| Path                                                                                                                                                                                                 | Role                                                    |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| [`app/core/UnlockNetworkMeter.ts`](../../app/core/UnlockNetworkMeter.ts)                                                                                                                             | Meter + fetch/XHR hooks                                 |
+| [`app/core/NitroFetchSetup.ts`](../../app/core/NitroFetchSetup.ts)                                                                                                                                   | Installs transport on real builds (`!hasTestOverrides`) |
+| [`app/core/Authentication/Authentication.ts`](../../app/core/Authentication/Authentication.ts)                                                                                                       | Starts window on unlock                                 |
+| [`app/components/Views/Homepage/hooks/useUnlockNetworkMeterEnd.ts`](../../app/components/Views/Homepage/hooks/useUnlockNetworkMeterEnd.ts)                                                           | Homepage ready + accessibility probe                    |
+| [`app/components/Views/Settings/DeveloperOptions/UnlockNetworkMeterDeveloperOptionsSection.tsx`](../../app/components/Views/Settings/DeveloperOptions/UnlockNetworkMeterDeveloperOptionsSection.tsx) | Local dump + copy JSON                                  |
+| [`tests/performance/budgets/wallet-unlock-api-calls.json`](../../tests/performance/budgets/wallet-unlock-api-calls.json)                                                                             | Real-network performance budget                         |
+| [`tests/performance/login/wallet-unlock-api-call-budget.spec.ts`](../../tests/performance/login/wallet-unlock-api-call-budget.spec.ts)                                                               | Performance E2E assert (zero Mockttp)                   |
+
+## Local workflow (primary)
+
+Use a normal Expo/dev or release build that talks to **live** backends.
+
+1. Run with `METAMASK_ENVIRONMENT=dev` so remote FFs map to LaunchDarkly **Development** (same world as day-to-day unlock).
+2. Unlock the wallet the way you usually do.
+3. Open **Settings → Developer options → Unlock HTTP meter**.
+4. Wait until status shows **Last unlock: N HTTP requests**.
+5. **Copy unlock HTTP summary JSON** and diff hosts in PRs when intentionally changing unlock fan-out.
+
+Expect totals in the DevTools Network ballpark (~140 for a full homepage unlock), not the old mocked smoke number.
+
+## Sentry
+
+On window end the app emits:
+
+```ts
+setMeasurement('unlock_http_request_count', total, 'none');
+```
+
+Use this for trends; local Developer Options remain the source of truth for host breakdowns.
+
+## Performance E2E gate (real network)
+
+Playwright performance builds already run with live network (`HAS_TEST_OVERRIDES` false — NitroFetch installed). The unlock API budget spec:
+
+1. Logs in / unlocks on a real device/emulator.
+2. Waits for the Homepage accessibility probe (`unlock-network-meter-summary`) whose label is the JSON summary.
+3. Asserts `total ≤ totalMax` (and optional host ceilings) from `tests/performance/budgets/wallet-unlock-api-calls.json`.
+
+**No Appium smoke Mockttp.** Absolute counts can move with backend/LD; re-baseline the JSON when intentional.
+
+Bootstrap mode: empty `hosts: {}` enforces only `totalMax`.
+
+## Feature-flag environment mapping
+
+| Build / env                      | Typical FF environment                 |
+| -------------------------------- | -------------------------------------- |
+| Local `METAMASK_ENVIRONMENT=dev` | LaunchDarkly Development               |
+| Performance / e2e builds         | Test (unless later pointed at prod/rc) |
+
+Local v1 should match your **dev** unlock. Perf CI may differ slightly until FF env is aligned.
+
+## Reducing the number over time
+
+1. Keep the real-network meter / perf budget from growing accidentally.
+2. Use Developer Options host dumps + RN DevTools to prioritize.
+3. Delete redundant unlock-time calls (see e.g. [ADR-0001](../decisions/0001-perps-homepage-hyperliquid-calls.md)).
+4. Lower `totalMax` / host ceilings in dedicated PRs after measuring a real unlock.

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -4378,6 +4378,14 @@
         "description": "Clears the persisted authentication session. Use this after toggling MM_DEV_API_ENV — otherwise a prod-minted JWT keeps being handed to dev-API consumers until it expires. Current MM_DEV_API_ENV: {{env}}.",
         "clear_auth_session_button": "Clear persisted auth session"
       },
+      "unlock_network_meter": {
+        "title": "Unlock HTTP meter",
+        "description": "Counts real fetch/XHR during unlock → homepage (no mocks). Unlock the wallet, wait for the window to settle, then copy the JSON. Expect DevTools-like totals under METAMASK_ENVIRONMENT=dev (LaunchDarkly Development).",
+        "status_empty": "No unlock measured yet. Unlock the wallet to capture a window.",
+        "status_active": "Measuring unlock window… {{count}} requests so far",
+        "status_last": "Last unlock: {{total}} HTTP requests (ended: {{reason}})",
+        "copy_json_button": "Copy unlock HTTP summary JSON"
+      },
       "notifications": {
         "title": "Notifications",
         "description": "Reset the push notification pre-prompt flag to re-trigger the sheet on next eligible launch.",

--- a/tests/performance/budgets/wallet-unlock-api-calls.json
+++ b/tests/performance/budgets/wallet-unlock-api-calls.json
@@ -1,0 +1,5 @@
+{
+  "flow": "wallet-unlock-to-homepage",
+  "totalMax": 1,
+  "hosts": {}
+}

--- a/tests/performance/login/wallet-unlock-api-call-budget.spec.ts
+++ b/tests/performance/login/wallet-unlock-api-call-budget.spec.ts
@@ -1,0 +1,148 @@
+/* eslint-disable import-x/no-nodejs-modules */
+import fs from 'fs';
+import path from 'path';
+
+import { test as perfTest } from '../../framework/fixtures/playwright';
+import {
+  asPlaywrightElement,
+  PlaywrightAssertions,
+  PlaywrightMatchers,
+} from '../../framework';
+import { PlatformDetector } from '../../framework/PlatformLocator';
+import { loginToAppPlaywright } from '../../flows/wallet.flow';
+import WalletView from '../../page-objects/wallet/WalletView';
+import { Performance, PerformanceLogin } from '../../tags.performance.js';
+import { UNLOCK_NETWORK_METER_SUMMARY_TEST_ID } from '../../../app/core/UnlockNetworkMeter';
+
+/**
+ * Real-network unlock HTTP budget (zero Mockttp).
+ *
+ * Reads the same in-app UnlockNetworkMeter summary exposed on Homepage via
+ * accessibility after unlock → homepage quiescence.
+ */
+
+interface UnlockApiCallBudget {
+  flow: string;
+  totalMax: number;
+  hosts: Record<string, number>;
+}
+
+interface UnlockMeterAccessibilitySummary {
+  total: number;
+  byHost: Record<string, number>;
+  endReason: string;
+}
+
+const BUDGET_PATH = path.resolve(
+  process.cwd(),
+  'tests/performance/budgets/wallet-unlock-api-calls.json',
+);
+
+function loadBudget(): UnlockApiCallBudget {
+  const raw = fs.readFileSync(BUDGET_PATH, 'utf8');
+  return JSON.parse(raw) as UnlockApiCallBudget;
+}
+
+function assertUnlockHttpBudget(
+  summary: UnlockMeterAccessibilitySummary,
+  budget: UnlockApiCallBudget,
+): void {
+  const failures: string[] = [];
+
+  if (summary.total > budget.totalMax) {
+    failures.push(
+      `total ${String(summary.total)} exceeds totalMax ${String(budget.totalMax)}`,
+    );
+  }
+
+  const budgetHosts = Object.keys(budget.hosts);
+  if (budgetHosts.length > 0) {
+    for (const [host, count] of Object.entries(summary.byHost)) {
+      if (!(host in budget.hosts)) {
+        failures.push(
+          `unknown host "${host}" with ${String(count)} request(s)`,
+        );
+        continue;
+      }
+      const ceiling = budget.hosts[host] ?? 0;
+      if (count > ceiling) {
+        failures.push(
+          `host "${host}" count ${String(count)} exceeds ceiling ${String(ceiling)}`,
+        );
+      }
+    }
+  }
+
+  if (failures.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    [
+      'Unlock HTTP call budget exceeded (in-app meter, real network):',
+      ...failures.map((line) => `  - ${line}`),
+      `summary: ${JSON.stringify(summary)}`,
+    ].join('\n'),
+  );
+}
+
+async function readUnlockMeterSummaryFromProbe(): Promise<UnlockMeterAccessibilitySummary> {
+  const probe = await PlaywrightMatchers.getElementById(
+    UNLOCK_NETWORK_METER_SUMMARY_TEST_ID,
+    {
+      exact: false,
+    },
+  );
+
+  await PlaywrightAssertions.expectElementToBeVisible(probe, {
+    description: 'Unlock network meter summary probe should be present',
+    timeout: 60_000,
+  });
+
+  const raw = probe.unwrap();
+  const isAndroid = await PlatformDetector.isAndroid();
+  const label = isAndroid
+    ? ((await raw.getAttribute('content-desc')) ?? '')
+    : ((await raw.getAttribute('label')) ??
+      (await raw.getAttribute('name')) ??
+      '');
+
+  // Labels can be joined with unrelated text by the assertion helper pattern;
+  // parse the first JSON object found.
+  const jsonStart = label.indexOf('{');
+  const jsonEnd = label.lastIndexOf('}');
+  if (jsonStart < 0 || jsonEnd <= jsonStart) {
+    throw new Error(
+      `Unlock meter probe accessibility label was not JSON: "${label}"`,
+    );
+  }
+
+  return JSON.parse(
+    label.slice(jsonStart, jsonEnd + 1),
+  ) as UnlockMeterAccessibilitySummary;
+}
+
+perfTest.describe(`${Performance} ${PerformanceLogin}`, () => {
+  perfTest(
+    'keeps unlock→homepage HTTP calls within the real-network in-app budget',
+    { tag: '@metamask-mobile-platform' },
+    async () => {
+      await loginToAppPlaywright();
+      await PlaywrightAssertions.expectElementToBeVisible(
+        asPlaywrightElement(WalletView.totalBalance),
+        {
+          description: 'Wallet should be visible after unlock',
+          timeout: 30_000,
+        },
+      );
+
+      const summary = await readUnlockMeterSummaryFromProbe();
+      const budget = loadBudget();
+      assertUnlockHttpBudget(summary, budget);
+
+      console.log(
+        `Unlock HTTP meter: total=${String(summary.total)} endReason=${summary.endReason}`,
+      );
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- Adds an in-app `UnlockNetworkMeter` on real `fetch`/`XHR` (no Mockttp) for unlock → homepage.
- Performance E2E asserts against `tests/performance/budgets/wallet-unlock-api-calls.json`.
- **Budget is intentionally `totalMax: 1`** so the first CI run fails and dumps measured `total` + `byHost` for baselining.
- Developer Options section exposes the same summary for local debugging.

## Why `totalMax: 1`
Capture run: open the failed unlock budget test log, copy the `summary: {...}` JSON (includes per-host map), then update the budget file in a follow-up commit.

## Test plan
- [ ] Confirm unit tests: `yarn jest app/core/UnlockNetworkMeter.test.ts --no-coverage`
- [ ] Confirm CI runs **performance** E2E via `run-performance-tests` label (imported-wallet build, live network)
- [ ] Confirm unlock budget spec fails with a dumped `summary` containing `total` and `byHost`
- [ ] Follow-up: commit measured budget (`totalMax` + `hosts`) so the gate becomes a real regression check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Globally wraps `fetch` and `XMLHttpRequest` on production Nitro builds; logic is gated to an active unlock window but any wrapper bug could affect all HTTP during unlock.
> 
> **Overview**
> Adds an **in-app unlock → homepage HTTP call meter** on real `fetch`/`XHR` (no Mockttp), wired from wallet unlock through homepage ready + network quiescence.
> 
> `UnlockNetworkMeter` starts in `unlockWallet`, hooks install from `NitroFetchSetup`, and the window ends after homepage signals ready and ~2.5s quiet (45s max). Summaries go to **Developer Options** (status + copy JSON), Sentry `unlock_http_request_count`, and an invisible Homepage accessibility probe for E2E.
> 
> A **real-network performance test** asserts against `wallet-unlock-api-calls.json`; **`totalMax: 1`** is deliberate so CI fails once and dumps `total`/`byHost` for baselining. Docs cover the unlock API call budget workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf74aa566d22fc33c758eb537323aa21e6ce8841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->