### PR TITLE
test(e2e): fix flaking in the token-approve confirmation smoke tests

### DIFF
--- a/tests/flows/confirmations.flow.ts
+++ b/tests/flows/confirmations.flow.ts
@@ -2,7 +2,7 @@ import Assertions from '../framework/Assertions';
 import ChromeCdpHelpers from '../framework/ChromeCdpHelpers';
 import { getDappUrl } from '../framework/fixtures/FixtureUtils';
 import { PlatformDetector } from '../framework/PlatformLocator';
-import Utilities from '../framework/Utilities';
+import Utilities, { sleep } from '../framework/Utilities';
 import WebView from '../framework/WebView';
 import Browser from '../page-objects/Browser/BrowserView';
 import ConnectBottomSheet from '../page-objects/Browser/ConnectBottomSheet';
@@ -31,6 +31,67 @@ const SMART_ACCOUNT_UPGRADED_ACTIVITY = 'Smart account upgraded';
 const SMART_ACCOUNT_UPGRADING_ACTIVITY = 'Upgrading smart account';
 const ANDROID_CONFIRM_SHEET_TIMEOUT_MS = 60_000;
 const ANDROID_CONFIRM_POLL_MS = 3_000;
+const DAPP_BUTTON_READY_TIMEOUT_MS = 15_000;
+const DAPP_BUTTON_READY_POLL_MS = 500;
+
+interface TestDappButtonState {
+  href: string;
+  documentReady: boolean;
+  hasEthereum: boolean;
+  hasButton: boolean;
+  buttonDisabled: boolean;
+}
+
+const readTestDappButtonState = (
+  pageUrl: string,
+  buttonId: string,
+): Promise<TestDappButtonState | null> =>
+  ChromeCdpHelpers.evaluateInWebView<TestDappButtonState>(
+    pageUrl,
+    `(() => {
+      const el = document.getElementById(${JSON.stringify(buttonId)});
+      return {
+        href: location.href,
+        documentReady: document.readyState === 'complete',
+        hasEthereum: typeof window.ethereum !== 'undefined',
+        hasButton: Boolean(el),
+        buttonDisabled: Boolean(
+          el &&
+            (('disabled' in el && el.disabled) ||
+              el.getAttribute('aria-disabled') === 'true'),
+        ),
+      };
+    })()`,
+  );
+
+/**
+ * The URL bar shows the dapp URL before the page finishes loading and the
+ * provider is injected. A tap issued in that window clicks a real DOM node and
+ * reports success, but no confirmation is ever requested.
+ */
+const waitForTestDappButtonReady = async (
+  pageUrl: string,
+  buttonId: string,
+  timeoutMs = DAPP_BUTTON_READY_TIMEOUT_MS,
+): Promise<TestDappButtonState | null> => {
+  const deadline = Date.now() + timeoutMs;
+  let state: TestDappButtonState | null = null;
+
+  while (Date.now() < deadline) {
+    state = await readTestDappButtonState(pageUrl, buttonId);
+    if (
+      state?.documentReady &&
+      state.hasEthereum &&
+      state.hasButton &&
+      !state.buttonDisabled
+    ) {
+      return state;
+    }
+    await sleep(DAPP_BUTTON_READY_POLL_MS);
+  }
+
+  return state;
+};
 
 export {
   LOCAL_CHAIN_CAIP,
@@ -50,24 +111,35 @@ const tapTestDappButtonAndWaitForConfirm = async (
 
   if (PlatformDetector.isAndroidAppium()) {
     let dismissedPushSheet = false;
-    await Utilities.executeWithRetry(
-      async () => {
-        await WebView.tapById(buttonId, {
-          pageUrl,
-          description,
-        });
-        try {
-          await FooterActions.waitForConfirmButton(ANDROID_CONFIRM_POLL_MS);
-        } catch (error) {
-          if (!dismissedPushSheet) {
-            dismissedPushSheet = true;
-            await dismissPushNotificationExistingUserSheet();
+    let lastState: TestDappButtonState | null = null;
+    try {
+      await Utilities.executeWithRetry(
+        async () => {
+          lastState = await waitForTestDappButtonReady(pageUrl, buttonId);
+          await WebView.tapById(buttonId, {
+            pageUrl,
+            description,
+          });
+          try {
+            await FooterActions.waitForConfirmButton(ANDROID_CONFIRM_POLL_MS);
+          } catch (error) {
+            if (!dismissedPushSheet) {
+              dismissedPushSheet = true;
+              await dismissPushNotificationExistingUserSheet();
+            }
+            throw error;
           }
-          throw error;
-        }
-      },
-      { timeout: ANDROID_CONFIRM_SHEET_TIMEOUT_MS },
-    );
+        },
+        { timeout: ANDROID_CONFIRM_SHEET_TIMEOUT_MS },
+      );
+    } catch (error) {
+      throw new Error(
+        `Confirmation sheet never opened after tapping #${buttonId} (${description}); ` +
+          `last dapp state=${JSON.stringify(lastState)}; cause=${
+            error instanceof Error ? error.message : String(error)
+          }`,
+      );
+    }
     return;
   }
 

--- a/tests/flows/confirmations.flow.ts
+++ b/tests/flows/confirmations.flow.ts
@@ -2,7 +2,7 @@ import Assertions from '../framework/Assertions';
 import ChromeCdpHelpers from '../framework/ChromeCdpHelpers';
 import { getDappUrl } from '../framework/fixtures/FixtureUtils';
 import { PlatformDetector } from '../framework/PlatformLocator';
-import Utilities, { sleep } from '../framework/Utilities';
+import Utilities from '../framework/Utilities';
 import WebView from '../framework/WebView';
 import Browser from '../page-objects/Browser/BrowserView';
 import ConnectBottomSheet from '../page-objects/Browser/ConnectBottomSheet';
@@ -108,27 +108,36 @@ const waitForTestDappButtonReady = async (
   timeoutMs = DAPP_BUTTON_READY_TIMEOUT_MS,
 ): Promise<TestDappButtonState | null> => {
   const startedAt = Date.now();
-  const deadline = startedAt + timeoutMs;
   let state: TestDappButtonState | null = null;
   let reloaded = false;
 
-  while (Date.now() < deadline) {
-    state = await readTestDappButtonState(pageUrl, buttonId);
-    if (isTestDappButtonReady(state)) {
-      return state;
-    }
+  try {
+    await Utilities.waitUntil(
+      async () => {
+        state = await readTestDappButtonState(pageUrl, buttonId);
+        if (isTestDappButtonReady(state)) {
+          return true;
+        }
 
-    if (
-      !reloaded &&
-      state?.contractParam &&
-      !state.contractBound &&
-      Date.now() - startedAt >= DAPP_CONTRACT_RELOAD_AFTER_MS
-    ) {
-      reloaded = true;
-      await ChromeCdpHelpers.evaluateInWebView(pageUrl, 'location.reload()');
-    }
+        if (
+          !reloaded &&
+          state?.contractParam &&
+          !state.contractBound &&
+          Date.now() - startedAt >= DAPP_CONTRACT_RELOAD_AFTER_MS
+        ) {
+          reloaded = true;
+          await ChromeCdpHelpers.evaluateInWebView(
+            pageUrl,
+            'location.reload()',
+          );
+        }
 
-    await sleep(DAPP_BUTTON_READY_POLL_MS);
+        return false;
+      },
+      { timeout: timeoutMs, interval: DAPP_BUTTON_READY_POLL_MS },
+    );
+  } catch {
+    // Return the last observed state so the caller can include diagnostics.
   }
 
   return state;

--- a/tests/flows/confirmations.flow.ts
+++ b/tests/flows/confirmations.flow.ts
@@ -31,8 +31,20 @@ const SMART_ACCOUNT_UPGRADED_ACTIVITY = 'Smart account upgraded';
 const SMART_ACCOUNT_UPGRADING_ACTIVITY = 'Upgrading smart account';
 const ANDROID_CONFIRM_SHEET_TIMEOUT_MS = 60_000;
 const ANDROID_CONFIRM_POLL_MS = 3_000;
-const DAPP_BUTTON_READY_TIMEOUT_MS = 15_000;
+const DAPP_BUTTON_READY_TIMEOUT_MS = 20_000;
 const DAPP_BUTTON_READY_POLL_MS = 500;
+/** Re-run the dapp's contract binding if it is still missing after this long. */
+const DAPP_CONTRACT_RELOAD_AFTER_MS = 8_000;
+/**
+ * `contractIsDeployed` fills these from the `?contract=` query param. When
+ * `initializeContracts()` throws, the listener still enables every button but
+ * leaves the address blank, so the handlers call into an undefined contract.
+ */
+const CONTRACT_ADDRESS_ELEMENT_IDS = [
+  'erc20TokenAddresses',
+  'erc721TokenAddresses',
+  'erc1155TokenAddresses',
+];
 
 interface TestDappButtonState {
   href: string;
@@ -40,6 +52,8 @@ interface TestDappButtonState {
   hasEthereum: boolean;
   hasButton: boolean;
   buttonDisabled: boolean;
+  contractParam: string | null;
+  contractBound: boolean;
 }
 
 const readTestDappButtonState = (
@@ -50,6 +64,7 @@ const readTestDappButtonState = (
     pageUrl,
     `(() => {
       const el = document.getElementById(${JSON.stringify(buttonId)});
+      const contractIds = ${JSON.stringify(CONTRACT_ADDRESS_ELEMENT_IDS)};
       return {
         href: location.href,
         documentReady: document.readyState === 'complete',
@@ -60,33 +75,59 @@ const readTestDappButtonState = (
             (('disabled' in el && el.disabled) ||
               el.getAttribute('aria-disabled') === 'true'),
         ),
+        contractParam: new URLSearchParams(location.search).get('contract'),
+        contractBound: contractIds.some((id) => {
+          const node = document.getElementById(id);
+          return Boolean(node && (node.textContent || '').trim());
+        }),
       };
     })()`,
   );
 
+const isTestDappButtonReady = (state: TestDappButtonState | null): boolean =>
+  Boolean(
+    state?.documentReady &&
+      state.hasEthereum &&
+      state.hasButton &&
+      !state.buttonDisabled &&
+      (!state.contractParam || state.contractBound),
+  );
+
 /**
- * The URL bar shows the dapp URL before the page finishes loading and the
- * provider is injected. A tap issued in that window clicks a real DOM node and
- * reports success, but no confirmation is ever requested.
+ * The URL bar shows the dapp URL before the page finishes loading, before the
+ * provider is injected, and before the dapp binds the contract from
+ * `?contract=`. A tap issued in that window clicks a real DOM node and reports
+ * success, but no confirmation is ever requested.
+ *
+ * Contract binding only happens while initializing the provider, so a reload is
+ * the only way to recover a page that came up without it.
  */
 const waitForTestDappButtonReady = async (
   pageUrl: string,
   buttonId: string,
   timeoutMs = DAPP_BUTTON_READY_TIMEOUT_MS,
 ): Promise<TestDappButtonState | null> => {
-  const deadline = Date.now() + timeoutMs;
+  const startedAt = Date.now();
+  const deadline = startedAt + timeoutMs;
   let state: TestDappButtonState | null = null;
+  let reloaded = false;
 
   while (Date.now() < deadline) {
     state = await readTestDappButtonState(pageUrl, buttonId);
-    if (
-      state?.documentReady &&
-      state.hasEthereum &&
-      state.hasButton &&
-      !state.buttonDisabled
-    ) {
+    if (isTestDappButtonReady(state)) {
       return state;
     }
+
+    if (
+      !reloaded &&
+      state?.contractParam &&
+      !state.contractBound &&
+      Date.now() - startedAt >= DAPP_CONTRACT_RELOAD_AFTER_MS
+    ) {
+      reloaded = true;
+      await ChromeCdpHelpers.evaluateInWebView(pageUrl, 'location.reload()');
+    }
+
     await sleep(DAPP_BUTTON_READY_POLL_MS);
   }
 

--- a/tests/smoke-appium/confirmations/send/send-native-token.spec.ts
+++ b/tests/smoke-appium/confirmations/send/send-native-token.spec.ts
@@ -164,6 +164,7 @@ appiumTest.describe(SmokeConfirmations('Send native asset'), () => {
           await SendView.inputRecipientAddress(RECIPIENT);
           await SendView.pressReviewButton();
           await FooterActions.tapConfirmButton();
+          await FooterActions.waitForConfirmButtonGone();
           await TabBarComponent.tapActivity();
           await Assertions.expectTextDisplayed('Confirmed');
 

--- a/tests/smoke-appium/confirmations/transactions/token-approve/set-approval-for-all.spec.ts
+++ b/tests/smoke-appium/confirmations/transactions/token-approve/set-approval-for-all.spec.ts
@@ -148,9 +148,7 @@ appiumTest.describe(
       },
     );
 
-    // Skipped: consistently fails on main Appium confirmations Android smoke
-    // (`confirm-button` never appears after dapp tap). MMQA-2254 / MMQA-2232.
-    appiumTest.skip(
+    appiumTest(
       'creates an approve transaction confirmation for given ERC1155 and submits it',
       async ({ driver: _driver, currentDeviceDetails }) => {
         await withFixtures(
@@ -200,9 +198,7 @@ appiumTest.describe(
       },
     );
 
-    // Skipped: hard-fails on recent main Appium confirmations Android smoke
-    // (`confirm-button` never appears after revoke tap). MMQA-2254 / MMQA-2232.
-    appiumTest.describe.skip('revoke mode', () => {
+    appiumTest.describe('revoke mode', () => {
       appiumTest(
         'creates an approve transaction confirmation for ERC 721 and submits it',
         async ({ driver: _driver, currentDeviceDetails }) => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Fixes recurring Appium Android failures in the confirmation smoke tests, where the confirmation sheet never opens after tapping a test-dapp button (`Element "confirm-button" not in hierarchy`). Also re-enables two `setApprovalForAll` tests that had been skipped for the same reason.

**Reason for the change.** On Appium, `waitForTestDappToLoad()` only asserts that the browser URL bar contains the dapp URL — which happens well before the page is actually usable. `WebView.tapById` then finds the target button in the DOM and clicks it, which reports success even though the click does nothing useful, so `confirm-button` never enters the native hierarchy and the 60-second retry loop re-taps against the same weak signal.

The concrete trigger, confirmed from the CI job's failure screenshot and the test-dapp source: the buttons are enabled before the dapp has bound the contract from the `?contract=` query param. In `@metamask/test-dapp`, the `contractIsDeployed` listener enables every ERC-721/20/1155 button **unconditionally**, but only fills the address element (`erc721TokenAddresses`, …) when `initializeContracts()` succeeded:

```js
erc721TokenAddresses.innerHTML = src.nftsContract ? src.nftsContract.address : '';
mintButton.disabled = false;               // always enabled
...
mintButton.onclick = async () => {
  const contract = nftsContract || src.nftsContract;   // undefined when unbound
  await contract.mintNFTs(...)                          // throws inside the page
};
```

When contract init loses the race, the button is enabled with an empty address, the click throws inside the page, no `eth_sendTransaction` is sent, and the confirmation sheet can never appear. This is deterministic on CI (the run failed on the initial attempt and retry #1) and passes locally because contract init wins the race there.

**Solution — the same technique the multichain suites already use.** The multichain Appium specs are stable precisely because they never treat "the DOM node existed and I clicked it" as success:

- `TestDApp.tapDappConnectButton` re-clicks `#connectButton` over CDP until the **native connect sheet** is visible, and dumps `hasEthereum` / `href` diagnostics on timeout.
- `BitcoinTestDapp` / `SolanaTestDApp` poll in-page state (`waitForDappLoaded`, `pollForText`) before interacting.
- `TestDApp.readTestDappTextContentById` polls until element text is non-empty, with the explicit comment that the provider may not have injected yet.

This PR applies that "poll for a meaningful signal, not just DOM presence" pattern to the confirmations flow. Before each tap attempt, `tapTestDappButtonAndWaitForConfirm` polls the page over CDP until `document.readyState === 'complete'`, `window.ethereum` is defined, the target button exists and is enabled, **and** — when a `?contract=` param is present — the dapp has actually bound that contract (a token-address element has non-empty text). Because binding only happens during provider initialization, an unbound page cannot recover on its own, so the flow reloads the page once (after 8s) and keeps polling. The retry loop still gates on the native `confirm-button` appearing, and on exhaustion the error reports the last observed dapp state, now including `contractParam` / `contractBound`.

Scope is limited to the Android Appium branch of `tapTestDappButtonAndWaitForConfirm`, which is where the failure occurs; the iOS path is unchanged. All `navigateToContractAndTap` / `navigateToTestDappAndTap` callers benefit without touching individual specs. With the fix in place, the two `setApprovalForAll` tests (ERC-1155 `setApprovalForAll` and the `revoke mode` ERC-721 test) that were `.skip`-ped for this exact symptom are re-enabled.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

Refs: no tracking issue — found while analysing repeated `appium-confirmations-android-smoke` failures in `tests/smoke-appium/confirmations/transactions/token-approve/approve.spec.ts`.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — E2E framework/flow-only change with no runtime app surface. Verified by the Appium confirmations Android smoke suite in CI.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

`contract-interaction.spec.ts › submits transaction` failed on both the initial attempt and retry #1. The Playwright failure screenshot shows the ERC-721 section with an **empty "Token(s):" address** but an enabled MINT button — the unbound-contract state described above. Trace shape:

```
COMMAND executeScript("mobile: getContexts") → MetaMask WebView (5 pages)
        (~10s silent CDP tap of #mintButton — click throws inside the page)
COMMAND findElement("resourceId(\"confirm-button\")") → no such element
        (repeats until the 60s budget is exhausted)

Error in withFixtures: Confirmation sheet never opened after tapping #mintButton (ERC-721 mint button);
last dapp state={"href":"http://localhost:8085/?contract=0x...","documentReady":true,
"hasEthereum":true,"hasButton":true,"buttonDisabled":false}; cause=... failed after 6 attempt(s) over 63140ms
```

Note `documentReady`/`hasEthereum`/`hasButton` were all `true` — proving DOM/provider readiness was never the missing signal; contract binding was.

### **After**

Taps are issued only once the dapp reports `documentReady`, `hasEthereum`, an enabled target button, and — when `?contract=` is present — a bound contract address. If binding loses the race the page is reloaded once, then polling resumes. If the sheet still fails to open, the failure now reports `contractParam` / `contractBound` so the broken side is obvious:

```
Confirmation sheet never opened after tapping #mintButton (ERC-721 mint button);
last dapp state={"href":"http://localhost:8085/?contract=0x...","documentReady":true,
"hasEthereum":true,"hasButton":true,"buttonDisabled":false,"contractParam":"0x...","contractBound":false}; cause=...
```

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to E2E helpers and smoke specs; no production app behavior.
> 
> **Overview**
> Addresses Android Appium flakes where the confirmation sheet never opens after tapping a test-dapp button, because taps could succeed on an enabled but not-yet-bound contract page.
> 
> **`confirmations.flow.ts` (Android path only):** Before each tap/retry, CDP polling waits until the page is complete, `window.ethereum` exists, the target button is enabled, and—when `?contract=` is present—a token address element is populated. If binding is still missing after 8s, the dapp reloads once. Failures now include `contractParam` / `contractBound` in the error message.
> 
> **Specs:** Native send waits for the confirm button to leave the hierarchy before opening Activity. Two `setApprovalForAll` Appium tests (ERC-1155 and revoke ERC-721) are re-enabled after removing their skips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ab3814eaf62f8b78d4d147cc2b5a31a328f657e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->