### PR TITLE
fix(agents): make mobile session IDs visible to knowledge store

### DIFF
--- a/tests/llm-workflow/__tests__/metamask-provider.test.ts
+++ b/tests/llm-workflow/__tests__/metamask-provider.test.ts
@@ -1,10 +1,12 @@
 /* eslint-disable import-x/no-nodejs-modules, import-x/no-extraneous-dependencies */
 import { execFileSync } from 'node:child_process';
-import type {
-  IPlatformDriver,
-  SessionLaunchInput,
-  StateSnapshotCapability,
-  WorkflowContext,
+import {
+  generateSessionId,
+  knowledgeStore,
+  type IPlatformDriver,
+  type SessionLaunchInput,
+  type StateSnapshotCapability,
+  type WorkflowContext,
 } from '@metamask/client-mcp-core';
 import { MetaMaskMobileSessionManager } from '../metamask-provider';
 import {
@@ -20,7 +22,12 @@ import {
   type ResolvedIOSLaunchOptions,
 } from '../launcher-types';
 
-jest.mock('@metamask/client-mcp-core', () => ({}));
+jest.mock('@metamask/client-mcp-core', () => ({
+  generateSessionId: jest.fn().mockReturnValue('mm-test-session-id'),
+  knowledgeStore: {
+    writeSessionMetadata: jest.fn().mockResolvedValue('/tmp/session.json'),
+  },
+}));
 jest.mock('node:child_process', () => ({ execFileSync: jest.fn() }));
 jest.mock('../ios/prerequisites', () => ({
   validateIOSPrerequisites: jest.fn(),
@@ -48,6 +55,10 @@ const mockEnsureAccessibilityBridgeEnabled = jest.mocked(
   ensureAccessibilityBridgeEnabled,
 );
 const mockProbeHermesHealthy = jest.mocked(probeHermesHealthy);
+const mockGenerateSessionId = jest.mocked(generateSessionId);
+const mockWriteSessionMetadata = jest.mocked(
+  knowledgeStore.writeSessionMetadata,
+);
 
 const resolved: ResolvedIOSLaunchOptions = {
   simulatorDeviceId: 'SIM-UDID',
@@ -203,6 +214,22 @@ describe('MetaMaskMobileSessionManager', () => {
       'xcrun',
       expect.arrayContaining(['fixtureServerPort']),
       expect.anything(),
+    );
+  });
+
+  it('generates an mm-prefixed session ID and persists session metadata', async () => {
+    await sessionManager.launch(createLaunchInput({ goal: 'test goal' }));
+
+    expect(mockGenerateSessionId).toHaveBeenCalledTimes(1);
+    expect(mockWriteSessionMetadata).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'mm-test-session-id',
+        goal: 'test goal',
+        schemaVersion: 1,
+      }),
+    );
+    expect(sessionManager.getSessionMetadata()).toEqual(
+      expect.objectContaining({ sessionId: 'mm-test-session-id' }),
     );
   });
 

--- a/tests/llm-workflow/__tests__/metamask-provider.test.ts
+++ b/tests/llm-workflow/__tests__/metamask-provider.test.ts
@@ -233,6 +233,23 @@ describe('MetaMaskMobileSessionManager', () => {
     );
   });
 
+  it('completes the launch even when session metadata persistence fails', async () => {
+    mockWriteSessionMetadata.mockRejectedValueOnce(new Error('disk full'));
+
+    const result = await sessionManager.launch(
+      createLaunchInput({ goal: 'test goal' }),
+    );
+
+    expect(result.extensionId).toBe('io.metamask.MetaMask');
+    expect(sessionManager.hasActiveSession()).toBe(true);
+    expect(sessionManager.getSessionMetadata()).toEqual(
+      expect.objectContaining({ sessionId: 'mm-test-session-id' }),
+    );
+    expect(stderrSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('disk full'),
+    );
+  });
+
   it('passes the core deviceId to iOS simulator prerequisite selection', async () => {
     await sessionManager.launch(createLaunchInput({ deviceId: 'INPUT-SIM' }));
 

--- a/tests/llm-workflow/metamask-provider.ts
+++ b/tests/llm-workflow/metamask-provider.ts
@@ -319,7 +319,12 @@ export class MetaMaskMobileSessionManager implements ISessionManager {
         },
       };
 
-      await knowledgeStore.writeSessionMetadata(this.sessionMetadata);
+      try {
+        await knowledgeStore.writeSessionMetadata(this.sessionMetadata);
+      } catch {
+        // Pass through: this is a non blocking behavior if it fails
+        // we can silently bypass it.
+      }
 
       return {
         sessionId,

--- a/tests/llm-workflow/metamask-provider.ts
+++ b/tests/llm-workflow/metamask-provider.ts
@@ -1,6 +1,5 @@
 /* eslint-disable import-x/no-nodejs-modules, import-x/no-extraneous-dependencies */
 import { execFileSync } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
 
 import type { BrowserContext, Page } from '@playwright/test';
 import {
@@ -22,6 +21,8 @@ import {
   type TabRole,
   type TrackedPage,
   type WorkflowContext,
+  generateSessionId,
+  knowledgeStore,
 } from '@metamask/client-mcp-core';
 
 import {
@@ -289,7 +290,7 @@ export class MetaMaskMobileSessionManager implements ISessionManager {
       }
 
       const state = await iosDriver.driver.getAppState();
-      const sessionId = randomUUID();
+      const sessionId = generateSessionId();
       const startedAt = new Date().toISOString();
 
       this.sessionId = sessionId;
@@ -317,6 +318,8 @@ export class MetaMaskMobileSessionManager implements ISessionManager {
           ports: undefined,
         },
       };
+
+      await knowledgeStore.writeSessionMetadata(this.sessionMetadata);
 
       return {
         sessionId,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`tests/llm-workflow/metamask-provider.ts` (the Playwright/MCP session manager backing the mobile `mm` CLI / LLM-driven test workflows) generated session IDs with a bare `randomUUID()` and never persisted its in-memory session metadata to disk.

`@metamask/client-mcp-core`'s `KnowledgeStore.getAllSessionIds()` only lists session directories whose name starts with the `mm-` prefix, and `listSessions()` skips any session that has no `session.json` on disk. Because mobile's session IDs carried no prefix and metadata was never written, every mobile session was permanently invisible to the `knowledge-sessions` and `knowledge-search` MCP tools, even though real step data existed under `test-artifacts/llm-knowledge/<uuid>/`. This forced agents driving mobile through the `mm` CLI to always rediscover navigation flows from scratch instead of reusing prior session knowledge.

This PR brings `MetaMaskMobileSessionManager.launch()` in line with the pattern MetaMask Extension's own Playwright harness (`test/e2e/playwright/llm-workflow/metamask-provider.ts`) already uses — both exports are already public on the `@metamask/client-mcp-core` version mobile depends on, so no dependency bump was needed:

- Replaced `randomUUID()` (from `node:crypto`) with `generateSessionId()` from `@metamask/client-mcp-core`, which produces `mm-<ts36>-<rand6>` IDs.
- Added `await knowledgeStore.writeSessionMetadata(this.sessionMetadata)` right after building the session metadata object, so `listSessions()` can find a `session.json` for the session.
- Updated `tests/llm-workflow/__tests__/metamask-provider.test.ts` to mock `generateSessionId` / `knowledgeStore.writeSessionMetadata` and assert both are called during `launch()`, mirroring the extension's existing test coverage for the same pattern.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4927

<!-- TODO(author): no GitHub issue or Jira ticket was found automatically from the branch name (`swaps-4927`), commit message, or a keyword search of MetaMask/metamask-mobile issues. If this maps to a Jira ticket, add `Refs: <TICKET-KEY>` before marking ready for review — an empty `Fixes:` line is not acceptable per docs/readme/ready-for-review.md. -->

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Knowledge-store visibility for MetaMask Mobile LLM workflow sessions

  Scenario: A launched mobile session is discoverable by knowledge-sessions
    Given the metamask-mobile Playwright/MCP test harness is set up locally
    And no MetaMask Mobile session is currently running

    When I launch a session via the harness (e.g. `mm launch` targeting the iOS simulator)
    Then the generated session ID is prefixed with "mm-"
    And a `session.json` file exists under `test-artifacts/llm-knowledge/<sessionId>/`

  Scenario: knowledge-sessions and knowledge-search return the active mobile session
    Given a MetaMask Mobile session was launched via the harness in this run

    When I run `mm knowledge-sessions`
    Then the current session ID appears in the results

    When I run `mm knowledge-search "<goal keyword used at launch>"`
    Then the current session is returned as a match

  Scenario: Existing session lifecycle is unaffected by the ID format change
    Given a MetaMask Mobile session was launched via the harness

    When I call `hasActiveSession()` and then `cleanup()`
    Then both behave exactly as before, since the session ID is only ever used as an opaque directory name
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — no UI change. Recommended: attach a terminal recording/log of `mm knowledge-sessions` run mid-session, before this fix, showing the current mobile session missing from the results.

### **After**

N/A — no UI change. Recommended: attach a terminal recording/log of `mm knowledge-sessions` / `mm knowledge-search` run mid-session, after this fix, showing the current mobile session now returned.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Not applicable — this change is confined to the Node/TypeScript Playwright test harness (`tests/llm-workflow/`), which is iOS-simulator-only today; no app runtime or platform-specific code is touched.
- [x] I've tested with a power user scenario
  - Not applicable — no app state, account, or token data path is touched.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - Not applicable — this is test tooling, not production app code.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness-only change in `tests/llm-workflow/`; no app runtime, auth, or production data paths.
> 
> **Overview**
> Mobile LLM workflow launches now use **`generateSessionId()`** from `@metamask/client-mcp-core` instead of bare `randomUUID()`, so session directories get the **`mm-`** prefix that `knowledge-sessions` / `knowledge-search` expect.
> 
> After building in-memory session metadata, **`MetaMaskMobileSessionManager.launch()`** calls **`knowledgeStore.writeSessionMetadata()`** so a `session.json` exists under `test-artifacts/llm-knowledge/<sessionId>/`. Write failures are **swallowed** so launch still succeeds.
> 
> Unit tests mock `generateSessionId` and `writeSessionMetadata`, assert they run on launch, and confirm launch completes when persistence fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 067d4bd630905a728fbd7bb8e356d78b5addd19f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->