### PR TITLE
fix(perps): restore Pro order form reduce-only checkbox and TP/SL arrow cp-8.7.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -351,13 +351,14 @@ describe('PerpsProOrderForm', () => {
       expect(screen.queryByTestId(ids.TPSL)).not.toBeOnTheScreen();
     });
 
-    it('exposes TP/SL as a button action', () => {
+    it('exposes TP/SL as a button action with a down arrow affordance', () => {
       renderForm({ onTPSLPress: jest.fn() });
 
       expect(screen.getByTestId(ids.TPSL)).toHaveProp(
         'accessibilityRole',
         'button',
       );
+      expect(screen.getByTestId(`${ids.TPSL}-arrow`)).toBeOnTheScreen();
     });
 
     it('calls onTPSLPress when TP/SL is pressed', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -10,6 +10,7 @@ import {
   ButtonIconSize,
   ButtonSemantic,
   ButtonSemanticSeverity,
+  Checkbox,
   FilterButton,
   FontWeight,
   Icon,
@@ -67,63 +68,13 @@ const summaryValueTextProps = {
   fontWeight: FontWeight.Medium,
 };
 
-interface SelectionIndicatorProps {
-  isSelected: boolean;
+interface TPSLRowProps {
+  label: string;
+  onPress?: () => void;
   testID: string;
 }
 
-const SelectionIndicator = ({ isSelected, testID }: SelectionIndicatorProps) =>
-  isSelected ? (
-    <Box
-      twClassName="size-5 items-center justify-center rounded-full bg-icon-default"
-      testID={`${testID}-indicator`}
-    >
-      <Icon
-        name={IconName.CheckBold}
-        size={IconSize.Xs}
-        color={IconColor.PrimaryInverse}
-      />
-    </Box>
-  ) : (
-    <Box
-      twClassName="size-5 rounded-full border-2 border-muted"
-      testID={`${testID}-indicator`}
-    />
-  );
-
-interface ReduceOnlyRowProps extends SelectionIndicatorProps {
-  label: string;
-  onChange: (value: boolean) => void;
-}
-
-const ReduceOnlyRow = ({
-  label,
-  isSelected,
-  onChange,
-  testID,
-}: ReduceOnlyRowProps) => (
-  <Pressable
-    accessibilityRole="checkbox"
-    accessibilityState={{ checked: isSelected }}
-    accessibilityLabel={label}
-    onPress={() => onChange(!isSelected)}
-    testID={testID}
-  >
-    <Box twClassName="h-12 flex-row items-center justify-between rounded-xl bg-muted px-3">
-      <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
-        {label}
-      </Text>
-      <SelectionIndicator isSelected={isSelected} testID={testID} />
-    </Box>
-  </Pressable>
-);
-
-interface TPSLRowProps extends SelectionIndicatorProps {
-  label: string;
-  onPress?: () => void;
-}
-
-const TPSLRow = ({ label, isSelected, onPress, testID }: TPSLRowProps) => {
+const TPSLRow = ({ label, onPress, testID }: TPSLRowProps) => {
   const isDisabled = !onPress;
 
   return (
@@ -143,7 +94,12 @@ const TPSLRow = ({ label, isSelected, onPress, testID }: TPSLRowProps) => {
         <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
           {label}
         </Text>
-        <SelectionIndicator isSelected={isSelected} testID={testID} />
+        <Icon
+          name={IconName.ArrowDown}
+          size={IconSize.Sm}
+          color={IconColor.IconDefault}
+          testID={`${testID}-arrow`}
+        />
       </Box>
     </Pressable>
   );
@@ -316,7 +272,6 @@ const PerpsProOrderForm = ({
   onAddFundsPress,
   reduceOnly,
   onReduceOnlyChange,
-  isTPSLConfigured,
   onTPSLPress,
   notices,
   summary,
@@ -485,16 +440,23 @@ const PerpsProOrderForm = ({
             availableBalance={availableBalance}
             onAddFundsPress={onAddFundsPress}
           />
-          <ReduceOnlyRow
-            label={strings('perps.order.reduce_only')}
-            isSelected={reduceOnly}
-            onChange={onReduceOnlyChange}
-            testID={ids.REDUCE_ONLY}
-          />
+          <Box twClassName="h-12 justify-center rounded-xl bg-muted px-3">
+            <Checkbox
+              label={strings('perps.order.reduce_only')}
+              labelProps={{
+                variant: TextVariant.BodySm,
+                fontWeight: FontWeight.Medium,
+                style: { marginLeft: 0, flex: 1 },
+              }}
+              isSelected={reduceOnly}
+              onChange={onReduceOnlyChange}
+              testID={ids.REDUCE_ONLY}
+              twClassName="w-full flex-row-reverse justify-between"
+            />
+          </Box>
           {!reduceOnly ? (
             <TPSLRow
               label={strings('perps.pro_order_form.tpsl')}
-              isSelected={isTPSLConfigured}
               onPress={onTPSLPress}
               testID={ids.TPSL}
             />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

PR #34381 regressed the Pro order form UI that shipped in #34398 by replacing the MMDS `Checkbox` reduce-only control and the TP/SL down-arrow affordance with custom circular selection indicators.

**Why:** The Pro order form no longer matches Figma or the accepted TAT-3654 polish from #34398.

**What changed:**
- Restore MMDS `Checkbox` for the reduce-only row
- Restore `ArrowDown` icon affordance on the TP/SL row
- Keep #34381 behavior that hides TP/SL while reduce-only is enabled
- Update unit tests to assert the restored controls

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Restored the Pro order form reduce-only checkbox and TP/SL arrow affordance after a UI regression

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://consensyssoftware.atlassian.net/browse/TAT-3654

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Pro order form reduce-only and TP/SL controls

  Scenario: reduce-only uses MMDS checkbox
    Given the user is on a Perps Pro market screen
    When the user views the order form
    Then the Reduce only row shows an MMDS checkbox instead of a custom circular selector

  Scenario: TP/SL shows down arrow affordance
    Given the user is on a Perps Pro market screen with reduce-only disabled
    When the user views the order form
    Then the TP/SL row shows a down arrow icon on the trailing edge

  Scenario: TP/SL hides when reduce-only is enabled
    Given the user is on a Perps Pro market screen
    When the user enables Reduce only
    Then the TP/SL row is hidden
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)