### PR TITLE
fix(social): show perp entry price for negative tokenAmount fills

### DIFF
--- a/app/components/Views/SocialLeaderboard/FeedView/utils/mapFeedItem.test.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/utils/mapFeedItem.test.ts
@@ -306,7 +306,7 @@ describe('mapFeedItem', () => {
 
     expect(result?.subHeader).toEqual({
       sizeLabel: '$36.3K',
-      contextValueLabel: '$63,908.45',
+      contextValueLabel: '$63,908',
       contextKind: 'price',
     });
   });
@@ -333,6 +333,63 @@ describe('mapFeedItem', () => {
     expect(result?.subHeader).toEqual({
       sizeLabel: '$40.4K',
       contextValueLabel: '$161.72',
+      contextKind: 'price',
+    });
+  });
+
+  it('derives sub-header price for sub-cent perp fills', () => {
+    const result = mapFeedItem(
+      mockPerpFeedItem({
+        perpPositionType: 'long',
+        perpLeverage: 10,
+        currentValueUSD: 92_234,
+        trades: [
+          {
+            direction: 'buy',
+            intent: 'enter',
+            tokenAmount: 1_451_472,
+            usdCost: 4_004.61,
+            timestamp: 1_700_000_000,
+            transactionHash: '0xhash',
+            classification: 'perp',
+            perpPositionType: 'long',
+            perpLeverage: 10,
+          },
+        ],
+        tokenSymbol: 'PUMP',
+        timestamp: 1_700_000_000,
+      }),
+    );
+
+    expect(result?.subHeader).toEqual({
+      sizeLabel: '$4K',
+      contextValueLabel: '$0.002759',
+      contextKind: 'price',
+    });
+  });
+
+  it('derives sub-header price for sub-cent spot fills without market cap', () => {
+    const result = mapFeedItem(
+      mockSpotFeedItem({
+        tokenSymbol: 'PEPE',
+        trades: [
+          {
+            direction: 'buy',
+            intent: 'enter',
+            tokenAmount: 1_000_000,
+            usdCost: 2_759,
+            marketCap: null,
+            timestamp: 1_700_000_000,
+            transactionHash: '0xhash',
+            classification: 'spot',
+          },
+        ],
+      }),
+    );
+
+    expect(result?.subHeader).toEqual({
+      sizeLabel: '$2.8K',
+      contextValueLabel: '$0.002759',
       contextKind: 'price',
     });
   });

--- a/app/components/Views/SocialLeaderboard/FeedView/utils/mapFeedItem.test.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/utils/mapFeedItem.test.ts
@@ -281,6 +281,62 @@ describe('mapFeedItem', () => {
     );
   });
 
+  it('derives sub-header price from negative tokenAmount on a short enter fill', () => {
+    const result = mapFeedItem(
+      mockPerpFeedItem({
+        perpPositionType: 'short',
+        perpLeverage: 5,
+        currentValueUSD: 36_300,
+        trades: [
+          {
+            direction: 'sell',
+            intent: 'enter',
+            tokenAmount: -0.568,
+            usdCost: -36_300,
+            timestamp: 1_700_000_000,
+            transactionHash: '0xhash',
+            classification: 'perp',
+            perpPositionType: 'short',
+            perpLeverage: 5,
+          },
+        ],
+        timestamp: 1_700_000_000,
+      }),
+    );
+
+    expect(result?.subHeader).toEqual({
+      sizeLabel: '$36.3K',
+      contextValueLabel: '$63,908.45',
+      contextKind: 'price',
+    });
+  });
+
+  it('derives sub-header price from negative tokenAmount on a perp exit fill', () => {
+    const result = mapFeedItem(
+      mockPerpFeedItem({
+        trades: [
+          {
+            direction: 'sell',
+            intent: 'exit',
+            tokenAmount: -250,
+            usdCost: -40_429,
+            timestamp: 1_700_000_500,
+            transactionHash: '0xhash',
+            classification: 'perp',
+            perpPositionType: 'long',
+            perpLeverage: 8,
+          },
+        ],
+      }),
+    );
+
+    expect(result?.subHeader).toEqual({
+      sizeLabel: '$40.4K',
+      contextValueLabel: '$161.72',
+      contextKind: 'price',
+    });
+  });
+
   it('omits market cap on perp trades even when Clicker provides it', () => {
     const result = mapFeedItem(
       mockPerpFeedItem({

--- a/app/components/Views/SocialLeaderboard/FeedView/utils/mapFeedItem.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/utils/mapFeedItem.ts
@@ -15,6 +15,7 @@ import {
   formatAbbreviatedUsd,
   formatPercent,
   formatSignedUsd,
+  formatTradeUnitPrice,
   formatUsd,
 } from '../../utils/formatters';
 import { tradeTimestampToMs } from '../../utils/tradeTimestamp';
@@ -122,11 +123,10 @@ function buildSubHeader(
   const tokenAmount = Math.abs(trade.tokenAmount);
   const price = tokenAmount > 0 ? Math.abs(trade.usdCost) / tokenAmount : null;
 
-  // Guard against sub-cent prices rendering as a misleading "$0.00".
-  if (price != null && price >= 0.01) {
+  if (price != null && price > 0) {
     return {
       sizeLabel,
-      contextValueLabel: formatUsd(price),
+      contextValueLabel: formatTradeUnitPrice(price),
       contextKind: 'price',
     };
   }

--- a/app/components/Views/SocialLeaderboard/FeedView/utils/mapFeedItem.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/utils/mapFeedItem.ts
@@ -119,8 +119,8 @@ function buildSubHeader(
     };
   }
 
-  const price =
-    trade.tokenAmount > 0 ? Math.abs(trade.usdCost / trade.tokenAmount) : null;
+  const tokenAmount = Math.abs(trade.tokenAmount);
+  const price = tokenAmount > 0 ? Math.abs(trade.usdCost) / tokenAmount : null;
 
   // Guard against sub-cent prices rendering as a misleading "$0.00".
   if (price != null && price >= 0.01) {

--- a/app/components/Views/SocialLeaderboard/utils/formatters.test.ts
+++ b/app/components/Views/SocialLeaderboard/utils/formatters.test.ts
@@ -1,5 +1,6 @@
 import {
   formatUsd,
+  formatTradeUnitPrice,
   formatSignedUsd,
   formatSignedAbbreviatedUsd,
   formatSignedFullUsdNoDecimals,
@@ -30,6 +31,22 @@ describe('formatUsd', () => {
 
   it('returns an em dash for undefined', () => {
     expect(formatUsd(undefined)).toBe('\u2014');
+  });
+});
+
+describe('formatTradeUnitPrice', () => {
+  it('formats sub-cent per-unit prices with perps precision', () => {
+    expect(formatTradeUnitPrice(0.002759)).toBe('$0.002759');
+  });
+
+  it('formats dollar-scale prices with tiered precision', () => {
+    expect(formatTradeUnitPrice(63_850)).toBe('$63,850');
+    expect(formatTradeUnitPrice(0.15)).toBe('$0.15');
+  });
+
+  it('returns an em dash for nullish values', () => {
+    expect(formatTradeUnitPrice(null)).toBe('\u2014');
+    expect(formatTradeUnitPrice(undefined)).toBe('\u2014');
   });
 });
 

--- a/app/components/Views/SocialLeaderboard/utils/formatters.ts
+++ b/app/components/Views/SocialLeaderboard/utils/formatters.ts
@@ -1,6 +1,7 @@
 import {
   formatPerpsFiat,
   formatPercentage,
+  PRICE_RANGES_UNIVERSAL,
 } from '../../../UI/Perps/utils/formatUtils';
 import {
   formatAmountWithThreshold,
@@ -23,6 +24,16 @@ export function formatUsd(value: number | null | undefined): string {
   if (value == null) return EM_DASH;
   const sign = value < 0 ? '-' : '';
   return sign + formatPerpsFiat(Math.abs(value), { stripTrailingZeros: false });
+}
+
+/**
+ * Per-unit trade price for feed sub-headers and similar copy. Uses the same
+ * tiered precision as Perps ({@link PRICE_RANGES_UNIVERSAL}) and the social
+ * API formatter so sub-cent assets (e.g. PUMP) don't collapse to `$0.00`.
+ */
+export function formatTradeUnitPrice(value: number | null | undefined): string {
+  if (value == null) return EM_DASH;
+  return formatPerpsFiat(Math.abs(value), { ranges: PRICE_RANGES_UNIVERSAL });
 }
 
 /**


### PR DESCRIPTION
## **Description**

Perp rows in the Follow trading feed were missing the `at $X` entry price in two cases:

1. **Negative `tokenAmount`** — Clicker reports negative `tokenAmount`/`usdCost` for short opens and exit fills; the mapper required `tokenAmount > 0`.
2. **Sub-cent prices** — A `$0.01` guard hid prices like PUMP (`~$0.002759`) because `formatUsd` would render them as `$0.00`.

This PR derives price with absolute values and formats unit prices via `PRICE_RANGES_UNIVERSAL` (same tiered precision as Perps and the social API notification copy). Spot rows without `marketCap` use the same path.

## **Changelog**

CHANGELOG entry: Fixed missing or incorrect entry price on some Follow trading feed rows, including shorts and sub-cent assets.

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Follow trading feed entry price

  Scenario: Short, closed, and sub-cent perp rows show entry price
    Given I am on the Top traders Feed tab with following activity loaded
    When I view perp rows that previously omitted price (e.g. NVDA short, CL, closed EWY)
    Then each row sub-header shows size and entry price in the format "$X at $Y"

  Scenario: Sub-cent perp rows show precise entry price
    Given I am on the Top traders Feed tab
    When I view a sub-cent perp row such as PUMP 10x LONG
    Then the sub-header shows the entry price with sub-cent precision (e.g. "$4K at $0.002759")
```

## **Screenshots/Recordings**

### **Before**

<img width="554" height="164" alt="Screenshot 2026-08-11 at 11 44 27" src="https://github.com/user-attachments/assets/f4322a19-9168-4b14-a79f-c17fd0b0d92f" />

### **After**

<img width="425" height="145" alt="Screenshot 2026-08-11 at 11 54 35" src="https://github.com/user-attachments/assets/80ce39c1-cf78-4500-96ee-cfa89aaae627" />
<img width="544" height="201" alt="Screenshot 2026-08-11 at 11 45 07" src="https://github.com/user-attachments/assets/6098b968-4d0b-4d24-809f-0d20a9cae29b" />
<img width="553" height="190" alt="Screenshot 2026-08-11 at 11 44 44" src="https://github.com/user-attachments/assets/e35328af-35f2-4546-8735-0db706638a74" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only mapping/formatting in the Social Leaderboard feed with unit tests; no auth, payments, or shared API contract changes.
> 
> **Overview**
> Restores the **“$X at $Y”** entry price on Follow trading feed rows when Clicker sends negative `tokenAmount`/`usdCost` (short opens, perp exits) and when unit prices are below one cent.
> 
> **`buildSubHeader`** now derives per-unit price from absolute `tokenAmount` and `usdCost`, drops the old **≥ $0.01** gate that hid sub-cent assets, and formats the price with new **`formatTradeUnitPrice`** (Perps **`PRICE_RANGES_UNIVERSAL`** tiering) instead of **`formatUsd`**, so labels like `$0.002759` render instead of `$0.00`. Spot rows without market cap use the same price path. Coverage added in **`mapFeedItem.test.ts`** and **`formatters.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a81f578ea1122bd46f869ab5def488a576ebb9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->