### PR TITLE
fix: MMQA-fix-performance-issues

### DIFF
--- a/.github/workflows/performance-test-runner.yml
+++ b/.github/workflows/performance-test-runner.yml
@@ -77,7 +77,7 @@ jobs:
   run-tests:
     name: Run ${{ inputs.build_type }} Tests on ${{ inputs.platform }} - ${{ matrix.device.name }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/tests/page-objects/Onboarding/ImportWalletView.ts
+++ b/tests/page-objects/Onboarding/ImportWalletView.ts
@@ -76,7 +76,7 @@ class ImportWalletView {
         android: () =>
           PlaywrightMatchers.getElementById(
             index === 0
-              ? ImportFromSeedSelectorsIDs.SEED_PHRASE_INPUT_ID
+              ? ImportFromSeedSelectorsIDs.SEED_PHRASE_INPUT_FIELD
               : `${ImportFromSeedSelectorsIDs.SEED_PHRASE_INPUT_ID}_${index}`,
             {
               exact: true,

--- a/tests/performance/onboarding/helpers/seedlessOnboardingTimers.ts
+++ b/tests/performance/onboarding/helpers/seedlessOnboardingTimers.ts
@@ -76,7 +76,6 @@ export async function measurePredictGtmModalIfShown(
       await PlaywrightAssertions.expectElementToBeVisible(
         asPlaywrightElement(PredictModalView.notNowButton),
         {
-          timeout: 10000,
           description: 'Predict modal should be visible',
         },
       );

--- a/tests/performance/onboarding/seedless-apple-onboarding.spec.ts
+++ b/tests/performance/onboarding/seedless-apple-onboarding.spec.ts
@@ -6,7 +6,10 @@ import {
   PlaywrightGestures,
 } from '../../framework';
 import { getPasswordForScenario } from '../../framework/utils/TestConstants.js';
-import { dismisspredictionsModalPlaywright } from '../../flows/wallet.flow';
+import {
+  dismisspredictionsModalPlaywright,
+  dismissPushNotificationExistingUserSheet,
+} from '../../flows/wallet.flow';
 import {
   Performance,
   System,
@@ -40,7 +43,7 @@ const waitForFirstSuccessful = async <T>(promises: Promise<T>[]): Promise<T> =>
 
 /* Seedless Onboarding: Apple Login */
 test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
-  test.setTimeout(300000);
+  test.setTimeout(360000);
 
   test(
     'Seedless Onboarding: Apple Login New User',
@@ -90,6 +93,7 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
       });
 
       await OnboardingSheet.tapAppleLoginButton();
+      await SocialLoginView.dismissUpdateModalIfPresent();
 
       let isNewUser = true;
 
@@ -141,6 +145,7 @@ test.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
           );
         });
         await OnboardingSuccessView.tapDone();
+        await dismissPushNotificationExistingUserSheet();
 
         // Optional Predict GTM: measure Done → modal when present (no pre-wait).
         const predictGtmOnboardingModalEnabled =


### PR DESCRIPTION
## **Description**

This PR fixes the Apple seedless onboarding performance flow. It updates the Android SRP input selector, aligns Apple onboarding cleanup with the Google flow, avoids duplicate Predict modal waits, and increases the Apple test timeout to match the Google scenario.

These changes prevent stale or blocked onboarding elements from inflating the measured Predict transition and improve reliability in cloud Appium runs.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: MMQA-fix-performance-issues

## **Manual testing steps**

```gherkin
Feature: Apple seedless onboarding performance

  Scenario: Run the Apple seedless onboarding performance test
    Given the Apple seedless onboarding performance test is configured
    When the test runs through TestMu or BrowserStack
    Then the SRP input is located using the current Android test ID
    And intermediate onboarding sheets are dismissed before Predict timing
    And the test does not perform duplicate modal waits
```

Validation commands:
- `yarn eslint tests/page-objects/Onboarding/ImportWalletView.ts tests/performance/onboarding/seedless-apple-onboarding.spec.ts tests/performance/onboarding/helpers/seedlessOnboardingTimers.ts`
- `yarn prettier --check tests/page-objects/Onboarding/ImportWalletView.ts tests/performance/onboarding/seedless-apple-onboarding.spec.ts tests/performance/onboarding/helpers/seedlessOnboardingTimers.ts`
- `git diff --check`

## **Screenshots/Recordings**

### **Before**

N/A — test selectors and performance flow changes only; no UI changes.

### **After**

N/A — test selectors and performance flow changes only; no UI changes.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented the code using [JSDoc](https://jsdoc.app/) where applicable
- [x] I've applied the appropriate PR labels.

#### Performance checks (if applicable)

- [x] I've assessed Android execution; runtime validation is delegated to CI/TestMu because this PR changes performance test code only.
- [x] I've assessed the power-user scenario; the existing scenario and SRP setup are unchanged.
- [x] I've assessed Sentry tracing; no production instrumentation changes are included in this PR.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.com/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E/performance test code and CI timeouts; no production app logic is modified.
> 
> **Overview**
> Improves **reliability and timing accuracy** for seedless onboarding performance tests without changing app behavior.
> 
> **Android import wallet:** The first seed phrase field on Appium now targets `SEED_PHRASE_INPUT_FIELD` instead of `SEED_PHRASE_INPUT_ID`, matching the current Android test ID.
> 
> **Apple seedless flow:** After Apple login, the spec dismisses the social login update modal when it appears and clears the push-notification sheet for existing users after onboarding success—aligned with other onboarding performance specs. The Playwright test timeout rises from 5 to 6 minutes, and the reusable performance workflow job timeout goes from 20 to 30 minutes.
> 
> **Predict GTM timing:** `measurePredictGtmModalIfShown` no longer passes a fixed 10s visibility timeout, avoiding an extra wait that could skew the measured Predict modal transition when the modal is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f3fbe2f24d203f469ec341b4f7732ac8b86b6e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->