### PR TITLE
test(e2e): await confirm sheet dismissal on appium confirm tap

### DIFF
--- a/tests/page-objects/Browser/Confirmations/FooterActions.ts
+++ b/tests/page-objects/Browser/Confirmations/FooterActions.ts
@@ -7,7 +7,6 @@ import { EncapsulatedElementType } from '../../../framework/EncapsulatedElement'
 import { FrameworkDetector } from '../../../framework/FrameworkDetector';
 import { PlatformDetector } from '../../../framework/PlatformLocator';
 import PlaywrightMatchers from '../../../framework/PlaywrightMatchers';
-import PlaywrightAssertions from '../../../framework/PlaywrightAssertions';
 import Utilities, { sleep } from '../../../framework/Utilities';
 import ToastModal from '../../wallet/ToastModal';
 
@@ -68,39 +67,28 @@ class FooterActions {
         await ToastModal.waitForToastToDismiss({ appearTimeout: 2_000 });
 
         const isAndroid = PlatformDetector.isAndroid();
-        const maxRetries = Math.max(5, Math.ceil((timeout ?? 30000) / 1000));
-        let didClick = false;
-        await PlaywrightAssertions.expectConditionWithRetry(
-          async () => {
-            const el = await PlaywrightMatchers.getElementById(
-              ConfirmationFooterSelectorIDs.CONFIRM_BUTTON,
-            );
-            const exists = await el.unwrap().isExisting();
-            if (!exists) {
-              if (didClick) {
-                return;
-              }
-              throw new Error('confirm-button not in hierarchy yet');
-            }
-
-            if (didClick) {
-              throw new Error('confirm-button still present after click');
-            }
-
-            if (isAndroid) {
-              const enabled = await el.unwrap().isEnabled();
-              if (!enabled) {
-                throw new Error('confirm-button not enabled yet');
-              }
-            }
-
-            await sleep(300);
-            await el.unwrap().click();
-            didClick = true;
-            throw new Error('waiting for confirm-button to leave hierarchy');
-          },
-          { maxRetries, interval: 1000 },
+        const readyTimeout = timeout ?? 30_000;
+        const el = await PlaywrightMatchers.getElementById(
+          ConfirmationFooterSelectorIDs.CONFIRM_BUTTON,
         );
+
+        await Utilities.waitUntil(
+          async () => {
+            if (!(await el.unwrap().isExisting())) {
+              return false;
+            }
+            if (isAndroid && !(await el.unwrap().isEnabled())) {
+              return false;
+            }
+            return true;
+          },
+          { interval: 1_000, timeout: readyTimeout },
+        );
+
+        await sleep(300);
+        await el.unwrap().click();
+
+        await this.waitForConfirmButtonGone(readyTimeout);
       },
     });
   }

--- a/tests/page-objects/Browser/Confirmations/FooterActions.ts
+++ b/tests/page-objects/Browser/Confirmations/FooterActions.ts
@@ -5,9 +5,11 @@ import Assertions from '../../../framework/Assertions';
 import { encapsulatedAction } from '../../../framework/encapsulatedAction';
 import { EncapsulatedElementType } from '../../../framework/EncapsulatedElement';
 import { FrameworkDetector } from '../../../framework/FrameworkDetector';
+import { PlatformDetector } from '../../../framework/PlatformLocator';
 import PlaywrightMatchers from '../../../framework/PlaywrightMatchers';
 import PlaywrightAssertions from '../../../framework/PlaywrightAssertions';
 import Utilities, { sleep } from '../../../framework/Utilities';
+import ToastModal from '../../wallet/ToastModal';
 
 class FooterActions {
   get confirmButton(): EncapsulatedElementType {
@@ -63,10 +65,9 @@ class FooterActions {
         });
       },
       appium: async () => {
-        // iOS BottomSheet confirmation containers often exist in the
-        // accessibility tree with isDisplayed=false. Click once by existence;
-        // if confirm is already gone after a prior click, treat as success
-        // (do not click again — avoids double-submit on retry).
+        await ToastModal.waitForToastToDismiss({ appearTimeout: 2_000 });
+
+        const isAndroid = PlatformDetector.isAndroid();
         const maxRetries = Math.max(5, Math.ceil((timeout ?? 30000) / 1000));
         let didClick = false;
         await PlaywrightAssertions.expectConditionWithRetry(
@@ -81,12 +82,22 @@ class FooterActions {
               }
               throw new Error('confirm-button not in hierarchy yet');
             }
+
             if (didClick) {
               throw new Error('confirm-button still present after click');
             }
+
+            if (isAndroid) {
+              const enabled = await el.unwrap().isEnabled();
+              if (!enabled) {
+                throw new Error('confirm-button not enabled yet');
+              }
+            }
+
             await sleep(300);
             await el.unwrap().click();
             didClick = true;
+            throw new Error('waiting for confirm-button to leave hierarchy');
           },
           { maxRetries, interval: 1000 },
         );


### PR DESCRIPTION
## **Description**

`FooterActions.tapConfirmButton` (Appium path) returned as soon as the WebDriver click succeeded, without checking that the confirmation actually went through. That made two real failure modes invisible at the point where they happened:

1. A toast sitting above the footer swallows the tap. Appium still reports the click as successful.
2. Confirm is present but still disabled (gas estimation / simulation / value updating), so the tap is a no-op.

In both cases the spec moved on with the confirm sheet still up, and the failure surfaced one or two steps later as something unrelated — most recently in `send-native-token.spec.ts`, where tapping Activity failed because the tab bar was still covered by the sheet.

The Appium path now:

- waits for any toast to dismiss first, reusing the existing `ToastModal.waitForToastToDismiss()` helper (returns immediately when no toast is present)
- requires the button to be enabled on Android before clicking
- polls until `confirm-button` leaves the hierarchy before returning, instead of returning right after the click

This brings it in line with the Detox branch of the same method, which already used `waitForElementToDisappear`. It still clicks only once, so a retry cannot double-submit a transaction.

Follow-up to #34596, which fixed the dapp-readiness half of the same flake.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/pull/34596

## **Manual testing steps**

```gherkin
Feature: Appium confirm tap waits for the sheet to dismiss

  Scenario: Send native token confirmation
    Given a fixture wallet with ETH on the local Anvil node
    When the user sends the MAX balance and taps Confirm
    Then tapConfirmButton returns only after the confirm sheet is gone
    And Activity shows the transaction as Confirmed
```

Android:

```bash
ANDROID_APK_PATH=build/ci-main-e2e/app-prod-release.apk \
ANDROID_AVD_NAME=<avd> \
yarn appium-smoke:android -- 'tests/smoke-appium/confirmations/send/send-native-token\.spec\.ts'
```

Other suites that call `tapConfirmButton` and are exercised by the same change: `confirmations/transactions/token-approve/`, `confirmations/transactions/7702/`, `confirmations/signatures/`.

## **Screenshots/Recordings**

N/A — E2E test helper change only, no product UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

Made with [Cursor](https://cursor.com)