### PR TITLE
feat(predict-next): add Kalshi browse lane

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -232,6 +232,7 @@ export MM_PERPS_PAY_WITH_ANY_TOKEN_ALLOWLIST_ASSETS=""
 
 ## Predict
 export MM_PREDICT_ENABLED="true"
+export MM_PREDICT_API_URL="http://localhost:3333"
 
 ## Card
 export MM_CARD_BAANX_API_CLIENT_KEY=""

--- a/app/components/UI/Predict/index.ts
+++ b/app/components/UI/Predict/index.ts
@@ -1,7 +1,7 @@
 // Main exports for Predict module
 export { default as PredictFeed } from './views/PredictFeed';
 export { default as PredictMarketDetails } from './views/PredictMarketDetails';
-export { default as PredictScreenStack } from './routes';
+export { default as PredictScreenStack } from './root/PredictRoot';
 export { selectPredictEnabledFlag } from './selectors/featureFlags';
 export { default as PredictSellPreview } from './views/PredictSellPreview/PredictSellPreview';
 export { PredictModalStack } from './routes';

--- a/app/components/UI/Predict/root/PredictRoot.tsx
+++ b/app/components/UI/Predict/root/PredictRoot.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useRoute, type RouteProp } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
+import PredictNextStack from '../../PredictNext/navigation/PredictNextStack';
+import { selectPredictConfig } from '../../PredictNext/selectors/predictConfig';
+import LegacyPredictScreenStack from '../routes';
+import type { RootStackParamList } from '../../../../core/NavigationService/types';
+import { resolvePredictRootLane } from './laneResolution';
+
+const PredictRoot = () => {
+  const config = useSelector(selectPredictConfig);
+  const route = useRoute<RouteProp<RootStackParamList, 'Predict'>>();
+  const lane = resolvePredictRootLane(config, route.params);
+
+  return lane === 'kalshi' ? (
+    <PredictNextStack key="kalshi" />
+  ) : (
+    <LegacyPredictScreenStack key="polymarket" />
+  );
+};
+
+export default PredictRoot;

--- a/app/components/UI/Predict/root/README.md
+++ b/app/components/UI/Predict/root/README.md
@@ -1,0 +1,7 @@
+# Temporary Predict lane router
+
+This boundary lives in legacy `Predict/` because the existing `Predict` root route is the shared entry point while production Polymarket remains on the legacy stack. It selects either the complete legacy Polymarket stack or the independent PredictNext Kalshi stack; controllers, navigation state, views, and domain models are not shared.
+
+Generic Predict and unparameterized `PredictMarketList` entries may use the resolved Active Venue. Legacy feed/search parameters, specific child routes, and existing Predict deep links stay on Polymarket. A live selection change remounts the chosen stack at its home screen rather than translating navigation state.
+
+PRED-1210 will replace the temporary preference (Kalshi only when it is the sole enabled Venue) with Venue Selection Preference and geolocation precedence. Delete this directory when legacy Predict is removed and the shared lane boundary is no longer needed.

--- a/app/components/UI/Predict/root/laneResolution.test.ts
+++ b/app/components/UI/Predict/root/laneResolution.test.ts
@@ -1,0 +1,72 @@
+import type { PredictConfig } from '../../PredictNext/config/predictConfig';
+import {
+  hasLegacyMarketListParams,
+  resolveActiveVenue,
+  resolvePredictMarketListLane,
+  resolvePredictRootLane,
+} from './laneResolution';
+
+const config = (polymarket: boolean, kalshi: boolean): PredictConfig => ({
+  enabled: true,
+  venues: {
+    polymarket: { enabled: polymarket },
+    kalshi: { enabled: kalshi },
+  },
+  venueSelection: { enabled: false },
+});
+
+describe('temporary Predict lane resolution', () => {
+  it.each([
+    [false, true, 'kalshi'],
+    [true, false, 'polymarket'],
+    [true, true, 'polymarket'],
+    [false, false, 'polymarket'],
+  ] as const)(
+    'resolves polymarket=%s kalshi=%s to %s',
+    (polymarket, kalshi, expected) => {
+      const result = resolveActiveVenue(config(polymarket, kalshi));
+
+      expect(result).toBe(expected);
+    },
+  );
+
+  it('falls back to Polymarket when the new architecture is disabled', () => {
+    const disabled = { ...config(false, true), enabled: false };
+
+    const result = resolveActiveVenue(disabled);
+
+    expect(result).toBe('polymarket');
+  });
+
+  it.each([
+    { feedId: 'sports' as const },
+    { tabId: 'basketball' },
+    { query: 'election' },
+  ])('recognizes legacy market-list parameters', (params) => {
+    const result = hasLegacyMarketListParams(params);
+
+    expect(result).toBe(true);
+  });
+
+  it('keeps a parameterized market list on Polymarket', () => {
+    const result = resolvePredictMarketListLane(config(false, true), {
+      query: 'election',
+    });
+
+    expect(result).toBe('polymarket');
+  });
+
+  it('routes a generic market list to Kalshi', () => {
+    const result = resolvePredictMarketListLane(config(false, true));
+
+    expect(result).toBe('kalshi');
+  });
+
+  it('keeps a specific child route on Polymarket', () => {
+    const result = resolvePredictRootLane(config(false, true), {
+      screen: 'PredictMarketDetails',
+    });
+
+    expect(result).toBe('polymarket');
+  });
+});

--- a/app/components/UI/Predict/root/laneResolution.ts
+++ b/app/components/UI/Predict/root/laneResolution.ts
@@ -1,0 +1,48 @@
+import type { PredictConfig } from '../../PredictNext/config/predictConfig';
+import type {
+  PredictMarketListRouteParams,
+  PredictStackParamList,
+} from '../types/navigation';
+
+export type PredictLane = 'polymarket' | 'kalshi';
+
+export const resolveActiveVenue = (config: PredictConfig): PredictLane => {
+  if (!config.enabled) {
+    return 'polymarket';
+  }
+  return config.venues.kalshi.enabled && !config.venues.polymarket.enabled
+    ? 'kalshi'
+    : 'polymarket';
+};
+
+export const hasLegacyMarketListParams = (
+  params?: PredictMarketListRouteParams,
+): boolean =>
+  Boolean(
+    params?.feedId ||
+      params?.tab ||
+      params?.tabId ||
+      params?.query ||
+      params?.transactionActiveAbTests,
+  );
+
+export const resolvePredictMarketListLane = (
+  config: PredictConfig,
+  params?: PredictMarketListRouteParams,
+): PredictLane =>
+  hasLegacyMarketListParams(params) ? 'polymarket' : resolveActiveVenue(config);
+
+export const resolvePredictRootLane = (
+  config: PredictConfig,
+  route?: {
+    screen?: keyof PredictStackParamList;
+    params?: PredictMarketListRouteParams;
+  },
+): PredictLane => {
+  if (!route?.screen) {
+    return resolveActiveVenue(config);
+  }
+  return route.screen === 'PredictMarketList'
+    ? resolvePredictMarketListLane(config, route.params)
+    : 'polymarket';
+};

--- a/app/components/UI/Predict/routes/PredictMarketListRoute.tsx
+++ b/app/components/UI/Predict/routes/PredictMarketListRoute.tsx
@@ -3,6 +3,11 @@ import { useSelector } from 'react-redux';
 import PredictFeed from '../views/PredictFeed';
 import PredictHome from '../views/PredictHome';
 import { selectPredictHomeRedesignEnabledFlag } from '../selectors/featureFlags';
+import { useRoute, type RouteProp } from '@react-navigation/native';
+import type { PredictStackParamList } from '../types/navigation';
+import { selectPredictConfig } from '../../PredictNext/selectors/predictConfig';
+import { resolvePredictMarketListLane } from '../root/laneResolution';
+import PredictNextStack from '../../PredictNext/navigation/PredictNextStack';
 
 /**
  * MARKET_LIST route component selector.
@@ -14,7 +19,13 @@ import { selectPredictHomeRedesignEnabledFlag } from '../selectors/featureFlags'
  */
 const PredictMarketListRoute = () => {
   const homeRedesignEnabled = useSelector(selectPredictHomeRedesignEnabledFlag);
+  const config = useSelector(selectPredictConfig);
+  const params =
+    useRoute<RouteProp<PredictStackParamList, 'PredictMarketList'>>().params;
 
+  if (resolvePredictMarketListLane(config, params) === 'kalshi') {
+    return <PredictNextStack />;
+  }
   return homeRedesignEnabled ? <PredictHome /> : <PredictFeed />;
 };
 

--- a/app/components/UI/Predict/routes/index.test.tsx
+++ b/app/components/UI/Predict/routes/index.test.tsx
@@ -293,6 +293,9 @@ describe('PredictScreenStack', () => {
 describe('PredictModalStack', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockPayWithAnyTokenEnabled = false;
+    mockPredictPortfolioEnabled = true;
+    mockPredictHomeRedesignEnabled = false;
     navigationRef = React.createRef();
   });
 

--- a/app/components/UI/Predict/routes/index.test.tsx
+++ b/app/components/UI/Predict/routes/index.test.tsx
@@ -10,6 +10,14 @@ import PredictScreenStack, { PredictModalStack } from './index';
 let mockPayWithAnyTokenEnabled = false;
 let mockPredictPortfolioEnabled = true;
 let mockPredictHomeRedesignEnabled = false;
+const mockPredictConfig = {
+  enabled: false,
+  venues: {
+    polymarket: { enabled: true },
+    kalshi: { enabled: false },
+  },
+  venueSelection: { enabled: false },
+};
 
 const mockSelectPredictWithAnyTokenEnabledFlag = jest.fn(
   () => mockPayWithAnyTokenEnabled,
@@ -32,6 +40,10 @@ jest.mock('../selectors/featureFlags', () => ({
     mockSelectPredictPortfolioEnabledFlag(),
   selectPredictHomeRedesignEnabledFlag: () =>
     mockSelectPredictHomeRedesignEnabledFlag(),
+}));
+
+jest.mock('../../PredictNext/selectors/predictConfig', () => ({
+  selectPredictConfig: () => mockPredictConfig,
 }));
 
 jest.mock('../contexts', () => {

--- a/app/components/UI/PredictNext/CONTEXT.md
+++ b/app/components/UI/PredictNext/CONTEXT.md
@@ -172,6 +172,14 @@ _Avoid_: Provider feature
 A dynamic availability projection for a Venue, such as available, degraded, or unavailable. It is distinct from static Venue Capabilities and from user-specific Account Readiness.
 _Avoid_: Capability, feature flag
 
+**Active Venue**:
+The Venue whose Predict experience is currently shown. The Active Venue may come from a regional default or a valid Venue Selection Preference.
+_Avoid_: Provider, selected provider, current market source
+
+**Venue Selection Preference**:
+A Predict User's explicit settings choice of Active Venue. It overrides regional defaulting only while that Venue remains selectable; it is not proof of eligibility or availability.
+_Avoid_: Provider toggle, eligibility, Venue Status
+
 **Remote Venue Adapter**:
 A mobile Venue Adapter implementation that translates canonical Predict calls into requests to a MetaMask Predict backend. The backend owns volatile Venue protocol logic and Venue credentials; mobile retains user intent, confirmation, and wallet signing.
 _Avoid_: New Venue, backend provider, opaque proxy
@@ -202,6 +210,9 @@ _Avoid_: New Venue, backend provider, opaque proxy
 - A crypto up/down Market compares asset prices against a Reference Price.
 - A Live Update refreshes the current understanding of an existing domain object; it is not a separate Event or Order.
 - A Service Event is not a prediction-market Event; always use the qualifier for internal messages.
+- Exactly one Venue is the Active Venue for a rendered Predict experience.
+- Without a valid Venue Selection Preference, US geolocation defaults the Active Venue to Kalshi and non-US geolocation defaults it to Polymarket.
+- A valid Venue Selection Preference takes precedence over regional defaulting, but does not override eligibility, Venue Status, or rollout controls.
 - A sports Event may have one Game, and a Game has participating Teams.
 - Extended sports child Events are represented as additional Markets grouped under one canonical parent Event, with child provenance preserved in metadata.
 
@@ -217,6 +228,7 @@ _Avoid_: New Venue, backend provider, opaque proxy
 - "target price" is legacy UI language for a crypto up/down Reference Price.
 - "event" is overloaded. Event is a product grouping of Markets; Service Event is an internal observation message.
 - "pending order" is ambiguous. Use Active Order for app workflow state and Resting Order for accepted order-book state.
+- "selected provider" conflates product choice with implementation language. Use Active Venue for the rendered Venue and Venue Selection Preference for an explicit settings choice.
 
 ## Venue Terminology Mapping
 

--- a/app/components/UI/PredictNext/components/EventCard/EventCard.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCard.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import {
+  Pressable as NativePressable,
+  type PressableProps,
+} from 'react-native';
+import {
+  Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import type { PredictEvent, PredictMarket, PredictOutcome } from '../../types';
+import { formatAskPrice } from './formatAskPrice';
+
+interface RootProps {
+  children: React.ReactNode;
+  testID?: string;
+}
+
+const Root = ({ children, testID }: RootProps) => (
+  <Box
+    twClassName="m-4 gap-3 rounded-xl border border-muted p-4"
+    testID={testID}
+  >
+    {children}
+  </Box>
+);
+
+const Pressable = ({ children, ...props }: PressableProps) => (
+  <NativePressable {...props}>{children}</NativePressable>
+);
+
+interface OutcomeProps {
+  event: PredictEvent;
+  market: PredictMarket;
+  outcome: PredictOutcome;
+  label?: string;
+  onOrder?: (
+    event: PredictEvent,
+    market: PredictMarket,
+    outcome: PredictOutcome,
+  ) => void;
+  testID?: string;
+}
+
+const Outcome = ({
+  event,
+  market,
+  outcome,
+  label = outcome.label,
+  onOrder,
+  testID,
+}: OutcomeProps) => {
+  const price = formatAskPrice(outcome.askPrice);
+  return (
+    <Button
+      testID={testID}
+      size={ButtonSize.Sm}
+      variant={ButtonVariant.Secondary}
+      isDisabled={!onOrder}
+      onPress={() => onOrder?.(event, market, outcome)}
+    >
+      {price ? `${label} ${price}` : label}
+    </Button>
+  );
+};
+
+const Title = ({ children }: { children: React.ReactNode }) => (
+  <Text variant={TextVariant.HeadingSm}>{children}</Text>
+);
+
+const Subtitle = ({ children }: { children: React.ReactNode }) => (
+  <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+    {children}
+  </Text>
+);
+
+export const EventCard = { Root, Pressable, Outcome, Title, Subtitle };

--- a/app/components/UI/PredictNext/components/EventCard/EventCardContent.test.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCardContent.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import type {
+  PredictDecimal,
+  PredictEntityId,
+  PredictEvent,
+  PredictMarket,
+  PredictOutcome,
+  PredictVenueId,
+} from '../../types';
+import { EventCardContent } from './EventCardContent';
+
+const outcome = (side: 'yes' | 'no', askPrice?: string): PredictOutcome => ({
+  id: `${side}-outcome` as PredictEntityId,
+  side,
+  label: side === 'yes' ? 'Yes' : 'No',
+  askPrice: askPrice as PredictDecimal | undefined,
+});
+
+const market = (id: string, askPrice = '0.42'): PredictMarket => ({
+  id: id as PredictEntityId,
+  question: `Question ${id}`,
+  status: 'open',
+  outcomes: [outcome('yes', askPrice), outcome('no', '0.58')],
+});
+
+const event = (markets: PredictMarket[]): PredictEvent => ({
+  id: 'event-1' as PredictEntityId,
+  venueId: 'kalshi' as PredictVenueId,
+  title: 'Election winner',
+  markets,
+});
+
+describe('EventCardContent', () => {
+  it('shows Yes and No controls for one Market', () => {
+    render(
+      <EventCardContent
+        event={event([market('market-1')])}
+        onPress={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Yes 42¢')).toBeOnTheScreen();
+    expect(screen.getByText('No 58¢')).toBeOnTheScreen();
+  });
+
+  it('shows three Yes rows and the hidden count for multiple Markets', () => {
+    render(
+      <EventCardContent
+        event={event([
+          market('market-1'),
+          market('market-2'),
+          market('market-3'),
+          market('market-4'),
+          market('market-5'),
+        ])}
+        onPress={jest.fn()}
+      />,
+    );
+
+    expect(screen.getAllByText('Yes 42¢')).toHaveLength(3);
+    expect(screen.getByLabelText('+2 more')).toBeOnTheScreen();
+    expect(screen.queryByText('Question market-4')).not.toBeOnTheScreen();
+  });
+
+  it('keeps Outcome controls disabled without an Order callback', () => {
+    render(
+      <EventCardContent
+        event={event([market('market-1')])}
+        onPress={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByTestId('predict-next-outcome-event-1-yes'),
+    ).toBeDisabled();
+  });
+
+  it('keeps card navigation independent from an Outcome action', () => {
+    const onPress = jest.fn();
+    const onOrder = jest.fn();
+    const value = event([market('market-1')]);
+    render(
+      <EventCardContent event={value} onPress={onPress} onOrder={onOrder} />,
+    );
+
+    fireEvent.press(
+      screen.getByTestId('predict-next-event-content-kalshi-event-1'),
+    );
+    fireEvent.press(screen.getByTestId('predict-next-outcome-event-1-yes'));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(onOrder).toHaveBeenCalledWith(
+      value,
+      value.markets[0],
+      value.markets[0].outcomes[0],
+    );
+  });
+});

--- a/app/components/UI/PredictNext/components/EventCard/EventCardContent.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCardContent.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import {
+  Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import type { PredictEvent, PredictMarket, PredictOutcome } from '../../types';
+import { EventCard } from './EventCard';
+
+interface EventCardContentProps {
+  event: PredictEvent;
+  onPress: () => void;
+  onOrder?: (
+    event: PredictEvent,
+    market: PredictMarket,
+    outcome: PredictOutcome,
+  ) => void;
+}
+
+const getOutcome = (market: PredictMarket, side: 'yes' | 'no') =>
+  market.outcomes.find((outcome) => outcome.side === side) as PredictOutcome;
+
+export const EventCardContent = ({
+  event,
+  onPress,
+  onOrder,
+}: EventCardContentProps) => {
+  const isSingleMarket = event.markets.length === 1;
+  const visibleMarkets = event.markets.slice(0, 3);
+  const hiddenCount = event.markets.length - visibleMarkets.length;
+
+  return (
+    <EventCard.Root testID={`predict-next-event-${event.venueId}-${event.id}`}>
+      <EventCard.Pressable
+        onPress={onPress}
+        testID={`predict-next-event-content-${event.venueId}-${event.id}`}
+      >
+        <EventCard.Title>{event.title}</EventCard.Title>
+        {event.subtitle ? (
+          <EventCard.Subtitle>{event.subtitle}</EventCard.Subtitle>
+        ) : null}
+      </EventCard.Pressable>
+
+      {isSingleMarket ? (
+        <Box twClassName="flex-row gap-2">
+          {(['yes', 'no'] as const).map((side) => (
+            <EventCard.Outcome
+              key={side}
+              event={event}
+              market={event.markets[0]}
+              outcome={getOutcome(event.markets[0], side)}
+              onOrder={onOrder}
+              testID={`predict-next-outcome-${event.id}-${side}`}
+            />
+          ))}
+        </Box>
+      ) : (
+        <Box twClassName="gap-2">
+          {visibleMarkets.map((market) => (
+            <Box
+              key={market.id}
+              twClassName="flex-row items-center justify-between gap-2"
+            >
+              <Text variant={TextVariant.BodyMd} twClassName="flex-1">
+                {market.question}
+              </Text>
+              <EventCard.Outcome
+                event={event}
+                market={market}
+                outcome={getOutcome(market, 'yes')}
+                label="Yes"
+                onOrder={onOrder}
+                testID={`predict-next-outcome-${event.id}-${market.id}-yes`}
+              />
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      {hiddenCount > 0 ? (
+        <Button
+          testID={`predict-next-event-more-${event.id}`}
+          accessibilityLabel={`+${hiddenCount} more`}
+          size={ButtonSize.Sm}
+          variant={ButtonVariant.Tertiary}
+          onPress={onPress}
+        >
+          +{hiddenCount} more
+        </Button>
+      ) : null}
+    </EventCard.Root>
+  );
+};

--- a/app/components/UI/PredictNext/components/EventCard/EventCardContent.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCardContent.tsx
@@ -89,7 +89,7 @@ export const EventCardContent = ({
           variant={ButtonVariant.Tertiary}
           onPress={onPress}
         >
-          +{hiddenCount} more
+          <Text>+{hiddenCount} more</Text>
         </Button>
       ) : null}
     </EventCard.Root>

--- a/app/components/UI/PredictNext/components/EventCard/formatAskPrice.test.ts
+++ b/app/components/UI/PredictNext/components/EventCard/formatAskPrice.test.ts
@@ -1,0 +1,22 @@
+import type { PredictDecimal } from '../../types';
+import { formatAskPrice } from './formatAskPrice';
+
+describe('formatAskPrice', () => {
+  it('formats an Ask Price as cents', () => {
+    const result = formatAskPrice('0.42' as PredictDecimal);
+
+    expect(result).toBe('42¢');
+  });
+
+  it('displays a zero Ask Price', () => {
+    const result = formatAskPrice('0' as PredictDecimal);
+
+    expect(result).toBe('0¢');
+  });
+
+  it('omits a missing Ask Price', () => {
+    const result = formatAskPrice();
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/app/components/UI/PredictNext/components/EventCard/formatAskPrice.ts
+++ b/app/components/UI/PredictNext/components/EventCard/formatAskPrice.ts
@@ -1,0 +1,6 @@
+import type { PredictDecimal } from '../../types';
+
+export const formatAskPrice = (
+  askPrice?: PredictDecimal,
+): string | undefined =>
+  askPrice === undefined ? undefined : `${Math.round(Number(askPrice) * 100)}¢`;

--- a/app/components/UI/PredictNext/config/predictConfig.test.ts
+++ b/app/components/UI/PredictNext/config/predictConfig.test.ts
@@ -1,0 +1,35 @@
+import { DEFAULT_PREDICT_CONFIG, parsePredictConfig } from './predictConfig';
+
+describe('parsePredictConfig', () => {
+  it('parses a complete config and removes unknown fields', () => {
+    const value = {
+      enabled: true,
+      venues: {
+        polymarket: { enabled: false },
+        kalshi: { enabled: true, ignored: 'value' },
+      },
+      venueSelection: { enabled: true },
+      ignored: 'value',
+    };
+
+    const result = parsePredictConfig(value);
+
+    expect(result).toEqual({
+      enabled: true,
+      venues: {
+        polymarket: { enabled: false },
+        kalshi: { enabled: true },
+      },
+      venueSelection: { enabled: true },
+    });
+  });
+
+  it.each([undefined, {}, { enabled: true }, { enabled: 'true' }])(
+    'returns the safe config for an unusable value',
+    (value) => {
+      const result = parsePredictConfig(value);
+
+      expect(result).toEqual(DEFAULT_PREDICT_CONFIG);
+    },
+  );
+});

--- a/app/components/UI/PredictNext/config/predictConfig.ts
+++ b/app/components/UI/PredictNext/config/predictConfig.ts
@@ -1,0 +1,37 @@
+import { boolean, mask, object, type Struct } from '@metamask/superstruct';
+
+export interface PredictConfig {
+  enabled: boolean;
+  venues: {
+    polymarket: { enabled: boolean };
+    kalshi: { enabled: boolean };
+  };
+  venueSelection: { enabled: boolean };
+}
+
+export const DEFAULT_PREDICT_CONFIG: PredictConfig = {
+  enabled: false,
+  venues: {
+    polymarket: { enabled: true },
+    kalshi: { enabled: false },
+  },
+  venueSelection: { enabled: false },
+};
+
+const enabledSchema = object({ enabled: boolean() });
+const predictConfigSchema = object({
+  enabled: boolean(),
+  venues: object({
+    polymarket: enabledSchema,
+    kalshi: enabledSchema,
+  }),
+  venueSelection: enabledSchema,
+});
+
+export const parsePredictConfig = (value: unknown): PredictConfig => {
+  try {
+    return mask(value, predictConfigSchema as Struct<PredictConfig>);
+  } catch {
+    return DEFAULT_PREDICT_CONFIG;
+  }
+};

--- a/app/components/UI/PredictNext/navigation/PredictNextStack.tsx
+++ b/app/components/UI/PredictNext/navigation/PredictNextStack.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { PredictHome } from '../views/PredictHome/PredictHome';
+import { PredictEventDetail } from '../views/PredictEventDetail/PredictEventDetail';
+import type { PredictNextStackParamList } from './types';
+import { PredictNextRoutes } from './routes';
+
+const Stack = createNativeStackNavigator<PredictNextStackParamList>();
+
+const PredictNextStack = () => (
+  <Stack.Navigator
+    initialRouteName={PredictNextRoutes.HOME}
+    screenOptions={{ headerShown: false }}
+  >
+    <Stack.Screen name={PredictNextRoutes.HOME} component={PredictHome} />
+    <Stack.Screen
+      name={PredictNextRoutes.EVENT_DETAIL}
+      component={PredictEventDetail}
+    />
+  </Stack.Navigator>
+);
+
+export default PredictNextStack;

--- a/app/components/UI/PredictNext/navigation/routes.ts
+++ b/app/components/UI/PredictNext/navigation/routes.ts
@@ -1,0 +1,4 @@
+export const PredictNextRoutes = {
+  HOME: 'PredictNextHome',
+  EVENT_DETAIL: 'PredictNextEventDetail',
+} as const;

--- a/app/components/UI/PredictNext/navigation/types.ts
+++ b/app/components/UI/PredictNext/navigation/types.ts
@@ -1,0 +1,14 @@
+import type { PredictEntityId, PredictVenueId } from '../types';
+
+export interface PredictNextEventDetailParams {
+  venueId: PredictVenueId;
+  eventId: PredictEntityId;
+  title: string;
+}
+
+// ParamListBase requires a type alias.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type PredictNextStackParamList = {
+  PredictNextHome: undefined;
+  PredictNextEventDetail: PredictNextEventDetailParams;
+};

--- a/app/components/UI/PredictNext/selectors/predictConfig.test.ts
+++ b/app/components/UI/PredictNext/selectors/predictConfig.test.ts
@@ -1,0 +1,50 @@
+import type { RootState } from '../../../../reducers';
+import { selectPredictConfig } from './predictConfig';
+
+const createState = (remote: unknown, override?: unknown): RootState =>
+  ({
+    settings: { basicFunctionalityEnabled: true },
+    engine: {
+      backgroundState: {
+        RemoteFeatureFlagController: {
+          remoteFeatureFlags: { predictConfig: remote },
+          localOverrides:
+            override === undefined ? {} : { predictConfig: override },
+        },
+      },
+    },
+  }) as unknown as RootState;
+
+const enabledConfig = {
+  enabled: true,
+  venues: {
+    polymarket: { enabled: false },
+    kalshi: { enabled: true },
+  },
+  venueSelection: { enabled: false },
+};
+
+describe('selectPredictConfig', () => {
+  it('reads a processed remote config', () => {
+    const state = createState(enabledConfig);
+
+    const result = selectPredictConfig(state);
+
+    expect(result).toEqual(enabledConfig);
+  });
+
+  it('prefers a local override', () => {
+    const override = {
+      ...enabledConfig,
+      venues: {
+        polymarket: { enabled: true },
+        kalshi: { enabled: false },
+      },
+    };
+    const state = createState(enabledConfig, override);
+
+    const result = selectPredictConfig(state);
+
+    expect(result).toEqual(override);
+  });
+});

--- a/app/components/UI/PredictNext/selectors/predictConfig.test.ts
+++ b/app/components/UI/PredictNext/selectors/predictConfig.test.ts
@@ -7,7 +7,9 @@ const createState = (remote: unknown, override?: unknown): RootState =>
     engine: {
       backgroundState: {
         RemoteFeatureFlagController: {
-          remoteFeatureFlags: { predictConfig: remote },
+          remoteFeatureFlags: {
+            predictConfig: override === undefined ? remote : override,
+          },
           localOverrides:
             override === undefined ? {} : { predictConfig: override },
         },

--- a/app/components/UI/PredictNext/selectors/predictConfig.ts
+++ b/app/components/UI/PredictNext/selectors/predictConfig.ts
@@ -1,0 +1,9 @@
+import { createSelector } from 'reselect';
+import { selectRemoteFeatureFlags } from '../../../../selectors/featureFlagController';
+import { parsePredictConfig } from '../config/predictConfig';
+
+/** Reads the controller's already version-resolved, override-aware value. */
+export const selectPredictConfig = createSelector(
+  selectRemoteFeatureFlags,
+  (flags) => parsePredictConfig(flags.predictConfig),
+);

--- a/app/components/UI/PredictNext/views/PredictEventDetail/PredictEventDetail.testIds.ts
+++ b/app/components/UI/PredictNext/views/PredictEventDetail/PredictEventDetail.testIds.ts
@@ -1,0 +1,4 @@
+export const PredictEventDetailTestIds = {
+  VIEW: 'predict-next-detail',
+  BACK: 'predict-next-detail-back',
+} as const;

--- a/app/components/UI/PredictNext/views/PredictEventDetail/PredictEventDetail.tsx
+++ b/app/components/UI/PredictNext/views/PredictEventDetail/PredictEventDetail.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {
+  useNavigation,
+  useRoute,
+  type RouteProp,
+} from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import {
+  Box,
+  Button,
+  ButtonVariant,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import type { PredictNextStackParamList } from '../../navigation/types';
+import { PredictNextRoutes } from '../../navigation/routes';
+
+export const PredictEventDetail = () => {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<PredictNextStackParamList>>();
+  const { title } =
+    useRoute<RouteProp<PredictNextStackParamList, 'PredictNextEventDetail'>>()
+      .params;
+  const handleBack = () =>
+    navigation.canGoBack()
+      ? navigation.goBack()
+      : navigation.navigate(PredictNextRoutes.HOME);
+
+  return (
+    <Box twClassName="flex-1 gap-6 p-4 pt-12" testID="predict-next-detail">
+      <Button
+        testID="predict-next-detail-back"
+        variant={ButtonVariant.Tertiary}
+        onPress={handleBack}
+      >
+        Back
+      </Button>
+      <Text variant={TextVariant.HeadingLg}>{title}</Text>
+    </Box>
+  );
+};

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.testIds.ts
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.testIds.ts
@@ -1,0 +1,13 @@
+export const PredictHomeTestIds = {
+  HOME: 'predict-next-home',
+  LOADING: 'predict-next-loading',
+  ERROR: 'predict-next-error',
+  EMPTY: 'predict-next-empty',
+  FEED: 'predict-next-event-feed',
+  FOOTER_LOADING: 'predict-next-footer-loading',
+  FOOTER_RETRY: 'predict-next-footer-retry',
+  event: (venueId: string, eventId: string) =>
+    `predict-next-event-${venueId}-${eventId}`,
+  eventContent: (venueId: string, eventId: string) =>
+    `predict-next-event-content-${venueId}-${eventId}`,
+} as const;

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.tsx
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.tsx
@@ -1,0 +1,124 @@
+import React, { useCallback, useMemo, useRef } from 'react';
+import { FlashList, type ListRenderItemInfo } from '@shopify/flash-list';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import {
+  Box,
+  Button,
+  ButtonVariant,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { useEventList } from '../../hooks/useEventList';
+import { useVenueStatus } from '../../hooks/useVenueStatus';
+import { KALSHI_VENUE_ID, type PredictEvent } from '../../types';
+import { EventCardContent } from '../../components/EventCard/EventCardContent';
+import type { PredictNextStackParamList } from '../../navigation/types';
+import { PredictNextRoutes } from '../../navigation/routes';
+
+const PAGE_SIZE = 20;
+
+export const PredictHome = () => {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<PredictNextStackParamList>>();
+  const statusQuery = useVenueStatus(KALSHI_VENUE_ID);
+  const eventsQuery = useEventList(KALSHI_VENUE_ID, { limit: PAGE_SIZE });
+  const endReached = useRef(false);
+  const events = useMemo(
+    () => eventsQuery.data?.pages.flatMap((page) => page.items) ?? [],
+    [eventsQuery.data],
+  );
+
+  const openEvent = useCallback(
+    (event: PredictEvent) =>
+      navigation.navigate(PredictNextRoutes.EVENT_DETAIL, {
+        venueId: event.venueId,
+        eventId: event.id,
+        title: event.title,
+      }),
+    [navigation],
+  );
+  const renderEvent = useCallback(
+    ({ item }: ListRenderItemInfo<PredictEvent>) => (
+      <EventCardContent event={item} onPress={() => openEvent(item)} />
+    ),
+    [openEvent],
+  );
+  const retryAll = () => {
+    statusQuery.refetch();
+    eventsQuery.refetch();
+  };
+  const loadNextPage = () => {
+    if (
+      !endReached.current &&
+      eventsQuery.hasNextPage &&
+      !eventsQuery.isFetchingNextPage
+    ) {
+      endReached.current = true;
+      eventsQuery.fetchNextPage().finally(() => {
+        endReached.current = false;
+      });
+    }
+  };
+
+  let blockingContent: React.ReactNode;
+  if (eventsQuery.isLoading) {
+    blockingContent = (
+      <Box testID="predict-next-loading" twClassName="gap-4 p-4">
+        <Box twClassName="h-32 rounded-xl bg-muted" />
+        <Box twClassName="h-32 rounded-xl bg-muted" />
+      </Box>
+    );
+  } else if (events.length === 0 && eventsQuery.isError) {
+    blockingContent = (
+      <Box testID="predict-next-error" twClassName="items-center gap-4 p-8">
+        <Text>Predictions could not be loaded.</Text>
+        <Button onPress={retryAll}>Retry</Button>
+      </Box>
+    );
+  } else if (events.length === 0) {
+    blockingContent = (
+      <Box testID="predict-next-empty" twClassName="items-center gap-4 p-8">
+        <Text>
+          {statusQuery.data?.status === 'unavailable'
+            ? 'Predictions are unavailable.'
+            : 'No predictions yet.'}
+        </Text>
+        {statusQuery.data?.status === 'unavailable' ? (
+          <Button onPress={retryAll}>Retry</Button>
+        ) : null}
+      </Box>
+    );
+  }
+
+  return (
+    <Box twClassName="flex-1 pt-12" testID="predict-next-home">
+      <Box twClassName="px-4 pb-2">
+        <Text variant={TextVariant.HeadingLg}>Predictions</Text>
+      </Box>
+      {blockingContent ?? (
+        <FlashList
+          testID="predict-next-event-feed"
+          data={events}
+          renderItem={renderEvent}
+          keyExtractor={(event) => `${event.venueId}:${event.id}`}
+          onEndReached={loadNextPage}
+          onEndReachedThreshold={0.5}
+          ListFooterComponent={
+            eventsQuery.isFetchingNextPage ? (
+              <Text testID="predict-next-footer-loading">Loading…</Text>
+            ) : eventsQuery.isError ? (
+              <Button
+                testID="predict-next-footer-retry"
+                variant={ButtonVariant.Tertiary}
+                onPress={() => eventsQuery.fetchNextPage()}
+              >
+                Retry
+              </Button>
+            ) : null
+          }
+        />
+      )}
+    </Box>
+  );
+};

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.tsx
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { FlashList, type ListRenderItemInfo } from '@shopify/flash-list';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -24,6 +24,7 @@ export const PredictHome = () => {
   const statusQuery = useVenueStatus(KALSHI_VENUE_ID);
   const eventsQuery = useEventList(KALSHI_VENUE_ID, { limit: PAGE_SIZE });
   const endReached = useRef(false);
+  const [paginationError, setPaginationError] = useState(false);
   const events = useMemo(
     () => eventsQuery.data?.pages.flatMap((page) => page.items) ?? [],
     [eventsQuery.data],
@@ -55,9 +56,13 @@ export const PredictHome = () => {
       !eventsQuery.isFetchingNextPage
     ) {
       endReached.current = true;
-      eventsQuery.fetchNextPage().finally(() => {
-        endReached.current = false;
-      });
+      eventsQuery
+        .fetchNextPage()
+        .then((result) => setPaginationError(result.isError))
+        .catch(() => setPaginationError(true))
+        .finally(() => {
+          endReached.current = false;
+        });
     }
   };
 
@@ -107,11 +112,11 @@ export const PredictHome = () => {
           ListFooterComponent={
             eventsQuery.isFetchingNextPage ? (
               <Text testID="predict-next-footer-loading">Loading…</Text>
-            ) : eventsQuery.isError ? (
+            ) : paginationError ? (
               <Button
                 testID="predict-next-footer-retry"
                 variant={ButtonVariant.Tertiary}
-                onPress={() => eventsQuery.fetchNextPage()}
+                onPress={loadNextPage}
               >
                 Retry
               </Button>

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.view.test.tsx
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.view.test.tsx
@@ -1,0 +1,180 @@
+import '../../../../../../tests/component-view/mocks';
+import { renderPredictNext } from '../../../../../../tests/component-view/renderers/predictNext';
+import Engine from '../../../../../core/Engine';
+import { fireEvent, waitFor, within } from '@testing-library/react-native';
+import { PredictHomeTestIds } from './PredictHome.testIds';
+import { PredictEventDetailTestIds } from '../PredictEventDetail/PredictEventDetail.testIds';
+import type { PredictEvent } from '../../types';
+
+const event: PredictEvent = {
+  venueId: 'kalshi' as PredictEvent['venueId'],
+  id: 'event-1' as PredictEvent['id'],
+  title: 'Who wins the election?',
+  subtitle: 'Election 2028',
+  markets: [
+    {
+      id: 'market-1' as PredictEvent['markets'][number]['id'],
+      question: 'Candidate A wins',
+      status: 'open',
+      outcomes: [
+        {
+          id: 'yes-1' as PredictEvent['markets'][number]['outcomes'][number]['id'],
+          side: 'yes',
+          label: 'Yes',
+          askPrice:
+            '0.42' as PredictEvent['markets'][number]['outcomes'][number]['askPrice'],
+        },
+        {
+          id: 'no-1' as PredictEvent['markets'][number]['outcomes'][number]['id'],
+          side: 'no',
+          label: 'No',
+          askPrice:
+            '0.58' as PredictEvent['markets'][number]['outcomes'][number]['askPrice'],
+        },
+      ],
+    },
+  ],
+};
+
+const messengerCall = Engine.controllerMessenger.call as unknown as jest.Mock;
+
+const configureQueries = (
+  events: readonly PredictEvent[] = [event],
+  status: 'available' | 'degraded' | 'unavailable' = 'available',
+) => {
+  messengerCall.mockImplementation((action: string) => {
+    if (action === 'PredictMarketDataService:getVenueStatus') {
+      return Promise.resolve({
+        venueId: 'kalshi',
+        status,
+        checkedAt: '2026-01-01T00:00:00Z',
+      });
+    }
+    if (action === 'PredictMarketDataService:getEvents') {
+      return Promise.resolve({ items: events });
+    }
+    return Promise.resolve(undefined);
+  });
+};
+
+describe('PredictHome', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    configureQueries();
+  });
+
+  it('loads complete Event data through the Engine messenger', async () => {
+    const view = renderPredictNext();
+
+    const card = await view.findByTestId(
+      PredictHomeTestIds.event('kalshi', 'event-1'),
+    );
+
+    expect(within(card).getByText('Who wins the election?')).toBeOnTheScreen();
+    expect(within(card).getByText('Election 2028')).toBeOnTheScreen();
+    expect(within(card).getByText('Yes 42¢')).toBeOnTheScreen();
+    expect(within(card).getByText('No 58¢')).toBeOnTheScreen();
+  });
+
+  it('opens detail and returns without fetching Event detail', async () => {
+    const view = renderPredictNext();
+    fireEvent.press(
+      await view.findByTestId(
+        PredictHomeTestIds.eventContent('kalshi', 'event-1'),
+      ),
+    );
+
+    expect(
+      await view.findByTestId(PredictEventDetailTestIds.VIEW),
+    ).toBeOnTheScreen();
+    expect(view.getByText('Who wins the election?')).toBeOnTheScreen();
+    expect(messengerCall).not.toHaveBeenCalledWith(
+      'PredictMarketDataService:getEvent',
+      expect.anything(),
+      expect.anything(),
+    );
+
+    fireEvent.press(view.getByTestId(PredictEventDetailTestIds.BACK));
+
+    await waitFor(() =>
+      expect(view.getByTestId(PredictHomeTestIds.HOME)).toBeOnTheScreen(),
+    );
+  });
+
+  it('shows an empty state after an empty Event response', async () => {
+    configureQueries([]);
+
+    const view = renderPredictNext();
+
+    expect(await view.findByText('No predictions yet.')).toBeOnTheScreen();
+  });
+
+  it('retries both queries after a first-page error', async () => {
+    configureQueries();
+    messengerCall.mockRejectedValueOnce(new Error('status failed'));
+    messengerCall.mockRejectedValueOnce(new Error('events failed'));
+    const view = renderPredictNext();
+    const retry = await view.findByText('Retry');
+    messengerCall.mockClear();
+
+    fireEvent.press(retry);
+
+    await waitFor(() => expect(messengerCall).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows unavailable when no Events can be displayed', async () => {
+    configureQueries([], 'unavailable');
+
+    const view = renderPredictNext();
+
+    expect(
+      await view.findByText('Predictions are unavailable.'),
+    ).toBeOnTheScreen();
+  });
+
+  it('preserves Events and retries a failed next page from the footer', async () => {
+    configureQueries();
+    let eventRequest = 0;
+    messengerCall.mockImplementation((action: string) => {
+      if (action === 'PredictMarketDataService:getVenueStatus') {
+        return Promise.resolve({
+          venueId: 'kalshi',
+          status: 'available',
+          checkedAt: '2026-01-01T00:00:00Z',
+        });
+      }
+      if (action === 'PredictMarketDataService:getEvents') {
+        eventRequest += 1;
+        if (eventRequest === 1) {
+          return Promise.resolve({ items: [event], nextCursor: 'next' });
+        }
+        if (eventRequest === 2) {
+          return Promise.reject(new Error('next page failed'));
+        }
+        return Promise.resolve({
+          items: [{ ...event, id: 'event-2', title: 'Second Event' }],
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+    const view = renderPredictNext();
+    const feed = await view.findByTestId(PredictHomeTestIds.FEED);
+
+    fireEvent(feed, 'onEndReached');
+    const retry = await view.findByTestId(PredictHomeTestIds.FOOTER_RETRY);
+
+    expect(view.getByText('Who wins the election?')).toBeOnTheScreen();
+    fireEvent.press(retry);
+    expect(await view.findByText('Second Event')).toBeOnTheScreen();
+  });
+
+  it('renders Events when Venue Status is unavailable', async () => {
+    configureQueries([event], 'unavailable');
+
+    const view = renderPredictNext();
+
+    expect(
+      await view.findByTestId(PredictHomeTestIds.event('kalshi', 'event-1')),
+    ).toBeOnTheScreen();
+  });
+});

--- a/tests/component-view/mocks.ts
+++ b/tests/component-view/mocks.ts
@@ -350,6 +350,7 @@ jest.mock('../../app/core/Engine', () => {
         setInputPrimaryDenomination: jest.fn(),
         trackUnifiedSwapBridgeEvent: jest.fn(),
       },
+      PredictNextController: {},
       PredictController: {
         getMarkets: jest.fn().mockResolvedValue({
           markets: [],
@@ -514,13 +515,9 @@ jest.mock('../../app/core/Engine', () => {
       },
     },
     controllerMessenger: {
-      subscribe() {
-        return undefined;
-      },
-      unsubscribe() {
-        return undefined;
-      },
-      call(action: string, ...args: unknown[]) {
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
+      call: jest.fn((action: string, ...args: unknown[]) => {
         // Non-EVM (e.g. TRON) amount validation calls SnapController:handleRequest with onAmountInput
         const params = args[0] as { request?: { method?: string } } | undefined;
         if (
@@ -530,7 +527,7 @@ jest.mock('../../app/core/Engine', () => {
           return Promise.resolve({ valid: true, errors: [] });
         }
         return Promise.resolve(undefined);
-      },
+      }),
     },
     getTotalEvmFiatAccountBalance() {
       return { balance: '0', fiatBalance: '0' };

--- a/tests/component-view/presets/predictNext.ts
+++ b/tests/component-view/presets/predictNext.ts
@@ -1,0 +1,22 @@
+import { createStateFixture } from '../stateFixture';
+
+export const initialStatePredictNext = () =>
+  createStateFixture()
+    .withMinimalAccounts()
+    .withMinimalMainnetNetwork()
+    .withMinimalKeyringController()
+    .withRemoteFeatureFlags({
+      predictTradingEnabled: {
+        enabled: true,
+        featureVersion: '1.0.0',
+        minimumVersion: '0.0.1',
+      },
+      predictConfig: {
+        enabled: true,
+        venues: {
+          polymarket: { enabled: false },
+          kalshi: { enabled: true },
+        },
+        venueSelection: { enabled: false },
+      },
+    });

--- a/tests/component-view/renderers/predictNext.ts
+++ b/tests/component-view/renderers/predictNext.ts
@@ -1,0 +1,20 @@
+import '../mocks';
+import React from 'react';
+import { renderScreenWithRoutes } from '../render';
+import { initialStatePredictNext } from '../presets/predictNext';
+import { PredictHome } from '../../../app/components/UI/PredictNext/views/PredictHome/PredictHome';
+import { PredictEventDetail } from '../../../app/components/UI/PredictNext/views/PredictEventDetail/PredictEventDetail';
+import { PredictNextRoutes } from '../../../app/components/UI/PredictNext/navigation/routes';
+
+export const renderPredictNext = () =>
+  renderScreenWithRoutes(
+    PredictHome as unknown as React.ComponentType,
+    { name: PredictNextRoutes.HOME },
+    [
+      {
+        name: PredictNextRoutes.EVENT_DETAIL,
+        Component: PredictEventDetail as unknown as React.ComponentType<object>,
+      },
+    ],
+    { state: initialStatePredictNext().build() },
+  );

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -4223,6 +4223,21 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  predictConfig: {
+    name: 'predictConfig',
+    type: FeatureFlagType.Remote,
+    inProd: false,
+    productionDefault: {
+      enabled: false,
+      venues: {
+        polymarket: { enabled: true },
+        kalshi: { enabled: false },
+      },
+      venueSelection: { enabled: false },
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
   predictFakOrders: {
     name: 'predictFakOrders',
     type: FeatureFlagType.Remote,


### PR DESCRIPTION
## **Description**

Adds the first user-visible PredictNext Kalshi browse surface and a temporary lane-selection boundary between legacy Polymarket and PredictNext.

The change atomically validates the override-aware `predictConfig`, safely defaults unusable configurations to legacy Polymarket, and routes generic Predict entry points to Kalshi only when Kalshi is the sole enabled Venue. Existing parameterized Predict routes and specific deep links remain on the legacy stack.

The new Kalshi lane includes a paginated FlashList Event feed, composable read-only Event cards, loading/empty/error/unavailable states, pagination retry, and a placeholder Event detail screen that uses a title snapshot without fetching detail data.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [PRED-1171](https://consensyssoftware.atlassian.net/browse/PRED-1171)

## **Manual testing steps**

```gherkin
Feature: PredictNext Kalshi browse lane

  Background:
    Given a non-production build has a working MM_PREDICT_API_URL
    And predictTradingEnabled is enabled
    And predictConfig enables Kalshi and disables Polymarket

  Scenario: user opens generic Predict
    When the user opens a generic Predict entry point
    Then the Predictions screen displays canonical Kalshi Events
    And Venue Status and Event list requests start independently

  Scenario: user views Event cards
    Given an Event contains one Market
    Then Yes and No Outcome controls display available Ask Prices in cents
    And the Outcome controls remain disabled

  Scenario: user views a multi-Market Event
    Given an Event contains more than three Markets
    Then at most three Market rows are displayed using each Market's Yes Outcome
    And the +N more count equals the number of hidden Markets

  Scenario: user opens Event detail
    When the user presses Event card content
    Then placeholder Event detail opens with the Event title snapshot
    And no Event detail request is made
    When the user presses Back
    Then the user returns to the Event feed

  Scenario: pagination fails
    Given the first Event page has loaded
    When the next-page request fails
    Then loaded Events remain visible
    And a footer Retry action is displayed
    When the user presses Retry after the endpoint recovers
    Then the next page is appended

  Scenario: the Kalshi Venue is unavailable but Events are usable
    Given Venue Status is unavailable
    And the Event list returns usable Events
    Then the usable Events remain visible

  Scenario: configuration is unusable
    Given predictConfig is missing, partial, malformed, disabled, or enables both Venues
    When the user opens Predict
    Then the legacy Polymarket experience is displayed

  Scenario: a legacy-specific Predict link is opened
    Given Kalshi is the sole enabled Venue
    When the user opens a parameterized feed, search, or Market detail deep link
    Then the legacy Polymarket experience handles the route
```

Automated verification completed:

- `yarn lint:tsc`
- focused ESLint and Prettier checks
- 25 focused unit tests
- 7 PredictNext component-view tests
- 18 existing Predict route tests
- The full unit suite was started but did not complete within the 10-minute local timeout.

## **Screenshots/Recordings**

### **Before**

N/A — no manual capture is attached to this draft PR.

### **After**

N/A — no manual capture is attached to this draft PR. Screenshots can be added after device QA.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Considered: device testing remains to be completed before this draft is marked ready for review.
- [ ] I've tested with a power user scenario
  - Considered: not applicable to this read-only public Event feed slice; pagination and stable FlashList keys are covered.
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - Considered: no new instrumentation was required for this initial read-only slice.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[PRED-1171]: https://consensyssoftware.atlassian.net/browse/PRED-1171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared Predict navigation entry and feature-flag routing, so mis-resolution could send users to the wrong stack. Risk is tempered by safe Polymarket defaults and a read-only Kalshi browse slice.
> 
> **Overview**
> Adds a **temporary lane boundary** at the shared Predict entry so generic routes can switch between legacy Polymarket and the new PredictNext Kalshi stack based on override-aware `predictConfig`. Kalshi is selected only when it is the sole enabled Venue; parameterized feeds, search, and specific deep links stay on Polymarket, and unusable configs safely fall back to legacy.
> 
> Ships the first **Kalshi browse surface**: a paginated Event feed with loading/empty/error/unavailable states, composable read-only Event cards (Yes/No ask prices, multi-market truncation), and a placeholder Event detail that uses a title snapshot without fetching detail data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef252276cc8ee4ecc4ba2384e7720e9ebdf29871. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->