### PR TITLE
fix(social): harden feed row value formatting and sub-header guards

### DIFF
--- a/app/components/Views/SocialLeaderboard/FeedView/utils/mapFeedItem.test.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/utils/mapFeedItem.test.ts
@@ -435,19 +435,103 @@ describe('mapFeedItem', () => {
     expect(result?.hasPnlData).toBe(false);
   });
 
-  it('leaves value and PnL labels empty when open-position fields are missing', () => {
+  it('omits sub-header size when usdCost is missing', () => {
     const result = mapFeedItem(
       mockSpotFeedItem({
-        currentValueUSD: null,
-        pnlPercent: null,
-        pnlValueUsd: null,
+        trades: [
+          {
+            direction: 'buy',
+            intent: 'enter',
+            tokenAmount: 1_000_000,
+            usdCost: undefined as unknown as number,
+            timestamp: 1_700_000_000,
+            transactionHash: '0xhash',
+            classification: 'spot',
+          },
+        ],
       }),
     );
 
-    expect(result?.valueLabel).toBe('');
-    expect(result?.pnlLabel).toBe('');
-    expect(result?.hasValueData).toBe(false);
-    expect(result?.hasPnlData).toBe(false);
+    expect(result?.subHeader).toEqual({ sizeLabel: '' });
+  });
+
+  it('omits sub-header size when usdCost is zero', () => {
+    const result = mapFeedItem(
+      mockSpotFeedItem({
+        trades: [
+          {
+            direction: 'buy',
+            intent: 'enter',
+            tokenAmount: 1_000_000,
+            usdCost: 0,
+            timestamp: 1_700_000_000,
+            transactionHash: '0xhash',
+            classification: 'spot',
+          },
+        ],
+      }),
+    );
+
+    expect(result?.subHeader).toEqual({ sizeLabel: '' });
+  });
+
+  it('formats sub-cent open position value without collapsing to $0.00', () => {
+    const result = mapFeedItem(
+      mockPerpFeedItem({
+        currentValueUSD: 0.002759,
+        pnlValueUsd: 0.001,
+        pnlPercent: 56.7,
+        realizedPnl: 0,
+        marginUsd: 0.002,
+        positionAmount: 1_000,
+        perpPositionType: 'long',
+        perpLeverage: 10,
+        trades: [
+          {
+            direction: 'buy',
+            intent: 'enter',
+            tokenAmount: 1_000,
+            usdCost: 4_000,
+            timestamp: 1_700_000_000,
+            transactionHash: '0xhash',
+            classification: 'perp',
+            perpPositionType: 'long',
+            perpLeverage: 10,
+          },
+        ],
+        timestamp: 1_700_000_000,
+      }),
+    );
+
+    expect(result?.action).toBe('opened');
+    expect(result?.valueLabel).toBe('$0.002759');
+  });
+
+  it('formats sub-cent realized PnL on closed rows', () => {
+    const result = mapFeedItem(
+      mockSpotFeedItem({
+        currentValueUSD: 0,
+        pnlValueUsd: 0.002759,
+        pnlPercent: 12,
+        realizedPnl: 0.002759,
+        positionAmount: 0,
+        soldUsd: 100,
+        trades: [
+          {
+            direction: 'sell',
+            intent: 'exit',
+            tokenAmount: 1000,
+            usdCost: 100,
+            timestamp: 1_700_000_000,
+            transactionHash: '0xhash',
+            classification: 'spot',
+          },
+        ],
+      }),
+    );
+
+    expect(result?.action).toBe('sold');
+    expect(result?.valueLabel).toBe('+$0.002759');
   });
 
   it('hides value and PnL for an open perp feed row without mark-to-market fields', () => {

--- a/app/components/Views/SocialLeaderboard/FeedView/utils/mapFeedItem.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/utils/mapFeedItem.ts
@@ -13,10 +13,10 @@ import {
 import { chainNameToId } from '../../utils/chainMapping';
 import {
   formatAbbreviatedUsd,
+  formatFeedValueUsd,
   formatPercent,
-  formatSignedUsd,
+  formatSignedFeedValueUsd,
   formatTradeUnitPrice,
-  formatUsd,
 } from '../../utils/formatters';
 import { tradeTimestampToMs } from '../../utils/tradeTimestamp';
 import type { PositionTokenAvatarData } from '../../components/PositionTokenAvatar';
@@ -106,7 +106,7 @@ function buildSubHeader(
   trade: Trade | undefined,
   isSpot: boolean,
 ): FeedSubHeader {
-  if (!trade) {
+  if (!trade || !isPresentNumber(trade.usdCost) || trade.usdCost === 0) {
     return { sizeLabel: '' };
   }
 
@@ -176,10 +176,10 @@ function resolveValueLabel(
     return '';
   }
   if (isClosed && isPresentNumber(pnlValue)) {
-    return formatSignedUsd(pnlValue);
+    return formatSignedFeedValueUsd(pnlValue);
   }
   if (isPresentNumber(currentValueUSD)) {
-    return formatUsd(currentValueUSD);
+    return formatFeedValueUsd(currentValueUSD);
   }
   return '';
 }

--- a/app/components/Views/SocialLeaderboard/utils/formatters.test.ts
+++ b/app/components/Views/SocialLeaderboard/utils/formatters.test.ts
@@ -1,6 +1,8 @@
 import {
   formatUsd,
   formatTradeUnitPrice,
+  formatFeedValueUsd,
+  formatSignedFeedValueUsd,
   formatSignedUsd,
   formatSignedAbbreviatedUsd,
   formatSignedFullUsdNoDecimals,
@@ -47,6 +49,36 @@ describe('formatTradeUnitPrice', () => {
   it('returns an em dash for nullish values', () => {
     expect(formatTradeUnitPrice(null)).toBe('\u2014');
     expect(formatTradeUnitPrice(undefined)).toBe('\u2014');
+  });
+});
+
+describe('formatFeedValueUsd', () => {
+  it('formats dollar-scale open position values with two decimals', () => {
+    expect(formatFeedValueUsd(92_234.5)).toBe('$92,234.50');
+  });
+
+  it('formats sub-cent open position values with tiered precision', () => {
+    expect(formatFeedValueUsd(0.002759)).toBe('$0.002759');
+  });
+
+  it('returns an em dash for nullish values', () => {
+    expect(formatFeedValueUsd(null)).toBe('\u2014');
+    expect(formatFeedValueUsd(undefined)).toBe('\u2014');
+  });
+});
+
+describe('formatSignedFeedValueUsd', () => {
+  it('formats dollar-scale realized PnL with two decimals', () => {
+    expect(formatSignedFeedValueUsd(4_659)).toBe('+$4,659.00');
+  });
+
+  it('formats sub-cent realized PnL with tiered precision', () => {
+    expect(formatSignedFeedValueUsd(0.002759)).toBe('+$0.002759');
+    expect(formatSignedFeedValueUsd(-0.002759)).toBe('-$0.002759');
+  });
+
+  it('delegates to formatSignedUsd for values at or above one cent', () => {
+    expect(formatSignedFeedValueUsd(0.12)).toBe(formatSignedUsd(0.12));
   });
 });
 

--- a/app/components/Views/SocialLeaderboard/utils/formatters.ts
+++ b/app/components/Views/SocialLeaderboard/utils/formatters.ts
@@ -15,6 +15,12 @@ import { tradeTimestampToMs } from './tradeTimestamp';
 /** Placeholder rendered wherever a numeric value is unavailable. */
 export const EM_DASH = '\u2014';
 
+/** Values below this collapse to `$0.00` under the default two-decimal fiat formatter. */
+const SUB_CENT_USD_THRESHOLD = 0.01;
+
+const needsSubCentUsdPrecision = (value: number): boolean =>
+  value !== 0 && Math.abs(value) < SUB_CENT_USD_THRESHOLD;
+
 /**
  * USD for social leaderboard rows/cards: match perps-style fiat (always two
  * fractional digits for whole dollars). Rewards `formatUsd`/`formatFiat` omits
@@ -45,6 +51,34 @@ export function formatSignedUsd(value: number | null | undefined): string {
   if (value === 0) return formatPerpsFiat(0, { stripTrailingZeros: false });
   const sign = value > 0 ? '+' : '-';
   return sign + formatPerpsFiat(Math.abs(value), { stripTrailingZeros: false });
+}
+
+/**
+ * Open-position value for feed rows. Uses tiered precision for sub-cent totals
+ * so tiny mark-to-market values don't collapse to `$0.00`.
+ */
+export function formatFeedValueUsd(value: number | null | undefined): string {
+  if (value == null) return EM_DASH;
+  if (needsSubCentUsdPrecision(value)) {
+    return formatTradeUnitPrice(Math.abs(value));
+  }
+  return formatUsd(value);
+}
+
+/**
+ * Signed PnL for feed rows. Mirrors {@link formatSignedUsd} but preserves
+ * sub-cent magnitudes the same way as {@link formatFeedValueUsd}.
+ */
+export function formatSignedFeedValueUsd(
+  value: number | null | undefined,
+): string {
+  if (value == null) return EM_DASH;
+  if (value === 0) return formatPerpsFiat(0, { stripTrailingZeros: false });
+  if (needsSubCentUsdPrecision(value)) {
+    const sign = value > 0 ? '+' : '-';
+    return sign + formatTradeUnitPrice(Math.abs(value));
+  }
+  return formatSignedUsd(value);
 }
 
 /**


### PR DESCRIPTION
## **Description**

Follow-up to #34601 (perp entry price in feed sub-headers). This PR audits the remaining `mapFeedItem` formatting paths and hardens edge cases:

- **Sub-cent position values** — open rows used `formatUsd` on `currentValueUSD`, which collapses tiny mark-to-market totals to `$0.00`. Closed rows had the same issue for sub-cent realized PnL via `formatSignedUsd`.
- **Invalid trade size** — `buildSubHeader` now skips the size label when `usdCost` is missing, non-finite, or zero instead of formatting `NaN`.

New helpers `formatFeedValueUsd` and `formatSignedFeedValueUsd` apply `PRICE_RANGES_UNIVERSAL` tiered precision only below the $0.01 threshold; dollar-scale values keep the existing two-decimal display.

## **Changelog**

CHANGELOG entry: Fixed sub-cent position values and realized PnL collapsing to $0.00 on some Follow trading feed rows

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Follow trading feed row value formatting

  Scenario: Open perp row shows sub-cent position value
    Given I am on the Top traders Feed tab with activity loaded
    When I view an open perp row for a sub-cent asset with a tiny mark-to-market value
    Then the value column shows the precise amount instead of $0.00

  Scenario: Closed row shows sub-cent realized PnL
    Given I am on the Top traders Feed tab
    When I view a closed spot or perp row with sub-cent realized PnL
    Then the value column shows a signed precise amount instead of +$0.00

  Scenario: Row with missing trade size omits sub-header size
    Given a feed item arrives without a usable usdCost on the triggering trade
    When the row renders
    Then the sub-header does not show a malformed or NaN size label
```

## **Screenshots/Recordings**

N/A — formatting-only change; best verified against feed rows with sub-cent assets (e.g. PUMP) or by comparing value column before/after on QA data.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.