### PR TITLE
fix(e2e): preserve smoke selection for shared page objects

### DIFF
--- a/tests/tools/e2e-ai-analyzer/modes/select-tags/handlers.ts
+++ b/tests/tools/e2e-ai-analyzer/modes/select-tags/handlers.ts
@@ -399,8 +399,7 @@ const HARD_RULES: HardRule[] = [
       // impact is considered. Documentation, assets, locale files, and
       // performance-only workflow changes do not affect smoke-tag reachability.
       const hasNonIgnorableNonTestChanges = changedFiles.some(
-        (f) =>
-          !f.startsWith('tests/') && !isIgnorableSharedInfraCompanion(f),
+        (f) => !f.startsWith('tests/') && !isIgnorableSharedInfraCompanion(f),
       );
       if (hasNonIgnorableNonTestChanges) return null;
 

--- a/tests/tools/e2e-ai-analyzer/modes/select-tags/handlers.ts
+++ b/tests/tools/e2e-ai-analyzer/modes/select-tags/handlers.ts
@@ -19,6 +19,7 @@ import {
   getFrameworkInfraChanges,
   getChangedSpecFiles,
   getChangedSharedInfraFiles,
+  isIgnorableSharedInfraCompanion,
   isSpecFile,
   SPEC_PATH_PREFIXES,
 } from './test-infrastructure-paths';
@@ -394,25 +395,14 @@ const HARD_RULES: HardRule[] = [
       const infraFiles = getChangedSharedInfraFiles(changedFiles);
       if (infraFiles.length === 0) return null;
 
-      // Paths that don't affect E2E test selection — CI, docs, scripts, config, etc.
-      // Changes to these alongside shared test infra should not prevent the hard rule.
-      const ignorablePathPrefixes = [
-        '.github/',
-        'scripts/',
-        'docs/',
-        '.changeset/',
-        '.yarn/',
-        '.vscode/',
-        '.cursor/',
-      ];
-
-      // Only bail to AI if there are actual app code changes (not just CI/docs/scripts)
-      const hasAppCodeChanges = changedFiles.some(
+      // App changes and E2E-relevant workflow changes go to AI so their wider
+      // impact is considered. Documentation, assets, locale files, and
+      // performance-only workflow changes do not affect smoke-tag reachability.
+      const hasNonIgnorableNonTestChanges = changedFiles.some(
         (f) =>
-          !f.startsWith('tests/') &&
-          !ignorablePathPrefixes.some((prefix) => f.startsWith(prefix)),
+          !f.startsWith('tests/') && !isIgnorableSharedInfraCompanion(f),
       );
-      if (hasAppCodeChanges) return null;
+      if (hasNonIgnorableNonTestChanges) return null;
 
       const validTags = new Set(SELECT_TAGS_CONFIG.map((c) => c.tag));
 

--- a/tests/tools/e2e-ai-analyzer/modes/select-tags/select-tags-hard-rules.test.ts
+++ b/tests/tools/e2e-ai-analyzer/modes/select-tags/select-tags-hard-rules.test.ts
@@ -92,6 +92,21 @@ describe('checkHardRules', () => {
     expect(result?.selectedTags).toContain('SmokeAccounts');
   });
 
+  it('keeps targeted smoke tags when a page object changes with a performance workflow', () => {
+    const changedFiles = [
+      '.github/workflows/performance-test-runner.yml',
+      'tests/page-objects/Onboarding/ImportWalletView.ts',
+      'tests/performance/onboarding/helpers/seedlessOnboardingTimers.ts',
+      'tests/performance/onboarding/seedless-apple-onboarding.spec.ts',
+    ];
+
+    const result = checkHardRules(changedFiles, context);
+
+    expect(result).not.toBeNull();
+    expect(result?.selectedTags).toContain('SmokeWalletPlatform');
+    expect(result?.reasoning).toContain('ImportWalletView.ts');
+  });
+
   it('runs all E2E tags when locales/languages/en.json changes', () => {
     const changedFiles = ['locales/languages/en.json'];
 

--- a/tests/tools/e2e-ai-analyzer/modes/select-tags/test-infrastructure-paths.ts
+++ b/tests/tools/e2e-ai-analyzer/modes/select-tags/test-infrastructure-paths.ts
@@ -97,6 +97,20 @@ const SHARED_TEST_INFRA_PREFIXES = [
 ] as const;
 
 /**
+ * Non-test files that do not change the smoke-test dependency graph or app
+ * behavior. These may accompany a shared-test-infrastructure change without
+ * preventing targeted tag extraction.
+ */
+const IGNORABLE_SHARED_INFRA_COMPANION_PATTERNS = [
+  /^docs\//,
+  /\.(md|mdx|txt)$/,
+  /\.(svg|png)$/,
+  /^locales\/languages\/.*\.json$/,
+  /^\.github\/workflows\/performance-test-runner\.yml$/,
+  /^\.github\/workflows\/run-performance-.*\.yml$/,
+] as const;
+
+/**
  * Returns changed files that are shared test infrastructure (flows, page objects,
  * selectors, locators) — but not spec files themselves.
  */
@@ -108,6 +122,18 @@ export function getChangedSharedInfraFiles(changedFiles: string[]): string[] {
         SHARED_TEST_INFRA_PREFIXES.some((prefix) => f.startsWith(prefix)) &&
         !SPEC_FILE_PATTERN.test(f),
     );
+}
+
+/**
+ * Returns whether a non-test file can safely accompany a shared test
+ * infrastructure change without widening or invalidating targeted smoke-tag
+ * selection.
+ */
+export function isIgnorableSharedInfraCompanion(file: string): boolean {
+  const normalizedFile = normalizeChangedFilePath(file);
+  return IGNORABLE_SHARED_INFRA_COMPANION_PATTERNS.some((pattern) =>
+    pattern.test(normalizedFile),
+  );
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Improve Smart E2E hard-rule selection for shared Page Objects and flows when a PR also changes an ignorable performance workflow file. The selector now preserves transitive smoke-spec tag extraction for changes like `ImportWalletView.ts` plus `performance-test-runner.yml`, while still deferring to AI analysis when app code or E2E-relevant workflow files are changed.

A regression test reproduces the MMQA performance PR file combination and verifies that `SmokeWalletPlatform` is selected through the Page Object → flow → smoke spec dependency chain.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: MMQA-fix-performance-issues

## **Manual testing steps**

```gherkin
Feature: Smart E2E shared infrastructure selection

  Scenario: Select smoke tags for a Page Object change with performance workflow changes
    Given the Smart E2E hard-rule test suite is available
    When the shared Page Object regression test is run with the performance workflow file in the changed-file set
    Then the transitive smoke spec tags include SmokeWalletPlatform
    And the selector does not fall through to AI selection
```

Validation commands:
- `yarn jest tests/tools/e2e-ai-analyzer/modes/select-tags/select-tags-hard-rules.test.ts --runInBand`
- `yarn prettier --check tests/tools/e2e-ai-analyzer/modes/select-tags/handlers.ts tests/tools/e2e-ai-analyzer/modes/select-tags/test-infrastructure-paths.ts tests/tools/e2e-ai-analyzer/modes/select-tags/select-tags-hard-rules.test.ts`
- `git diff --check`

## **Screenshots/Recordings**

### **Before**

N/A — CI selector logic and tests only.

### **After**

N/A — CI selector logic and tests only.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented the code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've assessed Android execution; this change only affects CI test selection logic.
- [x] I've assessed the power-user scenario; not applicable to selector logic.
- [x] I've assessed Sentry tracing; not applicable because no production code changed.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance%20Guide%20for%20Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3562b168-5233-4c6f-a87c-eb937ff384cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3562b168-5233-4c6f-a87c-eb937ff384cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

