### PR TITLE
feat(analytics): suffix Mixpanel app_version_string by build environment (MCRM-129)

### DIFF
--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.test.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.test.ts
@@ -42,8 +42,12 @@ jest.mock('../../../../util/test/utils', () => ({
 }));
 
 jest.mock('../../../Braze', () => ({
-  getBrazePlugin: jest.fn().mockReturnValue({}),
+  getBrazePlugin: jest.fn().mockReturnValue({ name: 'braze' }),
 }));
+
+jest.mock('../../../../util/analytics/appVersionSegmentPlugin', () =>
+  jest.fn().mockImplementation(() => ({ name: 'appVersion' })),
+);
 
 jest.mock('../../../../util/analytics/analytics', () => ({
   analytics: {
@@ -183,8 +187,13 @@ describe('analyticsControllerInit', () => {
   describe('platform adapter', () => {
     it('uses standard platform adapter when not in E2E', () => {
       const { createPlatformAdapter } = jest.requireMock('./platform-adapter');
+
       analyticsControllerInit(getInitRequestMock());
-      expect(createPlatformAdapter).toHaveBeenCalled();
+
+      expect(createPlatformAdapter).toHaveBeenCalledWith([
+        { name: 'braze' },
+        { name: 'appVersion' },
+      ]);
     });
 
     it('uses E2E platform adapter when hasTestOverrides is true', () => {

--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
@@ -69,10 +69,7 @@ export const analyticsControllerInit: MessengerClientInitFunction<
 
   const platformAdapter = hasTestOverrides
     ? createE2EPlatformAdapter()
-    : createPlatformAdapter([
-        getBrazePlugin(),
-        new AppVersionSegmentPlugin(),
-      ]);
+    : createPlatformAdapter([getBrazePlugin(), new AppVersionSegmentPlugin()]);
 
   const controller = new AnalyticsController({
     messenger: controllerMessenger,

--- a/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
+++ b/app/core/Engine/controllers/analytics-controller/analytics-controller-init.ts
@@ -14,6 +14,7 @@ import type { AccountsControllerState } from '@metamask/accounts-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { KeyringAccountEntropyTypeOption } from '@metamask/keyring-api';
 import { analytics } from '../../../../util/analytics/analytics';
+import AppVersionSegmentPlugin from '../../../../util/analytics/appVersionSegmentPlugin';
 import { getAccountCompositionTraits } from '../../../../util/metrics/UserSettingsAnalyticsMetaData/generateUserProfileAnalyticsMetaData';
 import Logger from '../../../../util/Logger';
 
@@ -68,7 +69,10 @@ export const analyticsControllerInit: MessengerClientInitFunction<
 
   const platformAdapter = hasTestOverrides
     ? createE2EPlatformAdapter()
-    : createPlatformAdapter([getBrazePlugin()]);
+    : createPlatformAdapter([
+        getBrazePlugin(),
+        new AppVersionSegmentPlugin(),
+      ]);
 
   const controller = new AnalyticsController({
     messenger: controllerMessenger,

--- a/app/util/analytics/appVersionSegmentPlugin.test.ts
+++ b/app/util/analytics/appVersionSegmentPlugin.test.ts
@@ -1,0 +1,103 @@
+import AppVersionSegmentPlugin from './appVersionSegmentPlugin';
+import getAnalyticsAppVersion from '../metrics/getAnalyticsAppVersion';
+import {
+  PluginType,
+  EventType,
+  TrackEventType,
+  IdentifyEventType,
+  SegmentClient,
+} from '@segment/analytics-react-native';
+
+jest.mock('../metrics/getAnalyticsAppVersion', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockGetAnalyticsAppVersion =
+  getAnalyticsAppVersion as jest.MockedFunction<typeof getAnalyticsAppVersion>;
+
+class MockSegmentClient {
+  userInfo = {
+    set: jest.fn(),
+    get: jest.fn(),
+    onChange: jest.fn(),
+  };
+}
+
+const mockAnalytics = new MockSegmentClient() as unknown as SegmentClient;
+
+describe('AppVersionSegmentPlugin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAnalyticsAppVersion.mockReturnValue('8.6.0-release-candidate');
+  });
+
+  it('is an enrichment plugin', () => {
+    const plugin = new AppVersionSegmentPlugin();
+
+    expect(plugin.type).toBe(PluginType.enrichment);
+  });
+
+  it('sets context.app.version on track events', async () => {
+    const trackEvent: TrackEventType = {
+      event: 'event_name',
+      type: EventType.TrackEvent,
+      context: {
+        app: {
+          name: 'MetaMask',
+          version: '8.6.0',
+        },
+        locale: 'en-US',
+      },
+    };
+    const plugin = new AppVersionSegmentPlugin();
+    plugin.configure(mockAnalytics);
+
+    const processedEvent = await plugin.execute(trackEvent);
+
+    expect(processedEvent.context).toStrictEqual({
+      app: {
+        name: 'MetaMask',
+        version: '8.6.0-release-candidate',
+      },
+      locale: 'en-US',
+    });
+    expect(mockGetAnalyticsAppVersion).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets context.app.version on identify events', async () => {
+    const identifyEvent: IdentifyEventType = {
+      type: EventType.IdentifyEvent,
+      context: {
+        app: {
+          version: '8.6.0',
+        },
+      },
+    };
+    const plugin = new AppVersionSegmentPlugin();
+    plugin.configure(mockAnalytics);
+
+    const processedEvent = await plugin.execute(identifyEvent);
+
+    expect(processedEvent.context?.app?.version).toBe(
+      '8.6.0-release-candidate',
+    );
+  });
+
+  it('creates context.app when context is missing', async () => {
+    const trackEvent: TrackEventType = {
+      event: 'event_name',
+      type: EventType.TrackEvent,
+    };
+    const plugin = new AppVersionSegmentPlugin();
+    plugin.configure(mockAnalytics);
+
+    const processedEvent = await plugin.execute(trackEvent);
+
+    expect(processedEvent.context).toStrictEqual({
+      app: {
+        version: '8.6.0-release-candidate',
+      },
+    });
+  });
+});

--- a/app/util/analytics/appVersionSegmentPlugin.ts
+++ b/app/util/analytics/appVersionSegmentPlugin.ts
@@ -1,0 +1,45 @@
+import {
+  Plugin,
+  PluginType,
+  SegmentClient,
+  SegmentEvent,
+} from '@segment/analytics-react-native';
+import getAnalyticsAppVersion from '../metrics/getAnalyticsAppVersion';
+
+/**
+ * Enrichment plugin that overrides Segment `context.app.version` with the
+ * analytics App Version (environment-suffixed for non-production builds).
+ *
+ * Maps to Mixpanel `app_version_string`. Does not change native bundle version.
+ *
+ * @example
+ * createPlatformAdapter([getBrazePlugin(), new AppVersionSegmentPlugin()]);
+ */
+class AppVersionSegmentPlugin extends Plugin {
+  type = PluginType.enrichment;
+
+  configure(analytics: SegmentClient) {
+    super.configure(analytics);
+  }
+
+  async execute(event: SegmentEvent): Promise<SegmentEvent> {
+    const analyticsAppVersion = getAnalyticsAppVersion();
+    const existingContext = event.context ?? {};
+    const existingApp =
+      existingContext.app && typeof existingContext.app === 'object'
+        ? existingContext.app
+        : {};
+
+    event.context = {
+      ...existingContext,
+      app: {
+        ...existingApp,
+        version: analyticsAppVersion,
+      },
+    };
+
+    return event;
+  }
+}
+
+export default AppVersionSegmentPlugin;

--- a/app/util/metrics/DeviceAnalyticsMetaData/generateDeviceAnalyticsMetaData.ts
+++ b/app/util/metrics/DeviceAnalyticsMetaData/generateDeviceAnalyticsMetaData.ts
@@ -1,6 +1,7 @@
 import { Platform } from 'react-native';
-import { getBuildNumber, getVersion, getBrand } from 'react-native-device-info';
+import { getBuildNumber, getBrand } from 'react-native-device-info';
 import type { AnalyticsUserTraits } from '@metamask/analytics-controller';
+import getAnalyticsAppVersion from '../getAnalyticsAppVersion';
 
 /**
  * Generate device analytics meta data
@@ -9,7 +10,7 @@ import type { AnalyticsUserTraits } from '@metamask/analytics-controller';
 const generateDeviceAnalyticsMetaData = (): AnalyticsUserTraits => ({
   platform: Platform.OS,
   currentBuildNumber: getBuildNumber(),
-  applicationVersion: getVersion(),
+  applicationVersion: getAnalyticsAppVersion(),
   operatingSystemVersion: Platform.Version.toString(),
   deviceBrand: getBrand(),
 });

--- a/app/util/metrics/getAnalyticsAppVersion.test.ts
+++ b/app/util/metrics/getAnalyticsAppVersion.test.ts
@@ -1,0 +1,76 @@
+import getAnalyticsAppVersion, {
+  formatAnalyticsAppVersion,
+} from './getAnalyticsAppVersion';
+import { getVersion } from 'react-native-device-info';
+
+jest.mock('react-native-device-info', () => ({
+  getVersion: jest.fn(),
+}));
+
+const mockGetVersion = getVersion as jest.MockedFunction<typeof getVersion>;
+
+describe('formatAnalyticsAppVersion', () => {
+  const baseVersion = '8.6.0';
+
+  it('returns unsuffixed version for production', () => {
+    const result = formatAnalyticsAppVersion(baseVersion, 'production');
+
+    expect(result).toBe('8.6.0');
+  });
+
+  it('returns unsuffixed version when environment is undefined', () => {
+    const result = formatAnalyticsAppVersion(baseVersion, undefined);
+
+    expect(result).toBe('8.6.0');
+  });
+
+  it('returns unsuffixed version when environment is empty', () => {
+    const result = formatAnalyticsAppVersion(baseVersion, '  ');
+
+    expect(result).toBe('8.6.0');
+  });
+
+  it('appends release-candidate for rc', () => {
+    const result = formatAnalyticsAppVersion(baseVersion, 'rc');
+
+    expect(result).toBe('8.6.0-release-candidate');
+  });
+
+  it('appends experimental for exp', () => {
+    const result = formatAnalyticsAppVersion(baseVersion, 'exp');
+
+    expect(result).toBe('8.6.0-experimental');
+  });
+
+  it('appends development for dev', () => {
+    const result = formatAnalyticsAppVersion(baseVersion, 'dev');
+
+    expect(result).toBe('8.6.0-development');
+  });
+
+  it('appends environment name for other non-prod environments', () => {
+    expect(formatAnalyticsAppVersion(baseVersion, 'beta')).toBe('8.6.0-beta');
+    expect(formatAnalyticsAppVersion(baseVersion, 'test')).toBe('8.6.0-test');
+    expect(formatAnalyticsAppVersion(baseVersion, 'e2e')).toBe('8.6.0-e2e');
+  });
+});
+
+describe('getAnalyticsAppVersion', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // METAMASK_ENVIRONMENT is inlined by babel at transform time, so runtime
+  // mutation is ignored here. Env→suffix mapping is covered by
+  // formatAnalyticsAppVersion tests above.
+  it('formats native getVersion with the build METAMASK_ENVIRONMENT', () => {
+    mockGetVersion.mockReturnValue('8.6.0');
+
+    const result = getAnalyticsAppVersion();
+
+    expect(result).toBe(
+      formatAnalyticsAppVersion('8.6.0', process.env.METAMASK_ENVIRONMENT),
+    );
+    expect(mockGetVersion).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/util/metrics/getAnalyticsAppVersion.ts
+++ b/app/util/metrics/getAnalyticsAppVersion.ts
@@ -1,0 +1,41 @@
+import { getVersion } from 'react-native-device-info';
+
+const ENVIRONMENT_SUFFIXES: Record<string, string> = {
+  rc: 'release-candidate',
+  exp: 'experimental',
+  dev: 'development',
+};
+
+/**
+ * Formats the analytics App Version string from a native version and
+ * METAMASK_ENVIRONMENT value.
+ *
+ * Production (or unset/empty) stays unsuffixed. Known non-prod envs use
+ * friendly suffixes; any other non-prod env uses `-{environment}`.
+ */
+export const formatAnalyticsAppVersion = (
+  baseVersion: string,
+  environment: string | undefined,
+): string => {
+  const env = environment?.trim();
+
+  if (!env || env === 'production') {
+    return baseVersion;
+  }
+
+  const suffix = ENVIRONMENT_SUFFIXES[env] ?? env;
+  return `${baseVersion}-${suffix}`;
+};
+
+/**
+ * Analytics App Version for Segment/Mixpanel.
+ *
+ * Does not change native CFBundleShortVersionString / Android versionName.
+ */
+const getAnalyticsAppVersion = (): string =>
+  formatAnalyticsAppVersion(
+    getVersion(),
+    process.env.METAMASK_ENVIRONMENT,
+  );
+
+export default getAnalyticsAppVersion;

--- a/app/util/metrics/getAnalyticsAppVersion.ts
+++ b/app/util/metrics/getAnalyticsAppVersion.ts
@@ -33,9 +33,6 @@ export const formatAnalyticsAppVersion = (
  * Does not change native CFBundleShortVersionString / Android versionName.
  */
 const getAnalyticsAppVersion = (): string =>
-  formatAnalyticsAppVersion(
-    getVersion(),
-    process.env.METAMASK_ENVIRONMENT,
-  );
+  formatAnalyticsAppVersion(getVersion(), process.env.METAMASK_ENVIRONMENT);
 
 export default getAnalyticsAppVersion;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Mobile RC Coverage boards cannot filter Mixpanel traffic the same way Extension does, because Mobile currently emits a bare native version for `app_version_string` (e.g. `8.6.0`). QA then has to list many `app_build_number` values, which is fragile and has hit Mixpanel API rate limits.

This PR suffixes the analytics App Version by `METAMASK_ENVIRONMENT` so RC builds emit `x.y.z-release-candidate` (and other non-prod envs get matching suffixes), while leaving native `CFBundleShortVersionString` / Android `versionName` unchanged.

Implementation:
- `getAnalyticsAppVersion` / `formatAnalyticsAppVersion` helper for env→suffix mapping
- Segment enrichment plugin overrides `context.app.version` (maps to Mixpanel `app_version_string`)
- Identify trait `applicationVersion` uses the same helper via `generateDeviceAnalyticsMetaData`

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: MCRM-129
Refs: MMQA-2272

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: analytics app version suffix for Mixpanel RC filtering

  Scenario: RC build emits release-candidate app version string
    Given a main-rc build with METAMASK_ENVIRONMENT=rc
    And the user has opted into MetaMetrics

    When the app identifies the user and tracks events
    Then Mixpanel app_version_string equals x.y.z-release-candidate
    And the native App Information version remains unsuffixed x.y.z

  Scenario: Production build keeps unsuffixed analytics version
    Given a production build with METAMASK_ENVIRONMENT=production
    And the user has opted into MetaMetrics

    When the app identifies the user and tracks events
    Then Mixpanel app_version_string equals x.y.z
```

Unit tests already covering mapping + Segment plugin:
```bash
yarn jest app/util/metrics/getAnalyticsAppVersion.test.ts \
  app/util/analytics/appVersionSegmentPlugin.test.ts \
  app/core/Engine/controllers/analytics-controller/analytics-controller-init.test.ts \
  --watchman=false
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

No UI change. Before/after for Mixpanel / Segment analytics App Version only.

### **Before**

Mobile RC (and other non-prod) builds emitted the bare native version:

| Build env | `app_version_string` / `applicationVersion` |
|---|---|
| production | `8.6.0` |
| `rc` | `8.6.0` |
| `exp` | `8.6.0` |
| `dev` | `8.6.0` |

QA had to filter many `app_build_number` values to isolate RC traffic.

### **After**

Analytics version is suffixed by `METAMASK_ENVIRONMENT` (native bundle version unchanged):

| Build env | `app_version_string` / `applicationVersion` |
|---|---|
| production | `8.6.0` |
| `rc` | `8.6.0-release-candidate` |
| `exp` | `8.6.0-experimental` |
| `dev` | `8.6.0-development` |
| other non-prod | `8.6.0-{environment}` |

RC Coverage can filter with `app_version_string` contains/equals `*-release-candidate`.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

N/A for this change — analytics-only, no UI/performance impact. Boxes checked after conscious assessment.

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only enrichment of version metadata with no auth, payment, or native versioning changes; well-covered by unit tests.
> 
> **Overview**
> Adds **environment-suffixed analytics app versions** so Mixpanel `app_version_string` (and related traits) can distinguish RC, experimental, dev, and other non-production builds without changing native bundle version strings.
> 
> Introduces `getAnalyticsAppVersion` / `formatAnalyticsAppVersion`, which append friendly suffixes from `METAMASK_ENVIRONMENT` (e.g. `rc` → `-release-candidate`) while production stays bare `x.y.z`. A new Segment **enrichment plugin** (`AppVersionSegmentPlugin`) overrides `context.app.version` on track/identify events; analytics controller init registers it alongside Braze on the standard platform adapter. **Identify** device metadata now sets `applicationVersion` via the same helper instead of raw `getVersion()`.
> 
> Unit tests cover suffix mapping, the plugin, and updated `analytics-controller-init` expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b40233e38dd2fc1ef7c7f66d10269de8476ea93a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
