### PR TITLE
fix(card): hide Set/View PIN when card has no PIN

### DIFF
--- a/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
@@ -4520,9 +4520,9 @@ describe('CardHome Component', () => {
         ).toBeNull();
       });
 
-      it('does not show view pin button for international virtual card', () => {
-        // Given: International user with virtual card
-        mockGetCapabilities.mockReturnValue({ supportsPinView: false });
+      it('does not show view pin button when card hasPin is false', () => {
+        // Given: Card issued without a PIN (provider still supports PIN view)
+        mockGetCapabilities.mockReturnValue({ supportsPinView: true });
         setupMockSelectors({
           isAuthenticated: true,
           userLocation: 'international',
@@ -4530,7 +4530,7 @@ describe('CardHome Component', () => {
         setupLoadCardDataMock({
           isAuthenticated: true,
 
-          cardDetails: { type: CardType.VIRTUAL },
+          cardDetails: { type: CardType.VIRTUAL, hasPin: false },
           isLoading: false,
           kycStatus: { verificationState: 'VERIFIED', userId: 'user-123' },
         });
@@ -4545,12 +4545,12 @@ describe('CardHome Component', () => {
       });
 
       it('shows view pin button for US user with virtual card', () => {
-        // Given: US user with virtual card
+        // Given: US user with virtual card that has a PIN
         setupMockSelectors({ isAuthenticated: true, userLocation: 'us' });
         setupLoadCardDataMock({
           isAuthenticated: true,
 
-          cardDetails: { type: CardType.VIRTUAL },
+          cardDetails: { type: CardType.VIRTUAL, hasPin: true },
           isLoading: false,
           kycStatus: { verificationState: 'VERIFIED', userId: 'user-123' },
         });
@@ -4565,7 +4565,7 @@ describe('CardHome Component', () => {
       });
 
       it('shows view pin button for international user with metal card', () => {
-        // Given: International user with metal card
+        // Given: International user with metal card that has a PIN
         setupMockSelectors({
           isAuthenticated: true,
           userLocation: 'international',
@@ -4573,7 +4573,7 @@ describe('CardHome Component', () => {
         setupLoadCardDataMock({
           isAuthenticated: true,
 
-          cardDetails: { type: CardType.METAL },
+          cardDetails: { type: CardType.METAL, hasPin: true },
           isLoading: false,
           kycStatus: { verificationState: 'VERIFIED', userId: 'user-123' },
         });
@@ -4581,7 +4581,7 @@ describe('CardHome Component', () => {
         // When: component renders
         render();
 
-        // Then: view pin button is shown (non-virtual card)
+        // Then: view pin button is shown
         expect(
           screen.getByTestId(CardHomeSelectors.VIEW_PIN_BUTTON),
         ).toBeOnTheScreen();

--- a/app/components/UI/Card/Views/CardHome/components/ManageCardOptions.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/components/ManageCardOptions.test.tsx
@@ -43,10 +43,14 @@ const renderComponent = (
   capabilities: CardProviderCapabilities,
   cardDetailsVisible = false,
   showUnlinkMoneyAccount = false,
+  overrides: {
+    card?: CardDetails;
+    isFrozen?: boolean;
+  } = {},
 ) =>
   render(
     <ManageCardOptions
-      card={CARD}
+      card={overrides.card ?? CARD}
       account={{ verificationStatus: 'VERIFIED' } as never}
       capabilities={capabilities}
       isMetalCardCheckoutEnabled={false}
@@ -56,7 +60,7 @@ const renderComponent = (
       hasAlertOnlyState={false}
       hasSetupAlerts={false}
       userLocation="gb"
-      isFrozen={false}
+      isFrozen={overrides.isFrozen ?? false}
       isFreezeLoading={false}
       isPinLoading={false}
       cardDetailsVisible={cardDetailsVisible}
@@ -169,6 +173,28 @@ describe('ManageCardOptions set PIN gating', () => {
     expect(getByTestId(CardHomeSelectors.SET_PIN_BUTTON)).toBeOnTheScreen();
   });
 
+  it('shows set PIN when hasPin is true', () => {
+    const { getByTestId } = renderComponent(
+      buildCapabilities({ supportsPinSet: true }),
+      false,
+      false,
+      { card: { ...CARD, hasPin: true } },
+    );
+
+    expect(getByTestId(CardHomeSelectors.SET_PIN_BUTTON)).toBeOnTheScreen();
+  });
+
+  it('hides set PIN when hasPin is false', () => {
+    const { queryByTestId } = renderComponent(
+      buildCapabilities({ supportsPinSet: true }),
+      false,
+      false,
+      { card: { ...CARD, hasPin: false } },
+    );
+
+    expect(queryByTestId(CardHomeSelectors.SET_PIN_BUTTON)).toBeNull();
+  });
+
   it('hides set PIN when supportsPinSet is false', () => {
     const { queryByTestId } = renderComponent(
       buildCapabilities({ supportsPinSet: false }),
@@ -179,38 +205,45 @@ describe('ManageCardOptions set PIN gating', () => {
 
   it('hides set PIN when the card is not ACTIVE', () => {
     const frozenCard = { ...CARD, status: CardStatus.FROZEN };
-    const { queryByTestId } = render(
-      <ManageCardOptions
-        card={frozenCard}
-        account={{ verificationStatus: 'VERIFIED' } as never}
-        capabilities={buildCapabilities({ supportsPinSet: true })}
-        isMetalCardCheckoutEnabled={false}
-        isAuthenticated
-        isLoading={false}
-        hasSetupActions={false}
-        hasAlertOnlyState={false}
-        hasSetupAlerts={false}
-        userLocation="gb"
-        isFrozen
-        isFreezeLoading={false}
-        isPinLoading={false}
-        cardDetailsVisible={false}
-        onViewCardDetails={jest.fn()}
-        onViewPin={jest.fn()}
-        onSetPin={jest.fn()}
-        onToggleFreeze={jest.fn()}
-        onManageSpendingLimit={jest.fn()}
-        showUnlinkMoneyAccount={false}
-        onUnlinkMoneyAccount={jest.fn()}
-        onOrderMetalCard={jest.fn()}
-        isSpendingLimitActive
-        onChangeAsset={jest.fn()}
-        hasPriorityTokenBalance
-        onCashback={jest.fn()}
-        onTravel={jest.fn()}
-      />,
+    const { queryByTestId } = renderComponent(
+      buildCapabilities({ supportsPinSet: true }),
+      false,
+      false,
+      { card: frozenCard, isFrozen: true },
     );
 
     expect(queryByTestId(CardHomeSelectors.SET_PIN_BUTTON)).toBeNull();
+  });
+});
+
+describe('ManageCardOptions view PIN gating', () => {
+  it('hides view PIN when hasPin is false', () => {
+    const { queryByTestId } = renderComponent(
+      buildCapabilities({ supportsPinView: true }),
+      false,
+      false,
+      { card: { ...CARD, hasPin: false } },
+    );
+
+    expect(queryByTestId(CardHomeSelectors.VIEW_PIN_BUTTON)).toBeNull();
+  });
+
+  it('shows view PIN when hasPin is true', () => {
+    const { getByTestId } = renderComponent(
+      buildCapabilities({ supportsPinView: true }),
+      false,
+      false,
+      { card: { ...CARD, hasPin: true } },
+    );
+
+    expect(getByTestId(CardHomeSelectors.VIEW_PIN_BUTTON)).toBeOnTheScreen();
+  });
+
+  it('shows view PIN when hasPin is absent', () => {
+    const { getByTestId } = renderComponent(
+      buildCapabilities({ supportsPinView: true }),
+    );
+
+    expect(getByTestId(CardHomeSelectors.VIEW_PIN_BUTTON)).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Card/Views/CardHome/components/ManageCardOptions.tsx
+++ b/app/components/UI/Card/Views/CardHome/components/ManageCardOptions.tsx
@@ -93,6 +93,9 @@ const ManageCardOptions = ({
     card?.type === CardType.VIRTUAL &&
     isFullySetUp;
 
+  // Providers set hasPin on CardDetails; absent means treat as true.
+  const cardHasPin = card?.hasPin !== false;
+
   // Providers without funding limits (e.g. Immersve) expose manage options as
   // soon as a card exists; balance-gating only applies to funding-limit
   // providers (Baanx), which hide them until the user has a spendable balance.
@@ -169,6 +172,7 @@ const ManageCardOptions = ({
           !isLoading &&
           card &&
           capabilities?.supportsPinView &&
+          cardHasPin &&
           !hideManageOptions) ||
           (showTeaserOptions && capabilities?.supportsPinView)) && (
           <ManageCardListItem
@@ -186,6 +190,7 @@ const ManageCardOptions = ({
           card &&
           card.status === CardStatus.ACTIVE &&
           capabilities?.supportsPinSet &&
+          cardHasPin &&
           !hideManageOptions) ||
           (showTeaserOptions && capabilities?.supportsPinSet)) && (
           <ManageCardListItem

--- a/app/core/Engine/controllers/card-controller/provider-types.ts
+++ b/app/core/Engine/controllers/card-controller/provider-types.ts
@@ -182,6 +182,8 @@ export interface CardDetails {
   isFreezable?: boolean;
   /** ISO region code from Immersve LIST/detail (e.g. "GB"). */
   regionCode?: string;
+  /** False when the card is issued without a PIN, e.g. Baanx virtual cards outside the US. */
+  hasPin?: boolean;
 }
 
 export interface CardSecureViewParams {

--- a/app/core/Engine/controllers/card-controller/providers/BaanxProvider.test.ts
+++ b/app/core/Engine/controllers/card-controller/providers/BaanxProvider.test.ts
@@ -773,6 +773,64 @@ describe('BaanxProvider', () => {
   });
 });
 
+describe('BaanxProvider — getCardDetails hasPin', () => {
+  const buildProvider = (get: jest.Mock) =>
+    new BaanxProvider({
+      service: { get, apiKey: 'k' } as unknown as BaanxService,
+    });
+
+  const buildCardStatus = (overrides: Record<string, unknown> = {}) => ({
+    id: 'card-1',
+    status: CardStatus.ACTIVE,
+    type: CardType.VIRTUAL,
+    panLast4: '1234',
+    holderName: 'Jane Doe',
+    isFreezable: true,
+    ...overrides,
+  });
+
+  it('sets hasPin false for international virtual cards', async () => {
+    const get = jest.fn().mockResolvedValue(buildCardStatus());
+    const tokens: CardAuthTokens = {
+      accessToken: 'at',
+      accessTokenExpiresAt: FIXED_NOW + 3_600_000,
+      location: 'international',
+    };
+
+    const card = await buildProvider(get).getCardDetails(tokens);
+
+    expect(card.hasPin).toBe(false);
+  });
+
+  it('sets hasPin true for US virtual cards', async () => {
+    const get = jest.fn().mockResolvedValue(buildCardStatus());
+    const tokens: CardAuthTokens = {
+      accessToken: 'at',
+      accessTokenExpiresAt: FIXED_NOW + 3_600_000,
+      location: 'us',
+    };
+
+    const card = await buildProvider(get).getCardDetails(tokens);
+
+    expect(card.hasPin).toBe(true);
+  });
+
+  it('sets hasPin true for international physical cards', async () => {
+    const get = jest
+      .fn()
+      .mockResolvedValue(buildCardStatus({ type: CardType.PHYSICAL }));
+    const tokens: CardAuthTokens = {
+      accessToken: 'at',
+      accessTokenExpiresAt: FIXED_NOW + 3_600_000,
+      location: 'international',
+    };
+
+    const card = await buildProvider(get).getCardDetails(tokens);
+
+    expect(card.hasPin).toBe(true);
+  });
+});
+
 describe('BaanxProvider — getOnChainAssets (unauthenticated on-chain path)', () => {
   const MockStaticJsonRpcProvider = ethers.providers
     .StaticJsonRpcProvider as jest.MockedClass<

--- a/app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts
+++ b/app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts
@@ -13,6 +13,7 @@ import {
   RegistrationSettingsResponse,
   CardLocation,
   CardStatus,
+  CardType,
   type CardNetwork,
 } from '../../../../../components/UI/Card/types';
 import type {
@@ -628,7 +629,10 @@ export class BaanxProvider implements ICardProvider {
       const primaryFundingAsset = this.pickPrimaryAsset(fundingAssets);
 
       const card = cardDetailsResponse
-        ? this.mapCardDetails(cardDetailsResponse)
+        ? this.mapCardDetails(
+            cardDetailsResponse,
+            tokens.location as CardLocation,
+          )
         : null;
       const account = user
         ? this.mapAccountStatus(user, cardDetailsResponse)
@@ -677,7 +681,7 @@ export class BaanxProvider implements ICardProvider {
         '/v1/card/status',
         tokens,
       );
-      return this.mapCardDetails(response);
+      return this.mapCardDetails(response, tokens.location as CardLocation);
     } catch (error) {
       if (error instanceof CardApiError && error.statusCode === 404) {
         throw new CardProviderError(
@@ -1806,7 +1810,10 @@ export class BaanxProvider implements ICardProvider {
     return fallback ?? userPriority;
   }
 
-  private mapCardDetails(response: CardDetailsResponse): CardDetails {
+  private mapCardDetails(
+    response: CardDetailsResponse,
+    location: CardLocation,
+  ): CardDetails {
     return {
       id: response.id,
       status: response.status,
@@ -1814,6 +1821,7 @@ export class BaanxProvider implements ICardProvider {
       lastFour: response.panLast4,
       holderName: response.holderName,
       isFreezable: response.isFreezable,
+      hasPin: location === 'us' || response.type !== CardType.VIRTUAL,
     };
   }
 

--- a/app/core/Engine/controllers/card-controller/providers/ImmersveProvider.test.ts
+++ b/app/core/Engine/controllers/card-controller/providers/ImmersveProvider.test.ts
@@ -958,6 +958,7 @@ describe('ImmersveProvider', () => {
         holderName: 'John Doe',
         isFreezable: true,
         regionCode: undefined,
+        hasPin: true,
       });
       expect(data.primaryFundingAsset).toStrictEqual({
         symbol: 'USDC',

--- a/app/core/Engine/controllers/card-controller/providers/ImmersveProvider.ts
+++ b/app/core/Engine/controllers/card-controller/providers/ImmersveProvider.ts
@@ -846,6 +846,7 @@ export class ImmersveProvider implements ICardProvider {
       holderName: detail.cardholderName,
       isFreezable: status === CardStatus.ACTIVE || status === CardStatus.FROZEN,
       regionCode: detail.regionCode,
+      hasPin: true,
     };
   }
 


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Virtual international Baanx cards do not have a PIN, but Card Home still showed View PIN, which then failed. This change adds an optional `hasPin` field on `CardDetails` that providers set when mapping card details, and gates authenticated Set/View PIN manage options on that flag.

- Baanx sets `hasPin` from token location and card type (`false` for international virtual cards)
- Immersve always sets `hasPin: true` so Set PIN remains available
- UI stays provider-agnostic (`card?.hasPin !== false`)

Fixes [CARD-503](https://consensyssoftware.atlassian.net/browse/CARD-503).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed View PIN being shown for virtual international cards that do not have a PIN

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: CARD-503

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Card PIN manage options by card type

  Scenario: international virtual Baanx cardholder does not see View PIN
    Given an authenticated international Baanx user with a virtual card
    When the user opens Card Home manage options
    Then View PIN is not shown

  Scenario: US virtual Baanx cardholder can view PIN
    Given an authenticated US Baanx user with a virtual card
    When the user opens Card Home manage options
    Then View PIN is shown

  Scenario: international physical or metal Baanx cardholder can view PIN
    Given an authenticated international Baanx user with a physical or metal card
    When the user opens Card Home manage options
    Then View PIN is shown

  Scenario: Immersve virtual cardholder can still set PIN
    Given an authenticated Immersve user with an active virtual card
    When the user opens Card Home manage options
    Then Set PIN is shown
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[CARD-503]: https://consensyssoftware.atlassian.net/browse/CARD-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI gating and provider mapping for PIN manage options; backward-compatible default when `hasPin` is omitted.
> 
> **Overview**
> **Card Home** no longer shows **View PIN** or **Set PIN** when the card was issued without a PIN, fixing failed View PIN flows for international virtual Baanx cards.
> 
> Providers populate a new optional `hasPin` on `CardDetails`: Baanx sets it from auth location and card type (`false` only for international virtual), Immersve always sets `true`. `ManageCardOptions` gates both PIN actions with `card?.hasPin !== false` so missing `hasPin` still shows PIN options. Tests cover provider mapping and UI gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 268c7b33984daf5b59b9fada7042a584e8880fb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->