### PR TITLE
fix(perps): [release-blocker] show Close long/short for Pro closing-order tags cp-8.7.0

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -526,6 +526,7 @@ export const PerpsProMarketViewSelectorsIDs = {
   ORDER_PRICE_EDIT: 'perps-pro-market-order-price-edit',
   ORDER_SIZE_EDIT: 'perps-pro-market-order-size-edit',
   ORDER_ROW: 'perps-pro-market-order-row',
+  ORDER_DIRECTION_TAG: 'perps-pro-market-order-direction-tag',
   ORDER_TYPE: 'perps-pro-market-order-type',
 };
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderCard.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderCard.test.tsx
@@ -1,3 +1,4 @@
+import { TagSeverity } from '@metamask/design-system-react-native';
 import { fireEvent, render, screen } from '@testing-library/react-native';
 import type { Order } from '@metamask/perps-controller';
 import React from 'react';
@@ -11,6 +12,35 @@ jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useSelector: jest.fn(() => false),
 }));
+
+// Tag maps severity into styles and does not forward it. Preserve severity on the
+// host so direction-tag assertions can verify the semantic color contract.
+jest.mock('@metamask/design-system-react-native', () => {
+  const ReactLocal = jest.requireActual<typeof React>('react');
+  const { Text, View } =
+    jest.requireActual<typeof import('react-native')>('react-native');
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+
+  return {
+    ...actual,
+    Tag: ({
+      children,
+      severity,
+      testID,
+    }: {
+      children?: React.ReactNode;
+      severity?: string;
+      testID?: string;
+    }) =>
+      ReactLocal.createElement(
+        View,
+        { testID, severity },
+        typeof children === 'string' || typeof children === 'number'
+          ? ReactLocal.createElement(Text, null, children)
+          : children,
+      ),
+  };
+});
 
 describe('PerpsProOrderCard', () => {
   const DOTS_SHORT = '•'.repeat(6);
@@ -51,7 +81,7 @@ describe('PerpsProOrderCard', () => {
     );
 
     expect(screen.getByText('SOL')).toBeOnTheScreen();
-    expect(screen.getByText('Long')).toBeOnTheScreen();
+    expect(screen.getByText('Close long')).toBeOnTheScreen();
     expect(screen.getByText('Stop market')).toBeOnTheScreen();
     expect(screen.getByText('13 SOL')).toBeOnTheScreen();
     // Trigger orders resolve display price from triggerPrice via
@@ -154,7 +184,6 @@ describe('PerpsProOrderCard', () => {
         reduceOnly: false,
       },
       typeLabel: 'Limit',
-      directionLabel: 'Long',
       reduceOnlyLabel: 'No',
     },
     {
@@ -168,7 +197,6 @@ describe('PerpsProOrderCard', () => {
         isTrigger: false,
       },
       typeLabel: 'Limit',
-      directionLabel: 'Long',
       reduceOnlyLabel: 'Yes',
     },
     {
@@ -182,7 +210,6 @@ describe('PerpsProOrderCard', () => {
         isTrigger: false,
       },
       typeLabel: 'Limit',
-      directionLabel: 'Short',
       reduceOnlyLabel: 'Yes',
     },
     {
@@ -195,7 +222,6 @@ describe('PerpsProOrderCard', () => {
         reduceOnly: false,
       },
       typeLabel: 'Market',
-      directionLabel: 'Short',
       reduceOnlyLabel: 'No',
     },
     {
@@ -210,7 +236,6 @@ describe('PerpsProOrderCard', () => {
         triggerPrice: '220',
       },
       typeLabel: 'Take profit limit',
-      directionLabel: 'Long',
       reduceOnlyLabel: 'Yes',
     },
     {
@@ -225,7 +250,6 @@ describe('PerpsProOrderCard', () => {
         triggerPrice: '101',
       },
       typeLabel: 'Stop limit',
-      directionLabel: 'Long',
       reduceOnlyLabel: 'Yes',
     },
     {
@@ -240,17 +264,110 @@ describe('PerpsProOrderCard', () => {
         triggerPrice: '101',
       },
       typeLabel: 'Stop market',
-      directionLabel: 'Short',
       reduceOnlyLabel: 'Yes',
     },
   ])(
-    'labels $name orders with type "$typeLabel" and direction "$directionLabel"',
-    ({ order, typeLabel, directionLabel, reduceOnlyLabel }) => {
+    'labels $name orders with type "$typeLabel" and reduce-only "$reduceOnlyLabel"',
+    ({ order, typeLabel, reduceOnlyLabel }) => {
       render(<PerpsProOrderCard order={order} />);
 
       expect(screen.getByText(typeLabel)).toBeOnTheScreen();
-      expect(screen.getByText(directionLabel)).toBeOnTheScreen();
       expect(screen.getByText(reduceOnlyLabel)).toBeOnTheScreen();
+    },
+  );
+
+  it.each([
+    {
+      name: 'opening buy',
+      order: {
+        ...baseOrder,
+        side: 'buy' as const,
+        detailedOrderType: 'Limit',
+        orderType: 'limit' as const,
+        reduceOnly: false,
+        isTrigger: false,
+      },
+      directionLabel: 'Long',
+      severity: TagSeverity.Success,
+    },
+    {
+      name: 'opening sell',
+      order: {
+        ...baseOrder,
+        side: 'sell' as const,
+        detailedOrderType: 'Market',
+        orderType: 'market' as const,
+        reduceOnly: false,
+        isTrigger: false,
+      },
+      directionLabel: 'Short',
+      severity: TagSeverity.Danger,
+    },
+    {
+      name: 'trigger-only sell',
+      order: {
+        ...baseOrder,
+        side: 'sell' as const,
+        detailedOrderType: 'Take Profit Market',
+        orderType: 'market' as const,
+        reduceOnly: false,
+        isTrigger: true,
+        triggerPrice: '220',
+      },
+      directionLabel: 'Close long',
+      severity: TagSeverity.Danger,
+    },
+    {
+      name: 'reduce-only sell',
+      order: {
+        ...baseOrder,
+        side: 'sell' as const,
+        detailedOrderType: 'Limit',
+        orderType: 'limit' as const,
+        reduceOnly: true,
+        isTrigger: false,
+      },
+      directionLabel: 'Close long',
+      severity: TagSeverity.Danger,
+    },
+    {
+      name: 'trigger-only buy',
+      order: {
+        ...baseOrder,
+        side: 'buy' as const,
+        detailedOrderType: 'Stop Market',
+        orderType: 'market' as const,
+        reduceOnly: false,
+        isTrigger: true,
+        triggerPrice: '101',
+      },
+      directionLabel: 'Close short',
+      severity: TagSeverity.Success,
+    },
+    {
+      name: 'reduce-only buy',
+      order: {
+        ...baseOrder,
+        side: 'buy' as const,
+        detailedOrderType: 'Limit',
+        orderType: 'limit' as const,
+        reduceOnly: true,
+        isTrigger: false,
+      },
+      directionLabel: 'Close short',
+      severity: TagSeverity.Success,
+    },
+  ] as const)(
+    'renders $name direction tag as "$directionLabel" with $severity severity',
+    ({ order, directionLabel, severity }) => {
+      render(<PerpsProOrderCard order={order} />);
+
+      const directionTag = screen.getByTestId(
+        PerpsProMarketViewSelectorsIDs.ORDER_DIRECTION_TAG,
+      );
+
+      expect(screen.getByText(directionLabel)).toBeOnTheScreen();
+      expect(directionTag).toHaveProp('severity', severity);
     },
   );
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderCard.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderCard.test.tsx
@@ -21,19 +21,21 @@ jest.mock('@metamask/design-system-react-native', () => {
     jest.requireActual<typeof import('react-native')>('react-native');
   const actual = jest.requireActual('@metamask/design-system-react-native');
 
+  interface MockTagProps {
+    children?: React.ReactNode;
+    severity?: string;
+    testID?: string;
+  }
+
+  // Test double host: widen View's props only for this mock so severity remains
+  // queryable without using `any` or inventing unsupported View attributes.
+  const MockTagHost = View as React.ComponentType<MockTagProps>;
+
   return {
     ...actual,
-    Tag: ({
-      children,
-      severity,
-      testID,
-    }: {
-      children?: React.ReactNode;
-      severity?: string;
-      testID?: string;
-    }) =>
+    Tag: ({ children, severity, testID }: MockTagProps) =>
       ReactLocal.createElement(
-        View,
+        MockTagHost,
         { testID, severity },
         typeof children === 'string' || typeof children === 'number'
           ? ReactLocal.createElement(Text, null, children)

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderCard.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderCard.tsx
@@ -36,6 +36,7 @@ import {
   formatProOrderCardTimestamp,
   PRICE_RANGES_UNIVERSAL,
 } from '../../../utils/formatUtils';
+import { isClosingOrder } from '../../../utils/orderDirection';
 import {
   formatOrderTypeLabel,
   getOrderPositionDirection,
@@ -146,8 +147,21 @@ const PerpsProOrderCard = ({
 }: PerpsProOrderCardProps) => {
   const privacyMode = useSelector(selectPrivacyMode);
   const displaySymbol = getPerpsDisplaySymbol(order.symbol);
-  const direction = getOrderPositionDirection(order);
-  const isLong = direction === 'long';
+  const isClosing = isClosingOrder(order);
+  const positionDirection = getOrderPositionDirection(order);
+  const isBuySide = order.side === 'buy';
+  const isLongPosition = positionDirection === 'long';
+  let directionLabel = isLongPosition
+    ? strings('perps.market.long')
+    : strings('perps.market.short');
+  if (isClosing) {
+    directionLabel = isLongPosition
+      ? strings('perps.market.close_long')
+      : strings('perps.market.close_short');
+  }
+  const directionSeverity = isBuySide
+    ? TagSeverity.Success
+    : TagSeverity.Danger;
   const size = formatPositionSize(order.originalSize);
   const { priceValue } = resolveOrderDisplayPriceAndLabel(order);
   const validTriggerPrice = getValidTriggerPrice(order);
@@ -247,11 +261,10 @@ const PerpsProOrderCard = ({
                     {displaySymbol}
                   </Text>
                   <Tag
-                    severity={isLong ? TagSeverity.Success : TagSeverity.Danger}
+                    testID={PerpsProMarketViewSelectorsIDs.ORDER_DIRECTION_TAG}
+                    severity={directionSeverity}
                   >
-                    {isLong
-                      ? strings('perps.market.long')
-                      : strings('perps.market.short')}
+                    {directionLabel}
                   </Tag>
                 </Box>
                 <Text


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Pro Orders tab direction tags for TPSL and other closing orders showed the position being closed as **Long** (green) or **Short** (red). That matched opening-order semantics and made reduce-only TP/SL look like new positions.

This change keeps opening orders as Long/Short with buy=green / sell=red, and for every closing order (`reduceOnly` or trigger) shows localized **Close long** / **Close short** with severity from the execution side (sell = red, buy = green).

1. **Reason:** Closing TP/SL on a long was displayed as Long (green), which was confusing and inconsistent with Lite / exchange conventions.
2. **Solution:** Derive Pro order-card direction tags from `isClosingOrder` + position direction for copy, and from `order.side` for color, without changing shared position-direction helpers used elsewhere (e.g. cancel toasts).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Perps Pro order tags so take-profit and stop-loss orders show Close long or Close short with the correct color instead of Long or Short

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3738

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps Pro closing-order direction tags
  Scenario: user views a take-profit order on a long position
    Given the user has an open long Perps position in Pro
    And a take-profit or stop-loss order is open for that position
    When the user opens the market Orders tab
    Then the order direction tag reads "Close long"
    And the tag uses the danger (red) severity
  Scenario: user views a take-profit order on a short position
    Given the user has an open short Perps position in Pro
    And a take-profit or stop-loss order is open for that position
    When the user opens the market Orders tab
    Then the order direction tag reads "Close short"
    And the tag uses the success (green) severity
  Scenario: user views an opening limit order
    Given the user has an open non-reducing limit buy order in Pro
    When the user opens the market Orders tab
    Then the order direction tag reads "Long"
    And the tag uses the success (green) severity
  Scenario: user views a reduce-only close limit order on a long
    Given the user has a reduce-only sell limit order closing a long
    When the user opens the market Orders tab
    Then the order direction tag reads "Close long"
    And the tag uses the danger (red) severity
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

ETH LONG TP/SL
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-11 at 16 47 16" src="https://github.com/user-attachments/assets/2db430d5-981d-40f9-8b1c-3c3288cf60be" />

BTC SHORT TP/SL
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-11 at 21 06 12" src="https://github.com/user-attachments/assets/8e405b37-570d-4291-85f4-49fab2357e0b" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only label and tag color change on Pro order cards; no trading, auth, or data-path logic is modified.
> 
> **Overview**
> Fixes Pro Orders tab direction tags so **closing** orders (reduce-only or TP/SL triggers) show **Close long** / **Close short** instead of Long / Short.
> 
> `PerpsProOrderCard` now uses `isClosingOrder` for the label copy and colors the tag from execution side (buy = green, sell = red). Opening orders stay Long/Short. Tests cover both label and severity contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 903f139a64ca035e02f381da56f751b5f363d6db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->