### PR TITLE
fix(smart-e2e): don't bail shared infra rule for CI/docs changes

### DIFF
--- a/tests/tools/e2e-ai-analyzer/modes/select-tags/handlers.ts
+++ b/tests/tools/e2e-ai-analyzer/modes/select-tags/handlers.ts
@@ -394,11 +394,25 @@ const HARD_RULES: HardRule[] = [
       const infraFiles = getChangedSharedInfraFiles(changedFiles);
       if (infraFiles.length === 0) return null;
 
-      // Only apply when all changes are within tests/ — app changes go to AI
-      const hasNonTestChanges = changedFiles.some(
-        (f) => !f.startsWith('tests/'),
+      // Paths that don't affect E2E test selection — CI, docs, scripts, config, etc.
+      // Changes to these alongside shared test infra should not prevent the hard rule.
+      const ignorablePathPrefixes = [
+        '.github/',
+        'scripts/',
+        'docs/',
+        '.changeset/',
+        '.yarn/',
+        '.vscode/',
+        '.cursor/',
+      ];
+
+      // Only bail to AI if there are actual app code changes (not just CI/docs/scripts)
+      const hasAppCodeChanges = changedFiles.some(
+        (f) =>
+          !f.startsWith('tests/') &&
+          !ignorablePathPrefixes.some((prefix) => f.startsWith(prefix)),
       );
-      if (hasNonTestChanges) return null;
+      if (hasAppCodeChanges) return null;
 
       const validTags = new Set(SELECT_TAGS_CONFIG.map((c) => c.tag));
 
@@ -453,7 +467,7 @@ const HARD_RULES: HardRule[] = [
   {
     name: 'test-spec-tag-extraction',
     description:
-      'Spec files in tests/smoke-appium/ changed — extract their tags and run directly',
+      'Spec files in tests/smoke/ or tests/smoke-appium/ changed — extract their tags and run directly',
     check: (changedFiles, context) => {
       const specFiles = getChangedSpecFiles(changedFiles);
       if (specFiles.length === 0) return null;

--- a/tests/tools/e2e-ai-analyzer/modes/select-tags/select-tags-hard-rules.test.ts
+++ b/tests/tools/e2e-ai-analyzer/modes/select-tags/select-tags-hard-rules.test.ts
@@ -115,4 +115,29 @@ describe('checkHardRules', () => {
     expect(result?.reasoning).toContain('en-locale-change');
     expect(result?.selectedTags.length).toBeGreaterThan(1);
   });
+
+  it('applies shared infra rule when page-object changes alongside .github/ files', () => {
+    const changedFiles = [
+      '.github/workflows/performance-test-runner.yml',
+      'tests/page-objects/wallet/AccountListBottomSheet.ts',
+    ];
+
+    const result = checkHardRules(changedFiles, context);
+
+    // Should NOT bail to AI — .github/ is ignorable, shared infra rule should apply
+    expect(result).not.toBeNull();
+    expect(result?.selectedTags).toContain('SmokeAccounts');
+  });
+
+  it('bails to AI when page-object changes alongside actual app code', () => {
+    const changedFiles = [
+      'app/components/Views/Wallet/index.tsx',
+      'tests/page-objects/wallet/AccountListBottomSheet.ts',
+    ];
+
+    const result = checkHardRules(changedFiles, context);
+
+    // Should bail to AI — app code changes require AI analysis
+    expect(result).toBeNull();
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

Fixes Smart E2E Selection skipping the shared test infrastructure hard rule when CI/docs files are also changed.

**Problem:**
[PR #34605](https://github.com/MetaMask/metamask-mobile/pull/34605) changed `tests/page-objects/Onboarding/ImportWalletView.ts` (shared test infra) alongside `.github/workflows/performance-test-runner.yml` (CI config). The `test-shared-infra-impact` hard rule bailed out because `.github/` doesn't start with `tests/`, so the rule didn't find the affected smoke specs. AI analysis then incorrectly claimed `ImportWalletView.ts` was "not used by any smoke E2E spec files" — causing E2E tests to be skipped and breaking them post-merge.

**Fix:**
Update `hasNonTestChanges` → `hasAppCodeChanges`, ignoring paths that don't affect test selection (`.github/`, `scripts/`, `docs/`, `.changeset/`, `.yarn/`, `.vscode/`, `.cursor/`). Now the hard rule applies when shared infra changes alongside CI/docs, but still bails to AI when actual app code changes.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: Flaky test investigation in #mm-qa-legends Slack — PR #34605 broke `import-wallet.spec.ts` analytics tests after merge

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Smart E2E Selection hard rule for shared test infra

  Scenario: Shared infra change with CI file triggers hard rule
    Given a PR changes tests/page-objects/Foo.ts and .github/workflows/bar.yml
    When Smart E2E Selection runs
    Then the test-shared-infra-impact hard rule applies
    And smoke specs importing Foo.ts have their tags selected

  Scenario: Shared infra change with app code bails to AI
    Given a PR changes tests/page-objects/Foo.ts and app/components/Bar.tsx
    When Smart E2E Selection runs
    Then the hard rule bails to AI analysis
```

Unit tests added:
- `applies shared infra rule when page-object changes alongside .github/ files`
- `bails to AI when page-object changes alongside actual app code`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — internal CI tooling change, no UI impact.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C08388MPZ9V/p1786462274495319?thread_ts=1786462274.495319&cid=C08388MPZ9V)

<div><a href="https://cursor.com/agents/bc-9ca1b285-bfad-5d7d-bf33-64a4d50279f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ca1b285-bfad-5d7d-bf33-64a4d50279f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

