### PR TITLE
test(appium): skip flaky multi-SRP account syncing smoke

### DIFF
--- a/tests/smoke-appium/accounts/multi-srp.spec.ts
+++ b/tests/smoke-appium/accounts/multi-srp.spec.ts
@@ -24,101 +24,104 @@ import ToastModal from '../../page-objects/wallet/ToastModal.js';
 import { identityFixtureOptions } from './identity-fixture-options.js';
 
 // Skipped (flaky): account syncing across multiple SRPs is intermittently failing in CI.
-appiumTest.describe.skip(SmokeAccounts('Account syncing - Multiple SRPs'), () => {
-  let sharedUserStorageController: UserStorageMockttpController;
+appiumTest.describe.skip(
+  SmokeAccounts('Account syncing - Multiple SRPs'),
+  () => {
+    let sharedUserStorageController: UserStorageMockttpController;
 
-  appiumTest.beforeAll(() => {
-    sharedUserStorageController = createUserStorageController();
-  });
+    appiumTest.beforeAll(() => {
+      sharedUserStorageController = createUserStorageController();
+    });
 
-  const DEFAULT_ACCOUNT_NAME = 'Account 1';
-  const SECOND_ACCOUNT_NAME = 'Account 2';
-  const SRP_2_RENAMED_ACCOUNT = 'Number 4';
+    const DEFAULT_ACCOUNT_NAME = 'Account 1';
+    const SECOND_ACCOUNT_NAME = 'Account 2';
+    const SRP_2_RENAMED_ACCOUNT = 'Number 4';
 
-  appiumTest(
-    'adds accounts across multiple SRPs and syncs them',
-    async ({ driver: _driver, currentDeviceDetails }) => {
-      const fixtureOptions = identityFixtureOptions(
-        sharedUserStorageController,
-        currentDeviceDetails,
-      );
+    appiumTest(
+      'adds accounts across multiple SRPs and syncs them',
+      async ({ driver: _driver, currentDeviceDetails }) => {
+        const fixtureOptions = identityFixtureOptions(
+          sharedUserStorageController,
+          currentDeviceDetails,
+        );
 
-      // Phase 1: Wait for the initial full sync, then add an account on SRP 1,
-      // import SRP 2, add and rename an account on SRP 2, and verify each
-      // mutation is reflected in the mocked user-storage backend.
-      await withIdentityFixtures(
-        fixtureOptions,
-        async ({ userStorageMockttpController }) => {
+        // Phase 1: Wait for the initial full sync, then add an account on SRP 1,
+        // import SRP 2, add and rename an account on SRP 2, and verify each
+        // mutation is reflected in the mocked user-storage backend.
+        await withIdentityFixtures(
+          fixtureOptions,
+          async ({ userStorageMockttpController }) => {
+            await loginAndOpenAccountList({
+              scenarioType: 'e2e',
+            });
+            await assertAccountCount(DEFAULT_ACCOUNT_NAME, 1);
+
+            const {
+              prepareEventsEmittedCounter,
+              waitUntilSyncedAccountsNumberEquals,
+            } = arrangeTestUtils(userStorageMockttpController);
+
+            await waitUntilSyncedAccountsNumberEquals(1);
+
+            const { waitUntilEventsEmittedNumberEquals } =
+              prepareEventsEmittedCounter(
+                UserStorageMockttpControllerEvents.PUT_SINGLE,
+              );
+
+            await AccountListBottomSheet.tapAddAccountButtonV2();
+            await waitUntilSyncedAccountsNumberEquals(2);
+            await assertAccountCount(SECOND_ACCOUNT_NAME, 1);
+
+            await openImportSrpFromAccountList();
+            await ImportSrpView.enterSrp(IDENTITY_TEAM_SEED_PHRASE_2);
+            await ImportSrpView.tapImportButton();
+            await waitForWalletHomePlaywright(20_000);
+            // Top import-success toast covers the account picker until it dismisses.
+            await ToastModal.waitForToastToDismiss({ appearTimeout: 10_000 });
+            // Retry-capable open: a single identicon tap can miss while the toast
+            // animates out or wallet chrome is still settling after SRP import.
+            await ensureAccountListOpenPlaywright();
+            await waitUntilSyncedAccountsNumberEquals(3);
+
+            await AccountListBottomSheet.tapAddAccountButtonV2({
+              srpIndex: 1,
+              shouldWait: true,
+            });
+            await waitUntilSyncedAccountsNumberEquals(4);
+            await assertAccountCount(DEFAULT_ACCOUNT_NAME, 2);
+            await assertAccountCount(SECOND_ACCOUNT_NAME, 2);
+
+            await renameAccountAtIndex(3, SRP_2_RENAMED_ACCOUNT, {
+              shouldWait: true,
+            });
+            await assertAccountCount(SRP_2_RENAMED_ACCOUNT, 1);
+
+            await waitUntilEventsEmittedNumberEquals(5);
+          },
+        );
+
+        // Phase 2: Restart the app with the same shared user-storage state.
+        // Re-import SRP 2 and verify all accounts from both SRPs are restored.
+        await withIdentityFixtures(fixtureOptions, async () => {
           await loginAndOpenAccountList({
             scenarioType: 'e2e',
           });
-          await assertAccountCount(DEFAULT_ACCOUNT_NAME, 1);
-
-          const {
-            prepareEventsEmittedCounter,
-            waitUntilSyncedAccountsNumberEquals,
-          } = arrangeTestUtils(userStorageMockttpController);
-
-          await waitUntilSyncedAccountsNumberEquals(1);
-
-          const { waitUntilEventsEmittedNumberEquals } =
-            prepareEventsEmittedCounter(
-              UserStorageMockttpControllerEvents.PUT_SINGLE,
-            );
-
-          await AccountListBottomSheet.tapAddAccountButtonV2();
-          await waitUntilSyncedAccountsNumberEquals(2);
-          await assertAccountCount(SECOND_ACCOUNT_NAME, 1);
-
           await openImportSrpFromAccountList();
           await ImportSrpView.enterSrp(IDENTITY_TEAM_SEED_PHRASE_2);
           await ImportSrpView.tapImportButton();
           await waitForWalletHomePlaywright(20_000);
           // Top import-success toast covers the account picker until it dismisses.
           await ToastModal.waitForToastToDismiss({ appearTimeout: 10_000 });
-          // Retry-capable open: a single identicon tap can miss while the toast
-          // animates out or wallet chrome is still settling after SRP import.
           await ensureAccountListOpenPlaywright();
-          await waitUntilSyncedAccountsNumberEquals(3);
-
-          await AccountListBottomSheet.tapAddAccountButtonV2({
-            srpIndex: 1,
-            shouldWait: true,
-          });
-          await waitUntilSyncedAccountsNumberEquals(4);
-          await assertAccountCount(DEFAULT_ACCOUNT_NAME, 2);
-          await assertAccountCount(SECOND_ACCOUNT_NAME, 2);
-
-          await renameAccountAtIndex(3, SRP_2_RENAMED_ACCOUNT, {
-            shouldWait: true,
-          });
-          await assertAccountCount(SRP_2_RENAMED_ACCOUNT, 1);
-
-          await waitUntilEventsEmittedNumberEquals(5);
-        },
-      );
-
-      // Phase 2: Restart the app with the same shared user-storage state.
-      // Re-import SRP 2 and verify all accounts from both SRPs are restored.
-      await withIdentityFixtures(fixtureOptions, async () => {
-        await loginAndOpenAccountList({
-          scenarioType: 'e2e',
+          for (const [accountName, count] of Object.entries({
+            [DEFAULT_ACCOUNT_NAME]: 2,
+            [SECOND_ACCOUNT_NAME]: 1,
+            [SRP_2_RENAMED_ACCOUNT]: 1,
+          })) {
+            await assertAccountCount(accountName, count, 10000);
+          }
         });
-        await openImportSrpFromAccountList();
-        await ImportSrpView.enterSrp(IDENTITY_TEAM_SEED_PHRASE_2);
-        await ImportSrpView.tapImportButton();
-        await waitForWalletHomePlaywright(20_000);
-        // Top import-success toast covers the account picker until it dismisses.
-        await ToastModal.waitForToastToDismiss({ appearTimeout: 10_000 });
-        await ensureAccountListOpenPlaywright();
-        for (const [accountName, count] of Object.entries({
-          [DEFAULT_ACCOUNT_NAME]: 2,
-          [SECOND_ACCOUNT_NAME]: 1,
-          [SRP_2_RENAMED_ACCOUNT]: 1,
-        })) {
-          await assertAccountCount(accountName, count, 10000);
-        }
-      });
-    },
-  );
-});
+      },
+    );
+  },
+);

--- a/tests/smoke-appium/accounts/multi-srp.spec.ts
+++ b/tests/smoke-appium/accounts/multi-srp.spec.ts
@@ -23,7 +23,8 @@ import ImportSrpView from '../../page-objects/importSrp/ImportSrpView.js';
 import ToastModal from '../../page-objects/wallet/ToastModal.js';
 import { identityFixtureOptions } from './identity-fixture-options.js';
 
-appiumTest.describe(SmokeAccounts('Account syncing - Multiple SRPs'), () => {
+// Skipped (flaky): account syncing across multiple SRPs is intermittently failing in CI.
+appiumTest.describe.skip(SmokeAccounts('Account syncing - Multiple SRPs'), () => {
   let sharedUserStorageController: UserStorageMockttpController;
 
   appiumTest.beforeAll(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

Temporarily skip the Appium smoke suite `Account syncing - Multiple SRPs` in `tests/smoke-appium/accounts/multi-srp.spec.ts` because it is flaky in CI and blocks SmokeAccounts.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — test skip only; no product behavior change.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — test skip only.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for draft PRs.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d25df27-9c12-48b2-abdf-13f2522168c6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d25df27-9c12-48b2-abdf-13f2522168c6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

