### PR TITLE
fix(perps): block geo-restricted Perps Pro order submission cp-8.7.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
@@ -1,5 +1,8 @@
 import { act, renderHook } from '@testing-library/react-native';
-import type { PerpsMarketData } from '@metamask/perps-controller';
+import {
+  PERPS_EVENT_VALUE,
+  type PerpsMarketData,
+} from '@metamask/perps-controller';
 import { usePerpsProOrderForm } from './usePerpsProOrderForm';
 
 // ---------------------------------------------------------------------------
@@ -11,9 +14,15 @@ const mockNavigate = jest.fn();
 const mockSetMaxSlippage = jest.fn();
 const mockHandleAddFunds = jest.fn();
 const mockCloseEligibilityModal = jest.fn();
+const mockShowEligibilityModal = jest.fn();
 const mockUpdatePositionTPSL = jest.fn().mockResolvedValue({ success: true });
 const mockExecuteOrder = jest.fn().mockResolvedValue({ success: true });
 const mockClearPendingTradeConfiguration = jest.fn();
+const mockComplianceGate = jest.fn((action: () => Promise<unknown>) =>
+  action(),
+);
+
+let mockIsEligible = true;
 
 let mockExecutionOptions: {
   onSuccess?: (position?: unknown) => void;
@@ -134,8 +143,19 @@ jest.mock('../../../../hooks', () => ({
 jest.mock('../../../../hooks/usePerpsHomeActions', () => ({
   usePerpsHomeActions: () => ({
     handleAddFunds: mockHandleAddFunds,
+    isEligible: mockIsEligible,
     isEligibilityModalVisible: false,
     closeEligibilityModal: mockCloseEligibilityModal,
+    showEligibilityModal: mockShowEligibilityModal,
+  }),
+}));
+
+jest.mock('../../../../../Compliance', () => ({
+  useComplianceGate: () => ({
+    gate: mockComplianceGate,
+    isBlocked: false,
+    isComplianceEnabled: false,
+    checkCompliance: jest.fn(),
   }),
 }));
 
@@ -187,6 +207,10 @@ jest.mock('react-redux', () => ({
   useSelector: () => false,
 }));
 
+jest.mock('../../../../../../../selectors/accountsController', () => ({
+  selectSelectedInternalAccountAddress: jest.fn(),
+}));
+
 jest.mock('../../../../../../../core/Engine', () => ({
   context: {
     PerpsController: {
@@ -218,6 +242,10 @@ describe('usePerpsProOrderForm', () => {
     mockEstimatedSlippageBps = 50;
     mockIsInitialized = true;
     mockPositionStreamLoading = false;
+    mockIsEligible = true;
+    mockComplianceGate.mockImplementation((action: () => Promise<unknown>) =>
+      action(),
+    );
     mockUpdatePositionTPSL.mockResolvedValue({ success: true });
   });
 
@@ -401,6 +429,76 @@ describe('usePerpsProOrderForm', () => {
   });
 
   describe('handlePlaceOrder', () => {
+    it('executes order for an eligible compliant user', async () => {
+      const { result } = renderProForm();
+
+      await act(async () => {
+        await result.current.onPlaceOrderPress();
+      });
+
+      expect(mockComplianceGate).toHaveBeenCalledTimes(1);
+      expect(mockShowEligibilityModal).not.toHaveBeenCalled();
+      expect(mockExecuteOrder).toHaveBeenCalledTimes(1);
+    });
+
+    it('opens geo-block modal and skips execution for an ineligible user', async () => {
+      mockIsEligible = false;
+      const { result } = renderProForm();
+
+      await act(async () => {
+        await result.current.onPlaceOrderPress();
+      });
+
+      expect(mockComplianceGate).toHaveBeenCalledTimes(1);
+      expect(mockShowEligibilityModal).toHaveBeenCalledWith(
+        PERPS_EVENT_VALUE.SOURCE.TRADE_ACTION,
+      );
+      expect(mockExecuteOrder).not.toHaveBeenCalled();
+    });
+
+    it('skips geo handling and execution when compliance gate blocks', async () => {
+      mockComplianceGate.mockResolvedValue(undefined);
+      mockIsEligible = false;
+      const { result } = renderProForm();
+
+      await act(async () => {
+        await result.current.onPlaceOrderPress();
+      });
+
+      expect(mockComplianceGate).toHaveBeenCalledTimes(1);
+      expect(mockShowEligibilityModal).not.toHaveBeenCalled();
+      expect(mockExecuteOrder).not.toHaveBeenCalled();
+    });
+
+    it('commits pending slider preview without invoking compliance or submitting', async () => {
+      const { result, rerender } = renderProForm();
+      act(() => {
+        result.current.sizeSlider.onValueChange(250);
+      });
+
+      await act(async () => {
+        await result.current.onPlaceOrderPress();
+      });
+
+      expect(mockSetAmount).toHaveBeenCalledWith('250');
+      expect(mockComplianceGate).not.toHaveBeenCalled();
+      expect(mockExecuteOrder).not.toHaveBeenCalled();
+
+      mockOrderForm.amount = '250';
+      mockIsEligible = false;
+      rerender({});
+
+      await act(async () => {
+        await result.current.onPlaceOrderPress();
+      });
+
+      expect(mockComplianceGate).toHaveBeenCalledTimes(1);
+      expect(mockShowEligibilityModal).toHaveBeenCalledWith(
+        PERPS_EVENT_VALUE.SOURCE.TRADE_ACTION,
+      );
+      expect(mockExecuteOrder).not.toHaveBeenCalled();
+    });
+
     it('builds OrderParams including reduceOnly and calls executeOrder', async () => {
       // Arrange: long form reduces a short position; stale TP must be ignored.
       mockExistingPosition = {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
@@ -22,7 +22,9 @@ import Engine from '../../../../../../../core/Engine';
 import { MetaMetricsEvents } from '../../../../../../../core/Analytics';
 import Routes from '../../../../../../../constants/navigation/Routes';
 import type { AppNavigationProp } from '../../../../../../../core/NavigationService/types';
+import { selectSelectedInternalAccountAddress } from '../../../../../../../selectors/accountsController';
 import { useVipTier } from '../../../../../Rewards/hooks/useVipTier';
+import { useComplianceGate } from '../../../../../Compliance';
 import type { PerpsTooltipContentKey } from '../../../../components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.types';
 import { bpsToPercent } from '../../../../constants/slippageConfig';
 import { usePerpsOrderContext } from '../../../../contexts/PerpsOrderContext';
@@ -335,10 +337,18 @@ export const usePerpsProOrderForm = ({
   const { isAtCap } = usePerpsOICap(symbol);
   const vipTier = useVipTier();
 
-  const { handleAddFunds, isEligibilityModalVisible, closeEligibilityModal } =
-    usePerpsHomeActions({
-      buttonLocation: PERPS_EVENT_VALUE.BUTTON_LOCATION.PERPS_ASSET_SCREEN,
-    });
+  const {
+    handleAddFunds,
+    isEligible,
+    isEligibilityModalVisible,
+    closeEligibilityModal,
+    showEligibilityModal,
+  } = usePerpsHomeActions({
+    buttonLocation: PERPS_EVENT_VALUE.BUTTON_LOCATION.PERPS_ASSET_SCREEN,
+  });
+
+  const selectedAddress = useSelector(selectSelectedInternalAccountAddress);
+  const { gate } = useComplianceGate(selectedAddress ?? '');
 
   const { marketData, isLoading: isMarketDataLoading } = usePerpsMarketData({
     asset: symbol,
@@ -1082,8 +1092,22 @@ export const usePerpsProOrderForm = ({
       return;
     }
 
-    handlePlaceOrder();
-  }, [commitPendingSliderPreview, handlePlaceOrder]);
+    // Compliance first, then geographic eligibility — matches Lite trade entry
+    // and the canonical compliance gate ordering (docs/compliance.md).
+    return gate(async () => {
+      if (!isEligible) {
+        showEligibilityModal(PERPS_EVENT_VALUE.SOURCE.TRADE_ACTION);
+        return;
+      }
+      await handlePlaceOrder();
+    });
+  }, [
+    commitPendingSliderPreview,
+    gate,
+    handlePlaceOrder,
+    isEligible,
+    showEligibilityModal,
+  ]);
 
   const onReduceOnlyChange = useCallback(
     (value: boolean) => {

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.test.ts
@@ -106,6 +106,7 @@ describe('usePerpsHomeActions', () => {
       expect(result.current.error).toBeNull();
       expect(typeof result.current.handleAddFunds).toBe('function');
       expect(typeof result.current.handleWithdraw).toBe('function');
+      expect(typeof result.current.showEligibilityModal).toBe('function');
       expect(typeof result.current.closeEligibilityModal).toBe('function');
     });
   });
@@ -117,6 +118,7 @@ describe('usePerpsHomeActions', () => {
       const initialFunctions = {
         handleAddFunds: result.current.handleAddFunds,
         handleWithdraw: result.current.handleWithdraw,
+        showEligibilityModal: result.current.showEligibilityModal,
         closeEligibilityModal: result.current.closeEligibilityModal,
       };
 
@@ -127,6 +129,9 @@ describe('usePerpsHomeActions', () => {
       );
       expect(initialFunctions.handleWithdraw).toBe(
         result.current.handleWithdraw,
+      );
+      expect(initialFunctions.showEligibilityModal).toBe(
+        result.current.showEligibilityModal,
       );
       expect(initialFunctions.closeEligibilityModal).toBe(
         result.current.closeEligibilityModal,
@@ -433,6 +438,26 @@ describe('usePerpsHomeActions', () => {
   });
 
   describe('eligibility modal management', () => {
+    it('opens eligibility modal and tracks the supplied source', () => {
+      const { result } = renderHook(() => usePerpsHomeActions());
+
+      act(() => {
+        result.current.showEligibilityModal(
+          PERPS_EVENT_VALUE.SOURCE.TRADE_ACTION,
+        );
+      });
+
+      expect(result.current.isEligibilityModalVisible).toBe(true);
+      expect(mockTrack).toHaveBeenCalledWith(
+        MetaMetricsEvents.PERPS_SCREEN_VIEWED,
+        {
+          [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
+            PERPS_EVENT_VALUE.SCREEN_TYPE.GEO_BLOCK_NOTIF,
+          [PERPS_EVENT_PROPERTY.SOURCE]: PERPS_EVENT_VALUE.SOURCE.TRADE_ACTION,
+        },
+      );
+    });
+
     it('closes eligibility modal when closeEligibilityModal is called', async () => {
       (useSelector as jest.Mock).mockReturnValue(false);
 

--- a/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
+++ b/app/components/UI/Perps/hooks/usePerpsHomeActions.ts
@@ -49,6 +49,11 @@ export interface UsePerpsHomeActionsReturn {
   handleAddFunds: () => Promise<void>;
   /** Handler for withdraw button */
   handleWithdraw: () => Promise<void>;
+  /**
+   * Opens the geo-block eligibility modal and tracks the screen view
+   * with the supplied analytics source.
+   */
+  showEligibilityModal: (source: string) => void;
   /** Close eligibility modal */
   closeEligibilityModal: () => void;
 }
@@ -90,6 +95,21 @@ export const usePerpsHomeActions = (
   const { onAddFundsSuccess, onWithdrawSuccess, onError, buttonLocation } =
     options || {};
 
+  const showEligibilityModal = useCallback(
+    (source: string) => {
+      DevLogger.log('[usePerpsHomeActions] Showing eligibility modal', {
+        source,
+      });
+      track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
+        [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
+          PERPS_EVENT_VALUE.SCREEN_TYPE.GEO_BLOCK_NOTIF,
+        [PERPS_EVENT_PROPERTY.SOURCE]: source,
+      });
+      setIsEligibilityModalVisible(true);
+    },
+    [track],
+  );
+
   const handleAddFunds = useCallback(
     () =>
       gate(async () => {
@@ -104,14 +124,7 @@ export const usePerpsHomeActions = (
 
         if (!isEligible) {
           DevLogger.log('[usePerpsHomeActions] User not eligible for deposit');
-          // Track geo-block screen viewed
-          track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
-            [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
-              PERPS_EVENT_VALUE.SCREEN_TYPE.GEO_BLOCK_NOTIF,
-            [PERPS_EVENT_PROPERTY.SOURCE]:
-              PERPS_EVENT_VALUE.SOURCE.DEPOSIT_BUTTON,
-          });
-          setIsEligibilityModalVisible(true);
+          showEligibilityModal(PERPS_EVENT_VALUE.SOURCE.DEPOSIT_BUTTON);
           return;
         }
 
@@ -162,6 +175,7 @@ export const usePerpsHomeActions = (
       onError,
       track,
       buttonLocation,
+      showEligibilityModal,
     ],
   );
 
@@ -245,6 +259,7 @@ export const usePerpsHomeActions = (
     error,
     handleAddFunds,
     handleWithdraw,
+    showEligibilityModal,
     closeEligibilityModal,
   };
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Geo-restricted users could still submit Perps Pro orders when they already had collateral. Lite blocks trade entry with compliance and eligibility checks, but Pro renders the form inline and called placeOrder with no equivalent gate. Add Funds was gated; Place Order was not.

This PR gates the real Pro Place Order path with compliance first, then geographic eligibility. Ineligible users see the existing geo-restriction sheet (TRADE_ACTION) and never reach order execution. Pending slider commits still happen before the gate. A reusable showEligibilityModal(source) helper centralizes the modal/tracking path used by Add Funds and Place Order. Focused unit tests cover eligible, geo-blocked, compliance-blocked, and pending-slider cases.



## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed geo-restricted users being able to place Perps Pro orders

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: TAT-3739

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps Pro geo-restricted order submission

  Scenario: geo-restricted funded user cannot place a Pro order
    Given the user is in Pro mode on a Perps market
    And the user has sufficient Perps collateral
    And the user is geographically restricted for Perps
    When the user presses Place Order with a valid market or limit order
    Then the geo-restriction sheet is shown
    And no order is submitted

  Scenario: eligible user can still place a Pro order
    Given the user is in Pro mode on a Perps market
    And the user has sufficient Perps collateral
    And the user is eligible for Perps
    When the user presses Place Order with a valid market or limit order
    Then the order is submitted
    And the geo-restriction sheet is not shown

  Scenario: pending slider preview commits before eligibility gating
    Given the user is in Pro mode on a Perps market
    And the size slider has a pending preview that differs from the committed amount
    And the user is geographically restricted for Perps
    When the user presses Place Order once
    Then the pending size preview is committed
    And no eligibility modal is shown yet
    And no order is submitted
    When the user presses Place Order again
    Then the geo-restriction sheet is shown
    And no order is submitted

  Scenario: Add Funds still shows geo restriction for ineligible users
    Given the user is in Pro mode on a Perps market
    And the user is geographically restricted for Perps
    When the user presses Add Funds
    Then the geo-restriction sheet is shown
    And the deposit flow does not start
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/67ce991d-0284-4f96-875f-1d501986b751



### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/6f7204b8-2284-49cf-aa62-28e253fe6679



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches compliance and geo-eligibility gating on the Pro order-submit path, which is regulatory-sensitive. Scope is focused and mirrors the existing Lite trade-entry pattern with unit coverage.
> 
> **Overview**
> **Blocks geo-restricted users from submitting Perps Pro orders**, closing a gap where Place Order skipped the compliance/eligibility checks that Lite already applies on trade entry.
> 
> `onPlaceOrderPress` now runs **compliance first, then geographic eligibility**. Ineligible users see the existing geo-restriction sheet (`TRADE_ACTION`) and never reach execution. Pending slider commits still flush before the gate.
> 
> Also extracts a reusable `showEligibilityModal(source)` helper in `usePerpsHomeActions` so Add Funds and Place Order share the same modal/tracking path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba6d7b4e46cec5d6463a815cec3a556be31ac551. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->