### PR TITLE
feat(networks): register Gravity Mainnet (L1) so its network logo renders

### DIFF
--- a/app/util/networks/customNetworks.tsx
+++ b/app/util/networks/customNetworks.tsx
@@ -399,6 +399,7 @@ export const NETWORK_CHAIN_ID: {
   readonly APECHAIN_TESTNET: '0x8157';
   readonly APECHAIN_MAINNET: '0x8173';
   readonly GRAVITY_ALPHA_MAINNET: '0x659';
+  readonly GRAVITY: '0x1f019';
   readonly KAIA_MAINNET: '0x2019';
   readonly KAIA_KAIROS_TESTNET: '0x3e9';
   readonly SONEIUM_MAINNET: '0x74c';
@@ -450,6 +451,7 @@ export const NETWORK_CHAIN_ID: {
   APECHAIN_TESTNET: '0x8157',
   APECHAIN_MAINNET: '0x8173',
   GRAVITY_ALPHA_MAINNET: '0x659',
+  GRAVITY: '0x1f019',
   KAIA_MAINNET: '0x2019',
   KAIA_KAIROS_TESTNET: '0x3e9',
   SONEIUM_MAINNET: '0x74c',
@@ -504,6 +506,7 @@ export const CustomNetworkImgMapping: Record<Hex, string> = {
   [NETWORK_CHAIN_ID.APECHAIN_TESTNET]: require('../../images/apechain.png'),
   [NETWORK_CHAIN_ID.APECHAIN_MAINNET]: require('../../images/apechain.png'),
   [NETWORK_CHAIN_ID.GRAVITY_ALPHA_MAINNET]: require('../../images/gravity.png'),
+  [NETWORK_CHAIN_ID.GRAVITY]: require('../../images/gravity.png'),
   [NETWORK_CHAIN_ID.LINEA_MAINNET]: require('../../images/linea-mainnet-logo.png'),
   [NETWORK_CHAIN_ID.KAIA_MAINNET]: require('../../images/kaia.png'),
   [NETWORK_CHAIN_ID.KAIA_KAIROS_TESTNET]: require('../../images/kaia.png'),


### PR DESCRIPTION
## Description

Gravity Mainnet (L1, chainId `127001` / `0x1f019`) currently renders a **blank network logo** in MetaMask Mobile.

The brand asset `app/images/gravity.png` is **already in this repo** — Gravity Alpha Mainnet (`0x659`) uses it today — but Gravity L1 is not present in `CustomNetworkImgMapping`, so it falls back to a letter placeholder.

This PR adds the chain ID to `NETWORK_CHAIN_ID` and maps it to the existing asset.

**Config only — no new assets, no new files.**

**`PopularList` is deliberately untouched.** Popular-network placement is a separate commercial discussion and is explicitly not part of this change.

### Not a duplicate of the existing Gravity entry

Gravity L1 (`0x1f019`) is a **different chain** from Gravity Alpha Mainnet (`0x659`), which is an Arbitrum Nitro rollup being deprecated. Different layer, different chain ID. The new constant is `GRAVITY` (vs. the existing `GRAVITY_ALPHA_MAINNET`), so there is no collision.

### Network details

| Field | Value |
| --- | --- |
| Name | Gravity |
| Chain ID | 127001 (`0x1f019`) |
| Native currency | G, 18 decimals |
| RPC | https://mainnet-rpc.gravity.xyz |
| Explorer | https://mainnet-explorer.gravity.xyz |

Chain metadata is registered upstream: [ethereum-lists/chains eip155-127001.json](https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-127001.json)

Supersedes #31683, which added a `PopularList` entry instead. That part has been dropped here so this PR is purely the logo registration.

## Changelog

Added the network logo for Gravity Mainnet (L1)

## Manual testing steps

1. Add Gravity Mainnet as a custom network: RPC `https://mainnet-rpc.gravity.xyz`, chain ID `127001`, symbol `G`, explorer `https://mainnet-explorer.gravity.xyz`.
2. Switch to it.
3. The network avatar shows the Gravity logo instead of a letter placeholder.

## Screenshots/Recordings

### Before

Network avatar renders as a letter placeholder.

### After

Renders `gravity.png`, matching how Gravity Alpha Mainnet already appears today.

## Pre-merge author checklist

- [x] I have followed the [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)
- [x] I have completed the PR template to the best of my ability
- [x] I have included tests if applicable — none needed; this adds entries to existing constant maps
- [x] I have documented my code using JSDoc format if applicable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only constant and image-map additions with no logic, security, or data-handling changes.
> 
> **Overview**
> Registers **Gravity Mainnet (L1)** chain ID `0x1f019` so its network avatar uses the existing `gravity.png` asset instead of a letter placeholder.
> 
> Adds `GRAVITY` to `NETWORK_CHAIN_ID` and maps it in `CustomNetworkImgMapping`. No new assets and no `PopularList` changes — this is logo registration only, separate from the existing Gravity Alpha Mainnet (`0x659`) entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ec0cf86e01de17f4ce640e30596f4d100feab13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->