### PR TITLE
fix(rewards): read benefit impression wallet from the trackingWallet URL param

### DIFF
--- a/app/components/UI/Rewards/Views/BenefitFullView.test.tsx
+++ b/app/components/UI/Rewards/Views/BenefitFullView.test.tsx
@@ -38,7 +38,7 @@ const mockBenefit: SubscriptionBenefitDto = {
   thumbnail: 'https://example.com/thumb.png',
   validFrom: '2026-01-01T00:00:00Z',
   validTo: '2026-12-31T23:59:59Z',
-  url: 'https://benefits.example.com/claim?wallet=0x1111111111111111111111111111111111111111',
+  url: 'https://benefits.example.com/claim?trackingWallet=0x1111111111111111111111111111111111111111',
   actionDate: '2026-12-30T00:00:00Z',
   companyName: 'Pudgy Penguins',
   chain: 'ethereum',
@@ -187,7 +187,7 @@ describe('BenefitFullView', () => {
     const otherWallet = '0x2222222222222222222222222222222222222222';
     mockRouteBenefit = {
       ...mockBenefit,
-      url: `https://benefits.example.com/claim?wallet=${otherWallet}&ref=abc`,
+      url: `https://benefits.example.com/claim?trackingWallet=${otherWallet}&ref=abc`,
     };
 
     render(<BenefitFullView />);

--- a/app/components/UI/Rewards/Views/BenefitFullView.tsx
+++ b/app/components/UI/Rewards/Views/BenefitFullView.tsx
@@ -39,7 +39,7 @@ import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 
 const BENEFIT_CLAIM_BUTTON_TYPE = 'claim';
-const BENEFIT_URL_WALLET_PARAM = 'wallet';
+const BENEFIT_URL_WALLET_PARAM = 'trackingWallet';
 
 const getBenefitWalletAddress = (url: string): string | undefined => {
   if (!url) return undefined;


### PR DESCRIPTION
## **Description**

Benefit impressions were meant to include the wallet address since 8.4.0, but partner-reported data showed no addresses arriving. The benefit click URLs carry the address as a `trackingWallet` query parameter (alongside `trackingBenefitId`, `trackingBenefitType` and `trackingSource`), while the client read a `wallet` parameter. The lookup always returned `undefined`, so the `walletAddress` field was omitted from every impression call.

This changes the parameter the client reads to `trackingWallet`, so the impression reports the same address that click attribution uses. Reproduced against a real benefit URL: `query['wallet']` is `undefined`, `query['trackingWallet']` holds the address.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A — reported by the benefits partner via Slack (impressions arriving without wallet addresses on 8.4.0).

## **Manual testing steps**

```gherkin
Feature: benefit impression wallet attribution

  Scenario: user opens a benefit whose URL carries a trackingWallet param
    Given a benefit whose url contains trackingWallet=<address>

    When the user opens the benefit detail view
    Then the client posts RewardsController:postBenefitImpression with <address>
    And the POST /benefits/impression body contains walletAddress=<address>

  Scenario: user opens a benefit whose URL has no wallet param
    Given a benefit whose url contains no trackingWallet param

    When the user opens the benefit detail view
    Then the impression is posted with walletAddress omitted
```

Unit coverage: `BenefitFullView.test.tsx` asserts the exact extracted address is passed to `postBenefitImpression`, including the no-param → `undefined` case (19 tests passing).

## **Screenshots/Recordings**

N/A — no UI change; analytics payload only.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line query-param rename for analytics attribution, with matching test updates and no auth or UI behavior changes.
> 
> **Overview**
> Fixes benefit impression attribution so the wallet address is included again.
> 
> `BenefitFullView` now reads the `trackingWallet` query param from benefit click URLs (instead of `wallet`), matching the param partners actually send. Tests were updated to use the corrected param.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a1647068f52d70c54c914f72d633e3c32bd8a9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->