### PR TITLE
fix: TSA-985-show QuickBuy for unfunded accounts

### DIFF
--- a/app/components/UI/TokenDetails/components/TokenDetailsStickyFooter.test.tsx
+++ b/app/components/UI/TokenDetails/components/TokenDetailsStickyFooter.test.tsx
@@ -1021,10 +1021,10 @@ describe('TokenDetailsStickyFooter', () => {
       expect(onQuickBuyPress).not.toHaveBeenCalled();
     });
 
-    it('hides the quick buy button when the account has no eligible swap source', () => {
+    it('renders the quick buy button when the account has no eligible swap source', () => {
       mockHasEligibleSwapTokens = false;
       const onQuickBuyPress = jest.fn();
-      const { queryByTestId } = render(
+      const { getByTestId } = render(
         <TokenDetailsStickyFooter
           {...defaultProps}
           onQuickBuyPress={onQuickBuyPress}
@@ -1032,7 +1032,9 @@ describe('TokenDetailsStickyFooter', () => {
         />,
       );
 
-      expect(queryByTestId(quickBuyTestID)).toBeNull();
+      fireEvent.press(getByTestId(quickBuyTestID));
+
+      expect(onQuickBuyPress).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/components/UI/TokenDetails/components/TokenDetailsStickyFooter.test.tsx
+++ b/app/components/UI/TokenDetails/components/TokenDetailsStickyFooter.test.tsx
@@ -149,6 +149,7 @@ describe('TokenDetailsStickyFooter', () => {
     jest.clearAllMocks();
     mockIsBuyable.mockReturnValue(true);
     mockIsTokenTradingOpen.mockReturnValue(true);
+    mockIsStockToken.mockReturnValue(false);
     mockHasEligibleSwapTokens = true;
     setupSelectorMock();
     mockUseABTest.mockReturnValue({

--- a/app/components/UI/TokenDetails/components/TokenDetailsStickyFooter.tsx
+++ b/app/components/UI/TokenDetails/components/TokenDetailsStickyFooter.tsx
@@ -215,8 +215,7 @@ const TokenDetailsStickyFooter: React.FC<TokenStickyFooterProps> = ({
     : isBuyable || !hasEligibleSwapTokens;
   const showMoneyEarnButton = isMoneyEarnCtaActive;
   const showBothButtons = showSwapButton && showBuyButton;
-  const showQuickBuyButton =
-    !isMoneyEarnCtaActive && Boolean(onQuickBuyPress) && hasEligibleSwapTokens;
+  const showQuickBuyButton = !isMoneyEarnCtaActive && Boolean(onQuickBuyPress);
 
   const tradingOpen = isTokenTradingOpen(token as BridgeToken);
   useEffect(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- decouple the asset details QuickBuy lightning button from swap-source eligibility
- keep existing swap/buy footer visibility logic unchanged
- update the QuickBuy button test to cover accounts without eligible swap sources
- reset the stock-token mock between footer tests so geo-restriction state does not leak across cases

<img width="3796" height="2153" alt="SCR-20260812-jydg" src="https://github.com/user-attachments/assets/19e3be17-8392-415d-adef-c4074c6d92b8" />


## Testing
- `yarn jest app/components/UI/TokenDetails/components/TokenDetailsStickyFooter.test.tsx -t "quick buy button"` — initially failed on the new no-swap-source expectation due leaked `mockIsStockToken` state from the preceding geo-restriction test; fixed by resetting the mock in `beforeEach`
- `NODE_OPTIONS="--max-old-space-size=8192" yarn jest app/components/UI/TokenDetails/components/TokenDetailsStickyFooter.test.tsx -t "renders the quick buy button when the account has no eligible swap source"` — assertion reported `PASS`; the Jest wrapper hung after printing results in this cloud environment and was terminated
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/D0BEW7886U9/p1783620917095449?thread_ts=1783620917.095449&cid=D0BEW7886U9)

<div><a href="https://cursor.com/agents/bc-e8a9be3e-b172-5d03-baf3-e333da1ae7e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8a9be3e-b172-5d03-baf3-e333da1ae7e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

