### PR TITLE
feat(quickbuy): enable Robinhood chain and fix empty pay-with picker

### DIFF
--- a/app/components/UI/QuickBuy/hooks/stablecoins.test.ts
+++ b/app/components/UI/QuickBuy/hooks/stablecoins.test.ts
@@ -5,11 +5,13 @@ describe('isStablecoinSymbol', () => {
     expect(isStablecoinSymbol('USDC')).toBe(true);
     expect(isStablecoinSymbol('USDT')).toBe(true);
     expect(isStablecoinSymbol('mUSD')).toBe(true);
+    expect(isStablecoinSymbol('USDe')).toBe(true);
   });
 
   it('matches case-insensitively', () => {
     expect(isStablecoinSymbol('usdc')).toBe(true);
     expect(isStablecoinSymbol('MUSD')).toBe(true);
+    expect(isStablecoinSymbol('usde')).toBe(true);
   });
 
   it('returns false for non-stablecoin symbols', () => {

--- a/app/components/UI/QuickBuy/hooks/stablecoins.ts
+++ b/app/components/UI/QuickBuy/hooks/stablecoins.ts
@@ -5,7 +5,7 @@
  * `DefaultSwapDestTokens` list. Matching is case-insensitive so the source
  * token definitions are handled regardless of their symbol casing.
  */
-const STABLECOIN_SYMBOLS = new Set(['musd', 'usdc', 'usdt']);
+const STABLECOIN_SYMBOLS = new Set(['musd', 'usdc', 'usdt', 'usde']);
 
 export const isStablecoinSymbol = (symbol: string | undefined): boolean =>
   symbol !== undefined && STABLECOIN_SYMBOLS.has(symbol.toLowerCase());

--- a/app/components/UI/QuickBuy/hooks/usePayWithTokens.test.ts
+++ b/app/components/UI/QuickBuy/hooks/usePayWithTokens.test.ts
@@ -9,7 +9,6 @@ import { TrxScope, BtcScope } from '@metamask/keyring-api';
 import { EVM_SCOPE } from '../../Earn/constants/networks';
 import { enrichTokenBalance } from './enrichTokenBalance';
 import { usePayWithTokens } from './usePayWithTokens';
-import { useNetworkEnabledPredicate } from './useNetworkEnabledPredicate';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(() => undefined),
@@ -58,14 +57,9 @@ jest.mock('./enrichTokenBalance', () => ({
   enrichTokenBalance: jest.fn(),
 }));
 
-jest.mock('./useNetworkEnabledPredicate', () => ({
-  useNetworkEnabledPredicate: jest.fn(),
-}));
-
 const mockUseSelector = useSelector as jest.Mock;
 const mockUseTokensWithBalance = useTokensWithBalance as jest.Mock;
 const mockEnrich = enrichTokenBalance as jest.Mock;
-const mockUseNetworkEnabledPredicate = useNetworkEnabledPredicate as jest.Mock;
 const mockGetIgnoredTokens =
   getTokensControllerAllIgnoredTokens as unknown as jest.Mock;
 const mockGetIgnoredAssets =
@@ -128,7 +122,6 @@ describe('usePayWithTokens', () => {
       selector(FAKE_STATE),
     );
     mockAccountByScope.mockReturnValue(() => undefined);
-    mockUseNetworkEnabledPredicate.mockReturnValue(() => true);
   });
 
   it('returns the held tokens enriched with priced balances', () => {
@@ -199,14 +192,17 @@ describe('usePayWithTokens', () => {
     expect(mockEnrich).not.toHaveBeenCalled();
   });
 
-  it('drops held tokens on networks the user has not enabled', () => {
+  it('keeps cross-chain holdings regardless of the wallet enabled-networks filter (TSA-921)', () => {
+    // Regression: an exclusive `enableNetwork('eip155:4663')` (Robinhood)
+    // used to collapse the wallet's enabled-map to Robinhood-only via
+    // `useNetworkEnabledPredicate`, dropping every held token on other
+    // chains. `usePayWithTokens` no longer consults that filter, so the
+    // caller sees every bridge-reachable holding.
     mockUseTokensWithBalance.mockReturnValue([
-      token('USDC', '0x1'),
-      token('CAKE', '0x38'),
+      token('ETH', '0x1237'),
+      token('MUSD', '0xe708'),
+      token('USDT', '0x89'),
     ]);
-    mockUseNetworkEnabledPredicate.mockReturnValue(
-      (chainId: string | undefined) => chainId === '0x1',
-    );
     mockEnrich.mockImplementation((t: BridgeToken) => ({
       balance: '10',
       balanceFiat: '$10.00',
@@ -216,11 +212,11 @@ describe('usePayWithTokens', () => {
 
     const { result } = renderHook(() => usePayWithTokens());
 
-    expect(result.current.options.map((o) => o.symbol)).toEqual(['USDC']);
-    expect(mockEnrich).not.toHaveBeenCalledWith(
-      expect.objectContaining({ symbol: 'CAKE' }),
-      expect.anything(),
-    );
+    expect(result.current.options.map((o) => o.symbol)).toEqual([
+      'ETH',
+      'MUSD',
+      'USDT',
+    ]);
   });
 
   it('enriches held tokens without a price fallback', () => {

--- a/app/components/UI/QuickBuy/hooks/usePayWithTokens.ts
+++ b/app/components/UI/QuickBuy/hooks/usePayWithTokens.ts
@@ -23,7 +23,6 @@ import { getTokensControllerAllIgnoredTokens } from '../../../../selectors/asset
 import { EVM_SCOPE } from '../../Earn/constants/networks';
 import { enrichTokenBalance } from './enrichTokenBalance';
 import { isPayWithTokenHidden } from './isPayWithTokenHidden';
-import { useNetworkEnabledPredicate } from './useNetworkEnabledPredicate';
 
 /**
  * Returns the "Pay with" token options for QuickBuy Buy mode: every tradable
@@ -35,6 +34,14 @@ import { useNetworkEnabledPredicate } from './useNetworkEnabledPredicate';
  * eligible — not just a curated stablecoin/native allowlist. Each token is then
  * re-priced through `enrichTokenBalance` to attach the USD `currencyExchangeRate`
  * the controller relies on, and unpriceable holdings are filtered out.
+ *
+ * Deliberately does NOT filter by `NetworkEnablementController`'s enabled-map:
+ * that map is a wallet-list display preference that can be flipped to a single
+ * chain by any `enableNetwork` caller (Trending / Add Popular Network /
+ * network picker — all exclusive), which would otherwise strand QuickBuy with
+ * only the destination chain and produce an empty picker even when the user
+ * has plenty of cross-chain balance. Bridge/Swaps itself ignores this filter
+ * for the same reason (TSA-921 follow-up).
  */
 export const usePayWithTokens = (): {
   options: BridgeToken[];
@@ -42,7 +49,6 @@ export const usePayWithTokens = (): {
 } => {
   const sourceChainIds = useSelector(selectSelectedSourceChainIds);
   const heldTokens = useTokensWithBalance({ chainIds: sourceChainIds });
-  const isChainEnabled = useNetworkEnabledPredicate();
 
   const accountByScope = useSelector(selectSelectedInternalAccountByScope);
   const accountAddress = accountByScope(EVM_SCOPE)?.address;
@@ -94,8 +100,6 @@ export const usePayWithTokens = (): {
 
     const result: BridgeToken[] = [];
     for (const token of heldTokens) {
-      // Scope holdings to networks the user has enabled in wallet settings.
-      if (!isChainEnabled(token.chainId)) continue;
       // Exclude tokens the user has hidden (TSA-649).
       if (
         isPayWithTokenHidden(token, {
@@ -116,7 +120,6 @@ export const usePayWithTokens = (): {
     return result;
   }, [
     heldTokens,
-    isChainEnabled,
     accountByScope,
     accountAddress,
     accountsByChainId,

--- a/app/components/UI/QuickBuy/hooks/usePayWithTokens.ts
+++ b/app/components/UI/QuickBuy/hooks/usePayWithTokens.ts
@@ -41,7 +41,7 @@ import { isPayWithTokenHidden } from './isPayWithTokenHidden';
  * network picker — all exclusive), which would otherwise strand QuickBuy with
  * only the destination chain and produce an empty picker even when the user
  * has plenty of cross-chain balance. Bridge/Swaps itself ignores this filter
- * for the same reason (TSA-921 follow-up).
+ * for the same reason.
  */
 export const usePayWithTokens = (): {
   options: BridgeToken[];

--- a/app/components/UI/QuickBuy/hooks/useReceiveTokens.test.ts
+++ b/app/components/UI/QuickBuy/hooks/useReceiveTokens.test.ts
@@ -80,6 +80,13 @@ jest.mock('../../Bridge/utils/getAllChainDefaultDestTokens', () => ({
       decimals: 6,
       name: 'Tether USD',
     },
+    {
+      symbol: 'USDe',
+      address: '0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34',
+      chainId: '0x1237',
+      decimals: 18,
+      name: 'Ethena USDe',
+    },
   ]),
 }));
 
@@ -134,6 +141,15 @@ jest.mock('../../Bridge/utils/tokenUtils', () => ({
         chainId: 'bip122:000000000019d6689c085ae165831e93',
       };
     }
+    if (chainId === '0x1237') {
+      return {
+        symbol: 'ETH',
+        name: 'Ethereum',
+        address: '0x0000000000000000000000000000000000000000',
+        decimals: 18,
+        chainId: '0x1237',
+      };
+    }
     throw new Error(`unsupported chain ${chainId}`);
   }),
 }));
@@ -147,6 +163,7 @@ const mockSelectSelectedInternalAccountByScope =
 const SOLANA_CHAIN_ID = SolScope.Mainnet;
 const TRON_CHAIN_ID = TrxScope.Mainnet;
 const BITCOIN_CHAIN_ID = BtcScope.Mainnet;
+const ROBINHOOD_CHAIN_ID = '0x1237';
 
 const MOCK_STATE = {
   engine: {
@@ -214,9 +231,14 @@ describe('useReceiveTokens', () => {
     const { result } = renderHook(() => useReceiveTokens(undefined));
 
     const natives = result.current.filter(
-      (t) => t.symbol === 'ETH' || t.symbol === 'POL',
+      (t) =>
+        t.address === '0x0000000000000000000000000000000000000000' &&
+        (t.symbol === 'ETH' || t.symbol === 'POL'),
     );
-    expect(natives).toHaveLength(2);
+    expect(natives).toHaveLength(3);
+    expect(natives.map((t) => t.chainId)).toEqual(
+      expect.arrayContaining(['0x1', '0x89', ROBINHOOD_CHAIN_ID]),
+    );
     natives.forEach((token) => {
       expect(token.address).toBe('0x0000000000000000000000000000000000000000');
     });
@@ -333,6 +355,48 @@ describe('useReceiveTokens', () => {
         }),
         { includeZeroBalance: true },
       );
+    });
+  });
+
+  describe('Robinhood candidates', () => {
+    it('includes USDe and native ETH when Robinhood is enabled', () => {
+      mockUseNetworkEnabledPredicate.mockReturnValue(
+        (chainId: string | undefined) => chainId === ROBINHOOD_CHAIN_ID,
+      );
+
+      const { result } = renderHook(() => useReceiveTokens(undefined));
+
+      const robinhoodTokens = result.current.filter(
+        (t) => t.chainId === ROBINHOOD_CHAIN_ID,
+      );
+      expect(robinhoodTokens.map((t) => t.symbol)).toEqual(['USDe', 'ETH']);
+      expect(robinhoodTokens[0].address).toBe(
+        '0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34',
+      );
+      expect(robinhoodTokens[1].address).toBe(
+        '0x0000000000000000000000000000000000000000',
+      );
+    });
+
+    it('omits Robinhood candidates when Robinhood is not enabled', () => {
+      mockUseNetworkEnabledPredicate.mockReturnValue(
+        (chainId: string | undefined) => chainId !== ROBINHOOD_CHAIN_ID,
+      );
+
+      const { result } = renderHook(() => useReceiveTokens(undefined));
+
+      const chainIds = result.current.map((t) => t.chainId);
+      expect(chainIds).not.toContain(ROBINHOOD_CHAIN_ID);
+      expect(chainIds).toContain('0x1');
+    });
+
+    it('sorts Robinhood USDe first when the preferred chain is Robinhood', () => {
+      mockUseNetworkEnabledPredicate.mockReturnValue(() => true);
+
+      const { result } = renderHook(() => useReceiveTokens(ROBINHOOD_CHAIN_ID));
+
+      expect(result.current[0].chainId).toBe(ROBINHOOD_CHAIN_ID);
+      expect(result.current[0].symbol).toBe('USDe');
     });
   });
 

--- a/app/components/Views/SocialLeaderboard/utils/chainMapping.test.ts
+++ b/app/components/Views/SocialLeaderboard/utils/chainMapping.test.ts
@@ -24,6 +24,7 @@ describe('chainNameToId', () => {
     ['linea', 'eip155:59144'],
     ['bsc', 'eip155:56'],
     ['solana', 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+    ['robinhood', 'eip155:4663'],
   ])('maps %s to %s', (chainName, expectedId) => {
     expect(chainNameToId(chainName)).toBe(expectedId);
   });
@@ -64,6 +65,7 @@ describe('isSupportedChain', () => {
       'linea',
       'bsc',
       'solana',
+      'robinhood',
     ];
     supported.forEach((chain) => {
       expect(isSupportedChain(chain)).toBe(true);

--- a/app/components/Views/SocialLeaderboard/utils/chainMapping.ts
+++ b/app/components/Views/SocialLeaderboard/utils/chainMapping.ts
@@ -13,6 +13,7 @@ const CHAIN_NAME_TO_ID: Record<string, CaipChainId> = {
   linea: 'eip155:59144',
   bsc: 'eip155:56',
   solana: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+  robinhood: 'eip155:4663',
 };
 
 export const chainNameToId = (chainName: string): CaipChainId | undefined =>


### PR DESCRIPTION
## **Description**

Adds Robinhood Chain support in QuickBuy and fixes a related Buy-mode bug discovered while testing on Robinhood ETH.
Swaps/Bridge already supports Robinhood (`0x1237` / `eip155:4663`). QuickBuy had a few gaps:

- **Sell → Receive picker**: Added `usde` to `STABLECOIN_SYMBOLS` so Robinhood USDe (from default swap dest tokens) appears alongside native ETH in the Receive list when selling on Robinhood.
- **Follow Trading / feed deeplinks**: Added `robinhood: 'eip155:4663'` to `chainMapping.ts` so `positionToQuickBuyTarget()` resolves Robinhood positions.

### Fix: empty Pay with when buying Robinhood ETH

While manually testing Buy mode on Robinhood ETH token details, Pay with showed no tokens (no chain pills, "No tokens available to pay with") even though the user held balances on Linea, Polygon, OP, etc. Full Swaps correctly offered those same holdings (e.g. Linea mUSD → Robinhood ETH).

**Root cause:** `usePayWithTokens` filtered held tokens through `useNetworkEnabledPredicate`, which reads `NetworkEnablementController.enabledNetworkMap`. That map is **exclusive** — any `enableNetwork()` call (Trending / Add Popular Network / network picker) disables every other network. After navigating to Robinhood (e.g. via the Robinhood swaps banner), the map could collapse to Robinhood-only. QuickBuy then only saw Robinhood ETH as a pay-with candidate; `useQuickBuyController` correctly excludes the destination asset → empty picker.

**Fix:** Remove the enabled-network filter from `usePayWithTokens`. Pay-with options are already scoped to bridge-supported chains via `selectSelectedSourceChainIds` / `useTokensWithBalance`, unpriceable tokens are dropped by `enrichTokenBalance`, and hidden tokens remain excluded via `isPayWithTokenHidden`. This matches Swaps behavior and does not mutate the user's network enablement preferences.

<img width="442" height="245" alt="Screenshot 2026-08-12 at 10 40 01" src="https://github.com/user-attachments/assets/64356573-bf1d-4f0d-a27c-0c49d405717e" />
<img width="453" height="268" alt="Screenshot 2026-08-12 at 10 40 29" src="https://github.com/user-attachments/assets/492e60d8-2020-41fd-9938-d6f4ca30958f" />
<img width="417" height="344" alt="Screenshot 2026-08-12 at 10 41 24" src="https://github.com/user-attachments/assets/d837ce59-a4dd-4f29-bfaf-f96cc46d146a" />
<img width="415" height="502" alt="Screenshot 2026-08-12 at 11 35 45" src="https://github.com/user-attachments/assets/a87611ca-3321-4685-8c25-799ccea4d428" />

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: TSA-921

## **Manual testing steps**

```gherkin
Feature: QuickBuy Robinhood support

  Scenario: Sell on Robinhood shows USDe and ETH in Receive picker
    Given Robinhood Chain is enabled and the user holds Robinhood ETH
    When the user opens QuickBuy in Sell mode for Robinhood ETH
    Then the Receive picker includes USDe and native ETH on Robinhood

  Scenario: Buy Robinhood ETH shows cross-chain Pay with options
    Given the user holds tokens on Linea/Polygon/other bridge-supported chains
    And NetworkEnablementController has been collapsed to Robinhood-only (e.g. after opening a Robinhood trending token)
    When the user opens QuickBuy in Buy mode on Robinhood ETH token details
    Then Pay with lists cross-chain holdings (e.g. Linea mUSD, Polygon USDT)
    And Robinhood ETH itself is not selectable as pay-with

  Scenario: Follow Trading deeplink resolves Robinhood chain
    Given a feed position on Robinhood chain
    When the user taps Quick Buy from Follow Trading
    Then QuickBuy opens with the Robinhood destination token
```

## **Screenshots/Recordings**

N/A — manual verification performed on simulator; Pay with populated after fix (cross-chain tokens visible when buying Robinhood ETH).

### **Before**

Pay with empty when buying Robinhood ETH after exclusive network enablement.

### **After**

Pay with lists cross-chain holdings consistent with full Swaps.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TSA-921]: https://consensyssoftware.atlassian.net/browse/TSA-921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tokens appear in QuickBuy Pay with by dropping the wallet enabled-network filter, which can surface more cross-chain holdings than before. Scope is limited to picker curation and aligns with existing Swaps behavior.
> 
> **Overview**
> Adds **Robinhood Chain** support to QuickBuy and fixes Buy-mode showing an empty Pay with list after exclusive network enablement.
> 
> **Pay with fix (TSA-921):** `usePayWithTokens` no longer filters holdings through `useNetworkEnabledPredicate`. Exclusive `enableNetwork` calls (e.g. opening Robinhood) could collapse the wallet enabled-map to one chain and hide cross-chain balances. Options stay scoped to bridge source chains, priced tokens, and non-hidden assets—matching Swaps.
> 
> **Robinhood receive / deeplinks:** Adds `usde` to `STABLECOIN_SYMBOLS` so Sell → Receive can offer Robinhood USDe with native ETH, and maps `robinhood` → `eip155:4663` in Social Leaderboard `chainMapping` so Follow Trading positions resolve correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22eba24327cbfb2ba36a6551a7512d50839a5814. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->