### PR TITLE
feat(homepage): update Predict discovery slots for Aug 17–30 window

### DIFF
--- a/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx
@@ -79,17 +79,33 @@ const HOMEPAGE_DISCOVERY_EPL_MARKET = {
   slug: 'epl-2027-champion-20260701200428749',
 };
 
-const HOMEPAGE_DISCOVERY_NBA_MARKET = {
+const HOMEPAGE_DISCOVERY_LA_LIGA_MARKET = {
   ...HOMEPAGE_DISCOVERY_MARKET_BASE,
-  id: '478277',
-  title: 'NBA: 2027 Champion',
-  slug: 'nba-2027-champion',
+  id: '659548',
+  title: 'La Liga: 2027 Champion',
+  slug: 'laliga-2027-champion-20260701200737375',
+};
+
+const HOMEPAGE_DISCOVERY_BUNDESLIGA_MARKET = {
+  ...HOMEPAGE_DISCOVERY_MARKET_BASE,
+  id: '681261',
+  title: 'Bundesliga: 2027 Champion',
+  slug: 'bundesliga-2027-champion-20260708164840303',
+};
+
+const HOMEPAGE_DISCOVERY_SERIE_A_MARKET = {
+  ...HOMEPAGE_DISCOVERY_MARKET_BASE,
+  id: '659488',
+  title: 'Serie A: 2027 Champion',
+  slug: 'serie-a-2027-champion-20260701200118390',
 };
 
 const homepageMarketSlotsMock = () =>
   homepageMarketSlotsResultMock([
     HOMEPAGE_DISCOVERY_EPL_MARKET,
-    HOMEPAGE_DISCOVERY_NBA_MARKET,
+    HOMEPAGE_DISCOVERY_LA_LIGA_MARKET,
+    HOMEPAGE_DISCOVERY_BUNDESLIGA_MARKET,
+    HOMEPAGE_DISCOVERY_SERIE_A_MARKET,
   ]);
 
 const mockUseABTest = jest.fn(
@@ -652,7 +668,9 @@ describe('PredictionsSection', () => {
 
       await waitFor(() => {
         expect(screen.getByText('EPL: 2027 Champion')).toBeOnTheScreen();
-        expect(screen.getByText('NBA: 2027 Champion')).toBeOnTheScreen();
+        expect(screen.getByText('La Liga: 2027 Champion')).toBeOnTheScreen();
+        expect(screen.getByText('Bundesliga: 2027 Champion')).toBeOnTheScreen();
+        expect(screen.getByText('Serie A: 2027 Champion')).toBeOnTheScreen();
       });
     });
 
@@ -674,6 +692,12 @@ describe('PredictionsSection', () => {
         expect(
           screen.getByTestId('homepage-predict-discovery-market-slot-3'),
         ).toBeOnTheScreen();
+        expect(
+          screen.getByTestId('homepage-predict-discovery-market-slot-4'),
+        ).toBeOnTheScreen();
+        expect(
+          screen.getByTestId('homepage-predict-discovery-market-slot-5'),
+        ).toBeOnTheScreen();
       });
       expect(
         within(
@@ -683,7 +707,17 @@ describe('PredictionsSection', () => {
       expect(
         within(
           screen.getByTestId('homepage-predict-discovery-market-slot-3'),
-        ).getByText('NBA: 2027 Champion'),
+        ).getByText('La Liga: 2027 Champion'),
+      ).toBeOnTheScreen();
+      expect(
+        within(
+          screen.getByTestId('homepage-predict-discovery-market-slot-4'),
+        ).getByText('Bundesliga: 2027 Champion'),
+      ).toBeOnTheScreen();
+      expect(
+        within(
+          screen.getByTestId('homepage-predict-discovery-market-slot-5'),
+        ).getByText('Serie A: 2027 Champion'),
       ).toBeOnTheScreen();
     });
 
@@ -743,7 +777,7 @@ describe('PredictionsSection', () => {
       });
     });
 
-    it('tracks the NBA slot click as a sports CTA', async () => {
+    it('tracks the La Liga slot click as a sports CTA', async () => {
       mockUsePredictMarketsForHomepage.mockReturnValue({
         markets: noPositionsTrendingMarkets,
         isLoading: false,
@@ -755,12 +789,12 @@ describe('PredictionsSection', () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText('NBA: 2027 Champion')).toBeOnTheScreen();
+        expect(screen.getByText('La Liga: 2027 Champion')).toBeOnTheScreen();
       });
 
       mockTrackEvent.mockClear();
 
-      fireEvent.press(screen.getByText('NBA: 2027 Champion'));
+      fireEvent.press(screen.getByText('La Liga: 2027 Champion'));
 
       expect(mockTrackEvent).toHaveBeenCalledTimes(1);
       expect(mockTrackEvent).toHaveBeenCalledWith({
@@ -794,6 +828,12 @@ describe('PredictionsSection', () => {
       ).toBeOnTheScreen();
       expect(
         screen.getByTestId('homepage-predict-discovery-market-slot-3'),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('homepage-predict-discovery-market-slot-4'),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('homepage-predict-discovery-market-slot-5'),
       ).toBeOnTheScreen();
     });
 
@@ -1129,7 +1169,15 @@ describe('PredictionsSection', () => {
         expect(screen.getByText('Claim $200.00')).toBeOnTheScreen();
       });
       expect(screen.queryByText('EPL: 2027 Champion')).not.toBeOnTheScreen();
-      expect(screen.queryByText('NBA: 2027 Champion')).not.toBeOnTheScreen();
+      expect(
+        screen.queryByText('La Liga: 2027 Champion'),
+      ).not.toBeOnTheScreen();
+      expect(
+        screen.queryByText('Bundesliga: 2027 Champion'),
+      ).not.toBeOnTheScreen();
+      expect(
+        screen.queryByText('Serie A: 2027 Champion'),
+      ).not.toBeOnTheScreen();
     });
 
     it('does not render active position rows in claimable-only state', async () => {

--- a/app/components/Views/Homepage/Sections/Predictions/constants/homepagePredictMarketSlots.test.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/constants/homepagePredictMarketSlots.test.ts
@@ -4,7 +4,7 @@ import {
 } from './homepagePredictMarketSlots';
 
 describe('homepagePredictMarketSlots', () => {
-  it('defines the August 3–16 slots in display order', () => {
+  it('defines the August 17–30 slots in display order', () => {
     const slots = HOMEPAGE_PREDICT_MARKET_SLOTS;
 
     expect(slots).toEqual([
@@ -24,17 +24,27 @@ describe('homepagePredictMarketSlots', () => {
       },
       {
         type: 'event',
-        id: '478277',
-        slug: 'nba-2027-champion',
+        id: '659548',
+        slug: 'laliga-2027-champion-20260701200737375',
+      },
+      {
+        type: 'event',
+        id: '681261',
+        slug: 'bundesliga-2027-champion-20260708164840303',
+      },
+      {
+        type: 'event',
+        id: '659488',
+        slug: 'serie-a-2027-champion-20260701200118390',
       },
     ]);
   });
 
-  it('queries both event-backed slots as open events', () => {
+  it('queries all event-backed slots as open events', () => {
     const query = HOMEPAGE_PREDICT_EVENT_QUERY;
 
     expect(query).toBe(
-      'active=true&archived=false&closed=false&id=659518&id=478277',
+      'active=true&archived=false&closed=false&id=659518&id=659548&id=681261&id=659488',
     );
   });
 });

--- a/app/components/Views/Homepage/Sections/Predictions/constants/homepagePredictMarketSlots.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/constants/homepagePredictMarketSlots.ts
@@ -17,7 +17,7 @@ export type HomepagePredictMarketSlot =
   | HomepagePredictEventSlot;
 
 /**
- * Predict homepage market slots for August 3–16, 2026.
+ * Predict homepage market slots for August 17–30, 2026.
  *
  * Polymarket represents the championship selections as events containing one
  * market per team, so their IDs are queried through the Gamma events endpoint.
@@ -30,8 +30,18 @@ export const HOMEPAGE_PREDICT_EVENT_SLOTS = [
   },
   {
     type: 'event',
-    id: '478277',
-    slug: 'nba-2027-champion',
+    id: '659548',
+    slug: 'laliga-2027-champion-20260701200737375',
+  },
+  {
+    type: 'event',
+    id: '681261',
+    slug: 'bundesliga-2027-champion-20260708164840303',
+  },
+  {
+    type: 'event',
+    id: '659488',
+    slug: 'serie-a-2027-champion-20260701200118390',
   },
 ] as const satisfies readonly HomepagePredictEventSlot[];
 

--- a/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictMarketSlots.test.ts
+++ b/app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictMarketSlots.test.ts
@@ -26,16 +26,35 @@ const createMarket = (
 
 describe('orderHomepagePredictEventMarkets', () => {
   it('returns configured events in slot order', () => {
-    const nba = createMarket('478277', 'nba-2027-champion', 'NBA');
+    const serieA = createMarket(
+      '659488',
+      'serie-a-2027-champion-20260701200118390',
+      'Serie A',
+    );
+    const bundesliga = createMarket(
+      '681261',
+      'bundesliga-2027-champion-20260708164840303',
+      'Bundesliga',
+    );
+    const laLiga = createMarket(
+      '659548',
+      'laliga-2027-champion-20260701200737375',
+      'La Liga',
+    );
     const epl = createMarket(
       '659518',
       'epl-2027-champion-20260701200428749',
       'EPL',
     );
 
-    const result = orderHomepagePredictEventMarkets([nba, epl]);
+    const result = orderHomepagePredictEventMarkets([
+      serieA,
+      bundesliga,
+      laLiga,
+      epl,
+    ]);
 
-    expect(result).toEqual([epl, nba]);
+    expect(result).toEqual([epl, laLiga, bundesliga, serieA]);
   });
 
   it('excludes an event when its slug does not match config', () => {


### PR DESCRIPTION
## Summary

- Updates `HOMEPAGE_PREDICT_EVENT_SLOTS` for the Aug 17–30 calendar window ([TMCU-1145](https://consensyssoftware.atlassian.net/browse/TMCU-1145))
- Replaces NBA with La Liga, Bundesliga, and Serie A championship markets (EPL unchanged)
- BTC 5m series slot unchanged; control carousel unaffected

## Test plan

- [ ] Verify treatment users (`coreMCU747AbtestPredictPositionsEmptyState` = treatment) see BTC live row + 4 league championship rows on wallet homepage Predict section
- [ ] Confirm EPL, La Liga, Bundesliga, and Serie A markets load and navigate correctly on tap
- [ ] Confirm control users still see the trending carousel (no change)
- [ ] Run unit tests:
  - `yarn jest app/components/Views/Homepage/Sections/Predictions/constants/homepagePredictMarketSlots.test.ts`
  - `yarn jest app/components/Views/Homepage/Sections/Predictions/hooks/useHomepagePredictMarketSlots.test.ts`
  - `yarn jest app/components/Views/Homepage/Sections/Predictions/PredictionsSection.test.tsx`


Made with [Cursor](https://cursor.com)

[TMCU-1145]: https://consensyssoftware.atlassian.net/browse/TMCU-1145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ