### PR TITLE
ci: add CI state read/write scripts for Auto RC OTA baseline tracking

### DIFF
--- a/.github/scripts/rc-ota-state-read.sh
+++ b/.github/scripts/rc-ota-state-read.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# rc-ota-state-read.sh
+#
+# Reads the Auto RC OTA state for a release branch from the CI state branch
+# (default `ci-state/rc-auto-ota`), which holds one JSON file per release branch at
+# `state/<release-branch>.json`:
+#
+#   {
+#     "baseline_sha":        "<commit of the last successful native RC build>",
+#     "baseline_short_sha":  "<short form of baseline_sha>",
+#     "fingerprint":         "<Expo fingerprint at baseline_sha>",
+#     "native_build_number": "<build number that native build was stamped with>",
+#     "ota_revision_count":  <highest auto-OTA revision reserved on top of that baseline>,
+#     "updated_at":          "<ISO8601>"
+#   }
+#
+# A missing state branch or missing file means no native baseline exists yet, so the
+# caller must build natively (the bootstrap case right after a release cut).
+#
+# Environment variables (required):
+#   RELEASE_BRANCH - Release branch the state belongs to (e.g. release/8.0.1)
+#
+# Environment variables (optional):
+#   STATE_BRANCH   - CI state branch to read from (default: ci-state/rc-auto-ota)
+#
+# Outputs (to GITHUB_OUTPUT):
+#   has_state, baseline_sha, baseline_short_sha, baseline_fingerprint,
+#   native_build_number, ota_revision_count
+#
+set -euo pipefail
+
+RELEASE_BRANCH="${RELEASE_BRANCH:?RELEASE_BRANCH environment variable must be set}"
+STATE_BRANCH="${STATE_BRANCH:-ci-state/rc-auto-ota}"
+
+STATE_PATH="state/${RELEASE_BRANCH}.json"
+
+emit() {
+  echo "$1=$2" >> "$GITHUB_OUTPUT"
+}
+
+emit_empty_state() {
+  emit has_state false
+  emit baseline_sha ''
+  emit baseline_short_sha ''
+  emit baseline_fingerprint ''
+  emit native_build_number ''
+  emit ota_revision_count 0
+}
+
+echo "🔍 Reading Auto RC OTA state for ${RELEASE_BRANCH} from ${STATE_BRANCH}:${STATE_PATH}"
+
+if ! git fetch --quiet --depth 1 origin "${STATE_BRANCH}" 2>/dev/null; then
+  echo "ℹ️  State branch ${STATE_BRANCH} does not exist yet — no native baseline recorded."
+  emit_empty_state
+  exit 0
+fi
+
+if ! STATE_JSON=$(git show "FETCH_HEAD:${STATE_PATH}" 2>/dev/null); then
+  echo "ℹ️  No state file at ${STATE_PATH} — no native baseline recorded for this branch yet."
+  emit_empty_state
+  exit 0
+fi
+
+BASELINE_SHA=$(jq -r '.baseline_sha // ""' <<<"$STATE_JSON")
+BASELINE_SHORT_SHA=$(jq -r '.baseline_short_sha // ""' <<<"$STATE_JSON")
+BASELINE_FINGERPRINT=$(jq -r '.fingerprint // ""' <<<"$STATE_JSON")
+NATIVE_BUILD_NUMBER=$(jq -r '.native_build_number // ""' <<<"$STATE_JSON")
+OTA_REVISION_COUNT=$(jq -r '.ota_revision_count // 0' <<<"$STATE_JSON")
+
+if [[ -z "$BASELINE_SHA" ]]; then
+  echo "::warning title=Incomplete Auto RC OTA state::${STATE_PATH} has no baseline_sha; treating as no baseline."
+  emit_empty_state
+  exit 0
+fi
+
+echo "✅ Found baseline for ${RELEASE_BRANCH}:"
+echo "  baseline_sha:        ${BASELINE_SHA}"
+echo "  fingerprint:         ${BASELINE_FINGERPRINT:-<unknown>}"
+echo "  native_build_number: ${NATIVE_BUILD_NUMBER:-<unknown>}"
+echo "  ota_revision_count:  ${OTA_REVISION_COUNT}"
+
+emit has_state true
+emit baseline_sha "$BASELINE_SHA"
+emit baseline_short_sha "$BASELINE_SHORT_SHA"
+emit baseline_fingerprint "$BASELINE_FINGERPRINT"
+emit native_build_number "$NATIVE_BUILD_NUMBER"
+emit ota_revision_count "$OTA_REVISION_COUNT"

--- a/.github/scripts/rc-ota-state-write.sh
+++ b/.github/scripts/rc-ota-state-write.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+#
+# rc-ota-state-write.sh
+#
+# Writes the Auto RC OTA state for a release branch to the CI state branch (default
+# `ci-state/rc-auto-ota`). See rc-ota-state-read.sh for the schema.
+#
+# Two modes:
+#   MODE=baseline      Record a new native baseline (after a successful native RC build)
+#                      and reset ota_revision_count to 0.
+#   MODE=ota-revision  Increment ota_revision_count (to reserve the revision an auto-OTA push is
+#                      about to publish under), leaving the baseline fields untouched.
+#
+# The state branch is an orphan branch holding nothing but these JSON files, so it is
+# never checked out over the working tree: the state repo is materialised in a temp
+# directory via `git init` + a shallow fetch, which also avoids cloning app history.
+# The branch is created as an orphan on first use.
+#
+# Because several release branches can write concurrently, the read-modify-commit-push
+# cycle is retried against the latest remote tip on push rejection.
+#
+# Environment variables (required):
+#   RELEASE_BRANCH      - Release branch the state belongs to (e.g. release/8.0.1)
+#   GITHUB_TOKEN        - Token authorised to push to STATE_BRANCH
+#   GITHUB_REPOSITORY   - owner/repo
+#   MODE                - baseline | ota-revision
+#
+# Environment variables (required when MODE=baseline):
+#   BASELINE_SHA         - Commit that was built natively
+#   BASELINE_FINGERPRINT - Expo fingerprint at BASELINE_SHA
+#   NATIVE_BUILD_NUMBER  - Build number the native build was stamped with
+#
+# Environment variables (optional):
+#   STATE_BRANCH  - CI state branch to write to (default: ci-state/rc-auto-ota)
+#   MAX_ATTEMPTS  - Push attempts before giving up (default: 5)
+#
+# Outputs (to GITHUB_OUTPUT):
+#   ota_revision_count - Value after the write (0 for MODE=baseline)
+#
+set -euo pipefail
+
+RELEASE_BRANCH="${RELEASE_BRANCH:?RELEASE_BRANCH environment variable must be set}"
+GITHUB_TOKEN="${GITHUB_TOKEN:?GITHUB_TOKEN environment variable must be set}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY environment variable must be set}"
+MODE="${MODE:?MODE environment variable must be set (baseline | ota-revision)}"
+STATE_BRANCH="${STATE_BRANCH:-ci-state/rc-auto-ota}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-5}"
+
+if [[ "$MODE" != "baseline" && "$MODE" != "ota-revision" ]]; then
+  echo "::error title=Invalid MODE::MODE must be 'baseline' or 'ota-revision', got: ${MODE}"
+  exit 1
+fi
+
+if [[ "$MODE" == "baseline" ]]; then
+  BASELINE_SHA="${BASELINE_SHA:?BASELINE_SHA must be set when MODE=baseline}"
+  BASELINE_FINGERPRINT="${BASELINE_FINGERPRINT:?BASELINE_FINGERPRINT must be set when MODE=baseline}"
+  NATIVE_BUILD_NUMBER="${NATIVE_BUILD_NUMBER:-}"
+fi
+
+STATE_PATH="state/${RELEASE_BRANCH}.json"
+AUTH_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+cd "${WORK_DIR}"
+git init --quiet
+git remote add origin "${AUTH_URL}"
+git config user.name 'metamaskbot'
+git config user.email 'metamaskbot@users.noreply.github.com'
+
+# Set once the attempt loop has a commit that has not made it to the remote yet. It only stays
+# true while the remote branch is still missing, i.e. during bootstrap: with no remote tip to
+# reconcile against, a rejected push is transient and the same commit can simply be pushed again.
+HAVE_PENDING_COMMIT=false
+
+# Materialises STATE_BRANCH at its current remote tip, or an empty orphan branch when the
+# branch does not exist yet. Called before every attempt so retries rebuild from the latest tip.
+sync_state_branch() {
+  if git fetch --quiet --depth 1 origin "${STATE_BRANCH}" 2>/dev/null; then
+    rm -rf ./state
+    git checkout --quiet -B "${STATE_BRANCH}" FETCH_HEAD
+    HAVE_PENDING_COMMIT=false
+    echo "📥 Synced ${STATE_BRANCH} at $(git rev-parse --short HEAD)"
+  elif [[ "${HAVE_PENDING_COMMIT}" == true ]]; then
+    # `--orphan` fails once the branch name exists locally, so reuse the branch this loop
+    # created on an earlier attempt instead of trying to create it a second time.
+    git checkout --quiet "${STATE_BRANCH}"
+    echo "🌱 Reusing the ${STATE_BRANCH} commit from the previous attempt (remote still has no such branch)"
+  else
+    rm -rf ./state
+    # --orphan on an empty repo leaves an unborn branch, so no `git rm` cleanup is needed.
+    git checkout --quiet --orphan "${STATE_BRANCH}"
+    echo "🌱 ${STATE_BRANCH} does not exist yet; will create it as an orphan branch"
+  fi
+}
+
+NEW_REVISION_COUNT=0
+
+# Rewrites STATE_PATH for the current MODE and sets NEW_REVISION_COUNT.
+# Returns 1 (and leaves the file untouched) when the meaningful fields are unchanged,
+# so re-running a workflow does not push a commit that only moves updated_at.
+write_state_file() {
+  local previous_json='{}'
+  if [[ -f "${STATE_PATH}" ]]; then
+    previous_json="$(cat "${STATE_PATH}")"
+  fi
+
+  local baseline_sha baseline_short_sha fingerprint native_build_number
+  if [[ "$MODE" == "baseline" ]]; then
+    # Only a genuinely new baseline commit resets the revision counter. Re-running the
+    # native build for the commit that is already the baseline must not rewind the count,
+    # or the next OTA would reuse a label that has already shipped.
+    if [[ "$(jq -r '.baseline_sha // ""' <<<"$previous_json")" == "${BASELINE_SHA}" ]]; then
+      NEW_REVISION_COUNT="$(jq -r '.ota_revision_count // 0' <<<"$previous_json")"
+      return 1
+    fi
+
+    baseline_sha="${BASELINE_SHA}"
+    baseline_short_sha="${BASELINE_SHA:0:7}"
+    fingerprint="${BASELINE_FINGERPRINT}"
+    native_build_number="${NATIVE_BUILD_NUMBER}"
+    NEW_REVISION_COUNT=0
+  else
+    baseline_sha="$(jq -r '.baseline_sha // ""' <<<"$previous_json")"
+    baseline_short_sha="$(jq -r '.baseline_short_sha // ""' <<<"$previous_json")"
+    fingerprint="$(jq -r '.fingerprint // ""' <<<"$previous_json")"
+    native_build_number="$(jq -r '.native_build_number // ""' <<<"$previous_json")"
+
+    if [[ -z "$baseline_sha" ]]; then
+      echo "::error title=No native baseline::Cannot record an OTA revision for ${RELEASE_BRANCH}: no baseline in ${STATE_PATH}."
+      exit 1
+    fi
+
+    NEW_REVISION_COUNT="$(( $(jq -r '.ota_revision_count // 0' <<<"$previous_json") + 1 ))"
+  fi
+
+  local candidate_json
+  candidate_json="$(jq -n \
+    --arg baseline_sha "$baseline_sha" \
+    --arg baseline_short_sha "$baseline_short_sha" \
+    --arg fingerprint "$fingerprint" \
+    --arg native_build_number "$native_build_number" \
+    --argjson ota_revision_count "$NEW_REVISION_COUNT" \
+    --arg updated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{
+      baseline_sha: $baseline_sha,
+      baseline_short_sha: $baseline_short_sha,
+      fingerprint: $fingerprint,
+      native_build_number: $native_build_number,
+      ota_revision_count: $ota_revision_count,
+      updated_at: $updated_at
+    }')"
+
+  if [[ -f "${STATE_PATH}" ]] &&
+    diff -q \
+      <(jq -S 'del(.updated_at)' <<<"$previous_json") \
+      <(jq -S 'del(.updated_at)' <<<"$candidate_json") >/dev/null 2>&1; then
+    return 1
+  fi
+
+  mkdir -p "$(dirname "${STATE_PATH}")"
+  printf '%s\n' "$candidate_json" > "${STATE_PATH}"
+}
+
+for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
+  echo "🔄 Attempt ${attempt}/${MAX_ATTEMPTS} to update ${STATE_BRANCH}:${STATE_PATH}"
+
+  sync_state_branch
+
+  # A pending commit already holds exactly what this run wants to write, and there is no new
+  # remote tip to rebase onto, so go straight back to pushing it.
+  if [[ "${HAVE_PENDING_COMMIT}" != true ]]; then
+    if ! write_state_file; then
+      echo "✅ ${STATE_PATH} already records this state (ota_revision_count=${NEW_REVISION_COUNT}); nothing to push."
+      break
+    fi
+
+    git add "${STATE_PATH}"
+    if [[ "$MODE" == "baseline" ]]; then
+      git commit --quiet -m "chore(rc-ota): baseline ${RELEASE_BRANCH} at ${BASELINE_SHA:0:7} (build ${NATIVE_BUILD_NUMBER:-unknown})"
+    else
+      git commit --quiet -m "chore(rc-ota): OTA revision ${NEW_REVISION_COUNT} for ${RELEASE_BRANCH}"
+    fi
+    HAVE_PENDING_COMMIT=true
+  fi
+
+  if git push --quiet origin "HEAD:refs/heads/${STATE_BRANCH}"; then
+    echo "✅ Pushed ${STATE_PATH} (ota_revision_count=${NEW_REVISION_COUNT})"
+    break
+  fi
+
+  if [[ "${attempt}" -eq "${MAX_ATTEMPTS}" ]]; then
+    echo "::error title=Auto RC OTA state push failed::Could not update ${STATE_BRANCH} after ${MAX_ATTEMPTS} attempts."
+    exit 1
+  fi
+
+  echo "⚠️  Push rejected (concurrent update?); retrying against the new remote tip..."
+  sleep $(( attempt * 2 ))
+done
+
+echo "ota_revision_count=${NEW_REVISION_COUNT}" >> "$GITHUB_OUTPUT"
+
+{
+  echo "### Auto RC OTA state updated"
+  echo ""
+  echo "- Branch: \`${RELEASE_BRANCH}\`"
+  echo "- State: \`${STATE_BRANCH}:${STATE_PATH}\`"
+  echo "- Mode: \`${MODE}\`"
+  echo "- OTA revision count: \`${NEW_REVISION_COUNT}\`"
+} >> "${GITHUB_STEP_SUMMARY:-/dev/null}"

--- a/.github/scripts/rc-ota-state-write.sh
+++ b/.github/scripts/rc-ota-state-write.sh
@@ -78,8 +78,12 @@ HAVE_PENDING_COMMIT=false
 # branch does not exist yet. Called before every attempt so retries rebuild from the latest tip.
 sync_state_branch() {
   if git fetch --quiet --depth 1 origin "${STATE_BRANCH}" 2>/dev/null; then
-    rm -rf ./state
-    git checkout --quiet -B "${STATE_BRANCH}" FETCH_HEAD
+    # -f discards any local modifications so this cannot be blocked by "local changes would be
+    # overwritten": on a retry, HEAD may already carry a commit from a previous attempt (its own
+    # release branch's file, plus whatever other release branches' files were fetched alongside
+    # it), and plain `rm -rf` + a non-forced checkout leaves those as unstaged deletions that a
+    # normal checkout refuses to clobber.
+    git checkout --quiet -f -B "${STATE_BRANCH}" FETCH_HEAD
     HAVE_PENDING_COMMIT=false
     echo "📥 Synced ${STATE_BRANCH} at $(git rev-parse --short HEAD)"
   elif [[ "${HAVE_PENDING_COMMIT}" == true ]]; then


### PR DESCRIPTION
## Summary

Part 2/7. Stacked on #34678.

Adds the two scripts backing the native-vs-OTA decision, not wired into any workflow yet (that's PR 3):

- **`rc-ota-state-read.sh`**: reads the recorded native baseline (commit, fingerprint, build number, OTA revision count) for a release branch from `ci-state/rc-auto-ota` — one JSON file per branch. A missing branch/file means no baseline yet (bootstrap case right after a release cut).
- **`rc-ota-state-write.sh`**: writes state in two modes — `baseline` (record a new native baseline, reset the revision counter) and `ota-revision` (reserve/increment it). Retries the read-modify-commit-push cycle on push rejection, reuses the pending local commit on retry during orphan bootstrap instead of re-running `--orphan`, and is idempotent.

## Stack

1. [#34678](https://github.com/MetaMask/metamask-mobile/pull/34678) — extract fingerprint comparison action
2. **This PR** — CI state read/write scripts
3. [#34680](https://github.com/MetaMask/metamask-mobile/pull/34680) — native baseline resolve/update workflows
4. [#34681](https://github.com/MetaMask/metamask-mobile/pull/34681) — in-app Auto RC OTA revision display
5. [#34684](https://github.com/MetaMask/metamask-mobile/pull/34684) — publish RC Auto OTA workflow
6. [#34686](https://github.com/MetaMask/metamask-mobile/pull/34686) — PR comment / Slack OTA rendering
7. [#34687](https://github.com/MetaMask/metamask-mobile/pull/34687) — wire into `build-rc-auto.yml`

## Testing

- `shellcheck` both scripts — clean.
- Exercised the full `baseline` / `ota-revision` / idempotency / read-back cycle against a throwaway bare git repo, including a forced first-push rejection to prove the orphan-bootstrap retry fix.

### Proof

```
🔄 Attempt 1/5 to update ci-state/rc-auto-ota:state/release/8.0.1.json
🌱 ci-state/rc-auto-ota does not exist yet; will create it as an orphan branch
remote: pre-receive: REJECTING first push attempt to simulate a transient race
⚠️  Push rejected (concurrent update?); retrying against the new remote tip...
🔄 Attempt 2/5 to update ci-state/rc-auto-ota:state/release/8.0.1.json
🌱 Reusing the ci-state/rc-auto-ota commit from the previous attempt (remote still has no such branch)
✅ Pushed state/release/8.0.1.json (ota_revision_count=0)
```

Revision reservation increments correctly (0→1→2) and `baseline` for an already-recorded state is a no-op push. `rc-ota-state-read.sh` reads back the same values.

Made with [Cursor](https://cursor.com)
