### PR TITLE
feat: display Auto RC OTA revision label in app info for testers

### DIFF
--- a/app/components/Views/Settings/AppInformation/EnvironmentInfo.tsx
+++ b/app/components/Views/Settings/AppInformation/EnvironmentInfo.tsx
@@ -8,7 +8,7 @@ import {
   updateId,
   checkAutomatically,
 } from 'expo-updates';
-import { OTA_VERSION } from '../../../../constants/ota';
+import { OTA_RC_AUTO_LABEL, OTA_VERSION } from '../../../../constants/ota';
 import {
   getFeatureFlagAppDistribution,
   getFeatureFlagAppEnvironment,
@@ -69,6 +69,11 @@ export const EnvironmentInfo = ({
             {`OTA Update status: ${otaUpdateMessage}`}
           </Text>
           <Text style={styles.branchInfo}>{`OTA Version: ${OTA_VERSION}`}</Text>
+          {OTA_RC_AUTO_LABEL ? (
+            <Text style={styles.branchInfo}>
+              {`Auto RC OTA revision: ${OTA_RC_AUTO_LABEL}`}
+            </Text>
+          ) : null}
         </>
       ) : null}
       {preinstalledSnaps.map((snap) => (

--- a/app/components/Views/Settings/AppInformation/EnvironmentInfo.tsx
+++ b/app/components/Views/Settings/AppInformation/EnvironmentInfo.tsx
@@ -8,7 +8,11 @@ import {
   updateId,
   checkAutomatically,
 } from 'expo-updates';
-import { OTA_RC_AUTO_LABEL, OTA_VERSION } from '../../../../constants/ota';
+import {
+  OTA_RC_AUTO_COMMIT,
+  OTA_RC_AUTO_LABEL,
+  OTA_VERSION,
+} from '../../../../constants/ota';
 import {
   getFeatureFlagAppDistribution,
   getFeatureFlagAppEnvironment,
@@ -72,6 +76,11 @@ export const EnvironmentInfo = ({
           {OTA_RC_AUTO_LABEL ? (
             <Text style={styles.branchInfo}>
               {`Auto RC OTA revision: ${OTA_RC_AUTO_LABEL}`}
+            </Text>
+          ) : null}
+          {OTA_RC_AUTO_COMMIT ? (
+            <Text style={styles.branchInfo}>
+              {`Auto RC OTA commit: ${OTA_RC_AUTO_COMMIT}`}
             </Text>
           ) : null}
         </>

--- a/app/components/Views/Settings/AppInformation/index.test.tsx
+++ b/app/components/Views/Settings/AppInformation/index.test.tsx
@@ -47,10 +47,14 @@ jest.mock(
 // Getters (rather than plain values) so individual tests can flip these without re-mocking:
 // the component reads both at render time.
 let mockOtaRcAutoLabel = '';
+let mockOtaRcAutoCommit = '';
 jest.mock('../../../../constants/ota', () => ({
   OTA_VERSION: 'v0',
   get OTA_RC_AUTO_LABEL() {
     return mockOtaRcAutoLabel;
+  },
+  get OTA_RC_AUTO_COMMIT() {
+    return mockOtaRcAutoCommit;
   },
 }));
 
@@ -106,6 +110,7 @@ describe('AppInformation', () => {
     mockGetFeatureFlagAppEnvironment.mockReturnValue('Development');
     mockGetFeatureFlagAppDistribution.mockReturnValue('main');
     mockOtaRcAutoLabel = '';
+    mockOtaRcAutoCommit = '';
     mockIsEmbeddedLaunch = true;
   });
 
@@ -709,6 +714,40 @@ describe('AppInformation', () => {
         expect(getByText('OTA Version: v0')).toBeOnTheScreen();
       });
       expect(queryByText(/Auto RC OTA revision:/)).not.toBeOnTheScreen();
+    });
+
+    it('displays the Auto RC OTA commit in the environment info panel', async () => {
+      // Given an Auto RC OTA update: the revision orders it, the commit identifies it
+      mockOtaRcAutoLabel = '8.0.1.2';
+      mockOtaRcAutoCommit = 'a1b2c3d';
+
+      const { getByText, UNSAFE_getAllByType } = renderScreen(
+        AppInformation,
+        { name: 'AppInformation' },
+        { state: MOCK_STATE },
+      );
+
+      longPressFox(UNSAFE_getAllByType(TouchableOpacity));
+
+      await waitFor(() => {
+        expect(getByText('Auto RC OTA commit: a1b2c3d')).toBeOnTheScreen();
+        expect(getByText('Auto RC OTA revision: 8.0.1.2')).toBeOnTheScreen();
+      });
+    });
+
+    it('omits the Auto RC OTA commit line when no commit is set', async () => {
+      const { getByText, queryByText, UNSAFE_getAllByType } = renderScreen(
+        AppInformation,
+        { name: 'AppInformation' },
+        { state: MOCK_STATE },
+      );
+
+      longPressFox(UNSAFE_getAllByType(TouchableOpacity));
+
+      await waitFor(() => {
+        expect(getByText('OTA Version: v0')).toBeOnTheScreen();
+      });
+      expect(queryByText(/Auto RC OTA commit:/)).not.toBeOnTheScreen();
     });
   });
 });

--- a/app/components/Views/Settings/AppInformation/index.test.tsx
+++ b/app/components/Views/Settings/AppInformation/index.test.tsx
@@ -44,8 +44,26 @@ jest.mock(
   }),
 );
 
+// Getters (rather than plain values) so individual tests can flip these without re-mocking:
+// the component reads both at render time.
+let mockOtaRcAutoLabel = '';
 jest.mock('../../../../constants/ota', () => ({
   OTA_VERSION: 'v0',
+  get OTA_RC_AUTO_LABEL() {
+    return mockOtaRcAutoLabel;
+  },
+}));
+
+let mockIsEmbeddedLaunch = true;
+jest.mock('expo-updates', () => ({
+  channel: 'test-channel',
+  runtimeVersion: '1.0.0',
+  isEnabled: true,
+  checkAutomatically: 'NEVER',
+  updateId: 'mock-update-id',
+  get isEmbeddedLaunch() {
+    return mockIsEmbeddedLaunch;
+  },
 }));
 
 const MOCK_STATE = {
@@ -87,6 +105,8 @@ describe('AppInformation', () => {
     mockIsProduction.mockReturnValue(true);
     mockGetFeatureFlagAppEnvironment.mockReturnValue('Development');
     mockGetFeatureFlagAppDistribution.mockReturnValue('main');
+    mockOtaRcAutoLabel = '';
+    mockIsEmbeddedLaunch = true;
   });
 
   afterEach(() => {
@@ -599,6 +619,96 @@ describe('AppInformation', () => {
         expect(getByText(/Check Automatically: NEVER/)).toBeTruthy();
         expect(getByText(/OTA Update status:/)).toBeTruthy();
       });
+    });
+  });
+
+  describe('Auto RC OTA revision label', () => {
+    const originalDev = (globalThis as unknown as { __DEV__: boolean }).__DEV__;
+
+    beforeEach(() => {
+      // The OTA version string is only shown outside dev mode while running a downloaded update.
+      (globalThis as unknown as { __DEV__: boolean }).__DEV__ = false;
+      mockIsEmbeddedLaunch = false;
+    });
+
+    afterEach(() => {
+      (globalThis as unknown as { __DEV__: boolean }).__DEV__ = originalDev;
+    });
+
+    const longPressFox = (
+      touchables: ReturnType<
+        ReturnType<typeof renderScreen>['UNSAFE_getAllByType']
+      >,
+    ) => {
+      const foxTouchable = touchables.find(
+        (item) => item.props.onLongPress !== undefined,
+      );
+      if (foxTouchable) {
+        fireEvent(foxTouchable, 'longPress');
+      }
+    };
+
+    it('displays the Auto RC OTA revision instead of OTA_VERSION when one is set', async () => {
+      // Given an OTA update published by the Auto RC OTA flow
+      mockOtaRcAutoLabel = '8.0.1.2';
+
+      const { getByText } = renderScreen(
+        AppInformation,
+        { name: 'AppInformation' },
+        { state: MOCK_STATE },
+      );
+
+      // When the version string renders
+      // Then it shows the 4-decimal revision testers were told to verify
+      await waitFor(() => {
+        expect(getByText('MetaMask ota 8.0.1.2 (1000)')).toBeOnTheScreen();
+      });
+    });
+
+    it('falls back to OTA_VERSION when no Auto RC OTA revision is set', async () => {
+      // Given an OTA update from the manual Runway flow (no Auto RC label inlined)
+      const { getByText } = renderScreen(
+        AppInformation,
+        { name: 'AppInformation' },
+        { state: MOCK_STATE },
+      );
+
+      await waitFor(() => {
+        expect(getByText('MetaMask ota v0 (1000)')).toBeOnTheScreen();
+      });
+    });
+
+    it('displays the Auto RC OTA revision in the environment info panel', async () => {
+      mockOtaRcAutoLabel = '8.0.1.2';
+
+      const { getByText, UNSAFE_getAllByType } = renderScreen(
+        AppInformation,
+        { name: 'AppInformation' },
+        { state: MOCK_STATE },
+      );
+
+      longPressFox(UNSAFE_getAllByType(TouchableOpacity));
+
+      await waitFor(() => {
+        expect(getByText('Auto RC OTA revision: 8.0.1.2')).toBeOnTheScreen();
+        // The manual-flow OTA version line stays alongside it
+        expect(getByText('OTA Version: v0')).toBeOnTheScreen();
+      });
+    });
+
+    it('omits the Auto RC OTA revision line when no revision is set', async () => {
+      const { getByText, queryByText, UNSAFE_getAllByType } = renderScreen(
+        AppInformation,
+        { name: 'AppInformation' },
+        { state: MOCK_STATE },
+      );
+
+      longPressFox(UNSAFE_getAllByType(TouchableOpacity));
+
+      await waitFor(() => {
+        expect(getByText('OTA Version: v0')).toBeOnTheScreen();
+      });
+      expect(queryByText(/Auto RC OTA revision:/)).not.toBeOnTheScreen();
     });
   });
 });

--- a/app/components/Views/Settings/AppInformation/index.tsx
+++ b/app/components/Views/Settings/AppInformation/index.tsx
@@ -13,7 +13,7 @@ import {
   isEnabled as isOTAUpdatesEnabled,
 } from 'expo-updates';
 import { connect } from 'react-redux';
-import { OTA_VERSION } from '../../../../constants/ota';
+import { OTA_RC_AUTO_LABEL, OTA_VERSION } from '../../../../constants/ota';
 import { strings } from '../../../../../locales/i18n';
 import AppConstants from '../../../../core/AppConstants';
 import { useTheme } from '../../../../util/theme';
@@ -123,10 +123,13 @@ const AppInformation = ({ navigation, preinstalledSnaps }: Props) => {
   /**
    * Returns the version string to display (native app version or OTA version).
    * When OTA is disabled we're always on embedded code; native isEmbeddedLaunch can be false in that case.
+   * On the RC channel, an Auto RC OTA revision label (e.g. 8.0.1.2) takes precedence over
+   * OTA_VERSION so testers can tell which OTA revision they are running.
    */
   const getVersionDisplay = () => {
     const appInfo = `${appName} v${appVersion} (${buildNumber})`;
-    const appInfoOta = `${appName} ota ${OTA_VERSION} (${buildNumber})`;
+    const otaLabel = OTA_RC_AUTO_LABEL || OTA_VERSION;
+    const appInfoOta = `${appName} ota ${otaLabel} (${buildNumber})`;
     const isRunningEmbedded = isEmbeddedLaunch || !isOTAUpdatesEnabled;
     return __DEV__ || isRunningEmbedded ? appInfo : appInfoOta;
   };

--- a/app/constants/ota.ts
+++ b/app/constants/ota.ts
@@ -13,6 +13,20 @@ import otaConfig from '../../ota.config.js';
  * Kept here (not only in ota.config.js) so changes there do not alter the Expo fingerprint and break CI.
  */
 export const OTA_VERSION: string = 'vX.XX.X';
+
+/**
+ * Auto RC OTA revision label (e.g. `8.0.1.2`) for RC-channel testers: the 4th decimal counts
+ * OTA updates published on top of the current native RC build, and resets on each new native
+ * build (see .github/workflows/build-rc-auto.yml).
+ *
+ * This is display-only and deliberately separate from production versioning — `package.json`,
+ * native build numbers, and `OTA_VERSION` are untouched by the Auto RC OTA flow. It is set as an
+ * env var by CI at publish time and inlined here by babel-plugin-transform-inline-environment-variables
+ * (the same mechanism as `GIT_BRANCH`), so no commit to the release branch is needed. Empty for
+ * every other flow, including local builds and the manual Runway OTA flows.
+ */
+export const OTA_RC_AUTO_LABEL: string = process.env.OTA_RC_AUTO_LABEL || '';
+
 export const RUNTIME_VERSION = otaConfig.RUNTIME_VERSION;
 export const PROJECT_ID = otaConfig.PROJECT_ID;
 export const UPDATE_URL = otaConfig.UPDATE_URL;

--- a/app/constants/ota.ts
+++ b/app/constants/ota.ts
@@ -27,6 +27,16 @@ export const OTA_VERSION: string = 'vX.XX.X';
  */
 export const OTA_RC_AUTO_LABEL: string = process.env.OTA_RC_AUTO_LABEL || '';
 
+/**
+ * Short commit SHA (7 chars) the Auto RC OTA revision above was published from.
+ *
+ * The revision counter resets on every new native baseline, so it orders revisions but does not
+ * identify a commit. This pairs it with the exact commit shipped, which is what an engineer needs
+ * to map a tester's report back to git history. Set and inlined by CI the same way as
+ * `OTA_RC_AUTO_LABEL`, and empty for every other flow.
+ */
+export const OTA_RC_AUTO_COMMIT: string = process.env.OTA_RC_AUTO_COMMIT || '';
+
 export const RUNTIME_VERSION = otaConfig.RUNTIME_VERSION;
 export const PROJECT_ID = otaConfig.PROJECT_ID;
 export const UPDATE_URL = otaConfig.UPDATE_URL;


### PR DESCRIPTION
## Summary

Part 4/7. Stacked on #34680 (→ #34679 → #34678). Independent of the CI-side pieces — a pure app-side change that just reads two env vars.

- Adds `OTA_RC_AUTO_LABEL` and `OTA_RC_AUTO_COMMIT` to `app/constants/ota.ts`, inlined at build time via `babel-plugin-transform-inline-environment-variables` (same mechanism as `GIT_BRANCH`).
- Version string (`getVersionDisplay`) shows `MetaMask ota 8.0.1.2 (1000)` instead of the `OTA_VERSION` sentinel when a label is set.
- Debug panel (`EnvironmentInfo`, long-press the fox) gets two new lines: `Auto RC OTA revision: 8.0.1.2` and `Auto RC OTA commit: a1b2c3d`. The revision orders updates and resets on each native baseline; the commit identifies the exact one, for mapping a tester's report back to git history.
- Both env vars are empty until PR 5 sets them, so this PR alone changes nothing visible.

## Stack

1. [#34678](https://github.com/MetaMask/metamask-mobile/pull/34678) — extract fingerprint comparison action
2. [#34679](https://github.com/MetaMask/metamask-mobile/pull/34679) — CI state read/write scripts
3. [#34680](https://github.com/MetaMask/metamask-mobile/pull/34680) — native baseline resolve/update workflows
4. **This PR** — in-app Auto RC OTA revision display
5. [#34684](https://github.com/MetaMask/metamask-mobile/pull/34684) — publish RC Auto OTA workflow
6. [#34686](https://github.com/MetaMask/metamask-mobile/pull/34686) — PR comment / Slack OTA rendering
7. [#34687](https://github.com/MetaMask/metamask-mobile/pull/34687) — wire into `build-rc-auto.yml`

## Testing

- `yarn jest app/components/Views/Settings/AppInformation/index.test.tsx` — 29/29 pass, including 6 new cases.
- `eslint` / `prettier --check` on all touched files — clean.
- `yarn lint:tsc` — no errors on any file touched by this PR.
- Manually: app locally with both env vars unset — Settings → About MetaMask unchanged. Full non-empty verification needs PR 5's build pipeline.

Made with [Cursor](https://cursor.com)
