### PR TITLE
ci: add Publish RC Auto OTA reusable workflow

### DIFF
--- a/.github/workflows/eas-update-platform.yml
+++ b/.github/workflows/eas-update-platform.yml
@@ -35,6 +35,13 @@ on:
         description: 'JSON mapping of secret aliases from builds.yml'
         type: string
         required: true
+      rc_auto_label:
+        description: >-
+          Auto RC OTA revision label (e.g. 8.0.0.2) to inline into the bundle so testers can see
+          which OTA revision they are running. Empty for every flow other than the Auto RC OTA path.
+        type: string
+        required: false
+        default: ''
 
 jobs:
   push-update:
@@ -50,6 +57,9 @@ jobs:
       TARGET_CHANNEL: ${{ inputs.channel }}
       OTA_PUSH_PLATFORM: ${{ inputs.platform }}
       GIT_BRANCH: ${{ github.ref_name }}
+      # Read by app/constants/ota.ts and inlined into the bundle by
+      # babel-plugin-transform-inline-environment-variables during expo export.
+      OTA_RC_AUTO_LABEL: ${{ inputs.rc_auto_label }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -160,6 +170,7 @@ jobs:
           echo "  Channel (vars.EXPO_CHANNEL): ${{ vars.EXPO_CHANNEL }}"
           echo "  Message: ${UPDATE_MESSAGE:-<not set>}"
           echo "  Runtime Version (target): ${TARGET_RUNTIME_VERSION}"
+          echo "  Auto RC OTA label: ${OTA_RC_AUTO_LABEL:-<not set>}"
 
       - name: Diagnose - expo export in isolation
         env:

--- a/.github/workflows/eas-update-platform.yml
+++ b/.github/workflows/eas-update-platform.yml
@@ -42,6 +42,13 @@ on:
         type: string
         required: false
         default: ''
+      rc_auto_commit_sha:
+        description: >-
+          Short SHA of the commit that Auto RC OTA revision was published from, inlined into the
+          bundle next to the label. Empty for every flow other than the Auto RC OTA path.
+        type: string
+        required: false
+        default: ''
 
 jobs:
   push-update:
@@ -60,6 +67,7 @@ jobs:
       # Read by app/constants/ota.ts and inlined into the bundle by
       # babel-plugin-transform-inline-environment-variables during expo export.
       OTA_RC_AUTO_LABEL: ${{ inputs.rc_auto_label }}
+      OTA_RC_AUTO_COMMIT: ${{ inputs.rc_auto_commit_sha }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -171,6 +179,7 @@ jobs:
           echo "  Message: ${UPDATE_MESSAGE:-<not set>}"
           echo "  Runtime Version (target): ${TARGET_RUNTIME_VERSION}"
           echo "  Auto RC OTA label: ${OTA_RC_AUTO_LABEL:-<not set>}"
+          echo "  Auto RC OTA commit: ${OTA_RC_AUTO_COMMIT:-<not set>}"
 
       - name: Diagnose - expo export in isolation
         env:

--- a/.github/workflows/publish-rc-auto-ota.yml
+++ b/.github/workflows/publish-rc-auto-ota.yml
@@ -14,7 +14,9 @@
 #
 # Revision labelling: the display label is `<semver>.<ota_revision_count>` (e.g. 8.0.0.2 for the
 # second OTA on top of native baseline 8.0.0). It is display-only — package.json, native build
-# numbers and OTA_VERSION are never written by this path.
+# numbers and OTA_VERSION are never written by this path. The short SHA of the published commit is
+# reported alongside it, since the revision counter restarts on every new native baseline and so
+# orders updates without identifying the commit behind one.
 #
 # The revision is reserved (incremented and pushed to the state branch) *before* the update is
 # published, because the label is baked into the bundle as OTA_RC_AUTO_LABEL. Incrementing
@@ -40,6 +42,10 @@ on:
         description: 'Release PR number (push-eas-update.yml resolves the HEAD commit from it)'
         required: true
         type: string
+      commit_sha:
+        description: 'Commit being published (the one resolve-rc-native-baseline.yml fingerprinted)'
+        required: true
+        type: string
       base_branch:
         description: 'Base ref push-eas-update.yml compares fingerprints against (e.g. v8.0.1)'
         required: true
@@ -61,6 +67,9 @@ on:
       ota_revision:
         description: 'Revision number published for this OTA update'
         value: ${{ jobs.compute-label.outputs.ota_revision }}
+      ota_commit_short_sha:
+        description: 'Short SHA of the commit this OTA revision was published from'
+        value: ${{ jobs.compute-label.outputs.ota_commit_short_sha }}
 
 permissions:
   contents: read
@@ -107,6 +116,7 @@ jobs:
     outputs:
       ota_label: ${{ steps.label.outputs.ota_label }}
       ota_revision: ${{ steps.label.outputs.ota_revision }}
+      ota_commit_short_sha: ${{ steps.label.outputs.ota_commit_short_sha }}
     steps:
       - name: Compute label
         id: label
@@ -115,12 +125,19 @@ jobs:
           # Already incremented by reserve-revision, so this is the revision being published.
           OTA_REVISION: ${{ needs.reserve-revision.outputs.ota_revision_count }}
           NATIVE_BUILD_NUMBER: ${{ inputs.native_build_number }}
+          COMMIT_SHA: ${{ inputs.commit_sha }}
         run: |
           set -euo pipefail
           LABEL="${SEMVER}.${OTA_REVISION}"
-          echo "ota_revision=${OTA_REVISION}" >> "$GITHUB_OUTPUT"
-          echo "ota_label=${LABEL}" >> "$GITHUB_OUTPUT"
-          echo "Publishing OTA revision ${OTA_REVISION} as ${LABEL} (native build ${NATIVE_BUILD_NUMBER:-unknown})"
+          # The revision resets on each new native baseline, so it orders updates but does not
+          # identify one — the short SHA is what maps a revision back to git history.
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+          {
+            echo "ota_revision=${OTA_REVISION}"
+            echo "ota_label=${LABEL}"
+            echo "ota_commit_short_sha=${SHORT_SHA}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Publishing OTA revision ${OTA_REVISION} as ${LABEL} from ${SHORT_SHA} (native build ${NATIVE_BUILD_NUMBER:-unknown})"
 
   push-ota:
     name: Push OTA update (rc)
@@ -135,4 +152,5 @@ jobs:
       channel: rc
       platform: all
       rc_auto_label: ${{ needs.compute-label.outputs.ota_label }}
+      rc_auto_commit_sha: ${{ needs.compute-label.outputs.ota_commit_short_sha }}
     secrets: inherit

--- a/.github/workflows/publish-rc-auto-ota.yml
+++ b/.github/workflows/publish-rc-auto-ota.yml
@@ -1,0 +1,138 @@
+##############################################################################################
+#
+# Publish RC Auto OTA (reusable)
+#
+# Reserves the next OTA revision on the CI state branch, then publishes an OTA update to the `rc`
+# channel for a release-branch push that resolve-rc-native-baseline.yml determined to be
+# OTA-eligible (fingerprint unchanged since the last native RC build).
+#
+# push-eas-update.yml resolves the commit to publish from the PR's HEAD rather than taking a SHA,
+# so in principle it could pick up a commit newer than the one that was fingerprinted. That is safe
+# on two counts: build-rc-auto.yml's cancel-in-progress concurrency cancels this run as soon as a
+# newer push arrives, and push-eas-update.yml independently re-compares the commit it is about to
+# publish against `base_branch` (the native baseline) and refuses to publish on a mismatch.
+#
+# Revision labelling: the display label is `<semver>.<ota_revision_count>` (e.g. 8.0.0.2 for the
+# second OTA on top of native baseline 8.0.0). It is display-only — package.json, native build
+# numbers and OTA_VERSION are never written by this path.
+#
+# The revision is reserved (incremented and pushed to the state branch) *before* the update is
+# published, because the label is baked into the bundle as OTA_RC_AUTO_LABEL. Incrementing
+# afterwards would leave a window in which cancel-in-progress kills the run between publishing and
+# recording, so the next run would hand the same label to a different bundle. Reserving first makes
+# a cancelled run cost at most a skipped revision number, never a duplicated one.
+#
+##############################################################################################
+name: Publish RC Auto OTA
+
+on:
+  workflow_call:
+    inputs:
+      release_branch:
+        description: 'Release branch being published (e.g. release/8.0.1)'
+        required: true
+        type: string
+      semver:
+        description: 'Release semver the OTA layers on top of (e.g. 8.0.1)'
+        required: true
+        type: string
+      pr_number:
+        description: 'Release PR number (push-eas-update.yml resolves the HEAD commit from it)'
+        required: true
+        type: string
+      base_branch:
+        description: 'Base ref push-eas-update.yml compares fingerprints against (e.g. v8.0.1)'
+        required: true
+        type: string
+      native_build_number:
+        description: 'Build number of the native baseline this OTA layers on top of'
+        required: false
+        type: string
+        default: ''
+      state_branch:
+        description: 'CI state branch holding the per-release baseline files'
+        required: false
+        type: string
+        default: ci-state/rc-auto-ota
+    outputs:
+      ota_label:
+        description: 'Display label published for this OTA revision (e.g. 8.0.1.2)'
+        value: ${{ jobs.compute-label.outputs.ota_label }}
+      ota_revision:
+        description: 'Revision number published for this OTA update'
+        value: ${{ jobs.compute-label.outputs.ota_revision }}
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  reserve-revision:
+    name: Reserve OTA revision in CI state
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      ota_revision_count: ${{ steps.reserve.outputs.ota_revision_count }}
+    steps:
+      # The state branch decides native-vs-OTA for every later push, so it is protected and only
+      # this App identity may push to it — the default GITHUB_TOKEN is deliberately not used.
+      - name: Get token
+        id: get-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            contents: write
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Increment OTA revision count
+        id: reserve
+        env:
+          RELEASE_BRANCH: ${{ inputs.release_branch }}
+          STATE_BRANCH: ${{ inputs.state_branch }}
+          MODE: ota-revision
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
+        run: .github/scripts/rc-ota-state-write.sh
+
+  compute-label:
+    name: Compute OTA revision label
+    needs: reserve-revision
+    runs-on: ubuntu-latest
+    outputs:
+      ota_label: ${{ steps.label.outputs.ota_label }}
+      ota_revision: ${{ steps.label.outputs.ota_revision }}
+    steps:
+      - name: Compute label
+        id: label
+        env:
+          SEMVER: ${{ inputs.semver }}
+          # Already incremented by reserve-revision, so this is the revision being published.
+          OTA_REVISION: ${{ needs.reserve-revision.outputs.ota_revision_count }}
+          NATIVE_BUILD_NUMBER: ${{ inputs.native_build_number }}
+        run: |
+          set -euo pipefail
+          LABEL="${SEMVER}.${OTA_REVISION}"
+          echo "ota_revision=${OTA_REVISION}" >> "$GITHUB_OUTPUT"
+          echo "ota_label=${LABEL}" >> "$GITHUB_OUTPUT"
+          echo "Publishing OTA revision ${OTA_REVISION} as ${LABEL} (native build ${NATIVE_BUILD_NUMBER:-unknown})"
+
+  push-ota:
+    name: Push OTA update (rc)
+    needs: compute-label
+    uses: ./.github/workflows/push-eas-update.yml
+    with:
+      pr_number: ${{ inputs.pr_number }}
+      base_branch: ${{ inputs.base_branch }}
+      message: >-
+        ${{ needs.compute-label.outputs.ota_label }} (auto RC OTA on native build
+        ${{ inputs.native_build_number || 'unknown' }})
+      channel: rc
+      platform: all
+      rc_auto_label: ${{ needs.compute-label.outputs.ota_label }}
+    secrets: inherit

--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -65,6 +65,13 @@ on:
         type: string
         required: false
         default: ''
+      rc_auto_commit_sha:
+        description: >-
+          Short SHA of the commit the Auto RC OTA revision was published from, surfaced in-app
+          next to the label. Set only by publish-rc-auto-ota.yml, like rc_auto_label.
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -402,6 +409,7 @@ jobs:
       github_environment: ${{ needs.prepare.outputs.github_environment }}
       secrets_json: ${{ needs.prepare.outputs.secrets_json }}
       rc_auto_label: ${{ inputs.rc_auto_label }}
+      rc_auto_commit_sha: ${{ inputs.rc_auto_commit_sha }}
     secrets: inherit
 
   push-update-android:
@@ -434,6 +442,7 @@ jobs:
       github_environment: ${{ needs.prepare.outputs.github_environment }}
       secrets_json: ${{ needs.prepare.outputs.secrets_json }}
       rc_auto_label: ${{ inputs.rc_auto_label }}
+      rc_auto_commit_sha: ${{ inputs.rc_auto_commit_sha }}
     secrets: inherit
 
   fingerprint-mismatch:

--- a/.github/workflows/push-eas-update.yml
+++ b/.github/workflows/push-eas-update.yml
@@ -58,6 +58,13 @@ on:
         type: string
         required: false
         default: all
+      rc_auto_label:
+        description: >-
+          Auto RC OTA revision label (e.g. 8.0.0.2) surfaced in-app for testers. Only the Auto RC
+          OTA path (publish-rc-auto-ota.yml) sets this; every other caller leaves it empty.
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -394,6 +401,7 @@ jobs:
       build_name: ${{ needs.prepare.outputs.build_name }}
       github_environment: ${{ needs.prepare.outputs.github_environment }}
       secrets_json: ${{ needs.prepare.outputs.secrets_json }}
+      rc_auto_label: ${{ inputs.rc_auto_label }}
     secrets: inherit
 
   push-update-android:
@@ -425,6 +433,7 @@ jobs:
       build_name: ${{ needs.prepare.outputs.build_name }}
       github_environment: ${{ needs.prepare.outputs.github_environment }}
       secrets_json: ${{ needs.prepare.outputs.secrets_json }}
+      rc_auto_label: ${{ inputs.rc_auto_label }}
     secrets: inherit
 
   fingerprint-mismatch:


### PR DESCRIPTION
## Summary

Part 5/7. Stacked on #34681 (→ #34680 → #34679 → #34678).

Adds the reusable workflow that publishes an Auto RC OTA update once #34680 has determined a push is OTA-eligible:

- **`reserve-revision`** increments the OTA revision counter on the CI state branch *before* publishing — the label is baked into the bundle, so reserving first means a cancelled run costs at most a skipped revision number, never a duplicated label on two different bundles.
- **`compute-label`** builds the display label (`<semver>.<revision>`, e.g. `8.0.0.2`) and derives the 7-char short SHA of the commit being published.
- **`push-ota`** calls `push-eas-update.yml` on the `rc` channel with both values.

`push-eas-update.yml`/`eas-update-platform.yml` gain `rc_auto_label`/`rc_auto_commit_sha` inputs, inlined into the bundle for #34681 to read. Empty for every other caller (manual `workflow_dispatch`, Runway). Not called from `build-rc-auto.yml` yet — that's PR 7.

## Stack

1. [#34678](https://github.com/MetaMask/metamask-mobile/pull/34678) — extract fingerprint comparison action
2. [#34679](https://github.com/MetaMask/metamask-mobile/pull/34679) — CI state read/write scripts
3. [#34680](https://github.com/MetaMask/metamask-mobile/pull/34680) — native baseline resolve/update workflows
4. [#34681](https://github.com/MetaMask/metamask-mobile/pull/34681) — in-app Auto RC OTA revision display
5. **This PR** — publish RC Auto OTA workflow
6. [#34686](https://github.com/MetaMask/metamask-mobile/pull/34686) — PR comment / Slack OTA rendering
7. [#34687](https://github.com/MetaMask/metamask-mobile/pull/34687) — wire into `build-rc-auto.yml`

## Testing

- `actionlint` on all three workflows — clean.
- Confirmed `push-eas-update.yml`'s diff vs. #34678 is exactly the two new inputs + passthrough — no changes to the reviewed fingerprint-comparison logic.
- Reservation behavior (increment-before-publish, no duplicate labels on cancellation) is covered by #34679's tests; `commit_sha` needs no reservation and adds no new race surface.
- Live `workflow_call` exercise needs a real release PR + EAS credentials — left for PR 7 or a maintainer.

Made with [Cursor](https://cursor.com)
