### PR TITLE
feat: render Auto RC OTA updates in the PR comment and Slack notification

### DIFF
--- a/.github/workflows/slack-rc-notification.yml
+++ b/.github/workflows/slack-rc-notification.yml
@@ -36,6 +36,18 @@ on:
         required: false
         type: string
         default: ''
+      ota_label:
+        description: >-
+          Auto RC OTA revision label (e.g. 8.0.1.2). When set, the notification reports an
+          OTA-only update instead of new builds to download.
+        required: false
+        type: string
+        default: ''
+      ota_native_build_number:
+        description: 'Native build number the OTA update runs on top of (paired with ota_label)'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   actions: read
@@ -64,7 +76,11 @@ jobs:
           node-version-file: '.nvmrc'
           cache: yarn
       - name: Read build metadata from repo
-        if: inputs.semver == '' || inputs.ios_build_number == '' || inputs.android_build_number == ''
+        # On the OTA path there are no new build numbers to report, so the repo fallback is
+        # pointless there — only semver is needed and the caller always provides it.
+        if: >
+          inputs.ota_label == '' &&
+          (inputs.semver == '' || inputs.ios_build_number == '' || inputs.android_build_number == '')
         id: build-meta
         run: ./scripts/get-build-metadata.sh --ci
       - name: Install dependencies
@@ -84,5 +100,7 @@ jobs:
           ANDROID_PUBLIC_URL: ${{ secrets.ANDROID_PUBLIC_BUCKET_URL }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           PR_NUMBER: ${{ inputs.pr_number }}
+          OTA_LABEL: ${{ inputs.ota_label }}
+          OTA_NATIVE_BUILD_NUMBER: ${{ inputs.ota_native_build_number }}
           # Disable android check msg for now
           #ANDROID_PLAY_STORE_CHECK_MRKDWN_FILE: ${{ github.workspace }}/android-play-store-check-out/android-play-store-check-slack.md

--- a/.github/workflows/slack-rc-notification.yml
+++ b/.github/workflows/slack-rc-notification.yml
@@ -48,6 +48,11 @@ on:
         required: false
         type: string
         default: ''
+      ota_commit_short_sha:
+        description: 'Short SHA of the commit the OTA revision was published from (paired with ota_label)'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   actions: read
@@ -102,5 +107,6 @@ jobs:
           PR_NUMBER: ${{ inputs.pr_number }}
           OTA_LABEL: ${{ inputs.ota_label }}
           OTA_NATIVE_BUILD_NUMBER: ${{ inputs.ota_native_build_number }}
+          OTA_COMMIT_SHORT_SHA: ${{ inputs.ota_commit_short_sha }}
           # Disable android check msg for now
           #ANDROID_PLAY_STORE_CHECK_MRKDWN_FILE: ${{ github.workspace }}/android-play-store-check-out/android-play-store-check-slack.md

--- a/.github/workflows/slack-rc-notification.yml
+++ b/.github/workflows/slack-rc-notification.yml
@@ -105,7 +105,9 @@ jobs:
           ANDROID_PUBLIC_URL: ${{ secrets.ANDROID_PUBLIC_BUCKET_URL }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           PR_NUMBER: ${{ inputs.pr_number }}
-          OTA_LABEL: ${{ inputs.ota_label }}
+          # Matches OTA_UPDATE_LABEL in scripts/build-announce/utils.ts (same underlying value,
+          # set by build-rc-auto.yml) so the two OTA-rendering consumers can't drift apart.
+          OTA_UPDATE_LABEL: ${{ inputs.ota_label }}
           OTA_NATIVE_BUILD_NUMBER: ${{ inputs.ota_native_build_number }}
           OTA_COMMIT_SHORT_SHA: ${{ inputs.ota_commit_short_sha }}
           # Disable android check msg for now

--- a/scripts/build-announce/index.ts
+++ b/scripts/build-announce/index.ts
@@ -29,7 +29,29 @@ import {
   type WhatsInRcResult,
 } from './cherry-picks-section';
 import { validateEnv } from './validate-env';
-import type { BuildInfo, TestPlanResult, EnvValidationResult } from './types';
+import type {
+  BuildInfo,
+  OtaUpdateInfo,
+  TestPlanResult,
+  EnvValidationResult,
+} from './types';
+
+/**
+ * Builds the delivery section for an OTA-only RC: no new binaries were produced, so testers keep
+ * the native build they already have and receive the update on next launch.
+ */
+function buildOtaUpdateSection(otaUpdate: OtaUpdateInfo): string {
+  const { label, nativeBuildNumber, baselineShortSha } = otaUpdate;
+
+  return `An OTA update was pushed to the \`rc\` channel — **no new builds to install**.
+
+| Field | Value |
+| :--- | :--- |
+| **OTA revision** | \`${label}\` |
+| **Runs on native build** | \`${nativeBuildNumber}\` (\`${baselineShortSha}\`) |
+
+Relaunch the app twice on the \`rc\` channel to pick it up. Verify you are on \`${label}\` under **Settings → About MetaMask**.`;
+}
 
 /**
  * Builds the build links section of the comment
@@ -68,17 +90,22 @@ ${rows.join('\n')}`;
  * Builds the "More Info" collapsible section
  */
 function buildMoreInfoSection(buildInfo: BuildInfo): string {
-  const { semver, iosBuildNumber, androidBuildNumber, pipelineUrl } = buildInfo;
+  const { semver, iosBuildNumber, androidBuildNumber, pipelineUrl, otaUpdate } = buildInfo;
   const pipelineLink = isValidUrl(pipelineUrl)
     ? `[View Pipeline](${pipelineUrl})`
     : 'Not available';
+
+  const buildNumberLines = otaUpdate
+    ? `*   **OTA Revision**: \`${otaUpdate.label}\`
+*   **Native Build Number**: \`${otaUpdate.nativeBuildNumber}\``
+    : `*   **iOS Build Number**: \`${iosBuildNumber}\`
+*   **Android Build Number**: \`${androidBuildNumber}\``;
 
   return `<details>
 <summary>More Info</summary>
 
 *   **Version**: \`${semver}\`
-*   **iOS Build Number**: \`${iosBuildNumber}\`
-*   **Android Build Number**: \`${androidBuildNumber}\`
+${buildNumberLines}
 *   **Build Pipeline**: ${pipelineLink}
 </details>`;
 }
@@ -163,10 +190,12 @@ function buildCommentBody(
   },
   testPlanError?: string,
 ): string {
-  let body = `${RC_BUILD_COMMENT_MARKER}
-### :rocket: RC Builds Ready for Testing
+  const { otaUpdate } = buildInfo;
 
-${buildBuildLinksSection(buildInfo)}
+  let body = `${RC_BUILD_COMMENT_MARKER}
+### :rocket: ${otaUpdate ? 'RC OTA Update Ready for Testing' : 'RC Builds Ready for Testing'}
+
+${otaUpdate ? buildOtaUpdateSection(otaUpdate) : buildBuildLinksSection(buildInfo)}
 
 ${buildMoreInfoSection(buildInfo)}
 
@@ -182,9 +211,12 @@ ${buildMoreInfoSection(buildInfo)}
   }
 
   // Add "What's in this RC" section (cherry-picks + changelog)
-  // Pass build number for unique anchor IDs (so Slack can link to correct comment)
+  // Pass build number for unique anchor IDs (so Slack can link to correct comment).
+  // OTA-only RCs have no new build number, so the OTA revision label discriminates instead —
+  // scripts/slack-rc-notification.mjs derives its anchors the same way.
   if (whatsInRc.result) {
-    const section = buildWhatsInRcSection(whatsInRc.result, buildInfo.androidBuildNumber);
+    const anchorDiscriminator = otaUpdate?.label ?? buildInfo.androidBuildNumber;
+    const section = buildWhatsInRcSection(whatsInRc.result, anchorDiscriminator);
     if (section) {
       body += `---\n\n`;
       body += section;
@@ -220,8 +252,13 @@ async function main(): Promise<void> {
   console.log(`Repository: ${owner}/${repo}`);
   console.log(`PR Number: ${prNumber}`);
   console.log(`Version: ${buildInfo.semver}`);
-  console.log(`iOS Build: ${buildInfo.iosBuildNumber}`);
-  console.log(`Android Build: ${buildInfo.androidBuildNumber}`);
+  if (buildInfo.otaUpdate) {
+    console.log(`OTA Revision: ${buildInfo.otaUpdate.label}`);
+    console.log(`Native Build: ${buildInfo.otaUpdate.nativeBuildNumber}`);
+  } else {
+    console.log(`iOS Build: ${buildInfo.iosBuildNumber}`);
+    console.log(`Android Build: ${buildInfo.androidBuildNumber}`);
+  }
 
   const octokit = new Octokit({ auth: token });
 

--- a/scripts/build-announce/index.ts
+++ b/scripts/build-announce/index.ts
@@ -41,13 +41,15 @@ import type {
  * the native build they already have and receive the update on next launch.
  */
 function buildOtaUpdateSection(otaUpdate: OtaUpdateInfo): string {
-  const { label, nativeBuildNumber, baselineShortSha } = otaUpdate;
+  const { label, nativeBuildNumber, baselineShortSha, commitShortSha } =
+    otaUpdate;
 
   return `An OTA update was pushed to the \`rc\` channel — **no new builds to install**.
 
 | Field | Value |
 | :--- | :--- |
 | **OTA revision** | \`${label}\` |
+| **Commit** | \`${commitShortSha}\` |
 | **Runs on native build** | \`${nativeBuildNumber}\` (\`${baselineShortSha}\`) |
 
 Relaunch the app twice on the \`rc\` channel to pick it up. Verify you are on \`${label}\` under **Settings → About MetaMask**.`;
@@ -97,6 +99,7 @@ function buildMoreInfoSection(buildInfo: BuildInfo): string {
 
   const buildNumberLines = otaUpdate
     ? `*   **OTA Revision**: \`${otaUpdate.label}\`
+*   **Commit**: \`${otaUpdate.commitShortSha}\`
 *   **Native Build Number**: \`${otaUpdate.nativeBuildNumber}\``
     : `*   **iOS Build Number**: \`${iosBuildNumber}\`
 *   **Android Build Number**: \`${androidBuildNumber}\``;
@@ -254,6 +257,7 @@ async function main(): Promise<void> {
   console.log(`Version: ${buildInfo.semver}`);
   if (buildInfo.otaUpdate) {
     console.log(`OTA Revision: ${buildInfo.otaUpdate.label}`);
+    console.log(`OTA Commit: ${buildInfo.otaUpdate.commitShortSha}`);
     console.log(`Native Build: ${buildInfo.otaUpdate.nativeBuildNumber}`);
   } else {
     console.log(`iOS Build: ${buildInfo.iosBuildNumber}`);

--- a/scripts/build-announce/types.ts
+++ b/scripts/build-announce/types.ts
@@ -13,6 +13,24 @@ export interface BuildInfo {
   androidBuildNumber: string;
   pipelineUrl?: string;
   androidPublicUrl?: string;
+  /**
+   * Auto RC OTA details, set only when this RC shipped as an OTA update on top of an existing
+   * native build (no new binaries). Absent for normal native RC builds.
+   */
+  otaUpdate?: OtaUpdateInfo;
+}
+
+/**
+ * Details of an Auto RC OTA update.
+ *
+ * `label` is the display-only 4th-decimal revision (e.g. `8.0.1.2`). Because the revision counter
+ * restarts on every new native baseline, the label is only unambiguous when paired with the
+ * native build it layers on top of, so both are always rendered together.
+ */
+export interface OtaUpdateInfo {
+  label: string;
+  nativeBuildNumber: string;
+  baselineShortSha: string;
 }
 
 /**

--- a/scripts/build-announce/types.ts
+++ b/scripts/build-announce/types.ts
@@ -26,11 +26,15 @@ export interface BuildInfo {
  * `label` is the display-only 4th-decimal revision (e.g. `8.0.1.2`). Because the revision counter
  * restarts on every new native baseline, the label is only unambiguous when paired with the
  * native build it layers on top of, so both are always rendered together.
+ *
+ * `commitShortSha` is the commit this revision shipped, `baselineShortSha` the commit the native
+ * build underneath it was made from.
  */
 export interface OtaUpdateInfo {
   label: string;
   nativeBuildNumber: string;
   baselineShortSha: string;
+  commitShortSha: string;
 }
 
 /**

--- a/scripts/build-announce/utils.ts
+++ b/scripts/build-announce/utils.ts
@@ -8,7 +8,7 @@ import { Octokit } from '@octokit/rest';
 import { execFileSync } from 'child_process';
 import { existsSync, unlinkSync, readFileSync } from 'fs';
 import { resolve, join } from 'path';
-import type { TestPlanResult } from './types';
+import type { BuildInfo, TestPlanResult } from './types';
 
 export const RC_BUILD_COMMENT_MARKER = '<!-- metamask-bot-rc-build-announce -->';
 export const TESTFLIGHT_URL = 'https://testflight.apple.com/join/hBrjtFuA';
@@ -178,20 +178,21 @@ export async function generateTestPlan(
 /**
  * Parses environment variables for build info
  */
-export function parseBuildInfo(): {
-  semver: string;
-  iosBuildNumber: string;
-  androidBuildNumber: string;
-  pipelineUrl?: string;
-  androidPublicUrl?: string;
-} {
+export function parseBuildInfo(): BuildInfo {
   const {
     SEMVER,
     IOS_BUILD_NUMBER,
     ANDROID_BUILD_NUMBER,
     BUILD_PIPELINE_URL,
     ANDROID_PUBLIC_URL,
+    OTA_UPDATE_LABEL,
+    OTA_NATIVE_BUILD_NUMBER,
+    OTA_BASELINE_SHORT_SHA,
   } = process.env;
+
+  // Only the Auto RC OTA path sets OTA_UPDATE_LABEL, so its presence is what distinguishes an
+  // OTA-only RC from a native one.
+  const otaLabel = OTA_UPDATE_LABEL?.trim();
 
   return {
     semver: SEMVER || 'Unknown',
@@ -199,6 +200,13 @@ export function parseBuildInfo(): {
     androidBuildNumber: ANDROID_BUILD_NUMBER || 'Unknown',
     pipelineUrl: BUILD_PIPELINE_URL,
     androidPublicUrl: ANDROID_PUBLIC_URL,
+    otaUpdate: otaLabel
+      ? {
+          label: otaLabel,
+          nativeBuildNumber: OTA_NATIVE_BUILD_NUMBER?.trim() || 'Unknown',
+          baselineShortSha: OTA_BASELINE_SHORT_SHA?.trim() || 'Unknown',
+        }
+      : undefined,
   };
 }
 

--- a/scripts/build-announce/utils.ts
+++ b/scripts/build-announce/utils.ts
@@ -188,6 +188,7 @@ export function parseBuildInfo(): BuildInfo {
     OTA_UPDATE_LABEL,
     OTA_NATIVE_BUILD_NUMBER,
     OTA_BASELINE_SHORT_SHA,
+    OTA_COMMIT_SHORT_SHA,
   } = process.env;
 
   // Only the Auto RC OTA path sets OTA_UPDATE_LABEL, so its presence is what distinguishes an
@@ -205,6 +206,7 @@ export function parseBuildInfo(): BuildInfo {
           label: otaLabel,
           nativeBuildNumber: OTA_NATIVE_BUILD_NUMBER?.trim() || 'Unknown',
           baselineShortSha: OTA_BASELINE_SHORT_SHA?.trim() || 'Unknown',
+          commitShortSha: OTA_COMMIT_SHORT_SHA?.trim() || 'Unknown',
         }
       : undefined,
   };

--- a/scripts/slack-rc-notification.mjs
+++ b/scripts/slack-rc-notification.mjs
@@ -10,7 +10,7 @@
  *               SLACK_RC_NOTIFICATION_DRY_RUN,
  *               ANDROID_PLAY_STORE_CHECK_MRKDWN_FILE (PLAY_STORE_CHECK_STATUS=pass|fail)
  *
- * OTA-only RCs (Auto RC OTA path, see .github/workflows/build-rc-auto.yml) set OTA_LABEL,
+ * OTA-only RCs (Auto RC OTA path, see .github/workflows/build-rc-auto.yml) set OTA_UPDATE_LABEL,
  * OTA_NATIVE_BUILD_NUMBER and OTA_COMMIT_SHORT_SHA instead of new build numbers: no binaries were
  * produced, so the message drops the download links and reports the OTA revision, the commit it
  * shipped, and the native build it runs on.
@@ -338,8 +338,10 @@ async function main() {
   const expectedChannelName = getSlackChannel(version);
 
   // OTA-only RC: no new binaries, so the OTA revision label identifies the delivery (and
-  // discriminates the PR-comment anchors, matching scripts/build-announce/index.ts).
-  const otaLabel = process.env.OTA_LABEL?.trim() || '';
+  // discriminates the PR-comment anchors, matching scripts/build-announce/index.ts). Env var
+  // name matches OTA_UPDATE_LABEL in scripts/build-announce/utils.ts (same underlying value,
+  // set by build-rc-auto.yml) so the two consumers can't drift apart.
+  const otaLabel = process.env.OTA_UPDATE_LABEL?.trim() || '';
   const otaNativeBuildNumber = process.env.OTA_NATIVE_BUILD_NUMBER?.trim() || 'Unknown';
   const otaCommitShortSha = process.env.OTA_COMMIT_SHORT_SHA?.trim() || 'Unknown';
   const anchorDiscriminator =

--- a/scripts/slack-rc-notification.mjs
+++ b/scripts/slack-rc-notification.mjs
@@ -10,9 +10,10 @@
  *               SLACK_RC_NOTIFICATION_DRY_RUN,
  *               ANDROID_PLAY_STORE_CHECK_MRKDWN_FILE (PLAY_STORE_CHECK_STATUS=pass|fail)
  *
- * OTA-only RCs (Auto RC OTA path, see .github/workflows/build-rc-auto.yml) set OTA_LABEL and
- * OTA_NATIVE_BUILD_NUMBER instead of new build numbers: no binaries were produced, so the message
- * drops the download links and reports the OTA revision plus the native build it runs on.
+ * OTA-only RCs (Auto RC OTA path, see .github/workflows/build-rc-auto.yml) set OTA_LABEL,
+ * OTA_NATIVE_BUILD_NUMBER and OTA_COMMIT_SHORT_SHA instead of new build numbers: no binaries were
+ * produced, so the message drops the download links and reports the OTA revision, the commit it
+ * shipped, and the native build it runs on.
  */
 
 import fs from 'fs';
@@ -81,6 +82,7 @@ function buildSlackMessage(options) {
     playStoreCheckMrkdwn,
     otaLabel,
     otaNativeBuildNumber,
+    otaCommitShortSha,
     anchorDiscriminator,
   } = options;
 
@@ -104,6 +106,10 @@ function buildSlackMessage(options) {
             {
               type: 'mrkdwn',
               text: `*Runs on native build:*\n${otaNativeBuildNumber}`,
+            },
+            {
+              type: 'mrkdwn',
+              text: `*Commit:*\n${otaCommitShortSha}`,
             },
           ],
         },
@@ -335,6 +341,7 @@ async function main() {
   // discriminates the PR-comment anchors, matching scripts/build-announce/index.ts).
   const otaLabel = process.env.OTA_LABEL?.trim() || '';
   const otaNativeBuildNumber = process.env.OTA_NATIVE_BUILD_NUMBER?.trim() || 'Unknown';
+  const otaCommitShortSha = process.env.OTA_COMMIT_SHORT_SHA?.trim() || 'Unknown';
   const anchorDiscriminator =
     otaLabel ||
     (androidBuildNumber && androidBuildNumber !== 'N/A' && androidBuildNumber !== 'Unknown'
@@ -343,7 +350,7 @@ async function main() {
 
   if (otaLabel) {
     console.log(
-      `\n📣 Preparing Slack notification for RC OTA ${otaLabel} (native build ${otaNativeBuildNumber})`,
+      `\n📣 Preparing Slack notification for RC OTA ${otaLabel} from ${otaCommitShortSha} (native build ${otaNativeBuildNumber})`,
     );
   } else {
     console.log(`\n📣 Preparing Slack notification for RC v${version} (${buildNumber})`);
@@ -371,6 +378,7 @@ async function main() {
     playStoreCheckMrkdwn,
     otaLabel,
     otaNativeBuildNumber,
+    otaCommitShortSha,
     anchorDiscriminator,
   });
 

--- a/scripts/slack-rc-notification.mjs
+++ b/scripts/slack-rc-notification.mjs
@@ -9,6 +9,10 @@
  *               IOS_PUBLIC_URL, BUILD_PIPELINE_URL, PR_NUMBER, GITHUB_REPOSITORY,
  *               SLACK_RC_NOTIFICATION_DRY_RUN,
  *               ANDROID_PLAY_STORE_CHECK_MRKDWN_FILE (PLAY_STORE_CHECK_STATUS=pass|fail)
+ *
+ * OTA-only RCs (Auto RC OTA path, see .github/workflows/build-rc-auto.yml) set OTA_LABEL and
+ * OTA_NATIVE_BUILD_NUMBER instead of new build numbers: no binaries were produced, so the message
+ * drops the download links and reports the OTA revision plus the native build it runs on.
  */
 
 import fs from 'fs';
@@ -70,67 +74,100 @@ function buildSlackMessage(options) {
   const {
     version,
     buildNumber,
-    androidBuildNumber,
     androidUrl,
     iosUrl,
     pipelineUrl,
     prNumber,
     playStoreCheckMrkdwn,
+    otaLabel,
+    otaNativeBuildNumber,
+    anchorDiscriminator,
   } = options;
 
-  const blocks = [
-    {
-      type: 'header',
-      text: {
-        type: 'plain_text',
-        text: `🚀 Mobile RC Build v${version} (${buildNumber})`,
-        emoji: true,
-      },
-    },
-    {
-      type: 'section',
-      fields: [
+  const blocks = otaLabel
+    ? [
         {
-          type: 'mrkdwn',
-          text: `*Version:*\n${version}`,
+          type: 'header',
+          text: {
+            type: 'plain_text',
+            text: `🚀 Mobile RC OTA Update ${otaLabel}`,
+            emoji: true,
+          },
         },
         {
-          type: 'mrkdwn',
-          text: `*Build Number:*\n${buildNumber}`,
-        },
-      ],
-    },
-    {
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: '*📦 Download Links:*',
-      },
-    },
-    {
-      type: 'section',
-      fields: [
-        {
-          type: 'mrkdwn',
-          text: isValidUrl(androidUrl)
-            ? `*Android APK:*\n<${androidUrl}|Download>`
-            : '*Android APK:*\n_Not available_',
+          type: 'section',
+          fields: [
+            {
+              type: 'mrkdwn',
+              text: `*OTA Revision:*\n${otaLabel}`,
+            },
+            {
+              type: 'mrkdwn',
+              text: `*Runs on native build:*\n${otaNativeBuildNumber}`,
+            },
+          ],
         },
         {
-          type: 'mrkdwn',
-          text: isValidUrl(iosUrl)
-            ? `*iOS Build:*\n<${iosUrl}|TestFlight>`
-            : '*iOS Build:*\n<https://testflight.apple.com/join/hBrjtFuA|Check TestFlight>',
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*📲 No new build to install* — relaunch the app twice on the `rc` channel to pick this up.',
+          },
         },
-      ],
-    },
-  ];
+      ]
+    : [
+        {
+          type: 'header',
+          text: {
+            type: 'plain_text',
+            text: `🚀 Mobile RC Build v${version} (${buildNumber})`,
+            emoji: true,
+          },
+        },
+        {
+          type: 'section',
+          fields: [
+            {
+              type: 'mrkdwn',
+              text: `*Version:*\n${version}`,
+            },
+            {
+              type: 'mrkdwn',
+              text: `*Build Number:*\n${buildNumber}`,
+            },
+          ],
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*📦 Download Links:*',
+          },
+        },
+        {
+          type: 'section',
+          fields: [
+            {
+              type: 'mrkdwn',
+              text: isValidUrl(androidUrl)
+                ? `*Android APK:*\n<${androidUrl}|Download>`
+                : '*Android APK:*\n_Not available_',
+            },
+            {
+              type: 'mrkdwn',
+              text: isValidUrl(iosUrl)
+                ? `*iOS Build:*\n<${iosUrl}|TestFlight>`
+                : '*iOS Build:*\n<https://testflight.apple.com/join/hBrjtFuA|Check TestFlight>',
+            },
+          ],
+        },
+      ];
 
   // Add link to cherry-picks section in PR comment
   // Note: GitHub prefixes user-provided anchor IDs with 'user-content-'
   // We use build number in anchor to link to the correct comment (not older builds)
   if (prNumber) {
-    const anchorSuffix = androidBuildNumber && androidBuildNumber !== 'N/A' ? `-${androidBuildNumber}` : '';
+    const anchorSuffix = anchorDiscriminator ? `-${anchorDiscriminator}` : '';
     const cherryPicksLink = `<${REPO_URL}/pull/${prNumber}#user-content-cherry-picks${anchorSuffix}|View cherry-picks>`;
     blocks.push(
       {
@@ -180,7 +217,7 @@ function buildSlackMessage(options) {
       links.push(`<${pipelineUrl}|View Build Pipeline>`);
     }
     if (prNumber) {
-      const anchorSuffix = androidBuildNumber && androidBuildNumber !== 'N/A' ? `-${androidBuildNumber}` : '';
+      const anchorSuffix = anchorDiscriminator ? `-${anchorDiscriminator}` : '';
       links.push(`<${REPO_URL}/pull/${prNumber}#user-content-whats-in-this-rc${anchorSuffix}|View full RC notes>`);
     }
     if (links.length > 0) {
@@ -203,7 +240,10 @@ function buildSlackMessage(options) {
 
   return {
     blocks,
-    text: `🚀 Mobile RC Build v${version} (${buildNumber}) is ready!`, // Fallback text
+    // Fallback text
+    text: otaLabel
+      ? `🚀 Mobile RC OTA Update ${otaLabel} (on native build ${otaNativeBuildNumber}) is ready!`
+      : `🚀 Mobile RC Build v${version} (${buildNumber}) is ready!`,
   };
 }
 
@@ -291,7 +331,23 @@ async function main() {
   const playStoreCheckMrkdwn = loadPlayStoreCheckMrkdwn();
   const expectedChannelName = getSlackChannel(version);
 
-  console.log(`\n📣 Preparing Slack notification for RC v${version} (${buildNumber})`);
+  // OTA-only RC: no new binaries, so the OTA revision label identifies the delivery (and
+  // discriminates the PR-comment anchors, matching scripts/build-announce/index.ts).
+  const otaLabel = process.env.OTA_LABEL?.trim() || '';
+  const otaNativeBuildNumber = process.env.OTA_NATIVE_BUILD_NUMBER?.trim() || 'Unknown';
+  const anchorDiscriminator =
+    otaLabel ||
+    (androidBuildNumber && androidBuildNumber !== 'N/A' && androidBuildNumber !== 'Unknown'
+      ? androidBuildNumber
+      : '');
+
+  if (otaLabel) {
+    console.log(
+      `\n📣 Preparing Slack notification for RC OTA ${otaLabel} (native build ${otaNativeBuildNumber})`,
+    );
+  } else {
+    console.log(`\n📣 Preparing Slack notification for RC v${version} (${buildNumber})`);
+  }
   if (prNumber) {
     console.log(`📍 Release PR: #${prNumber}`);
   }
@@ -313,6 +369,9 @@ async function main() {
     pipelineUrl,
     prNumber,
     playStoreCheckMrkdwn,
+    otaLabel,
+    otaNativeBuildNumber,
+    anchorDiscriminator,
   });
 
   if (isDryRun) {


### PR DESCRIPTION
## Summary

Part 6/7. Stacked on #34684 (→ #34681 → #34680 → #34679 → #34678).

The RC build PR comment and Slack notification currently assume every RC ships new native binaries. Adds OTA-specific rendering for when #34684 ships an OTA-only RC instead:

- **`build-announce`**: `BuildInfo.otaUpdate` (label, commit, native build, baseline) renders "no new builds to install" plus those fields instead of TestFlight/APK links. The "What's in this RC" anchor falls back to the OTA label when there's no new Android build number.
- **`slack-rc-notification`**: reads `OTA_LABEL`/`OTA_NATIVE_BUILD_NUMBER`/`OTA_COMMIT_SHORT_SHA` and renders a distinct "Mobile RC OTA Update" header with no download-link blocks.
- Both show revision + commit together: the revision orders updates (resets per native baseline, so testers/managers quote it), the commit identifies the exact one (for engineers).

Neither script is fed OTA data until PR 7 sets these env vars, so native RCs render byte-identical to today.

## Stack

1. [#34678](https://github.com/MetaMask/metamask-mobile/pull/34678) — extract fingerprint comparison action
2. [#34679](https://github.com/MetaMask/metamask-mobile/pull/34679) — CI state read/write scripts
3. [#34680](https://github.com/MetaMask/metamask-mobile/pull/34680) — native baseline resolve/update workflows
4. [#34681](https://github.com/MetaMask/metamask-mobile/pull/34681) — in-app Auto RC OTA revision display
5. [#34684](https://github.com/MetaMask/metamask-mobile/pull/34684) — publish RC Auto OTA workflow
6. **This PR** — PR comment / Slack OTA rendering
7. [#34687](https://github.com/MetaMask/metamask-mobile/pull/34687) — wire into `build-rc-auto.yml`

## Testing

- `actionlint` on the Slack workflow — clean.
- `eslint`/`prettier --check` on all 4 touched script files — clean.
- `yarn lint:tsc` — no errors (confirms `commitShortSha` is set at every construction site).
- Dry-ran the Slack script for both paths — native path unchanged, OTA path shows the new header with no download links and a commit field:

```
{ "type": "header", "text": { "text": "🚀 Mobile RC OTA Update 8.0.1.2" } },
{ "type": "section", "fields": [
    { "text": "*OTA Revision:*\n8.0.1.2" },
    { "text": "*Runs on native build:*\n1234" },
    { "text": "*Commit:*\na1b2c3d" } ] }
```

- Full end-to-end PR-comment rendering needs a real GitHub token/PR context — left for PR 7 or a maintainer.

Made with [Cursor](https://cursor.com)
