### PR TITLE
feat: enable Bank Account item in Add Funds sheet behind new Brazil Neobank feature flag

### DIFF
--- a/.github/scripts/known-feature-flag-constants.ts
+++ b/.github/scripts/known-feature-flag-constants.ts
@@ -15,6 +15,7 @@ const FILE_SOURCES: Array<{ key: string; file: string; exportName: string }> = [
   { key: 'TOKEN_LIST_SECURITY_BADGES_FLAG_KEY', file: sel('tokenListSecurityBadges'), exportName: 'TOKEN_LIST_SECURITY_BADGES_FLAG_KEY' },
   { key: 'MISSING_ENROLLED_ACCOUNTS_FLAG_NAME', file: REWARDS_FILE, exportName: 'MISSING_ENROLLED_ACCOUNTS_FLAG_NAME' },
   { key: 'MONEY_ACCOUNT_DEPOSIT_QUOTE_PIPELINE_FLAG_KEY', file: sel('moneyAccount'), exportName: 'MONEY_ACCOUNT_DEPOSIT_QUOTE_PIPELINE_FLAG_KEY' },
+  { key: 'MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY', file: sel('moneyAccount'), exportName: 'MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY' },
   { key: 'NETWORK_MANAGEMENT_FLAG_KEY', file: sel('networkManagement'), exportName: 'NETWORK_MANAGEMENT_FLAG_KEY' },
   // FEATURE_FLAG_NAME is omitted (non-unique across rwa / gasFeesSponsored); per-file fallback handles it.
   { key: 'OTA_UPDATES_FLAG_NAME', file: sel('otaUpdates'), exportName: 'OTA_UPDATES_FLAG_NAME' },

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
@@ -10,6 +10,7 @@ import { useMoneyAccountDeposit } from '../../hooks/useMoneyAccount';
 import { useMMPayFiatConfig } from '../../../../Views/confirmations/hooks/pay/useMMPayFiatConfig';
 import { useRegionHasFiatProvider } from '../../../Ramp/hooks/useRegionHasFiatProvider';
 import { selectHasAnyNonZeroTokenBalance } from '../../../../../selectors/tokenBalancesController';
+import { selectMoneyMovementBrazilNeobankEnabled } from '../../../../../selectors/featureFlagController/moneyAccount';
 import {
   MUSD_CONVERSION_DEFAULT_CHAIN_ID,
   MUSD_TOKEN_ADDRESS_BY_CHAIN,
@@ -74,6 +75,16 @@ jest.mock('../../../../../selectors/transactionController', () => ({
   selectHasUnapprovedTransactions: jest.fn(() => false),
 }));
 
+jest.mock(
+  '../../../../../selectors/featureFlagController/moneyAccount',
+  () => ({
+    ...jest.requireActual(
+      '../../../../../selectors/featureFlagController/moneyAccount',
+    ),
+    selectMoneyMovementBrazilNeobankEnabled: jest.fn(),
+  }),
+);
+
 jest.mock('../../../../../selectors/preferencesController', () => ({
   ...jest.requireActual('../../../../../selectors/preferencesController'),
   selectPrivacyMode: jest.fn(() => false),
@@ -133,6 +144,9 @@ describe('MoneyAddMoneySheet', () => {
       true,
     );
     (useRegionHasFiatProvider as jest.Mock).mockReturnValue(true);
+    (
+      selectMoneyMovementBrazilNeobankEnabled as unknown as jest.Mock
+    ).mockReturnValue(true);
   });
 
   it('renders all options', () => {
@@ -146,8 +160,9 @@ describe('MoneyAddMoneySheet', () => {
     expect(getByText('mUSD')).toBeOnTheScreen();
     expect(getByText('Bank account')).toBeOnTheScreen();
     expect(getByText('External address')).toBeOnTheScreen();
-    // Bank account and External address are both coming soon.
-    expect(getAllByText('Coming soon')).toHaveLength(2);
+    // Only External address is coming soon; Bank account is live with a "New" badge.
+    expect(getAllByText('Coming soon')).toHaveLength(1);
+    expect(getByText('New')).toBeOnTheScreen();
     expect(
       getByTestId(MoneyAddMoneySheetTestIds.RECEIVE_EXTERNAL_ROW),
     ).toBeOnTheScreen();
@@ -172,13 +187,34 @@ describe('MoneyAddMoneySheet', () => {
     }
   });
 
-  it('renders the Bank account row as a coming-soon, non-pressable option', () => {
-    const { getByTestId } = renderWithProvider(<MoneyAddMoneySheet />);
+  it('renders the Bank account row enabled with a "New" badge when the neobank flag is on', () => {
+    const { getByTestId, getByText } = renderWithProvider(
+      <MoneyAddMoneySheet />,
+    );
 
     const bankRow = getByTestId(MoneyAddMoneySheetTestIds.BANK_ACCOUNT_ROW);
     expect(bankRow).toBeOnTheScreen();
+    expect(getByText('New')).toBeOnTheScreen();
 
+    // The KYC flow is not wired up yet, so pressing must not start a deposit.
     fireEvent.press(bankRow);
+    expect(mockInitiateDeposit).not.toHaveBeenCalled();
+  });
+
+  it('keeps the Bank account row as a coming-soon, non-pressable option when the neobank flag is off', () => {
+    (
+      selectMoneyMovementBrazilNeobankEnabled as unknown as jest.Mock
+    ).mockReturnValue(false);
+
+    const { getByTestId, getAllByText, queryByText } = renderWithProvider(
+      <MoneyAddMoneySheet />,
+    );
+
+    // Bank account and External address are both coming soon again.
+    expect(getAllByText('Coming soon')).toHaveLength(2);
+    expect(queryByText('New')).toBeNull();
+
+    fireEvent.press(getByTestId(MoneyAddMoneySheetTestIds.BANK_ACCOUNT_ROW));
     expect(mockInitiateDeposit).not.toHaveBeenCalled();
   });
 
@@ -448,12 +484,12 @@ describe('MoneyAddMoneySheet', () => {
     });
   });
 
-  it('keeps Debit card or Apple Pay active, with only Bank account and External address coming soon', () => {
+  it('keeps Debit card or Apple Pay active, with only External address coming soon', () => {
     const { getByTestId, getAllByText } = renderWithProvider(
       <MoneyAddMoneySheet />,
     );
 
-    expect(getAllByText('Coming soon')).toHaveLength(2);
+    expect(getAllByText('Coming soon')).toHaveLength(1);
 
     fireEvent.press(
       getByTestId(MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION),
@@ -472,6 +508,7 @@ describe('MoneyAddMoneySheet', () => {
     root: ReturnType<typeof renderWithProvider>['UNSAFE_root'],
   ): string[] => {
     const optionTestIds: string[] = [
+      MoneyAddMoneySheetTestIds.BANK_ACCOUNT_ROW,
       MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION,
       MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
       MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION,
@@ -489,11 +526,12 @@ describe('MoneyAddMoneySheet', () => {
       });
   };
 
-  it('keeps the original order when all options are enabled', () => {
+  it('keeps the original order, with Bank account first, when all options are enabled', () => {
     const { UNSAFE_root } = renderWithProvider(<MoneyAddMoneySheet />);
     const order = getOptionOrder(UNSAFE_root);
 
     expect(order).toEqual([
+      MoneyAddMoneySheetTestIds.BANK_ACCOUNT_ROW,
       MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION,
       MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
       MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION,
@@ -509,6 +547,7 @@ describe('MoneyAddMoneySheet', () => {
     const order = getOptionOrder(UNSAFE_root);
 
     expect(order).toEqual([
+      MoneyAddMoneySheetTestIds.BANK_ACCOUNT_ROW,
       MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
       MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION,
       MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION,

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
@@ -121,6 +121,10 @@ jest.mock('@metamask/design-system-react-native', () => {
 describe('MoneyAddMoneySheet', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.resetAllMocks();
+    // Re-establish implementations wiped by resetAllMocks.
+    mockOnCloseBottomSheet.mockImplementation((cb?: () => void) => cb?.());
+    mockInitiateDeposit.mockImplementation(() => Promise.resolve());
 
     (useMoneyAnalytics as jest.Mock).mockReturnValue({
       trackBottomSheetViewed: mockTrackBottomSheetViewed,

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.test.tsx
@@ -510,13 +510,13 @@ describe('MoneyAddMoneySheet', () => {
   // dedupe to first occurrence (which preserves render order).
   const getOptionOrder = (
     root: ReturnType<typeof renderWithProvider>['UNSAFE_root'],
-  ): string[] => {
-    const optionTestIds: string[] = [
+    optionTestIds: string[] = [
       MoneyAddMoneySheetTestIds.BANK_ACCOUNT_ROW,
       MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION,
       MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
       MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION,
-    ];
+    ],
+  ): string[] => {
     const seen = new Set<string>();
     return root
       .findAll((node) => optionTestIds.includes(node.props.testID))
@@ -555,6 +555,34 @@ describe('MoneyAddMoneySheet', () => {
       MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
       MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION,
       MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION,
+    ]);
+  });
+
+  it('keeps the coming-soon Bank account row in its pre-flag position when the neobank flag is off', () => {
+    (
+      selectMoneyMovementBrazilNeobankEnabled as unknown as jest.Mock
+    ).mockReturnValue(false);
+    // Empty wallet: Convert crypto is disabled too, so the disabled rows'
+    // relative order must still match prod (Convert crypto above Bank account).
+    (selectHasAnyNonZeroTokenBalance as unknown as jest.Mock).mockReturnValue(
+      false,
+    );
+
+    const { UNSAFE_root } = renderWithProvider(<MoneyAddMoneySheet />);
+    const order = getOptionOrder(UNSAFE_root, [
+      MoneyAddMoneySheetTestIds.BANK_ACCOUNT_ROW,
+      MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION,
+      MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
+      MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION,
+      MoneyAddMoneySheetTestIds.RECEIVE_EXTERNAL_ROW,
+    ]);
+
+    expect(order).toEqual([
+      MoneyAddMoneySheetTestIds.DEPOSIT_FUNDS_OPTION,
+      MoneyAddMoneySheetTestIds.MOVE_MUSD_OPTION,
+      MoneyAddMoneySheetTestIds.CONVERT_CRYPTO_OPTION,
+      MoneyAddMoneySheetTestIds.BANK_ACCOUNT_ROW,
+      MoneyAddMoneySheetTestIds.RECEIVE_EXTERNAL_ROW,
     ]);
   });
 

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -37,6 +37,7 @@ import { useRegionHasFiatProvider } from '../../../Ramp/hooks/useRegionHasFiatPr
 import { useMoneyAccountDepositAssetId } from '../../hooks/useMoneyAccountDepositAssetId';
 import { selectHasUnapprovedTransactions } from '../../../../../selectors/transactionController';
 import { selectHasAnyNonZeroTokenBalance } from '../../../../../selectors/tokenBalancesController';
+import { selectMoneyMovementBrazilNeobankEnabled } from '../../../../../selectors/featureFlagController/moneyAccount';
 import MoneySheetOptionsList, {
   type MoneySheetOption,
 } from '../MoneySheetOptionsList';
@@ -69,6 +70,9 @@ const MoneyAddMoneySheet: React.FC = () => {
   const { enabledTransactionTypes } = useMMPayFiatConfig();
   const hasAnyCryptoBalance = useSelector(selectHasAnyNonZeroTokenBalance);
   const hasPendingTransaction = useSelector(selectHasUnapprovedTransactions);
+  const isVirtualBankAccountEnabled = useSelector(
+    selectMoneyMovementBrazilNeobankEnabled,
+  );
   // Derive the deposit asset (CAIP-19) from the same vault config the deposit
   // flow uses, so the entry gate checks the exact asset the deposit targets.
   const depositAssetId = useMoneyAccountDepositAssetId();
@@ -210,7 +214,26 @@ const MoneyAddMoneySheet: React.FC = () => {
     ? { maskedText: moveMusdAmount, suffix: MUSD_TOKEN.symbol }
     : strings('money.add_money_sheet.add_musd');
 
+  // Behind the money-movement-brazil-neobank flag the Bank account row is the
+  // live VBA entry (top of the list, "New" badge); without it, it stays the
+  // shipped coming-soon placeholder (disabled rows are reordered last).
+  const bankAccountOption: MoneySheetOption = isVirtualBankAccountEnabled
+    ? {
+        label: strings('money.add_money_sheet.bank_account'),
+        icon: IconName.Bank,
+        testID: MoneyAddMoneySheetTestIds.BANK_ACCOUNT_ROW,
+        newBadge: true,
+      }
+    : {
+        label: strings('money.add_money_sheet.bank_account'),
+        icon: IconName.Bank,
+        testID: MoneyAddMoneySheetTestIds.BANK_ACCOUNT_ROW,
+        disabled: true,
+        comingSoon: true,
+      };
+
   const baseOptions: MoneySheetOption[] = [
+    bankAccountOption,
     {
       label: strings('money.add_money_sheet.convert_crypto'),
       icon: IconName.Refresh,
@@ -244,13 +267,6 @@ const MoneyAddMoneySheet: React.FC = () => {
       // Without mUSD the row falls back to the MM Pay fiat deposit, so it is
       // only actionable when that flow is available.
       disabled: !hasMusdBalance && !canDepositFiat,
-    },
-    {
-      label: strings('money.add_money_sheet.bank_account'),
-      icon: IconName.Bank,
-      testID: MoneyAddMoneySheetTestIds.BANK_ACCOUNT_ROW,
-      disabled: true,
-      comingSoon: true,
     },
     {
       label: strings('money.add_money_sheet.receive_external'),

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -214,9 +214,6 @@ const MoneyAddMoneySheet: React.FC = () => {
     ? { maskedText: moveMusdAmount, suffix: MUSD_TOKEN.symbol }
     : strings('money.add_money_sheet.add_musd');
 
-  // Behind the money-movement-brazil-neobank flag the Bank account row is the
-  // live VBA entry (top of the list, "New" badge); without it, it stays the
-  // shipped coming-soon placeholder (disabled rows are reordered last).
   const bankAccountOption: MoneySheetOption = isVirtualBankAccountEnabled
     ? {
         label: strings('money.add_money_sheet.bank_account'),

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -218,6 +218,7 @@ const MoneyAddMoneySheet: React.FC = () => {
     ? {
         label: strings('money.add_money_sheet.bank_account'),
         icon: IconName.Bank,
+        // TODO: wire onPress to the VBA KYC flow entry point (follow-up PR #34703).
         testID: MoneyAddMoneySheetTestIds.BANK_ACCOUNT_ROW,
         newBadge: true,
       }

--- a/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
+++ b/app/components/UI/Money/components/MoneyAddMoneySheet/MoneyAddMoneySheet.tsx
@@ -231,7 +231,10 @@ const MoneyAddMoneySheet: React.FC = () => {
       };
 
   const baseOptions: MoneySheetOption[] = [
-    bankAccountOption,
+    // Flag on: the enabled Bank account row is promoted to the top of the
+    // sheet. Flag off: the coming-soon row keeps its pre-flag position
+    // further down so ordering is unchanged for existing users.
+    ...(isVirtualBankAccountEnabled ? [bankAccountOption] : []),
     {
       label: strings('money.add_money_sheet.convert_crypto'),
       icon: IconName.Refresh,
@@ -266,6 +269,7 @@ const MoneyAddMoneySheet: React.FC = () => {
       // only actionable when that flow is available.
       disabled: !hasMusdBalance && !canDepositFiat,
     },
+    ...(isVirtualBankAccountEnabled ? [] : [bankAccountOption]),
     {
       label: strings('money.add_money_sheet.receive_external'),
       icon: IconName.QrCode,

--- a/app/components/UI/Money/components/MoneySheetOptionsList/MoneySheetOptionsList.tsx
+++ b/app/components/UI/Money/components/MoneySheetOptionsList/MoneySheetOptionsList.tsx
@@ -12,6 +12,8 @@ import {
   IconSize,
   SensitiveText,
   SensitiveTextLength,
+  Tag as DSTag,
+  TagSeverity,
   Text,
   TextColor,
   TextVariant,
@@ -41,6 +43,8 @@ export interface MoneySheetOption {
   testID: string;
   disabled?: boolean;
   comingSoon?: boolean;
+  /** Renders a "✦ New" tag after the label to highlight a new option. */
+  newBadge?: boolean;
 }
 
 interface MoneySheetOptionsListProps {
@@ -129,13 +133,29 @@ const MoneySheetOptionsList = ({ options }: MoneySheetOptionsListProps) => {
                   ) : null}
                 </Box>
               ) : (
-                <Text
-                  variant={TextVariant.BodyMd}
-                  fontWeight={FontWeight.Medium}
-                  color={item.disabled ? TextColor.TextAlternative : undefined}
+                <Box
+                  flexDirection={BoxFlexDirection.Row}
+                  alignItems={BoxAlignItems.Center}
+                  gap={2}
                 >
-                  {item.label}
-                </Text>
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    fontWeight={FontWeight.Medium}
+                    color={
+                      item.disabled ? TextColor.TextAlternative : undefined
+                    }
+                  >
+                    {item.label}
+                  </Text>
+                  {item.newBadge ? (
+                    <DSTag
+                      severity={TagSeverity.Info}
+                      startIconName={IconName.Sparkle}
+                    >
+                      {strings('money.add_money_sheet.new_badge')}
+                    </DSTag>
+                  ) : null}
+                </Box>
               )}
             </View>
           )}

--- a/app/components/UI/Money/components/MoneySheetOptionsList/MoneySheetOptionsList.tsx
+++ b/app/components/UI/Money/components/MoneySheetOptionsList/MoneySheetOptionsList.tsx
@@ -151,6 +151,9 @@ const MoneySheetOptionsList = ({ options }: MoneySheetOptionsListProps) => {
                     <DSTag
                       severity={TagSeverity.Info}
                       startIconName={IconName.Sparkle}
+                      // Optically center the tag against the label — mathematical
+                      // centering leaves it looking slightly high next to the text.
+                      twClassName="mt-[1.25px]"
                     >
                       {strings('money.add_money_sheet.new_badge')}
                     </DSTag>

--- a/app/selectors/featureFlagController/moneyAccount/index.test.ts
+++ b/app/selectors/featureFlagController/moneyAccount/index.test.ts
@@ -3,9 +3,11 @@ import {
   selectMoneyAccountWithdrawEnabledFlag,
   selectMoneyAccountVaultConfig,
   selectMoneyAccountDepositQuotePipelineEnabled,
+  selectMoneyMovementBrazilNeobankEnabled,
   selectMoneyOnboardingStepperAnimationEnabled,
   MONEY_ACCOUNT_DEPOSIT_QUOTE_PIPELINE_FLAG_KEY,
   MONEY_ENABLE_ONBOARDING_STEPPER_ANIMATION_FLAG_KEY,
+  MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY,
   DEV_VAULT_CONFIG,
 } from './index';
 
@@ -92,6 +94,59 @@ describe('Money Account feature flag selectors', () => {
       });
 
       expect(result).toBe(false);
+    });
+  });
+
+  describe('selectMoneyMovementBrazilNeobankEnabled', () => {
+    const originalLocalOverride =
+      process.env.MM_MONEY_MOVEMENT_BRAZIL_NEOBANK_ENABLED;
+
+    afterEach(() => {
+      if (originalLocalOverride === undefined) {
+        delete process.env.MM_MONEY_MOVEMENT_BRAZIL_NEOBANK_ENABLED;
+      } else {
+        process.env.MM_MONEY_MOVEMENT_BRAZIL_NEOBANK_ENABLED =
+          originalLocalOverride;
+      }
+    });
+
+    it('uses the LaunchDarkly kebab-case flag key', () => {
+      expect(MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY).toBe(
+        'money-movement-brazil-neobank',
+      );
+    });
+
+    it('returns true when the flag serves {"enabled": true}', () => {
+      const result = selectMoneyMovementBrazilNeobankEnabled.resultFunc({
+        [MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY]: { enabled: true },
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when the flag serves {"enabled": false}', () => {
+      const result = selectMoneyMovementBrazilNeobankEnabled.resultFunc({
+        [MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY]: { enabled: false },
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when the flag is absent or malformed', () => {
+      expect(selectMoneyMovementBrazilNeobankEnabled.resultFunc({})).toBe(
+        false,
+      );
+      expect(
+        selectMoneyMovementBrazilNeobankEnabled.resultFunc({
+          [MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY]: 'not-an-object',
+        }),
+      ).toBe(false);
+    });
+
+    it('uses the local environment override when enabled', () => {
+      process.env.MM_MONEY_MOVEMENT_BRAZIL_NEOBANK_ENABLED = 'true';
+
+      expect(selectMoneyMovementBrazilNeobankEnabled.resultFunc({})).toBe(true);
     });
   });
 

--- a/app/selectors/featureFlagController/moneyAccount/index.test.ts
+++ b/app/selectors/featureFlagController/moneyAccount/index.test.ts
@@ -98,21 +98,9 @@ describe('Money Account feature flag selectors', () => {
   });
 
   describe('selectMoneyMovementBrazilNeobankEnabled', () => {
-    const originalLocalOverride =
-      process.env.MM_MONEY_MOVEMENT_BRAZIL_NEOBANK_ENABLED;
-
-    afterEach(() => {
-      if (originalLocalOverride === undefined) {
-        delete process.env.MM_MONEY_MOVEMENT_BRAZIL_NEOBANK_ENABLED;
-      } else {
-        process.env.MM_MONEY_MOVEMENT_BRAZIL_NEOBANK_ENABLED =
-          originalLocalOverride;
-      }
-    });
-
-    it('uses the LaunchDarkly kebab-case flag key', () => {
+    it('uses the camelCased key as served by client-config-api-mobile', () => {
       expect(MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY).toBe(
-        'money-movement-brazil-neobank',
+        'moneyMovementBrazilNeobank',
       );
     });
 
@@ -141,12 +129,6 @@ describe('Money Account feature flag selectors', () => {
           [MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY]: 'not-an-object',
         }),
       ).toBe(false);
-    });
-
-    it('uses the local environment override when enabled', () => {
-      process.env.MM_MONEY_MOVEMENT_BRAZIL_NEOBANK_ENABLED = 'true';
-
-      expect(selectMoneyMovementBrazilNeobankEnabled.resultFunc({})).toBe(true);
     });
   });
 

--- a/app/selectors/featureFlagController/moneyAccount/index.test.ts
+++ b/app/selectors/featureFlagController/moneyAccount/index.test.ts
@@ -10,6 +10,7 @@ import {
   MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY,
   DEV_VAULT_CONFIG,
 } from './index';
+import { getVersion } from 'react-native-device-info';
 
 jest.mock('react-native-device-info', () => ({
   getVersion: jest.fn().mockReturnValue('99.0.0'),
@@ -25,6 +26,9 @@ jest.mock(
 describe('Money Account feature flag selectors', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.resetAllMocks();
+    // Re-establish implementations wiped by resetAllMocks.
+    jest.mocked(getVersion).mockReturnValue('99.0.0');
   });
 
   describe('selectMoneyAccountDepositEnabledFlag', () => {

--- a/app/selectors/featureFlagController/moneyAccount/index.test.ts
+++ b/app/selectors/featureFlagController/moneyAccount/index.test.ts
@@ -23,6 +23,10 @@ jest.mock(
 );
 
 describe('Money Account feature flag selectors', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('selectMoneyAccountDepositEnabledFlag', () => {
     it('returns true when moneyAccountDepositEnabled is true', () => {
       const result = selectMoneyAccountDepositEnabledFlag.resultFunc({

--- a/app/selectors/featureFlagController/moneyAccount/index.test.ts
+++ b/app/selectors/featureFlagController/moneyAccount/index.test.ts
@@ -104,17 +104,34 @@ describe('Money Account feature flag selectors', () => {
       );
     });
 
-    it('returns true when the flag serves {"enabled": true}', () => {
+    it('returns true when enabled and the minimum version passes', () => {
       const result = selectMoneyMovementBrazilNeobankEnabled.resultFunc({
-        [MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY]: { enabled: true },
+        [MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY]: {
+          enabled: true,
+          minimumVersion: '0.0.0',
+        },
       });
 
       expect(result).toBe(true);
     });
 
-    it('returns false when the flag serves {"enabled": false}', () => {
+    it('returns false when the flag serves enabled: false', () => {
       const result = selectMoneyMovementBrazilNeobankEnabled.resultFunc({
-        [MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY]: { enabled: false },
+        [MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY]: {
+          enabled: false,
+          minimumVersion: '0.0.0',
+        },
+      });
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when the minimum version requirement fails', () => {
+      const result = selectMoneyMovementBrazilNeobankEnabled.resultFunc({
+        [MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY]: {
+          enabled: true,
+          minimumVersion: '999.0.0',
+        },
       });
 
       expect(result).toBe(false);
@@ -127,6 +144,12 @@ describe('Money Account feature flag selectors', () => {
       expect(
         selectMoneyMovementBrazilNeobankEnabled.resultFunc({
           [MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY]: 'not-an-object',
+        }),
+      ).toBe(false);
+      expect(
+        selectMoneyMovementBrazilNeobankEnabled.resultFunc({
+          // Missing minimumVersion — no longer a valid version-gated shape.
+          [MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY]: { enabled: true },
         }),
       ).toBe(false);
     });

--- a/app/selectors/featureFlagController/moneyAccount/index.ts
+++ b/app/selectors/featureFlagController/moneyAccount/index.ts
@@ -25,10 +25,6 @@ export const selectMoneyAccountWithdrawEnabledFlag = createSelector(
   },
 );
 
-// The LaunchDarkly flag key is the kebab-case `money-movement-brazil-neobank`,
-// but client-config-api-mobile camelCases every flag key in the served feed
-// (matching every other flag here, e.g. `moneyHomeScreenEnabled`) — this is
-// the key as it actually appears in `remoteFeatureFlags`.
 export const MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY =
   'moneyMovementBrazilNeobank' as const;
 
@@ -36,11 +32,6 @@ interface MoneyMovementBrazilNeobankFlag {
   enabled?: boolean;
 }
 
-/**
- * Gates the Virtual Bank Account (Brazil-first neobank) flow: the Bank
- * account entry in the Add funds sheet and the KYC flow behind it.
- * LaunchDarkly variations are `{"enabled": true|false}`.
- */
 export const selectMoneyMovementBrazilNeobankEnabled = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags): boolean => {

--- a/app/selectors/featureFlagController/moneyAccount/index.ts
+++ b/app/selectors/featureFlagController/moneyAccount/index.ts
@@ -25,6 +25,31 @@ export const selectMoneyAccountWithdrawEnabledFlag = createSelector(
   },
 );
 
+export const MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY =
+  'money-movement-brazil-neobank' as const;
+
+interface MoneyMovementBrazilNeobankFlag {
+  enabled?: boolean;
+}
+
+/**
+ * Gates the Virtual Bank Account (Brazil-first neobank) flow: the Bank
+ * account entry in the Add funds sheet and the KYC flow behind it.
+ * LaunchDarkly variations are `{"enabled": true|false}`; the local env
+ * override supports development while the flag is off in every environment.
+ */
+export const selectMoneyMovementBrazilNeobankEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags): boolean => {
+    const localOverrideEnabled =
+      process.env.MM_MONEY_MOVEMENT_BRAZIL_NEOBANK_ENABLED === 'true';
+    const flag = remoteFeatureFlags?.[
+      MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY
+    ] as unknown as MoneyMovementBrazilNeobankFlag | undefined;
+    return localOverrideEnabled || flag?.enabled === true;
+  },
+);
+
 export const MONEY_ENABLE_ONBOARDING_STEPPER_ANIMATION_FLAG_KEY =
   'moneyEnableOnboardingStepperAnimation' as const;
 

--- a/app/selectors/featureFlagController/moneyAccount/index.ts
+++ b/app/selectors/featureFlagController/moneyAccount/index.ts
@@ -25,8 +25,12 @@ export const selectMoneyAccountWithdrawEnabledFlag = createSelector(
   },
 );
 
+// The LaunchDarkly flag key is the kebab-case `money-movement-brazil-neobank`,
+// but client-config-api-mobile camelCases every flag key in the served feed
+// (matching every other flag here, e.g. `moneyHomeScreenEnabled`) — this is
+// the key as it actually appears in `remoteFeatureFlags`.
 export const MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY =
-  'money-movement-brazil-neobank' as const;
+  'moneyMovementBrazilNeobank' as const;
 
 interface MoneyMovementBrazilNeobankFlag {
   enabled?: boolean;
@@ -35,18 +39,15 @@ interface MoneyMovementBrazilNeobankFlag {
 /**
  * Gates the Virtual Bank Account (Brazil-first neobank) flow: the Bank
  * account entry in the Add funds sheet and the KYC flow behind it.
- * LaunchDarkly variations are `{"enabled": true|false}`; the local env
- * override supports development while the flag is off in every environment.
+ * LaunchDarkly variations are `{"enabled": true|false}`.
  */
 export const selectMoneyMovementBrazilNeobankEnabled = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags): boolean => {
-    const localOverrideEnabled =
-      process.env.MM_MONEY_MOVEMENT_BRAZIL_NEOBANK_ENABLED === 'true';
     const flag = remoteFeatureFlags?.[
       MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY
     ] as unknown as MoneyMovementBrazilNeobankFlag | undefined;
-    return localOverrideEnabled || flag?.enabled === true;
+    return flag?.enabled === true;
   },
 );
 

--- a/app/selectors/featureFlagController/moneyAccount/index.ts
+++ b/app/selectors/featureFlagController/moneyAccount/index.ts
@@ -28,17 +28,12 @@ export const selectMoneyAccountWithdrawEnabledFlag = createSelector(
 export const MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY =
   'moneyMovementBrazilNeobank' as const;
 
-interface MoneyMovementBrazilNeobankFlag {
-  enabled?: boolean;
-}
-
 export const selectMoneyMovementBrazilNeobankEnabled = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags): boolean => {
-    const flag = remoteFeatureFlags?.[
-      MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY
-    ] as unknown as MoneyMovementBrazilNeobankFlag | undefined;
-    return flag?.enabled === true;
+    const remoteFlag =
+      remoteFeatureFlags?.[MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY];
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
   },
 );
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -7839,7 +7839,8 @@
       "bank_account": "Bank account",
       "add_musd": "Add mUSD",
       "receive_external": "External address",
-      "coming_soon": "Coming soon"
+      "coming_soon": "Coming soon",
+      "new_badge": "New"
     },
     "more_sheet": {
       "title": "More",

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -3841,6 +3841,14 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  moneyMovementBrazilNeobank: {
+    name: 'moneyMovementBrazilNeobank',
+    type: FeatureFlagType.Remote,
+    inProd: false,
+    productionDefault: false,
+    status: FeatureFlagStatus.Active,
+  },
+
   moneyAccountGeoBlockedCountries: {
     name: 'moneyAccountGeoBlockedCountries',
     type: FeatureFlagType.Remote,


### PR DESCRIPTION
## **Description**

First slice of the Virtual Bank Account (Brazil-first neobank MVP) flow: the "Bank account" row in the Money Add funds sheet becomes a live entry point, gated behind the `money-movement-brazil-neobank` remote feature flag.

- With the flag **on** (`{"enabled": true}`): the Bank account row renders enabled, first in the list, with a "✦ New" badge (design-system `Tag`, `TagSeverity.Info` + `Sparkle` icon, the same pattern `TradeWalletActions` uses). It has no `onPress` yet; the VBA KYC flow navigator will attach here in a follow-up.
- With the flag **off** (default, current prod): the row stays the shipped disabled "Coming soon" placeholder, reordered to the bottom with the other disabled rows, with no behavior change.
- New selector `selectMoneyMovementBrazilNeobankEnabled` reads `remoteFeatureFlags.moneyMovementBrazilNeobank` (the client-config API camelCases the LaunchDarkly `money-movement-brazil-neobank` key) and defaults to `false` when the flag is absent or malformed.
- `MoneySheetOptionsList` gains an optional `newBadge` flag on option rows.
- Registered `moneyMovementBrazilNeobank` in the [feature flag registry](https://github.com/MetaMask/metamask-mobile/blob/main/tests/feature-flags/feature-flag-registry.ts) (`inProd: false`, not yet rolled out to production) and mapped `MONEY_MOVEMENT_BRAZIL_NEOBANK_FLAG_KEY` in `known-feature-flag-constants.ts` so CI can resolve the constant-based access.

## **Changelog**

CHANGELOG entry: Added a Bank account option to the Add funds sheet, behind the Brazil neobank feature flag

## **Related issues**

https://consensyssoftware.atlassian.net/browse/TRAM-3874

## **Manual testing steps**

```gherkin
Feature: Bank account entry in Add funds sheet

  Scenario: user opens the Add funds sheet with the neobank flag enabled
    Given the money-movement-brazil-neobank remote flag serves {"enabled": true}
    And the user is on the Money home screen

    When user taps Add and opens the Add funds sheet
    Then the Bank account row is first in the list, enabled, with a "New" badge
    And tapping it performs no action yet (KYC flow lands in a follow-up)

  Scenario: user opens the Add funds sheet with the neobank flag disabled
    Given the money-movement-brazil-neobank remote flag serves {"enabled": false} or is absent

    When user taps Add and opens the Add funds sheet
    Then the Bank account row renders disabled with a "Coming soon" tag, below the enabled options
```

## **Screenshots/Recordings**

### **Before**

<img width="302" height="656" alt="money-before" src="https://github.com/user-attachments/assets/f3ecc85f-bf1b-4ece-833b-f47346e74f0d" />

### **After**

<img width="302" height="656" alt="money resize" src="https://github.com/user-attachments/assets/20e4167c-3c3c-4084-9094-d8db8a9f610c" />

https://github.com/user-attachments/assets/0b40c8fb-c668-45f2-b296-dcb51a9b99b6

**LaunchDarkly flag:**

https://app.launchdarkly.com/projects/metamask-client-config-api-mobile/flags/money-movement-brazil-neobank/targeting?env=main-exp&env=production&env=qa-prod&env=test&selected-env=main-exp

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

