### PR TITLE
fix(onboarding): rename home fund step title to Add funds. (TEST DO NOT MERGE)

### DIFF
--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -3346,7 +3346,7 @@
     "home_onboarding_steps": {
       "header": "Steps",
       "get_started_title": "Get started on MetaMask",
-      "fund_title": "Fund your wallet",
+      "fund_title": "Add funds",
       "fund_subtitle": "No one likes an empty wallet. Easily add funds to start trading.",
       "fund_primary": "Add funds",
       "trade_title": "Make your first trade",


### PR DESCRIPTION
## Summary
- Change the home onboarding “get started” fund step title from “Fund your wallet” to “Add funds” so it matches the primary CTA.

## Test plan
- [ ] Run the app and open the home get-started onboarding carousel
- [ ] Confirm step 1/3 title reads “Add funds”
- [ ] Confirm subtitle and “Add funds” button copy are unchanged


Made with [Cursor](https://cursor.com)