### PR TITLE
feat(money): add mobile wrappers for Money Account vault deposit and withdraw

### DIFF
--- a/app/core/Engine/controllers/transaction-pay-controller/money-account-vault-actions.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/money-account-vault-actions.test.ts
@@ -1,0 +1,76 @@
+import type { Hex } from '@metamask/utils';
+
+import Engine from '../../Engine';
+import {
+  submitMoneyAccountVaultDeposit,
+  submitMoneyAccountVaultWithdraw,
+} from './money-account-vault-actions';
+
+jest.mock('../../Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      TransactionPayController: {
+        submitMoneyAccountVaultDeposit: jest.fn(),
+        submitMoneyAccountVaultWithdraw: jest.fn(),
+      },
+    },
+  },
+}));
+
+const MONEY_ACCOUNT_ADDRESS =
+  '0x1111111111111111111111111111111111111111' as Hex;
+const TRANSACTION_HASH =
+  '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as Hex;
+
+describe('Money Account vault actions', () => {
+  const controller = Engine.context.TransactionPayController as unknown as {
+    submitMoneyAccountVaultDeposit: jest.Mock;
+    submitMoneyAccountVaultWithdraw: jest.Mock;
+  };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('forwards a completed payout to TransactionPayController', async () => {
+    controller.submitMoneyAccountVaultDeposit.mockResolvedValue({
+      transactionHash: TRANSACTION_HASH,
+    });
+    const request = {
+      moneyAccountAddress: MONEY_ACCOUNT_ADDRESS,
+      transactionHash: TRANSACTION_HASH,
+    };
+
+    const result = await submitMoneyAccountVaultDeposit(request);
+
+    expect(controller.submitMoneyAccountVaultDeposit).toHaveBeenCalledWith(
+      request,
+    );
+    expect(result).toStrictEqual({ transactionHash: TRANSACTION_HASH });
+  });
+
+  it('forwards a trusted exact-out intent to TransactionPayController', async () => {
+    controller.submitMoneyAccountVaultWithdraw.mockResolvedValue({
+      batchId: '0xbatch',
+    });
+    const request = {
+      amountInRaw: '5000000',
+      autorampId: 'autoramp-id',
+      chainId: '0x8f' as Hex,
+      moneyAccountAddress: MONEY_ACCOUNT_ADDRESS,
+      quoteId: 'quote-id',
+      quoteValidUntil: '2026-08-12T18:00:00.000Z',
+      recipient: '0x2222222222222222222222222222222222222222' as Hex,
+      requestId: 'request-id',
+      tokenAddress: '0x0F075aF77B28D77a60470472343B6E2941E3D17e' as Hex,
+    };
+
+    const result = await submitMoneyAccountVaultWithdraw(request);
+
+    expect(controller.submitMoneyAccountVaultWithdraw).toHaveBeenCalledWith(
+      request,
+    );
+    expect(result).toStrictEqual({ batchId: '0xbatch' });
+  });
+});

--- a/app/core/Engine/controllers/transaction-pay-controller/money-account-vault-actions.test.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/money-account-vault-actions.test.ts
@@ -50,20 +50,30 @@ describe('Money Account vault actions', () => {
     expect(result).toStrictEqual({ transactionHash: TRANSACTION_HASH });
   });
 
-  it('forwards a trusted exact-out intent to TransactionPayController', async () => {
+  it('forwards skipped vault deposits without inventing a hash', async () => {
+    controller.submitMoneyAccountVaultDeposit.mockResolvedValue({
+      skipped: true,
+    });
+    const request = {
+      moneyAccountAddress: MONEY_ACCOUNT_ADDRESS,
+      transactionHash: TRANSACTION_HASH,
+      vaultDisabled: true,
+    };
+
+    const result = await submitMoneyAccountVaultDeposit(request);
+
+    expect(result).toStrictEqual({ skipped: true });
+  });
+
+  it('forwards a slim on-chain withdraw intent to TransactionPayController', async () => {
     controller.submitMoneyAccountVaultWithdraw.mockResolvedValue({
       batchId: '0xbatch',
     });
     const request = {
       amountInRaw: '5000000',
-      autorampId: 'autoramp-id',
-      chainId: '0x8f' as Hex,
       moneyAccountAddress: MONEY_ACCOUNT_ADDRESS,
-      quoteId: 'quote-id',
-      quoteValidUntil: '2026-08-12T18:00:00.000Z',
       recipient: '0x2222222222222222222222222222222222222222' as Hex,
       requestId: 'request-id',
-      tokenAddress: '0x0F075aF77B28D77a60470472343B6E2941E3D17e' as Hex,
     };
 
     const result = await submitMoneyAccountVaultWithdraw(request);

--- a/app/core/Engine/controllers/transaction-pay-controller/money-account-vault-actions.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/money-account-vault-actions.ts
@@ -1,0 +1,81 @@
+import type { TransactionBatchResult } from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+
+import Engine from '../../Engine';
+
+export interface SubmitMoneyAccountVaultDepositRequest {
+  moneyAccountAddress: Hex;
+  transactionHash: Hex;
+  vaultDisabled?: boolean;
+}
+
+export interface SubmitMoneyAccountVaultWithdrawRequest {
+  amountInRaw: string;
+  autorampId: string;
+  chainId: Hex;
+  moneyAccountAddress: Hex;
+  quoteId: string;
+  quoteValidUntil: string;
+  recipient: Hex;
+  requestId: string;
+  tokenAddress: Hex;
+}
+
+interface MoneyAccountVaultController {
+  submitMoneyAccountVaultDeposit: (
+    request: SubmitMoneyAccountVaultDepositRequest,
+  ) => Promise<{ transactionHash?: Hex }>;
+  submitMoneyAccountVaultWithdraw: (
+    request: SubmitMoneyAccountVaultWithdrawRequest,
+  ) => Promise<TransactionBatchResult>;
+}
+
+function getMoneyAccountVaultController(): MoneyAccountVaultController {
+  const controller = Engine.context.TransactionPayController as unknown as
+    | MoneyAccountVaultController
+    | undefined;
+  if (
+    !controller?.submitMoneyAccountVaultDeposit ||
+    !controller.submitMoneyAccountVaultWithdraw
+  ) {
+    throw new Error(
+      'Money Account vault actions require a newer TransactionPayController',
+    );
+  }
+  return controller;
+}
+
+/**
+ * Vault mUSD received by a Money Account in a completed Iron payout.
+ *
+ * This is intentionally independent of UI state so a future event listener or
+ * any Money surface can invoke the same controller action.
+ *
+ * @param request - Completed Iron payout transaction details.
+ * @returns Hash of the confirmed vault transaction.
+ */
+export async function submitMoneyAccountVaultDeposit(
+  request: SubmitMoneyAccountVaultDepositRequest,
+): Promise<{ transactionHash?: Hex }> {
+  return await getMoneyAccountVaultController().submitMoneyAccountVaultDeposit(
+    request,
+  );
+}
+
+/**
+ * Create a user-confirmed exact-out vmUSD withdrawal to an Iron address.
+ *
+ * Callers should open the standard Money confirmation surface before invoking
+ * this action. The controller creates an approval request and never broadcasts
+ * the atomic withdraw/transfer batch without user confirmation.
+ *
+ * @param request - Backend-bound exact-out Pix intent.
+ * @returns Pending transaction batch ID.
+ */
+export async function submitMoneyAccountVaultWithdraw(
+  request: SubmitMoneyAccountVaultWithdrawRequest,
+): Promise<TransactionBatchResult> {
+  return await getMoneyAccountVaultController().submitMoneyAccountVaultWithdraw(
+    request,
+  );
+}

--- a/app/core/Engine/controllers/transaction-pay-controller/money-account-vault-actions.ts
+++ b/app/core/Engine/controllers/transaction-pay-controller/money-account-vault-actions.ts
@@ -9,22 +9,22 @@ export interface SubmitMoneyAccountVaultDepositRequest {
   vaultDisabled?: boolean;
 }
 
+export interface SubmitMoneyAccountVaultDepositResult {
+  skipped?: true;
+  transactionHash?: Hex;
+}
+
 export interface SubmitMoneyAccountVaultWithdrawRequest {
   amountInRaw: string;
-  autorampId: string;
-  chainId: Hex;
   moneyAccountAddress: Hex;
-  quoteId: string;
-  quoteValidUntil: string;
   recipient: Hex;
   requestId: string;
-  tokenAddress: Hex;
 }
 
 interface MoneyAccountVaultController {
   submitMoneyAccountVaultDeposit: (
     request: SubmitMoneyAccountVaultDepositRequest,
-  ) => Promise<{ transactionHash?: Hex }>;
+  ) => Promise<SubmitMoneyAccountVaultDepositResult>;
   submitMoneyAccountVaultWithdraw: (
     request: SubmitMoneyAccountVaultWithdrawRequest,
   ) => Promise<TransactionBatchResult>;
@@ -52,11 +52,12 @@ function getMoneyAccountVaultController(): MoneyAccountVaultController {
  * any Money surface can invoke the same controller action.
  *
  * @param request - Completed Iron payout transaction details.
- * @returns Hash of the confirmed vault transaction.
+ * @returns Hash of the confirmed vault transaction, or `{ skipped: true }` when
+ * vaulting is disabled.
  */
 export async function submitMoneyAccountVaultDeposit(
   request: SubmitMoneyAccountVaultDepositRequest,
-): Promise<{ transactionHash?: Hex }> {
+): Promise<SubmitMoneyAccountVaultDepositResult> {
   return await getMoneyAccountVaultController().submitMoneyAccountVaultDeposit(
     request,
   );
@@ -69,7 +70,10 @@ export async function submitMoneyAccountVaultDeposit(
  * this action. The controller creates an approval request and never broadcasts
  * the atomic withdraw/transfer batch without user confirmation.
  *
- * @param request - Backend-bound exact-out Pix intent.
+ * Quote / Pix identifiers belong in RampsController / NeoBankService; this
+ * wrapper only forwards the on-chain withdraw intent.
+ *
+ * @param request - On-chain withdraw intent.
  * @returns Pending transaction batch ID.
  */
 export async function submitMoneyAccountVaultWithdraw(

--- a/app/core/Engine/messengers/transaction-pay-controller-messenger/transaction-pay-controller-messenger.test.ts
+++ b/app/core/Engine/messengers/transaction-pay-controller-messenger/transaction-pay-controller-messenger.test.ts
@@ -52,6 +52,22 @@ describe('getTransactionPayControllerMessenger', () => {
       }),
     );
   });
+
+  it('delegates Money Account vault submission actions', () => {
+    const rootMessenger = getRootMessenger();
+    const delegateSpy = jest.spyOn(rootMessenger, 'delegate');
+
+    getTransactionPayControllerMessenger(rootMessenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actions: expect.arrayContaining([
+          'MoneyAccountBalanceService:getMoneyAccountBalance',
+          'TransactionController:addTransactionBatch',
+        ]),
+      }),
+    );
+  });
 });
 
 describe('getTransactionPayControllerInitMessenger', () => {

--- a/app/core/Engine/messengers/transaction-pay-controller-messenger/transaction-pay-controller-messenger.ts
+++ b/app/core/Engine/messengers/transaction-pay-controller-messenger/transaction-pay-controller-messenger.ts
@@ -31,6 +31,9 @@ export function getTransactionPayControllerMessenger(
       'AssetsController:getStateForTransactionPay',
       'CurrencyRateController:getState',
       'GasFeeController:getState',
+      // This action is part of the next TransactionPayController release.
+      // Keep the cast until Mobile consumes that release's messenger types.
+      'MoneyAccountBalanceService:getMoneyAccountBalance' as never,
       'NetworkController:findNetworkClientIdByChainId',
       'NetworkController:getNetworkClientById',
       'NetworkController:getNetworkConfigurationByChainId',
@@ -43,6 +46,7 @@ export function getTransactionPayControllerMessenger(
       'TokensController:getState',
       'TransactionController:estimateGas',
       'TransactionController:estimateGasBatch',
+      'TransactionController:addTransactionBatch',
       'TransactionController:getGasFeeTokens',
       'TransactionController:getState',
       'TransactionController:updateTransaction',


### PR DESCRIPTION
## **Description**

Money Account only earns yield and funds Card spend through vault shares (vmUSD), so mUSD that arrives from an external payout has to be vaulted, and paying out to a partner (Iron, for the Pix flow) requires redeeming vmUSD back to mUSD and transferring it. Core now exposes both directions as `TransactionPayController` messenger actions (MetaMask/core#9849). This PR is the mobile-side plumbing for them.

It adds two thin wrappers in `app/core/Engine/controllers/transaction-pay-controller/money-account-vault-actions.ts`:

- `submitMoneyAccountVaultDeposit({ moneyAccountAddress, transactionHash })` vaults a completed mUSD payout. It is headless (no confirmation UI). Successful vaults are deduped in-memory for the Core controller lifetime, so retries in the same session return the prior hash; an app restart can try again. Disabled vaulting returns `{ skipped: true }` and does not permanently block a later retry after the feature flag is enabled. The upcoming MoonPay/Iron websocket listener can call it directly, as can any Money Account screen.
- `submitMoneyAccountVaultWithdraw({ amountInRaw, moneyAccountAddress, recipient, requestId })` redeems vmUSD and transfers the resulting mUSD to an Iron deposit address in one atomic batch, going through the normal transaction confirmation. Quote / Pix identifiers stay out of this wrapper; they belong in RampsController / NeoBankService.

It also delegates the two actions the controller now needs, `MoneyAccountBalanceService:getMoneyAccountBalance` and `TransactionController:addTransactionBatch`, in the transaction-pay-controller messenger.

No UI is wired up here, and no behavior changes for users yet. The websocket listener and the Pix send screen are separate tickets; this PR only gives them a stable entrypoint to call. The wrappers compile against the local controller interface, but they need the Core release containing MetaMask/core#9849 to actually work at runtime.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/MetaMask/core/pull/9849

## **Manual testing steps**

N/A. There is no user-reachable surface in this PR: it adds wrapper functions and messenger delegations that nothing calls yet, and the underlying Core actions are not in a released version of `@metamask/transaction-pay-controller` yet. Behavior is covered by unit tests in `money-account-vault-actions.test.ts` and `transaction-pay-controller-messenger.test.ts`. Manual Gherkin steps will accompany the PRs that add the Iron websocket listener and the Pix send button.

## **Screenshots/Recordings**

N/A. No UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

Performance boxes are left unchecked deliberately: this PR adds no UI and no runtime work on any user path, so there is nothing to measure on device yet. Tracing will be added with the screens that call these actions.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.