### PR TITLE
fix(engagement): adopt elevated tokens in TransactionNotification

### DIFF
--- a/app/components/UI/Notification/TransactionNotification/index.js
+++ b/app/components/UI/Notification/TransactionNotification/index.js
@@ -19,10 +19,6 @@ import BigNumber from 'bignumber.js';
 import { collectibleContractsSelector } from '../../../../reducers/collectibles';
 import { useTheme } from '../../../../util/theme';
 import {
-  getElevatedSurfaceColor,
-  isPureBlackEnabled,
-} from '../../../../util/theme/themeUtils';
-import {
   selectChainId,
   selectTickerByChainId,
 } from '../../../../selectors/networkController';
@@ -84,11 +80,9 @@ const createStyles = (theme) => {
     modalContainer: {
       width: '90%',
       borderRadius: 10,
-      backgroundColor: getElevatedSurfaceColor(theme),
-      ...(isPureBlackEnabled && {
-        borderWidth: 1,
-        borderColor: colors.border.muted,
-      }),
+      backgroundColor: theme.colors.background.elevated1,
+      borderWidth: 1,
+      borderColor: colors.border.alternative,
     },
   });
 };


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Update TransactionNotification styles to use elevated tokens instead of pure-black helpers.

**Depends on:** #34654 (preview packages). No `package.json` / `yarn.lock` changes here.

**CODEOWNERS:** @MetaMask/engagement

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://github.com/MetaMask/metamask-design-system/pull/1445
Refs: #34654

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A for draft split — verify affected engagement surfaces in dark mode after #34654 packages are present.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A for draft split — visual captures from the original preview validation session.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR (see labeling guidelines). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI styling in one engagement component with no logic or data changes.
> 
> **Overview**
> **Transaction notification modals** now use design-system elevated surface tokens instead of `getElevatedSurfaceColor` / `isPureBlackEnabled` from `themeUtils`.
> 
> For `modalContainer`, the background is **`theme.colors.background.elevated1`**, and a **1px border** with **`colors.border.alternative`** is always applied (previously the border only appeared when pure-black mode was enabled, using `colors.border.muted`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72162e5e7bffdb75f606417634861bab41764006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->