### PR TITLE
fix(swaps): drop usePureBlack mock after elevated-token preview

### DIFF
--- a/app/components/UI/Bridge/Views/BatchSellReview/BatchSellReviewTokenRow.test.tsx
+++ b/app/components/UI/Bridge/Views/BatchSellReview/BatchSellReviewTokenRow.test.tsx
@@ -23,7 +23,6 @@ jest.mock('@metamask/design-system-twrnc-preset', () => ({
     style: () => ({}),
   }),
   useTheme: () => 'light',
-  usePureBlack: () => false,
   getThemeColors: () => ({
     'icon-default': 'rgb(0, 0, 0)',
     'icon-alternative': 'rgb(102, 102, 102)',


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Remove obsolete `usePureBlack` mock from BatchSellReview token row tests after preview packages.

**Depends on:** #34654 (preview packages). No `package.json` / `yarn.lock` changes here.

**CODEOWNERS:** @MetaMask/swaps-engineers

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://github.com/MetaMask/metamask-design-system/pull/1445
Refs: #34654

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A for draft split — verify affected swaps-engineers surfaces in dark mode after #34654 packages are present.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A for draft split — visual captures from the original preview validation session.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed MetaMask Contributor Docs and MetaMask Mobile Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [x] I've applied the right labels on the PR (see labeling guidelines). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock cleanup with no production or runtime behavior changes.
> 
> **Overview**
> Removes **`usePureBlack`** from the `@metamask/design-system-twrnc-preset` Jest mock in `BatchSellReviewTokenRow.test.tsx`, aligning the test double with updated design-system preview packages (follow-up to #34654).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2ec9f280de2d02d148539e86df0826bf143f8c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->