### PR TITLE
feat(money): dynamic VBA KYC disclaimers on demo Iron flow

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -155,6 +155,11 @@ export MM_MONEY_ENABLE_ACTIVITY_DETAILS_BLOCKEXPLORER_LINK="true"
 export MM_MONEY_FIRST_TIME_DEPOSIT_ANIMATION_ENABLED="true"
 export MM_MONEY_PARALLAX_ANIMATION_ENABLED="true"
 export MM_MONEY_CARD_FLIP_ANIMATION_ENABLED="true"
+# Override for the VBA KYC API base URL (va-mmcx-universal-kyc-api), used to
+# fetch vendor legal disclaimers dynamically on the "Get your Pix Key"
+# screen. Leave empty to use the dev/UAT URL for METAMASK_ENVIRONMENT; set
+# this to point at a local server instead.
+export MM_VBA_KYC_API_BASE_URL=""
 export MM_MONEY_CARD_TILT_ANIMATION_ENABLED="true"
 export MM_CARD_ARRIVAL_ANIMATION_ENABLED="true"
 

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/GetPixKey.test.tsx
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/GetPixKey.test.tsx
@@ -4,11 +4,7 @@ import { fireEvent, waitFor } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import GetPixKey from './GetPixKey';
 import { GetPixKeySelectorsIDs } from './GetPixKey.testIds';
-import {
-  MOONPAY_PRIVACY_POLICY_URL,
-  MOONPAY_TERMS_URL,
-  TRACE_TERMS_URL,
-} from './constants';
+import { useKycDisclaimers } from './hooks/useKycDisclaimers';
 import { startIronKycFlow } from './ironKycFlow';
 
 const mockNavigate = jest.fn();
@@ -22,21 +18,41 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
+jest.mock('./hooks/useKycDisclaimers');
 jest.mock('./ironKycFlow');
 
+const mockUseKycDisclaimers = jest.mocked(useKycDisclaimers);
 const mockStartIronKycFlow = jest.mocked(startIronKycFlow);
+const mockRetry = jest.fn();
+
+const loadedDisclaimer = {
+  id: 'd-1',
+  url: 'https://iron.example/tc',
+  display_name: 'Iron T&C',
+};
 
 describe('GetPixKey', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockStartIronKycFlow.mockResolvedValue(undefined);
+    mockUseKycDisclaimers.mockReturnValue({
+      disclaimers: [loadedDisclaimer],
+      isLoading: false,
+      error: null,
+      retry: mockRetry,
+    });
   });
 
   it('renders the title, benefits, and agree and continue button', () => {
     const { getByText, getByTestId } = renderWithProvider(<GetPixKey />);
 
     expect(getByText('Get your Pix Key')).toBeOnTheScreen();
-    expect(getByText('Earn up to 4% APY on your balance')).toBeOnTheScreen();
+    expect(getByText('Deposit with')).toBeOnTheScreen();
+    expect(getByText('pix')).toBeOnTheScreen();
+    expect(
+      getByText('Send local and international payments'),
+    ).toBeOnTheScreen();
+    expect(getByText('Powered by MoonPay.')).toBeOnTheScreen();
     expect(
       getByTestId(GetPixKeySelectorsIDs.AGREE_AND_CONTINUE_BUTTON),
     ).toBeOnTheScreen();
@@ -50,7 +66,7 @@ describe('GetPixKey', () => {
     expect(mockGoBack).toHaveBeenCalled();
   });
 
-  it('starts the Iron KYC flow and navigates to verify identity when agree and continue is pressed', async () => {
+  it('starts the Iron KYC flow and navigates to verify identity when agree and continue is pressed after disclaimers load', async () => {
     const { getByTestId } = renderWithProvider(<GetPixKey />);
 
     fireEvent.press(
@@ -81,32 +97,83 @@ describe('GetPixKey', () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it('opens the MoonPay privacy policy link', () => {
-    const spy = jest.spyOn(Linking, 'openURL');
+  it('shows a skeleton loader instead of any disclaimer links while the fetch is in flight, and disables the CTA', () => {
+    mockUseKycDisclaimers.mockReturnValue({
+      disclaimers: [],
+      isLoading: true,
+      error: null,
+      retry: mockRetry,
+    });
+
     const { getByTestId } = renderWithProvider(<GetPixKey />);
+
+    expect(
+      getByTestId(GetPixKeySelectorsIDs.DISCLAIMERS_LOADING),
+    ).toBeOnTheScreen();
 
     fireEvent.press(
-      getByTestId(GetPixKeySelectorsIDs.MOONPAY_PRIVACY_POLICY_LINK),
+      getByTestId(GetPixKeySelectorsIDs.AGREE_AND_CONTINUE_BUTTON),
     );
-
-    expect(spy).toHaveBeenCalledWith(MOONPAY_PRIVACY_POLICY_URL);
+    expect(mockStartIronKycFlow).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it('opens the MoonPay terms link', () => {
-    const spy = jest.spyOn(Linking, 'openURL');
-    const { getByTestId } = renderWithProvider(<GetPixKey />);
+  it('renders no disclaimer links and disables the CTA when the fetch comes back empty and is not loading', () => {
+    mockUseKycDisclaimers.mockReturnValue({
+      disclaimers: [],
+      isLoading: false,
+      error: null,
+      retry: mockRetry,
+    });
 
-    fireEvent.press(getByTestId(GetPixKeySelectorsIDs.MOONPAY_TERMS_LINK));
+    const { queryByTestId, getByTestId } = renderWithProvider(<GetPixKey />);
 
-    expect(spy).toHaveBeenCalledWith(MOONPAY_TERMS_URL);
+    expect(
+      queryByTestId(GetPixKeySelectorsIDs.DISCLAIMERS_LOADING),
+    ).not.toBeOnTheScreen();
+    expect(
+      queryByTestId(`${GetPixKeySelectorsIDs.DISCLAIMER_LINK}-d-1`),
+    ).not.toBeOnTheScreen();
+
+    fireEvent.press(
+      getByTestId(GetPixKeySelectorsIDs.AGREE_AND_CONTINUE_BUTTON),
+    );
+    expect(mockStartIronKycFlow).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it('opens the Trace terms link', () => {
+  it('renders disclaimers from the KYC API and opens their URL when pressed', () => {
     const spy = jest.spyOn(Linking, 'openURL');
-    const { getByTestId } = renderWithProvider(<GetPixKey />);
+    const { getByText } = renderWithProvider(<GetPixKey />);
 
-    fireEvent.press(getByTestId(GetPixKeySelectorsIDs.TRACE_TERMS_LINK));
+    expect(getByText('Iron T&C')).toBeOnTheScreen();
 
-    expect(spy).toHaveBeenCalledWith(TRACE_TERMS_URL);
+    fireEvent.press(getByText('Iron T&C'));
+
+    expect(spy).toHaveBeenCalledWith('https://iron.example/tc');
+  });
+
+  it('shows an error with a retry action and keeps the CTA disabled when the fetch fails', () => {
+    mockUseKycDisclaimers.mockReturnValue({
+      disclaimers: [],
+      isLoading: false,
+      error: 'Request timed out',
+      retry: mockRetry,
+    });
+
+    const { getByTestId, getByText } = renderWithProvider(<GetPixKey />);
+
+    expect(
+      getByTestId(GetPixKeySelectorsIDs.DISCLAIMERS_ERROR),
+    ).toBeOnTheScreen();
+
+    fireEvent.press(
+      getByTestId(GetPixKeySelectorsIDs.AGREE_AND_CONTINUE_BUTTON),
+    );
+    expect(mockStartIronKycFlow).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    fireEvent.press(getByText('Try again'));
+    expect(mockRetry).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/GetPixKey.testIds.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/GetPixKey.testIds.ts
@@ -2,7 +2,8 @@ export const GetPixKeySelectorsIDs = {
   CONTAINER: 'get-pix-key-container',
   BACK_BUTTON: 'get-pix-key-back-button',
   AGREE_AND_CONTINUE_BUTTON: 'get-pix-key-agree-and-continue-button',
-  MOONPAY_PRIVACY_POLICY_LINK: 'get-pix-key-moonpay-privacy-policy-link',
-  MOONPAY_TERMS_LINK: 'get-pix-key-moonpay-terms-link',
-  TRACE_TERMS_LINK: 'get-pix-key-trace-terms-link',
+  DISCLAIMERS_LOADING: 'get-pix-key-disclaimers-loading',
+  DISCLAIMERS_ERROR: 'get-pix-key-disclaimers-error',
+  DISCLAIMERS_RETRY: 'get-pix-key-disclaimers-retry',
+  DISCLAIMER_LINK: 'get-pix-key-disclaimer-link',
 };

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/GetPixKey.tsx
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/GetPixKey.tsx
@@ -14,26 +14,31 @@ import {
   IconColor,
   IconName,
   IconSize,
-  Tag,
-  TagSeverity,
   Text,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { brandColor } from '@metamask/design-tokens';
+import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
+import TagBase from '../../../../../component-library/base-components/TagBase';
+import { TagShape } from '../../../../../component-library/base-components/TagBase/TagBase.types';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
-import {
-  MOONPAY_PRIVACY_POLICY_URL,
-  MOONPAY_TERMS_URL,
-  TRACE_TERMS_URL,
-} from './constants';
+import { PIX_BRAND_COLOR, VBA_KYC_COUNTRY_CODE } from './constants';
 import { GetPixKeySelectorsIDs } from './GetPixKey.testIds';
+import { useKycDisclaimers } from './hooks/useKycDisclaimers';
 import { startIronKycFlow } from './ironKycFlow';
 
-// Placeholder until the real vault/config APY feed is wired into this screen.
-const PIX_APY_PERCENTAGE = 4;
+// Pix's badge always renders bold italic white text on its brand teal,
+// regardless of app theme, so this is a plain style object rather than a
+// twClassName.
+const PIX_TAG_TEXT_STYLE = {
+  color: brandColor.white,
+  fontStyle: 'italic' as const,
+  fontWeight: 'bold' as const,
+};
 
 const BenefitRow = ({
   icon,
@@ -48,7 +53,7 @@ const BenefitRow = ({
     twClassName="gap-3"
   >
     <Box twClassName="shrink-0 pt-0.5">
-      <Icon name={icon} size={IconSize.Md} color={IconColor.IconAlternative} />
+      <Icon name={icon} size={IconSize.Md} color={IconColor.IconDefault} />
     </Box>
     <Box twClassName="flex-1">{children}</Box>
   </Box>
@@ -63,21 +68,39 @@ const LegalLink = ({
   testID: string;
   children: string;
 }) => (
-  <Text
-    variant={TextVariant.BodyMd}
-    color={TextColor.PrimaryDefault}
-    twClassName="underline"
-    onPress={onPress}
-    testID={testID}
+  <Box
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Center}
+    twClassName="gap-1 py-1"
   >
-    {children}
-  </Text>
+    <Text
+      variant={TextVariant.BodyMd}
+      twClassName="underline"
+      onPress={onPress}
+      testID={testID}
+    >
+      {children}
+    </Text>
+    <Icon
+      name={IconName.Export}
+      size={IconSize.Sm}
+      color={IconColor.IconDefault}
+    />
+  </Box>
 );
 
 const GetPixKey = () => {
   const navigation = useNavigation<AppNavigationProp>();
   const tw = useTailwind();
   const [isStartingKyc, setIsStartingKyc] = useState(false);
+  const { disclaimers, isLoading, error, retry } =
+    useKycDisclaimers(VBA_KYC_COUNTRY_CODE);
+
+  // The user must be able to see the disclaimers before agreeing to them, so
+  // the CTA stays disabled until they've successfully loaded. Also block while
+  // Iron `initialize` is in flight so Agree can't be double-tapped.
+  const canAgreeAndContinue =
+    !isLoading && !error && disclaimers.length > 0 && !isStartingKyc;
 
   const handleBack = useCallback(() => navigation.goBack(), [navigation]);
 
@@ -86,30 +109,17 @@ const GetPixKey = () => {
     try {
       await startIronKycFlow();
       navigation.navigate(Routes.RAMP.VBA_VERIFY_IDENTITY);
-    } catch (error) {
+    } catch (error_) {
       Alert.alert(
         strings('virtual_bank_account.kyc_error.title'),
-        error instanceof Error
-          ? error.message
+        error_ instanceof Error
+          ? error_.message
           : strings('virtual_bank_account.kyc_error.start_failed'),
       );
     } finally {
       setIsStartingKyc(false);
     }
   }, [navigation]);
-
-  const openMoonPayPrivacyPolicy = useCallback(
-    () => Linking.openURL(MOONPAY_PRIVACY_POLICY_URL),
-    [],
-  );
-  const openMoonPayTerms = useCallback(
-    () => Linking.openURL(MOONPAY_TERMS_URL),
-    [],
-  );
-  const openTraceTerms = useCallback(
-    () => Linking.openURL(TRACE_TERMS_URL),
-    [],
-  );
 
   return (
     <SafeAreaView
@@ -137,15 +147,8 @@ const GetPixKey = () => {
           {strings('virtual_bank_account.get_pix_key.description')}
         </Text>
 
-        <Box twClassName="mt-4 p-4 gap-4 rounded-xl bg-muted">
-          <BenefitRow icon={IconName.AttachMoney}>
-            <Text variant={TextVariant.BodyMd}>
-              {strings('virtual_bank_account.get_pix_key.benefit_apy', {
-                percentage: PIX_APY_PERCENTAGE,
-              })}
-            </Text>
-          </BenefitRow>
-          <BenefitRow icon={IconName.Receive}>
+        <Box twClassName="mt-4 p-5 gap-5 rounded-xl bg-muted">
+          <BenefitRow icon={IconName.Share}>
             <Box
               flexDirection={BoxFlexDirection.Row}
               alignItems={BoxAlignItems.Center}
@@ -156,15 +159,16 @@ const GetPixKey = () => {
                   'virtual_bank_account.get_pix_key.benefit_deposit_pix',
                 )}
               </Text>
-              <Tag severity={TagSeverity.Info}>Pix</Tag>
+              {/* Pix has no design-system token — this is its brand teal,
+              matched to the vendor's own badge styling. */}
+              <TagBase
+                shape={TagShape.Rectangle}
+                style={{ backgroundColor: PIX_BRAND_COLOR }}
+                textProps={{ style: PIX_TAG_TEXT_STYLE }}
+              >
+                pix
+              </TagBase>
             </Box>
-          </BenefitRow>
-          <BenefitRow icon={IconName.Bank}>
-            <Text variant={TextVariant.BodyMd}>
-              {strings(
-                'virtual_bank_account.get_pix_key.benefit_multi_currency',
-              )}
-            </Text>
           </BenefitRow>
           <BenefitRow icon={IconName.Global}>
             <Text variant={TextVariant.BodyMd}>
@@ -183,42 +187,89 @@ const GetPixKey = () => {
           )}
         </Text>
         <Box twClassName="mt-2 gap-2">
-          <LegalLink
-            onPress={openMoonPayPrivacyPolicy}
-            testID={GetPixKeySelectorsIDs.MOONPAY_PRIVACY_POLICY_LINK}
-          >
-            {strings('virtual_bank_account.get_pix_key.moonpay_privacy_policy')}
-          </LegalLink>
-          <LegalLink
-            onPress={openMoonPayTerms}
-            testID={GetPixKeySelectorsIDs.MOONPAY_TERMS_LINK}
-          >
-            {strings('virtual_bank_account.get_pix_key.moonpay_terms')}
-          </LegalLink>
-          <LegalLink
-            onPress={openTraceTerms}
-            testID={GetPixKeySelectorsIDs.TRACE_TERMS_LINK}
-          >
-            {strings('virtual_bank_account.get_pix_key.trace_terms')}
-          </LegalLink>
+          {isLoading ? (
+            <Box
+              testID={GetPixKeySelectorsIDs.DISCLAIMERS_LOADING}
+              twClassName="gap-2 py-1"
+            >
+              <Skeleton height={16} width="70%" />
+              <Skeleton height={16} width="55%" />
+            </Box>
+          ) : error ? (
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Start}
+              twClassName="gap-2 py-1"
+              testID={GetPixKeySelectorsIDs.DISCLAIMERS_ERROR}
+            >
+              <Box twClassName="shrink-0 pt-0.5">
+                <Icon
+                  name={IconName.Danger}
+                  size={IconSize.Sm}
+                  color={IconColor.ErrorDefault}
+                />
+              </Box>
+              <Box twClassName="flex-1 gap-1">
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.ErrorDefault}
+                >
+                  {strings(
+                    'virtual_bank_account.get_pix_key.disclaimers_error',
+                  )}
+                </Text>
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.PrimaryDefault}
+                  twClassName="underline"
+                  onPress={retry}
+                  testID={GetPixKeySelectorsIDs.DISCLAIMERS_RETRY}
+                >
+                  {strings(
+                    'virtual_bank_account.get_pix_key.disclaimers_retry',
+                  )}
+                </Text>
+              </Box>
+            </Box>
+          ) : (
+            disclaimers.map((disclaimer) => (
+              <LegalLink
+                key={disclaimer.id}
+                onPress={() => Linking.openURL(disclaimer.url)}
+                testID={`${GetPixKeySelectorsIDs.DISCLAIMER_LINK}-${disclaimer.id}`}
+              >
+                {disclaimer.display_name}
+              </LegalLink>
+            ))
+          )}
         </Box>
       </ScrollView>
 
       <Box twClassName="p-4 gap-3">
-        <Text variant={TextVariant.BodyXs} color={TextColor.TextMuted}>
+        <Text
+          variant={TextVariant.BodyXs}
+          color={TextColor.TextMuted}
+          twClassName="text-center"
+        >
           {strings('virtual_bank_account.get_pix_key.agreement_text')}
         </Text>
         <Button
           variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
           isFullWidth
-          isLoading={isStartingKyc}
-          isDisabled={isStartingKyc}
+          isDisabled={!canAgreeAndContinue}
           onPress={handleAgreeAndContinue}
           testID={GetPixKeySelectorsIDs.AGREE_AND_CONTINUE_BUTTON}
         >
           {strings('virtual_bank_account.get_pix_key.button')}
         </Button>
+        <Text
+          variant={TextVariant.BodyXs}
+          color={TextColor.TextMuted}
+          twClassName="text-center"
+        >
+          {strings('virtual_bank_account.get_pix_key.powered_by_moonpay')}
+        </Text>
       </Box>
     </SafeAreaView>
   );

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/VerifyIdentity.tsx
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/VerifyIdentity.tsx
@@ -54,9 +54,9 @@ const StepRow = ({
     alignItems={BoxAlignItems.Center}
     twClassName="gap-3"
   >
-    <Box twClassName="size-10 shrink-0 rounded-lg bg-default items-center justify-center">
-      <Icon name={icon} size={IconSize.Md} color={IconColor.IconAlternative} />
-    </Box>
+    {/* Plain icon, no background chip — matches the benefit rows on the
+    Get Pix Key screen for a consistent look across both VBA KYC screens. */}
+    <Icon name={icon} size={IconSize.Md} color={IconColor.IconDefault} />
     <Text variant={TextVariant.BodyMd}>{children}</Text>
   </Box>
 );

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/constants.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/constants.ts
@@ -1,10 +1,60 @@
-// Legal URLs shown on the VBA (Virtual Bank Account) "Get your Pix Key" screen.
-// MoonPay's is the real public policy; Trace's is a placeholder pending the
-// real legal URL from the Iron/Trace integration team.
-export const MOONPAY_PRIVACY_POLICY_URL =
-  'https://www.moonpay.com/legal/privacy_policy';
-export const MOONPAY_TERMS_URL = 'https://www.moonpay.com/legal/terms_of_use';
-export const TRACE_TERMS_URL = 'https://www.trace.money/legal/terms';
+// ISO 3166-1 alpha-3 country code the VBA KYC API scopes disclaimers to.
+// This MVP is Brazil-only.
+export const VBA_KYC_COUNTRY_CODE = 'BRA';
+
+// Pix's brand teal, used for the "pix" badge on the Get Pix Key screen. Pix
+// is a Brazilian instant-payment rail, not a MetaMask concept, so it has no
+// design-system color token — this matches Pix's own brand color.
+// eslint-disable-next-line @metamask/design-tokens/color-no-hex -- Pix's brand color has no design-token equivalent
+export const PIX_BRAND_COLOR = '#2CBFB0';
+
+// Deployed hosts for the VBA KYC API (`va-mmcx-universal-kyc-api`), per its
+// ArgoCD workload repo (`va-mmcx-kyc-api-workload`, workload/<env>/main).
+// Production isn't deployed yet.
+const KYC_API_DEV_BASE_URL = 'https://kyc-api.dev-api.cx.metamask.io';
+const KYC_API_UAT_BASE_URL = 'https://kyc-api.uat-api.cx.metamask.io';
+
+/**
+ * Resolves the VBA KYC API base URL for the current MetaMask environment.
+ *
+ * `MM_VBA_KYC_API_BASE_URL` lets developers point the app at a custom
+ * deployment (e.g. a local server), bypassing the environment-based mapping.
+ *
+ * @returns the VBA KYC API base URL for the current MetaMask environment
+ */
+const getKycApiBaseUrlForMetaMaskEnv = (): string => {
+  if (process.env.MM_VBA_KYC_API_BASE_URL) {
+    return process.env.MM_VBA_KYC_API_BASE_URL;
+  }
+
+  switch (process.env.METAMASK_ENVIRONMENT) {
+    case 'exp':
+      return KYC_API_UAT_BASE_URL;
+    case 'dev':
+    case 'test':
+    case 'e2e':
+    case 'local':
+      return KYC_API_DEV_BASE_URL;
+    case 'production':
+    case 'beta':
+    case 'rc':
+    case 'pre-release':
+    default:
+      // Not deployed to production yet; `useKycDisclaimers` skips the fetch
+      // when this is empty.
+      return '';
+  }
+};
+
+/**
+ * Base URL of the VBA KYC API, used by `useKycDisclaimers` to fetch the
+ * vendor's current Privacy Policy / T&C links for Get Pix Key display.
+ *
+ * Demo Iron → Sumsub still loads controller disclaimers via
+ * `KycController.initialize`; this fetch is the temporary UI source until
+ * screens read Iron disclaimers from controller state.
+ */
+export const KYC_API_BASE_URL = getKycApiBaseUrlForMetaMaskEnv();
 
 // Legal URLs shown on the VBA "Verify your identity" screen's "Data and
 // privacy" disclosure. MetaMask's and Sumsub's are real public policies;

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/hooks/useKycDisclaimers.notConfigured.test.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/hooks/useKycDisclaimers.notConfigured.test.ts
@@ -1,0 +1,28 @@
+import { renderHook } from '@testing-library/react-native';
+import { useKycDisclaimers } from './useKycDisclaimers';
+
+jest.mock('../../../../../../core/Engine', () => ({
+  context: {
+    AuthenticationController: {
+      getBearerToken: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../constants', () => ({
+  ...jest.requireActual('../constants'),
+  KYC_API_BASE_URL: '',
+}));
+
+describe('useKycDisclaimers when the KYC API base URL is not configured', () => {
+  it('skips the fetch and returns an empty list immediately', () => {
+    const globalFetchSpy = jest.spyOn(global, 'fetch');
+
+    const { result } = renderHook(() => useKycDisclaimers('BRA'));
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.disclaimers).toStrictEqual([]);
+    expect(result.current.error).toBeNull();
+    expect(globalFetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/hooks/useKycDisclaimers.test.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/hooks/useKycDisclaimers.test.ts
@@ -1,0 +1,119 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { useKycDisclaimers } from './useKycDisclaimers';
+
+const mockGetBearerToken = jest.fn();
+jest.mock('../../../../../../core/Engine', () => ({
+  context: {
+    AuthenticationController: {
+      getBearerToken: () => mockGetBearerToken(),
+    },
+  },
+}));
+
+jest.mock('../constants', () => ({
+  ...jest.requireActual('../constants'),
+  KYC_API_BASE_URL: 'https://kyc-api.test',
+}));
+
+describe('useKycDisclaimers', () => {
+  let globalFetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetBearerToken.mockResolvedValue('mock-bearer-token');
+    globalFetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  it('fetches disclaimers scoped to the given country using a bearer token', async () => {
+    globalFetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ id: '1', url: 'https://t.c', display_name: 'T&C' }],
+    });
+
+    const { result } = renderHook(() => useKycDisclaimers('BRA'));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.disclaimers).toStrictEqual([
+      { id: '1', url: 'https://t.c', display_name: 'T&C' },
+    ]);
+    expect(result.current.error).toBeNull();
+
+    const [calledUrl, calledOptions] = globalFetchSpy.mock.calls[0];
+    expect(calledUrl).toBe(
+      'https://kyc-api.test/vendors/moonpay/disclaimers?country=BRA',
+    );
+    expect(calledOptions.headers.Authorization).toBe(
+      'Bearer mock-bearer-token',
+    );
+  });
+
+  it('sets an error and empty list when the request fails', async () => {
+    globalFetchSpy.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    const { result } = renderHook(() => useKycDisclaimers('BRA'));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.disclaimers).toStrictEqual([]);
+    expect(result.current.error).toContain('500');
+  });
+
+  it('sets an error when getting the bearer token throws', async () => {
+    mockGetBearerToken.mockRejectedValueOnce(new Error('not signed in'));
+
+    const { result } = renderHook(() => useKycDisclaimers('BRA'));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.disclaimers).toStrictEqual([]);
+    expect(result.current.error).toBe('not signed in');
+    expect(globalFetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('sets a distinct timeout error and clears any stale disclaimers when the request is aborted', async () => {
+    const abortError = new Error('Aborted');
+    abortError.name = 'AbortError';
+    globalFetchSpy.mockRejectedValueOnce(abortError);
+
+    const { result } = renderHook(() => useKycDisclaimers('BRA'));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.disclaimers).toStrictEqual([]);
+    expect(result.current.error).toBe('Request timed out');
+
+    // The fetch is given an AbortSignal so the in-flight request can actually
+    // be cancelled once FETCH_TIMEOUT_MS elapses.
+    const [, calledOptions] = globalFetchSpy.mock.calls[0];
+    expect(calledOptions.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('re-fetches and clears the previous error when retry is called', async () => {
+    globalFetchSpy
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: '1', url: 'https://t.c', display_name: 'T&C' },
+        ],
+      });
+
+    const { result } = renderHook(() => useKycDisclaimers('BRA'));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toContain('500');
+
+    act(() => {
+      result.current.retry();
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.disclaimers).toStrictEqual([
+      { id: '1', url: 'https://t.c', display_name: 'T&C' },
+    ]);
+    expect(globalFetchSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/hooks/useKycDisclaimers.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/hooks/useKycDisclaimers.ts
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useState } from 'react';
+import Engine from '../../../../../../core/Engine';
+import { KYC_API_BASE_URL } from '../constants';
+
+export interface KycDisclaimer {
+  id: string;
+  url: string;
+  display_name: string;
+}
+
+interface UseKycDisclaimersResult {
+  disclaimers: KycDisclaimer[];
+  isLoading: boolean;
+  error: string | null;
+  retry: () => void;
+}
+
+// Bounds how long we'll wait on the KYC API before treating the request as
+// failed, so a hung request can't leave the screen stuck on the loading
+// state (and the CTA disabled) forever.
+const FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * Fetches the vendor-provided legal disclaimers (Privacy Policy / T&Cs) for
+ * the VBA KYC flow from the KYC API, so the client doesn't hardcode partner
+ * legal copy that the KYC/Iron team can change server-side.
+ *
+ * This is a thin, standalone fetch that gets a bearer token the same way
+ * `useFetchPopularTokens` does, rather than going through
+ * `@metamask/kyc-controller` — that package exists in `core` but isn't
+ * published or wired into Engine yet. Swap this hook for the real
+ * controller action once it lands.
+ *
+ * When {@link KYC_API_BASE_URL} isn't configured (e.g. production, which
+ * isn't deployed yet), this skips the fetch entirely and returns an empty
+ * list. There's intentionally no static fallback copy — this MVP only
+ * ships once the real KYC API is reachable in every environment it runs in.
+ *
+ * Callers should treat a non-empty `error`, or an empty `disclaimers` list
+ * once `isLoading` is `false`, as "the user hasn't seen the terms" and keep
+ * the flow's continue action disabled until a `retry()` succeeds.
+ *
+ * @param country - The ISO 3166-1 alpha-3 country code to scope the
+ * disclaimers to (e.g. `'BRA'` for Brazil).
+ * @returns The disclaimers, loading state, any error encountered, and a
+ * `retry` function to re-run the fetch.
+ */
+export const useKycDisclaimers = (country: string): UseKycDisclaimersResult => {
+  const [disclaimers, setDisclaimers] = useState<KycDisclaimer[]>([]);
+  const [isLoading, setIsLoading] = useState(Boolean(KYC_API_BASE_URL));
+  const [error, setError] = useState<string | null>(null);
+  const [retryCount, setRetryCount] = useState(0);
+
+  const retry = useCallback(() => setRetryCount((count) => count + 1), []);
+
+  useEffect(() => {
+    // TODO: Remove these debug console.logs before merging — added
+    // temporarily to trace the disclaimer fetch lifecycle during dev.
+    // eslint-disable-next-line no-console
+    console.log(
+      '🚨🚨🚨 [VBA KYC] useKycDisclaimers CALLED — country:',
+      country,
+      'KYC_API_BASE_URL:',
+      KYC_API_BASE_URL || '(empty — fetch will be SKIPPED)',
+      'attempt:',
+      retryCount + 1,
+    );
+
+    if (!KYC_API_BASE_URL) {
+      // eslint-disable-next-line no-console
+      console.log(
+        '🚨🚨🚨 [VBA KYC] Skipping fetch, KYC_API_BASE_URL is not configured',
+      );
+      setIsLoading(false);
+      return;
+    }
+
+    let isMounted = true;
+    setIsLoading(true);
+    setError(null);
+
+    const abortController = new AbortController();
+    const timeoutId = setTimeout(
+      () => abortController.abort(),
+      FETCH_TIMEOUT_MS,
+    );
+
+    const fetchDisclaimers = async () => {
+      try {
+        const bearerToken =
+          await Engine.context.AuthenticationController.getBearerToken();
+        const url = new URL('/vendors/moonpay/disclaimers', KYC_API_BASE_URL);
+        url.searchParams.set('country', country);
+
+        // eslint-disable-next-line no-console
+        console.log(
+          '🚨🚨🚨 [VBA KYC] Fetching disclaimers from:',
+          url.toString(),
+        );
+
+        const response = await fetch(url.toString(), {
+          headers: { Authorization: `Bearer ${bearerToken}` },
+          signal: abortController.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(
+            `Failed to fetch KYC disclaimers, status ${response.status}`,
+          );
+        }
+
+        const data: KycDisclaimer[] = await response.json();
+        // eslint-disable-next-line no-console
+        console.log('🚨🚨🚨 [VBA KYC] Fetch SUCCEEDED, disclaimers:', data);
+        if (isMounted) {
+          setDisclaimers(Array.isArray(data) ? data : []);
+        }
+      } catch (err) {
+        const isTimeout =
+          err instanceof Error &&
+          (err.name === 'AbortError' || err.name === 'TimeoutError');
+        // eslint-disable-next-line no-console
+        console.log(
+          isTimeout
+            ? '🚨🚨🚨 [VBA KYC] Fetch TIMED OUT'
+            : '🚨🚨🚨 [VBA KYC] Fetch FAILED:',
+          isTimeout ? undefined : err,
+        );
+        if (isMounted) {
+          setDisclaimers([]);
+          setError(
+            isTimeout
+              ? 'Request timed out'
+              : err instanceof Error
+                ? err.message
+                : 'Unknown error',
+          );
+        }
+      } finally {
+        clearTimeout(timeoutId);
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchDisclaimers();
+
+    return () => {
+      isMounted = false;
+      clearTimeout(timeoutId);
+      abortController.abort();
+    };
+  }, [country, retryCount]);
+
+  return { disclaimers, isLoading, error, retry };
+};

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1099,16 +1099,14 @@
     "get_pix_key": {
       "navbar_title": "Bank account",
       "title": "Get your Pix Key",
-      "description": "We've partnered with MoonPay so you can send funds directly to your Money account with Pix.",
-      "benefit_apy": "Earn up to {{percentage}}% APY on your balance",
+      "description": "Send funds directly to your Money account from any bank account.",
       "benefit_deposit_pix": "Deposit with",
-      "benefit_multi_currency": "Hold multi-currency accounts in BRL, USD, EUR",
       "benefit_payments": "Send local and international payments",
       "agreements_disclosures_title": "Agreements and disclosures",
-      "moonpay_privacy_policy": "MoonPay Privacy Policy",
-      "moonpay_terms": "MoonPay Terms and Conditions",
-      "trace_terms": "Trace Terms and Conditions",
-      "agreement_text": "By tapping \"Agree and continue\" you have read and agreed to the above Agreements and disclosures.",
+      "disclaimers_error": "Couldn't load the terms and conditions.",
+      "disclaimers_retry": "Try again",
+      "agreement_text": "By continuing, you agree to the terms and conditions above.",
+      "powered_by_moonpay": "Powered by MoonPay.",
       "button": "Agree and continue"
     },
     "verify_identity": {


### PR DESCRIPTION
## Summary
- **Retargeted onto `demo/vba-kyc`** (was stacked on `feat/vba-kyc-terms-screens`).
- **Iron / Engine wiring is already on demo** (`282df9c962` + `1651856c5e` with `ironKycFlow` + MockKycEmail). This PR no longer re-ports that work.
- Remaining delta from Arnold’s terms-screens branch: **`useKycDisclaimers`** + lean Get Pix Key / Verify identity polish, merged onto the live demo Iron path (Agree still calls `startIronKycFlow()`; Continue still goes to MockKycEmail).

## Not superseded
Useful UI that was **not** on `demo/vba-kyc` tip: dynamic disclaimer fetch, loading/error/retry, block Agree until loaded, Pix badge / lean benefits card, plain Verify identity step icons.

## Gaps / follow-ups
- [ ] Swap `useKycDisclaimers` → Iron disclaimers from `KycController` state (demo already loads them in `initialize`)
- [ ] Remove debug `console.log`s flagged in `useKycDisclaimers`
- [ ] Dual source of truth today: UI links from KYC API fetch; Iron consents still use controller disclaimers after `initialize`

## Test plan
- [x] `yarn jest` GetPixKey / VerifyIdentity / useKycDisclaimers suites (19 passed)
- [ ] Manual on `demo/vba-kyc` build: Get Pix Key shows fetched links; Agree runs Iron initialize then Verify identity → MockKycEmail → Sumsub

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> KYC consent UX now depends on a new authenticated API and gating logic; misconfiguration or API drift could block the Pix flow, though scope is demo/VBA-only with tests.
> 
> **Overview**
> Replaces **hardcoded MoonPay/Trace legal links** on the VBA **Get your Pix Key** screen with **server-driven disclaimers** from the VBA KYC API (`/vendors/moonpay/disclaimers?country=BRA`), via new **`useKycDisclaimers`** (bearer auth, 10s timeout, retry). **`MM_VBA_KYC_API_BASE_URL`** and env-based **`KYC_API_BASE_URL`** mapping are added; when the base URL is empty (e.g. prod not deployed yet), the hook skips fetch and **Agree and continue** stays disabled with no static fallback.
> 
> **Get Pix Key** gains skeleton loading, error + **Try again**, dynamic link rows with export icons, and **blocks Agree** until disclaimers load successfully (still calls **`startIronKycFlow()`** on success). Copy and benefits are refreshed (Pix brand badge, leaner card, **Powered by MoonPay**). **Verify identity** step icons are aligned to the same plain-icon style.
> 
> Tests cover the hook, unconfigured API URL, and updated **GetPixKey** flows. **Debug `console.log`s** in the hook are flagged for removal before merge; UI links and Iron controller disclaimers remain a **dual source** until controller state is wired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fed92f2d18f83e1695dba27d64f162d80c57726c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->