### PR TITLE
feat(perps): add triggered order types to Pro selector

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -860,6 +860,11 @@ export const PerpsOrderTypeBottomSheetSelectorsIDs = {
   CLOSE_BUTTON: 'perps-order-type-bottom-sheet-close',
   MARKET_OPTION: 'perps-order-type-market',
   LIMIT_OPTION: 'perps-order-type-limit',
+  STOP_LIMIT_OPTION: 'perps-order-type-stop-limit',
+  STOP_MARKET_OPTION: 'perps-order-type-stop-market',
+  TAKE_PROFIT_LIMIT_OPTION: 'perps-order-type-take-profit-limit',
+  TAKE_PROFIT_MARKET_OPTION: 'perps-order-type-take-profit-market',
+  TRIGGERED_SECTION_HEADER: 'perps-order-type-triggered-section-header',
 } as const;
 
 export const PerpsMarginModeBottomSheetSelectorsIDs = {

--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -864,6 +864,7 @@ export const PerpsOrderTypeBottomSheetSelectorsIDs = {
   STOP_MARKET_OPTION: 'perps-order-type-stop-market',
   TAKE_PROFIT_LIMIT_OPTION: 'perps-order-type-take-profit-limit',
   TAKE_PROFIT_MARKET_OPTION: 'perps-order-type-take-profit-market',
+  BASIC_SECTION_HEADER: 'perps-order-type-basic-section-header',
   TRIGGERED_SECTION_HEADER: 'perps-order-type-triggered-section-header',
 } as const;
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.view.test.tsx
@@ -23,11 +23,39 @@ import {
 
 const ids = PerpsProOrderFormSelectorsIDs;
 const TIMEOUT_MS = 5000;
+const triggeredOrderTypeIDs = [
+  PerpsOrderTypeBottomSheetSelectorsIDs.STOP_LIMIT_OPTION,
+  PerpsOrderTypeBottomSheetSelectorsIDs.STOP_MARKET_OPTION,
+  PerpsOrderTypeBottomSheetSelectorsIDs.TAKE_PROFIT_LIMIT_OPTION,
+  PerpsOrderTypeBottomSheetSelectorsIDs.TAKE_PROFIT_MARKET_OPTION,
+] as const;
 
 const renderFundedProMarket = () =>
   renderPerpsProMarketView({
     streamOverrides: {
       account: createFundedAccountForViews('1000'),
+    },
+  });
+
+const renderProMarketWithTriggeredOrdersFlag = (enabled: boolean) =>
+  renderPerpsProMarketView({
+    overrides: {
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              perpsProModeEnabled: {
+                enabled: true,
+                minimumVersion: '0.0.0',
+              },
+              perpsProTriggeredOrdersEnabled: {
+                enabled,
+                minimumVersion: '0.0.0',
+              },
+            },
+          },
+        },
+      },
     },
   });
 
@@ -65,6 +93,51 @@ describeForPlatforms('PerpsProMarketView input journeys', () => {
       fireEvent.changeText(limitPriceInput, '00025');
 
       await waitFor(() => expect(limitPriceInput).toHaveProp('value', '25'));
+    },
+  );
+
+  itForPlatforms(
+    'shows triggered order types when the remote flag is enabled',
+    async () => {
+      renderProMarketWithTriggeredOrdersFlag(true);
+      await findSizeInput();
+
+      fireEvent.press(screen.getByTestId(ids.ORDER_TYPE_BUTTON));
+
+      expect(
+        await screen.findByTestId(
+          PerpsOrderTypeBottomSheetSelectorsIDs.TRIGGERED_SECTION_HEADER,
+          {},
+          { timeout: TIMEOUT_MS },
+        ),
+      ).toBeOnTheScreen();
+      for (const testID of triggeredOrderTypeIDs) {
+        expect(screen.getByTestId(testID)).toBeOnTheScreen();
+      }
+    },
+  );
+
+  itForPlatforms(
+    'hides triggered order types when the remote flag is disabled',
+    async () => {
+      renderProMarketWithTriggeredOrdersFlag(false);
+      await findSizeInput();
+
+      fireEvent.press(screen.getByTestId(ids.ORDER_TYPE_BUTTON));
+      await screen.findByTestId(
+        PerpsOrderTypeBottomSheetSelectorsIDs.MARKET_OPTION,
+        {},
+        { timeout: TIMEOUT_MS },
+      );
+
+      expect(
+        screen.queryByTestId(
+          PerpsOrderTypeBottomSheetSelectorsIDs.TRIGGERED_SECTION_HEADER,
+        ),
+      ).not.toBeOnTheScreen();
+      for (const testID of triggeredOrderTypeIDs) {
+        expect(screen.queryByTestId(testID)).not.toBeOnTheScreen();
+      }
     },
   );
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.test.tsx
@@ -16,6 +16,17 @@ import {
 } from '../../../Perps.testIds';
 import { PERPS_PRO_MODAL_GESTURE_ROOT_TEST_ID } from './PerpsProModalPortal';
 
+const mockUseSelector = jest.fn();
+const mockUseIsPerpsProModeActive = jest.fn();
+
+jest.mock('react-redux', () => ({
+  useSelector: (selector: unknown) => mockUseSelector(selector),
+}));
+
+jest.mock('../../../utils/perpsModeSwitch', () => ({
+  useIsPerpsProModeActive: () => mockUseIsPerpsProModeActive(),
+}));
+
 jest.mock('../../../components/PerpsSlider', () => 'PerpsSlider');
 jest.mock('../../../components/PerpsFeesDisplay', () => 'PerpsFeesDisplay');
 
@@ -112,14 +123,17 @@ jest.mock(
       default: ({
         isVisible,
         onSelect,
+        showTriggeredTypes,
       }: {
         isVisible: boolean;
         onSelect: (type: string) => void;
+        showTriggeredTypes: boolean;
       }) =>
         isVisible
           ? ReactActual.createElement(P, {
               testID: 'mock-order-type-select',
               onPress: () => onSelect('limit'),
+              accessibilityState: { checked: showTriggeredTypes },
             })
           : null,
     };
@@ -187,6 +201,8 @@ const renderPanel = (
 describe('PerpsProOrderFormPanel', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseSelector.mockReturnValue(true);
+    mockUseIsPerpsProModeActive.mockReturnValue(true);
     // Fully restore every property (not just the few tests currently mutate) so
     // added tests can safely set any field without bleeding into later tests.
     Object.assign(mockHookResult, DEFAULT_MOCK_HOOK_RESULT);
@@ -371,6 +387,41 @@ describe('PerpsProOrderFormPanel', () => {
 
     // Assert
     expect(mockHookResult.onOrderTypeSelect).toHaveBeenCalledWith('limit');
+  });
+
+  it('shows triggered types when Pro mode and its remote flag are enabled', () => {
+    mockHookResult.isOrderTypeVisible = true;
+
+    renderPanel();
+
+    expect(screen.getByTestId('mock-order-type-select')).toHaveProp(
+      'accessibilityState',
+      { checked: true },
+    );
+  });
+
+  it('hides triggered types when Pro mode is inactive', () => {
+    mockUseIsPerpsProModeActive.mockReturnValue(false);
+    mockHookResult.isOrderTypeVisible = true;
+
+    renderPanel();
+
+    expect(screen.getByTestId('mock-order-type-select')).toHaveProp(
+      'accessibilityState',
+      { checked: false },
+    );
+  });
+
+  it('hides triggered types when the remote flag is disabled', () => {
+    mockUseSelector.mockReturnValue(false);
+    mockHookResult.isOrderTypeVisible = true;
+
+    renderPanel();
+
+    expect(screen.getByTestId('mock-order-type-select')).toHaveProp(
+      'accessibilityState',
+      { checked: false },
+    );
   });
 
   it('renders the fees tooltip when a tooltip is selected', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.test.tsx
@@ -18,6 +18,7 @@ import { PERPS_PRO_MODAL_GESTURE_ROOT_TEST_ID } from './PerpsProModalPortal';
 
 const mockUseSelector = jest.fn();
 const mockUseIsPerpsProModeActive = jest.fn();
+const mockOrderTypeBottomSheet = jest.fn();
 
 jest.mock('react-redux', () => ({
   useSelector: (selector: unknown) => mockUseSelector(selector),
@@ -113,32 +114,26 @@ jest.mock('./PerpsProOrderForm/usePerpsProOrderForm', () => ({
 }));
 
 // Lightweight sheet mocks that surface their key callbacks for wiring assertions.
-jest.mock(
-  '../../../components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView',
-  () => {
-    const { Pressable: P } = jest.requireActual('react-native');
-    const ReactActual = jest.requireActual('react');
-    return {
-      __esModule: true,
-      default: ({
-        isVisible,
-        onSelect,
-        showTriggeredTypes,
-      }: {
-        isVisible: boolean;
-        onSelect: (type: string) => void;
-        showTriggeredTypes: boolean;
-      }) =>
-        isVisible
-          ? ReactActual.createElement(P, {
-              testID: 'mock-order-type-select',
-              onPress: () => onSelect('limit'),
-              accessibilityState: { checked: showTriggeredTypes },
-            })
-          : null,
-    };
-  },
-);
+jest.mock('../../../components/PerpsOrderTypeBottomSheet', () => {
+  const { Pressable: P } = jest.requireActual('react-native');
+  const ReactActual = jest.requireActual('react');
+  return {
+    __esModule: true,
+    default: (props: {
+      isVisible: boolean;
+      onSelect: (type: string) => void;
+      showTriggeredTypes: boolean;
+    }) => {
+      mockOrderTypeBottomSheet(props);
+      return props.isVisible
+        ? ReactActual.createElement(P, {
+            testID: 'mock-order-type-select',
+            onPress: () => props.onSelect('limit'),
+          })
+        : null;
+    },
+  };
+});
 
 jest.mock('../../../components/PerpsLeverageBottomSheet', () => {
   const { Pressable: P } = jest.requireActual('react-native');
@@ -394,9 +389,14 @@ describe('PerpsProOrderFormPanel', () => {
 
     renderPanel();
 
-    expect(screen.getByTestId('mock-order-type-select')).toHaveProp(
-      'accessibilityState',
-      { checked: true },
+    expect(mockOrderTypeBottomSheet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        asset: 'BTC',
+        direction: 'long',
+        showSelectedIcon: true,
+        showTriggeredTypes: true,
+        title: 'Choose order type',
+      }),
     );
   });
 
@@ -406,9 +406,10 @@ describe('PerpsProOrderFormPanel', () => {
 
     renderPanel();
 
-    expect(screen.getByTestId('mock-order-type-select')).toHaveProp(
-      'accessibilityState',
-      { checked: false },
+    expect(mockOrderTypeBottomSheet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        showTriggeredTypes: false,
+      }),
     );
   });
 
@@ -418,9 +419,10 @@ describe('PerpsProOrderFormPanel', () => {
 
     renderPanel();
 
-    expect(screen.getByTestId('mock-order-type-select')).toHaveProp(
-      'accessibilityState',
-      { checked: false },
+    expect(mockOrderTypeBottomSheet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        showTriggeredTypes: false,
+      }),
     );
   });
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.tsx
@@ -2,6 +2,7 @@ import { Box } from '@metamask/design-system-react-native';
 import { PERPS_EVENT_VALUE } from '@metamask/perps-controller/constants';
 import type { PerpsMarketData } from '@metamask/perps-controller';
 import React, { useCallback, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../../locales/i18n';
 import { useStyles } from '../../../../../../component-library/hooks';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
@@ -10,6 +11,8 @@ import PerpsLeverageBottomSheet from '../../../components/PerpsLeverageBottomShe
 import PerpsMarginModeBottomSheet from '../../../components/PerpsMarginModeBottomSheet';
 import PerpsOrderTypeBottomSheetView from '../../../components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView';
 import PerpsSlippageBottomSheet from '../../../components/PerpsSlippageBottomSheet';
+import { selectPerpsProTriggeredOrdersEnabledFlag } from '../../../selectors/featureFlags';
+import { useIsPerpsProModeActive } from '../../../utils/perpsModeSwitch';
 import PerpsProModalPortal from './PerpsProModalPortal';
 import PerpsProOrderForm from './PerpsProOrderForm/PerpsProOrderForm';
 import { createStyles } from './PerpsProOrderFormPanel.styles';
@@ -81,6 +84,11 @@ const PerpsProOrderFormPanel = ({
   } = usePerpsProOrderForm({ market });
 
   const { styles } = useStyles(createStyles, {});
+  const isProModeActive = useIsPerpsProModeActive();
+  const isTriggeredOrdersEnabled = useSelector(
+    selectPerpsProTriggeredOrdersEnabledFlag,
+  );
+  const showTriggeredTypes = isProModeActive && isTriggeredOrdersEnabled;
 
   const [isMarginModeVisible, setIsMarginModeVisible] = useState(false);
   const openMarginMode = useCallback(() => setIsMarginModeVisible(true), []);
@@ -144,6 +152,7 @@ const PerpsProOrderFormPanel = ({
             currentOrderType={orderType}
             title={strings('perps.pro_order_form.choose_order_type')}
             showSelectedIcon
+            showTriggeredTypes={showTriggeredTypes}
           />
         </PerpsProModalPortal>
       )}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderFormPanel.tsx
@@ -9,7 +9,7 @@ import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
 import PerpsBottomSheetTooltip from '../../../components/PerpsBottomSheetTooltip';
 import PerpsLeverageBottomSheet from '../../../components/PerpsLeverageBottomSheet';
 import PerpsMarginModeBottomSheet from '../../../components/PerpsMarginModeBottomSheet';
-import PerpsOrderTypeBottomSheetView from '../../../components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView';
+import PerpsOrderTypeBottomSheet from '../../../components/PerpsOrderTypeBottomSheet';
 import PerpsSlippageBottomSheet from '../../../components/PerpsSlippageBottomSheet';
 import { selectPerpsProTriggeredOrdersEnabledFlag } from '../../../selectors/featureFlags';
 import { useIsPerpsProModeActive } from '../../../utils/perpsModeSwitch';
@@ -145,11 +145,13 @@ const PerpsProOrderFormPanel = ({
           animationType="fade"
           onRequestClose={closeOrderType}
         >
-          <PerpsOrderTypeBottomSheetView
+          <PerpsOrderTypeBottomSheet
             isVisible
             onClose={closeOrderType}
             onSelect={onOrderTypeSelect}
             currentOrderType={orderType}
+            asset={market.symbol}
+            direction={direction}
             title={strings('perps.pro_order_form.choose_order_type')}
             showSelectedIcon
             showTriggeredTypes={showTriggeredTypes}

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.test.tsx
@@ -140,6 +140,11 @@ describe('PerpsOrderTypeBottomSheet', () => {
 
       expect(
         screen.queryByTestId(
+          PerpsOrderTypeBottomSheetSelectorsIDs.BASIC_SECTION_HEADER,
+        ),
+      ).not.toBeOnTheScreen();
+      expect(
+        screen.queryByTestId(
           PerpsOrderTypeBottomSheetSelectorsIDs.TRIGGERED_SECTION_HEADER,
         ),
       ).not.toBeOnTheScreen();
@@ -153,7 +158,11 @@ describe('PerpsOrderTypeBottomSheet', () => {
         <PerpsOrderTypeBottomSheet {...defaultProps} showTriggeredTypes />,
       );
 
-      expect(screen.getByText('Basic')).toBeOnTheScreen();
+      expect(
+        screen.getByTestId(
+          PerpsOrderTypeBottomSheetSelectorsIDs.BASIC_SECTION_HEADER,
+        ),
+      ).toHaveTextContent('Basic');
       expect(
         screen.getByTestId(
           PerpsOrderTypeBottomSheetSelectorsIDs.TRIGGERED_SECTION_HEADER,
@@ -173,6 +182,40 @@ describe('PerpsOrderTypeBottomSheet', () => {
       expect(
         screen.getByTestId(PerpsOrderTypeBottomSheetSelectorsIDs.LIMIT_OPTION),
       ).toBeOnTheScreen();
+    });
+
+    it('shows order type icons only in the Pro presentation', () => {
+      const marketIconTestID = `${PerpsOrderTypeBottomSheetSelectorsIDs.MARKET_OPTION}-icon`;
+      const { rerender } = render(
+        <PerpsOrderTypeBottomSheet {...defaultProps} />,
+      );
+
+      expect(screen.queryByTestId(marketIconTestID)).not.toBeOnTheScreen();
+
+      rerender(
+        <PerpsOrderTypeBottomSheet {...defaultProps} showSelectedIcon />,
+      );
+
+      expect(screen.getByTestId(marketIconTestID)).toBeOnTheScreen();
+    });
+
+    it('forwards the Pro title and selected-icon presentation', () => {
+      render(
+        <PerpsOrderTypeBottomSheet
+          {...defaultProps}
+          title="Choose order type"
+          showSelectedIcon
+        />,
+      );
+
+      expect(screen.getByText('Choose order type')).toBeOnTheScreen();
+      expect(
+        within(
+          screen.getByTestId(
+            PerpsOrderTypeBottomSheetSelectorsIDs.MARKET_OPTION,
+          ),
+        ).UNSAFE_getByType(Icon).props.name,
+      ).toBe(IconName.Check);
     });
   });
 

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.test.tsx
@@ -18,8 +18,18 @@ import { MetaMetricsEvents } from '../../../../../core/Analytics';
 const mockTrack = jest.fn();
 
 jest.mock('@metamask/design-system-twrnc-preset', () => {
-  const tw = (..._args: unknown[]) => ({});
-  tw.style = jest.fn(() => ({}));
+  const resolveStyle = (...args: unknown[]) => {
+    const classNames = JSON.stringify(args);
+    if (classNames.includes('bg-transparent')) {
+      return { backgroundColor: 'transparent' };
+    }
+    if (classNames.includes('bg-background-muted')) {
+      return { backgroundColor: 'muted' };
+    }
+    return {};
+  };
+  const tw = (...args: unknown[]) => resolveStyle(...args);
+  tw.style = jest.fn(resolveStyle);
   return { useTailwind: () => tw };
 });
 
@@ -272,6 +282,27 @@ describe('PerpsOrderTypeBottomSheet', () => {
         IconName.Check,
       );
       expect(within(unselectedOption).UNSAFE_queryByType(Icon)).toBeNull();
+    });
+
+    it('preserves the selected background when selected icons are hidden', () => {
+      const { rerender } = render(
+        <PerpsOrderTypeBottomSheet {...defaultProps} />,
+      );
+
+      const selectedOption = screen.getByTestId(
+        PerpsOrderTypeBottomSheetSelectorsIDs.MARKET_OPTION,
+      );
+
+      expect(selectedOption).toHaveStyle({ backgroundColor: 'muted' });
+      expect(within(selectedOption).UNSAFE_queryByType(Icon)).toBeNull();
+
+      rerender(
+        <PerpsOrderTypeBottomSheet {...defaultProps} showTriggeredTypes />,
+      );
+
+      expect(
+        screen.getByTestId(PerpsOrderTypeBottomSheetSelectorsIDs.MARKET_OPTION),
+      ).toHaveStyle({ backgroundColor: 'transparent' });
     });
   });
 

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.test.tsx
@@ -45,10 +45,10 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'perps.order.type.title': 'Order Type',
       'perps.order.type.market.title': 'Market Order',
       'perps.order.type.market.description':
-        'Execute immediately at current market price',
+        'Execute instantly at best available price',
       'perps.order.type.limit.title': 'Limit Order',
       'perps.order.type.limit.description':
-        'Execute only at your specified price or better',
+        'Execute at your specified price or better',
       'perps.order.type.basic': 'Basic',
       'perps.order.type.triggered': 'Triggered',
       'perps.order.type.stop_limit.title': 'Stop limit',
@@ -121,10 +121,10 @@ describe('PerpsOrderTypeBottomSheet', () => {
       render(<PerpsOrderTypeBottomSheet {...defaultProps} />);
 
       expect(
-        screen.getByText('Execute immediately at current market price'),
+        screen.getByText('Execute instantly at best available price'),
       ).toBeOnTheScreen();
       expect(
-        screen.getByText('Execute only at your specified price or better'),
+        screen.getByText('Execute at your specified price or better'),
       ).toBeOnTheScreen();
     });
 

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.test.tsx
@@ -1,8 +1,21 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react-native';
+import {
+  render,
+  screen,
+  fireEvent,
+  within,
+} from '@testing-library/react-native';
+import { Icon, IconName } from '@metamask/design-system-react-native';
 import PerpsOrderTypeBottomSheet from './PerpsOrderTypeBottomSheet';
-import { type OrderType } from '@metamask/perps-controller';
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+  type OrderType,
+} from '@metamask/perps-controller';
 import { PerpsOrderTypeBottomSheetSelectorsIDs } from '../../Perps.testIds';
+import { MetaMetricsEvents } from '../../../../../core/Analytics';
+
+const mockTrack = jest.fn();
 
 jest.mock('@metamask/design-system-twrnc-preset', () => {
   const tw = (..._args: unknown[]) => ({});
@@ -12,7 +25,7 @@ jest.mock('@metamask/design-system-twrnc-preset', () => {
 
 jest.mock('../../hooks/usePerpsEventTracking', () => ({
   usePerpsEventTracking: () => ({
-    track: jest.fn(),
+    track: mockTrack,
   }),
 }));
 
@@ -26,6 +39,19 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'perps.order.type.limit.title': 'Limit Order',
       'perps.order.type.limit.description':
         'Execute only at your specified price or better',
+      'perps.order.type.basic': 'Basic',
+      'perps.order.type.triggered': 'Triggered',
+      'perps.order.type.stop_limit.title': 'Stop limit',
+      'perps.order.type.stop_limit.description': 'Limit fills at trigger price',
+      'perps.order.type.stop_market.title': 'Stop market',
+      'perps.order.type.stop_market.description':
+        'Market fills at trigger price',
+      'perps.order.type.take_profit_limit.title': 'Take limit',
+      'perps.order.type.take_profit_limit.description':
+        'Limit take-profit at trigger price',
+      'perps.order.type.take_profit_market.title': 'Take market',
+      'perps.order.type.take_profit_market.description':
+        'Market take-profit at trigger price',
     };
     return translations[key] || key;
   }),
@@ -38,6 +64,24 @@ describe('PerpsOrderTypeBottomSheet', () => {
     onSelect: jest.fn(),
     currentOrderType: 'market' as OrderType,
   };
+  const triggeredOptions = [
+    {
+      type: 'stop_limit',
+      testID: PerpsOrderTypeBottomSheetSelectorsIDs.STOP_LIMIT_OPTION,
+    },
+    {
+      type: 'stop_market',
+      testID: PerpsOrderTypeBottomSheetSelectorsIDs.STOP_MARKET_OPTION,
+    },
+    {
+      type: 'take_profit_limit',
+      testID: PerpsOrderTypeBottomSheetSelectorsIDs.TAKE_PROFIT_LIMIT_OPTION,
+    },
+    {
+      type: 'take_profit_market',
+      testID: PerpsOrderTypeBottomSheetSelectorsIDs.TAKE_PROFIT_MARKET_OPTION,
+    },
+  ] as const;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -79,6 +123,35 @@ describe('PerpsOrderTypeBottomSheet', () => {
 
       expect(screen.getByText('Market Order')).toBeOnTheScreen();
       expect(screen.getByText('Limit Order')).toBeOnTheScreen();
+    });
+
+    it('hides section labels and triggered options when disabled', () => {
+      render(<PerpsOrderTypeBottomSheet {...defaultProps} />);
+
+      expect(
+        screen.queryByTestId(
+          PerpsOrderTypeBottomSheetSelectorsIDs.TRIGGERED_SECTION_HEADER,
+        ),
+      ).not.toBeOnTheScreen();
+      for (const { testID } of triggeredOptions) {
+        expect(screen.queryByTestId(testID)).not.toBeOnTheScreen();
+      }
+    });
+
+    it('renders Basic and Triggered sections when enabled', () => {
+      render(
+        <PerpsOrderTypeBottomSheet {...defaultProps} showTriggeredTypes />,
+      );
+
+      expect(screen.getByText('Basic')).toBeOnTheScreen();
+      expect(
+        screen.getByTestId(
+          PerpsOrderTypeBottomSheetSelectorsIDs.TRIGGERED_SECTION_HEADER,
+        ),
+      ).toHaveTextContent('Triggered');
+      for (const { testID } of triggeredOptions) {
+        expect(screen.getByTestId(testID)).toBeOnTheScreen();
+      }
     });
 
     it('renders options with stable testIDs', () => {
@@ -156,6 +229,107 @@ describe('PerpsOrderTypeBottomSheet', () => {
       expect(onSelect).toHaveBeenCalledWith('market');
       expect(onClose).toHaveBeenCalled();
     });
+
+    it.each(triggeredOptions)(
+      'emits $type and closes when its option is pressed',
+      ({ type, testID }) => {
+        const onSelect = jest.fn();
+        const onClose = jest.fn();
+        render(
+          <PerpsOrderTypeBottomSheet
+            {...defaultProps}
+            currentOrderType="market"
+            onSelect={onSelect}
+            onClose={onClose}
+            showTriggeredTypes
+          />,
+        );
+
+        fireEvent.press(screen.getByTestId(testID));
+
+        expect(onSelect).toHaveBeenCalledWith(type);
+        expect(onClose).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    it('marks only the current triggered order type as selected', () => {
+      render(
+        <PerpsOrderTypeBottomSheet
+          {...defaultProps}
+          currentOrderType="stop_limit"
+          showTriggeredTypes
+        />,
+      );
+
+      const selectedOption = screen.getByTestId(
+        PerpsOrderTypeBottomSheetSelectorsIDs.STOP_LIMIT_OPTION,
+      );
+      const unselectedOption = screen.getByTestId(
+        PerpsOrderTypeBottomSheetSelectorsIDs.STOP_MARKET_OPTION,
+      );
+
+      expect(within(selectedOption).UNSAFE_getByType(Icon).props.name).toBe(
+        IconName.Check,
+      );
+      expect(within(unselectedOption).UNSAFE_queryByType(Icon)).toBeNull();
+    });
+  });
+
+  describe('Analytics', () => {
+    const analyticsCases = [
+      {
+        type: 'market',
+        testID: PerpsOrderTypeBottomSheetSelectorsIDs.MARKET_OPTION,
+        eventValue: PERPS_EVENT_VALUE.ORDER_TYPE.MARKET,
+      },
+      {
+        type: 'limit',
+        testID: PerpsOrderTypeBottomSheetSelectorsIDs.LIMIT_OPTION,
+        eventValue: PERPS_EVENT_VALUE.ORDER_TYPE.LIMIT,
+      },
+      {
+        type: 'stop_limit',
+        testID: PerpsOrderTypeBottomSheetSelectorsIDs.STOP_LIMIT_OPTION,
+        eventValue: PERPS_EVENT_VALUE.ORDER_TYPE.STOP_LIMIT,
+      },
+      {
+        type: 'stop_market',
+        testID: PerpsOrderTypeBottomSheetSelectorsIDs.STOP_MARKET_OPTION,
+        eventValue: PERPS_EVENT_VALUE.ORDER_TYPE.STOP_MARKET,
+      },
+      {
+        type: 'take_profit_limit',
+        testID: PerpsOrderTypeBottomSheetSelectorsIDs.TAKE_PROFIT_LIMIT_OPTION,
+        eventValue: PERPS_EVENT_VALUE.ORDER_TYPE.TAKE_PROFIT_LIMIT,
+      },
+      {
+        type: 'take_profit_market',
+        testID: PerpsOrderTypeBottomSheetSelectorsIDs.TAKE_PROFIT_MARKET_OPTION,
+        eventValue: PERPS_EVENT_VALUE.ORDER_TYPE.TAKE_PROFIT_MARKET,
+      },
+    ] as const;
+
+    it.each(analyticsCases)(
+      'tracks $type with its analytics value',
+      ({ testID, eventValue }) => {
+        render(
+          <PerpsOrderTypeBottomSheet
+            {...defaultProps}
+            currentOrderType={undefined}
+            showTriggeredTypes
+          />,
+        );
+
+        fireEvent.press(screen.getByTestId(testID));
+
+        expect(mockTrack).toHaveBeenCalledWith(
+          MetaMetricsEvents.PERPS_UI_INTERACTION,
+          expect.objectContaining({
+            [PERPS_EVENT_PROPERTY.ORDER_TYPE]: eventValue,
+          }),
+        );
+      },
+    );
   });
 
   describe('Bottom Sheet Interaction', () => {

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.tsx
@@ -26,6 +26,8 @@ interface PerpsOrderTypeBottomSheetProps {
   currentOrderType?: OrderType;
   asset?: string;
   direction?: 'long' | 'short';
+  title?: string;
+  showSelectedIcon?: boolean;
   showTriggeredTypes?: boolean;
   sheetRef?: React.RefObject<BottomSheetRef | null>;
 }
@@ -37,6 +39,8 @@ const PerpsOrderTypeBottomSheet: React.FC<PerpsOrderTypeBottomSheetProps> = ({
   currentOrderType,
   asset = 'BTC',
   direction = 'long',
+  title,
+  showSelectedIcon = false,
   showTriggeredTypes = false,
   sheetRef: externalSheetRef,
 }) => {
@@ -68,6 +72,8 @@ const PerpsOrderTypeBottomSheet: React.FC<PerpsOrderTypeBottomSheetProps> = ({
       onClose={onClose}
       onSelect={handleSelect}
       currentOrderType={currentOrderType}
+      title={title}
+      showSelectedIcon={showSelectedIcon}
       showTriggeredTypes={showTriggeredTypes}
       sheetRef={externalSheetRef}
     />
@@ -76,10 +82,4 @@ const PerpsOrderTypeBottomSheet: React.FC<PerpsOrderTypeBottomSheetProps> = ({
 
 PerpsOrderTypeBottomSheet.displayName = 'PerpsOrderTypeBottomSheet';
 
-export default memo(
-  PerpsOrderTypeBottomSheet,
-  (prevProps, nextProps) =>
-    prevProps.isVisible === nextProps.isVisible &&
-    prevProps.currentOrderType === nextProps.currentOrderType &&
-    prevProps.showTriggeredTypes === nextProps.showTriggeredTypes,
-);
+export default memo(PerpsOrderTypeBottomSheet);

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.tsx
@@ -10,6 +10,15 @@ import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import PerpsOrderTypeBottomSheetView from './PerpsOrderTypeBottomSheetView';
 
+const ORDER_TYPE_EVENT_VALUES = {
+  market: PERPS_EVENT_VALUE.ORDER_TYPE.MARKET,
+  limit: PERPS_EVENT_VALUE.ORDER_TYPE.LIMIT,
+  stop_market: PERPS_EVENT_VALUE.ORDER_TYPE.STOP_MARKET,
+  stop_limit: PERPS_EVENT_VALUE.ORDER_TYPE.STOP_LIMIT,
+  take_profit_market: PERPS_EVENT_VALUE.ORDER_TYPE.TAKE_PROFIT_MARKET,
+  take_profit_limit: PERPS_EVENT_VALUE.ORDER_TYPE.TAKE_PROFIT_LIMIT,
+} satisfies Record<OrderType, string>;
+
 interface PerpsOrderTypeBottomSheetProps {
   isVisible?: boolean;
   onClose: () => void;
@@ -17,6 +26,7 @@ interface PerpsOrderTypeBottomSheetProps {
   currentOrderType?: OrderType;
   asset?: string;
   direction?: 'long' | 'short';
+  showTriggeredTypes?: boolean;
   sheetRef?: React.RefObject<BottomSheetRef | null>;
 }
 
@@ -27,6 +37,7 @@ const PerpsOrderTypeBottomSheet: React.FC<PerpsOrderTypeBottomSheetProps> = ({
   currentOrderType,
   asset = 'BTC',
   direction = 'long',
+  showTriggeredTypes = false,
   sheetRef: externalSheetRef,
 }) => {
   const { track } = usePerpsEventTracking();
@@ -42,10 +53,7 @@ const PerpsOrderTypeBottomSheet: React.FC<PerpsOrderTypeBottomSheetProps> = ({
             direction === 'long'
               ? PERPS_EVENT_VALUE.DIRECTION.LONG
               : PERPS_EVENT_VALUE.DIRECTION.SHORT,
-          [PERPS_EVENT_PROPERTY.ORDER_TYPE]:
-            type === 'market'
-              ? PERPS_EVENT_VALUE.ORDER_TYPE.MARKET
-              : PERPS_EVENT_VALUE.ORDER_TYPE.LIMIT,
+          [PERPS_EVENT_PROPERTY.ORDER_TYPE]: ORDER_TYPE_EVENT_VALUES[type],
         });
       }
 
@@ -60,6 +68,7 @@ const PerpsOrderTypeBottomSheet: React.FC<PerpsOrderTypeBottomSheetProps> = ({
       onClose={onClose}
       onSelect={handleSelect}
       currentOrderType={currentOrderType}
+      showTriggeredTypes={showTriggeredTypes}
       sheetRef={externalSheetRef}
     />
   );
@@ -71,5 +80,6 @@ export default memo(
   PerpsOrderTypeBottomSheet,
   (prevProps, nextProps) =>
     prevProps.isVisible === nextProps.isVisible &&
-    prevProps.currentOrderType === nextProps.currentOrderType,
+    prevProps.currentOrderType === nextProps.currentOrderType &&
+    prevProps.showTriggeredTypes === nextProps.showTriggeredTypes,
 );

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx
@@ -1,13 +1,85 @@
 import {
+  Box,
+  BoxAlignItems,
+  BoxJustifyContent,
   BottomSheet,
   BottomSheetHeader,
+  FontWeight,
   type BottomSheetRef,
   ListItemSelect,
+  Text,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react-native';
-import type { OrderType } from '@metamask/perps-controller';
+import type { OrderType, TriggerOrderType } from '@metamask/perps-controller';
 import React, { useCallback, useEffect, useRef } from 'react';
+import type { SvgProps } from 'react-native-svg';
 import { strings } from '../../../../../../locales/i18n';
+import LimitIcon from '../../../../../images/perps/order-types/limit.svg';
+import MarketIcon from '../../../../../images/perps/order-types/market.svg';
+import StopLimitIcon from '../../../../../images/perps/order-types/stop-limit.svg';
+import StopMarketIcon from '../../../../../images/perps/order-types/stop-market.svg';
+import TakeLimitIcon from '../../../../../images/perps/order-types/take-limit.svg';
+import TakeMarketIcon from '../../../../../images/perps/order-types/take-market.svg';
 import { PerpsOrderTypeBottomSheetSelectorsIDs } from '../../Perps.testIds';
+
+interface OrderTypeOption {
+  type: OrderType;
+  titleKey: string;
+  descriptionKey: string;
+  IconComponent: React.ComponentType<SvgProps>;
+  testID: string;
+}
+
+const BASIC_ORDER_TYPES: readonly OrderTypeOption[] = [
+  {
+    type: 'market',
+    titleKey: 'perps.order.type.market.title',
+    descriptionKey: 'perps.order.type.market.description',
+    IconComponent: MarketIcon,
+    testID: PerpsOrderTypeBottomSheetSelectorsIDs.MARKET_OPTION,
+  },
+  {
+    type: 'limit',
+    titleKey: 'perps.order.type.limit.title',
+    descriptionKey: 'perps.order.type.limit.description',
+    IconComponent: LimitIcon,
+    testID: PerpsOrderTypeBottomSheetSelectorsIDs.LIMIT_OPTION,
+  },
+];
+
+const TRIGGERED_ORDER_TYPES: readonly (OrderTypeOption & {
+  type: TriggerOrderType;
+})[] = [
+  {
+    type: 'stop_limit',
+    titleKey: 'perps.order.type.stop_limit.title',
+    descriptionKey: 'perps.order.type.stop_limit.description',
+    IconComponent: StopLimitIcon,
+    testID: PerpsOrderTypeBottomSheetSelectorsIDs.STOP_LIMIT_OPTION,
+  },
+  {
+    type: 'stop_market',
+    titleKey: 'perps.order.type.stop_market.title',
+    descriptionKey: 'perps.order.type.stop_market.description',
+    IconComponent: StopMarketIcon,
+    testID: PerpsOrderTypeBottomSheetSelectorsIDs.STOP_MARKET_OPTION,
+  },
+  {
+    type: 'take_profit_limit',
+    titleKey: 'perps.order.type.take_profit_limit.title',
+    descriptionKey: 'perps.order.type.take_profit_limit.description',
+    IconComponent: TakeLimitIcon,
+    testID: PerpsOrderTypeBottomSheetSelectorsIDs.TAKE_PROFIT_LIMIT_OPTION,
+  },
+  {
+    type: 'take_profit_market',
+    titleKey: 'perps.order.type.take_profit_market.title',
+    descriptionKey: 'perps.order.type.take_profit_market.description',
+    IconComponent: TakeMarketIcon,
+    testID: PerpsOrderTypeBottomSheetSelectorsIDs.TAKE_PROFIT_MARKET_OPTION,
+  },
+];
 
 export interface PerpsOrderTypeBottomSheetViewProps {
   isVisible?: boolean;
@@ -16,6 +88,7 @@ export interface PerpsOrderTypeBottomSheetViewProps {
   currentOrderType?: OrderType;
   title?: string;
   showSelectedIcon?: boolean;
+  showTriggeredTypes?: boolean;
   sheetRef?: React.RefObject<BottomSheetRef | null>;
 }
 
@@ -26,24 +99,11 @@ const PerpsOrderTypeBottomSheetView = ({
   currentOrderType,
   title = strings('perps.order.type.title'),
   showSelectedIcon = false,
+  showTriggeredTypes = false,
   sheetRef: externalSheetRef,
 }: PerpsOrderTypeBottomSheetViewProps) => {
   const internalSheetRef = useRef<BottomSheetRef>(null);
   const sheetRef = externalSheetRef ?? internalSheetRef;
-  const orderTypes = [
-    {
-      type: 'market',
-      title: strings('perps.order.type.market.title'),
-      description: strings('perps.order.type.market.description'),
-      testID: PerpsOrderTypeBottomSheetSelectorsIDs.MARKET_OPTION,
-    },
-    {
-      type: 'limit',
-      title: strings('perps.order.type.limit.title'),
-      description: strings('perps.order.type.limit.description'),
-      testID: PerpsOrderTypeBottomSheetSelectorsIDs.LIMIT_OPTION,
-    },
-  ] as const;
 
   useEffect(() => {
     if (isVisible && !externalSheetRef) {
@@ -62,6 +122,44 @@ const PerpsOrderTypeBottomSheetView = ({
     },
     [handleClose, onSelect],
   );
+
+  const renderSectionHeader = (label: string, testID?: string) => (
+    <Box paddingHorizontal={4} paddingTop={2} paddingBottom={3} testID={testID}>
+      <Text
+        variant={TextVariant.BodySm}
+        fontWeight={FontWeight.Regular}
+        color={TextColor.TextAlternative}
+      >
+        {label}
+      </Text>
+    </Box>
+  );
+
+  const renderOrderType = (orderType: OrderTypeOption) => {
+    const { IconComponent } = orderType;
+
+    return (
+      <ListItemSelect
+        key={orderType.type}
+        title={strings(orderType.titleKey)}
+        description={strings(orderType.descriptionKey)}
+        startAccessory={
+          <Box
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Center}
+            twClassName="h-10 w-10"
+          >
+            <IconComponent width={32} height={32} />
+          </Box>
+        }
+        isSelected={currentOrderType === orderType.type}
+        showSelectedIcon={showSelectedIcon || showTriggeredTypes}
+        twClassName="bg-transparent"
+        onPress={() => handleSelect(orderType.type)}
+        testID={orderType.testID}
+      />
+    );
+  };
 
   if (!isVisible) {
     return null;
@@ -82,17 +180,15 @@ const PerpsOrderTypeBottomSheetView = ({
       >
         {title}
       </BottomSheetHeader>
-      {orderTypes.map((orderType) => (
-        <ListItemSelect
-          key={orderType.type}
-          title={orderType.title}
-          description={orderType.description}
-          isSelected={currentOrderType === orderType.type}
-          showSelectedIcon={showSelectedIcon}
-          onPress={() => handleSelect(orderType.type)}
-          testID={orderType.testID}
-        />
-      ))}
+      {showTriggeredTypes &&
+        renderSectionHeader(strings('perps.order.type.basic'))}
+      {BASIC_ORDER_TYPES.map(renderOrderType)}
+      {showTriggeredTypes &&
+        renderSectionHeader(
+          strings('perps.order.type.triggered'),
+          PerpsOrderTypeBottomSheetSelectorsIDs.TRIGGERED_SECTION_HEADER,
+        )}
+      {showTriggeredTypes && TRIGGERED_ORDER_TYPES.map(renderOrderType)}
     </BottomSheet>
   );
 };

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx
@@ -27,7 +27,7 @@ interface OrderTypeOption {
   type: OrderType;
   titleKey: string;
   descriptionKey: string;
-  IconComponent: React.ComponentType<SvgProps>;
+  IconComponent: React.FC<SvgProps & { name: string }>;
   testID: string;
 }
 
@@ -150,7 +150,11 @@ const PerpsOrderTypeBottomSheetView = ({
             justifyContent={BoxJustifyContent.Center}
             twClassName="h-10 w-10"
           >
-            <IconComponent width={32} height={32} />
+            <IconComponent
+              name={`perps-order-type-${orderType.type}`}
+              width={32}
+              height={32}
+            />
           </Box>
         }
         isSelected={currentOrderType === orderType.type}

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx
@@ -151,17 +151,20 @@ const PerpsOrderTypeBottomSheetView = ({
         descriptionProps={DESCRIPTION_PROPS}
         accessoryGap={2}
         startAccessory={
-          <Box
-            alignItems={BoxAlignItems.Center}
-            justifyContent={BoxJustifyContent.Center}
-            twClassName="h-10 w-10"
-          >
-            <IconComponent
-              name={`perps-order-type-${orderType.type}`}
-              width={32}
-              height={32}
-            />
-          </Box>
+          shouldShowSelectedIcon ? (
+            <Box
+              alignItems={BoxAlignItems.Center}
+              justifyContent={BoxJustifyContent.Center}
+              twClassName="h-10 w-10"
+              testID={`${orderType.testID}-icon`}
+            >
+              <IconComponent
+                name={`perps-order-type-${orderType.type}`}
+                width={32}
+                height={32}
+              />
+            </Box>
+          ) : undefined
         }
         isSelected={currentOrderType === orderType.type}
         showSelectedIcon={shouldShowSelectedIcon}
@@ -194,7 +197,10 @@ const PerpsOrderTypeBottomSheetView = ({
         {title}
       </BottomSheetHeader>
       {showTriggeredTypes &&
-        renderSectionHeader(strings('perps.order.type.basic'))}
+        renderSectionHeader(
+          strings('perps.order.type.basic'),
+          PerpsOrderTypeBottomSheetSelectorsIDs.BASIC_SECTION_HEADER,
+        )}
       {BASIC_ORDER_TYPES.map(renderOrderType)}
       {showTriggeredTypes &&
         renderSectionHeader(

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx
@@ -31,6 +31,10 @@ interface OrderTypeOption {
   testID: string;
 }
 
+const DESCRIPTION_PROPS = {
+  fontWeight: FontWeight.Regular,
+} as const;
+
 const BASIC_ORDER_TYPES: readonly OrderTypeOption[] = [
   {
     type: 'market',
@@ -144,6 +148,8 @@ const PerpsOrderTypeBottomSheetView = ({
         key={orderType.type}
         title={strings(orderType.titleKey)}
         description={strings(orderType.descriptionKey)}
+        descriptionProps={DESCRIPTION_PROPS}
+        accessoryGap={2}
         startAccessory={
           <Box
             alignItems={BoxAlignItems.Center}

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx
@@ -104,6 +104,7 @@ const PerpsOrderTypeBottomSheetView = ({
 }: PerpsOrderTypeBottomSheetViewProps) => {
   const internalSheetRef = useRef<BottomSheetRef>(null);
   const sheetRef = externalSheetRef ?? internalSheetRef;
+  const shouldShowSelectedIcon = showSelectedIcon || showTriggeredTypes;
 
   useEffect(() => {
     if (isVisible && !externalSheetRef) {
@@ -153,8 +154,10 @@ const PerpsOrderTypeBottomSheetView = ({
           </Box>
         }
         isSelected={currentOrderType === orderType.type}
-        showSelectedIcon={showSelectedIcon || showTriggeredTypes}
-        twClassName="bg-transparent"
+        showSelectedIcon={shouldShowSelectedIcon}
+        // The Pro design uses a checkmark without a selected-row fill. Shared
+        // sheets without checkmarks retain ListItemSelect's selected background.
+        twClassName={shouldShowSelectedIcon ? 'bg-transparent' : undefined}
         onPress={() => handleSelect(orderType.type)}
         testID={orderType.testID}
       />

--- a/app/components/UI/Perps/selectors/featureFlags/index.test.ts
+++ b/app/components/UI/Perps/selectors/featureFlags/index.test.ts
@@ -1,3 +1,4 @@
+import type { Json } from '@metamask/utils';
 import {
   selectPerpsEnabledFlag,
   selectPerpsServiceInterruptionBannerEnabledFlag,
@@ -17,6 +18,7 @@ import {
   selectPerpsMYXProviderEnabledFlag,
   selectPerpsWatchlistEnabledFlag,
   selectPerpsProModeEnabledFlag,
+  selectPerpsProTriggeredOrdersEnabledFlag,
   selectPerpsRecentlyAddedEnabledFlag,
   selectPerpsShowFullAssetNamesFlag,
   selectPerpsClosePositionLimitOrderEnabledFlag,
@@ -2097,6 +2099,85 @@ describe('Perps Feature Flag Selectors', () => {
           },
         },
       });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('selectPerpsProTriggeredOrdersEnabledFlag', () => {
+    const createStateWithFlag = (flag: Json) => ({
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              perpsProTriggeredOrdersEnabled: flag,
+            },
+            cacheTimestamp: 0,
+          },
+        },
+      },
+    });
+
+    it('returns true when the remote flag is enabled for the app version', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(true);
+      const state = createStateWithFlag({
+        enabled: true,
+        minimumVersion: '1.0.0',
+      });
+
+      const result = selectPerpsProTriggeredOrdersEnabledFlag(state);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when the remote flag is disabled', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(true);
+      const state = createStateWithFlag({
+        enabled: false,
+        minimumVersion: '1.0.0',
+      });
+
+      const result = selectPerpsProTriggeredOrdersEnabledFlag(state);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when the app version is below the minimum', () => {
+      mockHasMinimumRequiredVersion.mockReturnValue(false);
+      const state = createStateWithFlag({
+        enabled: true,
+        minimumVersion: '99.0.0',
+      });
+
+      const result = selectPerpsProTriggeredOrdersEnabledFlag(state);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when the remote flag is missing', () => {
+      const state = {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {},
+              cacheTimestamp: 0,
+            },
+          },
+        },
+      };
+
+      const result = selectPerpsProTriggeredOrdersEnabledFlag(state);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when the remote flag is malformed', () => {
+      const state = createStateWithFlag({
+        enabled: 'yes',
+        minimumVersion: 1,
+      });
+
+      const result = selectPerpsProTriggeredOrdersEnabledFlag(state);
 
       expect(result).toBe(false);
     });

--- a/app/components/UI/Perps/selectors/featureFlags/index.ts
+++ b/app/components/UI/Perps/selectors/featureFlags/index.ts
@@ -415,6 +415,22 @@ export const selectPerpsProModeEnabledFlag = createSelector(
 );
 
 /**
+ * Selector for triggered order types in the Perps Pro order form.
+ * Defaults to false so triggered types can be rolled out independently.
+ *
+ * @returns boolean - true if triggered order types can be shown, false otherwise
+ */
+export const selectPerpsProTriggeredOrdersEnabledFlag = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const remoteFlag =
+      remoteFeatureFlags?.perpsProTriggeredOrdersEnabled as unknown as VersionGatedFeatureFlag;
+
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
+  },
+);
+
+/**
  * Selector for Terminal Backend feature flag.
  * Controls whether market-data calls route through the MetaMask Terminal API
  * (with HyperLiquid fallback) or go directly to HyperLiquid.

--- a/app/images/perps/order-types/limit.svg
+++ b/app/images/perps/order-types/limit.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<line x1="4.5" y1="26.5" x2="23.5" y2="26.5" stroke="#8B99FF" stroke-linecap="round" stroke-dasharray="3 3"/>
+<path d="M4.37262 5.82843C4.37262 5.82843 12.4183 8.21726 17.3681 13.167C22.3178 18.1168 24.1716 25.6274 24.1716 25.6274" stroke="white" stroke-linecap="round"/>
+<circle cx="25" cy="26" r="3" transform="rotate(90 25 26)" fill="#8B99FF"/>
+</svg>

--- a/app/images/perps/order-types/market.svg
+++ b/app/images/perps/order-types/market.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.82843 27.6274C5.82843 27.6274 8.21726 19.5817 13.167 14.632C18.1168 9.68225 25.6274 7.82845 25.6274 7.82845" stroke="white" stroke-linecap="round"/>
+<circle cx="25" cy="8.00006" r="3" fill="#BAF24A"/>
+</svg>

--- a/app/images/perps/order-types/stop-limit.svg
+++ b/app/images/perps/order-types/stop-limit.svg
@@ -1,0 +1,7 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<line x1="14.5" y1="26.5" x2="23.5" y2="26.5" stroke="#8B99FF" stroke-linecap="round" stroke-dasharray="3 3"/>
+<path d="M6.50005 3.70711C6.50005 3.70711 10.1884 5.98129 13.0169 8.80972C15.8453 11.6381 17.8138 15.0208 17.8138 15.0208" stroke="white" stroke-linecap="round"/>
+<circle cx="25" cy="26" r="3" transform="rotate(90 25 26)" fill="#8B99FF"/>
+<line x1="4.5" y1="16.5" x2="27.5" y2="16.5" stroke="#FF7584" stroke-linecap="round" stroke-dasharray="3 3"/>
+<circle cx="18" cy="16" r="2.5" transform="rotate(90 18 16)" fill="#FF7584" stroke="#FF7584"/>
+</svg>

--- a/app/images/perps/order-types/stop-market.svg
+++ b/app/images/perps/order-types/stop-market.svg
@@ -1,0 +1,6 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<line x1="4.5" y1="18.5" x2="27.5" y2="18.5" stroke="#FF7584" stroke-linecap="round" stroke-dasharray="3 3"/>
+<path d="M4.37262 7.82843C4.37262 7.82843 12.4183 10.2173 17.3681 15.167C22.3178 20.1168 24.1716 27.6274 24.1716 27.6274" stroke="white" stroke-linecap="round"/>
+<path d="M24.1716 27.6274C24.1716 27.6274 23.0951 23.266 20.3925 19" stroke="#FF7584" stroke-linecap="round"/>
+<circle cx="21" cy="18" r="2.5" transform="rotate(90 21 18)" fill="#FF7584" stroke="#FF7584"/>
+</svg>

--- a/app/images/perps/order-types/take-limit.svg
+++ b/app/images/perps/order-types/take-limit.svg
@@ -1,0 +1,7 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<line x1="0.5" y1="-0.5" x2="9.5" y2="-0.5" transform="matrix(1 -8.74228e-08 -8.74228e-08 -1 18 15)" stroke="#8B99FF" stroke-linecap="round" stroke-dasharray="3 3"/>
+<path d="M6.50005 28.2929C6.50005 28.2929 10.1884 26.0187 13.0169 23.1903C15.8453 20.3619 17.8138 16.9792 17.8138 16.9792" stroke="white" stroke-linecap="round"/>
+<circle cx="3" cy="3" r="3" transform="matrix(0 -1 -1 0 21 19)" fill="#8B99FF"/>
+<line x1="0.5" y1="-0.5" x2="23.5" y2="-0.5" transform="matrix(1 -8.74228e-08 -8.74228e-08 -1 4 5)" stroke="#BAF24A" stroke-linecap="round" stroke-dasharray="3 3"/>
+<circle cx="3" cy="3" r="2.5" transform="matrix(0 -1 -1 0 28 8)" fill="#BAF24A" stroke="#BAF24A"/>
+</svg>

--- a/app/images/perps/order-types/take-market.svg
+++ b/app/images/perps/order-types/take-market.svg
@@ -1,0 +1,6 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<line x1="0.5" y1="-0.5" x2="23.5" y2="-0.5" transform="matrix(1 -8.74228e-08 -8.74228e-08 -1 4 13)" stroke="#BAF24A" stroke-linecap="round" stroke-dasharray="3 3"/>
+<path d="M4.37262 24.1716C4.37262 24.1716 12.4183 21.7827 17.3681 16.833C22.3178 11.8832 24.1716 4.37258 24.1716 4.37258" stroke="white" stroke-linecap="round"/>
+<path d="M24.1716 4.3726C24.1716 4.3726 23.0951 8.73397 20.3925 13" stroke="#BAF24A" stroke-linecap="round"/>
+<circle cx="3" cy="3" r="2.5" transform="matrix(0 -1 -1 0 24 17)" fill="#BAF24A" stroke="#BAF24A"/>
+</svg>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1718,6 +1718,8 @@
       },
       "type": {
         "title": "Order type",
+        "basic": "Basic",
+        "triggered": "Triggered",
         "market": {
           "title": "Market",
           "description": "Execute immediately at current market price"
@@ -1725,6 +1727,22 @@
         "limit": {
           "title": "Limit",
           "description": "Execute only at your specified price or better"
+        },
+        "stop_limit": {
+          "title": "Stop limit",
+          "description": "Limit fills at trigger price"
+        },
+        "stop_market": {
+          "title": "Stop market",
+          "description": "Market fills at trigger price"
+        },
+        "take_profit_limit": {
+          "title": "Take limit",
+          "description": "Limit take-profit at trigger price"
+        },
+        "take_profit_market": {
+          "title": "Take market",
+          "description": "Market take-profit at trigger price"
         }
       },
       "payment_token": "Payment token",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1722,11 +1722,11 @@
         "triggered": "Triggered",
         "market": {
           "title": "Market",
-          "description": "Execute immediately at current market price"
+          "description": "Execute instantly at best available price"
         },
         "limit": {
           "title": "Limit",
-          "description": "Execute only at your specified price or better"
+          "description": "Execute at your specified price or better"
         },
         "stop_limit": {
           "title": "Stop limit",

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -4047,6 +4047,14 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  perpsProTriggeredOrdersEnabled: {
+    name: 'perpsProTriggeredOrdersEnabled',
+    type: FeatureFlagType.Remote,
+    inProd: false,
+    productionDefault: false,
+    status: FeatureFlagStatus.Active,
+  },
+
   perpsHip3AllowlistMarkets: {
     name: 'perpsHip3AllowlistMarkets',
     type: FeatureFlagType.Remote,

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -4051,7 +4051,10 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     name: 'perpsProTriggeredOrdersEnabled',
     type: FeatureFlagType.Remote,
     inProd: false,
-    productionDefault: false,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '8.8.0',
+    },
     status: FeatureFlagStatus.Active,
   },
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

dds triggered order types to the Perps Pro selector: Stop limit, Stop market, Take limit, and Take market.

The options are remotely gated, version validated, and displayed in Basic and Triggered sections with matching icons, descriptions, selection states, and analytics.

Trigger price inputs and order submission are handled in a follow-up form ticket. The flag remains disabled in production until that work lands.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added triggered order types to the Perps Pro order selector

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3719

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps Pro triggered order types
  Scenario: user views triggered order types
    Given the user is on a Perps market screen in Pro mode
    And the perpsProTriggeredOrdersEnabled remote flag is enabled
    When the user opens the order-type selector
    Then Market and Limit appear in the Basic section
    And Stop limit, Stop market, Take limit, and Take market appear in the Triggered section
    And each order type displays its corresponding icon and description
    And the selected order type displays a checkmark without a highlighted background
 
  Scenario: user selects a triggered order type
    Given the triggered order-type selector is open
    When the user selects each of the following order types:
      | Order type  |
      | Stop limit  |
      | Stop market |
      | Take limit  |
      | Take market |
    Then the selector closes after each selection
    And the selected order type is shown on the Pro order form
    And reopening the selector shows a checkmark beside that order type

  Scenario: triggered order types are remotely disabled
    Given the perpsProTriggeredOrdersEnabled remote flag is disabled
    When the user opens the order-type selector
    Then only Market and Limit are displayed
    And the Triggered section is not displayed
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-12 at 23 00 12" src="https://github.com/user-attachments/assets/d4337651-443e-4702-bfc2-81a416b1e938" />



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches trading order-type UX and selection analytics; rollout is gated by remote flag and Pro mode, but wrong gating could expose incomplete triggered-order flows.
> 
> **Overview**
> Extends the Perps **order-type bottom sheet** so Pro users can pick **stop limit**, **stop market**, **take profit limit**, and **take profit market** when rollout allows it.
> 
> A new remote flag `perpsProTriggeredOrdersEnabled` (version-gated selector + registry entry) combines with active Pro mode to set `showTriggeredTypes` on `PerpsProOrderFormPanel`, which now uses the analytics-wrapped `PerpsOrderTypeBottomSheet` instead of the view-only component. When enabled, the sheet shows **Basic** and **Triggered** section headers, per-type SVG icons, updated copy, checkmark selection without a filled row, and tracking for all six order types.
> 
> Lite / flag-off behavior stays **market + limit only**. Coverage adds test IDs, locale strings, and unit/integration tests for flag gating, selection, and analytics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bf7a3bce495d760dbe86666744a73b29e52cdc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->