### PR TITLE
feat(money): register Money Account wallet after KYC success

### DIFF
--- a/app/components/UI/Ramp/Views/VirtualBankAccount/MockKycEmail.test.tsx
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/MockKycEmail.test.tsx
@@ -4,7 +4,10 @@ import { fireEvent, waitFor } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import MockKycEmail from './MockKycEmail';
 import { MockKycEmailSelectorsIDs } from './MockKycEmail.testIds';
-import { startIronKycVerification } from './ironKycFlow';
+import {
+  registerSelectedMoneyAccountWallet,
+  startIronKycVerification,
+} from './ironKycFlow';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -18,13 +21,21 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 jest.mock('./ironKycFlow');
+jest.mock('../../../../../util/Logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn(), log: jest.fn() },
+}));
 
 const mockStartIronKycVerification = jest.mocked(startIronKycVerification);
+const mockRegisterSelectedMoneyAccountWallet = jest.mocked(
+  registerSelectedMoneyAccountWallet,
+);
 
 describe('MockKycEmail', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockStartIronKycVerification.mockResolvedValue(undefined);
+    mockRegisterSelectedMoneyAccountWallet.mockResolvedValue(undefined);
   });
 
   it('navigates back when the header back button is pressed', () => {
@@ -48,6 +59,7 @@ describe('MockKycEmail', () => {
       expect(mockStartIronKycVerification).toHaveBeenCalledWith(
         'user@example.com',
       );
+      expect(mockRegisterSelectedMoneyAccountWallet).toHaveBeenCalled();
       expect(mockNavigate).toHaveBeenCalledWith('RampVbaMockKycSuccess');
     });
   });
@@ -77,6 +89,25 @@ describe('MockKycEmail', () => {
         'Iron session failed: consents.',
       );
     });
+    expect(mockRegisterSelectedMoneyAccountWallet).not.toHaveBeenCalled();
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('alerts but still navigates when wallet registration fails after KYC', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation();
+    mockRegisterSelectedMoneyAccountWallet.mockRejectedValue(
+      new Error('Wallet registration failed.'),
+    );
+    const { getByTestId } = renderWithProvider(<MockKycEmail />);
+
+    fireEvent.press(getByTestId(MockKycEmailSelectorsIDs.CONTINUE_BUTTON));
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Identity verification',
+        'Wallet registration failed.',
+      );
+      expect(mockNavigate).toHaveBeenCalledWith('RampVbaMockKycSuccess');
+    });
   });
 });

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/MockKycEmail.tsx
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/MockKycEmail.tsx
@@ -19,7 +19,11 @@ import type { AppNavigationProp } from '../../../../../core/NavigationService/ty
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
 import { MOCK_KYC_PREFILLED_EMAIL } from './constants';
-import { startIronKycVerification } from './ironKycFlow';
+import {
+  registerSelectedMoneyAccountWallet,
+  startIronKycVerification,
+} from './ironKycFlow';
+import Logger from '../../../../../util/Logger';
 import MockKycProgressBar from './MockKycProgressBar';
 import { MockKycEmailSelectorsIDs } from './MockKycEmail.testIds';
 
@@ -45,6 +49,25 @@ const MockKycEmail = () => {
     setIsVerifying(true);
     try {
       await startIronKycVerification(trimmedEmail);
+      try {
+        await registerSelectedMoneyAccountWallet();
+      } catch (registerError) {
+        // KYC already succeeded — soft-fail so the demo can continue.
+        Logger.error(
+          registerError instanceof Error
+            ? registerError
+            : new Error(String(registerError)),
+          { message: 'Money Account wallet registration failed after KYC' },
+        );
+        Alert.alert(
+          strings('virtual_bank_account.kyc_error.title'),
+          registerError instanceof Error
+            ? registerError.message
+            : strings(
+                'virtual_bank_account.kyc_error.wallet_registration_failed',
+              ),
+        );
+      }
       navigation.navigate(Routes.RAMP.VBA_MOCK_KYC_SUCCESS);
     } catch (error) {
       Alert.alert(

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/ironKycFlow.test.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/ironKycFlow.test.ts
@@ -1,22 +1,35 @@
 import Engine from '../../../../../core/Engine';
-import { startIronKycFlow, startIronKycVerification } from './ironKycFlow';
+import {
+  registerSelectedMoneyAccountWallet,
+  startIronKycFlow,
+  startIronKycVerification,
+} from './ironKycFlow';
 
 jest.mock('../../../../../core/Engine', () => ({
   context: {
+    AccountsController: {
+      getSelectedAccount: jest.fn(),
+    },
     KycController: {
       state: { error: null, disclaimers: [] },
       initialize: jest.fn(),
       createIronCustomer: jest.fn(),
       acceptTermsAndStartSession: jest.fn(),
+      registerMoneyAccountWallet: jest.fn(),
     },
   },
 }));
+
+const mockAccountsController = Engine.context.AccountsController as unknown as {
+  getSelectedAccount: jest.Mock;
+};
 
 const mockKycController = Engine.context.KycController as unknown as {
   state: { error: string | null; disclaimers: { id: string }[] };
   initialize: jest.Mock<Promise<void>, [unknown?]>;
   createIronCustomer: jest.Mock<Promise<void>, [unknown?]>;
   acceptTermsAndStartSession: jest.Mock<Promise<void>, [unknown?]>;
+  registerMoneyAccountWallet: jest.Mock<Promise<unknown>, [unknown?]>;
 };
 
 const resetControllerState = ({
@@ -118,5 +131,34 @@ describe('startIronKycVerification', () => {
     await expect(startIronKycVerification('user@example.com')).rejects.toThrow(
       'Iron session failed: consents.',
     );
+  });
+});
+
+describe('registerSelectedMoneyAccountWallet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAccountsController.getSelectedAccount.mockReturnValue({
+      address: '0xabc',
+    });
+    mockKycController.registerMoneyAccountWallet.mockResolvedValue({
+      type: 'registered',
+    });
+  });
+
+  it('registers the selected account address with KycController', async () => {
+    await registerSelectedMoneyAccountWallet();
+
+    expect(mockKycController.registerMoneyAccountWallet).toHaveBeenCalledWith({
+      address: '0xabc',
+    });
+  });
+
+  it('throws when no selected account is available', async () => {
+    mockAccountsController.getSelectedAccount.mockReturnValue(undefined);
+
+    await expect(registerSelectedMoneyAccountWallet()).rejects.toThrow(
+      'No selected account available to register.',
+    );
+    expect(mockKycController.registerMoneyAccountWallet).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/ironKycFlow.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/ironKycFlow.ts
@@ -1,3 +1,4 @@
+import type { Hex } from '@metamask/utils';
 import Engine from '../../../../../core/Engine';
 
 // Demo Iron → Sumsub helpers for the VBA Get Pix Key flow.
@@ -6,6 +7,7 @@ import Engine from '../../../../../core/Engine';
 // (file:../core/... dep for @metamask/kyc-controller).
 // - After yarn: yarn pod:install (SumSub SNSDK Specs + RN module).
 // - Builds use KYC_API_URL=https://kyc-api.dev-api.cx.metamask.io (builds.yml).
+// - Wallet registration uses neobankBaseUrl → on-ramp.dev-api neobank-proxy.
 // - Caller must be signed in with a MetaMask profile JWT.
 
 // The VBA flow runs for Money, so the controller scopes its KYC-required check
@@ -77,4 +79,24 @@ export async function startIronKycVerification(email: string): Promise<void> {
       idosTncSigned: true,
     }),
   );
+}
+
+/**
+ * Registers the currently selected account as a Money Account wallet after KYC
+ * succeeds (Sumsub complete). Signs an ownership proof via KeyringController
+ * and posts through neobank-proxy.
+ *
+ * Callers should soft-fail: verification already succeeded, so a registration
+ * error should not block the success screen.
+ */
+export async function registerSelectedMoneyAccountWallet(): Promise<void> {
+  const selectedAccount =
+    Engine.context.AccountsController.getSelectedAccount();
+  const address = selectedAccount?.address as Hex | undefined;
+
+  if (!address) {
+    throw new Error('No selected account available to register.');
+  }
+
+  await Engine.context.KycController.registerMoneyAccountWallet({ address });
 }

--- a/app/core/Engine/controllers/kyc/kyc-service-init.test.ts
+++ b/app/core/Engine/controllers/kyc/kyc-service-init.test.ts
@@ -72,4 +72,31 @@ describe('kycServiceInit', () => {
       env: 'development',
     });
   });
+
+  it('passes neobankBaseUrl for on-ramp wallet registration', () => {
+    mockIsProduction.mockReturnValue(false);
+    const previousEnv = process.env.METAMASK_ENVIRONMENT;
+    const previousNeobank = process.env.NEOBANK_API_URL;
+    process.env.METAMASK_ENVIRONMENT = 'dev';
+    delete process.env.NEOBANK_API_URL;
+
+    try {
+      const { controller } = kycServiceInit(getInitRequestMock());
+
+      expect(controller).toMatchObject({
+        neobankBaseUrl: 'https://on-ramp.dev-api.cx.metamask.io',
+      });
+    } finally {
+      if (previousEnv === undefined) {
+        delete process.env.METAMASK_ENVIRONMENT;
+      } else {
+        process.env.METAMASK_ENVIRONMENT = previousEnv;
+      }
+      if (previousNeobank === undefined) {
+        delete process.env.NEOBANK_API_URL;
+      } else {
+        process.env.NEOBANK_API_URL = previousNeobank;
+      }
+    }
+  });
 });

--- a/app/core/Engine/controllers/kyc/kyc-service-init.ts
+++ b/app/core/Engine/controllers/kyc/kyc-service-init.ts
@@ -23,6 +23,27 @@ function getFractalEncryptionBaseUrl(): string {
 }
 
 /**
+ * Resolves the on-ramp / neobank-proxy host used for Money Account wallet
+ * registration. Override with `NEOBANK_API_URL` when needed for local demos.
+ *
+ * @returns The neobank-proxy base URL for this environment.
+ */
+function getNeobankBaseUrl(): string {
+  if (process.env.NEOBANK_API_URL) {
+    return process.env.NEOBANK_API_URL;
+  }
+
+  const env = process.env.METAMASK_ENVIRONMENT;
+  if (env === 'dev' || env === 'exp' || env === 'test' || env === 'e2e') {
+    return 'https://on-ramp.dev-api.cx.metamask.io';
+  }
+  if (env === 'production' || env === 'beta' || env === 'rc') {
+    return 'https://api.onramp.metamask.io';
+  }
+  return 'https://on-ramp.uat-api.cx.metamask.io';
+}
+
+/**
  * Initialize the KycService.
  *
  * The service is a stateless HTTP client for the Universal KYC backend. It
@@ -42,6 +63,7 @@ export const kycServiceInit: MessengerClientInitFunction<
     env: isProduction() ? 'production' : 'development',
     messenger: controllerMessenger,
     baseUrl: process.env.KYC_API_URL,
+    neobankBaseUrl: getNeobankBaseUrl(),
     fractalEncryptionBaseUrl: getFractalEncryptionBaseUrl(),
   });
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1144,7 +1144,8 @@
     "kyc_error": {
       "title": "Identity verification",
       "start_failed": "We couldn't start identity verification. Try again.",
-      "verification_failed": "We couldn't verify your identity. Try again."
+      "verification_failed": "We couldn't verify your identity. Try again.",
+      "wallet_registration_failed": "Identity verified, but we couldn't register your Money Account wallet. You can continue."
     },
     "deposit_demo": {
       "success_toast": "Deposit successful"


### PR DESCRIPTION
## Summary
- After Iron → Sumsub KYC succeeds on the VBA email step, call `KycController.registerMoneyAccountWallet` for the selected account (`Engine.context.AccountsController.getSelectedAccount()`).
- Soft-fail registration errors (Alert + Logger) so navigation to the KYC success screen still proceeds.
- Configure `KycService.neobankBaseUrl` to the on-ramp / neobank-proxy host (`on-ramp.dev-api` for demo/dev; overridable via `NEOBANK_API_URL`).

Depends on MetaMask/core `neobank-demo` tip `a1b133dc46` (`registerMoneyAccountWallet` + neobank-proxy sync).

## Test plan
- [ ] Rebuild local core: `cd ../core && yarn && yarn build` (or package build for `kyc-controller`) so `file:../core/packages/kyc-controller` exposes the new API
- [ ] `yarn` in mobile if needed to refresh the local package link
- [ ] Run Iron → Sumsub VBA flow; on Sumsub success confirm wallet registration is attempted before success screen
- [ ] Force a registration failure (e.g. wrong neo URL) and confirm Alert soft-fails but success screen still opens
- [ ] `yarn jest app/components/UI/Ramp/Views/VirtualBankAccount/ironKycFlow.test.ts app/components/UI/Ramp/Views/VirtualBankAccount/MockKycEmail.test.tsx app/core/Engine/controllers/kyc/kyc-service-init.test.ts`


Made with [Cursor](https://cursor.com)