### PR TITLE
feat(predict-next): add authenticated Kalshi account readiness

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -233,7 +233,7 @@ export MM_PERPS_PAY_WITH_ANY_TOKEN_ALLOWLIST_ASSETS=""
 
 ## Predict
 export MM_PREDICT_ENABLED="true"
-export MM_PREDICT_API_URL="http://localhost:3333/predict/"
+export MM_PREDICT_API_URL="http://localhost:3333"
 
 ## Card
 export MM_CARD_BAANX_API_CLIENT_KEY=""

--- a/.js.env.example
+++ b/.js.env.example
@@ -233,7 +233,7 @@ export MM_PERPS_PAY_WITH_ANY_TOKEN_ALLOWLIST_ASSETS=""
 
 ## Predict
 export MM_PREDICT_ENABLED="true"
-export MM_PREDICT_API_URL="http://localhost:3333"
+export MM_PREDICT_API_URL="http://localhost:3333/predict/"
 
 ## Card
 export MM_CARD_BAANX_API_CLIENT_KEY=""

--- a/app/components/UI/PredictNext/adapters/remote/KalshiRemoteAdapter.test.ts
+++ b/app/components/UI/PredictNext/adapters/remote/KalshiRemoteAdapter.test.ts
@@ -5,6 +5,7 @@ import {
   type PredictApiReadTransport,
   PredictHttpError,
 } from './PredictApiReadClient';
+import type { PredictApiAccountTransport } from './PredictApiAccountClient';
 
 const eventId = 'event-1' as PredictEntityId;
 
@@ -44,13 +45,19 @@ const createClient = (): jest.Mocked<PredictApiReadTransport> => ({
   fetchEvent: jest.fn(),
 });
 
+const createAccountClient = (): jest.Mocked<PredictApiAccountTransport> => ({
+  fetchAccountReadiness: jest.fn(),
+});
+
 describe('KalshiRemoteAdapter', () => {
   let client: jest.Mocked<PredictApiReadTransport>;
+  let accountClient: jest.Mocked<PredictApiAccountTransport>;
   let adapter: KalshiRemoteAdapter;
 
   beforeEach(() => {
     client = createClient();
-    adapter = new KalshiRemoteAdapter(client);
+    accountClient = createAccountClient();
+    adapter = new KalshiRemoteAdapter(client, accountClient);
   });
 
   it('parses canonical Events from the Predict API', async () => {
@@ -120,6 +127,32 @@ describe('KalshiRemoteAdapter', () => {
     });
 
     await expect(adapter.marketData.fetchVenueStatus()).rejects.toEqual(
+      expect.objectContaining({ code: PredictErrorCode.INVALID_RESPONSE }),
+    );
+  });
+
+  it('parses account-scoped Account Readiness', async () => {
+    accountClient.fetchAccountReadiness.mockResolvedValue({
+      venueId: 'kalshi',
+      status: 'setup_required',
+      externalUserId: 'discard',
+    });
+
+    const result = await adapter.account?.fetchAccountReadiness();
+
+    expect(result).toEqual({
+      venueId: 'kalshi',
+      status: 'setup_required',
+    });
+  });
+
+  it('rejects Account Readiness for another Venue', async () => {
+    accountClient.fetchAccountReadiness.mockResolvedValue({
+      venueId: 'other',
+      status: 'ready',
+    });
+
+    await expect(adapter.account?.fetchAccountReadiness()).rejects.toEqual(
       expect.objectContaining({ code: PredictErrorCode.INVALID_RESPONSE }),
     );
   });

--- a/app/components/UI/PredictNext/adapters/remote/KalshiRemoteAdapter.ts
+++ b/app/components/UI/PredictNext/adapters/remote/KalshiRemoteAdapter.ts
@@ -3,9 +3,11 @@ import {
   parsePredictEventsPage,
   parsePredictVenueStatus,
 } from '../../contracts/v1/marketData';
+import { parsePredictAccountReadiness } from '../../contracts/v1/account';
 import { PredictError, PredictErrorCode } from '../../errors';
 import { KALSHI_VENUE_ID } from '../../types';
-import type { VenueMarketDataAdapter } from '../types';
+import type { VenueAccountAdapter, VenueMarketDataAdapter } from '../types';
+import type { PredictApiAccountTransport } from './PredictApiAccountClient';
 import {
   type PredictApiReadTransport,
   PredictHttpError,
@@ -40,9 +42,32 @@ const mapError = (error: unknown): never => {
 
 export class KalshiRemoteAdapter {
   readonly venueId = KALSHI_VENUE_ID;
+  readonly account?: VenueAccountAdapter;
   readonly marketData: VenueMarketDataAdapter;
 
-  constructor(client: PredictApiReadTransport) {
+  constructor(
+    client: PredictApiReadTransport,
+    accountClient?: PredictApiAccountTransport,
+  ) {
+    if (accountClient) {
+      this.account = {
+        fetchAccountReadiness: async (options) => {
+          try {
+            const value = await accountClient.fetchAccountReadiness(
+              this.venueId,
+              options,
+            );
+            const result = parsePredictAccountReadiness(value);
+            if (result.venueId !== this.venueId) {
+              throw PredictError.from(PredictErrorCode.INVALID_RESPONSE);
+            }
+            return result;
+          } catch (error) {
+            return mapError(error);
+          }
+        },
+      };
+    }
     this.marketData = {
       fetchVenueStatus: async (options) => {
         try {

--- a/app/components/UI/PredictNext/adapters/remote/PredictApiAccountClient.test.ts
+++ b/app/components/UI/PredictNext/adapters/remote/PredictApiAccountClient.test.ts
@@ -1,0 +1,85 @@
+import type { PredictVenueId } from '../../types';
+import {
+  PredictApiAccountClient,
+  type PredictApiAccountClientOptions,
+} from './PredictApiAccountClient';
+import { PredictHttpError } from './PredictApiReadClient';
+
+const venueId = 'kalshi' as PredictVenueId;
+
+const createResponse = ({
+  status = 200,
+  json = { venueId: 'kalshi', status: 'setup_required' },
+}: {
+  status?: number;
+  json?: unknown;
+} = {}): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: jest.fn().mockResolvedValue(json),
+  }) as unknown as Response;
+
+describe('PredictApiAccountClient', () => {
+  let fetchMock: jest.MockedFunction<typeof fetch>;
+  let getBearerToken: jest.MockedFunction<
+    PredictApiAccountClientOptions['getBearerToken']
+  >;
+  let client: PredictApiAccountClient;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    getBearerToken = jest.fn().mockResolvedValue('test-token');
+    client = new PredictApiAccountClient({
+      baseUrl: 'https://predict.example/predict/',
+      clientVersion: '7.0.0',
+      getBearerToken,
+      fetch: fetchMock,
+    });
+  });
+
+  it('uses required authentication without sending a user or wallet identifier', async () => {
+    fetchMock.mockResolvedValue(createResponse());
+
+    await client.fetchAccountReadiness(venueId);
+
+    expect(getBearerToken).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://predict.example/predict/v1/venues/kalshi/account/readiness',
+      {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          Authorization: 'Bearer test-token',
+          'x-metamask-clientproduct': 'metamask-mobile',
+          'x-metamask-clientversion': '7.0.0',
+        },
+        signal: undefined,
+      },
+    );
+    expect(fetchMock.mock.calls[0][0]).not.toContain('user');
+    expect(fetchMock.mock.calls[0][0]).not.toContain('wallet');
+  });
+
+  it('fails closed before HTTP when authentication is unavailable', async () => {
+    getBearerToken.mockResolvedValue('');
+
+    await expect(client.fetchAccountReadiness(venueId)).rejects.toEqual(
+      expect.objectContaining({ status: 401 }),
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards cancellation and makes one HTTP attempt', async () => {
+    fetchMock.mockResolvedValue(createResponse({ status: 503 }));
+    const signal = new AbortController().signal;
+
+    await expect(
+      client.fetchAccountReadiness(venueId, { signal }),
+    ).rejects.toBeInstanceOf(PredictHttpError);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][1]?.signal).toBe(signal);
+  });
+});

--- a/app/components/UI/PredictNext/adapters/remote/PredictApiAccountClient.ts
+++ b/app/components/UI/PredictNext/adapters/remote/PredictApiAccountClient.ts
@@ -1,0 +1,82 @@
+import type { PredictReadOptions, PredictVenueId } from '../../types';
+import { PredictHttpError } from './PredictApiReadClient';
+
+export interface PredictApiAccountTransport {
+  fetchAccountReadiness(
+    venueId: PredictVenueId,
+    options?: PredictReadOptions,
+  ): Promise<unknown>;
+}
+
+export interface PredictApiAccountClientOptions {
+  baseUrl: string;
+  clientVersion: string;
+  getBearerToken: () => Promise<string>;
+  fetch?: typeof fetch;
+}
+
+/** Required-auth transport for account-scoped Predict API reads. */
+export class PredictApiAccountClient implements PredictApiAccountTransport {
+  readonly #baseUrl: URL;
+  readonly #clientVersion: string;
+  readonly #getBearerToken: () => Promise<string>;
+  readonly #fetch: typeof fetch;
+
+  constructor({
+    baseUrl,
+    clientVersion,
+    getBearerToken,
+    fetch: fetchFn = global.fetch,
+  }: PredictApiAccountClientOptions) {
+    this.#baseUrl = new URL(baseUrl);
+    this.#clientVersion = clientVersion;
+    this.#getBearerToken = getBearerToken;
+    this.#fetch = fetchFn;
+  }
+
+  async fetchAccountReadiness(
+    venueId: PredictVenueId,
+    options?: PredictReadOptions,
+  ): Promise<unknown> {
+    const token = await this.#getBearerToken();
+    if (!token) {
+      throw new PredictHttpError(401);
+    }
+
+    const url = new URL(
+      ['v1', 'venues', venueId, 'account', 'readiness']
+        .map(encodeURIComponent)
+        .join('/'),
+      this.#baseUrlWithTrailingSlash(),
+    );
+    const response = await this.#fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${token}`,
+        'x-metamask-clientproduct': 'metamask-mobile',
+        'x-metamask-clientversion': this.#clientVersion,
+      },
+      signal: options?.signal,
+    });
+
+    if (!response.ok) {
+      throw new PredictHttpError(response.status);
+    }
+
+    try {
+      return await response.json();
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw error;
+      }
+      throw new PredictHttpError(response.status);
+    }
+  }
+
+  #baseUrlWithTrailingSlash(): URL {
+    const url = new URL(this.#baseUrl.toString());
+    url.pathname = `${url.pathname.replace(/\/$/u, '')}/`;
+    return url;
+  }
+}

--- a/app/components/UI/PredictNext/adapters/types.ts
+++ b/app/components/UI/PredictNext/adapters/types.ts
@@ -1,11 +1,18 @@
 import type {
   FetchEventsParams,
   PaginatedResult,
+  PredictAccountReadiness,
   PredictEntityId,
   PredictEvent,
   PredictReadOptions,
   PredictVenueStatus,
 } from '../types';
+
+export interface VenueAccountAdapter {
+  fetchAccountReadiness(
+    options?: PredictReadOptions,
+  ): Promise<PredictAccountReadiness>;
+}
 
 export interface VenueMarketDataAdapter {
   fetchVenueStatus(options?: PredictReadOptions): Promise<PredictVenueStatus>;

--- a/app/components/UI/PredictNext/contracts/v1/account.test.ts
+++ b/app/components/UI/PredictNext/contracts/v1/account.test.ts
@@ -1,0 +1,35 @@
+import { PredictError, PredictErrorCode } from '../../errors';
+import { parsePredictAccountReadiness } from './account';
+
+describe('Predict Account Readiness contract', () => {
+  it.each(['setup_required', 'ready'] as const)(
+    'parses %s readiness and discards unknown fields',
+    (status) => {
+      const result = parsePredictAccountReadiness({
+        venueId: 'kalshi',
+        status,
+        userId: 'discard',
+      });
+
+      expect(result).toEqual({ venueId: 'kalshi', status });
+      expect(result).not.toHaveProperty('userId');
+    },
+  );
+
+  it.each([
+    { venueId: '', status: 'ready' },
+    { venueId: 'kalshi', status: 'unknown' },
+    { venueId: 'kalshi' },
+  ])('fails closed for malformed readiness %#', (value) => {
+    expect(() => parsePredictAccountReadiness(value)).toThrow(
+      'Invalid Predict API response.',
+    );
+
+    try {
+      parsePredictAccountReadiness(value);
+    } catch (error) {
+      expect(error).toBeInstanceOf(PredictError);
+      expect((error as PredictError).code).toBe(PredictErrorCode.UNKNOWN);
+    }
+  });
+});

--- a/app/components/UI/PredictNext/contracts/v1/account.ts
+++ b/app/components/UI/PredictNext/contracts/v1/account.ts
@@ -1,0 +1,25 @@
+import { enums, mask, object, refine, string } from '@metamask/superstruct';
+import { PredictError, PredictErrorCode } from '../../errors';
+import type { PredictAccountReadiness } from '../../types';
+
+const venueId = refine(string(), 'PredictVenueId', (value) => value.length > 0);
+
+const accountReadinessSchema = object({
+  venueId,
+  status: enums(['setup_required', 'ready'] as const),
+});
+
+export const parsePredictAccountReadiness = (
+  value: unknown,
+): PredictAccountReadiness => {
+  try {
+    return mask(
+      value,
+      accountReadinessSchema,
+    ) as unknown as PredictAccountReadiness;
+  } catch {
+    throw PredictError.from(PredictErrorCode.UNKNOWN, {
+      message: 'Invalid Predict API response.',
+    });
+  }
+};

--- a/app/components/UI/PredictNext/hooks/usePredictGuard.ts
+++ b/app/components/UI/PredictNext/hooks/usePredictGuard.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import Engine from '../../../../core/Engine';
+import {
+  selectPredictCanSetup,
+  selectPredictCanTrade,
+} from '../selectors/predictSession';
+import type { PredictVenueId } from '../types';
+
+/** Loads Account Readiness and exposes fail-closed Predict capabilities. */
+export const usePredictGuard = (venueId: PredictVenueId) => {
+  const canSetup = useSelector(selectPredictCanSetup);
+  const canTrade = useSelector(selectPredictCanTrade);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    Engine.controllerMessenger
+      .call('PredictSessionService:refreshAccountReadiness', venueId, {
+        signal: controller.signal,
+      })
+      .catch(() => undefined);
+
+    return () => controller.abort();
+  }, [venueId]);
+
+  return { canSetup, canTrade };
+};

--- a/app/components/UI/PredictNext/selectors/predictSession.test.ts
+++ b/app/components/UI/PredictNext/selectors/predictSession.test.ts
@@ -1,0 +1,41 @@
+import type { RootState } from '../../../../reducers';
+import type { DeepPartial } from '../../../../util/test/renderWithProvider';
+import { selectPredictCanSetup, selectPredictCanTrade } from './predictSession';
+
+const buildState = (
+  status?: 'setup_required' | 'ready',
+): DeepPartial<RootState> => ({
+  engine: {
+    backgroundState: status
+      ? {
+          PredictSessionService: {
+            accountReadiness: { venueId: 'kalshi', status },
+            requestStatus: 'success',
+          },
+        }
+      : {},
+  },
+});
+
+describe('Predict Session selectors', () => {
+  it('allows setup only when the readiness projection requires setup', () => {
+    const state = buildState('setup_required') as RootState;
+
+    expect(selectPredictCanSetup(state)).toBe(true);
+    expect(selectPredictCanTrade(state)).toBe(false);
+  });
+
+  it('allows trading only when the readiness projection is ready', () => {
+    const state = buildState('ready') as RootState;
+
+    expect(selectPredictCanSetup(state)).toBe(false);
+    expect(selectPredictCanTrade(state)).toBe(true);
+  });
+
+  it('fails closed when session state is unavailable', () => {
+    const state = buildState() as RootState;
+
+    expect(selectPredictCanSetup(state)).toBe(false);
+    expect(selectPredictCanTrade(state)).toBe(false);
+  });
+});

--- a/app/components/UI/PredictNext/selectors/predictSession.ts
+++ b/app/components/UI/PredictNext/selectors/predictSession.ts
@@ -1,0 +1,20 @@
+import { createSelector } from 'reselect';
+import type { RootState } from '../../../../reducers';
+
+export const selectPredictSessionState = (state: RootState) =>
+  state.engine?.backgroundState?.PredictSessionService;
+
+export const selectPredictAccountReadiness = createSelector(
+  selectPredictSessionState,
+  (sessionState) => sessionState?.accountReadiness ?? null,
+);
+
+export const selectPredictCanSetup = createSelector(
+  selectPredictAccountReadiness,
+  (readiness) => readiness?.status === 'setup_required',
+);
+
+export const selectPredictCanTrade = createSelector(
+  selectPredictAccountReadiness,
+  (readiness) => readiness?.status === 'ready',
+);

--- a/app/components/UI/PredictNext/services/PredictMarketDataService.integration.test.ts
+++ b/app/components/UI/PredictNext/services/PredictMarketDataService.integration.test.ts
@@ -221,3 +221,30 @@ describe('PredictNext public market data', () => {
     ).toThrow();
   });
 });
+
+describe('PredictNext Account Readiness', () => {
+  it('reads readiness through required-auth transport without client identity', async () => {
+    const harness = createPredictNextIntegrationHarness(() => ({
+      body: { venueId: 'kalshi', status: 'setup_required' },
+    }));
+
+    const result = await harness.sessionMessenger.call(
+      'PredictSessionService:refreshAccountReadiness',
+      KALSHI_VENUE_ID,
+    );
+
+    expect(result).toEqual({ venueId: 'kalshi', status: 'setup_required' });
+    expect(harness.sessionService.state.accountReadiness).toEqual(result);
+    expect(harness.fetchMock).toHaveBeenCalledWith(
+      'https://predict.example/predict/v1/venues/kalshi/account/readiness',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer integration-token',
+        }),
+      }),
+    );
+    expect(String(harness.fetchMock.mock.calls[0][0])).not.toContain('user');
+    expect(String(harness.fetchMock.mock.calls[0][0])).not.toContain('wallet');
+    harness.destroy();
+  });
+});

--- a/app/components/UI/PredictNext/services/PredictSessionService.test.ts
+++ b/app/components/UI/PredictNext/services/PredictSessionService.test.ts
@@ -1,0 +1,229 @@
+import { deriveStateFromMetadata } from '@metamask/base-controller';
+import { Messenger } from '@metamask/messenger';
+import type { VenueAccountAdapter } from '../adapters/types';
+import { PredictErrorCode } from '../errors';
+import { KALSHI_VENUE_ID, type PredictAccountReadiness } from '../types';
+import {
+  PredictSessionService,
+  type PredictSessionServiceActions,
+  type PredictSessionServiceEvents,
+  type PredictSessionServiceMessenger,
+} from './PredictSessionService';
+
+const setupRequired: PredictAccountReadiness = {
+  venueId: KALSHI_VENUE_ID,
+  status: 'setup_required',
+};
+
+const ready: PredictAccountReadiness = {
+  venueId: KALSHI_VENUE_ID,
+  status: 'ready',
+};
+
+const createMessenger = (): PredictSessionServiceMessenger =>
+  new Messenger<
+    'PredictSessionService',
+    PredictSessionServiceActions,
+    PredictSessionServiceEvents
+  >({ namespace: 'PredictSessionService' });
+
+describe('PredictSessionService', () => {
+  let account: jest.Mocked<VenueAccountAdapter>;
+  let authenticate: jest.MockedFunction<() => Promise<void>>;
+  let messenger: PredictSessionServiceMessenger;
+  let service: PredictSessionService;
+
+  beforeEach(() => {
+    account = { fetchAccountReadiness: jest.fn() };
+    authenticate = jest.fn().mockResolvedValue(undefined);
+    messenger = createMessenger();
+    service = new PredictSessionService({
+      messenger,
+      account,
+      authenticate,
+      venueId: KALSHI_VENUE_ID,
+    });
+  });
+
+  afterEach(() => service.destroy());
+
+  it('projects a successful readiness response into runtime state', async () => {
+    account.fetchAccountReadiness.mockResolvedValue(setupRequired);
+
+    const result = await messenger.call(
+      'PredictSessionService:refreshAccountReadiness',
+      KALSHI_VENUE_ID,
+    );
+
+    expect(result).toEqual(setupRequired);
+    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(service.state).toEqual({
+      accountReadiness: setupRequired,
+      requestStatus: 'success',
+    });
+  });
+
+  it('continues after readiness is reset during authentication', async () => {
+    authenticate.mockImplementationOnce(async () => {
+      service.clearAccountReadiness();
+    });
+    account.fetchAccountReadiness.mockResolvedValue(setupRequired);
+
+    const result = await service.refreshAccountReadiness(KALSHI_VENUE_ID);
+
+    expect(result).toEqual(setupRequired);
+    expect(account.fetchAccountReadiness).toHaveBeenCalledTimes(1);
+    expect(service.state.accountReadiness).toEqual(setupRequired);
+  });
+
+  it('clears readiness and fails closed after a refresh error', async () => {
+    account.fetchAccountReadiness
+      .mockResolvedValueOnce(setupRequired)
+      .mockRejectedValueOnce(new Error('unavailable'));
+    await service.refreshAccountReadiness(KALSHI_VENUE_ID);
+
+    await expect(
+      service.refreshAccountReadiness(KALSHI_VENUE_ID),
+    ).rejects.toThrow('unavailable');
+
+    expect(service.state).toEqual({
+      accountReadiness: null,
+      requestStatus: 'error',
+    });
+  });
+
+  it('fails closed while a readiness refresh is in flight', async () => {
+    let resolveReadiness: (value: PredictAccountReadiness) => void = () =>
+      undefined;
+    account.fetchAccountReadiness
+      .mockResolvedValueOnce(setupRequired)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveReadiness = resolve;
+          }),
+      );
+    await service.refreshAccountReadiness(KALSHI_VENUE_ID);
+
+    const refresh = service.refreshAccountReadiness(KALSHI_VENUE_ID);
+    await Promise.resolve();
+
+    expect(service.state).toEqual({
+      accountReadiness: null,
+      requestStatus: 'loading',
+    });
+    resolveReadiness(setupRequired);
+    await refresh;
+  });
+
+  it('ignores an obsolete response after readiness is cleared', async () => {
+    let resolveReadiness: (value: PredictAccountReadiness) => void = () =>
+      undefined;
+    account.fetchAccountReadiness.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveReadiness = resolve;
+        }),
+    );
+    const refresh = service.refreshAccountReadiness(KALSHI_VENUE_ID);
+    await Promise.resolve();
+
+    service.clearAccountReadiness();
+    resolveReadiness(setupRequired);
+    await refresh;
+
+    expect(service.state).toEqual({
+      accountReadiness: null,
+      requestStatus: 'idle',
+    });
+  });
+
+  it('keeps the latest readiness when concurrent responses arrive out of order', async () => {
+    let resolveFirst: (value: PredictAccountReadiness) => void = () =>
+      undefined;
+    let resolveSecond: (value: PredictAccountReadiness) => void = () =>
+      undefined;
+    account.fetchAccountReadiness
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecond = resolve;
+          }),
+      );
+    const firstRefresh = service.refreshAccountReadiness(KALSHI_VENUE_ID);
+    const secondRefresh = service.refreshAccountReadiness(KALSHI_VENUE_ID);
+    await Promise.resolve();
+
+    resolveSecond(ready);
+    await secondRefresh;
+    resolveFirst(setupRequired);
+    await firstRefresh;
+
+    expect(service.state).toEqual({
+      accountReadiness: ready,
+      requestStatus: 'success',
+    });
+  });
+
+  it('does not project readiness when cancellation races with a response', async () => {
+    const controller = new AbortController();
+    account.fetchAccountReadiness.mockImplementationOnce(async () => {
+      controller.abort();
+      return setupRequired;
+    });
+
+    await service.refreshAccountReadiness(KALSHI_VENUE_ID, {
+      signal: controller.signal,
+    });
+
+    expect(service.state).toEqual({
+      accountReadiness: null,
+      requestStatus: 'idle',
+    });
+  });
+
+  it('rejects another Venue without calling the account capability', async () => {
+    await expect(
+      service.refreshAccountReadiness('other' as typeof KALSHI_VENUE_ID),
+    ).rejects.toMatchObject({ code: PredictErrorCode.UNSUPPORTED_VENUE });
+
+    expect(account.fetchAccountReadiness).not.toHaveBeenCalled();
+  });
+
+  it('keeps readiness state out of persistence, logs, and debug snapshots', () => {
+    expect(
+      deriveStateFromMetadata(service.state, service.metadata, 'persist'),
+    ).toEqual({});
+    expect(
+      deriveStateFromMetadata(
+        service.state,
+        service.metadata,
+        'includeInStateLogs',
+      ),
+    ).toEqual({});
+    expect(
+      deriveStateFromMetadata(
+        service.state,
+        service.metadata,
+        'includeInDebugSnapshot',
+      ),
+    ).toEqual({});
+  });
+
+  it('removes the readiness action on destroy', () => {
+    service.destroy();
+
+    expect(() =>
+      messenger.call(
+        'PredictSessionService:refreshAccountReadiness',
+        KALSHI_VENUE_ID,
+      ),
+    ).toThrow();
+  });
+});

--- a/app/components/UI/PredictNext/services/PredictSessionService.ts
+++ b/app/components/UI/PredictNext/services/PredictSessionService.ts
@@ -1,0 +1,252 @@
+import {
+  BaseController,
+  type ControllerGetStateAction,
+  type ControllerStateChangeEvent,
+  type StateMetadata,
+} from '@metamask/base-controller';
+import type { KeyringControllerLockEvent } from '@metamask/keyring-controller';
+import type { Messenger } from '@metamask/messenger';
+import type { AuthenticationController } from '@metamask/profile-sync-controller';
+import type { VenueAccountAdapter } from '../adapters/types';
+import { PredictError, PredictErrorCode } from '../errors';
+import type {
+  PredictAccountReadiness,
+  PredictReadOptions,
+  PredictVenueId,
+} from '../types';
+
+export const PREDICT_SESSION_SERVICE_NAME = 'PredictSessionService' as const;
+
+export type PredictSessionRequestStatus =
+  | 'idle'
+  | 'loading'
+  | 'success'
+  | 'error';
+
+// A type alias satisfies BaseController's JSON state constraint without widening
+// account readiness to an arbitrary record.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type PredictSessionServiceState = {
+  accountReadiness: PredictAccountReadiness | null;
+  requestStatus: PredictSessionRequestStatus;
+};
+
+export const defaultPredictSessionServiceState: PredictSessionServiceState = {
+  accountReadiness: null,
+  requestStatus: 'idle',
+};
+
+const metadata: StateMetadata<PredictSessionServiceState> = {
+  accountReadiness: {
+    persist: false,
+    includeInDebugSnapshot: false,
+    includeInStateLogs: false,
+    usedInUi: true,
+  },
+  requestStatus: {
+    persist: false,
+    includeInDebugSnapshot: false,
+    includeInStateLogs: false,
+    usedInUi: true,
+  },
+};
+
+export interface PredictSessionServiceRefreshAccountReadinessAction {
+  type: 'PredictSessionService:refreshAccountReadiness';
+  handler: (
+    venueId: PredictVenueId,
+    options?: PredictReadOptions,
+  ) => Promise<PredictAccountReadiness>;
+}
+
+export type PredictSessionServiceActions =
+  | ControllerGetStateAction<
+      typeof PREDICT_SESSION_SERVICE_NAME,
+      PredictSessionServiceState
+    >
+  | PredictSessionServiceRefreshAccountReadinessAction;
+
+// EngineService still consumes the legacy stateChange event.
+// eslint-disable-next-line @typescript-eslint/no-deprecated
+export type PredictSessionServiceEvents = ControllerStateChangeEvent<
+  typeof PREDICT_SESSION_SERVICE_NAME,
+  PredictSessionServiceState
+>;
+
+type PredictSessionServiceAllowedActions =
+  AuthenticationController.AuthenticationControllerGetBearerTokenAction;
+
+type PredictSessionServiceAllowedEvents =
+  | AuthenticationController.AuthenticationControllerStateChangeEvent
+  | KeyringControllerLockEvent;
+
+export type PredictSessionServiceMessenger = Messenger<
+  typeof PREDICT_SESSION_SERVICE_NAME,
+  PredictSessionServiceActions | PredictSessionServiceAllowedActions,
+  PredictSessionServiceEvents | PredictSessionServiceAllowedEvents
+>;
+
+export interface PredictSessionServiceOptions {
+  messenger: PredictSessionServiceMessenger;
+  account?: VenueAccountAdapter;
+  authenticate?: () => Promise<void>;
+  venueId: PredictVenueId;
+}
+
+/** Owns runtime-only authenticated context and Account Readiness projection. */
+export class PredictSessionService extends BaseController<
+  typeof PREDICT_SESSION_SERVICE_NAME,
+  PredictSessionServiceState,
+  PredictSessionServiceMessenger
+> {
+  readonly #account?: VenueAccountAdapter;
+  readonly #authenticate: () => Promise<void>;
+  readonly #venueId: PredictVenueId;
+  #destroyed = false;
+  #authenticationGeneration = 0;
+  #nextRequestGeneration = 0;
+  #requestGeneration = 0;
+  #authenticatingRequests = 0;
+  readonly #handleAuthenticationStateChange = () => {
+    if (this.#authenticatingRequests > 0) {
+      return;
+    }
+    this.#invalidateAuthentication();
+  };
+  readonly #handleKeyringLock = () => {
+    this.#invalidateAuthentication();
+  };
+
+  constructor({
+    messenger,
+    account,
+    authenticate,
+    venueId,
+  }: PredictSessionServiceOptions) {
+    super({
+      name: PREDICT_SESSION_SERVICE_NAME,
+      messenger,
+      metadata,
+      state: defaultPredictSessionServiceState,
+    });
+    this.#account = account;
+    this.#authenticate = authenticate ?? (async () => undefined);
+    this.#venueId = venueId;
+
+    messenger.registerActionHandler(
+      'PredictSessionService:refreshAccountReadiness',
+      this.refreshAccountReadiness.bind(this),
+    );
+    messenger.subscribe(
+      'AuthenticationController:stateChange',
+      this.#handleAuthenticationStateChange,
+    );
+    messenger.subscribe('KeyringController:lock', this.#handleKeyringLock);
+  }
+
+  async refreshAccountReadiness(
+    venueId: PredictVenueId,
+    options?: PredictReadOptions,
+  ): Promise<PredictAccountReadiness> {
+    if (venueId !== this.#venueId) {
+      throw PredictError.from(PredictErrorCode.UNSUPPORTED_VENUE);
+    }
+    if (!this.#account) {
+      throw PredictError.from(PredictErrorCode.SERVICE_DEGRADED);
+    }
+
+    const requestGeneration = ++this.#nextRequestGeneration;
+    this.update((state) => {
+      state.accountReadiness = null;
+      state.requestStatus = 'loading';
+    });
+
+    try {
+      this.#authenticatingRequests += 1;
+      try {
+        await this.#authenticate();
+      } finally {
+        this.#authenticatingRequests -= 1;
+      }
+      if (options?.signal?.aborted) {
+        throw this.#createAbortError();
+      }
+      const authenticationGeneration = this.#authenticationGeneration;
+      this.#requestGeneration = requestGeneration;
+      this.update((state) => {
+        state.accountReadiness = null;
+        state.requestStatus = 'loading';
+      });
+      const readiness = await this.#account.fetchAccountReadiness(options);
+      if (
+        options?.signal?.aborted ||
+        authenticationGeneration !== this.#authenticationGeneration ||
+        requestGeneration !== this.#requestGeneration
+      ) {
+        if (requestGeneration === this.#requestGeneration) {
+          this.#resetProjection();
+        }
+        return readiness;
+      }
+      this.update((state) => {
+        state.accountReadiness = readiness;
+        state.requestStatus = 'success';
+      });
+      return readiness;
+    } catch (error) {
+      if (requestGeneration !== this.#requestGeneration) {
+        throw error;
+      }
+      this.update((state) => {
+        state.accountReadiness = null;
+        state.requestStatus = 'error';
+      });
+      throw error;
+    }
+  }
+
+  clearAccountReadiness(): void {
+    this.#nextRequestGeneration += 1;
+    this.#requestGeneration = this.#nextRequestGeneration;
+    this.#resetProjection();
+  }
+
+  #invalidateAuthentication(): void {
+    this.#authenticationGeneration += 1;
+    this.#resetProjection();
+  }
+
+  #resetProjection(): void {
+    this.update((state) => {
+      state.accountReadiness = null;
+      state.requestStatus = 'idle';
+    });
+  }
+
+  #createAbortError(): Error {
+    const error = new Error('Predict Account Readiness request was cancelled.');
+    error.name = 'AbortError';
+    return error;
+  }
+
+  public destroy(): void {
+    if (this.#destroyed) {
+      return;
+    }
+    this.#destroyed = true;
+    this.#nextRequestGeneration += 1;
+    this.#requestGeneration = this.#nextRequestGeneration;
+    this.messenger.unregisterActionHandler(
+      'PredictSessionService:refreshAccountReadiness',
+    );
+    this.messenger.unsubscribe(
+      'AuthenticationController:stateChange',
+      this.#handleAuthenticationStateChange,
+    );
+    this.messenger.unsubscribe(
+      'KeyringController:lock',
+      this.#handleKeyringLock,
+    );
+    super.destroy();
+  }
+}

--- a/app/components/UI/PredictNext/types/index.ts
+++ b/app/components/UI/PredictNext/types/index.ts
@@ -64,6 +64,15 @@ export interface PredictVenueStatus {
   checkedAt: PredictTimestamp;
 }
 
+export type PredictAccountReadinessStatus = 'setup_required' | 'ready';
+
+// A type alias keeps the canonical model compatible with controller JSON state.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type PredictAccountReadiness = {
+  venueId: PredictVenueId;
+  status: PredictAccountReadinessStatus;
+};
+
 export interface PredictReadOptions {
   signal?: AbortSignal;
 }

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.testIds.ts
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.testIds.ts
@@ -6,6 +6,7 @@ export const PredictHomeTestIds = {
   FEED: 'predict-next-event-feed',
   FOOTER_LOADING: 'predict-next-footer-loading',
   FOOTER_RETRY: 'predict-next-footer-retry',
+  SETUP_ACCOUNT: 'predict-next-setup-account',
   event: (venueId: string, eventId: string) =>
     `predict-next-event-${venueId}-${eventId}`,
   eventContent: (venueId: string, eventId: string) =>

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.tsx
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.tsx
@@ -5,6 +5,7 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import {
   Box,
   Button,
+  ButtonSize,
   ButtonVariant,
   Text,
   TextVariant,
@@ -15,6 +16,8 @@ import { KALSHI_VENUE_ID, type PredictEvent } from '../../types';
 import { EventCardContent } from '../../components/EventCard/EventCardContent';
 import type { PredictNextStackParamList } from '../../navigation/types';
 import { PredictNextRoutes } from '../../navigation/routes';
+import { usePredictGuard } from '../../hooks/usePredictGuard';
+import { PredictHomeTestIds } from './PredictHome.testIds';
 
 const PAGE_SIZE = 20;
 
@@ -23,6 +26,7 @@ export const PredictHome = () => {
     useNavigation<NativeStackNavigationProp<PredictNextStackParamList>>();
   const statusQuery = useVenueStatus(KALSHI_VENUE_ID);
   const eventsQuery = useEventList(KALSHI_VENUE_ID, { limit: PAGE_SIZE });
+  const { canSetup } = usePredictGuard(KALSHI_VENUE_ID);
   const endReached = useRef(false);
   const [paginationError, setPaginationError] = useState(false);
   const events = useMemo(
@@ -101,6 +105,19 @@ export const PredictHome = () => {
       <Box twClassName="px-4 pb-2">
         <Text variant={TextVariant.HeadingLg}>Predictions</Text>
       </Box>
+      {canSetup ? (
+        <Box twClassName="px-4 pb-4">
+          <Button
+            testID={PredictHomeTestIds.SETUP_ACCOUNT}
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Lg}
+            isFullWidth
+            isDisabled
+          >
+            Set up your account
+          </Button>
+        </Box>
+      ) : null}
       {blockingContent ?? (
         <FlashList
           testID="predict-next-event-feed"

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.view.test.tsx
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.view.test.tsx
@@ -74,6 +74,78 @@ describe('PredictHome', () => {
     expect(within(card).getByText('Election 2028')).toBeOnTheScreen();
     expect(within(card).getByText('Yes 42¢')).toBeOnTheScreen();
     expect(within(card).getByText('No 58¢')).toBeOnTheScreen();
+    expect(messengerCall).toHaveBeenCalledWith(
+      'PredictSessionService:refreshAccountReadiness',
+      'kalshi',
+      expect.objectContaining({ signal: expect.any(Object) }),
+    );
+  });
+
+  it('shows account setup only when Account Readiness requires it', async () => {
+    const view = renderPredictNext({
+      engine: {
+        backgroundState: {
+          PredictSessionService: {
+            accountReadiness: {
+              venueId: 'kalshi',
+              status: 'setup_required',
+            },
+            requestStatus: 'success',
+          },
+        },
+      },
+    });
+
+    expect(
+      await view.findByTestId(PredictHomeTestIds.SETUP_ACCOUNT),
+    ).toHaveTextContent('Set up your account');
+    expect(view.getByTestId(PredictHomeTestIds.SETUP_ACCOUNT)).toBeDisabled();
+  });
+
+  it('hides account setup when the Predict User can trade', async () => {
+    const view = renderPredictNext({
+      engine: {
+        backgroundState: {
+          PredictSessionService: {
+            accountReadiness: { venueId: 'kalshi', status: 'ready' },
+            requestStatus: 'success',
+          },
+        },
+      },
+    });
+
+    await view.findByTestId(PredictHomeTestIds.FEED);
+    expect(
+      view.queryByTestId(PredictHomeTestIds.SETUP_ACCOUNT),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('fails closed while Account Readiness is unavailable', async () => {
+    const view = renderPredictNext();
+
+    await view.findByTestId(PredictHomeTestIds.FEED);
+    expect(
+      view.queryByTestId(PredictHomeTestIds.SETUP_ACCOUNT),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('cancels the Account Readiness request when the view unmounts', async () => {
+    const view = renderPredictNext();
+    await waitFor(() =>
+      expect(messengerCall).toHaveBeenCalledWith(
+        'PredictSessionService:refreshAccountReadiness',
+        'kalshi',
+        expect.objectContaining({ signal: expect.any(Object) }),
+      ),
+    );
+    const readinessCall = messengerCall.mock.calls.find(
+      ([action]) => action === 'PredictSessionService:refreshAccountReadiness',
+    );
+    const signal = readinessCall?.[2]?.signal as AbortSignal;
+
+    view.unmount();
+
+    expect(signal.aborted).toBe(true);
   });
 
   it('opens detail and returns without fetching Event detail', async () => {

--- a/app/core/Engine/Engine.test.ts
+++ b/app/core/Engine/Engine.test.ts
@@ -172,6 +172,7 @@ describe('Engine', () => {
     expect(engine.context).toHaveProperty('DeFiPositionsControllerV2');
     expect(engine.context).toHaveProperty('NetworkEnablementController');
     expect(engine.context).toHaveProperty('PerpsController');
+    expect(engine.context).toHaveProperty('PredictSessionService');
     expect(engine.context).toHaveProperty('GatorPermissionsController');
     expect(engine.context).toHaveProperty('RampsController');
     expect(engine.context).toHaveProperty('RampsService');
@@ -1131,6 +1132,18 @@ describe('Engine', () => {
       await engine.resetState();
 
       expect(clearStateSpy).toHaveBeenCalled();
+    });
+
+    it('clears Predict Account Readiness', async () => {
+      const engine = Engine.init(TEST_ANALYTICS_ID, backgroundState);
+      const clearReadinessSpy = jest.spyOn(
+        engine.context.PredictSessionService,
+        'clearAccountReadiness',
+      );
+
+      await engine.resetState();
+
+      expect(clearReadinessSpy).toHaveBeenCalled();
     });
   });
 });

--- a/app/core/Engine/Engine.ts
+++ b/app/core/Engine/Engine.ts
@@ -135,6 +135,7 @@ import { scanCompleted, scanRequested } from '../redux/slices/qrKeyringScanner';
 import { perpsControllerInit } from './controllers/perps-controller';
 import { predictControllerInit } from './controllers/predict-controller';
 import { predictNextControllerInit } from './controllers/predict-next-controller-init';
+import { predictSessionServiceInit } from './controllers/predict-session-service-init';
 import { rewardsControllerInit } from './controllers/rewards-controller';
 import { GatorPermissionsControllerInit } from './controllers/gator-permissions-controller';
 import type { GatorPermissionsController } from '@metamask/gator-permissions-controller';
@@ -383,6 +384,7 @@ export class Engine {
         PhishingController: phishingControllerInit,
         PredictController: predictControllerInit,
         PredictNextController: predictNextControllerInit,
+        PredictSessionService: predictSessionServiceInit,
         RewardsController: rewardsControllerInit,
         RewardsDataService: rewardsDataServiceInit,
         DelegationController: DelegationControllerInit,
@@ -439,6 +441,7 @@ export class Engine {
     const phishingController = messengerClientsByName.PhishingController;
     const predictController = messengerClientsByName.PredictController;
     const predictNextController = messengerClientsByName.PredictNextController;
+    const predictSessionService = messengerClientsByName.PredictSessionService;
     const rewardsController = messengerClientsByName.RewardsController;
     const gatorPermissionsController =
       messengerClientsByName.GatorPermissionsController;
@@ -655,6 +658,7 @@ export class Engine {
       PerpsController: perpsController,
       PredictController: predictController,
       PredictNextController: predictNextController,
+      PredictSessionService: predictSessionService,
       RewardsController: rewardsController,
       DelegationController: delegationController,
       ProfileMetricsController: profileMetricsController,
@@ -1291,6 +1295,7 @@ export class Engine {
       ///: END:ONLY_INCLUDE_IF
       LoggingController,
       MoneyAccountController,
+      PredictSessionService,
     } = this.context;
 
     // Remove all permissions.
@@ -1321,6 +1326,7 @@ export class Engine {
     }));
 
     LoggingController.clear();
+    PredictSessionService.clearAccountReadiness();
 
     // Accounts:
     MoneyAccountController.clearState();
@@ -1494,6 +1500,7 @@ export default {
       PerpsController,
       PhishingController,
       PredictController,
+      PredictSessionService,
       PreferencesController,
       RemoteFeatureFlagController,
       RewardsController,
@@ -1569,6 +1576,7 @@ export default {
       PerpsController: PerpsController.state,
       PhishingController: PhishingController.state,
       PredictController: PredictController.state,
+      PredictSessionService: PredictSessionService.state,
       PreferencesController: PreferencesController.state,
       RemoteFeatureFlagController: RemoteFeatureFlagController.state,
       RewardsController: RewardsController.state,

--- a/app/core/Engine/constants.ts
+++ b/app/core/Engine/constants.ts
@@ -100,6 +100,7 @@ export const BACKGROUND_STATE_CHANGE_EVENT_NAMES = [
   ///: END:ONLY_INCLUDE_IF
   'NetworkEnablementController:stateChange',
   'PredictController:stateChange',
+  'PredictSessionService:stateChange',
   'CardController:stateChange',
   'ClientController:stateChange',
   'DelegationController:stateChange',

--- a/app/core/Engine/controllers/predict-session-service-init.ts
+++ b/app/core/Engine/controllers/predict-session-service-init.ts
@@ -1,0 +1,56 @@
+import packageJSON from '../../../../package.json';
+import Logger from '../../../util/Logger';
+import { KalshiRemoteAdapter } from '../../../components/UI/PredictNext/adapters/remote/KalshiRemoteAdapter';
+import { PredictApiAccountClient } from '../../../components/UI/PredictNext/adapters/remote/PredictApiAccountClient';
+import { PredictApiReadClient } from '../../../components/UI/PredictNext/adapters/remote/PredictApiReadClient';
+import {
+  PredictSessionService,
+  type PredictSessionServiceMessenger,
+} from '../../../components/UI/PredictNext/services/PredictSessionService';
+import { KALSHI_VENUE_ID } from '../../../components/UI/PredictNext/types';
+import type { MessengerClientInitFunction } from '../types';
+
+export const predictSessionServiceInit: MessengerClientInitFunction<
+  PredictSessionService,
+  PredictSessionServiceMessenger
+> = ({ controllerMessenger }) => {
+  const baseUrl = process.env.MM_PREDICT_API_URL;
+  let account: InstanceType<typeof KalshiRemoteAdapter>['account'];
+
+  if (!baseUrl) {
+    Logger.error(new Error('PredictNext configuration is missing.'));
+  } else {
+    try {
+      const readClient = new PredictApiReadClient({
+        baseUrl,
+        clientVersion: packageJSON.version,
+      });
+      const accountClient = new PredictApiAccountClient({
+        baseUrl,
+        clientVersion: packageJSON.version,
+        getBearerToken: () =>
+          controllerMessenger.call('AuthenticationController:getBearerToken'),
+      });
+      account = new KalshiRemoteAdapter(readClient, accountClient).account;
+    } catch (error) {
+      Logger.error(
+        error instanceof Error
+          ? error
+          : new Error('PredictNext configuration is malformed.'),
+      );
+    }
+  }
+
+  return {
+    controller: new PredictSessionService({
+      messenger: controllerMessenger,
+      account,
+      authenticate: async () => {
+        await controllerMessenger.call(
+          'AuthenticationController:getBearerToken',
+        );
+      },
+      venueId: KALSHI_VENUE_ID,
+    }),
+  };
+};

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -48,6 +48,7 @@ import { getSamplePetnamesControllerMessenger } from '../../../features/SampleFe
 import { getPerpsControllerMessenger } from './perps-controller-messenger';
 import { getPredictControllerMessenger } from './predict-controller-messenger';
 import { getPredictNextControllerMessenger } from './predict-next-controller-messenger';
+import { getPredictSessionServiceMessenger } from './predict-session-service-messenger';
 import {
   getBridgeControllerMessenger,
   getBridgeControllerInitMessenger,
@@ -356,6 +357,10 @@ export const MESSENGER_FACTORIES = {
   },
   PredictNextController: {
     getMessenger: getPredictNextControllerMessenger,
+    getInitMessenger: noop,
+  },
+  PredictSessionService: {
+    getMessenger: getPredictSessionServiceMessenger,
     getInitMessenger: noop,
   },
   BridgeController: {

--- a/app/core/Engine/messengers/predict-session-service-messenger.test.ts
+++ b/app/core/Engine/messengers/predict-session-service-messenger.test.ts
@@ -1,0 +1,179 @@
+import {
+  Messenger,
+  MOCK_ANY_NAMESPACE,
+  type MessengerActions,
+  type MessengerEvents,
+  type MockAnyNamespace,
+} from '@metamask/messenger';
+import {
+  PredictSessionService,
+  type PredictSessionServiceMessenger,
+} from '../../../components/UI/PredictNext/services/PredictSessionService';
+import { KALSHI_VENUE_ID } from '../../../components/UI/PredictNext/types';
+import { getPredictSessionServiceMessenger } from './predict-session-service-messenger';
+
+type RootMessenger = Messenger<
+  MockAnyNamespace,
+  MessengerActions<PredictSessionServiceMessenger>,
+  MessengerEvents<PredictSessionServiceMessenger>
+>;
+
+describe('getPredictSessionServiceMessenger', () => {
+  it('delegates required authentication to the session service', async () => {
+    const rootMessenger: RootMessenger = new Messenger({
+      namespace: MOCK_ANY_NAMESPACE,
+    });
+    rootMessenger.registerActionHandler(
+      'AuthenticationController:getBearerToken',
+      jest.fn().mockResolvedValue('test-token'),
+    );
+    const messenger = getPredictSessionServiceMessenger(rootMessenger);
+
+    const result = await messenger.call(
+      'AuthenticationController:getBearerToken',
+    );
+
+    expect(result).toBe('test-token');
+  });
+
+  it('delegates authentication and lock events to the session service', () => {
+    const rootMessenger: RootMessenger = new Messenger({
+      namespace: MOCK_ANY_NAMESPACE,
+    });
+    const messenger = getPredictSessionServiceMessenger(rootMessenger);
+    const authListener = jest.fn();
+    const lockListener = jest.fn();
+    messenger.subscribe('AuthenticationController:stateChange', authListener);
+    messenger.subscribe('KeyringController:lock', lockListener);
+
+    rootMessenger.publish(
+      'AuthenticationController:stateChange',
+      { isSignedIn: false },
+      [],
+    );
+    rootMessenger.publish('KeyringController:lock');
+
+    expect(authListener).toHaveBeenCalled();
+    expect(lockListener).toHaveBeenCalled();
+  });
+
+  it('clears projected readiness after authentication changes or lock', async () => {
+    const rootMessenger: RootMessenger = new Messenger({
+      namespace: MOCK_ANY_NAMESPACE,
+    });
+    const messenger = getPredictSessionServiceMessenger(rootMessenger);
+    const service = new PredictSessionService({
+      messenger,
+      account: {
+        fetchAccountReadiness: jest.fn().mockResolvedValue({
+          venueId: KALSHI_VENUE_ID,
+          status: 'ready',
+        }),
+      },
+      authenticate: async () => undefined,
+      venueId: KALSHI_VENUE_ID,
+    });
+    await service.refreshAccountReadiness(KALSHI_VENUE_ID);
+
+    rootMessenger.publish(
+      'AuthenticationController:stateChange',
+      { isSignedIn: true },
+      [],
+    );
+    expect(service.state.accountReadiness).toBeNull();
+
+    await service.refreshAccountReadiness(KALSHI_VENUE_ID);
+    rootMessenger.publish('KeyringController:lock');
+    expect(service.state.accountReadiness).toBeNull();
+    service.destroy();
+  });
+
+  it('projects readiness after authentication changes during token acquisition', async () => {
+    const rootMessenger: RootMessenger = new Messenger({
+      namespace: MOCK_ANY_NAMESPACE,
+    });
+    const messenger = getPredictSessionServiceMessenger(rootMessenger);
+    const service = new PredictSessionService({
+      messenger,
+      account: {
+        fetchAccountReadiness: jest.fn().mockResolvedValue({
+          venueId: KALSHI_VENUE_ID,
+          status: 'ready',
+        }),
+      },
+      authenticate: async () => {
+        rootMessenger.publish(
+          'AuthenticationController:stateChange',
+          { isSignedIn: true },
+          [],
+        );
+      },
+      venueId: KALSHI_VENUE_ID,
+    });
+
+    await service.refreshAccountReadiness(KALSHI_VENUE_ID);
+
+    expect(service.state).toEqual({
+      accountReadiness: {
+        venueId: KALSHI_VENUE_ID,
+        status: 'ready',
+      },
+      requestStatus: 'success',
+    });
+    service.destroy();
+  });
+
+  it('invalidates readiness when authentication changes during the account request', async () => {
+    const rootMessenger: RootMessenger = new Messenger({
+      namespace: MOCK_ANY_NAMESPACE,
+    });
+    const messenger = getPredictSessionServiceMessenger(rootMessenger);
+    const service = new PredictSessionService({
+      messenger,
+      account: {
+        fetchAccountReadiness: jest.fn().mockImplementation(async () => {
+          rootMessenger.publish(
+            'AuthenticationController:stateChange',
+            { isSignedIn: false },
+            [],
+          );
+          return { venueId: KALSHI_VENUE_ID, status: 'ready' };
+        }),
+      },
+      authenticate: async () => undefined,
+      venueId: KALSHI_VENUE_ID,
+    });
+
+    await service.refreshAccountReadiness(KALSHI_VENUE_ID);
+
+    expect(service.state).toEqual({
+      accountReadiness: null,
+      requestStatus: 'idle',
+    });
+    service.destroy();
+  });
+
+  it('removes authentication and lock subscriptions on destroy', () => {
+    const rootMessenger: RootMessenger = new Messenger({
+      namespace: MOCK_ANY_NAMESPACE,
+    });
+    const messenger = getPredictSessionServiceMessenger(rootMessenger);
+    const service = new PredictSessionService({
+      messenger,
+      authenticate: async () => undefined,
+      venueId: KALSHI_VENUE_ID,
+    });
+    const clearReadinessSpy = jest.spyOn(service, 'clearAccountReadiness');
+    service.destroy();
+    clearReadinessSpy.mockClear();
+
+    rootMessenger.publish(
+      'AuthenticationController:stateChange',
+      { isSignedIn: false },
+      [],
+    );
+    rootMessenger.publish('KeyringController:lock');
+
+    expect(clearReadinessSpy).not.toHaveBeenCalled();
+  });
+});

--- a/app/core/Engine/messengers/predict-session-service-messenger.ts
+++ b/app/core/Engine/messengers/predict-session-service-messenger.ts
@@ -1,0 +1,29 @@
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import type { PredictSessionServiceMessenger } from '../../../components/UI/PredictNext/services/PredictSessionService';
+import type { RootMessenger } from '../types';
+
+export const getPredictSessionServiceMessenger = (
+  rootMessenger: RootMessenger,
+): PredictSessionServiceMessenger => {
+  const messenger = new Messenger<
+    'PredictSessionService',
+    MessengerActions<PredictSessionServiceMessenger>,
+    MessengerEvents<PredictSessionServiceMessenger>,
+    RootMessenger
+  >({
+    namespace: 'PredictSessionService',
+    parent: rootMessenger,
+  });
+
+  rootMessenger.delegate({
+    messenger,
+    actions: ['AuthenticationController:getBearerToken'],
+    events: ['AuthenticationController:stateChange', 'KeyringController:lock'],
+  });
+
+  return messenger;
+};

--- a/app/core/Engine/types.ts
+++ b/app/core/Engine/types.ts
@@ -363,6 +363,12 @@ import type {
   PredictMarketDataServiceActions,
   PredictMarketDataServiceEvents,
 } from '../../components/UI/PredictNext/services/PredictMarketDataService';
+import {
+  PredictSessionService,
+  type PredictSessionServiceActions,
+  type PredictSessionServiceEvents,
+  type PredictSessionServiceState,
+} from '../../components/UI/PredictNext/services/PredictSessionService';
 import type {
   CardControllerState,
   CardControllerActions,
@@ -633,6 +639,7 @@ export type GlobalActions =
   | PerpsControllerActions
   | PredictControllerActions
   | PredictMarketDataServiceActions
+  | PredictSessionServiceActions
   | CardControllerActions
   | QrSyncControllerActions
   | QrSyncProvisioningServiceActions
@@ -734,6 +741,7 @@ export type GlobalEvents =
   | PerpsControllerEvents
   | PredictControllerEvents
   | PredictMarketDataServiceEvents
+  | PredictSessionServiceEvents
   | CardControllerEvents
   | QrSyncControllerEvents
   | ClientControllerEvents
@@ -881,6 +889,7 @@ export type MessengerClients = {
   PerpsController: PerpsController;
   PredictController: PredictController;
   PredictNextController: PredictNextController;
+  PredictSessionService: PredictSessionService;
   CardController: CardController;
   QrSyncController: QrSyncController;
   QrSyncProvisioningService: QrSyncProvisioningService;
@@ -975,6 +984,7 @@ export type EngineState = {
   GeolocationController: GeolocationControllerState;
   PerpsController: PerpsControllerState;
   PredictController: PredictControllerState;
+  PredictSessionService: PredictSessionServiceState;
   CardController: CardControllerState;
   QrSyncController: QrSyncControllerState;
   ClientController: ClientControllerState;
@@ -1080,6 +1090,7 @@ export type MessengerClientsToInitialize =
   | 'PerpsController'
   | 'PredictController'
   | 'PredictNextController'
+  | 'PredictSessionService'
   | 'CardController'
   | 'QrSyncController'
   | 'QrSyncProvisioningService'

--- a/app/core/EngineService/EngineService.test.ts
+++ b/app/core/EngineService/EngineService.test.ts
@@ -60,6 +60,7 @@ jest.mock('../Engine/constants', () => ({
     'KeyringController:stateChange',
     'PreferencesController:stateChange',
     'NetworkController:stateChange',
+    'PredictSessionService:stateChange',
   ],
 }));
 
@@ -165,6 +166,7 @@ jest.mock('../Engine', () => {
           SignatureController: { subscribe: jest.fn() },
           MultichainBalancesController: { subscribe: jest.fn() },
           RatesController: { subscribe: jest.fn() },
+          PredictSessionService: { subscribe: jest.fn() },
         },
       };
       return mockInstance;
@@ -559,6 +561,28 @@ describe('EngineService', () => {
       );
     });
 
+    it('flushes Account Readiness updates immediately', async () => {
+      await engineService.start();
+      const mockSubscribe = (
+        Engine as unknown as {
+          controllerMessenger: MockControllerMessenger;
+        }
+      ).controllerMessenger.subscribe;
+      const readinessSubscription = mockSubscribe.mock.calls.find(
+        (call: unknown[]) =>
+          call[0] === 'PredictSessionService:stateChange' && call.length === 2,
+      );
+      expect(readinessSubscription).toBeDefined();
+
+      const callback = readinessSubscription?.[1] as () => void;
+      callback();
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: UPDATE_BG_STATE_KEY,
+        payload: { key: 'PredictSessionService' },
+      });
+    });
+
     it('skips CronjobController events', async () => {
       // Types for Engine mock
       interface MockEngineType {
@@ -732,7 +756,7 @@ describe('EngineService', () => {
       // Should subscribe to controllers that have persistent state
       // Based on the mock setup: KeyringController, PreferencesController, NetworkController
       // (KeyringController appears twice due to test setup)
-      expect(mockSubscribe).toHaveBeenCalledTimes(4);
+      expect(mockSubscribe).toHaveBeenCalledTimes(5);
 
       // Should NOT subscribe to CronjobController
       const subscribedEvents = (mockSubscribe as jest.Mock).mock.calls.map(
@@ -771,7 +795,7 @@ describe('EngineService', () => {
       );
 
       // Should only subscribe to controllers with persistent state
-      expect(mockSubscribe).toHaveBeenCalledTimes(4); // KeyringController (2x), PreferencesController, NetworkController
+      expect(mockSubscribe).toHaveBeenCalledTimes(5); // KeyringController (2x), PreferencesController, NetworkController, PredictSessionService
     });
 
     it('persists controller state changes to filesystem', async () => {

--- a/app/core/EngineService/EngineService.ts
+++ b/app/core/EngineService/EngineService.ts
@@ -91,7 +91,10 @@ export class EngineService {
       }
       this.updateBatcher.add(controllerName);
 
-      if (controllerName === 'ApprovalController') {
+      if (
+        controllerName === 'ApprovalController' ||
+        controllerName === 'PredictSessionService'
+      ) {
         this.updateBatcher.flush();
       }
     };

--- a/app/util/logs/index.test.ts
+++ b/app/util/logs/index.test.ts
@@ -142,6 +142,13 @@ describe('logs :: generateStateLogs', () => {
           DeFiPositionsController: { positions: [] },
           DeFiPositionsControllerV2: { positions: [] },
           PredictController: { predictions: [] },
+          PredictSessionService: {
+            accountReadiness: {
+              venueId: 'kalshi',
+              status: 'ready',
+            },
+            requestStatus: 'success',
+          },
           KeyringController: {
             vault: 'vault mock',
           },
@@ -160,6 +167,7 @@ describe('logs :: generateStateLogs', () => {
     expect(logs.includes('DeFiPositionsController')).toBe(false);
     expect(logs.includes('DeFiPositionsControllerV2')).toBe(false);
     expect(logs.includes('PredictController')).toBe(false);
+    expect(logs.includes('PredictSessionService')).toBe(false);
     expect(logs.includes("vault: 'vault mock'")).toBe(false);
   });
 

--- a/app/util/logs/index.ts
+++ b/app/util/logs/index.ts
@@ -90,6 +90,7 @@ export const generateStateLogs = (state: any, loggedIn = true): string => {
   delete fullState.engine.backgroundState.DeFiPositionsController;
   delete fullState.engine.backgroundState.DeFiPositionsControllerV2;
   delete fullState.engine.backgroundState.PredictController;
+  delete fullState.engine.backgroundState.PredictSessionService;
 
   // Strip cardHomeData to avoid leaking user PII (wallet addresses, holder names)
   delete fullState.engine.backgroundState.CardController?.cardHomeData;

--- a/tests/component-view/presets/predictNext.ts
+++ b/tests/component-view/presets/predictNext.ts
@@ -5,6 +5,16 @@ export const initialStatePredictNext = () =>
     .withMinimalAccounts()
     .withMinimalMainnetNetwork()
     .withMinimalKeyringController()
+    .withOverrides({
+      engine: {
+        backgroundState: {
+          PredictSessionService: {
+            accountReadiness: null,
+            requestStatus: 'idle',
+          },
+        },
+      },
+    })
     .withRemoteFeatureFlags({
       predictTradingEnabled: {
         enabled: true,

--- a/tests/component-view/renderers/predictNext.ts
+++ b/tests/component-view/renderers/predictNext.ts
@@ -5,8 +5,10 @@ import { initialStatePredictNext } from '../presets/predictNext';
 import { PredictHome } from '../../../app/components/UI/PredictNext/views/PredictHome/PredictHome';
 import { PredictEventDetail } from '../../../app/components/UI/PredictNext/views/PredictEventDetail/PredictEventDetail';
 import { PredictNextRoutes } from '../../../app/components/UI/PredictNext/navigation/routes';
+import type { DeepPartial } from '../../../app/util/test/renderWithProvider';
+import type { RootState } from '../../../app/reducers';
 
-export const renderPredictNext = () =>
+export const renderPredictNext = (overrides?: DeepPartial<RootState>) =>
   renderScreenWithRoutes(
     PredictHome as unknown as React.ComponentType,
     { name: PredictNextRoutes.HOME },
@@ -16,5 +18,9 @@ export const renderPredictNext = () =>
         Component: PredictEventDetail as unknown as React.ComponentType<object>,
       },
     ],
-    { state: initialStatePredictNext().build() },
+    {
+      state: overrides
+        ? initialStatePredictNext().withOverrides(overrides).build()
+        : initialStatePredictNext().build(),
+    },
   );

--- a/tests/integration/AGENTS.md
+++ b/tests/integration/AGENTS.md
@@ -37,10 +37,10 @@ Agent index for **integration tests** (`app/**/*.integration.test.ts`). Jest tes
 
 ### PredictNext — [`harnesses/predict-next.ts`](harnesses/predict-next.ts)
 
-- **Real:** `PredictNextController`, `PredictMarketDataService`, `KalshiRemoteAdapter`, `PredictApiReadClient`, and controller/service messengers
-- **Mocked:** HTTP fetch and app-shell base URL/client version configuration
+- **Real:** `PredictNextController`, `PredictMarketDataService`, `PredictSessionService`, `KalshiRemoteAdapter`, Predict API clients, and controller/service messengers
+- **Mocked:** HTTP fetch, required-auth token retrieval, and app-shell base URL/client version configuration
 - **Factory:** `buildPredictNextIntegrationHarness(responder)`
-- **Returns:** `{ controller, messenger, fetchMock, destroy }`
+- **Returns:** `{ controller, messenger, sessionService, sessionMessenger, fetchMock, destroy }`
 
 ---
 

--- a/tests/integration/harnesses/predict-next.ts
+++ b/tests/integration/harnesses/predict-next.ts
@@ -8,13 +8,22 @@ import type {
   PredictMarketDataServiceActions,
   PredictMarketDataServiceEvents,
 } from '../../../app/components/UI/PredictNext/services/PredictMarketDataService';
+import { KalshiRemoteAdapter } from '../../../app/components/UI/PredictNext/adapters/remote/KalshiRemoteAdapter';
+import { PredictApiAccountClient } from '../../../app/components/UI/PredictNext/adapters/remote/PredictApiAccountClient';
+import { PredictApiReadClient } from '../../../app/components/UI/PredictNext/adapters/remote/PredictApiReadClient';
+import {
+  PredictSessionService,
+  type PredictSessionServiceActions,
+  type PredictSessionServiceEvents,
+  type PredictSessionServiceMessenger,
+} from '../../../app/components/UI/PredictNext/services/PredictSessionService';
 
 /**
  * PredictNext integration-test harness.
  *
- * REAL: PredictNextController, PredictMarketDataService, KalshiRemoteAdapter,
- * PredictApiReadClient, and the public service messenger namespace.
- * MOCKED: HTTP fetch and app-shell base URL/client version configuration.
+ * REAL: PredictNextController, PredictMarketDataService, PredictSessionService,
+ * KalshiRemoteAdapter, Predict API clients, and service messengers.
+ * MOCKED: HTTP fetch, required-auth token retrieval, and app-shell configuration.
  */
 
 export interface PredictFetchResult {
@@ -30,6 +39,8 @@ export type PredictFetchResponder = (
 export interface PredictNextIntegrationHarness {
   controller: PredictNextController;
   messenger: PredictNextControllerMessenger;
+  sessionService: PredictSessionService;
+  sessionMessenger: PredictSessionServiceMessenger;
   fetchMock: jest.MockedFunction<typeof fetch>;
   destroy: () => void;
 }
@@ -52,9 +63,32 @@ export const buildPredictNextIntegrationHarness = (
   const fetchMock = jest.fn(async (input, init) =>
     jsonResponse(await responder(String(input), init)),
   ) as jest.MockedFunction<typeof fetch>;
+  const sessionMessenger = new Messenger<
+    'PredictSessionService',
+    PredictSessionServiceActions,
+    PredictSessionServiceEvents
+  >({ namespace: 'PredictSessionService' });
+  const readClient = new PredictApiReadClient({
+    baseUrl: 'https://predict.example/predict/',
+    clientVersion: '1.0.0',
+    fetch: fetchMock,
+  });
+  const accountClient = new PredictApiAccountClient({
+    baseUrl: 'https://predict.example/predict/',
+    clientVersion: '1.0.0',
+    getBearerToken: async () => 'integration-token',
+    fetch: fetchMock,
+  });
+  const adapter = new KalshiRemoteAdapter(readClient, accountClient);
+  const sessionService = new PredictSessionService({
+    messenger: sessionMessenger,
+    account: adapter.account,
+    authenticate: async () => undefined,
+    venueId: adapter.venueId,
+  });
   const controller = new PredictNextController({
     messenger,
-    baseUrl: 'https://predict.example/',
+    baseUrl: 'https://predict.example/predict/',
     clientVersion: '1.0.0',
     fetch: fetchMock,
     policyOptions: {
@@ -68,7 +102,12 @@ export const buildPredictNextIntegrationHarness = (
   return {
     controller,
     messenger,
+    sessionService,
+    sessionMessenger,
     fetchMock,
-    destroy: () => controller.destroy(),
+    destroy: () => {
+      sessionService.destroy();
+      controller.destroy();
+    },
   };
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Adds the mobile Account Readiness slice for the Kalshi-first PredictNext experience. The app can now make the required-auth `GET /predict/v1/venues/kalshi/account/readiness` request and project whether the authenticated Predict User requires Venue Account setup or is ready to trade.

This change:

- Adds canonical Account Readiness types and runtime response validation.
- Adds a required-bearer-token account transport without sending user, wallet, or Venue Account identifiers from mobile.
- Extends the Kalshi remote adapter with the account capability.
- Adds `PredictSessionService` as runtime-only Engine state with fail-closed `canSetup` and `canTrade` selectors.
- Refreshes readiness when Predict Home mounts and cancels the request when the view unmounts.
- Shows a disabled `Set up your account` CTA for `setup_required`. The CTA remains disabled because Account Setup is outside this ticket.
- Invalidates readiness on authentication changes, wallet lock, Engine reset, cancellation, and stale concurrent responses.
- Excludes readiness from persistence, state logs, exported logs, and debug snapshots.

The implementation is backend-ready, but live end-to-end behavior remains dependent on the authenticated readiness endpoint and the future Account Setup workflow.

Verification completed:

- PredictNext unit tests: 96 passed.
- Readiness and messenger hardening tests: 16 passed.
- Predict Home component-view tests: 11 passed.
- PredictNext integration tests: 10 passed.
- EngineService tests: 30 passed.
- `yarn lint:tsc`, focused ESLint, Prettier, and `git diff --check` passed.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Added account readiness checks to the Kalshi prediction markets experience

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-1176

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A: The live authenticated Account Readiness endpoint and Account Setup workflow are not available for end-to-end manual testing yet. The transport, runtime contract, Engine lifecycle, fail-closed selectors, UI states, cancellation, persistence exclusion, and log exclusion are covered by unit, integration, and component-view tests listed above.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A: The only new UI is a deliberately disabled setup CTA gated by readiness fixture state; the live backend and destination Account Setup workflow are not available for a representative recording.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A: No performance-sensitive rendering or native behavior is introduced; behavior is covered by component-view tests.
- [x] I've tested with a power user scenario
  - N/A: Readiness is one authenticated scalar response and does not vary with account or token count.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A: This safe read does not introduce a performance-critical workflow requiring a new trace.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.