### PR TITLE
feat: show NeoBank sandbox deposit success toast from Iron events

### DIFF
--- a/app/components/UI/Money/hooks/useNeobankSandboxDepositEvents.test.ts
+++ b/app/components/UI/Money/hooks/useNeobankSandboxDepositEvents.test.ts
@@ -1,0 +1,224 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
+import Engine from '../../../../core/Engine';
+import ToastService from '../../../../core/ToastService/ToastService';
+import { selectMoneyMovementBrazilNeobankEnabled } from '../../../../selectors/featureFlagController/moneyAccount';
+import { selectKycControllerState } from '../../../../selectors/kycController';
+import { getSessionProfileId } from '../../../../util/notifications/utils/get-session-profile-id';
+import { DEMO_NEOBANK_CUSTOMER_ID } from '../utils/neobankEvents';
+import { useNeobankSandboxDepositEvents } from './useNeobankSandboxDepositEvents';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../core/ToastService/ToastService', () => ({
+  showToast: jest.fn(),
+}));
+
+jest.mock('../../../../selectors/kycController', () => ({
+  selectKycControllerState: jest.fn(),
+}));
+
+jest.mock('../../../../selectors/featureFlagController/moneyAccount', () => ({
+  selectMoneyMovementBrazilNeobankEnabled: jest.fn(),
+}));
+
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    NeoBankService: {
+      getCustomerByExternalId: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../../../util/notifications/utils/get-session-profile-id', () => ({
+  getSessionProfileId: jest.fn(),
+}));
+
+const useSelectorMock = jest.mocked(useSelector);
+const showToastMock = jest.mocked(ToastService.showToast);
+const getSessionProfileIdMock = jest.mocked(getSessionProfileId);
+const getCustomerByExternalIdMock = jest.mocked(
+  Engine.context.NeoBankService.getCustomerByExternalId,
+);
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  readonly url: string;
+
+  onmessage?: (event: { data: string }) => void;
+
+  onerror?: () => void;
+
+  onclose?: () => void;
+
+  close = jest.fn();
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+}
+
+function mockSelectors(kycState: {
+  activeVendor?: string;
+  moonpayCustomerId?: string | null;
+}) {
+  // Re-renders after the async customer lookup call useSelector again, so the
+  // mock must stay stable across the whole hook lifetime.
+  useSelectorMock.mockImplementation((selector) => {
+    if (selector === selectMoneyMovementBrazilNeobankEnabled) {
+      return true;
+    }
+    if (selector === selectKycControllerState) {
+      return kycState;
+    }
+    return undefined;
+  });
+}
+
+describe('useNeobankSandboxDepositEvents', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MockWebSocket.instances = [];
+    global.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+    delete process.env.NEOBANK_DEMO_CUSTOMER_ID;
+    getSessionProfileIdMock.mockResolvedValue(undefined);
+    getCustomerByExternalIdMock.mockResolvedValue(null);
+  });
+
+  it('shows success for Completed without calling a vault action', async () => {
+    mockSelectors({ activeVendor: 'iron', moonpayCustomerId: 'customer-1' });
+    renderHook(() => useNeobankSandboxDepositEvents());
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances[0]?.url).toContain('userId=customer-1');
+    });
+
+    const socket = MockWebSocket.instances[0];
+
+    act(() => {
+      socket.onmessage?.({
+        data: JSON.stringify({
+          eventId: 'event-1',
+          type: 'transaction_status',
+          payload: {
+            data: {
+              message: {
+                TransactionStatus: {
+                  id: 'sandbox-uuid',
+                  transaction_status: 'Completed',
+                },
+              },
+            },
+          },
+        }),
+      });
+    });
+
+    expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        labelOptions: [
+          expect.objectContaining({ label: 'Deposit successful' }),
+        ],
+      }),
+    );
+    expect(getCustomerByExternalIdMock).not.toHaveBeenCalled();
+  });
+
+  it('prefers the real moonpayCustomerId over lookup and demo fallback', async () => {
+    mockSelectors({ activeVendor: 'iron', moonpayCustomerId: 'real-customer' });
+    renderHook(() => useNeobankSandboxDepositEvents());
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances[0]?.url).toContain('userId=real-customer');
+    });
+
+    expect(MockWebSocket.instances[0].url).not.toContain(
+      DEMO_NEOBANK_CUSTOMER_ID,
+    );
+    expect(getCustomerByExternalIdMock).not.toHaveBeenCalled();
+  });
+
+  it('uses the looked-up Iron customer id when moonpayCustomerId is unset', async () => {
+    mockSelectors({ activeVendor: 'iron', moonpayCustomerId: null });
+    getSessionProfileIdMock.mockResolvedValue('profile-1');
+    getCustomerByExternalIdMock.mockResolvedValue({
+      id: 'looked-up-customer',
+      external_id: 'profile-1',
+    });
+
+    renderHook(() => useNeobankSandboxDepositEvents());
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances[0]?.url).toContain(
+        'userId=looked-up-customer',
+      );
+    });
+
+    expect(getCustomerByExternalIdMock).toHaveBeenCalledWith('profile-1');
+    expect(MockWebSocket.instances[0].url).not.toContain(
+      DEMO_NEOBANK_CUSTOMER_ID,
+    );
+  });
+
+  it('falls back to the demo customer id when lookup fails', async () => {
+    mockSelectors({ activeVendor: 'iron', moonpayCustomerId: null });
+    getSessionProfileIdMock.mockResolvedValue('profile-1');
+    getCustomerByExternalIdMock.mockRejectedValue(new Error('network'));
+
+    renderHook(() => useNeobankSandboxDepositEvents());
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances[0]?.url).toContain(
+        `userId=${DEMO_NEOBANK_CUSTOMER_ID}`,
+      );
+    });
+  });
+
+  it('falls back to the demo customer id when lookup returns nothing', async () => {
+    mockSelectors({ activeVendor: 'iron', moonpayCustomerId: null });
+    getSessionProfileIdMock.mockResolvedValue(undefined);
+
+    renderHook(() => useNeobankSandboxDepositEvents());
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances[0]?.url).toContain(
+        `userId=${DEMO_NEOBANK_CUSTOMER_ID}`,
+      );
+    });
+
+    expect(getCustomerByExternalIdMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores duplicate Completed events', async () => {
+    mockSelectors({ activeVendor: 'iron', moonpayCustomerId: 'customer-1' });
+    renderHook(() => useNeobankSandboxDepositEvents());
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances[0]).toBeDefined();
+    });
+
+    const socket = MockWebSocket.instances[0];
+    const data = JSON.stringify({
+      eventId: 'event-1',
+      type: 'transaction_status',
+      payload: {
+        data: {
+          message: {
+            TransactionStatus: { transaction_status: 'Completed' },
+          },
+        },
+      },
+    });
+
+    act(() => {
+      socket.onmessage?.({ data });
+      socket.onmessage?.({ data });
+    });
+
+    expect(showToastMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/UI/Money/hooks/useNeobankSandboxDepositEvents.ts
+++ b/app/components/UI/Money/hooks/useNeobankSandboxDepositEvents.ts
@@ -1,0 +1,169 @@
+import { useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { IconName } from '../../../../component-library/components/Icons/Icon';
+import { ToastVariants } from '../../../../component-library/components/Toast';
+import Engine from '../../../../core/Engine';
+import ToastService from '../../../../core/ToastService/ToastService';
+import Logger from '../../../../util/Logger';
+import { getSessionProfileId } from '../../../../util/notifications/utils/get-session-profile-id';
+import { selectKycControllerState } from '../../../../selectors/kycController';
+import { selectMoneyMovementBrazilNeobankEnabled } from '../../../../selectors/featureFlagController/moneyAccount';
+import { strings } from '../../../../../locales/i18n';
+import {
+  getNeobankEventsUrl,
+  isCompletedNeobankDeposit,
+  parseNeobankEvent,
+  readNeobankCustomerId,
+  resolveNeobankDemoCustomerId,
+} from '../utils/neobankEvents';
+
+const RECONNECT_DELAY_MS = 3_000;
+
+/**
+ * Listens for the Iron sandbox deposit event used by the NeoBank demo.
+ *
+ * A sandbox `Completed` event proves the partner webhook and Mobile WebSocket
+ * path, but it does not represent a Monad transfer. This hook intentionally
+ * renders UI success without calling `submitMoneyAccountVaultDeposit`.
+ */
+export function useNeobankSandboxDepositEvents(): void {
+  const neobankEnabled = useSelector(
+    selectMoneyMovementBrazilNeobankEnabled,
+  );
+  const kycState = useSelector(selectKycControllerState);
+  const handledEventIds = useRef(new Set<string>());
+  const [lookedUpCustomerId, setLookedUpCustomerId] = useState<
+    string | null | undefined
+  >(undefined);
+
+  const isIronVendor = kycState.activeVendor === 'iron';
+  const persistedCustomerId = kycState.moonpayCustomerId;
+
+  // When Iron has no persisted customer id, resolve it once via the signed-in
+  // profile id (Iron `external_id`) through NeoBankService. Failures fall
+  // through to the demo constant so the sandbox toast still works.
+  useEffect(() => {
+    if (!neobankEnabled || !isIronVendor || persistedCustomerId) {
+      setLookedUpCustomerId(undefined);
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    const lookup = async () => {
+      try {
+        const profileId = await getSessionProfileId();
+        if (!profileId) {
+          if (!cancelled) {
+            setLookedUpCustomerId(null);
+          }
+          return;
+        }
+
+        const customer =
+          await Engine.context.NeoBankService.getCustomerByExternalId(
+            profileId,
+          );
+        const resolved = readNeobankCustomerId(customer);
+        if (!cancelled) {
+          setLookedUpCustomerId(resolved);
+        }
+      } catch (error) {
+        Logger.log('NeoBank demo customer lookup failed', error);
+        if (!cancelled) {
+          setLookedUpCustomerId(null);
+        }
+      }
+    };
+
+    lookup();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [neobankEnabled, isIronVendor, persistedCustomerId]);
+
+  // Only the Iron vendor path drives the sandbox demo. Wait for the async
+  // lookup to settle before opening the socket so we do not connect with the
+  // demo fallback and then reconnect with the real id.
+  const customerId = (() => {
+    if (!isIronVendor) {
+      return null;
+    }
+    if (persistedCustomerId) {
+      return persistedCustomerId;
+    }
+    if (lookedUpCustomerId === undefined) {
+      return null;
+    }
+    return resolveNeobankDemoCustomerId(null, lookedUpCustomerId);
+  })();
+
+  useEffect(() => {
+    if (!neobankEnabled || !customerId) {
+      return undefined;
+    }
+
+    let disposed = false;
+    let reconnectTimeout: ReturnType<typeof setTimeout> | undefined;
+    let socket: WebSocket | undefined;
+
+    const connect = () => {
+      if (disposed) {
+        return;
+      }
+
+      socket = new WebSocket(getNeobankEventsUrl(customerId));
+
+      socket.onmessage = (message) => {
+        const event = parseNeobankEvent(message.data);
+        if (!event || !isCompletedNeobankDeposit(event)) {
+          return;
+        }
+
+        if (event.eventId && handledEventIds.current.has(event.eventId)) {
+          return;
+        }
+        if (event.eventId) {
+          handledEventIds.current.add(event.eventId);
+        }
+
+        // Sandbox fiat and crypto are simulated. Do not pass the Iron UUID or
+        // its synthetic payout data to Core; there is no Monad receipt to vault.
+        ToastService.showToast({
+          variant: ToastVariants.Icon,
+          iconName: IconName.Confirmation,
+          labelOptions: [
+            {
+              label: strings(
+                'virtual_bank_account.deposit_demo.success_toast',
+              ),
+              isBold: true,
+            },
+          ],
+          hasNoTimeout: false,
+        });
+      };
+
+      socket.onerror = () => {
+        Logger.log('NeoBank demo WebSocket connection failed');
+      };
+
+      socket.onclose = () => {
+        if (!disposed) {
+          reconnectTimeout = setTimeout(connect, RECONNECT_DELAY_MS);
+        }
+      };
+    };
+
+    connect();
+
+    return () => {
+      disposed = true;
+      if (reconnectTimeout) {
+        clearTimeout(reconnectTimeout);
+      }
+      socket?.close();
+    };
+  }, [customerId, neobankEnabled]);
+}

--- a/app/components/UI/Money/routes/index.tsx
+++ b/app/components/UI/Money/routes/index.tsx
@@ -20,6 +20,7 @@ import MoneyEarnCryptoInfoSheet from '../components/MoneyEarnCryptoInfoSheet';
 import { Confirm } from '../../../Views/confirmations/components/confirm';
 import { useEmptyNavHeaderForConfirmations } from '../../../Views/confirmations/hooks/ui/useEmptyNavHeaderForConfirmations';
 import { useUpgradeMoneyAccountOnFocus } from '../hooks/useUpgradeMoneyAccountOnFocus';
+import { useNeobankSandboxDepositEvents } from '../hooks/useNeobankSandboxDepositEvents';
 import MoneyGeoBlockSheet from '../components/MoneyGeoBlockSheet/MoneyGeoBlockSheet';
 import type {
   MoneyConfirmationsNavigationParamList,
@@ -37,6 +38,7 @@ const MoneyTabScreenStack = () => {
   const { colors } = useTheme();
 
   useUpgradeMoneyAccountOnFocus();
+  useNeobankSandboxDepositEvents();
 
   return (
     <TabStack.Navigator

--- a/app/components/UI/Money/utils/neobankEvents.test.ts
+++ b/app/components/UI/Money/utils/neobankEvents.test.ts
@@ -1,0 +1,119 @@
+import {
+  DEMO_NEOBANK_CUSTOMER_ID,
+  getNeobankEventsUrl,
+  isCompletedNeobankDeposit,
+  parseNeobankEvent,
+  readNeobankCustomerId,
+  resolveNeobankDemoCustomerId,
+} from './neobankEvents';
+
+describe('neobankEvents', () => {
+  const completedEvent = {
+    eventId: 'event-1',
+    type: 'transaction_status',
+    payload: {
+      data: {
+        message: {
+          TransactionStatus: {
+            id: 'iron-sandbox-uuid',
+            transaction_status: 'Completed',
+          },
+        },
+      },
+    },
+  };
+
+  describe('parseNeobankEvent', () => {
+    it('parses a valid event', () => {
+      expect(parseNeobankEvent(JSON.stringify(completedEvent))).toStrictEqual(
+        completedEvent,
+      );
+    });
+
+    it.each([undefined, null, 1, '{invalid'])(
+      'returns null for malformed data: %p',
+      (value) => {
+        expect(parseNeobankEvent(value)).toBeNull();
+      },
+    );
+  });
+
+  describe('isCompletedNeobankDeposit', () => {
+    it('accepts a Completed transaction status event', () => {
+      expect(isCompletedNeobankDeposit(completedEvent)).toBe(true);
+    });
+
+    it('rejects non-completed and unrelated events', () => {
+      expect(
+        isCompletedNeobankDeposit({
+          ...completedEvent,
+          type: 'customer_status',
+        }),
+      ).toBe(false);
+      expect(
+        isCompletedNeobankDeposit({
+          ...completedEvent,
+          payload: {
+            data: {
+              message: {
+                TransactionStatus: {
+                  transaction_status: 'PayoutInProgress',
+                },
+              },
+            },
+          },
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('readNeobankCustomerId', () => {
+    it('reads id from a proxy customer payload', () => {
+      expect(
+        readNeobankCustomerId({ id: 'cust-1', external_id: 'ext-1' }),
+      ).toBe('cust-1');
+    });
+
+    it.each([null, undefined, {}, { id: '' }, { id: 1 }])(
+      'returns null for %p',
+      (value) => {
+        expect(readNeobankCustomerId(value)).toBeNull();
+      },
+    );
+  });
+
+  describe('resolveNeobankDemoCustomerId', () => {
+    it('prefers the persisted moonpay customer id', () => {
+      expect(
+        resolveNeobankDemoCustomerId('real-customer', 'looked-up'),
+      ).toBe('real-customer');
+    });
+
+    it('prefers the looked-up id when moonpayCustomerId is unset', () => {
+      expect(resolveNeobankDemoCustomerId(null, 'looked-up')).toBe(
+        'looked-up',
+      );
+    });
+
+    // The `NEOBANK_DEMO_CUSTOMER_ID` env override is inlined by Babel's
+    // `transform-inline-environment-variables` at transform time, so a runtime
+    // override cannot be exercised here. When it is unset (the common case,
+    // including George's demo build), the resolver returns the hardcoded id.
+    it.each([null, undefined, ''])(
+      'falls back to the demo id when moonpayCustomerId is %p and lookup is empty',
+      (value) => {
+        expect(resolveNeobankDemoCustomerId(value, null)).toBe(
+          DEMO_NEOBANK_CUSTOMER_ID,
+        );
+      },
+    );
+  });
+
+  describe('getNeobankEventsUrl', () => {
+    it('uses the dev proxy and safely encodes the customer id', () => {
+      expect(getNeobankEventsUrl('customer/a b')).toBe(
+        'wss://on-ramp.dev-api.cx.metamask.io/neobank/events?userId=customer%2Fa%20b',
+      );
+    });
+  });
+});

--- a/app/components/UI/Money/utils/neobankEvents.ts
+++ b/app/components/UI/Money/utils/neobankEvents.ts
@@ -1,0 +1,135 @@
+export interface NeobankEvent {
+  eventId?: string;
+  type?: string;
+  payload?: {
+    data?: {
+      message?: Record<string, unknown>;
+    };
+  };
+}
+
+interface TransactionStatusMessage {
+  transaction_status?: string;
+}
+
+/**
+ * Parses a NeoBank WebSocket payload without trusting the provider shape.
+ *
+ * @param value - Raw WebSocket message data.
+ * @returns A normalized event, or `null` for malformed data.
+ */
+export function parseNeobankEvent(value: unknown): NeobankEvent | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
+      return null;
+    }
+    return parsed as NeobankEvent;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns whether the event represents an Iron/MoonPay deposit completing.
+ *
+ * Sandbox completion is intentionally treated as UI success only. The caller
+ * must not pass the sandbox transaction id to the Core vault action because it
+ * is not a Monad transaction hash.
+ *
+ * @param event - Normalized NeoBank event.
+ * @returns Whether the transaction reached `Completed`.
+ */
+export function isCompletedNeobankDeposit(event: NeobankEvent): boolean {
+  if (event.type !== 'transaction_status') {
+    return false;
+  }
+
+  const message = event.payload?.data?.message;
+  if (!message) {
+    return false;
+  }
+
+  const status = message.TransactionStatus;
+  if (!status || Array.isArray(status) || typeof status !== 'object') {
+    return false;
+  }
+
+  return (
+    (status as TransactionStatusMessage).transaction_status === 'Completed'
+  );
+}
+
+/**
+ * Demo-only fallback Iron customer UUID for the NeoBank sandbox demo.
+ *
+ * `KycController.createIronCustomer` does not persist the returned Iron
+ * `customer.id`, so on the Iron KYC path `moonpayCustomerId` is often unset.
+ * Prefer looking the id up via `NeoBankService.getCustomerByExternalId` (profile
+ * id as Iron `external_id`). This UUID (ShaneTest, Approved/Active) is only the
+ * last resort so the socket still opens when lookup fails. It is only consulted
+ * while the neobank flag is on and the active vendor is Iron.
+ */
+export const DEMO_NEOBANK_CUSTOMER_ID =
+  '019ff69c-3039-77b0-9d5d-e4a3baefd7b7';
+
+/**
+ * Reads the Iron/MoonPay customer UUID from a neo-bank proxy customer payload.
+ *
+ * `NeoBankService.getCustomerByExternalId` returns proxy JSON shaped like
+ * `{ id, external_id, ... }`; the WebSocket routing key is `id`.
+ *
+ * @param customer - Parsed proxy response (or unknown failure value).
+ * @returns The customer UUID, or `null` when missing/malformed.
+ */
+export function readNeobankCustomerId(customer: unknown): string | null {
+  if (customer && typeof customer === 'object') {
+    const { id } = customer as { id?: unknown };
+    if (typeof id === 'string' && id.length > 0) {
+      return id;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolves the customer id used to route the demo NeoBank socket.
+ *
+ * Precedence: persisted `moonpayCustomerId`, then a looked-up Iron customer id
+ * (from `NeoBankService.getCustomerByExternalId`), then the
+ * `NEOBANK_DEMO_CUSTOMER_ID` env override / hardcoded {@link DEMO_NEOBANK_CUSTOMER_ID}.
+ *
+ * @param moonpayCustomerId - Persisted Iron/MoonPay customer id, if any.
+ * @param lookedUpCustomerId - Id fetched by profile/external id, if any.
+ * @returns The customer id to route the demo socket.
+ */
+export function resolveNeobankDemoCustomerId(
+  moonpayCustomerId: string | null | undefined,
+  lookedUpCustomerId?: string | null,
+): string {
+  if (moonpayCustomerId) {
+    return moonpayCustomerId;
+  }
+  if (lookedUpCustomerId) {
+    return lookedUpCustomerId;
+  }
+  return process.env.NEOBANK_DEMO_CUSTOMER_ID ?? DEMO_NEOBANK_CUSTOMER_ID;
+}
+
+/**
+ * Builds the dev NeoBank WebSocket URL for a MoonPay customer.
+ *
+ * @param customerId - MoonPay customer UUID used by the proxy as its routing key.
+ * @returns WebSocket URL for the demo proxy.
+ */
+export function getNeobankEventsUrl(customerId: string): string {
+  const baseUrl =
+    process.env.NEOBANK_WS_URL ??
+    'wss://on-ramp.dev-api.cx.metamask.io/neobank/events';
+  const separator = baseUrl.includes('?') ? '&' : '?';
+  return `${baseUrl}${separator}userId=${encodeURIComponent(customerId)}`;
+}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1165,6 +1165,9 @@
       "start_failed": "We couldn't start identity verification. Try again.",
       "verification_failed": "We couldn't verify your identity. Try again.",
       "wallet_registration_failed": "Identity verified, but we couldn't register your Money Account wallet. You can continue."
+    },
+    "deposit_demo": {
+      "success_toast": "Deposit successful"
     }
   },
   "social_leaderboard": {


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Isolated review PR for Shane's NeoBank sandbox deposit-toast work that already landed on the shared group demo branch `demo/vba-kyc`. This PR is **not** a merge path into `main` or `demo/vba-kyc`; its base is a snapshot branch so teammates can review only Shane's contribution as a clean diff.

**Why:** Iron/MoonPay sandbox deposits do not produce a Monad mUSD `Transfer` receipt, so `submitMoneyAccountVaultDeposit` cannot succeed against a sandbox payout. The vault path is a dead end for the demo.

**What:** A Money-tab hook listens to NeoBank/Iron sandbox events and shows a "Deposit successful" toast when a sandbox deposit completes, without calling the vault. Wiring is gated by the neobank feature flag and `activeVendor === 'iron'`.

**Customer id resolution precedence** for the socket subscription:
1. `moonpayCustomerId` when present
2. Iron customer id from `NeoBankService.getCustomerByExternalId`, using the signed-in MetaMask profile/canonical id as Iron `external_id`
3. Demo fallback constant `DEMO_NEOBANK_CUSTOMER_ID`

**Files:** `neobankEvents` helpers + tests, `useNeobankSandboxDepositEvents` hook + tests, one hook call in Money routes, and `virtual_bank_account.deposit_demo.success_toast` in `en.json`.

**Base/head strategy:** `saustrie/neobank-sandbox-deposit-toast-base` is `demo/vba-kyc` @ `c109228127` with only Shane's files reverted. Head re-applies the same final file tree. `demo/vba-kyc` was not modified.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: NeoBank / VBA sandbox demo on `demo/vba-kyc` (no standalone Jira ticket; review-only isolation of Shane's deposit-toast commits already present on the group demo branch).

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: NeoBank sandbox deposit success toast

  Scenario: user sees Deposit successful toast after Iron sandbox settlement
    Given the neobank feature flag is enabled
    And the active NeoBank vendor is iron
    And the Money tab is open so useNeobankSandboxDepositEvents is mounted

    When a sandbox transaction is settled on Iron autoramp 019ff87d-d37a-726c-b6b6-1af388fa9ab8
    And the customer id resolves to 019ff69c-3039-77b0-9d5d-e4a3baefd7b7
    Then the app shows a "Deposit successful" toast in the Money tab within about 2 seconds
    And no Money Account vault deposit transaction is submitted
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A - no toast capture attached for this review-isolation PR; toast was verified earlier on `demo/vba-kyc` @ `c109228127`.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)