### PR TITLE
ci: cache Foundry downloads for Appium smoke shards

### DIFF
--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -358,11 +358,18 @@ runs:
 
     - name: Install Foundry
       if: ${{ inputs.install-foundry == 'true' }}
-      shell: bash
-      run: |
-        echo "Installing Foundry via yarn install:foundryup (matches local dev and tests/seeder)..."
-        yarn install:foundryup
-        echo "$GITHUB_WORKSPACE/node_modules/.bin" >> "$GITHUB_PATH"
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 #v3.0.2
+      with:
+        timeout_minutes: 5
+        max_attempts: 3
+        retry_wait_seconds: 30
+        on_retry_command: |
+          echo "Foundry download failed; retrying after cleaning the partial cache..."
+          rm -rf .metamask/cache
+        command: |
+          echo "Installing Foundry via yarn install:foundryup (matches local dev and tests/seeder)..."
+          yarn install:foundryup
+          echo "$GITHUB_WORKSPACE/node_modules/.bin" >> "$GITHUB_PATH"
 
     ## iOS Setup ##
 

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .metamask
-          key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
+          key: .metamask-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package.json', 'yarn.lock') }}
 
       - name: Setup E2E environment (Android)
         if: ${{ inputs.platform == 'android' }}
@@ -132,7 +132,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: .metamask
-          key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
+          key: .metamask-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package.json', 'yarn.lock') }}
 
       - name: Cache ffmpeg (Homebrew)
         if: ${{ inputs.platform == 'ios' }}

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -85,6 +85,16 @@ jobs:
         uses: actions/checkout@v4
         if: ${{ inputs.runner_provider != 'namespace' }}
 
+      # Foundry's anvil binary is downloaded into .metamask by setup-e2e-env.
+      # Restore it before setup so every Appium shard can reuse the same
+      # immutable download instead of fetching it independently.
+      - name: Restore Foundry download cache
+        if: ${{ inputs.runner_provider != 'namespace' }}
+        uses: actions/cache/restore@v4
+        with:
+          path: .metamask
+          key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
+
       - name: Setup E2E environment (Android)
         if: ${{ inputs.platform == 'android' }}
         uses: ./.github/actions/setup-e2e-env

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -90,6 +90,7 @@ jobs:
       # immutable download instead of fetching it independently.
       - name: Restore Foundry download cache
         if: ${{ inputs.runner_provider != 'namespace' }}
+        id: foundry-cache
         uses: actions/cache/restore@v4
         with:
           path: .metamask
@@ -121,6 +122,17 @@ jobs:
           skip-pod-install: 'true'
           install-applesimutils: 'false'
           runner_provider: ${{ inputs.runner_provider }}
+
+      - name: Save Foundry download cache
+        if: >-
+          ${{
+            inputs.runner_provider != 'namespace' &&
+            steps.foundry-cache.outputs.cache-hit != 'true'
+          }}
+        uses: actions/cache/save@v4
+        with:
+          path: .metamask
+          key: .metamask-${{ hashFiles('package.json', 'yarn.lock') }}
 
       - name: Cache ffmpeg (Homebrew)
         if: ${{ inputs.platform == 'ios' }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- restore the `.metamask` Foundry download cache before Appium E2E setup
- save the cache after a successful Appium setup so the first Appium run can warm it
- retry transient Foundry downloads up to three times, cleaning partial cache state between attempts
- include runner OS and architecture in the cache key to prevent Linux/macOS or x64/arm64 binary collisions
- preserve existing per-runner isolation and smoke-test parallelism

## Testing
- `yarn prettier --check .github/actions/setup-e2e-env/action.yml .github/workflows/run-appium-e2e-workflow.yml`
- `git diff --check`

## Root cause addressed
The referenced job failed during `setup-e2e-env` because `foundryup` received `ECONNRESET` (`socket hang up`) while downloading `anvil` and the binary was not present in cache. The platform-specific key prevents one runner type from masking the cache miss for another.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-136bf98d-3d16-4446-a990-14d202ed85f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-136bf98d-3d16-4446-a990-14d202ed85f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

