### PR TITLE
feat(vba): auto register Money Account wallet and autoramp on KYC completion

### DIFF
--- a/app/components/UI/Ramp/Views/VirtualBankAccount/MockKycEmail.test.tsx
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/MockKycEmail.test.tsx
@@ -4,10 +4,7 @@ import { fireEvent, waitFor } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import MockKycEmail from './MockKycEmail';
 import { MockKycEmailSelectorsIDs } from './MockKycEmail.testIds';
-import {
-  registerSelectedMoneyAccountWallet,
-  startIronKycVerification,
-} from './ironKycFlow';
+import { startIronKycVerification } from './ironKycFlow';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -21,21 +18,13 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 jest.mock('./ironKycFlow');
-jest.mock('../../../../../util/Logger', () => ({
-  __esModule: true,
-  default: { error: jest.fn(), log: jest.fn() },
-}));
 
 const mockStartIronKycVerification = jest.mocked(startIronKycVerification);
-const mockRegisterSelectedMoneyAccountWallet = jest.mocked(
-  registerSelectedMoneyAccountWallet,
-);
 
 describe('MockKycEmail', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockStartIronKycVerification.mockResolvedValue(undefined);
-    mockRegisterSelectedMoneyAccountWallet.mockResolvedValue(undefined);
   });
 
   it('navigates back when the header back button is pressed', () => {
@@ -59,7 +48,6 @@ describe('MockKycEmail', () => {
       expect(mockStartIronKycVerification).toHaveBeenCalledWith(
         'user@example.com',
       );
-      expect(mockRegisterSelectedMoneyAccountWallet).toHaveBeenCalled();
       expect(mockNavigate).toHaveBeenCalledWith('RampVbaMockKycSuccess');
     });
   });
@@ -89,25 +77,6 @@ describe('MockKycEmail', () => {
         'Iron session failed: consents.',
       );
     });
-    expect(mockRegisterSelectedMoneyAccountWallet).not.toHaveBeenCalled();
     expect(mockNavigate).not.toHaveBeenCalled();
-  });
-
-  it('alerts but still navigates when wallet registration fails after KYC', async () => {
-    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation();
-    mockRegisterSelectedMoneyAccountWallet.mockRejectedValue(
-      new Error('Wallet registration failed.'),
-    );
-    const { getByTestId } = renderWithProvider(<MockKycEmail />);
-
-    fireEvent.press(getByTestId(MockKycEmailSelectorsIDs.CONTINUE_BUTTON));
-
-    await waitFor(() => {
-      expect(alertSpy).toHaveBeenCalledWith(
-        'Identity verification',
-        'Wallet registration failed.',
-      );
-      expect(mockNavigate).toHaveBeenCalledWith('RampVbaMockKycSuccess');
-    });
   });
 });

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/MockKycEmail.tsx
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/MockKycEmail.tsx
@@ -19,11 +19,7 @@ import type { AppNavigationProp } from '../../../../../core/NavigationService/ty
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
 import { MOCK_KYC_PREFILLED_EMAIL } from './constants';
-import {
-  registerSelectedMoneyAccountWallet,
-  startIronKycVerification,
-} from './ironKycFlow';
-import Logger from '../../../../../util/Logger';
+import { startIronKycVerification } from './ironKycFlow';
 import MockKycProgressBar from './MockKycProgressBar';
 import { MockKycEmailSelectorsIDs } from './MockKycEmail.testIds';
 
@@ -49,25 +45,9 @@ const MockKycEmail = () => {
     setIsVerifying(true);
     try {
       await startIronKycVerification(trimmedEmail);
-      try {
-        await registerSelectedMoneyAccountWallet();
-      } catch (registerError) {
-        // KYC already succeeded — soft-fail so the demo can continue.
-        Logger.error(
-          registerError instanceof Error
-            ? registerError
-            : new Error(String(registerError)),
-          { message: 'Money Account wallet registration failed after KYC' },
-        );
-        Alert.alert(
-          strings('virtual_bank_account.kyc_error.title'),
-          registerError instanceof Error
-            ? registerError.message
-            : strings(
-                'virtual_bank_account.kyc_error.wallet_registration_failed',
-              ),
-        );
-      }
+      // Wallet registration + autoramp now run off `KycController:statusChanged`
+      // (see registerMoneyAccountOnKycCompletion), so this screen only drives
+      // the SumSub hand-off and navigates on to the success screen.
       navigation.navigate(Routes.RAMP.VBA_MOCK_KYC_SUCCESS);
     } catch (error) {
       Alert.alert(

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/MockKycSuccess.tsx
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/MockKycSuccess.tsx
@@ -39,6 +39,7 @@ import {
   DEMO_AUTORAMP_DESTINATION_TOKEN,
   DEMO_AUTORAMP_SOURCE_CURRENCY_CODE,
 } from './constants';
+import { buildMoneyAccountAutorampParams } from './moneyAccountAutoramp';
 
 type StepId = 'identity' | 'customer' | 'autoramp' | 'live';
 
@@ -314,22 +315,9 @@ const MockKycSuccess = () => {
       });
 
       const account = await timed('autoramp', async () =>
-        Engine.context.RampsController.createAutoramp({
-          source_currencies: [
-            { type: 'Fiat', code: DEMO_AUTORAMP_SOURCE_CURRENCY_CODE },
-          ],
-          destination_currency: {
-            type: 'Crypto',
-            token: DEMO_AUTORAMP_DESTINATION_TOKEN,
-            blockchain: DEMO_AUTORAMP_DESTINATION_BLOCKCHAIN,
-          },
-          recipient_account: {
-            type: 'Crypto',
-            chain: DEMO_AUTORAMP_DESTINATION_BLOCKCHAIN,
-            address: walletAddress,
-          },
-          source_is_third_party: false,
-        }),
+        Engine.context.RampsController.createAutoramp(
+          buildMoneyAccountAutorampParams(walletAddress),
+        ),
       );
 
       if (!isMountedRef.current) {

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/ironKycFlow.test.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/ironKycFlow.test.ts
@@ -1,40 +1,22 @@
 import Engine from '../../../../../core/Engine';
-import {
-  registerSelectedMoneyAccountWallet,
-  startIronKycFlow,
-  startIronKycVerification,
-} from './ironKycFlow';
+import { startIronKycFlow, startIronKycVerification } from './ironKycFlow';
 
 jest.mock('../../../../../core/Engine', () => ({
   context: {
-    AccountsController: {
-      getSelectedAccount: jest.fn(),
-    },
     KycController: {
       state: { error: null, disclaimers: [] },
       initialize: jest.fn(),
       createIronCustomer: jest.fn(),
       acceptTermsAndStartSession: jest.fn(),
     },
-    RampsController: {
-      registerMoneyAccountWallet: jest.fn(),
-    },
   },
 }));
-
-const mockAccountsController = Engine.context.AccountsController as unknown as {
-  getSelectedAccount: jest.Mock;
-};
 
 const mockKycController = Engine.context.KycController as unknown as {
   state: { error: string | null; disclaimers: { id: string }[] };
   initialize: jest.Mock<Promise<void>, [unknown?]>;
   createIronCustomer: jest.Mock<Promise<void>, [unknown?]>;
   acceptTermsAndStartSession: jest.Mock<Promise<void>, [unknown?]>;
-};
-
-const mockRampsController = Engine.context.RampsController as unknown as {
-  registerMoneyAccountWallet: jest.Mock<Promise<unknown>, [unknown?]>;
 };
 
 const resetControllerState = ({
@@ -136,38 +118,5 @@ describe('startIronKycVerification', () => {
     await expect(startIronKycVerification('user@example.com')).rejects.toThrow(
       'Iron session failed: consents.',
     );
-  });
-});
-
-describe('registerSelectedMoneyAccountWallet', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockAccountsController.getSelectedAccount.mockReturnValue({
-      address: '0xabc',
-    });
-    mockRampsController.registerMoneyAccountWallet.mockResolvedValue({
-      type: 'registered',
-    });
-  });
-
-  it('registers the selected account address with RampsController', async () => {
-    await registerSelectedMoneyAccountWallet();
-
-    expect(mockRampsController.registerMoneyAccountWallet).toHaveBeenCalledWith(
-      {
-        address: '0xabc',
-      },
-    );
-  });
-
-  it('throws when no selected account is available', async () => {
-    mockAccountsController.getSelectedAccount.mockReturnValue(undefined);
-
-    await expect(registerSelectedMoneyAccountWallet()).rejects.toThrow(
-      'No selected account available to register.',
-    );
-    expect(
-      mockRampsController.registerMoneyAccountWallet,
-    ).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/ironKycFlow.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/ironKycFlow.ts
@@ -1,4 +1,3 @@
-import type { Hex } from '@metamask/utils';
 import Engine from '../../../../../core/Engine';
 
 // Demo Iron → Sumsub helpers for the VBA Get Pix Key flow.
@@ -79,24 +78,4 @@ export async function startIronKycVerification(email: string): Promise<void> {
       idosTncSigned: true,
     }),
   );
-}
-
-/**
- * Registers the currently selected account as a Money Account wallet after KYC
- * succeeds (Sumsub complete). Signs an ownership proof via KeyringController
- * and posts through neobank-proxy.
- *
- * Callers should soft-fail: verification already succeeded, so a registration
- * error should not block the success screen.
- */
-export async function registerSelectedMoneyAccountWallet(): Promise<void> {
-  const selectedAccount =
-    Engine.context.AccountsController.getSelectedAccount();
-  const address = selectedAccount?.address as Hex | undefined;
-
-  if (!address) {
-    throw new Error('No selected account available to register.');
-  }
-
-  await Engine.context.RampsController.registerMoneyAccountWallet({ address });
 }

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/moneyAccountAutoramp.test.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/moneyAccountAutoramp.test.ts
@@ -1,0 +1,31 @@
+import { buildMoneyAccountAutorampParams } from './moneyAccountAutoramp';
+import {
+  DEMO_AUTORAMP_DESTINATION_BLOCKCHAIN,
+  DEMO_AUTORAMP_DESTINATION_TOKEN,
+  DEMO_AUTORAMP_SOURCE_CURRENCY_CODE,
+} from './constants';
+
+describe('buildMoneyAccountAutorampParams', () => {
+  it('builds the demo autoramp request routed to the given address', () => {
+    const address = '0xabc';
+
+    const params = buildMoneyAccountAutorampParams(address);
+
+    expect(params).toStrictEqual({
+      source_currencies: [
+        { type: 'Fiat', code: DEMO_AUTORAMP_SOURCE_CURRENCY_CODE },
+      ],
+      destination_currency: {
+        type: 'Crypto',
+        token: DEMO_AUTORAMP_DESTINATION_TOKEN,
+        blockchain: DEMO_AUTORAMP_DESTINATION_BLOCKCHAIN,
+      },
+      recipient_account: {
+        type: 'Crypto',
+        chain: DEMO_AUTORAMP_DESTINATION_BLOCKCHAIN,
+        address,
+      },
+      source_is_third_party: false,
+    });
+  });
+});

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/moneyAccountAutoramp.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/moneyAccountAutoramp.ts
@@ -1,0 +1,42 @@
+import type { CreateAutorampRequest } from '@metamask/ramps-controller';
+import {
+  DEMO_AUTORAMP_DESTINATION_BLOCKCHAIN,
+  DEMO_AUTORAMP_DESTINATION_TOKEN,
+  DEMO_AUTORAMP_SOURCE_CURRENCY_CODE,
+} from './constants';
+
+/**
+ * Builds the demo autoramp request that converts a `BRL` Pix deposit into the
+ * demo destination token and routes it to `address`.
+ *
+ * `customer_id` is deliberately absent: `RampsController.createAutoramp`
+ * resolves it from KYC. The Ramps Dev API forwards the rest to MoonPay
+ * unchanged, so the vocabulary and casing are MoonPay's.
+ *
+ * Single-sourced here so the manual "Create my account" pipeline
+ * (`MockKycSuccess`) and the automated KYC-completion orchestrator stay in
+ * lockstep.
+ *
+ * @param address - The wallet address the autoramp pays out to.
+ * @returns The autoramp creation request body.
+ */
+export function buildMoneyAccountAutorampParams(
+  address: string,
+): CreateAutorampRequest {
+  return {
+    source_currencies: [
+      { type: 'Fiat', code: DEMO_AUTORAMP_SOURCE_CURRENCY_CODE },
+    ],
+    destination_currency: {
+      type: 'Crypto',
+      token: DEMO_AUTORAMP_DESTINATION_TOKEN,
+      blockchain: DEMO_AUTORAMP_DESTINATION_BLOCKCHAIN,
+    },
+    recipient_account: {
+      type: 'Crypto',
+      chain: DEMO_AUTORAMP_DESTINATION_BLOCKCHAIN,
+      address,
+    },
+    source_is_third_party: false,
+  };
+}

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/registerMoneyAccountOnKycCompletion.test.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/registerMoneyAccountOnKycCompletion.test.ts
@@ -1,0 +1,166 @@
+import Engine from '../../../../../core/Engine';
+import Logger from '../../../../../util/Logger';
+import { buildMoneyAccountAutorampParams } from './moneyAccountAutoramp';
+import { createRegisterMoneyAccountOnKycCompletion } from './registerMoneyAccountOnKycCompletion';
+
+jest.mock('../../../../../core/Engine', () => ({
+  context: {
+    AccountsController: {
+      getSelectedAccount: jest.fn(),
+    },
+    RampsController: {
+      registerMoneyAccountWallet: jest.fn(),
+      createAutoramp: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../../../../util/Logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn(), log: jest.fn() },
+}));
+
+const mockAccountsController = Engine.context.AccountsController as unknown as {
+  getSelectedAccount: jest.Mock;
+};
+
+const mockRampsController = Engine.context.RampsController as unknown as {
+  registerMoneyAccountWallet: jest.Mock<Promise<unknown>, [unknown?]>;
+  createAutoramp: jest.Mock<Promise<unknown>, [unknown?]>;
+};
+
+const completedEvent = {
+  status: 'completed' as const,
+  sumsubSessionId: null,
+  errorCode: null,
+};
+
+const setUp = () => {
+  jest.clearAllMocks();
+  mockAccountsController.getSelectedAccount.mockReturnValue({ address: '0xabc' });
+  mockRampsController.registerMoneyAccountWallet.mockResolvedValue({
+    type: 'registered',
+  });
+  mockRampsController.createAutoramp.mockResolvedValue({
+    id: 'autoramp-1',
+    status: 'created',
+  });
+  return createRegisterMoneyAccountOnKycCompletion();
+};
+
+describe('createRegisterMoneyAccountOnKycCompletion', () => {
+  it('ignores non-completed statuses', async () => {
+    const handle = setUp();
+
+    await handle({ status: 'pending', sumsubSessionId: null, errorCode: null });
+
+    expect(
+      mockRampsController.registerMoneyAccountWallet,
+    ).not.toHaveBeenCalled();
+    expect(mockRampsController.createAutoramp).not.toHaveBeenCalled();
+  });
+
+  it('registers the selected account then creates the autoramp on completion', async () => {
+    const handle = setUp();
+
+    await handle(completedEvent);
+
+    expect(mockRampsController.registerMoneyAccountWallet).toHaveBeenCalledWith({
+      address: '0xabc',
+    });
+    expect(mockRampsController.createAutoramp).toHaveBeenCalledWith(
+      buildMoneyAccountAutorampParams('0xabc'),
+    );
+  });
+
+  it('does not re-register once completed for the same address', async () => {
+    const handle = setUp();
+
+    await handle(completedEvent);
+    await handle(completedEvent);
+
+    expect(mockRampsController.registerMoneyAccountWallet).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(mockRampsController.createAutoramp).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers only once while a completion is already in flight', async () => {
+    const handle = setUp();
+    let resolveRegister: (value: unknown) => void = () => undefined;
+    mockRampsController.registerMoneyAccountWallet.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRegister = resolve;
+      }),
+    );
+
+    const first = handle(completedEvent);
+    const second = handle(completedEvent);
+    resolveRegister({ type: 'registered' });
+    await Promise.all([first, second]);
+
+    expect(mockRampsController.registerMoneyAccountWallet).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  it('soft-fails and skips the autoramp when registration rejects', async () => {
+    const handle = setUp();
+    const registrationError = new Error('registration failed');
+    mockRampsController.registerMoneyAccountWallet.mockRejectedValue(
+      registrationError,
+    );
+
+    await expect(handle(completedEvent)).resolves.toBeUndefined();
+
+    expect(mockRampsController.createAutoramp).not.toHaveBeenCalled();
+    expect(Logger.error).toHaveBeenCalledWith(
+      registrationError,
+      expect.objectContaining({
+        message: expect.stringContaining('registration'),
+      }),
+    );
+  });
+
+  it('retries registration on a later completion when it rejected', async () => {
+    const handle = setUp();
+    mockRampsController.registerMoneyAccountWallet
+      .mockRejectedValueOnce(new Error('registration failed'))
+      .mockResolvedValueOnce({ type: 'registered' });
+
+    await handle(completedEvent);
+    await handle(completedEvent);
+
+    expect(mockRampsController.registerMoneyAccountWallet).toHaveBeenCalledTimes(
+      2,
+    );
+    expect(mockRampsController.createAutoramp).toHaveBeenCalledTimes(1);
+  });
+
+  it('soft-fails when autoramp creation rejects', async () => {
+    const handle = setUp();
+    const autorampError = new Error('autoramp failed');
+    mockRampsController.createAutoramp.mockRejectedValue(autorampError);
+
+    await expect(handle(completedEvent)).resolves.toBeUndefined();
+
+    expect(Logger.error).toHaveBeenCalledWith(
+      autorampError,
+      expect.objectContaining({
+        message: expect.stringContaining('Autoramp'),
+      }),
+    );
+  });
+
+  it('logs and skips when no account is selected', async () => {
+    const handle = setUp();
+    mockAccountsController.getSelectedAccount.mockReturnValue(undefined);
+
+    await handle(completedEvent);
+
+    expect(
+      mockRampsController.registerMoneyAccountWallet,
+    ).not.toHaveBeenCalled();
+    expect(Logger.log).toHaveBeenCalled();
+  });
+});

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/registerMoneyAccountOnKycCompletion.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/registerMoneyAccountOnKycCompletion.ts
@@ -1,0 +1,96 @@
+import type { Hex } from '@metamask/utils';
+import Engine from '../../../../../core/Engine';
+import Logger from '../../../../../util/Logger';
+import { buildMoneyAccountAutorampParams } from './moneyAccountAutoramp';
+
+/**
+ * Payload published by `KycController:statusChanged`.
+ */
+type KycStatusChangedPayload = {
+  status: string;
+  sumsubSessionId: string | null;
+  errorCode: string | null;
+};
+
+const asError = (value: unknown): Error =>
+  value instanceof Error ? value : new Error(String(value));
+
+/**
+ * Builds the `KycController:statusChanged` subscriber that drives the demo
+ * chain KYC `completed` → Money Account wallet registration → autoramp.
+ *
+ * Wallet registration used to run eagerly right after the SumSub hand-off in
+ * `MockKycEmail`; the real signal is the user-keyed status flipping to
+ * `completed` (from the KYC status webhook / poll), so registration is deferred
+ * to that event here. On successful registration the same autoramp creation the
+ * "Create my account" pipeline runs is fired automatically, since the Iron
+ * signing webhook that would do this server-side is not ready yet.
+ *
+ * The subscriber is:
+ * - Idempotent: a given address is registered at most once per session, and
+ *   overlapping `completed` events are collapsed so registration never runs
+ *   twice concurrently. A rejected registration is retried on a later event.
+ * - Soft-failing: verification already succeeded, so neither a registration nor
+ *   an autoramp error is surfaced to the user — they are logged, and the manual
+ *   "Create my account" button on the success screen stays as the fallback.
+ *
+ * @returns The `KycController:statusChanged` handler.
+ */
+export function createRegisterMoneyAccountOnKycCompletion(): (
+  payload: KycStatusChangedPayload,
+) => Promise<void> {
+  const registeredAddresses = new Set<string>();
+  const inFlightAddresses = new Set<string>();
+
+  return async function handleKycStatusChanged({
+    status,
+  }: KycStatusChangedPayload): Promise<void> {
+    if (status !== 'completed') {
+      return;
+    }
+
+    const address = Engine.context.AccountsController.getSelectedAccount()
+      ?.address as Hex | undefined;
+
+    if (!address) {
+      Logger.log(
+        'Skipping Money Account wallet registration after KYC: no selected account.',
+      );
+      return;
+    }
+
+    const addressKey = address.toLowerCase();
+    if (
+      registeredAddresses.has(addressKey) ||
+      inFlightAddresses.has(addressKey)
+    ) {
+      return;
+    }
+    inFlightAddresses.add(addressKey);
+
+    try {
+      await Engine.context.RampsController.registerMoneyAccountWallet({
+        address,
+      });
+      registeredAddresses.add(addressKey);
+    } catch (error) {
+      Logger.error(asError(error), {
+        message: 'Money Account wallet registration failed after KYC completed',
+      });
+      return;
+    } finally {
+      inFlightAddresses.delete(addressKey);
+    }
+
+    try {
+      await Engine.context.RampsController.createAutoramp(
+        buildMoneyAccountAutorampParams(address),
+      );
+    } catch (error) {
+      Logger.error(asError(error), {
+        message:
+          'Autoramp creation failed after Money Account wallet registration',
+      });
+    }
+  };
+}

--- a/app/core/Engine/controllers/kyc/kyc-controller-init.test.ts
+++ b/app/core/Engine/controllers/kyc/kyc-controller-init.test.ts
@@ -1,8 +1,10 @@
 import { buildMessengerClientInitRequestMock } from '../../utils/test-utils';
 import { ExtendedMessenger } from '../../../ExtendedMessenger';
 import { getKycControllerMessenger } from '../../messengers/kyc/kyc-controller-messenger';
+import type { KycControllerInitMessenger } from '../../messengers/kyc/kyc-controller-messenger';
 import { MessengerClientInitRequest } from '../../types';
 import { kycControllerInit } from './kyc-controller-init';
+import { createRegisterMoneyAccountOnKycCompletion } from '../../../../components/UI/Ramp/Views/VirtualBankAccount/registerMoneyAccountOnKycCompletion';
 import {
   KycController,
   type KycControllerMessenger,
@@ -17,11 +19,26 @@ jest.mock('@metamask/kyc-controller', () => ({
   },
 }));
 
+const mockHandler = jest.fn();
+jest.mock(
+  '../../../../components/UI/Ramp/Views/VirtualBankAccount/registerMoneyAccountOnKycCompletion',
+  () => ({
+    createRegisterMoneyAccountOnKycCompletion: jest.fn(() => mockHandler),
+  }),
+);
+
+const createMockInitMessenger = (): KycControllerInitMessenger =>
+  ({
+    subscribe: jest.fn(),
+  }) as unknown as KycControllerInitMessenger;
+
 function getInitRequestMock(
   overrides: {
     persistedState?: Record<string, unknown>;
   } = {},
-): jest.Mocked<MessengerClientInitRequest<KycControllerMessenger>> {
+): jest.Mocked<
+  MessengerClientInitRequest<KycControllerMessenger, KycControllerInitMessenger>
+> {
   const { persistedState = {} } = overrides;
 
   const baseMessenger = new ExtendedMessenger<MockAnyNamespace, never>({
@@ -31,10 +48,16 @@ function getInitRequestMock(
   const requestMock = {
     ...buildMessengerClientInitRequestMock(baseMessenger),
     controllerMessenger: getKycControllerMessenger(baseMessenger),
+    initMessenger: createMockInitMessenger(),
     persistedState,
   };
 
-  return requestMock;
+  return requestMock as jest.Mocked<
+    MessengerClientInitRequest<
+      KycControllerMessenger,
+      KycControllerInitMessenger
+    >
+  >;
 }
 
 describe('kycControllerInit', () => {
@@ -61,5 +84,17 @@ describe('kycControllerInit', () => {
     );
 
     expect(controller).toBeInstanceOf(KycController);
+  });
+
+  it('subscribes the Money Account registration orchestrator to statusChanged', () => {
+    const request = getInitRequestMock();
+
+    kycControllerInit(request);
+
+    expect(createRegisterMoneyAccountOnKycCompletion).toHaveBeenCalledTimes(1);
+    expect(request.initMessenger.subscribe).toHaveBeenCalledWith(
+      'KycController:statusChanged',
+      mockHandler,
+    );
   });
 });

--- a/app/core/Engine/controllers/kyc/kyc-controller-init.ts
+++ b/app/core/Engine/controllers/kyc/kyc-controller-init.ts
@@ -3,7 +3,9 @@ import {
   type KycControllerMessenger,
 } from '@metamask/kyc-controller';
 import type { MessengerClientInitFunction } from '../../types';
+import type { KycControllerInitMessenger } from '../../messengers/kyc/kyc-controller-messenger';
 import { reactNativeSumSubLauncher } from './reactNativeSumSubLauncher';
+import { createRegisterMoneyAccountOnKycCompletion } from '../../../../components/UI/Ramp/Views/VirtualBankAccount/registerMoneyAccountOnKycCompletion';
 
 /**
  * Initialize the KycController.
@@ -12,20 +14,32 @@ import { reactNativeSumSubLauncher } from './reactNativeSumSubLauncher';
  * frames, KYC-required check, and the SumSub hand-off). Platform-specific SDK
  * presentation is delegated to the injected {@link reactNativeSumSubLauncher}.
  *
+ * Also subscribes the Money Account registration / autoramp orchestrator to
+ * `KycController:statusChanged` so a `completed` status drives wallet
+ * registration and autoramp creation without an in-flow screen having to stay
+ * mounted.
+ *
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger for the controller.
  * @param request.persistedState - Persisted state to hydrate from.
+ * @param request.initMessenger - The init messenger for status event subscriptions.
  * @returns The initialized KycController.
  */
 export const kycControllerInit: MessengerClientInitFunction<
   KycController,
-  KycControllerMessenger
-> = ({ controllerMessenger, persistedState }) => {
+  KycControllerMessenger,
+  KycControllerInitMessenger
+> = ({ controllerMessenger, persistedState, initMessenger }) => {
   const controller = new KycController({
     messenger: controllerMessenger,
     state: persistedState.KycController,
     sumsubLauncher: reactNativeSumSubLauncher,
   });
+
+  initMessenger.subscribe(
+    'KycController:statusChanged',
+    createRegisterMoneyAccountOnKycCompletion(),
+  );
 
   return { controller };
 };

--- a/app/core/Engine/messengers/index.ts
+++ b/app/core/Engine/messengers/index.ts
@@ -148,7 +148,10 @@ import { getQrSyncProvisioningServiceMessenger } from './qr-sync-provisioning-se
 import { getComplianceServiceMessenger } from './compliance/compliance-service-messenger';
 import { getComplianceControllerMessenger } from './compliance/compliance-controller-messenger';
 import { getKycServiceMessenger } from './kyc/kyc-service-messenger';
-import { getKycControllerMessenger } from './kyc/kyc-controller-messenger';
+import {
+  getKycControllerInitMessenger,
+  getKycControllerMessenger,
+} from './kyc/kyc-controller-messenger';
 import { getConfigRegistryApiServiceMessenger } from './config-registry-api-service-messenger.ts';
 import {
   getChompApiServiceMessenger,
@@ -507,7 +510,7 @@ export const MESSENGER_FACTORIES = {
   },
   KycController: {
     getMessenger: getKycControllerMessenger,
-    getInitMessenger: noop,
+    getInitMessenger: getKycControllerInitMessenger,
   },
   ChompApiService: {
     getMessenger: getChompApiServiceMessenger,

--- a/app/core/Engine/messengers/kyc/kyc-controller-messenger.ts
+++ b/app/core/Engine/messengers/kyc/kyc-controller-messenger.ts
@@ -3,7 +3,10 @@ import {
   type MessengerActions,
   type MessengerEvents,
 } from '@metamask/messenger';
-import type { KycControllerMessenger } from '@metamask/kyc-controller';
+import type {
+  KycControllerMessenger,
+  KycControllerStatusChangedEvent,
+} from '@metamask/kyc-controller';
 import type { RootMessenger } from '../../types';
 
 /**
@@ -48,5 +51,36 @@ export function getKycControllerMessenger(
     ],
     messenger,
   });
+  return messenger;
+}
+
+export type KycControllerInitMessenger = ReturnType<
+  typeof getKycControllerInitMessenger
+>;
+
+/**
+ * Get the init messenger for the KycController. Scoped to the
+ * `KycController:statusChanged` event that the Engine-level Money Account
+ * registration / autoramp orchestrator subscribes to.
+ *
+ * @param rootMessenger - The root messenger.
+ * @returns The KycControllerInitMessenger.
+ */
+export function getKycControllerInitMessenger(rootMessenger: RootMessenger) {
+  const messenger = new Messenger<
+    'KycControllerInit',
+    never,
+    KycControllerStatusChangedEvent,
+    RootMessenger
+  >({
+    namespace: 'KycControllerInit',
+    parent: rootMessenger,
+  });
+
+  rootMessenger.delegate({
+    events: ['KycController:statusChanged'],
+    messenger,
+  });
+
   return messenger;
 }


### PR DESCRIPTION
## Summary

Automates the demo chain **KYC `completed` → Money Account wallet registration → autoramp creation**, replacing the eager post-SumSub registration and keeping the manual "Create my account" pipeline as a fallback.

- **Deferred registration:** `MockKycEmail` no longer eagerly calls `registerSelectedMoneyAccountWallet()` after `startIronKycVerification`. It now only drives the SumSub hand-off and navigates to the success screen.
- **Engine-level orchestration (preferred design):** A new `KycController` init messenger delegates `KycController:statusChanged`; `kycControllerInit` subscribes a once-created handler. On `status === 'completed'` it resolves the selected account address, calls `RampsController.registerMoneyAccountWallet({ address })`, and on success chains `RampsController.createAutoramp(...)`.
- **Idempotent + soft-failing:** registration runs at most once per address per session (with an in-flight guard and retry-on-rejection); registration and autoramp errors are logged, never surfaced, so the manual **Run pipeline** button remains the fallback.
- **DRY payload:** the demo autoramp request body is single-sourced in `buildMoneyAccountAutorampParams`, reused by both the orchestrator and `MockKycSuccess`.
- No RampsController AllowedEvents / messenger-allowlist changes; the handler uses `Engine.context` directly like the existing screens/`ironKycFlow.ts`. No core changes required.

### Files
- `app/core/Engine/messengers/kyc/kyc-controller-messenger.ts` — add `getKycControllerInitMessenger` delegating `KycController:statusChanged`.
- `app/core/Engine/messengers/index.ts` — wire the KYC init messenger.
- `app/core/Engine/controllers/kyc/kyc-controller-init.ts` — subscribe the orchestrator once.
- `app/components/UI/Ramp/Views/VirtualBankAccount/registerMoneyAccountOnKycCompletion.ts` — the orchestrator factory.
- `app/components/UI/Ramp/Views/VirtualBankAccount/moneyAccountAutoramp.ts` — shared autoramp params builder.
- `MockKycEmail.tsx` — remove eager registration.
- `ironKycFlow.ts` — remove now-unused `registerSelectedMoneyAccountWallet`.
- `MockKycSuccess.tsx` — use the shared builder (manual pipeline unchanged).
- Focused tests for each new/changed unit.

## Test plan
- [x] `yarn jest` (focused) for `moneyAccountAutoramp`, `registerMoneyAccountOnKycCompletion`, `ironKycFlow`, `MockKycEmail`, `kyc-controller-init` — 23 passing.
- [x] Lint clean on all changed files.
- [x] Confirmed the email/Get Pix Key flow no longer eagerly registers.
- [x] Confirmed `statusChanged` `completed` path registers then autoramps (unit-level).
- [ ] Manual smoke on device once KYC status webhook (KYC API #37) is deployed.

## Residual risks
- Real end-to-end requires **KYC API #37** deployed so `GET /kyc/status` / the webhook actually flips `userStatus` to `completed`; until then the status event won't fire in the demo.
- Registration/autoramp use the **selected account** address at completion time (address-selection assumption).
- The demo autoramp request body fields (currencies/tokens/chain) are demo constants forwarded to MoonPay.

> Note: `MockKycSuccess.test.tsx` has a pre-existing failing case ("navigates to Money home when Finish is pressed") unrelated to this change — it was already failing on `demo/vba-kyc` before this PR.

Made with [Cursor](https://cursor.com)