### PR TITLE
fix: Bump logging-controller to `^9.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -309,7 +309,7 @@
     "@metamask/keyring-sdk": "^3.1.0",
     "@metamask/keyring-snap-client": "^10.0.0",
     "@metamask/keyring-utils": "^5.0.0",
-    "@metamask/logging-controller": "^8.0.0",
+    "@metamask/logging-controller": "^9.0.0",
     "@metamask/message-signing-snap": "^1.1.2",
     "@metamask/messenger": "^2.0.0",
     "@metamask/metamask-eth-abis": "3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9059,7 +9059,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/logging-controller@npm:^8.0.0, @metamask/logging-controller@npm:^8.0.2":
+"@metamask/logging-controller@npm:^8.0.2":
   version: 8.0.2
   resolution: "@metamask/logging-controller@npm:8.0.2"
   dependencies:
@@ -9068,6 +9068,18 @@ __metadata:
     "@metamask/messenger": "npm:^1.2.0"
     uuid: "npm:^8.3.2"
   checksum: 10/6dc5a9b4d643c427c2c95d5618975d98933314fb3e1ec11fed87e966332648cbb2e5725d8cde76111b619fd2a5dc76b4596a8d214b02227dae446625b4ecdb34
+  languageName: node
+  linkType: hard
+
+"@metamask/logging-controller@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@metamask/logging-controller@npm:9.0.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/utils": "npm:^11.11.0"
+    uuid: "npm:^8.3.2"
+  checksum: 10/9b4a3a17c1908b1190a5efbe963c804f8ac6fc45e5bdbc17e5e7df73569c92e2668822bf584006092a18f005ffe77a2fc7d791e18630f5137ce94a1d1380221b
   languageName: node
   linkType: hard
 
@@ -35658,7 +35670,7 @@ __metadata:
     "@metamask/keyring-sdk": "npm:^3.1.0"
     "@metamask/keyring-snap-client": "npm:^10.0.0"
     "@metamask/keyring-utils": "npm:^5.0.0"
-    "@metamask/logging-controller": "npm:^8.0.0"
+    "@metamask/logging-controller": "npm:^9.0.0"
     "@metamask/message-signing-snap": "npm:^1.1.2"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/messenger-cli": "npm:^0.2.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Bump `logging-controller` to latest version, this introduces an expiry for logs reducing the amount of storage used for the controller.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Reduce storage used for logging

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump; behavior change is limited to how long logs are retained in storage, with no auth or transaction logic touched in this diff.
> 
> **Overview**
> Upgrades **`@metamask/logging-controller`** from **^8.0.0** to **^9.0.0** in `package.json` and refreshes `yarn.lock` (9.0.0 pulls **`@metamask/messenger` ^2.0.0** and **`@metamask/utils`** instead of the v8 **`controller-utils`** / messenger v1 stack).
> 
> Per the PR description, **v9 adds log expiry** so persisted logging state uses less on-device storage. **No application source changes**—only the dependency version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e58cb9f2b282025de565ed5ccd0e6c32a9aac046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->