### PR TITLE
fix(quick-buy): hide bottom tab bar while sheet is open

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -147,6 +147,10 @@ import {
   selectPredictEnabledFlag,
 } from '../../UI/Predict';
 import {
+  QuickBuyTabBarVisibilityProvider,
+  useIsQuickBuyOpen,
+} from '../../UI/QuickBuy/QuickBuyTabBarVisibilityContext';
+import {
   MarketInsightsView,
   selectMarketInsightsEnabled,
 } from '../../UI/MarketInsights';
@@ -581,9 +585,10 @@ const BrowserFlowUnmountOnTabBlur = withUnmountOnTabBlur(BrowserFlow);
 const TransactionsHomeUnmountOnTabBlur = withUnmountOnTabBlur(TransactionsHome);
 const RewardsHomeUnmountOnTabBlur = withUnmountOnTabBlur(RewardsHome);
 
-const HomeTabs = () => {
+const HomeTabsContent = () => {
   const { trackEvent, createEventBuilder } = useAnalytics();
   const [isKeyboardHidden, setIsKeyboardHidden] = useState(true);
+  const isQuickBuyOpen = useIsQuickBuyOpen();
 
   const isMoneyAccountEnabled = useSelector(selectMoneyEnableMoneyAccountFlag);
   const isMoneyAccountGeoEligible = useSelector(
@@ -762,6 +767,10 @@ const HomeTabs = () => {
       }
     }
 
+    if (isQuickBuyOpen) {
+      return null;
+    }
+
     if (isKeyboardHidden) {
       return (
         <TabBar
@@ -858,6 +867,12 @@ const HomeTabs = () => {
     </PredictPreviewSheetProvider>
   );
 };
+
+const HomeTabs = () => (
+  <QuickBuyTabBarVisibilityProvider>
+    <HomeTabsContent />
+  </QuickBuyTabBarVisibilityProvider>
+);
 
 const Webview = () => (
   <NativeStack.Navigator screenOptions={{ headerShown: false }}>

--- a/app/components/Nav/Main/MainNavigator.test.tsx
+++ b/app/components/Nav/Main/MainNavigator.test.tsx
@@ -94,11 +94,23 @@ jest.mock('../../UI/Money/selectors/eligibility', () => ({
     mockSelectIsMoneyAccountGeoEligible(state),
 }));
 
+const mockUseIsQuickBuyOpen = jest.fn().mockReturnValue(false);
+jest.mock('../../UI/QuickBuy/QuickBuyTabBarVisibilityContext', () => {
+  const actual = jest.requireActual(
+    '../../UI/QuickBuy/QuickBuyTabBarVisibilityContext',
+  );
+  return {
+    ...actual,
+    useIsQuickBuyOpen: () => mockUseIsQuickBuyOpen(),
+  };
+});
+
 describe('MainNavigator', () => {
   const originalEnv = process.env.METAMASK_ENVIRONMENT;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseIsQuickBuyOpen.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -175,6 +187,24 @@ describe('MainNavigator', () => {
 
       // Then the tab bar should be visible
       expect(result).not.toBeNull();
+    });
+
+    it('hides tab bar when Quick Buy sheet is open', () => {
+      mockUseIsQuickBuyOpen.mockReturnValue(true);
+
+      const HomeTabs = getHomeTabsComponent();
+      const renderTabBar = getTabBarFn(HomeTabs);
+
+      const result = renderTabBar({
+        state: {
+          routes: [{ name: Routes.WALLET.HOME }],
+          index: 0,
+        },
+        descriptors: {},
+        navigation: {},
+      });
+
+      expect(result).toBeNull();
     });
 
     it('sets the wallet tab stack background to the theme background', () => {

--- a/app/components/UI/QuickBuy/QuickBuyRoot.test.tsx
+++ b/app/components/UI/QuickBuy/QuickBuyRoot.test.tsx
@@ -33,6 +33,17 @@ jest.mock('./hooks/useQuickBuySetup', () => ({
   useQuickBuySetup: jest.fn(),
 }));
 
+const mockRegisterQuickBuyOpen = jest.fn();
+const mockUnregisterQuickBuyOpen = jest.fn();
+
+jest.mock('./QuickBuyTabBarVisibilityContext', () => ({
+  useQuickBuyTabBarVisibility: jest.fn(() => ({
+    registerQuickBuyOpen: mockRegisterQuickBuyOpen,
+    unregisterQuickBuyOpen: mockUnregisterQuickBuyOpen,
+    isQuickBuyOpen: false,
+  })),
+}));
+
 const mockTrack = jest.fn();
 
 jest.mock('../../Views/SocialLeaderboard/analytics', () => {
@@ -314,6 +325,24 @@ describe('QuickBuyRoot', () => {
       isLoading: false,
       isUnsupportedChain: false,
     });
+  });
+
+  it('registers tab bar hide while the sheet is mounted', () => {
+    const { unmount } = renderWithProvider(
+      <QuickBuyRoot
+        isVisible
+        target={positionToQuickBuyTarget(createPosition())}
+        features={TOP_TRADERS_QUICK_BUY_FEATURES}
+        onClose={jest.fn()}
+      />,
+    );
+
+    expect(mockRegisterQuickBuyOpen).toHaveBeenCalledTimes(1);
+    expect(mockUnregisterQuickBuyOpen).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(mockUnregisterQuickBuyOpen).toHaveBeenCalledTimes(1);
   });
 
   it('renders default AmountScreen content when no children are passed', () => {

--- a/app/components/UI/QuickBuy/QuickBuyRoot.tsx
+++ b/app/components/UI/QuickBuy/QuickBuyRoot.tsx
@@ -42,6 +42,7 @@ import type {
   QuickBuyScreen,
   QuickBuyTarget,
 } from './types';
+import { useQuickBuyTabBarVisibility } from './QuickBuyTabBarVisibilityContext';
 
 export type { QuickBuyRootProps } from './types';
 
@@ -89,6 +90,8 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
   const { bottom: bottomInset } = useSafeAreaInsets();
   const { track } = useSocialLeaderboardAnalytics();
   const bottomSheetRef = useRef<BottomSheetDialogRef>(null);
+  const { registerQuickBuyOpen, unregisterQuickBuyOpen } =
+    useQuickBuyTabBarVisibility();
   const [isContentReady, setIsContentReady] = useState(false);
   const [activeScreen, setActiveScreen] = useState<QuickBuyScreen>('amount');
   // Baseline height for locked sub-screens (pay with / quotes / …). Refreshed
@@ -132,6 +135,11 @@ const QuickBuyRootInner: React.FC<QuickBuyRootInnerProps> = ({
         analyticsContext.traderTradeType ?? QuickBuyEventValues.TRADE_TYPE.BUY,
     });
   }, [analyticsContext, target.tokenSymbol, track]);
+
+  useEffect(() => {
+    registerQuickBuyOpen();
+    return () => unregisterQuickBuyOpen();
+  }, [registerQuickBuyOpen, unregisterQuickBuyOpen]);
 
   useEffect(() => {
     bottomSheetRef.current?.onOpenDialog(() => {

--- a/app/components/UI/QuickBuy/QuickBuyTabBarVisibilityContext.test.tsx
+++ b/app/components/UI/QuickBuy/QuickBuyTabBarVisibilityContext.test.tsx
@@ -1,0 +1,134 @@
+import React, { useEffect } from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { Text } from 'react-native';
+import {
+  QuickBuyTabBarVisibilityProvider,
+  useIsQuickBuyOpen,
+  useQuickBuyTabBarVisibility,
+} from './QuickBuyTabBarVisibilityContext';
+
+const OpenRegistrar: React.FC = () => {
+  const { registerQuickBuyOpen } = useQuickBuyTabBarVisibility();
+
+  useEffect(() => {
+    registerQuickBuyOpen();
+  }, [registerQuickBuyOpen]);
+
+  return null;
+};
+
+const StatusReader: React.FC = () => {
+  const isQuickBuyOpen = useIsQuickBuyOpen();
+  return (
+    <Text testID="quick-buy-open-status">
+      {isQuickBuyOpen ? 'open' : 'closed'}
+    </Text>
+  );
+};
+
+describe('QuickBuyTabBarVisibilityContext', () => {
+  it('reports closed when no sheet is registered', () => {
+    render(
+      <QuickBuyTabBarVisibilityProvider>
+        <StatusReader />
+      </QuickBuyTabBarVisibilityProvider>,
+    );
+
+    expect(screen.getByTestId('quick-buy-open-status').props.children).toBe(
+      'closed',
+    );
+  });
+
+  it('reports open after registerQuickBuyOpen', () => {
+    const Inner: React.FC = () => {
+      const { registerQuickBuyOpen } = useQuickBuyTabBarVisibility();
+      useEffect(() => {
+        registerQuickBuyOpen();
+      }, [registerQuickBuyOpen]);
+      return <StatusReader />;
+    };
+
+    render(
+      <QuickBuyTabBarVisibilityProvider>
+        <Inner />
+      </QuickBuyTabBarVisibilityProvider>,
+    );
+
+    expect(screen.getByTestId('quick-buy-open-status').props.children).toBe(
+      'open',
+    );
+  });
+
+  it('returns closed and no-op handlers outside the provider', () => {
+    const handlers: {
+      register?: () => void;
+      unregister?: () => void;
+      isOpen?: boolean;
+    } = {};
+
+    const Reader: React.FC = () => {
+      const ctx = useQuickBuyTabBarVisibility();
+      handlers.register = ctx.registerQuickBuyOpen;
+      handlers.unregister = ctx.unregisterQuickBuyOpen;
+      handlers.isOpen = ctx.isQuickBuyOpen;
+      return null;
+    };
+
+    render(<Reader />);
+
+    expect(handlers.isOpen).toBe(false);
+    handlers.register?.();
+    handlers.unregister?.();
+    expect(handlers.isOpen).toBe(false);
+  });
+
+  it('clears open state after unregisterQuickBuyOpen', () => {
+    const Toggle: React.FC = () => {
+      const { registerQuickBuyOpen, unregisterQuickBuyOpen } =
+        useQuickBuyTabBarVisibility();
+
+      useEffect(() => {
+        registerQuickBuyOpen();
+        return () => unregisterQuickBuyOpen();
+      }, [registerQuickBuyOpen, unregisterQuickBuyOpen]);
+
+      return <StatusReader />;
+    };
+
+    const { unmount } = render(
+      <QuickBuyTabBarVisibilityProvider>
+        <Toggle />
+      </QuickBuyTabBarVisibilityProvider>,
+    );
+
+    expect(screen.getByTestId('quick-buy-open-status').props.children).toBe(
+      'open',
+    );
+
+    unmount();
+
+    render(
+      <QuickBuyTabBarVisibilityProvider>
+        <StatusReader />
+      </QuickBuyTabBarVisibilityProvider>,
+    );
+
+    expect(screen.getByTestId('quick-buy-open-status').props.children).toBe(
+      'closed',
+    );
+  });
+
+  it('tracks multiple concurrent registrations with a ref count', () => {
+    render(
+      <QuickBuyTabBarVisibilityProvider>
+        <OpenRegistrar />
+        <OpenRegistrar />
+        <StatusReader />
+      </QuickBuyTabBarVisibilityProvider>,
+    );
+
+    expect(screen.getByTestId('quick-buy-open-status').props.children).toBe(
+      'open',
+    );
+  });
+});

--- a/app/components/UI/QuickBuy/QuickBuyTabBarVisibilityContext.test.tsx
+++ b/app/components/UI/QuickBuy/QuickBuyTabBarVisibilityContext.test.tsx
@@ -1,21 +1,11 @@
 import React, { useEffect } from 'react';
-import { render, screen } from '@testing-library/react-native';
-import { Text } from 'react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { Pressable, Text } from 'react-native';
 import {
   QuickBuyTabBarVisibilityProvider,
   useIsQuickBuyOpen,
   useQuickBuyTabBarVisibility,
 } from './QuickBuyTabBarVisibilityContext';
-
-const OpenRegistrar: React.FC = () => {
-  const { registerQuickBuyOpen } = useQuickBuyTabBarVisibility();
-
-  useEffect(() => {
-    registerQuickBuyOpen();
-  }, [registerQuickBuyOpen]);
-
-  return null;
-};
 
 const StatusReader: React.FC = () => {
   const isQuickBuyOpen = useIsQuickBuyOpen();
@@ -24,6 +14,18 @@ const StatusReader: React.FC = () => {
       {isQuickBuyOpen ? 'open' : 'closed'}
     </Text>
   );
+};
+
+const SheetRegistrar: React.FC<{ testID: string }> = ({ testID }) => {
+  const { registerQuickBuyOpen, unregisterQuickBuyOpen } =
+    useQuickBuyTabBarVisibility();
+
+  useEffect(() => {
+    registerQuickBuyOpen();
+    return () => unregisterQuickBuyOpen();
+  }, [registerQuickBuyOpen, unregisterQuickBuyOpen]);
+
+  return <Text testID={testID} />;
 };
 
 describe('QuickBuyTabBarVisibilityContext', () => {
@@ -82,22 +84,53 @@ describe('QuickBuyTabBarVisibilityContext', () => {
     expect(handlers.isOpen).toBe(false);
   });
 
-  it('clears open state after unregisterQuickBuyOpen', () => {
-    const Toggle: React.FC = () => {
+  it('clears open state after unregisterQuickBuyOpen within the same provider', () => {
+    const Controller: React.FC = () => {
       const { registerQuickBuyOpen, unregisterQuickBuyOpen } =
         useQuickBuyTabBarVisibility();
 
-      useEffect(() => {
-        registerQuickBuyOpen();
-        return () => unregisterQuickBuyOpen();
-      }, [registerQuickBuyOpen, unregisterQuickBuyOpen]);
-
-      return <StatusReader />;
+      return (
+        <>
+          <StatusReader />
+          <Pressable
+            testID="register-quick-buy"
+            onPress={() => registerQuickBuyOpen()}
+          />
+          <Pressable
+            testID="unregister-quick-buy"
+            onPress={() => unregisterQuickBuyOpen()}
+          />
+        </>
+      );
     };
 
-    const { unmount } = render(
+    render(
       <QuickBuyTabBarVisibilityProvider>
-        <Toggle />
+        <Controller />
+      </QuickBuyTabBarVisibilityProvider>,
+    );
+
+    expect(screen.getByTestId('quick-buy-open-status').props.children).toBe(
+      'closed',
+    );
+
+    fireEvent.press(screen.getByTestId('register-quick-buy'));
+    expect(screen.getByTestId('quick-buy-open-status').props.children).toBe(
+      'open',
+    );
+
+    fireEvent.press(screen.getByTestId('unregister-quick-buy'));
+    expect(screen.getByTestId('quick-buy-open-status').props.children).toBe(
+      'closed',
+    );
+  });
+
+  it('keeps tab bar hidden until all concurrent sheets unregister', () => {
+    const { rerender } = render(
+      <QuickBuyTabBarVisibilityProvider>
+        <SheetRegistrar testID="sheet-a" />
+        <SheetRegistrar testID="sheet-b" />
+        <StatusReader />
       </QuickBuyTabBarVisibilityProvider>,
     );
 
@@ -105,9 +138,18 @@ describe('QuickBuyTabBarVisibilityContext', () => {
       'open',
     );
 
-    unmount();
+    rerender(
+      <QuickBuyTabBarVisibilityProvider>
+        <SheetRegistrar testID="sheet-b" />
+        <StatusReader />
+      </QuickBuyTabBarVisibilityProvider>,
+    );
 
-    render(
+    expect(screen.getByTestId('quick-buy-open-status').props.children).toBe(
+      'open',
+    );
+
+    rerender(
       <QuickBuyTabBarVisibilityProvider>
         <StatusReader />
       </QuickBuyTabBarVisibilityProvider>,
@@ -115,20 +157,6 @@ describe('QuickBuyTabBarVisibilityContext', () => {
 
     expect(screen.getByTestId('quick-buy-open-status').props.children).toBe(
       'closed',
-    );
-  });
-
-  it('tracks multiple concurrent registrations with a ref count', () => {
-    render(
-      <QuickBuyTabBarVisibilityProvider>
-        <OpenRegistrar />
-        <OpenRegistrar />
-        <StatusReader />
-      </QuickBuyTabBarVisibilityProvider>,
-    );
-
-    expect(screen.getByTestId('quick-buy-open-status').props.children).toBe(
-      'open',
     );
   });
 });

--- a/app/components/UI/QuickBuy/QuickBuyTabBarVisibilityContext.tsx
+++ b/app/components/UI/QuickBuy/QuickBuyTabBarVisibilityContext.tsx
@@ -1,0 +1,65 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+
+interface QuickBuyTabBarVisibilityContextValue {
+  registerQuickBuyOpen: () => void;
+  unregisterQuickBuyOpen: () => void;
+  isQuickBuyOpen: boolean;
+}
+
+const noop = () => undefined;
+
+const defaultContextValue: QuickBuyTabBarVisibilityContextValue = {
+  registerQuickBuyOpen: noop,
+  unregisterQuickBuyOpen: noop,
+  isQuickBuyOpen: false,
+};
+
+const QuickBuyTabBarVisibilityContext =
+  createContext<QuickBuyTabBarVisibilityContextValue>(defaultContextValue);
+
+/**
+ * Tracks open Quick Buy sheets so HomeTabs can hide the bottom tab bar while
+ * the sheet is visible.
+ */
+export const QuickBuyTabBarVisibilityProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const [openCount, setOpenCount] = useState(0);
+
+  const registerQuickBuyOpen = useCallback(() => {
+    setOpenCount((count) => count + 1);
+  }, []);
+
+  const unregisterQuickBuyOpen = useCallback(() => {
+    setOpenCount((count) => Math.max(0, count - 1));
+  }, []);
+
+  const value = useMemo(
+    (): QuickBuyTabBarVisibilityContextValue => ({
+      registerQuickBuyOpen,
+      unregisterQuickBuyOpen,
+      isQuickBuyOpen: openCount > 0,
+    }),
+    [registerQuickBuyOpen, unregisterQuickBuyOpen, openCount],
+  );
+
+  return (
+    <QuickBuyTabBarVisibilityContext.Provider value={value}>
+      {children}
+    </QuickBuyTabBarVisibilityContext.Provider>
+  );
+};
+
+export function useQuickBuyTabBarVisibility(): QuickBuyTabBarVisibilityContextValue {
+  return useContext(QuickBuyTabBarVisibilityContext);
+}
+
+export function useIsQuickBuyOpen(): boolean {
+  return useQuickBuyTabBarVisibility().isQuickBuyOpen;
+}


### PR DESCRIPTION
## **Description**

QuickBuy on Explore (and other tabbed surfaces) opened a bottom sheet above the app tab bar. Stack-only entry points (e.g. trader position, trending full view) already had no tab bar and looked correct.

This change adds `QuickBuyTabBarVisibilityContext` with a ref-counted open state. `QuickBuyRoot` registers while mounted; `HomeTabs` hides the tab bar when any QuickBuy sheet is open, giving the sheet the full bottom area consistent with stack-only flows. Outside the provider, registration is a no-op so non-tab entry points are unaffected.


https://github.com/user-attachments/assets/c8b49405-7228-4bd2-946b-db0075af9a77

## **Changelog**

CHANGELOG entry: null
## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Quick Buy tab bar visibility

  Background:
    Given I am logged into MetaMask Mobile
    And Quick Buy is enabled for the surface I am testing

  Scenario: tab bar hides while Quick Buy is open on Explore
    Given I am on the Explore tab
    And I am on a tab that shows Quick Buy (e.g. Crypto)

    When user taps the lightning bolt on a token row
    Then the Quick Buy sheet should open
    And the bottom tab bar should not be visible

    When user closes the Quick Buy sheet
    Then the bottom tab bar should be visible again

  Scenario: stack-only Quick Buy entry points are unchanged
    Given I open Quick Buy from a screen without a bottom tab bar (e.g. trader position)

    When user opens and closes Quick Buy
    Then the sheet should use the full bottom of the screen
    And no tab bar should appear
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only tab bar visibility with safe defaults outside the provider; no auth, data, or trading logic changes.
> 
> **Overview**
> Hides the main **Home** bottom tab bar whenever a Quick Buy sheet is open on tabbed surfaces (e.g. Explore), so the sheet uses the full bottom area like stack-only Quick Buy flows.
> 
> Adds **`QuickBuyTabBarVisibilityContext`** with ref-counted `registerQuickBuyOpen` / `unregisterQuickBuyOpen`. **`QuickBuyRoot`** registers on mount and unregisters on unmount. **`HomeTabs`** wraps tab content in the provider and skips rendering **`TabBar`** when `useIsQuickBuyOpen()` is true. Outside the provider, hooks default to closed with no-op registration so non-tab entry points are unchanged.
> 
> Tests cover the context (including concurrent sheets), **`MainNavigator`** tab bar hiding, and **`QuickBuyRoot`** lifecycle registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d5ed0544a373990c03210d329a99c426bc4c125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->