### PR TITLE
fix(explore): host Quick Buy above tab bar for list entry points

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -146,6 +146,7 @@ import {
   PredictPreviewSheetProvider,
   selectPredictEnabledFlag,
 } from '../../UI/Predict';
+import { TrendingQuickBuySheetProvider } from '../../UI/Trending/contexts';
 import {
   MarketInsightsView,
   selectMarketInsightsEnabled,
@@ -776,8 +777,9 @@ const HomeTabs = () => {
 
   return (
     /*
-     * PredictPreviewSheetProvider is mounted here (above Tab.Navigator) so its
-     * BottomSheet renders inside the full-viewport Home screen card.
+     * PredictPreviewSheetProvider and TrendingQuickBuySheetProvider are
+     * mounted here (above Tab.Navigator) so their BottomSheets render inside
+     * the full-viewport Home screen card.
      * BottomSheet uses `absolute inset-0` (see
      * @metamask/design-system-react-native) and would be clipped by an
      * individual tab's content area if mounted lower in the tree.
@@ -788,73 +790,75 @@ const HomeTabs = () => {
      * Retry toasts so we don't double-fire when both are mounted.
      */
     <PredictPreviewSheetProvider>
-      {isMoneyAccountEnabled ? (
-        <MoneyTabPressTracker onRegister={registerMoneyTabPressTracker} />
-      ) : null}
-      <Tab.Navigator
-        initialRouteName={Routes.WALLET.HOME}
-        tabBar={renderTabBar}
-        screenOptions={{ headerShown: false }}
-      >
-        {/* Home Tab */}
-        <Tab.Screen
-          name={Routes.WALLET.HOME}
-          options={options.home}
-          component={WalletTabStackFlow}
-        />
-
-        {/* Explore Tab (w/ hidden browser) */}
-        <>
+      <TrendingQuickBuySheetProvider>
+        {isMoneyAccountEnabled ? (
+          <MoneyTabPressTracker onRegister={registerMoneyTabPressTracker} />
+        ) : null}
+        <Tab.Navigator
+          initialRouteName={Routes.WALLET.HOME}
+          tabBar={renderTabBar}
+          screenOptions={{ headerShown: false }}
+        >
+          {/* Home Tab */}
           <Tab.Screen
-            name={Routes.TRENDING_VIEW}
-            options={{
-              ...options.trending,
-              isSelected: (rootScreenName) =>
-                [Routes.TRENDING_VIEW, Routes.BROWSER.HOME].includes(
-                  rootScreenName,
-                ),
-            }}
-            component={ExploreHome}
+            name={Routes.WALLET.HOME}
+            options={options.home}
+            component={WalletTabStackFlow}
           />
-          <Tab.Screen
-            name={Routes.BROWSER.HOME}
-            options={{
-              ...options.browser,
-              isHidden: true,
-            }}
-            component={BrowserFlowUnmountOnTabBlur}
-          />
-        </>
 
-        {/* Trade Tab */}
-        <Tab.Screen
-          name={Routes.MODAL.TRADE_WALLET_ACTIONS}
-          options={options.trade}
-          component={WalletTabStackFlow}
-        />
+          {/* Explore Tab (w/ hidden browser) */}
+          <>
+            <Tab.Screen
+              name={Routes.TRENDING_VIEW}
+              options={{
+                ...options.trending,
+                isSelected: (rootScreenName) =>
+                  [Routes.TRENDING_VIEW, Routes.BROWSER.HOME].includes(
+                    rootScreenName,
+                  ),
+              }}
+              component={ExploreHome}
+            />
+            <Tab.Screen
+              name={Routes.BROWSER.HOME}
+              options={{
+                ...options.browser,
+                isHidden: true,
+              }}
+              component={BrowserFlowUnmountOnTabBlur}
+            />
+          </>
 
-        {/* Activity Tab (replaced by Money when feature flag is on and user is geo-eligible) */}
-        {isMoneyAccountVisible ? (
+          {/* Trade Tab */}
           <Tab.Screen
-            name={Routes.MONEY.ROOT}
-            options={options.money}
-            component={MoneyTabScreenStack}
+            name={Routes.MODAL.TRADE_WALLET_ACTIONS}
+            options={options.trade}
+            component={WalletTabStackFlow}
           />
-        ) : (
-          <Tab.Screen
-            name={Routes.TRANSACTIONS_VIEW}
-            options={options.activity}
-            component={TransactionsHomeUnmountOnTabBlur}
-          />
-        )}
 
-        {/* Rewards Tab */}
-        <Tab.Screen
-          name={Routes.REWARDS_VIEW}
-          options={options.rewards}
-          component={RewardsHomeUnmountOnTabBlur}
-        />
-      </Tab.Navigator>
+          {/* Activity Tab (replaced by Money when feature flag is on and user is geo-eligible) */}
+          {isMoneyAccountVisible ? (
+            <Tab.Screen
+              name={Routes.MONEY.ROOT}
+              options={options.money}
+              component={MoneyTabScreenStack}
+            />
+          ) : (
+            <Tab.Screen
+              name={Routes.TRANSACTIONS_VIEW}
+              options={options.activity}
+              component={TransactionsHomeUnmountOnTabBlur}
+            />
+          )}
+
+          {/* Rewards Tab */}
+          <Tab.Screen
+            name={Routes.REWARDS_VIEW}
+            options={options.rewards}
+            component={RewardsHomeUnmountOnTabBlur}
+          />
+        </Tab.Navigator>
+      </TrendingQuickBuySheetProvider>
     </PredictPreviewSheetProvider>
   );
 };

--- a/app/components/Nav/Main/MainNavigator.test.tsx
+++ b/app/components/Nav/Main/MainNavigator.test.tsx
@@ -59,6 +59,22 @@ jest.mock('../../UI/Predict', () => {
   };
 });
 
+jest.mock('../../UI/Trending/contexts', () => {
+  const { Fragment } = jest.requireActual('react');
+  return {
+    TrendingQuickBuySheetProvider: ({
+      children,
+    }: {
+      children: React.ReactNode;
+    }) => jest.requireActual('react').createElement(Fragment, null, children),
+    useTrendingQuickBuySheet: () => ({
+      openQuickBuy: jest.fn(),
+      closeQuickBuy: jest.fn(),
+      isQuickBuyOpen: false,
+    }),
+  };
+});
+
 jest.mock('../../UI/MarketInsights', () => ({
   MarketInsightsView: () => 'MarketInsightsView',
   selectMarketInsightsEnabled: (state: unknown) =>

--- a/app/components/UI/Trending/contexts/TrendingQuickBuySheetContext.test.tsx
+++ b/app/components/UI/Trending/contexts/TrendingQuickBuySheetContext.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { Pressable, Text } from 'react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import type { TrendingAsset } from '@metamask/assets-controllers';
+import {
+  TrendingQuickBuySheetProvider,
+  useTrendingQuickBuySheet,
+} from './TrendingQuickBuySheetContext';
+
+const mockTrendingQuickBuy = jest.fn();
+jest.mock('../components/TrendingQuickBuy/TrendingQuickBuy', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    mockTrendingQuickBuy(props);
+    return null;
+  },
+}));
+
+const makeToken = (overrides: Partial<TrendingAsset> = {}): TrendingAsset => ({
+  assetId: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  name: 'USD Coin',
+  symbol: 'USDC',
+  decimals: 6,
+  price: '1.00',
+  marketCap: 75_000_000_000,
+  aggregatedUsdVolume: 900_000_000,
+  ...overrides,
+});
+
+const StatusReader: React.FC = () => {
+  const { isQuickBuyOpen } = useTrendingQuickBuySheet();
+  return (
+    <Text testID="quick-buy-open-status">
+      {isQuickBuyOpen ? 'open' : 'closed'}
+    </Text>
+  );
+};
+
+const OpenButton: React.FC<{
+  token: TrendingAsset;
+  source?: 'explore_crypto' | 'explore_rwas';
+}> = ({ token, source }) => {
+  const { openQuickBuy } = useTrendingQuickBuySheet();
+  return (
+    <Pressable
+      testID="open-quick-buy"
+      onPress={() => openQuickBuy(token, source)}
+    />
+  );
+};
+
+const CloseButton: React.FC = () => {
+  const { closeQuickBuy } = useTrendingQuickBuySheet();
+  return <Pressable testID="close-quick-buy" onPress={closeQuickBuy} />;
+};
+
+describe('TrendingQuickBuySheetContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reports closed when no token is open', () => {
+    render(
+      <TrendingQuickBuySheetProvider>
+        <StatusReader />
+      </TrendingQuickBuySheetProvider>,
+    );
+
+    expect(screen.getByTestId('quick-buy-open-status').props.children).toBe(
+      'closed',
+    );
+    expect(mockTrendingQuickBuy).toHaveBeenCalledWith(
+      expect.objectContaining({ token: null }),
+    );
+  });
+
+  it('opens Quick Buy with the given token and source', () => {
+    const token = makeToken();
+
+    render(
+      <TrendingQuickBuySheetProvider>
+        <StatusReader />
+        <OpenButton token={token} source="explore_crypto" />
+      </TrendingQuickBuySheetProvider>,
+    );
+
+    fireEvent.press(screen.getByTestId('open-quick-buy'));
+
+    expect(screen.getByTestId('quick-buy-open-status').props.children).toBe(
+      'open',
+    );
+    expect(mockTrendingQuickBuy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        token,
+        source: 'explore_crypto',
+      }),
+    );
+  });
+
+  it('closes Quick Buy and clears the hosted token', () => {
+    const token = makeToken({ symbol: 'ETH' });
+
+    render(
+      <TrendingQuickBuySheetProvider>
+        <StatusReader />
+        <OpenButton token={token} source="explore_rwas" />
+        <CloseButton />
+      </TrendingQuickBuySheetProvider>,
+    );
+
+    fireEvent.press(screen.getByTestId('open-quick-buy'));
+    fireEvent.press(screen.getByTestId('close-quick-buy'));
+
+    expect(screen.getByTestId('quick-buy-open-status').props.children).toBe(
+      'closed',
+    );
+    expect(mockTrendingQuickBuy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ token: null }),
+    );
+  });
+
+  it('throws when useTrendingQuickBuySheet is used outside the provider', () => {
+    const Outside: React.FC = () => {
+      useTrendingQuickBuySheet();
+      return null;
+    };
+
+    expect(() => render(<Outside />)).toThrow(
+      'useTrendingQuickBuySheet must be used within TrendingQuickBuySheetProvider',
+    );
+  });
+});

--- a/app/components/UI/Trending/contexts/TrendingQuickBuySheetContext.tsx
+++ b/app/components/UI/Trending/contexts/TrendingQuickBuySheetContext.tsx
@@ -1,0 +1,78 @@
+import type { TrendingAsset } from '@metamask/assets-controllers';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import type { QuickBuySheetSource } from '../../QuickBuy/analytics';
+import TrendingQuickBuy from '../components/TrendingQuickBuy/TrendingQuickBuy';
+
+interface TrendingQuickBuySheetContextValue {
+  openQuickBuy: (token: TrendingAsset, source?: QuickBuySheetSource) => void;
+  closeQuickBuy: () => void;
+  isQuickBuyOpen: boolean;
+}
+
+const TrendingQuickBuySheetContext = createContext<
+  TrendingQuickBuySheetContextValue | undefined
+>(undefined);
+
+/**
+ * Hosts Explore-tab Quick Buy above the Home tab navigator so the sheet is
+ * not clipped by an individual tab's content area / bottom tab bar.
+ *
+ * Stack entry points (trending full view, search, token details) keep their
+ * local `TrendingQuickBuy` mounts — they already sit above HomeTabs.
+ */
+export const TrendingQuickBuySheetProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const [token, setToken] = useState<TrendingAsset | null>(null);
+  const [source, setSource] = useState<QuickBuySheetSource>('explore_search');
+
+  const openQuickBuy = useCallback(
+    (
+      nextToken: TrendingAsset,
+      nextSource: QuickBuySheetSource = 'explore_search',
+    ) => {
+      setSource(nextSource);
+      setToken(nextToken);
+    },
+    [],
+  );
+
+  const closeQuickBuy = useCallback(() => {
+    setToken(null);
+  }, []);
+
+  const value = useMemo(
+    (): TrendingQuickBuySheetContextValue => ({
+      openQuickBuy,
+      closeQuickBuy,
+      isQuickBuyOpen: token !== null,
+    }),
+    [openQuickBuy, closeQuickBuy, token],
+  );
+
+  return (
+    <TrendingQuickBuySheetContext.Provider value={value}>
+      {children}
+      <TrendingQuickBuy token={token} onClose={closeQuickBuy} source={source} />
+    </TrendingQuickBuySheetContext.Provider>
+  );
+};
+
+/**
+ * Opens Explore-tab Quick Buy via the root sheet host mounted above Tab.Navigator.
+ */
+export function useTrendingQuickBuySheet(): TrendingQuickBuySheetContextValue {
+  const ctx = useContext(TrendingQuickBuySheetContext);
+  if (!ctx) {
+    throw new Error(
+      'useTrendingQuickBuySheet must be used within TrendingQuickBuySheetProvider',
+    );
+  }
+  return ctx;
+}

--- a/app/components/UI/Trending/contexts/index.ts
+++ b/app/components/UI/Trending/contexts/index.ts
@@ -1,0 +1,4 @@
+export {
+  TrendingQuickBuySheetProvider,
+  useTrendingQuickBuySheet,
+} from './TrendingQuickBuySheetContext';

--- a/app/components/Views/TrendingView/tabs/CryptoTab.tsx
+++ b/app/components/Views/TrendingView/tabs/CryptoTab.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useNavigation, NavigationProp } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
@@ -34,7 +34,7 @@ import TileCarousel from '../components/TileCarousel';
 import type { TabProps } from '../hooks/useExploreRefresh';
 import { trackExploreInteracted } from '../search/analytics';
 import { TrendingViewSelectorsIDs } from '../TrendingView.testIds';
-import TrendingQuickBuy from '../../../UI/Trending/components/TrendingQuickBuy/TrendingQuickBuy';
+import { useTrendingQuickBuySheet } from '../../../UI/Trending/contexts';
 import { useABTest } from '../../../../hooks/useABTest';
 import {
   EXPLORE_QUICK_BUY_AB_KEY,
@@ -111,10 +111,7 @@ const CryptoTabContent: React.FC<TabProps> = ({
   const perpsNavigation =
     useNavigation<NavigationProp<PerpsNavigationParamList>>();
   const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
-
-  const [quickTradeToken, setQuickTradeToken] = useState<TrendingAsset | null>(
-    null,
-  );
+  const { openQuickBuy } = useTrendingQuickBuySheet();
 
   const { variant: quickBuyVariant } = useABTest(
     EXPLORE_QUICK_BUY_AB_KEY,
@@ -152,11 +149,13 @@ const CryptoTabContent: React.FC<TabProps> = ({
           })
         }
         onQuickTrade={
-          quickBuyVariant.showQuickTradeButton ? setQuickTradeToken : undefined
+          quickBuyVariant.showQuickTradeButton
+            ? (token) => openQuickBuy(token, 'explore_crypto')
+            : undefined
         }
       />
     ),
-    [quickBuyVariant.showQuickTradeButton],
+    [openQuickBuy, quickBuyVariant.showQuickTradeButton],
   );
 
   const showTokens = tokens.isLoading || tokens.data.length > 0;
@@ -251,12 +250,6 @@ const CryptoTabContent: React.FC<TabProps> = ({
       >
         <ExploreSectionList sections={sections} />
       </ExploreScroll>
-
-      <TrendingQuickBuy
-        token={quickTradeToken}
-        onClose={() => setQuickTradeToken(null)}
-        source="explore_crypto"
-      />
     </View>
   );
 };

--- a/app/components/Views/TrendingView/tabs/RwasTab.test.tsx
+++ b/app/components/Views/TrendingView/tabs/RwasTab.test.tsx
@@ -43,6 +43,21 @@ jest.mock('../../../UI/Predict', () => ({
   selectPredictEnabledFlag: jest.fn(() => false),
 }));
 
+const mockOpenQuickBuy = jest.fn();
+jest.mock('../../../UI/Trending/contexts', () => ({
+  useTrendingQuickBuySheet: () => ({
+    openQuickBuy: mockOpenQuickBuy,
+    closeQuickBuy: jest.fn(),
+    isQuickBuyOpen: false,
+  }),
+}));
+
+jest.mock('../../../../hooks/useABTest', () => ({
+  useABTest: () => ({
+    variant: { showQuickTradeButton: true },
+  }),
+}));
+
 jest.mock('../feeds/perps/usePerpsFeed');
 jest.mock('../feeds/stocks/useStocksFeed', () => ({
   useStocksFeed: jest.fn(),

--- a/app/components/Views/TrendingView/tabs/RwasTab.tsx
+++ b/app/components/Views/TrendingView/tabs/RwasTab.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useNavigation, NavigationProp } from '@react-navigation/native';
 import { useSelector } from 'react-redux';
@@ -43,7 +43,7 @@ import type { PillToggleCardListTab } from '../components/PillToggleCardList';
 import type { TabProps } from '../hooks/useExploreRefresh';
 import { trackExploreInteracted } from '../search/analytics';
 import { TrendingViewSelectorsIDs } from '../TrendingView.testIds';
-import TrendingQuickBuy from '../../../UI/Trending/components/TrendingQuickBuy/TrendingQuickBuy';
+import { useTrendingQuickBuySheet } from '../../../UI/Trending/contexts';
 import { useABTest } from '../../../../hooks/useABTest';
 import {
   EXPLORE_QUICK_BUY_AB_KEY,
@@ -119,10 +119,7 @@ const RwasTabContent: React.FC<TabProps> = ({
     useNavigation<NavigationProp<PerpsNavigationParamList>>();
   const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
   const isPredictEnabled = useSelector(selectPredictEnabledFlag);
-
-  const [quickTradeToken, setQuickTradeToken] = useState<TrendingAsset | null>(
-    null,
-  );
+  const { openQuickBuy } = useTrendingQuickBuySheet();
 
   const { variant: quickBuyVariant } = useABTest(
     EXPLORE_QUICK_BUY_AB_KEY,
@@ -156,11 +153,13 @@ const RwasTabContent: React.FC<TabProps> = ({
           })
         }
         onQuickTrade={
-          quickBuyVariant.showQuickTradeButton ? setQuickTradeToken : undefined
+          quickBuyVariant.showQuickTradeButton
+            ? (token) => openQuickBuy(token, 'explore_rwas')
+            : undefined
         }
       />
     ),
-    [quickBuyVariant.showQuickTradeButton],
+    [openQuickBuy, quickBuyVariant.showQuickTradeButton],
   );
 
   const showStocks = stocks.isLoading || stocks.data.length > 0;
@@ -258,12 +257,6 @@ const RwasTabContent: React.FC<TabProps> = ({
       >
         <ExploreSectionList sections={sections} />
       </ExploreScroll>
-
-      <TrendingQuickBuy
-        token={quickTradeToken}
-        onClose={() => setQuickTradeToken(null)}
-        source="explore_rwas"
-      />
     </View>
   );
 };

--- a/tests/component-view/renderers/trending.ts
+++ b/tests/component-view/renderers/trending.ts
@@ -9,6 +9,7 @@ import { ExploreFeed } from '../../../app/components/Views/TrendingView/Trending
 import ExploreSearchScreen from '../../../app/components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen';
 import TrendingTokensFullView from '../../../app/components/UI/Trending/Views/TrendingTokensFullView/TrendingTokensFullView';
 import RWATokensFullView from '../../../app/components/UI/Trending/Views/RWATokensFullView/RWATokensFullView';
+import { TrendingQuickBuySheetProvider } from '../../../app/components/UI/Trending/contexts';
 import { initialStateTrending } from '../presets/trending';
 
 interface RenderTrendingViewOptions {
@@ -37,6 +38,24 @@ function withQueryClient(
   };
 }
 
+/**
+ * Mirrors HomeTabs: Crypto/RWAs tabs call `useTrendingQuickBuySheet()` and
+ * require the provider that hosts the shared Explore Quick Buy sheet.
+ */
+function withExploreFeedProviders(
+  Component: React.ComponentType<unknown>,
+): React.ComponentType<unknown> {
+  const WithQueryClient = withQueryClient(Component);
+
+  return function WrappedWithExploreFeedProviders(props: unknown) {
+    return React.createElement(
+      TrendingQuickBuySheetProvider,
+      null,
+      React.createElement(WithQueryClient, props as Record<string, unknown>),
+    );
+  };
+}
+
 export function renderTrendingViewWithRoutes(
   options: RenderTrendingViewOptions = {},
 ): ReturnType<typeof renderScreenWithRoutes> {
@@ -49,7 +68,9 @@ export function renderTrendingViewWithRoutes(
   const state = builder.build();
 
   return renderScreenWithRoutes(
-    withQueryClient(ExploreFeed as unknown as React.ComponentType<unknown>),
+    withExploreFeedProviders(
+      ExploreFeed as unknown as React.ComponentType<unknown>,
+    ),
     { name: Routes.TRENDING_FEED },
     [
       {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Quick Buy opened from Explore list rows (Crypto/RWAs trending flash icon) was mounted inside the Explore tab content tree. `BottomSheetDialog` is absolutely positioned in its parent, so the sheet stopped above the app tab bar and the bottom bar stayed visible. Stack entry points (View all, search, token details) already mounted above `HomeTabs` and looked correct.

This mirrors the Predict preview sheet pattern: a `TrendingQuickBuySheetProvider` hosts one shared `TrendingQuickBuy` above `Tab.Navigator`. Explore Crypto/RWAs open via `useTrendingQuickBuySheet()` instead of local sheet state. Stack entry points are unchanged.


https://github.com/user-attachments/assets/d4644915-ea4a-4151-83df-ef2048f0a8fb



## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TSA-992

## **Manual testing steps**

```gherkin
Feature: Explore Quick Buy covers the tab bar

  Scenario: Explore Crypto list quick buy covers the bottom tab bar
    Given I am logged into MetaMask Mobile
    And Quick Buy is enabled on Explore
    And I am on Explore → Crypto

    When I tap the lightning bolt on a trending token row
    Then the Quick Buy sheet should open
    And the bottom tab bar should not remain visible under the sheet

    When I close the Quick Buy sheet
    Then the bottom tab bar should be visible again

  Scenario: Explore RWAs list quick buy covers the bottom tab bar
    Given I am on Explore → RWAs

    When I tap the lightning bolt on a stocks row
    Then the Quick Buy sheet should open above the tab bar

  Scenario: Stack entry points still work
    Given I open Quick Buy from View all, Explore search, or token details

    When I open and close Quick Buy
    Then the sheet presentation should match the existing full-screen behavior
```

## **Screenshots/Recordings**

### **Before**

N/A — see TSA-992 report (bottom tab bar visible under Explore list Quick Buy)

### **After**

N/A — needs device verification on Explore Crypto/RWAs list quick buy

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C092MDPA0LU/p1786611295793409?thread_ts=1786611295.793409&cid=C092MDPA0LU)

<div><a href="https://cursor.com/agents/bc-196cc1d7-1b22-53c3-8d60-97927f4151c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-196cc1d7-1b22-53c3-8d60-97927f4151c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

