### PR TITLE
test(appium): scroll before locating dapp network option on Android

### DIFF
--- a/tests/page-objects/Browser/TestDApp.ts
+++ b/tests/page-objects/Browser/TestDApp.ts
@@ -733,22 +733,6 @@ class TestDApp {
       networkName,
       exactMatch,
     );
-    // Picker list can populate after openNetworkPicker — wait before scroll
-    // (scrollIntoView fails immediately when the node is absent from the tree).
-    await Utilities.executeWithRetry(
-      async () => {
-        const exists = await networkItem.unwrap().isExisting();
-        if (!exists) {
-          throw new Error(
-            `Network option "${networkName}" not yet in dapp picker hierarchy`,
-          );
-        }
-      },
-      {
-        timeout: 20000,
-        description: `Wait for network option "${networkName}" in dapp picker`,
-      },
-    );
     const webview = await PlaywrightMatchers.getElementById(
       BrowserViewSelectorsIDs.BROWSER_WEBVIEW_ID,
     );


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`TestDApp.tapNetworkByName` waited for the network option to exist in the element hierarchy *before* scrolling it into view. On Android that wait can never succeed for an option that is below the fold: the WebView does not expose off-screen DOM nodes to the accessibility tree, so the option only enters the hierarchy once it has been scrolled into view. The result was `SmokeNetworkAbstractions` failing with `Wait for network option "Sepolia" in dapp picker failed after 6 attempt(s)`, having timed out before ever performing the scroll that would have revealed the element.

The gate was introduced in #34695 on the premise that `scrollIntoView` "fails immediately when the node is absent from the tree". That premise does not hold for the native mobile path — WebdriverIO's `mobileScrollUntilVisible` catches the not-found error from `isDisplayed()`, swipes, and re-checks on each iteration up to `maxScrolls`:

```js
while (!isVisible && scrolls < maxScrolls) {
  try {
    isVisible = await element.isDisplayed();
  } catch {
    isVisible = false;
  }
  if (isVisible) { break; }
  await browser.swipe({ direction, ...  });
}
```

This PR removes the pre-scroll existence gate so the scroll runs first, restoring the behaviour that shipped in #34353. The up/down scroll fallback added by #34695 is kept, since that part is an genuine improvement for options above the current scroll position.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

Refs: #34695 — follow-up correcting the pre-scroll wait introduced there.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — automation-only change. Coverage is exercised by the Appium smoke specs under `tests/smoke-appium/multichain/network-abstraction/`.

```gherkin
Feature: Test dapp network picker on Android

  Scenario: user switches to a network listed below the fold
    Given the test dapp is open and the network picker modal is displayed
    And the target network option is not currently on screen

    When the automation selects the network by name
    Then the WebView scrolls until the option is visible
    And the option is tapped without waiting for it to exist beforehand
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — no user-facing UI change. `permission-system-add-non-permitted.spec.ts` failed on Android with `Wait for network option "Sepolia" in dapp picker failed after 6 attempt(s) over 23693ms`.

### **After**

N/A — no user-facing UI change. The same spec passes locally on Android.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example
  - N/A for this PR (test-only; no production code paths)

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only page-object change with no production or security impact; behavior is restored for Android network-picker smoke specs.
> 
> **Overview**
> Fixes **Android Appium** failures when picking a network below the fold in the test dapp (e.g. **Sepolia** in `SmokeNetworkAbstractions`).
> 
> **`TestDApp.tapNetworkByName`** no longer runs a **`executeWithRetry`** loop that required the network label to exist in the hierarchy before scrolling. On Android, off-screen WebView nodes often are not in the accessibility tree until after a swipe, so that gate could time out without ever scrolling.
> 
> The method still **scrolls** the option into view (up, then down fallback) and **taps** it—the same flow as before #34695, while keeping the bidirectional scroll improvement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcbd3c49bd8d9f20048db59ae6bee3f21f97292e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->