### PR TITLE
fix(perps): cap Reduce Only slider to open position size

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.view.test.tsx
@@ -139,7 +139,15 @@ describeForPlatforms('PerpsProMarketView input journeys', () => {
         );
         expect(screen.getByTestId(ids.PLACE_ORDER_BUTTON)).toBeDisabled();
         expect(screen.queryByTestId(ids.TPSL)).not.toBeOnTheScreen();
+        expect(screen.getByTestId(ids.SIZE_INPUT)).toHaveProp('value', '');
       });
+
+      fireEvent(screen.getByTestId(ids.SIZE_SLIDER), 'valueChange', 50);
+      fireEvent(screen.getByTestId(ids.SIZE_SLIDER), 'dragEnd', 50);
+
+      await waitFor(() =>
+        expect(screen.getByTestId(ids.SIZE_INPUT)).toHaveProp('value', ''),
+      );
     },
   );
 
@@ -165,7 +173,15 @@ describeForPlatforms('PerpsProMarketView input journeys', () => {
         );
         expect(screen.getByTestId(ids.PLACE_ORDER_BUTTON)).toBeDisabled();
         expect(screen.queryByTestId(ids.TPSL)).not.toBeOnTheScreen();
+        expect(screen.getByTestId(ids.SIZE_INPUT)).toHaveProp('value', '');
       });
+
+      fireEvent(screen.getByTestId(ids.SIZE_SLIDER), 'valueChange', 50);
+      fireEvent(screen.getByTestId(ids.SIZE_SLIDER), 'dragEnd', 50);
+
+      await waitFor(() =>
+        expect(screen.getByTestId(ids.SIZE_INPUT)).toHaveProp('value', ''),
+      );
     },
   );
 
@@ -192,6 +208,7 @@ describeForPlatforms('PerpsProMarketView input journeys', () => {
         );
         expect(screen.getByTestId(ids.PLACE_ORDER_BUTTON)).toBeDisabled();
         expect(screen.queryByTestId(ids.TPSL)).not.toBeOnTheScreen();
+        expect(sizeInput).toHaveProp('value', '3000');
       });
     },
   );

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.view.test.tsx
@@ -195,4 +195,43 @@ describeForPlatforms('PerpsProMarketView input journeys', () => {
       });
     },
   );
+
+  itForPlatforms(
+    'sets the size slider max to the open position when Reduce Only is selected',
+    async () => {
+      renderPerpsProMarketView({
+        streamOverrides: {
+          account: createFundedAccountForViews('100'),
+          positions: [createLongPositionForViews({ size: '-1' })],
+          orders: [],
+        },
+      });
+      await findSizeInput();
+      const slider = screen.getByTestId(ids.SIZE_SLIDER);
+
+      fireEvent(slider, 'valueChange', 2500);
+      fireEvent(slider, 'dragEnd', 2500);
+
+      await waitFor(() => {
+        const marginCappedAmount = Number(
+          screen.getByTestId(ids.SIZE_INPUT).props.value,
+        );
+        expect(marginCappedAmount).toBeGreaterThan(0);
+        expect(marginCappedAmount).toBeLessThan(2500);
+      });
+
+      fireEvent.press(screen.getByTestId(ids.REDUCE_ONLY));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId(ids.TPSL)).not.toBeOnTheScreen();
+      });
+
+      fireEvent(screen.getByTestId(ids.SIZE_SLIDER), 'valueChange', 2500);
+      fireEvent(screen.getByTestId(ids.SIZE_SLIDER), 'dragEnd', 2500);
+
+      await waitFor(() =>
+        expect(screen.getByTestId(ids.SIZE_INPUT)).toHaveProp('value', '2500'),
+      );
+    },
+  );
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
@@ -1058,6 +1058,54 @@ describe('usePerpsProOrderForm', () => {
       expect(mockSetAmount).not.toHaveBeenCalled();
     });
 
+    it('does not restore a focused size after Reduce Only enables with no position', () => {
+      const { result } = renderProForm();
+
+      act(() => {
+        result.current.sizeInput.onFocus();
+        result.current.onReduceOnlyChange(true);
+        result.current.sizeInput.onBlur();
+      });
+
+      expect(result.current.sizeInput.value).toBe('');
+      expect(mockSetAmount).toHaveBeenCalledWith('0');
+      expect(mockSetAmount).not.toHaveBeenCalledWith('100');
+    });
+
+    it('does not clear typed size while the reduce-only position is loading', () => {
+      mockPositionStreamLoading = true;
+      const { result } = renderProForm();
+
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+
+      expect(mockSetAmount).not.toHaveBeenCalledWith('0');
+      expect(result.current.sizeInput.value).toBe('100');
+      expect(result.current.sizeSlider.maximumValue).toBe(1000);
+    });
+
+    it('keeps typed size when a valid closing position arrives after Reduce Only load', () => {
+      mockPositionStreamLoading = true;
+      const { result, rerender } = renderProForm();
+
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+
+      mockPositionStreamLoading = false;
+      mockExistingPosition = {
+        size: '-1',
+        leverage: { type: 'isolated', value: 5 },
+      };
+      rerender({});
+
+      expect(mockSetAmount).not.toHaveBeenCalledWith('0');
+      expect(result.current.sizeInput.value).toBe('100');
+      expect(result.current.sizeSlider.maximumValue).toBe(90000);
+      expect(mockSetMaxPossibleAmountOverride).toHaveBeenCalledWith(90000);
+    });
+
     it('uses the limit price for the Reduce Only slider max', () => {
       mockOrderForm.type = 'limit';
       mockOrderForm.limitPrice = '80000';

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
@@ -50,6 +50,7 @@ const mockSetLimitPrice = jest.fn();
 const mockSetOrderType = jest.fn();
 const mockHandlePercentageAmount = jest.fn();
 const mockUpdateOrderForm = jest.fn();
+const mockSetMaxPossibleAmountOverride = jest.fn();
 
 const mockContextValue = {
   orderForm: mockOrderForm,
@@ -63,6 +64,7 @@ const mockContextValue = {
   setOrderType: mockSetOrderType,
   handlePercentageAmount: mockHandlePercentageAmount,
   maxPossibleAmount: 1000,
+  setMaxPossibleAmountOverride: mockSetMaxPossibleAmountOverride,
   balanceForValidation: 500,
 };
 
@@ -970,7 +972,90 @@ describe('usePerpsProOrderForm', () => {
 
       expect(mockSetTakeProfitPrice).toHaveBeenCalledWith(undefined);
       expect(mockSetStopLossPrice).toHaveBeenCalledWith(undefined);
+      expect(mockSetMaxPossibleAmountOverride).toHaveBeenCalledWith(0);
       expect(result.current.reduceOnly).toBe(true);
+    });
+
+    it('sets the size slider max to the open position notional when Reduce Only is on', () => {
+      mockExistingPosition = {
+        size: '-1',
+        leverage: { type: 'isolated', value: 5 },
+      };
+      const { result } = renderProForm();
+
+      expect(result.current.sizeSlider.maximumValue).toBe(1000);
+
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+
+      expect(result.current.sizeSlider.maximumValue).toBe(90000);
+      expect(mockSetMaxPossibleAmountOverride).toHaveBeenCalledWith(90000);
+    });
+
+    it('sets the size slider max to 0 when Reduce Only is on with no position', () => {
+      const { result } = renderProForm();
+
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+
+      expect(result.current.sizeSlider.maximumValue).toBe(0);
+    });
+
+    it('uses the limit price for the Reduce Only slider max', () => {
+      mockOrderForm.type = 'limit';
+      mockOrderForm.limitPrice = '80000';
+      mockExistingPosition = {
+        size: '-0.5',
+        leverage: { type: 'isolated', value: 5 },
+      };
+      const { result } = renderProForm();
+
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+
+      expect(result.current.sizeSlider.maximumValue).toBe(40000);
+    });
+
+    it('restores the margin-based amount cap when Reduce Only turns off', () => {
+      mockExistingPosition = {
+        size: '-1',
+        leverage: { type: 'isolated', value: 5 },
+      };
+      const { result } = renderProForm();
+
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+      mockSetMaxPossibleAmountOverride.mockClear();
+      act(() => {
+        result.current.onReduceOnlyChange(false);
+      });
+
+      expect(mockSetMaxPossibleAmountOverride).toHaveBeenCalledWith(null);
+      expect(result.current.sizeSlider.maximumValue).toBe(1000);
+    });
+
+    it('does not clamp size to available margin when confirming leverage with Reduce Only on', () => {
+      mockOrderForm.amount = '6000';
+      mockExistingPosition = {
+        size: '-1',
+        leverage: { type: 'isolated', value: 5 },
+      };
+      const { result } = renderProForm();
+
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+      mockSetAmount.mockClear();
+      act(() => {
+        result.current.onLeverageConfirm(10, 'slider');
+      });
+
+      expect(mockSetLeverage).toHaveBeenCalledWith(10);
+      expect(mockSetAmount).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
@@ -546,6 +546,25 @@ describe('usePerpsProOrderForm', () => {
       expect(mockNavigate).not.toHaveBeenCalled();
     });
 
+    it('clears the size max override after a successful Reduce Only order', async () => {
+      mockExistingPosition = {
+        size: '-1',
+        leverage: { type: 'isolated', value: 5 },
+      };
+      const { result } = renderProForm();
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+      mockSetMaxPossibleAmountOverride.mockClear();
+
+      await act(async () => {
+        await result.current.onPlaceOrderPress();
+      });
+
+      expect(result.current.reduceOnly).toBe(false);
+      expect(mockSetMaxPossibleAmountOverride).toHaveBeenCalledWith(null);
+    });
+
     it('flushes a pending slider preview before allowing submission', async () => {
       // Arrange
       const { result, rerender } = renderProForm();

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.test.ts
@@ -972,7 +972,8 @@ describe('usePerpsProOrderForm', () => {
 
       expect(mockSetTakeProfitPrice).toHaveBeenCalledWith(undefined);
       expect(mockSetStopLossPrice).toHaveBeenCalledWith(undefined);
-      expect(mockSetMaxPossibleAmountOverride).toHaveBeenCalledWith(0);
+      expect(mockSetMaxPossibleAmountOverride).toHaveBeenCalledWith(null);
+      expect(mockSetAmount).toHaveBeenCalledWith('0');
       expect(result.current.reduceOnly).toBe(true);
     });
 
@@ -993,14 +994,49 @@ describe('usePerpsProOrderForm', () => {
       expect(mockSetMaxPossibleAmountOverride).toHaveBeenCalledWith(90000);
     });
 
-    it('sets the size slider max to 0 when Reduce Only is on with no position', () => {
+    it('keeps the margin-based slider max and empty size when Reduce Only is on with no position', () => {
       const { result } = renderProForm();
 
       act(() => {
         result.current.onReduceOnlyChange(true);
       });
 
-      expect(result.current.sizeSlider.maximumValue).toBe(0);
+      expect(result.current.sizeSlider.maximumValue).toBe(1000);
+      expect(result.current.sizeInput.value).toBe('');
+    });
+
+    it('keeps the margin-based slider max and empty size when Reduce Only is on with the wrong direction', () => {
+      mockExistingPosition = {
+        size: '1',
+        leverage: { type: 'isolated', value: 5 },
+      };
+      const { result } = renderProForm();
+
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+
+      expect(result.current.sizeSlider.maximumValue).toBe(1000);
+      expect(result.current.sizeInput.value).toBe('');
+      expect(mockSetMaxPossibleAmountOverride).toHaveBeenCalledWith(null);
+    });
+
+    it('does not commit slider amount when Reduce Only has a position error', () => {
+      const { result } = renderProForm();
+
+      act(() => {
+        result.current.onReduceOnlyChange(true);
+      });
+      mockSetAmount.mockClear();
+
+      act(() => {
+        result.current.sizeSlider.onValueChange(250);
+        result.current.sizeSlider.onDragEnd(250);
+      });
+
+      expect(result.current.sizeInput.value).toBe('');
+      expect(result.current.sizeSlider.value).toBe(250);
+      expect(mockSetAmount).not.toHaveBeenCalled();
     });
 
     it('uses the limit price for the Reduce Only slider max', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
@@ -796,6 +796,7 @@ export const usePerpsProOrderForm = ({
         stopLossPrice: undefined,
       });
       setReduceOnly(false);
+      setMaxPossibleAmountOverride(null);
     } finally {
       isSubmittingRef.current = false;
     }
@@ -833,6 +834,7 @@ export const usePerpsProOrderForm = ({
     chartLibrary,
     vipTier,
     executeOrder,
+    setMaxPossibleAmountOverride,
     updateOrderForm,
     updatePositionTPSL,
     showToast,
@@ -1189,6 +1191,7 @@ export const usePerpsProOrderForm = ({
 
   useEffect(() => {
     if (!reduceOnly) {
+      setMaxPossibleAmountOverride(null);
       return;
     }
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
@@ -15,7 +15,7 @@ import {
   useRoute,
   type RouteProp,
 } from '@react-navigation/native';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../../../../locales/i18n';
 import Engine from '../../../../../../../core/Engine';
@@ -60,7 +60,10 @@ import {
   buildPerpsOrderParams,
   buildPerpsOrderTrackingData,
 } from '../../../../utils/orderParams';
-import { deriveOrderSizing } from '../../../../utils/orderSizing';
+import {
+  deriveOrderSizing,
+  getReduceOnlyMaxUsdAmount,
+} from '../../../../utils/orderSizing';
 import { willFlipPosition } from '../../../../utils/orderUtils';
 import {
   validateReduceOnlyOrder,
@@ -320,6 +323,7 @@ export const usePerpsProOrderForm = ({
     setLimitPrice,
     setOrderType,
     maxPossibleAmount,
+    setMaxPossibleAmountOverride,
     balanceForValidation: spendableBalance,
   } = usePerpsOrderContext();
 
@@ -394,6 +398,24 @@ export const usePerpsProOrderForm = ({
     return parsedLimitPrice > 0 ? parsedLimitPrice : assetData.price;
   }, [assetData.price, orderForm.limitPrice, orderForm.type]);
 
+  // Reduce-only orders close existing size; slider 100% is the open position,
+  // not available-margin × leverage.
+  const sizeSliderMaxAmount = useMemo(() => {
+    if (!reduceOnly) {
+      return maxPossibleAmount;
+    }
+
+    return getReduceOnlyMaxUsdAmount({
+      positionSize: currentMarketPosition?.size,
+      price: effectiveInputPrice,
+    });
+  }, [
+    currentMarketPosition?.size,
+    effectiveInputPrice,
+    maxPossibleAmount,
+    reduceOnly,
+  ]);
+
   const {
     sizeInput,
     sizeSlider,
@@ -405,7 +427,7 @@ export const usePerpsProOrderForm = ({
     assetSymbol: symbol,
     effectivePrice: effectiveInputPrice,
     szDecimals,
-    maxPossibleAmount,
+    maxPossibleAmount: sizeSliderMaxAmount,
     maxDigits: MAX_PERPS_INPUT_DIGITS,
   });
 
@@ -853,7 +875,7 @@ export const usePerpsProOrderForm = ({
 
       const currentAmount = Number.parseFloat(effectiveUsdAmount || '0');
       const newMaxAmount = spendableBalance * leverage;
-      if (currentAmount > newMaxAmount) {
+      if (!reduceOnly && currentAmount > newMaxAmount) {
         setAmount(Math.floor(newMaxAmount).toString());
       }
 
@@ -889,6 +911,7 @@ export const usePerpsProOrderForm = ({
       orderForm.asset,
       orderForm.direction,
       orderForm.leverage,
+      reduceOnly,
       spendableBalance,
       track,
     ],
@@ -1115,10 +1138,43 @@ export const usePerpsProOrderForm = ({
       if (value) {
         setTakeProfitPrice(undefined);
         setStopLossPrice(undefined);
+        setMaxPossibleAmountOverride(
+          getReduceOnlyMaxUsdAmount({
+            positionSize: currentMarketPosition?.size,
+            price: effectiveInputPrice,
+          }),
+        );
+        return;
       }
+
+      setMaxPossibleAmountOverride(null);
     },
-    [setTakeProfitPrice, setStopLossPrice],
+    [
+      currentMarketPosition?.size,
+      effectiveInputPrice,
+      setMaxPossibleAmountOverride,
+      setTakeProfitPrice,
+      setStopLossPrice,
+    ],
   );
+
+  useEffect(() => {
+    if (!reduceOnly) {
+      return;
+    }
+
+    setMaxPossibleAmountOverride(
+      getReduceOnlyMaxUsdAmount({
+        positionSize: currentMarketPosition?.size,
+        price: effectiveInputPrice,
+      }),
+    );
+  }, [
+    currentMarketPosition?.size,
+    effectiveInputPrice,
+    reduceOnly,
+    setMaxPossibleAmountOverride,
+  ]);
 
   return {
     direction: orderForm.direction,

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
@@ -67,6 +67,7 @@ import {
 import { willFlipPosition } from '../../../../utils/orderUtils';
 import {
   validateReduceOnlyOrder,
+  getReduceOnlyPositionError,
   type ReduceOnlyValidationCode,
 } from '../../../../utils/reduceOnlyValidation';
 import {
@@ -398,10 +399,22 @@ export const usePerpsProOrderForm = ({
     return parsedLimitPrice > 0 ? parsedLimitPrice : assetData.price;
   }, [assetData.price, orderForm.limitPrice, orderForm.type]);
 
+  const reduceOnlyPositionError = useMemo(
+    () =>
+      getReduceOnlyPositionError({
+        reduceOnly,
+        direction: orderForm.direction,
+        position: currentMarketPosition,
+      }),
+    [currentMarketPosition, orderForm.direction, reduceOnly],
+  );
+  const keepReduceOnlySizeEmpty = Boolean(reduceOnlyPositionError);
+
   // Reduce-only orders close existing size; slider 100% is the open position,
-  // not available-margin × leverage.
+  // not available-margin × leverage. Position errors keep the margin-based
+  // range so the slider stays movable while the size field stays empty.
   const sizeSliderMaxAmount = useMemo(() => {
-    if (!reduceOnly) {
+    if (!reduceOnly || keepReduceOnlySizeEmpty) {
       return maxPossibleAmount;
     }
 
@@ -412,6 +425,7 @@ export const usePerpsProOrderForm = ({
   }, [
     currentMarketPosition?.size,
     effectiveInputPrice,
+    keepReduceOnlySizeEmpty,
     maxPossibleAmount,
     reduceOnly,
   ]);
@@ -429,6 +443,7 @@ export const usePerpsProOrderForm = ({
     szDecimals,
     maxPossibleAmount: sizeSliderMaxAmount,
     maxDigits: MAX_PERPS_INPUT_DIGITS,
+    keepSizeEmpty: keepReduceOnlySizeEmpty,
   });
 
   const feeResults = usePerpsOrderFees({
@@ -1135,23 +1150,37 @@ export const usePerpsProOrderForm = ({
   const onReduceOnlyChange = useCallback(
     (value: boolean) => {
       setReduceOnly(value);
-      if (value) {
-        setTakeProfitPrice(undefined);
-        setStopLossPrice(undefined);
-        setMaxPossibleAmountOverride(
-          getReduceOnlyMaxUsdAmount({
-            positionSize: currentMarketPosition?.size,
-            price: effectiveInputPrice,
-          }),
-        );
+      if (!value) {
+        setMaxPossibleAmountOverride(null);
         return;
       }
 
-      setMaxPossibleAmountOverride(null);
+      setTakeProfitPrice(undefined);
+      setStopLossPrice(undefined);
+
+      const positionError = getReduceOnlyPositionError({
+        reduceOnly: true,
+        direction: orderForm.direction,
+        position: currentMarketPosition,
+      });
+      if (positionError) {
+        setMaxPossibleAmountOverride(null);
+        setAmount('0');
+        return;
+      }
+
+      setMaxPossibleAmountOverride(
+        getReduceOnlyMaxUsdAmount({
+          positionSize: currentMarketPosition?.size,
+          price: effectiveInputPrice,
+        }),
+      );
     },
     [
-      currentMarketPosition?.size,
+      currentMarketPosition,
       effectiveInputPrice,
+      orderForm.direction,
+      setAmount,
       setMaxPossibleAmountOverride,
       setTakeProfitPrice,
       setStopLossPrice,
@@ -1160,6 +1189,14 @@ export const usePerpsProOrderForm = ({
 
   useEffect(() => {
     if (!reduceOnly) {
+      return;
+    }
+
+    if (keepReduceOnlySizeEmpty) {
+      setMaxPossibleAmountOverride(null);
+      if (orderForm.amount !== '0' && orderForm.amount !== '') {
+        setAmount('0');
+      }
       return;
     }
 
@@ -1172,7 +1209,10 @@ export const usePerpsProOrderForm = ({
   }, [
     currentMarketPosition?.size,
     effectiveInputPrice,
+    keepReduceOnlySizeEmpty,
+    orderForm.amount,
     reduceOnly,
+    setAmount,
     setMaxPossibleAmountOverride,
   ]);
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts
@@ -372,6 +372,7 @@ export const usePerpsProOrderForm = ({
     asset: symbol,
     loadOnMount: true,
   });
+  const isReduceOnlyPositionLoading = reduceOnly && isPositionStreamLoading;
 
   const prices = usePerpsLivePrices({ symbols: [symbol], throttleMs: 1000 });
   const currentPrice = prices[symbol];
@@ -408,13 +409,16 @@ export const usePerpsProOrderForm = ({
       }),
     [currentMarketPosition, orderForm.direction, reduceOnly],
   );
-  const keepReduceOnlySizeEmpty = Boolean(reduceOnlyPositionError);
+  const keepReduceOnlySizeEmpty =
+    Boolean(reduceOnlyPositionError) && !isReduceOnlyPositionLoading;
 
   // Reduce-only orders close existing size; slider 100% is the open position,
   // not available-margin × leverage. Position errors keep the margin-based
   // range so the slider stays movable while the size field stays empty.
+  // While the position stream is unresolved, keep the margin-based range and
+  // typed size — same as notices skipping until the snapshot can be evaluated.
   const sizeSliderMaxAmount = useMemo(() => {
-    if (!reduceOnly || keepReduceOnlySizeEmpty) {
+    if (!reduceOnly || isReduceOnlyPositionLoading || keepReduceOnlySizeEmpty) {
       return maxPossibleAmount;
     }
 
@@ -425,6 +429,7 @@ export const usePerpsProOrderForm = ({
   }, [
     currentMarketPosition?.size,
     effectiveInputPrice,
+    isReduceOnlyPositionLoading,
     keepReduceOnlySizeEmpty,
     maxPossibleAmount,
     reduceOnly,
@@ -534,8 +539,6 @@ export const usePerpsProOrderForm = ({
     () => ({ ...orderForm, amount: effectiveUsdAmount }),
     [effectiveUsdAmount, orderForm],
   );
-
-  const isReduceOnlyPositionLoading = reduceOnly && isPositionStreamLoading;
 
   const reduceOnlyValidation = useMemo(
     () =>
@@ -796,7 +799,6 @@ export const usePerpsProOrderForm = ({
         stopLossPrice: undefined,
       });
       setReduceOnly(false);
-      setMaxPossibleAmountOverride(null);
     } finally {
       isSubmittingRef.current = false;
     }
@@ -834,7 +836,6 @@ export const usePerpsProOrderForm = ({
     chartLibrary,
     vipTier,
     executeOrder,
-    setMaxPossibleAmountOverride,
     updateOrderForm,
     updatePositionTPSL,
     showToast,
@@ -1152,54 +1153,28 @@ export const usePerpsProOrderForm = ({
   const onReduceOnlyChange = useCallback(
     (value: boolean) => {
       setReduceOnly(value);
-      if (!value) {
-        setMaxPossibleAmountOverride(null);
-        return;
+      if (value) {
+        setTakeProfitPrice(undefined);
+        setStopLossPrice(undefined);
       }
-
-      setTakeProfitPrice(undefined);
-      setStopLossPrice(undefined);
-
-      const positionError = getReduceOnlyPositionError({
-        reduceOnly: true,
-        direction: orderForm.direction,
-        position: currentMarketPosition,
-      });
-      if (positionError) {
-        setMaxPossibleAmountOverride(null);
-        setAmount('0');
-        return;
-      }
-
-      setMaxPossibleAmountOverride(
-        getReduceOnlyMaxUsdAmount({
-          positionSize: currentMarketPosition?.size,
-          price: effectiveInputPrice,
-        }),
-      );
     },
-    [
-      currentMarketPosition,
-      effectiveInputPrice,
-      orderForm.direction,
-      setAmount,
-      setMaxPossibleAmountOverride,
-      setTakeProfitPrice,
-      setStopLossPrice,
-    ],
+    [setTakeProfitPrice, setStopLossPrice],
   );
 
+  // Single owner for the Reduce Only size-max override. Toggle and submit only
+  // flip `reduceOnly`; this effect applies or clears the cap.
   useEffect(() => {
     if (!reduceOnly) {
       setMaxPossibleAmountOverride(null);
       return;
     }
 
+    if (isReduceOnlyPositionLoading) {
+      return;
+    }
+
     if (keepReduceOnlySizeEmpty) {
       setMaxPossibleAmountOverride(null);
-      if (orderForm.amount !== '0' && orderForm.amount !== '') {
-        setAmount('0');
-      }
       return;
     }
 
@@ -1212,12 +1187,25 @@ export const usePerpsProOrderForm = ({
   }, [
     currentMarketPosition?.size,
     effectiveInputPrice,
+    isReduceOnlyPositionLoading,
     keepReduceOnlySizeEmpty,
-    orderForm.amount,
     reduceOnly,
-    setAmount,
     setMaxPossibleAmountOverride,
   ]);
+
+  const orderAmountRef = useRef(orderForm.amount);
+  orderAmountRef.current = orderForm.amount;
+
+  useEffect(() => {
+    if (!keepReduceOnlySizeEmpty) {
+      return;
+    }
+
+    const amount = orderAmountRef.current;
+    if (amount !== '0' && amount !== '') {
+      setAmount('0');
+    }
+  }, [keepReduceOnlySizeEmpty, setAmount]);
 
   return {
     direction: orderForm.direction,

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProSizeInput.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProSizeInput.test.ts
@@ -823,4 +823,39 @@ describe('usePerpsProSizeInput', () => {
     expect(result.current.sizeInput.value).toBe('');
     expect(mockSetAmount).not.toHaveBeenCalled();
   });
+
+  it('does not commit a stale draft on blur after size is kept empty', () => {
+    const { result, rerender } = renderHook(
+      (params: UsePerpsProSizeInputParams) => usePerpsProSizeInput(params),
+      { initialProps: createParams({ usdAmount: '100' }) },
+    );
+
+    act(() => {
+      result.current.sizeInput.onFocus();
+    });
+    rerender(createParams({ usdAmount: '0', keepSizeEmpty: true }));
+
+    act(() => {
+      result.current.sizeInput.onBlur();
+    });
+
+    expect(result.current.sizeInput.value).toBe('');
+    expect(mockSetAmount).not.toHaveBeenCalled();
+  });
+
+  it('does not commit on denomination toggle while the size field is kept empty', () => {
+    const { result } = renderHook(() =>
+      usePerpsProSizeInput(
+        createParams({ usdAmount: '100', keepSizeEmpty: true }),
+      ),
+    );
+
+    act(() => {
+      result.current.sizeInput.onToggleDenomination();
+    });
+
+    expect(result.current.sizeInput.value).toBe('');
+    expect(result.current.sizeInput.denomination).toEqual({ unit: 'usd' });
+    expect(mockSetAmount).not.toHaveBeenCalled();
+  });
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProSizeInput.test.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProSizeInput.test.ts
@@ -763,4 +763,64 @@ describe('usePerpsProSizeInput', () => {
     expect(mockSetAmount).not.toHaveBeenCalled();
     expect(result.current.commitPendingSliderPreview()).toBe(false);
   });
+
+  it('keeps the size field empty while the slider still moves', () => {
+    const { result } = renderHook(() =>
+      usePerpsProSizeInput(createParams({ keepSizeEmpty: true })),
+    );
+
+    act(() => {
+      result.current.sizeSlider.onValueChange(250);
+    });
+
+    expect(result.current.sizeInput.value).toBe('');
+    expect(result.current.effectiveUsdAmount).toBe('0');
+    expect(result.current.sizeSlider.value).toBe(250);
+    expect(result.current.sizeSlider.maximumValue).toBe(1000);
+    expect(mockSetAmount).not.toHaveBeenCalled();
+  });
+
+  it('does not commit slider drags while the size field is kept empty', () => {
+    const { result } = renderHook(() =>
+      usePerpsProSizeInput(createParams({ keepSizeEmpty: true })),
+    );
+
+    act(() => {
+      result.current.sizeSlider.onValueChange(250);
+      result.current.sizeSlider.onDragEnd(250);
+    });
+
+    expect(result.current.sizeInput.value).toBe('');
+    expect(result.current.sizeSlider.value).toBe(250);
+    expect(mockSetAmount).not.toHaveBeenCalled();
+    expect(result.current.commitPendingSliderPreview()).toBe(false);
+  });
+
+  it('reverts visual-only slider movement on drag cancel while size stays empty', () => {
+    const { result } = renderHook(() =>
+      usePerpsProSizeInput(createParams({ keepSizeEmpty: true })),
+    );
+
+    act(() => {
+      result.current.sizeSlider.onValueChange(250);
+      result.current.sizeSlider.onDragCancel();
+    });
+
+    expect(result.current.sizeInput.value).toBe('');
+    expect(result.current.sizeSlider.value).toBe(0);
+    expect(mockSetAmount).not.toHaveBeenCalled();
+  });
+
+  it('ignores typed size while the size field is kept empty', () => {
+    const { result } = renderHook(() =>
+      usePerpsProSizeInput(createParams({ keepSizeEmpty: true })),
+    );
+
+    act(() => {
+      result.current.sizeInput.onChange('50');
+    });
+
+    expect(result.current.sizeInput.value).toBe('');
+    expect(mockSetAmount).not.toHaveBeenCalled();
+  });
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProSizeInput.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProSizeInput.ts
@@ -292,6 +292,9 @@ export const usePerpsProSizeInput = ({
 
   const onBlur = useCallback(() => {
     setIsSizeFocused(false);
+    if (keepSizeEmpty) {
+      return;
+    }
 
     if (denominationUnit === 'usd') {
       const finalizedDraft = finalizeNumericTextInput(usdDraft);
@@ -340,6 +343,7 @@ export const usePerpsProSizeInput = ({
     commitUsdAmount,
     denominationUnit,
     effectivePrice,
+    keepSizeEmpty,
     szDecimals,
     usdDraft,
   ]);
@@ -350,7 +354,7 @@ export const usePerpsProSizeInput = ({
   }, [clearSliderPreview]);
 
   const onToggleDenomination = useCallback(() => {
-    if (!canToggleDenomination) {
+    if (!canToggleDenomination || keepSizeEmpty) {
       return;
     }
 
@@ -377,6 +381,7 @@ export const usePerpsProSizeInput = ({
     commitUsdAmount,
     denominationUnit,
     effectivePrice,
+    keepSizeEmpty,
     szDecimals,
     usdDraft,
   ]);

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProSizeInput.ts
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProSizeInput.ts
@@ -26,6 +26,11 @@ export interface UsePerpsProSizeInputParams {
   szDecimals: number;
   maxPossibleAmount: number;
   maxDigits?: number;
+  /**
+   * When true, the size field stays empty and slider drags are visual-only
+   * (used for reduce-only `no_position` / `wrong_side`).
+   */
+  keepSizeEmpty?: boolean;
 }
 
 export interface UsePerpsProSizeInputResult {
@@ -118,6 +123,7 @@ export const usePerpsProSizeInput = ({
   szDecimals,
   maxPossibleAmount,
   maxDigits,
+  keepSizeEmpty = false,
 }: UsePerpsProSizeInputParams): UsePerpsProSizeInputResult => {
   const canToggleDenomination =
     Number.isFinite(effectivePrice) && effectivePrice > 0;
@@ -146,6 +152,14 @@ export const usePerpsProSizeInput = ({
     sliderPreviewRef.current = null;
     setSliderPreview(null);
   }, []);
+
+  const wasKeepSizeEmptyRef = useRef(keepSizeEmpty);
+  useEffect(() => {
+    if (wasKeepSizeEmptyRef.current && !keepSizeEmpty) {
+      clearSliderPreview();
+    }
+    wasKeepSizeEmptyRef.current = keepSizeEmpty;
+  }, [clearSliderPreview, keepSizeEmpty]);
 
   const commitUsdAmount = useCallback(
     (nextUsdAmount: string) => {
@@ -232,6 +246,10 @@ export const usePerpsProSizeInput = ({
 
   const onChange = useCallback(
     (text: string) => {
+      if (keepSizeEmpty) {
+        return;
+      }
+
       const previousValue = denominationUnit === 'usd' ? usdDraft : assetDraft;
       const result = normalizeNumericTextInput(
         text,
@@ -267,6 +285,7 @@ export const usePerpsProSizeInput = ({
       denominationUnit,
       effectivePrice,
       inputOptions,
+      keepSizeEmpty,
       usdDraft,
     ],
   );
@@ -363,6 +382,10 @@ export const usePerpsProSizeInput = ({
   ]);
 
   const effectiveUsdAmount = useMemo(() => {
+    if (keepSizeEmpty) {
+      return '0';
+    }
+
     if (sliderPreview !== null) {
       return sliderPreview;
     }
@@ -389,6 +412,7 @@ export const usePerpsProSizeInput = ({
     canToggleDenomination,
     denominationUnit,
     effectivePrice,
+    keepSizeEmpty,
     sliderPreview,
     usdAmount,
     usdDraft,
@@ -427,28 +451,48 @@ export const usePerpsProSizeInput = ({
 
   const onSliderDragEnd = useCallback(
     (value: number) => {
-      commitSliderUsdAmount(clampSliderUsdAmount(value, maxPossibleAmount));
+      const nextUsdAmount = clampSliderUsdAmount(value, maxPossibleAmount);
+      if (keepSizeEmpty) {
+        sliderPreviewRef.current = nextUsdAmount;
+        setSliderPreview(nextUsdAmount);
+        return;
+      }
+
+      commitSliderUsdAmount(nextUsdAmount);
     },
-    [commitSliderUsdAmount, maxPossibleAmount],
+    [commitSliderUsdAmount, keepSizeEmpty, maxPossibleAmount],
   );
 
   const onSliderDragCancel = useCallback(() => {
+    if (keepSizeEmpty) {
+      clearSliderPreview();
+      return;
+    }
+
     const nextUsdAmount = sliderPreviewRef.current;
     if (nextUsdAmount !== null) {
       commitSliderUsdAmount(nextUsdAmount);
     }
-  }, [commitSliderUsdAmount]);
+  }, [clearSliderPreview, commitSliderUsdAmount, keepSizeEmpty]);
 
   const commitPendingSliderPreview = useCallback((): boolean => {
+    if (keepSizeEmpty) {
+      return false;
+    }
+
     const nextUsdAmount = sliderPreviewRef.current;
     if (nextUsdAmount === null) {
       return false;
     }
 
     return commitSliderUsdAmount(nextUsdAmount);
-  }, [commitSliderUsdAmount]);
+  }, [commitSliderUsdAmount, keepSizeEmpty]);
 
   const value = useMemo(() => {
+    if (keepSizeEmpty) {
+      return '';
+    }
+
     if (sliderPreview === null) {
       return denominationUnit === 'usd' ? usdDraft : assetDraft;
     }
@@ -464,6 +508,7 @@ export const usePerpsProSizeInput = ({
     canToggleDenomination,
     denominationUnit,
     effectivePrice,
+    keepSizeEmpty,
     sliderPreview,
     szDecimals,
     usdDraft,
@@ -500,7 +545,10 @@ export const usePerpsProSizeInput = ({
 
   const sizeSlider = useMemo<PerpsProSizeSliderModel>(
     () => ({
-      value: getSliderDisplayValue(effectiveUsdAmount, maxPossibleAmount),
+      value: getSliderDisplayValue(
+        keepSizeEmpty ? (sliderPreview ?? '0') : effectiveUsdAmount,
+        maxPossibleAmount,
+      ),
       maximumValue: Math.max(0, maxPossibleAmount),
       onValueChange: onSliderValueChange,
       onDragEnd: onSliderDragEnd,
@@ -508,10 +556,12 @@ export const usePerpsProSizeInput = ({
     }),
     [
       effectiveUsdAmount,
+      keepSizeEmpty,
       maxPossibleAmount,
       onSliderDragCancel,
       onSliderDragEnd,
       onSliderValueChange,
+      sliderPreview,
     ],
   );
 

--- a/app/components/UI/Perps/contexts/PerpsOrderContext.test.tsx
+++ b/app/components/UI/Perps/contexts/PerpsOrderContext.test.tsx
@@ -43,6 +43,7 @@ describe('PerpsOrderContext', () => {
     handleMaxAmount: jest.fn(),
     handleMinAmount: jest.fn(),
     maxPossibleAmount: 1000,
+    setMaxPossibleAmountOverride: jest.fn(),
     balanceForValidation: 1000,
   };
 

--- a/app/components/UI/Perps/hooks/usePerpsOrderForm.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderForm.test.ts
@@ -832,6 +832,36 @@ describe('usePerpsOrderForm', () => {
       expect(at100).toBe(result.current.maxPossibleAmount);
     });
 
+    it('does not clamp typed amounts while a max override is set', () => {
+      const { result } = renderHook(() => usePerpsOrderForm(), {
+        wrapper: createWrapper(),
+      });
+
+      act(() => {
+        result.current.setMaxPossibleAmountOverride(1000);
+        result.current.setAmount('5000');
+      });
+
+      expect(result.current.maxPossibleAmount).toBe(1000);
+      expect(result.current.orderForm.amount).toBe('5000');
+    });
+
+    it('restores the margin-based max when the override is cleared', () => {
+      const { result } = renderHook(() => usePerpsOrderForm(), {
+        wrapper: createWrapper(),
+      });
+      const marginMax = result.current.maxPossibleAmount;
+
+      act(() => {
+        result.current.setMaxPossibleAmountOverride(marginMax + 5000);
+      });
+      act(() => {
+        result.current.setMaxPossibleAmountOverride(null);
+      });
+
+      expect(result.current.maxPossibleAmount).toBe(marginMax);
+    });
+
     it('does not update amount when balance is 0', () => {
       mockUsePerpsLiveAccount.mockReturnValue({
         account: {

--- a/app/components/UI/Perps/hooks/usePerpsOrderForm.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderForm.ts
@@ -44,6 +44,11 @@ export interface UsePerpsOrderFormReturn {
   handleMaxAmount: () => void;
   handleMinAmount: () => void;
   maxPossibleAmount: number;
+  /**
+   * Temporarily replace the margin-based max (e.g. Reduce Only, where max is
+   * the open position notional). Pass `null` to restore the margin-based cap.
+   */
+  setMaxPossibleAmountOverride: (amount: number | null) => void;
   /** Balance to use for validation and UI (Perps balance or selected token amount in USD when paying with custom token) */
   balanceForValidation: number;
 }
@@ -193,10 +198,14 @@ export function usePerpsOrderForm(
     type: defaultOrderType,
   });
 
+  const [maxPossibleAmountOverride, setMaxPossibleAmountOverride] = useState<
+    number | null
+  >(null);
+
   // Calculate the maximum possible amount; when paying with custom token, capped by selected token amount in USD
   // For limit orders, use the limit price instead of market price so the 100% slider
   // correctly reflects the max order size at the user-specified price
-  const maxPossibleAmount = useMemo(() => {
+  const marginBasedMaxPossibleAmount = useMemo(() => {
     const marketPrice = Number.parseFloat(currentPrice?.price) || 0;
     const effectiveAssetPrice =
       orderForm.type === 'limit' &&
@@ -218,6 +227,11 @@ export function usePerpsOrderForm(
     marketData?.szDecimals,
     orderForm.leverage,
   ]);
+
+  const maxPossibleAmount =
+    maxPossibleAmountOverride !== null
+      ? maxPossibleAmountOverride
+      : marginBasedMaxPossibleAmount;
 
   // Update amount only once when the hook first calculates the initial value
   // We use a ref to track if we've already set the initial amount to avoid overwriting user input
@@ -270,8 +284,14 @@ export function usePerpsOrderForm(
     }
   }, [existingPositionLeverage, initialLeverage, orderForm.leverage]);
 
-  // When user changes payment token (or effective balance drops), reset amount to MAX if current amount exceeds new max
+  // When user changes payment token (or effective balance drops), reset amount to MAX if current amount exceeds new max.
+  // Skip while a max override is set (Reduce Only): size is capped by the open
+  // position, not available margin, and the user may type above that cap.
   useEffect(() => {
+    if (maxPossibleAmountOverride !== null) {
+      return;
+    }
+
     const currentAmount = Number.parseFloat(orderForm.amount);
     if (
       !Number.isFinite(currentAmount) ||
@@ -286,7 +306,12 @@ export function usePerpsOrderForm(
       ...prev,
       amount: newValue,
     }));
-  }, [balanceForMax, maxPossibleAmount, orderForm.amount]);
+  }, [
+    balanceForMax,
+    maxPossibleAmount,
+    maxPossibleAmountOverride,
+    orderForm.amount,
+  ]);
 
   // Update entire form
   const updateOrderForm = useCallback((updates: Partial<OrderFormState>) => {
@@ -393,6 +418,7 @@ export function usePerpsOrderForm(
       handleMaxAmount,
       handleMinAmount,
       maxPossibleAmount,
+      setMaxPossibleAmountOverride,
       balanceForValidation: balanceForMax,
     }),
     [
@@ -410,6 +436,7 @@ export function usePerpsOrderForm(
       handleMaxAmount,
       handleMinAmount,
       maxPossibleAmount,
+      setMaxPossibleAmountOverride,
       balanceForMax,
     ],
   );

--- a/app/components/UI/Perps/utils/orderSizing.test.ts
+++ b/app/components/UI/Perps/utils/orderSizing.test.ts
@@ -1,5 +1,5 @@
 import { PERPS_CONSTANTS } from '@metamask/perps-controller';
-import { deriveOrderSizing } from './orderSizing';
+import { deriveOrderSizing, getReduceOnlyMaxUsdAmount } from './orderSizing';
 
 describe('deriveOrderSizing', () => {
   const base = {
@@ -97,5 +97,42 @@ describe('deriveOrderSizing', () => {
 
     // Assert
     expect(result.positionSize).not.toBe(PERPS_CONSTANTS.FallbackDataDisplay);
+  });
+});
+
+describe('getReduceOnlyMaxUsdAmount', () => {
+  it('returns the USD notional of a long position', () => {
+    const result = getReduceOnlyMaxUsdAmount({
+      positionSize: '0.5',
+      price: 90000,
+    });
+
+    expect(result).toBe(45000);
+  });
+
+  it('uses the absolute size of a short position', () => {
+    const result = getReduceOnlyMaxUsdAmount({
+      positionSize: '-1',
+      price: 90000,
+    });
+
+    expect(result).toBe(90000);
+  });
+
+  it('returns 0 when size is missing, zero, or non-numeric', () => {
+    expect(getReduceOnlyMaxUsdAmount({ price: 90000 })).toBe(0);
+    expect(getReduceOnlyMaxUsdAmount({ positionSize: '0', price: 90000 })).toBe(
+      0,
+    );
+    expect(
+      getReduceOnlyMaxUsdAmount({ positionSize: 'abc', price: 90000 }),
+    ).toBe(0);
+  });
+
+  it('returns 0 when price is missing or non-positive', () => {
+    expect(getReduceOnlyMaxUsdAmount({ positionSize: '1', price: 0 })).toBe(0);
+    expect(
+      getReduceOnlyMaxUsdAmount({ positionSize: '1', price: Number.NaN }),
+    ).toBe(0);
   });
 });

--- a/app/components/UI/Perps/utils/orderSizing.ts
+++ b/app/components/UI/Perps/utils/orderSizing.ts
@@ -82,3 +82,35 @@ export const deriveOrderSizing = ({
 
   return { effectivePrice, positionSize, marginRequired };
 };
+
+export interface ReduceOnlyMaxUsdAmountInput {
+  /** Signed or unsigned position size in token units. */
+  positionSize?: string;
+  /** Price used to convert size to USD (limit price when set, else market). */
+  price: number;
+}
+
+/**
+ * USD notional of an open position at `price`. Used as the Pro size-slider
+ * max when Reduce Only is on so the range tracks position size, not
+ * available margin.
+ *
+ * @param input - Position size and conversion price.
+ * @returns The USD notional, or `0` when size or price is missing/invalid.
+ */
+export const getReduceOnlyMaxUsdAmount = ({
+  positionSize,
+  price,
+}: ReduceOnlyMaxUsdAmountInput): number => {
+  const absSize = Math.abs(Number.parseFloat(positionSize ?? ''));
+  if (
+    !Number.isFinite(absSize) ||
+    absSize <= 0 ||
+    !Number.isFinite(price) ||
+    price <= 0
+  ) {
+    return 0;
+  }
+
+  return new BigNumber(absSize).times(price).toNumber();
+};

--- a/app/components/UI/Perps/utils/reduceOnlyValidation.test.ts
+++ b/app/components/UI/Perps/utils/reduceOnlyValidation.test.ts
@@ -1,5 +1,8 @@
 import type { Position } from '@metamask/perps-controller';
-import { validateReduceOnlyOrder } from './reduceOnlyValidation';
+import {
+  validateReduceOnlyOrder,
+  getReduceOnlyPositionError,
+} from './reduceOnlyValidation';
 
 const createPosition = (overrides: Partial<Position> = {}): Position =>
   ({
@@ -141,5 +144,47 @@ describe('validateReduceOnlyOrder', () => {
 
     expect(result.isValid).toBe(true);
     expect(result.isFullClose).toBe(false);
+  });
+});
+
+describe('getReduceOnlyPositionError', () => {
+  it('returns undefined when reduceOnly is off', () => {
+    const result = getReduceOnlyPositionError({
+      reduceOnly: false,
+      direction: 'long',
+      position: null,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns no_position when there is no open position', () => {
+    const result = getReduceOnlyPositionError({
+      reduceOnly: true,
+      direction: 'short',
+      position: null,
+    });
+
+    expect(result).toBe('no_position');
+  });
+
+  it('returns wrong_side when the order matches the open position', () => {
+    const result = getReduceOnlyPositionError({
+      reduceOnly: true,
+      direction: 'long',
+      position: createPosition({ size: '1' }),
+    });
+
+    expect(result).toBe('wrong_side');
+  });
+
+  it('returns undefined for the closing side regardless of size', () => {
+    const result = getReduceOnlyPositionError({
+      reduceOnly: true,
+      direction: 'short',
+      position: createPosition({ size: '1' }),
+    });
+
+    expect(result).toBeUndefined();
   });
 });

--- a/app/components/UI/Perps/utils/reduceOnlyValidation.ts
+++ b/app/components/UI/Perps/utils/reduceOnlyValidation.ts
@@ -9,6 +9,12 @@ export type ReduceOnlyValidationCode =
   | 'wrong_side'
   | 'too_large';
 
+/** Size-independent reduce-only errors — the size field should stay empty. */
+export type ReduceOnlyPositionErrorCode = Extract<
+  ReduceOnlyValidationCode,
+  'no_position' | 'wrong_side'
+>;
+
 export type ReduceOnlyOrderDirection = 'long' | 'short';
 
 export interface ValidateReduceOnlyOrderParams {
@@ -98,4 +104,29 @@ export const validateReduceOnlyOrder = ({
     isValid: true,
     isFullClose,
   };
+};
+
+/**
+ * Size-independent reduce-only errors (`no_position`, `wrong_side`).
+ * `too_large` is excluded so callers can keep the typed/slid amount visible.
+ */
+export const getReduceOnlyPositionError = ({
+  reduceOnly,
+  direction,
+  position,
+}: Omit<ValidateReduceOnlyOrderParams, 'orderSize'>):
+  | ReduceOnlyPositionErrorCode
+  | undefined => {
+  const { errorCode } = validateReduceOnlyOrder({
+    reduceOnly,
+    direction,
+    orderSize: '0',
+    position,
+  });
+
+  if (errorCode === 'no_position' || errorCode === 'wrong_side') {
+    return errorCode;
+  }
+
+  return undefined;
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When Reduce Only is selected in Pro mode, the size slider was still capped by available margin times leverage. Reduce-only orders close existing size and do not consume free collateral, so a trader with a large position and little free margin could not slide to the full position.

This change sets the slider max to the open position USD notional (`|size| × price`, using the limit price when set). While Reduce Only is on and the order can close the position, the shared order-form amount clamp is skipped so typed sizes can still exceed the position and hit the existing too-large validation. Turning Reduce Only off restores the margin-based cap.

When Reduce Only cannot close a position (`no_position` or `wrong_side`), the slider stays on the margin-based range so it remains movable, but the size field stays empty and slider drags do not commit an amount. Size-too-large still shows the typed or slid amount.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Reduce Only size slider so the maximum matches the open position, and kept size empty when the order cannot close

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: TAT-3704

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Pro Reduce Only size slider

  Background:
    Given I am logged into MetaMask Mobile
    And Perps Pro mode is enabled

  Scenario: user slides to 100 percent with Reduce Only on
    Given I have an open short ETH position of 1 ETH
    And my available Perps margin is much smaller than the position notional
    And I am on the ETH Pro market order form
    And the order direction is long so the order can reduce the short
    And Reduce Only is off
    And dragging the size slider to the far right is limited by available margin

    When user enables Reduce Only
    And user drags the size slider to 100 percent
    Then the size field should equal the open position USD notional
    And Place Order should not be blocked by insufficient margin

  Scenario: user types a size larger than the open position
    Given I have an open short ETH position
    And I am on the ETH Pro market order form
    And Reduce Only is enabled against a valid closing side

    When user types a USD size larger than the open position
    Then the reduce-only too-large banner should appear
    And the size field should still show the typed amount
    And Place Order should be disabled

  Scenario: user enables Reduce Only with no open position
    Given I have no open ETH position
    And I am on the ETH Pro market order form

    When user enables Reduce Only
    Then the no-open-position banner should appear
    And the size field should be empty
    And user can still drag the size slider
    And dragging the slider should leave the size field empty
    And Place Order should be disabled

  Scenario: user enables Reduce Only on the same side as the open position
    Given I have an open long ETH position
    And I am on the ETH Pro market order form
    And the order direction is long

    When user enables Reduce Only
    Then the wrong-direction banner should appear
    And the size field should be empty
    And user can still drag the size slider
    And dragging the slider should leave the size field empty
    And Place Order should be disabled
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — slider range and empty-size behavior; no visual redesign. Capture a recording during the Gherkin steps if review needs evidence.

### **After**

https://github.com/user-attachments/assets/2c72b227-57e8-4955-b931-54dc3770571e


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes order sizing, slider caps, and amount clamping in Pro trading flows; behavior is heavily tested but mistakes could affect order size or submission.
> 
> **Overview**
> **Pro Reduce Only** now sizes against the **open position**, not free margin × leverage. With a valid closing side, the size slider max becomes **`|position| × price`** (limit price when set), via `getReduceOnlyMaxUsdAmount` and a temporary **`setMaxPossibleAmountOverride`** on the shared order form so typed sizes are not clamped to margin and **too-large** validation can still apply.
> 
> For **`no_position`** / **`wrong_side`**, the slider keeps the margin-based range for movement but **`keepSizeEmpty`** forces an empty size field and **visual-only** slider drags (no `setAmount`). Position stream loading preserves typed size until the snapshot resolves; leverage confirm no longer clamps amount while Reduce Only is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c445adabde221d7cbbeb32f0d4ee638546b28ae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

