### PR TITLE
fix(vba): point NeoBank WebSocket at proxy events URL with userId

### DIFF
--- a/app/components/UI/Money/utils/neobankEvents.ts
+++ b/app/components/UI/Money/utils/neobankEvents.ts
@@ -74,8 +74,7 @@ export function isCompletedNeobankDeposit(event: NeobankEvent): boolean {
  * last resort so the socket still opens when lookup fails. It is only consulted
  * while the neobank flag is on and the active vendor is Iron.
  */
-export const DEMO_NEOBANK_CUSTOMER_ID =
-  '019ff69c-3039-77b0-9d5d-e4a3baefd7b7';
+export const DEMO_NEOBANK_CUSTOMER_ID = '019ff69c-3039-77b0-9d5d-e4a3baefd7b7';
 
 /**
  * Reads the Iron/MoonPay customer UUID from a neo-bank proxy customer payload.
@@ -127,8 +126,10 @@ export function resolveNeobankDemoCustomerId(
  * @returns WebSocket URL for the demo proxy.
  */
 export function getNeobankEventsUrl(customerId: string): string {
+  // NEOBANK_WS_URL is the Money-demo env; MM_NEOBANK_WS_URL is used by VBA.
   const baseUrl =
     process.env.NEOBANK_WS_URL ??
+    process.env.MM_NEOBANK_WS_URL ??
     'wss://on-ramp.dev-api.cx.metamask.io/neobank/events';
   const separator = baseUrl.includes('?') ? '&' : '?';
   return `${baseUrl}${separator}userId=${encodeURIComponent(customerId)}`;

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/MockKycSuccess.tsx
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/MockKycSuccess.tsx
@@ -365,7 +365,7 @@ const MockKycSuccess = () => {
       });
 
       const socket = NeobankWebSocket.getInstance();
-      socket.connect();
+      socket.connect(customerId);
       updateStep('live', {
         status: 'waiting',
         detail:

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/VirtualBankAccount.tsx
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/VirtualBankAccount.tsx
@@ -23,6 +23,7 @@ import {
 import { strings } from '../../../../../../locales/i18n';
 import Engine from '../../../../../core/Engine';
 import { selectSelectedInternalAccountAddress } from '../../../../../selectors/accountsController';
+import { selectKycControllerState } from '../../../../../selectors/kycController';
 import { selectRampsAutoramps } from '../../../../../selectors/rampsController';
 import { VirtualBankAccountSelectorsIDs } from './VirtualBankAccount.testIds';
 import { NeobankWebSocket } from './neobank/NeobankWebSocket';
@@ -38,6 +39,7 @@ const VirtualBankAccount = () => {
   const tw = useTailwind();
   const walletAddress = useSelector(selectSelectedInternalAccountAddress);
   const autoramps = useSelector(selectRampsAutoramps);
+  const kycState = useSelector(selectKycControllerState);
   const previousStatusesRef = useRef<Record<string, string>>({});
 
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -45,6 +47,9 @@ const VirtualBankAccount = () => {
   const [statusBanner, setStatusBanner] = useState<string | null>(null);
   const [lastPushAt, setLastPushAt] = useState<number | null>(null);
   const [wsConnected, setWsConnected] = useState(false);
+
+  const customerId =
+    autoramps[0]?.customerId ?? kycState.moonpayCustomerId ?? null;
 
   const handleBackPress = useCallback(() => {
     navigation.goBack();
@@ -102,22 +107,27 @@ const VirtualBankAccount = () => {
 
   useFocusEffect(
     useCallback(() => {
+      catchUpFromRemote().catch(() => undefined);
+
+      if (!customerId) {
+        setWsConnected(false);
+        return undefined;
+      }
+
       const ws = NeobankWebSocket.getInstance();
-      ws.connect();
+      ws.connect(customerId);
       setWsConnected(true);
 
       const unsubscribe = ws.addListener(() => {
         setLastPushAt(Date.now());
       });
 
-      catchUpFromRemote().catch(() => undefined);
-
       return () => {
         unsubscribe();
         ws.disconnect();
         setWsConnected(false);
       };
-    }, [catchUpFromRemote]),
+    }, [catchUpFromRemote, customerId]),
   );
 
   useEffect(() => {

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/neobank/NeobankWebSocket.test.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/neobank/NeobankWebSocket.test.ts
@@ -1,0 +1,94 @@
+import {
+  interpretNeobankWsMessage,
+  mapNeobankWsMessageToRemoteSnapshot,
+} from './NeobankWebSocket';
+
+describe('interpretNeobankWsMessage', () => {
+  it('applies register_autoramp_status NormalizedEvents', () => {
+    expect(
+      interpretNeobankWsMessage({
+        eventId: 'evt-1',
+        userId: 'customer-1',
+        customerId: 'customer-1',
+        type: 'register_autoramp_status',
+        category: 'autoramp',
+        entity: {
+          id: 'autoramp-1',
+          status: 'Approved',
+          needsFetch: false,
+        },
+      }),
+    ).toStrictEqual({
+      action: 'apply',
+      remote: {
+        id: 'autoramp-1',
+        customerId: 'customer-1',
+        status: 'Approved',
+      },
+    });
+  });
+
+  it('refreshes pointer autoramp events that need a fetch', () => {
+    expect(
+      interpretNeobankWsMessage({
+        eventId: 'autoramp-2',
+        userId: 'customer-1',
+        customerId: 'customer-1',
+        type: 'new_autoramp',
+        category: 'autoramp',
+        entity: {
+          id: 'autoramp-2',
+          needsFetch: true,
+        },
+      }),
+    ).toStrictEqual({
+      action: 'refresh',
+      autorampId: 'autoramp-2',
+    });
+  });
+
+  it('refreshes deposit_address_created when status is absent', () => {
+    expect(
+      interpretNeobankWsMessage({
+        type: 'deposit_address_created',
+        category: 'autoramp',
+        customerId: 'customer-1',
+        entity: { id: 'autoramp-3', needsFetch: true },
+      }),
+    ).toStrictEqual({
+      action: 'refresh',
+      autorampId: 'autoramp-3',
+    });
+  });
+
+  it('ignores non-autoramp NormalizedEvents', () => {
+    expect(
+      interpretNeobankWsMessage({
+        type: 'transaction_status',
+        category: 'transaction',
+        customerId: 'customer-1',
+        entity: {
+          id: 'tx-1',
+          transactionStatus: 'Completed',
+          needsFetch: false,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it('still maps legacy bare MoonPay autoramp payloads', () => {
+    expect(
+      mapNeobankWsMessageToRemoteSnapshot({
+        id: 'autoramp-9',
+        customer_id: 'customer-9',
+        status: 'Authorized',
+        wallet_address: '0xabc',
+      }),
+    ).toStrictEqual({
+      id: 'autoramp-9',
+      customerId: 'customer-9',
+      status: 'Authorized',
+      walletAddress: '0xabc',
+    });
+  });
+});

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/neobank/NeobankWebSocket.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/neobank/NeobankWebSocket.ts
@@ -1,32 +1,78 @@
 import { AppState, type AppStateStatus } from 'react-native';
 import type { AutorampRemoteSnapshot } from '@metamask/ramps-controller';
 import Engine from '../../../../../../core/Engine';
-
-/**
- * Demo WebSocket URL for neo-bank status pushes from the Ramps Dev API.
- * Adjust if the real path differs from OpenAPI.
- */
-export const NEOBANK_WS_URL =
-  process.env.MM_NEOBANK_WS_URL ??
-  'wss://on-ramp.dev-api.cx.metamask.io/neobank/ws';
+import { getNeobankEventsUrl } from '../../../../Money/utils/neobankEvents';
 
 type NeobankWsListener = (event: {
   remote: AutorampRemoteSnapshot;
   raw: unknown;
 }) => void;
 
+const AUTORAMP_EVENT_TYPES = new Set([
+  'new_autoramp',
+  'register_autoramp_status',
+  'deposit_address_created',
+]);
+
+export type NeobankWsMessageAction =
+  | { action: 'apply'; remote: AutorampRemoteSnapshot }
+  | { action: 'refresh'; autorampId: string };
+
 /**
- * Best-effort mapper from a neo-bank websocket payload into an autoramp snapshot.
- * Accepts either a bare MoonPay-shaped object or a wrapped `{ type, data }` event.
+ * Interprets a neobank-proxy WebSocket JSON message.
+ *
+ * Prefers the proxy NormalizedEvent shape (`category` / `entity` /
+ * `customerId`). Falls back to a bare MoonPay-shaped autoramp object for
+ * older demos. Pointer events without a status become a REST refresh.
  */
-export function mapNeobankWsMessageToRemoteSnapshot(
+export function interpretNeobankWsMessage(
   raw: unknown,
-): AutorampRemoteSnapshot | null {
+): NeobankWsMessageAction | null {
   if (!raw || typeof raw !== 'object') {
     return null;
   }
 
   const envelope = raw as Record<string, unknown>;
+
+  const isNormalizedAutoramp =
+    envelope.category === 'autoramp' ||
+    (typeof envelope.type === 'string' &&
+      AUTORAMP_EVENT_TYPES.has(envelope.type));
+
+  if (isNormalizedAutoramp) {
+    const entity =
+      envelope.entity && typeof envelope.entity === 'object'
+        ? (envelope.entity as Record<string, unknown>)
+        : null;
+    const autorampId = typeof entity?.id === 'string' ? entity.id : null;
+    const customerId =
+      typeof envelope.customerId === 'string'
+        ? envelope.customerId
+        : typeof envelope.userId === 'string'
+          ? envelope.userId
+          : null;
+    const status = typeof entity?.status === 'string' ? entity.status : null;
+    const needsFetch = entity?.needsFetch === true;
+
+    if (!autorampId) {
+      return null;
+    }
+
+    if (status && customerId && !needsFetch) {
+      return {
+        action: 'apply',
+        remote: {
+          id: autorampId,
+          customerId,
+          status,
+        },
+      };
+    }
+
+    return { action: 'refresh', autorampId };
+  }
+
+  // Legacy / bare MoonPay-shaped payload (or `{ data: { … } }` wrap).
   const payload =
     envelope.data && typeof envelope.data === 'object'
       ? (envelope.data as Record<string, unknown>)
@@ -58,22 +104,41 @@ export function mapNeobankWsMessageToRemoteSnapshot(
         : undefined;
 
   return {
-    id,
-    customerId,
-    status,
-    walletAddress,
+    action: 'apply',
+    remote: {
+      id,
+      customerId,
+      status,
+      walletAddress,
+    },
   };
 }
 
 /**
+ * Maps a WebSocket payload to an autoramp snapshot when the message can be
+ * applied directly (no REST refresh required).
+ */
+export function mapNeobankWsMessageToRemoteSnapshot(
+  raw: unknown,
+): AutorampRemoteSnapshot | null {
+  const interpreted = interpretNeobankWsMessage(raw);
+  return interpreted?.action === 'apply' ? interpreted.remote : null;
+}
+
+/**
  * Feature-scoped neo-bank WebSocket client (demo).
- * Opens while the Virtual Bank Account screen is focused and forwards
- * status pushes into `RampsController.applyAutorampStatusFromPush`.
+ *
+ * Connects to `wss://…/neobank/events?userId=…` (proxy routing key). The proxy
+ * sends protocol-level ping frames ~every 30s to survive ALB idle timeout;
+ * React Native auto-replies with pong — no client ping timer is required.
+ * Still reconnects on close and refreshes autoramps on open so missed pushes
+ * are caught up.
  */
 export class NeobankWebSocket {
   static #instance: NeobankWebSocket | null = null;
 
   #socket: WebSocket | null = null;
+  #customerId: string | null = null;
   #appStateSubscription: { remove: () => void } | null = null;
   #shouldBeConnected = false;
   #reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -86,7 +151,28 @@ export class NeobankWebSocket {
     return NeobankWebSocket.#instance;
   }
 
-  connect(): void {
+  /** Test helper — tears down the singleton. */
+  static resetInstanceForTests(): void {
+    NeobankWebSocket.#instance?.disconnect();
+    NeobankWebSocket.#instance = null;
+  }
+
+  /**
+   * Opens (or reopens) the socket for the MoonPay customer routing key.
+   *
+   * @param customerId - MoonPay / Iron customer UUID (`userId` query param).
+   */
+  connect(customerId: string): void {
+    const trimmed = customerId.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    if (this.#customerId !== trimmed) {
+      this.#closeSocket();
+      this.#customerId = trimmed;
+    }
+
     this.#shouldBeConnected = true;
     this.#ensureAppStateListener();
     this.#openSocket();
@@ -133,6 +219,10 @@ export class NeobankWebSocket {
   };
 
   #openSocket(): void {
+    if (!this.#customerId) {
+      return;
+    }
+
     if (
       this.#socket &&
       (this.#socket.readyState === WebSocket.OPEN ||
@@ -144,8 +234,12 @@ export class NeobankWebSocket {
     this.#closeSocket();
 
     try {
-      const socket = new WebSocket(NEOBANK_WS_URL);
+      const socket = new WebSocket(getNeobankEventsUrl(this.#customerId));
       this.#socket = socket;
+
+      socket.onopen = () => {
+        this.#refreshAutorampsQuietly();
+      };
 
       socket.onmessage = (event) => {
         this.#handleMessage(event.data);
@@ -171,6 +265,7 @@ export class NeobankWebSocket {
       return;
     }
     try {
+      this.#socket.onopen = null;
       this.#socket.onmessage = null;
       this.#socket.onerror = null;
       this.#socket.onclose = null;
@@ -198,6 +293,14 @@ export class NeobankWebSocket {
     }
   }
 
+  #refreshAutorampsQuietly(): void {
+    try {
+      Engine.context.RampsController.refreshAutoramps().catch(() => undefined);
+    } catch {
+      // Engine may not be ready during early boot.
+    }
+  }
+
   #handleMessage(data: unknown): void {
     let parsed: unknown = data;
     if (typeof data === 'string') {
@@ -208,10 +311,23 @@ export class NeobankWebSocket {
       }
     }
 
-    const remote = mapNeobankWsMessageToRemoteSnapshot(parsed);
-    if (!remote) {
+    const interpreted = interpretNeobankWsMessage(parsed);
+    if (!interpreted) {
       return;
     }
+
+    if (interpreted.action === 'refresh') {
+      try {
+        Engine.context.RampsController.refreshAutoramp(
+          interpreted.autorampId,
+        ).catch(() => undefined);
+      } catch {
+        // Engine may not be ready during early boot.
+      }
+      return;
+    }
+
+    const { remote } = interpreted;
 
     try {
       Engine.context.RampsController.applyAutorampStatusFromPush(remote);


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

The VBA NeoBank WebSocket client was pointed at a non-existent `/neobank/ws` path and did not send `userId`, so it never stayed registered with neobank-proxy. It also could not interpret proxy `NormalizedEvent` autoramp pushes.

This change:
- Connects to `wss://…/neobank/events?userId=<customerId>` (shared URL helper with the Money demo hook)
- Requires `connect(customerId)` from Mock KYC success and Virtual Bank Account
- Maps autoramp NormalizedEvents into `applyAutorampStatusFromPush`, and REST-refreshes pointer / deposit-address events
- Refreshes autoramps on socket open/reconnect (complements the proxy’s ~30s protocol ping keepalive under ALB idle timeout; RN auto-pongs, no client ping timer)

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: neobank-proxy WS keepalive (va-mmcx-onramp-api #1124)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: VBA NeoBank WebSocket against neobank-proxy

  Scenario: socket registers and receives autoramp status
    Given the app is built from this branch against on-ramp.dev-api
    And Iron KYC / createAutoramp has produced a customer id
    When the Virtual Bank Account or Mock KYC success screen opens the socket
    Then Grafana shows socket registered for that userId on neobank-proxy
    And autoramp status pushes update local RampsController state
    And a quiet socket remains open beyond ~60s (proxy protocol ping)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — WebSocket client wiring; no UI visual change beyond connection succeeding.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time autoramp sync for VBA/demo flows (WebSocket URL, customer routing, and push vs REST refresh behavior); scope is limited to ramps neobank UI, not auth or payments core.
> 
> **Overview**
> Fixes VBA NeoBank live updates by wiring the client to **neobank-proxy** instead of a dead `/neobank/ws` endpoint.
> 
> **NeobankWebSocket** now uses shared `getNeobankEventsUrl(customerId)` (`…/neobank/events?userId=…`), requires `connect(customerId)`, and reconnects when the routing key changes. On open it quietly **refreshes autoramps**; incoming messages go through **`interpretNeobankWsMessage`**, which applies proxy **NormalizedEvent** autoramp status when complete or triggers **`refreshAutoramp`** for pointer / `needsFetch` events, with legacy MoonPay-shaped payloads still supported.
> 
> **Virtual Bank Account** resolves `customerId` from the first autoramp or KYC `moonpayCustomerId` and skips the socket when missing. **Mock KYC success** passes the looked-up customer id into `connect`. **`getNeobankEventsUrl`** also honors `MM_NEOBANK_WS_URL` for VBA. Unit tests cover the new message interpretation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b19b26f10a763b2ecd7bbfc33f20ce2befe0aae1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->