### PR TITLE
fix: something went wrong error during speedup/cancel for ledger

### DIFF
--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -84,6 +84,7 @@ import {
   useHardwareWallet,
   executeHardwareWalletOperation,
 } from '../../../core/HardwareWallet';
+import { skipHardwareWalletErrorIfReplacementSubmitted } from '../../../core/HardwareWallet/skipHardwareWalletErrorIfReplacementSubmitted';
 import { getTransactionUpdateErrorToastOptions } from '../../../util/confirmation/transactions';
 import { LedgerReplacementTxTypes } from '../LedgerModals/LedgerTransactionModal';
 import { selectIsActivityRedesignEnabled } from '../../../selectors/featureFlagController/activityRedesign';
@@ -495,6 +496,7 @@ const Transactions = (props) => {
       showAwaitingConfirmation: hardwareWallet.showAwaitingConfirmation,
       hideAwaitingConfirmation: hardwareWallet.hideAwaitingConfirmation,
       showHardwareWalletError: hardwareWallet.showHardwareWalletError,
+      onError: skipHardwareWalletErrorIfReplacementSubmitted(transaction.id),
       execute: async () => {
         if (
           transaction?.replacementParams?.type ===

--- a/app/components/UI/Transactions/index.test.tsx
+++ b/app/components/UI/Transactions/index.test.tsx
@@ -183,6 +183,9 @@ jest.mock('../../../core/Engine', () => ({
     TransactionController: {
       cancelTransaction: jest.fn(),
       stopTransaction: jest.fn(),
+      state: {
+        transactions: [],
+      },
     },
   },
 }));

--- a/app/components/Views/ActivityList/useUnifiedTxActions.test.ts
+++ b/app/components/Views/ActivityList/useUnifiedTxActions.test.ts
@@ -45,6 +45,9 @@ jest.mock('../../../core/Engine', () => ({
       },
       TransactionController: {
         stopTransaction: jest.fn(),
+        state: {
+          transactions: [],
+        },
       },
     },
   },

--- a/app/components/Views/ActivityList/useUnifiedTxActions.ts
+++ b/app/components/Views/ActivityList/useUnifiedTxActions.ts
@@ -38,6 +38,7 @@ import {
   useHardwareWallet,
   executeHardwareWalletOperation,
 } from '../../../core/HardwareWallet';
+import { skipHardwareWalletErrorIfReplacementSubmitted } from '../../../core/HardwareWallet/skipHardwareWalletErrorIfReplacementSubmitted';
 import { getTransactionUpdateErrorToastOptions } from '../../../util/confirmation/transactions';
 
 type Maybe<T> = T | null | undefined;
@@ -150,6 +151,7 @@ export function useUnifiedTxActions() {
         showAwaitingConfirmation,
         hideAwaitingConfirmation,
         showHardwareWalletError,
+        onError: skipHardwareWalletErrorIfReplacementSubmitted(transaction.id),
         execute: async () => {
           if (
             transaction?.replacementParams?.type ===

--- a/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.test.ts
+++ b/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.test.ts
@@ -22,6 +22,8 @@ import { selectAccounts } from '../../../selectors/accountTrackerController';
 import Engine from '../../../core/Engine';
 import {
   type TransactionMeta,
+  TransactionStatus,
+  TransactionType,
   GasFeeEstimateType,
   GasFeeEstimateLevel,
   type GasFeeEstimates,
@@ -112,7 +114,9 @@ jest.mock('../../../core/Engine', () => ({
   context: {
     TransactionController: {
       stopTransaction: jest.fn(),
-      getTransactions: jest.fn(() => []),
+      state: {
+        transactions: [],
+      },
     },
     ApprovalController: {
       acceptRequest: jest.fn(),
@@ -157,6 +161,69 @@ const renderUnifiedTxActions = () =>
     wrapper: TxActionsTestWrapper,
   });
 
+const SPEED_UP_GAS = {
+  maxFeePerGas: '0xff',
+  maxPriorityFeePerGas: '0xee',
+};
+
+function createDisconnectError(): Error {
+  return Object.assign(new Error('DisconnectedDevice'), {
+    name: 'DisconnectedDevice',
+  });
+}
+
+function createSubmittedTransaction(
+  id: string,
+  overrides: Partial<TransactionMeta> = {},
+): TransactionMeta {
+  return {
+    id,
+    type: TransactionType.simpleSend,
+    status: TransactionStatus.submitted,
+    chainId: '0x1',
+    txParams: { from: SELECTED_ADDRESS, nonce: '0x1' },
+    ...overrides,
+  } as TransactionMeta;
+}
+
+function mockExecutePropagatingOnError(): void {
+  mockExecuteHardwareWalletOperation.mockImplementationOnce(
+    async ({ execute, onError, showHardwareWalletError, onRejected }) => {
+      try {
+        await execute();
+        return true;
+      } catch (error) {
+        const handled = (await onError?.(error)) ?? false;
+        if (!handled) {
+          showHardwareWalletError(error);
+        }
+        await onRejected?.();
+        return false;
+      }
+    },
+  );
+}
+
+function getShowHardwareWalletErrorMock(): jest.Mock {
+  return (
+    mockExecuteHardwareWalletOperation.mock.calls[0][0] as {
+      showHardwareWalletError: jest.Mock;
+    }
+  ).showHardwareWalletError;
+}
+
+async function runLedgerSpeedUp(txId: string): Promise<jest.Mock> {
+  const { result } = renderUnifiedTxActions();
+  const tx = { id: txId } as unknown as TransactionMeta;
+
+  act(() => result.current.onSpeedUpAction(true, tx));
+  await act(async () => {
+    await result.current.speedUpTransaction(SPEED_UP_GAS);
+  });
+
+  return getShowHardwareWalletErrorMock();
+}
+
 describe('useUnifiedTxActions', () => {
   const mockUseSelector = useSelector as jest.MockedFunction<
     typeof useSelector
@@ -165,7 +232,7 @@ describe('useUnifiedTxActions', () => {
   interface EngineContextMock {
     TransactionController: {
       stopTransaction: jest.Mock;
-      getTransactions: jest.Mock;
+      state: { transactions: TransactionMeta[] };
     };
     ApprovalController: { acceptRequest: jest.Mock; rejectRequest: jest.Mock };
   }
@@ -179,7 +246,7 @@ describe('useUnifiedTxActions', () => {
       jest.requireActual('../../../util/confirmation/gas')
         .getGasValuesForReplacement,
     );
-    engineContext.TransactionController.getTransactions = jest.fn(() => []);
+    engineContext.TransactionController.state.transactions = [];
     mockShowToast.mockClear();
 
     (createQRSigningTransactionModalNavDetails as jest.Mock).mockReturnValue([
@@ -623,6 +690,7 @@ describe('useUnifiedTxActions', () => {
         showAwaitingConfirmation: expect.any(Function),
         hideAwaitingConfirmation: expect.any(Function),
         showHardwareWalletError: expect.any(Function),
+        onError: expect.any(Function),
         execute: expect.any(Function),
         onRejected: expect.any(Function),
       });
@@ -649,6 +717,7 @@ describe('useUnifiedTxActions', () => {
         showAwaitingConfirmation: expect.any(Function),
         hideAwaitingConfirmation: expect.any(Function),
         showHardwareWalletError: expect.any(Function),
+        onError: expect.any(Function),
         execute: expect.any(Function),
         onRejected: expect.any(Function),
       });
@@ -875,6 +944,59 @@ describe('useUnifiedTxActions', () => {
           expect(result.current.speedUpIsOpen).toBe(false);
           expect(result.current.speedUpTxId).toBeNull();
           expect(result.current.existingTx).toBeNull();
+        });
+
+        it('does not show the hardware wallet error sheet when speed-up rejects after a same-nonce replacement was submitted', async () => {
+          const originalId = 'ledger-speedup-submitted';
+          engineContext.TransactionController.state.transactions = [
+            createSubmittedTransaction(originalId),
+            createSubmittedTransaction('ledger-speedup-retry', {
+              type: TransactionType.retry,
+              hash: '0xabc',
+            }),
+          ];
+          (speedUpTx as jest.Mock).mockRejectedValueOnce(
+            createDisconnectError(),
+          );
+          mockExecutePropagatingOnError();
+
+          const showHardwareWalletError = await runLedgerSpeedUp(originalId);
+
+          expect(showHardwareWalletError).not.toHaveBeenCalled();
+        });
+
+        it('shows the hardware wallet error sheet when speed-up rejects and no replacement exists', async () => {
+          const originalId = 'ledger-speedup-no-replacement';
+          engineContext.TransactionController.state.transactions = [
+            createSubmittedTransaction(originalId),
+          ];
+          (speedUpTx as jest.Mock).mockRejectedValueOnce(
+            createDisconnectError(),
+          );
+          mockExecutePropagatingOnError();
+
+          const showHardwareWalletError = await runLedgerSpeedUp(originalId);
+
+          expect(showHardwareWalletError).toHaveBeenCalled();
+        });
+
+        it('shows the hardware wallet error sheet when speed-up rejects with a user rejection after a same-nonce replacement was submitted', async () => {
+          const originalId = 'ledger-speedup-real-error';
+          engineContext.TransactionController.state.transactions = [
+            createSubmittedTransaction(originalId),
+            createSubmittedTransaction('ledger-speedup-retry', {
+              type: TransactionType.retry,
+              hash: '0xabc',
+            }),
+          ];
+          (speedUpTx as jest.Mock).mockRejectedValueOnce(
+            new Error('User rejected'),
+          );
+          mockExecutePropagatingOnError();
+
+          const showHardwareWalletError = await runLedgerSpeedUp(originalId);
+
+          expect(showHardwareWalletError).toHaveBeenCalled();
         });
       });
 

--- a/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.ts
+++ b/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.ts
@@ -45,6 +45,7 @@ import {
   useHardwareWallet,
   executeHardwareWalletOperation,
 } from '../../../core/HardwareWallet';
+import { skipHardwareWalletErrorIfReplacementSubmitted } from '../../../core/HardwareWallet/skipHardwareWalletErrorIfReplacementSubmitted';
 import { getTransactionUpdateErrorToastOptions } from '../../../util/confirmation/transactions';
 
 type Maybe<T> = T | null | undefined;
@@ -174,6 +175,7 @@ export function useUnifiedTxActions() {
         showAwaitingConfirmation,
         hideAwaitingConfirmation,
         showHardwareWalletError,
+        onError: skipHardwareWalletErrorIfReplacementSubmitted(transaction.id),
         execute: async () => {
           if (
             transaction?.replacementParams?.type ===

--- a/app/core/HardwareWallet/index.ts
+++ b/app/core/HardwareWallet/index.ts
@@ -6,3 +6,4 @@ export {
   executeHardwareWalletOperation,
   type HardwareWalletOperationType,
 } from './executeHardwareWalletOperation';
+export { skipHardwareWalletErrorIfReplacementSubmitted } from './skipHardwareWalletErrorIfReplacementSubmitted';

--- a/app/core/HardwareWallet/skipHardwareWalletErrorIfReplacementSubmitted.test.ts
+++ b/app/core/HardwareWallet/skipHardwareWalletErrorIfReplacementSubmitted.test.ts
@@ -1,0 +1,161 @@
+import {
+  Category,
+  ErrorCode,
+  HardwareWalletError,
+  Severity,
+} from '@metamask/hw-wallet-sdk';
+import {
+  TransactionStatus,
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import Engine from '../Engine';
+import { skipHardwareWalletErrorIfReplacementSubmitted } from './skipHardwareWalletErrorIfReplacementSubmitted';
+
+jest.mock('../Engine', () => ({
+  context: {
+    TransactionController: {
+      state: {
+        transactions: [],
+      },
+    },
+  },
+}));
+
+const ORIGINAL_ID = 'original-tx';
+const FROM = '0xabc';
+const NONCE = '0x1';
+const CHAIN_ID = '0x1';
+
+function createTransaction(
+  overrides: Partial<TransactionMeta> & Pick<TransactionMeta, 'id' | 'type'>,
+): TransactionMeta {
+  const { txParams, ...rest } = overrides;
+
+  return {
+    chainId: CHAIN_ID,
+    status: TransactionStatus.submitted,
+    ...rest,
+    txParams: {
+      from: FROM,
+      nonce: NONCE,
+      ...txParams,
+    },
+  } as TransactionMeta;
+}
+
+function originalAndReplacement(
+  replacementType: TransactionType.retry | TransactionType.cancel,
+): TransactionMeta[] {
+  return [
+    createTransaction({
+      id: ORIGINAL_ID,
+      type: TransactionType.simpleSend,
+    }),
+    createTransaction({
+      id: 'replacement-tx',
+      type: replacementType,
+    }),
+  ];
+}
+
+function setTransactions(transactions: TransactionMeta[]): void {
+  Engine.context.TransactionController.state.transactions = transactions;
+}
+
+function createDisconnectError(): Error {
+  const error = new Error('DisconnectedDevice');
+  error.name = 'DisconnectedDevice';
+  return error;
+}
+
+function createWrappedDisconnectError(): HardwareWalletError {
+  return new HardwareWalletError('DisconnectedDevice', {
+    code: ErrorCode.Unknown,
+    severity: Severity.Err,
+    category: Category.Unknown,
+    userMessage: 'DisconnectedDevice',
+    cause: createDisconnectError(),
+  });
+}
+
+function createUserRejectedError(): HardwareWalletError {
+  return new HardwareWalletError('User rejected', {
+    code: ErrorCode.UserRejected,
+    severity: Severity.Err,
+    category: Category.UserAction,
+    userMessage: 'User rejected',
+  });
+}
+
+describe('skipHardwareWalletErrorIfReplacementSubmitted', () => {
+  beforeEach(() => {
+    setTransactions([]);
+  });
+
+  it('returns true from onError when a retry replacement shares the original nonce and the error is a BLE disconnect', () => {
+    setTransactions(originalAndReplacement(TransactionType.retry));
+
+    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
+
+    expect(onError(createDisconnectError())).toBe(true);
+  });
+
+  it('returns true from onError when a cancel replacement shares the original nonce and the error is a BLE disconnect', () => {
+    setTransactions(originalAndReplacement(TransactionType.cancel));
+
+    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
+
+    expect(onError(createDisconnectError())).toBe(true);
+  });
+
+  it('returns true from onError when the keyring wrapped DisconnectedDevice as Unknown', () => {
+    setTransactions(originalAndReplacement(TransactionType.retry));
+
+    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
+
+    expect(onError(createWrappedDisconnectError())).toBe(true);
+  });
+
+  it('returns false from onError when a replacement exists but the error is a user rejection', () => {
+    setTransactions(originalAndReplacement(TransactionType.retry));
+
+    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
+
+    expect(onError(createUserRejectedError())).toBe(false);
+  });
+
+  it('returns false from onError when a replacement exists but the error is not a disconnect', () => {
+    setTransactions(originalAndReplacement(TransactionType.retry));
+
+    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
+
+    expect(onError(new Error('signing failed'))).toBe(false);
+  });
+
+  it('returns false from onError when the error is a BLE disconnect but no replacement exists', () => {
+    setTransactions([
+      createTransaction({
+        id: ORIGINAL_ID,
+        type: TransactionType.simpleSend,
+      }),
+    ]);
+
+    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
+
+    expect(onError(createDisconnectError())).toBe(false);
+  });
+
+  it('returns false from onError when the original transaction is missing', () => {
+    setTransactions([
+      createTransaction({
+        id: 'replacement-tx',
+        type: TransactionType.retry,
+      }),
+    ]);
+
+    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
+
+    expect(onError(createDisconnectError())).toBe(false);
+  });
+});

--- a/app/core/HardwareWallet/skipHardwareWalletErrorIfReplacementSubmitted.test.ts
+++ b/app/core/HardwareWallet/skipHardwareWalletErrorIfReplacementSubmitted.test.ts
@@ -89,6 +89,8 @@ function createUserRejectedError(): HardwareWalletError {
 }
 
 describe('skipHardwareWalletErrorIfReplacementSubmitted', () => {
+  const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
+
   beforeEach(() => {
     setTransactions([]);
   });
@@ -96,15 +98,11 @@ describe('skipHardwareWalletErrorIfReplacementSubmitted', () => {
   it('returns true from onError when a retry replacement shares the original nonce and the error is a BLE disconnect', () => {
     setTransactions(originalAndReplacement(TransactionType.retry));
 
-    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
-
     expect(onError(createDisconnectError())).toBe(true);
   });
 
   it('returns true from onError when a cancel replacement shares the original nonce and the error is a BLE disconnect', () => {
     setTransactions(originalAndReplacement(TransactionType.cancel));
-
-    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
 
     expect(onError(createDisconnectError())).toBe(true);
   });
@@ -112,23 +110,17 @@ describe('skipHardwareWalletErrorIfReplacementSubmitted', () => {
   it('returns true from onError when the keyring wrapped DisconnectedDevice as Unknown', () => {
     setTransactions(originalAndReplacement(TransactionType.retry));
 
-    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
-
     expect(onError(createWrappedDisconnectError())).toBe(true);
   });
 
   it('returns false from onError when a replacement exists but the error is a user rejection', () => {
     setTransactions(originalAndReplacement(TransactionType.retry));
 
-    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
-
     expect(onError(createUserRejectedError())).toBe(false);
   });
 
   it('returns false from onError when a replacement exists but the error is not a disconnect', () => {
     setTransactions(originalAndReplacement(TransactionType.retry));
-
-    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
 
     expect(onError(new Error('signing failed'))).toBe(false);
   });
@@ -141,8 +133,6 @@ describe('skipHardwareWalletErrorIfReplacementSubmitted', () => {
       }),
     ]);
 
-    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
-
     expect(onError(createDisconnectError())).toBe(false);
   });
 
@@ -153,8 +143,6 @@ describe('skipHardwareWalletErrorIfReplacementSubmitted', () => {
         type: TransactionType.retry,
       }),
     ]);
-
-    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
 
     expect(onError(createDisconnectError())).toBe(false);
   });
@@ -172,8 +160,6 @@ describe('skipHardwareWalletErrorIfReplacementSubmitted', () => {
       }),
     ]);
 
-    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
-
     expect(onError(createDisconnectError())).toBe(false);
   });
 
@@ -189,8 +175,6 @@ describe('skipHardwareWalletErrorIfReplacementSubmitted', () => {
         status: TransactionStatus.signed,
       }),
     ]);
-
-    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
 
     expect(onError(createDisconnectError())).toBe(false);
   });
@@ -208,8 +192,6 @@ describe('skipHardwareWalletErrorIfReplacementSubmitted', () => {
       }),
     ]);
 
-    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
-
     expect(onError(createDisconnectError())).toBe(false);
   });
 
@@ -225,8 +207,6 @@ describe('skipHardwareWalletErrorIfReplacementSubmitted', () => {
         status: TransactionStatus.confirmed,
       }),
     ]);
-
-    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
 
     expect(onError(createDisconnectError())).toBe(true);
   });

--- a/app/core/HardwareWallet/skipHardwareWalletErrorIfReplacementSubmitted.test.ts
+++ b/app/core/HardwareWallet/skipHardwareWalletErrorIfReplacementSubmitted.test.ts
@@ -158,4 +158,76 @@ describe('skipHardwareWalletErrorIfReplacementSubmitted', () => {
 
     expect(onError(createDisconnectError())).toBe(false);
   });
+
+  it('returns false from onError when a same-nonce retry exists but is still unapproved', () => {
+    setTransactions([
+      createTransaction({
+        id: ORIGINAL_ID,
+        type: TransactionType.simpleSend,
+      }),
+      createTransaction({
+        id: 'replacement-tx',
+        type: TransactionType.retry,
+        status: TransactionStatus.unapproved,
+      }),
+    ]);
+
+    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
+
+    expect(onError(createDisconnectError())).toBe(false);
+  });
+
+  it('returns false from onError when a same-nonce retry exists but is only signed', () => {
+    setTransactions([
+      createTransaction({
+        id: ORIGINAL_ID,
+        type: TransactionType.simpleSend,
+      }),
+      createTransaction({
+        id: 'replacement-tx',
+        type: TransactionType.retry,
+        status: TransactionStatus.signed,
+      }),
+    ]);
+
+    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
+
+    expect(onError(createDisconnectError())).toBe(false);
+  });
+
+  it('returns false from onError when a leftover same-nonce retry failed', () => {
+    setTransactions([
+      createTransaction({
+        id: ORIGINAL_ID,
+        type: TransactionType.simpleSend,
+      }),
+      createTransaction({
+        id: 'replacement-tx',
+        type: TransactionType.retry,
+        status: TransactionStatus.failed,
+      }),
+    ]);
+
+    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
+
+    expect(onError(createDisconnectError())).toBe(false);
+  });
+
+  it('returns true from onError when a same-nonce retry is confirmed', () => {
+    setTransactions([
+      createTransaction({
+        id: ORIGINAL_ID,
+        type: TransactionType.simpleSend,
+      }),
+      createTransaction({
+        id: 'replacement-tx',
+        type: TransactionType.retry,
+        status: TransactionStatus.confirmed,
+      }),
+    ]);
+
+    const onError = skipHardwareWalletErrorIfReplacementSubmitted(ORIGINAL_ID);
+
+    expect(onError(createDisconnectError())).toBe(true);
+  });
 });

--- a/app/core/HardwareWallet/skipHardwareWalletErrorIfReplacementSubmitted.ts
+++ b/app/core/HardwareWallet/skipHardwareWalletErrorIfReplacementSubmitted.ts
@@ -1,0 +1,79 @@
+import { ErrorCode, HardwareWalletError } from '@metamask/hw-wallet-sdk';
+import {
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import Engine from '../Engine';
+import { isDisconnectError } from '../Ledger/ledgerErrors';
+
+function getTransactions(): TransactionMeta[] {
+  return Engine.context.TransactionController.state.transactions ?? [];
+}
+
+function hasSubmittedReplacementTransaction(
+  originalTransactionId: string,
+): boolean {
+  const transactions = getTransactions();
+  const original = transactions.find((tx) => tx.id === originalTransactionId);
+  if (!original) {
+    return false;
+  }
+
+  return transactions.some(
+    (tx) =>
+      tx.id !== originalTransactionId &&
+      (tx.type === TransactionType.retry ||
+        tx.type === TransactionType.cancel) &&
+      tx.txParams?.nonce === original.txParams?.nonce &&
+      tx.chainId === original.chainId,
+  );
+}
+
+function getErrorCause(error: unknown): unknown {
+  if (typeof error === 'object' && error !== null && 'cause' in error) {
+    return error.cause;
+  }
+  return undefined;
+}
+
+/**
+ * True for a Ledger BLE drop (`DisconnectedDevice`), including when the
+ * keyring wraps it as `HardwareWalletError` Unknown.
+ */
+function isEphemeralDisconnectError(error: unknown): boolean {
+  if (isDisconnectError(error) || isDisconnectError(getErrorCause(error))) {
+    return true;
+  }
+
+  if (!HardwareWalletError.isHardwareWalletError(error)) {
+    return false;
+  }
+
+  if (error.code === ErrorCode.DeviceDisconnected) {
+    return true;
+  }
+
+  // handleLedgerTransportError copies DisconnectedDevice onto message
+  // and sets code Unknown.
+  return (
+    error.code === ErrorCode.Unknown &&
+    isDisconnectError({ name: error.message })
+  );
+}
+
+/**
+ * `onError` for Ledger speed-up/cancel.
+ *
+ * After confirm, Ledger BLE often drops (`DisconnectedDevice`). The keyring
+ * wraps that as `HardwareWalletError` Unknown, so `execute()` rejects even
+ * when a `retry`/`cancel` with the original nonce is already in
+ * TransactionController. Skip the Unknown sheet only for that disconnect.
+ * Real device errors still show.
+ */
+export function skipHardwareWalletErrorIfReplacementSubmitted(
+  originalTransactionId: string,
+): (error: unknown) => boolean {
+  return (error: unknown) =>
+    isEphemeralDisconnectError(error) &&
+    hasSubmittedReplacementTransaction(originalTransactionId);
+}

--- a/app/core/HardwareWallet/skipHardwareWalletErrorIfReplacementSubmitted.ts
+++ b/app/core/HardwareWallet/skipHardwareWalletErrorIfReplacementSubmitted.ts
@@ -1,5 +1,6 @@
 import { ErrorCode, HardwareWalletError } from '@metamask/hw-wallet-sdk';
 import {
+  TransactionStatus,
   TransactionType,
   type TransactionMeta,
 } from '@metamask/transaction-controller';
@@ -9,6 +10,11 @@ import { isDisconnectError } from '../Ledger/ledgerErrors';
 function getTransactions(): TransactionMeta[] {
   return Engine.context.TransactionController.state.transactions ?? [];
 }
+
+const SUBMITTED_OR_LATER_STATUSES = new Set<TransactionStatus>([
+  TransactionStatus.submitted,
+  TransactionStatus.confirmed,
+]);
 
 function hasSubmittedReplacementTransaction(
   originalTransactionId: string,
@@ -24,6 +30,7 @@ function hasSubmittedReplacementTransaction(
       tx.id !== originalTransactionId &&
       (tx.type === TransactionType.retry ||
         tx.type === TransactionType.cancel) &&
+      SUBMITTED_OR_LATER_STATUSES.has(tx.status) &&
       tx.txParams?.nonce === original.txParams?.nonce &&
       tx.chainId === original.chainId,
   );
@@ -66,8 +73,10 @@ function isEphemeralDisconnectError(error: unknown): boolean {
  *
  * After confirm, Ledger BLE often drops (`DisconnectedDevice`). The keyring
  * wraps that as `HardwareWalletError` Unknown, so `execute()` rejects even
- * when a `retry`/`cancel` with the original nonce is already in
- * TransactionController. Skip the Unknown sheet only for that disconnect.
+ * when a `retry`/`cancel` with the original nonce is already submitted
+ * (or confirmed). Skip the Unknown sheet only for that disconnect.
+ * Unapproved/signed/failed replacements are not proof of success —
+ * TransactionController adds the replacement before signing finishes.
  * Real device errors still show.
  */
 export function skipHardwareWalletErrorIfReplacementSubmitted(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

This PR adds skipHardwareWalletErrorIfReplacementSubmitted, an onError handler wired into the three transaction action hooks. It suppresses the error sheet only when both are true: (1) the error is an ephemeral BLE disconnect, and (2) a replacement transaction with the same nonce and chain is already submitted. Real device errors still surface.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that showed a "something went wrong" error when speed-up or cancel succeeded on a Ledger hardware wallet

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-2018?atlOrigin=eyJpIjoiNzc0MzBjOGNhZDAwNDU3ODk4NjVhMzA2MWYwOWIzOTYiLCJwIjoiaiJ9

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

 Scenario: user speed-up/cancels a pending transaction on a Ledger
    Given a wallet connected to a Ledger over Bluetooth
      And a pending transaction in the activity list

    When user taps speed-up or cancel
      And confirms the replacement on the Ledger device
      And the BLE connection drops after signing
    Then no "something went wrong" error sheet is shown
      And the replacement transaction appears in the activity list
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow UX fix gated on disconnect detection and submitted replacement state; real signing failures and user rejections still surface errors.
> 
> **Overview**
> Fixes a **false "something went wrong" sheet** when Ledger **speed-up or cancel** actually succeeds but Bluetooth drops right after signing.
> 
> Adds **`skipHardwareWalletErrorIfReplacementSubmitted`**, passed as **`onError`** on **`executeHardwareWalletOperation`** from the transactions UI hooks (`Transactions`, `useUnifiedTxActions` in Activity List and Unified Transactions). The handler returns true (skip the generic error UI) only when the failure looks like an **ephemeral BLE disconnect** (including keyring-wrapped `DisconnectedDevice`) **and** `TransactionController` already has a **retry/cancel** replacement with the **same nonce and chain** in **submitted** or **confirmed** status. **User rejections**, other errors, and replacements still **unapproved/signed/failed** keep showing the error sheet.
> 
> Unit tests cover the helper and Ledger speed-up integration; test mocks now use **`TransactionController.state.transactions`** instead of **`getTransactions`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 061443f3c2933ba247abbe7f607d2e961351819c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->