### PR TITLE
feat(card): add provider-agnostic transaction history helpers

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -237,6 +237,7 @@ export MM_PREDICT_API_URL="http://localhost:3333"
 
 ## Card
 export MM_CARD_BAANX_API_CLIENT_KEY=""
+export MM_CARD_TRANSACTION_HISTORY_ENABLED="true"
 
 ## PNA25 (Privacy Notice)
 export MM_EXTENSION_UX_PNA25=""

--- a/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
@@ -646,6 +646,7 @@ const BAANX_CAPABILITIES = {
   supportsSensitiveDetailsView: false,
   supportsTravel: true,
   supportsTransactionHistory: true,
+  supportsMoneyAccountLinking: true,
 };
 
 const mockIsSolanaChainId = isSolanaChainId as jest.MockedFunction<

--- a/app/components/UI/Card/components/CardTransactionDetailsContent/CardTransactionDetailsContent.tsx
+++ b/app/components/UI/Card/components/CardTransactionDetailsContent/CardTransactionDetailsContent.tsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { ScrollView } from 'react-native';
+import {
+  AvatarToken,
+  AvatarTokenSize,
+  Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  HeaderStandard,
+  IconName,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import type { ImageOrSvgSrc } from '@metamask/design-system-react-native/dist/components/temp-components/ImageOrSvg/ImageOrSvg.types.d.cts';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { ButtonIconSizes } from '../../../../../component-library/components/Buttons/ButtonIcon';
+import { IconColor } from '../../../../../component-library/components/Icons/Icon';
+import { TransactionDetailDivider } from '../../../../Views/confirmations/components/activity/transaction-detail-divider/transaction-detail-divider';
+import { TransactionDetailsRow } from '../../../../Views/confirmations/components/activity/transaction-details-row/transaction-details-row';
+import CopyButton from '../../../../Views/confirmations/components/UI/copy-button/copy-button';
+import { strings } from '../../../../../../locales/i18n';
+import type { CardTransactionHeroToken } from '../../utils/getCardTransactionHeroToken';
+
+export interface CardTransactionDetailsContentProps {
+  heroCopy: string;
+  primaryAmount: string;
+  fiatAmount?: string;
+  amountColor?: TextColor;
+  statusLabel: string;
+  statusColor?: TextColor;
+  dateLabel: string;
+  merchantName?: string;
+  categoryLabel?: string;
+  locationLabel?: string;
+  declineReason?: string;
+  transactionId?: string;
+  heroToken: CardTransactionHeroToken;
+  heroIconTestID?: string;
+  onBack: () => void;
+  onReportPress?: () => void;
+  onViewOnExplorer?: () => void;
+  footer?: React.ReactNode;
+}
+
+const CardTransactionDetailsContent = ({
+  heroCopy,
+  primaryAmount,
+  fiatAmount,
+  amountColor = TextColor.TextDefault,
+  statusLabel,
+  statusColor = TextColor.SuccessDefault,
+  dateLabel,
+  merchantName,
+  categoryLabel,
+  locationLabel,
+  declineReason,
+  transactionId,
+  heroToken,
+  heroIconTestID = 'card-transaction-details-asset-icon',
+  onBack,
+  onReportPress,
+  onViewOnExplorer,
+  footer,
+}: CardTransactionDetailsContentProps) => {
+  const tw = useTailwind();
+
+  return (
+    <Box twClassName="flex-1 bg-background-default">
+      <HeaderStandard
+        title={strings('card.transactions.details_title')}
+        onBack={onBack}
+        backButtonProps={{ testID: 'card-transaction-details-back-button' }}
+        includesTopInset
+      />
+      <ScrollView contentContainerStyle={tw.style('pb-8')}>
+        <Box twClassName="px-4">
+          <Box twClassName="gap-3">
+            <Box twClassName="gap-1">
+              <Text color={TextColor.TextAlternative}>{heroCopy}</Text>
+              <Box twClassName="flex-row items-center gap-3">
+                <AvatarToken
+                  name={heroToken.symbol}
+                  src={heroToken.iconSource as ImageOrSvgSrc}
+                  size={AvatarTokenSize.Md}
+                  testID={heroIconTestID}
+                />
+                <Text variant={TextVariant.DisplayMd} color={amountColor}>
+                  {primaryAmount}
+                </Text>
+              </Box>
+              {fiatAmount ? (
+                <Text color={TextColor.TextAlternative}>{fiatAmount}</Text>
+              ) : null}
+            </Box>
+
+            <TransactionDetailDivider />
+
+            <TransactionDetailsRow label={strings('transactions.status')}>
+              <Text color={statusColor}>{statusLabel}</Text>
+            </TransactionDetailsRow>
+
+            <TransactionDetailsRow
+              label={strings('money.api_activity_details.date')}
+            >
+              <Text>{dateLabel}</Text>
+            </TransactionDetailsRow>
+
+            {merchantName ? (
+              <TransactionDetailsRow
+                label={strings('card.transactions.merchant')}
+              >
+                <Text>{merchantName}</Text>
+              </TransactionDetailsRow>
+            ) : null}
+
+            {categoryLabel ? (
+              <TransactionDetailsRow
+                label={strings('card.transactions.category')}
+              >
+                <Text>{categoryLabel}</Text>
+              </TransactionDetailsRow>
+            ) : null}
+
+            {locationLabel ? (
+              <TransactionDetailsRow
+                label={strings('card.transactions.location')}
+              >
+                <Text>{locationLabel}</Text>
+              </TransactionDetailsRow>
+            ) : null}
+
+            {transactionId ? (
+              <TransactionDetailsRow
+                label={strings('transaction.transaction_id')}
+              >
+                <Box twClassName="flex-row items-center gap-1.5">
+                  <Text color={TextColor.TextAlternative}>{transactionId}</Text>
+                  <CopyButton
+                    copyText={transactionId}
+                    size={ButtonIconSizes.Sm}
+                    iconColor={IconColor.Alternative}
+                    testID="card-transaction-details-copy-id"
+                  />
+                </Box>
+              </TransactionDetailsRow>
+            ) : null}
+
+            {declineReason ? (
+              <TransactionDetailsRow
+                label={strings('card.transactions.decline_reason')}
+              >
+                <Text color={TextColor.TextAlternative}>{declineReason}</Text>
+              </TransactionDetailsRow>
+            ) : null}
+
+            {footer}
+
+            {onViewOnExplorer ? (
+              <Box twClassName="w-full pt-2">
+                <Button
+                  variant={ButtonVariant.Secondary}
+                  size={ButtonSize.Lg}
+                  isFullWidth
+                  onPress={onViewOnExplorer}
+                  startIconName={IconName.Export}
+                  testID="card-transaction-details-explorer-button"
+                >
+                  {strings('card.transactions.view_on_explorer')}
+                </Button>
+              </Box>
+            ) : null}
+
+            {onReportPress ? (
+              <Box twClassName="w-full pt-2">
+                <Button
+                  variant={ButtonVariant.Primary}
+                  size={ButtonSize.Lg}
+                  onPress={onReportPress}
+                  isFullWidth
+                  testID="card-transaction-details-report-button"
+                >
+                  {strings('card.transactions.report_cta')}
+                </Button>
+              </Box>
+            ) : null}
+          </Box>
+        </Box>
+      </ScrollView>
+    </Box>
+  );
+};
+
+export default CardTransactionDetailsContent;

--- a/app/components/UI/Card/components/CardTransactionRow/CardTransactionRow.test.tsx
+++ b/app/components/UI/Card/components/CardTransactionRow/CardTransactionRow.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { IconName } from '@metamask/design-system-react-native';
+import {
+  CardTransactionStatus,
+  CardTransactionType,
+  type CardTransaction,
+} from '../../../../../core/Engine/controllers/card-controller/provider-types';
+import CardTransactionRow from './CardTransactionRow';
+
+const mockRowView = jest.fn((_props: unknown) => null);
+jest.mock(
+  '../../../Money/components/MoneyActivityItem/ActivityRowView',
+  () => ({
+    __esModule: true,
+    default: (props: unknown) => mockRowView(props),
+  }),
+);
+
+jest.mock('../../../../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+  default: { locale: 'en-US' },
+}));
+
+jest.mock('../../../../../util/intl', () => ({
+  getIntlDateTimeFormatter: () => ({
+    format: () => '15 Jan',
+  }),
+  getIntlNumberFormatter: () => ({
+    format: (value: number) => `$${value.toFixed(2)}`,
+  }),
+}));
+
+function createTransaction(
+  overrides: Partial<CardTransaction> = {},
+): CardTransaction {
+  return {
+    id: 'tx-1',
+    providerId: 'baanx',
+    timestamp: Date.now(),
+    status: CardTransactionStatus.Completed,
+    type: CardTransactionType.Purchase,
+    isDebit: true,
+    billingAmount: { value: '10.00', currency: 'USD' },
+    merchant: { name: 'Coffee Shop' },
+    fundingSources: [],
+    ...overrides,
+  };
+}
+
+interface CapturedRowProps {
+  id: string;
+  privacyMode?: boolean;
+  onPress?: () => void;
+  display: {
+    label: string;
+    description?: string;
+    icon: IconName;
+    primaryAmount: string;
+  };
+}
+
+const lastRowProps = () =>
+  mockRowView.mock.calls[0][0] as unknown as CapturedRowProps;
+
+describe('CardTransactionRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('maps the card transaction into ActivityRowView display props', () => {
+    render(<CardTransactionRow transaction={createTransaction()} />);
+
+    const props = lastRowProps();
+    expect(props.id).toBe('tx-1');
+    expect(props.display.label).toBe('money.transaction.purchase');
+    expect(props.display.description).toBe('Coffee Shop');
+    expect(props.display.icon).toBe(IconName.Card);
+    expect(props.display.primaryAmount).toBe('-$10.00');
+    expect(props.onPress).toBeUndefined();
+    expect(props.privacyMode).toBeUndefined();
+  });
+
+  it('forwards privacyMode to ActivityRowView', () => {
+    render(
+      <CardTransactionRow transaction={createTransaction()} privacyMode />,
+    );
+
+    expect(lastRowProps().privacyMode).toBe(true);
+  });
+
+  it('invokes onPress with the transaction when the row is pressed', () => {
+    const onPress = jest.fn();
+    const transaction = createTransaction();
+
+    render(<CardTransactionRow transaction={transaction} onPress={onPress} />);
+    lastRowProps().onPress?.();
+
+    expect(onPress).toHaveBeenCalledWith(transaction);
+  });
+});

--- a/app/components/UI/Card/components/CardTransactionRow/CardTransactionRow.tsx
+++ b/app/components/UI/Card/components/CardTransactionRow/CardTransactionRow.tsx
@@ -1,0 +1,32 @@
+import React, { useMemo } from 'react';
+import type { CardTransaction } from '../../../../../core/Engine/controllers/card-controller/provider-types';
+import ActivityRowView from '../../../Money/components/MoneyActivityItem/ActivityRowView';
+import { cardTransactionDisplayInfo } from '../../utils/cardTransactionDisplayInfo';
+
+export interface CardTransactionRowProps {
+  transaction: CardTransaction;
+  onPress?: (tx: CardTransaction) => void;
+  privacyMode?: boolean;
+}
+
+const CardTransactionRow = ({
+  transaction,
+  onPress,
+  privacyMode,
+}: CardTransactionRowProps) => {
+  const display = useMemo(
+    () => cardTransactionDisplayInfo(transaction),
+    [transaction],
+  );
+
+  return (
+    <ActivityRowView
+      id={transaction.id}
+      display={display}
+      privacyMode={privacyMode}
+      onPress={onPress ? () => onPress(transaction) : undefined}
+    />
+  );
+};
+
+export default React.memo(CardTransactionRow);

--- a/app/components/UI/Card/components/CardTransactionRow/CardTransactionRow.tsx
+++ b/app/components/UI/Card/components/CardTransactionRow/CardTransactionRow.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import type { CardTransaction } from '../../../../../core/Engine/controllers/card-controller/provider-types';
 import ActivityRowView from '../../../Money/components/MoneyActivityItem/ActivityRowView';
 import { cardTransactionDisplayInfo } from '../../utils/cardTransactionDisplayInfo';
@@ -19,12 +19,16 @@ const CardTransactionRow = ({
     [transaction],
   );
 
+  const handlePress = useCallback(() => {
+    onPress?.(transaction);
+  }, [onPress, transaction]);
+
   return (
     <ActivityRowView
       id={transaction.id}
       display={display}
       privacyMode={privacyMode}
-      onPress={onPress ? () => onPress(transaction) : undefined}
+      onPress={onPress ? handlePress : undefined}
     />
   );
 };

--- a/app/components/UI/Card/hooks/useCardTransactionIndex.test.ts
+++ b/app/components/UI/Card/hooks/useCardTransactionIndex.test.ts
@@ -1,21 +1,68 @@
+import React from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { notifyManager } from '@tanstack/query-core';
+import { useSelector } from 'react-redux';
 import {
   CARD_TX_INDEX_MAX_ITEMS,
   CARD_TX_INDEX_MAX_PAGES,
   classifyCardTransactionsForIndex,
   isSettledCardTransaction,
   settlementHashesForCardTransaction,
+  useCardTransactionIndex,
 } from './useCardTransactionIndex';
 import { isMoneyAccountCardTransaction } from '../utils/moneyAccountCardTransaction';
 import {
   CardTransactionStatus,
   CardTransactionType,
   type CardTransaction,
+  type CardTransactionPage,
 } from '../../../../core/Engine/controllers/card-controller/provider-types';
 import { MONEY_ACCOUNT_LAUNCH_MS } from '../../../../core/Engine/controllers/card-controller/types';
 import {
   MONEY_ACCOUNT_DELEGATION_CAIP_CHAIN_ID,
   MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
 } from '../util/vedaToken';
+import Engine from '../../../../core/Engine';
+import {
+  selectCardActiveProviderId,
+  selectCardProviderUserId,
+  selectIsCardAuthenticated,
+} from '../../../../selectors/cardController';
+import { cardQueries } from '../queries';
+
+notifyManager.setBatchNotifyFunction((callback: () => void) => {
+  callback();
+});
+
+const mockListTransactions = jest.fn();
+
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    CardController: {
+      listTransactions: jest.fn(),
+    },
+  },
+}));
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+let mockIsAuthenticated = true;
+let mockProviderId: string | null = 'baanx';
+let mockProviderUserId: string | null = 'user-1';
+let activeQueryClient: QueryClient | null = null;
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  activeQueryClient = queryClient;
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return { Wrapper, queryClient };
+};
 
 const createTx = (
   overrides: Partial<CardTransaction> = {},
@@ -29,6 +76,20 @@ const createTx = (
   billingAmount: { value: '10.00', currency: 'USD' },
   fundingSources: [],
   ...overrides,
+});
+
+const moneyAccountFunding = {
+  currency: MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
+  chainId: MONEY_ACCOUNT_DELEGATION_CAIP_CHAIN_ID,
+  txHash: '0xABC',
+};
+
+const buildPage = (
+  items: CardTransaction[],
+  nextCursor?: string,
+): CardTransactionPage => ({
+  items,
+  nextCursor,
 });
 
 describe('useCardTransactionIndex constants', () => {
@@ -197,5 +258,234 @@ describe('classifyCardTransactionsForIndex', () => {
     expect(result.bySettlementHash.get('0xone')).toBe(tx);
     expect(result.bySettlementHash.get('0xtwo')).toBe(tx);
     expect(result.declined).toEqual([]);
+  });
+});
+
+describe('useCardTransactionIndex', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsAuthenticated = true;
+    mockProviderId = 'baanx';
+    mockProviderUserId = 'user-1';
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === selectIsCardAuthenticated) {
+        return mockIsAuthenticated;
+      }
+      if (selector === selectCardActiveProviderId) {
+        return mockProviderId;
+      }
+      if (selector === selectCardProviderUserId) {
+        return mockProviderUserId;
+      }
+      return undefined;
+    });
+    mockListTransactions.mockResolvedValue(
+      buildPage([
+        createTx({
+          id: 'ma-settled',
+          fundingSources: [moneyAccountFunding],
+        }),
+        createTx({
+          id: 'other',
+          fundingSources: [
+            { currency: 'usdc', chainId: 'eip155:8453', txHash: '0xother' },
+          ],
+        }),
+      ]),
+    );
+    (Engine.context.CardController.listTransactions as jest.Mock) =
+      mockListTransactions;
+  });
+
+  afterEach(() => {
+    if (activeQueryClient) {
+      activeQueryClient.getQueryCache().clear();
+      activeQueryClient.clear();
+      activeQueryClient = null;
+    }
+  });
+
+  it('scopes the query key by provider and user under card transactions', async () => {
+    const { Wrapper, queryClient } = createWrapper();
+
+    const { result } = renderHook(() => useCardTransactionIndex(), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(result.current.isSettling).toBe(false));
+
+    expect(
+      queryClient.getQueryData(
+        cardQueries.transactions.keys.index('baanx', 'user-1'),
+      ),
+    ).toBeDefined();
+    expect(cardQueries.transactions.keys.index('baanx', 'user-1')).toEqual([
+      'card',
+      'transactions',
+      'index',
+      'baanx',
+      'user-1',
+    ]);
+  });
+
+  it('indexes Money Account settled txs and ignores other funding', async () => {
+    const { Wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useCardTransactionIndex(), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(result.current.isSettling).toBe(false));
+
+    expect(result.current.bySettlementHash.get('0xabc')?.id).toBe('ma-settled');
+    expect(result.current.bySettlementHash.has('0xother')).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('auto-paginates while oldest fetched time is above the visible floor', async () => {
+    const older = createTx({
+      id: 'older',
+      timestamp: Date.UTC(2026, 4, 10),
+      fundingSources: [{ ...moneyAccountFunding, txHash: '0xolder' }],
+    });
+    const newer = createTx({
+      id: 'newer',
+      timestamp: Date.UTC(2026, 6, 1),
+      fundingSources: [{ ...moneyAccountFunding, txHash: '0xnewer' }],
+    });
+    mockListTransactions
+      .mockResolvedValueOnce(buildPage([newer], 'cursor-1'))
+      .mockResolvedValueOnce(buildPage([older]));
+
+    const { Wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () =>
+        useCardTransactionIndex({
+          oldestVisibleTime: Date.UTC(2026, 4, 15),
+        }),
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSettling).toBe(false));
+    expect(mockListTransactions).toHaveBeenCalledTimes(2);
+    expect(result.current.bySettlementHash.get('0xnewer')?.id).toBe('newer');
+    expect(result.current.bySettlementHash.get('0xolder')?.id).toBe('older');
+  });
+
+  it('collects Money Account declined txs without settlement hashes', async () => {
+    mockListTransactions.mockResolvedValue(
+      buildPage([
+        createTx({
+          id: 'declined',
+          status: CardTransactionStatus.Failed,
+          fundingSources: [],
+          declineReason: {
+            message:
+              'You attempted this MONAD transaction with a balance of 0.500000 VEDA. The total transaction cost was $11.95.',
+          },
+        }),
+      ]),
+    );
+    const { Wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useCardTransactionIndex(), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(result.current.isSettling).toBe(false));
+
+    expect(result.current.declined.map((tx) => tx.id)).toEqual(['declined']);
+    expect(result.current.oldestFetchedTime).toBe(Date.UTC(2026, 5, 20));
+  });
+
+  it('does not fetch or expose cached index rows while unauthenticated', async () => {
+    const { Wrapper, queryClient } = createWrapper();
+    queryClient.setQueryData(
+      cardQueries.transactions.keys.index('baanx', 'user-1'),
+      {
+        pages: [
+          buildPage([
+            createTx({
+              id: 'cached',
+              fundingSources: [moneyAccountFunding],
+            }),
+          ]),
+        ],
+        pageParams: [undefined],
+      },
+    );
+    mockIsAuthenticated = false;
+
+    const { result } = renderHook(() => useCardTransactionIndex(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() =>
+      expect(
+        queryClient.getQueryData(
+          cardQueries.transactions.keys.index('baanx', 'user-1'),
+        ),
+      ).toBeUndefined(),
+    );
+    expect(mockListTransactions).not.toHaveBeenCalled();
+    expect(result.current.bySettlementHash.size).toBe(0);
+    expect(result.current.declined).toEqual([]);
+    expect(result.current.isSettling).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('uses legacy cache user id when providerUserId is missing', async () => {
+    mockProviderUserId = null;
+    const { Wrapper, queryClient } = createWrapper();
+
+    const { result } = renderHook(() => useCardTransactionIndex(), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(result.current.isSettling).toBe(false));
+
+    expect(
+      queryClient.getQueryData(
+        cardQueries.transactions.keys.index('baanx', 'legacy'),
+      ),
+    ).toBeDefined();
+  });
+
+  it('surfaces controller errors and stays unsettled only while enabled', async () => {
+    mockListTransactions.mockRejectedValue(new Error('auth'));
+    const { Wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useCardTransactionIndex(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.isSettling).toBe(false);
+  });
+
+  it('skips fetching when enabled is false', async () => {
+    const { Wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useCardTransactionIndex({ enabled: false }),
+      { wrapper: Wrapper },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockListTransactions).not.toHaveBeenCalled();
+    expect(result.current.isFetching).toBe(false);
+    expect(result.current.isSettling).toBe(false);
+  });
+
+  it('returns negative infinity oldestFetchedTime when there are no items', async () => {
+    mockListTransactions.mockResolvedValue(buildPage([]));
+    const { Wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useCardTransactionIndex(), {
+      wrapper: Wrapper,
+    });
+    await waitFor(() => expect(result.current.isSettling).toBe(false));
+
+    expect(result.current.oldestFetchedTime).toBe(Number.NEGATIVE_INFINITY);
   });
 });

--- a/app/components/UI/Card/hooks/useCardTransactionIndex.test.ts
+++ b/app/components/UI/Card/hooks/useCardTransactionIndex.test.ts
@@ -54,6 +54,12 @@ let mockProviderId: string | null = 'baanx';
 let mockProviderUserId: string | null = 'user-1';
 let activeQueryClient: QueryClient | null = null;
 
+beforeEach(() => {
+  mockIsAuthenticated = true;
+  mockProviderId = 'baanx';
+  mockProviderUserId = 'user-1';
+});
+
 const createWrapper = () => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -259,14 +265,46 @@ describe('classifyCardTransactionsForIndex', () => {
     expect(result.bySettlementHash.get('0xtwo')).toBe(tx);
     expect(result.declined).toEqual([]);
   });
+
+  it('excludes pending Money Account auths without a settlement hash from declined', () => {
+    const pendingAuth = createTx({
+      id: 'pending-ma',
+      status: CardTransactionStatus.Pending,
+      fundingSources: [
+        {
+          currency: MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
+          chainId: MONEY_ACCOUNT_DELEGATION_CAIP_CHAIN_ID,
+        },
+      ],
+    });
+
+    const result = classifyCardTransactionsForIndex([pendingAuth]);
+
+    expect(result.bySettlementHash.size).toBe(0);
+    expect(result.declined).toEqual([]);
+  });
+
+  it('excludes completed and reversed txs without a settlement hash from declined', () => {
+    const completed = createTx({
+      id: 'completed-no-hash',
+      status: CardTransactionStatus.Completed,
+      fundingSources: [],
+    });
+    const reversed = createTx({
+      id: 'reversed-no-hash',
+      status: CardTransactionStatus.Reversed,
+      fundingSources: [],
+    });
+
+    const result = classifyCardTransactionsForIndex([completed, reversed]);
+
+    expect(result.declined).toEqual([]);
+  });
 });
 
 describe('useCardTransactionIndex', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsAuthenticated = true;
-    mockProviderId = 'baanx';
-    mockProviderUserId = 'user-1';
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectIsCardAuthenticated) {
         return mockIsAuthenticated;

--- a/app/components/UI/Card/hooks/useCardTransactionIndex.test.ts
+++ b/app/components/UI/Card/hooks/useCardTransactionIndex.test.ts
@@ -1,0 +1,201 @@
+import {
+  CARD_TX_INDEX_MAX_ITEMS,
+  CARD_TX_INDEX_MAX_PAGES,
+  classifyCardTransactionsForIndex,
+  isSettledCardTransaction,
+  settlementHashesForCardTransaction,
+} from './useCardTransactionIndex';
+import { isMoneyAccountCardTransaction } from '../utils/moneyAccountCardTransaction';
+import {
+  CardTransactionStatus,
+  CardTransactionType,
+  type CardTransaction,
+} from '../../../../core/Engine/controllers/card-controller/provider-types';
+import { MONEY_ACCOUNT_LAUNCH_MS } from '../../../../core/Engine/controllers/card-controller/types';
+import {
+  MONEY_ACCOUNT_DELEGATION_CAIP_CHAIN_ID,
+  MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
+} from '../util/vedaToken';
+
+const createTx = (
+  overrides: Partial<CardTransaction> = {},
+): CardTransaction => ({
+  id: 'tx-1',
+  providerId: 'baanx',
+  timestamp: Date.UTC(2026, 5, 20),
+  status: CardTransactionStatus.Completed,
+  type: CardTransactionType.Purchase,
+  isDebit: true,
+  billingAmount: { value: '10.00', currency: 'USD' },
+  fundingSources: [],
+  ...overrides,
+});
+
+describe('useCardTransactionIndex constants', () => {
+  it('exposes finite safety valves', () => {
+    expect(CARD_TX_INDEX_MAX_PAGES).toBe(5);
+    expect(CARD_TX_INDEX_MAX_ITEMS).toBe(300);
+  });
+
+  it('uses Money Account launch date as the hard floor', () => {
+    expect(MONEY_ACCOUNT_LAUNCH_MS).toBe(Date.UTC(2026, 4, 1));
+  });
+});
+
+describe('isSettledCardTransaction', () => {
+  it('returns true when any funding source has a txHash', () => {
+    const tx = createTx({
+      fundingSources: [{ txHash: '0xABC' }],
+    });
+
+    expect(isSettledCardTransaction(tx)).toBe(true);
+  });
+
+  it('returns false when funding sources have no txHash', () => {
+    const tx = createTx({
+      status: CardTransactionStatus.Failed,
+      fundingSources: [{ address: '0xaddr' }],
+    });
+
+    expect(isSettledCardTransaction(tx)).toBe(false);
+  });
+
+  it('classifies by hash presence, not status', () => {
+    const pendingWithHash = createTx({
+      status: CardTransactionStatus.Pending,
+      fundingSources: [{ txHash: '0x1' }],
+    });
+    const completedWithoutHash = createTx({
+      status: CardTransactionStatus.Completed,
+      fundingSources: [],
+    });
+
+    expect(isSettledCardTransaction(pendingWithHash)).toBe(true);
+    expect(isSettledCardTransaction(completedWithoutHash)).toBe(false);
+  });
+});
+
+describe('settlementHashesForCardTransaction', () => {
+  it('lowercases and filters missing hashes', () => {
+    const tx = createTx({
+      fundingSources: [
+        { txHash: '0xAbCd' },
+        { address: '0xnohash' },
+        { txHash: '0xEF' },
+      ],
+    });
+
+    expect(settlementHashesForCardTransaction(tx)).toEqual(['0xabcd', '0xef']);
+  });
+});
+
+describe('isMoneyAccountCardTransaction', () => {
+  it('returns true for veda funding on Monad', () => {
+    expect(
+      isMoneyAccountCardTransaction(
+        createTx({
+          fundingSources: [
+            {
+              currency: MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
+              chainId: MONEY_ACCOUNT_DELEGATION_CAIP_CHAIN_ID,
+              txHash: '0x1',
+            },
+          ],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for base USDC funding', () => {
+    expect(
+      isMoneyAccountCardTransaction(
+        createTx({
+          fundingSources: [
+            {
+              currency: 'usdc',
+              chainId: 'eip155:8453',
+              txHash: '0x1',
+            },
+          ],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for monad USDC funding', () => {
+    expect(
+      isMoneyAccountCardTransaction(
+        createTx({
+          fundingSources: [
+            {
+              currency: 'usdc',
+              chainId: MONEY_ACCOUNT_DELEGATION_CAIP_CHAIN_ID,
+              txHash: '0x1',
+            },
+          ],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true for a VEDA decline with empty funding sources', () => {
+    expect(
+      isMoneyAccountCardTransaction(
+        createTx({
+          status: CardTransactionStatus.Failed,
+          fundingSources: [],
+          declineReason: {
+            message:
+              'You attempted this MONAD transaction with a balance of 0.500000 VEDA. The total transaction cost was $11.95.',
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for a MONAD USDC decline with empty funding sources', () => {
+    expect(
+      isMoneyAccountCardTransaction(
+        createTx({
+          status: CardTransactionStatus.Failed,
+          fundingSources: [],
+          declineReason: {
+            message:
+              'You attempted this MONAD transaction with a balance of 0.500000 USDC. The total transaction cost was $11.95.',
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('classifyCardTransactionsForIndex', () => {
+  it('indexes settled txs by lowercased hash and collects declined rows', () => {
+    const settled = createTx({
+      id: 'settled',
+      fundingSources: [{ txHash: '0xAbC' }],
+    });
+    const declined = createTx({
+      id: 'declined',
+      status: CardTransactionStatus.Failed,
+      fundingSources: [],
+    });
+
+    const result = classifyCardTransactionsForIndex([settled, declined]);
+
+    expect(result.bySettlementHash.get('0xabc')).toBe(settled);
+    expect(result.declined).toEqual([declined]);
+  });
+
+  it('maps multiple funding hashes of one tx to the same entry', () => {
+    const tx = createTx({
+      fundingSources: [{ txHash: '0xONE' }, { txHash: '0xTWO' }],
+    });
+
+    const result = classifyCardTransactionsForIndex([tx]);
+
+    expect(result.bySettlementHash.get('0xone')).toBe(tx);
+    expect(result.bySettlementHash.get('0xtwo')).toBe(tx);
+    expect(result.declined).toEqual([]);
+  });
+});

--- a/app/components/UI/Card/hooks/useCardTransactionIndex.ts
+++ b/app/components/UI/Card/hooks/useCardTransactionIndex.ts
@@ -3,9 +3,10 @@ import { useSelector } from 'react-redux';
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import Engine from '../../../../core/Engine';
 import { MONEY_ACCOUNT_LAUNCH_MS } from '../../../../core/Engine/controllers/card-controller/types';
-import type {
-  CardTransaction,
-  CardTransactionPage,
+import {
+  CardTransactionStatus,
+  type CardTransaction,
+  type CardTransactionPage,
 } from '../../../../core/Engine/controllers/card-controller/provider-types';
 import {
   selectCardActiveProviderId,
@@ -56,7 +57,11 @@ export function classifyCardTransactionsForIndex(items: CardTransaction[]): {
       for (const hash of settlementHashesForCardTransaction(tx)) {
         bySettlementHash.set(hash, tx);
       }
-    } else {
+      continue;
+    }
+    // Only failed txs are declines. Pending/completed/reversed without a hash
+    // must not enter the declined feed (e.g. pending Money Account auths).
+    if (tx.status === CardTransactionStatus.Failed) {
       declined.push(tx);
     }
   }

--- a/app/components/UI/Card/hooks/useCardTransactionIndex.ts
+++ b/app/components/UI/Card/hooks/useCardTransactionIndex.ts
@@ -1,0 +1,143 @@
+import { useEffect, useMemo } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import Engine from '../../../../core/Engine';
+import { MONEY_ACCOUNT_LAUNCH_MS } from '../../../../core/Engine/controllers/card-controller/types';
+import type {
+  CardTransaction,
+  CardTransactionPage,
+} from '../../../../core/Engine/controllers/card-controller/provider-types';
+import { isMoneyAccountCardTransaction } from '../utils/moneyAccountCardTransaction';
+
+const CARD_TX_INDEX_QUERY_KEY = 'cardTransactionIndex';
+export const CARD_TX_INDEX_MAX_PAGES = 5;
+export const CARD_TX_INDEX_MAX_ITEMS = 300;
+const CLOCK_SKEW_MS = 5 * 60 * 1000;
+
+export interface UseCardTransactionIndexOptions {
+  oldestVisibleTime?: number;
+  enabled?: boolean;
+}
+
+export interface UseCardTransactionIndexResult {
+  bySettlementHash: Map<string, CardTransaction>;
+  declined: CardTransaction[];
+  oldestFetchedTime: number;
+  isFetching: boolean;
+  isSettling: boolean;
+  isError: boolean;
+}
+
+export function isSettledCardTransaction(tx: CardTransaction): boolean {
+  return tx.fundingSources.some((fs) => Boolean(fs.txHash));
+}
+
+export function settlementHashesForCardTransaction(
+  tx: CardTransaction,
+): string[] {
+  return tx.fundingSources
+    .map((fs) => fs.txHash?.toLowerCase())
+    .filter((h): h is string => Boolean(h));
+}
+
+export function classifyCardTransactionsForIndex(items: CardTransaction[]): {
+  bySettlementHash: Map<string, CardTransaction>;
+  declined: CardTransaction[];
+} {
+  const bySettlementHash = new Map<string, CardTransaction>();
+  const declined: CardTransaction[] = [];
+  for (const tx of items) {
+    if (isSettledCardTransaction(tx)) {
+      for (const hash of settlementHashesForCardTransaction(tx)) {
+        bySettlementHash.set(hash, tx);
+      }
+    } else {
+      declined.push(tx);
+    }
+  }
+  return { bySettlementHash, declined };
+}
+
+export function useCardTransactionIndex({
+  oldestVisibleTime,
+  enabled = true,
+}: UseCardTransactionIndexOptions = {}): UseCardTransactionIndexResult {
+  const cardController = Engine.context?.CardController;
+  const queryEnabled = Boolean(enabled && cardController);
+
+  const query = useInfiniteQuery({
+    queryKey: [CARD_TX_INDEX_QUERY_KEY],
+    queryFn: async ({ pageParam }: { pageParam?: string }) => {
+      if (!cardController) {
+        throw new Error('CardController not available');
+      }
+      return cardController.listTransactions({
+        limit: 50,
+        cursor: pageParam,
+        fromDate: MONEY_ACCOUNT_LAUNCH_MS,
+        toDate: Date.now(),
+      });
+    },
+    getNextPageParam: (lastPage: CardTransactionPage) => lastPage.nextCursor,
+    enabled: queryEnabled,
+  });
+
+  const allItems = useMemo(
+    () => query.data?.pages.flatMap((page) => page.items) ?? [],
+    [query.data],
+  );
+
+  const oldestFetchedTime = useMemo(() => {
+    if (allItems.length === 0) {
+      return Number.POSITIVE_INFINITY;
+    }
+    return Math.min(...allItems.map((tx) => tx.timestamp));
+  }, [allItems]);
+
+  const targetFloor =
+    oldestVisibleTime != null
+      ? Math.max(oldestVisibleTime - CLOCK_SKEW_MS, MONEY_ACCOUNT_LAUNCH_MS)
+      : MONEY_ACCOUNT_LAUNCH_MS;
+
+  const pageCount = query.data?.pages.length ?? 0;
+  const hasMore = Boolean(
+    query.data?.pages[query.data.pages.length - 1]?.nextCursor,
+  );
+  const wantsMore =
+    queryEnabled &&
+    hasMore &&
+    !query.isFetchingNextPage &&
+    pageCount < CARD_TX_INDEX_MAX_PAGES &&
+    allItems.length < CARD_TX_INDEX_MAX_ITEMS &&
+    oldestFetchedTime > targetFloor;
+
+  useEffect(() => {
+    if (wantsMore) {
+      query.fetchNextPage();
+    }
+  }, [wantsMore, query]);
+
+  const moneyAccountItems = useMemo(
+    () => allItems.filter(isMoneyAccountCardTransaction),
+    [allItems],
+  );
+
+  const { bySettlementHash, declined } = useMemo(
+    () => classifyCardTransactionsForIndex(moneyAccountItems),
+    [moneyAccountItems],
+  );
+
+  return {
+    bySettlementHash,
+    declined,
+    oldestFetchedTime:
+      oldestFetchedTime === Number.POSITIVE_INFINITY
+        ? Number.NEGATIVE_INFINITY
+        : oldestFetchedTime,
+    isFetching: query.isFetching || query.isFetchingNextPage,
+    isSettling:
+      queryEnabled &&
+      !query.isError &&
+      (!query.isFetched || query.isFetchingNextPage || wantsMore),
+    isError: queryEnabled && Boolean(query.isError),
+  };
+}

--- a/app/components/UI/Card/hooks/useCardTransactionIndex.ts
+++ b/app/components/UI/Card/hooks/useCardTransactionIndex.ts
@@ -1,14 +1,20 @@
 import { useEffect, useMemo } from 'react';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
+import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import Engine from '../../../../core/Engine';
 import { MONEY_ACCOUNT_LAUNCH_MS } from '../../../../core/Engine/controllers/card-controller/types';
 import type {
   CardTransaction,
   CardTransactionPage,
 } from '../../../../core/Engine/controllers/card-controller/provider-types';
+import {
+  selectCardActiveProviderId,
+  selectCardProviderUserId,
+  selectIsCardAuthenticated,
+} from '../../../../selectors/cardController';
 import { isMoneyAccountCardTransaction } from '../utils/moneyAccountCardTransaction';
+import { cardQueries } from '../queries';
 
-const CARD_TX_INDEX_QUERY_KEY = 'cardTransactionIndex';
 export const CARD_TX_INDEX_MAX_PAGES = 5;
 export const CARD_TX_INDEX_MAX_ITEMS = 300;
 const CLOCK_SKEW_MS = 5 * 60 * 1000;
@@ -61,11 +67,31 @@ export function useCardTransactionIndex({
   oldestVisibleTime,
   enabled = true,
 }: UseCardTransactionIndexOptions = {}): UseCardTransactionIndexResult {
+  const queryClient = useQueryClient();
+  const isAuthenticated = useSelector(selectIsCardAuthenticated);
+  const providerId = useSelector(selectCardActiveProviderId);
+  const providerUserId = useSelector(selectCardProviderUserId);
+  // Existing production Card auth tokens predate providerUserId. Keep those
+  // users isolated by provider until their next login stores the stable ID.
+  const transactionCacheUserId = providerUserId ?? 'legacy';
   const cardController = Engine.context?.CardController;
-  const queryEnabled = Boolean(enabled && cardController);
+  const queryEnabled = Boolean(
+    enabled && cardController && isAuthenticated && providerId,
+  );
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      queryClient.removeQueries({
+        queryKey: cardQueries.transactions.keys.all(),
+      });
+    }
+  }, [isAuthenticated, queryClient]);
 
   const query = useInfiniteQuery({
-    queryKey: [CARD_TX_INDEX_QUERY_KEY],
+    queryKey: cardQueries.transactions.keys.index(
+      providerId,
+      transactionCacheUserId,
+    ),
     queryFn: async ({ pageParam }: { pageParam?: string }) => {
       if (!cardController) {
         throw new Error('CardController not available');
@@ -82,8 +108,11 @@ export function useCardTransactionIndex({
   });
 
   const allItems = useMemo(
-    () => query.data?.pages.flatMap((page) => page.items) ?? [],
-    [query.data],
+    () =>
+      queryEnabled
+        ? (query.data?.pages.flatMap((page) => page.items) ?? [])
+        : [],
+    [queryEnabled, query.data],
   );
 
   const oldestFetchedTime = useMemo(() => {
@@ -100,7 +129,7 @@ export function useCardTransactionIndex({
 
   const pageCount = query.data?.pages.length ?? 0;
   const hasMore = Boolean(
-    query.data?.pages[query.data.pages.length - 1]?.nextCursor,
+    queryEnabled && query.data?.pages[query.data.pages.length - 1]?.nextCursor,
   );
   const wantsMore =
     queryEnabled &&
@@ -109,12 +138,13 @@ export function useCardTransactionIndex({
     pageCount < CARD_TX_INDEX_MAX_PAGES &&
     allItems.length < CARD_TX_INDEX_MAX_ITEMS &&
     oldestFetchedTime > targetFloor;
+  const { fetchNextPage } = query;
 
   useEffect(() => {
     if (wantsMore) {
-      query.fetchNextPage();
+      fetchNextPage();
     }
-  }, [wantsMore, query]);
+  }, [wantsMore, fetchNextPage]);
 
   const moneyAccountItems = useMemo(
     () => allItems.filter(isMoneyAccountCardTransaction),
@@ -133,7 +163,7 @@ export function useCardTransactionIndex({
       oldestFetchedTime === Number.POSITIVE_INFINITY
         ? Number.NEGATIVE_INFINITY
         : oldestFetchedTime,
-    isFetching: query.isFetching || query.isFetchingNextPage,
+    isFetching: queryEnabled && (query.isFetching || query.isFetchingNextPage),
     isSettling:
       queryEnabled &&
       !query.isError &&

--- a/app/components/UI/Card/queries/index.ts
+++ b/app/components/UI/Card/queries/index.ts
@@ -29,6 +29,9 @@ const transactionKeys = {
       fromDate,
       toDate,
     ] as const,
+  /** Bounded Money Account enrichment index; scoped per provider/user. */
+  index: (providerId: string | null, providerUserId: string) =>
+    [...transactionKeys.all(), 'index', providerId, providerUserId] as const,
 };
 
 export const cardQueries = {

--- a/app/components/UI/Card/utils/cardTransactionAmount.test.ts
+++ b/app/components/UI/Card/utils/cardTransactionAmount.test.ts
@@ -1,0 +1,60 @@
+import { formatCardAmount } from './cardTransactionAmount';
+
+jest.mock('../../../../../locales/i18n', () => ({
+  default: { locale: 'en-US' },
+}));
+
+jest.mock('../../../../util/intl', () => ({
+  getIntlNumberFormatter: (
+    _locale: string,
+    options?: Intl.NumberFormatOptions,
+  ) => ({
+    format: (value: number) => {
+      if (options?.currency === 'BRL') {
+        return `R$${value.toFixed(2)}`;
+      }
+      if (options?.currency === 'USD') {
+        return `$${value.toFixed(2)}`;
+      }
+      if (options?.currency === 'INVALID') {
+        throw new RangeError('Invalid currency code');
+      }
+      return `${value} ${options?.currency ?? ''}`;
+    },
+  }),
+}));
+
+describe('formatCardAmount', () => {
+  it('formats a USD amount with a narrow dollar symbol', () => {
+    const result = formatCardAmount({ value: '11.95', currency: 'USD' });
+
+    expect(result).toBe('$11.95');
+  });
+
+  it('formats a BRL amount with a reais symbol', () => {
+    const result = formatCardAmount({ value: '61.35', currency: 'BRL' });
+
+    expect(result).toBe('R$61.35');
+  });
+
+  it('prefixes a debit amount with a minus sign', () => {
+    const result = formatCardAmount({ value: '11.95', currency: 'USD' }, true);
+
+    expect(result).toBe('-$11.95');
+  });
+
+  it('prefixes a credit amount with a plus sign', () => {
+    const result = formatCardAmount({ value: '5.00', currency: 'USD' }, false);
+
+    expect(result).toBe('+$5.00');
+  });
+
+  it('falls back to value and currency code when Intl rejects the currency', () => {
+    const result = formatCardAmount(
+      { value: '10.00', currency: 'INVALID' },
+      true,
+    );
+
+    expect(result).toBe('-10.00 INVALID');
+  });
+});

--- a/app/components/UI/Card/utils/cardTransactionAmount.test.ts
+++ b/app/components/UI/Card/utils/cardTransactionAmount.test.ts
@@ -64,10 +64,10 @@ describe('formatCardAmount', () => {
     expect(result).toBe('$3.00');
   });
 
-  it('formats non-numeric values without coercing them to zero', () => {
+  it('falls back to raw value and currency for non-numeric amounts', () => {
     const result = formatCardAmount({ value: 'n/a', currency: 'USD' }, true);
 
-    expect(result).toBe('-$NaN');
+    expect(result).toBe('-n/a USD');
   });
 
   it('keeps the unsigned fallback when Intl rejects the currency and isDebit is omitted', () => {

--- a/app/components/UI/Card/utils/cardTransactionAmount.test.ts
+++ b/app/components/UI/Card/utils/cardTransactionAmount.test.ts
@@ -57,4 +57,22 @@ describe('formatCardAmount', () => {
 
     expect(result).toBe('-10.00 INVALID');
   });
+
+  it('omits a sign when isDebit is omitted', () => {
+    const result = formatCardAmount({ value: '3.00', currency: 'USD' });
+
+    expect(result).toBe('$3.00');
+  });
+
+  it('formats non-numeric values without coercing them to zero', () => {
+    const result = formatCardAmount({ value: 'n/a', currency: 'USD' }, true);
+
+    expect(result).toBe('-$NaN');
+  });
+
+  it('keeps the unsigned fallback when Intl rejects the currency and isDebit is omitted', () => {
+    const result = formatCardAmount({ value: '10.00', currency: 'INVALID' });
+
+    expect(result).toBe('10.00 INVALID');
+  });
 });

--- a/app/components/UI/Card/utils/cardTransactionAmount.ts
+++ b/app/components/UI/Card/utils/cardTransactionAmount.ts
@@ -1,0 +1,31 @@
+import I18n from '../../../../../locales/i18n';
+import { getIntlNumberFormatter } from '../../../../util/intl';
+import type { CardTransactionAmount } from '../../../../core/Engine/controllers/card-controller/provider-types';
+
+export function formatCardAmount(
+  amount: CardTransactionAmount,
+  isDebit?: boolean,
+): string {
+  const numericValue = Number(amount.value);
+  const absValue = Number.isFinite(numericValue)
+    ? Math.abs(numericValue)
+    : amount.value;
+  const sign = isDebit === undefined ? '' : isDebit ? '-' : '+';
+
+  let formatted: string;
+  try {
+    formatted = getIntlNumberFormatter(I18n.locale, {
+      style: 'currency',
+      currency: amount.currency,
+      currencyDisplay: 'narrowSymbol',
+    }).format(typeof absValue === 'number' ? absValue : Number(absValue));
+  } catch {
+    formatted = `${amount.value} ${amount.currency}`;
+    return isDebit === undefined ? formatted : `${sign}${formatted}`;
+  }
+
+  // Intl may already include a minus for negative inputs; we always format the
+  // absolute value and apply our own debit/credit sign.
+  const withoutLeadingSign = formatted.replace(/^[+-]/, '');
+  return `${sign}${withoutLeadingSign}`;
+}

--- a/app/components/UI/Card/utils/cardTransactionAmount.ts
+++ b/app/components/UI/Card/utils/cardTransactionAmount.ts
@@ -7,10 +7,14 @@ export function formatCardAmount(
   isDebit?: boolean,
 ): string {
   const numericValue = Number(amount.value);
-  const absValue = Number.isFinite(numericValue)
-    ? Math.abs(numericValue)
-    : amount.value;
   const sign = isDebit === undefined ? '' : isDebit ? '-' : '+';
+
+  if (!Number.isFinite(numericValue)) {
+    const fallback = `${amount.value} ${amount.currency}`;
+    return isDebit === undefined ? fallback : `${sign}${fallback}`;
+  }
+
+  const absValue = Math.abs(numericValue);
 
   let formatted: string;
   try {
@@ -18,7 +22,7 @@ export function formatCardAmount(
       style: 'currency',
       currency: amount.currency,
       currencyDisplay: 'narrowSymbol',
-    }).format(typeof absValue === 'number' ? absValue : Number(absValue));
+    }).format(absValue);
   } catch {
     formatted = `${amount.value} ${amount.currency}`;
     return isDebit === undefined ? formatted : `${sign}${formatted}`;

--- a/app/components/UI/Card/utils/cardTransactionDisplayInfo.test.ts
+++ b/app/components/UI/Card/utils/cardTransactionDisplayInfo.test.ts
@@ -1,0 +1,172 @@
+import { IconName } from '@metamask/design-system-react-native';
+import {
+  CardTransactionStatus,
+  CardTransactionType,
+  type CardTransaction,
+} from '../../../../core/Engine/controllers/card-controller/provider-types';
+import {
+  cardTransactionDisplayInfo,
+  formatCardTransactionDate,
+} from './cardTransactionDisplayInfo';
+
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+  default: { locale: 'en-US' },
+}));
+
+jest.mock('../../../../util/intl', () => ({
+  getIntlDateTimeFormatter: () => ({
+    format: () => '15 Jan',
+  }),
+  getIntlNumberFormatter: (
+    _locale: string,
+    options?: Intl.NumberFormatOptions,
+  ) => ({
+    format: (value: number) => {
+      if (options?.currency === 'BRL') {
+        return `R$${value.toFixed(2)}`;
+      }
+      if (options?.currency === 'USD') {
+        return `$${value.toFixed(2)}`;
+      }
+      return `${value} ${options?.currency ?? ''}`;
+    },
+  }),
+}));
+
+function createTransaction(
+  overrides: Partial<CardTransaction> = {},
+): CardTransaction {
+  return {
+    id: 'tx-1',
+    providerId: 'baanx',
+    timestamp: Date.now(),
+    status: CardTransactionStatus.Completed,
+    type: CardTransactionType.Purchase,
+    isDebit: true,
+    billingAmount: { value: '10.00', currency: 'USD' },
+    fundingSources: [],
+    ...overrides,
+  };
+}
+
+describe('cardTransactionDisplayInfo', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-07-27T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('formatCardTransactionDate', () => {
+    it('returns today label for timestamps on the current day', () => {
+      const result = formatCardTransactionDate(
+        new Date('2026-07-27T08:00:00.000Z').getTime(),
+      );
+
+      expect(result).toBe('card.transactions.today');
+    });
+
+    it('returns yesterday label for timestamps on the previous day', () => {
+      const result = formatCardTransactionDate(
+        new Date('2026-07-26T08:00:00.000Z').getTime(),
+      );
+
+      expect(result).toBe('card.transactions.yesterday');
+    });
+
+    it('returns an absolute date for older timestamps', () => {
+      const result = formatCardTransactionDate(
+        new Date('2026-07-10T08:00:00.000Z').getTime(),
+      );
+
+      expect(result).toBe('15 Jan');
+    });
+  });
+
+  describe('cardTransactionDisplayInfo', () => {
+    it('uses the purchase type label and merchant name as description', () => {
+      const display = cardTransactionDisplayInfo(
+        createTransaction({
+          merchant: { name: 'Coffee Shop' },
+        }),
+      );
+
+      expect(display.label).toBe('money.transaction.purchase');
+      expect(display.description).toBe('Coffee Shop');
+      expect(display.icon).toBe(IconName.Card);
+    });
+
+    it('formats debit amounts with a currency symbol and minus sign', () => {
+      const display = cardTransactionDisplayInfo(
+        createTransaction({
+          isDebit: true,
+          billingAmount: { value: '42.50', currency: 'USD' },
+        }),
+      );
+
+      expect(display.primaryAmount).toBe('-$42.50');
+      expect(display.isIncoming).toBe(false);
+    });
+
+    it('shows merchant original amount when currency differs from billing', () => {
+      const display = cardTransactionDisplayInfo(
+        createTransaction({
+          billingAmount: { value: '11.95', currency: 'USD' },
+          originalAmount: { value: '61.35', currency: 'BRL' },
+        }),
+      );
+
+      expect(display.primaryAmount).toBe('-$11.95');
+      expect(display.fiatAmount).toBe('-R$61.35');
+    });
+
+    it('omits secondary amount when original currency matches billing', () => {
+      const display = cardTransactionDisplayInfo(
+        createTransaction({
+          billingAmount: { value: '10.00', currency: 'USD' },
+          originalAmount: { value: '10.00', currency: 'USD' },
+        }),
+      );
+
+      expect(display.fiatAmount).toBe('');
+    });
+
+    it('uses merchant name as description for pending transactions', () => {
+      const display = cardTransactionDisplayInfo(
+        createTransaction({
+          status: CardTransactionStatus.Pending,
+          merchant: { name: 'Pending Cafe' },
+        }),
+      );
+
+      expect(display.description).toBe('Pending Cafe');
+      expect(display.status).toBe('pending');
+    });
+
+    it('uses merchant name as description for failed transactions', () => {
+      const display = cardTransactionDisplayInfo(
+        createTransaction({
+          status: CardTransactionStatus.Failed,
+          merchant: { name: 'Failed Store' },
+          declineReason: { message: 'Insufficient funds' },
+        }),
+      );
+
+      expect(display.description).toBe('Failed Store');
+      expect(display.status).toBe('failed');
+    });
+
+    it('falls back to formatted date when merchant name is missing', () => {
+      const display = cardTransactionDisplayInfo(
+        createTransaction({
+          timestamp: new Date('2026-07-27T08:00:00.000Z').getTime(),
+        }),
+      );
+
+      expect(display.description).toBe('card.transactions.today');
+    });
+  });
+});

--- a/app/components/UI/Card/utils/cardTransactionDisplayInfo.test.ts
+++ b/app/components/UI/Card/utils/cardTransactionDisplayInfo.test.ts
@@ -7,6 +7,8 @@ import {
 import {
   cardTransactionDisplayInfo,
   formatCardTransactionDate,
+  formatCardTransactionStatus,
+  getCardTransactionTypeLabel,
 } from './cardTransactionDisplayInfo';
 
 jest.mock('../../../../../locales/i18n', () => ({
@@ -167,6 +169,70 @@ describe('cardTransactionDisplayInfo', () => {
       );
 
       expect(display.description).toBe('card.transactions.today');
+    });
+
+    it('falls back to provider description when merchant name is missing', () => {
+      const display = cardTransactionDisplayInfo(
+        createTransaction({
+          description: 'Provider note',
+          merchant: undefined,
+        }),
+      );
+
+      expect(display.description).toBe('Provider note');
+    });
+
+    it('marks credit transactions as incoming with a plus sign', () => {
+      const display = cardTransactionDisplayInfo(
+        createTransaction({
+          type: CardTransactionType.Refund,
+          isDebit: false,
+          billingAmount: { value: '5.00', currency: 'USD' },
+        }),
+      );
+
+      expect(display.label).toBe('money.transaction.refund');
+      expect(display.isIncoming).toBe(true);
+      expect(display.primaryAmount).toBe('+$5.00');
+      expect(display.status).toBe('confirmed');
+    });
+
+    it('maps reversed status to confirmed for activity rows', () => {
+      const display = cardTransactionDisplayInfo(
+        createTransaction({
+          status: CardTransactionStatus.Reversed,
+        }),
+      );
+
+      expect(display.status).toBe('confirmed');
+    });
+  });
+
+  describe('getCardTransactionTypeLabel', () => {
+    it('maps deposit and adjustment types to their i18n keys', () => {
+      expect(getCardTransactionTypeLabel(CardTransactionType.Deposit)).toBe(
+        'money.transaction.deposited',
+      );
+      expect(getCardTransactionTypeLabel(CardTransactionType.Adjustment)).toBe(
+        'money.transaction.card_transaction',
+      );
+    });
+  });
+
+  describe('formatCardTransactionStatus', () => {
+    it('localizes each card transaction status', () => {
+      expect(formatCardTransactionStatus(CardTransactionStatus.Pending)).toBe(
+        'card.transactions.pending',
+      );
+      expect(formatCardTransactionStatus(CardTransactionStatus.Failed)).toBe(
+        'money.transaction.failed',
+      );
+      expect(formatCardTransactionStatus(CardTransactionStatus.Reversed)).toBe(
+        'card.transactions.reversed',
+      );
+      expect(formatCardTransactionStatus(CardTransactionStatus.Completed)).toBe(
+        'card.transactions.completed',
+      );
     });
   });
 });

--- a/app/components/UI/Card/utils/cardTransactionDisplayInfo.ts
+++ b/app/components/UI/Card/utils/cardTransactionDisplayInfo.ts
@@ -1,0 +1,118 @@
+import { IconName } from '@metamask/design-system-react-native';
+import I18n, { strings } from '../../../../../locales/i18n';
+import { getIntlDateTimeFormatter } from '../../../../util/intl';
+import {
+  CardTransactionStatus,
+  CardTransactionType,
+  type CardTransaction,
+} from '../../../../core/Engine/controllers/card-controller/provider-types';
+import type { MoneyTransactionDisplayInfo } from '../../Money/hooks/useMoneyTransactionDisplayInfo';
+import type { MoneyActivityStatus } from '../../Money/utils/classifyMoneyActivity';
+import { formatCardAmount } from './cardTransactionAmount';
+
+const TYPE_LABEL_KEY: Record<CardTransactionType, string> = {
+  [CardTransactionType.Purchase]: 'money.transaction.purchase',
+  [CardTransactionType.Refund]: 'money.transaction.refund',
+  [CardTransactionType.Withdrawal]: 'money.transaction.sent',
+  [CardTransactionType.Deposit]: 'money.transaction.deposited',
+  [CardTransactionType.Transfer]: 'money.transaction.sent',
+  [CardTransactionType.Adjustment]: 'money.transaction.card_transaction',
+};
+
+function startOfDayMs(date: Date): number {
+  const copy = new Date(date);
+  copy.setHours(0, 0, 0, 0);
+  return copy.getTime();
+}
+
+export function formatCardTransactionDate(timestamp: number): string {
+  const now = new Date();
+  const date = new Date(timestamp);
+  const todayStart = startOfDayMs(now);
+  const yesterdayStart = todayStart - 86_400_000;
+  const dateStart = startOfDayMs(date);
+
+  if (dateStart === todayStart) {
+    return strings('card.transactions.today');
+  }
+  if (dateStart === yesterdayStart) {
+    return strings('card.transactions.yesterday');
+  }
+
+  return getIntlDateTimeFormatter(I18n.locale, {
+    day: 'numeric',
+    month: 'short',
+  }).format(date);
+}
+
+function mapCardTransactionStatus(
+  status: CardTransactionStatus,
+): MoneyActivityStatus {
+  switch (status) {
+    case CardTransactionStatus.Pending:
+      return 'pending';
+    case CardTransactionStatus.Failed:
+      return 'failed';
+    default:
+      return 'confirmed';
+  }
+}
+
+function getTransactionLabel(tx: CardTransaction): string {
+  return strings(TYPE_LABEL_KEY[tx.type]);
+}
+
+function getTransactionDescription(tx: CardTransaction): string | undefined {
+  if (tx.merchant?.name) {
+    return tx.merchant.name;
+  }
+  if (tx.description) {
+    return tx.description;
+  }
+  return formatCardTransactionDate(tx.timestamp);
+}
+
+function getSecondaryAmount(tx: CardTransaction): string {
+  const original = tx.originalAmount;
+  if (
+    !original ||
+    original.currency.toUpperCase() === tx.billingAmount.currency.toUpperCase()
+  ) {
+    return '';
+  }
+  return formatCardAmount(original, tx.isDebit);
+}
+
+export function cardTransactionDisplayInfo(
+  tx: CardTransaction,
+): MoneyTransactionDisplayInfo {
+  return {
+    label: getTransactionLabel(tx),
+    description: getTransactionDescription(tx),
+    primaryAmount: formatCardAmount(tx.billingAmount, tx.isDebit),
+    fiatAmount: getSecondaryAmount(tx),
+    isIncoming: !tx.isDebit,
+    icon: IconName.Card,
+    status: mapCardTransactionStatus(tx.status),
+  };
+}
+
+export function getCardTransactionTypeLabel(type: CardTransactionType): string {
+  return strings(TYPE_LABEL_KEY[type]);
+}
+
+export function formatCardTransactionStatus(
+  status: CardTransactionStatus,
+): string {
+  switch (status) {
+    case CardTransactionStatus.Pending:
+      return strings('card.transactions.pending');
+    case CardTransactionStatus.Failed:
+      return strings('money.transaction.failed');
+    case CardTransactionStatus.Reversed:
+      return 'Reversed';
+    case CardTransactionStatus.Completed:
+    default:
+      return 'Completed';
+  }
+}

--- a/app/components/UI/Card/utils/cardTransactionDisplayInfo.ts
+++ b/app/components/UI/Card/utils/cardTransactionDisplayInfo.ts
@@ -110,9 +110,9 @@ export function formatCardTransactionStatus(
     case CardTransactionStatus.Failed:
       return strings('money.transaction.failed');
     case CardTransactionStatus.Reversed:
-      return 'Reversed';
+      return strings('card.transactions.reversed');
     case CardTransactionStatus.Completed:
     default:
-      return 'Completed';
+      return strings('card.transactions.completed');
   }
 }

--- a/app/components/UI/Card/utils/getCardTransactionHeroToken.test.ts
+++ b/app/components/UI/Card/utils/getCardTransactionHeroToken.test.ts
@@ -1,0 +1,87 @@
+import {
+  CardTransactionStatus,
+  CardTransactionType,
+  type CardTransaction,
+} from '../../../../core/Engine/controllers/card-controller/provider-types';
+import { getCardTransactionHeroToken } from './getCardTransactionHeroToken';
+import { MONEY_ACCOUNT_DISPLAY_SYMBOL } from '../util/vedaToken';
+
+jest.mock('../util/buildTokenIconUrl', () => ({
+  buildTokenIconUrl: () => 'https://example.com/token.png',
+}));
+
+function createTransaction(
+  overrides: Partial<CardTransaction> = {},
+): CardTransaction {
+  return {
+    id: 'tx-1',
+    providerId: 'baanx',
+    timestamp: Date.now(),
+    status: CardTransactionStatus.Completed,
+    type: CardTransactionType.Purchase,
+    isDebit: true,
+    billingAmount: { value: '10.00', currency: 'USD' },
+    fundingSources: [],
+    ...overrides,
+  };
+}
+
+describe('getCardTransactionHeroToken', () => {
+  it('returns mUSD when there is no funding source and no fallback', () => {
+    const result = getCardTransactionHeroToken(createTransaction());
+
+    expect(result.symbol).toBe(MONEY_ACCOUNT_DISPLAY_SYMBOL);
+  });
+
+  it('returns the fallback token when there is no funding source', () => {
+    const result = getCardTransactionHeroToken(createTransaction(), {
+      address: '0xusdc',
+      caipChainId: 'eip155:8453',
+      symbol: 'USDC',
+      name: 'USD Coin',
+      decimals: 6,
+      fundingStatus: 'enabled',
+      spendableBalance: '10',
+    } as never);
+
+    expect(result.symbol).toBe('USDC');
+    expect(result.iconSource).toEqual({
+      uri: 'https://example.com/token.png',
+    });
+  });
+
+  it('returns mUSD for veda funding currency', () => {
+    const result = getCardTransactionHeroToken(
+      createTransaction({
+        fundingSources: [
+          {
+            currency: 'veda',
+            address: '0xabc',
+            chainId: 'eip155:143',
+          },
+        ],
+      }),
+    );
+
+    expect(result.symbol).toBe(MONEY_ACCOUNT_DISPLAY_SYMBOL);
+  });
+
+  it('returns funding token symbol when address and chainId are present', () => {
+    const result = getCardTransactionHeroToken(
+      createTransaction({
+        fundingSources: [
+          {
+            currency: 'usdc',
+            address: '0xusdc',
+            chainId: 'eip155:59144',
+          },
+        ],
+      }),
+    );
+
+    expect(result.symbol).toBe('USDC');
+    expect(result.iconSource).toEqual({
+      uri: 'https://example.com/token.png',
+    });
+  });
+});

--- a/app/components/UI/Card/utils/getCardTransactionHeroToken.test.ts
+++ b/app/components/UI/Card/utils/getCardTransactionHeroToken.test.ts
@@ -84,4 +84,49 @@ describe('getCardTransactionHeroToken', () => {
       uri: 'https://example.com/token.png',
     });
   });
+
+  it('returns mUSD for musd funding currency', () => {
+    const result = getCardTransactionHeroToken(
+      createTransaction({
+        fundingSources: [{ currency: 'musd' }],
+      }),
+    );
+
+    expect(result.symbol).toBe(MONEY_ACCOUNT_DISPLAY_SYMBOL);
+  });
+
+  it('returns the fallback token when funding has currency but no address or chain', () => {
+    const result = getCardTransactionHeroToken(
+      createTransaction({
+        fundingSources: [{ currency: 'eure' }],
+      }),
+      {
+        address: '0xusdc',
+        caipChainId: 'eip155:8453',
+        symbol: 'USDC',
+        name: 'USD Coin',
+        decimals: 6,
+        fundingStatus: 'enabled',
+        spendableBalance: '10',
+      } as never,
+    );
+
+    expect(result.symbol).toBe('USDC');
+  });
+
+  it('uppercases funding currency when there is no address, chain, or fallback', () => {
+    const result = getCardTransactionHeroToken(
+      createTransaction({
+        fundingSources: [{ currency: 'eure' }],
+      }),
+    );
+
+    expect(result.symbol).toBe('EURE');
+  });
+
+  it('returns mUSD when the transaction is undefined and no fallback is provided', () => {
+    const result = getCardTransactionHeroToken(undefined);
+
+    expect(result.symbol).toBe(MONEY_ACCOUNT_DISPLAY_SYMBOL);
+  });
 });

--- a/app/components/UI/Card/utils/getCardTransactionHeroToken.ts
+++ b/app/components/UI/Card/utils/getCardTransactionHeroToken.ts
@@ -1,0 +1,64 @@
+import type { ImageSourcePropType } from 'react-native';
+import type { CardTransaction } from '../../../../core/Engine/controllers/card-controller/provider-types';
+import { MUSD_TOKEN } from '../../Earn/constants/musd';
+import type { CardFundingToken } from '../types';
+import { getCardTokenDisplay } from '../util/getCardTokenDisplay';
+import {
+  MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
+  MONEY_ACCOUNT_DISPLAY_SYMBOL,
+} from '../util/vedaToken';
+
+export interface CardTransactionHeroToken {
+  symbol: string;
+  iconSource: ImageSourcePropType;
+}
+
+const MONEY_ACCOUNT_CURRENCIES = new Set([
+  MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
+  'musd',
+  MONEY_ACCOUNT_DISPLAY_SYMBOL.toLowerCase(),
+]);
+
+export function getCardTransactionHeroToken(
+  transaction?: CardTransaction,
+  fallbackToken?: CardFundingToken | null,
+): CardTransactionHeroToken {
+  const source = transaction?.fundingSources.find(
+    (item) => item.currency || item.address,
+  );
+
+  if (!source) {
+    if (fallbackToken) {
+      return getCardTokenDisplay(fallbackToken);
+    }
+    return {
+      symbol: MUSD_TOKEN.symbol,
+      iconSource: MUSD_TOKEN.imageSource,
+    };
+  }
+
+  const currency = source.currency?.toLowerCase() ?? '';
+  if (MONEY_ACCOUNT_CURRENCIES.has(currency)) {
+    return getCardTokenDisplay({
+      displaySymbol: MONEY_ACCOUNT_DISPLAY_SYMBOL,
+      isMoneyAccountEntry: true,
+    });
+  }
+
+  if (source.address && source.chainId) {
+    return getCardTokenDisplay({
+      address: source.address,
+      caipChainId: source.chainId,
+      symbol: source.currency?.toUpperCase() ?? '',
+    });
+  }
+
+  if (fallbackToken) {
+    return getCardTokenDisplay(fallbackToken);
+  }
+
+  return {
+    symbol: source.currency?.toUpperCase() || MUSD_TOKEN.symbol,
+    iconSource: MUSD_TOKEN.imageSource,
+  };
+}

--- a/app/components/UI/Card/utils/merchantCategoryLabel.test.ts
+++ b/app/components/UI/Card/utils/merchantCategoryLabel.test.ts
@@ -1,0 +1,32 @@
+import { CardMerchantCategory } from '../../../../core/Engine/controllers/card-controller/provider-types';
+import { getMerchantCategoryLabel } from './merchantCategoryLabel';
+
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+}));
+
+describe('getMerchantCategoryLabel', () => {
+  it('returns undefined when category is missing', () => {
+    const result = getMerchantCategoryLabel(undefined);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('maps food category to its i18n key', () => {
+    const result = getMerchantCategoryLabel(CardMerchantCategory.Food);
+
+    expect(result).toBe('card.transactions.categories.food');
+  });
+
+  it('maps misc category to its i18n key', () => {
+    const result = getMerchantCategoryLabel(CardMerchantCategory.Misc);
+
+    expect(result).toBe('card.transactions.categories.misc');
+  });
+
+  it('maps travel category to its i18n key', () => {
+    const result = getMerchantCategoryLabel(CardMerchantCategory.Travel);
+
+    expect(result).toBe('card.transactions.categories.travel');
+  });
+});

--- a/app/components/UI/Card/utils/merchantCategoryLabel.test.ts
+++ b/app/components/UI/Card/utils/merchantCategoryLabel.test.ts
@@ -29,4 +29,22 @@ describe('getMerchantCategoryLabel', () => {
 
     expect(result).toBe('card.transactions.categories.travel');
   });
+
+  it('maps remaining categories to their i18n keys', () => {
+    expect(getMerchantCategoryLabel(CardMerchantCategory.Subscriptions)).toBe(
+      'card.transactions.categories.subscriptions',
+    );
+    expect(getMerchantCategoryLabel(CardMerchantCategory.Entertainment)).toBe(
+      'card.transactions.categories.entertainment',
+    );
+    expect(getMerchantCategoryLabel(CardMerchantCategory.Health)).toBe(
+      'card.transactions.categories.health',
+    );
+    expect(getMerchantCategoryLabel(CardMerchantCategory.Atm)).toBe(
+      'card.transactions.categories.atm',
+    );
+    expect(getMerchantCategoryLabel(CardMerchantCategory.Utilities)).toBe(
+      'card.transactions.categories.utilities',
+    );
+  });
 });

--- a/app/components/UI/Card/utils/merchantCategoryLabel.ts
+++ b/app/components/UI/Card/utils/merchantCategoryLabel.ts
@@ -1,0 +1,25 @@
+import { strings } from '../../../../../locales/i18n';
+import { CardMerchantCategory } from '../../../../core/Engine/controllers/card-controller/provider-types';
+
+const CATEGORY_LABEL_KEY: Record<CardMerchantCategory, string> = {
+  [CardMerchantCategory.Subscriptions]:
+    'card.transactions.categories.subscriptions',
+  [CardMerchantCategory.Food]: 'card.transactions.categories.food',
+  [CardMerchantCategory.Travel]: 'card.transactions.categories.travel',
+  [CardMerchantCategory.Entertainment]:
+    'card.transactions.categories.entertainment',
+  [CardMerchantCategory.Health]: 'card.transactions.categories.health',
+  [CardMerchantCategory.Atm]: 'card.transactions.categories.atm',
+  [CardMerchantCategory.Utilities]: 'card.transactions.categories.utilities',
+  [CardMerchantCategory.Misc]: 'card.transactions.categories.misc',
+};
+
+export function getMerchantCategoryLabel(
+  category?: CardMerchantCategory,
+): string | undefined {
+  if (!category) {
+    return undefined;
+  }
+  const key = CATEGORY_LABEL_KEY[category];
+  return key ? strings(key) : undefined;
+}

--- a/app/components/UI/Card/utils/moneyAccountCardTransaction.test.ts
+++ b/app/components/UI/Card/utils/moneyAccountCardTransaction.test.ts
@@ -137,6 +137,22 @@ describe('isMoneyAccountCardTransaction', () => {
       ),
     ).toBe(true);
   });
+
+  it('returns false when funding sources omit currency', () => {
+    expect(
+      isMoneyAccountCardTransaction(
+        createTransaction({
+          status: CardTransactionStatus.Completed,
+          fundingSources: [
+            {
+              chainId: MONEY_ACCOUNT_DELEGATION_CAIP_CHAIN_ID,
+              txHash: '0xabc',
+            },
+          ],
+        }),
+      ),
+    ).toBe(false);
+  });
 });
 
 describe('getCardDeclineReasonLabel', () => {

--- a/app/components/UI/Card/utils/moneyAccountCardTransaction.test.ts
+++ b/app/components/UI/Card/utils/moneyAccountCardTransaction.test.ts
@@ -1,0 +1,170 @@
+import {
+  CardTransactionStatus,
+  CardTransactionType,
+  type CardTransaction,
+} from '../../../../core/Engine/controllers/card-controller/provider-types';
+import {
+  getCardDeclineReasonLabel,
+  isMoneyAccountCardTransaction,
+  isMoneyAccountDecline,
+  parseDeclineAttempt,
+} from './moneyAccountCardTransaction';
+import {
+  MONEY_ACCOUNT_DELEGATION_CAIP_CHAIN_ID,
+  MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
+} from '../util/vedaToken';
+
+jest.mock('../../../../../locales/i18n', () => ({
+  strings: (key: string) => key,
+}));
+
+function createTransaction(
+  overrides: Partial<CardTransaction> = {},
+): CardTransaction {
+  return {
+    id: 'tx-1',
+    providerId: 'baanx',
+    timestamp: Date.now(),
+    status: CardTransactionStatus.Failed,
+    type: CardTransactionType.Purchase,
+    isDebit: true,
+    billingAmount: { value: '10.00', currency: 'USD' },
+    fundingSources: [],
+    ...overrides,
+  };
+}
+
+describe('parseDeclineAttempt', () => {
+  it('extracts network and symbol from a Baanx insufficient-funds message', () => {
+    expect(
+      parseDeclineAttempt(
+        'You attempted this MONAD transaction with a balance of 0.500000 USDC. The total transaction cost was $11.95.',
+      ),
+    ).toEqual({ network: 'MONAD', symbol: 'USDC' });
+  });
+
+  it('returns undefined for unmatched messages', () => {
+    expect(parseDeclineAttempt('Card blocked')).toBeUndefined();
+    expect(parseDeclineAttempt(undefined)).toBeUndefined();
+  });
+});
+
+describe('isMoneyAccountDecline', () => {
+  it('returns true only for MONAD + VEDA declines', () => {
+    expect(
+      isMoneyAccountDecline(
+        createTransaction({
+          declineReason: {
+            message:
+              'You attempted this MONAD transaction with a balance of 0.500000 VEDA. The total transaction cost was $11.95.',
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for MONAD + USDC declines', () => {
+    expect(
+      isMoneyAccountDecline(
+        createTransaction({
+          declineReason: {
+            message:
+              'You attempted this MONAD transaction with a balance of 0.500000 USDC. The total transaction cost was $11.95.',
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for LINEA declines', () => {
+    expect(
+      isMoneyAccountDecline(
+        createTransaction({
+          declineReason: {
+            message:
+              'You attempted this LINEA transaction with a balance of 0.842067 MUSD. The total transaction cost was $10.04.',
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('isMoneyAccountCardTransaction', () => {
+  it('returns true for settled veda funding on the Money Account chain', () => {
+    expect(
+      isMoneyAccountCardTransaction(
+        createTransaction({
+          status: CardTransactionStatus.Completed,
+          fundingSources: [
+            {
+              currency: MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
+              chainId: MONEY_ACCOUNT_DELEGATION_CAIP_CHAIN_ID,
+              txHash: '0xabc',
+            },
+          ],
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for settled funding on a different chain', () => {
+    expect(
+      isMoneyAccountCardTransaction(
+        createTransaction({
+          status: CardTransactionStatus.Completed,
+          fundingSources: [
+            {
+              currency: MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
+              chainId: 'eip155:59144',
+              txHash: '0xabc',
+            },
+          ],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('falls back to decline classification when there are no funding sources', () => {
+    expect(
+      isMoneyAccountCardTransaction(
+        createTransaction({
+          declineReason: {
+            message:
+              'You attempted this MONAD transaction with a balance of 0.500000 VEDA. The total transaction cost was $11.95.',
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('getCardDeclineReasonLabel', () => {
+  it('maps the insufficient-funds pattern to a short label', () => {
+    expect(
+      getCardDeclineReasonLabel(
+        createTransaction({
+          declineReason: {
+            message:
+              'You attempted this LINEA transaction with a balance of 0.000000 EURE. The total transaction cost was $2.24.',
+          },
+        }),
+      ),
+    ).toBe('card.transactions.decline_reasons.insufficient_funds');
+  });
+
+  it('returns the raw message when the pattern does not match', () => {
+    expect(
+      getCardDeclineReasonLabel(
+        createTransaction({
+          declineReason: { message: 'Card blocked by issuer' },
+        }),
+      ),
+    ).toBe('Card blocked by issuer');
+  });
+
+  it('returns undefined when there is no decline reason', () => {
+    expect(getCardDeclineReasonLabel(createTransaction())).toBeUndefined();
+    expect(getCardDeclineReasonLabel(undefined)).toBeUndefined();
+  });
+});

--- a/app/components/UI/Card/utils/moneyAccountCardTransaction.ts
+++ b/app/components/UI/Card/utils/moneyAccountCardTransaction.ts
@@ -1,0 +1,66 @@
+import { strings } from '../../../../../locales/i18n';
+import type { CardTransaction } from '../../../../core/Engine/controllers/card-controller/provider-types';
+import {
+  MONEY_ACCOUNT_DELEGATION_CAIP_CHAIN_ID,
+  MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
+} from '../util/vedaToken';
+
+const DECLINE_ATTEMPT_PATTERN =
+  /you attempted this\s+([A-Z0-9-]+)\s+transaction with a balance of\s+[\d.,]+\s+([A-Z0-9]+)/i;
+
+export interface DeclineAttempt {
+  network: string;
+  symbol: string;
+}
+
+export function parseDeclineAttempt(
+  message?: string,
+): DeclineAttempt | undefined {
+  if (!message) {
+    return undefined;
+  }
+  const match = DECLINE_ATTEMPT_PATTERN.exec(message);
+  if (!match) {
+    return undefined;
+  }
+  return {
+    network: match[1].toUpperCase(),
+    symbol: match[2].toUpperCase(),
+  };
+}
+
+/** Provider-specific (Baanx decline copy); extend here for Immersve. */
+export function isMoneyAccountDecline(tx: CardTransaction): boolean {
+  const attempt = parseDeclineAttempt(tx.declineReason?.message);
+  if (!attempt) {
+    return false;
+  }
+  return (
+    attempt.network === 'MONAD' &&
+    attempt.symbol === MONEY_ACCOUNT_DELEGATION_TOKEN_KEY.toUpperCase()
+  );
+}
+
+export function isMoneyAccountCardTransaction(tx: CardTransaction): boolean {
+  if (tx.fundingSources.length === 0) {
+    return isMoneyAccountDecline(tx);
+  }
+  return tx.fundingSources.some(
+    (fs) =>
+      fs.currency?.toLowerCase() === MONEY_ACCOUNT_DELEGATION_TOKEN_KEY &&
+      fs.chainId === MONEY_ACCOUNT_DELEGATION_CAIP_CHAIN_ID,
+  );
+}
+
+export function getCardDeclineReasonLabel(
+  tx?: CardTransaction,
+): string | undefined {
+  const message = tx?.declineReason?.message;
+  if (!message) {
+    return undefined;
+  }
+  if (parseDeclineAttempt(message)) {
+    return strings('card.transactions.decline_reasons.insufficient_funds');
+  }
+  return message;
+}

--- a/app/components/UI/Card/utils/moneyAccountCardTransaction.ts
+++ b/app/components/UI/Card/utils/moneyAccountCardTransaction.ts
@@ -5,6 +5,11 @@ import {
   MONEY_ACCOUNT_DELEGATION_TOKEN_KEY,
 } from '../util/vedaToken';
 
+/**
+ * Baanx insufficient-funds decline copy only. Immersve (and future providers)
+ * do not use this template yet — extend with structured decline fields when
+ * available. This regex can break if Baanx changes the message wording.
+ */
 const DECLINE_ATTEMPT_PATTERN =
   /you attempted this\s+([A-Z0-9-]+)\s+transaction with a balance of\s+[\d.,]+\s+([A-Z0-9]+)/i;
 

--- a/app/core/Engine/controllers/card-controller/CardController.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.test.ts
@@ -2565,6 +2565,7 @@ describe('CardController — getCapabilities', () => {
     supportsCredit: true,
     supportsSensitiveDetailsView: false,
     supportsTravel: true,
+    supportsMoneyAccountLinking: true,
     supportsTransactionHistory: true,
   };
 

--- a/app/core/Engine/controllers/card-controller/provider-types.ts
+++ b/app/core/Engine/controllers/card-controller/provider-types.ts
@@ -143,6 +143,7 @@ export interface CardProviderCapabilities {
   supportsSensitiveDetailsView: boolean;
   supportsTravel: boolean;
   supportsTransactionHistory: boolean;
+  supportsMoneyAccountLinking: boolean;
 }
 
 // -- Funding Asset (provider-agnostic) --

--- a/app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts
+++ b/app/core/Engine/controllers/card-controller/providers/BaanxProvider.ts
@@ -396,6 +396,7 @@ export class BaanxProvider implements ICardProvider {
     supportsSensitiveDetailsView: false,
     supportsTravel: true,
     supportsTransactionHistory: true,
+    supportsMoneyAccountLinking: true,
   };
   private readonly service: BaanxService;
   private readonly getCardFeatureFlag: () => CardFeatureFlag | null;

--- a/app/core/Engine/controllers/card-controller/providers/ImmersveProvider.ts
+++ b/app/core/Engine/controllers/card-controller/providers/ImmersveProvider.ts
@@ -272,6 +272,7 @@ export class ImmersveProvider implements ICardProvider {
     supportsSensitiveDetailsView: true,
     supportsTravel: false,
     supportsTransactionHistory: false,
+    supportsMoneyAccountLinking: false,
   };
 
   private readonly service: ImmersveService;

--- a/app/core/Engine/controllers/card-controller/types.ts
+++ b/app/core/Engine/controllers/card-controller/types.ts
@@ -35,6 +35,8 @@ export const CARD_CONTROLLER_NAME = 'CardController';
 /** The provider ID used when no other provider has been selected. */
 export const DEFAULT_CARD_PROVIDER_ID = CardProviderIds.Baanx;
 
+export const MONEY_ACCOUNT_LAUNCH_MS = Date.UTC(2026, 4, 1);
+
 export type CardHomeDataStatus = 'idle' | 'loading' | 'error' | 'success';
 export type CardUnauthenticatedReason = 'onboarding_token_revoked';
 

--- a/app/selectors/featureFlagController/card/index.test.ts
+++ b/app/selectors/featureFlagController/card/index.test.ts
@@ -8,6 +8,7 @@ import {
   selectGalileoGoogleWalletProvisioningEnabled,
   selectCardForgotPasswordFeatureEnabled,
   selectImmersveOnboardingEnabled,
+  selectCardTransactionHistoryEnabled,
 } from '.';
 import mockedEngine from '../../../core/__mocks__/MockedEngine';
 import { mockedEmptyFlagsState, mockedUndefinedFlagsState } from '../mocks';
@@ -932,5 +933,80 @@ describe('selectImmersveOnboardingEnabled', () => {
         stateWithFlags({ cardFeature: { immersve: { enabled: true } } }),
       ),
     ).toBe(false);
+  });
+});
+
+describe('selectCardTransactionHistoryEnabled', () => {
+  const mockedValidatedVersionGatedFeatureFlag =
+    validatedVersionGatedFeatureFlag as jest.MockedFunction<
+      typeof validatedVersionGatedFeatureFlag
+    >;
+
+  const stateWithFlags = (remoteFeatureFlags: Record<string, unknown>) =>
+    ({
+      engine: {
+        backgroundState: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags,
+            cacheTimestamp: 0,
+          },
+        },
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.MM_CARD_TRANSACTION_HISTORY_ENABLED;
+  });
+
+  it('returns false when feature flag state is empty and env is unset', () => {
+    mockedValidatedVersionGatedFeatureFlag.mockReturnValue(undefined);
+
+    const result = selectCardTransactionHistoryEnabled(mockedEmptyFlagsState);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true when feature flag is enabled and version requirement is met', () => {
+    mockedValidatedVersionGatedFeatureFlag.mockReturnValue(true);
+
+    const result = selectCardTransactionHistoryEnabled(
+      stateWithFlags({
+        cardTransactionHistory: {
+          enabled: true,
+          minimumVersion: '7.0.0',
+        },
+      }),
+    );
+
+    expect(result).toBe(true);
+    expect(mockedValidatedVersionGatedFeatureFlag).toHaveBeenCalledWith({
+      enabled: true,
+      minimumVersion: '7.0.0',
+    });
+  });
+
+  it('returns false when feature flag is disabled', () => {
+    mockedValidatedVersionGatedFeatureFlag.mockReturnValue(false);
+
+    expect(
+      selectCardTransactionHistoryEnabled(
+        stateWithFlags({
+          cardTransactionHistory: {
+            enabled: false,
+            minimumVersion: '7.0.0',
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('falls back to env when remote flag is absent', () => {
+    mockedValidatedVersionGatedFeatureFlag.mockReturnValue(undefined);
+    process.env.MM_CARD_TRANSACTION_HISTORY_ENABLED = 'true';
+
+    // resultFunc bypasses createSelector memoization after env changes.
+    expect(selectCardTransactionHistoryEnabled.resultFunc({})).toBe(true);
   });
 });

--- a/app/selectors/featureFlagController/card/index.ts
+++ b/app/selectors/featureFlagController/card/index.ts
@@ -151,3 +151,15 @@ export const selectCardFiatCreditFeatureEnabled = createSelector(
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
   },
 );
+
+export const selectCardTransactionHistoryEnabled = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const localFlag =
+      process.env.MM_CARD_TRANSACTION_HISTORY_ENABLED === 'true';
+    const remoteFlag =
+      remoteFeatureFlags?.cardTransactionHistory as unknown as GateVersionedFeatureFlag;
+
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
+  },
+);

--- a/babel.config.tests.js
+++ b/babel.config.tests.js
@@ -50,6 +50,8 @@ const newOverrides = [
       'app/components/Views/confirmations/hooks/pay/useTransactionPayWithdraw.test.ts',
       'app/selectors/featureFlagController/moneyAccount/index.ts',
       'app/selectors/featureFlagController/moneyAccount/index.test.ts',
+      'app/selectors/featureFlagController/card/index.ts',
+      'app/selectors/featureFlagController/card/index.test.ts',
       'app/selectors/featureFlagController/legacyIosGoogleConfig/index.ts',
       'app/selectors/featureFlagController/legacyIosGoogleConfig/index.test.ts',
       'app/selectors/featureFlagController/googleLoginIosUnsupportedBlocking/index.ts',

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9428,6 +9428,8 @@
     },
     "transactions": {
       "pending": "Pending",
+      "completed": "Completed",
+      "reversed": "Reversed",
       "today": "Today",
       "yesterday": "Yesterday",
       "details_title": "Transaction",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9426,6 +9426,31 @@
         "change_asset_description": "Select a different token"
       }
     },
+    "transactions": {
+      "pending": "Pending",
+      "today": "Today",
+      "yesterday": "Yesterday",
+      "details_title": "Transaction",
+      "merchant": "Merchant",
+      "category": "Category",
+      "location": "Location",
+      "decline_reason": "Decline reason",
+      "decline_reasons": {
+        "insufficient_funds": "Insufficient funds"
+      },
+      "categories": {
+        "subscriptions": "Subscriptions",
+        "food": "Food and drink",
+        "travel": "Travel",
+        "entertainment": "Entertainment",
+        "health": "Health",
+        "atm": "ATM",
+        "utilities": "Utilities",
+        "misc": "Other"
+      },
+      "view_on_explorer": "View on block explorer",
+      "report_cta": "Report Transaction"
+    },
     "card_spending_limit": {
       "title_change_token": "Change token and network",
       "title_enable_token": "Enable token",

--- a/tests/component-view/mocks.ts
+++ b/tests/component-view/mocks.ts
@@ -116,6 +116,8 @@ jest.mock('../../app/core/Engine', () => {
           supportsCredit: true,
           supportsSensitiveDetailsView: false,
           supportsTravel: true,
+          supportsTransactionHistory: false,
+          supportsMoneyAccountLinking: false,
         }),
       },
       PhishingController: {

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -3470,6 +3470,17 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  cardTransactionHistory: {
+    name: 'cardTransactionHistory',
+    type: FeatureFlagType.Remote,
+    inProd: false,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '0.0.0',
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
   earnMoneyFirstTimeDepositAnimationEnabled: {
     name: 'earnMoneyFirstTimeDepositAnimationEnabled',
     type: FeatureFlagType.Remote,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Card provider transaction history already exists at the controller layer (`listTransactions`), but there is no shared UI/data layer for consumers. This PR adds the Card-side foundation: a bounded index hook, display/classifier utilities, shared row and details presentational components, the `supportsMoneyAccountLinking` capability, and the master `cardTransactionHistory` feature flag.

Money Activity wiring is intentionally out of scope and lands in the stacked follow-up PR.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: Money Account Card transaction history UI integration (foundation PR; no standalone ticket)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — no user-facing UI wiring in this PR. Covered by unit tests for the new Card utils, `useCardTransactionIndex`, and the feature flag selector.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

https://github.com/user-attachments/assets/07f787aa-181d-4358-8013-6ae1a9c106c1

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated pagination and cache invalidation around card transactions, plus provider-specific decline heuristics; impact is limited until follow-up wiring ships.
> 
> **Overview**
> Adds the **Card-side foundation** for showing provider card transactions in Money Activity (wiring is deferred). This includes a bounded **`useCardTransactionIndex`** hook that paginates `CardController.listTransactions`, keeps only Money Account–funded (or VEDA decline) rows, and exposes a settlement-hash map plus a declined list for enriching on-chain activity.
> 
> Shared **formatting and classification** utilities cover amounts, row labels, merchant categories, hero token display, and Baanx-specific decline parsing. **`CardTransactionRow`** and **`CardTransactionDetailsContent`** are presentational building blocks that reuse Money activity row patterns.
> 
> Gates and capabilities: remote/env **`cardTransactionHistory`** flag (`MM_CARD_TRANSACTION_HISTORY_ENABLED`), new **`supportsMoneyAccountLinking`** on card providers (Baanx on, Immersve off), **`MONEY_ACCOUNT_LAUNCH_MS`** as the index date floor, and new **`card.transactions`** copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce62c80199704095a9aeb4b644083dc713df3217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->