### PR TITLE
feat(vba): provision Money Account from a KYC status read as well as the event

### DIFF
--- a/app/components/UI/Ramp/Views/VirtualBankAccount/MockKycSuccess.test.tsx
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/MockKycSuccess.test.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
-import { fireEvent } from '@testing-library/react-native';
+import { fireEvent, waitFor } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import Engine from '../../../../../core/Engine';
+import { getSessionProfileId } from '../../../../../util/notifications/utils/get-session-profile-id';
 import MockKycSuccess from './MockKycSuccess';
 import { MockKycSuccessSelectorsIDs } from './MockKycSuccess.testIds';
+import { buildMoneyAccountAutorampParams } from './moneyAccountAutoramp';
+import { resetMoneyAccountProvisioning } from './moneyAccountProvisioning';
+
+const WALLET_ADDRESS = '0x1234567890123456789012345678901234567890';
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -15,12 +21,75 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
-describe('MockKycSuccess', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+jest.mock('../../../../../core/Engine', () => ({
+  context: {
+    KycController: { refreshKycStatus: jest.fn() },
+    NeoBankService: { getCustomerByExternalId: jest.fn() },
+    RampsController: {
+      registerMoneyAccountWallet: jest.fn(),
+      createAutoramp: jest.fn(),
+    },
+  },
+}));
 
+jest.mock('../../../../../util/notifications/utils/get-session-profile-id');
+
+jest.mock('../../../../../selectors/accountsController', () => ({
+  ...jest.requireActual('../../../../../selectors/accountsController'),
+  selectSelectedInternalAccountAddress: () => WALLET_ADDRESS,
+}));
+
+const mockConnect = jest.fn();
+const mockAddListener = jest.fn();
+
+jest.mock('./neobank/NeobankWebSocket', () => ({
+  NeobankWebSocket: {
+    getInstance: () => ({
+      connect: mockConnect,
+      addListener: mockAddListener,
+      disconnect: jest.fn(),
+    }),
+  },
+}));
+
+const mockKycController = Engine.context.KycController as unknown as {
+  refreshKycStatus: jest.Mock;
+};
+
+const mockNeoBankService = Engine.context.NeoBankService as unknown as {
+  getCustomerByExternalId: jest.Mock;
+};
+
+const mockRampsController = Engine.context.RampsController as unknown as {
+  registerMoneyAccountWallet: jest.Mock;
+  createAutoramp: jest.Mock;
+};
+
+const setUp = () => {
+  jest.clearAllMocks();
+  resetMoneyAccountProvisioning();
+  jest.mocked(getSessionProfileId).mockResolvedValue('profile-1');
+  mockNeoBankService.getCustomerByExternalId.mockResolvedValue({
+    id: 'cus_1',
+    status: 'Active',
+  });
+  mockKycController.refreshKycStatus.mockResolvedValue({
+    status: 'completed',
+    sumsubSessionId: null,
+    errorCode: null,
+  });
+  mockRampsController.registerMoneyAccountWallet.mockResolvedValue({
+    type: 'registered',
+  });
+  mockRampsController.createAutoramp.mockResolvedValue({
+    id: 'autoramp-1',
+    status: 'created',
+  });
+};
+
+describe('MockKycSuccess', () => {
   it('navigates back when the header back button is pressed', () => {
+    setUp();
     const { getByTestId } = renderWithProvider(<MockKycSuccess />);
 
     fireEvent.press(getByTestId(MockKycSuccessSelectorsIDs.BACK_BUTTON));
@@ -28,14 +97,65 @@ describe('MockKycSuccess', () => {
     expect(mockGoBack).toHaveBeenCalled();
   });
 
-  it('navigates to Money home when Finish is pressed', () => {
+  it('registers the wallet then creates the autoramp when the pulled status is completed', async () => {
+    setUp();
     const { getByTestId } = renderWithProvider(<MockKycSuccess />);
 
     fireEvent.press(getByTestId(MockKycSuccessSelectorsIDs.FINISH_BUTTON));
 
-    expect(mockNavigate).toHaveBeenCalledWith('Home', {
-      screen: 'MoneyScreens',
-      params: { screen: 'MoneyHome' },
+    await waitFor(() => {
+      expect(mockRampsController.createAutoramp).toHaveBeenCalledWith(
+        buildMoneyAccountAutorampParams(WALLET_ADDRESS),
+      );
     });
+    expect(mockKycController.refreshKycStatus).toHaveBeenCalled();
+    expect(mockRampsController.registerMoneyAccountWallet).toHaveBeenCalledWith({
+      address: WALLET_ADDRESS,
+    });
+  });
+
+  it('stops before the autoramp when the pulled status is not completed', async () => {
+    setUp();
+    mockKycController.refreshKycStatus.mockResolvedValue({
+      status: 'pending',
+      sumsubSessionId: null,
+      errorCode: null,
+    });
+    const { getByTestId, findByText } = renderWithProvider(<MockKycSuccess />);
+
+    fireEvent.press(getByTestId(MockKycSuccessSelectorsIDs.FINISH_BUTTON));
+
+    expect(await findByText(/KYC status is "pending"/u)).toBeOnTheScreen();
+    expect(
+      mockRampsController.registerMoneyAccountWallet,
+    ).not.toHaveBeenCalled();
+    expect(mockRampsController.createAutoramp).not.toHaveBeenCalled();
+  });
+
+  it('reuses the provisioned wallet and autoramp when the pipeline is re-run', async () => {
+    setUp();
+    const { getByTestId, findByText } = renderWithProvider(<MockKycSuccess />);
+
+    fireEvent.press(getByTestId(MockKycSuccessSelectorsIDs.FINISH_BUTTON));
+    await findByText('View bank account');
+    fireEvent.press(getByTestId(MockKycSuccessSelectorsIDs.FINISH_BUTTON));
+    await waitFor(() => {
+      expect(mockKycController.refreshKycStatus).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockRampsController.registerMoneyAccountWallet).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(mockRampsController.createAutoramp).toHaveBeenCalledTimes(1);
+  });
+
+  it('navigates to the bank account once the autoramp exists', async () => {
+    setUp();
+    const { getByTestId, findByText } = renderWithProvider(<MockKycSuccess />);
+
+    fireEvent.press(getByTestId(MockKycSuccessSelectorsIDs.FINISH_BUTTON));
+    fireEvent.press(await findByText('View bank account'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('RampVbaAccount');
   });
 });

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/MockKycSuccess.tsx
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/MockKycSuccess.tsx
@@ -39,9 +39,12 @@ import {
   DEMO_AUTORAMP_DESTINATION_TOKEN,
   DEMO_AUTORAMP_SOURCE_CURRENCY_CODE,
 } from './constants';
-import { buildMoneyAccountAutorampParams } from './moneyAccountAutoramp';
+import {
+  ensureMoneyAccountAutorampCreated,
+  ensureMoneyAccountWalletRegistered,
+} from './moneyAccountProvisioning';
 
-type StepId = 'identity' | 'customer' | 'autoramp' | 'live';
+type StepId = 'identity' | 'customer' | 'wallet' | 'autoramp' | 'live';
 
 type StepStatus = 'idle' | 'running' | 'waiting' | 'success' | 'failed';
 
@@ -52,7 +55,7 @@ interface StepState {
 }
 
 /**
- * The four stages the demo makes visible. `caller` is the actual code path or
+ * The stages the demo makes visible. `caller` is the actual code path or
  * HTTP route each stage exercises, shown verbatim so the audience can follow
  * along with the network tab / API logs.
  */
@@ -66,6 +69,11 @@ const STEPS: { id: StepId; title: string; caller: string }[] = [
     id: 'customer',
     title: 'Map identity to MoonPay customer',
     caller: 'GET /neobank/customers/{externalId}/external',
+  },
+  {
+    id: 'wallet',
+    title: 'Register Money Account wallet',
+    caller: 'KycController.refreshKycStatus() → registerMoneyAccountWallet()',
   },
   {
     id: 'autoramp',
@@ -82,6 +90,7 @@ const STEPS: { id: StepId; title: string; caller: string }[] = [
 const IDLE_STEPS: Record<StepId, StepState> = {
   identity: { status: 'idle' },
   customer: { status: 'idle' },
+  wallet: { status: 'idle' },
   autoramp: { status: 'idle' },
   live: { status: 'idle' },
 };
@@ -234,10 +243,18 @@ const StepRow = ({
  *
  * Rather than hiding the work behind a single spinner, this screen runs the
  * autoramp creation pipeline stage by stage and reports each one: resolving the
- * wallet's Profile Sync identity, mapping it to a MoonPay customer, creating
- * the autoramp, then holding a websocket open so MoonPay webhook pushes land
- * live. Failures surface the upstream message in place, which is what makes
- * this useful while the proxy routes are still being built out.
+ * wallet's Profile Sync identity, mapping it to a MoonPay customer, registering
+ * the Money Account wallet, creating the autoramp, then holding a websocket
+ * open so MoonPay webhook pushes land live. Failures surface the upstream
+ * message in place, which is what makes this useful while the proxy routes are
+ * still being built out.
+ *
+ * The wallet stage reads `GET /kyc/status` on demand rather than waiting for
+ * `KycController:statusChanged`, because a status that was already `completed`
+ * before this screen mounted publishes no event. That read and the event
+ * subscriber share {@link ensureMoneyAccountWalletRegistered} and
+ * {@link ensureMoneyAccountAutorampCreated}, so whichever arrives first does
+ * the work and the other reuses it — one signature prompt, one autoramp.
  *
  * The MoonPay `customer_id` is never passed from here: `createAutoramp`
  * resolves it itself. Stage 2 performs the same lookup only so the mapping is
@@ -336,10 +353,23 @@ const MockKycSuccess = () => {
           : `customer_id = ${truncateId(customerId)}`,
       });
 
+      const registration = await timed('wallet', async () => {
+        const { status: kycStatus } =
+          await Engine.context.KycController.refreshKycStatus();
+        if (kycStatus !== 'completed') {
+          throw new Error(
+            `KYC status is "${kycStatus}". The wallet can only be registered once it reads completed.`,
+          );
+        }
+        return await ensureMoneyAccountWalletRegistered(walletAddress);
+      });
+      updateStep('wallet', {
+        status: 'success',
+        detail: `status = completed · ${registration.type}`,
+      });
+
       const account = await timed('autoramp', async () =>
-        Engine.context.RampsController.createAutoramp(
-          buildMoneyAccountAutorampParams(walletAddress),
-        ),
+        ensureMoneyAccountAutorampCreated(walletAddress),
       );
 
       if (!isMountedRef.current) {
@@ -420,7 +450,7 @@ const MockKycSuccess = () => {
             color={TextColor.TextAlternative}
             twClassName="text-center"
           >
-            Creating your account runs four real steps. Watch each one report
+            Creating your account runs five real steps. Watch each one report
             back below.
           </Text>
         </Box>

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/moneyAccountProvisioning.test.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/moneyAccountProvisioning.test.ts
@@ -1,0 +1,171 @@
+import Engine from '../../../../../core/Engine';
+import { buildMoneyAccountAutorampParams } from './moneyAccountAutoramp';
+import {
+  ensureMoneyAccountAutorampCreated,
+  ensureMoneyAccountWalletRegistered,
+  resetMoneyAccountProvisioning,
+} from './moneyAccountProvisioning';
+
+jest.mock('../../../../../core/Engine', () => ({
+  context: {
+    RampsController: {
+      registerMoneyAccountWallet: jest.fn(),
+      createAutoramp: jest.fn(),
+    },
+  },
+}));
+
+const mockRampsController = Engine.context.RampsController as unknown as {
+  registerMoneyAccountWallet: jest.Mock<Promise<unknown>, [unknown?]>;
+  createAutoramp: jest.Mock<Promise<unknown>, [unknown?]>;
+};
+
+const setUp = () => {
+  jest.clearAllMocks();
+  resetMoneyAccountProvisioning();
+  mockRampsController.registerMoneyAccountWallet.mockResolvedValue({
+    type: 'registered',
+  });
+  mockRampsController.createAutoramp.mockResolvedValue({
+    id: 'autoramp-1',
+    status: 'created',
+  });
+};
+
+describe('ensureMoneyAccountWalletRegistered', () => {
+  it('registers the wallet and returns the result', async () => {
+    setUp();
+
+    const result = await ensureMoneyAccountWalletRegistered('0xabc');
+
+    expect(mockRampsController.registerMoneyAccountWallet).toHaveBeenCalledWith({
+      address: '0xabc',
+    });
+    expect(result).toStrictEqual({ type: 'registered' });
+  });
+
+  it('registers once for repeated calls with the same address', async () => {
+    setUp();
+
+    await ensureMoneyAccountWalletRegistered('0xabc');
+    await ensureMoneyAccountWalletRegistered('0xabc');
+
+    expect(mockRampsController.registerMoneyAccountWallet).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  it('treats addresses that differ only in casing as the same wallet', async () => {
+    setUp();
+
+    await ensureMoneyAccountWalletRegistered('0xABC');
+    await ensureMoneyAccountWalletRegistered('0xabc');
+
+    expect(mockRampsController.registerMoneyAccountWallet).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  it('collapses concurrent callers onto one registration', async () => {
+    setUp();
+    let resolveRegister: (value: unknown) => void = () => undefined;
+    mockRampsController.registerMoneyAccountWallet.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRegister = resolve;
+      }),
+    );
+
+    const first = ensureMoneyAccountWalletRegistered('0xabc');
+    const second = ensureMoneyAccountWalletRegistered('0xabc');
+    resolveRegister({ type: 'registered' });
+
+    await expect(Promise.all([first, second])).resolves.toStrictEqual([
+      { type: 'registered' },
+      { type: 'registered' },
+    ]);
+    expect(mockRampsController.registerMoneyAccountWallet).toHaveBeenCalledTimes(
+      1,
+    );
+  });
+
+  it('registers each address separately', async () => {
+    setUp();
+
+    await ensureMoneyAccountWalletRegistered('0xabc');
+    await ensureMoneyAccountWalletRegistered('0xdef');
+
+    expect(mockRampsController.registerMoneyAccountWallet).toHaveBeenCalledTimes(
+      2,
+    );
+  });
+
+  it('retries after a rejected registration', async () => {
+    setUp();
+    mockRampsController.registerMoneyAccountWallet
+      .mockRejectedValueOnce(new Error('signing rejected'))
+      .mockResolvedValueOnce({ type: 'registered' });
+
+    await expect(ensureMoneyAccountWalletRegistered('0xabc')).rejects.toThrow(
+      'signing rejected',
+    );
+
+    await expect(
+      ensureMoneyAccountWalletRegistered('0xabc'),
+    ).resolves.toStrictEqual({ type: 'registered' });
+  });
+});
+
+describe('ensureMoneyAccountAutorampCreated', () => {
+  it('creates the demo autoramp for the address', async () => {
+    setUp();
+
+    const account = await ensureMoneyAccountAutorampCreated('0xabc');
+
+    expect(mockRampsController.createAutoramp).toHaveBeenCalledWith(
+      buildMoneyAccountAutorampParams('0xabc'),
+    );
+    expect(account).toStrictEqual({ id: 'autoramp-1', status: 'created' });
+  });
+
+  it('returns the same autoramp instead of creating a second one', async () => {
+    setUp();
+
+    const first = await ensureMoneyAccountAutorampCreated('0xabc');
+    const second = await ensureMoneyAccountAutorampCreated('0xabc');
+
+    expect(mockRampsController.createAutoramp).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+  });
+
+  it('retries after a rejected creation', async () => {
+    setUp();
+    mockRampsController.createAutoramp
+      .mockRejectedValueOnce(new Error('customer is not active'))
+      .mockResolvedValueOnce({ id: 'autoramp-2', status: 'created' });
+
+    await expect(ensureMoneyAccountAutorampCreated('0xabc')).rejects.toThrow(
+      'customer is not active',
+    );
+
+    await expect(
+      ensureMoneyAccountAutorampCreated('0xabc'),
+    ).resolves.toStrictEqual({ id: 'autoramp-2', status: 'created' });
+  });
+});
+
+describe('resetMoneyAccountProvisioning', () => {
+  it('lets the same wallet be provisioned again', async () => {
+    setUp();
+    await ensureMoneyAccountWalletRegistered('0xabc');
+    await ensureMoneyAccountAutorampCreated('0xabc');
+
+    resetMoneyAccountProvisioning();
+    await ensureMoneyAccountWalletRegistered('0xabc');
+    await ensureMoneyAccountAutorampCreated('0xabc');
+
+    expect(mockRampsController.registerMoneyAccountWallet).toHaveBeenCalledTimes(
+      2,
+    );
+    expect(mockRampsController.createAutoramp).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/moneyAccountProvisioning.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/moneyAccountProvisioning.ts
@@ -1,0 +1,87 @@
+import type {
+  AutorampAccount,
+  MoneyAccountWalletRegistrationResult,
+} from '@metamask/ramps-controller';
+import Engine from '../../../../../core/Engine';
+import { buildMoneyAccountAutorampParams } from './moneyAccountAutoramp';
+
+/**
+ * Provisioning promises keyed by lowercased wallet address, so the two paths
+ * that react to KYC `completed` — the `KycController:statusChanged` subscriber
+ * (push) and the success screen's imperative status read (pull) — collapse onto
+ * one run instead of registering the wallet twice (two signature prompts) or
+ * creating two autoramps for the same wallet.
+ */
+const walletRegistrations = new Map<
+  string,
+  Promise<MoneyAccountWalletRegistrationResult>
+>();
+const autoramps = new Map<string, Promise<AutorampAccount>>();
+
+/**
+ * Returns the run already recorded for `address`, or starts and records one.
+ *
+ * A rejected run is evicted so the next caller retries: KYC stays `completed`,
+ * so a transient signing or proxy failure has to remain recoverable from either
+ * path.
+ *
+ * @param runs - The cache to read and write.
+ * @param address - The wallet address the run is keyed by.
+ * @param start - Starts the run when nothing is cached.
+ * @returns The cached or freshly started run.
+ */
+function dedupeByAddress<Result>(
+  runs: Map<string, Promise<Result>>,
+  address: string,
+  start: () => Promise<Result>,
+): Promise<Result> {
+  const key = address.toLowerCase();
+  const cached = runs.get(key);
+  if (cached) {
+    return cached;
+  }
+
+  const run = start();
+  runs.set(key, run);
+  run.catch(() => runs.delete(key));
+  return run;
+}
+
+/**
+ * Registers `address` as the Money Account wallet, at most once per address.
+ *
+ * @param address - Monad Money Account address to register.
+ * @returns The registration result, shared with any concurrent caller.
+ */
+export async function ensureMoneyAccountWalletRegistered(
+  address: string,
+): Promise<MoneyAccountWalletRegistrationResult> {
+  return await dedupeByAddress(walletRegistrations, address, async () =>
+    Engine.context.RampsController.registerMoneyAccountWallet({ address }),
+  );
+}
+
+/**
+ * Creates the demo autoramp paying out to `address`, at most once per address.
+ *
+ * @param address - The wallet address the autoramp pays out to.
+ * @returns The autoramp account, shared with any concurrent caller.
+ */
+export async function ensureMoneyAccountAutorampCreated(
+  address: string,
+): Promise<AutorampAccount> {
+  return await dedupeByAddress(autoramps, address, async () =>
+    Engine.context.RampsController.createAutoramp(
+      buildMoneyAccountAutorampParams(address),
+    ),
+  );
+}
+
+/**
+ * Clears what has been provisioned this session, so a demo can be re-run
+ * against the same wallet from a clean slate.
+ */
+export function resetMoneyAccountProvisioning(): void {
+  walletRegistrations.clear();
+  autoramps.clear();
+}

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/registerMoneyAccountOnKycCompletion.test.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/registerMoneyAccountOnKycCompletion.test.ts
@@ -1,6 +1,10 @@
 import Engine from '../../../../../core/Engine';
 import Logger from '../../../../../util/Logger';
 import { buildMoneyAccountAutorampParams } from './moneyAccountAutoramp';
+import {
+  ensureMoneyAccountWalletRegistered,
+  resetMoneyAccountProvisioning,
+} from './moneyAccountProvisioning';
 import { createRegisterMoneyAccountOnKycCompletion } from './registerMoneyAccountOnKycCompletion';
 
 jest.mock('../../../../../core/Engine', () => ({
@@ -37,6 +41,7 @@ const completedEvent = {
 
 const setUp = () => {
   jest.clearAllMocks();
+  resetMoneyAccountProvisioning();
   mockAccountsController.getSelectedAccount.mockReturnValue({ address: '0xabc' });
   mockRampsController.registerMoneyAccountWallet.mockResolvedValue({
     type: 'registered',
@@ -102,6 +107,18 @@ describe('createRegisterMoneyAccountOnKycCompletion', () => {
     expect(mockRampsController.registerMoneyAccountWallet).toHaveBeenCalledTimes(
       1,
     );
+  });
+
+  it('does not register again when the success screen already did', async () => {
+    const handle = setUp();
+
+    await ensureMoneyAccountWalletRegistered('0xabc');
+    await handle(completedEvent);
+
+    expect(mockRampsController.registerMoneyAccountWallet).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(mockRampsController.createAutoramp).toHaveBeenCalledTimes(1);
   });
 
   it('soft-fails and skips the autoramp when registration rejects', async () => {

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/registerMoneyAccountOnKycCompletion.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/registerMoneyAccountOnKycCompletion.ts
@@ -1,16 +1,19 @@
 import type { Hex } from '@metamask/utils';
 import Engine from '../../../../../core/Engine';
 import Logger from '../../../../../util/Logger';
-import { buildMoneyAccountAutorampParams } from './moneyAccountAutoramp';
+import {
+  ensureMoneyAccountAutorampCreated,
+  ensureMoneyAccountWalletRegistered,
+} from './moneyAccountProvisioning';
 
 /**
  * Payload published by `KycController:statusChanged`.
  */
-type KycStatusChangedPayload = {
+interface KycStatusChangedPayload {
   status: string;
   sumsubSessionId: string | null;
   errorCode: string | null;
-};
+}
 
 const asError = (value: unknown): Error =>
   value instanceof Error ? value : new Error(String(value));
@@ -27,9 +30,10 @@ const asError = (value: unknown): Error =>
  * signing webhook that would do this server-side is not ready yet.
  *
  * The subscriber is:
- * - Idempotent: a given address is registered at most once per session, and
- *   overlapping `completed` events are collapsed so registration never runs
- *   twice concurrently. A rejected registration is retried on a later event.
+ * - Idempotent: registration and autoramp creation go through the shared
+ *   `moneyAccountProvisioning` entry points, which each run at most once per
+ *   address whether the trigger was this event or the success screen's status
+ *   read. A rejected run is retried on a later event.
  * - Soft-failing: verification already succeeded, so neither a registration nor
  *   an autoramp error is surfaced to the user — they are logged, and the manual
  *   "Create my account" button on the success screen stays as the fallback.
@@ -39,9 +43,6 @@ const asError = (value: unknown): Error =>
 export function createRegisterMoneyAccountOnKycCompletion(): (
   payload: KycStatusChangedPayload,
 ) => Promise<void> {
-  const registeredAddresses = new Set<string>();
-  const inFlightAddresses = new Set<string>();
-
   return async function handleKycStatusChanged({
     status,
   }: KycStatusChangedPayload): Promise<void> {
@@ -59,33 +60,17 @@ export function createRegisterMoneyAccountOnKycCompletion(): (
       return;
     }
 
-    const addressKey = address.toLowerCase();
-    if (
-      registeredAddresses.has(addressKey) ||
-      inFlightAddresses.has(addressKey)
-    ) {
-      return;
-    }
-    inFlightAddresses.add(addressKey);
-
     try {
-      await Engine.context.RampsController.registerMoneyAccountWallet({
-        address,
-      });
-      registeredAddresses.add(addressKey);
+      await ensureMoneyAccountWalletRegistered(address);
     } catch (error) {
       Logger.error(asError(error), {
         message: 'Money Account wallet registration failed after KYC completed',
       });
       return;
-    } finally {
-      inFlightAddresses.delete(addressKey);
     }
 
     try {
-      await Engine.context.RampsController.createAutoramp(
-        buildMoneyAccountAutorampParams(address),
-      );
+      await ensureMoneyAccountAutorampCreated(address);
     } catch (error) {
       Logger.error(asError(error), {
         message:


### PR DESCRIPTION
## Summary

Demo-branch follow-up to #34729. The `KycController:statusChanged` subscriber added there only runs when the status *transitions* to `completed`, so a wallet that was already `completed` before the KYC success screen mounted (which is what happens now that idOS auto-approves and skips SumSub) never registers its Money Account wallet and never gets an autoramp. The demo just sits there.

- **Pull**: the "Create my account" pipeline gains a `Register Money Account wallet` stage that reads `GET /kyc/status` via `KycController.refreshKycStatus()` and, when it reads `completed`, registers the wallet before creating the autoramp. When it reads anything else the stage fails in place with the status it saw, and the autoramp stage does not run.
- **Push**: the `statusChanged` subscriber keeps working unchanged for wallets that flip to `completed` while the app is open.
- **Shared idempotency**: both paths now go through `moneyAccountProvisioning`, which dedupes per lowercased address. Whichever path arrives first performs the work and the other awaits/reuses it, so the user sees one signature prompt and MoonPay gets one autoramp. A rejected run is evicted so either path can retry — KYC stays `completed`, so a transient signing or proxy failure has to remain recoverable.

Also refreshes `MockKycSuccess.test.tsx`, which was still asserting a navigation the button stopped doing when the screen became a pipeline runner, and now covers the pull path instead.

## Test plan

- [x] `yarn jest app/components/UI/Ramp/Views/VirtualBankAccount/moneyAccountProvisioning.test.ts app/components/UI/Ramp/Views/VirtualBankAccount/registerMoneyAccountOnKycCompletion.test.ts` — 19 passed
- [x] `yarn jest app/components/UI/Ramp/Views/VirtualBankAccount/MockKycSuccess.test.tsx` — 5 passed
- [x] `yarn lint:tsc` — no new errors (only the pre-existing generated `termsOfUseContent` module errors)
- [ ] Demo build: complete Iron KYC, land on the success screen with status already `completed`, press "Create my account" → one signing prompt, wallet registered, autoramp created; press "Run again" → no second prompt and no second autoramp

Made with [Cursor](https://cursor.com)