### PR TITLE
Skip sticky Appium tests

### DIFF
--- a/tests/smoke-appium/accounts/contact-syncing.spec.ts
+++ b/tests/smoke-appium/accounts/contact-syncing.spec.ts
@@ -29,7 +29,9 @@ appiumTest.describe(SmokeAccounts('Contact syncing'), () => {
   const LOCAL_ONLY_CONTACT_ADDRESS =
     '0x0987654321098765432109876543210987654321';
 
-  appiumTest(
+  // 8.7.0: `contact-add-contact-button` not displayed (10s). Green on main
+  // and on release/8.7.0 branch CI; sticky on cherry-pick runners.
+  appiumTest.skip(
     'syncs contacts to user storage, restores after restart, and excludes contacts created when sync is disabled',
     async ({ driver: _driver, currentDeviceDetails }) => {
       const fixtureOptions = contactFixtureOptions(

--- a/tests/smoke-appium/snaps/test-snap-client-status.spec.ts
+++ b/tests/smoke-appium/snaps/test-snap-client-status.spec.ts
@@ -26,7 +26,10 @@ appiumTest.describe(SmokeSnaps('Client Status Snap Tests'), () => {
     },
   );
 
-  appiumTest(
+  // 8.7.0: spec pins platformVersion to @metamask/snaps-sdk in this
+  // branch (11.2.0); the client returns 12.0.0. Main already has sdk 12
+  // (#34460). Do not cherry-pick that train onto the RC.
+  appiumTest.skip(
     'returns the client status',
     async ({ driver: _driver, currentDeviceDetails }) => {
       await withSnapsFixtures(

--- a/tests/smoke-appium/swap/bridge-action-smoke.spec.ts
+++ b/tests/smoke-appium/swap/bridge-action-smoke.spec.ts
@@ -45,7 +45,10 @@ const ANVIL_MAINNET_LOCAL_NODE_OPTIONS = [
   },
 ];
 
-appiumTest.describe(SmokeSwap('Bridge functionality'), () => {
+// 8.7.0: ETH→Base bridge confirm never enables (`bridge-confirm-button`).
+// Same specs are green on main and on release/8.7.0 branch CI; sticky on
+// cherry-pick runners. Skip the whole file's cases (gasless is separate).
+appiumTest.describe.skip(SmokeSwap('Bridge functionality'), () => {
   appiumTest.describe.configure({ timeout: 180000 });
 
   appiumTest(

--- a/tests/smoke-appium/trending/trending-feed.spec.ts
+++ b/tests/smoke-appium/trending/trending-feed.spec.ts
@@ -83,7 +83,9 @@ appiumTest.describe(
         });
     };
 
-    appiumTest(
+    // 8.7.0: iOS `perps-market-details-view` isDisplayed is flaky (~1.5s).
+    // Main fixed this in #34454 (exist instead of visible). Not on this RC.
+    appiumTest.skip(
       'Navigate to all sections full views via View All and return to feed',
       async ({ driver: _driver, currentDeviceDetails }) => {
         await withFixtures(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only skips with comments; no app or production behavior changes.
> 
> **Overview**
> Marks several **Appium smoke specs as skipped** for the **8.7.0 RC / cherry-pick CI** path, with inline comments explaining why each case is flaky there while still passing on `main` and release branch CI.
> 
> **Contact syncing** — skips the full sync/restore scenario when `contact-add-contact-button` does not appear in time. **Snaps client status** — skips the assertion that compares `platformVersion` to `@metamask/snaps-sdk` (branch pins 11.2.0 vs client 12.0.0; fix is on main, not cherry-picked). **Bridge** — `describe.skip` on the whole bridge smoke suite when `bridge-confirm-button` never enables. **Trending feed** — skips View All navigation when iOS `perps-market-details-view` visibility is flaky (fix #34454 not on RC).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3247c9f05af66a0df067d1cf5c938cde50a413d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->