### PR TITLE
fix(perps): Fix UI and error handling for 'pay with token' in lite mode

### DIFF
--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -103,6 +103,8 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'perps.market.long': 'Long',
       'perps.market.short': 'Short',
       'perps.order.validation.insufficient_funds': 'Insufficient funds',
+      'perps.order.validation.insufficient_funds_to_cover_trade':
+        'Insufficient funds to cover the trade',
       'perps.deposit.max_button': 'Max',
       'perps.deposit.done_button': 'Done',
       'perps.errors.orderValidation.sizePositive':
@@ -5100,6 +5102,7 @@ describe('PerpsOrderView', () => {
       (usePerpsOrderValidation as jest.Mock).mockReturnValue({
         isValid: false,
         errors: [transientError],
+        insufficientBalanceErrors: [transientError],
         isValidating: false,
       });
       const { useInsufficientPayTokenBalanceAlert: mockAlert } =
@@ -5125,6 +5128,9 @@ describe('PerpsOrderView', () => {
       await screen.findByTestId(PerpsOrderViewSelectorsIDs.PLACE_ORDER_BUTTON);
       expect(screen.queryByText(transientError)).toBeNull();
       expect(screen.queryByText(transientAlert)).toBeNull();
+      expect(
+        screen.queryByText('Insufficient funds to cover the trade'),
+      ).toBeNull();
     });
 
     it('defers to the Perps balance when the Perps account is the payment method', async () => {

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -514,7 +514,7 @@ jest.mock(
 
 // Live wallet balance for the selected pay token, independent of the stale
 // `payToken.balanceUsd` controller snapshot.
-let mockPayTokenAccountBalanceUsd = '0';
+let mockPayTokenAccountBalanceUsd: string | undefined = '1000';
 jest.mock(
   '../../../../Views/confirmations/hooks/pay/usePayTokenAccountBalance',
   () => ({
@@ -1109,11 +1109,22 @@ describe('PerpsOrderView', () => {
     mockSliderDragValue = 0;
     mockLeverageConfirmValue = 3;
     mockIsPaySubmitReady = true;
-    mockPayTokenAccountBalanceUsd = '0';
+    mockPayTokenAccountBalanceUsd = '1000';
     mockProviderEffectiveAvailableBalance = undefined;
     mockIsPayQuoteLoading = false;
     mockPayTotals = undefined;
     mockPayRequiredTokens = [];
+    mockUseIsPerpsBalanceSelected.mockReturnValue(false);
+    mockUseTransactionPayToken.mockReturnValue({
+      payToken: {
+        address: '0xeeee',
+        chainId: '0x1',
+        symbol: 'ETH',
+        balanceUsd: '1000',
+      },
+      setPayToken: jest.fn(),
+      isNative: true,
+    });
 
     jest.mocked(useAnalytics).mockReturnValue({
       trackEvent: mockTrackEvent,
@@ -5047,7 +5058,7 @@ describe('PerpsOrderView', () => {
         setPayToken: jest.fn(),
         isNative: undefined,
       });
-      mockPayTokenAccountBalanceUsd = '0';
+      mockPayTokenAccountBalanceUsd = undefined;
       mockUseIsPerpsBalanceSelected.mockReturnValue(false);
 
       render(<PerpsOrderView />, { wrapper: TestWrapper });
@@ -5057,6 +5068,63 @@ describe('PerpsOrderView', () => {
       });
 
       expect(mockProviderEffectiveAvailableBalance).toBeUndefined();
+    });
+
+    it.each([
+      ['pay token', undefined, undefined],
+      ['live balance', PAY_TOKEN, undefined],
+    ])(
+      'disables Place Order while the %s is unresolved',
+      async (_, token, balance) => {
+        mockUseTransactionPayToken.mockReturnValue({
+          payToken: token,
+          setPayToken: jest.fn(),
+          isNative: false,
+        });
+        mockPayTokenAccountBalanceUsd = balance;
+        mockUseIsPerpsBalanceSelected.mockReturnValue(false);
+
+        render(<PerpsOrderView />, { wrapper: TestWrapper });
+
+        const placeOrderButton = await screen.findByTestId(
+          PerpsOrderViewSelectorsIDs.PLACE_ORDER_BUTTON,
+        );
+        expect(placeOrderButton).toBeDisabled();
+        expect(screen.queryByText('Insufficient funds')).toBeNull();
+      },
+    );
+
+    it('hides transient funding errors until the live balance resolves', async () => {
+      const transientError = 'Available: $0';
+      const transientAlert = 'Not enough funds available';
+      (usePerpsOrderValidation as jest.Mock).mockReturnValue({
+        isValid: false,
+        errors: [transientError],
+        isValidating: false,
+      });
+      const { useInsufficientPayTokenBalanceAlert: mockAlert } =
+        jest.requireMock(
+          '../../../../Views/confirmations/hooks/alerts/useInsufficientPayTokenBalanceAlert',
+        ) as { useInsufficientPayTokenBalanceAlert: jest.Mock };
+      mockAlert.mockReturnValue([
+        {
+          key: 'InsufficientPayTokenBalance',
+          message: transientAlert,
+          isBlocking: true,
+        },
+      ]);
+      mockUseTransactionPayToken.mockReturnValue({
+        payToken: PAY_TOKEN,
+        setPayToken: jest.fn(),
+        isNative: false,
+      });
+      mockPayTokenAccountBalanceUsd = undefined;
+
+      render(<PerpsOrderView />, { wrapper: TestWrapper });
+
+      await screen.findByTestId(PerpsOrderViewSelectorsIDs.PLACE_ORDER_BUTTON);
+      expect(screen.queryByText(transientError)).toBeNull();
+      expect(screen.queryByText(transientAlert)).toBeNull();
     });
 
     it('defers to the Perps balance when the Perps account is the payment method', async () => {

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -1185,7 +1185,8 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
 
   const { insufficientBalanceErrors } = orderValidation;
   const hasInsufficientFundsError =
-    hasInsufficientPayTokenBalance || insufficientBalanceErrors.length > 0;
+    !isPayTokenBalanceUnresolved &&
+    (hasInsufficientPayTokenBalance || insufficientBalanceErrors.length > 0);
 
   // The banner above already states the insufficient-funds condition, so drop
   // only those messages here — any other blocking error stays visible.

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -287,9 +287,13 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
     useState<PerpsTooltipContentKey | null>(null);
 
   const { payToken } = useTransactionPayToken();
-  const { balanceUsd: payTokenBalanceUsd } = usePayTokenAccountBalance();
+  const { balanceUsd: payTokenBalanceUsd } = usePayTokenAccountBalance({
+    requireLiveBalance: true,
+  });
   const isPayTokenPerpsBalance = useIsPerpsBalanceSelected();
   const hasCustomTokenSelected = !isPayTokenPerpsBalance;
+  const isPayTokenBalanceUnresolved =
+    hasCustomTokenSelected && (!payToken || payTokenBalanceUsd === undefined);
 
   const { track } = usePerpsEventTracking();
   const { openTooltipModal } = useTooltipModal();
@@ -777,12 +781,23 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
   }, [displayAmount, effectivePrice, szDecimals, isLoadingMarketData]);
 
   const hasInsufficientPayTokenBalance = useMemo(() => {
-    if (marginRequired == null || !payToken || !hasCustomTokenSelected) {
+    if (
+      marginRequired == null ||
+      !payToken ||
+      !hasCustomTokenSelected ||
+      isPayTokenBalanceUnresolved
+    ) {
       return false;
     }
     const requiredUsd = Number(marginRequired);
     return requiredUsd > Number(payTokenBalanceUsd);
-  }, [hasCustomTokenSelected, marginRequired, payToken, payTokenBalanceUsd]);
+  }, [
+    hasCustomTokenSelected,
+    isPayTokenBalanceUnresolved,
+    marginRequired,
+    payToken,
+    payTokenBalanceUsd,
+  ]);
 
   // Standard confirmation blocking alerts for pay-with-any-token flow.
   // These validate the relay quote totals (input + fees) against the actual
@@ -796,7 +811,9 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
   }, [insufficientPayAlerts, noQuotesAlerts]);
 
   const hasBlockingPayAlerts =
-    hasCustomTokenSelected && blockingPayAlerts.length > 0;
+    hasCustomTokenSelected &&
+    !isPayTokenBalanceUnresolved &&
+    blockingPayAlerts.length > 0;
 
   const blockingPayAlertMessage = useMemo(
     () => blockingPayAlerts[0]?.message ?? blockingPayAlerts[0]?.title,
@@ -1156,11 +1173,15 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
   // Filter out specific validation error(s) from display (similar to ClosePositionView pattern)
   // Hide the "Size must be a positive number" message from the error list
   const filteredErrors = useMemo(() => {
+    if (isPayTokenBalanceUnresolved) {
+      return [];
+    }
+
     const sizePositiveMsg = strings(
       'perps.errors.orderValidation.sizePositive',
     );
     return orderValidation.errors.filter((err) => err !== sizePositiveMsg);
-  }, [orderValidation.errors]);
+  }, [isPayTokenBalanceUnresolved, orderValidation.errors]);
 
   const { insufficientBalanceErrors } = orderValidation;
   const hasInsufficientFundsError =
@@ -1290,7 +1311,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
 
   const handlePlaceOrder = useCallback(
     async (forceTrade = false) => {
-      if (isSubmittingRef.current) {
+      if (isSubmittingRef.current || isPayTokenBalanceUnresolved) {
         return;
       }
 
@@ -1617,6 +1638,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
     },
     [
       isDraggingSlider,
+      isPayTokenBalanceUnresolved,
       commitAmount,
       liveDragAmount,
       orderValidation.isValid,
@@ -1740,7 +1762,9 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
       ? 'perps.order.button.long'
       : 'perps.order.button.short';
   const isInsufficientFunds =
-    !isLoadingAccount && amountTimesLeverage < minimumOrderAmount;
+    !isLoadingAccount &&
+    !isPayTokenBalanceUnresolved &&
+    amountTimesLeverage < minimumOrderAmount;
   const placeOrderLabel =
     isInsufficientFunds && !hasInsufficientFundsError
       ? strings('perps.order.validation.insufficient_funds')
@@ -1796,7 +1820,11 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
         {/* Amount Display */}
         <PerpsAmountDisplay
           amount={displayAmount}
-          showWarning={!isLoadingAccount && spendableBalance === 0}
+          showWarning={
+            !isLoadingAccount &&
+            !isPayTokenBalanceUnresolved &&
+            spendableBalance === 0
+          }
           onPress={handleAmountPress}
           isActive={isInputFocused}
           tokenAmount={livePositionSize}
@@ -2215,6 +2243,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
                 hasInvalidTPSL ||
                 isAtOICap ||
                 shouldBlockBecauseOfFeesLoading ||
+                isPayTokenBalanceUnresolved ||
                 hasBlockingPayAlerts
               }
               isLoading={isPlacingOrder}
@@ -2235,6 +2264,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
                 hasInvalidTPSL ||
                 isAtOICap ||
                 shouldBlockBecauseOfFeesLoading ||
+                isPayTokenBalanceUnresolved ||
                 hasBlockingPayAlerts
               }
               isLoading={isPlacingOrder}
@@ -2420,7 +2450,9 @@ PerpsOrderViewContent.displayName = 'PerpsOrderViewContent';
 const PerpsOrderView: React.FC = () => {
   const route = useRoute<RouteProp<{ params: OrderRouteParams }, 'params'>>();
   const { payToken } = useTransactionPayToken();
-  const { balanceUsd: payTokenBalanceUsd } = usePayTokenAccountBalance();
+  const { balanceUsd: payTokenBalanceUsd } = usePayTokenAccountBalance({
+    requireLiveBalance: true,
+  });
   const hasCustomTokenSelected = !useIsPerpsBalanceSelected();
 
   // Get navigation params to pass to context provider

--- a/app/components/Views/confirmations/hooks/pay/usePayTokenAccountBalance.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePayTokenAccountBalance.test.ts
@@ -37,6 +37,12 @@ function runHook() {
   return renderHookWithProvider(usePayTokenAccountBalance);
 }
 
+function runLiveHook() {
+  return renderHookWithProvider(() =>
+    usePayTokenAccountBalance({ requireLiveBalance: true }),
+  );
+}
+
 describe('usePayTokenAccountBalance', () => {
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
   const useAccountTokensMock = jest.mocked(useAccountTokens);
@@ -68,6 +74,20 @@ describe('usePayTokenAccountBalance', () => {
     });
   });
 
+  it('returns unresolved live balances when no pay token is selected', () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: undefined,
+      setPayToken: jest.fn(),
+    });
+
+    const { result } = runLiveHook();
+
+    expect(result.current).toStrictEqual({
+      balanceUsd: undefined,
+      balanceRaw: undefined,
+    });
+  });
+
   it('computes balance from matching account token and USD rate', () => {
     const { result } = runHook();
 
@@ -83,6 +103,47 @@ describe('usePayTokenAccountBalance', () => {
     expect(result.current).toStrictEqual({
       balanceUsd: PAY_TOKEN_MOCK.balanceUsd,
       balanceRaw: PAY_TOKEN_MOCK.balanceRaw,
+    });
+  });
+
+  it('keeps a missing live account-token balance unresolved', () => {
+    useAccountTokensMock.mockReturnValue([]);
+
+    const { result } = runLiveHook();
+
+    expect(result.current).toStrictEqual({
+      balanceUsd: undefined,
+      balanceRaw: undefined,
+    });
+  });
+
+  it('normalizes EVM chain IDs when matching a live balance', () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: { ...PAY_TOKEN_MOCK, chainId: '0x01' as Hex },
+      setPayToken: jest.fn(),
+    });
+
+    const { result } = runLiveHook();
+
+    expect(result.current).toStrictEqual({
+      balanceUsd: '3400',
+      balanceRaw: '2000000000000000000',
+    });
+    expect(useTokenFiatRateMock).toHaveBeenCalledWith(
+      PAY_TOKEN_MOCK.address,
+      '0x1',
+      'usd',
+    );
+  });
+
+  it('keeps live USD balance unresolved until its fiat rate is available', () => {
+    useTokenFiatRateMock.mockReturnValue(undefined);
+
+    const { result } = runLiveHook();
+
+    expect(result.current).toStrictEqual({
+      balanceUsd: undefined,
+      balanceRaw: '2000000000000000000',
     });
   });
 

--- a/app/components/Views/confirmations/hooks/pay/usePayTokenAccountBalance.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePayTokenAccountBalance.ts
@@ -1,39 +1,79 @@
 import { useMemo } from 'react';
 import { BigNumber } from 'bignumber.js';
-import { Hex } from '@metamask/utils';
+import { bigIntToHex, Hex, isStrictHexString } from '@metamask/utils';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { useAccountTokens } from '../send/useAccountTokens';
 import { useTokenFiatRate } from '../tokens/useTokenFiatRates';
 
 const ZERO_ADDRESS = '0x0' as Hex;
 
-// payToken.balanceUsd is a one-time snapshot that can be stale (race with
-// AccountTracker polling). Read from the same reactive asset source the
-// token selector uses so the balance stays in sync.
-export function usePayTokenAccountBalance(): {
+interface PayTokenAccountBalance {
   balanceUsd: string;
   balanceRaw: string;
-} {
+}
+
+interface LivePayTokenAccountBalance {
+  balanceUsd: string | undefined;
+  balanceRaw: string | undefined;
+}
+
+const normalizeEvmChainId = (chainId: string) =>
+  isStrictHexString(chainId) ? bigIntToHex(BigInt(chainId)) : chainId;
+
+export function usePayTokenAccountBalance(options: {
+  requireLiveBalance: true;
+}): LivePayTokenAccountBalance;
+export function usePayTokenAccountBalance(options?: {
+  requireLiveBalance?: false;
+}): PayTokenAccountBalance;
+/**
+ * Reads the reactive account-token balance. Existing confirmation callers keep
+ * the controller snapshot fallback; Perps can require live data and distinguish
+ * an unresolved balance from a measured zero.
+ */
+export function usePayTokenAccountBalance(
+  options: { requireLiveBalance?: boolean } = {},
+): PayTokenAccountBalance | LivePayTokenAccountBalance {
+  const { requireLiveBalance = false } = options;
   const { payToken } = useTransactionPayToken();
   const accountTokens = useAccountTokens({ includeNoBalance: true });
+  const payTokenChainId = payToken
+    ? requireLiveBalance
+      ? normalizeEvmChainId(payToken.chainId)
+      : payToken.chainId
+    : undefined;
   const usdRate = useTokenFiatRate(
     (payToken?.address ?? ZERO_ADDRESS) as Hex,
-    (payToken?.chainId ?? ZERO_ADDRESS) as Hex,
+    (payTokenChainId ?? ZERO_ADDRESS) as Hex,
     'usd',
   );
 
   return useMemo(() => {
     if (!payToken) {
-      return { balanceUsd: '0', balanceRaw: '0' };
+      return requireLiveBalance
+        ? { balanceUsd: undefined, balanceRaw: undefined }
+        : { balanceUsd: '0', balanceRaw: '0' };
     }
 
-    const matchingToken = accountTokens.find(
-      (t) =>
-        t.address?.toLowerCase() === payToken.address.toLowerCase() &&
-        t.chainId === payToken.chainId,
-    );
+    const matchingToken = accountTokens.find((token) => {
+      if (
+        token.address?.toLowerCase() !== payToken.address.toLowerCase() ||
+        !token.chainId
+      ) {
+        return false;
+      }
+
+      const tokenChainId = requireLiveBalance
+        ? normalizeEvmChainId(token.chainId)
+        : token.chainId;
+      return tokenChainId === payTokenChainId;
+    });
 
     if (!matchingToken?.rawBalance) {
+      if (requireLiveBalance) {
+        return { balanceUsd: undefined, balanceRaw: undefined };
+      }
+
       return {
         balanceUsd: payToken.balanceUsd ?? '0',
         balanceRaw: payToken.balanceRaw ?? '0',
@@ -45,10 +85,22 @@ export function usePayTokenAccountBalance(): {
     );
     const decimals = matchingToken.decimals ?? payToken.decimals;
     const humanBalance = new BigNumber(rawBalanceDecimal).shiftedBy(-decimals);
+
+    if (requireLiveBalance) {
+      return {
+        balanceUsd: humanBalance.isZero()
+          ? '0'
+          : usdRate != null
+            ? humanBalance.multipliedBy(usdRate).toString(10)
+            : undefined,
+        balanceRaw: rawBalanceDecimal,
+      };
+    }
+
     const balanceUsd = usdRate
       ? humanBalance.multipliedBy(usdRate).toString(10)
       : (payToken.balanceUsd ?? '0');
 
     return { balanceUsd, balanceRaw: rawBalanceDecimal };
-  }, [payToken, accountTokens, usdRate]);
+  }, [accountTokens, payToken, payTokenChainId, requireLiveBalance, usdRate]);
 }


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Fixes Lite Perps treating an unresolved wallet-token balance as zero after the user changes **Pay with**. Perps now requests live-only balance data and keeps **Place Order** visible but disabled until the token and balance resolve. Transient zero-balance and insufficient-funds errors stay hidden while that data loads.

Rebased onto current `main` via merge commits (no history rewrite). `#35145` landed a new insufficient-funds banner on the same screen; that banner keys off `insufficientBalanceErrors`, which stays truthy while the pay-token balance is unresolved, so it is now gated on the same unresolved-balance condition as the other surfaces.

The unrelated Pay With row Tailwind migration is split into #35220. #35221 was closed because review did not confirm a separate confirmations bug.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed false insufficient-funds errors when paying for a Perps trade with a wallet token

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [TAT-3742](https://consensyssoftware.atlassian.net/browse/TAT-3742)

Ticket: https://github.com/MetaMask/metamask-mobile/issues/34789

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Pay for a Lite Perps trade with a wallet token

  Scenario: the selected wallet-token balance is still resolving
    Given the user is on the Lite Perps order screen
    When the user selects a wallet token in Pay with
    And its live balance is not available yet
    Then transient zero-balance and insufficient-funds messages are not shown
    And the Place Order button remains visible and disabled

    When the live balance becomes available
    Then sizing uses the live wallet-token balance
    And Place Order returns to the existing validation flow
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<table>
<tr><td colspan="2"><strong>Switching to a wallet token no longer produces contradictory funding errors or removes the trade action</strong></td></tr>
<tr>
<td align="center" valign="top" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/34789/recipe-runs/inherited-9da27bd0-481b-42cd-9cc3-8a2b6807543e/before-ac1-after-payment-switch.png?sha=d4d19703232de795" alt="Before: contradictory funding errors and missing action" width="320" /></td>
<td align="center" valign="top" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/34789/recipe-runs/inherited-9da27bd0-481b-42cd-9cc3-8a2b6807543e/after-ac1-after-payment-switch.png?sha=91f454a402c5c693" alt="After: live wallet balance and available trade action" width="320" /></td>
</tr>
</table>

**Video**

<table>
<tr><td align="center" width="50%"><em>Before</em><br/><a href="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/34789/recipe-runs/inherited-9da27bd0-481b-42cd-9cc3-8a2b6807543e/before.mp4?sha=3e53114dab24c532">before.mp4</a></td>
<td align="center" width="50%"><em>After</em><br/><a href="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/34789/recipe-runs/inherited-9da27bd0-481b-42cd-9cc3-8a2b6807543e/after.mp4?sha=bddf46e0db7d80c3">after.mp4</a></td></tr>
</table>

## **Validation Recipe**

The unresolved-balance window is a sub-second transient race, so the recipe proves it through the two
suites that hold that state open rather than through device navigation. It asserts the guards are
present in source, then runs each suite and asserts its exit code, the named cases, and the exact
pass counts.

<details><summary>recipe.json (12 steps — source guards + both AC suites with exit-code, named-case, and pass-count assertions)</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "Perps lite pay-with-token unresolved balance",
  "description": "State-only proof that Lite Perps hides transient zero-balance and insufficient-funds surfaces while the selected wallet-token live balance is unresolved, keeps Place Order visible but disabled, and resumes normal validation once the live balance resolves.",
  "workflow": {
    "entry": "status",
    "nodes": {
      "status": {
        "action": "app.status",
        "next": "assert-guard-source",
        "intent": "Resolve the Mobile checkout and adapter status before the proof"
      },
      "assert-guard-source": {
        "action": "assert_file",
        "path": "app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx",
        "contains": "const isPayTokenBalanceUnresolved =",
        "next": "assert-live-balance-source",
        "intent": "Confirm the unresolved-balance guard under test is present in the order view"
      },
      "assert-live-balance-source": {
        "action": "assert_file",
        "path": "app/components/Views/confirmations/hooks/pay/usePayTokenAccountBalance.ts",
        "contains": "requireLiveBalance",
        "next": "run-ac1",
        "intent": "Confirm the live-only balance mode the order view depends on is present in the shared hook"
      },
      "run-ac1": {
        "action": "command",
        "cmd": "yarn jest app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx --no-coverage --ci 2>&1",
        "timeout_ms": 900000,
        "allow_failure": true,
        "next": "assert-ac1-exit",
        "intent": "Exercise AC1: order-view behaviour while the wallet-token live balance is unresolved"
      },
      "assert-ac1-exit": {
        "action": "assert_exit_code",
        "source": "run-ac1",
        "expected": 0,
        "next": "assert-ac1-case",
        "intent": "Prove the AC1 suite completed without a single failing case"
      },
      "assert-ac1-case": {
        "action": "assert_output",
        "source": "run-ac1",
        "stream": "stdout",
        "contains": "hides transient funding errors until the live balance resolves",
        "next": "assert-ac1-disabled-case",
        "intent": "Prove the specific AC1 transient-suppression case ran, not just the suite as a whole"
      },
      "assert-ac1-disabled-case": {
        "action": "assert_output",
        "source": "run-ac1",
        "stream": "stdout",
        "contains": "disables Place Order while the",
        "next": "assert-ac1-no-failures",
        "intent": "Prove the Place Order stays-visible-but-disabled case ran for both unresolved inputs"
      },
      "assert-ac1-no-failures": {
        "action": "assert_output",
        "source": "run-ac1",
        "stream": "stdout",
        "match": "Tests:\\s+132 passed, 132 total",
        "next": "run-ac2",
        "intent": "Prove the full AC1 suite count passed with no skipped or failed cases"
      },
      "run-ac2": {
        "action": "command",
        "cmd": "yarn jest app/components/Views/confirmations/hooks/pay/usePayTokenAccountBalance.test.ts --no-coverage --ci 2>&1",
        "timeout_ms": 900000,
        "allow_failure": true,
        "next": "assert-ac2-exit",
        "intent": "Exercise AC2: the shared hook's unresolved-versus-resolved live balance contract"
      },
      "assert-ac2-exit": {
        "action": "assert_exit_code",
        "source": "run-ac2",
        "expected": 0,
        "next": "assert-ac2-no-failures",
        "intent": "Prove the AC2 suite completed without a single failing case"
      },
      "assert-ac2-no-failures": {
        "action": "assert_output",
        "source": "run-ac2",
        "stream": "stdout",
        "match": "Tests:\\s+15 passed, 15 total",
        "next": "done",
        "intent": "Prove the full AC2 suite count passed with no skipped or failed cases"
      },
      "done": {
        "action": "end",
        "status": "pass"
      }
    }
  }
}
```
</details>

**Rebase note.** After rebasing onto current `main`, the AC1 suite is **132** cases, not 131 —
`main` added `pops back to the market page instead of stacking a duplicate over the order screen`
to `PerpsOrderView.test.tsx`. The recipe's `assert-ac1-no-failures` expectation above is updated to
132; the run log below is the original pre-rebase run and is left unedited. Re-validated on the
rebased branch: AC1 `Tests: 132 passed, 132 total` (exit 0), AC2 `Tests: 15 passed, 15 total` (exit 0).

## **Validation Logs**

Command:

```bash
  --adapter mobile \
  --target /Users/deeeed/dev/metamask/metamask-mobile-5 \
  --slot macwork-mmdev-5 \
  --json
```

<details><summary>Full output (12/12 nodes passed, exit 0, 56s)</summary>

```
Status: pass
Duration: 56s
Nodes: 12/12 passed

PASS status                     app.status             97ms
PASS assert-guard-source        assert_file            66ms
PASS assert-live-balance-source assert_file            63ms
PASS run-ac1                    command             35857ms
PASS assert-ac1-exit            assert_exit_code      113ms
PASS assert-ac1-case            assert_output         120ms
PASS assert-ac1-disabled-case   assert_output         183ms
PASS assert-ac1-no-failures     assert_output         163ms
PASS run-ac2                    command             18057ms
PASS assert-ac2-exit            assert_exit_code       87ms
PASS assert-ac2-no-failures     assert_output          95ms
PASS done                       end                     1ms

run-ac1  yarn jest app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx --no-coverage --ci
         exitCode=0
         Test Suites: 1 passed, 1 total
         Tests:       131 passed, 131 total

run-ac2  yarn jest app/components/Views/confirmations/hooks/pay/usePayTokenAccountBalance.test.ts --no-coverage --ci
         exitCode=0
         Test Suites: 1 passed, 1 total
         Tests:       15 passed, 15 total

sideFindings: clean — no application warnings or errors emitted during the run.
```
</details>

**Negative control.** Reverting the `hasInsufficientFundsError` guard makes
`hides transient funding errors until the live balance resolves` fail, so the assertion is
regression-proof rather than vacuous.

<details><summary>Other checks</summary>

```
Scoped ESLint (4 changed files)      0 errors (6 pre-existing warnings, none on changed lines)
Type diagnostics (4 changed files)   0 errors
Scoped Jest coverage (2 src files)   81.0% lines, 76.8% branches, 81.2% statements
```
</details>

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR. Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR.
- [ ] I confirm that this PR addresses all acceptance criteria and includes the necessary evidence.

[TAT-3742]: https://consensyssoftware.atlassian.net/browse/TAT-3742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Perps order validation and pay-balance sourcing for wallet-token trades; scoped to Lite pay-with-token flow but affects funding UX and submit gating on a trading screen.
> 
> **Overview**
> Fixes Lite Perps **pay with wallet token** showing false insufficient-funds UI while the selected token or its live balance is still loading.
> 
> `usePayTokenAccountBalance` gains an optional **`requireLiveBalance`** mode that returns **`undefined`** instead of a stale controller snapshot or implicit zero when the pay token, account token, or USD rate is not ready yet (with normalized EVM chain ID matching). Existing confirmation callers keep the prior fallback behavior.
> 
> **PerpsOrderView** uses live-only balances and treats **unresolved pay-token balance** (custom token selected, token or `balanceUsd` missing) as a loading state: **Place Order** stays visible but disabled, submit is blocked, and transient validation errors, pay alerts, zero-balance warnings, and insufficient-funds messaging are suppressed until resolution. Tests cover the hook contract and order-screen behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 252ff433ca9346d512aca8aecfd060f5d7c0d02e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- AEP_VISUAL_VALIDATION_START -->
## AEP Visual Validation

**✅ Passed**

Skipped visual validation: Three independent reasons make a visual run impossible and uninformative: (1) Wrong platform — this is metamask-mobile (React Native), not the MetaMask Extension; the mm CLI cannot launch, unlock, or screenshot a…

<details><summary>Validation details</summary>

Skipped visual validation: Three independent reasons make a visual run impossible and uninformative: (1) Wrong platform — this is metamask-mobile (React Native), not the MetaMask Extension; the mm CLI cannot launch, unlock, or screenshot a mobile app. (2) The defect is a sub-second transient race — the unresolved-balance window exists only between the moment the user changes 'Pay with' and the moment the live balance resolves; the PR authors explicitly say device navigation cannot hold that window open and prove the fix exclusively through Jest suites that mock the unresolved state. No screenshot flow can capture the transient condition. (3) The Perps lite-mode order screen requires a perpetual-trading environment (live market data, Perps-enabled account, pay-token routing infrastructure) that is not reachable through any supported fixture preset, mm mock-network stub, or mm cdp state write in the extension toolchain.

**metamask-mm-visual-validation** — passed. Visual validation did not run.

</details>

Run `937acaea-2119-4a3d-8afd-403fd21d5ecf`
<!-- AEP_VISUAL_VALIDATION_END -->

