### PR TITLE
chore(ai-analyzer): remove model overrides and use built-in defaults

### DIFF
--- a/.ai-pr-analyzer/config.yaml
+++ b/.ai-pr-analyzer/config.yaml
@@ -129,14 +129,10 @@ searchDirs:
   - .github/
 
 models:
-  default: grok-4-20-reasoning
-  escalation: claude-sonnet-4.6
-  escalationThreshold: 2
-
   escalationPatterns:                                                                                                                                                                         
     - 'confirm|transaction|swap|bridge|send'                                                                                                                                                
     - 'predict|perp|trade|stake|exchange'
-    - 'keyring|vault|seed|mnemonic|private.?key'                                                                                                                                              
+    - 'seed|mnemonic|private.?key'                                                                                                                                              
     - 'auth|permission|access.?control|role'
 
 

--- a/.github/workflows/ai-pr-risk-analysis.yml
+++ b/.github/workflows/ai-pr-risk-analysis.yml
@@ -32,16 +32,18 @@ jobs:
           fetch-depth: 0
 
       # https://github.com/MetaMask/ai-analyzer/releases
+
       - name: Run AI PR Analysis
         uses: MetaMask/ai-analyzer@9ff2c43af75a27192a4d9c7ae6da00919391b2fd
         with:
           mode: pr-risk-analysis
           add-comment: false
           add-label: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.AI_ANALYZER_TOKEN }}
           litellm-api-key: ${{ secrets.AI_ANALYZER_LITELLM_KEY }}
           # Gate override for Runway release-branch cherry-picks
           gate-override-risk-threshold: medium
           gate-override-base-pattern: '^release/'
           gate-override-author: 'runway-github[bot]'
           gate-override-title-pattern: 'cherry.?pick'
+

--- a/.github/workflows/ai-pr-risk-analysis.yml
+++ b/.github/workflows/ai-pr-risk-analysis.yml
@@ -32,6 +32,13 @@ jobs:
           fetch-depth: 0
 
       # https://github.com/MetaMask/ai-analyzer/releases
+      - name: Checkout AI Analyzer
+        uses: actions/checkout@v6
+        with:
+          repository: MetaMask/ai-analyzer
+          ref: 9ff2c43af75a27192a4d9c7ae6da00919391b2fd
+          path: .ai-analyzer-action
+          token: ${{ secrets.AI_ANALYZER_TOKEN }}
 
       - name: Run AI PR Analysis
         uses: MetaMask/ai-analyzer@9ff2c43af75a27192a4d9c7ae6da00919391b2fd
@@ -39,7 +46,7 @@ jobs:
           mode: pr-risk-analysis
           add-comment: false
           add-label: true
-          github-token: ${{ secrets.AI_ANALYZER_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           litellm-api-key: ${{ secrets.AI_ANALYZER_LITELLM_KEY }}
           # Gate override for Runway release-branch cherry-picks
           gate-override-risk-threshold: medium

--- a/.github/workflows/ai-pr-risk-analysis.yml
+++ b/.github/workflows/ai-pr-risk-analysis.yml
@@ -32,16 +32,8 @@ jobs:
           fetch-depth: 0
 
       # https://github.com/MetaMask/ai-analyzer/releases
-      - name: Checkout AI Analyzer
-        uses: actions/checkout@v6
-        with:
-          repository: MetaMask/ai-analyzer
-          ref: 9ff2c43af75a27192a4d9c7ae6da00919391b2fd
-          path: .ai-analyzer-action
-          token: ${{ secrets.AI_ANALYZER_TOKEN }}
-
       - name: Run AI PR Analysis
-        uses: ./.ai-analyzer-action
+        uses: MetaMask/ai-analyzer@9ff2c43af75a27192a4d9c7ae6da00919391b2fd
         with:
           mode: pr-risk-analysis
           add-comment: false

--- a/.github/workflows/ai-pr-risk-analysis.yml
+++ b/.github/workflows/ai-pr-risk-analysis.yml
@@ -41,7 +41,7 @@ jobs:
           token: ${{ secrets.AI_ANALYZER_TOKEN }}
 
       - name: Run AI PR Analysis
-        uses: MetaMask/ai-analyzer@9ff2c43af75a27192a4d9c7ae6da00919391b2fd
+        uses: ./.ai-analyzer-action
         with:
           mode: pr-risk-analysis
           add-comment: false
@@ -53,4 +53,3 @@ jobs:
           gate-override-base-pattern: '^release/'
           gate-override-author: 'runway-github[bot]'
           gate-override-title-pattern: 'cherry.?pick'
-

--- a/.github/workflows/ai-pr-risk-analysis.yml
+++ b/.github/workflows/ai-pr-risk-analysis.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: MetaMask/ai-analyzer
-          ref: v1
+          ref: 9ff2c43af75a27192a4d9c7ae6da00919391b2fd
           path: .ai-analyzer-action
           token: ${{ secrets.AI_ANALYZER_TOKEN }}
 


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Removes hardcoded `models.default`, `models.escalation`, and `models.escalationThreshold` overrides from `.ai-pr-analyzer/config.yaml` so MetaMask Mobile (and any other consumer of this config) inherits the AI analyzer core defaults.

Those defaults were selected after evals in the AI analyzer repo comparing default and escalation model choices against task-proven benchmarks. Keeping overrides here would pin consumers to stale local model picks; dropping them lets everyone follow the tested core defaults going forward.

Also narrows one escalation pattern since those were already covered in base patterns

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — tooling/config-only change to `.ai-pr-analyzer/config.yaml`; no app UI or user-facing behavior to exercise. Verify on a subsequent PR that AI PR risk analysis still runs and uses the core package’s default/escalation models.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and CI config only; no app, auth, or user-facing behavior changes.
> 
> **Overview**
> **Stops overriding AI PR risk-analysis models** in `.ai-pr-analyzer/config.yaml` by removing `models.default`, `models.escalation`, and `models.escalationThreshold`, so runs use the **eval-tested defaults from the ai-analyzer core** instead of pinned local model names.
> 
> **Tightens escalation patterns** by dropping `keyring|vault` from one regex (left as `seed|mnemonic|private.?key`) because those terms are already covered by base patterns.
> 
> **Pins the GitHub Action checkout** of `MetaMask/ai-analyzer` from tag `v1` to commit `9ff2c43af75a27192a4d9c7ae6da00919391b2fd` so CI picks up that revision of the analyzer alongside the config change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8af40bd33a44622637face8c4ad46c5ab5394177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->