### PR TITLE
chore: re-enable app theme setting

### DIFF
--- a/app/components/Views/Settings/GeneralSettings/GeneralSettings.view.test.tsx
+++ b/app/components/Views/Settings/GeneralSettings/GeneralSettings.view.test.tsx
@@ -12,8 +12,12 @@ import {
 import { strings } from '../../../../../locales/i18n';
 import { AvatarAccountType } from '../../../../component-library/components/Avatars/Avatar/variants/AvatarAccount';
 import Engine from '../../../../core/Engine';
-import { GENERAL_SETTINGS_CURRENCY_SELECTOR } from '.';
+import {
+  GENERAL_SETTINGS_CURRENCY_SELECTOR,
+  GENERAL_SETTINGS_THEME_SELECTOR,
+} from '.';
 import { GeneralSettingsSelectorsIDs } from './GeneralSettings.testIds';
+import { AppThemeKey } from '../../../../util/theme/models';
 
 describeForPlatforms('General Settings component view', () => {
   beforeEach(() => {
@@ -59,6 +63,17 @@ describeForPlatforms('General Settings component view', () => {
 
     expect(setCurrentCurrencySpy).toHaveBeenCalledWith('eur');
     expect(setSelectedCurrencySpy).toHaveBeenCalledWith('eur');
+  });
+
+  it('updates the app theme preference', async () => {
+    const { getByTestId, getByText, store } = renderGeneralSettings();
+
+    fireEvent.press(getByTestId(GENERAL_SETTINGS_THEME_SELECTOR));
+    fireEvent.press(getByText(strings('app_settings.theme_dark')));
+
+    await waitFor(() => {
+      expect(store.getState().user.appTheme).toBe(AppThemeKey.dark);
+    });
   });
 
   itEach([

--- a/app/components/Views/Settings/GeneralSettings/index.tsx
+++ b/app/components/Views/Settings/GeneralSettings/index.tsx
@@ -80,14 +80,6 @@ interface SelectOption {
   value: string;
 }
 
-const themeOptions: SelectOption[] = (
-  Object.values(AppThemeKey) as AppThemeKey[]
-).map((themeKey) => ({
-  value: themeKey,
-  label: strings(`app_settings.theme_${themeKey}`),
-  key: themeKey,
-}));
-
 interface SettingsState {
   searchEngine: string;
   primaryCurrency: string;
@@ -209,6 +201,15 @@ const Settings = ({
         key,
       })),
     [],
+  );
+  const themeOptions = useMemo<SelectOption[]>(
+    () =>
+      (Object.values(AppThemeKey) as AppThemeKey[]).map((themeKey) => ({
+        value: themeKey,
+        label: strings(`app_settings.theme_${themeKey}`),
+        key: themeKey,
+      })),
+    [currentLanguage],
   );
   const navigationTimeoutRef = useRef<
     ReturnType<typeof setTimeout> | undefined

--- a/app/components/Views/Settings/GeneralSettings/index.tsx
+++ b/app/components/Views/Settings/GeneralSettings/index.tsx
@@ -171,6 +171,10 @@ const Settings = ({
   const appTheme = useSelector(selectAppTheme);
   const { colors } = useTheme();
   const styles = createStyles(colors);
+  const themeLabel = strings(`app_settings.theme_${appTheme}`);
+  const themeTitle = strings('app_settings.theme_title', {
+    theme: themeLabel,
+  });
   const [currentLanguage, setCurrentLanguage] = useState(
     I18n.locale.substr(0, 2),
   );
@@ -329,9 +333,7 @@ const Settings = ({
           </View>
           <View style={styles.setting}>
             <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-              {strings('app_settings.theme_title', {
-                theme: strings(`app_settings.theme_${appTheme}`),
-              })}
+              {themeTitle}
             </Text>
             <Text
               variant={TextVariant.BodySm}
@@ -346,9 +348,7 @@ const Settings = ({
                 testID={GENERAL_SETTINGS_THEME_SELECTOR}
                 selectedValue={appTheme}
                 onValueChange={selectTheme}
-                label={strings('app_settings.theme_title', {
-                  theme: strings(`app_settings.theme_${appTheme}`),
-                })}
+                label={themeTitle}
                 options={themeOptions}
               />
             </View>

--- a/app/components/Views/Settings/GeneralSettings/index.tsx
+++ b/app/components/Views/Settings/GeneralSettings/index.tsx
@@ -175,6 +175,29 @@ const Settings = ({
   const themeTitle = strings('app_settings.theme_title', {
     theme: themeLabel,
   });
+  const renderSetting = (
+    title: string,
+    description: string,
+    content: React.ReactNode,
+    first = false,
+  ) => (
+    <View
+      style={first ? [styles.setting, styles.firstSetting] : styles.setting}
+    >
+      <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+        {title}
+      </Text>
+      <Text
+        variant={TextVariant.BodySm}
+        fontWeight={FontWeight.Medium}
+        color={TextColor.TextAlternative}
+        style={styles.desc}
+      >
+        {description}
+      </Text>
+      <View style={styles.accessory}>{content}</View>
+    </View>
+  );
   const [currentLanguage, setCurrentLanguage] = useState(
     I18n.locale.substr(0, 2),
   );
@@ -263,117 +286,61 @@ const Settings = ({
       />
       <ScrollView style={styles.content}>
         <View style={styles.inner}>
-          <View style={[styles.setting, styles.firstSetting]}>
-            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-              {strings('app_settings.conversion_title')}
-            </Text>
-            <Text
-              variant={TextVariant.BodySm}
-              fontWeight={FontWeight.Medium}
-              color={TextColor.TextAlternative}
-              style={styles.desc}
-            >
-              {strings('app_settings.conversion_desc')}
-            </Text>
-            <View style={styles.accessory}>
-              <SelectComponent
-                testID={GENERAL_SETTINGS_CURRENCY_SELECTOR}
-                selectedValue={currentCurrency}
-                onValueChange={selectCurrency}
-                label={strings('app_settings.current_conversion')}
-                options={infuraCurrencyOptions}
-              />
-            </View>
-          </View>
-          <View style={styles.setting}>
-            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-              {strings('app_settings.primary_currency_title')}
-            </Text>
-            <Text
-              variant={TextVariant.BodySm}
-              fontWeight={FontWeight.Medium}
-              color={TextColor.TextAlternative}
-              style={styles.desc}
-            >
-              {strings('app_settings.primary_currency_desc')}
-            </Text>
-            <View style={styles.accessory}>
-              <PickComponent
-                pick={selectPrimaryCurrency}
-                textFirst={strings('app_settings.primary_currency_text_first')}
-                valueFirst={'ETH'}
-                textSecond={strings(
-                  'app_settings.primary_currency_text_second',
-                )}
-                valueSecond={'Fiat'}
-                selectedValue={primaryCurrency}
-              />
-            </View>
-          </View>
-          <View style={styles.setting}>
-            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-              {strings('app_settings.current_language')}
-            </Text>
-            <Text
-              variant={TextVariant.BodySm}
-              fontWeight={FontWeight.Medium}
-              color={TextColor.TextAlternative}
-              style={styles.desc}
-            >
-              {strings('app_settings.language_desc')}
-            </Text>
-            <View style={styles.accessory}>
-              <SelectComponent
-                selectedValue={currentLanguage}
-                onValueChange={selectLanguage}
-                label={strings('app_settings.current_language')}
-                options={languageOptions}
-              />
-            </View>
-          </View>
-          <View style={styles.setting}>
-            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-              {themeTitle}
-            </Text>
-            <Text
-              variant={TextVariant.BodySm}
-              fontWeight={FontWeight.Medium}
-              color={TextColor.TextAlternative}
-              style={styles.desc}
-            >
-              {strings('app_settings.theme_description')}
-            </Text>
-            <View style={styles.accessory}>
-              <SelectComponent
-                testID={GENERAL_SETTINGS_THEME_SELECTOR}
-                selectedValue={appTheme}
-                onValueChange={selectTheme}
-                label={themeTitle}
-                options={themeOptions}
-              />
-            </View>
-          </View>
-          <View style={styles.setting}>
-            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-              {strings('app_settings.search_engine')}
-            </Text>
-            <Text
-              variant={TextVariant.BodySm}
-              fontWeight={FontWeight.Medium}
-              color={TextColor.TextAlternative}
-              style={styles.desc}
-            >
-              {strings('app_settings.engine_desc')}
-            </Text>
-            <View style={styles.accessory}>
-              <SelectComponent
-                selectedValue={searchEngine}
-                onValueChange={selectSearchEngine}
-                label={strings('app_settings.search_engine')}
-                options={searchEngineOptions}
-              />
-            </View>
-          </View>
+          {renderSetting(
+            strings('app_settings.conversion_title'),
+            strings('app_settings.conversion_desc'),
+            <SelectComponent
+              testID={GENERAL_SETTINGS_CURRENCY_SELECTOR}
+              selectedValue={currentCurrency}
+              onValueChange={selectCurrency}
+              label={strings('app_settings.current_conversion')}
+              options={infuraCurrencyOptions}
+            />,
+            true,
+          )}
+          {renderSetting(
+            strings('app_settings.primary_currency_title'),
+            strings('app_settings.primary_currency_desc'),
+            <PickComponent
+              pick={selectPrimaryCurrency}
+              textFirst={strings('app_settings.primary_currency_text_first')}
+              valueFirst={'ETH'}
+              textSecond={strings('app_settings.primary_currency_text_second')}
+              valueSecond={'Fiat'}
+              selectedValue={primaryCurrency}
+            />,
+          )}
+          {renderSetting(
+            strings('app_settings.current_language'),
+            strings('app_settings.language_desc'),
+            <SelectComponent
+              selectedValue={currentLanguage}
+              onValueChange={selectLanguage}
+              label={strings('app_settings.current_language')}
+              options={languageOptions}
+            />,
+          )}
+          {renderSetting(
+            themeTitle,
+            strings('app_settings.theme_description'),
+            <SelectComponent
+              testID={GENERAL_SETTINGS_THEME_SELECTOR}
+              selectedValue={appTheme}
+              onValueChange={selectTheme}
+              label={themeTitle}
+              options={themeOptions}
+            />,
+          )}
+          {renderSetting(
+            strings('app_settings.search_engine'),
+            strings('app_settings.engine_desc'),
+            <SelectComponent
+              selectedValue={searchEngine}
+              onValueChange={selectSearchEngine}
+              label={strings('app_settings.search_engine')}
+              options={searchEngineOptions}
+            />,
+          )}
           <SettingsToggleRow
             title={strings('app_settings.hide_zero_balance_tokens_title')}
             description={strings('app_settings.hide_zero_balance_tokens_desc')}
@@ -386,27 +353,16 @@ const Settings = ({
             value={hapticsEnabled}
             onValueChange={setHapticsEnabled}
           />
-          <View style={styles.setting}>
-            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-              {strings('app_settings.accounts_identicon_title')}
-            </Text>
-            <Text
-              variant={TextVariant.BodySm}
-              fontWeight={FontWeight.Medium}
-              color={TextColor.TextAlternative}
-              style={styles.desc}
-            >
-              {strings('app_settings.accounts_identicon_desc')}
-            </Text>
-            <View style={styles.accessory}>
-              <AvatarTypeSelector
-                address={selectedAddress}
-                onChange={setAvatarAccountType}
-                selectedType={avatarAccountType}
-                styles={styles}
-              />
-            </View>
-          </View>
+          {renderSetting(
+            strings('app_settings.accounts_identicon_title'),
+            strings('app_settings.accounts_identicon_desc'),
+            <AvatarTypeSelector
+              address={selectedAddress}
+              onChange={setAvatarAccountType}
+              selectedType={avatarAccountType}
+              styles={styles}
+            />,
+          )}
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/app/components/Views/Settings/GeneralSettings/index.tsx
+++ b/app/components/Views/Settings/GeneralSettings/index.tsx
@@ -202,14 +202,12 @@ const Settings = ({
       })),
     [],
   );
-  const themeOptions = useMemo<SelectOption[]>(
-    () =>
-      (Object.values(AppThemeKey) as AppThemeKey[]).map((themeKey) => ({
-        value: themeKey,
-        label: strings(`app_settings.theme_${themeKey}`),
-        key: themeKey,
-      })),
-    [currentLanguage],
+  const themeOptions = (Object.values(AppThemeKey) as AppThemeKey[]).map(
+    (themeKey) => ({
+      value: themeKey,
+      label: strings(`app_settings.theme_${themeKey}`),
+      key: themeKey,
+    }),
   );
   const navigationTimeoutRef = useRef<
     ReturnType<typeof setTimeout> | undefined

--- a/app/components/Views/Settings/GeneralSettings/index.tsx
+++ b/app/components/Views/Settings/GeneralSettings/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { ScrollView, View } from 'react-native';
+import { Appearance, ScrollView, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { connect } from 'react-redux';
+import { connect, useDispatch, useSelector } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import Engine from '../../../../core/Engine';
@@ -23,6 +23,9 @@ import {
 import PickComponent from '../../PickComponent';
 import { AvatarAccountType } from '../../../../component-library/components/Avatars/Avatar/variants/AvatarAccount';
 import { useTheme } from '../../../../util/theme';
+import { AppThemeKey } from '../../../../util/theme/models';
+import { setAppTheme } from '../../../../actions/user';
+import { selectAppTheme } from '../../../../selectors/user';
 import { selectCurrentCurrency } from '../../../../selectors/currencyRateController';
 import { analytics } from '../../../../util/analytics/analytics';
 import { AnalyticsEventBuilder } from '../../../../util/analytics/AnalyticsEventBuilder';
@@ -47,6 +50,9 @@ import { GeneralSettingsSelectorsIDs } from './GeneralSettings.testIds';
 
 export const GENERAL_SETTINGS_CURRENCY_SELECTOR =
   'general-settings-currency-selector';
+
+export const GENERAL_SETTINGS_THEME_SELECTOR =
+  'general-settings-theme-selector';
 
 const sortedCurrencies = infuraCurrencies.objects.sort((a, b) =>
   a.quote.code
@@ -73,6 +79,14 @@ interface SelectOption {
   key: string;
   value: string;
 }
+
+const themeOptions: SelectOption[] = (
+  Object.values(AppThemeKey) as AppThemeKey[]
+).map((themeKey) => ({
+  value: themeKey,
+  label: strings(`app_settings.theme_${themeKey}`),
+  key: themeKey,
+}));
 
 interface SettingsState {
   searchEngine: string;
@@ -153,6 +167,8 @@ const Settings = ({
   hapticsEnabled,
   setHapticsEnabled,
 }: Props) => {
+  const dispatch = useDispatch();
+  const appTheme = useSelector(selectAppTheme);
   const { colors } = useTheme();
   const styles = createStyles(colors);
   const [currentLanguage, setCurrentLanguage] = useState(
@@ -219,6 +235,18 @@ const Settings = ({
     setPrimaryCurrency(selectedPrimaryCurrency);
 
     updateUserTraitsWithCurrencyType(selectedPrimaryCurrency);
+  };
+
+  const selectTheme = (theme: string) => {
+    const selectedTheme = theme as AppThemeKey;
+    dispatch(setAppTheme(selectedTheme));
+    const themeStyle =
+      selectedTheme === AppThemeKey.os
+        ? Appearance.getColorScheme()
+        : selectedTheme;
+    analytics.identify({
+      [UserProfileProperty.THEME]: themeStyle ?? null,
+    });
   };
 
   return (
@@ -301,6 +329,32 @@ const Settings = ({
           </View>
           <View style={styles.setting}>
             <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+              {strings('app_settings.theme_title', {
+                theme: strings(`app_settings.theme_${appTheme}`),
+              })}
+            </Text>
+            <Text
+              variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
+              color={TextColor.TextAlternative}
+              style={styles.desc}
+            >
+              {strings('app_settings.theme_description')}
+            </Text>
+            <View style={styles.accessory}>
+              <SelectComponent
+                testID={GENERAL_SETTINGS_THEME_SELECTOR}
+                selectedValue={appTheme}
+                onValueChange={selectTheme}
+                label={strings('app_settings.theme_title', {
+                  theme: strings(`app_settings.theme_${appTheme}`),
+                })}
+                options={themeOptions}
+              />
+            </View>
+          </View>
+          <View style={styles.setting}>
+            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
               {strings('app_settings.search_engine')}
             </Text>
             <Text
@@ -368,7 +422,6 @@ const mapStateToProps = (state: SettingsRootState): StateProps => ({
   hideZeroBalanceTokens: state.settings.hideZeroBalanceTokens,
   hapticsEnabled: state.settings.hapticsEnabled !== false,
   isPushNotificationsEnabled: selectIsMetaMaskPushNotificationsEnabled(state),
-  // appTheme: state.user.appTheme,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({


### PR DESCRIPTION
## **Description**

Re-enabled the app theme preference in General Settings. Users can choose System, Light, or Dark, and the existing Redux theme resolution and analytics identification remain unchanged.

<img height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-14 at 10 02 16" src="https://github.com/user-attachments/assets/9b8939e9-2f92-4c60-bf5b-7006f7e23dda" />
<img height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-14 at 10 02 22" src="https://github.com/user-attachments/assets/d07b3d81-42be-4ccd-87b9-e8f5682a8f1c" />


## **Changelog**

CHANGELOG entry: Added an app theme selector to General Settings.

## **Related issues**

Refs: N/A

## **Manual testing steps**

```gherkin
Feature: App theme setting

  Scenario: User selects a theme
    Given the user is viewing General Settings
    When the user opens the Theme selector
    And the user selects Dark
    Then the app theme is saved as Dark
    And the app uses the dark theme

  Scenario: User selects System
    Given the user is viewing General Settings
    When the user opens the Theme selector
    And the user selects System
    Then the app follows the device theme preference
```

## **Screenshots/Recordings**

### **Before**

N/A — the previous picker was shown in the task-provided simulator screenshot.

### **After**

N/A — manual simulator verification is covered above; no recording was captured.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md).) Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Not applicable: this is a settings UI change with component view coverage.
- [x] I've tested with a power user scenario
  - Not applicable: this does not affect power-user flows.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - Not applicable: this does not introduce a performance-sensitive operation.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings UI only; uses existing theme actions and selectors with no auth or data-handling changes.
> 
> **Overview**
> **Re-enables the app theme control** on General Settings so users can pick **System**, **Light**, or **Dark** again.
> 
> The screen reads the current preference from Redux via `selectAppTheme`, dispatches `setAppTheme` on change, and updates analytics (resolving **System** to the device color scheme). A shared `renderSetting` helper replaces repeated title/description/accessory markup for currency, language, theme, search engine, and identicon rows. A component test asserts that choosing Dark updates `user.appTheme` in the store.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bde66cf94925560c0c4cd2819e5b36ea0d972d5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->