### PR TITLE
fix: TSA-984 stop the Quick Buy keypad flashing on funded accounts

### DIFF
--- a/app/components/UI/QuickBuy/QuickBuyAmount.tsx
+++ b/app/components/UI/QuickBuy/QuickBuyAmount.tsx
@@ -59,7 +59,10 @@ const QuickBuyAmount: React.FC = () => {
       isUnpricedSource={isUnpricedSource}
       sourceCryptoAmount={sourceAmountTokens}
       sourceSymbol={sourceToken?.symbol ?? target.tokenSymbol}
-      showCursor={isKeypadOpen}
+      // The keypad now stays expanded without funds, so the caret has to be
+      // suppressed explicitly — a blinking caret on a dead field would imply
+      // typing does something.
+      showCursor={isKeypadOpen && !hasNoPayWithFunds}
       hiddenInputRef={hiddenInputRef}
       // Omitting the handler drops the surrounding pressable entirely, so with
       // no funds the headline can neither reopen the keypad nor focus the

--- a/app/components/UI/QuickBuy/QuickBuyAmountScreen.test.tsx
+++ b/app/components/UI/QuickBuy/QuickBuyAmountScreen.test.tsx
@@ -68,10 +68,11 @@ describe('QuickBuyAmountScreen', () => {
     expect(screen.queryByTestId('quick-buy-amount-container')).toBeNull();
   });
 
-  it('leaves the amount area interactive when the user has funds to pay with', () => {
+  it('leaves the amount area and keypad interactive when the user has funds', () => {
     render(<QuickBuyAmountScreen />);
 
-    expect(screen.queryByTestId('quick-buy-disabled-section')).toBeNull();
+    expect(screen.queryByTestId('quick-buy-disabled-amount')).toBeNull();
+    expect(screen.queryByTestId('quick-buy-disabled-keypad')).toBeNull();
   });
 
   // TSA-984: with nothing to pay with no quote can be fetched, so the amount
@@ -84,12 +85,28 @@ describe('QuickBuyAmountScreen', () => {
 
     render(<QuickBuyAmountScreen />);
 
-    const disabled = screen.getByTestId('quick-buy-disabled-section');
+    const disabled = screen.getByTestId('quick-buy-disabled-amount');
     expect(disabled.props.pointerEvents).toBe('none');
     expect(screen.getByTestId('quick-buy-amount-container')).toBeOnTheScreen();
   });
 
-  it('keeps the toolbar outside the inert region so the sheet can still be closed', () => {
+  // Regression guard: the keypad must stay mounted and expanded so the sheet
+  // height never depends on `hasNoPayWithFunds` (that dependency made a funded
+  // account open collapsed then expand — a visible flash). It is blocked rather
+  // than collapsed, so its digit keys cannot type into a dead amount field.
+  it('keeps the keypad mounted but inert when the user has nothing to pay with', () => {
+    (useQuickBuyContext as jest.Mock).mockReturnValue({
+      isUnsupportedChain: false,
+      hasNoPayWithFunds: true,
+    });
+
+    render(<QuickBuyAmountScreen />);
+
+    const disabledKeypad = screen.getByTestId('quick-buy-disabled-keypad');
+    expect(disabledKeypad.props.pointerEvents).toBe('none');
+  });
+
+  it('keeps the toolbar outside the inert regions so the sheet can still be closed', () => {
     (useQuickBuyContext as jest.Mock).mockReturnValue({
       isUnsupportedChain: false,
       hasNoPayWithFunds: true,
@@ -99,8 +116,16 @@ describe('QuickBuyAmountScreen', () => {
 
     // The toolbar owns the close button — trapping the user in an inert sheet
     // would be a worse failure than the bug being fixed.
-    const disabled = screen.getByTestId('quick-buy-disabled-section');
     expect(screen.getByTestId('mock-toolbar')).toBeOnTheScreen();
-    expect(within(disabled).queryByTestId('mock-toolbar')).toBeNull();
+    expect(
+      within(screen.getByTestId('quick-buy-disabled-amount')).queryByTestId(
+        'mock-toolbar',
+      ),
+    ).toBeNull();
+    expect(
+      within(screen.getByTestId('quick-buy-disabled-keypad')).queryByTestId(
+        'mock-toolbar',
+      ),
+    ).toBeNull();
   });
 });

--- a/app/components/UI/QuickBuy/QuickBuyAmountScreen.tsx
+++ b/app/components/UI/QuickBuy/QuickBuyAmountScreen.tsx
@@ -35,13 +35,25 @@ const QuickBuyAmountScreen: React.FC = () => {
       {/* The toolbar stays live even with no funds — it owns the close button,
           so dimming it would leave the user with no way out of the sheet. */}
       <QuickBuyToolbar />
-      <QuickBuyDisabledSection isDisabled={hasNoPayWithFunds}>
+      <QuickBuyDisabledSection
+        isDisabled={hasNoPayWithFunds}
+        testID="quick-buy-disabled-amount"
+      >
         <Box testID="quick-buy-amount-container">
           <QuickBuyAmount />
         </Box>
       </QuickBuyDisabledSection>
       <QuickBuyActionFooter />
-      <QuickBuyKeypad />
+      {/* The keypad stays mounted and expanded whether or not the user has funds
+          — collapsing it would make the sheet height depend on a flag that is
+          not settled on first render, which flashed. It is dimmed and inert
+          instead, so its digit keys cannot type into a dead amount field. */}
+      <QuickBuyDisabledSection
+        isDisabled={hasNoPayWithFunds}
+        testID="quick-buy-disabled-keypad"
+      >
+        <QuickBuyKeypad />
+      </QuickBuyDisabledSection>
     </>
   );
 };

--- a/app/components/UI/QuickBuy/QuickBuyContext.test.tsx
+++ b/app/components/UI/QuickBuy/QuickBuyContext.test.tsx
@@ -310,18 +310,21 @@ describe('QuickBuyProvider — isKeypadOpen', () => {
     expect(ctx.current.isKeypadOpen).toBe(true);
   });
 
-  // TSA-984: there is no amount to type against without funds, so the keypad
-  // must never occupy the sheet in that state.
-  it('force-collapses the keypad when the user has nothing to pay with', () => {
+  // Regression guard: gating the keypad on funds made the sheet's height depend
+  // on a flag that is not settled on the first render, so a funded account
+  // opened collapsed and then expanded — a visible flash. The keypad must stay
+  // expanded regardless of funds; `QuickBuyAmountScreen` dims and blocks it
+  // instead, which keeps the height constant.
+  it('keeps the keypad open even when the user has nothing to pay with', () => {
     (useQuickBuyController as jest.Mock).mockReturnValue(
       buildController({ hasNoPayWithFunds: true }),
     );
 
     const ctx = renderProvider(featuresWithModal);
-    expect(ctx.current.isKeypadOpen).toBe(false);
+    expect(ctx.current.isKeypadOpen).toBe(true);
   });
 
-  it('cannot be reopened by a consumer while the user has nothing to pay with', () => {
+  it('lets a consumer collapse and reopen the keypad regardless of funds', () => {
     (useQuickBuyController as jest.Mock).mockReturnValue(
       buildController({ hasNoPayWithFunds: true }),
     );
@@ -329,11 +332,13 @@ describe('QuickBuyProvider — isKeypadOpen', () => {
     const ctx = renderProvider(featuresWithModal);
 
     act(() => {
+      ctx.current.setIsKeypadOpen(false);
+    });
+    expect(ctx.current.isKeypadOpen).toBe(false);
+
+    act(() => {
       ctx.current.setIsKeypadOpen(true);
     });
-
-    // Deriving the flag (rather than no-oping the setter) is what guarantees
-    // this — no screen can reopen the keypad into a dead state.
-    expect(ctx.current.isKeypadOpen).toBe(false);
+    expect(ctx.current.isKeypadOpen).toBe(true);
   });
 });

--- a/app/components/UI/QuickBuy/QuickBuyContext.tsx
+++ b/app/components/UI/QuickBuy/QuickBuyContext.tsx
@@ -65,21 +65,22 @@ export const QuickBuyProvider: React.FC<QuickBuyProviderProps> = ({
   const controller = useQuickBuyController(target, onClose, analyticsContext);
   // Open the keypad by default so the sheet matches the taller Figma layout
   // (footer + keypad visible together).
-  const [isKeypadRequestedOpen, setIsKeypadOpen] = useState(true);
+  //
+  // Deliberately independent of `hasNoPayWithFunds`: gating it on funds made the
+  // sheet's height depend on a flag that is not settled on the first render
+  // (`usePayWithTokens` options come from several redux slices that can each lag
+  // a render), so a funded account opened with the keypad collapsed and then
+  // expanded — a visible flash. With no funds the keypad stays expanded and is
+  // dimmed/inert alongside the rest of the sheet instead, which keeps the height
+  // constant no matter when the flag settles.
+  const [isKeypadOpen, setIsKeypadOpen] = useState(true);
   const {
     currentCurrency,
     usdToCurrentCurrencyRate,
     isPriceImpactError,
     isPresetAddFundsMode,
-    hasNoPayWithFunds,
     handleConfirm,
   } = controller;
-
-  // With nothing to pay with there is no amount to enter and no quote to fetch,
-  // so the keypad is force-collapsed regardless of what any caller requested
-  // (TSA-984). Deriving it here rather than no-oping the setter keeps this the
-  // single gate — no screen can reopen the keypad into a dead state.
-  const isKeypadOpen = isKeypadRequestedOpen && !hasNoPayWithFunds;
 
   const {
     buyAmounts: buyQuickAmounts,

--- a/app/components/UI/QuickBuy/components/QuickBuyActionFooter.test.tsx
+++ b/app/components/UI/QuickBuy/components/QuickBuyActionFooter.test.tsx
@@ -184,7 +184,7 @@ describe('QuickBuyActionFooter', () => {
 
       render(<QuickBuyActionFooter />);
 
-      const disabled = screen.getByTestId('quick-buy-disabled-section');
+      const disabled = screen.getByTestId('quick-buy-disabled-footer');
       expect(disabled.props.pointerEvents).toBe('none');
       expect(
         within(disabled).getByTestId('quick-buy-quick-amounts'),
@@ -219,7 +219,7 @@ describe('QuickBuyActionFooter', () => {
 
       render(<QuickBuyActionFooter />);
 
-      const disabled = screen.getByTestId('quick-buy-disabled-section');
+      const disabled = screen.getByTestId('quick-buy-disabled-footer');
       // The CTA is the one live control — it must not inherit pointerEvents:none.
       expect(screen.getByTestId('quick-buy-confirm-button')).toBeOnTheScreen();
       expect(

--- a/app/components/UI/QuickBuy/components/QuickBuyActionFooter.tsx
+++ b/app/components/UI/QuickBuy/components/QuickBuyActionFooter.tsx
@@ -55,7 +55,10 @@ const QuickBuyActionFooter: React.FC = () => {
       {/* Everything between the banners and the CTA depends on a quote that can
           never arrive without funds, so it is dimmed and inert as one block —
           leaving the "Add funds" CTA below as the only live control. */}
-      <QuickBuyDisabledSection isDisabled={hasNoPayWithFunds}>
+      <QuickBuyDisabledSection
+        isDisabled={hasNoPayWithFunds}
+        testID="quick-buy-disabled-footer"
+      >
         {features.quickAmountPills ? (
           <Box twClassName="pb-3">
             <QuickBuyQuickAmounts />

--- a/app/components/UI/QuickBuy/components/QuickBuyDisabledSection.test.tsx
+++ b/app/components/UI/QuickBuy/components/QuickBuyDisabledSection.test.tsx
@@ -28,6 +28,21 @@ describe('QuickBuyDisabledSection', () => {
     expect(screen.getByText('child')).toBeOnTheScreen();
   });
 
+  // The sheet wraps three disjoint regions (amount, footer rows, keypad), so a
+  // caller-supplied id is what lets a test target one unambiguously.
+  it('uses a caller-supplied testID when given', () => {
+    render(
+      <QuickBuyDisabledSection isDisabled testID="quick-buy-disabled-keypad">
+        <Text>child</Text>
+      </QuickBuyDisabledSection>,
+    );
+
+    expect(
+      screen.getByTestId('quick-buy-disabled-keypad').props.pointerEvents,
+    ).toBe('none');
+    expect(screen.queryByTestId('quick-buy-disabled-section')).toBeNull();
+  });
+
   // Dimmed rows still carry readable information (Pay with, Total). Hiding the
   // subtree wholesale would make the sheet read as empty to a screen reader, so
   // inertness is expressed via pointerEvents and per-control disabled props.

--- a/app/components/UI/QuickBuy/components/QuickBuyDisabledSection.tsx
+++ b/app/components/UI/QuickBuy/components/QuickBuyDisabledSection.tsx
@@ -4,6 +4,12 @@ import React from 'react';
 export interface QuickBuyDisabledSectionProps {
   /** When true, dims the subtree and blocks all touches inside it. */
   isDisabled: boolean;
+  /**
+   * Identifies which region is inert. The sheet wraps several disjoint regions
+   * (amount, footer rows, keypad), so each needs its own id for tests to target
+   * one unambiguously.
+   */
+  testID?: string;
   children: React.ReactNode;
 }
 
@@ -24,6 +30,7 @@ export interface QuickBuyDisabledSectionProps {
  */
 const QuickBuyDisabledSection: React.FC<QuickBuyDisabledSectionProps> = ({
   isDisabled,
+  testID = 'quick-buy-disabled-section',
   children,
 }) => {
   if (!isDisabled) {
@@ -35,12 +42,12 @@ const QuickBuyDisabledSection: React.FC<QuickBuyDisabledSectionProps> = ({
   // would leave a screen-reader user with a sheet that reads as empty. The
   // individual controls inside opt out via their own `disabled` props, so they
   // announce as unavailable rather than as live buttons that do nothing.
+  // `pointerEvents="none"` blocks the whole subtree on both platforms (iOS maps
+  // it to `userInteractionEnabled = NO`, which no descendant can re-enable), so
+  // it also neutralises the keypad's own `CollapsibleReveal` inner
+  // `pointerEvents="auto"` while the keypad stays visually expanded.
   return (
-    <Box
-      twClassName="opacity-50"
-      pointerEvents="none"
-      testID="quick-buy-disabled-section"
-    >
+    <Box twClassName="opacity-50" pointerEvents="none" testID={testID}>
       {children}
     </Box>
   );


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Follow-up to #34674, which fixed [TSA-984](https://consensyssoftware.atlassian.net/browse/TSA-984) but introduced a UI glitch on the common path.

**Reason for the change.** #34674 force-collapsed the numeric keypad when the account had nothing to pay with:

```js
const isKeypadOpen = isKeypadRequestedOpen && !hasNoPayWithFunds;
```

That made the sheet's height depend on `hasNoPayWithFunds`, which is **not settled on the first render**. `usePayWithTokens` derives its option list from several Redux slices that can each lag a render — most notably the EVM address from `selectSelectedInternalAccountByScope`, without which `enrichTokenBalance` returns `null` for *every* EVM token, plus account-tracker native balances and the `useNetworkEnabledPredicate` filter.

So on a **funded** account the flag transiently evaluated `true`, and the sheet opened with the keypad collapsed then expanded a frame later — the whole component visibly flashed. Since funded is the common path, this was worse than the unfunded-account flash the original PR set out to remove.

**Improvement/solution.** Keep the keypad expanded regardless of funds — back to plain `useState(true)`, exactly as it behaved before #34674 — and make it inert along with the rest of the sheet instead of collapsing it.

Sheet height no longer depends on `hasNoPayWithFunds` in either direction, so **no ordering of Redux updates can produce a flash**. This is structurally stronger than re-tuning when the flag settles.

Supporting details:

- `pointerEvents="none"` on the wrapper blocks the whole subtree on both platforms (iOS maps it to `userInteractionEnabled = NO`, which no descendant can re-enable), so it also neutralises the keypad's own `CollapsibleReveal` inner `pointerEvents="auto"` while the keys stay visible. The keypad cannot type into a dead amount field.
- The blinking caret is suppressed separately (`showCursor={isKeypadOpen && !hasNoPayWithFunds}`) — with the keypad now visible, a caret on a dead field would imply typing does something.
- `QuickBuyDisabledSection` gained a `testID` prop so the three disjoint inert regions (amount, footer rows, keypad) can be asserted individually.


https://github.com/user-attachments/assets/4d08453c-264c-464f-8617-7bd59de373bf



## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed the Quick Buy sheet briefly flashing on open by no longer collapsing and re-expanding the keypad.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TSA-984
Refs: #34674 — the PR that introduced this glitch; this is a follow-up to it.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Quick Buy keypad does not flash on open

  Scenario: funded account opens Quick Buy
    Given I hold a positive balance of a tradable token
    And I am viewing the Asset Details page for an ERC-20 token
    When I tap Quick Buy
    Then the keypad is already expanded on the first frame
    And the sheet height does not change after opening
    And no flash or resize is visible

  Scenario: unfunded account opens Quick Buy
    Given I am on a wallet with a zero balance on every network
    When I tap Quick Buy
    Then the keypad is visible but dimmed
    And the sheet height does not change after opening
    And the primary button reads "Add funds" and is enabled

  Scenario: unfunded account taps the dimmed keypad
    Given the Quick Buy sheet is open on an unfunded account
    When I tap digits on the keypad
    Then the amount does not change
    And no caret is shown on the amount

  Scenario: funded account can still use the keypad
    Given the Quick Buy sheet is open on a funded account
    When I tap digits on the keypad
    Then the amount updates and a caret blinks after the digits
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — screen recording to be attached: on a funded account the sheet opens with the keypad collapsed and expands a frame later.

### **After**

N/A — screen recording to be attached: the keypad is expanded on the first frame, no resize.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


[TSA-984]: https://consensyssoftware.atlassian.net/browse/TSA-984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Quick Buy UI and interaction gating; no changes to quotes, signing, or payment flows.
> 
> **Overview**
> Fixes a **visible flash** on funded accounts when opening Quick Buy: the sheet no longer ties keypad visibility to `hasNoPayWithFunds`, which can be wrong on the first frame while pay-with token data catches up in Redux.
> 
> **Keypad state** stays `useState(true)` instead of force-collapsing when there are no funds. Sheet height stays stable; unfunded users get the keypad **dimmed and touch-blocked** via `QuickBuyDisabledSection` (same pattern as amount and footer), not removed from the tree.
> 
> **Unfunded UX:** amount caret is hidden (`showCursor={isKeypadOpen && !hasNoPayWithFunds}`) so a visible keypad does not look typeable. `QuickBuyDisabledSection` accepts optional `testID`s (`quick-buy-disabled-amount`, `footer`, `keypad`) for targeted tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e37e9e0bded649e0e593d1fed0f1d86138a49597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->