### PR TITLE
docs(predict-next): define canonical read API

### DIFF
--- a/app/components/UI/PredictNext/AGENTS.md
+++ b/app/components/UI/PredictNext/AGENTS.md
@@ -10,7 +10,8 @@ Read, in order:
 2. `CONTEXT.md` — canonical Predict domain language.
 3. Accepted Kalshi ADRs linked from `README.md`.
 4. `docs/architecture.md` — stable boundaries and invariants.
-5. The Jira issue being implemented.
+5. `docs/canonical-read-model-and-api.md` — agreed working direction for public read types and routes.
+6. The Jira issue being implemented.
 
 ## Scope
 
@@ -26,7 +27,8 @@ Read, in order:
 2. Jira governs current scope and acceptance criteria.
 3. `CONTEXT.md` governs domain vocabulary.
 4. `docs/architecture.md` governs current module boundaries.
-5. Code and tests are the executable truth for implemented interfaces.
+5. `docs/canonical-read-model-and-api.md` governs the agreed next public-read contract until implementation supersedes it.
+6. Code and tests are the executable truth for implemented interfaces.
 
 Proposed ADRs and examples in these docs are working direction, not accepted contracts. Surface conflicts instead of silently choosing a side.
 

--- a/app/components/UI/PredictNext/AGENTS.md
+++ b/app/components/UI/PredictNext/AGENTS.md
@@ -11,7 +11,8 @@ Read, in order:
 3. Accepted Kalshi ADRs linked from `README.md`.
 4. `docs/architecture.md` — stable boundaries and invariants.
 5. `docs/canonical-read-model-and-api.md` — agreed working direction for public read types and routes.
-6. The Jira issue being implemented.
+6. `docs/ui-components.md` — composition rules for PredictNext core UI work.
+7. The Jira issue being implemented.
 
 ## Scope
 
@@ -39,6 +40,7 @@ Proposed ADRs and examples in these docs are working direction, not accepted con
 - Create Predict-local ADRs under `docs/adr/` only for durable, non-obvious decisions not governed elsewhere.
 - Never put credentials, bearer tokens, OTPs, PII/KYC values, or transfer-authorization material in Redux, persisted mobile storage, logs, analytics, traces, or fixtures.
 - Follow repository TypeScript, testing, design-system, and security guidance.
+- For core UI, follow `docs/ui-components.md`: prefer explicit variants and children-based composition, avoid boolean mode props, and use compound components only where independently useful parts or shared state justify them.
 - Work one behavior at a time: red → green → refactor.
 
 ## Agent readiness

--- a/app/components/UI/PredictNext/CONTEXT.md
+++ b/app/components/UI/PredictNext/CONTEXT.md
@@ -53,7 +53,7 @@ A single binary question within an Event, resolved as Yes or No, such as "Lakers
 _Avoid_: Outcome, PredictOutcome, condition
 
 **Outcome**:
-One side of a binary Market, representing a tradeable position, usually labeled Yes or No but sometimes using a custom label. An Outcome has a Venue-qualified identifier that may be native to the Venue or deterministically derived by the adapter when the Venue exposes only a side label; this identifier is not necessarily a token identifier.
+One side of a binary Market, representing a tradeable position, usually labeled Yes or No but sometimes using a custom label. An Outcome may have a Game Selection when it authoritatively represents the home Team, away Team, or draw.
 _Avoid_: OutcomeToken, token, share
 
 **Category**:
@@ -178,13 +178,25 @@ _Avoid_: Event without qualifier, UI event, overlay
 
 ### Sports Terms
 
+**Sport**:
+A product classification for one kind of athletic competition, such as American football.
+_Avoid_: Sports Category, Venue sport label
+
+**Competition**:
+A league or tournament within a Sport, such as the NFL or college football.
+_Avoid_: League when the contest is a tournament, Venue competition label
+
 **Game**:
-A sports contest represented as optional metadata on an Event, including scheduled time, live status, score, period, league, and participating Teams.
+A sports contest represented as optional metadata on an Event, including status, score, period, clock, and participating Teams. Game status is distinct from Market Lifecycle.
 _Avoid_: Match, fixture, raw sports payload
 
 **Team**:
-A participant in a sports Game, including canonical display metadata such as name, abbreviation, logo, and color.
+The home or away participant in a Game, including canonical display metadata such as name, abbreviation, logo, and color.
 _Avoid_: Team DTO, venue team
+
+**Game Selection**:
+An Outcome's authoritative association with the home Team, away Team, or draw. It complements the Outcome's Yes or No side and must not be inferred from display text.
+_Avoid_: Team side, parsed Outcome label
 
 ### Venue Terms
 
@@ -246,7 +258,11 @@ _Avoid_: New Venue, backend provider, opaque proxy
 - Exactly one Venue is the Active Venue for a rendered Predict experience.
 - Without a valid Venue Selection Preference, US geolocation defaults the Active Venue to Kalshi and non-US geolocation defaults it to Polymarket.
 - A valid Venue Selection Preference takes precedence over regional defaulting, but does not override eligibility, Venue Status, or rollout controls.
-- A sports Event may have one Game, and a Game has participating Teams.
+- A sports Event may have one Sports context containing one Sport, an optional Competition, and an optional Game.
+- Game Events and Game-specific prop Events may carry a Game; season props and futures have no Game.
+- A Game has one home Team and one away Team in the initial canonical model.
+- Game status and Market Lifecycle are independent and must not be derived from one another.
+- An Outcome may have one Game Selection of home, away, or draw; its Yes or No side remains unchanged.
 - Sports Events preserve Venue Event boundaries; related Venue Events are never flattened into Markets under a synthetic parent Event.
 
 ## Flagged Ambiguities

--- a/app/components/UI/PredictNext/CONTEXT.md
+++ b/app/components/UI/PredictNext/CONTEXT.md
@@ -40,9 +40,13 @@ _Avoid_: Venue Account, sub-wallet
 
 ### Core Data Model
 
+**Feed**:
+A product-owned, ordered selection of Events for a navigation surface. A Feed may represent a Category, curated collection, or supported filter combination.
+_Avoid_: Venue series, raw Event query, client-side category
+
 **Event**:
-A product grouping of one or more related binary Markets on a single topic, such as "2026 NBA Finals" or "Will ETH hit $5k?". A Venue's recurring series is a separate grouping and is not a canonical Event.
-_Avoid_: Market, PredictMarket
+A grouping of one or more related binary Markets from exactly one Venue Event, such as "2026 NBA Finals" or "Will ETH hit $5k?". An Event may have one Category and one Series.
+_Avoid_: Market, PredictMarket, composite Venue Events
 
 **Market**:
 A single binary question within an Event, resolved as Yes or No, such as "Lakers to win Game 7".
@@ -51,6 +55,26 @@ _Avoid_: Outcome, PredictOutcome, condition
 **Outcome**:
 One side of a binary Market, representing a tradeable position, usually labeled Yes or No but sometimes using a custom label. An Outcome has a Venue-qualified identifier that may be native to the Venue or deterministically derived by the adapter when the Venue exposes only a side label; this identifier is not necessarily a token identifier.
 _Avoid_: OutcomeToken, token, share
+
+**Category**:
+An Event's primary MetaMask product classification, such as Sports, Crypto, or Politics. Subjects such as Trump are Topics, not peer Categories.
+_Avoid_: Tag, Topic, Venue category array
+
+**Series**:
+A Venue-backed grouping of related Events. A Series is optional on an Event and is either a Collection Series or a Rolling Series.
+_Avoid_: Feed, Category, synthetic singleton Series
+
+**Collection Series**:
+A Series whose Events are independently current or browsable, such as NFL Games.
+_Avoid_: Current Event Series
+
+**Rolling Series**:
+A Series for which Predict follows one backend-selected current Event at a time, such as five-minute Bitcoin up-or-down Events.
+_Avoid_: Current Event wrapper, rotating Event identity
+
+**Market Lifecycle**:
+The progression of a Market through initialized, active, inactive, closed, determined, disputed, amended, and finalized states.
+_Avoid_: Simplified browse status, Event status
 
 **Position**:
 A Predict User's holdings in a specific Outcome, measured in shares.
@@ -132,6 +156,10 @@ _Avoid_: Price, sell price, Yes bid
 Total settlement currency traded on a Market or Event across all users.
 _Avoid_: Liquidity
 
+**24-Hour Volume**:
+Settlement currency traded on a Market or Event during the trailing 24-hour window at the backend observation time.
+_Avoid_: Daily Volume, total Volume
+
 **Liquidity**:
 The depth of available orders in a Market order book; higher liquidity means less price slippage.
 _Avoid_: Volume
@@ -195,8 +223,13 @@ _Avoid_: New Venue, backend provider, opaque proxy
 - Account Readiness is assessed for a Predict User at a Venue and may depend on Funding Wallet context for wallet-scoped Venues.
 - Account Setup can change Account Readiness from setup-required to ready.
 - Account Readiness is distinct from Balance and Venue Status; a Predict User can be ready with zero Balance, or funded while a Venue is unavailable.
-- Each Event originates from exactly one Venue and contains one or more Markets.
-- A Venue's recurring Series is distinct from the canonical Event grouping.
+- A Feed contains zero or more Events and owns their membership, ordering, and pagination semantics.
+- Each Event maps to exactly one Venue Event and contains one or more Markets; Predict never combines Markets from multiple Venue Events into one Event.
+- Each Event may have one primary Category and one Series.
+- A Category is product-owned and is distinct from Venue tags and future Topics.
+- A Series groups related Events; Predict does not fabricate a singleton Series for an Event without a meaningful Series.
+- A Collection Series may have multiple simultaneous or upcoming Events.
+- A Rolling Series selects one current Event at a time without changing that Event's identity.
 - Each Market contains exactly two Outcomes, typically Yes and No.
 - Each Position is tied to exactly one Outcome.
 - Each Order targets exactly one Outcome and may produce zero or more Fills.
@@ -214,7 +247,7 @@ _Avoid_: New Venue, backend provider, opaque proxy
 - Without a valid Venue Selection Preference, US geolocation defaults the Active Venue to Kalshi and non-US geolocation defaults it to Polymarket.
 - A valid Venue Selection Preference takes precedence over regional defaulting, but does not override eligibility, Venue Status, or rollout controls.
 - A sports Event may have one Game, and a Game has participating Teams.
-- Extended sports child Events are represented as additional Markets grouped under one canonical parent Event, with child provenance preserved in metadata.
+- Sports Events preserve Venue Event boundaries; related Venue Events are never flattened into Markets under a synthetic parent Event.
 
 ## Flagged Ambiguities
 
@@ -237,7 +270,10 @@ _Avoid_: New Venue, backend provider, opaque proxy
 | Predict User   | Wallet owner / user                        | Kalshi member, one real person                      |
 | Funding Wallet | Owner wallet                               | User-controlled payout/deposit wallet               |
 | Venue Account  | Safe / deposit wallet                      | MetaMask ISV sub-account                            |
+| Feed           | Product-owned projection                   | Product-owned projection                            |
 | Event          | Event                                      | Event                                               |
+| Category       | Product mapping from category/tags         | Product mapping, usually from Series metadata       |
+| Series         | Optional selected Series                   | Series                                              |
 | Market         | Market / Condition                         | Market / Contract                                   |
 | Outcome        | Outcome token                              | Yes/No side                                         |
 | Position       | Position                                   | Position                                            |

--- a/app/components/UI/PredictNext/README.md
+++ b/app/components/UI/PredictNext/README.md
@@ -77,6 +77,7 @@ These are boundaries, not a requirement to create every possible directory or mo
 - [`AGENTS.md`](./AGENTS.md) — instructions for coding agents and contributors.
 - [`CONTEXT.md`](./CONTEXT.md) — canonical product language.
 - [`docs/architecture.md`](./docs/architecture.md) — stable architecture boundaries and data flows.
+- [`docs/canonical-read-model-and-api.md`](./docs/canonical-read-model-and-api.md) — agreed working direction for public read types, relationships, and REST routes.
 - [`docs/venue-adapters.md`](./docs/venue-adapters.md) — capability adapter rules.
 - [`docs/remote-adapters.md`](./docs/remote-adapters.md) — remote trust and transport rules.
 - [`docs/agents/issue-tracker.md`](./docs/agents/issue-tracker.md) — Predict Jira conventions.

--- a/app/components/UI/PredictNext/README.md
+++ b/app/components/UI/PredictNext/README.md
@@ -78,6 +78,7 @@ These are boundaries, not a requirement to create every possible directory or mo
 - [`CONTEXT.md`](./CONTEXT.md) — canonical product language.
 - [`docs/architecture.md`](./docs/architecture.md) — stable architecture boundaries and data flows.
 - [`docs/canonical-read-model-and-api.md`](./docs/canonical-read-model-and-api.md) — agreed working direction for public read types, relationships, and REST routes.
+- [`docs/ui-components.md`](./docs/ui-components.md) — composition rules for complex PredictNext UI components.
 - [`docs/venue-adapters.md`](./docs/venue-adapters.md) — capability adapter rules.
 - [`docs/remote-adapters.md`](./docs/remote-adapters.md) — remote trust and transport rules.
 - [`docs/agents/issue-tracker.md`](./docs/agents/issue-tracker.md) — Predict Jira conventions.

--- a/app/components/UI/PredictNext/docs/architecture.md
+++ b/app/components/UI/PredictNext/docs/architecture.md
@@ -64,7 +64,7 @@ A Venue exposes only supported capability modules. Unsupported operations are ab
 
 A Venue adapter is the translation boundary for one Venue. Capabilities are grouped by independently varying product concerns:
 
-- `marketData` — public Feed, Event, Category, Series, Market, Outcome, status, Volume, media, and price reads,
+- `marketData` — public Feed, Event, Category, Series, Sports/Game context, Market, Outcome, status, Volume, media, and price reads,
 - `account` — Account Readiness and optional Account Setup,
 - `portfolio` — Balance, Position, Fill/Activity, and optional open Order reads,
 - `trading` — Order Preview and submission; optional Resting Order operations,
@@ -125,6 +125,7 @@ Properties:
 - rolling Series reads return the backend-selected current Event while immutable Event reads always preserve the requested Event identity,
 - transport and DTO normalization stay below the service,
 - Event and Market Volume remain independent decimal-string projections, and image URLs come from backend-approved HTTPS sources,
+- optional Sports/Game snapshots are normalized by the backend and Game status remains independent of Market lifecycle,
 - responses are runtime-validated and unknown fields are discarded,
 - the service alone owns response caching, deduplication, and bounded retry for safe reads.
 

--- a/app/components/UI/PredictNext/docs/architecture.md
+++ b/app/components/UI/PredictNext/docs/architecture.md
@@ -40,7 +40,9 @@ Do not add a forwarding layer that only repeats another module's interface. Do n
 
 Product-facing modules use the language in [`../CONTEXT.md`](../CONTEXT.md): Event, Market, Outcome, Order, Position, Predict User, Funding Wallet, and Venue Account. Kalshi DTO names and protocol mechanics remain inside the adapter/backend boundary.
 
-Every root Event, query, route, and operation is Venue-qualified. Nested Markets and Outcomes carry their own opaque identifiers and inherit Venue and parent scope through containment; raw Venue identifiers are not globally unique.
+Every root Feed, Event, query, route, and operation is Venue-qualified. A canonical Event maps to exactly one Venue Event; Feeds may combine discovery results but never merge Markets from multiple Venue Events into one Event. Nested Category, Series, Market, and Outcome identifiers inherit Venue and parent scope through containment; raw Venue identifiers are not globally unique.
+
+The public read-model direction is documented in [`canonical-read-model-and-api.md`](./canonical-read-model-and-api.md). Feed and detail reads initially share the complete Event model. An Event may have one product-owned Category and one genuine Venue-backed Series; synthetic singleton Series are not created merely to make the hierarchy uniform.
 
 ### Identity is not a wallet
 
@@ -62,7 +64,7 @@ A Venue exposes only supported capability modules. Unsupported operations are ab
 
 A Venue adapter is the translation boundary for one Venue. Capabilities are grouped by independently varying product concerns:
 
-- `marketData` — public Event, Market, Outcome, status, and price reads,
+- `marketData` — public Feed, Event, Category, Series, Market, Outcome, status, Volume, media, and price reads,
 - `account` — Account Readiness and optional Account Setup,
 - `portfolio` — Balance, Position, Fill/Activity, and optional open Order reads,
 - `trading` — Order Preview and submission; optional Resting Order operations,
@@ -119,8 +121,10 @@ Properties:
 
 - `venueId` is explicit and part of every cache key,
 - no selected wallet, bearer token, or account session is required,
-- Event list and detail responses include the initial Outcome Bid Price and Ask Price snapshot,
+- Feed and Event detail responses use the same complete canonical Event shape and include the initial Outcome Bid Price and Ask Price snapshot,
+- rolling Series reads return the backend-selected current Event while immutable Event reads always preserve the requested Event identity,
 - transport and DTO normalization stay below the service,
+- Event and Market Volume remain independent decimal-string projections, and image URLs come from backend-approved HTTPS sources,
 - responses are runtime-validated and unknown fields are discarded,
 - the service alone owns response caching, deduplication, and bounded retry for safe reads.
 

--- a/app/components/UI/PredictNext/docs/canonical-read-model-and-api.md
+++ b/app/components/UI/PredictNext/docs/canonical-read-model-and-api.md
@@ -1,0 +1,370 @@
+# Predict canonical read model and REST API
+
+- **Status:** Agreed working direction for team review; not yet implemented
+- **Scope:** Public, read-only Predict navigation and Event detail
+- **Venues:** Kalshi first, with a future Polymarket backend mapping
+
+## Recommendation
+
+Use one small canonical hierarchy everywhere:
+
+```text
+Feed
+  └── Event *
+       ├── Category 0..1
+       ├── Series 0..1
+       └── Market 1..*
+            └── Outcome exactly 2 (Yes and No sides)
+```
+
+Feed and detail responses use the same complete `PredictEvent` model. Do not introduce separate summary/detail types until payload size or presentation requirements prove the need.
+
+A canonical Event maps to exactly one Venue Event. A Feed may combine Events discovered through several Venue Series or metadata queries, but the backend must never merge Markets from multiple Venue Events into one canonical Event.
+
+## Ubiquitous language
+
+- **Feed** — a product-owned, ordered, paginated selection of Events for a navigation surface. A Feed can represent a Category, curated collection, or supported filter combination.
+- **Event** — one Venue Event containing one or more related Markets.
+- **Market** — one binary prediction question within an Event.
+- **Outcome** — the Yes or No side of a Market. Labels may be customized.
+- **Category** — the Event's optional primary MetaMask product classification, such as Sports, Crypto, or Politics.
+- **Series** — an optional Venue-backed grouping of related Events.
+- **Collection Series** — a Series whose Events can be independently current or browsable, such as NFL Games.
+- **Rolling Series** — a Series for which the product follows one backend-selected current Event at a time, such as a five-minute BTC up-or-down Series.
+
+`Trump` is not a second Category alongside `Politics`; it is a future Topic concept. Topic arrays are deferred until a product slice needs them.
+
+## Canonical TypeScript sketch
+
+Names are illustrative. Runtime schemas remain the executable trust boundary when this contract is implemented.
+
+```ts
+type PredictVenueId = string & { readonly __brand: 'PredictVenueId' };
+type PredictEntityId = string & { readonly __brand: 'PredictEntityId' };
+type PredictFeedId = string & { readonly __brand: 'PredictFeedId' };
+type PredictTimestamp = string & { readonly __brand: 'PredictTimestamp' };
+
+// Non-negative settlement-currency decimal string, for example "1250.45".
+type PredictAmount = string & { readonly __brand: 'PredictAmount' };
+
+// Decimal string in the inclusive range [0, 1], for example "0.42".
+type PredictPrice = string & { readonly __brand: 'PredictPrice' };
+
+type PredictHttpsUrl = string & { readonly __brand: 'PredictHttpsUrl' };
+
+interface PredictCategory {
+  id: PredictEntityId;
+  label: string;
+}
+
+type PredictSeriesMode = 'collection' | 'rolling';
+
+interface PredictSeries {
+  id: PredictEntityId;
+  title: string;
+  mode: PredictSeriesMode;
+
+  // ISO 8601 duration, for example PT5M or P1D. Informational when present.
+  recurrence?: string;
+}
+
+type PredictMarketStatus =
+  | 'initialized'
+  | 'active'
+  | 'inactive'
+  | 'closed'
+  | 'determined'
+  | 'disputed'
+  | 'amended'
+  | 'finalized';
+
+interface PredictOutcome {
+  id: PredictEntityId;
+  side: 'yes' | 'no';
+  label: string;
+  askPrice?: PredictPrice;
+  bidPrice?: PredictPrice;
+}
+
+interface PredictMarket {
+  id: PredictEntityId;
+  question: string;
+  status: PredictMarketStatus;
+  outcomes: readonly [PredictOutcome, PredictOutcome];
+
+  volume?: PredictAmount;
+  volume24h?: PredictAmount;
+  imageUrl?: PredictHttpsUrl;
+
+  createdAt?: PredictTimestamp;
+  updatedAt?: PredictTimestamp;
+  opensAt?: PredictTimestamp;
+  closesAt?: PredictTimestamp;
+  expectedResolutionAt?: PredictTimestamp;
+  latestResolutionAt?: PredictTimestamp;
+  finalizedAt?: PredictTimestamp;
+}
+
+interface PredictEvent {
+  venueId: PredictVenueId;
+  id: PredictEntityId;
+  title: string;
+  subtitle?: string;
+  description?: string;
+
+  category?: PredictCategory;
+  series?: PredictSeries;
+
+  volume?: PredictAmount;
+  volume24h?: PredictAmount;
+  imageUrl?: PredictHttpsUrl;
+
+  startsAt?: PredictTimestamp;
+  closesAt?: PredictTimestamp;
+  updatedAt?: PredictTimestamp;
+
+  markets: readonly PredictMarket[];
+}
+
+interface PredictFeed {
+  venueId: PredictVenueId;
+  id: PredictFeedId;
+  title: string;
+  events: readonly PredictEvent[];
+  nextCursor?: string;
+}
+```
+
+### Field semantics
+
+- `volume` is total settlement currency traded for that Event or Market across all users.
+- `volume24h` is settlement currency traded during the trailing 24-hour window at the backend observation time.
+- Event and Market Volume are independent backend projections. Mobile must not sum Market Volume to invent Event Volume.
+- Amounts and prices are decimal strings. Mobile must not use binary floating-point arithmetic for financial calculations.
+- `imageUrl` is an optional backend-approved absolute HTTPS URL. Mobile must not derive media from titles, tickers, or slugs.
+- Nested Category, Series, Market, and Outcome IDs inherit Venue scope from the containing Event.
+- `recurrence` describes a regular cadence but is not authoritative current-Event selection logic.
+
+## Series and rolling Events
+
+An Event has zero or one Series. This deliberately normalizes Polymarket's array-shaped Series metadata to the one Series the product can use.
+
+Backend mapping rules:
+
+- Kalshi's explicit `series_ticker` maps naturally to the canonical Series.
+- When Polymarket supplies several Series, the backend chooses at most one using deterministic product-owned rules; it must not select the first array element accidentally.
+- If no Series has useful product meaning, the backend omits `series`.
+- The backend never fabricates a singleton Series merely to make the hierarchy uniform.
+
+A `rolling` Series tells mobile that the visible Event can rotate. The Feed still contains an ordinary Event; there is no `CurrentEvent` type and no mutable Event identity.
+
+```text
+12:02 feed snapshot                  12:06 feed snapshot
+
+Series: btc-up-down-5m               Series: btc-up-down-5m
+Event:  btc-1200-1205       ->       Event:  btc-1205-1210
+```
+
+For a rolling card or detail screen:
+
+1. Render the Event returned by the Feed or current-Series endpoint.
+2. Revalidate at or shortly after the Event's `closesAt`.
+3. Revalidate when the app returns to the foreground after `closesAt`.
+4. Ask the backend for the Series' current Event; mobile never lists all Series Events and chooses one itself.
+5. Replace the rendered Event atomically only when the backend returns a different Event ID.
+6. Keep the old Event cached under its immutable Event ID.
+7. If the next Event is temporarily unavailable, retain the ended Event, show its ended state when designed, and retry safely.
+
+A `collection` Series does not imply one current Event. NFL Games, for example, may contain many simultaneous or upcoming Events.
+
+## Market lifecycle
+
+Use Kalshi's precise lifecycle vocabulary as the canonical Market lifecycle:
+
+| Status        | Canonical meaning                                     |
+| ------------- | ----------------------------------------------------- |
+| `initialized` | Created but not yet open for trading.                 |
+| `active`      | Open for trading.                                     |
+| `inactive`    | Temporarily paused by the Venue but not closed.       |
+| `closed`      | Trading ended; determination is pending.              |
+| `determined`  | Result is known; finalization is pending.             |
+| `disputed`    | The determination has been challenged.                |
+| `amended`     | The determination changed after a dispute.            |
+| `finalized`   | Venue settlement is complete and the result is final. |
+
+Polymarket lifecycle fields are mapped conservatively. The backend must not invent `disputed` or `amended` without authoritative Venue evidence. Whether a Predict User must perform a Claim is account/portfolio state, not Market lifecycle.
+
+Do not add a generic Event lifecycle by deriving it from child Markets. Sports Game state, Event display timing, and Market trading lifecycle are separate concepts.
+
+## REST API
+
+All public reads are Venue-qualified and return canonical Predict data rather than Venue DTOs.
+
+### Read a Feed
+
+```http
+GET /v1/venues/{venueId}/feeds/{feedId}?limit={limit}&cursor={cursor}
+```
+
+Response: `PredictFeed`
+
+Examples:
+
+```http
+# Home previews
+GET /v1/venues/kalshi/feeds/nfl-games?limit=2
+GET /v1/venues/kalshi/feeds/college-football-games?limit=2
+
+# Paginated MVP feeds
+GET /v1/venues/kalshi/feeds/nfl-games?limit=20&cursor=opaque
+GET /v1/venues/kalshi/feeds/nfl-props?limit=20&cursor=opaque
+
+# Future broader feeds and canonical filters
+GET /v1/venues/kalshi/feeds/sports?limit=20
+GET /v1/venues/kalshi/feeds/sports?timing=live&limit=20
+GET /v1/venues/kalshi/feeds/sports?sport=american-football&competition=nfl&content=games&limit=20
+GET /v1/venues/kalshi/feeds/sports?sport=american-football&competition=nfl&content=props&limit=20
+GET /v1/venues/kalshi/feeds/crypto?limit=20
+```
+
+Filter IDs are stable MetaMask product IDs. The backend maps them to current Venue Series, tags, catalogs, and metadata. Supported filter discovery is deferred until the UI requires a dynamic filter catalog; the backend rejects unsupported combinations rather than silently ignoring them.
+
+The backend owns Feed membership, ordering, and opaque cursor semantics. For the first Games feeds, live/current Games precede future Games and future Games are ordered by scheduled time.
+
+### Read one immutable Event
+
+```http
+GET /v1/venues/{venueId}/events/{eventId}
+```
+
+Response: `PredictEvent`
+
+This route always returns the requested Event. It must never rotate to a newer Event in the same Series. Use it for ordinary cards, deep links, history, Positions, and fixed Event detail.
+
+### Read the current Event in a rolling Series
+
+```http
+GET /v1/venues/{venueId}/series/{seriesId}/events/current
+```
+
+Responses:
+
+- `200` with `PredictEvent` when the backend has selected a current Event;
+- `204` when the Series exists but has no currently selectable Event;
+- `404` when the Series does not exist for that Venue.
+
+A card backed by a `rolling` Series opens detail in follow-Series mode and refreshes through this endpoint. A fixed Event link still uses the immutable Event endpoint.
+
+### Read Venue status
+
+The existing Venue-qualified status route remains:
+
+```http
+GET /v1/venues/{venueId}/status
+```
+
+## Backend normalization responsibilities
+
+The MetaMask Predict backend must:
+
+- map every canonical Event to exactly one Venue Event;
+- never merge Markets from multiple Venue Events into one Event;
+- build product-owned Feeds from one or more Venue discovery queries;
+- assign at most one primary MetaMask Category to an Event;
+- select at most one useful Series and classify it as `collection` or `rolling`;
+- select the current Event for rolling Series;
+- map Market lifecycle to the canonical eight-state vocabulary conservatively;
+- normalize prices and Volume as validated decimal strings;
+- provide Event and Market image URLs only from approved HTTPS sources;
+- preserve Venue-qualified opaque identity without parsing tickers or slugs;
+- own Feed ordering and stable opaque pagination across merged upstream calls;
+- omit unavailable optional fields rather than inventing values;
+- prevent raw Venue DTOs, credentials, PII, and protocol errors from reaching mobile.
+
+### Kalshi
+
+- Discover Events through explicit Series, sport catalog, category, tag, and product metadata relationships.
+- Use `series_ticker`, `event_ticker`, and Market ticker fields explicitly; do not parse ticker structure.
+- Map Kalshi Market statuses directly to the canonical lifecycle.
+- Treat NFL Games-like Series as `collection` and interval contracts such as five-minute up/down as `rolling` when product configuration establishes that behavior.
+
+### Polymarket
+
+- Map one Gamma Event to one canonical Event.
+- Select zero or one primary Series deterministically from Polymarket's optional Series array.
+- Keep Gamma Event ID, Market ID, condition ID, and Outcome token IDs distinct internally.
+- Map categories/tags to one primary MetaMask Category; do not expose an arbitrary array as peer Categories.
+- Derive lifecycle only from authoritative Gamma/CLOB state.
+
+## Relationship and behavior examples
+
+### NFL Game
+
+```text
+Feed: nfl-games
+  Event: Chiefs vs Bills
+    Category: Sports
+    Series: NFL Games (collection)
+    Markets: winner, spread, total
+```
+
+The same Venue Event may later appear in a Props Feed when its own Markets support that treatment. Feed-specific featured-Market presentation is deferred until a concrete UI requires it.
+
+### Standalone player prop
+
+```text
+Feed: nfl-props
+  Event: Will Mahomes throw 3+ touchdowns this week?
+    Category: Sports
+    Series: optional
+    Market: one binary question
+```
+
+No synthetic Game Event is created.
+
+### Five-minute BTC up/down
+
+```text
+Feed: crypto
+  Event: BTC Up or Down — 12:00–12:05
+    Category: Crypto
+    Series: BTC Up or Down 5m (rolling, PT5M)
+```
+
+After close, mobile reads `/series/{seriesId}/events/current`; the backend may return the 12:05–12:10 Event. The old Event ID remains immutable.
+
+### Politics Event
+
+```text
+Event: Will Trump win the election?
+  Category: Politics
+```
+
+`Trump` is not represented as another Category. Add Topics only when topic navigation becomes a real product requirement.
+
+## Change from the walking-skeleton v1 contract
+
+The implemented walking-skeleton contract currently returns paginated `PredictEvent` values directly and uses a reduced Market status enum. The next contract slice will need to:
+
+1. add `PredictFeed`, `PredictCategory`, and `PredictSeries`;
+2. add optional Event and Market `volume`, `volume24h`, and `imageUrl`;
+3. replace the reduced Market status enum with the canonical Kalshi lifecycle;
+4. replace Event-list reads with Feed reads where product Feed semantics are required;
+5. add the rolling-Series current-Event read;
+6. update runtime validation, adapter transport, query keys, service actions, fixtures, and tests together.
+
+Until that implementation lands, code and tests remain the executable contract.
+
+## Intentionally deferred
+
+- Category arrays and Topic/tag models;
+- public Series browsing or Series catalogs;
+- dynamic Feed-filter discovery;
+- separate Event summary/detail DTOs;
+- Feed-item or Current-Event wrapper resources;
+- cross-Venue-Event composition;
+- multi-Venue aggregated Feeds;
+- Feed-specific featured Market projections;
+- non-binary canonical Markets;
+- continuous live updates and WebSockets;
+- charts, history, rules, Game/Team live state, and account-scoped data.

--- a/app/components/UI/PredictNext/docs/canonical-read-model-and-api.md
+++ b/app/components/UI/PredictNext/docs/canonical-read-model-and-api.md
@@ -13,6 +13,8 @@ Feed
   └── Event *
        ├── Category 0..1
        ├── Series 0..1
+       ├── Sports Context 0..1
+       │    └── Game 0..1
        └── Market 1..*
             └── Outcome exactly 2 (Yes and No sides)
 ```
@@ -31,6 +33,11 @@ A canonical Event maps to exactly one Venue Event. A Feed may combine Events dis
 - **Series** — an optional Venue-backed grouping of related Events.
 - **Collection Series** — a Series whose Events can be independently current or browsable, such as NFL Games.
 - **Rolling Series** — a Series for which the product follows one backend-selected current Event at a time, such as a five-minute BTC up-or-down Series.
+- **Sport** — a stable product classification for one kind of athletic competition, such as American football.
+- **Competition** — a league or tournament within a Sport, such as the NFL or college football.
+- **Game** — an optional snapshot of the sports contest associated with an Event. Game status is independent of Market lifecycle.
+- **Team** — the home or away participant in a Game.
+- **Game Selection** — an Outcome's optional authoritative association with the home Team, away Team, or draw.
 
 `Trump` is not a second Category alongside `Politics`; it is a future Topic concept. Topic arrays are deferred until a product slice needs them.
 
@@ -51,6 +58,7 @@ type PredictAmount = string & { readonly __brand: 'PredictAmount' };
 type PredictPrice = string & { readonly __brand: 'PredictPrice' };
 
 type PredictHttpsUrl = string & { readonly __brand: 'PredictHttpsUrl' };
+type PredictHexColor = string & { readonly __brand: 'PredictHexColor' };
 
 interface PredictCategory {
   id: PredictEntityId;
@@ -66,6 +74,53 @@ interface PredictSeries {
 
   // ISO 8601 duration, for example PT5M or P1D. Informational when present.
   recurrence?: string;
+}
+
+interface PredictSport {
+  // Stable MetaMask product ID, for example "american-football".
+  id: PredictEntityId;
+  label: string;
+}
+
+interface PredictCompetition {
+  // Stable MetaMask product ID, for example "nfl" or "college-football".
+  id: PredictEntityId;
+  label: string;
+}
+
+interface PredictTeam {
+  name: string;
+  abbreviation?: string;
+  logoUrl?: PredictHttpsUrl;
+  primaryColor?: PredictHexColor;
+}
+
+type PredictGameStatus =
+  | 'scheduled'
+  | 'in_progress'
+  | 'delayed'
+  | 'suspended'
+  | 'postponed'
+  | 'completed'
+  | 'canceled';
+
+interface PredictGame {
+  status: PredictGameStatus;
+  homeTeam: PredictTeam;
+  awayTeam: PredictTeam;
+  score?: {
+    home: string;
+    away: string;
+  };
+  period?: string;
+  clock?: string;
+  observedAt: PredictTimestamp;
+}
+
+interface PredictSportsContext {
+  sport: PredictSport;
+  competition?: PredictCompetition;
+  game?: PredictGame;
 }
 
 type PredictMarketStatus =
@@ -84,6 +139,9 @@ interface PredictOutcome {
   label: string;
   askPrice?: PredictPrice;
   bidPrice?: PredictPrice;
+
+  // Present only when this Outcome authoritatively represents a Game selection.
+  gameSelection?: 'home' | 'away' | 'draw';
 }
 
 interface PredictMarket {
@@ -114,6 +172,7 @@ interface PredictEvent {
 
   category?: PredictCategory;
   series?: PredictSeries;
+  sports?: PredictSportsContext;
 
   volume?: PredictAmount;
   volume24h?: PredictAmount;
@@ -141,9 +200,15 @@ interface PredictFeed {
 - `volume24h` is settlement currency traded during the trailing 24-hour window at the backend observation time.
 - Event and Market Volume are independent backend projections. Mobile must not sum Market Volume to invent Event Volume.
 - Amounts and prices are decimal strings. Mobile must not use binary floating-point arithmetic for financial calculations.
-- `imageUrl` is an optional backend-approved absolute HTTPS URL. Mobile must not derive media from titles, tickers, or slugs.
+- `imageUrl` and `logoUrl` are optional backend-approved absolute HTTPS URLs. Mobile must not derive media from titles, tickers, or slugs.
+- `primaryColor` is a backend-approved six-digit hexadecimal RGB color such as `#E31837`; it is decorative and must not be the only way UI communicates meaning.
 - Nested Category, Series, Market, and Outcome IDs inherit Venue scope from the containing Event.
 - `recurrence` describes a regular cadence but is not authoritative current-Event selection logic.
+- For a Game Event, `Event.startsAt` is the scheduled Game start; the Game does not duplicate that timestamp.
+- `Game.score`, `period`, and `clock` are display-safe strings because their formats vary by Sport. Mobile must not parse them to recover Venue semantics.
+- `Game.observedAt` records when the backend observed the Game snapshot so mobile can identify stale REST data.
+- `Outcome.gameSelection` is authoritative when present. Mobile must not infer a Team or draw association from an Outcome label, Market question, title, ticker, or array order.
+- A `no` Outcome opposite a Team's `yes` Outcome does not automatically represent the other Team; draws and Venue resolution rules can make that inference false.
 
 ## Series and rolling Events
 
@@ -196,6 +261,32 @@ Polymarket lifecycle fields are mapped conservatively. The backend must not inve
 
 Do not add a generic Event lifecycle by deriving it from child Markets. Sports Game state, Event display timing, and Market trading lifecycle are separate concepts.
 
+## Sports and Game metadata
+
+Sports metadata is an optional Event projection rather than another resource hierarchy. This allows Game Events, Game-specific props, season props, and futures to share one Event model:
+
+| Event                              | Sports context                                    |
+| ---------------------------------- | ------------------------------------------------- |
+| Chiefs vs Bills                    | American football, NFL, and Game snapshot         |
+| Mahomes touchdowns against Buffalo | American football, NFL, and the same Game context |
+| Mahomes season passing yards       | American football and NFL; no Game                |
+| Super Bowl winner                  | American football and NFL; no Game                |
+
+A Game snapshot is initially limited to one home Team and one away Team. Sports with more than two competitors require a later contract change driven by a concrete product slice.
+
+Game status and Market lifecycle are independent:
+
+```text
+Game:   scheduled -> in_progress -> completed
+Market: initialized -> active -> closed -> determined -> finalized
+```
+
+For example, a Game can be `scheduled` while its Markets are already `active`, or `completed` while a Market remains `determined` pending finalization. Mobile never derives one lifecycle from the other.
+
+The backend maps authoritative Venue status into this small Game vocabulary. Overtime, shootout, forfeit, or other display detail can remain in `period` while `status` is `completed`. Unsupported or ambiguous Venue values fail closed rather than being guessed.
+
+`gameSelection` lets Game cards associate a displayed Outcome with `home`, `away`, or `draw` without replacing the canonical `yes | no` side used for trading. It is optional for totals, spreads, player props, and any Outcome without an authoritative Game-side association.
+
 ## REST API
 
 All public reads are Venue-qualified and return canonical Predict data rather than Venue DTOs.
@@ -229,7 +320,7 @@ GET /v1/venues/kalshi/feeds/crypto?limit=20
 
 Filter IDs are stable MetaMask product IDs. The backend maps them to current Venue Series, tags, catalogs, and metadata. Supported filter discovery is deferred until the UI requires a dynamic filter catalog; the backend rejects unsupported combinations rather than silently ignoring them.
 
-The backend owns Feed membership, ordering, and opaque cursor semantics. For the first Games feeds, live/current Games precede future Games and future Games are ordered by scheduled time.
+The backend owns Feed membership, ordering, and opaque cursor semantics. For the first Games feeds, in-progress Games precede future Games and future Games are ordered by scheduled time.
 
 ### Read one immutable Event
 
@@ -263,6 +354,10 @@ The existing Venue-qualified status route remains:
 GET /v1/venues/{venueId}/status
 ```
 
+### Refresh Game snapshots
+
+No Game-specific endpoint is required initially. Feed and immutable Event reads return the complete embedded Game snapshot. REST clients refresh the existing Feed or Event query according to the product's snapshot policy; a later live-data slice may patch the same canonical Game shape while REST remains the recovery path.
+
 ## Backend normalization responsibilities
 
 The MetaMask Predict backend must:
@@ -273,6 +368,7 @@ The MetaMask Predict backend must:
 - assign at most one primary MetaMask Category to an Event;
 - select at most one useful Series and classify it as `collection` or `rolling`;
 - select the current Event for rolling Series;
+- normalize optional Sport, Competition, Game, Team, Game status, score, period, clock, and Game Selection data only from authoritative sources;
 - map Market lifecycle to the canonical eight-state vocabulary conservatively;
 - normalize prices and Volume as validated decimal strings;
 - provide Event and Market image URLs only from approved HTTPS sources;
@@ -284,7 +380,8 @@ The MetaMask Predict backend must:
 ### Kalshi
 
 - Discover Events through explicit Series, sport catalog, category, tag, and product metadata relationships.
-- Use `series_ticker`, `event_ticker`, and Market ticker fields explicitly; do not parse ticker structure.
+- Join Event metadata and authoritative milestone/live-data sources when constructing Sports and Game snapshots.
+- Use `series_ticker`, `event_ticker`, and Market ticker fields explicitly; do not parse ticker structure or display text to recover Team or Game identity.
 - Map Kalshi Market statuses directly to the canonical lifecycle.
 - Treat NFL Games-like Series as `collection` and interval contracts such as five-minute up/down as `rolling` when product configuration establishes that behavior.
 
@@ -294,7 +391,8 @@ The MetaMask Predict backend must:
 - Select zero or one primary Series deterministically from Polymarket's optional Series array.
 - Keep Gamma Event ID, Market ID, condition ID, and Outcome token IDs distinct internally.
 - Map categories/tags to one primary MetaMask Category; do not expose an arbitrary array as peer Categories.
-- Derive lifecycle only from authoritative Gamma/CLOB state.
+- Normalize structured Gamma sports metadata and sports-stream updates, including splitting combined scores into canonical home and away values.
+- Derive Game Selection and both Game and Market lifecycles only from authoritative structured data.
 
 ## Relationship and behavior examples
 
@@ -305,7 +403,12 @@ Feed: nfl-games
   Event: Chiefs vs Bills
     Category: Sports
     Series: NFL Games (collection)
+    Sports:
+      Sport: American football
+      Competition: NFL
+      Game: in progress, BUF home 17, KC away 21, Q3 08:42
     Markets: winner, spread, total
+      Winner Outcomes: BUF (home), KC (away)
 ```
 
 The same Venue Event may later appear in a Props Feed when its own Markets support that treatment. Feed-specific featured-Market presentation is deferred until a concrete UI requires it.
@@ -317,10 +420,11 @@ Feed: nfl-props
   Event: Will Mahomes throw 3+ touchdowns this week?
     Category: Sports
     Series: optional
+    Sports: American football, NFL, and Game when the prop is Game-specific
     Market: one binary question
 ```
 
-No synthetic Game Event is created.
+No synthetic Game Event is created. A season prop or future has Sport and Competition context but omits Game.
 
 ### Five-minute BTC up/down
 
@@ -348,10 +452,11 @@ The implemented walking-skeleton contract currently returns paginated `PredictEv
 
 1. add `PredictFeed`, `PredictCategory`, and `PredictSeries`;
 2. add optional Event and Market `volume`, `volume24h`, and `imageUrl`;
-3. replace the reduced Market status enum with the canonical Kalshi lifecycle;
-4. replace Event-list reads with Feed reads where product Feed semantics are required;
-5. add the rolling-Series current-Event read;
-6. update runtime validation, adapter transport, query keys, service actions, fixtures, and tests together.
+3. add optional Sports, Competition, Game, Team, Game status, and Game Selection metadata;
+4. replace the reduced Market status enum with the canonical Kalshi lifecycle;
+5. replace Event-list reads with Feed reads where product Feed semantics are required;
+6. add the rolling-Series current-Event read;
+7. update runtime validation, adapter transport, query keys, service actions, fixtures, and tests together.
 
 Until that implementation lands, code and tests remain the executable contract.
 
@@ -367,4 +472,4 @@ Until that implementation lands, code and tests remain the executable contract.
 - Feed-specific featured Market projections;
 - non-binary canonical Markets;
 - continuous live updates and WebSockets;
-- charts, history, rules, Game/Team live state, and account-scoped data.
+- play-by-play, possession, down and distance, per-period scores, player entities and statistics, sports Market-type/line metadata, Games with more than two competitors, independently cached Team resources, charts, history, rules, and account-scoped data.

--- a/app/components/UI/PredictNext/docs/interface-ledger.md
+++ b/app/components/UI/PredictNext/docs/interface-ledger.md
@@ -1,6 +1,8 @@
 # PredictNext Interface Ledger
 
-This ledger records the mobile canonical read contract stabilized by PRED-1168 and refined by PRED-1169. Venue DTO mapping belongs to the Predict API backend; mobile validates canonical Predict API responses only.
+This ledger records the implemented mobile canonical read contract stabilized by PRED-1168 and refined by PRED-1169. Venue DTO mapping belongs to the Predict API backend; mobile validates canonical Predict API responses only.
+
+The agreed next-contract direction is documented in [`canonical-read-model-and-api.md`](./canonical-read-model-and-api.md). It is not executable until the types, runtime parsers, transport, service, fixtures, and tests are updated together.
 
 ## Canonical read models
 
@@ -15,6 +17,12 @@ This ledger records the mobile canonical read contract stabilized by PRED-1168 a
 - `PredictVenueStatus` contains the root `venueId`, an `available | degraded | unavailable` status, and the backend observation time as `PredictTimestamp`.
 - `PredictEntityId` is venue-local and opaque. An Outcome ID may be native or adapter-derived.
 - `PredictTimestamp` is an RFC 3339/ISO-8601 UTC string.
+
+## Agreed next-contract changes
+
+The next public-read contract will use `Feed → Event → Market → Outcome`, with the same complete Event shape in Feed and detail responses. It will add an optional single Category and Series to Event; optional Event and Market Volume, 24-Hour Volume, and image URL; product-owned Feed reads; and a current-Event read for Rolling Series. A canonical Event will continue to map to exactly one Venue Event.
+
+The reduced browse status will be replaced by the Kalshi lifecycle vocabulary: `initialized`, `active`, `inactive`, `closed`, `determined`, `disputed`, `amended`, and `finalized`. The existing binary Outcome invariant remains unchanged.
 
 ## Query descriptors
 

--- a/app/components/UI/PredictNext/docs/interface-ledger.md
+++ b/app/components/UI/PredictNext/docs/interface-ledger.md
@@ -20,9 +20,9 @@ The agreed next-contract direction is documented in [`canonical-read-model-and-a
 
 ## Agreed next-contract changes
 
-The next public-read contract will use `Feed → Event → Market → Outcome`, with the same complete Event shape in Feed and detail responses. It will add an optional single Category and Series to Event; optional Event and Market Volume, 24-Hour Volume, and image URL; product-owned Feed reads; and a current-Event read for Rolling Series. A canonical Event will continue to map to exactly one Venue Event.
+The next public-read contract will use `Feed → Event → Market → Outcome`, with the same complete Event shape in Feed and detail responses. It will add an optional single Category and Series to Event; optional Event and Market Volume, 24-Hour Volume, and image URL; optional Sport, Competition, Game, Team, Game status, and Game Selection metadata; product-owned Feed reads; and a current-Event read for Rolling Series. A canonical Event will continue to map to exactly one Venue Event.
 
-The reduced browse status will be replaced by the Kalshi lifecycle vocabulary: `initialized`, `active`, `inactive`, `closed`, `determined`, `disputed`, `amended`, and `finalized`. The existing binary Outcome invariant remains unchanged.
+The reduced browse status will be replaced by the Kalshi lifecycle vocabulary: `initialized`, `active`, `inactive`, `closed`, `determined`, `disputed`, `amended`, and `finalized`. The existing binary Outcome invariant remains unchanged: Game Selection complements rather than replaces an Outcome's `yes | no` side.
 
 ## Query descriptors
 

--- a/app/components/UI/PredictNext/docs/remote-adapters.md
+++ b/app/components/UI/PredictNext/docs/remote-adapters.md
@@ -71,7 +71,7 @@ The mobile/backend API exposes product capabilities, not raw Kalshi endpoints. R
 
 Contract-version header enforcement and cross-repository fixture tooling are deferred until their semantics and value are proven. The implemented first read-only slice needs only Venue Status and Event list/detail; Event responses embed the initial optional Outcome Bid Price and Ask Price snapshot.
 
-The agreed next public-read contract uses Venue-qualified Feed reads, immutable Event detail, and a Rolling Series current-Event read. All return complete canonical Events; the backend owns Feed selection/order, single Category and Series normalization, current-Event selection, Kalshi lifecycle mapping, decimal-string Volume, and approved HTTPS image URLs. See [`canonical-read-model-and-api.md`](./canonical-read-model-and-api.md). Do not define a separate price, account, or write route until a slice requires it.
+The agreed next public-read contract uses Venue-qualified Feed reads, immutable Event detail, and a Rolling Series current-Event read. All return complete canonical Events; the backend owns Feed selection/order, single Category and Series normalization, current-Event selection, Sports/Game snapshot normalization, Outcome Game Selection, Kalshi lifecycle mapping, decimal-string Volume, and approved HTTPS image URLs. No separate Game route is required initially. See [`canonical-read-model-and-api.md`](./canonical-read-model-and-api.md). Do not define a separate price, account, or write route until a slice requires it.
 
 ## Sensitive-data rule
 

--- a/app/components/UI/PredictNext/docs/remote-adapters.md
+++ b/app/components/UI/PredictNext/docs/remote-adapters.md
@@ -69,7 +69,9 @@ The mobile/backend API exposes product capabilities, not raw Kalshi endpoints. R
 - every response contains canonical Venue context where relevant,
 - credentials, PII, and raw KYC payloads never appear in canonical responses.
 
-Contract-version header enforcement and cross-repository fixture tooling are deferred until their semantics and value are proven. The first read-only slice needs only Venue Status and Event list/detail; Event responses embed the initial optional Outcome Bid Price and Ask Price snapshot. Do not define a separate price, account, or write route until a slice requires it.
+Contract-version header enforcement and cross-repository fixture tooling are deferred until their semantics and value are proven. The implemented first read-only slice needs only Venue Status and Event list/detail; Event responses embed the initial optional Outcome Bid Price and Ask Price snapshot.
+
+The agreed next public-read contract uses Venue-qualified Feed reads, immutable Event detail, and a Rolling Series current-Event read. All return complete canonical Events; the backend owns Feed selection/order, single Category and Series normalization, current-Event selection, Kalshi lifecycle mapping, decimal-string Volume, and approved HTTPS image URLs. See [`canonical-read-model-and-api.md`](./canonical-read-model-and-api.md). Do not define a separate price, account, or write route until a slice requires it.
 
 ## Sensitive-data rule
 

--- a/app/components/UI/PredictNext/docs/ui-components.md
+++ b/app/components/UI/PredictNext/docs/ui-components.md
@@ -1,0 +1,60 @@
+# PredictNext UI component architecture
+
+PredictNext core UI uses composition to keep product variants explicit and reusable without accumulating mode props. Apply this guidance to complex, reusable structures such as Event cards, Event detail, Market groups, and charts. Keep simple leaf components simple.
+
+## Rules
+
+### Prefer explicit composition
+
+- Compose static structure with `children` rather than `renderHeader`, `renderFooter`, or similar render props.
+- Use render callbacks only when a parent must supply item data, as with a virtualized list.
+- Let consumers include, omit, and arrange independently useful parts without placeholder widgets.
+- Do not hide substantial product structure behind a monolithic component.
+
+### Avoid boolean mode props
+
+Do not grow a core component through combinations such as `isGame`, `showChart`, `showRules`, or `isCompact`. Boolean props remain appropriate for intrinsic platform state such as `disabled`; they are not a variant system.
+
+Create explicit product compositions instead, such as `EventCardStandard` and `EventCardGame`, from shared primitives. Each variant should make its rendered structure and supported actions obvious.
+
+### Use compound components where they earn their cost
+
+A compound API is appropriate when a reusable structure has independently useful parts or sibling parts share state. For example:
+
+```tsx
+<EventDetail.Root>
+  <EventDetail.Header />
+  <EventDetail.Content>
+    <MarketList />
+    <EventDetail.About />
+  </EventDetail.Content>
+</EventDetail.Root>
+```
+
+When sibling parts need shared state, expose the smallest typed provider contract needed by current callers. Separate it into `state`, `actions`, and presentation metadata where that distinction is useful. The provider owns the state mechanism; presentational parts consume the interface rather than importing product hooks or services.
+
+Do not add context merely to avoid passing one or two ordinary props. Do not create compound namespaces for leaf components that have no meaningful composition.
+
+### Keep product orchestration outside primitives
+
+- Views and React integration select canonical data, run queries, and own product workflows.
+- Presentational primitives render canonical values and express user intent through narrow callbacks.
+- A chart renderer receives labelled series and presentation state; it does not fetch Kalshi history or choose the active Market.
+- Venue DTOs, transport state, and service ownership never enter UI primitives.
+
+### Add only proven seams
+
+Build the parts and variants required by the active vertical slice. Do not create widget registries, universal section schemas, speculative variants, or extension APIs for hypothetical callers.
+
+## Story and review expectations
+
+For each complex core UI story:
+
+- state the intended composition and explicit variants in acceptance criteria;
+- reject boolean-prop proliferation and hidden incompatible modes;
+- cover the composed public behavior rather than implementation details;
+- test that independently interactive regions remain independent;
+- preserve accessibility semantics in every composition;
+- use MetaMask design-system components and tokens first.
+
+The goal is not to make every component compound. The goal is to make complex product UI flexible through visible composition while leaving simple code simple.

--- a/app/components/UI/PredictNext/docs/venue-adapters.md
+++ b/app/components/UI/PredictNext/docs/venue-adapters.md
@@ -26,7 +26,7 @@ Structural presence is executable truth. Product capability metadata may control
 
 ## Public and account-scoped data
 
-Public Event, Market, Outcome, Bid Price, Ask Price, and Venue Status reads are scoped by `venueId`. The first Kalshi browse slice is deliberately unauthenticated and does not require a selected wallet or fake Venue Session.
+Public Feed, Event, Category, Series, Market, Outcome, Volume, image, Bid Price, Ask Price, and Venue Status reads are scoped by `venueId`. The first Kalshi browse slice is deliberately unauthenticated and does not require a selected wallet or fake Venue Session.
 
 A later account-scoped route must use explicit required authentication. Do not opportunistically attach identity to public reads unless the contract and cache scope are intentionally personalized.
 
@@ -36,8 +36,9 @@ Account Readiness, Account Setup, portfolio, trading, and funding are account-sc
 
 - Predict User identity is distinct from Funding Wallet and Venue Account.
 - The backend authorizes account-scoped requests from authenticated MetaMask identity, not client-supplied identity fields.
-- Every root Event, query key, route, and durable Venue Operation is Venue-qualified.
-- Nested Markets and Outcomes carry their own opaque identifiers and inherit Venue and parent scope through containment.
+- Every root Feed, Event, query key, route, and durable Venue Operation is Venue-qualified.
+- A canonical Event maps to exactly one Venue Event; adapters never merge Markets from multiple Venue Events into one Event.
+- Nested Category, Series, Market, and Outcome values carry opaque identifiers and inherit Venue and parent scope through containment.
 - A raw Venue identifier is meaningful only with its containing `venueId`.
 - Canonical entities contain no raw credentials, PII/KYC values, or authentication subjects.
 
@@ -87,7 +88,9 @@ interface VenueMarketDataAdapter {
 }
 ```
 
-Event list and detail include the initial optional `bidPrice` and `askPrice` snapshot on each Outcome. There is no separate price operation in the first slice. Future live data may identify an Event, Market, and Outcome and patch these prices in cached Events.
+The implemented Event list and detail include the initial optional `bidPrice` and `askPrice` snapshot on each Outcome. There is no separate price operation in the first slice. Future live data may identify an Event, Market, and Outcome and patch these prices in cached Events.
+
+The agreed next contract replaces product Event-list reads with Feed reads, adds optional Category and Series metadata, Event and Market Volume/media, and a current-Event read for Rolling Series. Both fixed Event detail and Rolling Series current-Event reads return the same canonical Event type. See [`canonical-read-model-and-api.md`](./canonical-read-model-and-api.md); do not partially implement it across the trust boundary.
 
 Only add price history, batch price reads, search, carousel, account, portfolio, trading, funding, or live-data operations when an active product slice requires them.
 

--- a/app/components/UI/PredictNext/docs/venue-adapters.md
+++ b/app/components/UI/PredictNext/docs/venue-adapters.md
@@ -26,7 +26,7 @@ Structural presence is executable truth. Product capability metadata may control
 
 ## Public and account-scoped data
 
-Public Feed, Event, Category, Series, Market, Outcome, Volume, image, Bid Price, Ask Price, and Venue Status reads are scoped by `venueId`. The first Kalshi browse slice is deliberately unauthenticated and does not require a selected wallet or fake Venue Session.
+Public Feed, Event, Category, Series, Sports/Game context, Market, Outcome, Volume, image, Bid Price, Ask Price, and Venue Status reads are scoped by `venueId`. The first Kalshi browse slice is deliberately unauthenticated and does not require a selected wallet or fake Venue Session.
 
 A later account-scoped route must use explicit required authentication. Do not opportunistically attach identity to public reads unless the contract and cache scope are intentionally personalized.
 
@@ -90,7 +90,7 @@ interface VenueMarketDataAdapter {
 
 The implemented Event list and detail include the initial optional `bidPrice` and `askPrice` snapshot on each Outcome. There is no separate price operation in the first slice. Future live data may identify an Event, Market, and Outcome and patch these prices in cached Events.
 
-The agreed next contract replaces product Event-list reads with Feed reads, adds optional Category and Series metadata, Event and Market Volume/media, and a current-Event read for Rolling Series. Both fixed Event detail and Rolling Series current-Event reads return the same canonical Event type. See [`canonical-read-model-and-api.md`](./canonical-read-model-and-api.md); do not partially implement it across the trust boundary.
+The agreed next contract replaces product Event-list reads with Feed reads, adds optional Category and Series metadata, Event and Market Volume/media, optional Sports/Game snapshots and Outcome Game Selection, and a current-Event read for Rolling Series. Both fixed Event detail and Rolling Series current-Event reads return the same canonical Event type. Sports/Game data comes through those existing Event-bearing reads rather than a separate Game endpoint. See [`canonical-read-model-and-api.md`](./canonical-read-model-and-api.md); do not partially implement it across the trust boundary.
 
 Only add price history, batch price reads, search, carousel, account, portfolio, trading, funding, or live-data operations when an active product slice requires them.
 


### PR DESCRIPTION
## **Description**

Defines the agreed working direction for PredictNext's canonical public read model and MetaMask Predict REST API.

The proposal uses `Feed → Event → Market → Outcome`, keeps one complete Event shape for feed and detail reads, normalizes each Event to exactly one Venue Event, and adds optional primary Category, Collection/Rolling Series, Volume, 24-Hour Volume, image metadata, and Sports/Game context. The sports extension covers stable Sport and Competition IDs, home/away Teams, Game status/score/period/clock snapshots, and authoritative Outcome `gameSelection` values for home, away, or draw. It also adopts Kalshi's full Market lifecycle and documents immutable Event versus Rolling Series refresh semantics.

The new shareable design document includes TypeScript DTO sketches, Venue-qualified REST endpoints, Kalshi/Polymarket normalization responsibilities, concrete Game/props/crypto examples, migration impact, and intentionally deferred scope. Sports/Game snapshots use existing Feed and Event reads rather than a new Game endpoint, and Game status remains independent of Market lifecycle. Supporting PredictNext glossary, architecture, interface, and adapter docs now reference the same direction.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-1227

## **Manual testing steps**

```gherkin
Feature: PredictNext canonical read-model documentation

  Scenario: reviewer validates the proposed contract
    Given this pull request is checked out
    When the reviewer opens app/components/UI/PredictNext/docs/canonical-read-model-and-api.md
    Then the document defines the Feed, Event, Market, and Outcome relationships
    And it includes TypeScript DTO sketches and Venue-qualified REST endpoint examples
    And it defines canonical Sports, Competition, Game, Team, and Game Selection metadata
    And the linked PredictNext glossary, architecture, interface, and adapter documents use the same terminology
```

Automated documentation checks run:

- `yarn prettier --check CONTEXT.md docs/architecture.md docs/interface-ledger.md docs/remote-adapters.md docs/venue-adapters.md docs/canonical-read-model-and-api.md`
- `git diff --check`

## **Screenshots/Recordings**

N/A — documentation-only change with no user-facing UI.

### **Before**

N/A — no user-facing UI.

### **After**

N/A — no user-facing UI.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

Performance checks are not applicable because this PR changes documentation only.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no production code, APIs, or user-facing behavior changes.
> 
> **Overview**
> **Defines the agreed next public-read contract** for PredictNext in a new `canonical-read-model-and-api.md`: **`Feed → Event → Market → Outcome`**, one full **`PredictEvent`** for feed and detail, **one canonical Event per Venue Event**, optional **Category**, **collection/rolling Series**, **volume/24h/image**, Kalshi’s **eight-state Market lifecycle**, and **Sports/Game** metadata including authoritative **`gameSelection`**. It also specifies Venue-qualified REST routes (Feed, immutable Event, rolling Series current Event), backend normalization rules, examples, migration from the walking-skeleton contract, and deferred scope.
> 
> **Aligns surrounding docs**: **`CONTEXT.md`** and architecture/interface/adapter ledgers gain the same vocabulary and invariants; **`AGENTS.md`** / **`README.md`** add the new docs to the reading order; **`docs/ui-components.md`** (new) documents composition rules (explicit variants, no boolean mode props). **No runtime code changes**—implementation is explicitly future work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef174b14a5b18ccb7a3223a93ba63b52733cc1de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->