### PR TITLE
fix(perps): restore watchlist star on Lite market header cp-8.8.0

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -624,12 +624,10 @@ jest.mock('../../hooks', () => ({
   })),
 }));
 
-const mockAddToWatchlist = jest.fn();
-const mockRemoveFromWatchlist = jest.fn();
 jest.mock('../../hooks/usePerpsWatchlistActions', () => ({
   usePerpsWatchlistActions: jest.fn(() => ({
-    addToWatchlist: mockAddToWatchlist,
-    removeFromWatchlist: mockRemoveFromWatchlist,
+    addToWatchlist: jest.fn(),
+    removeFromWatchlist: jest.fn(),
   })),
 }));
 
@@ -3917,24 +3915,6 @@ describe('PerpsMarketDetailsView', () => {
           [PERPS_EVENT_PROPERTY.ASSET]: 'BTC',
         }),
       );
-    });
-
-    it('adds the market to the watchlist when the favorite button is pressed', () => {
-      const { getByTestId } = renderWithProvider(
-        <PerpsConnectionProvider>
-          <PerpsMarketDetailsView />
-        </PerpsConnectionProvider>,
-        {
-          state: initialState,
-        },
-      );
-
-      fireEvent.press(
-        getByTestId(PerpsMarketHeaderSelectorsIDs.FAVORITE_BUTTON),
-      );
-
-      expect(mockAddToWatchlist).toHaveBeenCalledWith('BTC');
-      expect(mockRemoveFromWatchlist).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -624,6 +624,37 @@ jest.mock('../../hooks', () => ({
   })),
 }));
 
+const mockAddToWatchlist = jest.fn();
+const mockRemoveFromWatchlist = jest.fn();
+jest.mock('../../hooks/usePerpsWatchlistActions', () => ({
+  usePerpsWatchlistActions: jest.fn(() => ({
+    addToWatchlist: mockAddToWatchlist,
+    removeFromWatchlist: mockRemoveFromWatchlist,
+  })),
+}));
+
+// Direct-path mocks for usePerpsMarketHeaderActions dependencies (it does not
+// import these from the hooks barrel).
+jest.mock('../../hooks/usePerpsNavigation', () => ({
+  usePerpsNavigation: jest.fn(() => ({
+    navigateToHome: mockNavigateToHome,
+    navigateToActivity: mockNavigateToActivity,
+    navigateToOrder: mockNavigateToOrder,
+    navigateToTutorial: mockNavigateToTutorial,
+    navigateToMarketList: mockNavigateToMarketList,
+    navigateToMarketListFromHeader: mockNavigateToMarketListFromHeader,
+    navigateBack: mockNavigateBack,
+    canGoBack: mockCanGoBack(),
+  })),
+}));
+
+jest.mock('../../hooks/usePerpsMode', () => ({
+  usePerpsMode: jest.fn(() => ({
+    mode: mockPerpsModeValue,
+    setMode: mockSetPerpsMode,
+  })),
+}));
+
 // Mock useABTest to return default (control/white) variant
 jest.mock('../../../../../hooks/useABTest', () => ({
   useABTest: () => ({
@@ -1010,7 +1041,7 @@ describe('PerpsMarketDetailsView', () => {
     });
   };
 
-  it('shows the active-mode pill next to search when the Pro mode flag is enabled', () => {
+  it('shows the favorite button and active-mode pill when the Pro mode flag is enabled', () => {
     enableProModeFlag();
 
     const { getByTestId } = renderWithProvider(
@@ -1023,7 +1054,7 @@ describe('PerpsMarketDetailsView', () => {
     );
 
     expect(
-      getByTestId(PerpsMarketHeaderSelectorsIDs.MARKET_LIST_BUTTON),
+      getByTestId(PerpsMarketHeaderSelectorsIDs.FAVORITE_BUTTON),
     ).toBeOnTheScreen();
     expect(
       getByTestId(PerpsModeToggleSelectorsIDs.LITE_SEGMENT),
@@ -3886,6 +3917,24 @@ describe('PerpsMarketDetailsView', () => {
           [PERPS_EVENT_PROPERTY.ASSET]: 'BTC',
         }),
       );
+    });
+
+    it('adds the market to the watchlist when the favorite button is pressed', () => {
+      const { getByTestId } = renderWithProvider(
+        <PerpsConnectionProvider>
+          <PerpsMarketDetailsView />
+        </PerpsConnectionProvider>,
+        {
+          state: initialState,
+        },
+      );
+
+      fireEvent.press(
+        getByTestId(PerpsMarketHeaderSelectorsIDs.FAVORITE_BUTTON),
+      );
+
+      expect(mockAddToWatchlist).toHaveBeenCalledWith('BTC');
+      expect(mockRemoveFromWatchlist).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -1,8 +1,5 @@
 import {
   Box,
-  BoxAlignItems,
-  BoxFlexDirection,
-  BoxJustifyContent,
   Button as DSButton,
   ButtonIcon,
   ButtonIconSize,
@@ -42,7 +39,6 @@ import Animated, { useAnimatedScrollHandler } from 'react-native-reanimated';
 import { scheduleOnRN } from 'react-native-worklets';
 import {
   CandlePeriod,
-  PerpsMode,
   TimeDuration,
   PERPS_CONSTANTS,
   type Position,
@@ -82,9 +78,6 @@ import PerpsMarketHeader, {
   createLiteMarketHeaderTestIDs,
 } from '../../components/PerpsMarketHeader';
 import PerpsMarketSummary from '../../components/PerpsMarketSummary';
-import PerpsModeToggle from '../../components/PerpsModeToggle';
-import { useDropPerpsHomeFromStackHistory } from '../../utils/perpsModeSwitch';
-import { openPerpsModeSelectionIfNeeded } from '../../utils/openPerpsModeSelection';
 import PerpsMarketAboutSection from '../../components/PerpsMarketAboutSection';
 import PerpsMarketHoursBanner from '../../components/PerpsMarketHoursBanner';
 import PerpsMarketStatisticsCard from '../../components/PerpsMarketStatisticsCard';
@@ -122,9 +115,9 @@ import {
   usePositionManagement,
   usePerpsTrading,
   usePerpsMarketData,
-  usePerpsMode,
   usePerpsMarketAboutTracking,
 } from '../../hooks';
+import { usePerpsMarketHeaderActions } from '../../hooks/usePerpsMarketHeaderActions';
 import { useConfirmNavigation } from '../../../../Views/confirmations/hooks/useConfirmNavigation';
 import { useDefaultPayWithTokenWhenNoPerpsBalance } from '../../hooks/useDefaultPayWithTokenWhenNoPerpsBalance';
 import {
@@ -168,10 +161,7 @@ import {
 } from '../../../MarketInsights';
 import { MarketInsightsSelectorsIDs } from '../../../MarketInsights/MarketInsights.testIds';
 import { selectMarketInsightsPerpsEnabled } from '../../../../../selectors/featureFlagController/marketInsights';
-import {
-  createSelectIsWatchlistMarket,
-  selectPerpsEligibility,
-} from '../../selectors/perpsController';
+import { selectPerpsEligibility } from '../../selectors/perpsController';
 import { useComplianceGate } from '../../../Compliance';
 import { selectSelectedInternalAccountAddress } from '../../../../../selectors/accountsController';
 import { useABTest } from '../../../../../hooks/useABTest';
@@ -203,15 +193,8 @@ interface MarketDetailsRouteParams {
 
 const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   // Use centralized navigation hook for all Perps navigation
-  const {
-    navigateToHome,
-    navigateToMarketListFromHeader,
-    navigateToOrder,
-    navigateToTutorial,
-    navigateToClosePosition,
-    navigateBack,
-    canGoBack,
-  } = usePerpsNavigation();
+  const { navigateToOrder, navigateToTutorial, navigateToClosePosition } =
+    usePerpsNavigation();
 
   // Use position management hook for bottom sheet state and handlers
   const {
@@ -348,43 +331,18 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     isLoading: isPerpsInsightsLoading,
   } = useMarketInsights(market?.symbol, isPerpsInsightsEnabled);
 
-  // Check if current market is in watchlist
-  const selectIsWatchlist = useMemo(
-    () => createSelectIsWatchlistMarket(market?.symbol || ''),
-    [market?.symbol],
-  );
-  // Source of truth for the favorite icon. The controller applies its own
-  // synchronous optimistic update (so the icon flips on the same tick the toggle
-  // fires) and reverts internally on remote-write failure, so no separate
-  // component-level optimistic copy is needed — a second copy could disagree with
-  // Redux if the controller's optimistic-then-revert collapsed before a reconcile.
-  const isWatchlist = useSelector(selectIsWatchlist);
-
-  // Pro-mode active-mode pill in the header (TAT-3551, AC #6.3).
   const isPerpsProModeEnabled = useSelector(selectPerpsProModeEnabledFlag);
-  const { mode: perpsMode, setMode: setPerpsMode } = usePerpsMode();
-  const dropPerpsHomeFromStackHistory = useDropPerpsHomeFromStackHistory();
-  const handlePerpsModeChange = useCallback(
-    async (nextMode: PerpsMode): Promise<boolean> => {
-      // PerpsModeSwitchPill runs the shimmer before invoking this callback. The
-      // one-time chooser gates every header toggle, so show it here when the
-      // user has not completed it and let the sheet own the switch.
-      const openedChooser = await openPerpsModeSelectionIfNeeded(navigation, {
-        entry: 'market',
-        source: PERPS_EVENT_VALUE.SOURCE.PERP_ASSET_SCREEN,
-      });
-      if (openedChooser) {
-        return false;
-      }
-
-      setPerpsMode(nextMode);
-      if (nextMode === PerpsMode.Pro) {
-        dropPerpsHomeFromStackHistory();
-      }
-      return true;
-    },
-    [navigation, setPerpsMode, dropPerpsHomeFromStackHistory],
-  );
+  const {
+    perpsMode,
+    isWatchlist,
+    handleBackPress,
+    handleMarketListPress,
+    handleFavoritePress,
+    handlePerpsModeChange,
+  } = usePerpsMarketHeaderActions({
+    symbol: market?.symbol,
+    backFallback: 'home',
+  });
 
   // Keep current market symbol ref in sync for staleness checks in async callbacks
   useEffect(() => {
@@ -904,80 +862,9 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
   // Check if notifications feature is enabled once
   const isNotificationsEnabled = isNotificationsFeatureEnabled();
 
-  const handleBackPress = () => {
-    if (canGoBack) {
-      navigateBack();
-    } else {
-      // Fallback to markets list if no previous screen
-      navigateToHome(PERPS_EVENT_VALUE.SOURCE.PERP_ASSET_SCREEN);
-    }
-  };
-
   const { marketData } = usePerpsMarketData({
     asset: market?.symbol || '',
   });
-
-  const handleMarketListPress = useCallback(() => {
-    if (!market) return;
-
-    track(MetaMetricsEvents.PERPS_UI_INTERACTION, {
-      [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
-        PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
-      [PERPS_EVENT_PROPERTY.BUTTON_CLICKED]:
-        PERPS_EVENT_VALUE.BUTTON_CLICKED.MARKET_LIST,
-      [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
-        PERPS_EVENT_VALUE.BUTTON_LOCATION.PERP_MARKET_DETAILS,
-      [PERPS_EVENT_PROPERTY.ASSET]: market.symbol,
-    });
-
-    navigateToMarketListFromHeader({
-      source: PERPS_EVENT_VALUE.SOURCE.PERP_ASSET_SCREEN,
-    });
-  }, [market, track, navigateToMarketListFromHeader]);
-
-  const liteHeaderEndAccessory = useMemo(() => {
-    const searchButton = (
-      <Box
-        alignItems={BoxAlignItems.Center}
-        justifyContent={BoxJustifyContent.Center}
-        twClassName="size-10"
-      >
-        <ButtonIcon
-          iconName={IconName.Search}
-          size={ButtonIconSize.Md}
-          onPress={handleMarketListPress}
-          testID={PerpsMarketHeaderSelectorsIDs.MARKET_LIST_BUTTON}
-          accessibilityLabel={strings('perps.market_details.market_list')}
-        />
-      </Box>
-    );
-
-    if (!isPerpsProModeEnabled) {
-      return searchButton;
-    }
-
-    return (
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-      >
-        {searchButton}
-        <Box justifyContent={BoxJustifyContent.Center} twClassName="h-10">
-          <PerpsModeToggle
-            mode={perpsMode}
-            variant="active"
-            onChange={handlePerpsModeChange}
-            source={PERPS_EVENT_VALUE.SOURCE.PERP_ASSET_SCREEN}
-          />
-        </Box>
-      </Box>
-    );
-  }, [
-    handleMarketListPress,
-    isPerpsProModeEnabled,
-    perpsMode,
-    handlePerpsModeChange,
-  ]);
 
   const handleTradeAction = useCallback(
     (direction: 'long' | 'short') =>
@@ -1656,9 +1543,13 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
         market={market}
         testIDs={createLiteMarketHeaderTestIDs()}
         onBackPress={handleBackPress}
+        onIdentityPress={handleMarketListPress}
+        onFavoritePress={handleFavoritePress}
+        isFavorite={isWatchlist}
+        mode={isPerpsProModeEnabled ? perpsMode : undefined}
+        onModeChange={isPerpsProModeEnabled ? handlePerpsModeChange : undefined}
         scrollY={scrollYShared}
         priceSectionHeight={titleSectionHeightSv}
-        endAccessory={liteHeaderEndAccessory}
       />
 
       <View style={styles.scrollableContentContainer}>

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.view.test.tsx
@@ -27,12 +27,15 @@ import {
 import { renderPerpsMarketDetailsView } from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
 import { getModifyActionLabels } from '../../../../../../tests/component-view/helpers/perpsViewTestHelpers';
 import Routes from '../../../../../constants/navigation/Routes';
+import Engine from '../../../../../core/Engine';
 import MarketInsightsView from '../../../MarketInsights/Views/MarketInsightsView/MarketInsightsView';
 import { MarketInsightsSelectorsIDs } from '../../../MarketInsights/MarketInsights.testIds';
 import { analytics } from '../../../../../util/analytics/analytics';
 import {
   PerpsMarketDetailsViewSelectorsIDs,
   PerpsMarketHeaderSelectorsIDs,
+  PerpsProMarketViewSelectorsIDs,
+  PerpsModeToggleSelectorsIDs,
   PerpsBottomSheetTooltipSelectorsIDs,
   PerpsPositionCardSelectorsIDs,
   PerpsTutorialSelectorsIDs,
@@ -507,6 +510,94 @@ describe('PerpsMarketDetailsView', () => {
       expect(
         screen.getByTestId(PerpsMarketHeaderSelectorsIDs.SUBTITLE),
       ).toHaveTextContent('ETH-USD perp');
+    });
+
+    it('opens the market list when the header identity is pressed', async () => {
+      renderPerpsMarketDetailsView({
+        streamOverrides: { positions: [] },
+        overrides: {
+          engine: {
+            backgroundState: {
+              PerpsController: { isEligible: true },
+            },
+          },
+        },
+        extraRoutes: [{ name: Routes.PERPS.MARKET_LIST }],
+      });
+
+      fireEvent.press(
+        await screen.findByTestId(
+          PerpsMarketHeaderSelectorsIDs.MARKET_LIST_BUTTON,
+        ),
+      );
+
+      expect(
+        await screen.findByTestId(`route-${Routes.PERPS.MARKET_LIST}`),
+      ).toBeOnTheScreen();
+    });
+
+    it('toggles watchlist when the header favorite button is pressed', async () => {
+      const toggleWatchlistMarket = Engine.context.PerpsController
+        .toggleWatchlistMarket as jest.Mock;
+      const getWatchlistMarkets = Engine.context.PerpsController
+        .getWatchlistMarkets as jest.Mock;
+      getWatchlistMarkets.mockReturnValue([]);
+
+      renderEligibleNoPositionPerpsDetails();
+
+      fireEvent.press(
+        await screen.findByTestId(
+          PerpsMarketHeaderSelectorsIDs.FAVORITE_BUTTON,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(toggleWatchlistMarket).toHaveBeenCalledWith('ETH');
+      });
+    });
+
+    it('shows Lite header actions without the Pro wallet button', async () => {
+      renderEligibleNoPositionPerpsDetails({
+        overrides: {
+          engine: {
+            backgroundState: {
+              PerpsController: { isEligible: true },
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  perpsProModeEnabled: {
+                    enabled: true,
+                    minimumVersion: '0.0.0',
+                  },
+                },
+              },
+            },
+          },
+        },
+        extraRoutes: [{ name: Routes.PERPS.MARKET_LIST }],
+      });
+
+      expect(
+        await screen.findByTestId(PerpsMarketHeaderSelectorsIDs.BACK_BUTTON),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByTestId(PerpsMarketHeaderSelectorsIDs.FAVORITE_BUTTON),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByTestId(PerpsModeToggleSelectorsIDs.LITE_SEGMENT),
+      ).toBeOnTheScreen();
+      expect(
+        screen.queryByTestId(
+          PerpsProMarketViewSelectorsIDs.HEADER_WALLET_BUTTON,
+        ),
+      ).not.toBeOnTheScreen();
+
+      fireEvent.press(
+        screen.getByTestId(PerpsMarketHeaderSelectorsIDs.MARKET_LIST_BUTTON),
+      );
+
+      expect(
+        await screen.findByTestId(`route-${Routes.PERPS.MARKET_LIST}`),
+      ).toBeOnTheScreen();
     });
 
     it('renders live price, 24h change, and fullscreen button inside the market summary row', async () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.view.test.tsx
@@ -17,8 +17,11 @@ import {
 } from '../../../../../../tests/component-view/fixtures/perpsViewFixtures';
 import { strings } from '../../../../../../locales/i18n';
 import {
+  PerpsBalanceBottomSheetSelectorsIDs,
+  PerpsModeToggleSelectorsIDs,
   PerpsOrderTypeBottomSheetSelectorsIDs,
   PerpsProOrderFormSelectorsIDs,
+  PerpsProMarketViewSelectorsIDs,
 } from '../../Perps.testIds';
 
 const ids = PerpsProOrderFormSelectorsIDs;
@@ -324,4 +327,39 @@ describeForPlatforms('PerpsProMarketView input journeys', () => {
       );
     },
   );
+});
+
+describe('PerpsProMarketView header actions', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows Pro header actions including wallet, watchlist, and mode toggle', async () => {
+    renderPerpsProMarketView();
+
+    expect(
+      await screen.findByTestId(
+        PerpsProMarketViewSelectorsIDs.HEADER_BACK_BUTTON,
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(
+        PerpsProMarketViewSelectorsIDs.HEADER_MARKET_LIST_BUTTON,
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(PerpsProMarketViewSelectorsIDs.HEADER_FAVORITE_BUTTON),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId(PerpsModeToggleSelectorsIDs.PRO_SEGMENT),
+    ).toBeOnTheScreen();
+
+    fireEvent.press(
+      screen.getByTestId(PerpsProMarketViewSelectorsIDs.HEADER_WALLET_BUTTON),
+    );
+
+    expect(
+      await screen.findByTestId(PerpsBalanceBottomSheetSelectorsIDs.CONTAINER),
+    ).toBeOnTheScreen();
+  });
 });

--- a/app/components/UI/Perps/hooks/usePerpsMarketHeaderActions.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketHeaderActions.ts
@@ -18,6 +18,13 @@ import { openPerpsModeSelectionIfNeeded } from '../utils/openPerpsModeSelection'
 export interface UsePerpsMarketHeaderActionsParams {
   /** Market symbol from route params; undefined when the screen is in an error state. */
   symbol?: string;
+  /**
+   * Where Back goes when there is no stack to pop.
+   * Lite uses `'home'` (Perps hub). Pro uses `'wallet'` because Pro's stack
+   * root is itself a market screen, so falling back to Home would be a no-op.
+   * @default 'wallet'
+   */
+  backFallback?: 'home' | 'wallet';
 }
 
 export interface UsePerpsMarketHeaderActionsResult {
@@ -44,10 +51,12 @@ export interface UsePerpsMarketHeaderActionsResult {
  */
 export const usePerpsMarketHeaderActions = ({
   symbol,
+  backFallback = 'wallet',
 }: UsePerpsMarketHeaderActionsParams): UsePerpsMarketHeaderActionsResult => {
   const {
     navigateBack,
     navigateToWallet,
+    navigateToHome,
     navigateToMarketListFromHeader,
     canGoBack,
   } = usePerpsNavigation();
@@ -68,13 +77,19 @@ export const usePerpsMarketHeaderActions = ({
   const handleBackPress = useCallback(() => {
     if (canGoBack) {
       navigateBack();
-    } else {
-      // No back stack (e.g. this is the Pro-mode stack root): "home" while
-      // Pro mode is active is itself a market screen, so falling back to it
-      // here would often be a no-op. Leave Perps entirely instead.
-      navigateToWallet();
+      return;
     }
-  }, [canGoBack, navigateBack, navigateToWallet]);
+
+    if (backFallback === 'home') {
+      navigateToHome(PERPS_EVENT_VALUE.SOURCE.PERP_ASSET_SCREEN);
+      return;
+    }
+
+    // No back stack (e.g. this is the Pro-mode stack root): "home" while
+    // Pro mode is active is itself a market screen, so falling back to it
+    // here would often be a no-op. Leave Perps entirely instead.
+    navigateToWallet();
+  }, [backFallback, canGoBack, navigateBack, navigateToHome, navigateToWallet]);
 
   const handleMarketListPress = useCallback(() => {
     if (!symbol) {

--- a/app/components/UI/Perps/hooks/usePerpsProMarketHeaderActions.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsProMarketHeaderActions.test.ts
@@ -9,6 +9,7 @@ import { usePerpsProMarketHeaderActions } from './usePerpsProMarketHeaderActions
 
 const mockNavigateBack = jest.fn();
 const mockNavigateToWallet = jest.fn();
+const mockNavigateToHome = jest.fn();
 const mockNavigateToMarketList = jest.fn();
 const mockNavigateToMarketListFromHeader = jest.fn();
 let mockCanGoBack = true;
@@ -17,6 +18,7 @@ jest.mock('./usePerpsNavigation', () => ({
   usePerpsNavigation: jest.fn(() => ({
     navigateBack: mockNavigateBack,
     navigateToWallet: mockNavigateToWallet,
+    navigateToHome: mockNavigateToHome,
     navigateToMarketList: mockNavigateToMarketList,
     navigateToMarketListFromHeader: mockNavigateToMarketListFromHeader,
     get canGoBack() {
@@ -105,6 +107,27 @@ describe('usePerpsProMarketHeaderActions', () => {
     });
 
     expect(mockNavigateToWallet).toHaveBeenCalledTimes(1);
+    expect(mockNavigateBack).not.toHaveBeenCalled();
+    expect(mockNavigateToHome).not.toHaveBeenCalled();
+  });
+
+  it('falls back to Perps Home when backFallback is home and the stack cannot go back', () => {
+    mockCanGoBack = false;
+    const { result } = renderHook(() =>
+      usePerpsProMarketHeaderActions({
+        symbol: 'BTC',
+        backFallback: 'home',
+      }),
+    );
+
+    act(() => {
+      result.current.handleBackPress();
+    });
+
+    expect(mockNavigateToHome).toHaveBeenCalledWith(
+      PERPS_EVENT_VALUE.SOURCE.PERP_ASSET_SCREEN,
+    );
+    expect(mockNavigateToWallet).not.toHaveBeenCalled();
     expect(mockNavigateBack).not.toHaveBeenCalled();
   });
 

--- a/tests/component-view/mocks.ts
+++ b/tests/component-view/mocks.ts
@@ -515,6 +515,8 @@ jest.mock('../../app/core/Engine', () => {
         resetFirstTimeUserState: jest.fn(),
         clearPendingTransactionRequests: jest.fn(),
         recordMarketViewed: jest.fn(),
+        getWatchlistMarkets: jest.fn(() => []),
+        toggleWatchlistMarket: jest.fn().mockResolvedValue(undefined),
       },
     },
     controllerMessenger: {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Lite market header dropped the watchlist star, so users could not favorite a market from the Lite market page ([TAT-3759](https://consensyssoftware.atlassian.net/browse/TAT-3759)).

This restores Lite header behavior to match Pro for market identity and watchlist:

- Tap market identity (icon + name + caret) opens the market list (replaces the Lite search icon)
- Watchlist star is shown in the header
- Lite/Pro mode pill still shows when the Pro flag is on
- Wallet icon remains Pro-only
- Lite back fallback stays Perps Home (not Wallet)

Header handlers now live in `usePerpsMarketHeaderActions`, with a `backFallback` param (`home` for Lite, `wallet` for Pro) so Lite and Pro share the same wiring without changing Pro navigation.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Restored the watchlist star on the Perps Lite market header

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
Refs: TAT-3759

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Lite market header watchlist and market list

  Background:
    Given I am logged into MetaMask Mobile
    And Perps is enabled
    And I am in Perps Lite mode
    And I am on a market details screen (for example BTC)

  Scenario: user favorites a market from the Lite header
    Given the market is not on my watchlist

    When user taps the star in the market header
    Then the star should appear filled
    And the market should be on my watchlist

  Scenario: user opens the market list from the Lite header identity
    When user taps the market identity (icon, name, and caret)
    Then the market list should open
    And the header should not show a search icon

  Scenario: user goes back from Lite market details with no stack
    Given there is no previous screen to pop

    When user taps Back
    Then I should land on Perps Home
    And I should not land on Wallet

  Scenario: Lite header shows the mode pill when Pro mode is available
    Given the Perps Pro mode flag is enabled

    When I view the Lite market header
    Then the Lite/Pro mode pill should be visible
    And the wallet icon should not be visible
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — add screenshots before marking ready for review.

### **After**

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-14 at 12 45 54" src="https://github.com/user-attachments/assets/5defac51-df90-4b53-8263-9f1e58ae429c" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


[TAT-3759]: https://consensyssoftware.atlassian.net/browse/TAT-3759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and navigation wiring in Perps market headers with test coverage; no auth, payments, or data-model changes beyond existing watchlist APIs.
> 
> **Overview**
> Restores **Lite** Perps market header parity with Pro: users can favorite from the header star, open the market list from the **market identity** (icon/name/caret) instead of a separate search icon, and still see the Lite/Pro pill when the Pro flag is on (wallet stays Pro-only).
> 
> **`PerpsMarketDetailsView`** drops inline header logic (custom `endAccessory` with search + `PerpsModeToggle`, local watchlist/mode handlers) and wires **`PerpsMarketHeader`** through **`usePerpsMarketHeaderActions`** with `backFallback: 'home'` so empty-stack Back goes to Perps Home, not Wallet.
> 
> **`usePerpsMarketHeaderActions`** gains optional **`backFallback`** (`'home' | 'wallet'`, default `'wallet'`) for shared Lite/Pro back behavior without changing Pro’s default.
> 
> Tests and component-view mocks cover favorite button, identity → market list, watchlist toggle, Lite vs Pro header actions, and **`PerpsController`** watchlist helpers in **`tests/component-view/mocks.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2fcfd1e1ffd19ebab927e0598016b9abe4ad39e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->