### PR TITLE
fix(tron): special assets not being identified correctly cp-8.8.0

### DIFF
--- a/app/components/UI/Bridge/utils/isTradableToken/index.test.ts
+++ b/app/components/UI/Bridge/utils/isTradableToken/index.test.ts
@@ -1,6 +1,7 @@
 import { TrxScope } from '@metamask/keyring-api';
 import { isTradableToken } from './index';
 import { BridgeToken } from '../../types';
+import { KnownCaip19Id } from '../../../../../core/Multichain/constants';
 
 // Helper function to create test tokens
 const createTestToken = (
@@ -170,13 +171,25 @@ describe('isTradableToken', () => {
 
       expect(result).toBe(true);
     });
+
+    it('returns true for native TRX', () => {
+      const token = createTestToken({
+        chainId: TrxScope.Mainnet,
+        address: `${TrxScope.Mainnet}/slip44:195`,
+        symbol: 'TRX',
+      });
+
+      const result = isTradableToken(token);
+
+      expect(result).toBe(true);
+    });
   });
 
   describe('non-tradable Tron resource tokens', () => {
     it('returns false for Tron Energy token', () => {
       const token = createTestToken({
         chainId: TrxScope.Mainnet,
-        symbol: 'energy',
+        address: KnownCaip19Id.EnergyMainnet,
       });
 
       const result = isTradableToken(token);
@@ -187,7 +200,7 @@ describe('isTradableToken', () => {
     it('returns false for Tron Bandwidth token', () => {
       const token = createTestToken({
         chainId: TrxScope.Mainnet,
-        symbol: 'bandwidth',
+        address: KnownCaip19Id.BandwidthMainnet,
       });
 
       const result = isTradableToken(token);
@@ -195,10 +208,10 @@ describe('isTradableToken', () => {
       expect(result).toBe(false);
     });
 
-    it('returns false for Tron Max Bandwidth token', () => {
+    it('returns false for Tron Maximum Bandwidth token', () => {
       const token = createTestToken({
         chainId: TrxScope.Mainnet,
-        symbol: 'max-bandwidth',
+        address: KnownCaip19Id.MaximumBandwidthMainnet,
       });
 
       const result = isTradableToken(token);
@@ -206,10 +219,10 @@ describe('isTradableToken', () => {
       expect(result).toBe(false);
     });
 
-    it('returns false for Tron energy token with lowercase', () => {
+    it('returns false for Tron Maximum Energy token', () => {
       const token = createTestToken({
         chainId: TrxScope.Mainnet,
-        symbol: 'energy',
+        address: KnownCaip19Id.MaximumEnergyMainnet,
       });
 
       const result = isTradableToken(token);
@@ -217,21 +230,10 @@ describe('isTradableToken', () => {
       expect(result).toBe(false);
     });
 
-    it('returns false for Tron bandwidth token with uppercase', () => {
+    it('returns false for TRX staked for energy', () => {
       const token = createTestToken({
         chainId: TrxScope.Mainnet,
-        symbol: 'BANDWIDTH',
-      });
-
-      const result = isTradableToken(token);
-
-      expect(result).toBe(false);
-    });
-
-    it('returns false for Tron max bandwidth token with mixed case', () => {
-      const token = createTestToken({
-        chainId: TrxScope.Mainnet,
-        symbol: 'MaX-BaNdWiDtH',
+        address: KnownCaip19Id.TrxStakedForEnergyMainnet,
       });
 
       const result = isTradableToken(token);
@@ -242,7 +244,7 @@ describe('isTradableToken', () => {
     it('returns false for Tron Ready for Withdrawal token', () => {
       const token = createTestToken({
         chainId: TrxScope.Mainnet,
-        symbol: 'TRX-READY-FOR-WITHDRAWAL',
+        address: KnownCaip19Id.TrxReadyForWithdrawalMainnet,
       });
 
       const result = isTradableToken(token);
@@ -253,7 +255,7 @@ describe('isTradableToken', () => {
     it('returns false for Tron Staking Rewards token', () => {
       const token = createTestToken({
         chainId: TrxScope.Mainnet,
-        symbol: 'TRX-STAKING-REWARDS',
+        address: KnownCaip19Id.TrxStakingRewardsMainnet,
       });
 
       const result = isTradableToken(token);
@@ -264,7 +266,7 @@ describe('isTradableToken', () => {
     it('returns false for Tron In Lock Period token', () => {
       const token = createTestToken({
         chainId: TrxScope.Mainnet,
-        symbol: 'TRX-IN-LOCK-PERIOD',
+        address: KnownCaip19Id.TrxInLockPeriodMainnet,
       });
 
       const result = isTradableToken(token);

--- a/app/components/UI/Bridge/utils/isTradableToken/index.ts
+++ b/app/components/UI/Bridge/utils/isTradableToken/index.ts
@@ -1,8 +1,6 @@
-import { TrxScope } from '@metamask/keyring-api';
 import { BridgeToken } from '../../types';
 import { isTronSpecialAsset } from '../../../../../core/Multichain/utils';
 import { TokenI } from '../../../Tokens/types';
 
 export const isTradableToken = (token: BridgeToken | TokenI) =>
-  token.chainId !== TrxScope.Mainnet ||
-  !isTronSpecialAsset(token.chainId, token.symbol);
+  !isTronSpecialAsset(token.address);

--- a/app/core/Multichain/constants.ts
+++ b/app/core/Multichain/constants.ts
@@ -155,27 +155,49 @@ export const PRICE_API_CURRENCIES = [
  * These are virtual resources and staking state assets passed from the Tron Snap
  * to the extension for informational purposes, not actual tradeable tokens.
  */
-export const TRON_SPECIAL_ASSET_SYMBOLS = {
-  ENERGY: 'energy',
-  BANDWIDTH: 'bandwidth',
-  MAX_ENERGY: 'max-energy',
-  MAX_BANDWIDTH: 'max-bandwidth',
-  STRX_ENERGY: 'strx-energy',
-  STRX_BANDWIDTH: 'strx-bandwidth',
-  TRX_READY_FOR_WITHDRAWAL: 'trx-ready-for-withdrawal',
-  TRX_STAKING_REWARDS: 'trx-staking-rewards',
-  TRX_IN_LOCK_PERIOD: 'trx-in-lock-period',
-} as const;
+export enum KnownCaip19Id {
+  TrxStakedForBandwidthMainnet = `${TrxScope.Mainnet}/slip44:195-staked-for-bandwidth`,
+  TrxStakedForBandwidthNile = `${TrxScope.Nile}/slip44:195-staked-for-bandwidth`,
+  TrxStakedForBandwidthShasta = `${TrxScope.Shasta}/slip44:195-staked-for-bandwidth`,
+
+  TrxStakedForEnergyMainnet = `${TrxScope.Mainnet}/slip44:195-staked-for-energy`,
+  TrxStakedForEnergyNile = `${TrxScope.Nile}/slip44:195-staked-for-energy`,
+  TrxStakedForEnergyShasta = `${TrxScope.Shasta}/slip44:195-staked-for-energy`,
+
+  TrxReadyForWithdrawalMainnet = `${TrxScope.Mainnet}/slip44:195-ready-for-withdrawal`,
+  TrxReadyForWithdrawalNile = `${TrxScope.Nile}/slip44:195-ready-for-withdrawal`,
+  TrxReadyForWithdrawalShasta = `${TrxScope.Shasta}/slip44:195-ready-for-withdrawal`,
+
+  TrxStakingRewardsMainnet = `${TrxScope.Mainnet}/slip44:195-staking-rewards`,
+  TrxStakingRewardsNile = `${TrxScope.Nile}/slip44:195-staking-rewards`,
+  TrxStakingRewardsShasta = `${TrxScope.Shasta}/slip44:195-staking-rewards`,
+
+  TrxInLockPeriodMainnet = `${TrxScope.Mainnet}/slip44:195-in-lock-period`,
+  TrxInLockPeriodNile = `${TrxScope.Nile}/slip44:195-in-lock-period`,
+  TrxInLockPeriodShasta = `${TrxScope.Shasta}/slip44:195-in-lock-period`,
+
+  EnergyMainnet = `${TrxScope.Mainnet}/slip44:energy`,
+  EnergyNile = `${TrxScope.Nile}/slip44:energy`,
+  EnergyShasta = `${TrxScope.Shasta}/slip44:energy`,
+
+  MaximumEnergyMainnet = `${TrxScope.Mainnet}/slip44:maximum-energy`,
+  MaximumEnergyNile = `${TrxScope.Nile}/slip44:maximum-energy`,
+  MaximumEnergyShasta = `${TrxScope.Shasta}/slip44:maximum-energy`,
+
+  BandwidthMainnet = `${TrxScope.Mainnet}/slip44:bandwidth`,
+  BandwidthNile = `${TrxScope.Nile}/slip44:bandwidth`,
+  BandwidthShasta = `${TrxScope.Shasta}/slip44:bandwidth`,
+
+  MaximumBandwidthMainnet = `${TrxScope.Mainnet}/slip44:maximum-bandwidth`,
+  MaximumBandwidthNile = `${TrxScope.Nile}/slip44:maximum-bandwidth`,
+  MaximumBandwidthShasta = `${TrxScope.Shasta}/slip44:maximum-bandwidth`,
+}
 
 export enum TronResourceType {
   ENERGY = 'ENERGY',
   BANDWIDTH = 'BANDWIDTH',
 }
 
-export type TronSpecialAssetSymbol =
-  (typeof TRON_SPECIAL_ASSET_SYMBOLS)[keyof typeof TRON_SPECIAL_ASSET_SYMBOLS];
-
-export const TRON_SPECIAL_ASSET_SYMBOLS_SET: ReadonlySet<TronSpecialAssetSymbol> =
-  new Set(
-    Object.values(TRON_SPECIAL_ASSET_SYMBOLS) as TronSpecialAssetSymbol[],
-  );
+export const TRON_SPECIAL_ASSET_IDS_SET: ReadonlySet<string> = new Set(
+  Object.values(KnownCaip19Id),
+);

--- a/app/core/Multichain/test/utils.test.ts
+++ b/app/core/Multichain/test/utils.test.ts
@@ -25,11 +25,15 @@ import {
   getAddressUrl,
   getTransactionUrl,
   isTronAddress,
+  isTronSpecialAsset,
 } from '../utils';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import Engine from '../../Engine';
-import { MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP } from '../constants';
+import {
+  MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP,
+  KnownCaip19Id,
+} from '../constants';
 import { formatAddress } from '../../../util/address';
 import {
   formatBlockExplorerAddressUrl,
@@ -523,6 +527,29 @@ describe('MultiChain utils', () => {
         expect(formatAddress).toHaveBeenCalledWith(MOCK_BTC_TX_ID, 'short');
         expect(result).toBe(shortenedBtcTxId);
       });
+    });
+  });
+
+  describe('isTronSpecialAsset', () => {
+    it('detects staked TRX assets by CAIP-19 ID', () => {
+      expect(isTronSpecialAsset(KnownCaip19Id.TrxStakedForEnergyMainnet)).toBe(
+        true,
+      );
+      expect(isTronSpecialAsset(KnownCaip19Id.EnergyNile)).toBe(true);
+      expect(isTronSpecialAsset(KnownCaip19Id.MaximumEnergyMainnet)).toBe(true);
+    });
+
+    it('does not treat native TRX, USDT, or unrecognized IDs as special assets', () => {
+      expect(isTronSpecialAsset('tron:728126428/slip44:195')).toBe(false);
+      expect(
+        isTronSpecialAsset(
+          'tron:728126428/trc20:TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+        ),
+      ).toBe(false);
+      expect(isTronSpecialAsset('tron:728126428/slip44:strx-energy')).toBe(
+        false,
+      );
+      expect(isTronSpecialAsset(undefined)).toBe(false);
     });
   });
 });

--- a/app/core/Multichain/utils.ts
+++ b/app/core/Multichain/utils.ts
@@ -13,8 +13,7 @@ import { CaipChainId, Hex } from '@metamask/utils';
 import { validate, Network } from 'bitcoin-address-validation';
 import {
   MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP,
-  TRON_SPECIAL_ASSET_SYMBOLS_SET,
-  TronSpecialAssetSymbol,
+  TRON_SPECIAL_ASSET_IDS_SET,
 } from './constants';
 import { formatAddress, isEthAddress } from '../../util/address';
 import {
@@ -288,18 +287,10 @@ export function shortenTransactionId(txId: string) {
  * Checks if a token is a Tron special asset (resources, staking state, etc.)
  * that should be filtered out from user-facing asset lists.
  *
- * @param chainId - The chain ID to check
- * @param symbol - The token symbol to check
- * @returns true if the token is a Tron special asset
+ * Matching is by CAIP-19 asset ID only — symbols are not stable across
+ * AssetsController migrations.
  */
 export const isTronSpecialAsset = (
-  chainId: string | undefined,
-  symbol: string | undefined,
-): boolean => {
-  if (!chainId?.startsWith('tron:') || !symbol) {
-    return false;
-  }
-  return TRON_SPECIAL_ASSET_SYMBOLS_SET.has(
-    symbol.toLowerCase() as TronSpecialAssetSymbol,
-  );
-};
+  assetId: string | undefined,
+): assetId is string =>
+  Boolean(assetId && TRON_SPECIAL_ASSET_IDS_SET.has(assetId));

--- a/app/selectors/assets/assets-list.test.ts
+++ b/app/selectors/assets/assets-list.test.ts
@@ -1995,10 +1995,10 @@ describe('selectTronSpecialAssetsBySelectedAccountGroup', () => {
               '2d89e6a0-b4e6-45a8-a707-f10cef143b42': [
                 'tron:728126428/slip44:energy',
                 'tron:728126428/slip44:bandwidth',
-                'tron:728126428/slip44:max-energy',
-                'tron:728126428/slip44:max-bandwidth',
-                'tron:728126428/slip44:strx-energy',
-                'tron:728126428/slip44:strx-bandwidth',
+                'tron:728126428/slip44:maximum-energy',
+                'tron:728126428/slip44:maximum-bandwidth',
+                'tron:728126428/slip44:195-staked-for-energy',
+                'tron:728126428/slip44:195-staked-for-bandwidth',
                 'tron:728126428/slip44:195-ready-for-withdrawal',
                 'tron:728126428/slip44:195-staking-rewards',
                 'tron:728126428/slip44:195-in-lock-period',
@@ -2022,7 +2022,7 @@ describe('selectTronSpecialAssetsBySelectedAccountGroup', () => {
                   { name: 'Bandwidth', symbol: 'BANDWIDTH', decimals: 0 },
                 ],
               },
-              'tron:728126428/slip44:max-energy': {
+              'tron:728126428/slip44:maximum-energy': {
                 name: 'Max Energy',
                 symbol: 'MAX-ENERGY',
                 fungible: true as const,
@@ -2031,7 +2031,7 @@ describe('selectTronSpecialAssetsBySelectedAccountGroup', () => {
                   { name: 'Max Energy', symbol: 'MAX-ENERGY', decimals: 0 },
                 ],
               },
-              'tron:728126428/slip44:max-bandwidth': {
+              'tron:728126428/slip44:maximum-bandwidth': {
                 name: 'Max Bandwidth',
                 symbol: 'MAX-BANDWIDTH',
                 fungible: true as const,
@@ -2044,28 +2044,28 @@ describe('selectTronSpecialAssetsBySelectedAccountGroup', () => {
                   },
                 ],
               },
-              'tron:728126428/slip44:strx-energy': {
+              'tron:728126428/slip44:195-staked-for-energy': {
                 name: 'Staked TRX Energy',
-                symbol: 'STRX-ENERGY',
+                symbol: 'sTRX-ENERGY',
                 fungible: true as const,
                 iconUrl: 'test-url',
                 units: [
                   {
                     name: 'Staked TRX Energy',
-                    symbol: 'STRX-ENERGY',
+                    symbol: 'sTRX-ENERGY',
                     decimals: 6,
                   },
                 ],
               },
-              'tron:728126428/slip44:strx-bandwidth': {
+              'tron:728126428/slip44:195-staked-for-bandwidth': {
                 name: 'Staked TRX Bandwidth',
-                symbol: 'STRX-BANDWIDTH',
+                symbol: 'sTRX-BANDWIDTH',
                 fungible: true as const,
                 iconUrl: 'test-url',
                 units: [
                   {
                     name: 'Staked TRX Bandwidth',
-                    symbol: 'STRX-BANDWIDTH',
+                    symbol: 'sTRX-BANDWIDTH',
                     decimals: 6,
                   },
                 ],
@@ -2130,21 +2130,21 @@ describe('selectTronSpecialAssetsBySelectedAccountGroup', () => {
                   amount: '560',
                   unit: 'BANDWIDTH',
                 },
-                'tron:728126428/slip44:max-energy': {
+                'tron:728126428/slip44:maximum-energy': {
                   amount: '200000',
                   unit: 'MAX-ENERGY',
                 },
-                'tron:728126428/slip44:max-bandwidth': {
+                'tron:728126428/slip44:maximum-bandwidth': {
                   amount: '1000',
                   unit: 'MAX-BANDWIDTH',
                 },
-                'tron:728126428/slip44:strx-energy': {
+                'tron:728126428/slip44:195-staked-for-energy': {
                   amount: '65.48463',
-                  unit: 'STRX-ENERGY',
+                  unit: 'sTRX-ENERGY',
                 },
-                'tron:728126428/slip44:strx-bandwidth': {
+                'tron:728126428/slip44:195-staked-for-bandwidth': {
                   amount: '65.48463',
-                  unit: 'STRX-BANDWIDTH',
+                  unit: 'sTRX-BANDWIDTH',
                 },
                 'tron:728126428/slip44:195-ready-for-withdrawal': {
                   amount: '25.5',
@@ -2191,15 +2191,17 @@ describe('selectTronSpecialAssetsBySelectedAccountGroup', () => {
     // All 9 special assets should be mapped
     expect(result.energy?.assetId).toBe('tron:728126428/slip44:energy');
     expect(result.bandwidth?.assetId).toBe('tron:728126428/slip44:bandwidth');
-    expect(result.maxEnergy?.assetId).toBe('tron:728126428/slip44:max-energy');
+    expect(result.maxEnergy?.assetId).toBe(
+      'tron:728126428/slip44:maximum-energy',
+    );
     expect(result.maxBandwidth?.assetId).toBe(
-      'tron:728126428/slip44:max-bandwidth',
+      'tron:728126428/slip44:maximum-bandwidth',
     );
     expect(result.stakedTrxForEnergy?.assetId).toBe(
-      'tron:728126428/slip44:strx-energy',
+      'tron:728126428/slip44:195-staked-for-energy',
     );
     expect(result.stakedTrxForBandwidth?.assetId).toBe(
-      'tron:728126428/slip44:strx-bandwidth',
+      'tron:728126428/slip44:195-staked-for-bandwidth',
     );
     expect(result.trxReadyForWithdrawal?.assetId).toBe(
       'tron:728126428/slip44:195-ready-for-withdrawal',

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -19,11 +19,7 @@ import I18n from '../../../locales/i18n';
 import { getLocaleLanguageCode } from '../../components/hooks/useFormatters';
 import { TokenI } from '../../components/UI/Tokens/types';
 import { sortAssetsWithPriority } from '../../components/UI/Tokens/util/sortAssetsWithPriority';
-import {
-  TRON_SPECIAL_ASSET_SYMBOLS,
-  TRON_SPECIAL_ASSET_SYMBOLS_SET,
-  TronSpecialAssetSymbol,
-} from '../../core/Multichain/constants';
+import { KnownCaip19Id } from '../../core/Multichain/constants';
 import { isTronSpecialAsset } from '../../core/Multichain/utils';
 import { RootState } from '../../reducers';
 import { formatWithThreshold } from '../../util/assets';
@@ -93,6 +89,53 @@ export interface TronSpecialAssetsMap {
   /** TRX in lock period (unstaked but waiting for lock period to end) */
   trxInLockPeriod: Asset | undefined;
 }
+
+type TronSpecialAssetKey = Exclude<
+  keyof TronSpecialAssetsMap,
+  'totalStakedTrx'
+>;
+
+/**
+ * Maps each Tron special-asset CAIP-19 ID to its semantic key in
+ * {@link TronSpecialAssetsMap}. Network-specific IDs collapse to the same key.
+ */
+const TRON_SPECIAL_ASSET_KEYS = {
+  [KnownCaip19Id.EnergyMainnet]: 'energy',
+  [KnownCaip19Id.EnergyNile]: 'energy',
+  [KnownCaip19Id.EnergyShasta]: 'energy',
+
+  [KnownCaip19Id.BandwidthMainnet]: 'bandwidth',
+  [KnownCaip19Id.BandwidthNile]: 'bandwidth',
+  [KnownCaip19Id.BandwidthShasta]: 'bandwidth',
+
+  [KnownCaip19Id.MaximumEnergyMainnet]: 'maxEnergy',
+  [KnownCaip19Id.MaximumEnergyNile]: 'maxEnergy',
+  [KnownCaip19Id.MaximumEnergyShasta]: 'maxEnergy',
+
+  [KnownCaip19Id.MaximumBandwidthMainnet]: 'maxBandwidth',
+  [KnownCaip19Id.MaximumBandwidthNile]: 'maxBandwidth',
+  [KnownCaip19Id.MaximumBandwidthShasta]: 'maxBandwidth',
+
+  [KnownCaip19Id.TrxStakedForEnergyMainnet]: 'stakedTrxForEnergy',
+  [KnownCaip19Id.TrxStakedForEnergyNile]: 'stakedTrxForEnergy',
+  [KnownCaip19Id.TrxStakedForEnergyShasta]: 'stakedTrxForEnergy',
+
+  [KnownCaip19Id.TrxStakedForBandwidthMainnet]: 'stakedTrxForBandwidth',
+  [KnownCaip19Id.TrxStakedForBandwidthNile]: 'stakedTrxForBandwidth',
+  [KnownCaip19Id.TrxStakedForBandwidthShasta]: 'stakedTrxForBandwidth',
+
+  [KnownCaip19Id.TrxReadyForWithdrawalMainnet]: 'trxReadyForWithdrawal',
+  [KnownCaip19Id.TrxReadyForWithdrawalNile]: 'trxReadyForWithdrawal',
+  [KnownCaip19Id.TrxReadyForWithdrawalShasta]: 'trxReadyForWithdrawal',
+
+  [KnownCaip19Id.TrxStakingRewardsMainnet]: 'trxStakingRewards',
+  [KnownCaip19Id.TrxStakingRewardsNile]: 'trxStakingRewards',
+  [KnownCaip19Id.TrxStakingRewardsShasta]: 'trxStakingRewards',
+
+  [KnownCaip19Id.TrxInLockPeriodMainnet]: 'trxInLockPeriod',
+  [KnownCaip19Id.TrxInLockPeriodNile]: 'trxInLockPeriod',
+  [KnownCaip19Id.TrxInLockPeriodShasta]: 'trxInLockPeriod',
+} as const satisfies Record<KnownCaip19Id, TronSpecialAssetKey>;
 
 /**
  * Empty constant to avoid creating new objects on each call when no Tron networks are enabled.
@@ -343,7 +386,7 @@ export const createSelectSortedAssetsBySelectedAccountGroup = (
         .filter(([networkId]) => enabledNetworks.includes(networkId))
         .flatMap(([_, chainAssets]) =>
           chainAssets.filter((asset) => {
-            if (isTronSpecialAsset(asset.chainId, asset.symbol)) return false;
+            if (isTronSpecialAsset(asset.assetId)) return false;
             if (isAssetSupportActivation(asset.assetId)) return true;
             if (
               hideZeroBalance &&
@@ -468,9 +511,7 @@ export const selectSortedAssetsBySelectedAccountGroupForChainIds =
       const filteredAssets = Object.entries(bip44Assets)
         .filter(([networkId]) => allowedIds.has(networkId))
         .flatMap(([_, chainAssets]) =>
-          chainAssets.filter(
-            (asset) => !isTronSpecialAsset(asset.chainId, asset.symbol),
-          ),
+          chainAssets.filter((asset) => !isTronSpecialAsset(asset.assetId)),
         );
       return mergeStakedSortAndDedupeAssets(
         filteredAssets,
@@ -498,7 +539,7 @@ export const selectSortedAssetsBySelectedAccountGroupForChainIdsByBalance =
         .filter(([networkId]) => allowedIds.has(networkId))
         .flatMap(([_, chainAssets]) =>
           chainAssets.filter((asset) => {
-            if (isTronSpecialAsset(asset.chainId, asset.symbol)) return false;
+            if (isTronSpecialAsset(asset.assetId)) return false;
             if (isAssetSupportActivation(asset.assetId)) return true;
             if (hideZeroBalance && parseFloat(asset.balance ?? '0') === 0)
               return false;
@@ -689,38 +730,12 @@ export const selectTronSpecialAssetsBySelectedAccountGroup =
         if (!enabledTronNetworksSet.has(networkId)) continue;
 
         for (const asset of chainAssets) {
-          const symbol = asset.symbol?.toLowerCase() as TronSpecialAssetSymbol;
-          if (!TRON_SPECIAL_ASSET_SYMBOLS_SET.has(symbol)) continue;
-
-          switch (symbol) {
-            case TRON_SPECIAL_ASSET_SYMBOLS.ENERGY:
-              specialAssetsMap.energy = asset;
-              break;
-            case TRON_SPECIAL_ASSET_SYMBOLS.BANDWIDTH:
-              specialAssetsMap.bandwidth = asset;
-              break;
-            case TRON_SPECIAL_ASSET_SYMBOLS.MAX_ENERGY:
-              specialAssetsMap.maxEnergy = asset;
-              break;
-            case TRON_SPECIAL_ASSET_SYMBOLS.MAX_BANDWIDTH:
-              specialAssetsMap.maxBandwidth = asset;
-              break;
-            case TRON_SPECIAL_ASSET_SYMBOLS.STRX_ENERGY:
-              specialAssetsMap.stakedTrxForEnergy = asset;
-              break;
-            case TRON_SPECIAL_ASSET_SYMBOLS.STRX_BANDWIDTH:
-              specialAssetsMap.stakedTrxForBandwidth = asset;
-              break;
-            case TRON_SPECIAL_ASSET_SYMBOLS.TRX_READY_FOR_WITHDRAWAL:
-              specialAssetsMap.trxReadyForWithdrawal = asset;
-              break;
-            case TRON_SPECIAL_ASSET_SYMBOLS.TRX_STAKING_REWARDS:
-              specialAssetsMap.trxStakingRewards = asset;
-              break;
-            case TRON_SPECIAL_ASSET_SYMBOLS.TRX_IN_LOCK_PERIOD:
-              specialAssetsMap.trxInLockPeriod = asset;
-              break;
+          if (!Object.hasOwn(TRON_SPECIAL_ASSET_KEYS, asset.assetId)) {
+            continue;
           }
+
+          const key = TRON_SPECIAL_ASSET_KEYS[asset.assetId as KnownCaip19Id];
+          specialAssetsMap[key] = asset;
         }
       }
 

--- a/app/selectors/multichain/multichain.test.ts
+++ b/app/selectors/multichain/multichain.test.ts
@@ -753,7 +753,7 @@ describe('MultichainNonEvm Selectors', () => {
         const tronMainnetAssetId =
           `${tronMainnetChainId}/slip44:195` as CaipAssetType;
         const tronResourceAssetId =
-          `${tronMainnetChainId}/token:resource-energy` as CaipAssetType;
+          `${tronMainnetChainId}/slip44:energy` as CaipAssetType;
         const tronTestnetAssetId =
           `${tronTestnetChainId}/slip44:195` as CaipAssetType;
 

--- a/app/selectors/multichain/multichain.ts
+++ b/app/selectors/multichain/multichain.ts
@@ -291,6 +291,7 @@ export const selectMultichainTokenListForAccountsAnyChain =
 
           tokens.push({
             name: metadata?.name ?? '',
+            // TokenI has no assetId; non-EVM CAIP-19 IDs are stored in address.
             address: assetId,
             symbol: metadata?.symbol ?? '',
             image: metadata?.iconUrl,
@@ -349,7 +350,9 @@ export const selectAccountTokensAcrossChainsUnified = createDeepEqualSelector(
         selectMultichainTokenListForAccountsAnyChain(state, [account]) || [];
 
       for (const token of nonEvmTokensForAccount) {
-        if (isTronSpecialAsset(String(token.chainId), token.symbol)) {
+        // TokenI has no assetId. This Earn adapter maps CAIP-19 IDs onto
+        // TokenI.address (see selectMultichainTokenListForAccountsAnyChain).
+        if (isTronSpecialAsset(token.address)) {
           continue;
         }
         // We just need tron mainnet, at least for now


### PR DESCRIPTION
## **Description**

Tron special assets (staked TRX, energy, bandwidth, and staking lifecycle) were identified by **symbol** (`strx-energy`, `max-energy`, and similar). After the Assets Controller migration those values live under stable CAIP-19 IDs (for example `slip44:195-staked-for-energy` and `slip44:maximum-energy`), so the lookups never matched.

That left the TRX token detail page without a staked balance, and showed incorrect energy and bandwidth values, even though controller state was correct.

This change identifies special assets by CAIP-19 ID only (`KnownCaip19Id` / `TRON_SPECIAL_ASSET_IDS_SET`), using the same grouping pattern as the old symbol list.

## **Changelog**

CHANGELOG entry: Fixed Tron staked TRX, energy, and bandwidth not displaying correctly on token details

## **Related issues**

Fixes: [WPN-1854](https://consensyssoftware.atlassian.net/browse/WPN-1854)

## **Manual testing steps**

```gherkin
Feature: Tron special assets on token details

  Scenario: user opens TRX token details with staked TRX
    Given a Tron account with TRX staked for energy or bandwidth
    When the user opens the TRX token detail page
    Then the staked TRX balance is shown
    And stake and unstake actions are available
    And energy and bandwidth values match controller state
```

## **Screenshots/Recordings**

### **Before**

N/A — screenshots to be added after manual verification on device.

### **After**

N/A — screenshots to be added after manual verification on device.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[WPN-1854]: https://consensyssoftware.atlassian.net/browse/WPN-1854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ