### PR TITLE
perf: throttle perps PnL price ticks and gate Polymarket WS on focus

### DIFF
--- a/app/components/UI/Perps/hooks/stream/useLivePositions.test.ts
+++ b/app/components/UI/Perps/hooks/stream/useLivePositions.test.ts
@@ -126,7 +126,7 @@ describe('usePerpsLivePositions', () => {
       expect(mockPricesSubscribeToSymbols).toHaveBeenCalledWith({
         symbols: ['BTC-PERP', 'ETH-PERP'],
         callback: expect.any(Function),
-        throttleMs: 0,
+        throttleMs: 1000,
       });
       expect(mockPricesSubscribe).not.toHaveBeenCalled();
     });

--- a/app/components/UI/Perps/hooks/stream/usePerpsLivePositions.ts
+++ b/app/components/UI/Perps/hooks/stream/usePerpsLivePositions.ts
@@ -13,6 +13,12 @@ export interface UsePerpsLivePositionsOptions {
   throttleMs?: number;
   /** Whether to subscribe to price updates for live PnL calculations (default: false) */
   useLivePnl?: boolean;
+  /**
+   * Throttle delay for price updates when useLivePnl is true (default: 1000ms).
+   * PnL doesn't need sub-second precision; throttling reduces GC pressure from
+   * the `{...prev, ...newPriceData}` merge that runs on every price tick.
+   */
+  pnlThrottleMs?: number;
 }
 
 export interface UsePerpsLivePositionsReturn {
@@ -97,12 +103,13 @@ export function enrichPositionsWithLivePnL(
  * @param options - Configuration options for the hook
  * @param options.throttleMs - Throttle delay in milliseconds (default: 0)
  * @param options.useLivePnl - Whether to subscribe to price updates for live PnL calculations (default: false)
+ * @param options.pnlThrottleMs - Throttle delay for price updates used in PnL calculations (default: 1000)
  * @returns Object containing positions array with optional live PnL and loading state
  */
 export function usePerpsLivePositions(
   options: UsePerpsLivePositionsOptions = {},
 ): UsePerpsLivePositionsReturn {
-  const { throttleMs = 0, useLivePnl = false } = options; // No live PnL by default to avoid unnecessary re-renders
+  const { throttleMs = 0, useLivePnl = false, pnlThrottleMs = 1000 } = options; // No live PnL by default to avoid unnecessary re-renders
   const stream = usePerpsStream();
   const initialChannelPositions = stream.positions.getSnapshot();
   const [isInitialLoading, setIsInitialLoading] = useState(() => {
@@ -204,7 +211,7 @@ export function usePerpsLivePositions(
         // would wipe other positions' prices when a partial batch arrives.
         setPriceData((prev) => ({ ...prev, ...newPriceData }));
       },
-      throttleMs,
+      throttleMs: pnlThrottleMs,
     });
 
     return () => {
@@ -214,7 +221,7 @@ export function usePerpsLivePositions(
     // intentionally omitted to avoid re-subscribing when the array reference
     // changes but its contents are the same.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [stream, symbolsKey, throttleMs, useLivePnl]);
+  }, [stream, symbolsKey, pnlThrottleMs, useLivePnl]);
 
   return {
     positions,

--- a/app/components/UI/Predict/hooks/useLiveCryptoPrices.test.ts
+++ b/app/components/UI/Predict/hooks/useLiveCryptoPrices.test.ts
@@ -3,6 +3,10 @@ import { useLiveCryptoPrices } from './useLiveCryptoPrices';
 import Engine from '../../../../core/Engine';
 import { CryptoPriceUpdate } from '../types';
 
+jest.mock('@react-navigation/native', () => ({
+  useIsFocused: jest.fn(() => true),
+}));
+
 jest.mock('../../../../core/Engine', () => ({
   context: {
     PredictController: {

--- a/app/components/UI/Predict/hooks/useLiveCryptoPrices.ts
+++ b/app/components/UI/Predict/hooks/useLiveCryptoPrices.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
+import { useIsFocused } from '@react-navigation/native';
 import Engine from '../../../../core/Engine';
 import { CryptoPriceUpdate, type CryptoTwapWindowSeconds } from '../types';
 
@@ -12,6 +13,7 @@ export const useLiveCryptoPrices = (
   twapWindowSeconds?: CryptoTwapWindowSeconds,
 ): UseLiveCryptoPricesResult => {
   const [isConnected, setIsConnected] = useState(false);
+  const isFocused = useIsFocused();
   const isMountedRef = useRef(true);
   const isConnectedRef = useRef(false);
   const onUpdateRef = useRef(onUpdate);
@@ -20,7 +22,7 @@ export const useLiveCryptoPrices = (
   useEffect(() => {
     isMountedRef.current = true;
 
-    if (!symbol) {
+    if (!symbol || !isFocused) {
       isConnectedRef.current = false;
       setIsConnected(false);
       return () => {
@@ -54,7 +56,7 @@ export const useLiveCryptoPrices = (
       setIsConnected(false);
       unsubscribe();
     };
-  }, [symbol, twapWindowSeconds]);
+  }, [symbol, twapWindowSeconds, isFocused]);
 
   return { isConnected };
 };

--- a/app/components/UI/Predict/hooks/useLiveMarketPrices.test.ts
+++ b/app/components/UI/Predict/hooks/useLiveMarketPrices.test.ts
@@ -6,6 +6,10 @@ import {
 import Engine from '../../../../core/Engine';
 import { PriceUpdate } from '../types';
 
+jest.mock('@react-navigation/native', () => ({
+  useIsFocused: jest.fn(() => true),
+}));
+
 jest.mock('../../../../core/Engine', () => ({
   context: {
     PredictController: {

--- a/app/components/UI/Predict/hooks/useLiveMarketPrices.ts
+++ b/app/components/UI/Predict/hooks/useLiveMarketPrices.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
+import { useIsFocused } from '@react-navigation/native';
 import Engine from '../../../../core/Engine';
 import { PriceUpdate } from '../types';
 
@@ -64,6 +65,7 @@ export const useLiveMarketPrices = (
   options: UseLiveMarketPricesOptions = {},
 ): UseLiveMarketPricesResult => {
   const { enabled = true } = options;
+  const isFocused = useIsFocused();
   const [prices, setPrices] = useState<Map<string, PriceUpdate>>(
     () => getCachedPrices(tokenIds).prices,
   );
@@ -158,7 +160,7 @@ export const useLiveMarketPrices = (
       setLastUpdateTime(cachedPrices.lastUpdateTime);
     }
 
-    if (!enabled || currentTokenIds.length === 0) {
+    if (!enabled || !isFocused || currentTokenIds.length === 0) {
       setIsConnected(false);
       return;
     }
@@ -181,7 +183,7 @@ export const useLiveMarketPrices = (
       unsubscribe();
       unsubscribeStatus();
     };
-  }, [tokenIdsKey, enabled, handlePriceUpdates]);
+  }, [tokenIdsKey, enabled, isFocused, handlePriceUpdates]);
 
   const getPrice = useCallback(
     (tokenId: string): PriceUpdate | undefined => prices.get(tokenId),


### PR DESCRIPTION
## **Description**

Updates `@metamask/perps-controller` from v11 to v12 and adapts Mobile to the controller's new order types and error codes. Close-position flows remain restricted to ordinary market and limit orders, while the new TWAP, scale, and chase validation errors are mapped to user-facing English messages.

The change also updates Perps controller fixtures for the v12 `proLayoutPreferences` state and adds default Hyperliquid API mocks required by E2E initialization, including a valid `userAbstraction` response.

## **Changelog**

CHANGELOG entry: Updated Perps with the latest trading engine and clearer errors for advanced order types

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3761

## **Manual testing steps**

N/A — this dependency integration has no intentional visual changes. The affected behavior is covered by Perps error-translation tests, type checking, and E2E fixture validation.

```gherkin
Feature: Perps controller v12 integration

  Scenario: A user closes a Perps position
    Given the user has an open Perps position
    When the user selects a close-position order type
    Then only ordinary market and limit order types are accepted

  Scenario: A strategy order fails validation
    Given the Perps controller returns a v12 strategy-order error code
    When Mobile translates the error
    Then the corresponding user-facing message is displayed
```

## **Screenshots/Recordings**

N/A — no intentional visual changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.