### PR TITLE
feat: add tab navigation for limit and recurring orders

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -1208,7 +1208,7 @@ const MainNavigator = () => {
       <NativeStack.Screen
         name={Routes.BRIDGE.ROOT}
         component={BridgeScreenStack}
-        options={slideFromRightNativeOptions}
+        options={{ ...slideFromRightNativeOptions, gestureEnabled: false }}
       />
       <NativeStack.Screen
         name={Routes.BRIDGE.MODALS.ROOT}

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
@@ -2626,7 +2626,7 @@ describe('BridgeView', () => {
       });
     });
 
-    it('does not navigate back on a right swipe over the tab content when the tabs bar is hidden', async () => {
+    it('navigates back on a right swipe over the tab content when the tabs bar is hidden', async () => {
       renderScreen(
         BridgeView,
         { name: Routes.BRIDGE.ROOT },
@@ -2641,7 +2641,7 @@ describe('BridgeView', () => {
         await Promise.resolve();
       });
 
-      expect(mockGoBack).not.toHaveBeenCalled();
+      expect(mockGoBack).toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
@@ -2625,5 +2625,23 @@ describe('BridgeView', () => {
         ).toBeOnTheScreen();
       });
     });
+
+    it('does not navigate back on a right swipe over the tab content when the tabs bar is hidden', async () => {
+      renderScreen(
+        BridgeView,
+        { name: Routes.BRIDGE.ROOT },
+        { state: mockState },
+      );
+
+      await act(async () => {
+        fireGestureHandler(
+          getByGestureTestId(BridgeViewSelectorsIDs.TABS_SWIPE_GESTURE),
+          [{ translationX: 80, velocityX: 600 }],
+        );
+        await Promise.resolve();
+      });
+
+      expect(mockGoBack).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.test.tsx
@@ -1,3 +1,8 @@
+import {
+  fireGestureHandler,
+  getByGestureTestId,
+} from 'react-native-gesture-handler/jest-utils';
+import { merge } from 'lodash';
 import { initialState } from '../../_mocks_/initialState';
 import {
   renderScreen,
@@ -236,6 +241,7 @@ jest.mock(
 
 const mockNavigate = jest.fn();
 const mockSetParams = jest.fn();
+const mockGoBack = jest.fn();
 const mockFocusEffects: (() => void | (() => void))[] = [];
 const mockRoute = {
   params: {
@@ -254,6 +260,7 @@ jest.mock('@react-navigation/native', () => {
       navigate: mockNavigate,
       setParams: mockSetParams,
       setOptions: jest.fn(),
+      goBack: mockGoBack,
     }),
     useRoute: () => mockRoute,
   };
@@ -2511,6 +2518,112 @@ describe('BridgeView', () => {
       expect(
         getByText(strings('swaps.market_price_unavailable')),
       ).toBeOnTheScreen();
+    });
+  });
+
+  describe('Tab swipe navigation', () => {
+    const stateWithTabsEnabled = () =>
+      merge({}, mockState, {
+        engine: {
+          backgroundState: {
+            RemoteFeatureFlagController: {
+              remoteFeatureFlags: {
+                swapsLimitOrder: { enabled: true },
+                swapsRecurringBuy: { enabled: true },
+              },
+            },
+          },
+        },
+      }) as DeepPartial<RootState>;
+
+    const swipe = (translationX: number, velocityX = 0) => {
+      act(() => {
+        fireGestureHandler(
+          getByGestureTestId(BridgeViewSelectorsIDs.TABS_SWIPE_GESTURE),
+          [{ translationX, velocityX }],
+        );
+      });
+    };
+
+    it('navigates to the next tab on a left swipe', async () => {
+      const { getByTestId, queryByTestId } = renderScreen(
+        BridgeView,
+        { name: Routes.BRIDGE.ROOT },
+        { state: stateWithTabsEnabled() },
+      );
+
+      expect(
+        queryByTestId(BridgeViewSelectorsIDs.LIMIT_ORDER_CONTAINER),
+      ).toBeNull();
+
+      swipe(-80, -600);
+
+      await waitFor(() => {
+        expect(
+          getByTestId(BridgeViewSelectorsIDs.LIMIT_ORDER_CONTAINER),
+        ).toBeOnTheScreen();
+      });
+    });
+
+    it('navigates to the previous tab on a right swipe', async () => {
+      const { getByTestId, queryByTestId } = renderScreen(
+        BridgeView,
+        { name: Routes.BRIDGE.ROOT },
+        { state: stateWithTabsEnabled() },
+      );
+
+      fireEvent.press(getByTestId(BridgeViewSelectorsIDs.LIMIT_TAB));
+      await waitFor(() => {
+        expect(
+          getByTestId(BridgeViewSelectorsIDs.LIMIT_ORDER_CONTAINER),
+        ).toBeOnTheScreen();
+      });
+
+      swipe(80, 600);
+
+      await waitFor(() => {
+        expect(
+          queryByTestId(BridgeViewSelectorsIDs.LIMIT_ORDER_CONTAINER),
+        ).toBeNull();
+      });
+      expect(mockGoBack).not.toHaveBeenCalled();
+    });
+
+    it('navigates back when swiping right on the first tab', async () => {
+      renderScreen(
+        BridgeView,
+        { name: Routes.BRIDGE.ROOT },
+        { state: stateWithTabsEnabled() },
+      );
+
+      swipe(80, 600);
+
+      await waitFor(() => {
+        expect(mockGoBack).toHaveBeenCalled();
+      });
+    });
+
+    it('does not swipe past the last tab', async () => {
+      const { getByTestId, queryByTestId } = renderScreen(
+        BridgeView,
+        { name: Routes.BRIDGE.ROOT },
+        { state: stateWithTabsEnabled() },
+      );
+
+      fireEvent.press(getByTestId(BridgeViewSelectorsIDs.RECURRING_TAB));
+      await waitFor(() => {
+        expect(
+          getByTestId(BridgeViewSelectorsIDs.RECURRING_BUY_CONTAINER),
+        ).toBeOnTheScreen();
+      });
+
+      swipe(-80, -600);
+
+      await waitFor(() => {
+        expect(
+          queryByTestId(BridgeViewSelectorsIDs.RECURRING_BUY_CONTAINER),
+        ).toBeOnTheScreen();
+      });
     });
   });
 });

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.testIds.ts
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.testIds.ts
@@ -13,6 +13,8 @@ export const BridgeViewSelectorsIDs = {
   MISSING_PRICE_BANNER: 'bridge-missing-price-banner',
   NO_QUOTES_BANNER: 'bridge-no-quotes',
   TABS_BAR: 'bridge-tabs-bar',
+  TABS_CONTENT: 'bridge-tabs-content',
+  TABS_SWIPE_GESTURE: 'bridge-tabs-swipe-gesture',
   MARKET_TAB: 'bridge-market-tab',
   LIMIT_TAB: 'bridge-limit-tab',
   RECURRING_TAB: 'bridge-recurring-tab',

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -7,6 +7,8 @@ import React, {
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
+import { GestureDetector, Gesture } from 'react-native-gesture-handler';
+import { scheduleOnRN } from 'react-native-worklets';
 import {
   Box,
   HeaderStandard,
@@ -151,6 +153,42 @@ const BridgeView = () => {
     [tabs],
   );
 
+  const goToPreviousTab = useCallback(() => {
+    if (activeIndex > 0) {
+      handleTabPress(activeIndex - 1);
+    } else {
+      handleBack();
+    }
+  }, [activeIndex, handleTabPress, handleBack]);
+
+  const goToNextTab = useCallback(() => {
+    if (activeIndex < tabs.length - 1) {
+      handleTabPress(activeIndex + 1);
+    }
+  }, [activeIndex, tabs.length, handleTabPress]);
+
+  const swipeGesture = useMemo(
+    () =>
+      Gesture.Pan()
+        .withTestId(BridgeViewSelectorsIDs.TABS_SWIPE_GESTURE)
+        .activeOffsetX([-50, 50])
+        .failOffsetY([-15, 15])
+        .maxPointers(1)
+        .onEnd((gestureEvent) => {
+          'worklet';
+          const { translationX, velocityX } = gestureEvent;
+
+          if (Math.abs(translationX) > 50 || Math.abs(velocityX) > 500) {
+            if (translationX > 0) {
+              scheduleOnRN(goToPreviousTab);
+            } else {
+              scheduleOnRN(goToNextTab);
+            }
+          }
+        }),
+    [goToPreviousTab, goToNextTab],
+  );
+
   // A tab can disappear if its feature flag flips off while it's active
   // (e.g. remote flag update). Fall back to Market rather than rendering
   // nothing.
@@ -210,11 +248,15 @@ const BridgeView = () => {
           testID={BridgeViewSelectorsIDs.TABS_BAR}
         />
       ) : null}
-      {renderedTab === BridgeTabKey.Market ? <BridgeMarketView /> : null}
-      {renderedTab === BridgeTabKey.Limit ? <BridgeLimitOrderView /> : null}
-      {renderedTab === BridgeTabKey.Recurring ? (
-        <BridgeRecurringBuyView />
-      ) : null}
+      <GestureDetector gesture={swipeGesture}>
+        <Box twClassName="flex-1" testID={BridgeViewSelectorsIDs.TABS_CONTENT}>
+          {renderedTab === BridgeTabKey.Market ? <BridgeMarketView /> : null}
+          {renderedTab === BridgeTabKey.Limit ? <BridgeLimitOrderView /> : null}
+          {renderedTab === BridgeTabKey.Recurring ? (
+            <BridgeRecurringBuyView />
+          ) : null}
+        </Box>
+      </GestureDetector>
     </Box>
   );
 };

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -171,7 +171,6 @@ const BridgeView = () => {
     () =>
       Gesture.Pan()
         .withTestId(BridgeViewSelectorsIDs.TABS_SWIPE_GESTURE)
-        .enabled(showTabsBar)
         .activeOffsetX([-50, 50])
         .failOffsetY([-15, 15])
         .maxPointers(1)
@@ -187,7 +186,7 @@ const BridgeView = () => {
             }
           }
         }),
-    [goToPreviousTab, goToNextTab, showTabsBar],
+    [goToPreviousTab, goToNextTab],
   );
 
   // A tab can disappear if its feature flag flips off while it's active

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -171,6 +171,7 @@ const BridgeView = () => {
     () =>
       Gesture.Pan()
         .withTestId(BridgeViewSelectorsIDs.TABS_SWIPE_GESTURE)
+        .enabled(showTabsBar)
         .activeOffsetX([-50, 50])
         .failOffsetY([-15, 15])
         .maxPointers(1)
@@ -186,7 +187,7 @@ const BridgeView = () => {
             }
           }
         }),
-    [goToPreviousTab, goToNextTab],
+    [goToPreviousTab, goToNextTab, showTabsBar],
   );
 
   // A tab can disappear if its feature flag flips off while it's active


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Upcoming Swap/Bridge features (Limit Order and Recurring Buy) need a shared entry point alongside the existing market-order flow. This PR introduces a tab-based navigation shell in `BridgeView` and moves the current swap/bridge UI into a dedicated `BridgeMarketView`, leaving placeholder views for the WIP Limit and Recurring tabs.

**Reason:** The swaps team is building Limit Order and Recurring Buy on top of the existing Bridge screen. A tab system is required to host those flows without duplicating header, navigation, and lifecycle logic.

**Solution:**
- Refactored `BridgeView` into a lightweight tab container with `TabsBar`, swipe gestures, and deferred content rendering via `startTransition` for smoother tab presses.
- Extracted the existing market swap/bridge experience into `BridgeMarketView` (including footer, styles, and utils renames).
- Added `BridgeLimitOrderView` and `BridgeRecurringBuyView` as placeholder containers behind remote feature flags (`swapsLimitOrder`, `swapsRecurringBuy`) with local env overrides (`MM_BRIDGE_LIMIT_ORDER_TAB_ENABLED`, `MM_BRIDGE_RECURRING_BUY_TAB_ENABLED`).
- When both WIP flags are disabled, only the Market tab remains and the tabs bar is hidden — preserving today's user experience.
- Slippage settings in the header appear only on the Market tab.
- Tab switches clear amount inputs and stop BridgeController quote polling while preserving selected tokens; leaving the Bridge screen fully resets bridge state.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://consensyssoftware.atlassian.net/browse/SWAPS-4943

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Bridge tab navigation for Swap and Bridge

  Background:
    Given I am logged into MetaMask Mobile
    And remote feature flags swapsLimitOrder and swapsRecurringBuy are disabled

  Scenario: user opens Swap with WIP tabs disabled (production default)
    Given I navigate to the Swap screen from the wallet

    When the Swap screen loads
    Then I should not see a tabs bar
    And I should see the existing market swap UI (token inputs, quote details, confirm button)
    And I should see the slippage settings button in the header

  Scenario: user opens Swap with both WIP tabs enabled via remote flags
    Given remote feature flags swapsLimitOrder and swapsRecurringBuy are enabled
    And I navigate to the Swap screen

    When the Swap screen loads
    Then I should see a tabs bar with "Market", "Limit", and "Recurring" labels
    And the Market tab content should be visible by default
    And the slippage settings button should be visible in the header

    When I tap the "Limit" tab
    Then the Limit tab placeholder content should appear
    And the market token input areas should no longer be visible
    And the slippage settings button should be hidden

    When I tap the "Market" tab
    Then the market swap UI should be restored
    And the slippage settings button should reappear

    When I tap the "Recurring" tab
    Then the Recurring tab placeholder content should appear

  Scenario: user enables a single WIP tab locally for development
    Given MM_BRIDGE_LIMIT_ORDER_TAB_ENABLED is set to "true" in .js.env
    And MM_BRIDGE_RECURRING_BUY_TAB_ENABLED is not set or is "false"
    And remote feature flags for both tabs are absent or disabled

    When I navigate to the Swap screen
    Then I should see a tabs bar with "Market" and "Limit" only
    And tapping "Limit" should show the Limit placeholder view

  Scenario: user performs a market swap after tab navigation
    Given remote feature flags swapsLimitOrder and swapsRecurringBuy are enabled
    And I navigate to the Swap screen with tokens selected and an amount entered

    When I tap the "Limit" tab and return to the "Market" tab
    Then the selected token pair should be preserved
    And the amount input should be cleared

    When I enter a new amount and proceed with a swap
    Then the existing market swap flow should behave as before this change
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A — screenshots recommended when validating with WIP feature flags enabled (tabs bar visible with Market / Limit / Recurring labels).

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized navigation UX on the Bridge screen with unit tests; disabling stack gesture is intentional to avoid gesture conflicts, with back still available via swipe/header and goBack.
> 
> **Overview**
> Adds **horizontal swipe navigation** on the Swap/Bridge screen so users can move between Market, Limit, and Recurring tabs (when enabled) without tapping the tabs bar, and can **leave the screen** with a right swipe when they’re on the first tab or when only Market is shown.
> 
> Tab content is wrapped in a **pan gesture** (`react-native-gesture-handler` + `scheduleOnRN` from worklets): left swipe advances to the next tab (capped at the last tab), right swipe goes to the previous tab or calls **`goBack`** on Market. The root **`Routes.BRIDGE.ROOT`** stack screen sets **`gestureEnabled: false`** so the native edge back gesture doesn’t fight this horizontal handler.
> 
> New test IDs (`TABS_CONTENT`, `TABS_SWIPE_GESTURE`) and a **`Tab swipe navigation`** test suite cover tab changes, back on first/hidden-tabs cases, and that swipes don’t overshoot the last tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38b85aa0d3cc851c229217c9b6c68f4000e0004f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->