### PR TITLE
fix(ui): tighten account picker arrow size and spacing

### DIFF
--- a/app/component-library/components/Pickers/PickerAccount/PickerAccount.styles.ts
+++ b/app/component-library/components/Pickers/PickerAccount/PickerAccount.styles.ts
@@ -28,6 +28,9 @@ const styleSheet = (params: {
       flexDirection: 'row',
       borderWidth: 0,
     },
+    dropdownIcon: {
+      marginLeft: 8,
+    },
     accountAddressLabel: {
       color: colors.text.alternative,
       textAlign: 'center',

--- a/app/component-library/components/Pickers/PickerAccount/PickerAccount.tsx
+++ b/app/component-library/components/Pickers/PickerAccount/PickerAccount.tsx
@@ -7,6 +7,7 @@ import type { View } from 'react-native';
 // External dependencies.
 import DSText, { TextVariant } from '../../Texts/Text';
 import { useStyles } from '../../../hooks';
+import { IconSize } from '../../Icons/Icon';
 
 // Internal dependencies.
 import PickerBase from '../PickerBase';
@@ -25,6 +26,8 @@ const PickerAccount = forwardRef<View, PickerAccountProps>(
         onPress={onPress}
         hitSlop={hitSlop}
         {...props}
+        iconSize={IconSize.Sm}
+        dropdownIconStyle={styles.dropdownIcon}
       >
         <DSText
           variant={TextVariant.BodyMDMedium}


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

The wallet account picker dropdown arrow looked too large and spaced too far from the account name. This change reduces the arrow to `IconSize.Sm` (16px) and tightens the gap between the account name and arrow from 16px to 8px in `PickerAccount`, so the header control feels more compact and balanced.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Reduced the size and spacing of the account picker dropdown arrow on the wallet home screen

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Wallet account picker appearance

  Scenario: user views the account picker on the wallet home screen
    Given the user has an unlocked wallet and is on the wallet home screen

    When the user looks at the account name in the header
    Then the dropdown arrow is IconSize.Sm (16px)
    And the spacing between the account name and arrow is 8px
    And tapping the account picker still opens the account selector
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — small visual spacing/size tweak; please verify on device/simulator during review.

### **Before**

<img width="350" alt="image" src="https://github.com/user-attachments/assets/29684bc4-c4a8-4298-baf2-321c42e03d12" />

N/A

### **After**

<img width="350" alt="image" src="https://github.com/user-attachments/assets/d08f533b-439b-477e-95e9-3fedf295453c" />

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.