### PR TITLE
fix(qr-scanner): leave scanner when camera permission is denied

### DIFF
--- a/app/components/Views/QRScanner/index.test.tsx
+++ b/app/components/Views/QRScanner/index.test.tsx
@@ -345,6 +345,27 @@ describe('QrScanner', () => {
     });
   });
 
+  it('navigates back when camera permission is denied', async () => {
+    const mockRequestPermission = jest.fn().mockResolvedValue('denied');
+    mockUseCameraPermission.mockReturnValue({
+      hasPermission: false,
+      requestPermission: mockRequestPermission,
+    });
+
+    const alertModule = jest.requireMock(
+      'react-native/Libraries/Alert/Alert',
+    ).default;
+
+    renderWithProvider(<QrScanner onScanSuccess={jest.fn()} />, {
+      state: initialState,
+    });
+
+    await waitFor(() => {
+      expect(mockGoBack).toHaveBeenCalled();
+      expect(alertModule.alert).toHaveBeenCalled();
+    });
+  });
+
   it('marks permission check complete when requestPermission throws', async () => {
     const mockRequestPermission = jest
       .fn()

--- a/app/components/Views/QRScanner/index.tsx
+++ b/app/components/Views/QRScanner/index.tsx
@@ -815,6 +815,23 @@ const QRScanner = ({
     );
   }, []);
 
+  useEffect(() => {
+    if (isAddDeviceScanner || !permissionCheckCompleted || hasPermission) {
+      return;
+    }
+
+    navigation.goBack();
+    InteractionManager.runAfterInteractions(() => {
+      showCameraNotAuthorizedAlert();
+    });
+  }, [
+    hasPermission,
+    isAddDeviceScanner,
+    navigation,
+    permissionCheckCompleted,
+    showCameraNotAuthorizedAlert,
+  ]);
+
   const getScannerOverlayLabel = useCallback(() => {
     if (isAddDeviceScanner) {
       if (addDeviceScannerUiState === AddDeviceScannerUiState.Detected) {

--- a/app/components/Views/QRScanner/index.tsx
+++ b/app/components/Views/QRScanner/index.tsx
@@ -856,9 +856,6 @@ const QRScanner = ({
     [onScanError, navigation],
   );
 
-  // Only show the camera permission alert if:
-  // 1. Permission check has been completed
-  // 2. Permission is not granted
   if (isAddDeviceScanner && permissionCheckCompleted && !hasPermission) {
     return (
       <View style={styles.container}>
@@ -868,7 +865,6 @@ const QRScanner = ({
   }
 
   if (permissionCheckCompleted && !hasPermission) {
-    showCameraNotAuthorizedAlert();
     return null;
   }
 


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Denying camera permission rendered `null` (blank screen). Navigate back, then show the permission alert.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a blank screen after denying camera permission on QR scan

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: #25098
Refs: MCWP-792

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: QR scanner camera permission

  Scenario: cancel camera permission on QR scan
    Given the user taps Scan QR
    When the user denies camera permission
    Then the user returns to the previous screen
    And a camera permission alert is shown
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
