### PR TITLE
fix(perps): when opening perps quickly after wallet open, the app display $0 for 24h volume and OI

### DIFF
--- a/app/components/UI/Perps/hooks/usePerpsMarketStats.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketStats.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { CandlePeriod } from '@metamask/perps-controller';
+import { CandlePeriod, PERPS_CONSTANTS } from '@metamask/perps-controller';
 import { usePerpsMarketStats } from './usePerpsMarketStats';
 
 // Mock Engine
@@ -11,13 +11,19 @@ jest.mock('../../../../core/Engine', () => ({
   },
 }));
 
+jest.mock('./usePerpsConnection', () => ({
+  usePerpsConnection: jest.fn(() => ({ isInitialized: true })),
+}));
+
 // Mock the dependent hooks
 jest.mock('./stream/usePerpsLiveCandles');
 
 import Engine from '../../../../core/Engine';
 import { usePerpsLiveCandles } from './stream/usePerpsLiveCandles';
+import { usePerpsConnection } from './usePerpsConnection';
 
 const mockedUsePerpsLiveCandles = jest.mocked(usePerpsLiveCandles);
+const mockedUsePerpsConnection = jest.mocked(usePerpsConnection);
 const mockSubscribeToPrices = Engine.context.PerpsController
   .subscribeToPrices as jest.Mock;
 
@@ -25,6 +31,16 @@ describe('usePerpsMarketStats', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    mockedUsePerpsConnection.mockReturnValue({
+      isInitialized: true,
+      isConnected: true,
+      isConnecting: false,
+      error: null,
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+      resetError: jest.fn(),
+      reconnectWithNewContext: jest.fn(),
+    });
   });
 
   afterEach(() => {
@@ -138,8 +154,10 @@ describe('usePerpsMarketStats', () => {
     // PRICE_RANGES_UNIVERSAL: trailing zeros removed, so $0.00 → $0
     expect(result.current.high24h).toBe('$0');
     expect(result.current.low24h).toBe('$0');
-    expect(result.current.volume24h).toBe('$0.00'); // formatVolume keeps .00 for zero
-    expect(result.current.openInterest).toBe('$0.00'); // formatLargeNumber keeps .00 for zero
+    expect(result.current.volume24h).toBe(PERPS_CONSTANTS.FallbackPriceDisplay);
+    expect(result.current.openInterest).toBe(
+      PERPS_CONSTANTS.FallbackPriceDisplay,
+    );
     expect(result.current.fundingRate).toBe('0.0000%');
   });
 
@@ -224,5 +242,111 @@ describe('usePerpsMarketStats', () => {
     const { result } = renderHook(() => usePerpsMarketStats('BTC'));
 
     expect(result.current.fundingRate).toBe('-0.5000%');
+  });
+
+  it('displays formatted zero when volume and open interest are actually zero', () => {
+    // Arrange: confirmed zero volume and open interest (not missing data)
+    mockSubscribeToPrices.mockImplementation(({ callback }) => {
+      callback([
+        {
+          ...mockPriceData.BTC,
+          volume24h: 0,
+          openInterest: 0,
+        },
+      ]);
+      return jest.fn();
+    });
+    mockedUsePerpsLiveCandles.mockReturnValue({
+      candleData: mockCandleData,
+      isLoading: false,
+      isLoadingMore: false,
+      hasHistoricalData: true,
+      error: null,
+      fetchMoreHistory: jest.fn(),
+    });
+
+    // Act
+    const { result } = renderHook(() => usePerpsMarketStats('BTC'));
+
+    // Assert: actual zeros format as $0, not the missing-data placeholder
+    expect(result.current.volume24h).toBe('$0');
+    expect(result.current.openInterest).toBe('$0');
+  });
+
+  it('does not subscribe until the Perps connection is initialized', () => {
+    // Arrange: connection has not finished initializing
+    mockedUsePerpsConnection.mockReturnValue({
+      isInitialized: false,
+      isConnected: false,
+      isConnecting: true,
+      error: null,
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+      resetError: jest.fn(),
+      reconnectWithNewContext: jest.fn(),
+    });
+    mockedUsePerpsLiveCandles.mockReturnValue({
+      candleData: mockCandleData,
+      isLoading: false,
+      isLoadingMore: false,
+      hasHistoricalData: true,
+      error: null,
+      fetchMoreHistory: jest.fn(),
+    });
+
+    // Act
+    renderHook(() => usePerpsMarketStats('BTC'));
+
+    // Assert: subscribe is deferred until init so a fast Perps open can retry
+    expect(mockSubscribeToPrices).not.toHaveBeenCalled();
+  });
+
+  it('subscribes after the Perps connection initializes', () => {
+    // Arrange: start uninitialized, then flip to initialized
+    mockedUsePerpsConnection.mockReturnValue({
+      isInitialized: false,
+      isConnected: false,
+      isConnecting: true,
+      error: null,
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+      resetError: jest.fn(),
+      reconnectWithNewContext: jest.fn(),
+    });
+    mockedUsePerpsLiveCandles.mockReturnValue({
+      candleData: mockCandleData,
+      isLoading: false,
+      isLoadingMore: false,
+      hasHistoricalData: true,
+      error: null,
+      fetchMoreHistory: jest.fn(),
+    });
+    mockSubscribeToPrices.mockReturnValue(jest.fn());
+
+    // Act: first render before init, then rerender after init
+    const { rerender } = renderHook(() => usePerpsMarketStats('BTC'));
+
+    expect(mockSubscribeToPrices).not.toHaveBeenCalled();
+
+    mockedUsePerpsConnection.mockReturnValue({
+      isInitialized: true,
+      isConnected: true,
+      isConnecting: false,
+      error: null,
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+      resetError: jest.fn(),
+      reconnectWithNewContext: jest.fn(),
+    });
+    rerender();
+
+    // Assert: subscribe retries once the client is ready
+    expect(mockSubscribeToPrices).toHaveBeenCalledTimes(1);
+    expect(mockSubscribeToPrices).toHaveBeenCalledWith(
+      expect.objectContaining({
+        symbols: ['BTC'],
+        includeMarketData: true,
+      }),
+    );
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsMarketStats.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketStats.ts
@@ -6,7 +6,6 @@ import {
   calculate24hHighLow,
   type PriceUpdate,
 } from '@metamask/perps-controller';
-import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import {
   formatFundingRate,
   formatLargeNumber,
@@ -116,20 +115,6 @@ export const usePerpsMarketStats = (
       }
     };
   }, [symbol]);
-
-  useEffect(() => {
-    if (marketData.volume24h && marketData.openInterest) {
-      return;
-    }
-    DevLogger.log(
-      '[PR-TAT-3765] BUG_MARKER: 24h volume or OI missing; UI will show $0.00',
-      JSON.stringify({
-        symbol,
-        volume24h: marketData.volume24h,
-        openInterest: marketData.openInterest,
-      }),
-    );
-  }, [symbol, marketData.volume24h, marketData.openInterest]);
 
   // Calculate all statistics
   const stats = useMemo<MarketStats>(() => {

--- a/app/components/UI/Perps/hooks/usePerpsMarketStats.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketStats.ts
@@ -6,6 +6,7 @@ import {
   calculate24hHighLow,
   type PriceUpdate,
 } from '@metamask/perps-controller';
+import DevLogger from '../../../../core/SDKConnect/utils/DevLogger';
 import {
   formatFundingRate,
   formatLargeNumber,
@@ -115,6 +116,20 @@ export const usePerpsMarketStats = (
       }
     };
   }, [symbol]);
+
+  useEffect(() => {
+    if (marketData.volume24h && marketData.openInterest) {
+      return;
+    }
+    DevLogger.log(
+      '[PR-TAT-3765] BUG_MARKER: 24h volume or OI missing; UI will show $0.00',
+      JSON.stringify({
+        symbol,
+        volume24h: marketData.volume24h,
+        openInterest: marketData.openInterest,
+      }),
+    );
+  }, [symbol, marketData.volume24h, marketData.openInterest]);
 
   // Calculate all statistics
   const stats = useMemo<MarketStats>(() => {

--- a/app/components/UI/Perps/hooks/usePerpsMarketStats.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarketStats.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Engine from '../../../../core/Engine';
 import {
   CandlePeriod,
+  PERPS_CONSTANTS,
   TimeDuration,
   calculate24hHighLow,
   type PriceUpdate,
@@ -13,6 +14,7 @@ import {
   LARGE_NUMBER_RANGES_DETAILED,
   PRICE_RANGES_UNIVERSAL,
 } from '../utils/formatUtils';
+import { usePerpsConnection } from './usePerpsConnection';
 import { usePerpsLiveCandles } from './stream/usePerpsLiveCandles';
 
 interface MarketStats {
@@ -41,6 +43,7 @@ export interface UsePerpsMarketStatsReturn extends MarketStats {
 export const usePerpsMarketStats = (
   symbol: string,
 ): UsePerpsMarketStatsReturn => {
+  const { isInitialized } = usePerpsConnection();
   const [marketData, setMarketData] = useState<MarketDataUpdate>({});
   const [initialPrice, setInitialPrice] = useState<number | undefined>();
   // Track whether the initial price has been captured without making it a
@@ -57,10 +60,11 @@ export const usePerpsMarketStats = (
     throttleMs: 1000,
   });
 
-  // Subscribe to market data updates (funding, open interest, volume)
-  // Note: We still subscribe to prices but only extract market metadata, not price itself
+  // Subscribe to market data updates (funding, open interest, volume).
+  // Gate on isInitialized so a fast Perps open after wallet unlock does not
+  // get a no-op subscribe with no retry (same pattern as usePerpsPrices).
   useEffect(() => {
-    if (!symbol) return;
+    if (!symbol || !isInitialized) return;
 
     let unsubscribe: (() => void) | undefined;
     const findSymbol = (update: PriceUpdate) => update.symbol === symbol;
@@ -114,7 +118,7 @@ export const usePerpsMarketStats = (
         unsubscribe();
       }
     };
-  }, [symbol]);
+  }, [symbol, isInitialized]);
 
   // Calculate all statistics
   const stats = useMemo<MarketStats>(() => {
@@ -135,16 +139,18 @@ export const usePerpsMarketStats = (
           : formatPerpsFiat(fallbackPrice, {
               ranges: PRICE_RANGES_UNIVERSAL,
             }),
-      volume24h: marketData.volume24h
-        ? `$${formatLargeNumber(marketData.volume24h, {
-            ranges: LARGE_NUMBER_RANGES_DETAILED,
-          })}`
-        : '$0.00',
-      openInterest: marketData.openInterest
-        ? `$${formatLargeNumber(marketData.openInterest, {
-            ranges: LARGE_NUMBER_RANGES_DETAILED,
-          })}`
-        : '$0.00',
+      volume24h:
+        marketData.volume24h !== undefined
+          ? `$${formatLargeNumber(marketData.volume24h, {
+              ranges: LARGE_NUMBER_RANGES_DETAILED,
+            })}`
+          : PERPS_CONSTANTS.FallbackPriceDisplay,
+      openInterest:
+        marketData.openInterest !== undefined
+          ? `$${formatLargeNumber(marketData.openInterest, {
+              ranges: LARGE_NUMBER_RANGES_DETAILED,
+            })}`
+          : PERPS_CONSTANTS.FallbackPriceDisplay,
       fundingRate: formatFundingRate(marketData.funding),
       currentPrice: fallbackPrice,
       isLoading: !candleData,


### PR DESCRIPTION
## **Description**

Opening Perps immediately after wallet unlock could show **$0.00** for 24h volume and open interest while price, funding, and the order book were already live. `usePerpsMarketStats` subscribed before the Perps client was initialized and never retried, then formatted missing values as `$0.00`.

This waits for `isInitialized` before subscribing (same pattern as `usePerpsPrices`) and shows `PERPS_CONSTANTS.FallbackPriceDisplay` until volume and open interest arrive. Confirmed zeros still format as `$0`.

## **Changelog**

CHANGELOG entry: Fixed 24h volume and open interest showing $0.00 when opening Perps right after unlock

## **Related issues**

Fixes: [TAT-3765](https://consensyssoftware.atlassian.net/browse/TAT-3765)

## **Manual testing steps**

```gherkin
Feature: Perps market stats after a fast open

  Scenario: user opens a market immediately after unlocking
    Given the wallet is locked on the fixture account
    And Perps is enabled

    When the user unlocks and opens BTC market details immediately
    Then 24h volume is a real market figure, not $0.00
    And open interest is a real market figure, not $0.00
```

## **Screenshots/Recordings**

Fast Perps open: 24h volume and open interest load as real figures instead of $0.00.

<table>
<tr><td colspan="2"><strong>Fast Perps open no longer shows fake $0.00 for 24h volume and open interest</strong></td></tr>
<tr>
<td align="center" valign="top" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/34844/before-evidence-ac1-volume.png?sha=3ba9856c812db52a" alt="before" width="320" /></td>
<td align="center" valign="top" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/34844/after-ac1-volume.png?sha=62fb4f8ca25281cd" alt="after" width="320" /></td>
</tr>
</table>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>recipe.json</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "Perps 24h volume and open interest are not fake zeros after a fast open",
  "description": "Unlock, open BTC market detail immediately, and prove 24h volume and open interest render real market stats instead of $0.00. Requires an unlocked fixture wallet with Perps enabled. Lite market details is used so both figures are fully on screen; they come from the same usePerpsMarketStats hook as the Pro stats bar.",
  "workflow": {
    "entry": "setup-status",
    "nodes": {
      "setup-status": {
        "action": "app.status",
        "intent": "Confirm the mobile bridge is reachable before opening Perps",
        "next": "setup-cdp"
      },
      "setup-cdp": {
        "action": "cdp.target",
        "required": true,
        "timeout_ms": 15000,
        "intent": "Confirm the React Native debug bridge is reachable",
        "next": "setup-restart"
      },
      "setup-restart": {
        "action": "app.lifecycle",
        "command": "restart",
        "settle_ms": 3000,
        "runtime_ready_timeout_ms": 60000,
        "intent": "Restart the app so Perps opens from a fresh wallet-launch state",
        "next": "setup-unlock"
      },
      "setup-unlock": {
        "action": "metamask.wallet.ensure_unlocked",
        "intent": "Unlock the wallet so Perps can be opened immediately after launch",
        "target_timeout_ms": 45000,
        "unlock_timeout_ms": 45000,
        "next": "setup-navigate-market"
      },
      "setup-navigate-market": {
        "action": "ui.navigate",
        "page": "perps-market",
        "market": "BTC",
        "intent": "Open the BTC Perps market detail screen",
        "next": "setup-wait-header"
      },
      "setup-wait-header": {
        "action": "ui.wait_for",
        "test_id": "perps-market-header",
        "expected": "present",
        "timeout_ms": 20000,
        "intent": "Confirm BTC market details finished opening after the fast launch",
        "next": "setup-wait-scroll"
      },
      "setup-wait-scroll": {
        "action": "ui.wait_for",
        "test_id": "perps-market-details-scroll-view",
        "expected": "present",
        "timeout_ms": 15000,
        "intent": "Confirm the Lite market details scroll surface is ready",
        "next": "ac1-scroll-stats"
      },
      "ac1-scroll-stats": {
        "action": "ui.scroll",
        "test_id": "perps-market-details-scroll-view",
        "offset": 1050,
        "settle": true,
        "timeout_ms": 15000,
        "intent": "Confirm 24h volume and open interest can be read on the market stats card",
        "next": "ac1-wait-volume"
      },
      "ac1-wait-volume": {
        "action": "ui.wait_for",
        "text": "24h volume",
        "expected": "present",
        "timeout_ms": 15000,
        "intent": "Confirm the 24h volume label is on the BTC market stats card",
        "next": "ac1-screenshot-volume"
      },
      "ac1-screenshot-volume": {
        "action": "ui.screenshot",

        "label": "AC1: 24h volume on market stats card",
        "intent": "Show that 24h volume is a real market figure rather than $0.00",
        "next": "ac2-wait-oi-label"
      },
      "ac2-wait-oi-label": {
        "action": "ui.wait_for",
        "text": "Open interest",
        "expected": "present",
        "timeout_ms": 10000,
        "intent": "Confirm the open interest label is on the BTC market stats card",
        "next": "ac2-wait-oi-icon"
      },
      "ac2-wait-oi-icon": {
        "action": "ui.wait_for",
        "test_id": "perps-market-details-open-interest-info-icon",
        "expected": "present",
        "timeout_ms": 10000,
        "intent": "Confirm the open interest row is mounted on the stats card",
        "next": "ac2-screenshot-oi"
      },
      "ac2-screenshot-oi": {
        "action": "ui.screenshot",

        "label": "AC2: open interest on market stats card",
        "intent": "Show that open interest is a real market figure rather than $0.00",
        "next": "done"
      },
      "done": {
        "action": "end",
        "status": "pass"
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
flowchart TD
  setup-status --> setup-cdp
  setup-cdp --> setup-restart
  setup-restart --> setup-unlock
  setup-unlock --> setup-navigate-market
  setup-navigate-market --> setup-wait-header
  setup-wait-header --> setup-wait-scroll
  setup-wait-scroll --> ac1-scroll-stats
  ac1-scroll-stats --> ac1-wait-volume
  ac1-wait-volume --> ac1-screenshot-volume
  ac1-screenshot-volume --> ac2-wait-oi-label
  ac2-wait-oi-label --> ac2-wait-oi-icon
  ac2-wait-oi-icon --> ac2-screenshot-oi
  ac2-screenshot-oi --> done
```

</details>

[TAT-3765]: https://consensyssoftware.atlassian.net/browse/TAT-3765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Perps UI hook behavior and display formatting with unit tests; no auth, payments, or shared infrastructure changes.
> 
> **Overview**
> Fixes **24h volume and open interest** showing fake **$0.00** when Perps is opened right after wallet unlock.
> 
> `usePerpsMarketStats` now waits on **`isInitialized`** from `usePerpsConnection` before calling `subscribeToPrices`, matching `usePerpsPrices`, so an early no-op subscribe is retried once the client is ready. Until volume and open interest arrive, the UI uses **`PERPS_CONSTANTS.FallbackPriceDisplay`** instead of formatting missing values as `$0.00`; confirmed **zero** values still render as **`$0`**.
> 
> Tests mock `usePerpsConnection` and cover init gating, post-init subscribe, fallback display, and real zeros.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbf72c42faf6ff4f5fee7d58193580bf8326864f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->