### PR TITLE
fix: order book kPEPE price is being cut

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import { fireEvent, within } from '@testing-library/react-native';
 import PerpsProOrderBookPanel from './PerpsProOrderBookPanel';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
@@ -62,6 +63,50 @@ const mockOrderBook: OrderBookData = {
   // but a pinned constant keeps the fixture deterministic across runs.
   lastUpdated: 1700000000000,
   maxTotal: '3.5',
+};
+
+/**
+ * kPEPE-shaped book (TAT-3713): a sub-cent mid whose ladder prices need all six
+ * decimals to stay distinguishable at the 1e-6 grouping step.
+ */
+const subCentOrderBook: OrderBookData = {
+  bids: [
+    {
+      price: '0.002651',
+      size: '1500000',
+      total: '1500000',
+      notional: '3976.5',
+      totalNotional: '3976.5',
+    },
+    {
+      price: '0.002650',
+      size: '2000000',
+      total: '3500000',
+      notional: '5300',
+      totalNotional: '9276.5',
+    },
+  ],
+  asks: [
+    {
+      price: '0.002653',
+      size: '1200000',
+      total: '1200000',
+      notional: '3183.6',
+      totalNotional: '3183.6',
+    },
+    {
+      price: '0.002654',
+      size: '1800000',
+      total: '3000000',
+      notional: '4777.2',
+      totalNotional: '7960.8',
+    },
+  ],
+  spread: '0.000002',
+  spreadPercentage: '0.075',
+  midPrice: '0.002652',
+  lastUpdated: 1700000000000,
+  maxTotal: '3500000',
 };
 
 describe('PerpsProOrderBookPanel', () => {
@@ -502,6 +547,61 @@ describe('PerpsProOrderBookPanel', () => {
     expect(lastAggregatedCall).toMatchObject({
       symbol: 'ETH',
       nSigFigs: 4,
+    });
+  });
+
+  describe('sub-cent ladder prices (TAT-3713)', () => {
+    const renderSubCentLadder = () => {
+      mockUsePerpsLiveOrderBook.mockImplementation(() => ({
+        orderBook: subCentOrderBook,
+        isLoading: false,
+        error: null,
+        connectionStatus: 'connected',
+        reconnect: mockReconnect,
+      }));
+
+      return renderWithProvider(
+        <PerpsProOrderBookPanel symbol="kPEPE" marketPrice={0.002652} />,
+        { state: { engine: { backgroundState } } },
+      );
+    };
+
+    it('renders all six decimals of a ladder price on one line', () => {
+      const { getByTestId } = renderSubCentLadder();
+
+      const priceCell = getByTestId(`${testID}-bid-row-0-price`);
+
+      expect(priceCell).toHaveTextContent('$0.002651');
+      expect(priceCell).toHaveProp('numberOfLines', 1);
+    });
+
+    it('gives the price cell the width the value cell does not need', () => {
+      const { getByTestId } = renderSubCentLadder();
+
+      const priceStyle = StyleSheet.flatten(
+        getByTestId(`${testID}-bid-row-0-price`).props.style,
+      );
+      const valueStyle = StyleSheet.flatten(
+        getByTestId(`${testID}-bid-row-0-value`).props.style,
+      );
+
+      // An even split leaves each side 62px of the 132px order-book column,
+      // which cuts a nine-character price down to "$0.0026…".
+      expect(priceStyle).toMatchObject({ flexGrow: 1, flexBasis: '0%' });
+      expect(valueStyle).toMatchObject({ flexShrink: 0 });
+      expect(valueStyle.flexGrow).toBeUndefined();
+    });
+
+    it('gives the column headers the same width split as the rows', () => {
+      const { getByTestId } = renderSubCentLadder();
+
+      const headerValue = getByTestId(`${testID}-column-header-value`);
+      const headerValueStyle = StyleSheet.flatten(headerValue.props.style);
+
+      // "Total (USD)" is also wider than half the column.
+      expect(headerValue).toHaveTextContent('Total (USD)');
+      expect(headerValueStyle).toMatchObject({ flexShrink: 0 });
+      expect(headerValueStyle.flexGrow).toBeUndefined();
     });
   });
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import { fireEvent, within } from '@testing-library/react-native';
+import { strings } from '../../../../../../../locales/i18n';
 import PerpsProOrderBookPanel from './PerpsProOrderBookPanel';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
@@ -598,8 +599,10 @@ describe('PerpsProOrderBookPanel', () => {
       const headerValue = getByTestId(`${testID}-column-header-value`);
       const headerValueStyle = StyleSheet.flatten(headerValue.props.style);
 
-      // "Total (USD)" is also wider than half the column.
-      expect(headerValue).toHaveTextContent('Total (USD)');
+      // The value header is also wider than half the column.
+      expect(headerValue).toHaveTextContent(
+        `${strings('perps.order_book.total')} (USD)`,
+      );
       expect(headerValueStyle).toMatchObject({ flexShrink: 0 });
       expect(headerValueStyle.flexGrow).toBeUndefined();
     });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.tsx
@@ -80,12 +80,20 @@ export interface PerpsProOrderBookPanelProps {
 }
 
 /**
- * Price and value share the row equally (Figma: two 62px columns with an 8px
- * gutter). Fixed halves plus single-line text are what keep the two from
- * running into each other once either side grows.
+ * The row cannot be two equal halves. The order-book column is a fixed 132px
+ * (`PRO_ORDER_BOOK_COLUMN_WIDTH`), so equal halves give each side 62px, and a
+ * sub-cent price needs more than that: kPEPE renders "$0.002645" — nine
+ * characters at the 1e-6 grouping step — and got ellipsised to "$0.0026…",
+ * which makes every ladder row read the same (TAT-3713).
+ *
+ * The value side is the one with room to give: `formatColumnValue` compacts
+ * anything at or above 1,000 to K/M/B/T, so it never exceeds ~7 characters.
+ * Sizing it to its content and letting the price take the remainder keeps both
+ * whole. Each side still keeps single-line text, so the extreme case degrades
+ * to a truncated price rather than a row that wraps or overflows.
  */
-const COLUMN_CLASS = 'relative z-10 flex-1';
-const VALUE_COLUMN_CLASS = `${COLUMN_CLASS} text-right`;
+const PRICE_COLUMN_CLASS = 'relative z-10 flex-1';
+const VALUE_COLUMN_CLASS = 'relative z-10 shrink-0 text-right';
 
 interface OrderBookRowProps {
   level: OrderBookLevel;
@@ -149,7 +157,7 @@ const OrderBookRow = ({
         fontWeight={FontWeight.Medium}
         color={sideColor}
         numberOfLines={1}
-        twClassName={COLUMN_CLASS}
+        twClassName={PRICE_COLUMN_CLASS}
         testID={`${testID}-price`}
       >
         {priceLabel}
@@ -642,6 +650,7 @@ const PerpsProOrderBookPanel = ({
           color={TextColor.TextAlternative}
           numberOfLines={1}
           twClassName="flex-1"
+          testID={`${testID}-column-header-price`}
         >
           {strings('perps.order_book.price')}
         </Text>
@@ -650,7 +659,8 @@ const PerpsProOrderBookPanel = ({
           fontWeight={FontWeight.Medium}
           color={TextColor.TextAlternative}
           numberOfLines={1}
-          twClassName="flex-1 text-right"
+          twClassName="shrink-0 text-right"
+          testID={`${testID}-column-header-value`}
         >
           {`${metricLabel} (${unitLabel})`}
         </Text>

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.tsx
@@ -28,6 +28,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { strings } from '../../../../../../../locales/i18n';
+import DevLogger from '../../../../../../core/SDKConnect/utils/DevLogger';
 import { useTheme } from '../../../../../../util/theme';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
 import {
@@ -130,6 +131,14 @@ const OrderBookRow = ({
   }));
 
   const priceLabel = formatOrderBookPrice(level.price, priceFormat);
+
+  if (testID.endsWith('-bid-row-0')) {
+    DevLogger.log(
+      `[PR-TAT-3713] BUG_MARKER: ladder price label rendered in a 50/50 split column priceLabel=${priceLabel} length=${priceLabel.length} format=${JSON.stringify(
+        priceFormat,
+      )}`,
+    );
+  }
 
   const content = (
     <>

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderBookPanel.tsx
@@ -28,7 +28,6 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { strings } from '../../../../../../../locales/i18n';
-import DevLogger from '../../../../../../core/SDKConnect/utils/DevLogger';
 import { useTheme } from '../../../../../../util/theme';
 import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
 import {
@@ -131,14 +130,6 @@ const OrderBookRow = ({
   }));
 
   const priceLabel = formatOrderBookPrice(level.price, priceFormat);
-
-  if (testID.endsWith('-bid-row-0')) {
-    DevLogger.log(
-      `[PR-TAT-3713] BUG_MARKER: ladder price label rendered in a 50/50 split column priceLabel=${priceLabel} length=${priceLabel.length} format=${JSON.stringify(
-        priceFormat,
-      )}`,
-    );
-  }
 
   const content = (
     <>


### PR DESCRIPTION
## **Description**

The Pro-mode order-book ladder cut the last digits off every price on low-priced markets: kPEPE
rendered `$0.0026…` on all ten rows, so no level could be told apart and the book was unusable
(TAT-3713).

The order-book column is a fixed 132px and each row split it into two equal halves, giving the
price 62px — one character short of the nine a sub-cent price needs (`$0.002645` at the 1e-6
grouping step). The price string itself was already correct, so nothing about precision changes
here: the value column, which is compacted to K/M/B/T and never needs its full half, now sizes to
its content and the price takes the remainder. The same split applies to the column headers,
which is why `Total (US…` also reads in full again.

## **Changelog**

CHANGELOG entry: Fixed the Pro order book cutting off the last digits of prices on low-priced
markets

## **Related issues**

Fixes: [TAT-3713](https://consensyssoftware.atlassian.net/browse/TAT-3713)

## **Manual testing steps**

```gherkin
Feature: Pro order book ladder prices

  Scenario: user reads the order book of a sub-cent market
    Given the user is on the Perps market list with Pro mode enabled

    When user opens the kPEPE (or PUMP) market
    Then every order-book ladder row shows its full price, e.g. "$0.002655", not "$0.0026…"
    And the value column header reads "Total (USD)" instead of "Total (US…"
```

## **Screenshots/Recordings**

Pro order-book ladder on two sub-cent markets, before and after: prices no longer stop at "$0.0026…".

<table>
<tr><td colspan="2"><strong>kPEPE ladder prices readable end to end (and the Total header no longer cut)</strong></td></tr>
<tr>
<td align="center" valign="top" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/34845/before-evidence-ac1-kpepe-ladder-price.png?sha=6640c0e87750d2f1" alt="before" width="320" /></td>
<td align="center" valign="top" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/34845/after-ac1-kpepe-ladder-price.png?sha=211e5468ce4d6be6" alt="after" width="320" /></td>
</tr>
<tr><td colspan="2"><strong>PUMP shows the same fix, so it is not kPEPE-specific</strong></td></tr>
<tr>
<td align="center" valign="top" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/34845/before-evidence-ac2-pump-ladder-price.png?sha=5367122176484872" alt="before" width="320" /></td>
<td align="center" valign="top" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/34845/after-ac2-pump-ladder-price.png?sha=a24bb816d527602b" alt="after" width="320" /></td>
</tr>
</table>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

Validated on the iOS simulator; the change is shared JS (flexbox width allocation) with no
platform-specific branch, and it adds no work to the render path.

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

missing: 0). Run: `mm-harness run recipe.json --adapter mobile`.

<details>
<summary>recipe.json</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "Pro order book shows complete ladder prices (TAT-3713)",
  "description": "Opens the Pro-mode order book for two sub-cent markets (kPEPE, PUMP) and proves each ladder row renders its full price instead of an ellipsised one, while the 6-decimal ladder precision is unchanged.",
  "workflow": {
    "entry": "setup-status",
    "nodes": {
      "setup-status": {
        "action": "app.status",
        "intent": "Confirm the mobile bridge is reachable before touching the trading screens",
        "next": "setup-unlock"
      },
      "setup-unlock": {
        "action": "metamask.wallet.ensure_unlocked",
        "intent": "Reach an unlocked wallet so the Perps market screens can render",
        "next": "ac1-open-kpepe-market"
      },
      "ac1-open-kpepe-market": {
        "action": "ui.navigate",
        "page": "perps-market",
        "market": "kPEPE",
        "mode": "pro",
        "timeout_ms": 45000,
        "intent": "Reach the kPEPE Pro trading screen reported in the ticket",
        "next": "ac1-wait-order-book-visible"
      },
      "ac1-wait-order-book-visible": {
        "action": "ui.wait_for",
        "test_id": "perps-pro-market-order-book-panel",
        "expected": "visible",
        "timeout_ms": 30000,
        "intent": "The kPEPE order-book column occupies its place on the trading screen a trader looks at",
        "next": "ac1-wait-ladder-price"
      },
      "ac1-wait-ladder-price": {
        "action": "ui.wait_for",
        "test_id": "perps-pro-market-order-book-panel-bid-row-0-price",
        "expected": "present",
        "timeout_ms": 30000,
        "intent": "The kPEPE ladder has a first bid row with a price for the reader to compare against the screenshot",
        "next": "ac1-screenshot-kpepe-ladder"
      },
      "ac1-screenshot-kpepe-ladder": {
        "action": "ui.screenshot",

        "label": "AC1: kPEPE ladder prices readable end to end",
        "intent": "A trader reading the kPEPE order book sees every digit of each ladder price",
        "next": "ac2-open-pump-market"
      },
      "ac2-open-pump-market": {
        "action": "ui.navigate",
        "page": "perps-market",
        "market": "PUMP",
        "mode": "pro",
        "timeout_ms": 45000,
        "intent": "Reach a second sub-cent market to show the ticket is not kPEPE-specific",
        "next": "ac2-wait-order-book-visible"
      },
      "ac2-wait-order-book-visible": {
        "action": "ui.wait_for",
        "test_id": "perps-pro-market-order-book-panel",
        "expected": "visible",
        "timeout_ms": 30000,
        "intent": "The PUMP order-book column occupies its place on the trading screen a trader looks at",
        "next": "ac2-wait-ladder-price"
      },
      "ac2-wait-ladder-price": {
        "action": "ui.wait_for",
        "test_id": "perps-pro-market-order-book-panel-bid-row-0-price",
        "expected": "present",
        "timeout_ms": 30000,
        "intent": "The PUMP ladder has a first bid row with a price for the reader to compare against the screenshot",
        "next": "ac2-screenshot-pump-ladder"
      },
      "ac2-screenshot-pump-ladder": {
        "action": "ui.screenshot",

        "label": "AC2: PUMP ladder prices readable end to end",
        "intent": "A trader reading the PUMP order book sees every digit of each ladder price",
        "next": "ac3-run-panel-tests"
      },
      "ac3-run-panel-tests": {
        "action": "command",

        "timeout_ms": 600000,
        "intent": "Exercise the order-book panel unit suite that pins the ladder price text and its column allocation",
        "next": "ac3-assert-panel-tests"
      },
      "ac3-assert-panel-tests": {
        "action": "assert_exit_code",
        "source": "ac3-run-panel-tests",
        "expected": 0,
        "intent": "Prove the ladder still renders full 6-decimal prices and no longer squeezes them into half the column",
        "next": "ac3-index-test-log"
      },
      "ac3-index-test-log": {
        "action": "index_artifacts",
        "artifacts": [
          {

            "type": "log",
            "category": "evidence",
            "label": "AC3: order-book panel unit suite output"
          }
        ],
        "intent": "Register the unit-suite output as the state evidence for the unchanged price text",
        "next": "teardown-done"
      },
      "teardown-done": {
        "action": "end",
        "status": "pass"
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
flowchart TD
  setup-status["setup-status<br/>app.status"] --> setup-unlock["setup-unlock<br/>metamask.wallet.ensure_unlocked"]
  setup-unlock --> ac1-open["ac1-open-kpepe-market<br/>ui.navigate kPEPE (pro)"]
  ac1-open --> ac1-panel["ac1-wait-order-book-visible<br/>ui.wait_for visible"]
  ac1-panel --> ac1-price["ac1-wait-ladder-price<br/>ui.wait_for present"]
  ac1-price --> ac1-shot["ac1-screenshot-kpepe-ladder<br/>ui.screenshot"]
  ac1-shot --> ac2-open["ac2-open-pump-market<br/>ui.navigate PUMP (pro)"]
  ac2-open --> ac2-panel["ac2-wait-order-book-visible<br/>ui.wait_for visible"]
  ac2-panel --> ac2-price["ac2-wait-ladder-price<br/>ui.wait_for present"]
  ac2-price --> ac2-shot["ac2-screenshot-pump-ladder<br/>ui.screenshot"]
  ac2-shot --> ac3-tests["ac3-run-panel-tests<br/>command: jest panel suite"]
  ac3-tests --> ac3-assert["ac3-assert-panel-tests<br/>assert_exit_code 0"]
  ac3-assert --> ac3-index["ac3-index-test-log<br/>index_artifacts"]
  ac3-index --> done["teardown-done<br/>end: pass"]
```

</details>

[TAT-3713]: https://consensyssoftware.atlassian.net/browse/TAT-3713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1e2c3e1a9e97ba8384fa71f8d3bc5aa1f9a9040f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->