### PR TITLE
chore: Replace Settings modals with design-system BottomSheets

### DIFF
--- a/app/components/UI/Notification/SwitchLoadingModal/LoaderModal.tsx
+++ b/app/components/UI/Notification/SwitchLoadingModal/LoaderModal.tsx
@@ -16,17 +16,30 @@ const LoaderModal = (props: LoaderModalProps) => {
   const [isMounted, setIsMounted] = useState(isVisible);
   const sheetRef = useRef<BottomSheetRef>(null);
   const closingDueToVisibilityRef = useRef(false);
+  // Track latest visibility to disambiguate stale close callbacks.
+  const isVisibleRef = useRef(isVisible);
+  useEffect(() => {
+    isVisibleRef.current = isVisible;
+  }, [isVisible]);
 
   useEffect(() => {
     if (isVisible) {
+      // Reset programmatic-close marker on explicit reopen.
       closingDueToVisibilityRef.current = false;
       setIsMounted(true);
+      // Ensure the sheet is opened in case a previous close finished.
+      sheetRef.current?.onOpenBottomSheet();
       return;
     }
 
     if (isMounted) {
       closingDueToVisibilityRef.current = true;
       sheetRef.current?.onCloseBottomSheet(() => {
+        // If visibility flipped back to true while the close was animating,
+        // ignore this stale completion to avoid cancel/unmount flicker.
+        if (isVisibleRef.current) {
+          return;
+        }
         setIsMounted(false);
         closingDueToVisibilityRef.current = false;
       });
@@ -34,9 +47,16 @@ const LoaderModal = (props: LoaderModalProps) => {
   }, [isMounted, isVisible]);
 
   const handleSheetClosed = useCallback(() => {
+    // If the parent wants it visible again, ignore this stale close event.
+    if (isVisibleRef.current) {
+      return;
+    }
     setIsMounted(false);
     if (!closingDueToVisibilityRef.current) {
       onCancel();
+    } else {
+      // Programmatic close finished as intended; reset flag.
+      closingDueToVisibilityRef.current = false;
     }
   }, [onCancel]);
 

--- a/app/components/UI/Notification/SwitchLoadingModal/LoaderModal.tsx
+++ b/app/components/UI/Notification/SwitchLoadingModal/LoaderModal.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { StyleSheet } from 'react-native';
-import Modal from 'react-native-modal';
-import { useTheme } from '../../../../util/theme';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  BottomSheet,
+  type BottomSheetRef,
+} from '@metamask/design-system-react-native';
 
 export interface LoaderModalProps {
   isVisible: boolean;
@@ -9,33 +10,50 @@ export interface LoaderModalProps {
   children: React.ReactNode;
 }
 
-const styles = StyleSheet.create({
-  bottomModal: {
-    justifyContent: 'flex-end',
-    marginHorizontal: 0,
-  },
-});
-
 const LoaderModal = (props: LoaderModalProps) => {
-  const { colors } = useTheme();
+  const { isVisible, onCancel, children } = props;
+  // Keep mounted while animating closed.
+  const [isMounted, setIsMounted] = useState(isVisible);
+  const sheetRef = useRef<BottomSheetRef>(null);
+  const closingDueToVisibilityRef = useRef(false);
+
+  useEffect(() => {
+    if (isVisible) {
+      closingDueToVisibilityRef.current = false;
+      setIsMounted(true);
+      return;
+    }
+
+    if (isMounted) {
+      closingDueToVisibilityRef.current = true;
+      sheetRef.current?.onCloseBottomSheet(() => {
+        setIsMounted(false);
+        closingDueToVisibilityRef.current = false;
+      });
+    }
+  }, [isMounted, isVisible]);
+
+  const handleSheetClosed = useCallback(() => {
+    setIsMounted(false);
+    if (!closingDueToVisibilityRef.current) {
+      onCancel();
+    }
+  }, [onCancel]);
+
+  if (!isMounted) {
+    return null;
+  }
 
   return (
-    <Modal
-      isVisible={props.isVisible}
-      animationIn="slideInUp"
-      animationOut="slideOutDown"
-      style={styles.bottomModal}
-      backdropColor={colors.overlay.default}
-      backdropOpacity={1}
-      animationInTiming={600}
-      animationOutTiming={600}
-      onBackdropPress={props.onCancel}
-      onSwipeComplete={props.onCancel}
-      swipeDirection={'down'}
-      propagateSwipe
+    <BottomSheet
+      ref={sheetRef}
+      isInteractable
+      onClose={handleSheetClosed}
+      keyboardAvoidingViewEnabled
     >
-      {props.children}
-    </Modal>
+      {/* Children can include their own card/container styling */}
+      {children}
+    </BottomSheet>
   );
 };
 

--- a/app/components/Views/Settings/AdvancedSettings/AdvancedSettings.styles.ts
+++ b/app/components/Views/Settings/AdvancedSettings/AdvancedSettings.styles.ts
@@ -24,17 +24,6 @@ export const createStyles = (colors: Colors) =>
     firstSetting: {
       marginTop: 0,
     },
-    modalView: {
-      alignItems: 'center',
-      flex: 1,
-      flexDirection: 'column',
-      justifyContent: 'center',
-      padding: 20,
-    },
-    modalTitle: {
-      textAlign: 'center',
-      marginBottom: 20,
-    },
     picker: {
       borderColor: colors.border.default,
       borderRadius: 5,

--- a/app/components/Views/Settings/AdvancedSettings/ResetAccountModal/ResetAccountModal.test.tsx
+++ b/app/components/Views/Settings/AdvancedSettings/ResetAccountModal/ResetAccountModal.test.tsx
@@ -63,11 +63,6 @@ describe('ResetAccountModal', () => {
   const defaultProps = {
     resetModalVisible: true,
     cancelResetAccount: jest.fn(),
-    styles: {
-      modalView: {},
-      modalTitle: {},
-      modalText: {},
-    },
   };
 
   beforeEach(() => {

--- a/app/components/Views/Settings/AdvancedSettings/ResetAccountModal/ResetAccountModal.test.tsx
+++ b/app/components/Views/Settings/AdvancedSettings/ResetAccountModal/ResetAccountModal.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { fireEvent, act } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
-import { strings } from '../../../../../../locales/i18n';
 import { ResetAccountModal } from './ResetAccountModal';
+import { AdvancedViewSelectorsIDs } from '../AdvancedView.testIds';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../../selectors/accountsController';
 import { selectChainId } from '../../../../../selectors/networkController';
 import { wipeTransactions } from '../../../../../util/transaction-controller';
@@ -79,13 +79,13 @@ describe('ResetAccountModal', () => {
   });
 
   it('calls wipeBridgeStatus, wipeTransactions, and wipeSmartTransactions when reset button is pressed', async () => {
-    const { getByText } = renderWithProvider(
+    const { getByTestId } = renderWithProvider(
       <ResetAccountModal {...defaultProps} />,
       { state: initialState },
     );
 
-    const confirmButton = getByText(
-      strings('app_settings.reset_account_confirm_button'),
+    const confirmButton = getByTestId(
+      AdvancedViewSelectorsIDs.RESET_ACCOUNT_CONFIRM_BUTTON,
     );
     fireEvent.press(confirmButton);
 
@@ -105,13 +105,13 @@ describe('ResetAccountModal', () => {
       selectSelectedInternalAccountFormattedAddress as unknown as jest.Mock
     ).mockReturnValue(undefined);
 
-    const { getByText } = renderWithProvider(
+    const { getByTestId } = renderWithProvider(
       <ResetAccountModal {...defaultProps} />,
       { state: initialState },
     );
 
-    const confirmButton = getByText(
-      strings('app_settings.reset_account_confirm_button'),
+    const confirmButton = getByTestId(
+      AdvancedViewSelectorsIDs.RESET_ACCOUNT_CONFIRM_BUTTON,
     );
     fireEvent.press(confirmButton);
 

--- a/app/components/Views/Settings/AdvancedSettings/ResetAccountModal/ResetAccountModal.tsx
+++ b/app/components/Views/Settings/AdvancedSettings/ResetAccountModal/ResetAccountModal.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
-import { View } from 'react-native';
+import React, { useCallback, useRef } from 'react';
 import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { strings } from '../../../../../../locales/i18n';
-import ActionModal from '../../../../UI/ActionModal';
 import { wipeTransactions } from '../../../../../util/transaction-controller';
 import { wipeSmartTransactions } from '../../../../../util/smart-transactions';
 import { wipeBridgeStatus } from '../../../../UI/Bridge/utils';
@@ -15,6 +13,13 @@ import { selectSelectedInternalAccountFormattedAddress } from '../../../../../se
 import { selectChainId } from '../../../../../selectors/networkController';
 import { usePerpsFirstTimeUser } from '../../../../UI/Perps/hooks/usePerpsFirstTimeUser';
 import { AdvancedViewSelectorsIDs } from '../AdvancedView.testIds';
+import {
+  BottomSheet,
+  BottomSheetFooter,
+  BottomSheetHeader,
+  type BottomSheetRef,
+  Box,
+} from '@metamask/design-system-react-native';
 
 export const ResetAccountModal = ({
   resetModalVisible,
@@ -27,6 +32,7 @@ export const ResetAccountModal = ({
   styles: any;
 }) => {
   const navigation = useNavigation<AppNavigationProp>();
+  const sheetRef = useRef<BottomSheetRef>(null);
   const selectedAddress = useSelector(
     selectSelectedInternalAccountFormattedAddress,
   );
@@ -34,7 +40,7 @@ export const ResetAccountModal = ({
   const { resetFirstTimeUserState, clearPendingTransactionRequests } =
     usePerpsFirstTimeUser();
 
-  const resetAccount = () => {
+  const resetAccount = useCallback(() => {
     if (selectedAddress) {
       wipeBridgeStatus(selectedAddress, chainId);
       wipeSmartTransactions(selectedAddress);
@@ -45,26 +51,57 @@ export const ResetAccountModal = ({
     // Clear any stuck pending Perps transactions
     clearPendingTransactionRequests();
     navigation.navigate('WalletView');
-  };
+  }, [
+    chainId,
+    clearPendingTransactionRequests,
+    navigation,
+    resetFirstTimeUserState,
+    selectedAddress,
+  ]);
+
+  const handleRequestClose = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet(() => {
+      resetAccount();
+    });
+  }, [resetAccount]);
+
+  if (!resetModalVisible) {
+    return null;
+  }
 
   return (
-    <ActionModal
-      modalVisible={resetModalVisible}
-      confirmText={strings('app_settings.reset_account_confirm_button')}
-      cancelText={strings('app_settings.reset_account_cancel_button')}
-      confirmTestID={AdvancedViewSelectorsIDs.RESET_ACCOUNT_CONFIRM_BUTTON}
-      onCancelPress={cancelResetAccount}
-      onRequestClose={cancelResetAccount}
-      onConfirmPress={resetAccount}
+    <BottomSheet
+      ref={sheetRef}
+      isInteractable
+      onClose={cancelResetAccount}
+      keyboardAvoidingViewEnabled
     >
-      <View style={styles.modalView}>
+      <BottomSheetHeader onClose={handleRequestClose}>
         <Text style={styles.modalTitle} variant={TextVariant.HeadingMD}>
           {strings('app_settings.reset_account_modal_title')}
         </Text>
+      </BottomSheetHeader>
+      <Box twClassName="px-4 pt-2 pb-6">
         <Text style={styles.modalText}>
           {strings('app_settings.reset_account_modal_message')}
         </Text>
-      </View>
-    </ActionModal>
+      </Box>
+      <BottomSheetFooter
+        secondaryButtonProps={{
+          children: strings('app_settings.reset_account_cancel_button'),
+          onPress: handleRequestClose,
+        }}
+        primaryButtonProps={{
+          children: strings('app_settings.reset_account_confirm_button'),
+          onPress: handleConfirm,
+          isDanger: true,
+          testID: AdvancedViewSelectorsIDs.RESET_ACCOUNT_CONFIRM_BUTTON,
+        }}
+      />
+    </BottomSheet>
   );
 };

--- a/app/components/Views/Settings/AdvancedSettings/ResetAccountModal/ResetAccountModal.tsx
+++ b/app/components/Views/Settings/AdvancedSettings/ResetAccountModal/ResetAccountModal.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useRef } from 'react';
-import Text from '../../../../../component-library/components/Texts/Text';
 import { strings } from '../../../../../../locales/i18n';
 import { wipeTransactions } from '../../../../../util/transaction-controller';
 import { wipeSmartTransactions } from '../../../../../util/smart-transactions';
@@ -17,17 +16,16 @@ import {
   BottomSheetHeader,
   type BottomSheetRef,
   Box,
+  Text,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 
 export const ResetAccountModal = ({
   resetModalVisible,
   cancelResetAccount,
-  styles,
 }: {
   resetModalVisible: boolean;
   cancelResetAccount: () => void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  styles: any;
 }) => {
   const navigation = useNavigation<AppNavigationProp>();
   const sheetRef = useRef<BottomSheetRef>(null);
@@ -82,7 +80,7 @@ export const ResetAccountModal = ({
         {strings('app_settings.reset_account_modal_title')}
       </BottomSheetHeader>
       <Box twClassName="px-4 pt-2 pb-6">
-        <Text style={styles.modalText}>
+        <Text variant={TextVariant.BodyMd} twClassName="text-center">
           {strings('app_settings.reset_account_modal_message')}
         </Text>
       </Box>

--- a/app/components/Views/Settings/AdvancedSettings/ResetAccountModal/ResetAccountModal.tsx
+++ b/app/components/Views/Settings/AdvancedSettings/ResetAccountModal/ResetAccountModal.tsx
@@ -1,7 +1,5 @@
 import React, { useCallback, useRef } from 'react';
-import Text, {
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
+import Text from '../../../../../component-library/components/Texts/Text';
 import { strings } from '../../../../../../locales/i18n';
 import { wipeTransactions } from '../../../../../util/transaction-controller';
 import { wipeSmartTransactions } from '../../../../../util/smart-transactions';
@@ -81,9 +79,7 @@ export const ResetAccountModal = ({
       keyboardAvoidingViewEnabled
     >
       <BottomSheetHeader onClose={handleRequestClose}>
-        <Text style={styles.modalTitle} variant={TextVariant.HeadingMD}>
-          {strings('app_settings.reset_account_modal_title')}
-        </Text>
+        {strings('app_settings.reset_account_modal_title')}
       </BottomSheetHeader>
       <Box twClassName="px-4 pt-2 pb-6">
         <Text style={styles.modalText}>

--- a/app/components/Views/Settings/AdvancedSettings/index.tsx
+++ b/app/components/Views/Settings/AdvancedSettings/index.tsx
@@ -282,7 +282,6 @@ const AdvancedSettings = ({
       <ResetAccountModal
         resetModalVisible={resetModalVisible}
         cancelResetAccount={cancelResetAccount}
-        styles={styles}
       />
     </SafeAreaView>
   );

--- a/app/components/Views/Settings/AdvancedSettings/index.tsx
+++ b/app/components/Views/Settings/AdvancedSettings/index.tsx
@@ -172,11 +172,6 @@ const AdvancedSettings = ({
         ref={scrollView}
       >
         <View style={styles.inner} testID={AdvancedViewSelectorsIDs.CONTAINER}>
-          <ResetAccountModal
-            resetModalVisible={resetModalVisible}
-            cancelResetAccount={cancelResetAccount}
-            styles={styles}
-          />
           <View style={[styles.setting, styles.firstSetting]}>
             <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
               {strings('app_settings.reset_account')}
@@ -284,6 +279,11 @@ const AdvancedSettings = ({
           </View>
         </View>
       </KeyboardAwareScrollView>
+      <ResetAccountModal
+        resetModalVisible={resetModalVisible}
+        cancelResetAccount={cancelResetAccount}
+        styles={styles}
+      />
     </SafeAreaView>
   );
 };

--- a/app/components/Views/Settings/SecuritySettings/Sections/ClearCookiesSection.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/ClearCookiesSection.tsx
@@ -1,10 +1,6 @@
-import CookieManager from '@react-native-cookies/cookies';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { strings } from '../../../../../../locales/i18n';
-import Device from '../../../../../util/device';
-import Logger from '../../../../../util/Logger';
-import ActionModal from '../../../../UI/ActionModal';
 import {
   Button,
   ButtonVariant,
@@ -26,103 +22,44 @@ const createStyles = () =>
     accessory: {
       marginTop: 16,
     },
-    modalView: {
-      alignItems: 'center',
-      flex: 1,
-      flexDirection: 'column',
-      justifyContent: 'center',
-      padding: 20,
-    },
-    modalTitle: {
-      textAlign: 'center',
-      marginBottom: 20,
-    },
-    modalText: {
-      textAlign: 'center',
-    },
   });
 
-const ClearCookiesSection = () => {
-  const [cookiesModalVisible, setCookiesModalVisible] = useState(false);
-  const [hasCookies, setHasCookies] = useState(false);
+interface ClearCookiesSectionProps {
+  hasCookies: boolean;
+  onPressClearCookies: () => void;
+}
+
+const ClearCookiesSection = ({
+  hasCookies,
+  onPressClearCookies,
+}: ClearCookiesSectionProps) => {
   const styles = createStyles();
 
-  useEffect(() => {
-    const run = async () => {
-      if (Device.isAndroid()) {
-        setHasCookies(true);
-      }
-
-      if (Device.isIos()) {
-        const useWebKit = true;
-        const cookies = await CookieManager.getAll(useWebKit);
-        setHasCookies(Object.keys(cookies).length > 0);
-      }
-    };
-
-    run();
-  }, []);
-
-  const toggleClearCookiesModal = () =>
-    setCookiesModalVisible(!cookiesModalVisible);
-
-  const clearCookies = async () => {
-    const useWebKit = true;
-    await CookieManager.clearAll(useWebKit);
-    Logger.log('Browser cookies cleared');
-
-    if (Device.isIos()) {
-      const cookies = await CookieManager.getAll(useWebKit);
-      setHasCookies(Object.keys(cookies).length > 0);
-    }
-
-    toggleClearCookiesModal();
-  };
-
   return (
-    <>
-      <View style={styles.setting}>
-        <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-          {strings('app_settings.clear_browser_cookies_desc')}
-        </Text>
-        <Text
-          variant={TextVariant.BodySm}
-          fontWeight={FontWeight.Medium}
-          color={TextColor.TextAlternative}
-          style={styles.desc}
-        >
-          {strings('app_settings.clear_cookies_desc')}
-        </Text>
-        <View style={styles.accessory}>
-          <Button
-            size={ButtonSize.Lg}
-            variant={ButtonVariant.Secondary}
-            isFullWidth
-            onPress={toggleClearCookiesModal}
-            isDisabled={!hasCookies}
-          >
-            {strings('app_settings.clear_browser_cookies_desc')}
-          </Button>
-        </View>
-      </View>
-      <ActionModal
-        modalVisible={cookiesModalVisible}
-        confirmText={strings('app_settings.clear')}
-        cancelText={strings('app_settings.reset_account_cancel_button')}
-        onCancelPress={toggleClearCookiesModal}
-        onRequestClose={toggleClearCookiesModal}
-        onConfirmPress={clearCookies}
+    <View style={styles.setting}>
+      <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+        {strings('app_settings.clear_browser_cookies_desc')}
+      </Text>
+      <Text
+        variant={TextVariant.BodySm}
+        fontWeight={FontWeight.Medium}
+        color={TextColor.TextAlternative}
+        style={styles.desc}
       >
-        <View style={styles.modalView}>
-          <Text variant={TextVariant.HeadingMd} style={styles.modalTitle}>
-            {strings('app_settings.clear_cookies_modal_title')}
-          </Text>
-          <Text variant={TextVariant.BodyMd} style={styles.modalText}>
-            {strings('app_settings.clear_cookies_modal_message')}
-          </Text>
-        </View>
-      </ActionModal>
-    </>
+        {strings('app_settings.clear_cookies_desc')}
+      </Text>
+      <View style={styles.accessory}>
+        <Button
+          size={ButtonSize.Lg}
+          variant={ButtonVariant.Secondary}
+          isFullWidth
+          onPress={onPressClearCookies}
+          isDisabled={!hasCookies}
+        >
+          {strings('app_settings.clear_browser_cookies_desc')}
+        </Button>
+      </View>
+    </View>
   );
 };
 

--- a/app/components/Views/Settings/SecuritySettings/Sections/ClearPrivacy/ClearPrivacy.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/ClearPrivacy/ClearPrivacy.tsx
@@ -1,9 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { View } from 'react-native';
 import { styleSheet } from './styles';
-import Engine from '../../../../../../core/Engine';
 import { useStyles } from '../../../../../../component-library/hooks';
-import ActionModal from '../../../../../UI/ActionModal';
 import { strings } from '../../../../../../../locales/i18n';
 import { CLEAR_PRIVACY_SECTION } from '../../SecuritySettings.constants';
 import {
@@ -15,47 +13,14 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import SDKConnect from '../../../../../../../app/core/SDKConnect/SDKConnect';
 import { SecurityPrivacyViewSelectorsIDs } from '../../SecurityPrivacyView.testIds';
-import { ClearPrivacyModalSelectorsIDs } from './ClearPrivacyModal.testIds';
-import { isSnapId } from '@metamask/snaps-utils';
 
-const ClearPrivacy = () => {
+interface ClearPrivacyProps {
+  onPressClearPrivacy: () => void;
+}
+
+const ClearPrivacy = ({ onPressClearPrivacy }: ClearPrivacyProps) => {
   const { styles } = useStyles(styleSheet, {});
-
-  const [modalVisible, setModalVisible] = useState<boolean>(false);
-
-  const clearApprovals = () => {
-    const { PermissionController } = Engine.context;
-    PermissionController.getSubjectNames()
-      .filter((subject) => !isSnapId(subject))
-      .forEach((subject) => PermissionController.revokeAllPermissions(subject));
-    SDKConnect.getInstance().removeAll();
-    setModalVisible(false);
-  };
-
-  const approvalModal = () => (
-    <ActionModal
-      modalVisible={modalVisible}
-      confirmText={strings('app_settings.clear')}
-      cancelText={strings('app_settings.reset_account_cancel_button')}
-      onCancelPress={() => setModalVisible(false)}
-      onRequestClose={() => setModalVisible(false)}
-      onConfirmPress={clearApprovals}
-    >
-      <View
-        style={styles.modalView}
-        testID={ClearPrivacyModalSelectorsIDs.CONTAINER}
-      >
-        <Text variant={TextVariant.HeadingMd} style={styles.modalTitle}>
-          {strings('app_settings.clear_approvals_modal_title')}
-        </Text>
-        <Text variant={TextVariant.BodyMd} style={styles.modalText}>
-          {strings('app_settings.clear_approvals_modal_message')}
-        </Text>
-      </View>
-    </ActionModal>
-  );
 
   return (
     <View style={[styles.setting]} testID={CLEAR_PRIVACY_SECTION}>
@@ -76,12 +41,11 @@ const ClearPrivacy = () => {
           testID={SecurityPrivacyViewSelectorsIDs.CLEAR_PRIVACY_DATA_BUTTON}
           size={ButtonSize.Lg}
           isFullWidth
-          onPress={() => setModalVisible(true)}
+          onPress={onPressClearPrivacy}
         >
           {strings('app_settings.clear_privacy_title')}
         </Button>
       </View>
-      {approvalModal()}
     </View>
   );
 };

--- a/app/components/Views/Settings/SecuritySettings/Sections/ClearPrivacy/styles.ts
+++ b/app/components/Views/Settings/SecuritySettings/Sections/ClearPrivacy/styles.ts
@@ -12,18 +12,4 @@ export const styleSheet = () =>
     accessory: {
       marginTop: 16,
     },
-    modalView: {
-      alignItems: 'center',
-      flex: 1,
-      flexDirection: 'column',
-      justifyContent: 'center',
-      padding: 20,
-    },
-    modalText: {
-      textAlign: 'center',
-    },
-    modalTitle: {
-      textAlign: 'center',
-      marginBottom: 20,
-    },
   });

--- a/app/components/Views/Settings/SecuritySettings/SecuritySettings.styles.ts
+++ b/app/components/Views/Settings/SecuritySettings/SecuritySettings.styles.ts
@@ -50,28 +50,6 @@ const createStyles = ({ theme: { colors } }: { theme: Theme }) =>
     halfSetting: {
       marginTop: 24,
     },
-    modalView: {
-      alignItems: 'center',
-      flex: 1,
-      flexDirection: 'column',
-      justifyContent: 'center',
-      padding: 20,
-    },
-    modalText: {
-      textAlign: 'center',
-    },
-    modalTitle: {
-      textAlign: 'center',
-      marginBottom: 20,
-    },
-    bottomSheetContent: {
-      paddingHorizontal: 16,
-      paddingTop: 8,
-      paddingBottom: 24,
-    },
-    bottomSheetParagraph: {
-      marginBottom: 16,
-    },
     protect: {
       flexDirection: 'row',
       justifyContent: 'space-between',

--- a/app/components/Views/Settings/SecuritySettings/SecuritySettings.styles.ts
+++ b/app/components/Views/Settings/SecuritySettings/SecuritySettings.styles.ts
@@ -64,6 +64,14 @@ const createStyles = ({ theme: { colors } }: { theme: Theme }) =>
       textAlign: 'center',
       marginBottom: 20,
     },
+    bottomSheetContent: {
+      paddingHorizontal: 16,
+      paddingTop: 8,
+      paddingBottom: 24,
+    },
+    bottomSheetParagraph: {
+      marginBottom: 16,
+    },
     protect: {
       flexDirection: 'row',
       justifyContent: 'space-between',

--- a/app/components/Views/Settings/SecuritySettings/SecuritySettings.tsx
+++ b/app/components/Views/Settings/SecuritySettings/SecuritySettings.tsx
@@ -9,16 +9,15 @@ import {
   InteractionManager,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import CookieManager from '@react-native-cookies/cookies';
 import StorageWrapper from '../../../../store/storage-wrapper';
 import { useDispatch, useSelector } from 'react-redux';
 import { MAINNET } from '../../../../constants/network';
-import ActionModal from '../../../UI/ActionModal';
 import { clearHistory } from '../../../../actions/browser';
 import { SIMULATION_DETALS_ARTICLE_URL } from '../../../../constants/urls';
 import { strings } from '../../../../../locales/i18n';
 import Engine from '../../../../core/Engine';
 import { SEED_PHRASE_HINTS } from '../../../../constants/storage';
-import HintModal from '../../../UI/HintModal';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { trackExternalLinkClicked } from '../../../../util/analytics/externalLinkTracking';
 import {
@@ -42,11 +41,16 @@ import type { AppNavigationProp } from '../../../../core/NavigationService/types
 import { useParams } from '../../../../util/navigation/navUtils';
 import { CLEAR_BROWSER_HISTORY_SECTION } from './SecuritySettings.constants';
 import {
+  BottomSheet,
+  BottomSheetFooter,
+  BottomSheetHeader,
+  type BottomSheetRef,
   Button,
   ButtonVariant,
   ButtonSize,
   HeaderStandard,
   FontWeight,
+  TextArea,
   Text,
   TextColor,
   TextVariant,
@@ -72,6 +76,11 @@ import BatchAccountBalanceSettings from '../../Settings/BatchAccountBalanceSetti
 import useCheckNftAutoDetectionModal from '../../../hooks/useCheckNftAutoDetectionModal';
 import useCheckMultiRpcModal from '../../../hooks/useCheckMultiRpcModal';
 import { useStyles } from '../../../../component-library/hooks/useStyles';
+import Device from '../../../../util/device';
+import Logger from '../../../../util/Logger';
+import SDKConnect from '../../../../core/SDKConnect/SDKConnect';
+import { isSnapId } from '@metamask/snaps-utils';
+import { ClearPrivacyModalSelectorsIDs } from './Sections/ClearPrivacy/ClearPrivacyModal.testIds';
 
 const Settings: React.FC = () => {
   const { trackEvent, isEnabled, createEventBuilder } = useAnalytics();
@@ -84,12 +93,21 @@ const Settings: React.FC = () => {
   const dispatch = useDispatch();
   const [browserHistoryModalVisible, setBrowserHistoryModalVisible] =
     useState(false);
+  const [clearPrivacySheetVisible, setClearPrivacySheetVisible] =
+    useState(false);
+  const [clearCookiesSheetVisible, setClearCookiesSheetVisible] =
+    useState(false);
   const [analyticsEnabled, setAnalyticsEnabled] = useState(false);
   const [showHint, setShowHint] = useState(false);
   const [hintText, setHintText] = useState('');
+  const [hasCookies, setHasCookies] = useState(false);
   const isBasicFunctionalityEnabled = useSelector(
     (state: RootState) => state?.settings?.basicFunctionalityEnabled,
   );
+  const clearBrowserHistorySheetRef = useRef<BottomSheetRef>(null);
+  const clearPrivacySheetRef = useRef<BottomSheetRef>(null);
+  const clearCookiesSheetRef = useRef<BottomSheetRef>(null);
+  const hintSheetRef = useRef<BottomSheetRef>(null);
   const scrollViewRef = useRef<ScrollView>(null);
   const metaMetricsSectionRef = useRef<View>(null);
   const dataCollectionSectionRef = useRef<View>(null);
@@ -149,6 +167,23 @@ const Settings: React.FC = () => {
   }, [handleHintText, setAnalyticsEnabled, isEnabled]);
 
   useEffect(() => {
+    const run = async () => {
+      if (Device.isAndroid()) {
+        setHasCookies(true);
+        return;
+      }
+
+      if (Device.isIos()) {
+        const useWebKit = true;
+        const cookies = await CookieManager.getAll(useWebKit);
+        setHasCookies(Object.keys(cookies).length > 0);
+      }
+    };
+
+    run();
+  }, []);
+
+  useEffect(() => {
     const triggerCascadeBasicFunctionalityDisable = async () => {
       if (!isBasicFunctionalityEnabled) {
         isNotificationEnabled && (await disableNotifications());
@@ -191,27 +226,41 @@ const Settings: React.FC = () => {
     }, [scrollToSection, params?.scrollToSection]),
   );
 
-  const toggleHint = () => {
-    setShowHint(!showHint);
-  };
+  const openHintSheet = () => setShowHint(true);
+
+  const requestCloseHintSheet = useCallback(() => {
+    Keyboard.dismiss();
+    hintSheetRef.current?.onCloseBottomSheet();
+  }, []);
 
   const saveHint = async () => {
     if (!hintText) return;
-    toggleHint();
-    const currentSeedphraseHints =
-      await StorageWrapper.getItem(SEED_PHRASE_HINTS);
-    if (currentSeedphraseHints) {
-      const parsedHints = JSON.parse(currentSeedphraseHints);
-      await StorageWrapper.setItem(
-        SEED_PHRASE_HINTS,
-        JSON.stringify({ ...parsedHints, manualBackup: hintText }),
-      );
-    }
+    Keyboard.dismiss();
+    hintSheetRef.current?.onCloseBottomSheet(() => {
+      (async () => {
+        const currentSeedphraseHints =
+          await StorageWrapper.getItem(SEED_PHRASE_HINTS);
+        if (currentSeedphraseHints) {
+          const parsedHints = JSON.parse(currentSeedphraseHints);
+          await StorageWrapper.setItem(
+            SEED_PHRASE_HINTS,
+            JSON.stringify({ ...parsedHints, manualBackup: hintText }),
+          );
+        }
+      })().catch((error) => {
+        Logger.error(error as Error, 'SecuritySettings: Failed to save hint');
+      });
+    });
   };
 
-  const toggleClearBrowserHistoryModal = () => {
-    setBrowserHistoryModalVisible(!browserHistoryModalVisible);
-  };
+  const openClearBrowserHistorySheet = () => setBrowserHistoryModalVisible(true);
+
+  const closeClearBrowserHistorySheet = () =>
+    setBrowserHistoryModalVisible(false);
+
+  const requestCloseClearBrowserHistorySheet = useCallback(() => {
+    clearBrowserHistorySheetRef.current?.onCloseBottomSheet();
+  }, []);
 
   const renderClearBrowserHistorySection = () => (
     <View style={styles.setting} testID={CLEAR_BROWSER_HISTORY_SECTION}>
@@ -231,7 +280,7 @@ const Settings: React.FC = () => {
           variant={ButtonVariant.Secondary}
           size={ButtonSize.Lg}
           isFullWidth
-          onPress={toggleClearBrowserHistoryModal}
+          onPress={openClearBrowserHistorySheet}
           isDisabled={browserHistory.length === 0}
         >
           {strings('app_settings.clear_browser_history_desc')}
@@ -240,30 +289,165 @@ const Settings: React.FC = () => {
     </View>
   );
 
-  const clearBrowserHistory = () => {
+  const clearBrowserHistory = useCallback(() => {
     dispatch(clearHistory(isEnabled(), isDataCollectionForMarketingEnabled));
-    toggleClearBrowserHistoryModal();
+  }, [dispatch, isDataCollectionForMarketingEnabled, isEnabled]);
+
+  const renderClearBrowserHistorySheet = () => {
+    if (!browserHistoryModalVisible) {
+      return null;
+    }
+
+    return (
+      <BottomSheet
+        ref={clearBrowserHistorySheetRef}
+        isInteractable
+        onClose={closeClearBrowserHistorySheet}
+      >
+        <BottomSheetHeader onClose={requestCloseClearBrowserHistorySheet}>
+          <Text variant={TextVariant.HeadingMd}>
+            {strings('app_settings.clear_browser_history_modal_title')}
+          </Text>
+        </BottomSheetHeader>
+        <View style={styles.bottomSheetContent}>
+          <Text variant={TextVariant.BodyMd} style={styles.modalText}>
+            {strings('app_settings.clear_browser_history_modal_message')}
+          </Text>
+        </View>
+        <BottomSheetFooter
+          secondaryButtonProps={{
+            children: strings('app_settings.reset_account_cancel_button'),
+            onPress: requestCloseClearBrowserHistorySheet,
+          }}
+          primaryButtonProps={{
+            children: strings('app_settings.clear'),
+            isDanger: true,
+            onPress: () =>
+              clearBrowserHistorySheetRef.current?.onCloseBottomSheet(() => {
+                clearBrowserHistory();
+              }),
+          }}
+        />
+      </BottomSheet>
+    );
   };
 
-  const renderHistoryModal = () => (
-    <ActionModal
-      modalVisible={browserHistoryModalVisible}
-      confirmText={strings('app_settings.clear')}
-      cancelText={strings('app_settings.reset_account_cancel_button')}
-      onCancelPress={toggleClearBrowserHistoryModal}
-      onRequestClose={toggleClearBrowserHistoryModal}
-      onConfirmPress={clearBrowserHistory}
-    >
-      <View style={styles.modalView}>
-        <Text variant={TextVariant.HeadingMd} style={styles.modalTitle}>
-          {strings('app_settings.clear_browser_history_modal_title')}
-        </Text>
-        <Text variant={TextVariant.BodyMd} style={styles.modalText}>
-          {strings('app_settings.clear_browser_history_modal_message')}
-        </Text>
-      </View>
-    </ActionModal>
-  );
+  const openClearPrivacySheet = () => setClearPrivacySheetVisible(true);
+  const closeClearPrivacySheet = () => setClearPrivacySheetVisible(false);
+  const requestCloseClearPrivacySheet = useCallback(() => {
+    clearPrivacySheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  const clearApprovals = useCallback(() => {
+    const { PermissionController } = Engine.context;
+    PermissionController.getSubjectNames()
+      .filter((subject) => !isSnapId(subject))
+      .forEach((subject) => PermissionController.revokeAllPermissions(subject));
+    SDKConnect.getInstance().removeAll();
+  }, []);
+
+  const renderClearPrivacySheet = () => {
+    if (!clearPrivacySheetVisible) {
+      return null;
+    }
+
+    return (
+      <BottomSheet
+        ref={clearPrivacySheetRef}
+        isInteractable
+        onClose={closeClearPrivacySheet}
+      >
+        <BottomSheetHeader onClose={requestCloseClearPrivacySheet}>
+          <Text variant={TextVariant.HeadingMd}>
+            {strings('app_settings.clear_approvals_modal_title')}
+          </Text>
+        </BottomSheetHeader>
+        <View
+          style={styles.bottomSheetContent}
+          testID={ClearPrivacyModalSelectorsIDs.CONTAINER}
+        >
+          <Text variant={TextVariant.BodyMd} style={styles.modalText}>
+            {strings('app_settings.clear_approvals_modal_message')}
+          </Text>
+        </View>
+        <BottomSheetFooter
+          secondaryButtonProps={{
+            children: strings('app_settings.reset_account_cancel_button'),
+            onPress: requestCloseClearPrivacySheet,
+          }}
+          primaryButtonProps={{
+            children: strings('app_settings.clear'),
+            isDanger: true,
+            onPress: () =>
+              clearPrivacySheetRef.current?.onCloseBottomSheet(() => {
+                clearApprovals();
+              }),
+          }}
+        />
+      </BottomSheet>
+    );
+  };
+
+  const openClearCookiesSheet = () => setClearCookiesSheetVisible(true);
+  const closeClearCookiesSheet = () => setClearCookiesSheetVisible(false);
+  const requestCloseClearCookiesSheet = useCallback(() => {
+    clearCookiesSheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  const clearCookies = useCallback(async () => {
+    const useWebKit = true;
+    await CookieManager.clearAll(useWebKit);
+    Logger.log('Browser cookies cleared');
+
+    if (Device.isIos()) {
+      const cookies = await CookieManager.getAll(useWebKit);
+      setHasCookies(Object.keys(cookies).length > 0);
+    }
+  }, []);
+
+  const renderClearCookiesSheet = () => {
+    if (!clearCookiesSheetVisible) {
+      return null;
+    }
+
+    return (
+      <BottomSheet
+        ref={clearCookiesSheetRef}
+        isInteractable
+        onClose={closeClearCookiesSheet}
+      >
+        <BottomSheetHeader onClose={requestCloseClearCookiesSheet}>
+          <Text variant={TextVariant.HeadingMd}>
+            {strings('app_settings.clear_cookies_modal_title')}
+          </Text>
+        </BottomSheetHeader>
+        <View style={styles.bottomSheetContent}>
+          <Text variant={TextVariant.BodyMd} style={styles.modalText}>
+            {strings('app_settings.clear_cookies_modal_message')}
+          </Text>
+        </View>
+        <BottomSheetFooter
+          secondaryButtonProps={{
+            children: strings('app_settings.reset_account_cancel_button'),
+            onPress: requestCloseClearCookiesSheet,
+          }}
+          primaryButtonProps={{
+            children: strings('app_settings.clear'),
+            isDanger: true,
+            onPress: () =>
+              clearCookiesSheetRef.current?.onCloseBottomSheet(() => {
+                clearCookies().catch((error) => {
+                  Logger.error(
+                    error as Error,
+                    'SecuritySettings: Failed to clear cookies',
+                  );
+                });
+              }),
+          }}
+        />
+      </BottomSheet>
+    );
+  };
 
   const toggleUseTransactionSimulations = (value: boolean) => {
     const { PreferencesController } = Engine.context;
@@ -331,16 +515,53 @@ const Settings: React.FC = () => {
 
   const handleChangeText = (text: string) => setHintText(text);
 
-  const renderHint = () => (
-    <HintModal
-      onConfirm={saveHint}
-      onCancel={toggleHint}
-      modalVisible={showHint}
-      onRequestClose={Keyboard.dismiss}
-      value={hintText}
-      onChangeText={handleChangeText}
-    />
-  );
+  const renderHintSheet = () => {
+    if (!showHint) {
+      return null;
+    }
+
+    return (
+      <BottomSheet
+        ref={hintSheetRef}
+        isInteractable
+        onClose={() => setShowHint(false)}
+      >
+        <BottomSheetHeader onClose={requestCloseHintSheet}>
+          <Text variant={TextVariant.HeadingMd}>
+            {strings('manual_backup_step_3.recovery_hint')}
+          </Text>
+        </BottomSheetHeader>
+        <View style={styles.bottomSheetContent}>
+          <Text variant={TextVariant.BodyMd} style={styles.bottomSheetParagraph}>
+            {strings('manual_backup_step_3.leave_hint')}
+          </Text>
+          <Text
+            variant={TextVariant.BodyMd}
+            color={TextColor.ErrorDefault}
+            style={styles.bottomSheetParagraph}
+          >
+            {strings('manual_backup_step_3.no_seedphrase')}
+          </Text>
+          <TextArea
+            value={hintText}
+            placeholder={strings('manual_backup_step_3.example')}
+            onChangeText={handleChangeText}
+            textAlignVertical="top"
+          />
+        </View>
+        <BottomSheetFooter
+          secondaryButtonProps={{
+            children: strings('action_view.cancel'),
+            onPress: requestCloseHintSheet,
+          }}
+          primaryButtonProps={{
+            children: strings('manual_backup_step_3.save'),
+            onPress: saveHint,
+          }}
+        />
+      </BottomSheet>
+    );
+  };
 
   const toggleBasicFunctionality = () => {
     navigation.navigate(Routes.MODAL.ROOT_MODAL_FLOW, {
@@ -374,7 +595,7 @@ const Settings: React.FC = () => {
           <ProtectYourWallet
             srpBackedup={seedphraseBackedUp}
             hintText={hintText}
-            toggleHint={toggleHint}
+            toggleHint={openHintSheet}
           />
           <ChangePassword />
           <AutoLock />
@@ -389,9 +610,12 @@ const Settings: React.FC = () => {
               handleSwitchToggle={toggleBasicFunctionality}
             />
           </View>
-          <ClearPrivacy />
+          <ClearPrivacy onPressClearPrivacy={openClearPrivacySheet} />
           {renderClearBrowserHistorySection()}
-          <ClearCookiesSection />
+          <ClearCookiesSection
+            hasCookies={hasCookies}
+            onPressClearCookies={openClearCookiesSheet}
+          />
           <Text variant={TextVariant.HeadingMd} style={styles.subHeading}>
             {strings('app_settings.network_provider')}
           </Text>
@@ -400,7 +624,6 @@ const Settings: React.FC = () => {
             {strings('app_settings.transactions_subheading')}
           </Text>
           <BatchAccountBalanceSettings />
-          {renderHistoryModal()}
           {renderUseTransactionSimulations()}
           <Text variant={TextVariant.HeadingMd} style={styles.subHeading}>
             {strings('app_settings.token_nft_ens_subheading')}
@@ -418,9 +641,12 @@ const Settings: React.FC = () => {
           <DeleteMetaMetricsData metricsOptin={analyticsEnabled} />
           <DeleteWalletData />
           <TopTradersSection />
-          {renderHint()}
         </View>
       </ScrollView>
+      {renderClearBrowserHistorySheet()}
+      {renderClearPrivacySheet()}
+      {renderClearCookiesSheet()}
+      {renderHintSheet()}
       <SwitchLoadingModal
         loading={modalLoading}
         loadingText=""

--- a/app/components/Views/Settings/SecuritySettings/SecuritySettings.tsx
+++ b/app/components/Views/Settings/SecuritySettings/SecuritySettings.tsx
@@ -45,6 +45,7 @@ import {
   BottomSheetFooter,
   BottomSheetHeader,
   type BottomSheetRef,
+  Box,
   Button,
   ButtonVariant,
   ButtonSize,
@@ -305,15 +306,13 @@ const Settings: React.FC = () => {
         onClose={closeClearBrowserHistorySheet}
       >
         <BottomSheetHeader onClose={requestCloseClearBrowserHistorySheet}>
-          <Text variant={TextVariant.HeadingMd}>
-            {strings('app_settings.clear_browser_history_modal_title')}
-          </Text>
+          {strings('app_settings.clear_browser_history_modal_title')}
         </BottomSheetHeader>
-        <View style={styles.bottomSheetContent}>
-          <Text variant={TextVariant.BodyMd} style={styles.modalText}>
+        <Box twClassName="px-4 pt-2 pb-6">
+          <Text variant={TextVariant.BodyMd} twClassName="text-center">
             {strings('app_settings.clear_browser_history_modal_message')}
           </Text>
-        </View>
+        </Box>
         <BottomSheetFooter
           secondaryButtonProps={{
             children: strings('app_settings.reset_account_cancel_button'),
@@ -358,18 +357,16 @@ const Settings: React.FC = () => {
         onClose={closeClearPrivacySheet}
       >
         <BottomSheetHeader onClose={requestCloseClearPrivacySheet}>
-          <Text variant={TextVariant.HeadingMd}>
-            {strings('app_settings.clear_approvals_modal_title')}
-          </Text>
+          {strings('app_settings.clear_approvals_modal_title')}
         </BottomSheetHeader>
-        <View
-          style={styles.bottomSheetContent}
+        <Box
+          twClassName="px-4 pt-2 pb-6"
           testID={ClearPrivacyModalSelectorsIDs.CONTAINER}
         >
-          <Text variant={TextVariant.BodyMd} style={styles.modalText}>
+          <Text variant={TextVariant.BodyMd} twClassName="text-center">
             {strings('app_settings.clear_approvals_modal_message')}
           </Text>
-        </View>
+        </Box>
         <BottomSheetFooter
           secondaryButtonProps={{
             children: strings('app_settings.reset_account_cancel_button'),
@@ -417,15 +414,13 @@ const Settings: React.FC = () => {
         onClose={closeClearCookiesSheet}
       >
         <BottomSheetHeader onClose={requestCloseClearCookiesSheet}>
-          <Text variant={TextVariant.HeadingMd}>
-            {strings('app_settings.clear_cookies_modal_title')}
-          </Text>
+          {strings('app_settings.clear_cookies_modal_title')}
         </BottomSheetHeader>
-        <View style={styles.bottomSheetContent}>
-          <Text variant={TextVariant.BodyMd} style={styles.modalText}>
+        <Box twClassName="px-4 pt-2 pb-6">
+          <Text variant={TextVariant.BodyMd} twClassName="text-center">
             {strings('app_settings.clear_cookies_modal_message')}
           </Text>
-        </View>
+        </Box>
         <BottomSheetFooter
           secondaryButtonProps={{
             children: strings('app_settings.reset_account_cancel_button'),
@@ -527,18 +522,16 @@ const Settings: React.FC = () => {
         onClose={() => setShowHint(false)}
       >
         <BottomSheetHeader onClose={requestCloseHintSheet}>
-          <Text variant={TextVariant.HeadingMd}>
-            {strings('manual_backup_step_3.recovery_hint')}
-          </Text>
+          {strings('manual_backup_step_3.recovery_hint')}
         </BottomSheetHeader>
-        <View style={styles.bottomSheetContent}>
-          <Text variant={TextVariant.BodyMd} style={styles.bottomSheetParagraph}>
+        <Box twClassName="px-4 pt-2 pb-6">
+          <Text variant={TextVariant.BodyMd} twClassName="mb-4">
             {strings('manual_backup_step_3.leave_hint')}
           </Text>
           <Text
             variant={TextVariant.BodyMd}
             color={TextColor.ErrorDefault}
-            style={styles.bottomSheetParagraph}
+            twClassName="mb-4"
           >
             {strings('manual_backup_step_3.no_seedphrase')}
           </Text>
@@ -548,7 +541,7 @@ const Settings: React.FC = () => {
             onChangeText={handleChangeText}
             textAlignVertical="top"
           />
-        </View>
+        </Box>
         <BottomSheetFooter
           secondaryButtonProps={{
             children: strings('action_view.cancel'),

--- a/app/components/Views/Settings/SecuritySettings/SecuritySettings.tsx
+++ b/app/components/Views/Settings/SecuritySettings/SecuritySettings.tsx
@@ -254,7 +254,8 @@ const Settings: React.FC = () => {
     });
   };
 
-  const openClearBrowserHistorySheet = () => setBrowserHistoryModalVisible(true);
+  const openClearBrowserHistorySheet = () =>
+    setBrowserHistoryModalVisible(true);
 
   const closeClearBrowserHistorySheet = () =>
     setBrowserHistoryModalVisible(false);

--- a/app/util/test/testSetup.js
+++ b/app/util/test/testSetup.js
@@ -466,6 +466,15 @@ jest.mock(
 );
 jest.mock('@react-native-cookies/cookies', () => 'RNCookies');
 
+// Mock react-native-material-textfield, which accesses RN internals at import time
+// and can crash under Jest (we only need a renderable stand-in).
+jest.mock('react-native-material-textfield', () => {
+  const React = require('react');
+  const { TextInput } = require('react-native');
+  const OutlinedTextField = (props) => React.createElement(TextInput, props);
+  return { OutlinedTextField };
+});
+
 /**
  * Use the official `react-native-worklets` Jest mock. Reanimated 4 depends on
  * react-native-worklets, and requiring the real package eagerly initializes its


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Converted Settings confirmation dialogs that were using deprecated / `react-native-modal`-based modals to `BottomSheet` from `@metamask/design-system-react-native`, mounted at the screen root so they properly overlay content.

Follow-up: migrated the new sheets to the most up-to-date MMDS usage patterns (string titles for `BottomSheetHeader`, `Box`/MMDS `Text`, and `twClassName` where applicable) and removed leftover custom modal styles.

Follow-up: ran `yarn format:check` and applied formatting fixes (no behavior changes).

Specifically:
- Security & Privacy: Clear privacy approvals, clear browser history, clear cookies, and the recovery hint editor
- Advanced Settings: Reset account confirmation
- Notification toggle loading/error UI: replaced `react-native-modal` wrapper with a design-system `BottomSheet`

## **Changelog**

CHANGELOG entry: Updated Settings confirmation dialogs to use BottomSheets instead of deprecated modals.

## **Related issues**

Refs: N/A

## **Manual testing steps**

```gherkin
Feature: Settings bottom sheets

  Scenario: User sees bottom sheet confirmations in Security & Privacy
    Given the user is on Settings > Security & privacy

    When the user taps "Clear privacy data"
    Then a bottom sheet confirmation is shown

    When the user dismisses the sheet (close button / swipe down / tap outside)
    Then the sheet closes and the screen remains usable

  Scenario: User sees bottom sheet confirmation in Advanced Settings
    Given the user is on Settings > Advanced

    When the user taps "Reset account"
    Then a bottom sheet confirmation is shown

    When the user taps the confirm button
    Then the sheet closes and the reset behavior is triggered
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c8a4d57-2fb3-4f14-ae34-4d7f22c0e2f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c8a4d57-2fb3-4f14-ae34-4d7f22c0e2f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

