### PR TITLE
feat: disable simulation for MetaMask Pay transactions

### DIFF
--- a/app/core/Engine/wallet-init/instance-options/transaction-controller.test.ts
+++ b/app/core/Engine/wallet-init/instance-options/transaction-controller.test.ts
@@ -10,6 +10,7 @@ import {
   TransactionStatus,
 } from '@metamask/transaction-controller';
 
+import { MM_PAY_TRANSACTION_TYPES } from '../../../../components/Views/confirmations/constants/confirmations';
 import { isSendBundleSupported } from '../../../../util/transactions/sentinel-api';
 import { accountSupports7702 } from '../../../../util/transactions/account-supports-7702';
 import { selectShouldUseSmartTransaction } from '../../../../selectors/smartTransactionsController';
@@ -130,6 +131,53 @@ describe('TransactionController wallet instance options', () => {
 
     expect(isSimulationEnabled?.()).toBe(true);
   });
+
+  it('determines if simulation is enabled using preferences for non-MM Pay transactions', () => {
+    const isSimulationEnabled = testConstructorOption('isSimulationEnabled', {
+      preferencesState: {
+        useTransactionSimulations: true,
+      },
+    });
+
+    expect(
+      isSimulationEnabled?.({
+        id: '1',
+        type: TransactionType.contractInteraction,
+        chainId: CHAIN_ID_MOCK,
+        networkClientId: 'test-network',
+        status: TransactionStatus.unapproved,
+        time: Date.now(),
+        txParams: {
+          from: '0x0000000000000000000000000000000000000000',
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it.each(MM_PAY_TRANSACTION_TYPES)(
+    'disables simulation for MM Pay transaction type %s even when preferences enable it',
+    (type) => {
+      const isSimulationEnabled = testConstructorOption('isSimulationEnabled', {
+        preferencesState: {
+          useTransactionSimulations: true,
+        },
+      });
+
+      expect(
+        isSimulationEnabled?.({
+          id: '1',
+          type,
+          chainId: CHAIN_ID_MOCK,
+          networkClientId: 'test-network',
+          status: TransactionStatus.unapproved,
+          time: Date.now(),
+          txParams: {
+            from: '0x0000000000000000000000000000000000000000',
+          },
+        }),
+      ).toBe(false);
+    },
+  );
 
   describe('isAutomaticGasFeeUpdateEnabled', () => {
     function buildTransactionMeta(

--- a/app/core/Engine/wallet-init/instance-options/transaction-controller.ts
+++ b/app/core/Engine/wallet-init/instance-options/transaction-controller.ts
@@ -77,14 +77,8 @@ export function getTransactionControllerInstanceOptions({
     }),
     isFirstTimeInteractionEnabled: () =>
       isFirstTimeInteractionEnabled(initMessenger),
-    isSimulationEnabled: (transactionMeta?: TransactionMeta) => {
-      if (hasTransactionType(transactionMeta, MM_PAY_TRANSACTION_TYPES)) {
-        return false;
-      }
-
-      return initMessenger.call('PreferencesController:getState')
-        .useTransactionSimulations;
-    },
+    isSimulationEnabled: (transactionMeta) =>
+      isSimulationEnabled(transactionMeta, initMessenger),
     getSavedGasFees: (chainIdOrTransactionMeta) =>
       getSavedGasFees(chainIdOrTransactionMeta, initMessenger),
     publicKeyEIP7702: AppConstants.EIP_7702_PUBLIC_KEY as Hex | undefined,
@@ -199,6 +193,28 @@ function isFirstTimeInteractionEnabled(
     initMessenger.call('PreferencesController:getState')
       ?.securityAlertsEnabled === true
   );
+}
+
+/**
+ * Determine whether simulation is enabled for a transaction.
+ *
+ * Simulation is always disabled for MetaMask Pay transactions, otherwise it
+ * follows the user preference.
+ *
+ * @param transactionMeta - The transaction being simulated, if any.
+ * @param initMessenger - The TransactionController init messenger.
+ * @returns True if simulation is enabled.
+ */
+function isSimulationEnabled(
+  transactionMeta: TransactionMeta | undefined,
+  initMessenger: TransactionControllerInitMessenger,
+): boolean {
+  if (hasTransactionType(transactionMeta, MM_PAY_TRANSACTION_TYPES)) {
+    return false;
+  }
+
+  return initMessenger.call('PreferencesController:getState')
+    .useTransactionSimulations;
 }
 
 function getKeyringController(messenger: TransactionControllerInitMessenger) {

--- a/app/core/Engine/wallet-init/instance-options/transaction-controller.ts
+++ b/app/core/Engine/wallet-init/instance-options/transaction-controller.ts
@@ -14,6 +14,7 @@ import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
 
 import {
+  MM_PAY_TRANSACTION_TYPES,
   REDESIGNED_TRANSACTION_TYPES,
   RELAY_DEPOSIT_TYPES,
 } from '../../../../components/Views/confirmations/constants/confirmations';
@@ -76,9 +77,14 @@ export function getTransactionControllerInstanceOptions({
     }),
     isFirstTimeInteractionEnabled: () =>
       isFirstTimeInteractionEnabled(initMessenger),
-    isSimulationEnabled: () =>
-      initMessenger.call('PreferencesController:getState')
-        .useTransactionSimulations,
+    isSimulationEnabled: (transactionMeta?: TransactionMeta) => {
+      if (hasTransactionType(transactionMeta, MM_PAY_TRANSACTION_TYPES)) {
+        return false;
+      }
+
+      return initMessenger.call('PreferencesController:getState')
+        .useTransactionSimulations;
+    },
     getSavedGasFees: (chainIdOrTransactionMeta) =>
       getSavedGasFees(chainIdOrTransactionMeta, initMessenger),
     publicKeyEIP7702: AppConstants.EIP_7702_PUBLIC_KEY as Hex | undefined,

--- a/package.json
+++ b/package.json
@@ -254,6 +254,12 @@
     "@ledgerhq/context-module/ethers": "^6.16.0",
     "@ledgerhq/device-signer-kit-ethereum/ethers": "^6.16.0"
   },
+  "previewBuilds": {
+    "@metamask/transaction-controller": {
+      "type": "non-breaking",
+      "previewVersion": "69.5.2-preview-7585e3a"
+    }
+  },
   "dependencies": {
     "@braze/react-native-sdk": "patch:@braze/react-native-sdk@npm%3A19.1.0#~/.yarn/patches/@braze-react-native-sdk-npm-19.1.0-076-reactmoduleinfo.patch",
     "@consensys/on-ramp-sdk": "2.1.12",

--- a/package.json
+++ b/package.json
@@ -244,7 +244,7 @@
     "react-native-quick-base64@npm:^2.0.5": "patch:react-native-quick-base64@npm%3A2.2.0#~/.yarn/patches/react-native-quick-base64-npm-2.2.0-9083eb316a.patch",
     "@metamask/permission-controller": "^13.1.1",
     "react-native-ble-plx@npm:3.4.0": "patch:react-native-ble-plx@npm%3A3.4.0#~/.yarn/patches/react-native-ble-plx-npm-3.4.0-401e8b3343.patch",
-    "@metamask/transaction-controller": "69.5.1",
+    "@metamask/transaction-controller": "69.6.0",
     "@metamask/keyring-controller": "^27.1.1",
     "expo-web-browser@npm:~55.0.16": "55.0.16",
     "@expo/cli@npm:55.0.32": "patch:@expo/cli@npm%3A55.0.32#~/.yarn/patches/@expo-cli-npm-55.0.32-5fb47bae24.patch",
@@ -253,12 +253,6 @@
     "@metamask/network-enablement-controller@npm:^5.4.1": "patch:@metamask/network-enablement-controller@npm%3A5.4.1#~/.yarn/patches/@metamask-network-enablement-controller-npm-5.4.1-020a82a308.patch",
     "@ledgerhq/context-module/ethers": "^6.16.0",
     "@ledgerhq/device-signer-kit-ethereum/ethers": "^6.16.0"
-  },
-  "previewBuilds": {
-    "@metamask/transaction-controller": {
-      "type": "non-breaking",
-      "previewVersion": "69.5.2-preview-7585e3a"
-    }
   },
   "dependencies": {
     "@braze/react-native-sdk": "patch:@braze/react-native-sdk@npm%3A19.1.0#~/.yarn/patches/@braze-react-native-sdk-npm-19.1.0-076-reactmoduleinfo.patch",
@@ -404,7 +398,7 @@
     "@metamask/subscription-controller": "^8.0.0",
     "@metamask/superstruct": "^3.2.1",
     "@metamask/swappable-obj-proxy": "^2.1.0",
-    "@metamask/transaction-controller": "^69.5.2",
+    "@metamask/transaction-controller": "^69.6.0",
     "@metamask/transaction-pay-controller": "^26.4.1",
     "@metamask/tron-wallet-snap": "^1.33.1",
     "@metamask/utils": "^11.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7650,6 +7650,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/account-tree-controller@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@metamask/account-tree-controller@npm:8.0.0"
+  dependencies:
+    "@metamask/accounts-controller": "npm:^39.1.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/keyring-api": "npm:^24.0.0"
+    "@metamask/keyring-controller": "npm:^27.1.1"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/multichain-account-service": "npm:^13.0.2"
+    "@metamask/profile-sync-controller": "npm:^29.0.0"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/snaps-sdk": "npm:^11.0.0"
+    "@metamask/snaps-utils": "npm:^12.1.2"
+    "@metamask/superstruct": "npm:^3.4.1"
+    "@metamask/utils": "npm:^11.11.0"
+    fast-deep-equal: "npm:^3.1.3"
+    lodash: "npm:^4.17.21"
+  peerDependencies:
+    "@metamask/providers": ^22.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/3366bbea744c3012ea54f0c0fd932f14c0172cac1efe07d0d05980389743fe306a5bd1f5796cff2367ec90a3fb74a96914777997b5833d22c2a81546ea193bf0
+  languageName: node
+  linkType: hard
+
 "@metamask/accounts-controller@npm:^39.1.0":
   version: 39.1.0
   resolution: "@metamask/accounts-controller@npm:39.1.0"
@@ -8282,6 +8307,25 @@ __metadata:
     cockatiel: "npm:^3.1.2"
     uuid: "npm:^8.3.2"
   checksum: 10/3715995cc7cc8e1d6c2e7543a948ccea135cb6a3bb2e2afe4b55793b2d97523dc4884f487a0cc11d9aeac11eca97dae980c6e527d52132dce09d983304f41520
+  languageName: node
+  linkType: hard
+
+"@metamask/core-backend@npm:^8.1.2":
+  version: 8.1.2
+  resolution: "@metamask/core-backend@npm:8.1.2"
+  dependencies:
+    "@metamask/account-tree-controller": "npm:^8.0.0"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/keyring-controller": "npm:^27.1.1"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/profile-sync-controller": "npm:^29.0.0"
+    "@metamask/remote-feature-flag-controller": "npm:^5.0.0"
+    "@metamask/utils": "npm:^11.11.0"
+    "@tanstack/query-core": "npm:^5.62.16"
+    async-mutex: "npm:^0.5.0"
+    cockatiel: "npm:^3.1.2"
+    uuid: "npm:^8.3.2"
+  checksum: 10/d8dffe22b270bc4e47f188b2314eda02ffeead162149889c6a69b11a05053d7d482228ccf38aa79caf72a5007ce2d7b14da9f3b89b7f87d2fda0d99dc7a3592f
   languageName: node
   linkType: hard
 
@@ -9272,6 +9316,37 @@ __metadata:
   linkType: hard
 
 "@metamask/multichain-account-service@npm:^13.0.0":
+  version: 13.0.2
+  resolution: "@metamask/multichain-account-service@npm:13.0.2"
+  dependencies:
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@metamask/account-api": "npm:^2.0.0"
+    "@metamask/accounts-controller": "npm:^39.1.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/eth-snap-keyring": "npm:^24.0.0"
+    "@metamask/key-tree": "npm:^10.1.1"
+    "@metamask/keyring-api": "npm:^24.0.0"
+    "@metamask/keyring-controller": "npm:^27.1.1"
+    "@metamask/keyring-internal-api": "npm:^12.0.0"
+    "@metamask/keyring-snap-client": "npm:^10.0.0"
+    "@metamask/keyring-utils": "npm:^5.0.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/snap-account-service": "npm:^2.1.2"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/snaps-sdk": "npm:^11.0.0"
+    "@metamask/snaps-utils": "npm:^12.1.2"
+    "@metamask/superstruct": "npm:^3.4.1"
+    "@metamask/utils": "npm:^11.11.0"
+    async-mutex: "npm:^0.5.0"
+    lodash: "npm:^4.17.21"
+  peerDependencies:
+    "@metamask/providers": ^22.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/43f554ee1e58d9700b7f5d47b3e194262d8f8192a6298f177fc29c670efc0c3f659f40b4fbedcfeb9a14b894e5d7d2b59c051d9222a899648e1923f362d83bd5
+  languageName: node
+  linkType: hard
+
+"@metamask/multichain-account-service@npm:^13.0.2":
   version: 13.0.2
   resolution: "@metamask/multichain-account-service@npm:13.0.2"
   dependencies:
@@ -10571,9 +10646,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:69.5.1":
-  version: 69.5.1
-  resolution: "@metamask/transaction-controller@npm:69.5.1"
+"@metamask/transaction-controller@npm:@metamask-previews/transaction-controller@69.5.2-preview-7585e3a":
+  version: 69.5.2-preview-7585e3a
+  resolution: "@metamask-previews/transaction-controller@npm:69.5.2-preview-7585e3a"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/rlp": "npm:^5.0.2"
@@ -10582,11 +10657,11 @@ __metadata:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/wallet": "npm:^5.7.0"
-    "@metamask/accounts-controller": "npm:^39.0.7"
+    "@metamask/accounts-controller": "npm:^39.1.0"
     "@metamask/approval-controller": "npm:^9.0.2"
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/controller-utils": "npm:^12.3.0"
-    "@metamask/core-backend": "npm:^8.1.1"
+    "@metamask/core-backend": "npm:^8.1.2"
     "@metamask/gas-fee-controller": "npm:^26.3.1"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
@@ -10606,7 +10681,7 @@ __metadata:
   peerDependencies:
     "@babel/runtime": ^7.0.0
     "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/192050170a357f182c170ec1eeeee3d879fefcbaf4a85a0d0eccbfc24c8f5e91ee505c602583a1650a4828c7f301871eda9c97c4b5351c73a1ea16e48c36b208
+  checksum: 10/47b899b778f7d3be0c7d2740d0b9f58db15265e95eef47973da27e5667f5441065549497fce53d13d7b4f7f2195d662346bf980a7121be1b2d3f296965f6745c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7650,31 +7650,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/account-tree-controller@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@metamask/account-tree-controller@npm:8.0.0"
-  dependencies:
-    "@metamask/accounts-controller": "npm:^39.1.0"
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/keyring-api": "npm:^24.0.0"
-    "@metamask/keyring-controller": "npm:^27.1.1"
-    "@metamask/messenger": "npm:^2.0.0"
-    "@metamask/multichain-account-service": "npm:^13.0.2"
-    "@metamask/profile-sync-controller": "npm:^29.0.0"
-    "@metamask/snaps-controllers": "npm:^19.0.0"
-    "@metamask/snaps-sdk": "npm:^11.0.0"
-    "@metamask/snaps-utils": "npm:^12.1.2"
-    "@metamask/superstruct": "npm:^3.4.1"
-    "@metamask/utils": "npm:^11.11.0"
-    fast-deep-equal: "npm:^3.1.3"
-    lodash: "npm:^4.17.21"
-  peerDependencies:
-    "@metamask/providers": ^22.0.0
-    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/3366bbea744c3012ea54f0c0fd932f14c0172cac1efe07d0d05980389743fe306a5bd1f5796cff2367ec90a3fb74a96914777997b5833d22c2a81546ea193bf0
-  languageName: node
-  linkType: hard
-
 "@metamask/accounts-controller@npm:^39.1.0":
   version: 39.1.0
   resolution: "@metamask/accounts-controller@npm:39.1.0"
@@ -8272,7 +8247,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/core-backend@npm:^8.1.1, @metamask/core-backend@npm:^8.1.2":
+"@metamask/core-backend@npm:^8.1.2":
   version: 8.1.2
   resolution: "@metamask/core-backend@npm:8.1.2"
   dependencies:
@@ -8307,25 +8282,6 @@ __metadata:
     cockatiel: "npm:^3.1.2"
     uuid: "npm:^8.3.2"
   checksum: 10/3715995cc7cc8e1d6c2e7543a948ccea135cb6a3bb2e2afe4b55793b2d97523dc4884f487a0cc11d9aeac11eca97dae980c6e527d52132dce09d983304f41520
-  languageName: node
-  linkType: hard
-
-"@metamask/core-backend@npm:^8.1.2":
-  version: 8.1.2
-  resolution: "@metamask/core-backend@npm:8.1.2"
-  dependencies:
-    "@metamask/account-tree-controller": "npm:^8.0.0"
-    "@metamask/controller-utils": "npm:^12.3.0"
-    "@metamask/keyring-controller": "npm:^27.1.1"
-    "@metamask/messenger": "npm:^2.0.0"
-    "@metamask/profile-sync-controller": "npm:^29.0.0"
-    "@metamask/remote-feature-flag-controller": "npm:^5.0.0"
-    "@metamask/utils": "npm:^11.11.0"
-    "@tanstack/query-core": "npm:^5.62.16"
-    async-mutex: "npm:^0.5.0"
-    cockatiel: "npm:^3.1.2"
-    uuid: "npm:^8.3.2"
-  checksum: 10/d8dffe22b270bc4e47f188b2314eda02ffeead162149889c6a69b11a05053d7d482228ccf38aa79caf72a5007ce2d7b14da9f3b89b7f87d2fda0d99dc7a3592f
   languageName: node
   linkType: hard
 
@@ -9316,37 +9272,6 @@ __metadata:
   linkType: hard
 
 "@metamask/multichain-account-service@npm:^13.0.0":
-  version: 13.0.2
-  resolution: "@metamask/multichain-account-service@npm:13.0.2"
-  dependencies:
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@metamask/account-api": "npm:^2.0.0"
-    "@metamask/accounts-controller": "npm:^39.1.0"
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/eth-snap-keyring": "npm:^24.0.0"
-    "@metamask/key-tree": "npm:^10.1.1"
-    "@metamask/keyring-api": "npm:^24.0.0"
-    "@metamask/keyring-controller": "npm:^27.1.1"
-    "@metamask/keyring-internal-api": "npm:^12.0.0"
-    "@metamask/keyring-snap-client": "npm:^10.0.0"
-    "@metamask/keyring-utils": "npm:^5.0.0"
-    "@metamask/messenger": "npm:^2.0.0"
-    "@metamask/snap-account-service": "npm:^2.1.2"
-    "@metamask/snaps-controllers": "npm:^19.0.0"
-    "@metamask/snaps-sdk": "npm:^11.0.0"
-    "@metamask/snaps-utils": "npm:^12.1.2"
-    "@metamask/superstruct": "npm:^3.4.1"
-    "@metamask/utils": "npm:^11.11.0"
-    async-mutex: "npm:^0.5.0"
-    lodash: "npm:^4.17.21"
-  peerDependencies:
-    "@metamask/providers": ^22.0.0
-    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/43f554ee1e58d9700b7f5d47b3e194262d8f8192a6298f177fc29c670efc0c3f659f40b4fbedcfeb9a14b894e5d7d2b59c051d9222a899648e1923f362d83bd5
-  languageName: node
-  linkType: hard
-
-"@metamask/multichain-account-service@npm:^13.0.2":
   version: 13.0.2
   resolution: "@metamask/multichain-account-service@npm:13.0.2"
   dependencies:
@@ -10646,9 +10571,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:@metamask-previews/transaction-controller@69.5.2-preview-7585e3a":
-  version: 69.5.2-preview-7585e3a
-  resolution: "@metamask-previews/transaction-controller@npm:69.5.2-preview-7585e3a"
+"@metamask/transaction-controller@npm:69.6.0":
+  version: 69.6.0
+  resolution: "@metamask/transaction-controller@npm:69.6.0"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/rlp": "npm:^5.0.2"
@@ -10661,13 +10586,13 @@ __metadata:
     "@metamask/approval-controller": "npm:^9.0.2"
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/controller-utils": "npm:^12.3.0"
-    "@metamask/core-backend": "npm:^8.1.2"
+    "@metamask/core-backend": "npm:^9.0.0"
     "@metamask/gas-fee-controller": "npm:^26.3.1"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^35.0.1"
     "@metamask/nonce-tracker": "npm:^6.0.0"
-    "@metamask/remote-feature-flag-controller": "npm:^5.0.0"
+    "@metamask/remote-feature-flag-controller": "npm:^6.0.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/utils": "npm:^11.11.0"
     async-mutex: "npm:^0.5.0"
@@ -10681,7 +10606,7 @@ __metadata:
   peerDependencies:
     "@babel/runtime": ^7.0.0
     "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/47b899b778f7d3be0c7d2740d0b9f58db15265e95eef47973da27e5667f5441065549497fce53d13d7b4f7f2195d662346bf980a7121be1b2d3f296965f6745c
+  checksum: 10/01a654c004d673bd5e03bee7407ce7ed54772ecd031dbf93ce96325973c5e45f6d43cc2ee88947da51913e28c3afe31d5600ad01d8758be825d005f5b1d20762
   languageName: node
   linkType: hard
 
@@ -35918,7 +35843,7 @@ __metadata:
     "@metamask/test-dapp-multichain": "npm:^0.17.1"
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/tooling-insight": "npm:^1.0.0"
-    "@metamask/transaction-controller": "npm:^69.5.2"
+    "@metamask/transaction-controller": "npm:^69.6.0"
     "@metamask/transaction-pay-controller": "npm:^26.4.1"
     "@metamask/tron-wallet-snap": "npm:^1.33.1"
     "@metamask/utils": "npm:^11.11.0"


### PR DESCRIPTION
## **Description**

Transaction simulation was previously enabled or disabled solely based on the user's `useTransactionSimulations` preference, with no awareness of the transaction being processed. MetaMask Pay transactions (deposits, orders, conversions, claims, withdrawals) do not benefit from simulation and should never be simulated regardless of that preference.

This wires the transaction meta through to the `isSimulationEnabled` callback and returns `false` whenever the transaction matches one of the MetaMask Pay transaction types (`MM_PAY_TRANSACTION_TYPES`), falling through to the existing preference-based behaviour for all other transactions.

This depends on the extended `isSimulationEnabled` callback signature in `@metamask/transaction-controller`, consumed here via a preview build (`69.5.2-preview-7585e3a`) from MetaMask/core#9800 until that change is released.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Simulation disabled for MetaMask Pay transactions

  Scenario: user initiates a MetaMask Pay transaction with simulations enabled
    Given transaction simulations are enabled in settings
    When user initiates a MetaMask Pay transaction (e.g. a Perps deposit)
    Then the confirmation does not run or display a simulation

  Scenario: user initiates a non-Pay transaction with simulations enabled
    Given transaction simulations are enabled in settings
    When user initiates a standard transaction (e.g. a token transfer)
    Then the confirmation runs and displays a simulation as before
```

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped confirmation behavior change that disables simulation only for Pay transaction types; standard transactions and preference handling are unchanged aside from the new callback shape.
> 
> **Overview**
> **Transaction simulation is now decided per transaction** instead of only from the `useTransactionSimulations` preference. The wallet passes `transactionMeta` into `isSimulationEnabled` and **always returns false** when the type is in `MM_PAY_TRANSACTION_TYPES` (deposits, orders, conversions, claims, withdrawals across Pay flows); all other transactions still follow the user preference.
> 
> **`@metamask/transaction-controller` is bumped to 69.6.0** so mobile can use the updated `isSimulationEnabled(transactionMeta)` callback. Unit tests cover non-Pay txs with simulations on and each MM Pay type with simulations forced off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25099a0f4ea99a460cf8dab67bba38ba76964564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->