### PR TITLE
fix: allow back navigation through onboarding without skipping to success

### DIFF
--- a/app/components/Nav/App/App.tsx
+++ b/app/components/Nav/App/App.tsx
@@ -346,12 +346,12 @@ const OnboardingNav = () => {
       <NativeStack.Screen
         name={Routes.ONBOARDING.INTEREST_QUESTIONNAIRE}
         component={OnboardingInterestQuestionnaire}
-        options={{ headerShown: false, gestureEnabled: false }}
+        options={{ headerShown: false }}
       />
       <NativeStack.Screen
         name={Routes.ONBOARDING.CRYPTO_EXPERIENCE_QUESTIONNAIRE}
         component={OnboardingCryptoExperienceQuestionnaire}
-        options={{ headerShown: false, gestureEnabled: false }}
+        options={{ headerShown: false }}
       />
       <NativeStack.Screen
         name="AccountStatus"

--- a/app/components/UI/OptinMetrics/MetaMetricsOptIn.testIds.ts
+++ b/app/components/UI/OptinMetrics/MetaMetricsOptIn.testIds.ts
@@ -10,4 +10,5 @@ export const MetaMetricsOptInSelectorsIDs = {
   METAMETRICS_OPT_IN_CONTAINER_ID: 'meta-metrics-container',
   OPTIN_METRICS_METRICS_CHECKBOX: 'optin-metrics-metrics-checkbox',
   OPTIN_METRICS_MARKETING_CHECKBOX: 'optin-metrics-marketing-checkbox',
+  OPTIN_METRICS_BACK_BUTTON_ID: 'optin-metrics-back-button',
 };

--- a/app/components/UI/OptinMetrics/OptinMetrics.navigation.test.tsx
+++ b/app/components/UI/OptinMetrics/OptinMetrics.navigation.test.tsx
@@ -266,6 +266,26 @@ describe('OptinMetrics — interest questionnaire navigation branching', () => {
         );
       });
     });
+
+    it('does not apply metrics or finish onboarding when continuing to the questionnaire', async () => {
+      renderScreen(OptinMetrics, { name: 'OptinMetrics' }, { state: {} });
+
+      fireEvent.press(
+        screen.getByRole('button', {
+          name: strings('privacy_policy.continue'),
+        }),
+      );
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith(
+          Routes.ONBOARDING.INTEREST_QUESTIONNAIRE,
+          expect.anything(),
+        );
+      });
+
+      expect(mockAnalytics.optIn).not.toHaveBeenCalled();
+      expect(mockReset).not.toHaveBeenCalled();
+    });
   });
 
   describe('when basic usage data is checked and AB test assigns control', () => {

--- a/app/components/UI/OptinMetrics/index.test.tsx
+++ b/app/components/UI/OptinMetrics/index.test.tsx
@@ -47,6 +47,22 @@ jest.mock(
 
 jest.mock('../../hooks/useAnalytics/useAnalytics');
 
+const mockGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useNavigation: () => ({
+      navigate: jest.fn(),
+      goBack: mockGoBack,
+      reset: jest.fn(),
+      setOptions: jest.fn(),
+      dispatch: jest.fn(),
+    }),
+  };
+});
+
 // Import analytics to access mocks
 import { analytics } from '../../../util/analytics/analytics';
 import { AppStateEventProcessor } from '../../../core/AppStateEventListener';
@@ -928,6 +944,45 @@ describe('OptinMetrics', () => {
         expect.any(Function),
       );
       expect(mockRemove).toHaveBeenCalled();
+
+      addSpy.mockRestore();
+    });
+
+    it('renders the back button', () => {
+      renderScreen(OptinMetrics, { name: 'OptinMetrics' }, { state: {} });
+
+      expect(
+        screen.getByTestId(
+          MetaMetricsOptInSelectorsIDs.OPTIN_METRICS_BACK_BUTTON_ID,
+        ),
+      ).toBeOnTheScreen();
+    });
+
+    it('navigates to the previous screen when the back button is pressed', () => {
+      renderScreen(OptinMetrics, { name: 'OptinMetrics' }, { state: {} });
+
+      fireEvent.press(
+        screen.getByTestId(
+          MetaMetricsOptInSelectorsIDs.OPTIN_METRICS_BACK_BUTTON_ID,
+        ),
+      );
+
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
+    });
+
+    it('navigates back and consumes the hardware back press', () => {
+      const { BackHandler } = jest.requireMock('react-native');
+      const addSpy = jest.spyOn(BackHandler, 'addEventListener');
+
+      renderScreen(OptinMetrics, { name: 'OptinMetrics' }, { state: {} });
+
+      const call = addSpy.mock.calls.find(
+        (c: [string, () => boolean]) => c[0] === 'hardwareBackPress',
+      );
+      const handler = call?.[1] as () => boolean;
+
+      expect(handler()).toBe(true);
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
 
       addSpy.mockRestore();
     });

--- a/app/components/UI/OptinMetrics/index.tsx
+++ b/app/components/UI/OptinMetrics/index.tsx
@@ -2,11 +2,9 @@ import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import {
   ScrollView,
   BackHandler,
-  Alert,
   Pressable,
   Platform,
   Image,
-  StatusBar,
   NativeScrollEvent,
   NativeSyntheticEvent,
   LayoutChangeEvent,
@@ -67,6 +65,7 @@ import { getWalletSetupAttributionPropsFromStore } from '../../../util/analytics
 import { scheduleBufferedOnboardingEventReplay } from '../../../util/analytics/walletSetupCompletedAttributionReplay';
 import { finalizeOnboardingCompletion } from '../../../util/onboarding/finalizeOnboardingCompletion';
 import { useOnboardingInterestQuestionnaireEligibility } from '../../../hooks/useOnboardingInterestQuestionnaireEligibility';
+import HeaderCompactStandard from '../../../component-library/components-temp/HeaderCompactStandard';
 
 /**
  * View that is displayed in the flow to agree to metrics
@@ -118,16 +117,14 @@ const OptinMetrics = () => {
     [isMediumDevice],
   );
 
-  /**
-   * Temporary disabling the back button so users can't go back
-   */
+  const handleBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
   const handleBackPress = useCallback(() => {
-    Alert.alert(
-      strings('onboarding.optin_back_title'),
-      strings('onboarding.optin_back_desc'),
-    );
+    handleBack();
     return true;
-  }, []);
+  }, [handleBack]);
 
   // Component lifecycle effects
   useEffect(() => {
@@ -160,44 +157,9 @@ const OptinMetrics = () => {
    */
   const accountType = route?.params?.accountType ?? reduxAccountType;
 
-  const continueNavigation = useCallback(async () => {
-    await markMetricsOptInUISeen();
-
-    const successFlow = route?.params?.successFlow;
-    finalizeOnboardingCompletion({
-      successFlow,
-      accountType,
-      isBasicFunctionalityEnabled,
-      walletSetupAttributionProps,
-      dispatch,
-      discoverAccountsLogContext: 'OptinMetrics',
-      needsQrProvisioning,
-    });
-
-    const onContinue = route?.params?.onContinue as (() => void) | undefined;
-    if (onContinue) {
-      return onContinue();
-    }
-
-    navigation.reset({
-      routes: [{ name: Routes.ONBOARDING.HOME_NAV }],
-    });
-  }, [
-    dispatch,
-    navigation,
-    route?.params,
-    accountType,
-    isBasicFunctionalityEnabled,
-    walletSetupAttributionProps,
-    needsQrProvisioning,
-  ]);
-
-  /**
-   * Callback on press confirm
-   */
-  const onConfirm = useCallback(async () => {
+  const applyMetricsPreferences = useCallback(async () => {
     await metrics.enable(isBasicUsageChecked);
-    await setupSentry(); // enabled/disabled depend on the isBasicUsageChecked
+    await setupSentry();
 
     if (isBasicUsageChecked) {
       await flushBufferedTraces();
@@ -208,7 +170,6 @@ const OptinMetrics = () => {
 
     dispatch(setDataCollectionForMarketing(isMarketingChecked));
 
-    // Track opt-in / opt-out for metrics
     metrics.trackEvent(
       metrics
         .createEventBuilder(
@@ -244,8 +205,6 @@ const OptinMetrics = () => {
       [UserProfileProperty.CHAIN_IDS]: getConfiguredCaipChainIds(),
     });
 
-    // track onboarding events that were stored before user opted in
-    // only if the user eventually opts in.
     if (events?.length && isBasicUsageChecked) {
       const attributionProps =
         getWalletSetupAttributionPropsFromStore(isMarketingChecked);
@@ -257,25 +216,71 @@ const OptinMetrics = () => {
     }
 
     dispatch(clearOnboardingEvents());
+  }, [
+    metrics,
+    isBasicUsageChecked,
+    isMarketingChecked,
+    accountType,
+    events,
+    dispatch,
+  ]);
 
+  const continueNavigation = useCallback(async () => {
+    await applyMetricsPreferences();
+    await markMetricsOptInUISeen();
+
+    const successFlow = route?.params?.successFlow;
+    finalizeOnboardingCompletion({
+      successFlow,
+      accountType,
+      isBasicFunctionalityEnabled,
+      walletSetupAttributionProps,
+      dispatch,
+      discoverAccountsLogContext: 'OptinMetrics',
+      needsQrProvisioning,
+    });
+
+    const onContinue = route?.params?.onContinue as (() => void) | undefined;
+    if (onContinue) {
+      return onContinue();
+    }
+
+    navigation.reset({
+      routes: [{ name: Routes.ONBOARDING.HOME_NAV }],
+    });
+  }, [
+    applyMetricsPreferences,
+    dispatch,
+    navigation,
+    route?.params,
+    accountType,
+    isBasicFunctionalityEnabled,
+    walletSetupAttributionProps,
+    needsQrProvisioning,
+  ]);
+
+  /**
+   * Callback on press confirm.
+   * Metrics consent is applied only when the flow actually finishes so that
+   * going back to an earlier step (e.g. SRP "Remind me later") does not skip
+   * remaining onboarding screens.
+   */
+  const onConfirm = useCallback(async () => {
     if (isBasicUsageChecked && shouldShowQuestionnaire) {
       navigation.navigate(Routes.ONBOARDING.INTEREST_QUESTIONNAIRE, {
         onComplete: continueNavigation,
         ...(accountType && { accountType }),
       });
-    } else {
-      await continueNavigation();
+      return;
     }
+
+    await continueNavigation();
   }, [
-    metrics,
     isBasicUsageChecked,
     shouldShowQuestionnaire,
-    dispatch,
-    isMarketingChecked,
-    accountType,
-    events,
     navigation,
     continueNavigation,
+    accountType,
   ]);
 
   /**
@@ -385,14 +390,7 @@ const OptinMetrics = () => {
     [isEndReached],
   );
 
-  const rootStyle = useMemo(
-    () =>
-      tw.style('flex-1 bg-default', {
-        paddingTop:
-          Platform.OS === 'android' ? StatusBar.currentHeight || 40 : 40,
-      }),
-    [tw],
-  );
+  const rootStyle = useMemo(() => tw.style('flex-1 bg-default'), [tw]);
 
   const goToDefaultSettings = () => {
     navigation.navigate(Routes.ONBOARDING.SUCCESS_FLOW, {
@@ -402,6 +400,14 @@ const OptinMetrics = () => {
 
   return (
     <SafeAreaView edges={{ bottom: 'additive' }} style={rootStyle}>
+      <HeaderCompactStandard
+        includesTopInset
+        onBack={handleBack}
+        backButtonProps={{
+          testID: MetaMetricsOptInSelectorsIDs.OPTIN_METRICS_BACK_BUTTON_ID,
+          accessibilityLabel: strings('navigation.back'),
+        }}
+      />
       <ScrollView
         style={tw.style('flex-1')}
         scrollEventThrottle={150}

--- a/app/components/Views/OnboardingCryptoExperienceQuestionnaire/OnboardingCryptoExperienceQuestionnaire.test.tsx
+++ b/app/components/Views/OnboardingCryptoExperienceQuestionnaire/OnboardingCryptoExperienceQuestionnaire.test.tsx
@@ -13,6 +13,7 @@ import { useAnalytics } from '../../hooks/useAnalytics/useAnalytics';
 
 jest.mock('../../hooks/useAnalytics/useAnalytics');
 
+const mockGoBack = jest.fn();
 const mockOnComplete = jest.fn();
 
 const mockCryptoExperienceRouteParams: {
@@ -26,6 +27,12 @@ jest.mock('@react-navigation/native', () => {
   const actual = jest.requireActual('@react-navigation/native');
   return {
     ...actual,
+    useNavigation: () => ({
+      navigate: jest.fn(),
+      goBack: mockGoBack,
+      reset: jest.fn(),
+      setOptions: jest.fn(),
+    }),
     useRoute: () => ({
       key: 'OnboardingCryptoExperienceQuestionnaire',
       name: 'OnboardingCryptoExperienceQuestionnaire',
@@ -98,8 +105,32 @@ describe('OnboardingCryptoExperienceQuestionnaire', () => {
     });
   });
 
+  describe('back button', () => {
+    it('renders the back button', () => {
+      renderComponent();
+
+      expect(
+        screen.getByTestId(
+          OnboardingCryptoExperienceQuestionnaireTestIds.BACK_BUTTON,
+        ),
+      ).toBeOnTheScreen();
+    });
+
+    it('navigates to the previous screen when the back button is pressed', () => {
+      renderComponent();
+
+      fireEvent.press(
+        screen.getByTestId(
+          OnboardingCryptoExperienceQuestionnaireTestIds.BACK_BUTTON,
+        ),
+      );
+
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('hardware back', () => {
-    it('subscribes to hardware back and consumes the back press', () => {
+    it('navigates back and consumes the hardware back press', () => {
       const spy = jest.spyOn(BackHandler, 'addEventListener');
 
       renderComponent();
@@ -110,7 +141,9 @@ describe('OnboardingCryptoExperienceQuestionnaire', () => {
       );
       const call = spy.mock.calls.find((c) => c[0] === 'hardwareBackPress');
       const handler = call?.[1] as () => boolean;
+
       expect(handler()).toBe(true);
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
 
       spy.mockRestore();
     });

--- a/app/components/Views/OnboardingCryptoExperienceQuestionnaire/OnboardingCryptoExperienceQuestionnaire.testIds.ts
+++ b/app/components/Views/OnboardingCryptoExperienceQuestionnaire/OnboardingCryptoExperienceQuestionnaire.testIds.ts
@@ -3,4 +3,5 @@ export enum OnboardingCryptoExperienceQuestionnaireTestIds {
   OPTION_PREFIX = 'onboarding-crypto-experience-option-',
   CONTINUE_BUTTON = 'onboarding-crypto-experience-continue-button',
   SKILL_BAR_PREFIX = 'onboarding-crypto-experience-skill-bar-',
+  BACK_BUTTON = 'onboarding-crypto-experience-back-button',
 }

--- a/app/components/Views/OnboardingCryptoExperienceQuestionnaire/OnboardingCryptoExperienceQuestionnaire.tsx
+++ b/app/components/Views/OnboardingCryptoExperienceQuestionnaire/OnboardingCryptoExperienceQuestionnaire.tsx
@@ -1,13 +1,11 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import {
-  BackHandler,
-  Platform,
-  ScrollView,
-  StatusBar,
-  TouchableOpacity,
-} from 'react-native';
+import { BackHandler, ScrollView, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useRoute, type RouteProp } from '@react-navigation/native';
+import {
+  useNavigation,
+  useRoute,
+  type RouteProp,
+} from '@react-navigation/native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
@@ -32,6 +30,7 @@ import type { RootStackParamList } from '../../../core/NavigationService/types';
 import { OnboardingCryptoExperienceQuestionnaireTestIds } from './OnboardingCryptoExperienceQuestionnaire.testIds';
 import type { CryptoExperienceLevel } from './OnboardingCryptoExperienceQuestionnaire.types';
 import { ExperienceSkillBar } from './ExperienceSkillBar';
+import HeaderCompactStandard from '../../../component-library/components-temp/HeaderCompactStandard';
 
 interface ExperienceOption {
   id: CryptoExperienceLevel;
@@ -59,6 +58,7 @@ const EXPERIENCE_OPTIONS: ExperienceOption[] = [
 
 const OnboardingCryptoExperienceQuestionnaire = () => {
   const tw = useTailwind();
+  const navigation = useNavigation();
   const { trackEvent, createEventBuilder } = useAnalytics();
   const route =
     useRoute<
@@ -86,7 +86,14 @@ const OnboardingCryptoExperienceQuestionnaire = () => {
     );
   }, [trackEvent, createEventBuilder, accountType]);
 
-  const handleBackPress = useCallback(() => true, []);
+  const handleBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  const handleBackPress = useCallback(() => {
+    handleBack();
+    return true;
+  }, [handleBack]);
 
   useEffect(() => {
     const backHandlerSubscription = BackHandler.addEventListener(
@@ -119,13 +126,18 @@ const OnboardingCryptoExperienceQuestionnaire = () => {
   return (
     <SafeAreaView
       edges={{ bottom: 'additive' }}
-      style={tw.style('flex-1 bg-default', {
-        paddingTop:
-          Platform.OS === 'android' ? StatusBar.currentHeight || 40 : 40,
-      })}
+      style={tw.style('flex-1 bg-default')}
       testID={OnboardingCryptoExperienceQuestionnaireTestIds.SCREEN}
     >
-      <Box twClassName="mx-4 mt-4 mb-2">
+      <HeaderCompactStandard
+        includesTopInset
+        onBack={handleBack}
+        backButtonProps={{
+          testID: OnboardingCryptoExperienceQuestionnaireTestIds.BACK_BUTTON,
+          accessibilityLabel: strings('navigation.back'),
+        }}
+      />
+      <Box twClassName="mx-4 mb-2">
         <Text
           variant={TextVariant.DisplayMd}
           color={TextColor.TextDefault}

--- a/app/components/Views/OnboardingInterestQuestionnaire/OnboardingInterestQuestionnaire.test.tsx
+++ b/app/components/Views/OnboardingInterestQuestionnaire/OnboardingInterestQuestionnaire.test.tsx
@@ -54,6 +54,7 @@ jest.mock('./OtherBottomSheet', () => ({
 jest.mock('../../hooks/useAnalytics/useAnalytics');
 
 const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
 const mockOnComplete = jest.fn();
 
 const mockInterestQuestionnaireRouteParams: {
@@ -69,7 +70,7 @@ jest.mock('@react-navigation/native', () => {
     ...actual,
     useNavigation: () => ({
       navigate: mockNavigate,
-      goBack: jest.fn(),
+      goBack: mockGoBack,
       reset: jest.fn(),
       setOptions: jest.fn(),
     }),
@@ -175,10 +176,33 @@ describe('OnboardingInterestQuestionnaire', () => {
         screen.getByTestId(OnboardingInterestQuestionnaireTestIds.SKIP_BUTTON),
       ).toBeOnTheScreen();
     });
+
+    it('renders the back button on the same header as Skip', () => {
+      renderComponent();
+
+      expect(
+        screen.getByTestId(OnboardingInterestQuestionnaireTestIds.BACK_BUTTON),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByTestId(OnboardingInterestQuestionnaireTestIds.SKIP_BUTTON),
+      ).toBeOnTheScreen();
+    });
+  });
+
+  describe('back button', () => {
+    it('navigates to the previous screen when the back button is pressed', () => {
+      renderComponent();
+
+      fireEvent.press(
+        screen.getByTestId(OnboardingInterestQuestionnaireTestIds.BACK_BUTTON),
+      );
+
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('hardware back', () => {
-    it('subscribes to hardware back and consumes the back press', () => {
+    it('navigates back and consumes the hardware back press', () => {
       const spy = jest.spyOn(BackHandler, 'addEventListener');
 
       renderComponent();
@@ -189,7 +213,9 @@ describe('OnboardingInterestQuestionnaire', () => {
       );
       const call = spy.mock.calls.find((c) => c[0] === 'hardwareBackPress');
       const handler = call?.[1] as () => boolean;
+
       expect(handler()).toBe(true);
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
 
       spy.mockRestore();
     });

--- a/app/components/Views/OnboardingInterestQuestionnaire/OnboardingInterestQuestionnaire.testIds.ts
+++ b/app/components/Views/OnboardingInterestQuestionnaire/OnboardingInterestQuestionnaire.testIds.ts
@@ -5,5 +5,6 @@ export enum OnboardingInterestQuestionnaireTestIds {
   OPTION_ICON_PREFIX = 'onboarding-interest-option-icon-',
   CONTINUE_BUTTON = 'onboarding-interest-continue-button',
   SKIP_BUTTON = 'onboarding-interest-skip-button',
+  BACK_BUTTON = 'onboarding-interest-back-button',
   OTHER_TEXT = 'onboarding-interest-other-text',
 }

--- a/app/components/Views/OnboardingInterestQuestionnaire/OnboardingInterestQuestionnaire.tsx
+++ b/app/components/Views/OnboardingInterestQuestionnaire/OnboardingInterestQuestionnaire.tsx
@@ -6,7 +6,11 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useRoute, type RouteProp } from '@react-navigation/native';
+import {
+  useNavigation,
+  useRoute,
+  type RouteProp,
+} from '@react-navigation/native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
@@ -84,6 +88,7 @@ const INTEREST_OPTIONS: InterestOption[] = [
 
 const OnboardingInterestQuestionnaire = () => {
   const tw = useTailwind();
+  const navigation = useNavigation();
   const { trackEvent, createEventBuilder } = useAnalytics();
   const route =
     useRoute<
@@ -115,7 +120,14 @@ const OnboardingInterestQuestionnaire = () => {
     );
   }, [trackEvent, createEventBuilder, accountType]);
 
-  const handleBackPress = useCallback(() => true, []);
+  const handleBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  const handleBackPress = useCallback(() => {
+    handleBack();
+    return true;
+  }, [handleBack]);
 
   useEffect(() => {
     const backHandlerSubscription = BackHandler.addEventListener(
@@ -223,6 +235,11 @@ const OnboardingInterestQuestionnaire = () => {
       <HeaderCompactStandard
         includesTopInset
         twClassName="mb-2"
+        onBack={handleBack}
+        backButtonProps={{
+          testID: OnboardingInterestQuestionnaireTestIds.BACK_BUTTON,
+          accessibilityLabel: strings('navigation.back'),
+        }}
         endAccessory={
           <Text
             variant={TextVariant.BodyLg}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Onboarding screens in the metrics and questionnaire steps blocked going back, and pressing Continue on Improve MetaMask applied metrics consent immediately. After visiting those screens, going back to Save your Secret Recovery Phrase and tapping Remind me later treated metrics as already enabled and jumped to Your wallet is ready.

This PR adds design-system back buttons on Improve MetaMask and the onboarding questionnaires, enables iOS swipe-back on those screens, and applies metrics consent only when the flow actually finishes.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed onboarding back navigation so Remind me later no longer skips to the wallet-ready screen

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A — found during local iOS simulator testing of onboarding back navigation

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: onboarding back navigation

  Scenario: user goes back from Improve MetaMask to the SRP screen and reminds later
    Given the user is creating a new wallet and is on Save your Secret Recovery Phrase
    When the user continues through Improve MetaMask to How will you use MetaMask
    And the user goes all the way back to Save your Secret Recovery Phrase
    And the user taps Remind me later
    Then the app returns to Improve MetaMask
    And the app does not show Your wallet is ready

  Scenario: user can move forward and back through onboarding questionnaires
    Given the user is on Improve MetaMask
    When the user taps the back button
    Then the previous onboarding screen is shown
    When the user continues again and taps back on How will you use MetaMask
    Then Improve MetaMask is shown again
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — verified on iOS Simulator (iPhone 17 Pro). Back button appears on Improve MetaMask and the interest questionnaire; Remind me later after a round-trip no longer opens Your wallet is ready.

### **Before**

Continue on Improve MetaMask enabled metrics immediately. Remind me later on the SRP screen then skipped to Your wallet is ready.

### **After**

Back control is on the same header row as Skip / the top of Improve MetaMask. Metrics consent is applied only when the last onboarding step finishes.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)