### PR TITLE
refactor: use design-system SelectButton for onboarding network picker

### DIFF
--- a/app/components/UI/ManageNetworks/ManageNetworks.styles.ts
+++ b/app/components/UI/ManageNetworks/ManageNetworks.styles.ts
@@ -16,10 +16,6 @@ const styles = StyleSheet.create({
     lineHeight: 22,
     fontWeight: '400',
   },
-  networkPicker: {
-    marginVertical: 16,
-    alignSelf: 'flex-start',
-  },
 });
 
 export default styles;

--- a/app/components/UI/ManageNetworks/ManageNetworks.test.js
+++ b/app/components/UI/ManageNetworks/ManageNetworks.test.js
@@ -1,21 +1,29 @@
-// Third party dependencies.
 import React from 'react';
 import { Linking } from 'react-native';
-// Internal dependencies.
+import { fireEvent } from '@testing-library/react-native';
+import { useSelector } from 'react-redux';
 import ManageNetworks from './ManageNetworks';
 import renderWithProvider from '../../../util/test/renderWithProvider';
-import { useNavigation } from '@react-navigation/native';
-import { useSelector } from 'react-redux';
 import { selectNetworkName } from '../../../selectors/networkInfos';
 import AppConstants from '../../../core/AppConstants';
-import { fireEvent } from '@testing-library/react-native';
+import Routes from '../../../constants/navigation/Routes';
+import { ConnectedAccountsSelectorsIDs } from '../../Views/MultichainAccounts/shared/ConnectedAccountModal.testIds';
+
+const mockNavigate = jest.fn();
+const mockTrackEvent = jest.fn();
+const mockBuild = jest
+  .fn()
+  .mockReturnValue({ name: 'NETWORK_SELECTOR_PRESSED' });
+const mockCreateEventBuilder = jest.fn().mockReturnValue({
+  build: mockBuild,
+});
 
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
   return {
     ...actualReactNavigation,
     useNavigation: () => ({
-      navigate: jest.fn(),
+      navigate: mockNavigate,
     }),
   };
 });
@@ -25,39 +33,65 @@ jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
 
+jest.mock('../../../components/hooks/useAnalytics/useAnalytics', () => ({
+  useAnalytics: () => ({
+    trackEvent: mockTrackEvent,
+    createEventBuilder: mockCreateEventBuilder,
+  }),
+}));
+
 const mockNetworkName = 'Ethereum Main Network';
 
+const mockUseSelectorWithNetworkName = () => {
+  useSelector.mockImplementation((selector) => {
+    if (selector === selectNetworkName) {
+      return mockNetworkName;
+    }
+
+    return undefined;
+  });
+};
+
 describe('ManageNetworks', () => {
-  it('should render correctly', () => {
-    useSelector.mockImplementation((selector) => {
-      if (selector === selectNetworkName) return mockNetworkName;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSelectorWithNetworkName();
+  });
+
+  it('renders the current network on the select button', () => {
+    const { getByTestId, getByText } = renderWithProvider(<ManageNetworks />);
+
+    expect(
+      getByTestId(ConnectedAccountsSelectorsIDs.NETWORK_PICKER),
+    ).toBeOnTheScreen();
+    expect(getByText(mockNetworkName)).toBeOnTheScreen();
+  });
+
+  it('opens the network selector when the select button is pressed', () => {
+    const { getByTestId } = renderWithProvider(<ManageNetworks />);
+
+    fireEvent.press(getByTestId(ConnectedAccountsSelectorsIDs.NETWORK_PICKER));
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.MODAL.ROOT_MODAL_FLOW, {
+      screen: Routes.SHEET.NETWORK_SELECTOR,
     });
-    const { toJSON } = renderWithProvider(
-      <ManageNetworks navigation={useNavigation()} />,
-    );
-    expect(toJSON()).not.toBeNull();
+    expect(mockTrackEvent).toHaveBeenCalledWith(mockBuild());
   });
 
   it.each([
-    [
-      {
-        link: AppConstants.URLS.PRIVACY_POLICY_2024,
-        testId: 'privacy-policy-link',
-      },
-      {
-        link: AppConstants.URLS.ADD_SOLANA_ACCOUNT_PRIVACY_POLICY,
-        testId: 'solana-privacy-policy-link',
-      },
-    ],
-  ])('opens link %link', ({ link, testId }) => {
-    useSelector.mockImplementation((selector) => {
-      if (selector === selectNetworkName) return mockNetworkName;
-    });
-    const { getByTestId } = renderWithProvider(
-      <ManageNetworks navigation={useNavigation()} />,
-    );
-    const button = getByTestId(testId);
-    fireEvent.press(button);
+    {
+      link: AppConstants.URLS.PRIVACY_POLICY_2024,
+      testId: 'privacy-policy-link',
+    },
+    {
+      link: AppConstants.URLS.ADD_SOLANA_ACCOUNT_PRIVACY_POLICY,
+      testId: 'solana-privacy-policy-link',
+    },
+  ])('opens $testId', ({ link, testId }) => {
+    const { getByTestId } = renderWithProvider(<ManageNetworks />);
+
+    fireEvent.press(getByTestId(testId));
+
     expect(Linking.openURL).toHaveBeenCalledWith(link);
   });
 });

--- a/app/components/UI/ManageNetworks/ManageNetworks.tsx
+++ b/app/components/UI/ManageNetworks/ManageNetworks.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
 import { View, Linking } from 'react-native';
-import PickerNetwork from '../../../component-library/components/Pickers/PickerNetwork';
 import { strings } from '../../../../locales/i18n';
 import { useSelector } from 'react-redux';
 import {
@@ -16,9 +15,13 @@ import { ConnectedAccountsSelectorsIDs } from '../../Views/MultichainAccounts/sh
 import AppConstants from '../../../core/AppConstants';
 import styles from './ManageNetworks.styles';
 import {
+  AvatarNetwork,
+  AvatarNetworkSize,
+  SelectButton,
+  SelectButtonVariant,
   Text,
-  TextVariant,
   TextColor,
+  TextVariant,
 } from '@metamask/design-system-react-native';
 
 export default function ManageNetworksComponent() {
@@ -75,12 +78,23 @@ export default function ManageNetworksComponent() {
           {strings('default_settings.manage_networks_body3')}
         </Text>
       </Text>
-      <PickerNetwork
-        label={networkName}
-        imageSource={networkImageSource}
-        onPress={switchNetwork}
-        style={styles.networkPicker}
+      <SelectButton
         testID={ConnectedAccountsSelectorsIDs.NETWORK_PICKER}
+        variant={SelectButtonVariant.Primary}
+        placeholder={strings('wallet.current_network')}
+        value={networkName}
+        startAccessory={
+          <AvatarNetwork
+            src={networkImageSource}
+            size={AvatarNetworkSize.Xs}
+            name={networkName}
+          />
+        }
+        textProps={{
+          numberOfLines: 1,
+        }}
+        onPress={switchNetwork}
+        twClassName="self-start my-4"
       />
     </View>
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

The Choose your network control on the onboarding Default settings → General screen (reached from Improve MetaMask → manage other default settings) still used the legacy `PickerNetwork` component. The Tokens page already uses the design-system `SelectButton`.

This PR replaces that picker with `SelectButton` and `AvatarNetwork` from `@metamask/design-system-react-native` so the onboarding network selector matches the Tokens page control. Pressing it still opens the existing network selector sheet.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Updated the onboarding default settings network selector to use the design system Select button

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: N/A — design-system alignment found during local iOS simulator review of onboarding default settings

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: onboarding default settings network selector

  Scenario: user opens the network selector from onboarding General settings
    Given the user is on Improve MetaMask
    When the user taps manage other default settings
    And the user opens General
    Then Choose your network shows a SelectButton with the current network name and avatar
    When the user taps the SelectButton
    Then the network selector sheet opens
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

The Choose your network control on onboarding Default settings → General now uses the same design-system SelectButton as the Tokens page.

### **Before**

`PickerNetwork` pill with Ethereum avatar, "Ethereum Main Network", and a down chevron.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-08-16 at 18 53 06" src="https://github.com/user-attachments/assets/d36eb9e8-d093-40da-bc29-f889b025c391" />

https://github.com/user-attachments/assets/0ad4f4f9-f32d-42a8-9d79-631eb9083827

### **After**

Design-system `SelectButton` with `AvatarNetwork` start accessory, current network name, and the same network selector sheet on press.

https://github.com/user-attachments/assets/07f91d59-b08a-4777-9410-7b9d02eb9109

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-08-16 at 18 53 14" src="https://github.com/user-attachments/assets/269f1951-8bf0-4e95-8db5-253c6d7887cc" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)