### PR TITLE
fix(accounts): use default colors on add account row

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.styles.ts
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.styles.ts
@@ -29,7 +29,6 @@ const createStyles = ({ theme }: { theme: Theme }) =>
       justifyContent: 'center',
     },
     buttonText: {
-      color: theme.colors.primary.default,
       fontWeight: '500',
     },
   });

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.test.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.test.tsx
@@ -34,16 +34,6 @@ jest.mock('../../../../../util/Logger', () => ({
   error: jest.fn(),
 }));
 
-// Mock AnimatedSpinner
-jest.mock('../../../../../components/UI/AnimatedSpinner', () => ({
-  __esModule: true,
-  default: () => null,
-  SpinnerSize: {
-    SM: 'SM',
-    MD: 'MD',
-  },
-}));
-
 jest.mock(
   '../../../../../util/accounts/useAccountWalletOperationsLoadingStates',
   () => ({

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.tsx
@@ -15,13 +15,12 @@ import {
   IconName,
   IconSize,
   IconColor,
+  Spinner,
   Text,
+  TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../hooks';
-import AnimatedSpinner, {
-  SpinnerSize,
-} from '../../../../../components/UI/AnimatedSpinner';
 import Logger from '../../../../../util/Logger';
 import { strings } from '../../../../../../locales/i18n';
 import { selectWalletsMap } from '../../../../../selectors/multichainAccounts/accountTreeController';
@@ -204,17 +203,21 @@ const AccountListFooter = memo(
         >
           <View style={styles.iconContainer}>
             {isLoadingState ? (
-              <AnimatedSpinner size={SpinnerSize.SM} />
+              <Spinner
+                color={IconColor.IconDefault}
+                spinnerIconProps={{ size: IconSize.Md }}
+              />
             ) : (
               <Icon
                 name={IconName.Add}
                 size={IconSize.Md}
-                color={IconColor.PrimaryDefault}
+                color={IconColor.IconDefault}
               />
             )}
           </View>
           <Text
             variant={TextVariant.BodyMd}
+            color={TextColor.TextDefault}
             style={styles.buttonText}
             testID={AccountListBottomSheetSelectorsIDs.CREATE_ACCOUNT}
           >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Add account row in the accounts menu used primary blue for the plus icon, label, and loading spinner, which made it stand out from the rest of the list.

This change uses design-system default tokens instead: `IconColor.IconDefault` for the plus icon and loading spinner, and `TextColor.TextDefault` for the label. The deprecated primary-colored `AnimatedSpinner` is replaced with the design-system `Spinner`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated the Add account row in the accounts menu to use default icon and text colors

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A — visual polish on the accounts menu Add account row; no tracking issue.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Accounts menu Add account colors

  Background:
    Given I am logged into MetaMask Mobile
    And I have at least one HD wallet with existing accounts

  Scenario: Add account row uses default icon and text colors
    Given I am on the Wallet home screen

    When user opens the account selector
    Then the "Add account" row should be visible
    And the plus icon should use the default icon color
    And the "Add account" label should use the default text color
    And neither the icon nor the label should use primary blue

  Scenario: Creating an account shows a monochromatic loading spinner
    Given I am on the account selector

    When user taps "Add account"
    Then the row should show a loading spinner
    And the spinner should use the default icon color
    And the label should read "Adding account..."
    And a new account should appear in the list when creation finishes
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

The Add account icon, label, and loading spinner previously used primary blue.

<img width="350" alt="Screenshot 2026-08-16 at 7 06 39 PM" src="https://github.com/user-attachments/assets/a0b4cc11-cf43-4ae0-afa6-b4369d15aff3" />

https://github.com/user-attachments/assets/fb361d05-dcae-4489-a5e0-6f09da52257f

### **After**

The Add account icon, label, and loading spinner now use default icon and text colors.

<img width="350" alt="Screenshot 2026-08-16 at 7 18 02 PM" src="https://github.com/user-attachments/assets/c5952a62-24ac-49fb-b2e0-e767f71d8204" />

https://github.com/user-attachments/assets/c6f3deeb-5012-46e4-8d21-0a05996ba723

https://github.com/user-attachments/assets/5a640230-e794-48eb-b569-937d5105768d

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)