### PR TITLE
test: ActivityDetails Perps component-view coverage (MMQA-2167)

### DIFF
--- a/app/components/Views/ActivityDetails/ActivityDetails.perps.view.test.tsx
+++ b/app/components/Views/ActivityDetails/ActivityDetails.perps.view.test.tsx
@@ -1,0 +1,927 @@
+import '../../../../tests/component-view/mocks';
+import { fireEvent, waitFor, within } from '@testing-library/react-native';
+import { Text, TextColor } from '@metamask/design-system-react-native';
+import { strings } from '../../../../locales/i18n';
+import { renderShortAddress } from '../../../util/address';
+import { describeForPlatforms } from '../../../../tests/component-view/platform';
+import {
+  ACTIVITY_CV_ACCOUNT,
+  ACTIVITY_CV_PERPS_ORDER_FEE,
+  buildActivityCvPerpsCompletedDepositItem,
+  buildActivityCvPerpsCompletedWithdrawalItem,
+  buildActivityCvPerpsFailedDepositItem,
+  buildActivityCvPerpsFundingItem,
+  buildActivityCvPerpsOrderFill,
+  buildActivityCvPerpsOrderItem,
+  buildActivityCvPerpsOrderTransaction,
+  buildActivityCvPerpsPayTransaction,
+  buildActivityCvPerpsPendingDepositItem,
+  buildActivityCvPerpsTradeItem,
+  initialStateActivityWithPerpsDetails,
+} from '../../../../tests/component-view/presets/activity';
+import { renderPreloadedActivityDetailsView } from '../../../../tests/component-view/renderers/activity';
+import { getRouteProbeTestId } from '../../../../tests/component-view/render';
+import Engine from '../../../core/Engine';
+import Routes from '../../../constants/navigation/Routes';
+import type { ActivityListItem } from '../../../util/activity-adapters';
+import {
+  formatPerpsOrderFee,
+  formatSignedPerpsFiat,
+  formatPerpsTransactionDate,
+  formatPositiveFiat,
+  getPerpsPositionSize,
+  getPerpsPriceValue,
+  getPerpsTransaction,
+} from './components/ActivityDetailsPerps.utils';
+import {
+  ActivityDetailsSelectorsIDs,
+  getActivityDetailsStepIconTestId,
+  getActivityDetailsStepTestId,
+} from './ActivityDetails.testIds';
+
+const findAmountTextColor = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  unsafeGetAllByType: (type: typeof Text) => any[],
+  amountPattern: RegExp,
+): TextColor | undefined => {
+  const amountText = unsafeGetAllByType(Text).find((node) => {
+    const { children } = node.props;
+    return typeof children === 'string' && amountPattern.test(children);
+  });
+  return amountText?.props.color as TextColor | undefined;
+};
+
+const {
+  SCREEN,
+  HEADER,
+  AMOUNT_HEADER,
+  AMOUNT_AVATAR_SINGLE,
+  STATUS_PILL,
+  DATE_ROW,
+  ACCOUNT_ROW,
+  NETWORK_ROW,
+  NETWORK_FEE_ROW,
+  BRIDGE_FEE_ROW,
+  TOTAL_ROW,
+  FEE_TOKEN_AVATAR,
+  SIZE_ROW,
+  PRICE_ROW,
+  FEES_ROW,
+  PNL_ROW,
+  LIMIT_PRICE_ROW,
+  FILLED_ROW,
+  TOTAL_FEE_ROW,
+  RATE_ROW,
+  FUNDING_FEE_ROW,
+  BLOCK_EXPLORER_BUTTON,
+  DO_IT_AGAIN_BUTTON,
+} = ActivityDetailsSelectorsIDs;
+
+const renderPerpsDetails = (item: ActivityListItem) => {
+  const state = initialStateActivityWithPerpsDetails([
+    buildActivityCvPerpsPayTransaction(item.hash),
+  ]).build();
+
+  return renderPreloadedActivityDetailsView(item, { state });
+};
+
+const renderPerpsTradeDetails = (item: ActivityListItem) => {
+  const state = initialStateActivityWithPerpsDetails().build();
+
+  return renderPreloadedActivityDetailsView(item, { state });
+};
+
+describeForPlatforms('ActivityDetails — Perps funds', () => {
+  it('shows confirmed Account funded details with fees, completed steps, and Fund again', async () => {
+    const item = buildActivityCvPerpsCompletedDepositItem();
+
+    const {
+      findByTestId,
+      findByText,
+      getByTestId,
+      getByText,
+      queryByTestId,
+      UNSAFE_getAllByType,
+    } = renderPerpsDetails(item);
+
+    expect(await findByTestId(SCREEN)).toBeOnTheScreen();
+    expect(
+      await findByText(strings('transactions.activity_perps_account_funded')),
+    ).toBeOnTheScreen();
+    expect(getByTestId(HEADER)).toBeOnTheScreen();
+
+    const amountHeader = await findByTestId(AMOUNT_HEADER);
+    expect(
+      within(amountHeader).getByTestId(AMOUNT_AVATAR_SINGLE),
+    ).toBeOnTheScreen();
+    expect(within(amountHeader).getByText('+$1,000')).toBeOnTheScreen();
+    expect(findAmountTextColor(UNSAFE_getAllByType, /^\+\$1,000$/)).toBe(
+      TextColor.SuccessDefault,
+    );
+
+    expect(await findByTestId(STATUS_PILL)).toHaveTextContent(
+      strings('transaction.confirmed'),
+    );
+    expect(getByTestId(DATE_ROW)).toHaveTextContent(
+      formatPerpsTransactionDate(item.timestamp),
+      { exact: false },
+    );
+    expect(queryByTestId(NETWORK_ROW)).toBeNull();
+
+    const networkFeeRow = getByTestId(NETWORK_FEE_ROW);
+    expect(networkFeeRow).toHaveTextContent(
+      strings('activity_details.transaction_fee'),
+      { exact: false },
+    );
+    expect(within(networkFeeRow).getByText(/\$/)).toBeOnTheScreen();
+    expect(within(networkFeeRow).getByText('ETH')).toBeOnTheScreen();
+    expect(
+      within(networkFeeRow).getByTestId(FEE_TOKEN_AVATAR),
+    ).toBeOnTheScreen();
+
+    const bridgeFeeRow = getByTestId(BRIDGE_FEE_ROW);
+    expect(bridgeFeeRow).toHaveTextContent(
+      strings('activity_details.bridge_fee'),
+      { exact: false },
+    );
+    expect(within(bridgeFeeRow).getByText(/\$/)).toBeOnTheScreen();
+    expect(within(bridgeFeeRow).getByText('USDC')).toBeOnTheScreen();
+    expect(
+      within(bridgeFeeRow).getByTestId(FEE_TOKEN_AVATAR),
+    ).toBeOnTheScreen();
+
+    expect(getByTestId(TOTAL_ROW)).toHaveTextContent(/\$/);
+    expect(queryByTestId(BLOCK_EXPLORER_BUTTON)).toBeNull();
+
+    expect(
+      getByText(
+        strings('perps.transactions.steps.title_completed', { completed: 4 }),
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('perps.transactions.steps.approve_funds')),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('perps.transactions.steps.bridge_funds')),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('perps.transactions.steps.receive_usdc')),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('perps.transactions.steps.add_funds')),
+    ).toBeOnTheScreen();
+
+    for (const stepIndex of [0, 1, 2, 3]) {
+      const step = getByTestId(getActivityDetailsStepTestId(stepIndex));
+      expect(step).toBeOnTheScreen();
+      expect(step).toHaveTextContent(/\d.+\s-\s/, { exact: false });
+      expect(
+        getByTestId(getActivityDetailsStepIconTestId(stepIndex)),
+      ).toBeOnTheScreen();
+    }
+
+    const fundAgain = getByTestId(DO_IT_AGAIN_BUTTON);
+    expect(fundAgain).toHaveTextContent(
+      strings('perps.transactions.fund_again'),
+    );
+
+    fireEvent.press(fundAgain);
+
+    expect(
+      await findByTestId(getRouteProbeTestId(Routes.PERPS.ROOT)),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows pending funding-in-progress details with mixed steps and Fund again', async () => {
+    const item = buildActivityCvPerpsPendingDepositItem();
+
+    const {
+      findByTestId,
+      findByText,
+      getByTestId,
+      getByText,
+      queryByTestId,
+      UNSAFE_getAllByType,
+    } = renderPerpsDetails(item);
+
+    expect(await findByTestId(SCREEN)).toBeOnTheScreen();
+    expect(
+      await findByText(strings('transactions.activity_perps_account_funded')),
+    ).toBeOnTheScreen();
+
+    const amountHeader = await findByTestId(AMOUNT_HEADER);
+    expect(
+      within(amountHeader).getByTestId(AMOUNT_AVATAR_SINGLE),
+    ).toBeOnTheScreen();
+    expect(within(amountHeader).getByText('+$1,000')).toBeOnTheScreen();
+    expect(findAmountTextColor(UNSAFE_getAllByType, /^\+\$1,000$/)).toBe(
+      TextColor.SuccessDefault,
+    );
+
+    expect(await findByTestId(STATUS_PILL)).toHaveTextContent(
+      strings('transaction.pending'),
+    );
+    expect(
+      findAmountTextColor(
+        UNSAFE_getAllByType,
+        new RegExp(`^${strings('transaction.pending')}$`),
+      ),
+    ).toBe(TextColor.WarningDefault);
+    expect(getByTestId(DATE_ROW)).toHaveTextContent(
+      formatPerpsTransactionDate(item.timestamp),
+      { exact: false },
+    );
+    expect(queryByTestId(NETWORK_ROW)).toBeNull();
+
+    const networkFeeRow = getByTestId(NETWORK_FEE_ROW);
+    expect(within(networkFeeRow).getByText('ETH')).toBeOnTheScreen();
+    expect(
+      within(networkFeeRow).getByTestId(FEE_TOKEN_AVATAR),
+    ).toBeOnTheScreen();
+
+    const bridgeFeeRow = getByTestId(BRIDGE_FEE_ROW);
+    expect(within(bridgeFeeRow).getByText('USDC')).toBeOnTheScreen();
+    expect(
+      within(bridgeFeeRow).getByTestId(FEE_TOKEN_AVATAR),
+    ).toBeOnTheScreen();
+    expect(getByTestId(TOTAL_ROW)).toHaveTextContent(/\$/);
+    expect(queryByTestId(BLOCK_EXPLORER_BUTTON)).toBeNull();
+
+    expect(
+      getByText(
+        strings('perps.transactions.steps.title_pending', {
+          completed: 1,
+          pending: 3,
+        }),
+      ),
+    ).toBeOnTheScreen();
+
+    const completedStep = getByTestId(getActivityDetailsStepTestId(0));
+    expect(completedStep).toHaveTextContent(
+      strings('perps.transactions.steps.approve_funds'),
+      { exact: false },
+    );
+    expect(completedStep).toHaveTextContent(/\d.+\s-\s/, { exact: false });
+
+    const pendingStep = getByTestId(getActivityDetailsStepTestId(1));
+    expect(pendingStep).toHaveTextContent(
+      strings('perps.transactions.steps.bridge_funds'),
+      { exact: false },
+    );
+    expect(pendingStep).toHaveTextContent(strings('transaction.pending'), {
+      exact: false,
+    });
+
+    const upcomingReceive = getByTestId(getActivityDetailsStepTestId(2));
+    expect(upcomingReceive).toHaveTextContent(
+      strings('perps.transactions.steps.receive_usdc'),
+      { exact: false },
+    );
+    expect(upcomingReceive).not.toHaveTextContent(
+      strings('transaction.pending'),
+      { exact: false },
+    );
+    expect(upcomingReceive).not.toHaveTextContent(/\d.+\s-\s/, {
+      exact: false,
+    });
+
+    const upcomingAddFunds = getByTestId(getActivityDetailsStepTestId(3));
+    expect(upcomingAddFunds).toHaveTextContent(
+      strings('perps.transactions.steps.add_funds'),
+      { exact: false },
+    );
+    expect(upcomingAddFunds).not.toHaveTextContent(
+      strings('transaction.pending'),
+      { exact: false },
+    );
+
+    for (const stepIndex of [0, 1, 2, 3]) {
+      expect(
+        getByTestId(getActivityDetailsStepIconTestId(stepIndex)),
+      ).toBeOnTheScreen();
+    }
+
+    const fundAgain = getByTestId(DO_IT_AGAIN_BUTTON);
+    expect(fundAgain).toHaveTextContent(
+      strings('perps.transactions.fund_again'),
+    );
+
+    fireEvent.press(fundAgain);
+
+    expect(
+      await findByTestId(getRouteProbeTestId(Routes.PERPS.ROOT)),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows failed funding details with mixed steps and Try again', async () => {
+    const item = buildActivityCvPerpsFailedDepositItem();
+
+    const {
+      findByTestId,
+      getByTestId,
+      getByText,
+      queryByTestId,
+      UNSAFE_getAllByType,
+    } = renderPerpsDetails(item);
+
+    expect(await findByTestId(SCREEN)).toBeOnTheScreen();
+    expect(getByTestId(HEADER)).toHaveTextContent(
+      `${strings('transactions.activity_perps_account_funded')} — ${strings(
+        'transaction.failed',
+      )}`,
+    );
+
+    const amountHeader = await findByTestId(AMOUNT_HEADER);
+    expect(
+      within(amountHeader).getByTestId(AMOUNT_AVATAR_SINGLE),
+    ).toBeOnTheScreen();
+    expect(within(amountHeader).getByText('+$1,000')).toBeOnTheScreen();
+    expect(findAmountTextColor(UNSAFE_getAllByType, /^\+\$1,000$/)).toBe(
+      TextColor.TextDefault,
+    );
+
+    expect(await findByTestId(STATUS_PILL)).toHaveTextContent(
+      strings('transaction.failed'),
+    );
+    expect(
+      findAmountTextColor(
+        UNSAFE_getAllByType,
+        new RegExp(`^${strings('transaction.failed')}$`),
+      ),
+    ).toBe(TextColor.ErrorDefault);
+    expect(getByTestId(DATE_ROW)).toHaveTextContent(
+      formatPerpsTransactionDate(item.timestamp),
+      { exact: false },
+    );
+    expect(queryByTestId(NETWORK_ROW)).toBeNull();
+
+    const networkFeeRow = getByTestId(NETWORK_FEE_ROW);
+    expect(within(networkFeeRow).getByText('ETH')).toBeOnTheScreen();
+    expect(
+      within(networkFeeRow).getByTestId(FEE_TOKEN_AVATAR),
+    ).toBeOnTheScreen();
+
+    const bridgeFeeRow = getByTestId(BRIDGE_FEE_ROW);
+    expect(within(bridgeFeeRow).getByText('USDC')).toBeOnTheScreen();
+    expect(
+      within(bridgeFeeRow).getByTestId(FEE_TOKEN_AVATAR),
+    ).toBeOnTheScreen();
+    expect(getByTestId(TOTAL_ROW)).toHaveTextContent(/\$/);
+    expect(queryByTestId(BLOCK_EXPLORER_BUTTON)).toBeNull();
+
+    expect(
+      getByText(
+        strings('perps.transactions.steps.title_failed', {
+          completed: 3,
+          failed: 1,
+        }),
+      ),
+    ).toBeOnTheScreen();
+
+    for (const [stepIndex, labelKey] of [
+      [0, 'perps.transactions.steps.approve_funds'],
+      [1, 'perps.transactions.steps.bridge_funds'],
+      [2, 'perps.transactions.steps.receive_usdc'],
+    ] as const) {
+      const completedStep = getByTestId(
+        getActivityDetailsStepTestId(stepIndex),
+      );
+      expect(completedStep).toHaveTextContent(strings(labelKey), {
+        exact: false,
+      });
+      expect(completedStep).toHaveTextContent(/\d.+\s-\s/, { exact: false });
+      expect(completedStep).not.toHaveTextContent(
+        strings('transaction.failed'),
+        { exact: false },
+      );
+    }
+
+    const failedStep = getByTestId(getActivityDetailsStepTestId(3));
+    expect(failedStep).toHaveTextContent(
+      strings('perps.transactions.steps.add_funds'),
+      { exact: false },
+    );
+    expect(failedStep).toHaveTextContent(strings('transaction.failed'), {
+      exact: false,
+    });
+    expect(failedStep).not.toHaveTextContent(/\d.+\s-\s/, { exact: false });
+
+    for (const stepIndex of [0, 1, 2, 3]) {
+      expect(
+        getByTestId(getActivityDetailsStepIconTestId(stepIndex)),
+      ).toBeOnTheScreen();
+    }
+
+    const tryAgain = getByTestId(DO_IT_AGAIN_BUTTON);
+    expect(tryAgain).toHaveTextContent(strings('perps.transactions.try_again'));
+
+    fireEvent.press(tryAgain);
+
+    expect(
+      await findByTestId(getRouteProbeTestId(Routes.PERPS.ROOT)),
+    ).toBeOnTheScreen();
+  });
+
+  it('shows confirmed Perps withdrawal details with Ethereum network, completed steps, and Withdraw', async () => {
+    const item = buildActivityCvPerpsCompletedWithdrawalItem();
+
+    const {
+      findByTestId,
+      getByTestId,
+      getByText,
+      queryByTestId,
+      queryByText,
+      UNSAFE_getAllByType,
+    } = renderPerpsDetails(item);
+
+    expect(await findByTestId(SCREEN)).toBeOnTheScreen();
+    expect(getByTestId(HEADER)).toHaveTextContent(
+      strings('transactions.activity_perps_withdrawal'),
+    );
+
+    const amountHeader = await findByTestId(AMOUNT_HEADER);
+    expect(
+      within(amountHeader).getByTestId(AMOUNT_AVATAR_SINGLE),
+    ).toBeOnTheScreen();
+    expect(within(amountHeader).getByText('-$1,000')).toBeOnTheScreen();
+    expect(findAmountTextColor(UNSAFE_getAllByType, /^-\$1,000$/)).toBe(
+      TextColor.TextDefault,
+    );
+
+    expect(await findByTestId(STATUS_PILL)).toHaveTextContent(
+      strings('transaction.confirmed'),
+    );
+    expect(getByTestId(DATE_ROW)).toHaveTextContent(
+      formatPerpsTransactionDate(item.timestamp),
+      { exact: false },
+    );
+
+    const accountRow = getByTestId(ACCOUNT_ROW);
+    expect(accountRow).toHaveTextContent(
+      renderShortAddress(ACTIVITY_CV_ACCOUNT),
+      { exact: false },
+    );
+
+    expect(getByTestId(NETWORK_ROW)).toHaveTextContent('Ethereum', {
+      exact: false,
+    });
+    expect(queryByText('Arbitrum')).toBeNull();
+
+    expect(queryByTestId(NETWORK_FEE_ROW)).toBeNull();
+    expect(queryByTestId(BRIDGE_FEE_ROW)).toBeNull();
+    expect(queryByTestId(TOTAL_ROW)).toBeNull();
+    expect(queryByTestId(BLOCK_EXPLORER_BUTTON)).toBeNull();
+
+    expect(
+      getByText(
+        strings('perps.transactions.steps.title_completed', { completed: 3 }),
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('perps.transactions.steps.initiate_withdrawal')),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('perps.transactions.steps.process_withdrawal')),
+    ).toBeOnTheScreen();
+    expect(
+      getByText(strings('perps.transactions.steps.receive_funds')),
+    ).toBeOnTheScreen();
+
+    for (const stepIndex of [0, 1, 2]) {
+      const step = getByTestId(getActivityDetailsStepTestId(stepIndex));
+      expect(step).toBeOnTheScreen();
+      expect(step).toHaveTextContent(/\d.+\s-\s/, { exact: false });
+      expect(
+        getByTestId(getActivityDetailsStepIconTestId(stepIndex)),
+      ).toBeOnTheScreen();
+    }
+
+    const withdraw = getByTestId(DO_IT_AGAIN_BUTTON);
+    expect(withdraw).toHaveTextContent(strings('perps.withdrawal.withdraw'));
+
+    fireEvent.press(withdraw);
+
+    expect(
+      await findByTestId(getRouteProbeTestId(Routes.PERPS.ROOT)),
+    ).toBeOnTheScreen();
+  });
+});
+
+describeForPlatforms('ActivityDetails — Perps trades', () => {
+  const expectTradeDetails = async ({
+    item,
+    title,
+    priceLabel,
+    pnl,
+  }: {
+    item: ActivityListItem;
+    title: string;
+    priceLabel: string;
+    pnl?: { amount: string; color: TextColor };
+  }) => {
+    const transaction = getPerpsTransaction(item);
+    const fill = transaction?.fill;
+
+    const { findByTestId, getByTestId, queryByTestId, UNSAFE_getAllByType } =
+      renderPerpsTradeDetails(item);
+
+    expect(await findByTestId(SCREEN)).toBeOnTheScreen();
+    expect(getByTestId(HEADER)).toHaveTextContent(title);
+
+    const amountHeader = await findByTestId(AMOUNT_HEADER);
+    expect(
+      within(amountHeader).getByTestId(AMOUNT_AVATAR_SINGLE),
+    ).toBeOnTheScreen();
+    expect(within(amountHeader).getByText('0.0001 BTC')).toBeOnTheScreen();
+    expect(findAmountTextColor(UNSAFE_getAllByType, /^0\.0001 BTC$/)).toBe(
+      TextColor.SuccessDefault,
+    );
+
+    expect(await findByTestId(STATUS_PILL)).toHaveTextContent(
+      strings('transaction.confirmed'),
+    );
+    expect(getByTestId(DATE_ROW)).toHaveTextContent(
+      formatPerpsTransactionDate(item.timestamp),
+      { exact: false },
+    );
+
+    const sizeRow = getByTestId(SIZE_ROW);
+    expect(sizeRow).toHaveTextContent(
+      strings('perps.transactions.position.size'),
+      { exact: false },
+    );
+    expect(
+      within(sizeRow).getByText(getPerpsPositionSize(fill) ?? ''),
+    ).toBeOnTheScreen();
+
+    const priceRow = getByTestId(PRICE_ROW);
+    expect(priceRow).toHaveTextContent(priceLabel, { exact: false });
+    expect(
+      within(priceRow).getByText(getPerpsPriceValue(fill?.entryPrice) ?? ''),
+    ).toBeOnTheScreen();
+
+    const feesRow = getByTestId(FEES_ROW);
+    expect(feesRow).toHaveTextContent(
+      strings('perps.transactions.position.fees'),
+      { exact: false },
+    );
+    expect(
+      within(feesRow).getByText(fill?.fee ? formatPositiveFiat(fill.fee) : ''),
+    ).toBeOnTheScreen();
+
+    if (pnl) {
+      const pnlRow = getByTestId(PNL_ROW);
+      expect(pnlRow).toHaveTextContent(
+        strings('perps.transactions.position.pnl'),
+        { exact: false },
+      );
+      expect(within(pnlRow).getByText(pnl.amount)).toBeOnTheScreen();
+      expect(
+        findAmountTextColor(
+          UNSAFE_getAllByType,
+          new RegExp(`^${pnl.amount.replace(/[+$]/g, '\\$&')}$`),
+        ),
+      ).toBe(pnl.color);
+    } else {
+      expect(queryByTestId(PNL_ROW)).toBeNull();
+    }
+
+    const explorer = getByTestId(BLOCK_EXPLORER_BUTTON);
+    expect(explorer).toHaveTextContent(
+      strings('activity_details.view_on_block_explorer'),
+    );
+
+    const tradeAgain = getByTestId(DO_IT_AGAIN_BUTTON);
+    expect(tradeAgain).toHaveTextContent(
+      strings('perps.transactions.trade_again'),
+    );
+
+    fireEvent.press(tradeAgain);
+
+    expect(
+      await findByTestId(getRouteProbeTestId(Routes.PERPS.ROOT)),
+    ).toBeOnTheScreen();
+  };
+
+  it('shows confirmed Opened short details with entry price and Trade again', async () => {
+    await expectTradeDetails({
+      item: buildActivityCvPerpsTradeItem('openShort'),
+      title: strings('transactions.activity_perps_open_short'),
+      priceLabel: strings('perps.transactions.position.entry_price'),
+    });
+  });
+
+  it('shows confirmed Opened long details with entry price and Trade again', async () => {
+    await expectTradeDetails({
+      item: buildActivityCvPerpsTradeItem('openLong'),
+      title: strings('transactions.activity_perps_open_long'),
+      priceLabel: strings('perps.transactions.position.entry_price'),
+    });
+  });
+
+  it('shows confirmed Closed short details with close price, red Net P&L, and Trade again', async () => {
+    await expectTradeDetails({
+      item: buildActivityCvPerpsTradeItem('closeShort'),
+      title: strings('transactions.activity_perps_close_short'),
+      priceLabel: strings('perps.transactions.position.close_price'),
+      pnl: { amount: '-$12.34', color: TextColor.ErrorDefault },
+    });
+  });
+
+  it('shows confirmed Closed long details with close price, green Net P&L, and Trade again', async () => {
+    await expectTradeDetails({
+      item: buildActivityCvPerpsTradeItem('closeLong'),
+      title: strings('transactions.activity_perps_close_long'),
+      priceLabel: strings('perps.transactions.position.close_price'),
+      pnl: { amount: '+$45.67', color: TextColor.SuccessDefault },
+    });
+  });
+});
+
+describeForPlatforms('ActivityDetails — Perps orders', () => {
+  const perpsController = Engine.context.PerpsController as unknown as {
+    getActiveProviderOrNull: jest.Mock;
+    getOrderFills: jest.Mock;
+  };
+
+  const orderKinds = [
+    'marketCloseShort',
+    'stopMarketCloseShort',
+    'takeProfitCanceled',
+    'takeProfitFilled',
+  ] as const;
+
+  beforeEach(() => {
+    perpsController.getActiveProviderOrNull.mockReturnValue({});
+    perpsController.getOrderFills.mockResolvedValue(
+      orderKinds.map((kind) =>
+        buildActivityCvPerpsOrderFill(
+          buildActivityCvPerpsOrderTransaction(kind).order?.orderId ?? kind,
+        ),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    perpsController.getActiveProviderOrNull.mockReturnValue(null);
+    perpsController.getOrderFills.mockResolvedValue([]);
+  });
+
+  const expectOrderDetails = async ({
+    item,
+    title,
+    filled,
+    status,
+    statusColor,
+    showTryAgain,
+  }: {
+    item: ActivityListItem;
+    title: string;
+    filled: string;
+    status: string;
+    statusColor: TextColor;
+    showTryAgain: boolean;
+  }) => {
+    const order = getPerpsTransaction(item)?.order;
+
+    const {
+      findByTestId,
+      getByTestId,
+      queryByTestId,
+      queryByText,
+      UNSAFE_getAllByType,
+    } = renderPerpsTradeDetails(item);
+
+    expect(await findByTestId(SCREEN)).toBeOnTheScreen();
+    expect(getByTestId(HEADER)).toHaveTextContent(title);
+
+    const amountHeader = await findByTestId(AMOUNT_HEADER);
+    expect(
+      within(amountHeader).getByTestId(AMOUNT_AVATAR_SINGLE),
+    ).toBeOnTheScreen();
+    expect(within(amountHeader).getByText('0.0001 BTC')).toBeOnTheScreen();
+
+    expect(await findByTestId(STATUS_PILL)).toHaveTextContent(status);
+    expect(
+      findAmountTextColor(UNSAFE_getAllByType, new RegExp(`^${status}$`)),
+    ).toBe(statusColor);
+    expect(getByTestId(STATUS_PILL)).not.toHaveTextContent(
+      strings('transaction.confirmed'),
+    );
+    expect(getByTestId(DATE_ROW)).toHaveTextContent(
+      formatPerpsTransactionDate(item.timestamp),
+      { exact: false },
+    );
+
+    const sizeRow = getByTestId(SIZE_ROW);
+    expect(sizeRow).toHaveTextContent(
+      strings('perps.transactions.order.size'),
+      {
+        exact: false,
+      },
+    );
+    expect(
+      within(sizeRow).getByText(getPerpsPriceValue(order?.size) ?? ''),
+    ).toBeOnTheScreen();
+
+    const limitPriceRow = getByTestId(LIMIT_PRICE_ROW);
+    expect(limitPriceRow).toHaveTextContent(
+      strings('perps.transactions.order.limit_price'),
+      { exact: false },
+    );
+    expect(
+      within(limitPriceRow).getByText(
+        getPerpsPriceValue(order?.limitPrice) ?? '',
+      ),
+    ).toBeOnTheScreen();
+
+    expect(getByTestId(FILLED_ROW)).toHaveTextContent(filled, {
+      exact: false,
+    });
+
+    expect(
+      queryByText(strings('perps.transactions.order.metamask_fee')),
+    ).toBeNull();
+    expect(
+      queryByText(strings('perps.transactions.order.hyperliquid_fee')),
+    ).toBeNull();
+
+    await waitFor(() => {
+      expect(getByTestId(TOTAL_FEE_ROW)).toHaveTextContent(
+        formatPerpsOrderFee(Number(ACTIVITY_CV_PERPS_ORDER_FEE)),
+        { exact: false },
+      );
+    });
+    expect(getByTestId(TOTAL_FEE_ROW)).not.toHaveTextContent('—');
+
+    const explorer = getByTestId(BLOCK_EXPLORER_BUTTON);
+    expect(explorer).toHaveTextContent(
+      strings('activity_details.view_on_block_explorer'),
+    );
+
+    if (showTryAgain) {
+      const tryAgain = getByTestId(DO_IT_AGAIN_BUTTON);
+      expect(tryAgain).toHaveTextContent(
+        strings('perps.transactions.try_again'),
+      );
+      fireEvent.press(tryAgain);
+      expect(
+        await findByTestId(getRouteProbeTestId(Routes.PERPS.ROOT)),
+      ).toBeOnTheScreen();
+      return;
+    }
+
+    expect(queryByTestId(DO_IT_AGAIN_BUTTON)).toBeNull();
+    fireEvent.press(explorer);
+    expect(
+      await findByTestId(getRouteProbeTestId(Routes.WEBVIEW.MAIN)),
+    ).toBeOnTheScreen();
+  };
+
+  it('shows filled market-close-short order details with Total fee and explorer', async () => {
+    await expectOrderDetails({
+      item: buildActivityCvPerpsOrderItem('marketCloseShort'),
+      title: strings('transactions.activity_market_close_short'),
+      filled: '100%',
+      status: strings('transactions.activity_order_status_filled'),
+      statusColor: TextColor.SuccessDefault,
+      showTryAgain: false,
+    });
+  });
+
+  it('shows filled stop-market-close-short order details with Total fee and explorer', async () => {
+    await expectOrderDetails({
+      item: buildActivityCvPerpsOrderItem('stopMarketCloseShort'),
+      title: strings('transactions.activity_stop_market_close_short'),
+      filled: '100%',
+      status: strings('transactions.activity_order_status_filled'),
+      statusColor: TextColor.SuccessDefault,
+      showTryAgain: false,
+    });
+  });
+
+  it('shows canceled take-profit order details with Try again', async () => {
+    await expectOrderDetails({
+      item: buildActivityCvPerpsOrderItem('takeProfitCanceled'),
+      title: strings('transactions.activity_limit_close_short'),
+      filled: '0%',
+      status: strings('transactions.activity_order_status_canceled'),
+      statusColor: TextColor.ErrorDefault,
+      showTryAgain: true,
+    });
+  });
+
+  it('shows filled take-profit order details with explorer and no Try again', async () => {
+    await expectOrderDetails({
+      item: buildActivityCvPerpsOrderItem('takeProfitFilled'),
+      title: strings('transactions.activity_limit_close_short'),
+      filled: '100%',
+      status: strings('transactions.activity_order_status_filled'),
+      statusColor: TextColor.SuccessDefault,
+      showTryAgain: false,
+    });
+  });
+});
+
+describeForPlatforms('ActivityDetails — Perps funding', () => {
+  const expectFundingDetails = async ({
+    item,
+    title,
+    rate,
+    feeAmount,
+    feeColor,
+  }: {
+    item: ActivityListItem;
+    title: string;
+    rate: string;
+    feeAmount: string;
+    feeColor: TextColor;
+  }) => {
+    const { findByTestId, getByTestId, queryByTestId, UNSAFE_getAllByType } =
+      renderPerpsTradeDetails(item);
+
+    expect(await findByTestId(SCREEN)).toBeOnTheScreen();
+    expect(getByTestId(HEADER)).toHaveTextContent(title);
+
+    const amountHeader = await findByTestId(AMOUNT_HEADER);
+    expect(
+      within(amountHeader).getByTestId(AMOUNT_AVATAR_SINGLE),
+    ).toBeOnTheScreen();
+    expect(within(amountHeader).getByText('BTC')).toBeOnTheScreen();
+    expect(findAmountTextColor(UNSAFE_getAllByType, /^BTC$/)).toBe(
+      TextColor.SuccessDefault,
+    );
+
+    expect(await findByTestId(STATUS_PILL)).toHaveTextContent(
+      strings('transaction.confirmed'),
+    );
+    expect(getByTestId(DATE_ROW)).toHaveTextContent(
+      formatPerpsTransactionDate(item.timestamp),
+      { exact: false },
+    );
+
+    expect(getByTestId(RATE_ROW)).toHaveTextContent(
+      strings('perps.transactions.funding.rate'),
+      { exact: false },
+    );
+    expect(within(getByTestId(RATE_ROW)).getByText(rate)).toBeOnTheScreen();
+
+    const fundingFeeRow = getByTestId(FUNDING_FEE_ROW);
+    expect(fundingFeeRow).toHaveTextContent(
+      strings('perps.transactions.funding.funding_fee'),
+      { exact: false },
+    );
+    expect(within(fundingFeeRow).getByText(feeAmount)).toBeOnTheScreen();
+    expect(
+      findAmountTextColor(
+        UNSAFE_getAllByType,
+        new RegExp(`^${feeAmount.replace(/[+$]/g, '\\$&')}$`),
+      ),
+    ).toBe(feeColor);
+
+    expect(queryByTestId(DO_IT_AGAIN_BUTTON)).toBeNull();
+
+    const explorer = getByTestId(BLOCK_EXPLORER_BUTTON);
+    expect(explorer).toHaveTextContent(
+      strings('activity_details.view_on_block_explorer'),
+    );
+
+    fireEvent.press(explorer);
+
+    expect(
+      await findByTestId(getRouteProbeTestId(Routes.WEBVIEW.MAIN)),
+    ).toBeOnTheScreen();
+  };
+
+  it('shows received funding fees with a green fee and explorer', async () => {
+    const item = buildActivityCvPerpsFundingItem('received');
+    const funding = getPerpsTransaction(item)?.fundingAmount;
+
+    await expectFundingDetails({
+      item,
+      title: strings('transactions.activity_perps_received_funding_fees'),
+      rate: '-0.0125%',
+      feeAmount: formatSignedPerpsFiat(
+        funding?.feeNumber ?? 1.23,
+        Boolean(funding?.isPositive),
+      ),
+      feeColor: TextColor.SuccessDefault,
+    });
+  });
+
+  it('shows paid funding fees with a default fee and explorer', async () => {
+    const item = buildActivityCvPerpsFundingItem('paid');
+    const funding = getPerpsTransaction(item)?.fundingAmount;
+
+    await expectFundingDetails({
+      item,
+      title: strings('transactions.activity_perps_paid_funding_fees'),
+      rate: '0.01%',
+      feeAmount: formatSignedPerpsFiat(
+        funding?.feeNumber ?? 0.5,
+        Boolean(funding?.isPositive),
+      ),
+      feeColor: TextColor.TextDefault,
+    });
+  });
+});

--- a/app/components/Views/ActivityDetails/ActivityDetails.testIds.ts
+++ b/app/components/Views/ActivityDetails/ActivityDetails.testIds.ts
@@ -21,6 +21,15 @@ export const ActivityDetailsSelectorsIDs = {
   BRIDGE_FEE_ROW: 'activity-details-bridge-fee-row',
   TOTAL_ROW: 'activity-details-total-row',
   FEE_TOKEN_AVATAR: 'fee-token-avatar',
+  SIZE_ROW: 'activity-details-size-row',
+  PRICE_ROW: 'activity-details-price-row',
+  FEES_ROW: 'activity-details-fees-row',
+  PNL_ROW: 'activity-details-pnl-row',
+  LIMIT_PRICE_ROW: 'activity-details-limit-price-row',
+  FILLED_ROW: 'activity-details-filled-row',
+  TOTAL_FEE_ROW: 'activity-details-total-fee-row',
+  RATE_ROW: 'activity-details-rate-row',
+  FUNDING_FEE_ROW: 'activity-details-funding-fee-row',
   FOOTER: 'activity-details-footer',
   BLOCK_EXPLORER_BUTTON: 'activity-details-block-explorer-button',
   DO_IT_AGAIN_BUTTON: 'activity-details-do-it-again-button',
@@ -32,3 +41,9 @@ export const ActivityDetailsSelectorsIDs = {
   PENDING_QR_CANCEL_BUTTON: 'activity-details-pending-qr-cancel-button',
   PENDING_LEDGER_SIGN_BUTTON: 'activity-details-pending-ledger-sign-button',
 } as const;
+
+export const getActivityDetailsStepTestId = (index: number): string =>
+  `activity-details-step-${index}`;
+
+export const getActivityDetailsStepIconTestId = (index: number): string =>
+  `activity-details-step-${index}-icon`;

--- a/app/components/Views/ActivityDetails/components/ActivityDetailsPerpsHero.tsx
+++ b/app/components/Views/ActivityDetails/components/ActivityDetailsPerpsHero.tsx
@@ -41,27 +41,29 @@ function PerpsHeroIcon({ symbol }: { symbol: string | undefined }) {
   const displaySymbol = getPerpsDisplaySymbol(symbol);
 
   return (
-    <AvatarBase
-      size={AvatarBaseSize.Xl}
-      shape={AvatarBaseShape.Circle}
-      fallbackText={showFallback ? displaySymbol.substring(0, 2) : undefined}
-    >
-      {!showFallback && imageUri ? (
-        <Image
-          source={{ uri: imageUri }}
-          style={imageStyle.fill}
-          contentFit="contain"
-          cachePolicy="memory-disk"
-          onError={() => {
-            if (!useFallbackUrl && iconUrls?.fallback) {
-              setUseFallbackUrl(true);
-            } else {
-              setHasError(true);
-            }
-          }}
-        />
-      ) : null}
-    </AvatarBase>
+    <Box testID={ActivityDetailsSelectorsIDs.AMOUNT_AVATAR_SINGLE}>
+      <AvatarBase
+        size={AvatarBaseSize.Xl}
+        shape={AvatarBaseShape.Circle}
+        fallbackText={showFallback ? displaySymbol.substring(0, 2) : undefined}
+      >
+        {!showFallback && imageUri ? (
+          <Image
+            source={{ uri: imageUri }}
+            style={imageStyle.fill}
+            contentFit="contain"
+            cachePolicy="memory-disk"
+            onError={() => {
+              if (!useFallbackUrl && iconUrls?.fallback) {
+                setUseFallbackUrl(true);
+              } else {
+                setHasError(true);
+              }
+            }}
+          />
+        ) : null}
+      </AvatarBase>
+    </Box>
   );
 }
 

--- a/app/components/Views/ActivityDetails/components/ActivityDetailsPerpsStepTimeline.test.tsx
+++ b/app/components/Views/ActivityDetails/components/ActivityDetailsPerpsStepTimeline.test.tsx
@@ -3,6 +3,10 @@ import { fireEvent } from '@testing-library/react-native';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import Routes from '../../../../constants/navigation/Routes';
 import { useActivityBlockExplorer } from '../hooks/useActivityBlockExplorer';
+import {
+  getActivityDetailsStepIconTestId,
+  getActivityDetailsStepTestId,
+} from '../ActivityDetails.testIds';
 import { ActivityDetailsPerpsStepTimeline } from './ActivityDetailsPerpsStepTimeline';
 
 const mockNavigate = jest.fn();
@@ -34,7 +38,7 @@ describe('ActivityDetailsPerpsStepTimeline', () => {
       />,
     );
 
-    fireEvent.press(getByTestId('activity-details-step-0'));
+    fireEvent.press(getByTestId(getActivityDetailsStepTestId(0)));
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.WEBVIEW.MAIN, {
       screen: Routes.WEBVIEW.SIMPLE,
@@ -56,6 +60,6 @@ describe('ActivityDetailsPerpsStepTimeline', () => {
       />,
     );
 
-    expect(queryByTestId('activity-details-step-0-icon')).toBeNull();
+    expect(queryByTestId(getActivityDetailsStepIconTestId(0))).toBeNull();
   });
 });

--- a/app/components/Views/ActivityDetails/components/ActivityDetailsStepTimeline.tsx
+++ b/app/components/Views/ActivityDetails/components/ActivityDetailsStepTimeline.tsx
@@ -24,6 +24,10 @@ import {
   type ActivityExplorerLink,
 } from '../hooks/useActivityBlockExplorer';
 import { ActivityDetailSection } from './ActivityDetailsLayout';
+import {
+  getActivityDetailsStepIconTestId,
+  getActivityDetailsStepTestId,
+} from '../ActivityDetails.testIds';
 
 export type ActivityDetailsStepStatus =
   | 'completed'
@@ -114,7 +118,7 @@ export function ActivityDetailsStepTimeline({
               key={`${step.label}-${index}`}
               disabled={!explorerLink}
               onPress={openExplorer}
-              testID={`activity-details-step-${index}`}
+              testID={getActivityDetailsStepTestId(index)}
             >
               <Box twClassName="flex-row items-start gap-3">
                 <Box twClassName="items-center">
@@ -145,7 +149,7 @@ export function ActivityDetailsStepTimeline({
                     name={IconName.Export}
                     size={IconSize.Sm}
                     color={IconColor.IconAlternative}
-                    testID={`activity-details-step-${index}-icon`}
+                    testID={getActivityDetailsStepIconTestId(index)}
                   />
                 ) : null}
               </Box>

--- a/app/components/Views/ActivityDetails/templates/PerpsDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/PerpsDetails.tsx
@@ -145,10 +145,12 @@ function TradeDetails({
           <ActivityDetailRow
             label={strings('perps.transactions.position.size')}
             value={getPerpsPositionSize(fill)}
+            testID={ActivityDetailsSelectorsIDs.SIZE_ROW}
           />
           <ActivityDetailRow
             label={getPerpsPriceLabel(fill)}
             value={getPerpsPriceValue(fill?.entryPrice)}
+            testID={ActivityDetailsSelectorsIDs.PRICE_ROW}
           />
         </ActivityDetailSection>
       }
@@ -157,6 +159,7 @@ function TradeDetails({
           <ActivityDetailRow
             label={strings('perps.transactions.position.fees')}
             value={fill?.fee ? formatPositiveFiat(fill.fee) : undefined}
+            testID={ActivityDetailsSelectorsIDs.FEES_ROW}
           />
           {shouldShowPerpsPnl(fill) ? (
             <ActivityDetailRow
@@ -174,6 +177,7 @@ function TradeDetails({
                   {fill?.amount}
                 </Text>
               }
+              testID={ActivityDetailsSelectorsIDs.PNL_ROW}
             />
           ) : null}
         </ActivityDetailSection>
@@ -234,14 +238,17 @@ function OrderDetails({
           <ActivityDetailRow
             label={strings('perps.transactions.order.size')}
             value={order?.size ? getPerpsPriceValue(order.size) : undefined}
+            testID={ActivityDetailsSelectorsIDs.SIZE_ROW}
           />
           <ActivityDetailRow
             label={strings('perps.transactions.order.limit_price')}
             value={getPerpsPriceValue(order?.limitPrice)}
+            testID={ActivityDetailsSelectorsIDs.LIMIT_PRICE_ROW}
           />
           <ActivityDetailRow
             label={strings('perps.transactions.order.filled')}
             value={order?.filled}
+            testID={ActivityDetailsSelectorsIDs.FILLED_ROW}
           />
         </ActivityDetailSection>
       }
@@ -250,6 +257,7 @@ function OrderDetails({
           <ActivityDetailRow
             label={strings('perps.transactions.order.total_fee')}
             value={totalFeeValue}
+            testID={ActivityDetailsSelectorsIDs.TOTAL_FEE_ROW}
           />
         </ActivityDetailSection>
       }
@@ -295,6 +303,7 @@ function FundingDetails({
           <ActivityDetailRow
             label={strings('perps.transactions.funding.rate')}
             value={funding?.rate}
+            testID={ActivityDetailsSelectorsIDs.RATE_ROW}
           />
           <ActivityDetailRow
             label={strings('perps.transactions.funding.funding_fee')}
@@ -313,6 +322,7 @@ function FundingDetails({
                 </Text>
               ) : undefined
             }
+            testID={ActivityDetailsSelectorsIDs.FUNDING_FEE_ROW}
           />
         </ActivityDetailSection>
       }

--- a/tests/component-view/mocks.ts
+++ b/tests/component-view/mocks.ts
@@ -428,8 +428,14 @@ jest.mock('../../app/core/Engine', () => {
           getOrderFills: jest.fn().mockResolvedValue([]),
         })),
         getActiveProviderOrNull: jest.fn(() => null),
+        getBlockExplorerUrl: jest.fn((address?: string) =>
+          address
+            ? `https://app.hyperliquid.xyz/explorer/address/${address}`
+            : 'https://app.hyperliquid.xyz/explorer',
+        ),
         switchProvider: jest.fn().mockResolvedValue({ success: true }),
         subscribeToPrices: jest.fn(() => () => undefined),
+        subscribeToOrderFills: jest.fn(() => () => undefined),
         getOrderFills: jest.fn().mockResolvedValue([]),
         closePosition: jest.fn().mockResolvedValue({
           success: true,

--- a/tests/component-view/presets/activity.ts
+++ b/tests/component-view/presets/activity.ts
@@ -3,6 +3,7 @@ import {
   TransactionType,
   type TransactionMeta,
 } from '@metamask/transaction-controller';
+import type { CaipChainId } from '@metamask/utils';
 import { OrderOrderTypeEnum } from '@consensys/on-ramp-sdk/dist/API';
 import {
   FIAT_ORDER_PROVIDERS,
@@ -13,6 +14,16 @@ import { createStateFixture } from '../stateFixture';
 import type { DeepPartial } from '../../../app/util/test/renderWithProvider';
 import type { RootState } from '../../../app/reducers';
 import type { PredictActivity } from '../../../app/components/UI/Predict/types';
+import {
+  FillType,
+  PerpsOrderTransactionStatus,
+  PerpsOrderTransactionStatusType,
+  type PerpsTransaction,
+} from '../../../app/components/UI/Perps/types/transactionHistory';
+import {
+  mapPerpsTransaction,
+  type ActivityListItem,
+} from '../../../app/util/activity-adapters';
 
 export const ACTIVITY_CV_ACCOUNT = '0x0000000000000000000000000000000000000001';
 
@@ -1337,3 +1348,522 @@ export const activityCvSolanaSendStateOverrides = {
     },
   },
 } as unknown as DeepPartial<RootState>;
+
+/** HyperLiquid settlement chain used by Perps Activity Details CV. */
+export const ACTIVITY_CV_PERPS_CHAIN_ID = 'eip155:42161' as CaipChainId;
+
+export const ACTIVITY_CV_PERPS_DEPOSIT_HASH = '0xactivitycvperpsdeposit';
+
+export const ACTIVITY_CV_PERPS_DEPOSIT_TIMESTAMP_MS = 1_765_361_640_000;
+
+const ACTIVITY_CV_PERPS_COLLATERAL_ASSET_ID =
+  `${ACTIVITY_CV_PERPS_CHAIN_ID}/erc20:0xaf88d065e77c8cc2239327c5edb3a432268e5831` as const;
+
+const activityCvPerpsPayMetadata = {
+  chainId: '0x1' as const,
+  tokenAddress: ACTIVITY_CV_USDC,
+  networkFeeFiat: '1.23',
+  bridgeFeeFiat: '0.09',
+  totalFiat: '1001.24',
+};
+
+/**
+ * Local Pay transaction matched to a feed-backed Perps deposit by hash.
+ * `chainId` is Arbitrum so it matches the activity row; `metamaskPay.chainId`
+ * is Ethereum so the network fee is denominated in ETH.
+ */
+export const buildActivityCvPerpsPayTransaction = (
+  hash = ACTIVITY_CV_PERPS_DEPOSIT_HASH,
+): TransactionMeta =>
+  ({
+    id: 'activity-cv-perps-pay-tx',
+    hash,
+    chainId: '0xa4b1',
+    status: TransactionStatus.confirmed,
+    time: ACTIVITY_CV_PERPS_DEPOSIT_TIMESTAMP_MS,
+    type: TransactionType.perpsDeposit,
+    txParams: {
+      from: ACTIVITY_CV_ACCOUNT,
+      to: ACTIVITY_CV_USDC,
+      value: '0x0',
+    },
+    metamaskPay: activityCvPerpsPayMetadata,
+  }) as unknown as TransactionMeta;
+
+export const buildActivityCvPerpsDepositTransaction = (
+  status: 'completed' | 'pending' | 'failed' | 'bridging',
+  hash = ACTIVITY_CV_PERPS_DEPOSIT_HASH,
+): PerpsTransaction => ({
+  id: `wallet-activity-cv-perps-deposit-${status}`,
+  type: 'deposit',
+  category: 'deposit',
+  title: 'Account funded',
+  subtitle: '+$1,000',
+  timestamp: ACTIVITY_CV_PERPS_DEPOSIT_TIMESTAMP_MS,
+  asset: 'USDC',
+  depositWithdrawal: {
+    amount: '+$1,000',
+    amountNumber: 1000,
+    isPositive: true,
+    asset: 'USDC',
+    txHash: hash,
+    status,
+    type: 'deposit',
+  },
+});
+
+export const buildActivityCvPerpsCompletedDepositTransaction =
+  (): PerpsTransaction => buildActivityCvPerpsDepositTransaction('completed');
+
+export const buildActivityCvPerpsPendingDepositTransaction =
+  (): PerpsTransaction =>
+    buildActivityCvPerpsDepositTransaction(
+      'pending',
+      `${ACTIVITY_CV_PERPS_DEPOSIT_HASH}pending`,
+    );
+
+export const buildActivityCvPerpsFailedDepositTransaction =
+  (): PerpsTransaction => {
+    const transaction = buildActivityCvPerpsDepositTransaction(
+      'failed',
+      `${ACTIVITY_CV_PERPS_DEPOSIT_HASH}failed`,
+    );
+    const depositWithdrawal = transaction.depositWithdrawal;
+
+    if (!depositWithdrawal) {
+      throw new Error('Expected a Perps depositWithdrawal payload');
+    }
+
+    // Failed deposits do not credit the account; FundsDetails colors the hero
+    // from `isPositive`, which is TextDefault when false.
+    return {
+      ...transaction,
+      depositWithdrawal: {
+        ...depositWithdrawal,
+        isPositive: false,
+      },
+    };
+  };
+
+export const buildActivityCvPerpsFundsItem = (
+  transaction: PerpsTransaction,
+): ActivityListItem => {
+  const item = mapPerpsTransaction({
+    transaction,
+    chainId: ACTIVITY_CV_PERPS_CHAIN_ID,
+    collateralAssetId: ACTIVITY_CV_PERPS_COLLATERAL_ASSET_ID,
+  });
+
+  if (!item) {
+    throw new Error('Expected a mapped Perps funds activity item');
+  }
+
+  return item;
+};
+
+export const buildActivityCvPerpsCompletedDepositItem = (): ActivityListItem =>
+  buildActivityCvPerpsFundsItem(
+    buildActivityCvPerpsCompletedDepositTransaction(),
+  );
+
+export const buildActivityCvPerpsPendingDepositItem = (): ActivityListItem =>
+  buildActivityCvPerpsFundsItem(
+    buildActivityCvPerpsPendingDepositTransaction(),
+  );
+
+export const buildActivityCvPerpsFailedDepositItem = (): ActivityListItem =>
+  buildActivityCvPerpsFundsItem(buildActivityCvPerpsFailedDepositTransaction());
+
+export const ACTIVITY_CV_PERPS_WITHDRAWAL_HASH = '0xactivitycvperpswithdraw';
+
+export const buildActivityCvPerpsCompletedWithdrawalTransaction =
+  (): PerpsTransaction => ({
+    id: 'wallet-activity-cv-perps-withdrawal-completed',
+    type: 'withdrawal',
+    category: 'withdrawal',
+    title: 'Withdrawal',
+    subtitle: '-$1,000',
+    timestamp: ACTIVITY_CV_PERPS_DEPOSIT_TIMESTAMP_MS,
+    asset: 'USDC',
+    depositWithdrawal: {
+      amount: '-$1,000',
+      amountNumber: 1000,
+      isPositive: false,
+      asset: 'USDC',
+      txHash: ACTIVITY_CV_PERPS_WITHDRAWAL_HASH,
+      status: 'completed',
+      type: 'withdrawal',
+    },
+  });
+
+export const buildActivityCvPerpsCompletedWithdrawalItem =
+  (): ActivityListItem =>
+    buildActivityCvPerpsFundsItem(
+      buildActivityCvPerpsCompletedWithdrawalTransaction(),
+    );
+
+const ACTIVITY_CV_PERPS_TRADE_SIZE = '0.0001';
+const ACTIVITY_CV_PERPS_TRADE_PRICE = '92113';
+const ACTIVITY_CV_PERPS_TRADE_FEE = '0.50';
+const ACTIVITY_CV_PERPS_TRADE_ASSET = 'BTC';
+const ACTIVITY_CV_PERPS_TRADE_SUBTITLE = `${ACTIVITY_CV_PERPS_TRADE_SIZE} ${ACTIVITY_CV_PERPS_TRADE_ASSET}`;
+
+type ActivityCvPerpsTradeKind =
+  | 'openShort'
+  | 'openLong'
+  | 'closeShort'
+  | 'closeLong';
+
+const ACTIVITY_CV_PERPS_TRADE_SPECS: Record<
+  ActivityCvPerpsTradeKind,
+  {
+    id: string;
+    shortTitle: string;
+    action: 'Opened' | 'Closed';
+    category: 'position_open' | 'position_close';
+    amount: string;
+    amountNumber: number;
+    isPositive: boolean;
+    pnl: string;
+  }
+> = {
+  openShort: {
+    id: 'activity-cv-perps-open-short',
+    shortTitle: 'Opened short',
+    action: 'Opened',
+    category: 'position_open',
+    amount: '-$0.50',
+    amountNumber: -0.5,
+    isPositive: false,
+    pnl: '0',
+  },
+  openLong: {
+    id: 'activity-cv-perps-open-long',
+    shortTitle: 'Opened long',
+    action: 'Opened',
+    category: 'position_open',
+    amount: '-$0.50',
+    amountNumber: -0.5,
+    isPositive: false,
+    pnl: '0',
+  },
+  closeShort: {
+    id: 'activity-cv-perps-close-short',
+    shortTitle: 'Closed short',
+    action: 'Closed',
+    category: 'position_close',
+    amount: '-$12.34',
+    amountNumber: -12.34,
+    isPositive: false,
+    pnl: '-$12.34',
+  },
+  closeLong: {
+    id: 'activity-cv-perps-close-long',
+    shortTitle: 'Closed long',
+    action: 'Closed',
+    category: 'position_close',
+    amount: '+$45.67',
+    amountNumber: 45.67,
+    isPositive: true,
+    pnl: '+$45.67',
+  },
+};
+
+export const buildActivityCvPerpsTradeTransaction = (
+  kind: ActivityCvPerpsTradeKind,
+): PerpsTransaction => {
+  const spec = ACTIVITY_CV_PERPS_TRADE_SPECS[kind];
+
+  return {
+    id: spec.id,
+    type: 'trade',
+    category: spec.category,
+    title: spec.shortTitle,
+    subtitle: ACTIVITY_CV_PERPS_TRADE_SUBTITLE,
+    timestamp: ACTIVITY_CV_PERPS_DEPOSIT_TIMESTAMP_MS,
+    asset: ACTIVITY_CV_PERPS_TRADE_ASSET,
+    fill: {
+      shortTitle: spec.shortTitle,
+      amount: spec.amount,
+      amountNumber: spec.amountNumber,
+      isPositive: spec.isPositive,
+      size: ACTIVITY_CV_PERPS_TRADE_SIZE,
+      entryPrice: ACTIVITY_CV_PERPS_TRADE_PRICE,
+      points: '0',
+      pnl: spec.pnl,
+      fee: ACTIVITY_CV_PERPS_TRADE_FEE,
+      action: spec.action,
+      feeToken: 'USDC',
+      fillType: FillType.Standard,
+    },
+  };
+};
+
+export const buildActivityCvPerpsTradeItem = (
+  kind: ActivityCvPerpsTradeKind,
+): ActivityListItem => {
+  const item = mapPerpsTransaction({
+    transaction: buildActivityCvPerpsTradeTransaction(kind),
+    chainId: ACTIVITY_CV_PERPS_CHAIN_ID,
+  });
+
+  if (!item) {
+    throw new Error(`Expected a mapped Perps ${kind} activity item`);
+  }
+
+  return item;
+};
+
+export const ACTIVITY_CV_PERPS_ORDER_FEE = '2.345';
+
+type ActivityCvPerpsOrderKind =
+  | 'marketCloseShort'
+  | 'stopMarketCloseShort'
+  | 'takeProfitCanceled'
+  | 'takeProfitFilled';
+
+const ACTIVITY_CV_PERPS_ORDER_SPECS: Record<
+  ActivityCvPerpsOrderKind,
+  {
+    id: string;
+    title: string;
+    orderType: 'market' | 'limit';
+    filled: string;
+    statusText: PerpsOrderTransactionStatus;
+    statusType: PerpsOrderTransactionStatusType;
+    reduceOnly?: boolean;
+    isTrigger?: boolean;
+    detailedOrderType?: string;
+  }
+> = {
+  marketCloseShort: {
+    id: 'activity-cv-perps-order-market-close-short',
+    title: 'Market close short',
+    orderType: 'market',
+    filled: '100%',
+    statusText: PerpsOrderTransactionStatus.Filled,
+    statusType: PerpsOrderTransactionStatusType.Filled,
+    reduceOnly: true,
+  },
+  stopMarketCloseShort: {
+    id: 'activity-cv-perps-order-stop-market-close-short',
+    title: 'Stop market close short',
+    orderType: 'market',
+    filled: '100%',
+    statusText: PerpsOrderTransactionStatus.Filled,
+    statusType: PerpsOrderTransactionStatusType.Filled,
+    isTrigger: true,
+    detailedOrderType: 'Stop Market',
+  },
+  takeProfitCanceled: {
+    id: 'activity-cv-perps-order-tp-canceled',
+    title: 'Take profit limit close short',
+    orderType: 'limit',
+    filled: '0%',
+    statusText: PerpsOrderTransactionStatus.Canceled,
+    statusType: PerpsOrderTransactionStatusType.Canceled,
+    isTrigger: true,
+    detailedOrderType: 'Take Profit Limit',
+  },
+  takeProfitFilled: {
+    id: 'activity-cv-perps-order-tp-filled',
+    title: 'Take profit limit close short',
+    orderType: 'limit',
+    filled: '100%',
+    statusText: PerpsOrderTransactionStatus.Filled,
+    statusType: PerpsOrderTransactionStatusType.Filled,
+    isTrigger: true,
+    detailedOrderType: 'Take Profit Limit',
+  },
+};
+
+export const buildActivityCvPerpsOrderTransaction = (
+  kind: ActivityCvPerpsOrderKind,
+): PerpsTransaction => {
+  const spec = ACTIVITY_CV_PERPS_ORDER_SPECS[kind];
+
+  return {
+    id: spec.id,
+    type: 'order',
+    category: 'limit_order',
+    title: spec.title,
+    subtitle: ACTIVITY_CV_PERPS_TRADE_SUBTITLE,
+    timestamp: ACTIVITY_CV_PERPS_DEPOSIT_TIMESTAMP_MS,
+    asset: ACTIVITY_CV_PERPS_TRADE_ASSET,
+    order: {
+      orderId: spec.id,
+      text: spec.statusText,
+      statusType: spec.statusType,
+      type: spec.orderType,
+      size: '9.2113',
+      limitPrice: ACTIVITY_CV_PERPS_TRADE_PRICE,
+      filled: spec.filled,
+      side: 'buy',
+      reduceOnly: spec.reduceOnly,
+      isTrigger: spec.isTrigger,
+      detailedOrderType: spec.detailedOrderType,
+    },
+  };
+};
+
+export const buildActivityCvPerpsOrderItem = (
+  kind: ActivityCvPerpsOrderKind,
+): ActivityListItem => {
+  const item = mapPerpsTransaction({
+    transaction: buildActivityCvPerpsOrderTransaction(kind),
+    chainId: ACTIVITY_CV_PERPS_CHAIN_ID,
+  });
+
+  if (!item) {
+    throw new Error(`Expected a mapped Perps ${kind} order activity item`);
+  }
+
+  return item;
+};
+
+export const buildActivityCvPerpsOrderFill = (orderId: string) => ({
+  orderId,
+  symbol: ACTIVITY_CV_PERPS_TRADE_ASSET,
+  side: 'buy' as const,
+  size: ACTIVITY_CV_PERPS_TRADE_SIZE,
+  price: ACTIVITY_CV_PERPS_TRADE_PRICE,
+  pnl: '0',
+  direction: 'Close Short',
+  fee: ACTIVITY_CV_PERPS_ORDER_FEE,
+  feeToken: 'USDC',
+  timestamp: ACTIVITY_CV_PERPS_DEPOSIT_TIMESTAMP_MS,
+  startPosition: ACTIVITY_CV_PERPS_TRADE_SIZE,
+  success: true,
+});
+
+type ActivityCvPerpsFundingKind = 'received' | 'paid';
+
+const ACTIVITY_CV_PERPS_FUNDING_SPECS: Record<
+  ActivityCvPerpsFundingKind,
+  {
+    id: string;
+    title: string;
+    isPositive: boolean;
+    fee: string;
+    feeNumber: number;
+    rate: string;
+  }
+> = {
+  received: {
+    id: 'activity-cv-perps-funding-received',
+    title: 'Received funding fee',
+    isPositive: true,
+    fee: '+$1.23',
+    feeNumber: 1.23,
+    rate: '-0.0125%',
+  },
+  paid: {
+    id: 'activity-cv-perps-funding-paid',
+    title: 'Paid funding fee',
+    isPositive: false,
+    fee: '-$0.50',
+    feeNumber: -0.5,
+    rate: '0.01%',
+  },
+};
+
+export const buildActivityCvPerpsFundingTransaction = (
+  kind: ActivityCvPerpsFundingKind,
+): PerpsTransaction => {
+  const spec = ACTIVITY_CV_PERPS_FUNDING_SPECS[kind];
+
+  return {
+    id: spec.id,
+    type: 'funding',
+    category: 'funding_fee',
+    title: spec.title,
+    subtitle: ACTIVITY_CV_PERPS_TRADE_ASSET,
+    timestamp: ACTIVITY_CV_PERPS_DEPOSIT_TIMESTAMP_MS,
+    asset: ACTIVITY_CV_PERPS_TRADE_ASSET,
+    fundingAmount: {
+      isPositive: spec.isPositive,
+      fee: spec.fee,
+      feeNumber: spec.feeNumber,
+      rate: spec.rate,
+    },
+  };
+};
+
+export const buildActivityCvPerpsFundingItem = (
+  kind: ActivityCvPerpsFundingKind,
+): ActivityListItem => {
+  const item = mapPerpsTransaction({
+    transaction: buildActivityCvPerpsFundingTransaction(kind),
+    chainId: ACTIVITY_CV_PERPS_CHAIN_ID,
+  });
+
+  if (!item) {
+    throw new Error(`Expected a mapped Perps ${kind} funding activity item`);
+  }
+
+  return item;
+};
+
+/** Arbitrum + PerpsController + mainnet USDC so Pay fee avatars resolve. */
+export const activityPerpsDetailsStateOverrides = {
+  engine: {
+    backgroundState: {
+      PerpsController: {
+        isEligible: true,
+        initializationState: 'initialized',
+        mode: 'lite',
+        activeProvider: 'hyperliquid',
+        isTestnet: false,
+      },
+      NetworkController: {
+        networkConfigurationsByChainId: {
+          '0xa4b1': {
+            chainId: '0xa4b1',
+            name: 'Arbitrum One',
+            nativeCurrency: 'ETH',
+            rpcEndpoints: [
+              {
+                networkClientId: 'arbitrum-mainnet',
+                type: 'infura',
+                url: 'https://arbitrum-mainnet.infura.io/v3/{infuraProjectId}',
+              },
+            ],
+            defaultRpcEndpointIndex: 0,
+            blockExplorerUrls: ['https://arbiscan.io'],
+            defaultBlockExplorerUrlIndex: 0,
+          },
+        },
+      },
+      TokensController: {
+        allTokens: {
+          '0x1': {
+            [ACTIVITY_CV_ACCOUNT]: [
+              {
+                address: ACTIVITY_CV_USDC,
+                symbol: 'USDC',
+                decimals: 6,
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+} as unknown as DeepPartial<RootState>;
+
+export const initialStateActivityWithPerpsDetails = (
+  transactions: TransactionMeta[] = [],
+) =>
+  initialStateActivity()
+    .withRemoteFeatureFlags({ tmcuActivityRedesignEnabled: true })
+    .withOverrides(activityPerpsDetailsStateOverrides)
+    .withOverrides({
+      engine: {
+        backgroundState: {
+          TransactionController: {
+            transactions,
+            swapsTransactions: {},
+          },
+        },
+      },
+    } as unknown as DeepPartial<RootState>);

--- a/tests/component-view/renderers/activity.ts
+++ b/tests/component-view/renderers/activity.ts
@@ -25,6 +25,8 @@ import {
   initialStateActivityWithRedesignEnabled,
 } from '../presets/activity';
 import type { ActivityDetailsParams } from '../../../app/components/Views/ActivityDetails/ActivityDetails.types';
+import type { ActivityListItem } from '../../../app/util/activity-adapters';
+import { stashPreloadedActivityItem } from '../../../app/components/Views/ActivityList/preloadedActivityItemStore';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { notifyManager } from '@tanstack/query-core';
 import { createUIQueryClient } from '@metamask/react-data-query';
@@ -322,9 +324,32 @@ export function renderActivityDetailsView(
         Component: createRouteParamsProbe(Routes.BRIDGE.MODALS.ROOT),
       },
       { name: Routes.BRIDGE.MODALS.TRANSACTION_DETAILS_BLOCK_EXPLORER },
+      { name: Routes.PERPS.ROOT },
+      { name: Routes.WEBVIEW.MAIN },
       ...(options.extraRoutes ?? []),
     ],
     { state },
     options.params as unknown as Record<string, unknown>,
   );
+}
+
+/**
+ * Stashes a provider-backed Activity row (Perps / Predict) and opens Details
+ * with the serializable `{ chainId, txIdentifier, preloadKey }` params used in
+ * production.
+ */
+export function renderPreloadedActivityDetailsView(
+  item: ActivityListItem,
+  options: Omit<RenderActivityDetailsViewOptions, 'params'> = {},
+): ReturnType<typeof renderScreenWithRoutes> {
+  const preloadKey = stashPreloadedActivityItem(item);
+
+  return renderActivityDetailsView({
+    ...options,
+    params: {
+      chainId: item.chainId,
+      txIdentifier: item.hash,
+      preloadKey,
+    },
+  });
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Adds component-view coverage for Perps Activity Details against current production UI (funds, trades, orders, and funding). Provider-backed rows are opened via stash + `{ chainId, txIdentifier, preloadKey }`. Also wires row/step/hero testIDs and Perps presets so assertions can target production layout without importing ActivityList.

### Tests added (`ActivityDetails — Perps`)

| Case | Suite | Sub-task | Regression prevented |
| --- | --- | --- | --- |
| Account funded | ActivityDetails — Perps funds | MMQA-2167 (Perps) | Confirmed deposit: green `+$1,000`, ETH network fee + USDC bridge fee, 4 completed steps, Fund again → Perps |
| Funding in progress | ActivityDetails — Perps funds | MMQA-2167 (Perps) | Pending (yellow) status with still-green amount, Steps (1 completed, 3 pending), Fund again |
| Funding failed | ActivityDetails — Perps funds | MMQA-2167 (Perps) | Title suffix `— Failed`, TextDefault amount, Steps (3 completed, 1 failed), Try again |
| Perps withdrawal | ActivityDetails — Perps funds | MMQA-2167 (Perps) | Ethereum network, no fee block, 3 completed steps, Withdraw CTA |
| Opened short | ActivityDetails — Perps trades | MMQA-2167 (Perps) | Entry price, no PnL row, Trade again |
| Opened long | ActivityDetails — Perps trades | MMQA-2167 (Perps) | Entry price, no PnL row, Trade again |
| Closed short | ActivityDetails — Perps trades | MMQA-2167 (Perps) | Close price, red `-$12.34` Net P&L, Trade again |
| Closed long | ActivityDetails — Perps trades | MMQA-2167 (Perps) | Close price, green `+$45.67` Net P&L, Trade again |
| Market close short | ActivityDetails — Perps orders | MMQA-2167 (Perps) | Filled 100%, Total fee only (no MM/HL fee split), explorer → webview, no Try again |
| Stop market close short | ActivityDetails — Perps orders | MMQA-2167 (Perps) | Filled 100%, Total fee only, explorer → webview, no Try again |
| Take profit canceled | ActivityDetails — Perps orders | MMQA-2167 (Perps) | Canceled (red) at 0% filled, Try again → Perps |
| Take profit filled | ActivityDetails — Perps orders | MMQA-2167 (Perps) | Filled 100%, explorer → webview, no Try again |
| Received funding | ActivityDetails — Perps funding | MMQA-2167 (Perps) | Rate `-0.0125%`, green `+$` fee, explorer, no CTA |
| Paid funding | ActivityDetails — Perps funding | MMQA-2167 (Perps) | Rate `0.01%`, default `-$` fee, explorer, no CTA |

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: MMQA-2167
Refs: MMQA-2082

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — coverage is component-view only; verified with:

```bash
yarn jest -c jest.config.view.js app/components/Views/ActivityDetails/ActivityDetails.perps.view.test.tsx --runInBand --silent --coverage=false
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — test-only coverage; no user-facing UI change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6bce11276daf65538838b6d6f4d7b772d95d2c3c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->