### PR TITLE
perf(money): eliminate card loading state latency regression introduced by lazy card data fetching cp-8.8.0

### DIFF
--- a/app/components/UI/Money/routes/index.test.tsx
+++ b/app/components/UI/Money/routes/index.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { Text as MockText, View as MockView } from 'react-native';
-import renderWithProvider from '../../../../util/test/renderWithProvider';
+import { fireEvent } from '@testing-library/react-native';
+import Engine from '../../../../core/Engine';
+import Routes from '../../../../constants/navigation/Routes';
 import { mockTheme } from '../../../../util/theme';
+import renderWithProvider from '../../../../util/test/renderWithProvider';
 import { useUpgradeMoneyAccountOnFocus } from '../hooks/useUpgradeMoneyAccountOnFocus';
 import {
   MoneyConfirmationScreenStack,
@@ -16,6 +19,14 @@ jest.mock('../hooks/useUpgradeMoneyAccountOnFocus', () => ({
 const mockUseUpgradeMoneyAccountOnFocus = jest.mocked(
   useUpgradeMoneyAccountOnFocus,
 );
+
+jest.mock('../../../../core/Engine', () => ({
+  context: {
+    CardController: {
+      fetchCardHomeData: jest.fn(),
+    },
+  },
+}));
 
 jest.mock(
   '../../../Views/confirmations/hooks/ui/useEmptyNavHeaderForConfirmations',
@@ -59,9 +70,23 @@ jest.mock('@react-navigation/native-stack', () => ({
         {children}
       </MockView>
     ),
-    Screen: ({ name }: { name: string }) => (
+    Screen: ({
+      name,
+      listeners,
+    }: {
+      name: string;
+      listeners?: { focus?: () => void };
+    }) => (
       <MockView testID={`money-screen-${name}`}>
         <MockText>{name}</MockText>
+        {listeners?.focus && (
+          <MockText
+            testID={`money-screen-${name}-focus`}
+            onPress={listeners.focus}
+          >
+            focus
+          </MockText>
+        )}
       </MockView>
     ),
   }),
@@ -149,6 +174,34 @@ describe('MoneyTabScreenStack', () => {
     });
 
     expect(mockUseUpgradeMoneyAccountOnFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefetches card home data when Money home receives focus', () => {
+    const { getByTestId } = renderWithProvider(<MoneyTabScreenStack />, {
+      theme: themeWithCustomBackground,
+    });
+
+    fireEvent.press(getByTestId(`money-screen-${Routes.MONEY.HOME}-focus`));
+
+    expect(
+      Engine.context.CardController.fetchCardHomeData,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      Engine.context.CardController.fetchCardHomeData,
+    ).toHaveBeenCalledWith();
+  });
+
+  it('does not attach card prefetch listeners to other Money routes', () => {
+    const { queryByTestId } = renderWithProvider(<MoneyTabScreenStack />, {
+      theme: themeWithCustomBackground,
+    });
+
+    expect(
+      queryByTestId(`money-screen-${Routes.MONEY.ACTIVITY}-focus`),
+    ).not.toBeOnTheScreen();
+    expect(
+      queryByTestId(`money-screen-${Routes.MONEY.HOW_IT_WORKS}-focus`),
+    ).not.toBeOnTheScreen();
   });
 });
 

--- a/app/components/UI/Money/routes/index.tsx
+++ b/app/components/UI/Money/routes/index.tsx
@@ -26,6 +26,7 @@ import type {
   MoneyModalsNavigationParamList,
   MoneyScreensStackParamList,
 } from '../types/navigation';
+import Engine from '../../../../core/Engine';
 
 const TabStack = createNativeStackNavigator<MoneyScreensStackParamList>();
 const ConfirmationStack =
@@ -46,7 +47,15 @@ const MoneyTabScreenStack = () => {
         contentStyle: { backgroundColor: colors.background.default },
       }}
     >
-      <TabStack.Screen name={Routes.MONEY.HOME} component={MoneyHomeView} />
+      <TabStack.Screen
+        name={Routes.MONEY.HOME}
+        component={MoneyHomeView}
+        listeners={{
+          focus: () => {
+            Engine.context.CardController.fetchCardHomeData();
+          },
+        }}
+      />
       <TabStack.Screen
         name={Routes.MONEY.ACTIVITY}
         component={MoneyActivityView}

--- a/app/core/Engine/controllers/card-controller/CardController.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.test.ts
@@ -1523,14 +1523,42 @@ describe('CardController — event subscriptions', () => {
     const validateSpy = jest
       .spyOn(controller, 'validateAndRefreshSession')
       .mockResolvedValue({ isAuthenticated: false });
+    const fetchSpy = jest
+      .spyOn(controller, 'fetchCardHomeData')
+      .mockResolvedValue();
 
     // Simulate unlock event
     const unlockHandler = (
       mockMessenger.subscribe as jest.Mock
     ).mock.calls.find(([event]) => event === 'KeyringController:unlock')?.[1];
     await unlockHandler?.();
+    await Promise.resolve();
 
     expect(validateSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('prefetches card home data on unlock when the Card session is authenticated', async () => {
+    const provider = buildMockProvider();
+    const mockMessenger = buildMessengerForUnlock();
+    const controller = new CardController({
+      cardService: buildMockCardService(),
+      messenger: mockMessenger,
+      providers: { baanx: provider },
+      state: { activeProviderId: 'baanx' },
+    });
+    jest
+      .spyOn(controller, 'validateAndRefreshSession')
+      .mockResolvedValue({ isAuthenticated: true });
+    const fetchSpy = jest
+      .spyOn(controller, 'fetchCardHomeData')
+      .mockResolvedValue();
+
+    getHandler(mockMessenger, 'KeyringController:unlock')?.();
+    await Promise.resolve();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith({});
   });
 
   function buildMessengerForUnlock() {

--- a/app/core/Engine/controllers/card-controller/CardController.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.ts
@@ -241,12 +241,18 @@ export class CardController extends BaseController<
     this.messenger.subscribe('KeyringController:unlock', () => {
       if (this.resetInProgress) return;
       this.#triggerCardholderCheck();
-      this.validateAndRefreshSession().catch((error) =>
-        Logger.error(error as Error, {
-          tags: { feature: 'card' },
-          context: { name: 'CardController', data: { method: '#onUnlock' } },
-        }),
-      );
+      this.validateAndRefreshSession()
+        .then(({ isAuthenticated }) => {
+          if (isAuthenticated && !this.resetInProgress) {
+            this.#fetchCardHomeDataWithLogging('#onUnlock/fetchCardHomeData');
+          }
+        })
+        .catch((error) =>
+          Logger.error(error as Error, {
+            tags: { feature: 'card' },
+            context: { name: 'CardController', data: { method: '#onUnlock' } },
+          }),
+        );
     });
 
     // Re-check when the account tree changes (account added/removed).

--- a/app/selectors/cardController.test.ts
+++ b/app/selectors/cardController.test.ts
@@ -574,6 +574,28 @@ describe('selectIsCardStateResolved', () => {
     expect(selectIsCardStateResolved(state)).toBe(false);
   });
 
+  it('returns true while refreshing existing data for an authenticated user', () => {
+    const state = createMockRootState({
+      cardHomeDataStatus: 'loading',
+      isAuthenticated: true,
+      cardHomeData: {
+        account: { verificationStatus: 'VERIFIED' },
+      } as unknown as CardControllerState['cardHomeData'],
+    });
+    expect(selectIsCardStateResolved(state)).toBe(true);
+  });
+
+  it('returns true when a background refresh fails with existing data', () => {
+    const state = createMockRootState({
+      cardHomeDataStatus: 'error',
+      isAuthenticated: true,
+      cardHomeData: {
+        account: { verificationStatus: 'VERIFIED' },
+      } as unknown as CardControllerState['cardHomeData'],
+    });
+    expect(selectIsCardStateResolved(state)).toBe(true);
+  });
+
   it('returns false while idle for a cardholder', () => {
     mockSelectSelectedInternalAccountByScope.mockReturnValue(
       jest.fn().mockReturnValue({

--- a/app/selectors/cardController.ts
+++ b/app/selectors/cardController.ts
@@ -199,11 +199,12 @@ export const selectCardHomeDataStatus = createSelector(
 
 export const selectIsCardStateResolved = createSelector(
   selectCardHomeDataStatus,
+  selectCardHomeData,
   selectCardVerificationStatus,
   selectIsCardAuthenticated,
   selectIsCardholder,
-  (status, verificationStatus, isAuthenticated, isCardholder) =>
-    (status === 'success' &&
+  (status, cardHomeData, verificationStatus, isAuthenticated, isCardholder) =>
+    ((status === 'success' || cardHomeData !== null) &&
       (!isAuthenticated || verificationStatus !== null)) ||
     (!isAuthenticated && !isCardholder),
 );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Prefetches MetaMask Card home data after an authenticated Card session is confirmed on wallet unlock, with Money Home focus retained as a freshness-aware fallback. This reduces the likelihood that users see an initial Card loading state after opening Money or Card Home.

### Architecture

```mermaid
flowchart LR
    unlock["Wallet unlock"] --> auth["Validate Card session"]
    auth -->|authenticated| prefetch
    navigation["Money Home focus"] --> prefetch["Card home prefetch"]
    prefetch --> controller["CardController freshness and in-flight guards"]
    screen[MoneyHomeView] --> fallback[useCardHomeData]
    fallback --> controller
    controller --> loading["Loading spinner"]
    controller --> resolved["Manage or Link card"]
```

### What changed

- Starts a non-forced Card home-data prefetch after wallet unlock when Card session validation confirms the user is authenticated.
- Starts a non-forced Card home-data fetch from the Money Home focus listener.
- Covers every Money Home entry path, including the bottom tab, onboarding completion, deeplinks, and return navigation.
- Keeps `useCardHomeData` as the screen-level fallback.
- Preserves the existing loading spinner and prevents the identity-verification warning from flashing while Card state is unresolved.
- Keeps existing Manage or Link content visible during stale-data background refreshes instead of flashing the loading spinner.
- Preserves the controller's 60-second freshness window and in-flight request deduplication.
- Leaves unauthenticated unlocks and feature-flag invalidation free of Card home-data requests.
- Preserves Baanx 429 handling.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed MetaMask Card data loading delays when opening Money Home.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://github.com/MetaMask/metamask-mobile/pull/34021

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

1. Start with an authenticated Card session, lock the wallet, and clear the development logs.
2. Unlock the wallet and confirm one Card home-data request begins after session validation.
3. Navigate to Money Home and confirm the unlock prefetch is reused rather than duplicated.
4. Confirm the MetaMask Card section shows a spinner rather than a blank state or identity-verification warning.
5. Confirm the section resolves to the expected Manage or Link card state.
6. Leave Money Home and return within 60 seconds; confirm no redundant provider request occurs.
7. Return after the freshness window and confirm the existing Manage or Link content remains visible while Card data refreshes.
8. Repeat with no authenticated Card session and confirm unlock does not fetch Card home data.
9. Run `yarn jest app/components/UI/Money/routes/index.test.tsx app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.test.tsx app/components/UI/Money/utils/moneyMetaMaskCardMode.test.ts app/components/UI/Card/hooks/useCardHomeData.test.ts app/selectors/cardController.test.ts app/core/Engine/controllers/card-controller/CardController.test.ts --runInBand --watchman=false --coverage=false`.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — no static visual design changed; this updates request timing and retains the existing loading spinner.

### **Before**

Card home data starts loading after Money Home mounts, leaving the Card section visibly unresolved during the request.

### **After**

Authenticated Card home data starts warming after wallet unlock. Money Home focus remains a freshness-aware fallback; initial uncached loads show the spinner, while background refreshes retain existing Manage or Link card content.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A — manually validated on iOS; the navigation listener and controller freshness behavior are platform-independent.
- [x] I've tested with a power user scenario
  - N/A — the change only adjusts Card request timing when Money Home receives focus.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A — this reuses existing Card controller and provider logging; no new operation was introduced.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when Card API requests fire (unlock + navigation) and how loading UI is derived from controller state; behavior relies on existing 60s freshness and in-flight deduplication rather than new endpoints.
> 
> **Overview**
> Reduces visible Card loading on Money Home by **warming card home data earlier** and **avoiding loading flashes** when stale data is already on screen.
> 
> **Prefetch triggers:** After wallet unlock, `CardController` starts a non-forced `fetchCardHomeData` only when `validateAndRefreshSession` reports an authenticated Card session (unauthenticated unlocks still skip the fetch). The Money Home tab route adds a **focus listener** that calls `fetchCardHomeData()` so tab, deeplink, and return navigation paths all hit the same freshness-aware path; other Money tab routes do not attach this listener.
> 
> **UI resolution:** `selectIsCardStateResolved` now treats Card state as resolved when `cardHomeData` is already present, not only when `cardHomeDataStatus === 'success'`. Authenticated users with cached data stay on Manage/Link content while a background refresh is `loading` or fails with `error`, instead of dropping back to the full loading spinner.
> 
> Tests cover unlock prefetch (authenticated vs not), Money Home focus prefetch, and the updated selector behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3079166863263638d8de11f80113abf25894b2f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->