### PR TITLE
feat: pass allowed chain ranking via navigation params in swaps

### DIFF
--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -14,6 +14,7 @@ import {
   setIsSelectingToken,
   setSourceAmount,
   setTokenSelectorNetworkFilter,
+  selectAllowedChainRanking,
 } from '../../../../../core/redux/slices/bridge';
 import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
 import Routes from '../../../../../constants/navigation/Routes';
@@ -113,7 +114,10 @@ const mockSetOptions = jest.fn();
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 const mockNavigationDispatch = jest.fn();
-let mockRouteParams: { type: 'source' | 'dest' } = { type: 'source' };
+let mockRouteParams: {
+  type: 'source' | 'dest';
+  enabledChainIds?: CaipChainId[];
+} = { type: 'source' };
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -484,11 +488,13 @@ jest.mock('./NetworkPills', () => ({
     onMorePress,
     onWatchlistFilterPress,
     showWatchlistFilter,
+    enabledChainIds,
   }: {
     onChainSelect: (chainId?: CaipChainId) => void;
     onMorePress: () => void;
     onWatchlistFilterPress?: () => void;
     showWatchlistFilter?: boolean;
+    enabledChainIds?: CaipChainId[];
   }) => {
     const { createElement } = jest.requireActual('react');
     const { View, TouchableOpacity, Text } = jest.requireActual('react-native');
@@ -528,6 +534,11 @@ jest.mock('./NetworkPills', () => ({
         Text,
         { testID: 'visible-pill-chain-ids' },
         JSON.stringify(visiblePillChainIds ?? []),
+      ),
+      createElement(
+        Text,
+        { testID: 'network-pills-enabled-chain-ids' },
+        JSON.stringify(enabledChainIds ?? null),
       ),
     );
   },
@@ -1295,6 +1306,29 @@ describe('BridgeTokenSelector', () => {
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.MODALS.ROOT, {
         screen: Routes.BRIDGE.MODALS.NETWORK_LIST_MODAL,
+        params: { enabledChainIds: undefined },
+      });
+    });
+
+    it('passes enabledChainIds from route params to the selector, NetworkPills, and the network list modal navigation', () => {
+      const enabledChainIds = [MOCK_CHAIN_IDS.ethereum];
+      mockRouteParams = { type: 'source', enabledChainIds };
+
+      const { getByTestId } = renderWithReduxProvider(<BridgeTokenSelector />);
+
+      expect(selectAllowedChainRanking).toHaveBeenCalledWith(
+        expect.anything(),
+        enabledChainIds,
+      );
+      expect(
+        getByTestId('network-pills-enabled-chain-ids').props.children,
+      ).toBe(JSON.stringify(enabledChainIds));
+
+      fireEvent.press(getByTestId('open-network-modal'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.MODALS.ROOT, {
+        screen: Routes.BRIDGE.MODALS.NETWORK_LIST_MODAL,
+        params: { enabledChainIds },
       });
     });
 

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -19,6 +19,7 @@ import {
   StackActions,
 } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
+import type { RootState } from '../../../../../reducers';
 import { useSelector, useDispatch } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
 import {
@@ -100,6 +101,11 @@ import {
 
 export interface BridgeTokenSelectorRouteParams {
   type: TokenSelectorType;
+  /**
+   * When provided, restricts the network list to these chains instead
+   * of the default allowed chainRanking.
+   */
+  enabledChainIds?: CaipChainId[];
 }
 
 const MIN_SEARCH_LENGTH = 3;
@@ -230,7 +236,10 @@ export const BridgeTokenSelector: React.FC = () => {
     [searchString],
   );
 
-  const enabledChainRanking = useSelector(selectAllowedChainRanking);
+  const enabledChainIds = route.params?.enabledChainIds;
+  const enabledChainRanking = useSelector((state: RootState) =>
+    selectAllowedChainRanking(state, enabledChainIds),
+  );
   const bridgeFeatureFlags = useSelector(selectBridgeFeatureFlags);
   const isRWAEnabled = useSelector(selectRWAEnabledFlag);
   const { variant: balanceLayoutConfig } = useABTest(
@@ -922,9 +931,11 @@ export const BridgeTokenSelector: React.FC = () => {
           showWatchlistFilter={isWatchlistEnabled}
           isWatchlistFilterActive={isWatchlistFilterActive}
           onWatchlistFilterPress={handleWatchlistFilterPress}
+          enabledChainIds={enabledChainIds}
           onMorePress={() =>
             navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
               screen: Routes.BRIDGE.MODALS.NETWORK_LIST_MODAL,
+              params: { enabledChainIds },
             })
           }
         />

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkListModal.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkListModal.test.tsx
@@ -11,10 +11,16 @@ import { useABTest } from '../../../../../hooks';
 import { useChainValueOrder } from '../../hooks/useChainValueOrder';
 
 const mockOnCloseBottomSheet = jest.fn();
+let mockRouteParams: { enabledChainIds?: CaipChainId[] } = {};
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
   useDispatch: jest.fn(),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useRoute: () => ({ params: mockRouteParams }),
 }));
 
 jest.mock('../../../../../hooks', () => ({
@@ -118,6 +124,7 @@ jest.mock('../../../../../component-library/components/Cells/Cell', () => {
 describe('NetworkListModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRouteParams = {};
     (useDispatch as jest.Mock).mockReturnValue(mockDispatch);
     jest.mocked(useABTest).mockReturnValue({
       variant: { orderByValue: false },
@@ -125,16 +132,15 @@ describe('NetworkListModal', () => {
       isActive: true,
     });
     jest.mocked(useChainValueOrder).mockReturnValue(mockChainRanking);
-
-    mockUseSelector.mockImplementation((selector: unknown) => {
-      if (selector === selectAllowedChainRanking) {
-        return mockChainRanking;
-      }
-      if (selector === selectTokenSelectorNetworkFilter) {
-        return undefined;
-      }
-      return undefined;
-    });
+    jest.mocked(selectAllowedChainRanking).mockReturnValue(mockChainRanking);
+    jest.mocked(selectTokenSelectorNetworkFilter).mockReturnValue(undefined);
+    // NetworkListModal calls useSelector(selectTokenSelectorNetworkFilter)
+    // directly, and wraps selectAllowedChainRanking in an inline lambda (to
+    // forward the optional enabledChainIds route param) — invoke whatever
+    // selector is passed so both routes resolve through the mocks above.
+    mockUseSelector.mockImplementation(
+      (selector: (state: unknown) => unknown) => selector({}),
+    );
   });
 
   describe('rendering', () => {
@@ -185,6 +191,29 @@ describe('NetworkListModal', () => {
         'network-option-eip155:137',
         'network-option-eip155:1',
       ]);
+    });
+  });
+
+  describe('enabledChainIds route param', () => {
+    it('forwards enabledChainIds from route params to selectAllowedChainRanking', () => {
+      const enabledChainIds: CaipChainId[] = ['eip155:1', 'eip155:56'];
+      mockRouteParams = { enabledChainIds };
+
+      render(<NetworkListModal />);
+
+      expect(selectAllowedChainRanking).toHaveBeenCalledWith(
+        expect.anything(),
+        enabledChainIds,
+      );
+    });
+
+    it('calls selectAllowedChainRanking with undefined when no route params are provided', () => {
+      render(<NetworkListModal />);
+
+      expect(selectAllowedChainRanking).toHaveBeenCalledWith(
+        expect.anything(),
+        undefined,
+      );
     });
   });
 

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkListModal.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkListModal.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useRef } from 'react';
 import { ScrollView } from 'react-native-gesture-handler'; // Must use this to make sure scroll works inside a bottom sheet on Android
 import { useSelector, useDispatch } from 'react-redux';
+import { useRoute, RouteProp } from '@react-navigation/native';
 import { Icon, IconName, IconSize } from '@metamask/design-system-react-native';
 import { IconName as ComponentLibraryIconName } from '../../../../../component-library/components/Icons/Icon';
 import { strings } from '../../../../../../locales/i18n';
@@ -15,6 +16,7 @@ import { AvatarVariant } from '../../../../../component-library/components/Avata
 import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar/Avatar.types';
 import { CaipChainId } from '@metamask/utils';
 import { getNetworkImageSource } from '../../../../../util/networks';
+import type { RootState } from '../../../../../reducers';
 import {
   selectAllowedChainRanking,
   selectTokenSelectorNetworkFilter,
@@ -31,6 +33,14 @@ import {
 interface ChainRankingEntry {
   chainId: CaipChainId;
   name: string;
+}
+
+export interface NetworkListModalParams {
+  /**
+   * When provided, restricts the network list to these chains instead
+   * of the default allowed chainRanking.
+   */
+  enabledChainIds?: CaipChainId[];
 }
 
 interface NetworkListModalContentProps {
@@ -118,8 +128,11 @@ const NetworkValueOrderedListModal: React.FC<NetworkListModalContentProps> = ({
 };
 
 const NetworkListModal: React.FC = () => {
-  const chainRanking: ChainRankingEntry[] = useSelector(
-    selectAllowedChainRanking,
+  const route =
+    useRoute<RouteProp<{ params: NetworkListModalParams }, 'params'>>();
+  const enabledChainIds = route.params?.enabledChainIds;
+  const chainRanking: ChainRankingEntry[] = useSelector((state: RootState) =>
+    selectAllowedChainRanking(state, enabledChainIds),
   );
   const { variant } = useABTest(
     CHAIN_VALUE_ORDER_AB_KEY,

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
@@ -123,14 +123,49 @@ describe('NetworkPills', () => {
       isActive: true,
     });
     jest.mocked(useChainValueOrder).mockReturnValue(mockChainRanking);
-    mockUseSelector.mockImplementation((selector: unknown) => {
-      if (selector === selectAllowedChainRanking) {
-        return mockChainRanking;
-      }
-      if (selector === selectVisiblePillChainIds) {
-        return undefined; // default: use first N from chainRanking
-      }
-      return undefined;
+    jest.mocked(selectAllowedChainRanking).mockReturnValue(mockChainRanking);
+    jest.mocked(selectVisiblePillChainIds).mockReturnValue(undefined); // default: use first N from chainRanking
+    // NetworkPills calls useSelector(selectVisiblePillChainIds) directly, and
+    // wraps selectAllowedChainRanking in an inline lambda (to forward the
+    // optional enabledChainIds prop) — invoke whatever selector is passed so
+    // both routes resolve through the mocked selector functions above.
+    mockUseSelector.mockImplementation(
+      (selector: (state: unknown) => unknown) => selector({}),
+    );
+  });
+
+  describe('enabledChainIds', () => {
+    it('forwards the enabledChainIds prop to selectAllowedChainRanking', () => {
+      const enabledChainIds = ['eip155:1' as CaipChainId];
+
+      render(
+        <NetworkPills
+          selectedChainId={undefined}
+          onChainSelect={mockOnChainSelect}
+          onMorePress={mockOnMorePress}
+          enabledChainIds={enabledChainIds}
+        />,
+      );
+
+      expect(selectAllowedChainRanking).toHaveBeenCalledWith(
+        expect.anything(),
+        enabledChainIds,
+      );
+    });
+
+    it('calls selectAllowedChainRanking with undefined when enabledChainIds is not provided', () => {
+      render(
+        <NetworkPills
+          selectedChainId={undefined}
+          onChainSelect={mockOnChainSelect}
+          onMorePress={mockOnMorePress}
+        />,
+      );
+
+      expect(selectAllowedChainRanking).toHaveBeenCalledWith(
+        expect.anything(),
+        undefined,
+      );
     });
   });
 
@@ -198,10 +233,9 @@ describe('NetworkPills', () => {
     });
 
     it('does not render "+X more" when all networks are visible', () => {
-      mockUseSelector.mockImplementation((selector: unknown) => {
-        if (selector === selectVisiblePillChainIds) return undefined;
-        return mockSmallChainRanking;
-      });
+      jest
+        .mocked(selectAllowedChainRanking)
+        .mockReturnValue(mockSmallChainRanking);
 
       const { queryByTestId } = render(
         <NetworkPills
@@ -218,10 +252,9 @@ describe('NetworkPills', () => {
       const singleChainRanking = [
         { chainId: 'eip155:1' as CaipChainId, name: 'Ethereum' },
       ];
-      mockUseSelector.mockImplementation((selector: unknown) => {
-        if (selector === selectVisiblePillChainIds) return undefined;
-        return singleChainRanking;
-      });
+      jest
+        .mocked(selectAllowedChainRanking)
+        .mockReturnValue(singleChainRanking);
 
       const { getByText, queryByTestId } = render(
         <NetworkPills
@@ -243,10 +276,7 @@ describe('NetworkPills', () => {
         { chainId: 'eip155:1' as CaipChainId, name: 'Ethereum' },
         { chainId: 'eip155:56' as CaipChainId, name: 'BNB Chain' },
       ];
-      mockUseSelector.mockImplementation((selector: unknown) => {
-        if (selector === selectVisiblePillChainIds) return undefined;
-        return customRanking;
-      });
+      jest.mocked(selectAllowedChainRanking).mockReturnValue(customRanking);
 
       const { getByText, queryByText } = render(
         <NetworkPills
@@ -429,16 +459,6 @@ describe('NetworkPills', () => {
     });
 
     it('dispatches rolling order for consecutive non-visible selections', () => {
-      mockUseSelector.mockImplementation((selector: unknown) => {
-        if (selector === selectAllowedChainRanking) {
-          return mockChainRanking;
-        }
-        if (selector === selectVisiblePillChainIds) {
-          return undefined;
-        }
-        return undefined;
-      });
-
       const { rerender } = render(
         <NetworkPills
           selectedChainId={undefined}
@@ -465,15 +485,9 @@ describe('NetworkPills', () => {
         'bip122:000000000019d6689c085ae165831e93',
       ]);
 
-      mockUseSelector.mockImplementation((selector: unknown) => {
-        if (selector === selectAllowedChainRanking) {
-          return mockChainRanking;
-        }
-        if (selector === selectVisiblePillChainIds) {
-          return firstSelectionPayload;
-        }
-        return undefined;
-      });
+      jest
+        .mocked(selectVisiblePillChainIds)
+        .mockReturnValue(firstSelectionPayload);
       mockDispatch.mockClear();
 
       rerender(
@@ -561,15 +575,9 @@ describe('NetworkPills', () => {
         isActive: true,
       });
       jest.mocked(useChainValueOrder).mockReturnValue(treatmentRanking);
-      mockUseSelector.mockImplementation((selector: unknown) => {
-        if (selector === selectAllowedChainRanking) {
-          return mockChainRanking;
-        }
-        if (selector === selectVisiblePillChainIds) {
-          return pinnedVisibleChainIds;
-        }
-        return undefined;
-      });
+      jest
+        .mocked(selectVisiblePillChainIds)
+        .mockReturnValue(pinnedVisibleChainIds);
 
       const { rerender, getByText, queryByText } = render(
         <NetworkPills

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
@@ -19,6 +19,7 @@ import Icon, {
 } from '../../../../../component-library/components/Icons/Icon';
 import { useTheme } from '../../../../../util/theme';
 import { strings } from '../../../../../../locales/i18n';
+import type { RootState } from '../../../../../reducers';
 import {
   selectAllowedChainRanking,
   selectVisiblePillChainIds,
@@ -53,6 +54,11 @@ interface NetworkPillsProps {
   isWatchlistFilterActive?: boolean;
   /** Called when the watchlist star filter is toggled. */
   onWatchlistFilterPress?: () => void;
+  /**
+   * When provided, restricts the network list to these chains instead
+   * of the default allowed chainRanking.
+   */
+  enabledChainIds?: CaipChainId[];
 }
 
 interface ChainRankingEntry {
@@ -245,9 +251,12 @@ const NetworkValueOrderedPills: React.FC<NetworkPillsContentProps> = ({
   return <NetworkPillsContent {...props} chainRanking={orderedChainRanking} />;
 };
 
-export const NetworkPills: React.FC<NetworkPillsProps> = (props) => {
-  const chainRanking: ChainRankingEntry[] = useSelector(
-    selectAllowedChainRanking,
+export const NetworkPills: React.FC<NetworkPillsProps> = ({
+  enabledChainIds,
+  ...props
+}) => {
+  const chainRanking: ChainRankingEntry[] = useSelector((state: RootState) =>
+    selectAllowedChainRanking(state, enabledChainIds),
   );
   const { variant } = useABTest(
     CHAIN_VALUE_ORDER_AB_KEY,

--- a/app/components/UI/Bridge/components/TokenInputArea/TokenInputArea.test.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/TokenInputArea.test.tsx
@@ -1,14 +1,35 @@
 import React, { createRef } from 'react';
+import { CaipChainId } from '@metamask/utils';
 import { initialState } from '../../_mocks_/initialState';
 import { act, fireEvent } from '@testing-library/react-native';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
 import { TokenInputArea, TokenInputAreaRef, TokenInputAreaType } from '.';
-import { BridgeToken } from '../../types';
+import { BridgeToken, TokenSelectorType } from '../../types';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { POLYGON_NATIVE_TOKEN } from '../../constants/assets';
+import Routes from '../../../../../constants/navigation/Routes';
 
 jest.mock('../../hooks/useLatestBalance', () => ({
   useLatestBalance: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+const mockTrackUnifiedSwapBridgeEvent = jest.fn();
+jest.mock('../../../../../core/Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      BridgeController: {
+        trackUnifiedSwapBridgeEvent: (...args: unknown[]) =>
+          mockTrackUnifiedSwapBridgeEvent(...args),
+      },
+    },
+  },
 }));
 
 // Mock Input to expose focus/blur/isFocused on its ref for imperative handle tests.
@@ -111,6 +132,73 @@ describe('TokenInputArea', () => {
     mockUseFormattedBalanceWithThreshold.mockReturnValue('100');
     mockUseDisplayCurrencyValue.mockReturnValue('$100.00');
     mockUseIsInsufficientBalance.mockReturnValue(false);
+  });
+
+  describe('empty state token selector navigation', () => {
+    it('navigates to the source token selector with enabledChainIds when the source "Select token" button is pressed', () => {
+      const enabledChainIds: CaipChainId[] = ['eip155:1', 'eip155:56'];
+      const { getByTestId } = renderScreen(
+        () => (
+          <TokenInputArea
+            testID="token-input"
+            tokenType={TokenInputAreaType.Source}
+            isSourceToken
+            enabledChainIds={enabledChainIds}
+          />
+        ),
+        { name: 'TokenInputArea' },
+        { state: initialState },
+      );
+
+      fireEvent.press(getByTestId('token-input'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.TOKEN_SELECTOR, {
+        type: TokenSelectorType.Source,
+        enabledChainIds,
+      });
+    });
+
+    it('navigates to the destination token selector with enabledChainIds when the dest "Select token" button is pressed', () => {
+      const enabledChainIds: CaipChainId[] = ['eip155:1', 'eip155:56'];
+      const { getByTestId } = renderScreen(
+        () => (
+          <TokenInputArea
+            testID="token-input"
+            tokenType={TokenInputAreaType.Destination}
+            enabledChainIds={enabledChainIds}
+          />
+        ),
+        { name: 'TokenInputArea' },
+        { state: initialState },
+      );
+
+      fireEvent.press(getByTestId('token-input'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.TOKEN_SELECTOR, {
+        type: TokenSelectorType.Dest,
+        enabledChainIds,
+      });
+    });
+
+    it('navigates with enabledChainIds undefined when the prop is not provided', () => {
+      const { getByTestId } = renderScreen(
+        () => (
+          <TokenInputArea
+            testID="token-input"
+            tokenType={TokenInputAreaType.Destination}
+          />
+        ),
+        { name: 'TokenInputArea' },
+        { state: initialState },
+      );
+
+      fireEvent.press(getByTestId('token-input'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.TOKEN_SELECTOR, {
+        type: TokenSelectorType.Dest,
+        enabledChainIds: undefined,
+      });
+    });
   });
 
   it('renders with initial state', () => {

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -48,7 +48,11 @@ import {
 } from '../../../../../core/redux/slices/bridge';
 import { useBridgeExchangeRates } from '../../hooks/useBridgeExchangeRates';
 import useIsInsufficientBalance from '../../hooks/useInsufficientBalance';
-import { isCaipAssetType, parseCaipAssetType } from '@metamask/utils';
+import {
+  CaipChainId,
+  isCaipAssetType,
+  parseCaipAssetType,
+} from '@metamask/utils';
 import { renderShortAddress } from '../../../../../util/address';
 import { FlexDirection } from '../../../Box/box.types';
 import {
@@ -186,6 +190,11 @@ interface TokenInputAreaProps {
   onAmountTypeTogglePress?: () => void;
   amountTypeToggleTestID?: string;
   showFiatAmountAsPrimary?: boolean;
+  /**
+   * When provided, restricts the network list to these chains instead
+   * of the default allowed chainRanking.
+   */
+  enabledChainIds?: CaipChainId[];
 }
 
 export const TokenInputArea = forwardRef<
@@ -219,6 +228,7 @@ export const TokenInputArea = forwardRef<
       onAmountTypeTogglePress,
       amountTypeToggleTestID,
       showFiatAmountAsPrimary = false,
+      enabledChainIds,
     },
     ref,
   ) => {
@@ -278,6 +288,7 @@ export const TokenInputArea = forwardRef<
       trackAssetPickerOpened(TokenSelectorType.Dest);
       navigation.navigate(Routes.BRIDGE.TOKEN_SELECTOR, {
         type: TokenSelectorType.Dest,
+        enabledChainIds,
       });
     };
 
@@ -285,6 +296,7 @@ export const TokenInputArea = forwardRef<
       trackAssetPickerOpened(TokenSelectorType.Source);
       navigation.navigate(Routes.BRIDGE.TOKEN_SELECTOR, {
         type: TokenSelectorType.Source,
+        enabledChainIds,
       });
     };
 

--- a/app/components/UI/Bridge/types/navigation.ts
+++ b/app/components/UI/Bridge/types/navigation.ts
@@ -20,6 +20,7 @@ import type { PostTradeBottomSheetParams } from '../components/PostTradeBottomSh
 import type { BatchSellPriceImpactInfoModalParams } from '../components/BatchSellPriceImpactInfoModal/BatchSellPriceImpactInfoModal.types';
 import type { BatchSellNetworkFeeInfoModalParams } from '../components/BatchSellNetworkFeeInfoModal/BatchSellNetworkFeeInfoModal.types';
 import type { BatchSellMinimumReceivedInfoModalParams } from '../components/BatchSellMinimumReceivedInfoModal/BatchSellMinimumReceivedInfoModal.types';
+import type { NetworkListModalParams } from '../components/BridgeTokenSelector/NetworkListModal';
 
 /**
  * Param list for screens inside the Bridge screen stack (`BridgeScreenStack`).
@@ -52,7 +53,7 @@ export type BridgeModalsNavigationParamList = {
   BlockaidModal: BlockaidModalParams;
   RecipientSelectorModal: undefined;
   MarketClosedModal: undefined;
-  NetworkListModal: undefined;
+  NetworkListModal: NetworkListModalParams | undefined;
   PriceImpactModal: PriceImpactModalRouterParams;
   MissingPriceModal: MissingPriceModalParams;
   TokenWarningModal: TokenWarningModalParams;

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -878,6 +878,48 @@ describe('bridge slice', () => {
         ),
       ).toBe(true);
     });
+
+    it('restricts chainRanking to enabledChainIds when provided, ignoring ALLOWED_BRIDGE_CHAIN_IDS', () => {
+      const mockState = cloneDeep(mockRootState);
+      mockState.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.bridgeConfigV2.chainRanking =
+        [
+          { chainId: 'eip155:1', name: 'Ethereum' },
+          { chainId: 'eip155:137', name: 'Polygon' },
+          // Not in ALLOWED_BRIDGE_CHAIN_IDS, but included in enabledChainIds below.
+          { chainId: 'eip155:99999', name: 'Unsupported Future Chain' },
+        ];
+
+      const result = selectAllowedChainRanking(
+        mockState as unknown as RootState,
+        ['eip155:1' as CaipChainId, 'eip155:99999' as CaipChainId],
+      );
+
+      expect(result).toEqual([
+        { chainId: 'eip155:1', name: 'Ethereum' },
+        { chainId: 'eip155:99999', name: 'Unsupported Future Chain' },
+      ]);
+    });
+
+    it('returns an empty array when enabledChainIds is an empty array', () => {
+      const result = selectAllowedChainRanking(
+        mockRootState as unknown as RootState,
+        [],
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('falls back to the ALLOWED_BRIDGE_CHAIN_IDS filter when enabledChainIds is undefined', () => {
+      const withoutOverride = selectAllowedChainRanking(
+        mockRootState as unknown as RootState,
+      );
+      const withUndefinedOverride = selectAllowedChainRanking(
+        mockRootState as unknown as RootState,
+        undefined,
+      );
+
+      expect(withUndefinedOverride).toEqual(withoutOverride);
+    });
   });
 
   describe('selectBatchSellDestStablecoins', () => {

--- a/app/core/redux/slices/bridge/index.ts
+++ b/app/core/redux/slices/bridge/index.ts
@@ -580,13 +580,29 @@ const isAllowedBridgeChainId = (caipChainId: string): boolean => {
  * Selector that returns chainRanking from feature flags filtered by
  * ALLOWED_BRIDGE_CHAIN_IDS. This ensures chains added to the remote flag
  * in the future won't be surfaced by older app versions that lack support.
+ *
+ * When `enabledChainIds` is provided, it fully replaces the
+ * ALLOWED_BRIDGE_CHAIN_IDS filter: only chains present in `enabledChainIds`
+ * are returned. Callers that pass this argument must pass a stable
+ * (e.g. module-level) array reference to avoid busting memoization.
  */
 export const selectAllowedChainRanking = createSelector(
   selectBridgeFeatureFlags,
-  (bridgeFeatureFlags) =>
-    (bridgeFeatureFlags.chainRanking ?? []).filter((chain) =>
+  (_state: RootState, enabledChainIds?: CaipChainId[]) => enabledChainIds,
+  (bridgeFeatureFlags, enabledChainIds) => {
+    const chainRanking = bridgeFeatureFlags.chainRanking ?? [];
+
+    if (enabledChainIds) {
+      const enabledChainIdsSet = new Set(enabledChainIds);
+      return chainRanking.filter((chain) =>
+        enabledChainIdsSet.has(chain.chainId),
+      );
+    }
+
+    return chainRanking.filter((chain) =>
       isAllowedBridgeChainId(chain.chainId),
-    ),
+    );
+  },
 );
 
 /**
@@ -597,7 +613,12 @@ export const selectAllowedChainRanking = createSelector(
  * const isBridgeEnabledSource = getIsBridgeEnabledSource(chainId);
  */
 export const selectIsBridgeEnabledSourceFactory = createSelector(
-  selectAllowedChainRanking,
+  // Called with only `state`: selectIsBridgeEnabledSourceFactory is itself
+  // used as an input selector to selectIsBridgeEnabledSource, which is
+  // invoked with a `chainId` second argument. Reselect forwards outer
+  // arguments to input selectors, so without this wrapper that chainId
+  // would leak into selectAllowedChainRanking's `enabledChainIds` param.
+  (state: RootState) => selectAllowedChainRanking(state),
   (allowedChains) => (chainId: Hex | CaipChainId) => {
     const caipChainId = formatChainIdToCaip(chainId);
     return allowedChains.some((chain) => chain.chainId === caipChainId);
@@ -630,7 +651,10 @@ export const selectTopAssetsFromFeatureFlags = createSelector(
  * TODO The MultichainNetworkConfiguration.chainId type is wrong. It can be both Hex or CaipChainId.
  */
 export const selectEnabledSourceChains = createSelector(
-  selectAllowedChainRanking,
+  // Called with only `state` for the same reason as
+  // selectIsBridgeEnabledSourceFactory above: guards against any outer
+  // selector args leaking into selectAllowedChainRanking's `enabledChainIds`.
+  (state: RootState) => selectAllowedChainRanking(state),
   selectNetworkConfigurations,
   (allowedChainRanking, networkConfigurations) => {
     const allowedCaipIds = new Set(allowedChainRanking.map((c) => c.chainId));


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The bridge token selector, network pills, and network list modal previously read `selectAllowedChainRanking` directly from Redux. That made every bridge flow share the same global chain list and prevented callers from restricting networks (for example, EVM-only chains for limit orders).

This change passes `allowedChainRanking` explicitly from the calling view through navigation route params and component props:

- `BridgeMarketView` reads `selectAllowedChainRanking` from Redux and forwards it to `TokenInputArea` and the token selector route.
- `BridgeTokenSelector`, `NetworkPills`, and `NetworkListModal` consume the caller-provided ranking instead of selecting it from Redux.
- Navigation types are updated so `NetworkListModal` accepts `allowedChainRanking` params.

Behavior for the market swap flow should remain unchanged; the refactor decouples chain filtering from global Redux state so downstream flows can supply their own ranking.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4945

Refs: SWAPS-4945

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Bridge token selector chain filtering

  Background:
    Given I am logged into MetaMask Mobile
    And bridge/swaps is enabled

  Scenario: market view token selector shows the same networks as before
    Given I am on the Bridge market swap screen

    When user taps the source token selector
    Then the token selector should open
    And network pills should list the supported bridge networks
    And tapping "+X more" should open the network list modal with the same networks

    When user dismisses the modal and taps the destination token selector
    Then the token selector should open with the same network filtering behavior

  Scenario: selecting a network pill filters tokens by chain
    Given I am on the Bridge token selector from the market view

    When user selects a specific network pill (e.g. Polygon)
    Then only tokens on that network should appear in the list

    When user selects "All"
    Then tokens from all allowed bridge networks should be searchable
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the navigation contract for the token selector and network modal; callers must pass `allowedChainRanking` or users see no networks, though the primary market path still wires Redux through.
> 
> **Overview**
> **Per-flow chain lists** for the bridge token picker: `allowedChainRanking` is no longer read from `selectAllowedChainRanking` inside `BridgeTokenSelector`, `NetworkPills`, or `NetworkListModal`. Callers pass it through route params and props so each flow can restrict networks (e.g. EVM-only for limit orders).
> 
> `BridgeMarketView` still selects the ranking from Redux and forwards it when opening the token selector and into both `TokenInputArea` instances. `TokenInputArea` includes the same param on empty-state navigation to source/dest pickers. Token fetch/search (`chainIdsToFetch`), network pills, and the “more networks” modal all scope to that list; `NetworkListModal` types now require `allowedChainRanking` in modal params.
> 
> Market swap behavior should match the previous global ranking when the market view supplies it. Any screen that opens the token selector without `allowedChainRanking` gets an empty list (no network pills / no chain fetches) until it passes a ranking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b66f28e4491e040d2e12cec62229652d4ee300b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->