### PR TITLE
feat: add Android fallback animation for wallet onboarding checklist

### DIFF
--- a/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.test.tsx
+++ b/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.test.tsx
@@ -81,6 +81,7 @@ describe('WalletHomeOnboardingSteps', () => {
     jest.useRealTimers();
     Object.defineProperty(Platform, 'OS', {
       configurable: true,
+      writable: true,
       value: originalPlatformOS,
     });
   });
@@ -440,6 +441,7 @@ describe('WalletHomeOnboardingSteps', () => {
   it('plays the main animation without firing a state input after returning on Android', async () => {
     Object.defineProperty(Platform, 'OS', {
       configurable: true,
+      writable: true,
       value: 'android',
     });
     const onTradePrimaryPress = jest.fn();

--- a/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.test.tsx
+++ b/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { act, fireEvent, waitFor } from '@testing-library/react-native';
+import { Platform } from 'react-native';
 import WalletHomeOnboardingSteps from './WalletHomeOnboardingSteps';
 import renderWithProvider from '../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../util/test/initial-root-state';
@@ -11,6 +12,7 @@ import {
 } from '../../../__mocks__/rive-react-native';
 import {
   WALLET_HOME_ONBOARDING_CHECKLIST_COMPLETE_TRANSITION_MS,
+  WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_MAIN_ANIMATION,
   WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_MAIN_TRIGGER,
   WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_OUTRO_TRIGGER,
   WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_STATE_MACHINE,
@@ -61,6 +63,8 @@ async function flushWalletHomeStepTransition() {
 }
 
 describe('WalletHomeOnboardingSteps', () => {
+  const originalPlatformOS = Platform.OS;
+
   beforeEach(() => {
     jest.useFakeTimers({ legacyFakeTimers: false });
     __clearLastMockedMethods();
@@ -75,6 +79,10 @@ describe('WalletHomeOnboardingSteps', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      value: originalPlatformOS,
+    });
   });
 
   const baseOnboarding = {
@@ -427,6 +435,56 @@ describe('WalletHomeOnboardingSteps', () => {
         expect.objectContaining({ stepIndex: 2 }),
       );
     });
+  });
+
+  it('plays the main animation without firing a state input after returning on Android', async () => {
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      value: 'android',
+    });
+    const onTradePrimaryPress = jest.fn();
+    const { getByTestId, rerender } = renderWithProvider(
+      <WalletHomeOnboardingSteps
+        testID="steps-root"
+        onTradePrimaryPress={onTradePrimaryPress}
+      />,
+      {
+        state: {
+          onboarding: {
+            ...baseOnboarding,
+            walletHomeOnboardingSteps: {
+              suppressedReason: null,
+              stepIndex: 1,
+            },
+          },
+          engine: { backgroundState },
+        },
+      },
+    );
+
+    fireEvent.press(getByTestId(primaryTestId));
+    mockUseIsFocused.mockReturnValue(false);
+    rerender(
+      <WalletHomeOnboardingSteps
+        testID="steps-root"
+        onTradePrimaryPress={onTradePrimaryPress}
+      />,
+    );
+    mockUseIsFocused.mockReturnValue(true);
+    rerender(
+      <WalletHomeOnboardingSteps
+        testID="steps-root"
+        onTradePrimaryPress={onTradePrimaryPress}
+      />,
+    );
+    await act(async () => {
+      jest.advanceTimersByTime(60);
+    });
+
+    expect(__getLastMockedMethods()?.play).toHaveBeenCalledWith(
+      WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_MAIN_ANIMATION,
+    );
+    expect(__mockRiveFireState).not.toHaveBeenCalled();
   });
 
   it('completes notifications step after return when primary navigates away', async () => {

--- a/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.tsx
+++ b/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.tsx
@@ -13,6 +13,7 @@ import {
   Dimensions,
   Easing,
   Image,
+  Platform,
   View,
 } from 'react-native';
 import Rive, { Alignment, Fit, RiveRef } from 'rive-react-native';
@@ -46,6 +47,7 @@ import onboardChecklistV07Animation from '../../../animations/onboard_checklist_
 import { hasTestOverrides } from '../../../util/test/utils';
 import {
   WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_ARTBOARD,
+  WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_MAIN_ANIMATION,
   WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_MAIN_TRIGGER,
   WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_OUTRO_TRIGGER,
   WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_STATE_MACHINE,
@@ -338,11 +340,18 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
         return;
       }
       try {
-        rive.fireState(
-          WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_STATE_MACHINE,
-          WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_MAIN_TRIGGER,
-        );
-        rive.play();
+        // onboard_checklist_v07.riv does not expose the Main input. On Android,
+        // firing a missing Rive input aborts in JNI before this JS catch can run.
+        // TODO(#33825): Remove this guard after v07 is re-exported with Main on every artboard.
+        if (Platform.OS === 'android') {
+          rive.play(WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_MAIN_ANIMATION);
+        } else {
+          rive.fireState(
+            WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_STATE_MACHINE,
+            WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_MAIN_TRIGGER,
+          );
+          rive.play();
+        }
       } catch (error) {
         Logger.error(
           error as Error,

--- a/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingChecklistRive.ts
+++ b/app/components/UI/WalletHomeOnboardingSteps/walletHomeOnboardingChecklistRive.ts
@@ -13,6 +13,9 @@ export const WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_STATE_MACHINE =
 /** Trigger on {@link WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_STATE_MACHINE} to enter the main (post-intro) pose. */
 export const WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_MAIN_TRIGGER = 'Main';
 
+/** Linear animation used as the Android fallback while v07 has no `Main` trigger input. */
+export const WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_MAIN_ANIMATION = 'Main';
+
 /** Trigger on {@link WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_STATE_MACHINE} before leaving the step. */
 export const WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_OUTRO_TRIGGER = 'Outro';
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Prevents an Android native crash when the wallet-home onboarding checklist resumes after the user leaves the app to enable notifications.

`onboard_checklist_v07.riv` does not expose the `Main` state-machine input. Calling `fireState` with that missing input aborts in Android's Rive JNI layer before JavaScript error handling can catch it. Android now resumes the checklist by playing the existing `Main` linear animation directly. iOS keeps the existing state-machine behavior.

This is a temporary platform fallback until #33825 re-exports the Rive asset with the `Main` input on every artboard.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a crash when enabling notifications during wallet onboarding on Android

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1309
Refs: https://github.com/MetaMask/metamask-mobile/issues/33825

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Android wallet onboarding notifications

  Scenario: user enables notifications during wallet onboarding
    Given the app is running on Android
    And a new wallet has completed onboarding with a zero balance
    And the wallet-home onboarding checklist is displayed
    And notification permission has not previously been requested

    When the user advances to the notifications checklist step
    And taps the primary button to open notification settings
    And enables notifications
    And returns to MetaMask
    Then the app does not crash
    And the checklist resumes in its main animation state
    And the notifications step completes

  Scenario: iOS keeps the existing checklist transition
    Given the app is running on iOS
    And the wallet-home onboarding checklist is displayed

    When the user returns from a checklist action that navigates away
    Then the checklist resumes through the existing Rive state-machine transition
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped platform branch in onboarding UI animation resume; iOS behavior unchanged and covered by existing tests plus a new Android-specific test.
> 
> **Overview**
> Fixes an **Android native crash** when the wallet-home onboarding checklist resumes after the user leaves the app (e.g. to enable notifications).
> 
> The deferred-resume path no longer calls `fireState` with the missing **`Main`** input on `onboard_checklist_v07.riv` on Android—that call aborts in Rive JNI before JS can catch it. **Android** now calls `rive.play` with the **`Main`** linear animation constant instead; **iOS** still uses the state machine trigger plus `play()`.
> 
> Adds `WALLET_HOME_ONBOARDING_CHECKLIST_RIVE_MAIN_ANIMATION` and a unit test that asserts Android plays that animation and does not fire state after focus returns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b970b36adf1f59987a49e5ae0b0c0a915c07372. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->