### PR TITLE
feat: add blacklist network feature flag in useNetworkManagementDataHook cp-8.8.0

### DIFF
--- a/app/components/Views/NetworksManagement/hooks/useNetworkManagementData.test.ts
+++ b/app/components/Views/NetworksManagement/hooks/useNetworkManagementData.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@metamask/network-controller';
 import { useNetworkManagementData } from './useNetworkManagementData';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../selectors/networkController';
+import { selectAdditionalNetworksBlacklistFeatureFlag } from '../../../../selectors/featureFlagController/networkBlacklist';
 import { SECTION_KEYS } from '../NetworksManagementView.constants';
 
 jest.mock('react-redux', () => ({
@@ -22,6 +23,7 @@ jest.mock('../../../../util/networks', () => ({
 }));
 
 jest.mock('../../../../util/networks/customNetworks', () => ({
+  ...jest.requireActual('../../../../util/networks/customNetworks'),
   PopularList: [
     {
       chainId: '0xa86a',
@@ -68,12 +70,17 @@ describe('useNetworkManagementData', () => {
 
   const setupMockSelectors = ({
     networkConfigurations = {},
+    blacklistedChainIds = [],
   }: {
     networkConfigurations?: Record<Hex, NetworkConfiguration>;
+    blacklistedChainIds?: string[];
   } = {}) => {
     mockUseSelector.mockImplementation((selector) => {
       if (selector === selectEvmNetworkConfigurationsByChainId) {
         return networkConfigurations;
+      }
+      if (selector === selectAdditionalNetworksBlacklistFeatureFlag) {
+        return blacklistedChainIds;
       }
       return undefined;
     });
@@ -325,5 +332,72 @@ describe('useNetworkManagementData', () => {
 
     // All sections should be filtered out since no data matches
     expect(result.current.sections).toHaveLength(0);
+  });
+
+  it('excludes blacklisted networks from available networks', () => {
+    setupMockSelectors({
+      networkConfigurations: {},
+      blacklistedChainIds: ['0xa86a'], // Avalanche
+    });
+
+    const { result } = renderHook(() =>
+      useNetworkManagementData({ searchQuery: '' }),
+    );
+
+    const available = result.current.sections.find(
+      (s) => s.key === SECTION_KEYS.AVAILABLE_NETWORKS,
+    );
+
+    expect(available?.data).toHaveLength(1);
+    expect(available?.data[0].name).toBe('Arbitrum');
+    expect(available?.data[0].chainId).toBe('0xa4b1');
+  });
+
+  it('does not show available networks section when all remaining popular networks are blacklisted', () => {
+    setupMockSelectors({
+      networkConfigurations: {},
+      blacklistedChainIds: ['0xa86a', '0xa4b1'],
+    });
+
+    const { result } = renderHook(() =>
+      useNetworkManagementData({ searchQuery: '' }),
+    );
+
+    const available = result.current.sections.find(
+      (s) => s.key === SECTION_KEYS.AVAILABLE_NETWORKS,
+    );
+
+    expect(available).toBeUndefined();
+  });
+
+  it('still shows already-added blacklisted networks in enabled sections', () => {
+    const networkConfigurations: Record<Hex, NetworkConfiguration> = {
+      '0xa86a': createMockNetworkConfig({
+        chainId: '0xa86a',
+        name: 'Avalanche',
+      }),
+    };
+
+    setupMockSelectors({
+      networkConfigurations,
+      blacklistedChainIds: ['0xa86a'],
+    });
+
+    const { result } = renderHook(() =>
+      useNetworkManagementData({ searchQuery: '' }),
+    );
+
+    const addedMainnets = result.current.sections.find(
+      (s) => s.key === SECTION_KEYS.ADDED_MAINNETS,
+    );
+    const available = result.current.sections.find(
+      (s) => s.key === SECTION_KEYS.AVAILABLE_NETWORKS,
+    );
+
+    expect(addedMainnets?.data).toHaveLength(1);
+    expect(addedMainnets?.data[0].name).toBe('Avalanche');
+    // Arbitrum remains available; Avalanche is added so not in available
+    expect(available?.data).toHaveLength(1);
+    expect(available?.data[0].name).toBe('Arbitrum');
   });
 });

--- a/app/components/Views/NetworksManagement/hooks/useNetworkManagementData.ts
+++ b/app/components/Views/NetworksManagement/hooks/useNetworkManagementData.ts
@@ -9,7 +9,6 @@ import {
   getFilteredPopularNetworks,
   PopularList,
 } from '../../../../util/networks/customNetworks';
-import { Network } from '../../Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.types';
 import { SECTION_KEYS } from '../NetworksManagementView.constants';
 import {
   NetworkManagementItem,
@@ -51,7 +50,7 @@ const buildAddedNetworkItem = (
  * Builds a NetworkManagementItem from a popular network that is NOT yet added.
  */
 const buildAvailableNetworkItem = (
-  popular: Network,
+  popular: ReturnType<typeof getFilteredPopularNetworks>[number],
 ): NetworkManagementItem => ({
   chainId: popular.chainId as Hex,
   name: popular.nickname,

--- a/app/components/Views/NetworksManagement/hooks/useNetworkManagementData.ts
+++ b/app/components/Views/NetworksManagement/hooks/useNetworkManagementData.ts
@@ -9,6 +9,7 @@ import {
   getFilteredPopularNetworks,
   PopularList,
 } from '../../../../util/networks/customNetworks';
+import { Network } from '../../Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.types';
 import { SECTION_KEYS } from '../NetworksManagementView.constants';
 import {
   NetworkManagementItem,
@@ -47,12 +48,12 @@ const buildAddedNetworkItem = (
 };
 
 /**
- * Builds a NetworkManagementItem from a PopularList entry that is NOT yet added.
+ * Builds a NetworkManagementItem from a popular network that is NOT yet added.
  */
 const buildAvailableNetworkItem = (
-  popular: (typeof PopularList)[number],
+  popular: Network,
 ): NetworkManagementItem => ({
-  chainId: popular.chainId,
+  chainId: popular.chainId as Hex,
   name: popular.nickname,
   isTestNet: false,
   imageSource:

--- a/app/components/Views/NetworksManagement/hooks/useNetworkManagementData.ts
+++ b/app/components/Views/NetworksManagement/hooks/useNetworkManagementData.ts
@@ -3,8 +3,12 @@ import { useSelector } from 'react-redux';
 import { Hex } from '@metamask/utils';
 import { NetworkConfiguration } from '@metamask/network-controller';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../selectors/networkController';
+import { selectAdditionalNetworksBlacklistFeatureFlag } from '../../../../selectors/featureFlagController/networkBlacklist';
 import { isTestNet, getNetworkImageSource } from '../../../../util/networks';
-import { PopularList } from '../../../../util/networks/customNetworks';
+import {
+  getFilteredPopularNetworks,
+  PopularList,
+} from '../../../../util/networks/customNetworks';
 import { SECTION_KEYS } from '../NetworksManagementView.constants';
 import {
   NetworkManagementItem,
@@ -77,7 +81,8 @@ const filterBySearch = (
  *
  * Reads the user's added networks from NetworkController, classifies them
  * as mainnet or testnet, and computes which popular networks are still
- * available to add. Supports search filtering across all sections.
+ * available to add. Available networks respect the additional networks
+ * blacklist feature flag. Supports search filtering across all sections.
  */
 export const useNetworkManagementData = ({
   searchQuery,
@@ -85,10 +90,18 @@ export const useNetworkManagementData = ({
   const networkConfigurationsByChainId = useSelector(
     selectEvmNetworkConfigurationsByChainId,
   );
+  const blacklistedChainIds = useSelector(
+    selectAdditionalNetworksBlacklistFeatureFlag,
+  );
 
   const popularChainIds = useMemo(
     () => new Set(PopularList.map((p) => p.chainId)),
     [],
+  );
+
+  const filteredPopularNetworks = useMemo(
+    () => getFilteredPopularNetworks(blacklistedChainIds, PopularList),
+    [blacklistedChainIds],
   );
 
   const addedNetworks = useMemo(() => {
@@ -101,10 +114,13 @@ export const useNetworkManagementData = ({
 
   const availableNetworks = useMemo(
     () =>
-      PopularList.filter(
-        (popular) => !networkConfigurationsByChainId?.[popular.chainId as Hex],
-      ).map(buildAvailableNetworkItem),
-    [networkConfigurationsByChainId],
+      filteredPopularNetworks
+        .filter(
+          (popular) =>
+            !networkConfigurationsByChainId?.[popular.chainId as Hex],
+        )
+        .map(buildAvailableNetworkItem),
+    [filteredPopularNetworks, networkConfigurationsByChainId],
   );
 
   const sections = useMemo(() => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

- Apply `additionalNetworksBlacklist` in `useNetworkManagementData` via `selectAdditionalNetworksBlacklistFeatureFlag` and `getFilteredPopularNetworks`, matching `CustomNetwork`
- Hide blacklisted chains from Additional Networks; already-added blacklisted networks still appear in enabled/test sections
- Cover blacklist behavior with unit tests

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: apply `additionalNetworksBlacklist` to Network Management, hiding blacklisted chains from Additional Networks while preserving already-added networks, with unit test coverage.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: WPN-1865

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

The recording below shows that when Arc is included in the neural network blacklist, it no longer appears in the network list. When Arc is removed from the blacklist, it appears again.


https://github.com/user-attachments/assets/69fe04ae-849a-459a-9c77-7446dafd8301



<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only list filtering behind an existing feature flag, aligned with CustomNetwork; no auth or data-layer changes.
> 
> **Overview**
> **Network Management** now honors the `additionalNetworksBlacklist` feature flag when building the **Additional Networks** list, consistent with `CustomNetwork`.
> 
> `useNetworkManagementData` reads `selectAdditionalNetworksBlacklistFeatureFlag` and builds available networks from `getFilteredPopularNetworks` instead of raw `PopularList`. Blacklisted chains are omitted from **available** networks; if every popular option is blacklisted, the available section is dropped. Networks the user already added still show in the mainnet/testnet sections even when blacklisted.
> 
> Unit tests mock the blacklist selector and cover filtering, empty available section, and preserving already-added blacklisted networks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b4600af001cfa861a2bb8708409ee3fd94e226f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->