### PR TITLE
refactor(quick-buy): remove stream quotes feature flag

### DIFF
--- a/app/components/UI/QuickBuy/hooks/useQuickBuyQuotes.test.ts
+++ b/app/components/UI/QuickBuy/hooks/useQuickBuyQuotes.test.ts
@@ -24,7 +24,6 @@ import {
   selectGasIncludedQuoteParams,
   selectSourceWalletAddress,
 } from '../../../../selectors/bridge';
-import { selectSocialAIQuickBuyStreamQuotesEnabled } from '../../../../selectors/featureFlagController/socialLeaderboard';
 import Logger from '../../../../util/Logger';
 
 jest.mock('../../../../util/Logger', () => ({
@@ -59,13 +58,6 @@ jest.mock('../../../../util/analytics/analytics', () => ({
 jest.mock('../../../../selectors/featureFlagController', () => ({
   selectRemoteFeatureFlags: jest.fn(() => ({ bridgeConfig: {} })),
 }));
-
-jest.mock(
-  '../../../../selectors/featureFlagController/socialLeaderboard',
-  () => ({
-    selectSocialAIQuickBuyStreamQuotesEnabled: jest.fn(() => true),
-  }),
-);
 
 jest.mock('../../../../core/redux/slices/bridge', () => ({
   selectDestAddress: jest.fn(),
@@ -115,8 +107,6 @@ const fetchQuotesMock = Engine.context.BridgeController
 const useSelectorMock = useSelector as jest.Mock;
 const isQuoteStreamingEnabledMock = isQuoteStreamingEnabled as jest.Mock;
 const streamQuickBuyQuotesMock = streamQuickBuyQuotes as jest.Mock;
-const isStreamQuotesFlagEnabledMock =
-  selectSocialAIQuickBuyStreamQuotesEnabled as unknown as jest.Mock;
 
 const createSourceToken = (overrides: Partial<BridgeToken> = {}): BridgeToken =>
   ({
@@ -238,10 +228,8 @@ describe('useQuickBuyQuotes', () => {
     jest.useFakeTimers();
     jest.clearAllMocks();
     setupSelectors();
-    // The QuickBuy stream flag is on by default, so `isQuoteStreamingEnabled`
-    // (bridge SSE) is the effective switch: default to the one-shot path; the
-    // streaming suite opts in explicitly.
-    isStreamQuotesFlagEnabledMock.mockReturnValue(true);
+    // `isQuoteStreamingEnabled` (bridge SSE) is the stream switch: default to
+    // the one-shot path; the streaming suite opts in explicitly.
     isQuoteStreamingEnabledMock.mockReturnValue(false);
     mockSelectBridgeQuotesBase.mockReturnValue({
       sortedQuotes: [],
@@ -840,29 +828,6 @@ describe('useQuickBuyQuotes', () => {
 
     expect(fetchQuotesMock).toHaveBeenCalledTimes(1);
     expect(result.current.isQuoteRequestStale).toBe(false);
-  });
-
-  it('uses the one-shot fetch when the QuickBuy stream flag is off, even with bridge SSE on', async () => {
-    isStreamQuotesFlagEnabledMock.mockReturnValue(false);
-    isQuoteStreamingEnabledMock.mockReturnValue(true);
-    fetchQuotesMock.mockResolvedValue([createFetchedQuote()]);
-
-    renderHook(() =>
-      useQuickBuyQuotes(
-        quotesParams({
-          sourceToken: createSourceToken(),
-          destToken: createDestToken(),
-          sourceTokenAmount: '0.001',
-        }),
-      ),
-    );
-
-    act(() => {
-      jest.advanceTimersByTime(QUICK_BUY_QUOTE_DEBOUNCE_MS);
-    });
-
-    await waitFor(() => expect(fetchQuotesMock).toHaveBeenCalledTimes(1));
-    expect(streamQuickBuyQuotesMock).not.toHaveBeenCalled();
   });
 
   describe('streaming path', () => {

--- a/app/components/UI/QuickBuy/hooks/useQuickBuyQuotes.ts
+++ b/app/components/UI/QuickBuy/hooks/useQuickBuyQuotes.ts
@@ -22,7 +22,6 @@ import { areAddressesEqual } from '../../../../util/address';
 import { calcTokenValue } from '../../../../util/transactions';
 import { analytics } from '../../../../util/analytics/analytics';
 import { selectRemoteFeatureFlags } from '../../../../selectors/featureFlagController';
-import { selectSocialAIQuickBuyStreamQuotesEnabled } from '../../../../selectors/featureFlagController/socialLeaderboard';
 import {
   selectBridgeFeatureFlags,
   selectDestAddress,
@@ -196,19 +195,11 @@ export function useQuickBuyQuotes({
     selectGasIncludedQuoteParams,
   );
   const bridgeFeatureFlags = useSelector(selectBridgeFeatureFlags);
-  const isStreamQuotesFlagEnabled = useSelector(
-    selectSocialAIQuickBuyStreamQuotesEnabled,
-  );
   const { track } = useSocialLeaderboardAnalytics();
 
-  // Stream quotes (surfacing each provider as it replies) only when the
-  // QuickBuy-specific `socialAIQuickBuyStreamQuotes` flag is on AND the client is
+  // Stream quotes (surfacing each provider as it replies) when the client is
   // gated on for bridge SSE — otherwise fall back to the one-shot fetch.
-  const shouldStream = useMemo(
-    () =>
-      isStreamQuotesFlagEnabled && isQuoteStreamingEnabled(bridgeFeatureFlags),
-    [isStreamQuotesFlagEnabled, bridgeFeatureFlags],
-  );
+  const shouldStream = isQuoteStreamingEnabled(bridgeFeatureFlags);
 
   const [rawQuotes, setRawQuotes] = useState<QuickBuyQuote[]>([]);
   const [isQuoteLoading, setIsQuoteLoading] = useState(false);

--- a/app/selectors/featureFlagController/socialLeaderboard/index.test.ts
+++ b/app/selectors/featureFlagController/socialLeaderboard/index.test.ts
@@ -1,7 +1,6 @@
 import {
   selectAiSocialAusCacheRefreshEnabled,
   selectAiSocialLeaderboardOnboardingEnabled,
-  selectSocialAIQuickBuyStreamQuotesEnabled,
   selectSocialLeaderboardEnabled,
   selectSocialLeaderboardOptFlowEnabled,
   selectSocialLeaderboardPerpsEnabled,
@@ -266,74 +265,6 @@ describe('selectAiSocialLeaderboardOnboardingEnabled', () => {
       aiSocialLeaderboardOnboardingEnabled: {
         enabled: true,
         minimumVersion: '99.0.0',
-      },
-    });
-
-    expect(result).toBe(false);
-  });
-});
-
-describe('selectSocialAIQuickBuyStreamQuotesEnabled', () => {
-  let mockHasMinimumRequiredVersion: jest.SpyInstance;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockHasMinimumRequiredVersion = jest.spyOn(
-      remoteFeatureFlagModule,
-      'hasMinimumRequiredVersion',
-    );
-    mockHasMinimumRequiredVersion.mockReturnValue(true);
-  });
-
-  afterEach(() => {
-    mockHasMinimumRequiredVersion?.mockRestore();
-  });
-
-  it('returns true when remote flag is enabled and version requirement is met', () => {
-    const result = selectSocialAIQuickBuyStreamQuotesEnabled.resultFunc({
-      socialAIQuickBuyStreamQuotes: {
-        enabled: true,
-        minimumVersion: '7.72.0',
-      },
-    });
-
-    expect(result).toBe(true);
-  });
-
-  it('returns false when remote flag is disabled', () => {
-    const result = selectSocialAIQuickBuyStreamQuotesEnabled.resultFunc({
-      socialAIQuickBuyStreamQuotes: {
-        enabled: false,
-        minimumVersion: '7.72.0',
-      },
-    });
-
-    expect(result).toBe(false);
-  });
-
-  it('returns false when version requirement is not met', () => {
-    mockHasMinimumRequiredVersion.mockReturnValue(false);
-    const result = selectSocialAIQuickBuyStreamQuotesEnabled.resultFunc({
-      socialAIQuickBuyStreamQuotes: {
-        enabled: true,
-        minimumVersion: '99.0.0',
-      },
-    });
-
-    expect(result).toBe(false);
-  });
-
-  it('returns false when remote flag is absent', () => {
-    const result = selectSocialAIQuickBuyStreamQuotesEnabled.resultFunc({});
-
-    expect(result).toBe(false);
-  });
-
-  it('returns false when remote flag has an invalid shape', () => {
-    const result = selectSocialAIQuickBuyStreamQuotesEnabled.resultFunc({
-      socialAIQuickBuyStreamQuotes: {
-        enabled: 'invalid',
-        minimumVersion: 123,
       },
     });
 

--- a/app/selectors/featureFlagController/socialLeaderboard/index.ts
+++ b/app/selectors/featureFlagController/socialLeaderboard/index.ts
@@ -55,16 +55,6 @@ export const selectAiSocialLeaderboardOnboardingEnabled = createSelector(
   },
 );
 
-export const selectSocialAIQuickBuyStreamQuotesEnabled = createSelector(
-  selectRemoteFeatureFlags,
-  (remoteFeatureFlags) => {
-    const remoteFlag =
-      remoteFeatureFlags?.socialAIQuickBuyStreamQuotes as unknown as VersionGatedFeatureFlag;
-
-    return validatedVersionGatedFeatureFlag(remoteFlag) ?? false;
-  },
-);
-
 export const selectAiSocialAusCacheRefreshEnabled = createSelector(
   selectRemoteFeatureFlags,
   (remoteFeatureFlags) => {

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -4809,17 +4809,6 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
-  socialAIQuickBuyStreamQuotes: {
-    name: 'socialAIQuickBuyStreamQuotes',
-    type: FeatureFlagType.Remote,
-    inProd: false,
-    productionDefault: {
-      enabled: false,
-      minimumVersion: '8.2.0',
-    },
-    status: FeatureFlagStatus.Active,
-  },
-
   socialAiTSA612AbtestQuickBuy: {
     name: 'socialAiTSA612AbtestQuickBuy',
     type: FeatureFlagType.Remote,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`socialAIQuickBuyStreamQuotes` is fully rolled out as the intended Quick Buy quote path, so the extra gate is unused. This PR removes the flag and streams quotes whenever bridge SSE is enabled.

What changed:
- `useQuickBuyQuotes` streams when `isQuoteStreamingEnabled(bridgeFeatureFlags)` is true; otherwise it still uses the one-shot `BridgeController.fetchQuotes` fallback.
- `selectSocialAIQuickBuyStreamQuotesEnabled` and its tests are removed.
- `socialAIQuickBuyStreamQuotes` is removed from the feature-flag registry.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Quick Buy quote streaming

  Background:
    Given I am logged into MetaMask Mobile
    And Follow Trading is enabled

  Scenario: user sees quotes stream when bridge SSE is on
    Given I open a trader spot position
    And I tap Buy

    When quotes start loading
    Then the first quote should appear without waiting for every provider
    And later quotes should accumulate in the list
    And I should still be able to submit a trade on the recommended quote

  Scenario: user still gets quotes when bridge SSE is off
    Given bridge SSE is disabled for this client
    And I open Quick Buy from a Follow Trading spot position

    When quotes finish loading
    Then I should see the one-shot quote list
    And I should still be able to submit a trade
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — flag cleanup; quote UI is unchanged when streaming is already on.

### **After**

N/A — attach a recording of Quick Buy quote load when marking ready for review.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit acb1cd39f277e038aed86392aa9b0879028337b3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->