### PR TITLE
fix(perps): keep market header and chart prices in sync

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -126,7 +126,6 @@ import {
   usePerpsLivePrices,
   usePerpsLiveFocusedPrice,
 } from '../../hooks/stream';
-import { usePerpsLiveCandles } from '../../hooks/stream/usePerpsLiveCandles';
 import { useHasExistingPosition } from '../../hooks/useHasExistingPosition';
 import { useIsPriceDeviatedAboveThreshold } from '../../hooks/useIsPriceDeviatedAboveThreshold';
 import {
@@ -138,6 +137,7 @@ import { usePerpsChartInteractions } from '../../hooks/usePerpsChartInteractions
 import { usePerpsMarkets } from '../../hooks/usePerpsMarkets';
 import { usePerpsMarketStats } from '../../hooks/usePerpsMarketStats';
 import { usePerpsMeasurement } from '../../hooks/usePerpsMeasurement';
+import { usePerpsSyncedChartPrice } from '../../hooks/usePerpsSyncedChartPrice';
 import { buildPerpsCufStartTags } from '../../utils/perpsCufTrace';
 import { PERPS_CUF_TAG, PERPS_CUF_VARIANT } from '../../constants/perpsCufTags';
 import { usePerpsOICap } from '../../hooks/usePerpsOICap';
@@ -530,31 +530,13 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     isLoading: isLoadingHistory,
     hasHistoricalData,
     fetchMoreHistory,
-  } = usePerpsLiveCandles({
+    syncedChartCurrentPrice,
+    setAdvancedChartCurrentPrice,
+  } = usePerpsSyncedChartPrice({
     symbol: market?.symbol || '',
     interval: selectedCandlePeriod,
-    duration: TimeDuration.YearToDate,
-    throttleMs: 1000,
+    isAdvancedChartEnabled,
   });
-
-  // Get current price from the last candle's close price for chart synchronization
-  // This ensures the current price line matches the live candle close price exactly
-  const chartCurrentPrice = useMemo(() => {
-    if (!candleData?.candles?.length) return 0;
-    const lastCandle = candleData.candles.at(-1);
-    return lastCandle?.close ? Number.parseFloat(lastCandle.close) : 0;
-  }, [candleData]);
-  const [advancedChartCurrentPrice, setAdvancedChartCurrentPrice] = useState<
-    number | undefined
-  >(undefined);
-  const syncedChartCurrentPrice =
-    isAdvancedChartEnabled && advancedChartCurrentPrice !== undefined
-      ? advancedChartCurrentPrice
-      : chartCurrentPrice;
-
-  useEffect(() => {
-    setAdvancedChartCurrentPrice(undefined);
-  }, [isAdvancedChartEnabled, market?.symbol, selectedCandlePeriod]);
 
   // Auto-zoom to latest candle when interval changes and new data arrives
   // This ensures the chart shows the most recent data after interval change
@@ -1550,6 +1532,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
         onModeChange={isPerpsProModeEnabled ? handlePerpsModeChange : undefined}
         scrollY={scrollYShared}
         priceSectionHeight={titleSectionHeightSv}
+        currentPrice={syncedChartCurrentPrice}
       />
 
       <View style={styles.scrollableContentContainer}>

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.test.tsx
@@ -48,6 +48,8 @@ interface MockChartPanelProps {
   symbol: string;
   selectedCandlePeriod: CandlePeriod;
   onMorePress: () => void;
+  currentPrice?: number;
+  onLatestPriceChange?: (price: number | undefined) => void;
 }
 
 interface MockCandlePeriodBottomSheetProps {
@@ -248,6 +250,15 @@ jest.mock('../../hooks/stream', () => ({
     isInitialLoading: false,
   })),
   usePerpsLivePrices: jest.fn(() => ({})),
+}));
+
+jest.mock('../../hooks/stream/usePerpsLiveCandles', () => ({
+  usePerpsLiveCandles: jest.fn(() => ({
+    candleData: null,
+    isLoading: false,
+    hasHistoricalData: false,
+    fetchMoreHistory: jest.fn(),
+  })),
 }));
 
 jest.mock('../../hooks/usePerpsProPositionsPanelActions', () => ({
@@ -702,6 +713,17 @@ describe('PerpsProMarketView', () => {
         PerpsProMarketViewSelectorsIDs.MARKET_SUMMARY,
       ),
     ).toBeOnTheScreen();
+  });
+
+  it('wires the chart-synced price into the compact header', () => {
+    renderView();
+
+    expect(mockPerpsProChartPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentPrice: expect.any(Number),
+        onLatestPriceChange: expect.any(Function),
+      }),
+    );
   });
 
   it('shows the asset name from route params in the header', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.tsx
@@ -42,6 +42,7 @@ import { usePerpsChartInteractions } from '../../hooks/usePerpsChartInteractions
 import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 import { usePerpsMarkets } from '../../hooks/usePerpsMarkets';
 import { usePerpsMarketHeaderActions } from '../../hooks/usePerpsMarketHeaderActions';
+import { usePerpsSyncedChartPrice } from '../../hooks/usePerpsSyncedChartPrice';
 import {
   PerpsOrderProvider,
   usePerpsOrderContext,
@@ -218,6 +219,15 @@ const PerpsProMarketView = () => {
 
   const [isBalanceSheetVisible, setIsBalanceSheetVisible] = useState(false);
 
+  // Same parent-owned merge as Lite: last candle close, overridden by the
+  // Advanced Chart latest-bar close while that chart is reporting.
+  const { syncedChartCurrentPrice, setAdvancedChartCurrentPrice } =
+    usePerpsSyncedChartPrice({
+      symbol: market?.symbol || '',
+      interval: selectedCandlePeriod,
+      isAdvancedChartEnabled,
+    });
+
   const handleWalletPress = useCallback(() => {
     setIsBalanceSheetVisible(true);
   }, []);
@@ -328,6 +338,7 @@ const PerpsProMarketView = () => {
         onModeChange={handlePerpsModeChange}
         scrollY={scrollY}
         priceSectionHeight={titleSectionHeightSv}
+        currentPrice={syncedChartCurrentPrice}
       />
       <Animated.ScrollView
         ref={scrollViewRef}
@@ -348,6 +359,8 @@ const PerpsProMarketView = () => {
           onCandlePeriodChange={handleCandlePeriodChange}
           onMorePress={() => setIsMoreCandlePeriodsVisible(true)}
           onChartError={handleChartError}
+          currentPrice={syncedChartCurrentPrice}
+          onLatestPriceChange={setAdvancedChartCurrentPrice}
         />
         {/* The chart's own height (`PerpsProChartPanel`) animates when
             expanded/collapsed above this point — wrap everything that would

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.test.tsx
@@ -205,6 +205,7 @@ const renderChartPanel = (overrides: Partial<PerpsProChartPanelProps> = {}) =>
       onCandlePeriodChange={mockOnCandlePeriodChange}
       onMorePress={mockOnMorePress}
       onChartError={mockOnChartError}
+      currentPrice={50500}
       {...overrides}
     />,
   );
@@ -365,24 +366,44 @@ describe('PerpsProChartPanel', () => {
     ).not.toBeOnTheScreen();
   });
 
-  it('renders the latest candle price in the market summary', () => {
-    renderChartPanel();
+  it('renders the provided currentPrice in the market summary', () => {
+    renderChartPanel({ currentPrice: 50500 });
 
     expect(mockLivePriceHeader).toHaveBeenLastCalledWith(
       expect.objectContaining({ currentPrice: 50500 }),
     );
   });
 
-  it('synchronizes the market summary with the Advanced Chart price', () => {
-    renderChartPanel();
+  it('updates the market summary when the parent currentPrice changes', () => {
+    const view = renderChartPanel({ currentPrice: 50500 });
+
+    view.rerender(
+      <PerpsProChartPanel
+        symbol="BTC"
+        selectedCandlePeriod={CandlePeriod.FifteenMinutes}
+        isAdvancedChartEnabled
+        effectiveChartLibrary={PERPS_EVENT_VALUE.CHART_LIBRARY.ADVANCED}
+        onCandlePeriodChange={mockOnCandlePeriodChange}
+        onMorePress={mockOnMorePress}
+        onChartError={mockOnChartError}
+        currentPrice={51000}
+      />,
+    );
+
+    expect(mockLivePriceHeader).toHaveBeenLastCalledWith(
+      expect.objectContaining({ currentPrice: 51000 }),
+    );
+  });
+
+  it('forwards Advanced Chart latest-bar close to the parent', () => {
+    const onLatestPriceChange = jest.fn();
+    renderChartPanel({ onLatestPriceChange });
 
     act(() => {
       getLastAdvancedChartProps().onLatestPriceChange?.(51000);
     });
 
-    expect(mockLivePriceHeader).toHaveBeenLastCalledWith(
-      expect.objectContaining({ currentPrice: 51000 }),
-    );
+    expect(onLatestPriceChange).toHaveBeenCalledWith(51000);
   });
 
   it('renders OHLCV values reported by the active chart', () => {
@@ -570,19 +591,10 @@ describe('PerpsProChartPanel', () => {
       ).not.toBeOnTheScreen();
     });
 
-    it('follows the candle price (not the frozen Advanced Chart price) after collapsing', () => {
-      const view = renderChartPanel();
+    it('clears the Advanced Chart price when the chart collapses', () => {
+      const onLatestPriceChange = jest.fn();
+      const view = renderChartPanel({ onLatestPriceChange });
 
-      // Advanced Chart reports a live price while expanded.
-      act(() => {
-        getLastAdvancedChartProps().onLatestPriceChange?.(51000);
-      });
-      expect(mockLivePriceHeader).toHaveBeenLastCalledWith(
-        expect.objectContaining({ currentPrice: 51000 }),
-      );
-
-      // Collapse: the Advanced Chart unmounts and can no longer report prices,
-      // so the summary must fall back to the retained candle price (50500).
       mockUsePerpsProChartExpanded.mockReturnValue({
         isChartExpanded: false,
         setChartExpanded: mockSetChartExpanded,
@@ -596,8 +608,16 @@ describe('PerpsProChartPanel', () => {
           onCandlePeriodChange={mockOnCandlePeriodChange}
           onMorePress={mockOnMorePress}
           onChartError={mockOnChartError}
+          currentPrice={50500}
+          onLatestPriceChange={onLatestPriceChange}
         />,
       );
+
+      expect(onLatestPriceChange).toHaveBeenCalledWith(undefined);
+    });
+
+    it('keeps showing the parent-provided price while collapsed', () => {
+      renderCollapsed({ currentPrice: 50500 });
 
       expect(mockLivePriceHeader).toHaveBeenLastCalledWith(
         expect.objectContaining({ currentPrice: 50500 }),

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProChartPanel.tsx
@@ -77,6 +77,13 @@ interface PerpsProChartPanelProps {
   onCandlePeriodChange: (period: CandlePeriod) => void;
   onMorePress: () => void;
   onChartError: (error?: Error | string) => void;
+  /**
+   * Parent-owned display price (`usePerpsSyncedChartPrice`), same value as
+   * the compact header. Shown in the summary and chart current-price line.
+   */
+  currentPrice: number;
+  /** Forwards Advanced Chart latest-bar close into `usePerpsSyncedChartPrice`. */
+  onLatestPriceChange?: (price: number | undefined) => void;
 }
 
 /**
@@ -90,27 +97,26 @@ const PerpsProChartPanel = ({
   onCandlePeriodChange,
   onMorePress,
   onChartError,
+  currentPrice,
+  onLatestPriceChange,
 }: PerpsProChartPanelProps) => {
   const { track } = usePerpsEventTracking();
   const { isChartExpanded, setChartExpanded } = usePerpsProChartExpanded();
   const [isFullscreenChartVisible, setIsFullscreenChartVisible] =
     useState(false);
   const [ohlcData, setOhlcData] = useState<OhlcData | null>(null);
-  const [advancedChartCurrentPrice, setAdvancedChartCurrentPrice] = useState<
-    number | undefined
-  >(undefined);
   const chartRef = useRef<TradingViewChartRef>(null);
   const previousIntervalRef = useRef<CandlePeriod | null>(null);
   const visibleCandleCount = PERPS_CHART_CONFIG.CANDLE_COUNT.DEFAULT;
 
-  // Clear the Advanced Chart's synced price whenever it (un)mounts or changes
-  // subject: symbol/period/flag changes, and collapse/expand. While collapsed
-  // the Advanced Chart is unmounted and can no longer report prices, so the
-  // always-visible summary must fall back to the retained candle price instead
-  // of freezing on the last Advanced Chart value.
+  // Pro-only: the Advanced Chart unmounts while collapsed, so drop its last
+  // reported close. Symbol/period/flag resets are owned by
+  // `usePerpsSyncedChartPrice` (same as Lite).
   useEffect(() => {
-    setAdvancedChartCurrentPrice(undefined);
-  }, [isAdvancedChartEnabled, isChartExpanded, selectedCandlePeriod, symbol]);
+    if (!isChartExpanded) {
+      onLatestPriceChange?.(undefined);
+    }
+  }, [isChartExpanded, onLatestPriceChange]);
 
   const chartAnalyticsProperties = useMemo(
     () => getPerpsChartAnalyticsProperties(effectiveChartLibrary),
@@ -134,25 +140,12 @@ const PerpsProChartPanel = ({
     isLoading: isLoadingTradingHalted,
   } = useIsPriceDeviatedAboveThreshold(symbol);
 
-  const chartCurrentPrice = useMemo(() => {
-    const lastCandle = candleData?.candles.at(-1);
-    return lastCandle?.close ? Number.parseFloat(lastCandle.close) : 0;
-  }, [candleData]);
-  const syncedChartCurrentPrice =
-    isChartExpanded &&
-    isAdvancedChartEnabled &&
-    advancedChartCurrentPrice !== undefined
-      ? advancedChartCurrentPrice
-      : chartCurrentPrice;
-
   const tpslLines = useMemo(() => {
-    const currentPrice =
-      syncedChartCurrentPrice > 0
-        ? syncedChartCurrentPrice.toString()
-        : undefined;
+    const chartPriceStr =
+      currentPrice > 0 ? currentPrice.toString() : undefined;
 
     if (!existingPosition) {
-      return currentPrice ? { currentPrice } : undefined;
+      return chartPriceStr ? { currentPrice: chartPriceStr } : undefined;
     }
 
     return {
@@ -160,9 +153,9 @@ const PerpsProChartPanel = ({
       takeProfitPrice: existingPosition.takeProfitPrice,
       stopLossPrice: existingPosition.stopLossPrice,
       liquidationPrice: existingPosition.liquidationPrice || undefined,
-      currentPrice,
+      currentPrice: chartPriceStr,
     };
-  }, [existingPosition, syncedChartCurrentPrice]);
+  }, [currentPrice, existingPosition]);
 
   useEffect(() => {
     const hasIntervalChanged =
@@ -212,7 +205,7 @@ const PerpsProChartPanel = ({
         positionSize={existingPosition?.size}
         szDecimals={marketData?.szDecimals}
         onCrosshairDataChange={setOhlcData}
-        onLatestPriceChange={setAdvancedChartCurrentPrice}
+        onLatestPriceChange={onLatestPriceChange}
         onError={onChartError}
         fallbackCandleData={candleData}
         fallbackFetchMoreHistory={fetchMoreHistory}
@@ -249,7 +242,7 @@ const PerpsProChartPanel = ({
     <>
       <PerpsMarketSummary
         symbol={symbol}
-        currentPrice={syncedChartCurrentPrice}
+        currentPrice={currentPrice}
         testID={PerpsProMarketViewSelectorsIDs.MARKET_SUMMARY}
         testIDPrice={PerpsProMarketViewSelectorsIDs.MARKET_PRICE}
         testIDChange={PerpsProMarketViewSelectorsIDs.MARKET_PRICE_CHANGE}

--- a/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.test.tsx
@@ -15,6 +15,18 @@ import { GLOW_TOTAL_MS } from '../PerpsModeToggle/PerpsModeSwitchPill';
 
 jest.mock('../../providers/PerpsStreamManager');
 
+jest.mock('../../hooks/stream', () => ({
+  usePerpsLivePrices: jest.fn(() => ({
+    BTC: {
+      symbol: 'BTC',
+      price: '45000',
+      percentChange24h: '2.5',
+      timestamp: 1700000000000,
+      isTradable: true,
+    },
+  })),
+}));
+
 const mockMarket: PerpsMarketData = {
   symbol: 'BTC',
   name: 'Bitcoin',
@@ -280,5 +292,29 @@ describe('PerpsMarketHeader', () => {
     expect(
       queryByTestId(PerpsProMarketViewSelectorsIDs.HEADER_FAVORITE_BUTTON),
     ).toBeNull();
+  });
+
+  it('displays the chart-synced currentPrice instead of the live stream price', () => {
+    const { getByTestId } = renderHeader({ currentPrice: 51000 });
+
+    expect(
+      getByTestId(PerpsProMarketViewSelectorsIDs.HEADER_PRICE),
+    ).toHaveTextContent('$51,000');
+  });
+
+  it('falls back to the live stream price when currentPrice is omitted', () => {
+    const { getByTestId } = renderHeader();
+
+    expect(
+      getByTestId(PerpsProMarketViewSelectorsIDs.HEADER_PRICE),
+    ).toHaveTextContent('$45,000');
+  });
+
+  it('displays a placeholder when the chart-synced currentPrice is 0', () => {
+    const { getByTestId } = renderHeader({ currentPrice: 0 });
+
+    expect(
+      getByTestId(PerpsProMarketViewSelectorsIDs.HEADER_PRICE),
+    ).toHaveTextContent('$---');
   });
 });

--- a/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.tsx
@@ -119,6 +119,7 @@ const PerpsMarketHeader = ({
   onModeChange,
   scrollY,
   priceSectionHeight,
+  currentPrice: currentPriceOverride,
 }: PerpsMarketHeaderProps) => {
   const fallbackScrollY = useSharedValue(0);
   const fallbackPriceSectionHeight = useSharedValue(0);
@@ -163,7 +164,15 @@ const PerpsMarketHeader = ({
     throttleMs: 1000,
   });
   const priceData = livePrices[market.symbol];
-  const currentPrice = priceData?.price ? parseFloat(priceData.price) : 0;
+  // Same as Lite: when the parent passes the chart-synced price, display it
+  // as-is (including 0 → "$---"). Live mids are only used when the parent
+  // does not supply a price.
+  const currentPrice =
+    currentPriceOverride !== undefined
+      ? currentPriceOverride
+      : priceData?.price
+        ? parseFloat(priceData.price)
+        : 0;
   const percentChange24h =
     priceData?.percentChange24h !== undefined
       ? parseFloat(priceData.percentChange24h)

--- a/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.types.ts
+++ b/app/components/UI/Perps/components/PerpsMarketHeader/PerpsMarketHeader.types.ts
@@ -47,4 +47,11 @@ export interface PerpsMarketHeaderProps {
    * (e.g. `PRICE_SECTION_HEIGHT` from `PerpsMarketSummary`).
    */
   priceSectionHeight?: SharedValue<number>;
+  /**
+   * Chart-synced price for the compact header (shown after scrolling past
+   * the summary). Pass the same `syncedChartCurrentPrice` given to
+   * `PerpsMarketSummary` so the header and chart prices match. When omitted,
+   * falls back to the live mid-price stream.
+   */
+  currentPrice?: number;
 }

--- a/app/components/UI/Perps/hooks/index.ts
+++ b/app/components/UI/Perps/hooks/index.ts
@@ -23,6 +23,7 @@ export { usePerpsSorting } from './usePerpsSorting';
 export { usePerpsNavigation } from './usePerpsNavigation';
 export { usePerpsMode } from './usePerpsMode';
 export { usePerpsProChartExpanded } from './usePerpsProChartExpanded';
+export { usePerpsSyncedChartPrice } from './usePerpsSyncedChartPrice';
 
 // Connection management hooks
 export { usePerpsConnection } from './usePerpsConnection';

--- a/app/components/UI/Perps/hooks/usePerpsSyncedChartPrice.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsSyncedChartPrice.test.ts
@@ -1,0 +1,115 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { CandlePeriod, type CandleData } from '@metamask/perps-controller';
+import { usePerpsLiveCandles } from './stream/usePerpsLiveCandles';
+import { usePerpsSyncedChartPrice } from './usePerpsSyncedChartPrice';
+
+jest.mock('./stream/usePerpsLiveCandles', () => ({
+  usePerpsLiveCandles: jest.fn(),
+}));
+
+const mockUsePerpsLiveCandles = usePerpsLiveCandles as jest.MockedFunction<
+  typeof usePerpsLiveCandles
+>;
+
+const MOCK_CANDLE_DATA: CandleData = {
+  symbol: 'BTC',
+  interval: CandlePeriod.FifteenMinutes,
+  candles: [
+    {
+      time: 1700000000000,
+      open: '50000',
+      high: '51000',
+      low: '49000',
+      close: '50500',
+      volume: '100',
+    },
+  ],
+};
+
+const renderSyncedPrice = (
+  overrides: Partial<Parameters<typeof usePerpsSyncedChartPrice>[0]> = {},
+) =>
+  renderHook(() =>
+    usePerpsSyncedChartPrice({
+      symbol: 'BTC',
+      interval: CandlePeriod.FifteenMinutes,
+      isAdvancedChartEnabled: true,
+      ...overrides,
+    }),
+  );
+
+describe('usePerpsSyncedChartPrice', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePerpsLiveCandles.mockReturnValue({
+      candleData: MOCK_CANDLE_DATA,
+      isLoading: false,
+      isLoadingMore: false,
+      hasHistoricalData: true,
+      error: null,
+      fetchMoreHistory: jest.fn(),
+    });
+  });
+
+  it('uses the last candle close as the display price', () => {
+    const { result } = renderSyncedPrice();
+
+    expect(result.current.syncedChartCurrentPrice).toBe(50500);
+  });
+
+  it('prefers the Advanced Chart latest-bar close when it is reporting', () => {
+    const { result } = renderSyncedPrice();
+
+    act(() => {
+      result.current.setAdvancedChartCurrentPrice(51000);
+    });
+
+    expect(result.current.syncedChartCurrentPrice).toBe(51000);
+  });
+
+  it('keeps the candle close when Advanced Chart is disabled', () => {
+    const { result } = renderSyncedPrice({ isAdvancedChartEnabled: false });
+
+    act(() => {
+      result.current.setAdvancedChartCurrentPrice(51000);
+    });
+
+    expect(result.current.syncedChartCurrentPrice).toBe(50500);
+  });
+
+  it('returns 0 when candle history has not loaded', () => {
+    mockUsePerpsLiveCandles.mockReturnValue({
+      candleData: null,
+      isLoading: true,
+      isLoadingMore: false,
+      hasHistoricalData: false,
+      error: null,
+      fetchMoreHistory: jest.fn(),
+    });
+
+    const { result } = renderSyncedPrice();
+
+    expect(result.current.syncedChartCurrentPrice).toBe(0);
+  });
+
+  it('clears the Advanced Chart price when the symbol changes', () => {
+    const { result, rerender } = renderHook(
+      ({ symbol }: { symbol: string }) =>
+        usePerpsSyncedChartPrice({
+          symbol,
+          interval: CandlePeriod.FifteenMinutes,
+          isAdvancedChartEnabled: true,
+        }),
+      { initialProps: { symbol: 'BTC' } },
+    );
+
+    act(() => {
+      result.current.setAdvancedChartCurrentPrice(51000);
+    });
+    expect(result.current.syncedChartCurrentPrice).toBe(51000);
+
+    rerender({ symbol: 'ETH' });
+
+    expect(result.current.syncedChartCurrentPrice).toBe(50500);
+  });
+});

--- a/app/components/UI/Perps/hooks/usePerpsSyncedChartPrice.ts
+++ b/app/components/UI/Perps/hooks/usePerpsSyncedChartPrice.ts
@@ -1,0 +1,78 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  CandlePeriod,
+  TimeDuration,
+  type CandleData,
+} from '@metamask/perps-controller';
+import { usePerpsLiveCandles } from './stream/usePerpsLiveCandles';
+
+export interface UsePerpsSyncedChartPriceParams {
+  symbol: string;
+  interval: CandlePeriod;
+  isAdvancedChartEnabled: boolean;
+}
+
+export interface UsePerpsSyncedChartPriceResult {
+  candleData: CandleData | null;
+  isLoading: boolean;
+  hasHistoricalData: boolean;
+  fetchMoreHistory: () => Promise<void>;
+  /**
+   * Price shown in the market header, summary, and chart current-price line.
+   * Advanced Chart latest-bar close when that chart is reporting, otherwise
+   * the last candle close.
+   */
+  syncedChartCurrentPrice: number;
+  setAdvancedChartCurrentPrice: (price: number | undefined) => void;
+}
+
+/**
+ * Shared Lite/Pro source of truth for the market-detail display price.
+ *
+ * Last candle close is the baseline so the header and chart price line stay
+ * in sync. When the Advanced Chart is enabled and reporting, its latest bar
+ * close is preferred (same merge as `PerpsMarketDetailsView`).
+ */
+export function usePerpsSyncedChartPrice({
+  symbol,
+  interval,
+  isAdvancedChartEnabled,
+}: UsePerpsSyncedChartPriceParams): UsePerpsSyncedChartPriceResult {
+  const { candleData, isLoading, hasHistoricalData, fetchMoreHistory } =
+    usePerpsLiveCandles({
+      symbol,
+      interval,
+      duration: TimeDuration.YearToDate,
+      throttleMs: 1000,
+    });
+
+  const chartCurrentPrice = useMemo(() => {
+    if (!candleData?.candles?.length) {
+      return 0;
+    }
+    const lastCandle = candleData.candles.at(-1);
+    return lastCandle?.close ? Number.parseFloat(lastCandle.close) : 0;
+  }, [candleData]);
+
+  const [advancedChartCurrentPrice, setAdvancedChartCurrentPrice] = useState<
+    number | undefined
+  >(undefined);
+
+  const syncedChartCurrentPrice =
+    isAdvancedChartEnabled && advancedChartCurrentPrice !== undefined
+      ? advancedChartCurrentPrice
+      : chartCurrentPrice;
+
+  useEffect(() => {
+    setAdvancedChartCurrentPrice(undefined);
+  }, [isAdvancedChartEnabled, symbol, interval]);
+
+  return {
+    candleData,
+    isLoading,
+    hasHistoricalData,
+    fetchMoreHistory,
+    syncedChartCurrentPrice,
+    setAdvancedChartCurrentPrice,
+  };
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

On the Perps market detail screen, the compact header price (shown after scrolling) came from the live mid stream, while the summary and chart current-price line used the last candle close (or the Advanced Chart latest bar). Those values drifted, so the header and chart did not match.

This PR uses one parent-owned display price for both Lite and Pro. Shared hook `usePerpsSyncedChartPrice` merges last candle close with the Advanced Chart latest-bar close (same merge Lite already used). Lite and Pro both pass that `syncedChartCurrentPrice` into the header and the chart summary. Pro still clears the Advanced Chart price when the inline chart is collapsed, because that chart unmounts in Pro.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Perps market detail header price not matching the live chart price

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
Refs: TAT-3708

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps market detail header and chart price sync

  Background:
    Given I am logged into MetaMask Mobile
    And Perps is available for my account
    And I open a market detail screen

  Scenario: header compact price matches the chart summary in Pro mode
    Given Pro mode is enabled
    And I am on a Perps market detail screen with a live chart

    When the chart summary shows a live price
    Then that price matches the chart current-price line
    When I scroll until the compact header price appears
    Then the compact header price matches the chart summary price

  Scenario: header compact price matches the chart summary in Lite mode
    Given Pro mode is disabled
    And I am on a Perps market detail screen with a live chart

    When the chart summary shows a live price
    Then that price matches the chart current-price line
    When I scroll until the compact header price appears
    Then the compact header price matches the chart summary price

  Scenario: Pro collapsed chart still keeps header and summary aligned
    Given Pro mode is enabled
    And I am on a Perps market detail screen
    And the inline chart is collapsed

    When the market summary shows a live price
    And I scroll until the compact header price appears
    Then the compact header price matches the market summary price
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


### **After**

https://github.com/user-attachments/assets/de48cf7c-a75c-46a0-bdbe-dc77deb3fcfe


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only price display alignment with no auth, trading, or payment changes; existing live streams remain for other flows (e.g. stop-loss).
> 
> **Overview**
> Fixes Perps market detail screens where the **compact header** showed the live mid stream while the **summary and chart** used candle/Advanced Chart prices, so they could drift apart.
> 
> Introduces **`usePerpsSyncedChartPrice`** as the shared parent-owned display price: last candle close by default, overridden by the Advanced Chart latest-bar close when enabled and reporting. **Lite** (`PerpsMarketDetailsView`) refactors inline merge logic into this hook and passes **`syncedChartCurrentPrice`** into **`PerpsMarketHeader`**. **Pro** adopts the same hook at the view level and threads **`currentPrice`** / **`onLatestPriceChange`** through **`PerpsProChartPanel`** instead of local merge state.
> 
> **`PerpsMarketHeader`** gains an optional **`currentPrice`** prop so the scrolled compact price matches the chart summary; when omitted it still falls back to **`usePerpsLivePrices`**. Pro still clears the Advanced Chart override when the inline chart **collapses** (chart unmounts). Unit tests cover the hook, header override behavior, and Pro chart wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8edb846b1a11adae54fd841d164ed248a2c379dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->