### PR TITLE
feat(bridge): allow overriding the asset picker's allowed chains

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx
@@ -236,6 +236,97 @@ describeForPlatforms('BridgeView', () => {
       expect(store.getState().bridge.isDestTokenManuallySet).toBe(false);
     });
 
+    it('re-anchors the destination to the source token chain when returning to the market tab without a route source token', async () => {
+      // Same as above, but Market has no source token on its route params, so it
+      // keeps the source the Limit tab left in Redux. The destination has to
+      // follow that source's chain rather than the bip44 default pair, whose
+      // dest asset always sits on Ethereum.
+      const bscUsdt: BridgeToken = {
+        address: '0x55d398326f99059ff775485246999027b3197955',
+        chainId: '0x38',
+        decimals: 18,
+        symbol: 'USDT',
+        name: 'Tether USD',
+      };
+      const bscNative: BridgeToken = {
+        address: '0x0000000000000000000000000000000000000000',
+        chainId: '0x38',
+        decimals: 18,
+        symbol: 'BNB',
+        name: 'BNB',
+      };
+      const state = initialStateBridge({ deterministicFiat: true })
+        .withOverrides({
+          bridge: { ...DEFAULT_BRIDGE },
+          engine: {
+            backgroundState: {
+              RemoteFeatureFlagController: {
+                remoteFeatureFlags: {
+                  // The bip44 default pair is what a source token left on
+                  // another chain could wrongly get paired with.
+                  bridgeConfigV2: {
+                    minimumVersion: '0.0.0',
+                    maxRefreshCount: 5,
+                    refreshRate: 30000,
+                    support: true,
+                    chains: {
+                      'eip155:1': { isActiveSrc: true, isActiveDest: true },
+                      'eip155:56': { isActiveSrc: true, isActiveDest: true },
+                    },
+                    bip44DefaultPairs: {
+                      eip155: {
+                        other: {},
+                        standard: {
+                          'eip155:1/slip44:60':
+                            'eip155:1/erc20:0xaca92e438df0b2401ff60da7e4337b687a2435da',
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        } as unknown as DeepPartial<RootState>)
+        .build();
+
+      const { getByTestId, store } = renderComponentViewScreen(
+        BridgeView as unknown as React.ComponentType,
+        { name: Routes.BRIDGE.BRIDGE_VIEW },
+        { state },
+        {
+          sourcePage: 'test',
+          bridgeViewMode: BridgeViewMode.Unified,
+        },
+      );
+
+      fireEvent.press(getByTestId(BridgeViewSelectorsIDs.LIMIT_TAB));
+      await waitFor(() => {
+        expect(
+          getByTestId(BridgeViewSelectorsIDs.LIMIT_ORDER_CONTAINER),
+        ).toBeOnTheScreen();
+      });
+
+      act(() => {
+        store.dispatch(setSourceToken(bscNative));
+        store.dispatch(setDestToken(bscUsdt));
+      });
+
+      fireEvent.press(getByTestId(BridgeViewSelectorsIDs.MARKET_TAB));
+
+      await waitFor(() => {
+        expect(
+          getByTestId(BridgeViewSelectorsIDs.SOURCE_TOKEN_AREA),
+        ).toBeOnTheScreen();
+      });
+      await waitFor(() => {
+        expect(store.getState().bridge.destToken).toEqual(
+          expect.objectContaining({ symbol: 'USDT', chainId: '0x38' }),
+        );
+      });
+      expect(store.getState().bridge.sourceToken?.chainId).toBe('0x38');
+    });
+
     it('clears the amount inputs and stops controller polling after switching away from the market tab, keeping the selected tokens', async () => {
       const { getByTestId, store } = defaultBridgeWithTokens();
 

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx
@@ -17,9 +17,12 @@ import { BridgeViewSelectorsIDs } from './BridgeView.testIds';
 import { BuildQuoteSelectors } from '../../../Ramp/Aggregator/Views/BuildQuote/BuildQuote.testIds';
 import { CommonSelectorsIDs } from '../../../../../util/Common.testIds';
 import {
+  setDestToken,
   setSlippage,
   setSourceAmount,
+  setSourceToken,
 } from '../../../../../core/redux/slices/bridge';
+import { BridgeViewMode, type BridgeToken } from '../../types';
 import { BridgeTokenSelector } from '../../components/BridgeTokenSelector/BridgeTokenSelector';
 import Engine from '../../../../../core/Engine';
 import type { DeepPartial } from '../../../../../util/test/renderWithProvider';
@@ -169,6 +172,68 @@ describeForPlatforms('BridgeView', () => {
       expect(
         queryByTestId(BridgeViewSelectorsIDs.LIMIT_ORDER_CONTAINER),
       ).not.toBeOnTheScreen();
+    });
+
+    it('re-anchors the destination to the source token default pair when returning to the market tab', async () => {
+      // The user picks a Robinhood-chain pair on the Limit tab and goes back to
+      // Market, which anchors its source token from the route params. The
+      // destination has to follow that source instead of being left behind on
+      // the Robinhood chain, which would turn a swap into a cross-chain bridge.
+      const robinhoodChainId = '0x1237';
+      const robinhoodEth: BridgeToken = {
+        address: '0x0000000000000000000000000000000000000000',
+        chainId: robinhoodChainId,
+        decimals: 18,
+        symbol: 'ETH',
+        name: 'Ether',
+      };
+      const robinhoodUsde: BridgeToken = {
+        address: '0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34',
+        chainId: robinhoodChainId,
+        decimals: 18,
+        symbol: 'USDe',
+        name: 'Ethena USDe',
+      };
+      const state = initialStateBridge({ deterministicFiat: true })
+        .withOverrides({
+          bridge: { ...DEFAULT_BRIDGE },
+        } as unknown as DeepPartial<RootState>)
+        .build();
+
+      const { getByTestId, store } = renderComponentViewScreen(
+        BridgeView as unknown as React.ComponentType,
+        { name: Routes.BRIDGE.BRIDGE_VIEW },
+        { state },
+        {
+          sourcePage: 'test',
+          bridgeViewMode: BridgeViewMode.Unified,
+          sourceToken: ETH_SOURCE,
+        },
+      );
+
+      fireEvent.press(getByTestId(BridgeViewSelectorsIDs.LIMIT_TAB));
+      await waitFor(() => {
+        expect(
+          getByTestId(BridgeViewSelectorsIDs.LIMIT_ORDER_CONTAINER),
+        ).toBeOnTheScreen();
+      });
+
+      act(() => {
+        store.dispatch(setSourceToken(robinhoodEth));
+        store.dispatch(setDestToken(robinhoodUsde));
+      });
+
+      fireEvent.press(getByTestId(BridgeViewSelectorsIDs.MARKET_TAB));
+
+      await waitFor(() => {
+        expect(store.getState().bridge.sourceToken?.chainId).toBe('0x1');
+      });
+      await waitFor(() => {
+        expect(store.getState().bridge.destToken).toEqual(
+          expect.objectContaining({ symbol: 'mUSD', chainId: '0x1' }),
+        );
+      });
+      expect(store.getState().bridge.isDestTokenManuallySet).toBe(false);
     });
 
     it('clears the amount inputs and stops controller polling after switching away from the market tab, keeping the selected tokens', async () => {

--- a/app/components/UI/Bridge/Views/BridgeView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/index.tsx
@@ -21,6 +21,7 @@ import Routes from '../../../../../constants/navigation/Routes';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import Engine from '../../../../../core/Engine';
 import {
+  resetBridgeDestToken,
   resetBridgeState,
   resetBridgeTokenInputs,
   selectBridgeViewMode,
@@ -161,20 +162,25 @@ const BridgeView = () => {
     }
   }, [tabs, renderedTab]);
 
-  // Stops any in-flight BridgeController quote polling and clears the
-  // amount inputs (not the selected tokens) for the tab being left,
-  // whenever the rendered tab changes. This intentionally runs as the
-  // effect's cleanup rather than eagerly inside handleTabPress: cleanups
-  // fire after React commits the tab switch (deferred via startTransition
-  // above), so the outgoing tab is already gone by the time this runs
-  // instead of visibly flashing back to a reset state right before it's
-  // replaced.
+  // Stops any in-flight BridgeController quote polling, clears the amount
+  // inputs and drops the destination token for the tab being left, whenever
+  // the rendered tab changes. The destination goes because each tab anchors
+  // its own source token as it mounts (Market from its route params, Limit to
+  // the default pair of its restricted chains), so a destination kept from the
+  // previous tab would be left on an unrelated chain; clearing it lets the
+  // incoming tab derive the destination from its own source token's default
+  // pair. This intentionally runs as the effect's cleanup rather than eagerly
+  // inside handleTabPress: cleanups fire after React commits the tab switch
+  // (deferred via startTransition above), so the outgoing tab is already gone
+  // by the time this runs instead of visibly flashing back to a reset state
+  // right before it's replaced.
   useEffect(
     () => () => {
       if (Engine.context.BridgeController?.resetState) {
         Engine.context.BridgeController.resetState();
       }
       dispatch(resetBridgeTokenInputs());
+      dispatch(resetBridgeDestToken());
     },
     [renderedTab, dispatch],
   );

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -14,6 +14,8 @@ import {
   setIsSelectingToken,
   setSourceAmount,
   setTokenSelectorNetworkFilter,
+  setSourceToken,
+  setDestToken,
   selectAllowedChainRanking,
 } from '../../../../../core/redux/slices/bridge';
 import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
@@ -44,6 +46,15 @@ const defaultMockBridgeState: MockBridgeState = {
   tokenSelectorNetworkFilter: undefined,
   visiblePillChainIds: undefined,
 };
+
+interface MockBridgeAction {
+  type: string;
+  payload?:
+    | CaipChainId
+    | CaipChainId[]
+    | ReturnType<typeof createMockToken>
+    | undefined;
+}
 
 // Create a Redux store with all the state needed by the component
 const createMockStore = (bridgeStateOverrides: Partial<MockBridgeState> = {}) =>
@@ -78,7 +89,7 @@ const createMockStore = (bridgeStateOverrides: Partial<MockBridgeState> = {}) =>
       }),
       bridge: (
         state: MockBridgeState | undefined,
-        action: { type: string; payload?: CaipChainId | CaipChainId[] },
+        action: MockBridgeAction,
       ) => {
         const resolvedState = state ?? {
           ...defaultMockBridgeState,
@@ -97,6 +108,22 @@ const createMockStore = (bridgeStateOverrides: Partial<MockBridgeState> = {}) =>
           return {
             ...resolvedState,
             visiblePillChainIds: action.payload as CaipChainId[] | undefined,
+          };
+        }
+        if (action.type === 'bridge/setSourceToken') {
+          return {
+            ...resolvedState,
+            sourceToken: action.payload as ReturnType<
+              typeof createMockToken
+            > | null,
+          };
+        }
+        if (action.type === 'bridge/setDestToken') {
+          return {
+            ...resolvedState,
+            destToken: action.payload as ReturnType<
+              typeof createMockToken
+            > | null,
           };
         }
         return resolvedState;
@@ -153,7 +180,7 @@ jest.mock('../../../../../hooks', () => ({
 // Use a getter to access mockBridgeFeatureFlags at runtime (after variable is defined)
 // This is needed because jest.mock is hoisted before variable declarations
 jest.mock('../../../../../core/redux/slices/bridge', () => {
-  const emptyChainRanking: CaipChainId[] = [];
+  const emptyChainRanking: { chainId: CaipChainId; name: string }[] = [];
   return {
     selectBridgeFeatureFlags: jest.fn(
       (state: {
@@ -172,7 +199,9 @@ jest.mock('../../../../../core/redux/slices/bridge', () => {
           backgroundState: {
             BridgeController: {
               bridgeState: {
-                bridgeFeatureFlags?: { chainRanking?: CaipChainId[] };
+                bridgeFeatureFlags?: {
+                  chainRanking?: { chainId: CaipChainId; name: string }[];
+                };
               };
             };
           };
@@ -199,6 +228,14 @@ jest.mock('../../../../../core/redux/slices/bridge', () => {
     setVisiblePillChainIds: jest.fn((chainIds) => ({
       type: 'bridge/setVisiblePillChainIds',
       payload: chainIds,
+    })),
+    setSourceToken: jest.fn((token) => ({
+      type: 'bridge/setSourceToken',
+      payload: token,
+    })),
+    setDestToken: jest.fn((token) => ({
+      type: 'bridge/setDestToken',
+      payload: token,
     })),
   };
 });
@@ -1004,6 +1041,33 @@ describe('BridgeTokenSelector', () => {
       });
     });
 
+    // Restores the default (unfiltered-by-enabledChainIds) mock
+    // implementation for subsequent tests.
+    const restoreDefaultAllowedChainRankingMock = () => {
+      // The state shape here mirrors this file's local jest.mock stub for
+      // the bridge slice (see top of file), not the real RootState, since
+      // this module is fully mocked. Cast past the real selector's type to
+      // keep jest.mocked() happy about the mockImplementation's signature.
+      jest.mocked(selectAllowedChainRanking).mockImplementation(
+        ((state: {
+          engine: {
+            backgroundState: {
+              BridgeController: {
+                bridgeState: {
+                  bridgeFeatureFlags?: {
+                    chainRanking?: { chainId: CaipChainId; name: string }[];
+                  };
+                };
+              };
+            };
+          };
+        }) =>
+          state.engine.backgroundState.BridgeController.bridgeState
+            .bridgeFeatureFlags?.chainRanking ??
+          []) as unknown as typeof selectAllowedChainRanking,
+      );
+    };
+
     it('falls back to all enabled chains when the initial dest filter chain is outside enabledChainIds', async () => {
       // Selected dest token lives on Polygon, but this picker (e.g. Limit
       // Order) is scoped to Ethereum only, so Polygon is excluded from the
@@ -1031,23 +1095,94 @@ describe('BridgeTokenSelector', () => {
           MOCK_CHAIN_IDS.polygon,
         ]);
       } finally {
-        // Restore the default (unfiltered-by-enabledChainIds) mock
-        // implementation for subsequent tests.
-        jest.mocked(selectAllowedChainRanking).mockImplementation(
-          (state: {
-            engine: {
-              backgroundState: {
-                BridgeController: {
-                  bridgeState: {
-                    bridgeFeatureFlags?: { chainRanking?: CaipChainId[] };
-                  };
-                };
-              };
-            };
-          }) =>
-            state.engine.backgroundState.BridgeController.bridgeState
-              .bridgeFeatureFlags?.chainRanking ?? [],
+        restoreDefaultAllowedChainRankingMock();
+      }
+    });
+
+    it('clears a stale Redux network filter and re-anchors source/dest to ETH/mUSD when Ethereum is enabled', async () => {
+      // Redux still holds a filter set by a previous (unrestricted) picker
+      // instance, but this picker (e.g. Limit Order) is scoped to Ethereum
+      // only, so Polygon is excluded from the allowed chainRanking. Leaving
+      // the stale filter in place would fetch all enabled chains while no
+      // pill (and no "All networks" option) appears selected, and the
+      // underlying source/dest pair would still reference an unsupported
+      // chain for this picker.
+      const enabledChainIds = [MOCK_CHAIN_IDS.ethereum];
+      mockRouteParams = { type: 'source', enabledChainIds };
+
+      const restrictedRanking = [
+        { chainId: MOCK_CHAIN_IDS.ethereum, name: 'Ethereum' },
+      ];
+      jest
+        .mocked(selectAllowedChainRanking)
+        .mockImplementation(() => restrictedRanking);
+
+      const store = createMockStore({
+        tokenSelectorNetworkFilter: MOCK_CHAIN_IDS.polygon,
+      });
+
+      try {
+        renderWithReduxProvider(<BridgeTokenSelector />, store);
+
+        await waitFor(() => {
+          expect(
+            store.getState().bridge.tokenSelectorNetworkFilter,
+          ).toBeUndefined();
+        });
+
+        expect(setSourceToken).toHaveBeenCalledWith(
+          expect.objectContaining({ chainId: '0x1', symbol: 'ETH' }),
         );
+        expect(setDestToken).toHaveBeenCalledWith(
+          expect.objectContaining({ chainId: '0x1', symbol: 'mUSD' }),
+        );
+        // Source and dest must share the same chainId format (hex for EVM).
+        const [dispatchedSourceToken] =
+          jest.mocked(setSourceToken).mock.calls[0];
+        const [dispatchedDestToken] = jest.mocked(setDestToken).mock.calls[0];
+        expect(dispatchedSourceToken?.chainId).toBe(
+          dispatchedDestToken?.chainId,
+        );
+      } finally {
+        restoreDefaultAllowedChainRankingMock();
+      }
+    });
+
+    it('re-anchors source/dest to the first enabled chain default pair when Ethereum is not enabled', async () => {
+      // Picker is scoped to Polygon only (e.g. a Polygon-only flow), so
+      // Ethereum isn't an option — the fallback pair should come from the
+      // top-ranked enabled chain instead.
+      const enabledChainIds = [MOCK_CHAIN_IDS.polygon];
+      mockRouteParams = { type: 'source', enabledChainIds };
+
+      const restrictedRanking = [
+        { chainId: MOCK_CHAIN_IDS.polygon, name: 'Polygon' },
+      ];
+      jest
+        .mocked(selectAllowedChainRanking)
+        .mockImplementation(() => restrictedRanking);
+
+      const store = createMockStore({
+        tokenSelectorNetworkFilter: MOCK_CHAIN_IDS.ethereum,
+      });
+
+      try {
+        renderWithReduxProvider(<BridgeTokenSelector />, store);
+
+        await waitFor(() => {
+          expect(
+            store.getState().bridge.tokenSelectorNetworkFilter,
+          ).toBeUndefined();
+        });
+
+        expect(setSourceToken).toHaveBeenCalledWith(
+          expect.objectContaining({ chainId: '0x89' }),
+        );
+        expect(setSourceToken).not.toHaveBeenCalledWith(
+          expect.objectContaining({ symbol: 'ETH' }),
+        );
+      } finally {
+        restoreDefaultAllowedChainRankingMock();
       }
     });
   });

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -1003,6 +1003,53 @@ describe('BridgeTokenSelector', () => {
         ]);
       });
     });
+
+    it('falls back to all enabled chains when the initial dest filter chain is outside enabledChainIds', async () => {
+      // Selected dest token lives on Polygon, but this picker (e.g. Limit
+      // Order) is scoped to Ethereum only, so Polygon is excluded from the
+      // allowed chainRanking returned to pills/network modal.
+      const enabledChainIds = [MOCK_CHAIN_IDS.ethereum];
+      mockRouteParams = { type: 'dest', enabledChainIds };
+      mockSelectedToken = createMockToken({ chainId: '0x89' });
+
+      const restrictedRanking = [
+        { chainId: MOCK_CHAIN_IDS.ethereum, name: 'Ethereum' },
+      ];
+      jest
+        .mocked(selectAllowedChainRanking)
+        .mockImplementation(() => restrictedRanking);
+
+      renderWithReduxProvider(<BridgeTokenSelector />);
+
+      try {
+        await waitFor(() => {
+          expect(mockUseInitialBridgeTokens).toHaveBeenCalledWith([
+            MOCK_CHAIN_IDS.ethereum,
+          ]);
+        });
+        expect(mockUseInitialBridgeTokens).not.toHaveBeenCalledWith([
+          MOCK_CHAIN_IDS.polygon,
+        ]);
+      } finally {
+        // Restore the default (unfiltered-by-enabledChainIds) mock
+        // implementation for subsequent tests.
+        jest.mocked(selectAllowedChainRanking).mockImplementation(
+          (state: {
+            engine: {
+              backgroundState: {
+                BridgeController: {
+                  bridgeState: {
+                    bridgeFeatureFlags?: { chainRanking?: CaipChainId[] };
+                  };
+                };
+              };
+            };
+          }) =>
+            state.engine.backgroundState.BridgeController.bridgeState
+              .bridgeFeatureFlags?.chainRanking ?? [],
+        );
+      }
+    });
   });
 
   describe('token selection', () => {

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -14,6 +14,7 @@ import {
   setIsSelectingToken,
   setSourceAmount,
   setTokenSelectorNetworkFilter,
+  selectAllowedChainRanking,
 } from '../../../../../core/redux/slices/bridge';
 import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
 import Routes from '../../../../../constants/navigation/Routes';
@@ -113,7 +114,10 @@ const mockSetOptions = jest.fn();
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 const mockNavigationDispatch = jest.fn();
-let mockRouteParams: { type: 'source' | 'dest' } = { type: 'source' };
+let mockRouteParams: {
+  type: 'source' | 'dest';
+  enabledChainIds?: CaipChainId[];
+} = { type: 'source' };
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -484,11 +488,13 @@ jest.mock('./NetworkPills', () => ({
     onMorePress,
     onWatchlistFilterPress,
     showWatchlistFilter,
+    enabledChainIds,
   }: {
     onChainSelect: (chainId?: CaipChainId) => void;
     onMorePress: () => void;
     onWatchlistFilterPress?: () => void;
     showWatchlistFilter?: boolean;
+    enabledChainIds?: CaipChainId[];
   }) => {
     const { createElement } = jest.requireActual('react');
     const { View, TouchableOpacity, Text } = jest.requireActual('react-native');
@@ -528,6 +534,11 @@ jest.mock('./NetworkPills', () => ({
         Text,
         { testID: 'visible-pill-chain-ids' },
         JSON.stringify(visiblePillChainIds ?? []),
+      ),
+      createElement(
+        Text,
+        { testID: 'network-pills-enabled-chain-ids' },
+        JSON.stringify(enabledChainIds ?? null),
       ),
     );
   },
@@ -1295,6 +1306,29 @@ describe('BridgeTokenSelector', () => {
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.MODALS.ROOT, {
         screen: Routes.BRIDGE.MODALS.NETWORK_LIST_MODAL,
+        params: { enabledChainIds: undefined },
+      });
+    });
+
+    it('passes enabledChainIds from route params to the selector, NetworkPills, and the network list modal navigation', () => {
+      const enabledChainIds = [MOCK_CHAIN_IDS.ethereum];
+      mockRouteParams = { type: 'source', enabledChainIds };
+
+      const { getByTestId } = renderWithReduxProvider(<BridgeTokenSelector />);
+
+      expect(selectAllowedChainRanking).toHaveBeenCalledWith(
+        expect.anything(),
+        enabledChainIds,
+      );
+      expect(
+        getByTestId('network-pills-enabled-chain-ids').props.children,
+      ).toBe(JSON.stringify(enabledChainIds));
+
+      fireEvent.press(getByTestId('open-network-modal'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.MODALS.ROOT, {
+        screen: Routes.BRIDGE.MODALS.NETWORK_LIST_MODAL,
+        params: { enabledChainIds },
       });
     });
 

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -19,6 +19,7 @@ import {
   StackActions,
 } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
+import type { RootState } from '../../../../../reducers';
 import { useSelector, useDispatch } from 'react-redux';
 import { strings } from '../../../../../../locales/i18n';
 import {
@@ -100,6 +101,11 @@ import {
 
 export interface BridgeTokenSelectorRouteParams {
   type: TokenSelectorType;
+  /**
+   * When provided, restricts the network list to these chains instead
+   * of the default allowed chainRanking.
+   */
+  enabledChainIds?: CaipChainId[];
 }
 
 const MIN_SEARCH_LENGTH = 3;
@@ -230,7 +236,10 @@ export const BridgeTokenSelector: React.FC = () => {
     [searchString],
   );
 
-  const enabledChainRanking = useSelector(selectAllowedChainRanking);
+  const enabledChainIds = route.params?.enabledChainIds;
+  const enabledChainRanking = useSelector((state: RootState) =>
+    selectAllowedChainRanking(state, enabledChainIds),
+  );
   const bridgeFeatureFlags = useSelector(selectBridgeFeatureFlags);
   const isRWAEnabled = useSelector(selectRWAEnabledFlag);
   const { variant: balanceLayoutConfig } = useABTest(
@@ -922,9 +931,11 @@ export const BridgeTokenSelector: React.FC = () => {
           showWatchlistFilter={isWatchlistEnabled}
           isWatchlistFilterActive={isWatchlistFilterActive}
           onWatchlistFilterPress={handleWatchlistFilterPress}
+          enabledChainIds={enabledChainIds}
           onMorePress={() =>
             navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
               screen: Routes.BRIDGE.MODALS.NETWORK_LIST_MODAL,
+              params: { enabledChainIds },
             })
           }
         />

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -36,7 +36,9 @@ import {
   selectAllowedChainRanking,
   selectBridgeFeatureFlags,
   selectTokenSelectorNetworkFilter,
+  setDestToken,
   setIsSelectingToken,
+  setSourceToken,
   setTokenSelectorNetworkFilter,
 } from '../../../../../core/redux/slices/bridge';
 import {
@@ -68,6 +70,7 @@ import { usePopularTokens } from '../../hooks/usePopularTokens';
 import { useSearchTokens } from '../../hooks/useSearchTokens';
 import { useTokensWithBalances } from '../../hooks/useTokensWithBalances';
 import { useTokenSelection } from '../../hooks/useTokenSelection';
+import { getDefaultTokenPairForChains } from '../../utils/tokenUtils';
 import { createStyles } from './BridgeTokenSelector.styles';
 import Engine from '../../../../../core/Engine';
 import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
@@ -354,23 +357,65 @@ export const BridgeTokenSelector: React.FC = () => {
     });
   }, [dispatch, selectedChainId]);
 
+  // A selectedChainId can come from sources (initialFilter, stale Redux
+  // filter) that predate/ignore this picker's enabledChainIds override, so
+  // it must be validated against enabledChainRanking before being trusted.
+  const isSelectedChainInEnabledRanking = useMemo(
+    () =>
+      Boolean(selectedChainId) &&
+      enabledChainRanking.some(
+        (chain: { chainId: CaipChainId }) => chain.chainId === selectedChainId,
+      ),
+    [selectedChainId, enabledChainRanking],
+  );
+
+  // If the current filter falls outside this picker's allowed chain set,
+  // clear it in Redux so pills, the network modal, and the fetched token
+  // list all agree on "All networks" instead of silently diverging (token
+  // list matching an all-chains fetch while no pill appears selected).
+  // The stale selection also means the actual source/dest pair is no longer
+  // valid for this picker's chain scope (e.g. a Limit Order flow scoped to
+  // Ethereum with a dest token left over from a broader Polygon session), so
+  // re-anchor both tokens to a sane default pair on the fallback chain.
+  useEffect(() => {
+    if (
+      !selectedChainId ||
+      enabledChainRanking.length === 0 ||
+      isSelectedChainInEnabledRanking
+    ) {
+      return;
+    }
+
+    dispatch(setTokenSelectorNetworkFilter(undefined));
+
+    const defaultPair = getDefaultTokenPairForChains(
+      enabledChainRanking.map(
+        (chain: { chainId: CaipChainId }) => chain.chainId,
+      ),
+    );
+    if (!defaultPair) {
+      return;
+    }
+
+    dispatch(setSourceToken(defaultPair.sourceToken));
+    if (defaultPair.destToken) {
+      dispatch(setDestToken(defaultPair.destToken));
+    }
+  }, [
+    selectedChainId,
+    enabledChainRanking,
+    isSelectedChainInEnabledRanking,
+    dispatch,
+  ]);
+
   const chainIdsToFetch = useMemo(() => {
     if (!enabledChainRanking || enabledChainRanking.length === 0) {
       return [];
     }
 
     // If a specific chain is selected and it's part of the allowed chain
-    // set, use only that chain. A selectedChainId can come from sources
-    // (initialFilter, stale Redux filter) that predate/ignore this
-    // picker's enabledChainIds override, so it must be validated against
-    // enabledChainRanking before being trusted, otherwise the fetched
-    // list could include a chain the pills/network modal don't show.
-    if (
-      selectedChainId &&
-      enabledChainRanking.some(
-        (chain: { chainId: CaipChainId }) => chain.chainId === selectedChainId,
-      )
-    ) {
+    // set, use only that chain.
+    if (selectedChainId && isSelectedChainInEnabledRanking) {
       return [selectedChainId];
     }
 
@@ -379,7 +424,7 @@ export const BridgeTokenSelector: React.FC = () => {
     return enabledChainRanking.map(
       (chain: { chainId: CaipChainId }) => chain.chainId,
     );
-  }, [selectedChainId, enabledChainRanking]);
+  }, [selectedChainId, enabledChainRanking, isSelectedChainInEnabledRanking]);
 
   const {
     includeAssets,

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -359,12 +359,23 @@ export const BridgeTokenSelector: React.FC = () => {
       return [];
     }
 
-    // If a specific chain is selected, use only that chain
-    if (selectedChainId) {
+    // If a specific chain is selected and it's part of the allowed chain
+    // set, use only that chain. A selectedChainId can come from sources
+    // (initialFilter, stale Redux filter) that predate/ignore this
+    // picker's enabledChainIds override, so it must be validated against
+    // enabledChainRanking before being trusted, otherwise the fetched
+    // list could include a chain the pills/network modal don't show.
+    if (
+      selectedChainId &&
+      enabledChainRanking.some(
+        (chain: { chainId: CaipChainId }) => chain.chainId === selectedChainId,
+      )
+    ) {
       return [selectedChainId];
     }
 
-    // If "All" is selected, use all chains from filtered chainRanking
+    // If "All" is selected, or the selected chain isn't part of the
+    // allowed chain set, use all chains from filtered chainRanking.
     return enabledChainRanking.map(
       (chain: { chainId: CaipChainId }) => chain.chainId,
     );

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkListModal.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkListModal.test.tsx
@@ -11,10 +11,16 @@ import { useABTest } from '../../../../../hooks';
 import { useChainValueOrder } from '../../hooks/useChainValueOrder';
 
 const mockOnCloseBottomSheet = jest.fn();
+let mockRouteParams: { enabledChainIds?: CaipChainId[] } = {};
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
   useDispatch: jest.fn(),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useRoute: () => ({ params: mockRouteParams }),
 }));
 
 jest.mock('../../../../../hooks', () => ({
@@ -118,6 +124,7 @@ jest.mock('../../../../../component-library/components/Cells/Cell', () => {
 describe('NetworkListModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRouteParams = {};
     (useDispatch as jest.Mock).mockReturnValue(mockDispatch);
     jest.mocked(useABTest).mockReturnValue({
       variant: { orderByValue: false },
@@ -125,16 +132,15 @@ describe('NetworkListModal', () => {
       isActive: true,
     });
     jest.mocked(useChainValueOrder).mockReturnValue(mockChainRanking);
-
-    mockUseSelector.mockImplementation((selector: unknown) => {
-      if (selector === selectAllowedChainRanking) {
-        return mockChainRanking;
-      }
-      if (selector === selectTokenSelectorNetworkFilter) {
-        return undefined;
-      }
-      return undefined;
-    });
+    jest.mocked(selectAllowedChainRanking).mockReturnValue(mockChainRanking);
+    jest.mocked(selectTokenSelectorNetworkFilter).mockReturnValue(undefined);
+    // NetworkListModal calls useSelector(selectTokenSelectorNetworkFilter)
+    // directly, and wraps selectAllowedChainRanking in an inline lambda (to
+    // forward the optional enabledChainIds route param) — invoke whatever
+    // selector is passed so both routes resolve through the mocks above.
+    mockUseSelector.mockImplementation(
+      (selector: (state: unknown) => unknown) => selector({}),
+    );
   });
 
   describe('rendering', () => {
@@ -185,6 +191,29 @@ describe('NetworkListModal', () => {
         'network-option-eip155:137',
         'network-option-eip155:1',
       ]);
+    });
+  });
+
+  describe('enabledChainIds route param', () => {
+    it('forwards enabledChainIds from route params to selectAllowedChainRanking', () => {
+      const enabledChainIds: CaipChainId[] = ['eip155:1', 'eip155:56'];
+      mockRouteParams = { enabledChainIds };
+
+      render(<NetworkListModal />);
+
+      expect(selectAllowedChainRanking).toHaveBeenCalledWith(
+        expect.anything(),
+        enabledChainIds,
+      );
+    });
+
+    it('calls selectAllowedChainRanking with undefined when no route params are provided', () => {
+      render(<NetworkListModal />);
+
+      expect(selectAllowedChainRanking).toHaveBeenCalledWith(
+        expect.anything(),
+        undefined,
+      );
     });
   });
 

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkListModal.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkListModal.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useRef } from 'react';
 import { ScrollView } from 'react-native-gesture-handler'; // Must use this to make sure scroll works inside a bottom sheet on Android
 import { useSelector, useDispatch } from 'react-redux';
+import { useRoute, RouteProp } from '@react-navigation/native';
 import { Icon, IconName, IconSize } from '@metamask/design-system-react-native';
 import { IconName as ComponentLibraryIconName } from '../../../../../component-library/components/Icons/Icon';
 import { strings } from '../../../../../../locales/i18n';
@@ -15,6 +16,7 @@ import { AvatarVariant } from '../../../../../component-library/components/Avata
 import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar/Avatar.types';
 import { CaipChainId } from '@metamask/utils';
 import { getNetworkImageSource } from '../../../../../util/networks';
+import type { RootState } from '../../../../../reducers';
 import {
   selectAllowedChainRanking,
   selectTokenSelectorNetworkFilter,
@@ -31,6 +33,14 @@ import {
 interface ChainRankingEntry {
   chainId: CaipChainId;
   name: string;
+}
+
+export interface NetworkListModalParams {
+  /**
+   * When provided, restricts the network list to these chains instead
+   * of the default allowed chainRanking.
+   */
+  enabledChainIds?: CaipChainId[];
 }
 
 interface NetworkListModalContentProps {
@@ -118,8 +128,11 @@ const NetworkValueOrderedListModal: React.FC<NetworkListModalContentProps> = ({
 };
 
 const NetworkListModal: React.FC = () => {
-  const chainRanking: ChainRankingEntry[] = useSelector(
-    selectAllowedChainRanking,
+  const route =
+    useRoute<RouteProp<{ params: NetworkListModalParams }, 'params'>>();
+  const enabledChainIds = route.params?.enabledChainIds;
+  const chainRanking: ChainRankingEntry[] = useSelector((state: RootState) =>
+    selectAllowedChainRanking(state, enabledChainIds),
   );
   const { variant } = useABTest(
     CHAIN_VALUE_ORDER_AB_KEY,

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
@@ -646,6 +646,29 @@ describe('NetworkPills', () => {
       expect(queryByTestId('network-pills-more-button')).toBeNull();
     });
 
+    it('does not promote a selectedChainId that is outside chainRanking into the session pin', () => {
+      // selectedChainId belongs to neither the default chainRanking nor any
+      // narrower scope here — e.g. a stale Redux filter or an initialFilter
+      // derived from a token whose chain isn't part of this picker's allowed
+      // chain set.
+      const { getByText, queryByText } = render(
+        <NetworkPills
+          selectedChainId={'eip155:8453' as CaipChainId}
+          onChainSelect={mockOnChainSelect}
+          onMorePress={mockOnMorePress}
+        />,
+      );
+
+      expect(mockDispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'bridge/setVisiblePillChainIds' }),
+      );
+      // No pill for the out-of-scope chain should render, and none of the
+      // rendered pills should be treated as selected.
+      expect(queryByText('Base')).not.toBeOnTheScreen();
+      // Visible pills still come from the default first-N chainRanking.
+      expect(getByText('Ethereum')).toBeOnTheScreen();
+    });
+
     it('mixes valid pinned ids with backfilled ranking entries in a narrower picker', () => {
       // Only one of the pinned ids exists in the narrower ranking.
       jest

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
@@ -610,6 +610,73 @@ describe('NetworkPills', () => {
         }),
       );
     });
+
+    it('backfills from chainRanking when a session pin has no ids in a narrower enabledChainIds picker', () => {
+      // Pinned during a normal (unrestricted) bridge session.
+      jest
+        .mocked(selectVisiblePillChainIds)
+        .mockReturnValue([
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          'bip122:000000000019d6689c085ae165831e93',
+          'eip155:10',
+          'eip155:42161',
+        ] as CaipChainId[]);
+
+      // Narrower picker (e.g. Limit Order) whose chainRanking doesn't
+      // contain any of the pinned ids.
+      const narrowRanking = [
+        { chainId: 'eip155:1' as CaipChainId, name: 'Ethereum' },
+        { chainId: 'eip155:56' as CaipChainId, name: 'BNB Chain' },
+        { chainId: 'eip155:8453' as CaipChainId, name: 'Base' },
+      ];
+      jest.mocked(selectAllowedChainRanking).mockReturnValue(narrowRanking);
+
+      const { getByText, queryByTestId } = render(
+        <NetworkPills
+          selectedChainId={undefined}
+          onChainSelect={mockOnChainSelect}
+          onMorePress={mockOnMorePress}
+          enabledChainIds={['eip155:1', 'eip155:56', 'eip155:8453']}
+        />,
+      );
+
+      expect(getByText('Ethereum')).toBeOnTheScreen();
+      expect(getByText('BNB Chain')).toBeOnTheScreen();
+      expect(getByText('Base')).toBeOnTheScreen();
+      expect(queryByTestId('network-pills-more-button')).toBeNull();
+    });
+
+    it('mixes valid pinned ids with backfilled ranking entries in a narrower picker', () => {
+      // Only one of the pinned ids exists in the narrower ranking.
+      jest
+        .mocked(selectVisiblePillChainIds)
+        .mockReturnValue([
+          'eip155:56',
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        ] as CaipChainId[]);
+
+      const narrowRanking = [
+        { chainId: 'eip155:1' as CaipChainId, name: 'Ethereum' },
+        { chainId: 'eip155:56' as CaipChainId, name: 'BNB Chain' },
+        { chainId: 'eip155:8453' as CaipChainId, name: 'Base' },
+      ];
+      jest.mocked(selectAllowedChainRanking).mockReturnValue(narrowRanking);
+
+      const { getByText } = render(
+        <NetworkPills
+          selectedChainId={undefined}
+          onChainSelect={mockOnChainSelect}
+          onMorePress={mockOnMorePress}
+          enabledChainIds={['eip155:1', 'eip155:56', 'eip155:8453']}
+        />,
+      );
+
+      // The valid pin (BNB Chain) is kept, and the remaining slots are
+      // backfilled from the narrower ranking instead of being dropped.
+      expect(getByText('BNB Chain')).toBeOnTheScreen();
+      expect(getByText('Ethereum')).toBeOnTheScreen();
+      expect(getByText('Base')).toBeOnTheScreen();
+    });
   });
 
   describe('watchlist filter', () => {

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.test.tsx
@@ -123,14 +123,49 @@ describe('NetworkPills', () => {
       isActive: true,
     });
     jest.mocked(useChainValueOrder).mockReturnValue(mockChainRanking);
-    mockUseSelector.mockImplementation((selector: unknown) => {
-      if (selector === selectAllowedChainRanking) {
-        return mockChainRanking;
-      }
-      if (selector === selectVisiblePillChainIds) {
-        return undefined; // default: use first N from chainRanking
-      }
-      return undefined;
+    jest.mocked(selectAllowedChainRanking).mockReturnValue(mockChainRanking);
+    jest.mocked(selectVisiblePillChainIds).mockReturnValue(undefined); // default: use first N from chainRanking
+    // NetworkPills calls useSelector(selectVisiblePillChainIds) directly, and
+    // wraps selectAllowedChainRanking in an inline lambda (to forward the
+    // optional enabledChainIds prop) — invoke whatever selector is passed so
+    // both routes resolve through the mocked selector functions above.
+    mockUseSelector.mockImplementation(
+      (selector: (state: unknown) => unknown) => selector({}),
+    );
+  });
+
+  describe('enabledChainIds', () => {
+    it('forwards the enabledChainIds prop to selectAllowedChainRanking', () => {
+      const enabledChainIds = ['eip155:1' as CaipChainId];
+
+      render(
+        <NetworkPills
+          selectedChainId={undefined}
+          onChainSelect={mockOnChainSelect}
+          onMorePress={mockOnMorePress}
+          enabledChainIds={enabledChainIds}
+        />,
+      );
+
+      expect(selectAllowedChainRanking).toHaveBeenCalledWith(
+        expect.anything(),
+        enabledChainIds,
+      );
+    });
+
+    it('calls selectAllowedChainRanking with undefined when enabledChainIds is not provided', () => {
+      render(
+        <NetworkPills
+          selectedChainId={undefined}
+          onChainSelect={mockOnChainSelect}
+          onMorePress={mockOnMorePress}
+        />,
+      );
+
+      expect(selectAllowedChainRanking).toHaveBeenCalledWith(
+        expect.anything(),
+        undefined,
+      );
     });
   });
 
@@ -198,10 +233,9 @@ describe('NetworkPills', () => {
     });
 
     it('does not render "+X more" when all networks are visible', () => {
-      mockUseSelector.mockImplementation((selector: unknown) => {
-        if (selector === selectVisiblePillChainIds) return undefined;
-        return mockSmallChainRanking;
-      });
+      jest
+        .mocked(selectAllowedChainRanking)
+        .mockReturnValue(mockSmallChainRanking);
 
       const { queryByTestId } = render(
         <NetworkPills
@@ -218,10 +252,9 @@ describe('NetworkPills', () => {
       const singleChainRanking = [
         { chainId: 'eip155:1' as CaipChainId, name: 'Ethereum' },
       ];
-      mockUseSelector.mockImplementation((selector: unknown) => {
-        if (selector === selectVisiblePillChainIds) return undefined;
-        return singleChainRanking;
-      });
+      jest
+        .mocked(selectAllowedChainRanking)
+        .mockReturnValue(singleChainRanking);
 
       const { getByText, queryByTestId } = render(
         <NetworkPills
@@ -243,10 +276,7 @@ describe('NetworkPills', () => {
         { chainId: 'eip155:1' as CaipChainId, name: 'Ethereum' },
         { chainId: 'eip155:56' as CaipChainId, name: 'BNB Chain' },
       ];
-      mockUseSelector.mockImplementation((selector: unknown) => {
-        if (selector === selectVisiblePillChainIds) return undefined;
-        return customRanking;
-      });
+      jest.mocked(selectAllowedChainRanking).mockReturnValue(customRanking);
 
       const { getByText, queryByText } = render(
         <NetworkPills
@@ -429,16 +459,6 @@ describe('NetworkPills', () => {
     });
 
     it('dispatches rolling order for consecutive non-visible selections', () => {
-      mockUseSelector.mockImplementation((selector: unknown) => {
-        if (selector === selectAllowedChainRanking) {
-          return mockChainRanking;
-        }
-        if (selector === selectVisiblePillChainIds) {
-          return undefined;
-        }
-        return undefined;
-      });
-
       const { rerender } = render(
         <NetworkPills
           selectedChainId={undefined}
@@ -465,15 +485,9 @@ describe('NetworkPills', () => {
         'bip122:000000000019d6689c085ae165831e93',
       ]);
 
-      mockUseSelector.mockImplementation((selector: unknown) => {
-        if (selector === selectAllowedChainRanking) {
-          return mockChainRanking;
-        }
-        if (selector === selectVisiblePillChainIds) {
-          return firstSelectionPayload;
-        }
-        return undefined;
-      });
+      jest
+        .mocked(selectVisiblePillChainIds)
+        .mockReturnValue(firstSelectionPayload);
       mockDispatch.mockClear();
 
       rerender(
@@ -561,15 +575,9 @@ describe('NetworkPills', () => {
         isActive: true,
       });
       jest.mocked(useChainValueOrder).mockReturnValue(treatmentRanking);
-      mockUseSelector.mockImplementation((selector: unknown) => {
-        if (selector === selectAllowedChainRanking) {
-          return mockChainRanking;
-        }
-        if (selector === selectVisiblePillChainIds) {
-          return pinnedVisibleChainIds;
-        }
-        return undefined;
-      });
+      jest
+        .mocked(selectVisiblePillChainIds)
+        .mockReturnValue(pinnedVisibleChainIds);
 
       const { rerender, getByText, queryByText } = render(
         <NetworkPills

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
@@ -96,9 +96,37 @@ const NetworkPillsContent: React.FC<NetworkPillsContentProps> = ({
   // Once set (out-of-list promotion), Redux is the session SSOT — holdings /
   // treatment ranking updates must not change membership. While unset, fall
   // back to the first N from the current chainRanking.
+  //
+  // The pin is a *global* session value, but a picker may be scoped to a
+  // narrower `enabledChainIds` (e.g. Limit Order chains) than whichever
+  // picker originally set the pin. Drop any pinned ids that aren't part of
+  // the current chainRanking, then backfill remaining slots from
+  // chainRanking so a narrower picker never ends up with zero network pills.
   const reduxVisibleChainIds = useSelector(selectVisiblePillChainIds);
-  const visibleChainIds =
-    reduxVisibleChainIds ?? getVisibleChainIds(chainRanking);
+  const visibleChainIds = useMemo(() => {
+    if (!reduxVisibleChainIds) {
+      return getVisibleChainIds(chainRanking);
+    }
+
+    const rankingChainIds = chainRanking.map((c) => c.chainId);
+    const rankingChainIdSet = new Set(rankingChainIds);
+    const validPinnedChainIds = reduxVisibleChainIds.filter((id) =>
+      rankingChainIdSet.has(id),
+    );
+
+    if (validPinnedChainIds.length >= MAX_VISIBLE_PILLS) {
+      return validPinnedChainIds;
+    }
+
+    const backfillChainIds = rankingChainIds.filter(
+      (id) => !validPinnedChainIds.includes(id),
+    );
+
+    return [...validPinnedChainIds, ...backfillChainIds].slice(
+      0,
+      MAX_VISIBLE_PILLS,
+    );
+  }, [reduxVisibleChainIds, chainRanking]);
 
   // Resolve visible chains to full entries from chainRanking
   const visibleChains = useMemo(

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
@@ -19,6 +19,7 @@ import Icon, {
 } from '../../../../../component-library/components/Icons/Icon';
 import { useTheme } from '../../../../../util/theme';
 import { strings } from '../../../../../../locales/i18n';
+import type { RootState } from '../../../../../reducers';
 import {
   selectAllowedChainRanking,
   selectVisiblePillChainIds,
@@ -53,6 +54,11 @@ interface NetworkPillsProps {
   isWatchlistFilterActive?: boolean;
   /** Called when the watchlist star filter is toggled. */
   onWatchlistFilterPress?: () => void;
+  /**
+   * When provided, restricts the network list to these chains instead
+   * of the default allowed chainRanking.
+   */
+  enabledChainIds?: CaipChainId[];
 }
 
 interface ChainRankingEntry {
@@ -245,9 +251,12 @@ const NetworkValueOrderedPills: React.FC<NetworkPillsContentProps> = ({
   return <NetworkPillsContent {...props} chainRanking={orderedChainRanking} />;
 };
 
-export const NetworkPills: React.FC<NetworkPillsProps> = (props) => {
-  const chainRanking: ChainRankingEntry[] = useSelector(
-    selectAllowedChainRanking,
+export const NetworkPills: React.FC<NetworkPillsProps> = ({
+  enabledChainIds,
+  ...props
+}) => {
+  const chainRanking: ChainRankingEntry[] = useSelector((state: RootState) =>
+    selectAllowedChainRanking(state, enabledChainIds),
   );
   const { variant } = useABTest(
     CHAIN_VALUE_ORDER_AB_KEY,

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx
@@ -153,6 +153,20 @@ const NetworkPillsContent: React.FC<NetworkPillsContentProps> = ({
       return;
     }
 
+    // A selectedChainId that isn't part of this picker's chainRanking (e.g.
+    // a stale Redux filter, or one derived from a token whose chain isn't
+    // part of a narrower `enabledChainIds` scope) must not be promoted into
+    // the shared session pin. Treat it like "no chain selected" for pill
+    // purposes instead of leaking an out-of-scope chain into Redux.
+    const isSelectedChainInRanking = chainRanking.some(
+      (chain) => chain.chainId === selectedChainId,
+    );
+
+    if (!isSelectedChainInRanking) {
+      scrollViewRef.current?.scrollTo({ x: 0, animated: true });
+      return;
+    }
+
     const existingIndex = visibleChainIds.indexOf(selectedChainId);
 
     if (existingIndex === -1) {

--- a/app/components/UI/Bridge/components/TokenInputArea/TokenInputArea.test.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/TokenInputArea.test.tsx
@@ -1,14 +1,35 @@
 import React, { createRef } from 'react';
+import { CaipChainId } from '@metamask/utils';
 import { initialState } from '../../_mocks_/initialState';
 import { act, fireEvent } from '@testing-library/react-native';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
 import { TokenInputArea, TokenInputAreaRef, TokenInputAreaType } from '.';
-import { BridgeToken } from '../../types';
+import { BridgeToken, TokenSelectorType } from '../../types';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { POLYGON_NATIVE_TOKEN } from '../../constants/assets';
+import Routes from '../../../../../constants/navigation/Routes';
 
 jest.mock('../../hooks/useLatestBalance', () => ({
   useLatestBalance: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+const mockTrackUnifiedSwapBridgeEvent = jest.fn();
+jest.mock('../../../../../core/Engine', () => ({
+  __esModule: true,
+  default: {
+    context: {
+      BridgeController: {
+        trackUnifiedSwapBridgeEvent: (...args: unknown[]) =>
+          mockTrackUnifiedSwapBridgeEvent(...args),
+      },
+    },
+  },
 }));
 
 // Mock Input to expose focus/blur/isFocused on its ref for imperative handle tests.
@@ -111,6 +132,73 @@ describe('TokenInputArea', () => {
     mockUseFormattedBalanceWithThreshold.mockReturnValue('100');
     mockUseDisplayCurrencyValue.mockReturnValue('$100.00');
     mockUseIsInsufficientBalance.mockReturnValue(false);
+  });
+
+  describe('empty state token selector navigation', () => {
+    it('navigates to the source token selector with enabledChainIds when the source "Select token" button is pressed', () => {
+      const enabledChainIds: CaipChainId[] = ['eip155:1', 'eip155:56'];
+      const { getByTestId } = renderScreen(
+        () => (
+          <TokenInputArea
+            testID="token-input"
+            tokenType={TokenInputAreaType.Source}
+            isSourceToken
+            enabledChainIds={enabledChainIds}
+          />
+        ),
+        { name: 'TokenInputArea' },
+        { state: initialState },
+      );
+
+      fireEvent.press(getByTestId('token-input'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.TOKEN_SELECTOR, {
+        type: TokenSelectorType.Source,
+        enabledChainIds,
+      });
+    });
+
+    it('navigates to the destination token selector with enabledChainIds when the dest "Select token" button is pressed', () => {
+      const enabledChainIds: CaipChainId[] = ['eip155:1', 'eip155:56'];
+      const { getByTestId } = renderScreen(
+        () => (
+          <TokenInputArea
+            testID="token-input"
+            tokenType={TokenInputAreaType.Destination}
+            enabledChainIds={enabledChainIds}
+          />
+        ),
+        { name: 'TokenInputArea' },
+        { state: initialState },
+      );
+
+      fireEvent.press(getByTestId('token-input'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.TOKEN_SELECTOR, {
+        type: TokenSelectorType.Dest,
+        enabledChainIds,
+      });
+    });
+
+    it('navigates with enabledChainIds undefined when the prop is not provided', () => {
+      const { getByTestId } = renderScreen(
+        () => (
+          <TokenInputArea
+            testID="token-input"
+            tokenType={TokenInputAreaType.Destination}
+          />
+        ),
+        { name: 'TokenInputArea' },
+        { state: initialState },
+      );
+
+      fireEvent.press(getByTestId('token-input'));
+
+      expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.TOKEN_SELECTOR, {
+        type: TokenSelectorType.Dest,
+        enabledChainIds: undefined,
+      });
+    });
   });
 
   it('renders with initial state', () => {

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -48,7 +48,11 @@ import {
 } from '../../../../../core/redux/slices/bridge';
 import { useBridgeExchangeRates } from '../../hooks/useBridgeExchangeRates';
 import useIsInsufficientBalance from '../../hooks/useInsufficientBalance';
-import { isCaipAssetType, parseCaipAssetType } from '@metamask/utils';
+import {
+  CaipChainId,
+  isCaipAssetType,
+  parseCaipAssetType,
+} from '@metamask/utils';
 import { renderShortAddress } from '../../../../../util/address';
 import { FlexDirection } from '../../../Box/box.types';
 import {
@@ -186,6 +190,11 @@ interface TokenInputAreaProps {
   onAmountTypeTogglePress?: () => void;
   amountTypeToggleTestID?: string;
   showFiatAmountAsPrimary?: boolean;
+  /**
+   * When provided, restricts the network list to these chains instead
+   * of the default allowed chainRanking.
+   */
+  enabledChainIds?: CaipChainId[];
 }
 
 export const TokenInputArea = forwardRef<
@@ -219,6 +228,7 @@ export const TokenInputArea = forwardRef<
       onAmountTypeTogglePress,
       amountTypeToggleTestID,
       showFiatAmountAsPrimary = false,
+      enabledChainIds,
     },
     ref,
   ) => {
@@ -278,6 +288,7 @@ export const TokenInputArea = forwardRef<
       trackAssetPickerOpened(TokenSelectorType.Dest);
       navigation.navigate(Routes.BRIDGE.TOKEN_SELECTOR, {
         type: TokenSelectorType.Dest,
+        enabledChainIds,
       });
     };
 
@@ -285,6 +296,7 @@ export const TokenInputArea = forwardRef<
       trackAssetPickerOpened(TokenSelectorType.Source);
       navigation.navigate(Routes.BRIDGE.TOKEN_SELECTOR, {
         type: TokenSelectorType.Source,
+        enabledChainIds,
       });
     };
 

--- a/app/components/UI/Bridge/hooks/useInitialDestToken/index.ts
+++ b/app/components/UI/Bridge/hooks/useInitialDestToken/index.ts
@@ -2,6 +2,7 @@ import {
   setDestToken,
   selectBridgeViewMode,
   selectDestToken,
+  selectSourceToken,
   selectBip44DefaultPair,
 } from '../../../../../core/redux/slices/bridge';
 import { useDispatch, useSelector } from 'react-redux';
@@ -25,6 +26,7 @@ export const useInitialDestToken = (
   const selectedChainId = useSelector(selectChainId);
   const bridgeViewMode = useSelector(selectBridgeViewMode);
   const destToken = useSelector(selectDestToken);
+  const sourceToken = useSelector(selectSourceToken);
   const bip44DefaultPair = useSelector(selectBip44DefaultPair);
 
   const isSwap =
@@ -60,20 +62,25 @@ export const useInitialDestToken = (
       }
     }
 
+    // The default dest belongs to the source token's network. Prefer the token
+    // coming in on the route (which useInitialSourceToken is about to apply)
+    // and fall back to the one already in Redux, e.g. when this view remounts
+    // after a sibling Bridge tab anchored the source to a different chain.
+    const effectiveSourceToken = initialSourceToken ?? sourceToken;
     const destTokenTargetChainId =
-      initialSourceToken?.chainId ?? selectedChainId;
+      effectiveSourceToken?.chainId ?? selectedChainId;
     let defaultDestToken = getDefaultDestToken(destTokenTargetChainId);
 
-    // If the initial source token is the same as the default dest token, set the default dest token to the native token
+    // If the source token is the same as the default dest token, set the default dest token to the native token
     if (
       destTokenTargetChainId === SolScope.Mainnet &&
-      initialSourceToken?.address === defaultDestToken?.address
+      effectiveSourceToken?.address === defaultDestToken?.address
     ) {
       // Solana addresses are case sensitive
       defaultDestToken = getNativeSourceToken(destTokenTargetChainId);
     } else if (
       destTokenTargetChainId !== SolScope.Mainnet &&
-      initialSourceToken?.address?.toLowerCase() ===
+      effectiveSourceToken?.address?.toLowerCase() ===
         defaultDestToken?.address?.toLowerCase()
     ) {
       // EVM addresses are NOT case sensitive
@@ -84,7 +91,7 @@ export const useInitialDestToken = (
       isSwap &&
       !destToken &&
       defaultDestToken &&
-      initialSourceToken?.address !== defaultDestToken.address
+      effectiveSourceToken?.address !== defaultDestToken.address
     ) {
       dispatch(setDestToken(defaultDestToken));
     }
@@ -93,10 +100,10 @@ export const useInitialDestToken = (
     prevInitialDestToken,
     dispatch,
     initialSourceToken,
+    sourceToken,
     selectedChainId,
     destToken,
     isSwap,
-    initialSourceToken?.address,
     bip44DefaultPair,
   ]);
 };

--- a/app/components/UI/Bridge/hooks/useInitialDestToken/index.ts
+++ b/app/components/UI/Bridge/hooks/useInitialDestToken/index.ts
@@ -46,8 +46,17 @@ export const useInitialDestToken = (
       return;
     }
 
-    // Entering Swaps NOT from asset details page or deeplink
-    if (!initialDestToken && !initialSourceToken) {
+    // The default dest belongs to the source token's network. Prefer the token
+    // coming in on the route (which useInitialSourceToken is about to apply)
+    // and fall back to the one already in Redux, e.g. when this view remounts
+    // after a sibling Bridge tab anchored the source to a different chain.
+    const effectiveSourceToken = initialSourceToken ?? sourceToken;
+
+    // Entering Swaps NOT from asset details page or deeplink. The pair's dest
+    // asset sits on a fixed chain, so it's only a valid destination while
+    // useInitialSourceToken is going to apply the pair's source asset too,
+    // which it only does when no source token is anchored anywhere yet.
+    if (!initialDestToken && !effectiveSourceToken) {
       if (isSwap && bip44DefaultPair && !destToken) {
         dispatch(setDestToken(bip44DefaultPair.destAsset));
         return;
@@ -55,18 +64,13 @@ export const useInitialDestToken = (
     }
 
     // Use BIP44 default pair for Bitcoin source token (i.e. entered Swaps from Bitcoin Asset Details page)
-    if (initialSourceToken && initialSourceToken.chainId === BtcScope.Mainnet) {
+    if (effectiveSourceToken?.chainId === BtcScope.Mainnet) {
       if (bip44DefaultPair && !destToken) {
         dispatch(setDestToken(bip44DefaultPair.destAsset));
         return;
       }
     }
 
-    // The default dest belongs to the source token's network. Prefer the token
-    // coming in on the route (which useInitialSourceToken is about to apply)
-    // and fall back to the one already in Redux, e.g. when this view remounts
-    // after a sibling Bridge tab anchored the source to a different chain.
-    const effectiveSourceToken = initialSourceToken ?? sourceToken;
     const destTokenTargetChainId =
       effectiveSourceToken?.chainId ?? selectedChainId;
     let defaultDestToken = getDefaultDestToken(destTokenTargetChainId);

--- a/app/components/UI/Bridge/hooks/useInitialDestToken/useInitialDestToken.test.ts
+++ b/app/components/UI/Bridge/hooks/useInitialDestToken/useInitialDestToken.test.ts
@@ -7,7 +7,9 @@ import { getSwapDestToken } from '../../utils/getSwapDestToken';
 import { SolScope, BtcScope } from '@metamask/keyring-api';
 import { selectChainId } from '../../../../../selectors/networkController';
 import {
+  selectBip44DefaultPair,
   selectBridgeViewMode,
+  selectSourceToken,
   setDestToken,
 } from '../../../../../core/redux/slices/bridge';
 
@@ -25,6 +27,7 @@ jest.mock('../../../../../core/redux/slices/bridge', () => {
     setDestToken: jest.fn(actual.setDestToken),
     selectBridgeViewMode: jest.fn().mockReturnValue('Bridge'),
     selectBip44DefaultPair: jest.fn(actual.selectBip44DefaultPair),
+    selectSourceToken: jest.fn(actual.selectSourceToken),
   };
 });
 
@@ -67,6 +70,17 @@ describe('useInitialDestToken', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // clearAllMocks leaves implementations in place, so restore the selectors
+    // individual tests stub out to their real ones.
+    const actualSlice = jest.requireActual(
+      '../../../../../core/redux/slices/bridge',
+    );
+    (selectBip44DefaultPair as unknown as jest.Mock).mockImplementation(
+      actualSlice.selectBip44DefaultPair,
+    );
+    (selectSourceToken as unknown as jest.Mock).mockImplementation(
+      actualSlice.selectSourceToken,
+    );
   });
 
   it('should not set dest token when not in swap mode', () => {
@@ -112,6 +126,31 @@ describe('useInitialDestToken', () => {
       expect(setDestToken).toHaveBeenCalledWith(
         getSwapDestToken(SolScope.Mainnet),
       );
+    });
+  });
+
+  it('derives the dest token from the selected source token when none comes in on the route', async () => {
+    // A tab switch can leave the source token anchored to a chain other than
+    // the wallet's selected one, so the dest default must follow the source.
+    (selectBridgeViewMode as unknown as jest.Mock).mockReturnValue(
+      BridgeViewMode.Unified,
+    );
+    (selectChainId as unknown as jest.Mock).mockReturnValue('0x1');
+    (selectBip44DefaultPair as unknown as jest.Mock).mockReturnValue(undefined);
+    (selectSourceToken as unknown as jest.Mock).mockReturnValue({
+      address: '0x0000000000000000000000000000000000000000',
+      symbol: 'POL',
+      decimals: 18,
+      name: 'Polygon',
+      chainId: '0x89',
+    });
+
+    renderHookWithProvider(() => useInitialDestToken(), {
+      state: initialState,
+    });
+
+    await waitFor(() => {
+      expect(setDestToken).toHaveBeenCalledWith(getSwapDestToken('0x89'));
     });
   });
 

--- a/app/components/UI/Bridge/types/navigation.ts
+++ b/app/components/UI/Bridge/types/navigation.ts
@@ -20,6 +20,7 @@ import type { PostTradeBottomSheetParams } from '../components/PostTradeBottomSh
 import type { BatchSellPriceImpactInfoModalParams } from '../components/BatchSellPriceImpactInfoModal/BatchSellPriceImpactInfoModal.types';
 import type { BatchSellNetworkFeeInfoModalParams } from '../components/BatchSellNetworkFeeInfoModal/BatchSellNetworkFeeInfoModal.types';
 import type { BatchSellMinimumReceivedInfoModalParams } from '../components/BatchSellMinimumReceivedInfoModal/BatchSellMinimumReceivedInfoModal.types';
+import type { NetworkListModalParams } from '../components/BridgeTokenSelector/NetworkListModal';
 
 /**
  * Param list for screens inside the Bridge screen stack (`BridgeScreenStack`).
@@ -52,7 +53,7 @@ export type BridgeModalsNavigationParamList = {
   BlockaidModal: BlockaidModalParams;
   RecipientSelectorModal: undefined;
   MarketClosedModal: undefined;
-  NetworkListModal: undefined;
+  NetworkListModal: NetworkListModalParams | undefined;
   PriceImpactModal: PriceImpactModalRouterParams;
   MissingPriceModal: MissingPriceModalParams;
   TokenWarningModal: TokenWarningModalParams;

--- a/app/components/UI/Bridge/utils/tokenUtils.test.ts
+++ b/app/components/UI/Bridge/utils/tokenUtils.test.ts
@@ -2,6 +2,7 @@ import { constants } from 'ethers';
 import {
   getNativeSourceToken,
   getDefaultDestToken,
+  getDefaultTokenPairForChains,
   isSameBridgeToken,
   tokenMatchesQuery,
 } from './tokenUtils';
@@ -236,6 +237,43 @@ describe('tokenUtils', () => {
       // Only chainId should be different (CAIP format instead of hex)
       expect(result?.chainId).toBe(caipChainId);
       expect(result?.chainId).not.toBe(originalToken.chainId);
+    });
+  });
+
+  describe('getDefaultTokenPairForChains', () => {
+    it('returns undefined when there are no enabled chains', () => {
+      const result = getDefaultTokenPairForChains([]);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('anchors on Ethereum mainnet ETH/mUSD when Ethereum is enabled', () => {
+      const result = getDefaultTokenPairForChains(['eip155:56', 'eip155:1']);
+
+      expect(result?.sourceToken).toEqual(getNativeSourceToken('eip155:1'));
+      expect(result?.sourceToken.chainId).toBe('0x1');
+      expect(result?.destToken?.symbol).toBe('mUSD');
+      expect(result?.destToken?.chainId).toBe('0x1');
+    });
+
+    it('falls back to the first enabled chain when Ethereum is not enabled', () => {
+      const result = getDefaultTokenPairForChains(['eip155:56', 'eip155:8453']);
+
+      expect(result?.sourceToken).toEqual(getNativeSourceToken('eip155:56'));
+      expect(result?.sourceToken.chainId).toBe('0x38');
+      expect(result?.destToken?.chainId).toBe('0x38');
+    });
+
+    it('omits destToken when the default dest would equal the source token', () => {
+      // eip155:999999 has no configured dest token and no native token
+      // mapping conflict scenario is hard to construct naturally, so this
+      // guards against getDefaultDestToken returning undefined gracefully.
+      const result = getDefaultTokenPairForChains(['eip155:999999']);
+
+      expect(result?.sourceToken).toEqual(
+        getNativeSourceToken('eip155:999999'),
+      );
+      expect(result?.destToken).toBeUndefined();
     });
   });
 

--- a/app/components/UI/Bridge/utils/tokenUtils.ts
+++ b/app/components/UI/Bridge/utils/tokenUtils.ts
@@ -5,6 +5,7 @@ import {
   parseCaipAssetType,
   toCaipAssetType,
 } from '@metamask/utils';
+import { EthScope } from '@metamask/keyring-api';
 import {
   formatAddressToAssetId,
   formatChainIdToCaip,
@@ -168,6 +169,41 @@ export const getDefaultDestToken = (
   }
 
   return undefined;
+};
+
+/**
+ * Computes a default source/dest token pair to re-anchor a swap/bridge
+ * selection on when it's found to be outside a set of enabled chains (e.g.
+ * a token selected in an unrestricted flow that isn't supported by a
+ * narrower one like Limit Order). Prefers Ethereum mainnet's ETH/mUSD pair
+ * when Ethereum is part of the enabled chains, otherwise falls back to the
+ * native token + configured default dest token of the first enabled chain.
+ *
+ * Returns `undefined` when there are no enabled chains to anchor on.
+ */
+export const getDefaultTokenPairForChains = (
+  chainIds: CaipChainId[],
+): { sourceToken: BridgeToken; destToken?: BridgeToken } | undefined => {
+  if (chainIds.length === 0) {
+    return undefined;
+  }
+
+  const fallbackChainId = chainIds.includes(EthScope.Mainnet)
+    ? EthScope.Mainnet
+    : chainIds[0];
+
+  const sourceToken = getNativeSourceToken(fallbackChainId);
+  // Look up the dest default using the source token's already-formatted
+  // chainId (not the raw fallbackChainId) so both tokens end up in the
+  // same chainId format (hex for EVM chains).
+  const destTokenCandidate = getDefaultDestToken(sourceToken.chainId);
+  const destToken =
+    destTokenCandidate &&
+    !areAddressesEqual(destTokenCandidate.address, sourceToken.address)
+      ? destTokenCandidate
+      : undefined;
+
+  return { sourceToken, destToken };
 };
 
 /**

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -5,6 +5,7 @@ import reducer, {
   setSourceAmount,
   setDestAmount,
   resetBridgeState,
+  resetBridgeDestToken,
   setSlippage,
   setSlippageUserOverride,
   setBridgeViewMode,
@@ -581,6 +582,41 @@ describe('bridge slice', () => {
       const newState = reducer(stateWithVisiblePills, resetBridgeState());
 
       expect(newState.visiblePillChainIds).toBeUndefined();
+    });
+  });
+
+  describe('resetBridgeDestToken', () => {
+    const stateWithDestSelection = {
+      ...initialState,
+      sourceToken: mockToken,
+      sourceAmount: '1.5',
+      destToken: mockDestToken,
+      selectedDestChainId: '0x89' as Hex,
+      isDestTokenManuallySet: true,
+      slippage: '3.5',
+      isSlippageUserOverride: true,
+    };
+
+    it('clears the destination token, its chain and the manual selection flag', () => {
+      const newState = reducer(stateWithDestSelection, resetBridgeDestToken());
+
+      expect(newState.destToken).toBeUndefined();
+      expect(newState.selectedDestChainId).toBeUndefined();
+      expect(newState.isDestTokenManuallySet).toBe(false);
+    });
+
+    it('clears slippage since it belonged to the cleared token pair', () => {
+      const newState = reducer(stateWithDestSelection, resetBridgeDestToken());
+
+      expect(newState.slippage).toBeUndefined();
+      expect(newState.isSlippageUserOverride).toBe(false);
+    });
+
+    it('leaves the source selection and amount untouched', () => {
+      const newState = reducer(stateWithDestSelection, resetBridgeDestToken());
+
+      expect(newState.sourceToken).toEqual(mockToken);
+      expect(newState.sourceAmount).toBe('1.5');
     });
   });
 

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -878,6 +878,48 @@ describe('bridge slice', () => {
         ),
       ).toBe(true);
     });
+
+    it('restricts chainRanking to enabledChainIds when provided, ignoring ALLOWED_BRIDGE_CHAIN_IDS', () => {
+      const mockState = cloneDeep(mockRootState);
+      mockState.engine.backgroundState.RemoteFeatureFlagController.remoteFeatureFlags.bridgeConfigV2.chainRanking =
+        [
+          { chainId: 'eip155:1', name: 'Ethereum' },
+          { chainId: 'eip155:137', name: 'Polygon' },
+          // Not in ALLOWED_BRIDGE_CHAIN_IDS, but included in enabledChainIds below.
+          { chainId: 'eip155:99999', name: 'Unsupported Future Chain' },
+        ];
+
+      const result = selectAllowedChainRanking(
+        mockState as unknown as RootState,
+        ['eip155:1' as CaipChainId, 'eip155:99999' as CaipChainId],
+      );
+
+      expect(result).toEqual([
+        { chainId: 'eip155:1', name: 'Ethereum' },
+        { chainId: 'eip155:99999', name: 'Unsupported Future Chain' },
+      ]);
+    });
+
+    it('returns an empty array when enabledChainIds is an empty array', () => {
+      const result = selectAllowedChainRanking(
+        mockRootState as unknown as RootState,
+        [],
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('falls back to the ALLOWED_BRIDGE_CHAIN_IDS filter when enabledChainIds is undefined', () => {
+      const withoutOverride = selectAllowedChainRanking(
+        mockRootState as unknown as RootState,
+      );
+      const withUndefinedOverride = selectAllowedChainRanking(
+        mockRootState as unknown as RootState,
+        undefined,
+      );
+
+      expect(withUndefinedOverride).toEqual(withoutOverride);
+    });
   });
 
   describe('selectBatchSellDestStablecoins', () => {

--- a/app/core/redux/slices/bridge/index.ts
+++ b/app/core/redux/slices/bridge/index.ts
@@ -226,6 +226,12 @@ const slice = createSlice({
       state.isMaxSourceAmount = false;
       state.selectedQuoteRequestId = undefined;
     },
+    resetBridgeDestToken: (state) => {
+      state.destToken = undefined;
+      state.selectedDestChainId = undefined;
+      state.isDestTokenManuallySet = false;
+      clearSlippageState(state);
+    },
     incrementBridgeBalanceRefreshKey: (state) => {
       state.balanceRefreshKey += 1;
     },
@@ -1062,6 +1068,7 @@ export const {
   setDestAmount,
   resetBridgeState,
   resetBridgeTokenInputs,
+  resetBridgeDestToken,
   incrementBridgeBalanceRefreshKey,
   setSourceToken,
   setDestToken,

--- a/app/core/redux/slices/bridge/index.ts
+++ b/app/core/redux/slices/bridge/index.ts
@@ -580,13 +580,29 @@ const isAllowedBridgeChainId = (caipChainId: string): boolean => {
  * Selector that returns chainRanking from feature flags filtered by
  * ALLOWED_BRIDGE_CHAIN_IDS. This ensures chains added to the remote flag
  * in the future won't be surfaced by older app versions that lack support.
+ *
+ * When `enabledChainIds` is provided, it fully replaces the
+ * ALLOWED_BRIDGE_CHAIN_IDS filter: only chains present in `enabledChainIds`
+ * are returned. Callers that pass this argument must pass a stable
+ * (e.g. module-level) array reference to avoid busting memoization.
  */
 export const selectAllowedChainRanking = createSelector(
   selectBridgeFeatureFlags,
-  (bridgeFeatureFlags) =>
-    (bridgeFeatureFlags.chainRanking ?? []).filter((chain) =>
+  (_state: RootState, enabledChainIds?: CaipChainId[]) => enabledChainIds,
+  (bridgeFeatureFlags, enabledChainIds) => {
+    const chainRanking = bridgeFeatureFlags.chainRanking ?? [];
+
+    if (enabledChainIds) {
+      const enabledChainIdsSet = new Set(enabledChainIds);
+      return chainRanking.filter((chain) =>
+        enabledChainIdsSet.has(chain.chainId),
+      );
+    }
+
+    return chainRanking.filter((chain) =>
       isAllowedBridgeChainId(chain.chainId),
-    ),
+    );
+  },
 );
 
 /**
@@ -597,7 +613,12 @@ export const selectAllowedChainRanking = createSelector(
  * const isBridgeEnabledSource = getIsBridgeEnabledSource(chainId);
  */
 export const selectIsBridgeEnabledSourceFactory = createSelector(
-  selectAllowedChainRanking,
+  // Called with only `state`: selectIsBridgeEnabledSourceFactory is itself
+  // used as an input selector to selectIsBridgeEnabledSource, which is
+  // invoked with a `chainId` second argument. Reselect forwards outer
+  // arguments to input selectors, so without this wrapper that chainId
+  // would leak into selectAllowedChainRanking's `enabledChainIds` param.
+  (state: RootState) => selectAllowedChainRanking(state),
   (allowedChains) => (chainId: Hex | CaipChainId) => {
     const caipChainId = formatChainIdToCaip(chainId);
     return allowedChains.some((chain) => chain.chainId === caipChainId);
@@ -630,7 +651,10 @@ export const selectTopAssetsFromFeatureFlags = createSelector(
  * TODO The MultichainNetworkConfiguration.chainId type is wrong. It can be both Hex or CaipChainId.
  */
 export const selectEnabledSourceChains = createSelector(
-  selectAllowedChainRanking,
+  // Called with only `state` for the same reason as
+  // selectIsBridgeEnabledSourceFactory above: guards against any outer
+  // selector args leaking into selectAllowedChainRanking's `enabledChainIds`.
+  (state: RootState) => selectAllowedChainRanking(state),
   selectNetworkConfigurations,
   (allowedChainRanking, networkConfigurations) => {
     const allowedCaipIds = new Set(allowedChainRanking.map((c) => c.chainId));


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The bridge asset picker (`BridgeTokenSelector`, `NetworkPills`, `NetworkListModal`) always read `selectAllowedChainRanking` unparameterized, which filters the feature-flagged `chainRanking` down to `ALLOWED_BRIDGE_CHAIN_IDS`. There was no way for a caller to further restrict which chains the picker shows — every consumer got the same global list. Upcoming flows (e.g. limit orders) need the picker restricted to a fixed, smaller set of chains regardless of the global bridge chain ranking.

This PR adds an optional `enabledChainIds: CaipChainId[]` override that threads through the whole picker:

- `selectAllowedChainRanking(state, enabledChainIds?)` now accepts a second argument. When provided, it fully replaces the `ALLOWED_BRIDGE_CHAIN_IDS` filter with an exact match against `enabledChainIds`; when omitted, behavior is unchanged.
- `BridgeTokenSelectorRouteParams` and `NetworkListModalParams` gained an optional `enabledChainIds` field, and `BridgeTokenSelector` forwards it to `NetworkPills` and to the "more networks" navigation call so the token list, pills, and modal all stay in sync.
- `NetworkPills` and `TokenInputArea` gained a matching optional `enabledChainIds` prop; `TokenInputArea` forwards it when it navigates to the token selector (including from its own empty "Select token" state).
- No existing caller passes `enabledChainIds` yet, so current bridge/swap flows keep their existing behavior (falls back to the `ALLOWED_BRIDGE_CHAIN_IDS` filter). This lands the plumbing ahead of the limit-order flow that will consume it.
- While wiring this up, fixed a latent reselect composition issue: `selectIsBridgeEnabledSourceFactory` and `selectEnabledSourceChains` used `selectAllowedChainRanking` directly as an input selector, so any extra argument passed to an outer selector (e.g. the `chainId` in `selectIsBridgeEnabledSource(state, chainId)`) was silently forwarded into `selectAllowedChainRanking`'s new `enabledChainIds` parameter. Both selectors now call `selectAllowedChainRanking` with only `state` to prevent this.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

Refs: https://consensyssoftware.atlassian.net/browse/SWAPS-4945

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Bridge asset picker default behavior is unchanged

  Background:
    Given I am logged into MetaMask Mobile
    And bridge/swap is enabled

  Scenario: token selector still shows the default allowed networks
    Given I am on the Bridge/Swap screen

    When user taps the source token selector
    Then the token selector should open
    And network pills should list the default ALLOWED_BRIDGE_CHAIN_IDS networks

    When user taps "+X more"
    Then the network list modal should open with the same set of networks

  Scenario: per-chain bridge enablement checks still work correctly
    Given I am on the Bridge/Swap screen with a source token selected on a supported chain

    When user views the source token input
    Then bridging from that chain should still be reported as enabled

    When user switches the source token to an unsupported chain
    Then bridging from that chain should be reported as disabled
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — this PR only adds an opt-in parameter; no UI changes for existing flows.

### **After**

N/A — this PR only adds an opt-in parameter; no UI changes for existing flows.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared bridge Redux state, tab transitions, and chain ranking selectors used across swap/bridge UI; changes are well covered by tests but incorrect token pairing could affect quotes and user trades.
> 
> **Overview**
> Adds an optional **`enabledChainIds`** override so bridge asset pickers can show a narrower network list than the global `ALLOWED_BRIDGE_CHAIN_IDS` filter. **`selectAllowedChainRanking(state, enabledChainIds?)`** uses that list when provided; the same value flows through **`BridgeTokenSelector`**, **`NetworkPills`**, **`NetworkListModal`**, and **`TokenInputArea`** navigation params. Existing flows omit it and behave as before.
> 
> **Scoped-picker hardening:** when a stale Redux network filter or token chain is outside the allowed set, the selector clears the filter, fetches all enabled chains, and re-anchors source/dest via new **`getDefaultTokenPairForChains`**. **`NetworkPills`** filters session-pinned pills to the current ranking and backfills slots; out-of-scope **`selectedChainId`** values are no longer promoted into the shared pin.
> 
> **Tab switching:** leaving a Bridge tab now dispatches **`resetBridgeDestToken`** (along with clearing amounts) so the incoming tab can derive destination from its own source; **`useInitialDestToken`** also follows Redux **`sourceToken`** when route params are absent.
> 
> **Reselect:** **`selectIsBridgeEnabledSourceFactory`** and **`selectEnabledSourceChains`** call **`selectAllowedChainRanking(state)`** only so outer selector args (e.g. `chainId`) do not leak into **`enabledChainIds`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8d925a709237e06500d3674a0bace0d6ed062ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->