### PR TITLE
chore: replace deprecated StyleSheet.absoluteFillObject with absoluteFill (trading & assets)

### DIFF
--- a/app/components/UI/AssetOverview/Price/Price.styles.tsx
+++ b/app/components/UI/AssetOverview/Price/Price.styles.tsx
@@ -55,7 +55,7 @@ const styleSheet = (params: { theme: Theme }) =>
       alignSelf: 'stretch',
     } as ViewStyle,
     noDataOverlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'center',
       alignItems: 'center',
       zIndex: 2,

--- a/app/components/UI/AssetOverview/PriceChart/PriceChart.styles.tsx
+++ b/app/components/UI/AssetOverview/PriceChart/PriceChart.styles.tsx
@@ -30,12 +30,12 @@ const styleSheet = (params: {
     },
     /** Same pattern as AdvancedChart: overlay does not participate in flex layout with AreaChart. */
     loadingOverlayContainer: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'center',
       alignItems: 'center',
     },
     noDataOverlayContainer: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     chartLoading: {
       width: '100%',

--- a/app/components/UI/Assets/watchlist/Views/WatchlistFullScreenView/WatchlistSearchContent.styles.ts
+++ b/app/components/UI/Assets/watchlist/Views/WatchlistFullScreenView/WatchlistSearchContent.styles.ts
@@ -28,7 +28,7 @@ const styleSheet = (params: {
       paddingVertical: 16,
     },
     skeletonOverlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       paddingHorizontal: 16,
       backgroundColor: theme.colors.background.default,
     },

--- a/app/components/UI/Bridge/components/TransactionDetails/PulsingCircle.tsx
+++ b/app/components/UI/Bridge/components/TransactionDetails/PulsingCircle.tsx
@@ -32,7 +32,7 @@ const styleSheet = (params: { theme: Theme }) =>
       borderRadius: 8,
     },
     hollowCircleContainer: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'center',
       alignItems: 'center',
     },

--- a/app/components/UI/CollectibleMedia/CollectibleMedia.styles.ts
+++ b/app/components/UI/CollectibleMedia/CollectibleMedia.styles.ts
@@ -66,7 +66,7 @@ const styleSheet = (params: {
     mediaPlayer: {
       minHeight: 10,
     },
-    imageFallBackTextContainer: StyleSheet.absoluteFillObject,
+    imageFallBackTextContainer: StyleSheet.absoluteFill,
     imageFallBackShowContainer: {
       bottom: 32,
     },

--- a/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.styles.ts
+++ b/app/components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.styles.ts
@@ -5,7 +5,7 @@ export const createStyles = () =>
     // Offscreen remount target after a slider gesture — keep StyleSheet for
     // absoluteFill; Tailwind cannot express this cleanly.
     sliderIncoming: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       opacity: 0,
     },
     helpTextContainer: {

--- a/app/components/UI/Predict/components/PredictDetailsChart/PredictDetailsChart.tsx
+++ b/app/components/UI/Predict/components/PredictDetailsChart/PredictDetailsChart.tsx
@@ -531,7 +531,7 @@ const PredictDetailsChart: React.FC<PredictDetailsChartProps> = ({
           {overlaySeries.map((series, index) => (
             <LineChart
               key={`${series.label}-${index}`}
-              style={StyleSheet.absoluteFillObject}
+              style={StyleSheet.absoluteFill}
               data={series.data.map((point) => point.value)}
               svg={{ stroke: series.color, strokeWidth: 2 }}
               contentInset={CHART_CONTENT_INSET}
@@ -543,7 +543,7 @@ const PredictDetailsChart: React.FC<PredictDetailsChartProps> = ({
           ))}
           {/* Tooltip overlay - rendered last to appear on top */}
           <LineChart
-            style={StyleSheet.absoluteFillObject}
+            style={StyleSheet.absoluteFill}
             data={primaryChartData}
             svg={{ stroke: 'transparent', strokeWidth: 0 }}
             contentInset={CHART_CONTENT_INSET}

--- a/app/components/UI/SlippageSlider/index.js
+++ b/app/components/UI/SlippageSlider/index.js
@@ -88,7 +88,7 @@ const createStyles = (colors, shadows) =>
       top: 4,
     },
     tooltipText: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       textAlign: 'center',
       ...fontStyles.normal,
       color: colors.overlay.inverse,

--- a/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.styles.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.styles.ts
@@ -38,7 +38,7 @@ const styleSheet = (params: {
       marginBottom: 16,
     },
     shimmerOverlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: theme.colors.icon.alternative,
       borderRadius: CARD_BORDER_RADIUS,
     },

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -505,10 +505,10 @@ function TradeWalletActions() {
   return (
     <View style={tw.style('flex-1 justify-end')}>
       <Animated.View
-        style={[StyleSheet.absoluteFillObject, backdropAnimatedStyle]}
+        style={[StyleSheet.absoluteFill, backdropAnimatedStyle]}
       >
         <Pressable
-          style={StyleSheet.absoluteFillObject}
+          style={StyleSheet.absoluteFill}
           onPress={handleNavigateBack}
         >
           <OverlayWithHole

--- a/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
+++ b/app/components/Views/TradeWalletActions/TradeWalletActions.tsx
@@ -504,13 +504,8 @@ function TradeWalletActions() {
 
   return (
     <View style={tw.style('flex-1 justify-end')}>
-      <Animated.View
-        style={[StyleSheet.absoluteFill, backdropAnimatedStyle]}
-      >
-        <Pressable
-          style={StyleSheet.absoluteFill}
-          onPress={handleNavigateBack}
-        >
+      <Animated.View style={[StyleSheet.absoluteFill, backdropAnimatedStyle]}>
+        <Pressable style={StyleSheet.absoluteFill} onPress={handleNavigateBack}>
           <OverlayWithHole
             width={windowWidth}
             height={windowHeight + insetsTop}


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Mechanical rename: `StyleSheet.absoluteFillObject` → `StyleSheet.absoluteFill` in Perps, Predict, Bridge and Assets surfaces (10 files, 13 usages). `absoluteFillObject` is removed in RN 0.85 — these usages crash at runtime after the upgrade (#34283). No behavior change on current RN: both resolve to the same `{position:'absolute',top:0,left:0,right:0,bottom:0}` style.

Part 1/3 of the split of #34424 (split for easier per-team review).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #34283 (RN 0.85 upgrade — pre-upgrade ladder)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: overlays still fill their containers

  Scenario: affected surfaces render unchanged
    Given the app is running
    When I view the asset price chart, Perps leverage sheet, Predict details chart and Bridge transaction details
    Then overlay elements fill their containers exactly as before
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — no visual change (identical resolved style).

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 12537948dd4d135f7f75b0076d8ad7fd9f83b8a6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
