### PR TITLE
chore: replace deprecated StyleSheet.absoluteFillObject with absoluteFill (money, card, ramps)

### DIFF
--- a/app/components/UI/Card/Views/SpendingLimit/components/ShimmerOverlay.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/components/ShimmerOverlay.tsx
@@ -37,7 +37,7 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   overlay: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     overflow: 'hidden',
   },
 });

--- a/app/components/UI/Card/components/DaimoPayModal/DaimoPayModal.tsx
+++ b/app/components/UI/Card/components/DaimoPayModal/DaimoPayModal.tsx
@@ -55,7 +55,7 @@ export interface DaimoPayModalParams {
 
 const baseStyles = StyleSheet.create({
   absoluteFill: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
   },
 });
 

--- a/app/components/UI/Money/Views/MoneyFirstTimeDepositView/MoneyFirstTimeDepositView.tsx
+++ b/app/components/UI/Money/Views/MoneyFirstTimeDepositView/MoneyFirstTimeDepositView.tsx
@@ -143,7 +143,7 @@ const MoneyFirstTimeDepositView = () => {
         dataBinding={AutoBind(true)}
         fit={Fit.Layout}
         layoutScaleFactor={PixelRatio.get()}
-        style={StyleSheet.absoluteFillObject}
+        style={StyleSheet.absoluteFill}
         onError={handleError}
         testID={MoneyFirstTimeDepositViewTestIds.RIVE_ANIMATION}
       />

--- a/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx
+++ b/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx
@@ -523,7 +523,7 @@ const MoneyOnboardingView = () => {
         layoutScaleFactor={PixelRatio.get()}
         onStateChanged={handleStateChanged}
         onError={handleError}
-        style={StyleSheet.absoluteFillObject}
+        style={StyleSheet.absoluteFill}
         testID={MoneyOnboardingViewTestIds.RIVE_ANIMATION}
       />
       <MoneyOnboardingTextOverlay

--- a/app/components/UI/Ramp/Aggregator/components/LoadingAnimation/index.tsx
+++ b/app/components/UI/Ramp/Aggregator/components/LoadingAnimation/index.tsx
@@ -77,7 +77,7 @@ const createStyles = (
       zIndex: 2,
     },
     backgroundShapes: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       zIndex: 1,
       justifyContent: 'center',
       alignItems: 'center',


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Mechanical rename: `StyleSheet.absoluteFillObject` → `StyleSheet.absoluteFill` in Card, Money and Ramp surfaces (5 files, 5 usages). `absoluteFillObject` is removed in RN 0.85 — these usages crash at runtime after the upgrade (#34283). No behavior change on current RN: both resolve to the same `{position:'absolute',top:0,left:0,right:0,bottom:0}` style.

Part 2/3 of the split of #34424 (split for easier per-team review).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #34283 (RN 0.85 upgrade — pre-upgrade ladder)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: overlays still fill their containers

  Scenario: affected surfaces render unchanged
    Given the app is running
    When I view Money onboarding, first-time deposit, Card spending limit and the Ramp loading animation
    Then overlay elements fill their containers exactly as before
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — no visual change (identical resolved style).

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Identical style semantics and no logic changes; low risk aside from routine regression on overlay layout in the touched screens.
> 
> **Overview**
> Replaces deprecated **`StyleSheet.absoluteFillObject`** with **`StyleSheet.absoluteFill`** in five Card, Money, and Ramp UI files (shimmer overlay, Daimo Pay modal, two Rive full-screen animations, Ramp loading animation). This is a mechanical API swap ahead of React Native 0.85, where `absoluteFillObject` is removed; the resolved style is unchanged on current RN.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c2840ed5cbba3700045fca9c209d6276b1cfce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
