### PR TITLE
chore: replace deprecated StyleSheet.absoluteFillObject with absoluteFill (platform, social, notifications)

### DIFF
--- a/app/components/UI/ButtonReveal/index.tsx
+++ b/app/components/UI/ButtonReveal/index.tsx
@@ -45,20 +45,20 @@ const createStyles = (colors: any) =>
       marginRight: 12,
     },
     absoluteFillWithCenter: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       alignItems: 'center',
       justifyContent: 'center',
     },
     absoluteFill: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     preCompletedContainerStyle: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       borderRadius: radius,
       backgroundColor: colors.primary.default,
     },
     outerCircle: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       borderRadius: radius,
       backgroundColor: colors.primary.inverse,
     },

--- a/app/components/UI/DesignerMode/DesignerModeRN.tsx
+++ b/app/components/UI/DesignerMode/DesignerModeRN.tsx
@@ -1295,7 +1295,7 @@ function createDesignerStyles() {
 
     // Backdrop
     backdrop: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: C.backdrop,
     } as ViewStyle,
 

--- a/app/components/UI/HardwareWallet/Swaps/HwQrScanner.tsx
+++ b/app/components/UI/HardwareWallet/Swaps/HwQrScanner.tsx
@@ -131,7 +131,7 @@ const styles = StyleSheet.create({
     position: 'relative',
   },
   overlayCenter: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -374,7 +374,7 @@ export function HwQrScanner() {
     return (
       <>
         <Camera
-          style={StyleSheet.absoluteFillObject}
+          style={StyleSheet.absoluteFill}
           device={cameraDevice}
           isActive={isFocused && hasPermission}
           codeScanner={codeScanner}

--- a/app/components/UI/Notification/NotifCard/index.tsx
+++ b/app/components/UI/Notification/NotifCard/index.tsx
@@ -101,7 +101,7 @@ const NotifCard = ({
 
       {/* Border overlay — MaskedView fades the border top-to-transparent */}
       <MaskedView
-        style={StyleSheet.absoluteFillObject}
+        style={StyleSheet.absoluteFill}
         maskElement={
           <LinearGradient
             colors={['black', 'black', 'transparent']}
@@ -112,7 +112,7 @@ const NotifCard = ({
       >
         <View
           style={[
-            StyleSheet.absoluteFillObject,
+            StyleSheet.absoluteFill,
             styles.border,
             { borderColor: mutedBorderColor },
           ]}

--- a/app/components/UI/Notification/TransactionNotification/index.js
+++ b/app/components/UI/Notification/TransactionNotification/index.js
@@ -41,7 +41,7 @@ const createStyles = (theme) => {
 
   return StyleSheet.create({
     absoluteFill: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     titleWrapper: {
       borderBottomWidth: StyleSheet.hairlineWidth,

--- a/app/components/UI/ReusableModal/styles.ts
+++ b/app/components/UI/ReusableModal/styles.ts
@@ -16,10 +16,10 @@ const styleSheet = (params: { theme: Theme }) => {
   const { colors } = theme;
   return StyleSheet.create({
     absoluteFill: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     overlay: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: colors.overlay.default,
     },
   });

--- a/app/components/UI/Tabs/TabThumbnail/TabThumbnail.styles.ts
+++ b/app/components/UI/Tabs/TabThumbnail/TabThumbnail.styles.ts
@@ -47,7 +47,7 @@ const createStyles = (colors: ThemeColors) =>
       flex: 1,
     },
     tabImage: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       resizeMode: 'cover',
     },
     activeTab: {

--- a/app/components/UI/UrlAutocomplete/styles.ts
+++ b/app/components/UI/UrlAutocomplete/styles.ts
@@ -8,7 +8,7 @@ import {
 const styleSheet = ({ theme: { colors, typography } }: { theme: Theme }) =>
   StyleSheet.create({
     wrapper: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: colors.background.default,
       // Hidden by default
       display: 'none',

--- a/app/components/UI/WebviewError/index.js
+++ b/app/components/UI/WebviewError/index.js
@@ -10,7 +10,7 @@ import { WebviewErrorSelectorsIDs } from './WebviewError.testIds';
 const createStyles = (colors) =>
   StyleSheet.create({
     wrapper: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       backgroundColor: colors.background.default,
       justifyContent: 'center',
       alignItems: 'center',

--- a/app/components/Views/MediaPlayer/index.js
+++ b/app/components/Views/MediaPlayer/index.js
@@ -34,7 +34,7 @@ const styleSheet = ({ theme: { colors }, vars: { isPlaying } }) =>
       alignItems: 'center',
     },
     videoControlsStyle: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
       justifyContent: 'center',
       alignItems: 'center',
     },

--- a/app/components/Views/Onboarding/index.tsx
+++ b/app/components/Views/Onboarding/index.tsx
@@ -205,7 +205,7 @@ async function isDeviceOffline(): Promise<boolean> {
 
 const styles = StyleSheet.create({
   androidNotificationOverlay: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     zIndex: 999,
     elevation: 999,
   },

--- a/app/components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.tsx
+++ b/app/components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.tsx
@@ -54,7 +54,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   labelActive: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.styles.ts
+++ b/app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.styles.ts
@@ -37,7 +37,7 @@ export const OVERLAY_TOP_OFFSET = 80;
  * visual (background, trader cards, buttons). In the v4 ("hybrid") artboard the
  * step title + description are NOT baked into the Rive, so React Native renders
  * them as a non-interactive overlay pinned to the top of the screen, above the
- * Rive element which fills the container via `StyleSheet.absoluteFillObject`.
+ * Rive element which fills the container via `StyleSheet.absoluteFill`.
  */
 const createStyles = () =>
   StyleSheet.create({
@@ -45,7 +45,7 @@ const createStyles = () =>
       flex: 1,
     },
     gradient: {
-      ...StyleSheet.absoluteFillObject,
+      ...StyleSheet.absoluteFill,
     },
     textOverlay: {
       position: 'absolute',

--- a/app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx
+++ b/app/components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx
@@ -850,7 +850,7 @@ const SocialLeaderboardOnboarding: React.FC = () => {
           shows. */}
       {referencedAssets && (
         <Animated.View
-          style={[StyleSheet.absoluteFillObject, { opacity: riveOpacity }]}
+          style={[StyleSheet.absoluteFill, { opacity: riveOpacity }]}
         >
           <Rive
             ref={ref}
@@ -863,7 +863,7 @@ const SocialLeaderboardOnboarding: React.FC = () => {
             layoutScaleFactor={PixelRatio.get()}
             onPlay={revealRive}
             onError={handleError}
-            style={StyleSheet.absoluteFillObject}
+            style={StyleSheet.absoluteFill}
             testID={SocialLeaderboardOnboardingSelectorsIDs.RIVE_ANIMATION}
           />
         </Animated.View>

--- a/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionAnimatedHeader.tsx
+++ b/app/components/Views/SocialLeaderboard/TraderPositionView/components/TraderPositionAnimatedHeader.tsx
@@ -41,7 +41,7 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   layer: {
-    ...StyleSheet.absoluteFillObject,
+    ...StyleSheet.absoluteFill,
     alignItems: 'center',
     justifyContent: 'center',
   },


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Mechanical rename: `StyleSheet.absoluteFillObject` → `StyleSheet.absoluteFill` in Onboarding, SocialLeaderboard, Notifications, HardwareWallet and shared UI (15 files, 23 usages). `absoluteFillObject` is removed in RN 0.85 — these usages crash at runtime after the upgrade (#34283). No behavior change on current RN: both resolve to the same `{position:'absolute',top:0,left:0,right:0,bottom:0}` style.

Part 3/3 of the split of #34424 (split for easier per-team review).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #34283 (RN 0.85 upgrade — pre-upgrade ladder)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: overlays still fill their containers

  Scenario: affected surfaces render unchanged
    Given the app is running
    When I view onboarding, Social Leaderboard, notification cards, the HW QR scanner and browser tab thumbnails
    Then overlay elements fill their containers exactly as before
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — no visual change (identical resolved style).

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8ba1cb19b1c5031efb965d96684342b88f7e788d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
