### PR TITLE
fix(accounts): use default colors on add account row

### DIFF
--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.styles.ts
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.styles.ts
@@ -29,7 +29,6 @@ const createStyles = ({ theme }: { theme: Theme }) =>
       justifyContent: 'center',
     },
     buttonText: {
-      color: theme.colors.primary.default,
       fontWeight: '500',
     },
   });

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.test.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.test.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import {
+  Icon,
+  IconColor,
+  Spinner,
+  Text,
+  TextColor,
+} from '@metamask/design-system-react-native';
 
 import AccountListFooter, {
   abandonCreateMultichainAccountTrace,
@@ -32,16 +39,6 @@ jest.mock(
 );
 jest.mock('../../../../../util/Logger', () => ({
   error: jest.fn(),
-}));
-
-// Mock AnimatedSpinner
-jest.mock('../../../../../components/UI/AnimatedSpinner', () => ({
-  __esModule: true,
-  default: () => null,
-  SpinnerSize: {
-    SM: 'SM',
-    MD: 'MD',
-  },
 }));
 
 jest.mock(
@@ -276,6 +273,21 @@ describe('AccountListFooter', () => {
       );
       expect(getByText('Add account')).toBeOnTheScreen();
     });
+
+    it('renders Add account icon and label with default colors', () => {
+      const { UNSAFE_getByType } = render(
+        <AccountListFooter
+          walletId={mockWalletId}
+          onAccountCreated={jest.fn()}
+        />,
+      );
+
+      const icon = UNSAFE_getByType(Icon);
+      const label = UNSAFE_getByType(Text);
+
+      expect(icon.props.color).toBe(IconColor.IconDefault);
+      expect(label.props.color).toBe(TextColor.TextDefault);
+    });
   });
 
   describe('Button Interactions', () => {
@@ -360,7 +372,13 @@ describe('AccountListFooter', () => {
 
   describe('Loading State Management', () => {
     it('shows spinner when loading', async () => {
-      const { getByText } = render(
+      mockMultichainAccountService.createNextMultichainAccountGroup.mockReturnValue(
+        new Promise(() => {
+          // Keep creation in-flight so the spinner stays visible.
+        }),
+      );
+
+      const { getByText, UNSAFE_getByType } = render(
         <AccountListFooter
           walletId={mockWalletId}
           onAccountCreated={jest.fn()}
@@ -371,6 +389,9 @@ describe('AccountListFooter', () => {
 
       await waitFor(() => {
         expect(getByText('Adding account...')).toBeOnTheScreen();
+        expect(UNSAFE_getByType(Spinner).props.color).toBe(
+          IconColor.IconDefault,
+        );
       });
     });
 

--- a/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.tsx
+++ b/app/component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.tsx
@@ -15,13 +15,12 @@ import {
   IconName,
   IconSize,
   IconColor,
+  Spinner,
   Text,
+  TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../hooks';
-import AnimatedSpinner, {
-  SpinnerSize,
-} from '../../../../../components/UI/AnimatedSpinner';
 import Logger from '../../../../../util/Logger';
 import { strings } from '../../../../../../locales/i18n';
 import { selectWalletsMap } from '../../../../../selectors/multichainAccounts/accountTreeController';
@@ -204,17 +203,21 @@ const AccountListFooter = memo(
         >
           <View style={styles.iconContainer}>
             {isLoadingState ? (
-              <AnimatedSpinner size={SpinnerSize.SM} />
+              <Spinner
+                color={IconColor.IconDefault}
+                spinnerIconProps={{ size: IconSize.Md }}
+              />
             ) : (
               <Icon
                 name={IconName.Add}
                 size={IconSize.Md}
-                color={IconColor.PrimaryDefault}
+                color={IconColor.IconDefault}
               />
             )}
           </View>
           <Text
             variant={TextVariant.BodyMd}
+            color={TextColor.TextDefault}
             style={styles.buttonText}
             testID={AccountListBottomSheetSelectorsIDs.CREATE_ACCOUNT}
           >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

The Add account row in the accounts list used primary blue for the plus icon, label, and loading spinner. That made the action look like a primary CTA and broke visual consistency with the rest of the list.

This change uses default design-system tokens instead: `TextColor.TextDefault` for the label, `IconColor.IconDefault` for the plus icon, and the design-system `Spinner` with `IconColor.IconDefault` for the loader.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Updated the Add account row to use default text and icon colors

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A — workshop demo of a visual token consistency fix; no tracking issue.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Add account row colors

  Scenario: user opens the accounts list
    Given the wallet has at least one account
    When user opens the Accounts sheet
    Then the Add account plus icon uses icon default
    And the Add account label uses text default

  Scenario: user creates an account
    Given the Accounts sheet is open
    When user taps Add account
    Then the loader uses icon default instead of primary blue
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

Verified on iPhone 17 Pro Max simulator. Before: plus icon and Add account label were primary blue. After: both use default text/icon colors, and the loader matches.

### **Before**

Primary blue plus icon and Add account label.

<img width="350" alt="Screenshot 2026-08-17 at 11 09 50 AM" src="https://github.com/user-attachments/assets/478ae22d-f69f-4b3d-a281-0743bb17e953" />

https://github.com/user-attachments/assets/bd8b910c-3b23-4fa2-a661-9da0d84bfa7c

### **After**

Default text and icon colors on the Add account row and loader.

<img width="350" alt="Screenshot 2026-08-17 at 11 26 12 AM" src="https://github.com/user-attachments/assets/0db982cf-2363-4eda-b8be-47ae0a082be9" />

https://github.com/user-attachments/assets/23db68a7-5c12-42ef-acbc-6f6e54d00a27

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fd9f509c80e7ff1f5dfafb1dcbc310d782cf2dd6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->