### PR TITLE
fix(card): complete Exodus onboarding spending limit flow

### DIFF
--- a/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.test.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.test.tsx
@@ -45,18 +45,46 @@ jest.mock('../../../../hooks/useAnalytics/useAnalytics', () => ({
 }));
 
 // Mock useCardHomeData hook (SpendingLimit now reads from it)
+const mockRefetchCardHomeData = jest.fn();
 jest.mock('../../hooks/useCardHomeData', () => ({
   useCardHomeData: jest.fn(() => ({
     data: null,
     isLoading: false,
+    isRefreshing: false,
     isError: false,
-    refetch: jest.fn(),
+    refetch: mockRefetchCardHomeData,
     primaryToken: null,
     availableTokens: [],
     fundingTokens: [],
     balanceMap: new Map(),
   })),
 }));
+
+const mockSelectIsCardStateResolved = jest.fn(() => false);
+const mockSelectCardHomeDataStatus = jest.fn(
+  (): 'idle' | 'loading' | 'success' | 'error' => 'idle',
+);
+
+jest.mock('../../../../../selectors/cardController', () => {
+  const actual = jest.requireActual('../../../../../selectors/cardController');
+  return {
+    ...actual,
+    selectIsCardStateResolved: () => mockSelectIsCardStateResolved(),
+    selectCardHomeDataStatus: () => mockSelectCardHomeDataStatus(),
+  };
+});
+
+const defaultCardHomeDataReturn = () => ({
+  data: null,
+  isLoading: false,
+  isRefreshing: false,
+  isError: false,
+  refetch: mockRefetchCardHomeData,
+  primaryToken: null,
+  availableTokens: [] as never[],
+  fundingTokens: [] as never[],
+  balanceMap: new Map(),
+});
 
 // Mock useSpendingLimitData hook
 jest.mock('../../hooks/useSpendingLimitData', () => jest.fn());
@@ -277,7 +305,7 @@ jest.mock('@metamask/design-system-react-native', () => {
 });
 
 import React from 'react';
-import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react-native';
 import SpendingLimit from './SpendingLimit';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
 import { useCardDelegation } from '../../hooks/useCardDelegation';
@@ -285,6 +313,7 @@ import Logger from '../../../../../util/Logger';
 import { ToastContext } from '../../../../../component-library/components/Toast';
 import useSpendingLimitData from '../../hooks/useSpendingLimitData';
 import useSpendingLimit from '../../hooks/useSpendingLimit';
+import { useCardHomeData } from '../../hooks/useCardHomeData';
 
 jest.spyOn(Logger, 'error').mockImplementation(() => undefined);
 
@@ -302,6 +331,10 @@ const mockUseSpendingLimitData = useSpendingLimitData as jest.MockedFunction<
 
 const mockUseSpendingLimit = useSpendingLimit as jest.MockedFunction<
   typeof useSpendingLimit
+>;
+
+const mockUseCardHomeData = useCardHomeData as jest.MockedFunction<
+  typeof useCardHomeData
 >;
 
 const mockRoute: MockRoute = {
@@ -348,6 +381,7 @@ describe('SpendingLimit Component', () => {
     customLimit: '',
     isLoading: false,
     isUiInteractionLocked: false,
+    shouldBlockNavigation: jest.fn(() => false),
     setSelectedToken: mockSetSelectedToken,
     handleAccountSelect: mockHandleAccountSelect,
     handleOtherSelect: mockHandleOtherSelect,
@@ -373,6 +407,10 @@ describe('SpendingLimit Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockSubmitDelegation.mockResolvedValue(undefined);
+    mockFetchSpendingLimitData.mockResolvedValue(undefined);
+    mockSelectIsCardStateResolved.mockReturnValue(false);
+    mockSelectCardHomeDataStatus.mockReturnValue('idle');
+    mockUseCardHomeData.mockReturnValue(defaultCardHomeDataReturn());
 
     // Mock addListener to return an unsubscribe function
     mockAddListener.mockReturnValue(jest.fn());
@@ -770,11 +808,12 @@ describe('SpendingLimit Component', () => {
       );
     });
 
-    it('blocks navigation when UI interaction is locked', () => {
+    it('blocks navigation when shouldBlockNavigation returns true', () => {
       mockUseSpendingLimit.mockReturnValue({
         ...getDefaultUseSpendingLimitMock(),
         isLoading: true,
         isUiInteractionLocked: true,
+        shouldBlockNavigation: jest.fn(() => true),
       });
 
       render();
@@ -793,6 +832,7 @@ describe('SpendingLimit Component', () => {
         isLoading: true,
         isMoneyAccountSource: true,
         isUiInteractionLocked: false,
+        shouldBlockNavigation: jest.fn(() => false),
       });
 
       render();
@@ -811,6 +851,7 @@ describe('SpendingLimit Component', () => {
         isLoading: true,
         isMoneyAccountSource: true,
         isUiInteractionLocked: true,
+        shouldBlockNavigation: jest.fn(() => true),
       });
 
       render({ params: { flow: 'onboarding' } });
@@ -823,7 +864,7 @@ describe('SpendingLimit Component', () => {
       expect(mockEvent.preventDefault).toHaveBeenCalled();
     });
 
-    it('allows navigation when isLoading is false', () => {
+    it('allows navigation when shouldBlockNavigation returns false', () => {
       render();
 
       const mockEvent = { preventDefault: jest.fn() };
@@ -922,10 +963,108 @@ describe('SpendingLimit Component', () => {
       },
     };
 
-    it('fetches data on mount when flow is onboarding', () => {
+    const setupAuthenticatedHomeReady = (
+      overrides: {
+        delegationSettings?: object | null;
+        availableTokens?: CardFundingToken[];
+      } = {},
+    ) => {
+      const delegationSettings =
+        overrides.delegationSettings === undefined
+          ? { networks: [] }
+          : overrides.delegationSettings;
+      mockSelectIsCardStateResolved.mockReturnValue(true);
+      mockSelectCardHomeDataStatus.mockReturnValue('success');
+      mockUseCardHomeData.mockReturnValue({
+        data: {
+          primaryFundingAsset: null,
+          fundingAssets: [],
+          availableFundingAssets: [],
+          card: null,
+          account: { verificationStatus: 'VERIFIED' },
+          alerts: [],
+          actions: [],
+          delegationSettings,
+        } as never,
+        isLoading: false,
+        isRefreshing: false,
+        isError: false,
+        refetch: mockRefetchCardHomeData,
+        primaryToken: null,
+        availableTokens: (overrides.availableTokens ?? [
+          mockPriorityToken,
+        ]) as never[],
+        fundingTokens: [] as never[],
+        balanceMap: new Map(),
+      });
+    };
+
+    it('fetches fallback data after card home settles without delegation settings', () => {
+      setupAuthenticatedHomeReady({
+        delegationSettings: null,
+        availableTokens: [],
+      });
+
       render(onboardingRoute);
 
       expect(mockFetchSpendingLimitData).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders the form without a fallback fetch when card home has delegation settings but card state is unresolved', () => {
+      setupAuthenticatedHomeReady();
+      mockSelectIsCardStateResolved.mockReturnValue(false);
+
+      render(onboardingRoute);
+
+      expect(screen.getByTestId('token-row')).toBeOnTheScreen();
+      expect(
+        screen.queryByTestId('spending-limit-loading-indicator'),
+      ).not.toBeOnTheScreen();
+      expect(mockFetchSpendingLimitData).not.toHaveBeenCalled();
+    });
+
+    it('keeps the error state after the load timeout instead of returning to the spinner', () => {
+      jest.useFakeTimers();
+      mockSelectIsCardStateResolved.mockReturnValue(false);
+      mockSelectCardHomeDataStatus.mockReturnValue('loading');
+
+      try {
+        render(onboardingRoute);
+
+        expect(
+          screen.getByTestId('spending-limit-loading-indicator'),
+        ).toBeOnTheScreen();
+
+        act(() => {
+          jest.advanceTimersByTime(30_000);
+        });
+
+        expect(
+          screen.getByTestId('spending-limit-error-container'),
+        ).toBeOnTheScreen();
+
+        act(() => {
+          jest.advanceTimersByTime(30_000);
+        });
+
+        expect(
+          screen.getByTestId('spending-limit-error-container'),
+        ).toBeOnTheScreen();
+        expect(
+          screen.queryByTestId('spending-limit-loading-indicator'),
+        ).not.toBeOnTheScreen();
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('does not fetch fallback while card home is still loading', () => {
+      mockSelectIsCardStateResolved.mockReturnValue(false);
+      mockSelectCardHomeDataStatus.mockReturnValue('loading');
+
+      render(onboardingRoute);
+
+      expect(mockFetchSpendingLimitData).not.toHaveBeenCalled();
     });
 
     it('does not fetch data on mount when flow is manage', () => {
@@ -934,14 +1073,9 @@ describe('SpendingLimit Component', () => {
       expect(mockFetchSpendingLimitData).not.toHaveBeenCalled();
     });
 
-    it('displays loading state while fetching data in onboarding flow', () => {
-      mockUseSpendingLimitData.mockReturnValue({
-        availableTokens: [],
-        delegationSettings: null,
-        isLoading: true,
-        error: null,
-        fetchData: mockFetchSpendingLimitData,
-      });
+    it('displays loading state while card home is loading in onboarding flow', () => {
+      mockSelectIsCardStateResolved.mockReturnValue(false);
+      mockSelectCardHomeDataStatus.mockReturnValue('loading');
 
       render(onboardingRoute);
 
@@ -951,7 +1085,11 @@ describe('SpendingLimit Component', () => {
       ).toBeOnTheScreen();
     });
 
-    it('displays error state with retry and skip buttons when fetch fails', () => {
+    it('displays error state with retry and skip buttons when fallback fetch fails', () => {
+      setupAuthenticatedHomeReady({
+        delegationSettings: null,
+        availableTokens: [],
+      });
       mockUseSpendingLimitData.mockReturnValue({
         availableTokens: [],
         delegationSettings: null,
@@ -967,9 +1105,16 @@ describe('SpendingLimit Component', () => {
       ).toBeOnTheScreen();
       expect(screen.getByText('Try again')).toBeOnTheScreen();
       expect(screen.getByText('Skip for now')).toBeOnTheScreen();
+      expect(
+        screen.getByTestId('spending-limit-error-container'),
+      ).toBeOnTheScreen();
     });
 
-    it('calls fetchData when retry button is pressed on error state', () => {
+    it('calls refetch and fetchData when retry button is pressed on error state', () => {
+      setupAuthenticatedHomeReady({
+        delegationSettings: null,
+        availableTokens: [],
+      });
       mockUseSpendingLimitData.mockReturnValue({
         availableTokens: [],
         delegationSettings: null,
@@ -983,11 +1128,15 @@ describe('SpendingLimit Component', () => {
       const retryButton = screen.getByText('Try again');
       fireEvent.press(retryButton);
 
-      // fetchData is called once on mount, and once when retry is pressed
-      expect(mockFetchSpendingLimitData).toHaveBeenCalledTimes(2);
+      expect(mockRefetchCardHomeData).toHaveBeenCalled();
+      expect(mockFetchSpendingLimitData).toHaveBeenCalled();
     });
 
     it('calls skip when skip button is pressed on error state', () => {
+      setupAuthenticatedHomeReady({
+        delegationSettings: null,
+        availableTokens: [],
+      });
       mockUseSpendingLimitData.mockReturnValue({
         availableTokens: [],
         delegationSettings: null,
@@ -1005,12 +1154,14 @@ describe('SpendingLimit Component', () => {
     });
 
     it('renders Cancel button in onboarding flow', () => {
+      setupAuthenticatedHomeReady();
       render(onboardingRoute);
 
       expect(screen.getByText('Cancel')).toBeOnTheScreen();
     });
 
     it('calls skip when cancel is pressed in onboarding flow', () => {
+      setupAuthenticatedHomeReady();
       render(onboardingRoute);
 
       const cancelButton = screen.getByText('Cancel');
@@ -1020,6 +1171,7 @@ describe('SpendingLimit Component', () => {
     });
 
     it('renders confirm button in onboarding flow', () => {
+      setupAuthenticatedHomeReady();
       mockUseSpendingLimitData.mockReturnValue({
         availableTokens: [mockPriorityToken, mockMUSDToken],
         delegationSettings: null,
@@ -1034,6 +1186,7 @@ describe('SpendingLimit Component', () => {
     });
 
     it('renders token row with selected token in onboarding flow', () => {
+      setupAuthenticatedHomeReady();
       mockUseSpendingLimitData.mockReturnValue({
         availableTokens: [mockMUSDToken],
         delegationSettings: null,
@@ -1054,6 +1207,7 @@ describe('SpendingLimit Component', () => {
     });
 
     it('calls submit when confirm is pressed in onboarding flow', async () => {
+      setupAuthenticatedHomeReady();
       const onboardingWithToken: MockRoute = {
         params: {
           flow: 'onboarding' as const,
@@ -1072,6 +1226,7 @@ describe('SpendingLimit Component', () => {
     });
 
     it('renders onboarding route with token', () => {
+      setupAuthenticatedHomeReady();
       const onboardingWithToken: MockRoute = {
         params: {
           flow: 'onboarding' as const,
@@ -1085,6 +1240,7 @@ describe('SpendingLimit Component', () => {
     });
 
     it('renders cancel button during loading state in onboarding', () => {
+      setupAuthenticatedHomeReady();
       mockUseSpendingLimit.mockReturnValue({
         ...getDefaultUseSpendingLimitMock(),
         isLoading: true,
@@ -1116,11 +1272,37 @@ describe('SpendingLimit Component', () => {
       delegationContract: '0xMonadDelegation',
     };
 
+    const setupOnboardingReady = () => {
+      mockSelectIsCardStateResolved.mockReturnValue(true);
+      mockSelectCardHomeDataStatus.mockReturnValue('success');
+      mockUseCardHomeData.mockReturnValue({
+        data: {
+          primaryFundingAsset: null,
+          fundingAssets: [],
+          availableFundingAssets: [],
+          card: null,
+          account: { verificationStatus: 'VERIFIED' },
+          alerts: [],
+          actions: [],
+          delegationSettings: { networks: [] },
+        } as never,
+        isLoading: false,
+        isRefreshing: false,
+        isError: false,
+        refetch: mockRefetchCardHomeData,
+        primaryToken: null,
+        availableTokens: [mockPriorityToken] as never[],
+        fundingTokens: [] as never[],
+        balanceMap: new Map(),
+      });
+    };
+
     const mountWithMoneyAccount = (
       overrides: Partial<
         ReturnType<typeof getDefaultUseSpendingLimitMock>
       > = {},
     ) => {
+      setupOnboardingReady();
       mockUseSpendingLimit.mockReturnValue({
         ...getDefaultUseSpendingLimitMock(),
         isMoneyAccountSource: true,
@@ -1168,6 +1350,7 @@ describe('SpendingLimit Component', () => {
     });
 
     it('renders the spend-and-earn promo card with title, full description and CTA label when canShowMoneyAccountCta is true', () => {
+      setupOnboardingReady();
       mockUseSpendingLimit.mockReturnValue({
         ...getDefaultUseSpendingLimitMock(),
         isMoneyAccountSource: false,
@@ -1189,6 +1372,7 @@ describe('SpendingLimit Component', () => {
     });
 
     it('drops the explicit APY clause when moneyAccountApyPercent is undefined', () => {
+      setupOnboardingReady();
       mockUseSpendingLimit.mockReturnValue({
         ...getDefaultUseSpendingLimitMock(),
         isMoneyAccountSource: false,
@@ -1209,6 +1393,7 @@ describe('SpendingLimit Component', () => {
     });
 
     it('renders the same promo copy when the user has a Metal card', () => {
+      setupOnboardingReady();
       mockUseSpendingLimit.mockReturnValue({
         ...getDefaultUseSpendingLimitMock(),
         isMoneyAccountSource: false,
@@ -1227,6 +1412,7 @@ describe('SpendingLimit Component', () => {
     });
 
     it('invokes selectMoneyAccountAsSource when the switch-back CTA is pressed', () => {
+      setupOnboardingReady();
       mockUseSpendingLimit.mockReturnValue({
         ...getDefaultUseSpendingLimitMock(),
         isMoneyAccountSource: false,
@@ -1241,6 +1427,7 @@ describe('SpendingLimit Component', () => {
     });
 
     it('does NOT render the switch-back CTA when canShowMoneyAccountCta is false', () => {
+      setupOnboardingReady();
       mockUseSpendingLimit.mockReturnValue({
         ...getDefaultUseSpendingLimitMock(),
         isMoneyAccountSource: false,
@@ -1255,6 +1442,7 @@ describe('SpendingLimit Component', () => {
     });
 
     it('does NOT render the money-account CTA when canLinkMoneyAccount is false (sponsorship/7702 gating propagates through canShowMoneyAccountCta)', () => {
+      setupOnboardingReady();
       mockUseSpendingLimit.mockReturnValue({
         ...getDefaultUseSpendingLimitMock(),
         isMoneyAccountSource: false,

--- a/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.test.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.test.tsx
@@ -1010,6 +1010,19 @@ describe('SpendingLimit Component', () => {
       expect(mockFetchSpendingLimitData).toHaveBeenCalledTimes(1);
     });
 
+    it('displays error state when fallback settles without delegation settings', async () => {
+      setupAuthenticatedHomeReady({
+        delegationSettings: null,
+        availableTokens: [],
+      });
+
+      render(onboardingRoute);
+
+      expect(
+        await screen.findByTestId('spending-limit-error-container'),
+      ).toBeOnTheScreen();
+    });
+
     it('renders the form without a fallback fetch when card home has delegation settings but card state is unresolved', () => {
       setupAuthenticatedHomeReady();
       mockSelectIsCardStateResolved.mockReturnValue(false);
@@ -1065,6 +1078,37 @@ describe('SpendingLimit Component', () => {
       render(onboardingRoute);
 
       expect(mockFetchSpendingLimitData).not.toHaveBeenCalled();
+    });
+
+    it('returns to the spinner on retry after timeout while card home is still loading', () => {
+      jest.useFakeTimers();
+      mockSelectIsCardStateResolved.mockReturnValue(false);
+      mockSelectCardHomeDataStatus.mockReturnValue('loading');
+
+      try {
+        render(onboardingRoute);
+
+        act(() => {
+          jest.advanceTimersByTime(30_000);
+        });
+
+        expect(
+          screen.getByTestId('spending-limit-error-container'),
+        ).toBeOnTheScreen();
+
+        fireEvent.press(screen.getByTestId('spending-limit-retry-button'));
+
+        expect(mockRefetchCardHomeData).toHaveBeenCalledTimes(1);
+        expect(mockFetchSpendingLimitData).not.toHaveBeenCalled();
+        expect(
+          screen.getByTestId('spending-limit-loading-indicator'),
+        ).toBeOnTheScreen();
+        expect(
+          screen.queryByTestId('spending-limit-error-container'),
+        ).not.toBeOnTheScreen();
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('does not fetch data on mount when flow is manage', () => {

--- a/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.testIds.ts
+++ b/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.testIds.ts
@@ -1,5 +1,7 @@
 export const SpendingLimitSelectors = {
   LOADING_INDICATOR: 'spending-limit-loading-indicator',
+  ERROR_CONTAINER: 'spending-limit-error-container',
+  RETRY_BUTTON: 'spending-limit-retry-button',
   ACCOUNT_ROW: 'account-row',
   ACCOUNT_ROW_LOCKED: 'account-row-locked',
   ACCOUNT_ROW_MONEY_ACCOUNT: 'account-row-money-account',

--- a/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { ActivityIndicator, TouchableOpacity } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
@@ -27,6 +33,10 @@ import { useTheme } from '../../../../../util/theme';
 import { strings } from '../../../../../../locales/i18n';
 import { selectSelectedInternalAccount } from '../../../../../selectors/accountsController';
 import { selectAvatarAccountType } from '../../../../../selectors/settings';
+import {
+  selectCardHomeDataStatus,
+  selectIsCardStateResolved,
+} from '../../../../../selectors/cardController';
 import { useAccountGroupName } from '../../../../hooks/multichainAccounts/useAccountGroupName';
 import { CardFundingToken } from '../../types';
 import useSpendingLimit from '../../hooks/useSpendingLimit';
@@ -40,6 +50,8 @@ import AccountRow from './components/AccountRow';
 import TokenRow from './components/TokenRow';
 import SpendAndEarnPromoCard from './components/SpendAndEarnPromoCard';
 import { SpendingLimitSelectors } from './SpendingLimit.testIds';
+
+const ONBOARDING_LOAD_TIMEOUT_MS = 30_000;
 
 interface SpendingLimitRouteParams {
   flow?: 'manage' | 'enable' | 'onboarding' | 'enable_card';
@@ -65,6 +77,8 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
   const selectedAccount = useSelector(selectSelectedInternalAccount);
   const avatarAccountType = useSelector(selectAvatarAccountType);
   const accountGroupName = useAccountGroupName();
+  const isCardStateResolved = useSelector(selectIsCardStateResolved);
+  const cardHomeDataStatus = useSelector(selectCardHomeDataStatus);
 
   const flow = route?.params?.flow || 'manage';
   const isOnboardingFlow = flow === 'onboarding';
@@ -79,20 +93,54 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
     primaryToken,
     availableTokens: homeAvailableTokens,
     data: cardHomeData,
+    refetch: refetchCardHomeData,
   } = useCardHomeData();
   const {
     availableTokens: hookAvailableTokens,
     delegationSettings: hookDelegationSettings,
-    isLoading: isLoadingHookData,
     error: hookError,
     fetchData: fetchHookData,
   } = useSpendingLimitData();
 
+  const [loadTimedOut, setLoadTimedOut] = useState(false);
+  const [fallbackStatus, setFallbackStatus] = useState<
+    'idle' | 'pending' | 'settled'
+  >('idle');
+  const isMountedRef = useRef(true);
+
+  useEffect(
+    () => () => {
+      isMountedRef.current = false;
+    },
+    [],
+  );
+
+  const homeDelegationSettings = cardHomeData?.delegationSettings ?? null;
+  const cardHomeSettled =
+    cardHomeDataStatus === 'success' || cardHomeDataStatus === 'error';
+  // Card home data is only trusted once its fetch settles, so a stale pre-auth
+  // payload cannot be mistaken for the authenticated one.
+  const hasDelegationSettings =
+    (cardHomeSettled && homeDelegationSettings !== null) ||
+    hookDelegationSettings !== null;
+  const needsFallbackFetch =
+    homeDelegationSettings === null && (cardHomeSettled || isCardStateResolved);
+
+  const runFallbackFetch = useCallback(() => {
+    setFallbackStatus('pending');
+    fetchHookData()
+      .catch(() => undefined)
+      .finally(() => {
+        if (isMountedRef.current) setFallbackStatus('settled');
+      });
+  }, [fetchHookData]);
+
+  // Fallback only after card home settles without delegation settings.
   useEffect(() => {
-    if (isOnboardingFlow && homeAvailableTokens.length === 0) {
-      fetchHookData();
-    }
-  }, [isOnboardingFlow, homeAvailableTokens.length, fetchHookData]);
+    if (!isOnboardingFlow) return;
+    if (!needsFallbackFetch) return;
+    runFallbackFetch();
+  }, [isOnboardingFlow, needsFallbackFetch, runFallbackFetch]);
 
   const allTokens =
     homeAvailableTokens.length > 0
@@ -101,15 +149,44 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
         ? hookAvailableTokens
         : [];
   const delegationSettings =
-    cardHomeData?.delegationSettings ??
+    homeDelegationSettings ??
     (isOnboardingFlow ? hookDelegationSettings : null);
+
+  // Waiting while card home is unsettled, or while the fallback it triggers runs.
+  const isLoadInFlight =
+    isOnboardingFlow &&
+    !hasDelegationSettings &&
+    (!needsFallbackFetch || fallbackStatus !== 'settled');
+
+  // The timer is not tied to loadTimedOut, so firing it cannot clear it.
+  useEffect(() => {
+    if (!isLoadInFlight) {
+      setLoadTimedOut(false);
+      return;
+    }
+    const timer = setTimeout(() => {
+      setLoadTimedOut(true);
+    }, ONBOARDING_LOAD_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [isLoadInFlight]);
+
+  const isOnboardingError =
+    isOnboardingFlow &&
+    !hasDelegationSettings &&
+    (loadTimedOut || Boolean(hookError) || fallbackStatus === 'settled');
+  const isOnboardingPending = isLoadInFlight && !isOnboardingError;
+
+  const handleRetry = useCallback(() => {
+    setLoadTimedOut(false);
+    refetchCardHomeData();
+    runFallbackFetch();
+  }, [refetchCardHomeData, runFallbackFetch]);
 
   const {
     selectedToken,
     limitType,
     customLimit,
     isLoading,
-    isUiInteractionLocked,
     handleAccountSelect,
     handleOtherSelect,
     handleLimitSelect,
@@ -122,6 +199,7 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
     canShowMoneyAccountCta,
     selectMoneyAccountAsSource,
     moneyAccountApyPercent,
+    shouldBlockNavigation,
   } = useSpendingLimit({
     flow,
     initialToken: selectedTokenFromRoute,
@@ -131,18 +209,13 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
     routeParams: route?.params as Record<string, unknown> | undefined,
   });
 
-  const isUiInteractionLockedRef = useRef(isUiInteractionLocked);
-  useEffect(() => {
-    isUiInteractionLockedRef.current = isUiInteractionLocked;
-  }, [isUiInteractionLocked]);
-
   useEffect(() => {
     const unsubscribe = navigation.addListener('beforeRemove', (e) => {
-      if (!isUiInteractionLockedRef.current) return;
+      if (!shouldBlockNavigation()) return;
       e.preventDefault();
     });
     return unsubscribe;
-  }, [navigation]);
+  }, [navigation, shouldBlockNavigation]);
 
   const tokenLabel = useMemo(() => {
     if (!selectedToken) return '';
@@ -166,7 +239,7 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
     return customLimit || '0';
   }, [limitType, customLimit]);
 
-  if (isOnboardingFlow && isLoadingHookData) {
+  if (isOnboardingPending) {
     return (
       <SafeAreaView
         style={tw.style('flex-1 bg-background-default')}
@@ -194,8 +267,7 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
     );
   }
 
-  // Error state for onboarding
-  if (isOnboardingFlow && hookError && !delegationSettings) {
+  if (isOnboardingError) {
     return (
       <SafeAreaView
         style={tw.style('flex-1 bg-background-default')}
@@ -206,7 +278,10 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
           twClassName="bg-background-default"
           {...headerHandlers}
         />
-        <Box twClassName="flex-1 justify-center items-center px-6">
+        <Box
+          twClassName="flex-1 justify-center items-center px-6"
+          testID={SpendingLimitSelectors.ERROR_CONTAINER}
+        >
           <Icon
             name={IconName.Danger}
             size={IconSize.Xl}
@@ -222,8 +297,9 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
             <Button
               variant={ButtonVariant.Primary}
               size={ButtonSize.Md}
-              onPress={fetchHookData}
+              onPress={handleRetry}
               isFullWidth
+              testID={SpendingLimitSelectors.RETRY_BUTTON}
             >
               {strings('card.card_spending_limit.retry')}
             </Button>

--- a/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.tsx
+++ b/app/components/UI/Card/Views/SpendingLimit/SpendingLimit.tsx
@@ -107,6 +107,7 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
     'idle' | 'pending' | 'settled'
   >('idle');
   const isMountedRef = useRef(true);
+  const fallbackRequestIdRef = useRef(0);
 
   useEffect(
     () => () => {
@@ -127,20 +128,28 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
     homeDelegationSettings === null && (cardHomeSettled || isCardStateResolved);
 
   const runFallbackFetch = useCallback(() => {
+    const requestId = ++fallbackRequestIdRef.current;
     setFallbackStatus('pending');
     fetchHookData()
       .catch(() => undefined)
       .finally(() => {
-        if (isMountedRef.current) setFallbackStatus('settled');
+        if (
+          isMountedRef.current &&
+          fallbackRequestIdRef.current === requestId
+        ) {
+          setFallbackStatus('settled');
+        }
       });
   }, [fetchHookData]);
 
   // Fallback only after card home settles without delegation settings.
+  // Idle guard keeps this from re-firing when fetchHookData identity changes.
   useEffect(() => {
     if (!isOnboardingFlow) return;
     if (!needsFallbackFetch) return;
+    if (fallbackStatus !== 'idle') return;
     runFallbackFetch();
-  }, [isOnboardingFlow, needsFallbackFetch, runFallbackFetch]);
+  }, [isOnboardingFlow, needsFallbackFetch, fallbackStatus, runFallbackFetch]);
 
   const allTokens =
     homeAvailableTokens.length > 0
@@ -158,29 +167,34 @@ const SpendingLimit: React.FC<SpendingLimitProps> = ({ route }) => {
     !hasDelegationSettings &&
     (!needsFallbackFetch || fallbackStatus !== 'settled');
 
-  // The timer is not tied to loadTimedOut, so firing it cannot clear it.
+  // loadTimedOut is in the deps so Retry can start a fresh timer, but a fired
+  // timeout must not schedule another one or the error UI would unlatch.
   useEffect(() => {
     if (!isLoadInFlight) {
       setLoadTimedOut(false);
       return;
     }
+    if (loadTimedOut) return;
     const timer = setTimeout(() => {
       setLoadTimedOut(true);
     }, ONBOARDING_LOAD_TIMEOUT_MS);
     return () => clearTimeout(timer);
-  }, [isLoadInFlight]);
+  }, [isLoadInFlight, loadTimedOut]);
 
   const isOnboardingError =
     isOnboardingFlow &&
     !hasDelegationSettings &&
-    (loadTimedOut || Boolean(hookError) || fallbackStatus === 'settled');
+    (loadTimedOut ||
+      Boolean(hookError) ||
+      (needsFallbackFetch && fallbackStatus === 'settled'));
   const isOnboardingPending = isLoadInFlight && !isOnboardingError;
 
   const handleRetry = useCallback(() => {
+    fallbackRequestIdRef.current += 1;
     setLoadTimedOut(false);
+    setFallbackStatus('idle');
     refetchCardHomeData();
-    runFallbackFetch();
-  }, [refetchCardHomeData, runFallbackFetch]);
+  }, [refetchCardHomeData]);
 
   const {
     selectedToken,

--- a/app/components/UI/Card/components/Onboarding/PhysicalAddress.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/PhysicalAddress.test.tsx
@@ -51,7 +51,7 @@ jest.mock('../../../../../core/Engine', () => ({
   default: {
     context: {
       CardController: {
-        validateAndRefreshSession: jest.fn().mockResolvedValue(undefined),
+        syncSessionAfterExternalAuth: jest.fn().mockResolvedValue(undefined),
       },
     },
   },

--- a/app/components/UI/Card/components/Onboarding/PhysicalAddress.tsx
+++ b/app/components/UI/Card/components/Onboarding/PhysicalAddress.tsx
@@ -62,6 +62,7 @@ import { COINME_TERMS_URL, CRB_PRIVACY_POLICY_URL } from '../../constants';
 import { getCardUsDisclosureUrls } from '../../util/registrationSettings';
 
 const VERIFICATION_POLLING_INTERVAL_MS = 3000;
+const VERIFICATION_POLLING_TIMEOUT_MS = 6000;
 
 export const AddressFields = ({
   addressLine1,
@@ -248,14 +249,21 @@ const PhysicalAddress = () => {
   const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(
     null,
   );
+  const pollingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isMountedRef = useRef(true);
   const { data: registrationSettings } = useRegistrationSettings();
 
-  // Cleanup polling interval on unmount
+  // Cleanup polling timers on unmount
   useEffect(
     () => () => {
+      isMountedRef.current = false;
       if (pollingIntervalRef.current) {
         clearInterval(pollingIntervalRef.current);
         pollingIntervalRef.current = null;
+      }
+      if (pollingTimeoutRef.current) {
+        clearTimeout(pollingTimeoutRef.current);
+        pollingTimeoutRef.current = null;
       }
     },
     [],
@@ -516,9 +524,7 @@ const PhysicalAddress = () => {
         });
 
         if (storeResult.success) {
-          // Sync controller state: sets CardController.isAuthenticated = true
-          // and providerData.baanx.location so route guards read the correct state.
-          await Engine.context.CardController.validateAndRefreshSession().catch(
+          await Engine.context.CardController.syncSessionAfterExternalAuth().catch(
             () => undefined,
           );
         }
@@ -544,6 +550,13 @@ const PhysicalAddress = () => {
           if (pollingIntervalRef.current) {
             clearInterval(pollingIntervalRef.current);
             pollingIntervalRef.current = null;
+          }
+          if (pollingTimeoutRef.current) {
+            clearTimeout(pollingTimeoutRef.current);
+            pollingTimeoutRef.current = null;
+          }
+          if (!isMountedRef.current) {
+            return;
           }
           setIsPollingVerification(false);
           dispatch(resetOnboardingState());
@@ -613,13 +626,11 @@ const PhysicalAddress = () => {
             pollVerificationState();
           }, VERIFICATION_POLLING_INTERVAL_MS);
 
-          // Set a timeout to stop polling after a reasonable time and redirect to Card Home
-          // This prevents infinite polling if the status never changes
-          setTimeout(() => {
+          pollingTimeoutRef.current = setTimeout(() => {
             if (pollingIntervalRef.current) {
               stopPollingAndNavigate({ name: Routes.CARD.HOME });
             }
-          }, VERIFICATION_POLLING_INTERVAL_MS * 2); // Poll 2 times max (6 seconds total)
+          }, VERIFICATION_POLLING_TIMEOUT_MS);
         }
 
         return;

--- a/app/components/UI/Card/hooks/useSpendingLimit.test.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimit.test.ts
@@ -1732,6 +1732,36 @@ describe('useSpendingLimit', () => {
       expect(result.current.isUiInteractionLocked).toBe(true);
     });
 
+    it('shouldBlockNavigation mirrors isUiInteractionLocked until an intentional exit', () => {
+      mockUseCardDelegation.mockReturnValue({
+        submitDelegation: mockSubmitDelegation,
+        isLoading: true,
+        error: null,
+        needsFaucet: false,
+        isFaucetCheckLoading: false,
+        refetchFaucetCheck: jest.fn(),
+      });
+
+      const { result } = renderHook(() =>
+        useSpendingLimit(createDefaultParams()),
+      );
+
+      expect(result.current.shouldBlockNavigation()).toBe(true);
+    });
+
+    it('shouldBlockNavigation returns false after skip starts an intentional exit', () => {
+      const { result } = renderHook(() =>
+        useSpendingLimit(createDefaultParams({ flow: 'onboarding' })),
+      );
+
+      act(() => {
+        result.current.skip();
+      });
+
+      expect(result.current.shouldBlockNavigation()).toBe(false);
+      expect(mockNavigation.dispatch).toHaveBeenCalled();
+    });
+
     it('returns false when Money Account linkage is processing outside onboarding', async () => {
       const MONEY_ACCOUNT_TOKEN: CardFundingToken = {
         address: '0xMonadUsdc',
@@ -1894,6 +1924,55 @@ describe('useSpendingLimit', () => {
       expect(result.current.isMoneyAccountSource).toBe(true);
       expect(result.current.selectedToken).toEqual(MONEY_ACCOUNT_TOKEN);
       expect(result.current.canShowMoneyAccountCta).toBe(false);
+    });
+
+    it('upgrades an auto-picked wallet default to Money Account when canLink resolves late', () => {
+      const priorityToken = createMockToken({
+        symbol: 'USDC',
+        address: '0xusdc',
+        fundingStatus: FundingStatus.NotEnabled,
+      });
+
+      mockUseMoneyAccountCardLinkage.mockReturnValue(
+        buildLinkageReturn({
+          hasMoneyAccountRequirements: true,
+          isCardAuthenticated: true,
+          moneyAccountCardToken: null,
+          canLink: false,
+        }),
+      );
+
+      const { result, rerender } = renderHook(
+        (props) => useSpendingLimit(props),
+        {
+          initialProps: createDefaultParams({
+            flow: 'onboarding',
+            priorityToken,
+          }),
+        },
+      );
+
+      expect(result.current.isMoneyAccountSource).toBe(false);
+      expect(result.current.selectedToken).toEqual(priorityToken);
+
+      mockUseMoneyAccountCardLinkage.mockReturnValue(
+        buildLinkageReturn({
+          hasMoneyAccountRequirements: true,
+          isCardAuthenticated: true,
+          moneyAccountCardToken: MONEY_ACCOUNT_TOKEN,
+          canLink: true,
+        }),
+      );
+
+      rerender(
+        createDefaultParams({
+          flow: 'onboarding',
+          priorityToken,
+        }),
+      );
+
+      expect(result.current.isMoneyAccountSource).toBe(true);
+      expect(result.current.selectedToken).toEqual(MONEY_ACCOUNT_TOKEN);
     });
 
     it('preselects Money Account on the onboarding flow even when balance is zero', () => {

--- a/app/components/UI/Card/hooks/useSpendingLimit.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimit.ts
@@ -108,6 +108,9 @@ export interface UseSpendingLimitReturn {
   canLinkMoneyAccount: boolean;
   moneyAccountApyPercent: number | undefined;
   hasMetalCard: boolean;
+
+  /** False for intentional exits so beforeRemove cannot swallow navigation. */
+  shouldBlockNavigation: () => boolean;
 }
 
 const deriveLimitStateFromToken = (
@@ -169,6 +172,8 @@ const useSpendingLimit = ({
   const [isProcessing, setIsProcessing] = useState(false);
   const [hasInitialized, setHasInitialized] = useState(false);
   const [isMoneyAccountSource, setIsMoneyAccountSource] = useState(false);
+  // True when selectedToken came from auto-init (not an explicit user choice).
+  const [isAutoSelectedDefault, setIsAutoSelectedDefault] = useState(false);
 
   const isOnboardingFlow = flow === 'onboarding';
   const isEnableCardFlow = flow === 'enable_card';
@@ -192,6 +197,9 @@ const useSpendingLimit = ({
   const hasMetalCard = cardHomeData?.card?.type === CardType.METAL;
 
   const hasUserExitedMoneyAccountSourceRef = useRef(false);
+  const isExitingRef = useRef(false);
+  const isLoadingRef = useRef(false);
+  const isMoneyAccountSourceRef = useRef(false);
 
   // Track account changes to reset token selection when user switches account
   const selectedAccount = useSelector(selectSelectedInternalAccount);
@@ -206,6 +214,7 @@ const useSpendingLimit = ({
       accountIdRef.current = selectedAccount.id;
       setHasInitialized(false);
       setSelectedToken(null);
+      setIsAutoSelectedDefault(false);
       if (isMoneyAccountSource) {
         setIsMoneyAccountSource(false);
         hasUserExitedMoneyAccountSourceRef.current = true;
@@ -224,6 +233,9 @@ const useSpendingLimit = ({
   const isLoading = isDelegationLoading || isProcessing;
   const isUiInteractionLocked =
     isLoading && (!isMoneyAccountSource || isOnboardingFlow);
+
+  isLoadingRef.current = isLoading;
+  isMoneyAccountSourceRef.current = isMoneyAccountSource;
 
   // Wallet-only token balances for the currently selected MetaMask account.
   // Using this (instead of useAssetBalances) ensures sorting reflects the active
@@ -350,6 +362,7 @@ const useSpendingLimit = ({
 
     if (initialToken) {
       applySelectedToken(initialToken);
+      setIsAutoSelectedDefault(false);
       setHasInitialized(true);
       return;
     }
@@ -361,6 +374,7 @@ const useSpendingLimit = ({
     ) {
       setIsMoneyAccountSource(true);
       applySelectedToken(priorityToken);
+      setIsAutoSelectedDefault(true);
       setHasInitialized(true);
       return;
     }
@@ -373,12 +387,14 @@ const useSpendingLimit = ({
     ) {
       setIsMoneyAccountSource(true);
       applySelectedToken(moneyAccountCardToken);
+      setIsAutoSelectedDefault(true);
       setHasInitialized(true);
       return;
     }
 
     if (!selectedToken && priorityToken) {
       applySelectedToken(priorityToken);
+      setIsAutoSelectedDefault(true);
       setHasInitialized(true);
       return;
     }
@@ -421,6 +437,7 @@ const useSpendingLimit = ({
       const defaultToken = sorted[0]?.token;
       if (defaultToken) {
         applySelectedToken(defaultToken);
+        setIsAutoSelectedDefault(true);
         setHasInitialized(true);
       }
     }
@@ -440,6 +457,26 @@ const useSpendingLimit = ({
     moneyAccountCardToken,
   ]);
 
+  // Upgrade auto-picked default to Money Account when canLink resolves late.
+  useEffect(() => {
+    if (!isMoneyAccountPreselectAllowed) return;
+    if (!isAutoSelectedDefault) return;
+    if (isMoneyAccountSource) return;
+    if (hasUserExitedMoneyAccountSourceRef.current) return;
+    if (!canLinkMoneyAccount || !moneyAccountCardToken) return;
+
+    setIsMoneyAccountSource(true);
+    applySelectedToken(moneyAccountCardToken);
+    setIsAutoSelectedDefault(true);
+  }, [
+    isMoneyAccountPreselectAllowed,
+    isAutoSelectedDefault,
+    isMoneyAccountSource,
+    canLinkMoneyAccount,
+    moneyAccountCardToken,
+    applySelectedToken,
+  ]);
+
   // Handle returned values from modal sheets
   useFocusEffect(
     useCallback(() => {
@@ -453,6 +490,7 @@ const useSpendingLimit = ({
 
       if (params?.returnedSelectedToken) {
         applySelectedToken(params.returnedSelectedToken);
+        setIsAutoSelectedDefault(false);
         setHasInitialized(true);
         navigation.setParams({
           returnedSelectedToken: undefined,
@@ -548,6 +586,7 @@ const useSpendingLimit = ({
     hasUserExitedMoneyAccountSourceRef.current = false;
     setIsMoneyAccountSource(true);
     applySelectedToken(moneyAccountCardToken);
+    setIsAutoSelectedDefault(false);
   }, [moneyAccountCardToken, applySelectedToken]);
 
   const canShowMoneyAccountCta =
@@ -607,12 +646,20 @@ const useSpendingLimit = ({
 
   // Navigation helpers
   const navigateToCardHome = useCallback(() => {
+    isExitingRef.current = true;
     navigation.dispatch(
       StackActions.replace(Routes.CARD.HOME, {
         fromCardOnboarding: isOnboardingFlow,
       }),
     );
   }, [navigation, isOnboardingFlow]);
+
+  const shouldBlockNavigation = useCallback(() => {
+    if (isExitingRef.current) return false;
+    const loading = isLoadingRef.current;
+    const moneySource = isMoneyAccountSourceRef.current;
+    return loading && (!moneySource || isOnboardingFlow);
+  }, [isOnboardingFlow]);
 
   // Actions
   const submit = useCallback(async () => {
@@ -643,13 +690,12 @@ const useSpendingLimit = ({
               'Failed to refresh card home data after Money Account link',
             );
           }
-          setTimeout(() => {
-            if (isOnboardingFlow) {
-              navigateToCardHome();
-            } else if (navigation.isFocused()) {
-              navigation.goBack();
-            }
-          }, 0);
+          if (isOnboardingFlow) {
+            navigateToCardHome();
+          } else if (navigation.isFocused()) {
+            isExitingRef.current = true;
+            navigation.goBack();
+          }
         }
       } finally {
         setIsProcessing(false);
@@ -700,13 +746,12 @@ const useSpendingLimit = ({
 
       setIsProcessing(false);
 
-      setTimeout(() => {
-        if (isOnboardingFlow) {
-          navigateToCardHome();
-        } else {
-          navigation.goBack();
-        }
-      }, 0);
+      if (isOnboardingFlow) {
+        navigateToCardHome();
+      } else {
+        isExitingRef.current = true;
+        navigation.goBack();
+      }
     } catch (error) {
       setIsProcessing(false);
 
@@ -749,6 +794,7 @@ const useSpendingLimit = ({
         .build(),
     );
 
+    isExitingRef.current = true;
     navigation.goBack();
   }, [navigation, trackEvent, createEventBuilder, activeProviderId, isLoading]);
 
@@ -811,6 +857,7 @@ const useSpendingLimit = ({
     canLinkMoneyAccount,
     moneyAccountApyPercent,
     hasMetalCard,
+    shouldBlockNavigation,
   };
 };
 

--- a/app/components/UI/Card/hooks/useSpendingLimitData.test.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimitData.test.ts
@@ -529,6 +529,17 @@ describe('useSpendingLimitData', () => {
 
       expect(mockFetchDelegationSettings).not.toHaveBeenCalled();
     });
+
+    it('swallows fetchDelegationSettings rejections so they surface via observer error', async () => {
+      mockIsAuthenticated = true;
+      mockFetchDelegationSettings.mockRejectedValueOnce(
+        new Error('Network error'),
+      );
+
+      const { result } = renderHook(() => useSpendingLimitData());
+
+      await expect(result.current.fetchData()).resolves.toBeUndefined();
+    });
   });
 
   describe('Return Value Structure', () => {

--- a/app/components/UI/Card/hooks/useSpendingLimitData.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimitData.ts
@@ -48,7 +48,11 @@ const useSpendingLimitData = (): UseSpendingLimitDataReturn => {
 
   const fetchData = useCallback(async () => {
     if (!isAuthenticated) return;
-    await fetchDelegationSettings();
+    try {
+      await fetchDelegationSettings();
+    } catch {
+      // Surfaced via useGetDelegationSettings error.
+    }
   }, [isAuthenticated, fetchDelegationSettings]);
 
   return {

--- a/app/core/Engine/controllers/card-controller/CardController.test.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.test.ts
@@ -1127,6 +1127,48 @@ describe('CardController — auth methods', () => {
       expect(fetchSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe('syncSessionAfterExternalAuth', () => {
+    it('returns early without clearing or refetching when not authenticated', async () => {
+      const provider = buildMockProvider();
+      mockTokenStore.get.mockResolvedValue(null);
+      const controller = buildController(provider, {
+        cardHomeData: mockCardHomeData as unknown as Record<string, null>,
+        cardHomeDataStatus: 'success',
+      });
+      const fetchSpy = jest
+        .spyOn(controller, 'fetchCardHomeData')
+        .mockResolvedValue();
+
+      await controller.syncSessionAfterExternalAuth();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(controller.state.cardHomeData).toStrictEqual(mockCardHomeData);
+      expect(controller.state.cardHomeDataStatus).toBe('success');
+    });
+
+    it('clears stale card home data and force-refetches when authenticated', async () => {
+      const provider = buildMockProvider();
+      mockTokenStore.get.mockResolvedValue(mockTokenSet);
+      provider.validateTokens.mockReturnValue('valid');
+      provider.getCardHomeData.mockResolvedValue(mockCardHomeData);
+      const { controller } = buildControllerWithMockMessenger(provider, {
+        isAuthenticated: false,
+        cardHomeData: {
+          ...mockCardHomeData,
+          delegationSettings: null,
+        } as unknown as Record<string, null>,
+        cardHomeDataStatus: 'success',
+      });
+
+      await controller.syncSessionAfterExternalAuth();
+
+      expect(controller.state.isAuthenticated).toBe(true);
+      expect(controller.state.cardHomeDataStatus).toBe('success');
+      expect(controller.state.cardHomeData).toStrictEqual(mockCardHomeData);
+      expect(provider.getCardHomeData).toHaveBeenCalled();
+    });
+  });
 });
 
 describe('CardController — 401 retry and forced logout', () => {

--- a/app/core/Engine/controllers/card-controller/CardController.ts
+++ b/app/core/Engine/controllers/card-controller/CardController.ts
@@ -823,6 +823,17 @@ export class CardController extends BaseController<
     return { isAuthenticated: true, location: tokens.location };
   }
 
+  /**
+   * Post-auth sync for tokens written outside `submitCredentials` (e.g. onboarding vault write).
+   * Clears stale card home data and force-refetches authenticated home data.
+   */
+  async syncSessionAfterExternalAuth(): Promise<void> {
+    const { isAuthenticated } = await this.validateAndRefreshSession();
+    if (!isAuthenticated) return;
+    this.#invalidateAndClear();
+    await this.fetchCardHomeData({ force: true });
+  }
+
   // -- Token helpers --
 
   /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

After Exodus KYC completes, Physical Address stored the Baanx token and only called `validateAndRefreshSession()`. That flipped `isAuthenticated` but left stale pre-auth card home data in place (`delegationSettings=null`, Linea USDC as the primary asset, `account=null`). Spending Limit then defaulted to USDC on Linea, never loaded the token list, and could spin forever instead of reaching Card Home.

This change:

- Adds `CardController.syncSessionAfterExternalAuth()` to validate the session, clear stale home data, and force-refetch authenticated card home data. Physical Address now calls that after the vault write.
- Gates onboarding Spending Limit on settled card-home / fallback delegation settings, with an explicit error/retry/skip path and a 30s timeout that latches instead of resetting into another spinner.
- Treats card-home `delegationSettings` as usable once the home fetch settles, even if `selectIsCardStateResolved` is still false.
- Upgrades an auto-picked default token to the Money Account asset if eligibility resolves later, without overriding an explicit user choice.
- Blocks accidental back navigation during onboarding submit via a ref-backed `shouldBlockNavigation`, and lets intentional skip/cancel/submit proceed.

Non-onboarding Spending Limit flows are unchanged and do not trigger the fallback fetch.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Card onboarding getting stuck on the spending limit screen after verification

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: CARD-484

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Exodus Card onboarding spending limit

  Background:
    Given I am logged into MetaMask Mobile
    And I have a Money Account that is eligible to link to Card

  Scenario: verified Exodus user reaches Spending Limit with Money Account selected
    Given I complete Exodus Card onboarding through Physical Address
    And KYC verification succeeds within the expected window

    When I am redirected to Spending Limit with flow "onboarding"
    Then the available token list should load
    And the default asset should be my Money Account asset
    And I should not see USDC on Linea as the default unless I am not Money Account eligible

  Scenario: user confirms spending limit and lands on Card Home
    Given I am on Spending Limit in the onboarding flow
    And a token and limit are selected

    When I tap Confirm
    Then I should be navigated to Card Home
    And I should not remain on a loading spinner

  Scenario: load failure shows retry and skip instead of an infinite spinner
    Given I am on Spending Limit in the onboarding flow
    And card home and fallback delegation requests fail or time out

    When the error state is shown
    Then I should see Retry and Skip actions
    And Retry should refetch card home and fallback data
    And Skip should navigate to Card Home

  Scenario: manage spending limit is unchanged
    Given I already have a Card
    And I open Spending Limit from Card Home (manage flow)

    When the screen loads
    Then no extra onboarding fallback fetch should run
    And I can update or cancel the limit as before
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches card onboarding, session/home data invalidation, and spending-limit defaults; well-covered by tests but affects a critical user path after KYC.
> 
> **Overview**
> Fixes Card onboarding getting stuck on **Spending Limit** after Exodus KYC by syncing authenticated card home data and tightening onboarding load/navigation behavior.
> 
> **Physical Address** now calls **`CardController.syncSessionAfterExternalAuth()`** after the Baanx vault write instead of only validating the session. That path clears stale pre-auth home payload and **force-refetches** card home so delegation settings and tokens match the authenticated user.
> 
> **Onboarding Spending Limit** waits for **settled card home** (or resolved card state) before trusting data, runs a **fallback delegation fetch** only when home has no delegation settings, and shows a **30s latched timeout** with **retry** (refetch home + fallback) and **skip** instead of an infinite spinner. Manage/enable flows are unchanged.
> 
> **`useSpendingLimit`** exposes **`shouldBlockNavigation()`** so skip/cancel/submit can exit while blocking accidental back during submit; it can **upgrade an auto-picked token to Money Account** when `canLink` resolves late without overriding explicit picks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1611e480e3c6c75fef38402e24f36d82a7623268. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->