### PR TITLE
feat: Add React Compiler failure reports for assets

### DIFF
--- a/app/components/UI/AssetOverview/PriceChart/PriceChart.tsx
+++ b/app/components/UI/AssetOverview/PriceChart/PriceChart.tsx
@@ -1,6 +1,13 @@
 /* eslint-disable react/no-unstable-nested-components */
 import { TokenPrice } from 'app/components/hooks/useTokenHistoricalPrices';
-import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   Dimensions,
   GestureResponderEvent,
@@ -67,6 +74,51 @@ export function findNearestIndex(
   }
   return lo;
 }
+
+interface ChartPanHandlers {
+  updatePosition: (pixelX: number) => void;
+  setIsChartBeingTouched: (isTouched: boolean) => void;
+}
+
+const createChartPanResponder = ({
+  updatePosition,
+  setIsChartBeingTouched,
+}: ChartPanHandlers) => {
+  const prevTouch = { current: { x: 0, y: 0 } };
+
+  return PanResponder.create({
+    onStartShouldSetPanResponder: () => true,
+    onStartShouldSetPanResponderCapture: () => true,
+    onMoveShouldSetPanResponder: () => true,
+    onMoveShouldSetPanResponderCapture: () => true,
+    onPanResponderTerminationRequest: () => true,
+    onPanResponderGrant: (evt: GestureResponderEvent) => {
+      prevTouch.current = {
+        x: evt.nativeEvent.locationX,
+        y: evt.nativeEvent.locationY,
+      };
+      updatePosition(evt.nativeEvent.locationX);
+    },
+    onPanResponderMove: (evt: GestureResponderEvent) => {
+      const deltaX = evt.nativeEvent.locationX - prevTouch.current.x;
+      const deltaY = evt.nativeEvent.locationY - prevTouch.current.y;
+      const isHorizontalSwipe = Math.abs(deltaX) > Math.abs(deltaY);
+
+      setIsChartBeingTouched(isHorizontalSwipe);
+      updatePosition(isHorizontalSwipe ? evt.nativeEvent.locationX : -1);
+
+      prevTouch.current = {
+        x: evt.nativeEvent.locationX,
+        y: evt.nativeEvent.locationY,
+      };
+    },
+
+    onPanResponderRelease: () => {
+      setIsChartBeingTouched(false);
+      updatePosition(-1);
+    },
+  });
+};
 
 interface PriceChartProps {
   prices: TokenPrice[];
@@ -141,12 +193,11 @@ const PriceChart = ({
   // Stable x-domain for the time-based axis. Recalculated when the data or
   // time-period changes so the "now" anchor matches the fetch moment.
   const { chartXMin, chartXMax } = useMemo(() => {
-    if (!isTimeBased) {
+    if (!isTimeBased || prices.length === 0) {
       return { chartXMin: undefined, chartXMax: undefined };
     }
     const now = Date.now();
     return { chartXMin: now - timePeriodMs, chartXMax: now };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isTimeBased, timePeriodMs, prices]);
 
   // Detect if this is a stablecoin and calculate appropriate Y-axis range
@@ -211,79 +262,55 @@ const PriceChart = ({
     );
   }, [chartHasData, isLoading, trackEvent, createEventBuilder]);
 
-  const onActiveIndexChange = (index: number) => {
-    setPositionX(index);
-    onChartIndexChange(index);
-  };
+  const onActiveIndexChange = useCallback(
+    (index: number) => {
+      setPositionX(index);
+      onChartIndexChange(index);
+    },
+    [onChartIndexChange],
+  );
 
-  const updatePosition = (pixelX: number) => {
-    if (pixelX === -1) {
-      onActiveIndexChange(-1);
-      return;
-    }
-    const chartWidth =
-      chartRowWidth > 0 ? chartRowWidth : Dimensions.get('window').width;
-
-    if (isTimeBased && chartXMin != null && chartXMax != null) {
-      const rangeMax = chartWidth - endDotInsetRight;
-      const clamped = Math.max(0, Math.min(pixelX, rangeMax));
-      const fraction = rangeMax > 0 ? clamped / rangeMax : 0;
-      const targetTs = chartXMin + fraction * (chartXMax - chartXMin);
-      const idx = findNearestIndex(prices, targetTs);
-      onActiveIndexChange(idx);
-    } else {
-      const xDistance = chartWidth / priceList.length;
-      const clamped = Math.max(0, Math.min(pixelX, chartWidth));
-      let value = Number((clamped / xDistance).toFixed(0));
-      if (value >= priceList.length - 1) {
-        value = priceList.length - 1;
+  const updatePosition = useCallback(
+    (pixelX: number) => {
+      if (pixelX === -1) {
+        onActiveIndexChange(-1);
+        return;
       }
-      onActiveIndexChange(value);
-    }
-  };
+      const chartWidth =
+        chartRowWidth > 0 ? chartRowWidth : Dimensions.get('window').width;
 
-  // Refs so the PanResponder closure always calls the latest functions.
-  const updatePositionRef = useRef(updatePosition);
-  updatePositionRef.current = updatePosition;
-  const setIsChartBeingTouchedRef = useRef(setIsChartBeingTouched);
-  setIsChartBeingTouchedRef.current = setIsChartBeingTouched;
+      if (isTimeBased && chartXMin != null && chartXMax != null) {
+        const rangeMax = chartWidth - endDotInsetRight;
+        const clamped = Math.max(0, Math.min(pixelX, rangeMax));
+        const fraction = rangeMax > 0 ? clamped / rangeMax : 0;
+        const targetTs = chartXMin + fraction * (chartXMax - chartXMin);
+        const idx = findNearestIndex(prices, targetTs);
+        onActiveIndexChange(idx);
+      } else {
+        const xDistance = chartWidth / priceList.length;
+        const clamped = Math.max(0, Math.min(pixelX, chartWidth));
+        let value = Number((clamped / xDistance).toFixed(0));
+        if (value >= priceList.length - 1) {
+          value = priceList.length - 1;
+        }
+        onActiveIndexChange(value);
+      }
+    },
+    [
+      onActiveIndexChange,
+      chartRowWidth,
+      isTimeBased,
+      chartXMin,
+      chartXMax,
+      endDotInsetRight,
+      prices,
+      priceList,
+    ],
+  );
 
-  const prevTouch = useRef({ x: 0, y: 0 });
-  const panResponder = useRef(
-    PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
-      onStartShouldSetPanResponderCapture: () => true,
-      onMoveShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponderCapture: () => true,
-      onPanResponderTerminationRequest: () => true,
-      onPanResponderGrant: (evt: GestureResponderEvent) => {
-        prevTouch.current = {
-          x: evt.nativeEvent.locationX,
-          y: evt.nativeEvent.locationY,
-        };
-        updatePositionRef.current(evt.nativeEvent.locationX);
-      },
-      onPanResponderMove: (evt: GestureResponderEvent) => {
-        const deltaX = evt.nativeEvent.locationX - prevTouch.current.x;
-        const deltaY = evt.nativeEvent.locationY - prevTouch.current.y;
-        const isHorizontalSwipe = Math.abs(deltaX) > Math.abs(deltaY);
-
-        setIsChartBeingTouchedRef.current(isHorizontalSwipe);
-        updatePositionRef.current(
-          isHorizontalSwipe ? evt.nativeEvent.locationX : -1,
-        );
-
-        prevTouch.current = {
-          x: evt.nativeEvent.locationX,
-          y: evt.nativeEvent.locationY,
-        };
-      },
-
-      onPanResponderRelease: () => {
-        setIsChartBeingTouchedRef.current(false);
-        updatePositionRef.current(-1);
-      },
-    }),
+  const panResponder = useMemo(
+    () => createChartPanResponder({ updatePosition, setIsChartBeingTouched }),
+    [updatePosition, setIsChartBeingTouched],
   );
 
   const Line = (props: Partial<LineProps>) => {
@@ -399,7 +426,7 @@ const PriceChart = ({
       <View
         style={styles.chartAreaWrapper}
         testID={chartHasData ? 'price-chart-area' : undefined}
-        {...(chartHasData ? panResponder.current.panHandlers : {})}
+        {...(chartHasData ? panResponder.panHandlers : {})}
       >
         {chartHasData ? (
           <AreaChart

--- a/app/components/UI/Assets/DeFiPositions/components/DeFiPositionsListV2.tsx
+++ b/app/components/UI/Assets/DeFiPositions/components/DeFiPositionsListV2.tsx
@@ -92,11 +92,7 @@ const DeFiPositionsListV2: React.FC<DeFiPositionsListV2Props> = ({
 
   const handleDeFiRefresh = useCallback(async () => {
     setRefreshing(true);
-    try {
-      await refresh();
-    } finally {
-      setRefreshing(false);
-    }
+    await refresh().finally(() => setRefreshing(false));
   }, [refresh]);
 
   const listLength = formattedPositions.length;

--- a/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx
+++ b/app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx
@@ -36,6 +36,7 @@ import {
   ToastContext,
   ToastVariants,
 } from '../../../../../../component-library/components/Toast';
+import type { ToastOptions } from '../../../../../../component-library/components/Toast/Toast.types';
 import { IconName } from '../../../../../../component-library/components/Icons/Icon';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { formatPriceWithSubscriptNotation } from '../../../../Predict/utils/format';
@@ -76,6 +77,11 @@ const analyticsPropsForAlert = (priceAlert: Alert) =>
       }
     : { alert_type: PriceAlertAnalytics.TYPE.THRESHOLD };
 
+// Extracted because React Compiler (BuildHIR) cannot lower a `throw` written inside a try/catch.
+function failRequest(message: string): never {
+  throw new Error(message);
+}
+
 const ManagePriceAlertsView: React.FC = () => {
   const tw = useTailwind();
   const { colors, brandColors } = useTheme();
@@ -93,6 +99,13 @@ const ManagePriceAlertsView: React.FC = () => {
     route.params;
   const displayTicker = ticker || symbol;
   const { trackEvent, createEventBuilder } = useAnalytics();
+
+  const showToast = useCallback(
+    (options: ToastOptions) => {
+      toastRef?.current?.showToast(options);
+    },
+    [toastRef],
+  );
 
   const hasResolvedInitialFetch = useRef(false);
   const {
@@ -130,7 +143,7 @@ const ManagePriceAlertsView: React.FC = () => {
     }
     hasResolvedInitialFetch.current = true;
     if (isError) {
-      toastRef?.current?.showToast({
+      showToast({
         variant: ToastVariants.Icon,
         iconName: IconName.Danger,
         iconColor: colors.error.default,
@@ -157,7 +170,7 @@ const ManagePriceAlertsView: React.FC = () => {
     currentPrice,
     currentCurrency,
     assetId,
-    toastRef,
+    showToast,
     colors,
   ]);
 
@@ -204,9 +217,9 @@ const ManagePriceAlertsView: React.FC = () => {
       const target = previous.find((a) => a.id === id);
 
       try {
-        if (!target) throw new Error('Alert not found');
+        if (!target) failRequest('Alert not found');
         const response = await deleteAlertByType(target);
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        if (!response.ok) failRequest(`HTTP ${response.status}`);
 
         trackEvent(
           createEventBuilder(MetaMetricsEvents.PRICE_ALERT_CREATION_INTERACTION)
@@ -224,7 +237,7 @@ const ManagePriceAlertsView: React.FC = () => {
 
         const next = previous.filter((a) => a.id !== id);
         queryClient.setQueryData(queryKey, next);
-        toastRef?.current?.showToast({
+        showToast({
           variant: ToastVariants.Icon,
           iconName: IconName.Trash,
           iconColor: colors.text.default,
@@ -235,7 +248,7 @@ const ManagePriceAlertsView: React.FC = () => {
           navigation.goBack();
         }
       } catch {
-        toastRef?.current?.showToast({
+        showToast({
           variant: ToastVariants.Icon,
           iconName: IconName.Danger,
           iconColor: colors.error.default,
@@ -249,15 +262,15 @@ const ManagePriceAlertsView: React.FC = () => {
         } else {
           queryClient.setQueryData(queryKey, previous);
         }
-      } finally {
-        finishDelete(id);
       }
+
+      finishDelete(id);
     },
     [
       navigation,
       assetId,
       queryClient,
-      toastRef,
+      showToast,
       colors,
       displayTicker,
       trackEvent,
@@ -282,11 +295,11 @@ const ManagePriceAlertsView: React.FC = () => {
       );
 
       try {
-        if (!toggled) throw new Error('Alert not found');
+        if (!toggled) failRequest('Alert not found');
         const response = await updateAlertByType(toggled, {
           active: newValue,
         });
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        if (!response.ok) failRequest(`HTTP ${response.status}`);
 
         trackEvent(
           createEventBuilder(MetaMetricsEvents.PRICE_ALERT_CREATION_INTERACTION)
@@ -305,7 +318,7 @@ const ManagePriceAlertsView: React.FC = () => {
             .build(),
         );
       } catch {
-        toastRef?.current?.showToast({
+        showToast({
           variant: ToastVariants.Icon,
           iconName: IconName.Danger,
           iconColor: colors.error.default,
@@ -316,14 +329,14 @@ const ManagePriceAlertsView: React.FC = () => {
           queryKey,
           previous.map((a) => (a.id === id ? { ...a, active: !newValue } : a)),
         );
-      } finally {
-        finishToggle(id);
       }
+
+      finishToggle(id);
     },
     [
       assetId,
       queryClient,
-      toastRef,
+      showToast,
       colors,
       displayTicker,
       trackEvent,

--- a/app/components/UI/Assets/PriceAlerts/components/AlertAmountInput.tsx
+++ b/app/components/UI/Assets/PriceAlerts/components/AlertAmountInput.tsx
@@ -1,5 +1,10 @@
-import React, { useEffect, useRef } from 'react';
-import { Animated, StyleSheet, Text as RNText } from 'react-native';
+import React, { useEffect } from 'react';
+import {
+  Animated,
+  StyleSheet,
+  Text as RNText,
+  useAnimatedValue,
+} from 'react-native';
 import {
   Box,
   BoxAlignItems,
@@ -39,7 +44,7 @@ const AlertAmountInput: React.FC<AlertAmountInputProps> = ({
 }) => {
   const tw = useTailwind();
   const { colors } = useTheme();
-  const fadeAnim = useRef(new Animated.Value(1)).current;
+  const fadeAnim = useAnimatedValue(1);
 
   useEffect(() => {
     const animation = Animated.loop(

--- a/app/components/UI/Assets/PriceAlerts/components/SlidingPillToggle.tsx
+++ b/app/components/UI/Assets/PriceAlerts/components/SlidingPillToggle.tsx
@@ -1,5 +1,11 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Animated, Pressable, StyleSheet, type ViewStyle } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import {
+  Animated,
+  Pressable,
+  StyleSheet,
+  useAnimatedValue,
+  type ViewStyle,
+} from 'react-native';
 import {
   Box,
   BoxFlexDirection,
@@ -71,7 +77,7 @@ function SlidingPillToggle<T extends string>({
   weightBySelection = false,
   style,
 }: SlidingPillToggleProps<T>) {
-  const slideAnim = useRef(new Animated.Value(0)).current;
+  const slideAnim = useAnimatedValue(0);
   const [pillWidth, setPillWidth] = useState(0);
   const [firstOption, secondOption] = options;
 

--- a/app/components/UI/Assets/components/Balance/AccountGroupBalance.tsx
+++ b/app/components/UI/Assets/components/Balance/AccountGroupBalance.tsx
@@ -80,9 +80,10 @@ const AccountGroupBalance = ({
   // Stabilize chain IDs by content so selector identity doesn't change every render (avoids max depth / infinite loop).
   const popularChainIdsKey = (popularNetworks ?? []).join(',');
   const chainIdsForBalance = useMemo<CaipChainId[]>(
-    () => [...(popularNetworks ?? [])],
-    // popularChainIdsKey stabilizes by content; popularNetworks is a new array ref every render from the hook
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    () =>
+      popularChainIdsKey
+        ? (popularChainIdsKey.split(',') as CaipChainId[])
+        : [],
     [popularChainIdsKey],
   );
 

--- a/app/components/UI/TokenDetails/components/useAssetVisibility.ts
+++ b/app/components/UI/TokenDetails/components/useAssetVisibility.ts
@@ -79,6 +79,12 @@ const resolveAssetId = (
   return toAssetId(address, caipChainId);
 };
 
+const isNonEvmAssetIgnored = (
+  allIgnoredAssets: Record<string, CaipAssetType[] | undefined>,
+  accountId: string,
+  assetId: CaipAssetType,
+) => allIgnoredAssets[accountId]?.includes(assetId) ?? false;
+
 const useAssetVisibility = (asset?: TokenI): UseAssetVisibilityReturn => {
   // Globally selected account — always EVM, used as fallback when no asset
   // chainId is available.
@@ -98,21 +104,24 @@ const useAssetVisibility = (asset?: TokenI): UseAssetVisibilityReturn => {
   // Resolve the account ID scoped to the asset's chain.
   // Non-EVM assets (Solana, BTC, …) are stored under their own account ID —
   // using the global EVM account would miss all non-EVM balance/custom entries.
+  const assetChainId = asset?.chainId;
+  const assetAddress = asset?.address;
+
   const accountId = useMemo(() => {
-    if (!asset?.chainId) return globalAccountId;
-    const caipChainId: CaipChainId | undefined = isCaipChainId(asset.chainId)
-      ? (asset.chainId as CaipChainId)
-      : toEvmCaipChainId(asset.chainId as Hex);
+    if (!assetChainId) return globalAccountId;
+    const caipChainId: CaipChainId | undefined = isCaipChainId(assetChainId)
+      ? (assetChainId as CaipChainId)
+      : toEvmCaipChainId(assetChainId as Hex);
     if (!caipChainId) return globalAccountId;
     return internalAccountByScope(caipChainId)?.id ?? globalAccountId;
-  }, [asset?.chainId, internalAccountByScope, globalAccountId]);
+  }, [assetChainId, internalAccountByScope, globalAccountId]);
 
   const assetId = useMemo(
     () =>
-      asset?.address && asset?.chainId
-        ? resolveAssetId(asset.address, asset.chainId)
+      assetAddress && assetChainId
+        ? resolveAssetId(assetAddress, assetChainId)
         : undefined,
-    [asset?.address, asset?.chainId],
+    [assetAddress, assetChainId],
   );
 
   const isCustomAsset = useMemo(() => {
@@ -166,7 +175,7 @@ const useAssetVisibility = (asset?: TokenI): UseAssetVisibilityReturn => {
         AssetsController.unhideAsset(assetId);
         // For non-EVM tokens the hidden state also lives in
         // MultichainAssetsController.allIgnoredAssets; addAssets restores it.
-        if (allIgnoredNonEvmAssets[accountId]?.includes(assetId)) {
+        if (isNonEvmAssetIgnored(allIgnoredNonEvmAssets, accountId, assetId)) {
           MultichainAssetsController.addAssets([assetId], accountId);
         }
       } else {

--- a/app/components/UI/TokenDetails/hooks/useTokenTransactions.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenTransactions.ts
@@ -128,11 +128,94 @@ export const getSwapLegTokenIdentifiers = (
   };
 };
 
+///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)
+type NonEvmFilterAsset = Pick<
+  TokenI,
+  'chainId' | 'address' | 'symbol' | 'isNative' | 'isETH'
+>;
+
+const filterTransactionsForNonEvmAsset = (
+  txs: Transaction[],
+  asset: NonEvmFilterAsset,
+): Transaction[] => {
+  if (asset.isNative || asset.isETH) {
+    const nativeAssetId =
+      AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS[
+        asset.chainId as SupportedCaipChainId
+      ]?.nativeCurrency;
+
+    return txs.filter((tx: Transaction) => {
+      const txData = (tx.from || []).concat(tx.to || []);
+
+      return txData.some(
+        (participant: { asset?: { type?: string } }) =>
+          participant.asset &&
+          typeof participant.asset === 'object' &&
+          participant.asset.type === nativeAssetId,
+      );
+    });
+  }
+
+  const assetAddress = asset.address?.toLowerCase();
+  const assetSymbol = asset.symbol?.toLowerCase();
+
+  if (!assetAddress && !assetSymbol) {
+    return txs;
+  }
+
+  return txs.filter((tx: Transaction) => {
+    const txData = (tx.from || []).concat(tx.to || []);
+
+    const involvesToken = txData.some(
+      (participant: { asset?: { type?: string; unit?: string } }) => {
+        if (participant.asset && typeof participant.asset === 'object') {
+          const assetType = participant.asset.type || '';
+          const assetUnit = participant.asset.unit || '';
+
+          if (assetAddress && assetType.toLowerCase().includes(assetAddress)) {
+            return true;
+          }
+
+          if (assetSymbol && assetUnit.toLowerCase() === assetSymbol) {
+            return true;
+          }
+        }
+        return false;
+      },
+    );
+
+    return involvesToken;
+  });
+};
+
 // Cache for non-EVM transactions
-// eslint-disable-next-line import-x/no-mutable-exports
-let cachedFilteredTransactions: Transaction[] | null = null;
-// eslint-disable-next-line import-x/no-mutable-exports
-let cacheKey: string | null = null;
+const nonEvmFilterCache: {
+  key: string | null;
+  transactions: Transaction[] | null;
+} = { key: null, transactions: null };
+
+const getFilteredNonEvmTransactions = (
+  txs: Transaction[],
+  asset: NonEvmFilterAsset,
+): Transaction[] => {
+  const key = JSON.stringify({
+    txCount: txs.length,
+    assetAddress: asset.address?.toLowerCase(),
+    assetSymbol: asset.symbol?.toLowerCase(),
+    isNativeAsset: asset.isNative || asset.isETH,
+    lastTxId: txs[0]?.id,
+  });
+
+  if (nonEvmFilterCache.key === key && nonEvmFilterCache.transactions) {
+    return nonEvmFilterCache.transactions;
+  }
+
+  const filtered = filterTransactionsForNonEvmAsset(txs, asset);
+  nonEvmFilterCache.transactions = filtered;
+  nonEvmFilterCache.key = key;
+  return filtered;
+};
+///: END:ONLY_INCLUDE_IF
 
 /**
  * Hook that handles transaction fetching, filtering, and normalization for a token.
@@ -221,77 +304,13 @@ export const useTokenTransactions = (
           (tx: Transaction) => tx.chain === asset.chainId,
         ) || [];
 
-      const assetAddress = asset.address?.toLowerCase();
-      const assetSymbol = asset.symbol?.toLowerCase();
-      const isNativeAsset = asset.isNative || asset.isETH;
-
-      const newCacheKey = JSON.stringify({
-        txCount: txs.length,
-        assetAddress,
-        assetSymbol,
-        isNativeAsset,
-        lastTxId: txs[0]?.id,
+      const filteredTransactions = getFilteredNonEvmTransactions(txs, {
+        chainId: asset.chainId,
+        address: asset.address,
+        symbol: asset.symbol,
+        isNative: asset.isNative,
+        isETH: asset.isETH,
       });
-
-      let filteredTransactions: Transaction[];
-      if (cacheKey === newCacheKey && cachedFilteredTransactions) {
-        filteredTransactions = cachedFilteredTransactions;
-      } else {
-        filteredTransactions = txs;
-
-        if (isNativeAsset) {
-          const nativeAssetId =
-            AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS[
-              asset.chainId as SupportedCaipChainId
-            ]?.nativeCurrency;
-
-          filteredTransactions = txs.filter((tx: Transaction) => {
-            const txData = (tx.from || []).concat(tx.to || []);
-
-            return txData.some(
-              (participant: { asset?: { type?: string } }) =>
-                participant.asset &&
-                typeof participant.asset === 'object' &&
-                participant.asset.type === nativeAssetId,
-            );
-          });
-        } else if (assetAddress || assetSymbol) {
-          filteredTransactions = txs.filter((tx: Transaction) => {
-            const txData = (tx.from || []).concat(tx.to || []);
-
-            const involvesToken = txData.some(
-              (participant: { asset?: { type?: string; unit?: string } }) => {
-                if (
-                  participant.asset &&
-                  typeof participant.asset === 'object'
-                ) {
-                  const assetType = participant.asset.type || '';
-                  const assetUnit = participant.asset.unit || '';
-
-                  if (
-                    assetAddress &&
-                    assetType.toLowerCase().includes(assetAddress)
-                  ) {
-                    return true;
-                  }
-
-                  if (assetSymbol && assetUnit.toLowerCase() === assetSymbol) {
-                    return true;
-                  }
-                }
-                return false;
-              },
-            );
-
-            return involvesToken;
-          });
-        }
-
-        // eslint-disable-next-line react-compiler/react-compiler
-        cachedFilteredTransactions = filteredTransactions;
-        // eslint-disable-next-line react-compiler/react-compiler
-        cacheKey = newCacheKey;
-      }
 
       transactions = [...filteredTransactions].sort(
         (a, b) => (b?.time ?? 0) - (a?.time ?? 0),
@@ -493,11 +512,19 @@ export const useTokenTransactions = (
         return true;
       }
 
+      const fromAddress = from ?? '';
+      const toAddress = to ?? '';
+      const accountAddress = selectedAddress ?? '';
+
+      const involvesSelectedAddress =
+        areAddressesEqual(fromAddress, accountAddress) ||
+        areAddressesEqual(toAddress, accountAddress);
+      const matchesCurrentChain =
+        chainId === tx.chainId || (!tx.chainId && networkId === tx.networkID);
+
       if (
-        (areAddressesEqual(from ?? '', selectedAddress ?? '') ||
-          areAddressesEqual(to ?? '', selectedAddress ?? '')) &&
-        (chainId === tx.chainId ||
-          (!tx.chainId && networkId === tx.networkID)) &&
+        involvesSelectedAddress &&
+        matchesCurrentChain &&
         tx.status !== 'unapproved'
       ) {
         if (
@@ -542,11 +569,19 @@ export const useTokenTransactions = (
         return true;
       }
 
+      const fromAddress = from ?? '';
+      const toAddress = to ?? '';
+      const accountAddress = selectedAddress ?? '';
+
+      const involvesSelectedAddress =
+        areAddressesEqual(fromAddress, accountAddress) ||
+        areAddressesEqual(toAddress, accountAddress);
+      const matchesCurrentChain =
+        chainId === tx.chainId || (!tx.chainId && networkId === tx.networkID);
+
       if (
-        (areAddressesEqual(from ?? '', selectedAddress ?? '') ||
-          areAddressesEqual(to ?? '', selectedAddress ?? '')) &&
-        (chainId === tx.chainId ||
-          (!tx.chainId && networkId === tx.networkID)) &&
+        involvesSelectedAddress &&
+        matchesCurrentChain &&
         tx.status !== 'unapproved'
       ) {
         if (to?.toLowerCase() === navAddress) return true;
@@ -679,12 +714,17 @@ export const useTokenTransactions = (
             }
             const alreadySubmitted = submittedNonces.includes(nonce);
             const alreadyConfirmed = confirmedTxs.find(
-              (confirmedTransaction: Transaction) =>
-                areAddressesEqual(
+              (confirmedTransaction: Transaction) => {
+                const confirmedFrom =
                   safeToChecksumAddress(confirmedTransaction.txParams.from) ??
-                    '',
-                  selectedAddress ?? '',
-                ) && confirmedTransaction.txParams.nonce === nonce,
+                  '';
+                const accountAddress = selectedAddress ?? '';
+
+                return (
+                  areAddressesEqual(confirmedFrom, accountAddress) &&
+                  confirmedTransaction.txParams.nonce === nonce
+                );
+              },
             );
             if (alreadyConfirmed) {
               return false;

--- a/app/components/Views/Homepage/Sections/Tokens/hooks/usePopularTokens.ts
+++ b/app/components/Views/Homepage/Sections/Tokens/hooks/usePopularTokens.ts
@@ -196,13 +196,13 @@ export const usePopularTokens = () => {
           priceChange1d: undefined,
         })),
       );
-    } finally {
-      // Only update loading states if this is still the latest fetch
-      if (fetchId === fetchIdRef.current) {
-        setIsInitialLoading(false);
-        setIsRefreshing(false);
-        hasFetchedOnceRef.current = true;
-      }
+    }
+
+    // Only update loading states if this is still the latest fetch
+    if (fetchId === fetchIdRef.current) {
+      setIsInitialLoading(false);
+      setIsRefreshing(false);
+      hasFetchedOnceRef.current = true;
     }
   }, [currentCurrency]);
 

--- a/docs/skills/react-compiler-migration/SKILL.md
+++ b/docs/skills/react-compiler-migration/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: react-compiler-migration
+description: Migrate existing files so the React Compiler can optimize them, using react-compiler-marker output as the source of truth. Use when fixing React Compiler bail-outs, working through a react-compiler-marker report, or when the user mentions rcm, compiler failures, "Cannot access refs during render", "Existing memoization could not be preserved", or other compiler diagnostics.
+---
+
+# React Compiler Migration
+
+Make a file compile. Nothing else. The marker tells you what is broken and, after the edit, whether you actually fixed it.
+
+## Rule
+
+**`react-compiler-marker` is the source of truth.** Run it before the first edit and after every edit. A fix is not done because the reasoning is sound; it is done because the failure count dropped.
+
+It earns that status: it loads the workspace's own `babel-plugin-react-compiler` and runs a real `transformFromAstSync` with `noEmit: false`, failing if codegen fails. It is not a lint pass or a heuristic. It also runs with `compilationMode: "infer"` and `panicThreshold: "none"` — the plugin defaults this repo builds with — plus `enableTreatRefLikeIdentifiersAsRefs: true`, which the build does not set. That last flag makes it *stricter* than the app build, so a marker-clean file is build-clean, not the other way round.
+
+Know the one thing it cannot tell you: the compiled output is generated and thrown away, never executed. Jest disables the compiler (`scripts/react-compiler.js` gates on `NODE_ENV === 'test'`), so a green test run proves the *source* still behaves, not the compiled version. Codegen is verified; runtime behavior of the memoized output is not. Say so when reporting anything beyond a trivial fix.
+
+Never fix a bail-out by suppressing it. `"use no memo"`, a fresh `eslint-disable`, or deleting the behavior that failed are all non-fixes.
+
+## Workflow
+
+### 1. Baseline
+
+The CLI scans directories, not files, and resolves `babel-plugin-react-compiler` relative to the scanned path — so pass the plugin path explicitly and run from the repo root:
+
+```bash
+npx -y react-compiler-marker@latest \
+  --babel-plugin-path node_modules/babel-plugin-react-compiler \
+  app/path/to/containing/dir
+```
+
+Record the failing lines for the target file. If the file does not appear in the failures, there is nothing to do — say so and stop.
+
+Capture the same run with `--format json ... 2>/dev/null` now if you intend to report before/after memo metrics (step 4). A failing file has no `success` entry to compare against later, and reconstructing a baseline afterwards means stashing your work in a dirty tree — not worth it.
+
+The reported count is a **lower bound**, in two ways. A component skipped wholesale (see the ESLint-disable pattern) hides every other diagnostic inside it, and the compiler stops at the first failure in each function — so an identical construct three functions down stays invisible until you fix the first one. Counts often *rise* on the next run, and a "2 failure" file can take four rounds. That is progress, not regression; report it as such.
+
+The converse is equally normal: plenty of files are one edit and done. Stop when the marker says zero — do not keep digging for a cascade because this section warned you one was possible.
+
+When a fix reveals a new reason, grep the file for the construct you just fixed before re-running. Sibling copies are the common case, and knowing they exist tells you whether you are two edits from done or twenty.
+
+### 2. Understand before editing
+
+Read the failing lines *and* the code that made someone write them. Suppressions and defensive `try`/`finally` blocks usually encode a real bug someone hit. Preserve that behavior; change only the shape the compiler cannot digest.
+
+Look up the failure in [references/patterns.md](references/patterns.md). Each entry has a validated before/after.
+
+**Some failures should not be fixed, and saying so is a successful outcome.** Check these before editing:
+
+- **Test files.** `*.test.tsx` shows up in reports and gains nothing — the compiler is off under Jest, so migrating a test optimizes code that never runs compiled. They are also the files most likely to show pruned memo blocks. Skip them.
+- **False positives.** Some diagnostics name a rule of React rather than a syntax the compiler cannot lower. Establish the code actually breaks the rule before restructuring anything — `Hooks may not be referenced as normal values` fires on any `use[A-Z]` identifier, including a plain boolean prop.
+- **Fixes that live outside the file.** If the only real fix is renaming an export, changing a shared hook, or editing another team's module, stop and report it with the suggested change. A local workaround for a non-local cause is worse than the bail-out.
+
+Report these as findings with the reason and the suggested owner, and move to the next file.
+
+### 3. Edit
+
+Follow the principles below. Make **one** change at a time and re-run — the marker is cheap, and it is the only way to learn which specific construct the compiler objected to. Guessing at two fixes at once wastes the signal.
+
+### 4. Verify
+
+Re-run the exact command from step 1. Confirm the file's failures are gone and no new failures appeared elsewhere in the directory.
+
+Zero failures is necessary, not sufficient. Add `--format json` and read the per-function counts: `memoBlocks` and `memoValues` are what the compiler managed to memoize, and `prunedMemoBlocks` / `prunedMemoValues` are what it had to discard. A file can compile with zero failures and still be partly de-optimized, which is the actual thing the migration is for.
+
+The CLI writes progress to stderr, so redirect it or the output will not parse:
+
+```bash
+npx -y react-compiler-marker@latest \
+  --babel-plugin-path node_modules/babel-plugin-react-compiler \
+  --format json app/path/to/dir 2>/dev/null
+```
+
+Expect `prunedMemoBlocks` and `prunedMemoValues` to be `0` on a finished file — a fix that clears the failure while pruning memo blocks is not a win.
+
+A file that was failing has **no** `success` entry, so its "before" `memoBlocks` is undefined rather than zero. Do not go stashing changes to reconstruct it: either capture the JSON in step 1 before your first edit, or report before-metrics as N/A and give the after-figures alone. Ignore test files here; they routinely show pruning and gain nothing from being migrated. Then:
+
+```bash
+yarn prettier --write <file> && yarn eslint <file> && yarn jest <dir>
+```
+
+Add `yarn lint:tsc` when the change has type surface — a new helper signature, a changed parameter type, a `Pick<...>`. It checks the whole project and takes about a minute, so skip it when the diff is purely statement-level (relocating a `finally`, hoisting a `const`) and say that you did.
+
+All three matter. A compiler-clean file with a new ESLint error is not done — this repo still enforces `react-hooks` rules, so keep the `useMemo`/`useCallback` the linter asks for even where the compiler makes them redundant. Stripping manual memoization is a separate codemod for after the migration, not part of it.
+
+If failures remain, go back to step 2 — do not report a partial fix as done.
+
+### 5. Report
+
+State the diff, why the original code existed, what behavior is preserved, and the before/after failure counts. Flag any new type assertion or behavioral risk for review rather than burying it.
+
+Give the change a risk tier, because a reviewer cannot infer it from a green checklist — every fix in this skill produces the same "0 failures, tests pass" line regardless of blast radius:
+
+- **Rename-level** — a swap to an existing API, or hoisting an expression into a `const`. Behavior is unchanged by construction.
+- **Structural** — control flow moved: `finally` relocated, a `try` reshaped, a helper extracted from a hook. Behavior is preserved by an argument you should state, and the argument is what the reviewer checks.
+- **Stateful** — anything touching a cache, a ref's lifetime, or memo dependencies that decide when work re-runs. Name the screen to smoke-test, and remember Jest ran this code *un*compiled.
+
+## Principles
+
+These outrank compiler-satisfaction. A file that compiles but reads worse is a failed migration.
+
+1. **`let` is a smell.** Reassignment means the reader has to track a variable through the function. Prefer a `const` with a ternary, an extracted function with early returns, or a derived value.
+2. **Minimum diff.** Change the lines the compiler objects to. Do not reformat, rename, reorder imports, or "improve" untouched code in the same pass. Most of the compiler's restrictions are lexical — they care where a construct is *written*, not what runs — so the fix is usually to move that construct behind a helper, not to restructure the logic around it. New branches in the diff mean you took the wrong route.
+3. **Look for the existing API before writing one.** The construct the compiler rejected is rarely unique to this file, and the library that supplied it often ships a hook that already hides it (`useAnimatedValue` for `useRef(new Animated.Value(x)).current`). Grep for the candidate first: with precedent in the repo it is a one-line rename and the smallest possible diff; without precedent, it is a new API in a migration pass and belongs in the report.
+4. **Extract freely.** A closure or a plain function above/below the component is cheap and usually clearer than inlined branching. Module scope is also outside the compiler's analysis, which makes it the escape hatch for syntax the compiler rejects. Split at a seam that already exists — a helper needing ten parameters means you cut in the wrong place. Match the file's existing naming; a fresh `alert` or `data` parameter can trip lint rules the file was already avoiding. Move the body verbatim so the diff reads as a relocation, and land it inside the same `ONLY_INCLUDE_IF` build fence as the imports it uses.
+5. **Stay in the file.** No new files unless the user asks. Do not edit the upstream hook or shared util to fix a local bail-out.
+6. **No comment slop.** No JSDoc on new functions. No comment restating what the next line does. Keep a comment only when it explains a constraint the code cannot show — a non-obvious invariant, or the bug a workaround prevents. Delete comments that described a suppression you removed. A helper that exists solely to satisfy the compiler qualifies: one line leading with why it was extracted and naming the diagnostic that forced it, so the next reader can search for it and knows when it can be deleted.
+7. **Extraction moves code out of a restricted region; it never changes what that region covers.** Shrinking the span of a `try`, a `catch`, or an effect is a behavior change wearing a refactor's clothes. If the compiler-friendly shape genuinely cannot cover the same span, say so instead of shipping it quietly. There is exactly one enumerated exception: converting a `finally` into a trailing statement, which *does* shrink a protected region and is permitted only when both preconditions in the try/catch pattern entry are cleared and stated. Anything else that narrows a protected span is a finding, not a fix.
+
+## Patterns
+
+One entry per validated failure reason, with before/after: [references/patterns.md](references/patterns.md).
+
+Append a new entry only after a fix has been verified by the marker and accepted in review. An unvalidated pattern is worse than no pattern.

--- a/docs/skills/react-compiler-migration/references/patterns.md
+++ b/docs/skills/react-compiler-migration/references/patterns.md
@@ -1,0 +1,447 @@
+# Validated Patterns
+
+One entry per failure reason from `react-compiler-marker`. Every entry here has been verified: marker failures dropped to zero and the change passed review.
+
+---
+
+## `React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled`
+
+The compiler skips the **entire component** if any React ESLint rule is disabled anywhere inside it. The reported line is the `eslint-disable` comment, not a defect at that line.
+
+So the only fix is to delete the suppression. That means making the code honest, not re-suppressing elsewhere and not deleting the behavior the suppression protected.
+
+### `exhaustive-deps` disabled to stabilize a value by content
+
+A value is memoized on a derived content key while the factory closes over the original unstable value. The dep list lies, so it was suppressed.
+
+Fix: derive the value *from* the key. The factory then closes over nothing else and the dep list is true.
+
+```tsx
+// Before — factory reads popularNetworks, deps list only the key
+const popularChainIdsKey = (popularNetworks ?? []).join(',');
+const chainIdsForBalance = useMemo<CaipChainId[]>(
+  () => [...(popularNetworks ?? [])],
+  // popularChainIdsKey stabilizes by content; popularNetworks is a new array ref every render
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [popularChainIdsKey],
+);
+
+// After — factory reads only the key
+const popularChainIdsKey = (popularNetworks ?? []).join(',');
+const chainIdsForBalance = useMemo<CaipChainId[]>(
+  () =>
+    popularChainIdsKey ? (popularChainIdsKey.split(',') as CaipChainId[]) : [],
+  [popularChainIdsKey],
+);
+```
+
+Do not "simplify" this to depend on the unstable value directly. The content key exists because ref churn caused a render loop; keeping identity stable across equal contents is the behavior under migration.
+
+Flag the round-trip cast (`split` returns `string[]`) in the report — it is new surface area a reviewer should see.
+
+Verified on `app/components/UI/Assets/components/Balance/AccountGroupBalance.tsx` (1 failure to 0).
+
+### `exhaustive-deps` disabled to add an extra dep
+
+The mirror image: the dep list carries a value the factory never reads, listed on purpose to force recomputation. Here the memo re-anchors `Date.now()` whenever a new price series arrives.
+
+Fix: give the factory a real reason to read the extra dep. A guard clause is usually already justified on its own terms.
+
+```tsx
+// Before — prices is listed but never read
+const { chartXMin, chartXMax } = useMemo(() => {
+  if (!isTimeBased) {
+    return { chartXMin: undefined, chartXMax: undefined };
+  }
+  const now = Date.now();
+  return { chartXMin: now - timePeriodMs, chartXMax: now };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+}, [isTimeBased, timePeriodMs, prices]);
+
+// After — prices is read, so the dep is honest
+const { chartXMin, chartXMax } = useMemo(() => {
+  if (!isTimeBased || prices.length === 0) {
+    return { chartXMin: undefined, chartXMax: undefined };
+  }
+  const now = Date.now();
+  return { chartXMin: now - timePeriodMs, chartXMax: now };
+}, [isTimeBased, timePeriodMs, prices]);
+```
+
+Only sound if the new branch is unreachable or harmless. Check every consumer first — both readers here were already null-guarded, so an empty series yielding no domain changed nothing.
+
+Verified on `app/components/UI/AssetOverview/PriceChart/PriceChart.tsx` (revealed 3 further failures, see below).
+
+---
+
+## `Cannot access refs during render`
+
+Broader than it sounds. The compiler rejects all of:
+
+- writing `someRef.current = x` in the render body
+- reading `someRef.current` in the render body or JSX
+- **passing a ref object into any call during render** — including a `useMemo` factory, which the compiler treats as render-time code
+
+That third one is the surprising one, and it means the "latest ref" pattern cannot be *constructed* during render at all. No amount of rearranging the call helps; the refs have to stop being refs.
+
+Work the ladder in order, re-running the marker after each rung:
+
+0. **Check whether the platform already ships a hook that owns the ref.** A ref you create only to hold one object for the component's lifetime is a generic need, and the library that gave you the object has usually solved it. React Native's `useAnimatedValue` is exactly `useRef(new Animated.Value(x)).current`, minus the render-time `.current` read:
+
+```tsx
+// Before
+const slideAnim = useRef(new Animated.Value(0)).current;
+
+// After
+const slideAnim = useAnimatedValue(0);
+```
+
+The ref still exists, one stack frame up inside the hook, where it is opaque to the compiler. Nothing else in the file changes: the value has the same identity and lifetime, so effects, dep arrays, and animation calls all stay as they are. It also fixes the incidental waste in the original, which constructed a throwaway `Animated.Value` on every render.
+
+Prefer this over rung 2 whenever it applies. Rung 2 makes lifetime depend on `useMemo`, which React may discard; a hook wrapping a `useRef` guarantees it — and per "Keep the memoization" below, guarantees are what survive Jest with the compiler off.
+
+Grep the codebase for the hook before adopting it. If it has precedent here it is a rename; if not, you are introducing an API in a migration pass, which needs a mention in the report.
+
+1. **Ref writes during render** move into an effect with no dep array:
+
+```tsx
+// Before
+const updatePositionRef = useRef(updatePosition);
+updatePositionRef.current = updatePosition;
+
+// After
+const updatePositionRef = useRef(updatePosition);
+useEffect(() => {
+  updatePositionRef.current = updatePosition;
+});
+```
+
+2. **`useRef(createSomething(...))`** becomes `useMemo`. The `useRef` form re-runs the initializer every render and discards the result anyway, so this is a bug fix as well as a compiler fix. Update the read site from `x.current` to `x`.
+
+3. **Config objects whose callbacks touch refs** move to a module-scope factory. Hoisting the callbacks out of the component takes them out of the compiler's render analysis, and it shortens the component body:
+
+```tsx
+const createChartPanResponder = ({
+  updatePosition,
+  setIsChartBeingTouched,
+}: ChartPanHandlers) => {
+  const prevTouch = { current: { x: 0, y: 0 } };
+  return PanResponder.create({ /* handlers */ });
+};
+```
+
+4. **Per-instance mutable state that only handlers touch** is not React state at all. `prevTouch` above became a plain closure `const` holding a mutable object — no `useRef`, no `let`.
+
+5. **If the factory still needs "latest" values**, stop passing refs and pass the functions, memoizing on them.
+
+### Keep the memoization
+
+Step 5 tempts you to delete the `useMemo` and let the compiler memoize the call. Do not, for two reasons.
+
+`react-hooks/exhaustive-deps` is still enforced here and will error that the function "makes the dependencies of useMemo change on every render". Wrap the function in `useCallback` instead — the lint rule cannot see that the compiler already memoized it.
+
+More importantly, the compiler is **disabled under Jest** (`scripts/react-compiler.js` gates on `NODE_ENV === 'test'`). Anything whose *correctness* depends on compiler memoization behaves differently in tests than in the app. A `PanResponder` that is rebuilt every render loses its gesture state mid-drag, so its stability has to survive without the compiler.
+
+Verified on `app/components/UI/AssetOverview/PriceChart/PriceChart.tsx` (4 failures to 0, ESLint clean, 25 tests passing), and on `SlidingPillToggle.tsx` + `AlertAmountInput.tsx` in `app/components/UI/Assets/PriceAlerts/components` (12 failures to 0 via rung 0 alone, one line each).
+
+The count per site is noise — the same `useRef(new Animated.Value(...)).current` reported 7 failures in one file and 5 in another, one per downstream use. One construct, many diagnostics: fix the construct and they all clear at once, so do not budget effort by failure count.
+
+---
+
+## The try/catch family
+
+Covers three diagnostics, which surface one at a time:
+
+- `(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause`
+- `(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch`
+- `Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement`
+
+(The fourth, `Handle TryStatement without a catch clause`, has its own entry below — its fix is different and the `finally` rewrite here is *wrong* for it.)
+
+| Rejected | Allowed |
+| --- | --- |
+| `finally` clause | `try` with a `catch` |
+| `throw` written inside a `try` | `throw` written outside, *called* from inside |
+| ternary, `&&`/`\|\|`, `?.` written as a statement of the `try` block | the same constructs inside a nested function body, or in the `catch` |
+| `try` with no `catch` | `if`/`else` and plain calls in the `try` block |
+
+**Every restriction is lexical, and only on the `try` block's own statements.** Two consequences, and the second is easy to get wrong in the cautious direction:
+
+The `catch` body is not checked — it can keep its optional chaining and ternaries untouched. And a `throw` merely has to not *appear* inside the `try`; it may still execute from there.
+
+A **nested function body inside the `try` is not the `try` block.** Optional chaining inside a callback compiles fine:
+
+```ts
+try {
+  const response = await handleFetch(url);
+  setRawTokens(
+    POPULAR_TOKENS.map((token) => ({
+      ...token,
+      price: response[token.assetId]?.price, // fine — inside a .map() arrow
+    })),
+  );
+} catch { /* ... */ }
+```
+
+Do not hoist those. Check where the reported line actually sits before touching anything; the diagnostic points at the construct, not at the scope that owns it.
+
+Together this means the reason needs no restructuring at all. Do not rewrite the branching.
+
+In particular, do not convert the request into a helper that returns a boolean instead of throwing, deleting the `try`. The `catch` is a blanket net over the *whole* body — the analytics call, the cache write, the navigation — so branching on a return value silently narrows error handling to just the network call. Nor should you replace the `throw` guards with nested `if`/`else`: it works, but it turns one failure path into three, and the diff stops resembling the original.
+
+Three mechanical substitutions, no control flow changes.
+
+**`throw` moves behind a module-scope function returning `never`.** The `never` annotation preserves TypeScript's narrowing, so the guard still convinces the compiler that `target` is defined afterwards.
+
+```tsx
+// Extracted because React Compiler (BuildHIR) cannot lower a `throw` written inside a try/catch.
+function failRequest(message: string): never {
+  throw new Error(message);
+}
+
+// in the try block
+if (!target) failRequest('Alert not found');
+const response = await deleteAlertByType(target);
+if (!response.ok) failRequest(`HTTP ${response.status}`);
+```
+
+Comment this one, in a single line that leads with *why it was extracted* and names `BuildHIR` — a bare thrower otherwise reads like indirection for its own sake, and the diagnostic name is what lets the next reader search it and know when the helper can go.
+
+**Value blocks in the `try` get hoisted behind a helper.** Usually this is a repeated optional-chained call. Wrapping it once removes the construct from every `try` at the same time, and reads better than the original:
+
+```tsx
+const showToast = useCallback(
+  (options: ToastOptions) => {
+    toastRef?.current?.showToast(options);
+  },
+  [toastRef],
+);
+```
+
+Leave identical calls in `catch` bodies alone unless you are replacing them wholesale — consistency within the file is worth more than a minimal diff here.
+
+For a single-use value block a module-scope helper does the same job, and the file usually has one to match:
+
+```ts
+const isNonEvmAssetIgnored = (
+  allIgnoredAssets: Record<string, CaipAssetType[] | undefined>,
+  accountId: string,
+  assetId: CaipAssetType,
+) => allIgnoredAssets[accountId]?.includes(assetId) ?? false;
+```
+
+Note what this does *not* do: compute the value above the `try`. That is the tempting one-liner, and it quietly moves the read outside the `catch`'s coverage — principle 6. Putting the expression in a helper keeps the *call* inside the `try`, so the protected region is unchanged and only the rejected syntax moved.
+
+(Hoisting above the `try` can be safe when the value is a render snapshot that the hoisted-past statements cannot mutate — but you have to prove that, and the helper is free.)
+
+**`finally` becomes a trailing statement — but only after clearing both preconditions.** A trailing statement runs on strictly fewer paths than a `finally`, so this is the one rewrite in this skill that can silently change behavior. Check both:
+
+1. **The `catch` does not rethrow.** If the `try` throws, `catch` handles it and execution falls through to the next statement. A rethrowing `catch` skips the trailing statement entirely, and the `finally` guarantee was real — flag it instead of rewriting.
+2. **Neither the `try` nor the `catch` can exit early past the relocated code** — no `return`, `break`, or `continue`. `finally` runs on those paths; a trailing statement does not. This one is easy to miss because the early exit is often several lines above the `finally`.
+
+If precondition 2 fails, the rewrite is still valid when the relocated statements are provably no-ops on exactly those exit paths — but you have to show it. In `usePopularTokens.ts` both blocks `return` early on `fetchId !== fetchIdRef.current`, and the relocated body is wrapped in `if (fetchId === fetchIdRef.current)`, the exact negation, so the old `finally` did nothing on those paths:
+
+```ts
+try {
+  // ...
+  if (fetchId !== fetchIdRef.current) return; // stale fetch
+  setRawTokens(/* ... */);
+} catch (err) {
+  if (fetchId !== fetchIdRef.current) return; // stale fetch
+  setError(/* ... */);
+}
+
+// was `finally` — the guard is the negation of both early returns,
+// so relocating it out of the finally changes nothing
+if (fetchId === fetchIdRef.current) {
+  setIsInitialLoading(false);
+  setIsRefreshing(false);
+}
+```
+
+Without that guard — a `finally` that unconditionally ran `setIsRefreshing(false)` — the same rewrite strands the spinner on every superseded fetch. State which precondition you cleared, and how, in the report.
+
+The result should be a diff of substitutions: `throw new Error(x)` to `failRequest(x)`, `finally { cleanup() }` to a trailing `cleanup()`, and a helper swap. If your diff has new branches in it, back up.
+
+The three diagnostics surface in sequence, so the value-block error usually appears only once the `finally` and `throw` errors are gone, and a stale dep array often follows. Not always, though — a file with one `finally` and no other rejected syntax is genuinely done after one edit. Let the marker decide when you are finished rather than digging for a cascade the skill led you to expect.
+
+---
+
+## `Cannot reassign variables declared outside of the component/hook`
+
+A module-scope `let` written from inside the hook — nearly always a hand-rolled cache that outlives the component. The reassignment is what the compiler rejects; the cache itself is fine.
+
+Move the cache **and its writes** into a module-scope function and have the hook call it. Same escape hatch as the `try`/`catch` helpers: module-scope functions are not components or hooks, so nothing inside them is analyzed.
+
+```ts
+const nonEvmFilterCache: {
+  key: string | null;
+  transactions: Transaction[] | null;
+} = { key: null, transactions: null };
+
+const getFilteredNonEvmTransactions = (txs, asset) => {
+  const key = JSON.stringify({ txCount: txs.length, lastTxId: txs[0]?.id /* ... */ });
+  if (nonEvmFilterCache.key === key && nonEvmFilterCache.transactions) {
+    return nonEvmFilterCache.transactions;
+  }
+  const filtered = filterTransactionsForNonEvmAsset(txs, asset);
+  nonEvmFilterCache.transactions = filtered;
+  nonEvmFilterCache.key = key;
+  return filtered;
+};
+```
+
+Two `let` slots become one `const` object whose fields are assigned. The mutation is still there — a cache cannot exist without it — but it is now named, scoped to the function that owns it, and no longer a binding the rest of the module could reassign. That also retires the `import-x/no-mutable-exports` suppressions the `let`s needed.
+
+Split the pure work out of the cache wrapper (`filterTransactionsForNonEvmAsset` above). The wrapper then reads as exactly what it is, and the `let` accumulator inside the original branching collapses into early returns.
+
+**Pass primitives, not the object.** The hook's `useMemo` listed `asset.chainId`, `asset.address`, `asset.symbol`, `asset.isNative`, `asset.isETH` — reading plain `asset` in the body would make `exhaustive-deps` demand `asset` itself, widening the memo to any new asset identity. Passing a literal of the same five fields keeps every dep entry byte-identical:
+
+```ts
+const filteredTransactions = getFilteredNonEvmTransactions(txs, {
+  chainId: asset.chainId,
+  address: asset.address,
+  symbol: asset.symbol,
+  isNative: asset.isNative,
+  isETH: asset.isETH,
+});
+```
+
+An unchanged dep array is the proof that a large extraction did not change when the memo recomputes. Type the parameter as a `Pick<...>` of the original so the field list stays honest.
+
+**Land the extraction inside the same build fence.** This block sits in `///: BEGIN:ONLY_INCLUDE_IF(keyring-snaps)`, and it uses imports that are themselves fenced — hoisting it to unfenced module scope compiles here and breaks the build that strips `keyring-snaps`. The original `let`s were unfenced only because they referenced nothing fenced. Check the imports your extracted code needs, wrap the extraction in the same fence, and confirm `BEGIN` and `END` counts still match.
+
+Verified on `app/components/UI/TokenDetails/hooks/useTokenTransactions.ts` (2 failures to 0, revealing the logical-test failures below).
+
+---
+
+## `Unexpected terminal kind ... for logical test block`
+
+Reported as `` `logical` `` or `` `optional` ``, and the reported line is the whole expression, which is misleading — only one operand is at fault.
+
+The compiler cannot lower a logical expression whose **test operand** (the left side of `&&`/`||`, evaluated to decide the branch) is itself something that branches. Both of these are rejected:
+
+```ts
+// nested logical group in the left operand
+(areAddressesEqual(a, x) || areAddressesEqual(b, x)) && chainMatches && notUnapproved
+
+// ?? inside a call in the left operand — the subtler one
+areAddressesEqual(from ?? '', selectedAddress ?? '') && tx.nonce === nonce
+```
+
+`??` and `?.` branch, so they count even when buried in the arguments of a call. Note the *right* operand is unrestricted: `a === b || (!b && c === d)` compiles untouched, which is why only half of a symmetric-looking condition needs changing.
+
+Fix by hoisting each branching sub-expression into a `const` above the statement, leaving operands that are plain values or calls:
+
+```ts
+const fromAddress = from ?? '';
+const accountAddress = selectedAddress ?? '';
+
+const involvesSelectedAddress =
+  areAddressesEqual(fromAddress, accountAddress) ||
+  areAddressesEqual(toAddress, accountAddress);
+const matchesCurrentChain =
+  chainId === tx.chainId || (!tx.chainId && networkId === tx.networkID);
+
+if (involvesSelectedAddress && matchesCurrentChain && tx.status !== 'unapproved') {
+```
+
+A same-operator chain of simple operands (`a && b && c`) is fine, so the hoist does not have to go all the way to nested `if`s. Naming the conjuncts is the whole change, and it is usually the version worth reading anyway.
+
+For an expression-bodied arrow, convert to a block body so there is somewhere to hoist to — that, not the condition, is the only structural edit.
+
+Verified on `app/components/UI/TokenDetails/hooks/useTokenTransactions.ts` (3 occurrences to 0, ESLint and `tsc` clean, 484 tests passing).
+
+---
+
+## `Hooks may not be referenced as normal values`
+
+Check whether it is actually a hook before doing anything. The compiler identifies hooks by name — any identifier matching `use[A-Z]` — so a plain value whose name starts with `use` trips it:
+
+```tsx
+useSubscriptPriceFormat={
+  advancedChartLineChromePresets.tokenOverview.useSubscriptPriceFormat
+}
+```
+
+`useSubscriptPriceFormat` is a `boolean` config property and a component prop. There is no hook anywhere in the diagnostic, and no amount of restructuring the reported file will satisfy it — the only fix is renaming the property.
+
+That rename is out of scope for a migration pass: the name spans a presets module, two type files, the component, and a serialized `window.CONFIG` key baked into a webview template string, all owned by another team. Report it as a false positive with the suggested rename and leave the file alone.
+
+The general rule: when a diagnostic names a *rule of React* rather than a syntax the compiler cannot lower, first establish that the code actually breaks the rule.
+
+Seen on `app/components/UI/AssetOverview/Price/Price.advanced.tsx` (not fixed, by design).
+
+---
+
+## `(BuildHIR::lowerStatement) Handle TryStatement without a catch clause`
+
+A `try`/`finally` with no `catch` — nearly always a pull-to-refresh or in-flight flag being reset:
+
+```tsx
+const handleDeFiRefresh = useCallback(async () => {
+  setRefreshing(true);
+  try {
+    await refresh();
+  } finally {
+    setRefreshing(false);
+  }
+}, [refresh]);
+```
+
+**Do not reach for the `finally`-to-trailing-statement rewrite from the try/catch entry above.** That rewrite is sound only because a `catch` swallows the error and execution falls through. Here nothing catches, so a rejected `refresh()` propagates — and a trailing `setRefreshing(false)` would never run, leaving the spinner stuck forever. The `finally` is load-bearing precisely because there is no `catch`.
+
+Move the cleanup to the promise instead. Same guarantee, no `TryStatement`:
+
+```tsx
+const handleDeFiRefresh = useCallback(async () => {
+  setRefreshing(true);
+  await refresh().finally(() => setRefreshing(false));
+}, [refresh]);
+```
+
+`Promise.prototype.finally` runs on both settle paths and passes the rejection through untouched, so the error still propagates out of the callback exactly as before.
+
+Check one thing before using it: the call must always *return* a promise. `refresh` is declared `() => Promise<void>`, and an `async` function cannot throw synchronously, so `.finally` is guaranteed to attach. If the callee is synchronous, might return `undefined`, or could throw before returning, `.finally` either crashes or never attaches — in that case keep `try`/`finally` and move the whole thing into a module-scope helper instead.
+
+Verified on `app/components/UI/Assets/DeFiPositions/components/DeFiPositionsListV2.tsx` (1 failure to 0, 20 memo blocks, 0 pruned, 54 tests passing). The same shape sits in `DeFiPositionsList.tsx` and `Tokens/index.tsx`.
+
+---
+
+## `Existing memoization could not be preserved`
+
+The compiler reproduces manual memoization only when it can express the same dependencies. It gives up when the written deps are *narrower* than what the body actually reads.
+
+### Optional chaining in the dep array
+
+The common primary cause. The body reads `asset`, but the deps claim to track only a field of it:
+
+```ts
+// Before — deps say asset?.chainId, body reads asset
+const accountId = useMemo(() => {
+  if (!asset?.chainId) return globalAccountId;
+  // ...
+}, [asset?.chainId, internalAccountByScope, globalAccountId]);
+
+// After — body and deps read the same local
+const assetChainId = asset?.chainId;
+
+const accountId = useMemo(() => {
+  if (!assetChainId) return globalAccountId;
+  // ...
+}, [assetChainId, internalAccountByScope, globalAccountId]);
+```
+
+Hoisting the optional access above the hook is the whole fix. It is also strictly more correct: `asset?.chainId` as a dep entry was always a promise the code could not keep, since the memo really did re-run whenever `asset` changed identity.
+
+Verified on `app/components/UI/TokenDetails/components/useAssetVisibility.ts` (2 failures to 0, then a hidden value-block failure surfaced — see below).
+
+### As a consequence of another fix
+
+Also seen after extracting `toastRef?.current?.showToast` into a `showToast` helper, which left three dep arrays still listing `toastRef` that the hooks no longer read.
+
+`yarn eslint` names the exact hook and the missing dependency, so run it before guessing. Swap the stale entry for the new one rather than appending.
+
+Preserve odd-looking fallbacks exactly. `response.json().catch(() => [])` resets the cache to empty rather than to `previous`; that asymmetry is behavior, not a typo to tidy up mid-migration.
+
+Verified on `app/components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx` (6 failures to 0, ESLint clean, 203 tests passing).

--- a/rcm-assets-report.txt
+++ b/rcm-assets-report.txt
@@ -1,0 +1,209 @@
+Assets React Compiler Failures
+========================================
+Team:             @MetaMask/metamask-assets
+Unique files:     34
+Failure lines:    74
+Unique reasons:   10
+
+By reason
+----------------------------------------
+  40×  Cannot access refs during render
+      components/Views/Homepage/Sections/NFTs/NFTsSection.tsx
+      components/UI/Tokens/TokenList/TokenList.test.tsx
+      components/UI/TokenDetails/components/AssetOverviewContent.tsx
+      components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx
+      components/UI/TokenDetails/components/TokenDetailsActions.tsx
+      components/UI/TokenDetails/Views/TokenDetails.tsx
+      components/UI/CollectibleOverview/index.js
+      components/UI/Assets/components/AssetLogo/AssetLogo.hook.tsx
+      components/UI/Assets/PriceAlerts/components/AlertAmountInput.tsx
+      components/UI/Assets/PriceAlerts/components/SlidingPillToggle.tsx
+
+  8×  (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+      components/Views/Homepage/Sections/Tokens/hooks/usePopularTokens.ts
+      components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx
+      components/Views/AddAsset/components/AddCustomCollectible/AddCustomCollectible.tsx
+      components/UI/TokenDetails/hooks/useAssetActivation.ts
+      components/UI/TokenDetails/hooks/useTokenSecurityData.ts
+      components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx
+
+  6×  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+      components/hooks/useTokenBalance.tsx
+      components/Views/NftDetails/NftDetails.tsx
+      components/UI/TokenDetails/hooks/useTokenPrice.ts
+      components/UI/Assets/components/Balance/AccountGroupBalance.tsx
+      components/UI/Assets/DeFiPositions/hooks/useDeFiPositionsV2.ts
+      components/UI/AssetOverview/PriceChart/PriceChart.tsx
+
+  5×  Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+      components/hooks/useIsOriginalNativeTokenSymbol/useIsOriginalNativeTokenSymbol.ts
+      components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx
+      components/UI/TokenDetails/Views/TokenDetails.tsx
+      components/UI/Assets/PriceAlerts/hooks/useAlertSaveFlow.ts
+      components/UI/AssetOverview/TokenDetails/TokenDetails.tsx
+
+  4×  (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+      components/Views/AddAsset/components/AddCustomCollectible/AddCustomCollectible.tsx
+      components/UI/Tokens/index.tsx
+      components/UI/DeFiPositions/DeFiPositionsList.tsx
+      components/UI/Assets/DeFiPositions/components/DeFiPositionsListV2.tsx
+
+  4×  (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+      components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx
+
+  3×  Existing memoization could not be preserved
+      components/UI/TokenDetails/components/ShareTokenBottomSheet.tsx
+      components/UI/TokenDetails/components/useAssetVisibility.ts
+
+  2×  Cannot reassign variables declared outside of the component/hook
+      components/UI/TokenDetails/hooks/useTokenTransactions.ts
+
+  1×  Unexpected terminal kind `optional` for logical test block
+      components/UI/Tokens/TokenList/TokenList.tsx
+
+  1×  Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values
+      components/UI/AssetOverview/Price/Price.advanced.tsx
+
+By file
+----------------------------------------
+  components/UI/TokenDetails/components/TokenDetailsActions.tsx (8)
+      L206: (anonymous): Cannot access refs during render
+      L214: (anonymous): Cannot access refs during render
+      L225: (anonymous): Cannot access refs during render
+      L234: (anonymous): Cannot access refs during render
+      L245: (anonymous): Cannot access refs during render
+      L256: (anonymous): Cannot access refs during render
+      L266: (anonymous): Cannot access refs during render
+      L276: (anonymous): Cannot access refs during render
+
+  components/UI/Assets/PriceAlerts/components/SlidingPillToggle.tsx (7)
+      L74: (anonymous): Cannot access refs during render
+      L74: (anonymous): Cannot access refs during render
+      L74: (anonymous): Cannot access refs during render
+      L74: (anonymous): Cannot access refs during render
+      L74: (anonymous): Cannot access refs during render
+      L74: (anonymous): Cannot access refs during render
+      L74: (anonymous): Cannot access refs during render
+
+  components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx (6)
+      L206: (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+      L207: (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+      L209: (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+      L284: (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+      L285: (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+      L289: (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+
+  components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx (5)
+      L265: (anonymous): Cannot access refs during render
+      L277: (anonymous): Cannot access refs during render
+      L289: (anonymous): Cannot access refs during render
+      L301: (anonymous): Cannot access refs during render
+      L312: (anonymous): Cannot access refs during render
+
+  components/UI/CollectibleOverview/index.js (5)
+      L169: (anonymous): Cannot access refs during render
+      L169: (anonymous): Cannot access refs during render
+      L169: (anonymous): Cannot access refs during render
+      L169: (anonymous): Cannot access refs during render
+      L169: (anonymous): Cannot access refs during render
+
+  components/UI/Assets/PriceAlerts/components/AlertAmountInput.tsx (5)
+      L42: (anonymous): Cannot access refs during render
+      L42: (anonymous): Cannot access refs during render
+      L42: (anonymous): Cannot access refs during render
+      L42: (anonymous): Cannot access refs during render
+      L42: (anonymous): Cannot access refs during render
+
+  components/UI/TokenDetails/Views/TokenDetails.tsx (4)
+      L210: (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+      L687: (anonymous): Cannot access refs during render
+      L775: (anonymous): Cannot access refs during render
+      L776: (anonymous): Cannot access refs during render
+
+  components/Views/Homepage/Sections/NFTs/NFTsSection.tsx (2)
+      L69: (anonymous): Cannot access refs during render
+      L88: (anonymous): Cannot access refs during render
+
+  components/Views/AddAsset/components/AddCustomCollectible/AddCustomCollectible.tsx (2)
+      L78: (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+      L233: (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+
+  components/UI/TokenDetails/hooks/useAssetActivation.ts (2)
+      L98: (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+      L153: (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+
+  components/UI/TokenDetails/hooks/useTokenTransactions.ts (2)
+      L291: (anonymous): Cannot reassign variables declared outside of the component/hook
+      L293: (anonymous): Cannot reassign variables declared outside of the component/hook
+
+  components/UI/TokenDetails/components/AssetOverviewContent.tsx (2)
+      L446: (anonymous): Cannot access refs during render
+      L448: (anonymous): Cannot access refs during render
+
+  components/UI/TokenDetails/components/useAssetVisibility.ts (2)
+      L101: (anonymous): Existing memoization could not be preserved
+      L111: (anonymous): Existing memoization could not be preserved
+
+  components/UI/Assets/components/AssetLogo/AssetLogo.hook.tsx (2)
+      L16: (anonymous): Cannot access refs during render
+      L17: (anonymous): Cannot access refs during render
+
+  components/hooks/useTokenBalance.tsx (1)
+      L41: (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+
+  components/hooks/useIsOriginalNativeTokenSymbol/useIsOriginalNativeTokenSymbol.ts (1)
+      L38: (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+
+  components/Views/NftDetails/NftDetails.tsx (1)
+      L107: (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+
+  components/Views/Homepage/Sections/Tokens/hooks/usePopularTokens.ts (1)
+      L162: (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+
+  components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx (1)
+      L210: (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+
+  components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx (1)
+      L135: (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+
+  components/UI/Tokens/index.tsx (1)
+      L208: (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+
+  components/UI/Tokens/TokenList/TokenList.test.tsx (1)
+      L154: (anonymous): Cannot access refs during render
+
+  components/UI/Tokens/TokenList/TokenList.tsx (1)
+      L119: (anonymous): Unexpected terminal kind `optional` for logical test block
+
+  components/UI/TokenDetails/hooks/useTokenPrice.ts (1)
+      L188: (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+
+  components/UI/TokenDetails/hooks/useTokenSecurityData.ts (1)
+      L44: (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+
+  components/UI/TokenDetails/components/ShareTokenBottomSheet.tsx (1)
+      L247: (anonymous): Existing memoization could not be preserved
+
+  components/UI/DeFiPositions/DeFiPositionsList.tsx (1)
+      L108: (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+
+  components/UI/Assets/components/Balance/AccountGroupBalance.tsx (1)
+      L85: (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+
+  components/UI/Assets/PriceAlerts/hooks/useAlertSaveFlow.ts (1)
+      L143: (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+
+  components/UI/Assets/DeFiPositions/hooks/useDeFiPositionsV2.ts (1)
+      L176: (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+
+  components/UI/Assets/DeFiPositions/components/DeFiPositionsListV2.tsx (1)
+      L95: (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+
+  components/UI/AssetOverview/TokenDetails/TokenDetails.tsx (1)
+      L141: (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+
+  components/UI/AssetOverview/PriceChart/PriceChart.tsx (1)
+      L149: (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+
+  components/UI/AssetOverview/Price/Price.advanced.tsx (1)
+      L1050: (anonymous): Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values

--- a/rcm-assets.txt
+++ b/rcm-assets.txt
@@ -1,0 +1,83 @@
+React Compiler Report (Assets CODEOWNERS)
+========================================
+Source:              /Users/prithpalsooriya/Desktop/projects/metamask-mobile/rcm-raw.txt
+Team:                @MetaMask/metamask-assets
+Files with failures: 34
+Failure lines:       74
+
+Failures:
+----------------------------------------
+  components/hooks/useTokenBalance.tsx:41 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/hooks/useIsOriginalNativeTokenSymbol/useIsOriginalNativeTokenSymbol.ts:38 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/NftDetails/NftDetails.tsx:107 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/Homepage/Sections/Tokens/hooks/usePopularTokens.ts:162 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/Homepage/Sections/NFTs/NFTsSection.tsx:69 - (anonymous): Cannot access refs during render
+  components/Views/Homepage/Sections/NFTs/NFTsSection.tsx:88 - (anonymous): Cannot access refs during render
+  components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx:210 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx:135 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/AddAsset/components/AddCustomCollectible/AddCustomCollectible.tsx:78 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/AddAsset/components/AddCustomCollectible/AddCustomCollectible.tsx:233 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/Tokens/index.tsx:208 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/Tokens/TokenList/TokenList.test.tsx:154 - (anonymous): Cannot access refs during render
+  components/UI/Tokens/TokenList/TokenList.tsx:119 - (anonymous): Unexpected terminal kind `optional` for logical test block
+  components/UI/TokenDetails/hooks/useAssetActivation.ts:98 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/TokenDetails/hooks/useAssetActivation.ts:153 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/TokenDetails/hooks/useTokenPrice.ts:188 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/TokenDetails/hooks/useTokenSecurityData.ts:44 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/TokenDetails/hooks/useTokenTransactions.ts:291 - (anonymous): Cannot reassign variables declared outside of the component/hook
+  components/UI/TokenDetails/hooks/useTokenTransactions.ts:293 - (anonymous): Cannot reassign variables declared outside of the component/hook
+  components/UI/TokenDetails/components/AssetOverviewContent.tsx:446 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/AssetOverviewContent.tsx:448 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx:265 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx:277 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx:289 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx:301 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx:312 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/ShareTokenBottomSheet.tsx:247 - (anonymous): Existing memoization could not be preserved
+  components/UI/TokenDetails/components/TokenDetailsActions.tsx:206 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/TokenDetailsActions.tsx:214 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/TokenDetailsActions.tsx:225 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/TokenDetailsActions.tsx:234 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/TokenDetailsActions.tsx:245 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/TokenDetailsActions.tsx:256 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/TokenDetailsActions.tsx:266 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/TokenDetailsActions.tsx:276 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/useAssetVisibility.ts:101 - (anonymous): Existing memoization could not be preserved
+  components/UI/TokenDetails/components/useAssetVisibility.ts:111 - (anonymous): Existing memoization could not be preserved
+  components/UI/TokenDetails/Views/TokenDetails.tsx:210 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/TokenDetails/Views/TokenDetails.tsx:687 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/Views/TokenDetails.tsx:775 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/Views/TokenDetails.tsx:776 - (anonymous): Cannot access refs during render
+  components/UI/DeFiPositions/DeFiPositionsList.tsx:108 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/CollectibleOverview/index.js:169 - (anonymous): Cannot access refs during render
+  components/UI/CollectibleOverview/index.js:169 - (anonymous): Cannot access refs during render
+  components/UI/CollectibleOverview/index.js:169 - (anonymous): Cannot access refs during render
+  components/UI/CollectibleOverview/index.js:169 - (anonymous): Cannot access refs during render
+  components/UI/CollectibleOverview/index.js:169 - (anonymous): Cannot access refs during render
+  components/UI/Assets/components/Balance/AccountGroupBalance.tsx:85 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Assets/components/AssetLogo/AssetLogo.hook.tsx:16 - (anonymous): Cannot access refs during render
+  components/UI/Assets/components/AssetLogo/AssetLogo.hook.tsx:17 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/hooks/useAlertSaveFlow.ts:143 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Assets/PriceAlerts/components/AlertAmountInput.tsx:42 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/AlertAmountInput.tsx:42 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/AlertAmountInput.tsx:42 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/AlertAmountInput.tsx:42 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/AlertAmountInput.tsx:42 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/SlidingPillToggle.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/SlidingPillToggle.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/SlidingPillToggle.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/SlidingPillToggle.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/SlidingPillToggle.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/SlidingPillToggle.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/SlidingPillToggle.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx:206 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx:207 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx:209 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx:284 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx:285 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx:289 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Assets/DeFiPositions/hooks/useDeFiPositionsV2.ts:176 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Assets/DeFiPositions/components/DeFiPositionsListV2.tsx:95 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/AssetOverview/TokenDetails/TokenDetails.tsx:141 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/AssetOverview/PriceChart/PriceChart.tsx:149 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/AssetOverview/Price/Price.advanced.tsx:1050 - (anonymous): Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values

--- a/rcm-raw.txt
+++ b/rcm-raw.txt
@@ -1,0 +1,1200 @@
+React Compiler Report
+========================================
+Files scanned:      12607
+Files with results: 3467
+Compiled (success): 3830
+Failed:             1191
+
+Failures:
+----------------------------------------
+  util/theme/index.ts:99 - (anonymous): Expected the first argument to be an inline function expression
+  util/test/testSetup.js:832 - (anonymous): Hooks must always be called in a consistent order, and may not be called conditionally. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning)
+  util/social/socialServiceTelemetry.ts:340 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  util/notifications/hooks/usePushPrePromptVariant.ts:210 - (anonymous): Cannot access refs during render
+  util/notifications/hooks/usePushPrePromptVariant.ts:210 - (anonymous): Cannot access refs during render
+  util/notifications/hooks/usePushPrePromptVariant.ts:210 - (anonymous): Cannot access refs during render
+  util/notifications/hooks/usePushPrePromptVariant.ts:210 - (anonymous): Cannot access refs during render
+  util/notifications/hooks/useStartupNotificationsEffect.ts:88 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  util/notifications/hooks/useStartupNotificationsEffect.ts:136 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  util/notifications/hooks/useSwitchNotifications.ts:71 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  util/notifications/hooks/useSwitchNotifications.ts:115 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  util/bridge/hooks/useValidateBridgeTx.ts:13 - (anonymous): Existing memoization could not be preserved
+  store/storage-wrapper-hooks.ts:49 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  messengers/route-with-messenger.tsx:46 - (anonymous): Cannot access refs during render
+  messengers/route-with-messenger.tsx:70 - (anonymous): Cannot access refs during render
+  core/HardwareWallet/HardwareWalletProvider.memoization.test.tsx:132 - (anonymous): Cannot reassign variables declared outside of the component/hook
+  core/HardwareWallet/HardwareWalletProvider.memoization.test.tsx:134 - (anonymous): Cannot reassign variables declared outside of the component/hook
+  core/HardwareWallet/HardwareWalletProvider.tsx:213 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  core/HardwareWallet/hooks/useAdapterLifecycle.ts:88 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  core/HardwareWallet/hooks/useAdapterLifecycle.ts:123 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  core/HardwareWallet/hooks/useDeviceConnectionFlow.ts:173 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  core/HardwareWallet/hooks/useDeviceConnectionFlow.ts:176 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  core/HardwareWallet/hooks/useDeviceConnectionFlow.ts:275 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  core/HardwareWallet/hooks/useDeviceConnectionFlow.ts:304 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  core/HardwareWallet/hooks/useDeviceEventHandlers.ts:74 - (anonymous): This value cannot be modified
+  core/HardwareWallet/hooks/useDeviceEventHandlers.ts:94 - (anonymous): This value cannot be modified
+  core/HardwareWallet/hooks/useQrConfirm.ts:91 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  core/HardwareWallet/hooks/useTransportMonitoring.ts:56 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  core/HardwareWallet/hooks/useTransportMonitoring.ts:112 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  core/HardwareWallet/components/HardwareWalletBottomSheet/HardwareWalletBottomSheet.test.tsx:75 - (anonymous): This value cannot be modified
+  core/HardwareWallet/components/HardwareWalletBottomSheet/contents/AwaitingConfirmationContent.tsx:180 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  core/HardwareWallet/components/HardwareWalletBottomSheet/contents/ErrorContent.tsx:135 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  core/Braze/hooks/useBrazeIdentity/useBrazeIdentity.ts:28 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  core/Authentication/hooks/useAuthCapabilities.ts:27 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/product-safety/scam-questionnaire/security-check-header.tsx:33 - (anonymous): Cannot access refs during render
+  components/product-safety/scam-questionnaire/security-check-header.tsx:33 - (anonymous): Cannot access refs during render
+  components/product-safety/scam-questionnaire/security-check-header.tsx:43 - (anonymous): Cannot access refs during render
+  components/product-safety/scam-questionnaire/security-check-header.tsx:43 - (anonymous): Cannot access refs during render
+  components/hooks/useBluetoothPermissions.ts:105 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/hooks/useFollowToggle.ts:115 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/hooks/useNftDetection.ts:81 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/hooks/usePolling.ts:41 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/hooks/usePolling.ts:53 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/hooks/usePrevious.ts:17 - (anonymous): Cannot access refs during render
+  components/hooks/useSyncSRPs.ts:17 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/hooks/useTokenBalance.tsx:41 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/hooks/useTokenDescriptions.ts:63 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/hooks/useTokenHistoricalPrices.ts:93 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/hooks/useNetworkSelection/useNetworkSelection.ts:167 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/hooks/useNetworkEnablement/useNetworkEnablement.ts:95 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/hooks/useNetworkConnectionBanner/useNetworkConnectionBanner.ts:157 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/hooks/useMultichainActivityMaliciousTokenKeys/useMultichainActivityMaliciousTokenKeys.ts:85 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/hooks/useMultichainActivityMaliciousTokenKeys/useMultichainActivityMaliciousTokenKeys.ts:98 - (anonymous): (BuildHIR::lowerExpression) Handle ??= operators in AssignmentExpression
+  components/hooks/useIsOriginalNativeTokenSymbol/useIsOriginalNativeTokenSymbol.ts:38 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/hooks/useEnsNameByAddress/index.ts:27 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/hooks/useAddressBalance/useAddressBalance.ts:101 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/transactions/SmartTransactionStatus/useRemainingTime.ts:75 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/confirmations/legacy/components/WatchAssetRequest/index.js:186 - (anonymous): (BuildHIR::lowerExpression) Handle ThisExpression expressions
+  components/Views/confirmations/hooks/useConfirmActions.ts:50 - (anonymous): Existing memoization could not be preserved
+  components/Views/confirmations/hooks/useConfirmActions.ts:74 - (anonymous): Existing memoization could not be preserved
+  components/Views/confirmations/hooks/useDeepMemo.ts:14 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/useDeepMemo.ts:15 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/useDeepMemo.ts:16 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/useDeepMemo.ts:19 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/useGetTokenStandardAndDetails.ts:59 - (anonymous): This value cannot be modified
+  components/Views/confirmations/hooks/useLedgerConfirm.ts:57 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/confirmations/hooks/useTokenAmount.ts:142 - (anonymous): Existing memoization could not be preserved
+  components/Views/confirmations/hooks/useTokenAmount.ts:164 - (anonymous): Existing memoization could not be preserved
+  components/Views/confirmations/hooks/useTokenAmount.ts:148 - (anonymous): Existing memoization could not be preserved
+  components/Views/confirmations/hooks/ui/useMMPayNavigation.ts:34 - (anonymous): This value cannot be modified
+  components/Views/confirmations/hooks/transactions/useTransactionCustomAmount.ts:499 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/confirmations/hooks/tokens/useEnsurePayToken.ts:84 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/confirmations/hooks/send/useAccountTokens.ts:122 - (anonymous): (BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas.
+  components/Views/confirmations/hooks/send/useAmountValidation.ts:104 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/send/useAmountValidation.ts:108 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/send/useSendActions.ts:68 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/confirmations/hooks/send/useSendType.ts:38 - (anonymous): Existing memoization could not be preserved
+  components/Views/confirmations/hooks/send/useSendType.ts:45 - (anonymous): Existing memoization could not be preserved
+  components/Views/confirmations/hooks/send/useSendType.ts:52 - (anonymous): Existing memoization could not be preserved
+  components/Views/confirmations/hooks/pay/useAssetFiatFormatter.ts:49 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts:247 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useFiatConfirm.ts:54 - (anonymous): Existing memoization could not be preserved
+  components/Views/confirmations/hooks/pay/usePaySectionSourceMetrics.ts:46 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/usePaySectionSourceMetrics.ts:51 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/usePaySectionSourceMetrics.ts:51 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/usePaySectionSourceMetrics.ts:51 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/usePaySectionSourceMetrics.ts:50 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/usePaySectionSourceMetrics.ts:54 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/usePaySectionSourceMetrics.ts:54 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useSectionTracking.ts:15 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useSectionTracking.ts:15 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useSectionTracking.ts:15 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useSectionTracking.ts:15 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useSectionTracking.ts:25 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useSectionTracking.ts:26 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useSectionTracking.ts:26 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useSectionTracking.ts:27 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useSectionTracking.ts:32 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useSectionTracking.ts:32 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useSectionTracking.ts:34 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useSectionTracking.ts:31 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:93 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:93 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:126 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:128 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:140 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:140 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:140 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:140 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:149 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:148 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:149 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:164 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:166 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:166 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:166 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:166 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:254 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:254 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:254 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:257 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:257 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:257 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:261 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:279 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:281 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:284 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayMetrics.ts:285 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/hooks/pay/useTransactionPayPostQuote.ts:65 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/confirmations/hooks/pay/useTransactionPaySelectedFiatPaymentMethod.ts:13 - (anonymous): Existing memoization could not be preserved
+  components/Views/confirmations/hooks/metrics/useConfirmationLocation.ts:108 - (anonymous): Calling setState from useMemo may trigger an infinite loop
+  components/Views/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.ts:74 - (anonymous): Unexpected terminal kind `optional` for logical test block
+  components/Views/confirmations/hooks/alerts/useAddressTrustSignalAlerts.ts:72 - (anonymous): Existing memoization could not be preserved
+  components/Views/confirmations/hooks/alerts/useDomainMismatchAlerts.ts:29 - (anonymous): Unexpected terminal in optional
+  components/Views/confirmations/hooks/alerts/useTokenContractAlert.ts:53 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/confirmations/components/send/amount/animated-cursor.tsx:31 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/components/send/amount/animated-cursor.tsx:31 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/components/send/amount/animated-cursor.tsx:31 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/components/send/amount/animated-cursor.tsx:31 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/components/send/amount/animated-cursor.tsx:31 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/components/send/amount/animated-cursor.tsx:31 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/components/send/amount/animated-cursor.tsx:31 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx:81 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx:95 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx:95 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx:95 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx:95 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/components/rows/pay-with-row/pay-with-row.tsx:95 - (anonymous): Cannot access refs during render
+  components/Views/confirmations/components/recipient-input/recipient-input.tsx:73 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx:200 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx:242 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/confirmations/components/gas/gas-fee-token-modal/gas-fee-token-modal.tsx:55 - (anonymous): Existing memoization could not be preserved
+  components/Views/confirmations/components/gas/gas-fee-token-modal/gas-fee-token-modal.tsx:46 - (anonymous): Existing memoization could not be preserved
+  components/Views/confirmations/components/custom-amount/custom-amount-buy/custom-amount-buy.tsx:38 - (anonymous): Unexpected terminal kind `optional` for logical test block
+  components/Views/confirmations/components/UI/info-section-accordion/info-section-accordion.tsx:95 - (anonymous): This value cannot be modified
+  components/Views/confirmations/components/UI/animated-pulse/animated-pulse.tsx:83 - (anonymous): Cannot access variable before it is declared
+  components/Views/WhatsHappeningDetailView/WhatsHappeningDetailView.tsx:131 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/WhatsHappeningDetailView/hooks/useWhatsHappeningAssetPrices.ts:66 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/Wallet/index.test.tsx:242 - (anonymous): Cannot reassign variables declared outside of the component/hook
+  components/Views/Wallet/index.tsx:865 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/TrendingView/tabs/SportsTab.tsx:139 - (anonymous): Cannot access refs during render
+  components/Views/TrendingView/search/SearchFeedRow.tsx:55 - (anonymous): Cannot access refs during render
+  components/Views/TrendingView/search/SearchFeedRow.tsx:57 - (anonymous): Cannot access refs during render
+  components/Views/TrendingView/search/analytics.ts:247 - (anonymous): Cannot access refs during render
+  components/Views/TrendingView/search/analytics.ts:250 - (anonymous): Cannot access refs during render
+  components/Views/TrendingView/feeds/tokens/useTokensFeed.ts:122 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/TrendingView/feeds/perps/usePerpsLiveMovers.ts:198 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/TrendingView/feeds/perps/usePerpsLiveMovers.ts:324 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.tsx:208 - (anonymous): Cannot access refs during render
+  components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.tsx:210 - (anonymous): Cannot access refs during render
+  components/Views/TrendingView/Views/ExploreSearchScreen/ExploreSearchScreen.tsx:216 - (anonymous): Cannot access refs during render
+  components/Views/TradeWalletActions/TradeWalletActions.tsx:144 - (anonymous): This value cannot be modified
+  components/Views/TradeWalletActions/TradeWalletActions.tsx:148 - (anonymous): This value cannot be modified
+  components/Views/ThemeSettings/index.tsx:75 - (anonymous): Existing memoization could not be preserved
+  components/Views/SocialLeaderboard/hooks/useOpenTradingSignalsSetup.ts:66 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/components/PositionTokenAvatar.tsx:95 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/SocialLeaderboard/components/TraderMuteChip.tsx:127 - (anonymous): This value cannot be modified
+  components/Views/SocialLeaderboard/components/TraderMuteChip.tsx:131 - (anonymous): This value cannot be modified
+  components/Views/SocialLeaderboard/components/TradingSignalsSetupBottomSheet/TradingSignalsSetupBottomSheet.tsx:46 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/TraderProfileView/TraderProfileView.tsx:223 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/Views/SocialLeaderboard/TraderPositionView/TraderPositionView.tsx:300 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/SocialLeaderboard/TraderPositionView/usePerpsTraderPositionPrices.ts:211 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/TraderPositionView/useSpotTraderPositionPrices.ts:82 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.tsx:48 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.tsx:48 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.tsx:48 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.tsx:48 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/TraderPositionView/components/TradeRow.tsx:48 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/TraderPositionView/components/TraderPriceChart.tsx:163 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/TraderPositionView/components/TraderPriceChart.tsx:354 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/TraderPositionView/components/TraderTradesSection.tsx:137 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/TopTradersView/TopTradersView.tsx:493 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.tsx:92 - (anonymous): This value cannot be modified
+  components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.tsx:97 - (anonymous): This value cannot be modified
+  components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.tsx:110 - (anonymous): This value cannot be modified
+  components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.tsx:157 - (anonymous): This value cannot be modified
+  components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.tsx:155 - (anonymous): This value cannot be modified
+  components/Views/SocialLeaderboard/SocialTradersTabsView/SocialTradersTabsView.tsx:292 - (anonymous): This value cannot be modified
+  components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx:416 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx:777 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx:778 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx:815 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx:466 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx:466 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx:466 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx:467 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx:467 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx:778 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx:778 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx:778 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx:777 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx:777 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx:777 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/Onboarding/SocialLeaderboardOnboarding.tsx:467 - (anonymous): Cannot access refs during render
+  components/Views/SocialLeaderboard/FeedView/FeedView.tsx:225 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.tsx:107 - (anonymous): This value cannot be modified
+  components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.tsx:137 - (anonymous): This value cannot be modified
+  components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.tsx:203 - (anonymous): This value cannot be modified
+  components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.tsx:204 - (anonymous): This value cannot be modified
+  components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.tsx:242 - (anonymous): This value cannot be modified
+  components/Views/Snaps/SnapSettings/SnapSettings.tsx:137 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/SitesFullView/SitesFullView.tsx:100 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/Settings/SecuritySettings/Sections/TopTradersSection.tsx:52 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/Settings/NotificationsSettings/AccountsList.tsx:63 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/Settings/NotificationsSettings/FeatureNotificationsGateSheet.tsx:119 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/Settings/NotificationsSettings/hooks/useOptimisticToggleValue.ts:31 - (anonymous): Cannot access refs during render
+  components/Views/Settings/NotificationsSettings/hooks/useOptimisticToggleValue.ts:33 - (anonymous): Cannot access refs during render
+  components/Views/SDK/SDKDisconnectModal/SDKDisconnectModal.tsx:85 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/Root/index.tsx:51 - (anonymous): Cannot access refs during render
+  components/Views/Root/index.tsx:55 - (anonymous): Cannot access refs during render
+  components/Views/QRTabSwitcher/QRTabSwitcher.tsx:101 - (anonymous): Cannot access refs during render
+  components/Views/QRTabSwitcher/QRTabSwitcher.tsx:103 - (anonymous): Cannot access refs during render
+  components/Views/QRTabSwitcher/QRTabSwitcher.tsx:106 - (anonymous): Cannot access refs during render
+  components/Views/QRTabSwitcher/QRTabSwitcher.tsx:153 - (anonymous): Cannot access refs during render
+  components/Views/QRScanner/useQrScannerCameraPermission.ts:22 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/OAuthRehydration/index.tsx:473 - (anonymous): Existing memoization could not be preserved
+  components/Views/OAuthRehydration/index.tsx:562 - (anonymous): Existing memoization could not be preserved
+  components/Views/Notifications/PushNotificationOnboarding/index.tsx:181 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/Views/NftDetails/NftDetails.tsx:107 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/NetworksManagement/hooks/useExpandableFormAnimation.ts:41 - (anonymous): This value cannot be modified
+  components/Views/NetworksManagement/hooks/useExpandableFormAnimation.ts:42 - (anonymous): This value cannot be modified
+  components/Views/NetworksManagement/hooks/useExpandableFormAnimation.ts:48 - (anonymous): This value cannot be modified
+  components/Views/NetworksManagement/hooks/useExpandableFormAnimation.ts:49 - (anonymous): This value cannot be modified
+  components/Views/NetworksManagement/NetworkDetailsView/NetworkDetailsView.tsx:129 - (anonymous): Cannot access refs during render
+  components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkForm.ts:318 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkForm.ts:328 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkOperations.ts:327 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/NetworksManagement/NetworkDetailsView/hooks/useNetworkValidation.ts:240 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/NetworksManagement/NetworkDetailsView/components/BlockExplorerSection.tsx:189 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/NetworksManagement/NetworkDetailsView/components/RpcEndpointSection.tsx:310 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/MultichainAccounts/MultichainAccountPermissions/MultichainAccountPermissions.tsx:176 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/Views/MultichainAccounts/MultichainAccountPermissions/MultichainAccountPermissions.tsx:236 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/Views/MultichainAccounts/MultichainAccountConnect/MultichainAccountConnect.tsx:701 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/MultichainAccounts/IntroModal/MultichainAccountsIntroModal.tsx:52 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/MultichainAccounts/IntroModal/MultichainAccountsIntroModal.tsx:97 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/MultichainAccounts/AccountGroupDetails/components/SecretRecoveryPhrase.tsx:55 - (anonymous): Existing memoization could not be preserved
+  components/Views/MediaPlayer/AndroidMediaPlayer.js:193 - (anonymous): Cannot access refs during render
+  components/Views/MediaPlayer/AndroidMediaPlayer.js:194 - (anonymous): Cannot access refs during render
+  components/Views/MediaPlayer/AndroidMediaPlayer.js:197 - (anonymous): Cannot access refs during render
+  components/Views/MediaPlayer/AndroidMediaPlayer.js:198 - (anonymous): Cannot access refs during render
+  components/Views/MediaPlayer/AndroidMediaPlayer.js:201 - (anonymous): Cannot access refs during render
+  components/Views/MediaPlayer/AndroidMediaPlayer.js:204 - (anonymous): Cannot access refs during render
+  components/Views/MediaPlayer/AndroidMediaPlayer.js:192 - (anonymous): Cannot access refs during render
+  components/Views/MediaPlayer/AndroidMediaPlayer.js:196 - (anonymous): Cannot access refs during render
+  components/Views/MediaPlayer/AndroidMediaPlayer.js:201 - (anonymous): Cannot access refs during render
+  components/Views/MediaPlayer/AndroidMediaPlayer.js:204 - (anonymous): Cannot access refs during render
+  components/Views/MediaPlayer/AndroidMediaPlayer.js:361 - (anonymous): Cannot access refs during render
+  components/Views/MediaPlayer/AndroidMediaPlayer.js:624 - (anonymous): Cannot access refs during render
+  components/Views/MediaPlayer/AndroidMediaPlayer.js:625 - (anonymous): Cannot access refs during render
+  components/Views/MediaPlayer/AndroidMediaPlayer.js:626 - (anonymous): Cannot access refs during render
+  components/Views/MediaPlayer/index.js:95 - (anonymous): This value cannot be modified
+  components/Views/LedgerSelectAccount/index.tsx:188 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/LedgerSelectAccount/index.tsx:225 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/ImportPrivateKey/index.tsx:108 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/ImportFromSecretRecoveryPhrase/index.tsx:601 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/Homepage/hooks/usePillViewedEvent.ts:22 - (anonymous): Cannot access refs during render
+  components/Views/Homepage/hooks/usePillViewedEvent.ts:25 - (anonymous): Cannot access refs during render
+  components/Views/Homepage/hooks/usePillViewedEvent.ts:28 - (anonymous): Cannot access refs during render
+  components/Views/Homepage/components/HomepageBalanceBreakdown/useHomepageBalanceBreakdownHero.ts:104 - (anonymous): This value cannot be modified
+  components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx:220 - (anonymous): Cannot access refs during render
+  components/Views/Homepage/Sections/TopTraders/hooks/usePrefetchTraderProfiles.ts:26 - (anonymous): Cannot access refs during render
+  components/Views/Homepage/Sections/TopTraders/hooks/usePrefetchTraderProfiles.ts:31 - (anonymous): Cannot access refs during render
+  components/Views/Homepage/Sections/Tokens/hooks/usePopularTokens.ts:162 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/Homepage/Sections/Perpetuals/hooks/useHomepageSparklines.ts:102 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Views/Homepage/Sections/Perpetuals/components/SparklineChart/SparklineChart.tsx:34 - (anonymous): Cannot access refs during render
+  components/Views/Homepage/Sections/Perpetuals/components/SparklineChart/SparklineChart.tsx:34 - (anonymous): Cannot access refs during render
+  components/Views/Homepage/Sections/Perpetuals/components/SparklineChart/SparklineChart.tsx:89 - (anonymous): Cannot access refs during render
+  components/Views/Homepage/Sections/Perpetuals/components/SparklineChart/SparklineChart.tsx:89 - (anonymous): Cannot access refs during render
+  components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.tsx:63 - (anonymous): Cannot access refs during render
+  components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.tsx:63 - (anonymous): Cannot access refs during render
+  components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.tsx:182 - (anonymous): Cannot access refs during render
+  components/Views/Homepage/Sections/Perpetuals/components/PerpsMarketTileCard/PerpsMarketTileCard.tsx:182 - (anonymous): Cannot access refs during render
+  components/Views/Homepage/Sections/NFTs/NFTsSection.tsx:69 - (anonymous): Cannot access refs during render
+  components/Views/Homepage/Sections/NFTs/NFTsSection.tsx:88 - (anonymous): Cannot access refs during render
+  components/Views/DiscoveryTab/DiscoveryTab.test.tsx:65 - (anonymous): Cannot reassign variables declared outside of the component/hook
+  components/Views/DiscoveryTab/DiscoveryTab.test.tsx:66 - (anonymous): Cannot reassign variables declared outside of the component/hook
+  components/Views/DiscoveryTab/DiscoveryTab.test.tsx:67 - (anonymous): Cannot reassign variables declared outside of the component/hook
+  components/Views/DiscoveryTab/DiscoveryTab.test.tsx:71 - (anonymous): Cannot reassign variables declared outside of the component/hook
+  components/Views/DiscoveryTab/DiscoveryTab.test.tsx:72 - (anonymous): Cannot reassign variables declared outside of the component/hook
+  components/Views/DiscoveryTab/DiscoveryTab.test.tsx:134 - (anonymous): Cannot reassign variables declared outside of the component/hook
+  components/Views/DiscoveryTab/DiscoveryTab.test.tsx:135 - (anonymous): Cannot reassign variables declared outside of the component/hook
+  components/Views/ConnectQRHardware/index.tsx:130 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/Views/ConnectQRHardware/index.tsx:268 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/ConnectHardware/SearchingForDevice/index.tsx:48 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/ConnectHardware/HardwareWalletDiscoveryFlow/screens/errors/DiscoveryErrorScreenLayout.tsx:46 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/CashTokensFullView/CashTokensFullView.tsx:168 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/CashTokensFullView/useCashTokensRefresh.ts:18 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/BrowserTab/BrowserTab.tsx:1017 - (anonymous): This value cannot be modified
+  components/Views/BrowserTab/BrowserTab.tsx:1140 - (anonymous): This value cannot be modified
+  components/Views/AddAsset/components/SearchTokenAutoComplete/SearchTokenAutocomplete.tsx:210 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx:135 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/AddAsset/components/AddCustomCollectible/AddCustomCollectible.tsx:78 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/Views/AddAsset/components/AddCustomCollectible/AddCustomCollectible.tsx:233 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/Views/ActivityScreen/ActivityScreen.tsx:74 - (anonymous): This value cannot be modified
+  components/Views/ActivityScreen/hooks/useActivityScreenViewed.ts:62 - (anonymous): Cannot access refs during render
+  components/Views/ActivityList/ActivityList.tsx:848 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/Views/ActivityList/useTransactionAutoScroll.ts:125 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Views/ActivityList/useUnifiedTxActions.ts:298 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/Views/ActivityList/useUnifiedTxActions.ts:301 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/Views/ActivityList/useUnifiedTxActions.ts:365 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/Views/ActivityList/useUnifiedTxActions.ts:368 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/Views/ActivityDetails/ActivityDetails.tsx:62 - (anonymous): Cannot access refs during render
+  components/Views/ActivityDetails/ActivityDetails.tsx:63 - (anonymous): Cannot access refs during render
+  components/Views/ActivityDetails/ActivityDetails.tsx:70 - (anonymous): Cannot access refs during render
+  components/Views/AccountStatus/index.tsx:121 - (anonymous): Existing memoization could not be preserved
+  components/Views/AccountStatus/index.tsx:121 - (anonymous): Existing memoization could not be preserved
+  components/Views/AccountStatus/index.tsx:204 - (anonymous): Existing memoization could not be preserved
+  components/Views/AccountStatus/index.tsx:196 - (anonymous): Existing memoization could not be preserved
+  components/Views/AccountStatus/index.tsx:218 - (anonymous): Existing memoization could not be preserved
+  components/Views/AccountStatus/index.tsx:213 - (anonymous): Existing memoization could not be preserved
+  components/Views/AccountPermissions/PermittedNetworksInfoSheet/PermittedNetworksInfoSheet.test.tsx:20 - (anonymous): Cannot access refs during render
+  components/Views/AccountPermissions/AccountPermissionsConfirmRevokeAll/AccountPermissionsConfirmRevokeAll.tsx:61 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/WhatsNewModal/WhatsNewModal.tsx:418 - (anonymous): Cannot access refs during render
+  components/UI/WhatsHappening/hooks/useWhatsHappening.ts:200 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/WalletHomeOnboardingSteps/useWalletHomeOnboardingFundStepBalanceGate.ts:54 - (anonymous): Cannot access refs during render
+  components/UI/Trending/hooks/useTrendingSearch/useTrendingSearch.ts:162 - (anonymous): Cannot access refs during render
+  components/UI/Trending/hooks/useTrendingRequest/useTrendingRequest.ts:238 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Trending/hooks/useSearchRequest/useSearchRequest.ts:97 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Trending/hooks/useSearchRequest/useSearchRequest.ts:137 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Trending/hooks/useRwaTokens/useRwaTokens.ts:114 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Trending/hooks/useRwaTokens/useRwaTokens.ts:150 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Trending/hooks/useQuickBuySearchKeyboard/useQuickBuySearchKeyboard.ts:16 - (anonymous): Cannot access refs during render
+  components/UI/Trending/hooks/useQuickBuySearchKeyboard/useQuickBuySearchKeyboard.ts:19 - (anonymous): Cannot access refs during render
+  components/UI/Trending/hooks/useNetworkName/useNetworkName.ts:40 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenNetworkBottomSheet.test.tsx:61 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenPriceChangeBottomSheet.test.tsx:34 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Trending/components/TrendingTokensBottomSheet/TrendingTokenTimeBottomSheet.test.tsx:34 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Trending/Views/TrendingTokensFullView/TrendingTokensFullView.tsx:278 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Trending/Views/RWATokensFullView/RWATokensFullView.tsx:52 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Transactions/index.js:383 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Transactions/index.js:400 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Tokens/index.tsx:208 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/Tokens/TokenList/TokenList.test.tsx:154 - (anonymous): Cannot access refs during render
+  components/UI/Tokens/TokenList/TokenList.tsx:119 - (anonymous): Unexpected terminal kind `optional` for logical test block
+  components/UI/TokenDetails/hooks/useAssetActivation.ts:98 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/TokenDetails/hooks/useAssetActivation.ts:153 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/TokenDetails/hooks/useTokenPrice.ts:188 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/TokenDetails/hooks/useTokenSecurityData.ts:44 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/TokenDetails/hooks/useTokenTransactions.ts:291 - (anonymous): Cannot reassign variables declared outside of the component/hook
+  components/UI/TokenDetails/hooks/useTokenTransactions.ts:293 - (anonymous): Cannot reassign variables declared outside of the component/hook
+  components/UI/TokenDetails/components/AssetOverviewContent.tsx:446 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/AssetOverviewContent.tsx:448 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx:265 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx:277 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx:289 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx:301 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/MoreTokenActionsMenu.tsx:312 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/ShareTokenBottomSheet.tsx:247 - (anonymous): Existing memoization could not be preserved
+  components/UI/TokenDetails/components/TokenDetailsActions.tsx:206 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/TokenDetailsActions.tsx:214 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/TokenDetailsActions.tsx:225 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/TokenDetailsActions.tsx:234 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/TokenDetailsActions.tsx:245 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/TokenDetailsActions.tsx:256 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/TokenDetailsActions.tsx:266 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/TokenDetailsActions.tsx:276 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/components/useAssetVisibility.ts:101 - (anonymous): Existing memoization could not be preserved
+  components/UI/TokenDetails/components/useAssetVisibility.ts:111 - (anonymous): Existing memoization could not be preserved
+  components/UI/TokenDetails/Views/TokenDetails.tsx:210 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/TokenDetails/Views/TokenDetails.tsx:687 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/Views/TokenDetails.tsx:775 - (anonymous): Cannot access refs during render
+  components/UI/TokenDetails/Views/TokenDetails.tsx:776 - (anonymous): Cannot access refs during render
+  components/UI/Stake/sdk/stakeSdkProvider.test.tsx:28 - (anonymous): Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values
+  components/UI/Stake/hooks/usePooledStakes.ts:28 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Stake/hooks/useStakingEligibility.ts:28 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Stake/hooks/useVaultApyAverages.tsx:19 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Stake/hooks/useVaultApys.tsx:18 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Stake/hooks/useVaultMetadata.ts:27 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Stake/hooks/usePoolStakedDeposit/index.ts:106 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Stake/components/StakingConfirmation/ConfirmationFooter/FooterButtonGroup/FooterButtonGroup.tsx:156 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Stake/components/StakingBalance/StakingBanners/ClaimBanner/ClaimBanner.tsx:72 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Stake/components/GasImpactModal/index.tsx:97 - (anonymous): Existing memoization could not be preserved
+  components/UI/SlippageSlider/index.js:144 - (anonymous): Cannot access refs during render
+  components/UI/SlippageSlider/index.js:144 - (anonymous): Cannot access refs during render
+  components/UI/SlippageSlider/index.js:142 - (anonymous): Cannot access refs during render
+  components/UI/SlippageSlider/index.js:163 - (anonymous): Cannot access refs during render
+  components/UI/SlippageSlider/index.js:163 - (anonymous): Cannot access refs during render
+  components/UI/SlippageSlider/index.js:179 - (anonymous): Cannot access refs during render
+  components/UI/SliderButton/index.js:139 - (anonymous): Cannot access refs during render
+  components/UI/SliderButton/index.js:139 - (anonymous): Cannot access refs during render
+  components/UI/SliderButton/index.js:158 - (anonymous): Cannot access refs during render
+  components/UI/SliderButton/index.js:158 - (anonymous): Cannot access refs during render
+  components/UI/SliderButton/index.js:162 - (anonymous): Cannot access refs during render
+  components/UI/SliderButton/index.js:162 - (anonymous): Cannot access refs during render
+  components/UI/SliderButton/index.js:207 - (anonymous): Cannot access refs during render
+  components/UI/SliderButton/index.js:207 - (anonymous): Cannot access refs during render
+  components/UI/SliderButton/index.js:207 - (anonymous): Cannot access refs during render
+  components/UI/SliderButton/index.js:207 - (anonymous): Cannot access refs during render
+  components/UI/SliderButton/index.js:203 - (anonymous): Cannot access refs during render
+  components/UI/SliderButton/index.js:120 - (anonymous): Cannot access refs during render
+  components/UI/SliderButton/index.js:120 - (anonymous): Cannot access refs during render
+  components/UI/SliderButton/index.js:290 - (anonymous): Cannot access refs during render
+  components/UI/SliderButton/index.js:290 - (anonymous): Cannot access refs during render
+  components/UI/Sites/hooks/useSiteData/useSitesData.ts:141 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Sites/hooks/useSiteData/useSitesData.ts:156 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/SimulationDetails/useSimulationMetrics.ts:112 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/RiveOnboardingStepper/RiveOnboardingStepper.tsx:113 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/RiveOnboardingStepper/useStepperProgress.ts:41 - (anonymous): This value cannot be modified
+  components/UI/RiveOnboardingStepper/useStepperProgress.ts:81 - (anonymous): This value cannot be modified
+  components/UI/Rewards/hooks/useApplyBonusCode.ts:56 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useApplyReferralCode.ts:56 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useBenefits.ts:41 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useCampaignOutcomeToast.ts:69 - (anonymous): Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks
+  components/UI/Rewards/hooks/useCampaignParticipantOutcome.ts:42 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useClaimReward.ts:44 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useCursorPaginatedList.ts:225 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Rewards/hooks/useFirstPredictOnUsOrder.ts:40 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useGeoRewardsMetadata.ts:43 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useGetCampaignParticipantStatus.ts:43 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useGetOndoCampaignDeposits.ts:50 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useGetOndoLeaderboard.ts:95 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useGetOndoLeaderboardPosition.ts:57 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useGetOndoPortfolioPosition.ts:54 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useGetPerpsTradingCampaignLeaderboard.ts:54 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useGetPerpsTradingCampaignLeaderboardPosition.ts:47 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useGetPerpsTradingCampaignVolume.ts:50 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useGetPredictThePitchLeaderboard.ts:54 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useGetPredictThePitchLeaderboardPosition.ts:47 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useGetPredictThePitchOutcomeToast.ts:9 - (anonymous): Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values
+  components/UI/Rewards/hooks/useGetPredictThePitchPositions.ts:44 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useGetPredictThePitchPrizePool.ts:50 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useLineaSeasonOneTokenReward.ts:48 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useLinkAccountAddress.ts:44 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useLinkAccountGroup.ts:60 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useLinkedOffDeviceAccounts.ts:49 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Rewards/hooks/useOndoOutcomeToast.ts:9 - (anonymous): Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values
+  components/UI/Rewards/hooks/useOptIn.ts:172 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Rewards/hooks/useOptInToCampaign.ts:38 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useOptout.ts:48 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/usePerpsTradingCampaignEndedOutcomeToast.ts:9 - (anonymous): Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values
+  components/UI/Rewards/hooks/useReferralDetails.ts:36 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useRewardCampaigns.ts:69 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useRewardDashboardModals.tsx:165 - (anonymous): Existing memoization could not be preserved
+  components/UI/Rewards/hooks/useRewardDashboardModals.tsx:223 - (anonymous): Existing memoization could not be preserved
+  components/UI/Rewards/hooks/useRewardOptinSummary.ts:256 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useRewardsAnimation.ts:140 - (anonymous): This value cannot be modified
+  components/UI/Rewards/hooks/useRewardsAnimation.ts:144 - (anonymous): This value cannot be modified
+  components/UI/Rewards/hooks/useRewardsAnimation.ts:165 - (anonymous): This value cannot be modified
+  components/UI/Rewards/hooks/useRewardsAnimation.ts:171 - (anonymous): This value cannot be modified
+  components/UI/Rewards/hooks/useRewardsAnimation.ts:197 - (anonymous): This value cannot be modified
+  components/UI/Rewards/hooks/useRewardsAnimation.ts:206 - (anonymous): This value cannot be modified
+  components/UI/Rewards/hooks/useRewardsAnimation.ts:236 - (anonymous): This value cannot be modified
+  components/UI/Rewards/hooks/useRewardsAnimation.ts:240 - (anonymous): This value cannot be modified
+  components/UI/Rewards/hooks/useRewardsAnimation.ts:265 - (anonymous): This value cannot be modified
+  components/UI/Rewards/hooks/useRewardsAnimation.ts:273 - (anonymous): This value cannot be modified
+  components/UI/Rewards/hooks/useRewardsNotificationsNudge.ts:96 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useRewardsNotificationsNudge.ts:116 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useRewardsToast.tsx:88 - (anonymous): Existing memoization could not be preserved
+  components/UI/Rewards/hooks/useRewardsVersionGuard.ts:38 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useSeasonStatus.ts:50 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useSeasonStatus.ts:73 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Rewards/hooks/useUnlockedRewards.ts:44 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useValidateBonusCode.ts:79 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useValidateReferralCode.ts:186 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Rewards/hooks/useVipDashboard.ts:57 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useVipEquityMultiplier.ts:113 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/hooks/useVipRefereeDashboard.ts:55 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/components/RewardsBottomSheetModal.tsx:106 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Rewards/components/Tabs/MusdCalculatorTab/MusdCalculatorTab.tsx:159 - (anonymous): This value cannot be modified
+  components/UI/Rewards/components/Tabs/MusdCalculatorTab/MusdCalculatorTab.tsx:173 - (anonymous): This value cannot be modified
+  components/UI/Rewards/components/Tabs/MusdCalculatorTab/MusdCalculatorTab.tsx:182 - (anonymous): This value cannot be modified
+  components/UI/Rewards/components/Tabs/MusdCalculatorTab/MusdCalculatorTab.tsx:189 - (anonymous): This value cannot be modified
+  components/UI/Rewards/components/Tabs/MusdCalculatorTab/MusdCalculatorTab.tsx:231 - (anonymous): This value cannot be modified
+  components/UI/Rewards/components/Settings/ReferredByCodeSection.tsx:83 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Rewards/components/Onboarding/OnboardingStep.tsx:119 - (anonymous): Cannot access refs during render
+  components/UI/Rewards/components/EndOfSeasonClaimBottomSheet/EndOfSeasonClaimBottomSheet.tsx:375 - (anonymous): (BuildHIR::lowerExpression) Handle BigIntLiteral expressions
+  components/UI/Rewards/components/Campaigns/CampaignOptInSheet.tsx:50 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Rewards/Views/BenefitsFullView.tsx:38 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/ReusableModal/index.tsx:142 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Ramp/hooks/useBlinkingCursor.ts:14 - (anonymous): Cannot access refs during render
+  components/UI/Ramp/hooks/useBlinkingCursor.ts:14 - (anonymous): Cannot access refs during render
+  components/UI/Ramp/hooks/useBlinkingCursor.ts:14 - (anonymous): Cannot access refs during render
+  components/UI/Ramp/hooks/useContinueWithQuote.ts:206 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/hooks/useContinueWithQuote.ts:367 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/Ramp/hooks/useRampTokens.ts:79 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/hooks/useRampsButtonClickData.ts:32 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Ramp/hooks/useTransakController.ts:133 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Ramp/hooks/useTransakIdProofPolling.ts:47 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/hooks/useTransakRouting.ts:312 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/hooks/useTransakRouting.ts:326 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/hooks/useTransakRouting.ts:340 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/hooks/useTransakRouting.ts:557 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/hooks/useTransakRouting.ts:794 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/hooks/useTransakRouting.ts:1012 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/hooks/useTransakRouting.ts:980 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/hooks/useTransakRouting.ts:924 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/hooks/useTransakRouting.ts:926 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/hooks/useTransakRouting.ts:801 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/hooks/useTransakRouting.ts:813 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/hooks/useTransakRouting.ts:901 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/hooks/useTransakRouting.ts:913 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/headless/useHeadlessSessionDismissal.ts:47 - (anonymous): Cannot access refs during render
+  components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.ts:27 - (anonymous): Cannot access refs during render
+  components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.ts:30 - (anonymous): Cannot access refs during render
+  components/UI/Ramp/headless/useHeadlessSessionFocusDismissal.ts:33 - (anonymous): Cannot access refs during render
+  components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx:108 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Views/OrderDetails/OrderDetails.tsx:239 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Views/NativeFlow/BankDetails.tsx:116 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Views/NativeFlow/BankDetails.tsx:239 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Views/NativeFlow/BankDetails.tsx:305 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Views/NativeFlow/BasicInfo.tsx:204 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Views/NativeFlow/EnterAddress.tsx:218 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Views/NativeFlow/EnterEmail.tsx:109 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Views/NativeFlow/EnterEmail.tsx:117 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/Views/NativeFlow/KycProcessing.tsx:162 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Views/NativeFlow/OtpCode.tsx:217 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/Views/NativeFlow/OtpCode.tsx:252 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Views/NativeFlow/OtpCode.tsx:257 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/Views/NativeFlow/OtpCode.tsx:267 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.tsx:79 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Ramp/Views/Checkout/Checkout.tsx:508 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/Views/BuildQuote/BuildQuote.tsx:621 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Aggregator/hooks/useApplePay.ts:59 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/Aggregator/hooks/useApplePay.ts:70 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/Aggregator/hooks/useApplePay.ts:72 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/Aggregator/hooks/useFetchRampNetworks.ts:22 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Aggregator/hooks/useInAppBrowser.ts:70 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Aggregator/hooks/useIntentAmount.ts:31 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Aggregator/hooks/useRampNetworksDetail.ts:12 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Aggregator/hooks/useSDKMethod.ts:124 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Ramp/Aggregator/containers/ApplePayButton.tsx:50 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Aggregator/components/TokenSelectModal/TokenSelectModal.tsx:94 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Ramp/Aggregator/components/OrderListItem/OrderListItem.tsx:105 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Ramp/Aggregator/components/LoadingAnimation/index.tsx:113 - (anonymous): This value cannot be modified
+  components/UI/Ramp/Aggregator/components/LoadingAnimation/index.tsx:124 - (anonymous): This value cannot be modified
+  components/UI/Ramp/Aggregator/Views/SendTransaction/SendTransaction.tsx:152 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Aggregator/Views/Quotes/Quotes.tsx:324 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Aggregator/Views/Quotes/Quotes.tsx:392 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/Aggregator/Views/Quotes/Quotes.tsx:423 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Aggregator/Views/Quotes/Quotes.tsx:506 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/Aggregator/Views/OrderDetails/OrderDetails.tsx:152 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Ramp/Aggregator/Views/Checkout/Checkout.tsx:165 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Ramp/Aggregator/Views/BuildQuote/BuildQuote.tsx:470 - (anonymous): Existing memoization could not be preserved
+  components/UI/QuickBuy/QuickBuyContext.test.tsx:147 - (anonymous): This value cannot be modified
+  components/UI/QuickBuy/QuickBuyPriceImpactConfirmScreen.tsx:41 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/QuickBuy/hooks/useQuickBuyAnalytics.ts:88 - (anonymous): Cannot access refs during render
+  components/UI/QuickBuy/hooks/useQuickBuyController.ts:1538 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/QuickBuy/hooks/useQuickBuyQuickAmountPreferences.ts:118 - (anonymous): Cannot access refs during render
+  components/UI/QuickBuy/hooks/useQuickBuyQuotes.ts:487 - (anonymous): Cannot access refs during render
+  components/UI/QuickBuy/hooks/useQuickBuyQuotes.ts:689 - (anonymous): Cannot access refs during render
+  components/UI/QuickBuy/hooks/useQuickBuyQuotes.ts:689 - (anonymous): Cannot access refs during render
+  components/UI/QuickBuy/hooks/useQuickBuyQuotes.ts:689 - (anonymous): Cannot access refs during render
+  components/UI/QuickBuy/hooks/useQuickBuyQuotes.ts:688 - (anonymous): Cannot access refs during render
+  components/UI/QuickBuy/hooks/useQuickBuyQuotes.ts:688 - (anonymous): Cannot access refs during render
+  components/UI/QuickBuy/hooks/useQuickBuySetup.ts:142 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/QuickBuy/components/CollapsibleReveal.tsx:117 - (anonymous): This value cannot be modified
+  components/UI/QuickBuy/components/CollapsibleReveal.tsx:118 - (anonymous): This value cannot be modified
+  components/UI/QuickBuy/components/CollapsibleReveal.tsx:119 - (anonymous): This value cannot be modified
+  components/UI/QuickBuy/components/CollapsibleReveal.tsx:133 - (anonymous): This value cannot be modified
+  components/UI/QuickBuy/components/CollapsibleReveal.tsx:140 - (anonymous): This value cannot be modified
+  components/UI/QuickBuy/components/CollapsibleReveal.tsx:141 - (anonymous): This value cannot be modified
+  components/UI/QuickBuy/components/QuickBuyQuoteCountdown.tsx:51 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/QuickBuy/components/QuickBuyTradeModeToggle.tsx:129 - (anonymous): This value cannot be modified
+  components/UI/QuickBuy/components/QuickBuyTradeModeToggle.tsx:130 - (anonymous): This value cannot be modified
+  components/UI/QuickBuy/components/QuickBuyTradeModeToggle.tsx:159 - (anonymous): This value cannot be modified
+  components/UI/QRHardware/AnimatedQRScanner.tsx:248 - (anonymous): Cannot access refs during render
+  components/UI/QRHardware/QRSigningTransactionModal.tsx:111 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/PredictNext/components/EventCard/EventCard.tsx:53 - (anonymous): (BuildHIR::node.lowerReorderableExpression) Expression type `MemberExpression` cannot be safely reordered
+  components/UI/Predict/views/PredictSellPreview/PredictSellPreview.tsx:178 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Predict/views/PredictMarketDetails/hooks/useOpenOutcomes.ts:99 - (anonymous): Cannot access refs during render
+  components/UI/Predict/views/PredictMarketDetails/hooks/useOpenOutcomes.ts:100 - (anonymous): Cannot access refs during render
+  components/UI/Predict/views/PredictMarketDetails/hooks/useOpenOutcomes.ts:100 - (anonymous): Cannot access refs during render
+  components/UI/Predict/views/PredictMarketDetails/hooks/useOpenOutcomes.ts:101 - (anonymous): Cannot access refs during render
+  components/UI/Predict/views/PredictMarketDetails/hooks/useOpenOutcomes.ts:101 - (anonymous): Cannot access refs during render
+  components/UI/Predict/views/PredictMarketDetails/hooks/useOpenOutcomes.ts:134 - (anonymous): Cannot access refs during render
+  components/UI/Predict/views/PredictMarketDetails/hooks/useOpenOutcomes.ts:135 - (anonymous): Cannot access refs during render
+  components/UI/Predict/views/PredictFeed/PredictFeed.tsx:360 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyActions.ts:110 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.ts:141 - (anonymous): Existing memoization could not be preserved
+  components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyConditions.ts:141 - (anonymous): Existing memoization could not be preserved
+  components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.ts:80 - (anonymous): Existing memoization could not be preserved
+  components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.ts:80 - (anonymous): Existing memoization could not be preserved
+  components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyError.ts:231 - (anonymous): Existing memoization could not be preserved
+  components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInfo.ts:51 - (anonymous): Existing memoization could not be preserved
+  components/UI/Predict/views/PredictBuyWithAnyToken/hooks/usePredictBuyInputState.ts:16 - (anonymous): Cannot access refs during render
+  components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyAmountSection/PredictBuyAmountSection.tsx:45 - (anonymous): Cannot access refs during render
+  components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyAmountSection/PredictBuyAmountSection.tsx:45 - (anonymous): Cannot access refs during render
+  components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyAmountSection/PredictBuyAmountSection.tsx:45 - (anonymous): Cannot access refs during render
+  components/UI/Predict/views/PredictBuyWithAnyToken/components/PredictBuyAmountSection/PredictBuyAmountSection.tsx:45 - (anonymous): Cannot access refs during render
+  components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx:132 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Predict/views/PredictBuyPreview/PredictBuyPreview.tsx:267 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Predict/views/PredictAddFundsModal/PredictAddFundsModal.tsx:65 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:196 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:197 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:198 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:199 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:204 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:205 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:213 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:214 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:218 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:219 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:220 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:222 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:223 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:224 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:225 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:448 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:448 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:448 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:476 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:448 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:536 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:536 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:448 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:448 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:448 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:448 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useCryptoUpDownChartData.ts:448 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/useFeedScrollManager.ts:120 - (anonymous): This value cannot be modified
+  components/UI/Predict/hooks/useFeedScrollManager.ts:131 - (anonymous): This value cannot be modified
+  components/UI/Predict/hooks/useFeedScrollManager.ts:219 - (anonymous): This value cannot be modified
+  components/UI/Predict/hooks/useLiveCryptoPrices.ts:18 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/usePredictCashOut.ts:41 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Predict/hooks/usePredictClaim.ts:129 - (anonymous): Cannot access variable before it is declared
+  components/UI/Predict/hooks/usePredictDeposit.ts:73 - (anonymous): Cannot access variable before it is declared
+  components/UI/Predict/hooks/usePredictEligibility.ts:207 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/usePredictFeedConfig.ts:179 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/usePredictFeedConfig.ts:185 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/usePredictMarketData.tsx:82 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Predict/hooks/usePredictMarketData.tsx:169 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Predict/hooks/usePredictMarketData.tsx:114 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Predict/hooks/usePredictMarketData.tsx:119 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Predict/hooks/usePredictOrderRetry.ts:64 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Predict/hooks/usePredictOrderRetry.ts:81 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Predict/hooks/usePredictPlaceOrder.ts:247 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Predict/hooks/usePredictPriceHistory.tsx:64 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Predict/hooks/usePredictPriceHistory.tsx:76 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Predict/hooks/usePredictPriceHistory.tsx:123 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Predict/hooks/usePredictPrices.tsx:143 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Predict/hooks/usePredictRewards.ts:108 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Predict/hooks/usePredictSectionImpressions.ts:54 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/usePredictSectionImpressions.ts:55 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/usePredictShare.ts:54 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Predict/hooks/usePredictStackedHeader.ts:46 - (anonymous): This value cannot be modified
+  components/UI/Predict/hooks/usePredictTabs.ts:89 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/usePredictTabs.ts:138 - (anonymous): Cannot access refs during render
+  components/UI/Predict/hooks/usePredictTabs.ts:138 - (anonymous): Cannot access refs during render
+  components/UI/Predict/contexts/PredictPreviewSheetContext.tsx:267 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PulsingLiveDot/PulsingLiveDot.tsx:38 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PulsingLiveDot/PulsingLiveDot.tsx:37 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PulsingLiveDot/PulsingLiveDot.tsx:63 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PulsingLiveDot/PulsingLiveDot.tsx:37 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PulsingLiveDot/PulsingLiveDot.tsx:37 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PulsingLiveDot/PulsingLiveDot.tsx:38 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PulsingLiveDot/PulsingLiveDot.tsx:37 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PulsingLiveDot/PulsingLiveDot.tsx:68 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PulsingLiveDot/PulsingLiveDot.tsx:90 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.tsx:66 - (anonymous): This value cannot be modified
+  components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.tsx:67 - (anonymous): This value cannot be modified
+  components/UI/Predict/components/PredictSportLineSelector/PredictSportLineSelector.tsx:75 - (anonymous): This value cannot be modified
+  components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.tsx:98 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Predict/components/PredictGameDetailsContent/usePricedOutcomeGroup.ts:193 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictGameDetailsContent/usePricedOutcomeGroup.ts:194 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx:291 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx:291 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx:291 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx:291 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx:305 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictGameChart/PredictGameChart.tsx:305 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictGameChart/PredictGameChartContent.tsx:101 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictGameChart/PredictGameChartContent.tsx:110 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictGameChart/PredictGameChartContent.tsx:137 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictGameChart/PredictGameChartContent.tsx:364 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictDetailsChart/PredictDetailsChart.tsx:370 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx:154 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx:207 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx:209 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx:207 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx:207 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx:207 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx:207 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx:207 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx:207 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx:207 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx:207 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx:207 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx:207 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx:207 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx:207 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx:432 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx:207 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx:207 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.tsx:51 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.tsx:51 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.tsx:51 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.tsx:51 - (anonymous): Cannot access refs during render
+  components/UI/Predict/components/PredictAmountDisplay/PredictAmountDisplay.tsx:51 - (anonymous): Cannot access refs during render
+  components/UI/Perps/hooks/useColorPulseAnimation.ts:50 - (anonymous): (BuildHIR::node.lowerReorderableExpression) Expression type `ObjectExpression` cannot be safely reordered
+  components/UI/Perps/hooks/useDepositRequests.ts:122 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/useDepositRequests.ts:137 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Perps/hooks/useDepositRequests.ts:148 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Perps/hooks/useHasExistingPosition.ts:131 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Perps/hooks/useIsPriceDeviatedAboveThreshold.ts:54 - (anonymous): Existing memoization could not be preserved
+  components/UI/Perps/hooks/useIsPriceDeviatedAboveThreshold.ts:54 - (anonymous): Existing memoization could not be preserved
+  components/UI/Perps/hooks/usePerpsAdvancedChartAdapter.ts:265 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Perps/hooks/usePerpsBlockExplorerUrl.ts:36 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Perps/hooks/usePerpsCancelAllOrders.ts:76 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsCancelAllOrders.ts:103 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Perps/hooks/usePerpsCloseAllCalculations.ts:494 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Perps/hooks/usePerpsCloseAllPositions.ts:94 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsCloseAllPositions.ts:124 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Perps/hooks/usePerpsClosePosition.ts:128 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsClosePosition.ts:271 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Perps/hooks/usePerpsClosePositionValidation.ts:141 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Perps/hooks/usePerpsDataMonitor.ts:224 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Perps/hooks/usePerpsFlipPosition.ts:43 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsFunding.ts:82 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsHomeActions.ts:136 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsHomeActions.ts:205 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsHomeData.ts:127 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Perps/hooks/usePerpsLiquidationPrice.ts:45 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsMarginAdjustment.ts:39 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsMarketData.ts:93 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Perps/hooks/usePerpsMarketFills.ts:200 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/Perps/hooks/usePerpsMarketForAsset.ts:158 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Perps/hooks/usePerpsMarkets.ts:126 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsMaxSlippage.ts:48 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Perps/hooks/usePerpsNetworkManagement.ts:64 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Perps/hooks/usePerpsOrderExecution.ts:181 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsOrderFees.ts:553 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsOrderFills.ts:82 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsOrderForm.ts:264 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Perps/hooks/usePerpsOrderValidation.ts:146 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Perps/hooks/usePerpsOrders.ts:66 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsPaymentTokens.ts:130 - (anonymous): Cannot access refs during render
+  components/UI/Perps/hooks/usePerpsPaymentTokens.ts:134 - (anonymous): Cannot access refs during render
+  components/UI/Perps/hooks/usePerpsPaymentTokens.ts:138 - (anonymous): Cannot access refs during render
+  components/UI/Perps/hooks/usePerpsPositionForAsset.ts:168 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Perps/hooks/usePerpsProOrderEdit.tsx:217 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsProPositionsPanelActions.tsx:291 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsRewardAccountOptedIn.ts:80 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Perps/hooks/usePerpsTPSLForm.ts:243 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Perps/hooks/usePerpsTPSLForm.ts:308 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Perps/hooks/usePerpsTPSLUpdate.ts:70 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsToasts.tsx:384 - (anonymous): Existing memoization could not be preserved
+  components/UI/Perps/hooks/usePerpsTrading.ts:98 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Perps/hooks/usePerpsTransactionHistory.ts:177 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsTransactionHistory.ts:183 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Perps/hooks/usePerpsTransactionHistory.ts:316 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/usePerpsWithdrawConfirmation.ts:126 - (anonymous): Unsupported declaration type for hoisting
+  components/UI/Perps/hooks/useStableArray.ts:11 - (anonymous): Cannot access refs during render
+  components/UI/Perps/hooks/useStableArray.ts:11 - (anonymous): Cannot access refs during render
+  components/UI/Perps/hooks/useStableArray.ts:11 - (anonymous): Cannot access refs during render
+  components/UI/Perps/hooks/useStableArray.ts:11 - (anonymous): Cannot access refs during render
+  components/UI/Perps/hooks/useStableArray.ts:12 - (anonymous): Cannot access refs during render
+  components/UI/Perps/hooks/useStableArray.ts:11 - (anonymous): Cannot access refs during render
+  components/UI/Perps/hooks/useStableArray.ts:11 - (anonymous): Cannot access refs during render
+  components/UI/Perps/hooks/useStableArray.ts:11 - (anonymous): Cannot access refs during render
+  components/UI/Perps/hooks/useStableArray.ts:13 - (anonymous): Cannot access refs during render
+  components/UI/Perps/hooks/useStableArray.ts:13 - (anonymous): Cannot access refs during render
+  components/UI/Perps/hooks/useStableArray.ts:17 - (anonymous): Cannot access refs during render
+  components/UI/Perps/hooks/useUserHistory.ts:36 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/useUserHistory.ts:42 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Perps/hooks/useWithdrawalRequests.ts:204 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/Perps/hooks/useWithdrawalRequests.ts:223 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/Perps/hooks/stream/usePerpsLiveCandles.ts:196 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/hooks/stream/usePerpsLivePositions.ts:216 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Perps/hooks/stream/usePerpsLivePrices.ts:53 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Perps/components/TradingViewChart/TradingViewChart.tsx:314 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Perps/components/PerpsWebSocketHealthToast/PerpsWebSocketHealthToast.tsx:200 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx:64 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx:64 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx:64 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx:64 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx:64 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx:64 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx:64 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsStopLossPromptBanner/PerpsStopLossPromptBanner.tsx:64 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsSlippageBottomSheet/PerpsCustomSlippageBottomSheet.tsx:62 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsSlippageBottomSheet/PerpsCustomSlippageBottomSheet.tsx:62 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsSlippageBottomSheet/PerpsCustomSlippageBottomSheet.tsx:62 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsSlippageBottomSheet/PerpsCustomSlippageBottomSheet.tsx:62 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsSlippageBottomSheet/PerpsCustomSlippageBottomSheet.tsx:62 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsProgressBar/PerpsProgressBar.tsx:163 - (anonymous): This value cannot be modified
+  components/UI/Perps/components/PerpsProgressBar/PerpsProgressBar.tsx:322 - (anonymous): This value cannot be modified
+  components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx:119 - (anonymous): Existing memoization could not be preserved
+  components/UI/Perps/components/PerpsOrderBookTable/PerpsOrderBookTable.tsx:188 - (anonymous): Existing memoization could not be preserved
+  components/UI/Perps/components/PerpsOrderBookTable/PerpsOrderBookTable.tsx:194 - (anonymous): Existing memoization could not be preserved
+  components/UI/Perps/components/PerpsNotificationBottomSheet/PerpsNotificationBottomSheet.tsx:46 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Perps/components/PerpsModeToggle/PerpsModeSwitchPill.tsx:151 - (anonymous): This value cannot be modified
+  components/UI/Perps/components/PerpsModeToggle/PerpsModeSwitchPill.tsx:152 - (anonymous): This value cannot be modified
+  components/UI/Perps/components/PerpsMarginModeBottomSheet/PerpsMarginModeBottomSheet.tsx:31 - (anonymous): Existing memoization could not be preserved
+  components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx:274 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsLeverageBottomSheet/PerpsLeverageBottomSheet.tsx:274 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsProviderToggle.tsx:52 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/Perps/components/PerpsAmountDisplay/PerpsAmountDisplay.tsx:55 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsAmountDisplay/PerpsAmountDisplay.tsx:55 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsAmountDisplay/PerpsAmountDisplay.tsx:55 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsAmountDisplay/PerpsAmountDisplay.tsx:55 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsAmountDisplay/PerpsAmountDisplay.tsx:55 - (anonymous): Cannot access refs during render
+  components/UI/Perps/components/PerpsActionSheet/PerpsActionSheet.tsx:31 - (anonymous): Existing memoization could not be preserved
+  components/UI/Perps/components/LivePriceDisplay/LivePriceHeader.tsx:183 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.tsx:266 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/Views/PerpsTransactionsView/PerpsPositionTransactionView.tsx:59 - (anonymous): Existing memoization could not be preserved
+  components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx:202 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx:245 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/Views/PerpsTPSLView/PerpsTPSLView.tsx:501 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/Perps/Views/PerpsSelectOrderTypeView/PerpsSelectOrderTypeView.tsx:31 - (anonymous): Existing memoization could not be preserved
+  components/UI/Perps/Views/PerpsSelectOrderTypeView/PerpsSelectOrderTypeView.tsx:41 - (anonymous): Existing memoization could not be preserved
+  components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsOptionSheet.tsx:104 - (anonymous): Cannot access refs during render
+  components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/usePerpsProOrderForm.ts:671 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx:258 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx:1257 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Perps/Views/PerpsOrderView/useInitPerpsPaymentToken.ts:25 - (anonymous): Cannot access refs during render
+  components/UI/Perps/Views/PerpsOrderView/useInitPerpsPaymentToken.ts:26 - (anonymous): Cannot access refs during render
+  components/UI/Perps/Views/PerpsOrderView/useInitPerpsPaymentToken.ts:27 - (anonymous): Cannot access refs during render
+  components/UI/Perps/Views/PerpsOrderDetailsView/PerpsOrderDetailsView.tsx:216 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx:116 - (anonymous): Cannot access refs during render
+  components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx:116 - (anonymous): Cannot access refs during render
+  components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx:443 - (anonymous): Cannot access refs during render
+  components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx:506 - (anonymous): Cannot access refs during render
+  components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx:543 - (anonymous): Cannot access refs during render
+  components/UI/Perps/Views/PerpsMarketListView/PerpsMarketListView.tsx:935 - (anonymous): Cannot access refs during render
+  components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx:838 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx:1189 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx:295 - (anonymous): This value cannot be modified
+  components/UI/Perps/Views/PerpsHeroCardView/PerpsHeroCardView.tsx:397 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Perps/Views/PerpsClosePositionView/PerpsClosePositionView.tsx:735 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx:297 - (anonymous): Cannot access refs during render
+  components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx:299 - (anonymous): Cannot access refs during render
+  components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx:301 - (anonymous): Cannot access refs during render
+  components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx:301 - (anonymous): Cannot access refs during render
+  components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx:302 - (anonymous): Cannot access refs during render
+  components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx:364 - (anonymous): Cannot access refs during render
+  components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx:383 - (anonymous): Cannot access refs during render
+  components/UI/Perps/Views/PerpsAdjustMarginView/PerpsAdjustMarginView.tsx:384 - (anonymous): Cannot access refs during render
+  components/UI/Perps/Debug/HIP3DebugView.tsx:256 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Perps/Debug/HIP3DebugView.tsx:314 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Perps/Debug/HIP3DebugView.tsx:347 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Perps/Debug/HIP3DebugView.tsx:354 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Perps/Debug/HIP3DebugView.tsx:362 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Perps/Debug/HIP3DebugView.tsx:414 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Perps/Debug/HIP3DebugView.tsx:464 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Notification/NotificationMenuItem/Icon.tsx:33 - (anonymous): Existing memoization could not be preserved
+  components/UI/NftGrid/NftGridItemBottomSheet.test.tsx:55 - (anonymous): Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks
+  components/UI/NftGrid/useNftRefresh.ts:38 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/NetworkManager/index.tsx:362 - (anonymous): Cannot access refs during render
+  components/UI/NetworkManager/index.tsx:362 - (anonymous): Cannot access refs during render
+  components/UI/NetworkConnectionBanner/NetworkConnectionBanner.tsx:60 - (anonymous): (BuildHIR::lowerExpression) Handle tagged template with interpolations
+  components/UI/Money/hooks/useMoneyHomePerformance.ts:87 - (anonymous): Expected branch block to end in an instruction that sets the test value
+  components/UI/Money/hooks/useMoneyToasts.tsx:232 - (anonymous): Existing memoization could not be preserved
+  components/UI/Money/hooks/useMountEffect.ts:14 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Money/components/MoneySheetEntrance/MoneySheetEntrance.tsx:72 - (anonymous): This value cannot be modified
+  components/UI/Money/components/MoneySheetEntrance/MoneySheetEntrance.tsx:73 - (anonymous): This value cannot be modified
+  components/UI/Money/components/MoneyMoreSheet/MoneyMoreSheet.tsx:135 - (anonymous): Cannot access refs during render
+  components/UI/Money/components/MoneyMoreSheet/MoneyMoreSheet.tsx:135 - (anonymous): Cannot access refs during render
+  components/UI/Money/components/MoneyEarnBanner/MoneyEarnBanner.tsx:265 - (anonymous): Existing memoization could not be preserved
+  components/UI/Money/components/MoneyEarnBanner/MoneyEarnBanner.tsx:242 - (anonymous): Existing memoization could not be preserved
+  components/UI/Money/components/MoneyConvertStablecoins/MoneyConvertStablecoins.tsx:165 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Money/components/MoneyCardFlipAnimation/MoneyCardFlipAnimation.tsx:96 - (anonymous): This value cannot be modified
+  components/UI/Money/components/MoneyCardFlipAnimation/MoneyCardFlipAnimation.tsx:97 - (anonymous): This value cannot be modified
+  components/UI/Money/Views/MoneyPotentialEarningsView/MoneyPotentialEarningsView.tsx:143 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx:178 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/MarketInsights/hooks/useMarketInsights.ts:58 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/MarketInsights/components/MarketInsightsEntryCard/AnimatedGradientBorder.tsx:217 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsEntryCard.tsx:189 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/MarketInsights/components/MarketInsightsEntryCard/SlidingTextCarousel.tsx:134 - (anonymous): This value cannot be modified
+  components/UI/MarketInsights/components/MarketInsightsEntryCard/SlidingTextCarousel.tsx:134 - (anonymous): This value cannot be modified
+  components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx:116 - (anonymous): Cannot access refs during render
+  components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx:117 - (anonymous): Cannot access refs during render
+  components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx:145 - (anonymous): Cannot access refs during render
+  components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx:117 - (anonymous): Cannot access refs during render
+  components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx:117 - (anonymous): Cannot access refs during render
+  components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx:116 - (anonymous): Cannot access refs during render
+  components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx:117 - (anonymous): Cannot access refs during render
+  components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx:148 - (anonymous): Cannot access refs during render
+  components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx:284 - (anonymous): Existing memoization could not be preserved
+  components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx:536 - (anonymous): Existing memoization could not be preserved
+  components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx:558 - (anonymous): Existing memoization could not be preserved
+  components/UI/LedgerModals/LedgerConfirmationModal.tsx:97 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/LedgerModals/LedgerTransactionModal.tsx:76 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/HardwareWallet/Swaps/HwQrScanner.tsx:275 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/HardwareWallet/Swaps/useHardwareWalletSubmit.ts:227 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/HardwareWallet/Swaps/useHwBatchSignTracker.ts:286 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/HardwareWallet/Swaps/useHwBatchSignTracker.ts:300 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/HardwareWallet/Swaps/useHwBatchSignTracker.ts:384 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/HardwareWallet/Swaps/useHwSwapLifecycle.ts:408 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/HardwareWallet/AccountSelector/hooks.tsx:44 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/FundActionMenu/FundActionMenu.tsx:83 - (anonymous): Existing memoization could not be preserved
+  components/UI/FoxLoader/FoxLoader.tsx:44 - (anonymous): Cannot access refs during render
+  components/UI/FoxLoader/FoxLoader.tsx:73 - (anonymous): Cannot access refs during render
+  components/UI/FoxLoader/FoxLoader.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/FoxLoader/FoxLoader.tsx:75 - (anonymous): Cannot access refs during render
+  components/UI/FoxLoader/FoxLoader.tsx:121 - (anonymous): Cannot access refs during render
+  components/UI/FoxLoader/FoxLoader.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/FoxLoader/FoxLoader.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/FoxLoader/FoxLoader.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/FoxLoader/FoxLoader.tsx:75 - (anonymous): Cannot access refs during render
+  components/UI/FoxLoader/FoxLoader.tsx:75 - (anonymous): Cannot access refs during render
+  components/UI/FoxLoader/FoxLoader.tsx:75 - (anonymous): Cannot access refs during render
+  components/UI/FoxAnimation/FoxAnimation.tsx:90 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Fox/index.tsx:46 - (anonymous): This value cannot be modified
+  components/UI/FadeAnimationView/index.js:16 - (anonymous): Cannot access refs during render
+  components/UI/FadeAnimationView/index.js:16 - (anonymous): Cannot access refs during render
+  components/UI/Earn/modals/LendingMaxWithdrawalModal/LendingMaxWithdrawalModal.test.tsx:17 - (anonymous): Cannot access refs during render
+  components/UI/Earn/hooks/useEarnGasFee.ts:115 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Earn/hooks/useEarnInput.ts:154 - (anonymous): Cannot access refs during render
+  components/UI/Earn/hooks/useEarnInput.ts:161 - (anonymous): Cannot access refs during render
+  components/UI/Earn/hooks/useEarnInput.ts:161 - (anonymous): Cannot access refs during render
+  components/UI/Earn/hooks/useEarnInput.ts:161 - (anonymous): Cannot access refs during render
+  components/UI/Earn/hooks/useEarnToasts.tsx:175 - (anonymous): Existing memoization could not be preserved
+  components/UI/Earn/hooks/useEarnWithdrawInput.ts:84 - (anonymous): Existing memoization could not be preserved
+  components/UI/Earn/hooks/useEarningsHistory.ts:49 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Earn/hooks/useEarningsHistory.ts:67 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Earn/hooks/useLendingMarketApys.ts:31 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Earn/hooks/useMultichainInputHandlers.ts:57 - (anonymous): Existing memoization could not be preserved
+  components/UI/Earn/hooks/useMusdConversion.ts:218 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Earn/hooks/useMusdConversion.ts:222 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Earn/hooks/useMusdConversion.ts:227 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Earn/hooks/useMusdConversion.ts:361 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/Earn/hooks/useMusdConversion.ts:464 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Earn/hooks/useMusdConversion.ts:468 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Earn/hooks/useMusdConversion.ts:545 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/Earn/hooks/useMusdConversionStatus.ts:64 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Earn/hooks/useTronClaimUnstakedTrx.ts:35 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Earn/hooks/useTronStake.ts:111 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Earn/hooks/useTronStakeApy.ts:74 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Earn/hooks/useTronUnstake.ts:157 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Earn/components/Tron/TronUnstakedBanner/TronUnstakedBanner.tsx:35 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Earn/components/Tron/StakePreview/TronStakePreview.tsx:94 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/Tron/StakePreview/TronStakePreview.tsx:93 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/Tron/StakePreview/TronStakePreview.tsx:111 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/Tron/StakePreview/TronStakePreview.tsx:93 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/Tron/StakePreview/TronStakePreview.tsx:93 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/Tron/StakePreview/TronStakePreview.tsx:93 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/Tron/StakePreview/TronStakePreview.tsx:94 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/Tron/StakePreview/TronStakePreview.tsx:94 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/Tron/StakePreview/TronStakePreview.tsx:94 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/Tron/ResourceToggle/ResourceToggle.tsx:39 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/Tron/ResourceToggle/ResourceToggle.tsx:39 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/Tron/ResourceToggle/ResourceToggle.tsx:51 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/Tron/ResourceToggle/ResourceToggle.tsx:51 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/Musd/MusdConversionAssetOverviewCta/index.tsx:83 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Earn/components/InputDisplay/index.tsx:147 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/InputDisplay/index.tsx:147 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/InputDisplay/index.tsx:147 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/InputDisplay/index.tsx:147 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/InputDisplay/index.tsx:147 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/FadeInView/index.tsx:14 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/FadeInView/index.tsx:14 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/FadeInView/index.tsx:14 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/FadeInView/index.tsx:14 - (anonymous): Cannot access refs during render
+  components/UI/Earn/components/Earnings/EarningsHistory/EarningsHistory.tsx:174 - (anonymous): (BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas.
+  components/UI/Earn/components/Earnings/EarningsHistory/EarningsHistory.tsx:212 - (anonymous): (BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas.
+  components/UI/Earn/components/Earnings/EarningsHistory/EarningsHistoryChart/EarningsHistoryChart.tsx:54 - (anonymous): (BuildHIR::node.lowerReorderableExpression) Expression type `ArrowFunctionExpression` cannot be safely reordered
+  components/UI/Earn/components/EarnLendingBalance/index.tsx:127 - (anonymous): Existing memoization could not be preserved
+  components/UI/Earn/Views/EarnWithdrawInputView/EarnWithdrawInputView.tsx:243 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Earn/Views/EarnWithdrawInputView/EarnWithdrawInputView.tsx:295 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Earn/Views/EarnMusdConversionEducationView/index.tsx:325 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx:242 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Earn/Views/EarnLendingDepositConfirmationView/index.tsx:232 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Earn/Views/EarnInputView/EarnInputView.tsx:240 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/DesignerMode/DesignerModeRN.tsx:259 - (anonymous): Cannot access refs during render
+  components/UI/DesignerMode/DesignerModeRN.tsx:259 - (anonymous): Cannot access refs during render
+  components/UI/DesignerMode/DesignerModeRN.tsx:259 - (anonymous): Cannot access refs during render
+  components/UI/DesignerMode/DesignerModeRN.tsx:259 - (anonymous): Cannot access refs during render
+  components/UI/DesignerMode/DesignerModeRN.tsx:259 - (anonymous): Cannot access refs during render
+  components/UI/DesignerMode/DesignerModeRN.tsx:599 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/DeFiPositions/DeFiPositionsList.tsx:108 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/Confetti/index.js:20 - (anonymous): This value cannot be modified
+  components/UI/Compliance/hooks/useComplianceGate.ts:89 - (anonymous): Cannot access refs during render
+  components/UI/Compliance/hooks/useComplianceGate.ts:94 - (anonymous): Cannot access refs during render
+  components/UI/CollectibleOverview/index.js:169 - (anonymous): Cannot access refs during render
+  components/UI/CollectibleOverview/index.js:169 - (anonymous): Cannot access refs during render
+  components/UI/CollectibleOverview/index.js:169 - (anonymous): Cannot access refs during render
+  components/UI/CollectibleOverview/index.js:169 - (anonymous): Cannot access refs during render
+  components/UI/CollectibleOverview/index.js:169 - (anonymous): Cannot access refs during render
+  components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts:108 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/CliLoginPushNudge/useCliLoginPushNudge.ts:188 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Charts/LivelineChart/LivelineChart.tsx:64 - (anonymous): Cannot access refs during render
+  components/UI/Charts/LivelineChart/__demos__/LivelineDemo.tsx:246 - (anonymous): Cannot access refs during render
+  components/UI/Charts/LivelineChart/__demos__/LivelineDemo.tsx:283 - (anonymous): Cannot access refs during render
+  components/UI/Charts/AdvancedChart/AdvancedChart.tsx:226 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Charts/AdvancedChart/useOHLCVChart.ts:132 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Carousel/index.tsx:245 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Card/sdk/index.tsx:132 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Card/routes/OnboardingNavigator.tsx:79 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Card/pushProvisioning/hooks/usePushProvisioning.ts:79 - (anonymous): Cannot access refs during render
+  components/UI/Card/hooks/useAssetBalances.tsx:704 - (anonymous): Unexpected terminal kind `optional` for logical test block
+  components/UI/Card/hooks/useCardCapabilities.ts:18 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Card/hooks/useCardDelegation.ts:181 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Card/hooks/useCardDelegation.ts:246 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Card/hooks/useCardDelegation.ts:353 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Card/hooks/useCardDelegation.ts:376 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Card/hooks/useCardDelegation.ts:421 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Card/hooks/useCardDetailsToken.ts:63 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/hooks/useEmailVerificationSend.ts:45 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/hooks/useEmailVerificationVerify.ts:74 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/hooks/useGetDelegationSettings.ts:19 - (anonymous): Cannot access refs during render
+  components/UI/Card/hooks/useImmersveFunding.ts:93 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Card/hooks/useImmersveResumeOnboarding.ts:66 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Card/hooks/useImmersveSiweAuth.ts:56 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/hooks/useImmersveSiweAuth.ts:69 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx:508 - (anonymous): Existing memoization could not be preserved
+  components/UI/Card/hooks/useNeedsGasFaucet.ts:127 - (anonymous): (BuildHIR::lowerExpression) Handle BigIntLiteral expressions
+  components/UI/Card/hooks/useNeedsGasFaucet.ts:202 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/hooks/usePhoneVerificationSend.ts:50 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/hooks/usePhoneVerificationVerify.ts:47 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/hooks/useRedeemableWallet.ts:167 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Card/hooks/useRegisterPersonalDetails.ts:47 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/hooks/useRegisterPhysicalAddress.ts:50 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/hooks/useRegisterUserConsent.ts:178 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Card/hooks/useSpendingLimit.ts:631 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/Card/hooks/useUpdateFundingPriority.ts:58 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Card/components/WaitlistFormModal/WaitlistFormModal.tsx:86 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Card/components/PasswordBottomSheet/PasswordBottomSheet.tsx:60 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/components/Onboarding/Complete.tsx:83 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/components/Onboarding/ConfirmEmail.tsx:148 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Card/components/Onboarding/ConfirmPhoneNumber.tsx:163 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/components/Onboarding/ImmersveKYCProcessing.tsx:178 - (anonymous): Cannot access refs during render
+  components/UI/Card/components/Onboarding/ImmersveKYCProcessing.tsx:178 - (anonymous): Cannot access refs during render
+  components/UI/Card/components/Onboarding/ImmersveKYCProcessing.tsx:178 - (anonymous): Cannot access refs during render
+  components/UI/Card/components/Onboarding/ImmersveKYCProcessing.tsx:178 - (anonymous): Cannot access refs during render
+  components/UI/Card/components/Onboarding/ImmersveKYCProcessing.tsx:265 - (anonymous): Cannot access refs during render
+  components/UI/Card/components/Onboarding/ImmersveKYCProcessing.tsx:266 - (anonymous): Cannot access refs during render
+  components/UI/Card/components/Onboarding/PersonalDetails.tsx:250 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Card/components/Onboarding/PhysicalAddress.tsx:474 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Card/components/Onboarding/SignUp.tsx:315 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/components/Onboarding/VerifyIdentity.tsx:93 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/components/ForgotPasswordModal/ForgotPasswordModal.tsx:247 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Card/components/DaimoPayModal/DaimoPayModal.tsx:314 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Card/components/CardDeveloperOptionsSection/CardDeveloperOptionsSection.tsx:36 - (anonymous): Existing memoization could not be preserved
+  components/UI/Card/components/AssetSelectionBottomSheet/AssetSelectionBottomSheet.tsx:98 - (anonymous): Unexpected terminal kind `optional` for logical test block
+  components/UI/Card/Views/SetCardPin/ConfirmCardPin.tsx:144 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/Views/SetCardPin/hooks/usePinEntry.ts:20 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:70 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:73 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:76 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:60 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:60 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:122 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:122 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:123 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:126 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:126 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:126 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:126 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:123 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:123 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:137 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:137 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:137 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:137 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:137 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:137 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:123 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:60 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:60 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:123 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:60 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:60 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:154 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:154 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:157 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:164 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:60 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/SetCardPin/components/PinDots.tsx:60 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/ReviewOrder/ReviewOrder.tsx:142 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/Views/RedeemWallet/RedeemWallet.tsx:331 - (anonymous): Existing memoization could not be preserved
+  components/UI/Card/Views/ChooseYourCard/ChooseYourCard.tsx:80 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/ChooseYourCard/ChooseYourCard.tsx:80 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/ChooseYourCard/ChooseYourCard.tsx:80 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/ChooseYourCard/ChooseYourCard.tsx:80 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/ChooseYourCard/ChooseYourCard.tsx:80 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/ChooseYourCard/ChooseYourCard.tsx:80 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/ChooseYourCard/ChooseYourCard.tsx:80 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/CardHome/CardHome.tsx:241 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/Card/Views/CardHome/hooks/useCardArrivalAnimation.ts:143 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/CardHome/hooks/useCardArrivalAnimation.ts:143 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/CardHome/hooks/useCardArrivalAnimation.ts:143 - (anonymous): Cannot access refs during render
+  components/UI/Card/Views/CardHome/hooks/useCardHomeActions.ts:268 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/Views/CardHome/hooks/useCardHomeActions.ts:367 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/Views/CardHome/hooks/useCardProvisioning.ts:24 - (anonymous): Existing memoization could not be preserved
+  components/UI/Card/Views/CardHome/hooks/useCardProvisioning.ts:34 - (anonymous): Existing memoization could not be preserved
+  components/UI/Card/Views/CardHome/hooks/useImmersveCardProvisioning.ts:99 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Card/Views/CardAuthentication/CardAuthentication.tsx:402 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/ButtonReveal/index.tsx:116 - (anonymous): This value cannot be modified
+  components/UI/ButtonReveal/index.tsx:170 - (anonymous): This value cannot be modified
+  components/UI/ButtonReveal/index.tsx:173 - (anonymous): This value cannot be modified
+  components/UI/ButtonReveal/index.tsx:184 - (anonymous): This value cannot be modified
+  components/UI/ButtonReveal/index.tsx:187 - (anonymous): This value cannot be modified
+  components/UI/Bridge/hooks/useFetchPopularTokens.ts:75 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Bridge/hooks/useInitialBridgeTokens.ts:79 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Bridge/hooks/useRecipientInitialization.ts:95 - (anonymous): This value cannot be modified
+  components/UI/Bridge/hooks/useSearchTokens.ts:111 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Bridge/hooks/useSearchTokens.ts:155 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Bridge/hooks/useTokenSelection.ts:80 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Bridge/hooks/useTokensWithBalance/index.ts:260 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Bridge/hooks/useTokenSearch/index.ts:31 - (anonymous): Cannot access refs during render
+  components/UI/Bridge/hooks/useTokenSearch/index.ts:31 - (anonymous): Cannot access refs during render
+  components/UI/Bridge/hooks/useTokenBalanceInUsd/index.ts:109 - (anonymous): (BuildHIR::lowerExpression) Expected Identifier, got CallExpression key in ObjectExpression
+  components/UI/Bridge/hooks/useTokenBalanceInUsd/index.ts:118 - (anonymous): (BuildHIR::lowerExpression) Expected Identifier, got TSAsExpression key in ObjectExpression
+  components/UI/Bridge/hooks/useRewards/useRewards.ts:142 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Bridge/hooks/useLegacySwapsBlockExplorer/index.ts:53 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Bridge/hooks/useLegacySwapsBlockExplorer/index.ts:58 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Bridge/hooks/useLatestBalance/index.ts:130 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/Bridge/hooks/useInsufficientBalance/index.ts:87 - (anonymous): Unexpected terminal kind `optional` for optional fallthrough block
+  components/UI/Bridge/hooks/useHasSufficientGasEvenIfGasIncludedOrSponsored/index.ts:49 - (anonymous): Unexpected terminal kind `optional` for optional fallthrough block
+  components/UI/Bridge/hooks/useHasSufficientGas/index.ts:54 - (anonymous): Unexpected terminal kind `optional` for optional fallthrough block
+  components/UI/Bridge/hooks/useFormattedBalanceWithThreshold/index.ts:11 - (anonymous): Existing memoization could not be preserved
+  components/UI/Bridge/hooks/useBridgeQuoteEvents/index.ts:102 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Bridge/hooks/useBridgeQuoteData/index.ts:334 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Bridge/hooks/useBridgeConfirm/index.ts:61 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/Bridge/hooks/useBridgeConfirm/index.ts:98 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Bridge/hooks/useBatchSellQuoteData/index.ts:250 - (anonymous): Cannot access refs during render
+  components/UI/Bridge/hooks/useBatchSellQuoteData/index.ts:251 - (anonymous): Cannot access refs during render
+  components/UI/Bridge/hooks/useBatchSellQuoteData/index.ts:250 - (anonymous): Cannot access refs during render
+  components/UI/Bridge/components/SwapsTokenSecurityBadge.tsx:17 - (anonymous): Existing memoization could not be preserved
+  components/UI/Bridge/components/SwapsConfirmButton/index.tsx:182 - (anonymous): Cannot access refs during render
+  components/UI/Bridge/components/SwapsConfirmButton/index.tsx:198 - (anonymous): Cannot access refs during render
+  components/UI/Bridge/components/QuoteSelectorView/index.tsx:87 - (anonymous): Unexpected terminal kind `optional` for optional fallthrough block
+  components/UI/Bridge/components/PostTradeBottomSheet/PostTradeTokenSuggestions.tsx:111 - (anonymous): Existing memoization could not be preserved
+  components/UI/Bridge/components/FlipQuoteButton/index.tsx:81 - (anonymous): Cannot access refs during render
+  components/UI/Bridge/components/FlipQuoteButton/index.tsx:81 - (anonymous): Cannot access refs during render
+  components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx:294 - (anonymous): Cannot access refs during render
+  components/UI/Bridge/components/BridgeTokenSelector/NetworkPills.tsx:138 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Bridge/components/BatchSellFinalReviewModal/index.tsx:406 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Assets/components/Balance/AccountGroupBalance.tsx:85 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Assets/components/AssetLogo/AssetLogo.hook.tsx:16 - (anonymous): Cannot access refs during render
+  components/UI/Assets/components/AssetLogo/AssetLogo.hook.tsx:17 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/hooks/useAlertSaveFlow.ts:143 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/Assets/PriceAlerts/components/AlertAmountInput.tsx:42 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/AlertAmountInput.tsx:42 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/AlertAmountInput.tsx:42 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/AlertAmountInput.tsx:42 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/AlertAmountInput.tsx:42 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/SlidingPillToggle.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/SlidingPillToggle.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/SlidingPillToggle.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/SlidingPillToggle.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/SlidingPillToggle.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/SlidingPillToggle.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/components/SlidingPillToggle.tsx:74 - (anonymous): Cannot access refs during render
+  components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx:206 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx:207 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx:209 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx:284 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx:285 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Assets/PriceAlerts/Views/ManagePriceAlertsView/ManagePriceAlertsView.tsx:289 - (anonymous): (BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch
+  components/UI/Assets/DeFiPositions/hooks/useDeFiPositionsV2.ts:176 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/Assets/DeFiPositions/components/DeFiPositionsListV2.tsx:95 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement without a catch clause
+  components/UI/AssetOverview/TokenDetails/TokenDetails.tsx:141 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/UI/AssetOverview/PriceChart/PriceChart.tsx:149 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/UI/AssetOverview/Price/Price.advanced.tsx:1050 - (anonymous): Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values
+  components/Snaps/SnapInterfaceContext.tsx:121 - (anonymous): (BuildHIR::node.lowerReorderableExpression) Expression type `ConditionalExpression` cannot be safely reordered
+  components/Snaps/SnapUIRenderer/SnapUIRenderer.tsx:30 - (anonymous): Cannot access refs during render
+  components/Snaps/SnapUIRenderer/SnapUIRenderer.tsx:30 - (anonymous): Cannot access refs during render
+  components/Snaps/SnapUIRenderer/SnapUIRenderer.tsx:32 - (anonymous): Cannot access refs during render
+  components/Snaps/SnapUIAssetSelector/useSnapAssetDisplay.tsx:162 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  components/Base/RemoteImage/index.tsx:89 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Base/Keypad/index.tsx:68 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  components/Approvals/InstallSnapApproval/InstallSnapApproval.tsx:112 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  component-library/providers/ThemeProvider/ThemeProvider.test.tsx:58 - (anonymous): Cannot reassign variables declared outside of the component/hook
+  component-library/hooks/useAnimatedPressable.ts:52 - (anonymous): Cannot access refs during render
+  component-library/hooks/useAnimatedPressable.ts:80 - (anonymous): Cannot access refs during render
+  component-library/components-temp/Tabs/TabsBar/TabsBar.tsx:127 - (anonymous): This value cannot be modified
+  component-library/components-temp/Tabs/TabsBar/TabsBar.tsx:128 - (anonymous): This value cannot be modified
+  component-library/components-temp/StepperCard/StepperCard.tsx:35 - (anonymous): Cannot access refs during render
+  component-library/components-temp/MultichainAccounts/MultichainAccountSelectorList/AccountListFooter/AccountListFooter.tsx:139 - (anonymous): (BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause
+  component-library/components-temp/BaseNotification/index.tsx:485 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  component-library/components/Toast/Toast.tsx:531 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  component-library/components/Skeleton/Skeleton.tsx:31 - (anonymous): Cannot access refs during render
+  component-library/components/Skeleton/Skeleton.tsx:31 - (anonymous): Cannot access refs during render
+  component-library/components/Skeleton/Skeleton.tsx:31 - (anonymous): Cannot access refs during render
+  component-library/components/Overlay/Overlay.tsx:36 - (anonymous): This value cannot be modified
+  component-library/components/BottomSheets/BottomSheet/foundation/BottomSheetDialog/BottomSheetDialog.tsx:173 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  component-library/components/Avatars/Avatar/variants/AvatarToken/AvatarToken.tsx:50 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled
+  component-library/components/Avatars/Avatar/variants/AvatarFavicon/AvatarFavicon.tsx:78 - (anonymous): Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement
+  __mocks__/rive-react-native.tsx:81 - (anonymous): React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled

--- a/scripts/filter-rcm-asset-co.mjs
+++ b/scripts/filter-rcm-asset-co.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/**
+ * Filter a react-compiler-marker report down to Assets CODEOWNERS files.
+ *
+ *   node scripts/filter-rcm-asset-co.mjs
+ *   node scripts/filter-rcm-asset-co.mjs --input rcm-raw.txt --output rcm-assets.txt
+ *
+ * Paths in rcm-raw.txt are relative to ./app (the marker was run on ./app).
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const ASSETS_OWNER = '@MetaMask/metamask-assets';
+
+const args = parseArgs(process.argv.slice(2));
+const inputPath = resolve(ROOT, args.input ?? 'rcm-raw.txt');
+const outputPath = resolve(ROOT, args.output ?? 'rcm-assets.txt');
+const reportPath = resolve(ROOT, args.report ?? 'rcm-assets-report.txt');
+const owner = args.owner ?? ASSETS_OWNER;
+
+const rules = parseCodeowners(readFileSync(resolve(ROOT, '.github/CODEOWNERS'), 'utf8'));
+const raw = readFileSync(inputPath, 'utf8');
+const failures = parseFailures(raw);
+const assetFailures = failures.filter((entry) =>
+  ownersFor(toRepoPath(entry.file), rules).includes(owner),
+);
+
+const filtered = formatFilteredReport({ owner, inputPath, assetFailures });
+const report = formatSummaryReport({ owner, assetFailures });
+
+writeFileSync(outputPath, filtered);
+writeFileSync(reportPath, report);
+process.stdout.write(report);
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const key = argv[i];
+    if (!key.startsWith('--')) continue;
+    out[key.slice(2)] = argv[i + 1];
+    i += 1;
+  }
+  return out;
+}
+
+function parseCodeowners(text) {
+  const parsed = [];
+  for (const line of text.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const [pattern, ...owners] = trimmed.split(/\s+/);
+    parsed.push({ pattern, owners, regex: codeownersToRegex(pattern) });
+  }
+  return parsed;
+}
+
+function codeownersToRegex(pattern) {
+  const trimmed = pattern.replace(/\/+$/, '');
+  let source = '';
+  for (let i = 0; i < trimmed.length; i += 1) {
+    const char = trimmed[i];
+    if (char === '*' && trimmed[i + 1] === '*') {
+      source += trimmed[i + 2] === '/' ? '(?:.*/)?' : '.*';
+      i += trimmed[i + 2] === '/' ? 2 : 1;
+    } else if (char === '*') {
+      source += '[^/]*';
+    } else if (char === '?') {
+      source += '[^/]';
+    } else {
+      source += char.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+    }
+  }
+  // Directory-style CODEOWNERS rules own the path and everything under it.
+  return new RegExp(`^${source}(?:/.*)?$`);
+}
+
+function ownersFor(repoPath, codeownersRules) {
+  let owners = [];
+  for (const rule of codeownersRules) {
+    if (rule.regex.test(repoPath)) owners = rule.owners;
+  }
+  return owners;
+}
+
+function toRepoPath(rcmFile) {
+  const normalized = rcmFile.replace(/^\.\//, '');
+  return normalized.startsWith('app/') ? normalized : `app/${normalized}`;
+}
+
+function parseFailures(text) {
+  const entries = [];
+  for (const line of text.split('\n')) {
+    const match = line.match(/^\s+(\S+):(\d+) - (.+)$/);
+    if (!match) continue;
+    entries.push({
+      raw: line.replace(/^\s+/, ''),
+      file: match[1],
+      line: Number(match[2]),
+      reason: match[3],
+    });
+  }
+  return entries;
+}
+
+function formatFilteredReport({ owner, inputPath: source, assetFailures }) {
+  const files = new Set(assetFailures.map((entry) => entry.file));
+  const lines = [
+    'React Compiler Report (Assets CODEOWNERS)',
+    '========================================',
+    `Source:              ${source}`,
+    `Team:                ${owner}`,
+    `Files with failures: ${files.size}`,
+    `Failure lines:       ${assetFailures.length}`,
+    '',
+    'Failures:',
+    '----------------------------------------',
+    ...assetFailures.map((entry) => `  ${entry.raw}`),
+    '',
+  ];
+  return lines.join('\n');
+}
+
+function formatSummaryReport({ owner, assetFailures }) {
+  const byFile = new Map();
+  const byReason = new Map();
+  for (const entry of assetFailures) {
+    if (!byFile.has(entry.file)) byFile.set(entry.file, []);
+    byFile.get(entry.file).push(entry);
+    const reason = simplifyReason(entry.reason);
+    if (!byReason.has(reason)) byReason.set(reason, []);
+    byReason.get(reason).push(entry);
+  }
+
+  const sortedFiles = [...byFile.entries()].sort((a, b) => b[1].length - a[1].length);
+  const sortedReasons = [...byReason.entries()].sort((a, b) => b[1].length - a[1].length);
+
+  const lines = [
+    'Assets React Compiler Failures',
+    '========================================',
+    `Team:             ${owner}`,
+    `Unique files:     ${byFile.size}`,
+    `Failure lines:    ${assetFailures.length}`,
+    `Unique reasons:   ${byReason.size}`,
+    '',
+    'By reason',
+    '----------------------------------------',
+    ...sortedReasons.flatMap(([reason, entries]) => {
+      const files = [...new Set(entries.map((entry) => entry.file))];
+      return [`  ${entries.length}×  ${reason}`, ...files.map((file) => `      ${file}`), ''];
+    }),
+    'By file',
+    '----------------------------------------',
+    ...sortedFiles.flatMap(([file, entries]) => [
+      `  ${file} (${entries.length})`,
+      ...entries.map((entry) => `      L${entry.line}: ${entry.reason}`),
+      '',
+    ]),
+  ];
+  return lines.join('\n');
+}
+
+function simplifyReason(reason) {
+  return reason.replace(/^\(anonymous\):\s*/, '');
+}


### PR DESCRIPTION
This commit introduces new reports detailing React Compiler failures related to assets, including unique files, failure lines, and reasons for the failures. The reports are structured to provide insights into the issues encountered during compilation, helping the team address and resolve them effectively. The new files include `rcm-assets-report.txt`, `rcm-assets.txt`, and `rcm-raw.txt`, which summarize the failures and their contexts for better tracking and debugging.

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches gesture handling (price chart), price-alert mutations, token transaction filtering/caching, and wallet balance memoization—mostly structural refactors with documented parity, but worth smoke-testing chart scrub, alert delete/toggle, token activity lists, and group balance.
> 
> **Overview**
> This PR **migrates a batch of Assets-owned screens** so `babel-plugin-react-compiler` can optimize them, and adds **team tracking artifacts** plus an internal **migration playbook**.
> 
> **Compiler-oriented code changes** (behavior preserved; shape changed for BuildHIR):
> 
> - **`PriceChart`**: Removes an `exhaustive-deps` suppression by honestly depending on `prices` (empty-series guard). Replaces ref-synced `PanResponder` with a module `createChartPanResponder`, `useCallback` touch mapping, and a memoized responder (stable under Jest where the compiler is off).
> - **Price alerts UI**: `AlertAmountInput` / `SlidingPillToggle` switch to `useAnimatedValue`. **`ManagePriceAlertsView`** uses `failRequest()` for throws in `try/catch`, a `showToast` helper, and trailing cleanup instead of `finally` on delete/toggle flows.
> - **Wallet / token details**: **`AccountGroupBalance`** rebuilds popular chain IDs from a content key (no lying deps). **`useAssetVisibility`** hoists `asset` fields for honest memo deps and extracts optional-chaining in hide logic. **`useTokenTransactions`** moves non-EVM filter cache to module scope and hoists branching in EVM filter predicates.
> - **Lists / hooks**: **`DeFiPositionsListV2`** uses `refresh().finally()` instead of `try/finally` without `catch`. **`usePopularTokens`** relocates loading reset out of `finally` with the same stale-fetch guard as before.
> 
> **Docs & reports**: Adds `docs/skills/react-compiler-migration/` (`SKILL.md` + validated `patterns.md` from these fixes). Adds **`rcm-assets-report.txt`** and **`rcm-assets.txt`** summarizing remaining Assets compiler failures (34 files / 74 lines in the report).
> 
> **Not in this diff**: Many failures listed in the reports (e.g. `Price.advanced.tsx` `useSubscriptPriceFormat` false positive) are documented as out-of-scope or not yet migrated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 797c0b8940650c2165eb514000b39ecada7472df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->