### PR TITLE
feat: Perps order type picker copy and theme icons

### DIFF
--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheet.test.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  render,
-  screen,
-  fireEvent,
-  within,
-} from '@testing-library/react-native';
+import { screen, fireEvent, within } from '@testing-library/react-native';
 import { Icon, IconName } from '@metamask/design-system-react-native';
 import PerpsOrderTypeBottomSheet from './PerpsOrderTypeBottomSheet';
 import {
@@ -14,8 +9,31 @@ import {
 } from '@metamask/perps-controller';
 import { PerpsOrderTypeBottomSheetSelectorsIDs } from '../../Perps.testIds';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import { mockTheme } from '../../../../../util/theme';
+import { AppThemeKey } from '../../../../../util/theme/models';
 
 const mockTrack = jest.fn();
+
+function render(
+  ui: React.ReactElement,
+  appTheme: AppThemeKey = AppThemeKey.dark,
+) {
+  const themeAppearance =
+    appTheme === AppThemeKey.light ? AppThemeKey.light : AppThemeKey.dark;
+
+  return renderWithProvider(
+    ui,
+    {
+      state: { user: { appTheme } },
+      theme: {
+        ...mockTheme,
+        themeAppearance,
+      },
+    },
+    false,
+  );
+}
 
 jest.mock('@metamask/design-system-twrnc-preset', () => {
   const resolveStyle = (...args: unknown[]) => {
@@ -52,16 +70,17 @@ jest.mock('../../../../../../locales/i18n', () => ({
       'perps.order.type.basic': 'Basic',
       'perps.order.type.triggered': 'Triggered',
       'perps.order.type.stop_limit.title': 'Stop limit',
-      'perps.order.type.stop_limit.description': 'Limit fills at trigger price',
+      'perps.order.type.stop_limit.description':
+        'Place a limit order if trigger price hits',
       'perps.order.type.stop_market.title': 'Stop market',
       'perps.order.type.stop_market.description':
-        'Market fills at trigger price',
+        'Place a market order if trigger price hits',
       'perps.order.type.take_profit_limit.title': 'Take limit',
       'perps.order.type.take_profit_limit.description':
-        'Limit take-profit at trigger price',
+        'Place a limit order if trigger price is reached',
       'perps.order.type.take_profit_market.title': 'Take market',
       'perps.order.type.take_profit_market.description':
-        'Market take-profit at trigger price',
+        'Place a market order if trigger price is reached',
     };
     return translations[key] || key;
   }),
@@ -125,6 +144,25 @@ describe('PerpsOrderTypeBottomSheet', () => {
       ).toBeOnTheScreen();
       expect(
         screen.getByText('Execute at your specified price or better'),
+      ).toBeOnTheScreen();
+    });
+
+    it('renders triggered order type descriptions when enabled', () => {
+      render(
+        <PerpsOrderTypeBottomSheet {...defaultProps} showTriggeredTypes />,
+      );
+
+      expect(
+        screen.getByText('Place a limit order if trigger price hits'),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByText('Place a market order if trigger price hits'),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByText('Place a limit order if trigger price is reached'),
+      ).toBeOnTheScreen();
+      expect(
+        screen.getByText('Place a market order if trigger price is reached'),
       ).toBeOnTheScreen();
     });
 
@@ -197,6 +235,34 @@ describe('PerpsOrderTypeBottomSheet', () => {
       );
 
       expect(screen.getByTestId(marketIconTestID)).toBeOnTheScreen();
+    });
+
+    it('renders dark order type icons when the app theme is dark', () => {
+      render(
+        <PerpsOrderTypeBottomSheet
+          {...defaultProps}
+          showSelectedIcon
+          showTriggeredTypes
+        />,
+        AppThemeKey.dark,
+      );
+
+      expect(screen.getAllByLabelText(/-icon-dark$/)).toHaveLength(6);
+      expect(screen.queryByLabelText(/-icon-light$/)).not.toBeOnTheScreen();
+    });
+
+    it('renders light order type icons when the app theme is light', () => {
+      render(
+        <PerpsOrderTypeBottomSheet
+          {...defaultProps}
+          showSelectedIcon
+          showTriggeredTypes
+        />,
+        AppThemeKey.light,
+      );
+
+      expect(screen.getAllByLabelText(/-icon-light$/)).toHaveLength(6);
+      expect(screen.queryByLabelText(/-icon-dark$/)).not.toBeOnTheScreen();
     });
 
     it('forwards the Pro title and selected-icon presentation', () => {

--- a/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx
+++ b/app/components/UI/Perps/components/PerpsOrderTypeBottomSheet/PerpsOrderTypeBottomSheetView.tsx
@@ -15,19 +15,29 @@ import type { OrderType, TriggerOrderType } from '@metamask/perps-controller';
 import React, { useCallback, useEffect, useRef } from 'react';
 import type { SvgProps } from 'react-native-svg';
 import { strings } from '../../../../../../locales/i18n';
-import LimitIcon from '../../../../../images/perps/order-types/limit.svg';
-import MarketIcon from '../../../../../images/perps/order-types/market.svg';
-import StopLimitIcon from '../../../../../images/perps/order-types/stop-limit.svg';
-import StopMarketIcon from '../../../../../images/perps/order-types/stop-market.svg';
-import TakeLimitIcon from '../../../../../images/perps/order-types/take-limit.svg';
-import TakeMarketIcon from '../../../../../images/perps/order-types/take-market.svg';
+import { useAssetFromTheme, useTheme } from '../../../../../util/theme';
+import LimitIconDark from '../../../../../images/perps/order-types/limit.svg';
+import LimitIconLight from '../../../../../images/perps/order-types/limit-light.svg';
+import MarketIconDark from '../../../../../images/perps/order-types/market.svg';
+import MarketIconLight from '../../../../../images/perps/order-types/market-light.svg';
+import StopLimitIconDark from '../../../../../images/perps/order-types/stop-limit.svg';
+import StopLimitIconLight from '../../../../../images/perps/order-types/stop-limit-light.svg';
+import StopMarketIconDark from '../../../../../images/perps/order-types/stop-market.svg';
+import StopMarketIconLight from '../../../../../images/perps/order-types/stop-market-light.svg';
+import TakeLimitIconDark from '../../../../../images/perps/order-types/take-limit.svg';
+import TakeLimitIconLight from '../../../../../images/perps/order-types/take-limit-light.svg';
+import TakeMarketIconDark from '../../../../../images/perps/order-types/take-market.svg';
+import TakeMarketIconLight from '../../../../../images/perps/order-types/take-market-light.svg';
 import { PerpsOrderTypeBottomSheetSelectorsIDs } from '../../Perps.testIds';
+
+type OrderTypeIcon = React.FC<SvgProps & { name: string }>;
 
 interface OrderTypeOption {
   type: OrderType;
   titleKey: string;
   descriptionKey: string;
-  IconComponent: React.FC<SvgProps & { name: string }>;
+  LightIcon: OrderTypeIcon;
+  DarkIcon: OrderTypeIcon;
   testID: string;
 }
 
@@ -40,14 +50,16 @@ const BASIC_ORDER_TYPES: readonly OrderTypeOption[] = [
     type: 'market',
     titleKey: 'perps.order.type.market.title',
     descriptionKey: 'perps.order.type.market.description',
-    IconComponent: MarketIcon,
+    LightIcon: MarketIconLight,
+    DarkIcon: MarketIconDark,
     testID: PerpsOrderTypeBottomSheetSelectorsIDs.MARKET_OPTION,
   },
   {
     type: 'limit',
     titleKey: 'perps.order.type.limit.title',
     descriptionKey: 'perps.order.type.limit.description',
-    IconComponent: LimitIcon,
+    LightIcon: LimitIconLight,
+    DarkIcon: LimitIconDark,
     testID: PerpsOrderTypeBottomSheetSelectorsIDs.LIMIT_OPTION,
   },
 ];
@@ -59,31 +71,62 @@ const TRIGGERED_ORDER_TYPES: readonly (OrderTypeOption & {
     type: 'stop_limit',
     titleKey: 'perps.order.type.stop_limit.title',
     descriptionKey: 'perps.order.type.stop_limit.description',
-    IconComponent: StopLimitIcon,
+    LightIcon: StopLimitIconLight,
+    DarkIcon: StopLimitIconDark,
     testID: PerpsOrderTypeBottomSheetSelectorsIDs.STOP_LIMIT_OPTION,
   },
   {
     type: 'stop_market',
     titleKey: 'perps.order.type.stop_market.title',
     descriptionKey: 'perps.order.type.stop_market.description',
-    IconComponent: StopMarketIcon,
+    LightIcon: StopMarketIconLight,
+    DarkIcon: StopMarketIconDark,
     testID: PerpsOrderTypeBottomSheetSelectorsIDs.STOP_MARKET_OPTION,
   },
   {
     type: 'take_profit_limit',
     titleKey: 'perps.order.type.take_profit_limit.title',
     descriptionKey: 'perps.order.type.take_profit_limit.description',
-    IconComponent: TakeLimitIcon,
+    LightIcon: TakeLimitIconLight,
+    DarkIcon: TakeLimitIconDark,
     testID: PerpsOrderTypeBottomSheetSelectorsIDs.TAKE_PROFIT_LIMIT_OPTION,
   },
   {
     type: 'take_profit_market',
     titleKey: 'perps.order.type.take_profit_market.title',
     descriptionKey: 'perps.order.type.take_profit_market.description',
-    IconComponent: TakeMarketIcon,
+    LightIcon: TakeMarketIconLight,
+    DarkIcon: TakeMarketIconDark,
     testID: PerpsOrderTypeBottomSheetSelectorsIDs.TAKE_PROFIT_MARKET_OPTION,
   },
 ];
+
+const OrderTypeStartAccessory = ({
+  LightIcon,
+  DarkIcon,
+  type,
+  testID,
+}: {
+  LightIcon: OrderTypeIcon;
+  DarkIcon: OrderTypeIcon;
+  type: OrderType;
+  testID: string;
+}) => {
+  const { themeAppearance } = useTheme();
+  const IconComponent = useAssetFromTheme(LightIcon, DarkIcon);
+
+  return (
+    <Box
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Center}
+      twClassName="h-10 w-10"
+      testID={`${testID}-icon`}
+      accessibilityLabel={`${testID}-icon-${themeAppearance}`}
+    >
+      <IconComponent name={`perps-order-type-${type}`} width={32} height={32} />
+    </Box>
+  );
+};
 
 export interface PerpsOrderTypeBottomSheetViewProps {
   isVisible?: boolean;
@@ -140,42 +183,32 @@ const PerpsOrderTypeBottomSheetView = ({
     </Box>
   );
 
-  const renderOrderType = (orderType: OrderTypeOption) => {
-    const { IconComponent } = orderType;
-
-    return (
-      <ListItemSelect
-        key={orderType.type}
-        title={strings(orderType.titleKey)}
-        description={strings(orderType.descriptionKey)}
-        descriptionProps={DESCRIPTION_PROPS}
-        accessoryGap={2}
-        startAccessory={
-          shouldShowSelectedIcon ? (
-            <Box
-              alignItems={BoxAlignItems.Center}
-              justifyContent={BoxJustifyContent.Center}
-              twClassName="h-10 w-10"
-              testID={`${orderType.testID}-icon`}
-            >
-              <IconComponent
-                name={`perps-order-type-${orderType.type}`}
-                width={32}
-                height={32}
-              />
-            </Box>
-          ) : undefined
-        }
-        isSelected={currentOrderType === orderType.type}
-        showSelectedIcon={shouldShowSelectedIcon}
-        // The Pro design uses a checkmark without a selected-row fill. Shared
-        // sheets without checkmarks retain ListItemSelect's selected background.
-        twClassName={shouldShowSelectedIcon ? 'bg-transparent' : undefined}
-        onPress={() => handleSelect(orderType.type)}
-        testID={orderType.testID}
-      />
-    );
-  };
+  const renderOrderType = (orderType: OrderTypeOption) => (
+    <ListItemSelect
+      key={orderType.type}
+      title={strings(orderType.titleKey)}
+      description={strings(orderType.descriptionKey)}
+      descriptionProps={DESCRIPTION_PROPS}
+      accessoryGap={2}
+      startAccessory={
+        shouldShowSelectedIcon ? (
+          <OrderTypeStartAccessory
+            LightIcon={orderType.LightIcon}
+            DarkIcon={orderType.DarkIcon}
+            type={orderType.type}
+            testID={orderType.testID}
+          />
+        ) : undefined
+      }
+      isSelected={currentOrderType === orderType.type}
+      showSelectedIcon={shouldShowSelectedIcon}
+      // The Pro design uses a checkmark without a selected-row fill. Shared
+      // sheets without checkmarks retain ListItemSelect's selected background.
+      twClassName={shouldShowSelectedIcon ? 'bg-transparent' : undefined}
+      onPress={() => handleSelect(orderType.type)}
+      testID={orderType.testID}
+    />
+  );
 
   if (!isVisible) {
     return null;

--- a/app/images/perps/order-types/limit-light.svg
+++ b/app/images/perps/order-types/limit-light.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<line x1="4.5" y1="26.5" x2="23.5" y2="26.5" stroke="#4459FF" stroke-linecap="round" stroke-dasharray="3 3"/>
+<path d="M4.37262 5.82843C4.37262 5.82843 12.4183 8.21726 17.3681 13.167C22.3178 18.1168 24.1716 25.6274 24.1716 25.6274" stroke="#121314" stroke-linecap="round"/>
+<circle cx="25" cy="26" r="3" transform="rotate(90 25 26)" fill="#4459FF"/>
+</svg>

--- a/app/images/perps/order-types/market-light.svg
+++ b/app/images/perps/order-types/market-light.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.82843 27.6274C5.82843 27.6274 8.21726 19.5817 13.167 14.6319C18.1168 9.68219 25.6274 7.82839 25.6274 7.82839" stroke="#121314" stroke-linecap="round"/>
+<circle cx="25" cy="8" r="3" fill="#457A39"/>
+</svg>

--- a/app/images/perps/order-types/stop-limit-light.svg
+++ b/app/images/perps/order-types/stop-limit-light.svg
@@ -1,0 +1,7 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<line x1="14.5" y1="26.5" x2="23.5" y2="26.5" stroke="#4459FF" stroke-linecap="round" stroke-dasharray="3 3"/>
+<path d="M6.50005 3.70711C6.50005 3.70711 10.1884 5.98129 13.0169 8.80972C15.8453 11.6381 17.8138 15.0208 17.8138 15.0208" stroke="#121314" stroke-linecap="round"/>
+<circle cx="25" cy="26" r="3" transform="rotate(90 25 26)" fill="#4459FF"/>
+<line x1="4.5" y1="16.5" x2="27.5" y2="16.5" stroke="#CA3542" stroke-linecap="round" stroke-dasharray="3 3"/>
+<circle cx="18" cy="16" r="2.5" transform="rotate(90 18 16)" fill="#CA3542" stroke="#CA3542"/>
+</svg>

--- a/app/images/perps/order-types/stop-market-light.svg
+++ b/app/images/perps/order-types/stop-market-light.svg
@@ -1,0 +1,6 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<line x1="4.5" y1="18.5" x2="27.5" y2="18.5" stroke="#CA3542" stroke-linecap="round" stroke-dasharray="3 3"/>
+<path d="M4.37262 7.82843C4.37262 7.82843 12.4183 10.2173 17.3681 15.167C22.3178 20.1168 24.1716 27.6274 24.1716 27.6274" stroke="#121314" stroke-linecap="round"/>
+<path d="M24.1716 27.6274C24.1716 27.6274 23.0951 23.266 20.3925 19" stroke="#CA3542" stroke-linecap="round"/>
+<circle cx="21" cy="18" r="2.5" transform="rotate(90 21 18)" fill="#CA3542" stroke="#CA3542"/>
+</svg>

--- a/app/images/perps/order-types/take-limit-light.svg
+++ b/app/images/perps/order-types/take-limit-light.svg
@@ -1,0 +1,7 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<line x1="0.5" y1="-0.5" x2="9.5" y2="-0.5" transform="matrix(1 -8.74228e-08 -8.74228e-08 -1 18 15)" stroke="#4459FF" stroke-linecap="round" stroke-dasharray="3 3"/>
+<path d="M6.50005 28.2929C6.50005 28.2929 10.1884 26.0187 13.0169 23.1903C15.8453 20.3619 17.8138 16.9792 17.8138 16.9792" stroke="#121314" stroke-linecap="round"/>
+<circle cx="3" cy="3" r="3" transform="matrix(0 -1 -1 0 21 19)" fill="#4459FF"/>
+<line x1="0.5" y1="-0.5" x2="23.5" y2="-0.5" transform="matrix(1 -8.74228e-08 -8.74228e-08 -1 4 5)" stroke="#457A39" stroke-linecap="round" stroke-dasharray="3 3"/>
+<circle cx="3" cy="3" r="2.5" transform="matrix(0 -1 -1 0 28 8)" fill="#457A39" stroke="#457A39"/>
+</svg>

--- a/app/images/perps/order-types/take-market-light.svg
+++ b/app/images/perps/order-types/take-market-light.svg
@@ -1,0 +1,6 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<line x1="0.5" y1="-0.5" x2="23.5" y2="-0.5" transform="matrix(1 -8.74228e-08 -8.74228e-08 -1 4 13)" stroke="#457A39" stroke-linecap="round" stroke-dasharray="3 3"/>
+<path d="M4.37262 24.1716C4.37262 24.1716 12.4183 21.7827 17.3681 16.833C22.3178 11.8832 24.1716 4.37258 24.1716 4.37258" stroke="#121314" stroke-linecap="round"/>
+<path d="M24.1716 4.3726C24.1716 4.3726 23.0951 8.73397 20.3925 13" stroke="#457A39" stroke-linecap="round"/>
+<circle cx="3" cy="3" r="2.5" transform="matrix(0 -1 -1 0 24 17)" fill="#457A39" stroke="#457A39"/>
+</svg>

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1732,19 +1732,19 @@
         },
         "stop_limit": {
           "title": "Stop limit",
-          "description": "Limit fills at trigger price"
+          "description": "Place a limit order if trigger price hits"
         },
         "stop_market": {
           "title": "Stop market",
-          "description": "Market fills at trigger price"
+          "description": "Place a market order if trigger price hits"
         },
         "take_profit_limit": {
           "title": "Take limit",
-          "description": "Limit take-profit at trigger price"
+          "description": "Place a limit order if trigger price is reached"
         },
         "take_profit_market": {
           "title": "Take market",
-          "description": "Market take-profit at trigger price"
+          "description": "Place a market order if trigger price is reached"
         }
       },
       "payment_token": "Payment token",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Choose order type sheet was still using older triggered-order copy, and its icons were dark-only. That made the Pro picker look wrong in light mode and out of date versus the latest Figma.

This change updates the four triggered-order descriptions to the Figma wording and wires each order type to a light/dark SVG pair through useAssetFromTheme, so explicit app theme and OS-following theme both get the intended assets. Market and Limit copy was already correct and is unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated Perps order type descriptions and added light-mode icons

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3788

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps order type picker copy and theme icons

  Background:
    Given I am logged into MetaMask Mobile
    And Perps Pro and triggered order types are enabled
    And I am on a Perps Pro market screen

  Scenario: user sees the updated triggered order descriptions
    When the user opens the order type picker
    Then the Basic section shows Market and Limit with their existing descriptions
    And the Triggered section shows the following descriptions:
      | Order type  | Description                                        |
      | Stop limit  | Place a limit order if trigger price hits          |
      | Stop market | Place a market order if trigger price hits         |
      | Take limit  | Place a limit order if trigger price is reached    |
      | Take market | Place a market order if trigger price is reached   |

  Scenario: user sees light-mode order type icons
    Given the app theme is Light
    When the user opens the order type picker
    Then each order type shows its light-mode icon
    And the selected order type still shows a checkmark

  Scenario: user sees dark-mode order type icons
    Given the app theme is Dark
    When the user opens the order type picker
    Then each order type shows its dark-mode icon
    And the selected order type still shows a checkmark
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-17 at 18 15 01" src="https://github.com/user-attachments/assets/e6b59452-75a1-4a81-a13f-e76fad1b7094" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-17 at 18 22 36" src="https://github.com/user-attachments/assets/1ed98be3-2ae3-4862-87cc-1437ef36360f" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Perps picker copy and themed assets with no trading, auth, or data-path changes.
> 
> **Overview**
> Updates the **Perps “Choose order type”** sheet so triggered-order descriptions match Figma and icons respect light/dark theme.
> 
> **Copy:** The four triggered types (stop limit/market, take limit/market) get new English strings in `en.json` (e.g. “Place a limit order if trigger price hits”). Market and limit descriptions are unchanged.
> 
> **Icons:** `PerpsOrderTypeBottomSheetView` swaps single SVGs for light/dark pairs and renders them via a new `OrderTypeStartAccessory` using `useAssetFromTheme` and `useTheme`, with `accessibilityLabel` suffixes for theme (`-icon-light` / `-icon-dark`).
> 
> **Tests:** The bottom sheet tests use `renderWithProvider` with app theme, assert the new triggered copy when `showTriggeredTypes` is on, and verify six icons per theme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b67bfe88741479e9ca22e7b0045094951469584b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->