### PR TITLE
fix(predict): reduce crypto stream telemetry cp-8.8.0

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts
@@ -1,6 +1,5 @@
 import { AppState, AppStateStatus } from 'react-native';
 import Logger from '../../../../../util/Logger';
-import { endTrace, trace, TraceName } from '../../../../../util/trace';
 import { GameCache } from './GameCache';
 import { POLYMARKET_PROVIDER_ID } from './constants';
 import { PREDICT_CONSTANTS } from '../../constants/errors';
@@ -11,12 +10,6 @@ jest.mock('../../../../../util/Logger', () => ({
   __esModule: true,
   default: { error: jest.fn(), log: jest.fn() },
 }));
-jest.mock('../../../../../util/trace', () => ({
-  ...jest.requireActual('../../../../../util/trace'),
-  trace: jest.fn(),
-  endTrace: jest.fn(),
-}));
-
 const mockedLoggerError = jest.mocked(Logger.error);
 
 const mockGameCacheInstance = {
@@ -422,22 +415,6 @@ describe('WebSocketManager', () => {
       expect(callback).not.toHaveBeenCalled();
     });
 
-    it('does not trace RTDS messages when JSON parsing throws', () => {
-      const manager = WebSocketManager.getInstance();
-
-      manager.subscribeToCryptoPrices(['btc/usd'], jest.fn());
-      const rtdsInstance =
-        mockWebSocketInstances[mockWebSocketInstances.length - 1];
-      rtdsInstance.simulateOpen();
-
-      rtdsInstance.onmessage?.({
-        data: 'not valid json',
-      } as MessageEvent);
-
-      expect(trace).not.toHaveBeenCalled();
-      expect(endTrace).not.toHaveBeenCalled();
-    });
-
     it('continues flushing buffered prices when a callback throws', () => {
       const manager = WebSocketManager.getInstance();
       const callback = jest.fn().mockImplementationOnce(() => {
@@ -462,9 +439,6 @@ describe('WebSocketManager', () => {
       });
 
       expect(() => jest.advanceTimersByTime(250)).not.toThrow();
-      expect(endTrace).toHaveBeenCalledWith({
-        name: TraceName.CryptoUpDownBufferFlush,
-      });
       expect(callback).toHaveBeenCalledTimes(2);
       expect(callback).toHaveBeenCalledWith({
         symbol: 'eth/usd',
@@ -486,37 +460,6 @@ describe('WebSocketManager', () => {
         symbol: 'eth/usd',
         price: 3500,
         timestamp: 1700000001,
-      });
-    });
-
-    it('does not end an unmatched buffer flush trace when trace start throws', () => {
-      const manager = WebSocketManager.getInstance();
-      const traceError = new Error('trace failed');
-      (trace as jest.Mock)
-        .mockImplementationOnce(() => undefined)
-        .mockImplementationOnce(() => {
-          throw traceError;
-        });
-
-      manager.subscribeToCryptoPrices(['btc/usd'], jest.fn());
-      const rtdsInstance =
-        mockWebSocketInstances[mockWebSocketInstances.length - 1];
-      rtdsInstance.simulateOpen();
-      rtdsInstance.simulateMessage({
-        topic: 'crypto_prices_chainlink',
-        type: 'update',
-        timestamp: 1700000000,
-        payload: { symbol: 'btc/usd', timestamp: 1700000000, value: 67234.5 },
-      });
-      (endTrace as jest.Mock).mockClear();
-
-      try {
-        expect(() => jest.advanceTimersByTime(250)).toThrow(traceError);
-      } finally {
-        WebSocketManager.resetInstance();
-      }
-      expect(endTrace).not.toHaveBeenCalledWith({
-        name: TraceName.CryptoUpDownBufferFlush,
       });
     });
   });
@@ -1408,13 +1351,6 @@ describe('WebSocketManager', () => {
         price: 67234.5,
         timestamp: 1700000001,
       });
-      expect(trace).toHaveBeenCalledWith({
-        name: TraceName.CryptoUpDownWsMessage,
-        op: 'rtds.message',
-      });
-      expect(endTrace).toHaveBeenCalledWith({
-        name: TraceName.CryptoUpDownWsMessage,
-      });
     });
 
     it('filters pong messages without calling callback', () => {
@@ -1456,6 +1392,32 @@ describe('WebSocketManager', () => {
       jest.advanceTimersByTime(250);
 
       expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('does not start buffering updates for unsubscribed symbols', () => {
+      const manager = WebSocketManager.getInstance();
+
+      manager.subscribeToCryptoPrices(['btc/usd'], jest.fn(), {
+        twapWindowSeconds: 30,
+      });
+      const rtdsInstance =
+        mockWebSocketInstances[mockWebSocketInstances.length - 1];
+      rtdsInstance.simulateOpen();
+      const timerCountBeforeMessage = jest.getTimerCount();
+
+      rtdsInstance.simulateMessage({
+        topic: 'crypto_prices_twap_thirty',
+        type: 'update',
+        timestamp: 1700000002000,
+        payload: {
+          symbol: 'eth/usd',
+          timestamp: 1700000001000,
+          value: 3500,
+          window_s: 30,
+        },
+      });
+
+      expect(jest.getTimerCount()).toBe(timerCountBeforeMessage);
     });
 
     it('sends unsubscribe message when all callbacks removed', () => {
@@ -2067,10 +2029,6 @@ describe('WebSocketManager', () => {
       jest.advanceTimersByTime(250);
 
       expect(callback).not.toHaveBeenCalled();
-      expect(trace).not.toHaveBeenCalledWith({
-        name: TraceName.CryptoUpDownWsMessage,
-        op: 'rtds.message',
-      });
     });
 
     it('ignores messages with missing payload', () => {
@@ -2170,18 +2128,17 @@ describe('WebSocketManager', () => {
         mockWebSocketInstances[mockWebSocketInstances.length - 1];
       secondInstance.simulateOpen();
 
-      const subscribeCalls = secondInstance.send.mock.calls.filter(
-        (call: string[]) => {
-          try {
-            const msg = JSON.parse(call[0]);
-            return msg.action === 'subscribe';
-          } catch {
-            return false;
-          }
-        },
+      expect(secondInstance.send).toHaveBeenCalledWith(
+        JSON.stringify({
+          action: 'subscribe',
+          subscriptions: [
+            {
+              topic: 'crypto_prices_chainlink',
+              type: 'update',
+            },
+          ],
+        }),
       );
-
-      expect(subscribeCalls.length).toBeGreaterThan(0);
     });
 
     it('reconnectAll only connects RTDS when only RTDS has subscriptions', () => {

--- a/app/components/UI/Predict/providers/polymarket/WebSocketManager.ts
+++ b/app/components/UI/Predict/providers/polymarket/WebSocketManager.ts
@@ -18,7 +18,6 @@ import { GameCache } from './GameCache';
 import { POLYMARKET_PROVIDER_ID } from './constants';
 import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 import Logger, { type LoggerErrorOptions } from '../../../../../util/Logger';
-import { trace, endTrace, TraceName } from '../../../../../util/trace';
 import { OrderBook } from './types';
 
 type WebSocketChannel = 'sports' | 'market' | 'rtds';
@@ -1300,8 +1299,6 @@ export class WebSocketManager {
   private handleRtdsMessage = (event: WebSocketMessageEvent): void => {
     this.rtdsLastMessageAt = Date.now();
 
-    let traceStarted = false;
-
     try {
       if (event.data === 'pong' || event.data === '') {
         return;
@@ -1336,9 +1333,9 @@ export class WebSocketManager {
       ) {
         return;
       }
-
-      trace({ name: TraceName.CryptoUpDownWsMessage, op: 'rtds.message' });
-      traceStarted = true;
+      if (!this.hasCryptoPriceSubscription(data.topic, symbol)) {
+        return;
+      }
 
       const bufferKey = `${data.topic}|${symbol}`;
       const latestObservation = twapWindowSeconds
@@ -1371,10 +1368,6 @@ export class WebSocketManager {
         this.toError(error),
         this.getErrorContext('handleRtdsMessage', 'rtds'),
       );
-    } finally {
-      if (traceStarted) {
-        endTrace({ name: TraceName.CryptoUpDownWsMessage });
-      }
     }
   };
 
@@ -1397,12 +1390,7 @@ export class WebSocketManager {
       return;
     }
 
-    let traceStarted = false;
-
     try {
-      trace({ name: TraceName.CryptoUpDownBufferFlush, op: 'rtds.flush' });
-      traceStarted = true;
-
       this.cryptoPriceSubscriptions.forEach((callbacks, key) => {
         const { topic, symbols } = parseCryptoSubscriptionKey(key);
         const subscribedSymbols = new Set(symbols);
@@ -1436,10 +1424,21 @@ export class WebSocketManager {
       });
     } finally {
       this.cryptoPriceBuffer.clear();
-      if (traceStarted) {
-        endTrace({ name: TraceName.CryptoUpDownBufferFlush });
-      }
     }
+  }
+
+  private hasCryptoPriceSubscription(topic: string, symbol: string): boolean {
+    let isSubscribed = false;
+    this.cryptoPriceSubscriptions.forEach((_, key) => {
+      const parsedSubscription = parseCryptoSubscriptionKey(key);
+      if (
+        parsedSubscription.topic === topic &&
+        parsedSubscription.symbols.includes(symbol)
+      ) {
+        isSubscribed = true;
+      }
+    });
+    return isSubscribed;
   }
 
   private getRtdsCryptoSubscriptions(): RtdsSubscription[] {

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -69,8 +69,6 @@ export enum TraceName {
   EvmDiscoverAccounts = 'EVM Discover Accounts',
   SnapDiscoverAccounts = 'Snap Discover Accounts',
   FetchHistoricalPrices = 'Fetch Historical Prices',
-  CryptoUpDownWsMessage = 'Crypto Up Down WS Message',
-  CryptoUpDownBufferFlush = 'Crypto Up Down Buffer Flush',
   /** Token overview advanced chart: skeleton cleared after initial load / asset or currency change. */
   TokenOverviewAdvancedChartInitialVisible = 'Token Overview Advanced Chart Initial Visible',
   /** Token overview advanced chart: skeleton cleared after time range selector change only. */


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Mobile Sentry transaction volume increased by 2.84x, with `Crypto Up Down WS Message` and `Crypto Up Down Buffer Flush` accounting for about 90.8% of the increase and an estimated 51 million billed transactions per month. These traces wrapped high-frequency RTDS work, so their volume scaled with WebSocket traffic and buffer flushes rather than user actions. The recent addition of broad 30-second and 60-second TWAP topics increased the amount of RTDS traffic reaching this path.

This change removes those two per-message/per-flush Sentry traces and their `TraceName` entries. It also rejects RTDS updates whose topic and symbol have no active local subscriber before adding them to the buffer or starting the flush timer. This preserves topic-wide RTDS subscriptions, TWAP settlement pricing, chart routing, duplicate/out-of-order handling, and existing non-TWAP behavior while eliminating the runaway telemetry and avoiding unnecessary processing of unrelated broad-topic updates.

After release, the billed transaction volume must be remeasured over a comparable four-day production window and recorded in #34896. The `AssetsUpdateEnrichment` and spike-protection follow-ups in that issue are outside this PR's Crypto Up/Down scope.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/issues/34896

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Crypto Up/Down RTDS telemetry mitigation

  Scenario: A TWAP market receives live prices
    Given Predict is enabled and an active Crypto Up/Down TWAP market is open
    When the market receives live RTDS price updates
    Then the current price and chart continue updating from the configured TWAP window
    And no `Crypto Up Down WS Message` or `Crypto Up Down Buffer Flush` transaction is emitted

  Scenario: A broad TWAP topic sends an unrelated symbol
    Given the app has subscribed to BTC/USD on a TWAP topic
    When RTDS sends an ETH/USD update on the same topic
    Then the ETH/USD update is ignored before buffering
    And the BTC/USD stream continues updating normally

  Scenario: A non-TWAP market receives live prices
    Given an active non-TWAP Crypto Up/Down market is open
    When the market receives Chainlink RTDS updates
    Then the current price and chart continue updating with existing behavior
```

Automated validation completed:
- `NODE_OPTIONS=--max-old-space-size=8192 yarn jest app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts app/util/trace.test.ts --runInBand --forceExit --coverage=false --watch=false` (178 tests passed)
- `yarn eslint app/components/UI/Predict/providers/polymarket/WebSocketManager.ts app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts app/util/trace.ts` (no errors; one pre-existing deprecation warning)
- `yarn prettier --check app/components/UI/Predict/providers/polymarket/WebSocketManager.ts app/components/UI/Predict/providers/polymarket/WebSocketManager.test.ts app/util/trace.ts`

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — this is a non-visual telemetry and RTDS hot-path change. Production billed-volume evidence can only be captured after the fix is released; the before measurements and post-release remeasurement requirement are tracked in #34896.

### **Before**

N/A — see #34896 for the production Sentry baseline and spike measurements.

### **After**

N/A — post-release Sentry remeasurement is required in #34896.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've assessed Android performance testing; this platform-independent TypeScript telemetry fix is covered by focused WebSocket tests and CI, with production remeasurement required after release.
- [x] I've assessed power-user wallet testing; the changed stream behavior is independent of wallet account and token volume.
- [x] I've assessed Sentry instrumentation; the per-message and per-flush traces are intentionally removed because they generated approximately 51 million billed transactions per month.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6f76e70409fda923188a508e083a57632575a27c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->