### PR TITLE
chore: replace Enable with Turn on for notification and basic functionality CTAs

### DIFF
--- a/app/components/UI/BasicFunctionality/BasicFunctionalityEmptyState/BasicFunctionalityEmptyState.test.tsx
+++ b/app/components/UI/BasicFunctionality/BasicFunctionalityEmptyState/BasicFunctionalityEmptyState.test.tsx
@@ -29,7 +29,7 @@ describe('BasicFunctionalityEmptyState', () => {
         "We can't fetch the required metadata when basic functionality is disabled.",
       ),
     ).toBeOnTheScreen();
-    expect(getByText('Enable basic functionality')).toBeOnTheScreen();
+    expect(getByText('Turn on basic functionality')).toBeOnTheScreen();
     expect(
       queryByTestId('basic-functionality-empty-state-icon-container'),
     ).toBeNull();
@@ -57,7 +57,7 @@ describe('BasicFunctionalityEmptyState', () => {
   it('navigates to basic functionality settings when button is pressed', () => {
     const { getByText } = render(<BasicFunctionalityEmptyState />);
 
-    const enableButton = getByText('Enable basic functionality');
+    const enableButton = getByText('Turn on basic functionality');
 
     fireEvent.press(enableButton);
 

--- a/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
+++ b/app/components/UI/CliLoginPushNudge/useCliLoginPushNudge.test.tsx
@@ -127,7 +127,7 @@ describe('useCliLoginPushNudge', () => {
 
     expect(Alert.alert).toHaveBeenCalledWith(
       'Something went wrong',
-      "We couldn't enable notifications. Please try again later.",
+      "We couldn't turn on notifications. Please try again later.",
     );
     expect(result.current.isVisible).toBe(false);
   });

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -9726,10 +9726,10 @@
       "title": "Don't miss out",
       "description": "Turn on notifications to stay informed on campaigns.",
       "turn_on_button": "Turn on",
-      "loading": "Enabling notifications...",
+      "loading": "Turning on notifications...",
       "loading_description": "This may take a moment.",
       "enable_error": "Failed to turn on notifications",
-      "success": "Notifications enabled"
+      "success": "Notifications turned on"
     },
     "version_guard": {
       "title": "Update required",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -4024,7 +4024,7 @@
     "notifications_title": "Notifications",
     "notifications_desc": "Manage your notifications",
     "allow_notifications": "Allow notifications",
-    "enable_push_notifications": "Enable push notifications",
+    "enable_push_notifications": "Turn on push notifications",
     "allow_notifications_desc": "Choose what you're notified about and how.",
     "notifications_opts": {
       "preferences_title": "Preferences",
@@ -6125,7 +6125,7 @@
     "lido_stake_ready_to_be_withdrawn_message": "Withdrawal requested",
     "prompt_title": "Receive push notifications",
     "notifications_enabled_error_title": "Something went wrong",
-    "notifications_enabled_error_desc": "We couldn't enable notifications. Please try again later.",
+    "notifications_enabled_error_desc": "We couldn't turn on notifications. Please try again later.",
     "prompt_desc": "Turn on notifications from Settings to get important alerts on wallet activity and more.",
     "prompt_ok": "Turn on",
     "prompt_cancel": "Maybe later",
@@ -6173,7 +6173,7 @@
       "new_user": {
         "title": "Never miss a move",
         "body": "Get real-time alerts on price moves, trade confirmations, portfolio activity, and rewards based on how you use MetaMask.",
-        "button_yes": "Enable notifications",
+        "button_yes": "Turn on notifications",
         "button_not_now": "Not now",
         "preview_card_1": {
           "time": "now",
@@ -6215,7 +6215,7 @@
         }
       },
       "toast_enabled": "Notifications enabled",
-      "toast_settings_hint": "You can enable notifications any time in Settings > Notifications"
+      "toast_settings_hint": "You can turn on notifications any time in Settings > Notifications"
     }
   },
   "protect_your_wallet_modal": {
@@ -9724,11 +9724,11 @@
     },
     "notifications_nudge": {
       "title": "Don't miss out",
-      "description": "Enable notifications to stay informed on campaigns.",
+      "description": "Turn on notifications to stay informed on campaigns.",
       "turn_on_button": "Turn on",
       "loading": "Enabling notifications...",
       "loading_description": "This may take a moment.",
-      "enable_error": "Failed to enable notifications",
+      "enable_error": "Failed to turn on notifications",
       "success": "Notifications enabled"
     },
     "version_guard": {
@@ -10527,7 +10527,7 @@
     "push_nudge": {
       "title": "Never miss a transaction",
       "description": "Get real-time alerts to review and approve transactions from your CLI session.",
-      "turn_on_button": "Enable notifications",
+      "turn_on_button": "Turn on notifications",
       "preview_title": "Transaction request",
       "preview_message": "Your agent needs approval on a new limit.",
       "preview_timestamp": "now"
@@ -10625,7 +10625,7 @@
     "view_all": "View all",
     "view_more": "View more",
     "view_x_more": "View {{count}} more",
-    "enable_basic_functionality": "Enable basic functionality",
+    "enable_basic_functionality": "Turn on basic functionality",
     "basic_functionality_disabled_title": "Explore is not available",
     "basic_functionality_disabled_description": "We can't fetch the required metadata when basic functionality is disabled.",
     "empty_error_trending_state": {


### PR DESCRIPTION
## **Description**

Updates English copy in `locales/languages/en.json` so push-notification prompts, toasts, and the basic functionality toggle use **Turn on** instead of **Enable**, matching the existing "Turn on" pattern already used elsewhere in the app (e.g. `prompt_ok: "Turn on"`). Sentence/title case of each string is preserved.

This supersedes #34647, which took a much broader sweep across the whole file (Ledger Bluetooth/blind-signing, Card, biometrics, NFT autodetection, token detection, etc.) and was closed as too messy. This PR is scoped to only the notification and basic-functionality strings below:

- `enable_push_notifications`: "Enable push notifications" → "Turn on push notifications"
- `notifications_enabled_error_desc`: "We couldn't enable notifications..." → "We couldn't turn on notifications..."
- `button_yes` (notifications new-user prompt): "Enable notifications" → "Turn on notifications"
- `toast_settings_hint`: "You can enable notifications..." → "You can turn on notifications..."
- `notifications_nudge.description`: "Enable notifications to stay informed on campaigns." → "Turn on notifications to stay informed on campaigns."
- `notifications_nudge.enable_error`: "Failed to enable notifications" → "Failed to turn on notifications"
- `push_nudge.turn_on_button`: "Enable notifications" → "Turn on notifications"
- `enable_basic_functionality`: "Enable basic functionality" → "Turn on basic functionality"

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A — copy consistency follow-up, no linked ticket

## **Manual testing steps**

```gherkin
Feature: Notification and basic functionality copy

  Scenario: user views notification prompts and settings
    Given the user opens the notifications opt-in prompt, settings, or the basic functionality toggle
    When the relevant screen renders
    Then the copy reads "Turn on ..." instead of "Enable ..." in each of the 8 updated strings
```

## **Screenshots/Recordings**

N/A — string-only copy change, no layout impact.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)