### PR TITLE
ci: slack production build notification

### DIFF
--- a/.github/workflows/runway-production-builds.yml
+++ b/.github/workflows/runway-production-builds.yml
@@ -65,10 +65,11 @@ jobs:
     name: Slack Production Notification
     needs: build
     if: success()
-    uses: ./.github/workflows/slack-production-notification.yml
+    uses: ./.github/workflows/slack-rc-notification.yml
     with:
       source_branch: ${{ inputs.source_branch || github.ref_name }}
       semver: ${{ needs.build.outputs.semantic_version }}
       ios_build_number: ${{ needs.build.outputs.ios_version_code }}
       android_build_number: ${{ needs.build.outputs.android_version_code }}
+      build_kind: production
     secrets: inherit

--- a/.github/workflows/runway-production-builds.yml
+++ b/.github/workflows/runway-production-builds.yml
@@ -60,3 +60,15 @@ jobs:
       build_version: ${{ needs.build.outputs.semantic_version }}
       build_number: ${{ needs.build.outputs.ios_version_code }}
     secrets: inherit
+
+  slack-notification:
+    name: Slack Production Notification
+    needs: build
+    if: success()
+    uses: ./.github/workflows/slack-production-notification.yml
+    with:
+      source_branch: ${{ inputs.source_branch || github.ref_name }}
+      semver: ${{ needs.build.outputs.semantic_version }}
+      ios_build_number: ${{ needs.build.outputs.ios_version_code }}
+      android_build_number: ${{ needs.build.outputs.android_version_code }}
+    secrets: inherit

--- a/.github/workflows/slack-rc-notification.yml
+++ b/.github/workflows/slack-rc-notification.yml
@@ -2,7 +2,7 @@
 #
 # Slack RC Notification (reusable)
 #
-# Posts an RC build notification to the release Slack channel.
+# Posts an RC or production build notification to the release Slack channel.
 # Callers can pass build metadata (semver, build numbers) directly from build
 # outputs for accuracy, or omit them to fall back to reading from the branch.
 #
@@ -36,6 +36,11 @@ on:
         required: false
         type: string
         default: ''
+      build_kind:
+        description: 'rc (default) or production — changes header copy and Android download target'
+        required: false
+        type: string
+        default: 'rc'
 
 permissions:
   actions: read
@@ -84,5 +89,6 @@ jobs:
           ANDROID_PUBLIC_URL: ${{ secrets.ANDROID_PUBLIC_BUCKET_URL }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           PR_NUMBER: ${{ inputs.pr_number }}
+          BUILD_KIND: ${{ inputs.build_kind }}
           # Disable android check msg for now
           #ANDROID_PLAY_STORE_CHECK_MRKDWN_FILE: ${{ github.workspace }}/android-play-store-check-out/android-play-store-check-slack.md

--- a/scripts/slack-rc-notification.mjs
+++ b/scripts/slack-rc-notification.mjs
@@ -1,12 +1,13 @@
 /**
- * Slack RC Build Notification Script
+ * Slack RC / Production Build Notification Script
  *
- * Posts a Slack message after an RC build with download links
- * and a link to the cherry-picks section in the release PR comment.
+ * Posts a Slack message after an RC or production build with download links.
+ * RC also links to the cherry-picks section in the release PR comment.
  *
  * Required env: SEMVER, SLACK_BOT_TOKEN
  * Optional env: IOS_BUILD_NUMBER, ANDROID_BUILD_NUMBER, ANDROID_PUBLIC_URL,
  *               IOS_PUBLIC_URL, BUILD_PIPELINE_URL, PR_NUMBER, GITHUB_REPOSITORY,
+ *               BUILD_KIND (rc | production; default rc),
  *               SLACK_RC_NOTIFICATION_DRY_RUN,
  *               ANDROID_PLAY_STORE_CHECK_MRKDWN_FILE (PLAY_STORE_CHECK_STATUS=pass|fail)
  */
@@ -60,9 +61,16 @@ function isValidUrl(url) {
   }
 }
 
+function resolveBuildKind(buildKind) {
+  return String(buildKind || 'rc').toLowerCase() === 'production'
+    ? 'production'
+    : 'rc';
+}
+
 /**
  * Build the Slack message payload
  * @param {Object} options - Message options
+ * @param {string} [options.buildKind] - rc (default) or production
  * @param {string|null} [options.playStoreCheckMrkdwn] - Optional mrkdwn from Android Play Store check
  * @returns {Object} Slack message payload
  */
@@ -76,14 +84,27 @@ function buildSlackMessage(options) {
     pipelineUrl,
     prNumber,
     playStoreCheckMrkdwn,
+    buildKind: buildKindInput,
   } = options;
+
+  const buildKind = resolveBuildKind(buildKindInput);
+  const isProduction = buildKind === 'production';
+  const label = isProduction ? 'Production' : 'RC';
+
+  const androidLink = isProduction
+    ? isValidUrl(pipelineUrl)
+      ? `*Android APK:*\n<${pipelineUrl}|Download from CI>`
+      : '*Android APK:*\n_Not available_'
+    : isValidUrl(androidUrl)
+      ? `*Android APK:*\n<${androidUrl}|Download>`
+      : '*Android APK:*\n_Not available_';
 
   const blocks = [
     {
       type: 'header',
       text: {
         type: 'plain_text',
-        text: `🚀 Mobile RC Build v${version} (${buildNumber})`,
+        text: `🚀 Mobile ${label} Build v${version} (${buildNumber})`,
         emoji: true,
       },
     },
@@ -112,9 +133,7 @@ function buildSlackMessage(options) {
       fields: [
         {
           type: 'mrkdwn',
-          text: isValidUrl(androidUrl)
-            ? `*Android APK:*\n<${androidUrl}|Download>`
-            : '*Android APK:*\n_Not available_',
+          text: androidLink,
         },
         {
           type: 'mrkdwn',
@@ -126,32 +145,34 @@ function buildSlackMessage(options) {
     },
   ];
 
-  // Add link to cherry-picks section in PR comment
+  // Cherry-picks are RC-only (linked to the release PR comment).
   // Note: GitHub prefixes user-provided anchor IDs with 'user-content-'
   // We use build number in anchor to link to the correct comment (not older builds)
-  if (prNumber) {
-    const anchorSuffix = androidBuildNumber && androidBuildNumber !== 'N/A' ? `-${androidBuildNumber}` : '';
-    const cherryPicksLink = `<${REPO_URL}/pull/${prNumber}#user-content-cherry-picks${anchorSuffix}|View cherry-picks>`;
-    blocks.push(
-      {
-        type: 'divider',
-      },
-      {
+  if (!isProduction) {
+    if (prNumber) {
+      const anchorSuffix = androidBuildNumber && androidBuildNumber !== 'N/A' ? `-${androidBuildNumber}` : '';
+      const cherryPicksLink = `<${REPO_URL}/pull/${prNumber}#user-content-cherry-picks${anchorSuffix}|View cherry-picks>`;
+      blocks.push(
+        {
+          type: 'divider',
+        },
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*🍒 Cherry-picks:* ${cherryPicksLink}`,
+          },
+        },
+      );
+    } else {
+      blocks.push({
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `*🍒 Cherry-picks:* ${cherryPicksLink}`,
+          text: `_Cherry-picks available in the release PR._`,
         },
-      },
-    );
-  } else {
-    blocks.push({
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: `_Cherry-picks available in the release PR._`,
-      },
-    });
+      });
+    }
   }
 
   if (playStoreCheckMrkdwn) {
@@ -174,12 +195,12 @@ function buildSlackMessage(options) {
   }
 
   // Add pipeline and RC notes links
-  if (pipelineUrl || prNumber) {
+  if (pipelineUrl || (!isProduction && prNumber)) {
     const links = [];
     if (pipelineUrl) {
       links.push(`<${pipelineUrl}|View Build Pipeline>`);
     }
-    if (prNumber) {
+    if (!isProduction && prNumber) {
       const anchorSuffix = androidBuildNumber && androidBuildNumber !== 'N/A' ? `-${androidBuildNumber}` : '';
       links.push(`<${REPO_URL}/pull/${prNumber}#user-content-whats-in-this-rc${anchorSuffix}|View full RC notes>`);
     }
@@ -203,7 +224,7 @@ function buildSlackMessage(options) {
 
   return {
     blocks,
-    text: `🚀 Mobile RC Build v${version} (${buildNumber}) is ready!`, // Fallback text
+    text: `🚀 Mobile ${label} Build v${version} (${buildNumber}) is ready!`, // Fallback text
   };
 }
 
@@ -286,12 +307,14 @@ async function main() {
   const iosUrl = process.env.IOS_PUBLIC_URL;
   const pipelineUrl = process.env.BUILD_PIPELINE_URL;
   const botToken = process.env.SLACK_BOT_TOKEN;
+  const buildKind = resolveBuildKind(process.env.BUILD_KIND);
+  const label = buildKind === 'production' ? 'Production' : 'RC';
 
   const prNumber = process.env.PR_NUMBER || '';
   const playStoreCheckMrkdwn = loadPlayStoreCheckMrkdwn();
   const expectedChannelName = getSlackChannel(version);
 
-  console.log(`\n📣 Preparing Slack notification for RC v${version} (${buildNumber})`);
+  console.log(`\n📣 Preparing Slack notification for ${label} v${version} (${buildNumber})`);
   if (prNumber) {
     console.log(`📍 Release PR: #${prNumber}`);
   }
@@ -313,6 +336,7 @@ async function main() {
     pipelineUrl,
     prNumber,
     playStoreCheckMrkdwn,
+    buildKind,
   });
 
   if (isDryRun) {
@@ -330,7 +354,7 @@ async function main() {
   const result = await postToSlack(botToken, expectedChannelName, payload);
 
   if (result.success) {
-    console.log(`\n✅ RC notification sent to ${expectedChannelName}`);
+    console.log(`\n✅ ${label} notification sent to ${expectedChannelName}`);
   } else if (result.channelNotFound) {
     console.warn(`\n⚠️ Channel ${expectedChannelName} not found in Slack workspace`);
     console.warn('   This could mean:');
@@ -340,7 +364,7 @@ async function main() {
     console.warn('Skipping Slack notification (non-critical)');
   } else {
     // Fail open - log the error but don't exit with error code
-    console.log('\n⚠️ RC notification failed but continuing (non-critical)');
+    console.log(`\n⚠️ ${label} notification failed but continuing (non-critical)`);
   }
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
 - Adds formatted Slack notification with direct download links for        
  production builds                                                         
  - iOS: TestFlight link                                                    
  - Android: GitHub Actions run (download `android-apk-main-prod` artifact) 
  - Posts to `#release-mobile-X-Y-Z`, same channel pattern as RC builds
<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Runway's default notification just says "artifact uploaded" — this adds   
  actionable links so testers can quickly install builds. 

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
https://consensyssoftware.atlassian.net/browse/MCRM-140
## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only notification plumbing; RC paths keep default `build_kind` and existing message shape.
> 
> **Overview**
> **Runway production builds** now post to the same release Slack channel as RCs after a successful `main-prod` build, reusing the existing Slack workflow with build metadata from the build job.
> 
> The reusable workflow and `slack-rc-notification.mjs` gain a **`build_kind`** (`rc` | `production`, default `rc`). **Production** messages use “Production” in the title/fallback text, point **Android** at the **CI run** (“Download from CI”) instead of the public APK URL, and **omit** cherry-pick and “full RC notes” PR links. RC behavior is unchanged when `build_kind` is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7f92f369a6f6f9b8b2d2ed7551a87b36c080600. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->