### PR TITLE
WIP: fix(predict): hide claim CTA for losing positions

### DIFF
--- a/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.test.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.test.tsx
@@ -208,13 +208,13 @@ jest.mock(
       __esModule: true,
       default: jest.fn(
         ({
-          hasPositivePnl,
+          hasClaimableWinnings,
           onClaimPress,
         }: {
-          hasPositivePnl: boolean;
+          hasClaimableWinnings: boolean;
           onClaimPress: () => void;
         }) =>
-          hasPositivePnl
+          hasClaimableWinnings
             ? React.createElement(TouchableOpacity, {
                 testID: 'predict-market-details-claim-winnings-button',
                 onPress: onClaimPress,
@@ -607,7 +607,7 @@ describe('PredictCryptoUpDownDetails', () => {
         market={market}
         onBack={mockOnBack}
         onClaimPress={onClaimPress}
-        hasPositivePnl
+        hasClaimableWinnings
       />,
     );
 

--- a/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx
@@ -116,7 +116,7 @@ export interface PredictCryptoUpDownDetailsProps {
   ) => void;
   onClaimPress?: () => void;
   isClaimablePositionsLoading?: boolean;
-  hasPositivePnl?: boolean;
+  hasClaimableWinnings?: boolean;
   isMarketLoading?: boolean;
   isClaimPending?: boolean;
 }
@@ -129,7 +129,7 @@ const PredictCryptoUpDownDetails: React.FC<PredictCryptoUpDownDetailsProps> = ({
   onRefresh,
   refreshing = false,
   isClaimablePositionsLoading = false,
-  hasPositivePnl = false,
+  hasClaimableWinnings = false,
   isMarketLoading = false,
   isClaimPending = false,
 }) => {
@@ -309,7 +309,7 @@ const PredictCryptoUpDownDetails: React.FC<PredictCryptoUpDownDetailsProps> = ({
   const { openOutcomes: selectedOpenOutcomes } = useOpenOutcomes({
     market: selectedMarket,
   });
-  const canClaim = Boolean(onClaimPress && hasPositivePnl);
+  const canClaim = Boolean(onClaimPress && hasClaimableWinnings);
   const shouldRenderActions = Boolean(onBetPress || canClaim);
 
   const handleCurrentPriceChange = useCallback((value: number | undefined) => {
@@ -697,7 +697,7 @@ const PredictCryptoUpDownDetails: React.FC<PredictCryptoUpDownDetailsProps> = ({
         <Box twClassName="px-4 pb-8">
           <PredictMarketDetailsActions
             isClaimablePositionsLoading={isClaimablePositionsLoading}
-            hasPositivePnl={canClaim}
+            hasClaimableWinnings={canClaim}
             marketStatus={selectedMarket.status as PredictMarketStatus}
             singleOutcomeMarket={selectedMarket.outcomes.length === 1}
             isMarketLoading={isMarketLoading}

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.test.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.test.tsx
@@ -415,10 +415,31 @@ describe('PredictSportCardFooter', () => {
   });
 
   describe('claimable positions - resolved market', () => {
-    it('renders claim button when positions are claimable', () => {
+    it('does not render claim actions for a resolved losing position', () => {
       const market = createMockMarket({ status: PredictMarketStatus.RESOLVED });
       const claimablePositions = [
-        createMockPosition({ claimable: true, currentValue: 50 }),
+        createMockPosition({
+          claimable: true,
+          status: PredictPositionStatus.LOST,
+          currentValue: 0,
+        }),
+      ];
+      setupPositionsMock({ claimablePositions });
+
+      render(<PredictSportCardFooter market={market} testID="footer" />);
+
+      expect(screen.queryByTestId('footer-action-buttons')).toBeNull();
+      expect(screen.queryByText(/Claim/)).toBeNull();
+    });
+
+    it('renders claim button for a claimable winning position', () => {
+      const market = createMockMarket({ status: PredictMarketStatus.RESOLVED });
+      const claimablePositions = [
+        createMockPosition({
+          claimable: true,
+          status: PredictPositionStatus.WON,
+          currentValue: 50,
+        }),
       ];
       setupPositionsMock({
         activePositions: claimablePositions,
@@ -430,10 +451,14 @@ describe('PredictSportCardFooter', () => {
       expect(screen.getByText('Claim $50')).toBeOnTheScreen();
     });
 
-    it('renders claimable positions with claim button when claimable', () => {
+    it('renders winning positions with the claim button', () => {
       const market = createMockMarket({ status: PredictMarketStatus.RESOLVED });
       const claimablePositions = [
-        createMockPosition({ claimable: true, currentValue: 50 }),
+        createMockPosition({
+          claimable: true,
+          status: PredictPositionStatus.WON,
+          currentValue: 50,
+        }),
       ];
       setupPositionsMock({
         activePositions: [],
@@ -446,18 +471,29 @@ describe('PredictSportCardFooter', () => {
       expect(screen.getByTestId('footer-action-buttons')).toBeOnTheScreen();
     });
 
-    it('calculates total claimable amount from claimable positions only', () => {
+    it('calculates total claimable amount from winning positions only', () => {
       const market = createMockMarket({ status: PredictMarketStatus.RESOLVED });
       const allPositions = [
-        createMockPosition({ id: 'pos-1', claimable: true, currentValue: 30 }),
-        createMockPosition({ id: 'pos-2', claimable: true, currentValue: 20 }),
+        createMockPosition({
+          id: 'pos-1',
+          claimable: true,
+          status: PredictPositionStatus.WON,
+          currentValue: 30,
+        }),
+        createMockPosition({
+          id: 'pos-2',
+          claimable: true,
+          status: PredictPositionStatus.WON,
+          currentValue: 20,
+        }),
         createMockPosition({
           id: 'pos-3',
-          claimable: false,
+          claimable: true,
+          status: PredictPositionStatus.LOST,
           currentValue: 100,
         }),
       ];
-      const claimablePositions = allPositions.filter((p) => p.claimable);
+      const claimablePositions = allPositions;
       setupPositionsMock({
         activePositions: allPositions,
         claimablePositions,
@@ -471,7 +507,11 @@ describe('PredictSportCardFooter', () => {
     it('does not render bet buttons when market is resolved', () => {
       const market = createMockMarket({ status: PredictMarketStatus.RESOLVED });
       const claimablePositions = [
-        createMockPosition({ claimable: true, currentValue: 50 }),
+        createMockPosition({
+          claimable: true,
+          status: PredictPositionStatus.WON,
+          currentValue: 50,
+        }),
       ];
       setupPositionsMock({
         activePositions: claimablePositions,
@@ -640,7 +680,11 @@ describe('PredictSportCardFooter', () => {
     it('calls claim function when claim button is pressed', async () => {
       const market = createMockMarket({ status: PredictMarketStatus.RESOLVED });
       const claimablePositions = [
-        createMockPosition({ claimable: true, currentValue: 50 }),
+        createMockPosition({
+          claimable: true,
+          status: PredictPositionStatus.WON,
+          currentValue: 50,
+        }),
       ];
       setupPositionsMock({
         activePositions: claimablePositions,
@@ -664,7 +708,11 @@ describe('PredictSportCardFooter', () => {
     it('executes claim through guarded action', async () => {
       const market = createMockMarket({ status: PredictMarketStatus.RESOLVED });
       const claimablePositions = [
-        createMockPosition({ claimable: true, currentValue: 50 }),
+        createMockPosition({
+          claimable: true,
+          status: PredictPositionStatus.WON,
+          currentValue: 50,
+        }),
       ];
       setupPositionsMock({
         activePositions: claimablePositions,
@@ -698,9 +746,15 @@ describe('PredictSportCardFooter', () => {
       const claimablePositions = [
         createMockPosition({
           claimable: true,
+          status: PredictPositionStatus.WON,
           currentValue: undefined as unknown as number,
         }),
-        createMockPosition({ id: 'pos-2', claimable: true, currentValue: 30 }),
+        createMockPosition({
+          id: 'pos-2',
+          claimable: true,
+          status: PredictPositionStatus.WON,
+          currentValue: 30,
+        }),
       ];
       setupPositionsMock({
         activePositions: claimablePositions,
@@ -734,7 +788,11 @@ describe('PredictSportCardFooter', () => {
     it('renders claim button without testID when testID prop is not provided', () => {
       const market = createMockMarket({ status: PredictMarketStatus.RESOLVED });
       const claimablePositions = [
-        createMockPosition({ claimable: true, currentValue: 50 }),
+        createMockPosition({
+          claimable: true,
+          status: PredictPositionStatus.WON,
+          currentValue: 50,
+        }),
       ];
       setupPositionsMock({
         activePositions: claimablePositions,

--- a/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
+++ b/app/components/UI/Predict/components/PredictSportCardFooter/PredictSportCardFooter.tsx
@@ -19,6 +19,7 @@ import { usePredictPositions } from '../../hooks/usePredictPositions';
 import { usePredictActionGuard } from '../../hooks/usePredictActionGuard';
 import { usePredictClaim } from '../../hooks/usePredictClaim';
 import { PREDICT_SPORT_CARD_FOOTER_TEST_IDS } from './PredictSportCardFooter.testIds';
+import { isClaimableWinningPosition } from '../../utils/positions';
 
 interface PredictSportCardFooterProps {
   market: PredictMarketType;
@@ -111,8 +112,11 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
   }, [executeGuardedAction, claim, resolvedEntryPoint]);
 
   const hasPositions = positions.length > 0;
-  const hasClaimablePositions = claimablePositions.length > 0;
-  const claimableAmount = claimablePositions.reduce(
+  const winningClaimablePositions = claimablePositions.filter(
+    isClaimableWinningPosition,
+  );
+  const hasClaimablePositions = winningClaimablePositions.length > 0;
+  const claimableAmount = winningClaimablePositions.reduce(
     (sum, p) => sum + (p.currentValue ?? 0),
     0,
   );
@@ -177,7 +181,7 @@ const PredictSportCardFooter: React.FC<PredictSportCardFooterProps> = ({
       {hasClaimablePositions && (
         <PredictPicksForCard
           marketId={market.id}
-          positions={claimablePositions}
+          positions={winningClaimablePositions}
           showSeparator
           testID={
             testID

--- a/app/components/UI/Predict/utils/positions.test.ts
+++ b/app/components/UI/Predict/utils/positions.test.ts
@@ -1,0 +1,51 @@
+import { PredictPosition, PredictPositionStatus } from '../types';
+import { isClaimableWinningPosition } from './positions';
+
+const createPosition = (
+  overrides: Partial<PredictPosition> = {},
+): PredictPosition => ({
+  id: 'position-1',
+  providerId: 'provider-1',
+  marketId: 'market-1',
+  outcomeId: 'outcome-1',
+  outcome: 'Yes',
+  outcomeTokenId: 'token-1',
+  currentValue: 10,
+  title: 'Test position',
+  icon: '',
+  amount: 10,
+  price: 0.5,
+  status: PredictPositionStatus.WON,
+  size: 20,
+  outcomeIndex: 0,
+  percentPnl: 100,
+  cashPnl: 10,
+  claimable: true,
+  initialValue: 10,
+  avgPrice: 0.5,
+  endDate: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('isClaimableWinningPosition', () => {
+  it('returns true for a claimable win with positive value', () => {
+    const position = createPosition();
+
+    const result = isClaimableWinningPosition(position);
+
+    expect(result).toBe(true);
+  });
+
+  it.each<[string, PredictPositionStatus, number]>([
+    ['lost', PredictPositionStatus.LOST, 10],
+    ['open', PredictPositionStatus.OPEN, 10],
+    ['redeemable', PredictPositionStatus.REDEEMABLE, 10],
+    ['zero-value won', PredictPositionStatus.WON, 0],
+  ])('returns false for a %s position', (_label, status, currentValue) => {
+    const position = createPosition({ status, currentValue });
+
+    const result = isClaimableWinningPosition(position);
+
+    expect(result).toBe(false);
+  });
+});

--- a/app/components/UI/Predict/utils/positions.ts
+++ b/app/components/UI/Predict/utils/positions.ts
@@ -1,0 +1,4 @@
+import { PredictPosition, PredictPositionStatus } from '../types';
+
+export const isClaimableWinningPosition = (position: PredictPosition) =>
+  position.status === PredictPositionStatus.WON && position.currentValue > 0;

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.tsx
@@ -58,6 +58,7 @@ import { useOpenOutcomes } from './hooks/useOpenOutcomes';
 import { useSelector } from 'react-redux';
 import { usePredictPreviewSheet } from '../../contexts';
 import PredictOffline from '../../components/PredictOffline';
+import { isClaimableWinningPosition } from '../../utils/positions';
 
 // Use theme tokens instead of hex values for multi-series charts
 
@@ -452,10 +453,10 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
     }
   }, [market, tabsReady, activeTab, tabs, trackMarketDetailsOpened]);
 
-  // see if there are any positions with positive percentPnl
-  const hasPositivePnl = claimablePositions.some(
-    (position) => position.percentPnl > 0,
+  const winningClaimablePositions = claimablePositions.filter(
+    isClaimableWinningPosition,
   );
+  const hasClaimableWinnings = winningClaimablePositions.length > 0;
 
   const isMarketUnavailable = isMarketUnresolved;
   const resolvedMarketError = marketError ?? currentSeriesMarketError;
@@ -491,7 +492,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
         onBetPress={handleBuyPress}
         onClaimPress={handleClaimPress}
         isClaimablePositionsLoading={isClaimablePositionsLoading}
-        hasPositivePnl={hasPositivePnl}
+        hasClaimableWinnings={hasClaimableWinnings}
         isMarketLoading={isResolvedMarketLoading}
         isClaimPending={isClaimPending}
       />
@@ -506,7 +507,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
         refreshing={isRefreshing}
         onBetPress={handleBuyPress}
         onClaimPress={handleClaimPress}
-        claimableAmount={claimablePositions.reduce(
+        claimableAmount={winningClaimablePositions.reduce(
           (sum, p) => sum + (p.currentValue ?? 0),
           0,
         )}
@@ -627,7 +628,7 @@ const PredictMarketDetails: React.FC<PredictMarketDetailsProps> = () => {
       {!isMarketUnavailable && (
         <PredictMarketDetailsActions
           isClaimablePositionsLoading={isClaimablePositionsLoading}
-          hasPositivePnl={hasPositivePnl}
+          hasClaimableWinnings={hasClaimableWinnings}
           marketStatus={market?.status as PredictMarketStatus | undefined}
           singleOutcomeMarket={singleOutcomeMarket}
           isMarketLoading={isResolvedMarketLoading}

--- a/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.view.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/PredictMarketDetails.view.test.tsx
@@ -37,9 +37,10 @@ import {
   buildMockPredictPosition,
 } from '../../../../../../tests/component-view/fixtures/predict';
 import { PREDICT_GAME_DETAILS_CONTENT_TEST_IDS } from '../../components/PredictGameDetailsContent/PredictGameDetailsContent.testIds';
-import type {
+import {
   PredictMarket,
   PredictPosition,
+  PredictPositionStatus,
   PredictPriceHistoryPoint,
 } from '../../types';
 
@@ -652,6 +653,8 @@ describe('PredictMarketDetails', () => {
         buildMockPredictPosition({
           marketId: MOCK_PREDICT_CLOSED_MARKET.id,
           claimable: true,
+          status: PredictPositionStatus.WON,
+          currentValue: 60,
           percentPnl: 42,
         }),
       ]);
@@ -671,6 +674,28 @@ describe('PredictMarketDetails', () => {
       await waitFor(() => {
         expect(claimSpy).toHaveBeenCalled();
       });
+    });
+
+    it('does not show the claim button for a resolved losing position', async () => {
+      givenMarket(MOCK_PREDICT_CLOSED_MARKET);
+      givenPositions([
+        buildMockPredictPosition({
+          marketId: MOCK_PREDICT_CLOSED_MARKET.id,
+          claimable: true,
+          status: PredictPositionStatus.LOST,
+          currentValue: 0,
+          percentPnl: -100,
+        }),
+      ]);
+
+      const { findByTestId, queryByTestId } = renderPredictMarketDetailsView({
+        initialParams: { marketId: MOCK_PREDICT_CLOSED_MARKET.id },
+      });
+
+      await findByTestId(PredictMarketDetailsSelectorsIDs.SCREEN);
+      expect(
+        queryByTestId(PredictMarketDetailsSelectorsIDs.CLAIM_WINNINGS_BUTTON),
+      ).not.toBeOnTheScreen();
     });
   });
 

--- a/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsActions/PredictMarketDetailsActions.test.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsActions/PredictMarketDetailsActions.test.tsx
@@ -55,7 +55,7 @@ const createProps = (
   > = {},
 ) => ({
   isClaimablePositionsLoading: false,
-  hasPositivePnl: false,
+  hasClaimableWinnings: false,
   marketStatus: PredictMarketStatus.OPEN,
   singleOutcomeMarket: true,
   isMarketLoading: false,
@@ -109,7 +109,7 @@ describe('PredictMarketDetailsActions', () => {
   it('renders claim button when claimable pnl is available', () => {
     const onClaimPress = jest.fn();
     const props = createProps({
-      hasPositivePnl: true,
+      hasClaimableWinnings: true,
       onClaimPress,
     });
 
@@ -131,7 +131,7 @@ describe('PredictMarketDetailsActions', () => {
       ],
     });
     const props = createProps({
-      hasPositivePnl: false,
+      hasClaimableWinnings: false,
       onBuyPress,
       openOutcomes: [openOutcome],
     });
@@ -246,7 +246,7 @@ describe('PredictMarketDetailsActions', () => {
     const props = createProps({
       marketStatus: PredictMarketStatus.CLOSED,
       singleOutcomeMarket: false,
-      hasPositivePnl: false,
+      hasClaimableWinnings: false,
       isClaimablePositionsLoading: false,
       isMarketLoading: false,
     });

--- a/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsActions/PredictMarketDetailsActions.tsx
+++ b/app/components/UI/Predict/views/PredictMarketDetails/components/PredictMarketDetailsActions/PredictMarketDetailsActions.tsx
@@ -59,7 +59,7 @@ const formatPayoutEstimate = (
 
 export interface PredictMarketDetailsActionsProps {
   isClaimablePositionsLoading: boolean;
-  hasPositivePnl: boolean;
+  hasClaimableWinnings: boolean;
   marketStatus: PredictMarketStatus | undefined;
   singleOutcomeMarket: boolean;
   isMarketLoading: boolean;
@@ -74,7 +74,7 @@ export interface PredictMarketDetailsActionsProps {
 const PredictMarketDetailsActions = memo(
   ({
     isClaimablePositionsLoading,
-    hasPositivePnl,
+    hasClaimableWinnings,
     marketStatus,
     singleOutcomeMarket,
     isMarketLoading,
@@ -124,7 +124,7 @@ const PredictMarketDetailsActions = memo(
     };
 
     const content = (() => {
-      if (!isClaimablePositionsLoading && hasPositivePnl) {
+      if (!isClaimablePositionsLoading && hasClaimableWinnings) {
         return (
           <PredictClaimButton
             onPress={onClaimPress}

--- a/tests/component-view/fixtures/predict.ts
+++ b/tests/component-view/fixtures/predict.ts
@@ -106,8 +106,8 @@ export const MOCK_PREDICT_PARTIALLY_RESOLVED_MARKET: PredictMarket = {
 };
 
 /**
- * Builds a position for the default market fixture. Override `claimable` and
- * `percentPnl` to drive the claim CTA (shown for claimable positions in profit).
+ * Builds a position for the default market fixture. Override `claimable`,
+ * `status`, and `currentValue` to drive the claim CTA.
  */
 export const buildMockPredictPosition = (
   overrides: Partial<PredictPosition> = {},


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Polymarket marks both winning and losing resolved positions as `redeemable`, because both outcome tokens can be redeemed even when a loser pays $0. Several Predict card and details surfaces treated that flag alone as evidence of claimable winnings, so resolved losses could display a Claim CTA and could be attributed to an unrelated open market.

This change centralizes the UI guard for claimable winnings as `status === WON && currentValue > 0`. Sport cards now filter their claim amount and displayed claimable picks through that guard. Market details use the same filtered positions before passing claim state or amounts to the standard, game, and crypto up/down action surfaces. Prop names were updated from the ambiguous `hasPositivePnl` to `hasClaimableWinnings`. Regression coverage verifies losing, open, redeemable, and zero-value positions do not qualify while a positive-value win does.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed Claim buttons appearing for resolved losing Predict positions

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: PRED-1246
Refs: PRED-797

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Predict claim CTA eligibility

  Scenario: resolved losing position does not show Claim
    Given a Predict account has a resolved position with redeemable true, status LOST, and currentValue 0
    When the user views the market card and market details
    Then no Claim CTA is displayed for that position or market

  Scenario: unrelated open position does not inherit a Claim CTA
    Given the account has an open position and one or more resolved losing positions
    When the user views the open market card or game details
    Then no Claim CTA is attributed to the open market

  Scenario: resolved winning position shows Claim
    Given a Predict account has a claimable position with status WON and currentValue greater than 0
    When the user views the market card or market details
    Then the Claim CTA is displayed with the winning amount
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A: This is a conditional visibility fix covered by unit and component-view regression tests; no new UI was introduced.

### **Before**

N/A: A resolved losing position could display a Claim CTA.

### **After**

N/A: Only positive-value positions with status WON display a Claim CTA.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - N/A: This change only narrows a synchronous position eligibility predicate and adds no performance-sensitive behavior.
- [x] I've tested with a power user scenario
  - N/A: The behavior is independent of account size; regression tests cover mixed losing and winning position inputs.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A: No new asynchronous or performance-sensitive operation was added.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
