### PR TITLE
feat: instrument Deeplink Ready CUF for cold-start deeplink navigation

### DIFF
--- a/app/components/Views/Login/index.tsx
+++ b/app/components/Views/Login/index.tsx
@@ -104,6 +104,11 @@ import {
   startHomepageReadyTrace,
   type HomepageReadyTraceToken,
 } from '../../../core/Performance/HomepageReady';
+import {
+  cancelDeeplinkReadyTrace,
+  startDeeplinkReadyTrace,
+  type DeeplinkReadyTraceToken,
+} from '../../../core/Performance/DeeplinkReady';
 
 interface LoginRouteParams {
   locked: boolean;
@@ -318,6 +323,13 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
         source: 'unlock',
         appStartType: loginPerformanceTags.current.app_start_type,
       });
+    // Sibling CUF: no-ops unless this launch is resolving a deeplink, in which
+    // case the user lands on the deeplink destination rather than Home.
+    const deeplinkReadyTraceToken: DeeplinkReadyTraceToken | null =
+      startDeeplinkReadyTrace({
+        source: 'unlock',
+        appStartType: loginPerformanceTags.current.app_start_type,
+      });
     endTrace({
       name: TraceName.LoginUserInteraction,
       data: getLoginInteractionEndData(),
@@ -364,6 +376,10 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
         reason: 'unlock_failed',
         traceToken: homepageReadyTraceToken,
       });
+      cancelDeeplinkReadyTrace({
+        reason: 'unlock_failed',
+        traceToken: deeplinkReadyTraceToken,
+      });
       await handleLoginError(loginErr as Error);
     }
     setLoading(false);
@@ -390,6 +406,13 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
         source: 'unlock',
         appStartType: loginPerformanceTags.current.app_start_type,
       });
+    // Sibling CUF: no-ops unless this launch is resolving a deeplink, in which
+    // case the user lands on the deeplink destination rather than Home.
+    const deeplinkReadyTraceToken: DeeplinkReadyTraceToken | null =
+      startDeeplinkReadyTrace({
+        source: 'unlock',
+        appStartType: loginPerformanceTags.current.app_start_type,
+      });
     endTrace({
       name: TraceName.LoginUserInteraction,
       data: getLoginInteractionEndData(),
@@ -411,6 +434,10 @@ const Login: React.FC<LoginProps> = ({ saveOnboardingEvent }) => {
       cancelHomepageReadyTrace({
         reason: 'unlock_failed',
         traceToken: homepageReadyTraceToken,
+      });
+      cancelDeeplinkReadyTrace({
+        reason: 'unlock_failed',
+        traceToken: deeplinkReadyTraceToken,
       });
       await handleLoginError(loginerror as Error);
     }

--- a/app/components/Views/OAuthRehydration/index.tsx
+++ b/app/components/Views/OAuthRehydration/index.tsx
@@ -66,6 +66,11 @@ import {
   startHomepageReadyTrace,
   type HomepageReadyTraceToken,
 } from '../../../core/Performance/HomepageReady';
+import {
+  cancelDeeplinkReadyTrace,
+  startDeeplinkReadyTrace,
+  type DeeplinkReadyTraceToken,
+} from '../../../core/Performance/DeeplinkReady';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { getLoginAppStartType } from '../Login/loginPerformanceTags';
 import { useNetInfo } from '@react-native-community/netinfo';
@@ -566,11 +571,18 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
       biometrics: biometryChoice,
     });
     let homepageReadyTraceToken: HomepageReadyTraceToken | null = null;
+    let deeplinkReadyTraceToken: DeeplinkReadyTraceToken | null = null;
 
     try {
       if (finalLoading) return;
 
       homepageReadyTraceToken = startHomepageReadyTrace({
+        source: 'unlock',
+        appStartType: getLoginAppStartType(),
+      });
+      // Sibling CUF: no-ops unless this launch is resolving a deeplink, in which
+      // case the user lands on the deeplink destination rather than Home.
+      deeplinkReadyTraceToken = startDeeplinkReadyTrace({
         source: 'unlock',
         appStartType: getLoginAppStartType(),
       });
@@ -654,6 +666,10 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
         reason: 'unlock_failed',
         traceToken: homepageReadyTraceToken,
       });
+      cancelDeeplinkReadyTrace({
+        reason: 'unlock_failed',
+        traceToken: deeplinkReadyTraceToken,
+      });
       await handleLoginError(ensureError(loginErr, 'Rehydrate login failed'));
       if (passwordLoginAttemptTraceCtxRef.current) {
         endTrace({
@@ -680,11 +696,18 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
 
   const newGlobalPasswordLogin = useCallback(async () => {
     let homepageReadyTraceToken: HomepageReadyTraceToken | null = null;
+    let deeplinkReadyTraceToken: DeeplinkReadyTraceToken | null = null;
 
     try {
       if (finalLoading) return;
 
       homepageReadyTraceToken = startHomepageReadyTrace({
+        source: 'unlock',
+        appStartType: getLoginAppStartType(),
+      });
+      // Sibling CUF: no-ops unless this launch is resolving a deeplink, in which
+      // case the user lands on the deeplink destination rather than Home.
+      deeplinkReadyTraceToken = startDeeplinkReadyTrace({
         source: 'unlock',
         appStartType: getLoginAppStartType(),
       });
@@ -724,6 +747,10 @@ const OAuthRehydration: React.FC<OAuthRehydrationProps> = ({
       cancelHomepageReadyTrace({
         reason: 'unlock_failed',
         traceToken: homepageReadyTraceToken,
+      });
+      cancelDeeplinkReadyTrace({
+        reason: 'unlock_failed',
+        traceToken: deeplinkReadyTraceToken,
       });
       await handleLoginError(
         ensureError(loginErr, 'Global password login failed'),

--- a/app/components/Views/TrendingView/tabs/NowTab.test.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.test.tsx
@@ -193,6 +193,12 @@ jest.mock('../../../UI/WhatsHappening', () => ({
   default: jest.fn(() => null),
 }));
 
+const mockEndDeeplinkReadyTrace = jest.fn();
+jest.mock('../../../../core/Performance/DeeplinkReady', () => ({
+  endDeeplinkReadyTrace: (options: unknown) =>
+    mockEndDeeplinkReadyTrace(options),
+}));
+
 import { useSelector } from 'react-redux';
 import { selectPerpsEnabledFlag } from '../../../UI/Perps';
 import { selectPredictEnabledFlag } from '../../../UI/Predict';
@@ -750,5 +756,188 @@ describe('NowTab — section ordering', () => {
       'explore-section-crypto_movers',
       'explore-section-stocks',
     ]);
+  });
+});
+
+describe('NowTab — Deeplink Ready CUF', () => {
+  const arrangeEmptyFeeds = () => {
+    const mocks = arrangeMocks();
+    mocks.usePredictionsFeed.mockReturnValue({
+      data: [],
+      isLoading: true,
+      refetch: jest.fn(),
+    });
+    mocks.usePerpsFeed.mockReturnValue({
+      data: [],
+      isLoading: true,
+      refetch: jest.fn(),
+      defaultSortOptionId: 'priceChange',
+    });
+    mocks.useTokensFeed.mockReturnValue({
+      data: [],
+      isLoading: true,
+      refetch: jest.fn(),
+    });
+    mocks.useStocksFeed.mockReturnValue({
+      data: [],
+      isLoading: true,
+      refetch: jest.fn(),
+    });
+    mocks.useWhatsHappening.mockReturnValue({
+      items: [],
+      isLoading: true,
+      error: null,
+      refresh: mockWhatsHappeningRefresh,
+    });
+
+    return mocks;
+  };
+
+  const arrangeSettledEmptyFeeds = () => {
+    const mocks = arrangeEmptyFeeds();
+    mocks.usePredictionsFeed.mockReturnValue({
+      data: [],
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+    mocks.usePerpsFeed.mockReturnValue({
+      data: [],
+      isLoading: false,
+      refetch: jest.fn(),
+      defaultSortOptionId: 'priceChange',
+    });
+    mocks.useTokensFeed.mockReturnValue({
+      data: [],
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+    mocks.useStocksFeed.mockReturnValue({
+      data: [],
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+    mocks.useWhatsHappening.mockReturnValue({
+      items: [],
+      isLoading: false,
+      error: null,
+      refresh: mockWhatsHappeningRefresh,
+    });
+
+    return mocks;
+  };
+
+  const arrangeSettledFilledFeeds = () => {
+    const mocks = arrangeSettledEmptyFeeds();
+    mocks.useTokensFeed.mockReturnValue({
+      data: [
+        {
+          assetId: 'eip155:1/erc20:0x1',
+          symbol: 'ONE',
+          priceChangePct: { h1: '1.23' },
+        },
+      ] as never,
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+
+    return mocks;
+  };
+
+  it('does not end the CUF while every section is still a skeleton', () => {
+    arrangeEmptyFeeds();
+
+    renderNowTab();
+
+    expect(mockEndDeeplinkReadyTrace).not.toHaveBeenCalled();
+  });
+
+  it('does not end the CUF while a single feed is still loading', () => {
+    const mocks = arrangeSettledFilledFeeds();
+    mocks.useStocksFeed.mockReturnValue({
+      data: [],
+      isLoading: true,
+      refetch: jest.fn(),
+    });
+
+    renderNowTab();
+
+    expect(mockEndDeeplinkReadyTrace).not.toHaveBeenCalled();
+  });
+
+  it('ends the CUF as filled once every feed has settled', () => {
+    arrangeSettledFilledFeeds();
+
+    renderNowTab();
+
+    expect(mockEndDeeplinkReadyTrace).toHaveBeenCalledWith({
+      route: 'trending',
+      contentState: 'filled',
+    });
+  });
+
+  it('ends the CUF as empty once every feed has settled with no rows', () => {
+    arrangeSettledEmptyFeeds();
+
+    renderNowTab();
+
+    expect(mockEndDeeplinkReadyTrace).toHaveBeenCalledWith({
+      route: 'trending',
+      contentState: 'empty',
+    });
+  });
+
+  it('ends the CUF when the last feed resolves after the first render', () => {
+    const mocks = arrangeEmptyFeeds();
+
+    const { rerender } = renderNowTab();
+
+    expect(mockEndDeeplinkReadyTrace).not.toHaveBeenCalled();
+
+    // Every feed settles; crypto movers is the one that came back with rows.
+    mocks.usePredictionsFeed.mockReturnValue({
+      data: [],
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+    mocks.usePerpsFeed.mockReturnValue({
+      data: [],
+      isLoading: false,
+      refetch: jest.fn(),
+      defaultSortOptionId: 'priceChange',
+    });
+    mocks.useStocksFeed.mockReturnValue({
+      data: [],
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+    mocks.useWhatsHappening.mockReturnValue({
+      items: [],
+      isLoading: false,
+      error: null,
+      refresh: mockWhatsHappeningRefresh,
+    });
+    mocks.useTokensFeed.mockReturnValue({
+      data: [
+        {
+          assetId: 'eip155:1/erc20:0x1',
+          symbol: 'ONE',
+          priceChangePct: { h1: '1.23' },
+        },
+      ] as never,
+      isLoading: false,
+      refetch: jest.fn(),
+    });
+    rerender(
+      <NavigationContainer>
+        <ExploreActiveTabProvider activeTab={'Now' as ExploreTabName}>
+          <NowTab {...defaultTabProps} />
+        </ExploreActiveTabProvider>
+      </NavigationContainer>,
+    );
+
+    expect(mockEndDeeplinkReadyTrace).toHaveBeenCalledWith({
+      route: 'trending',
+      contentState: 'filled',
+    });
   });
 });

--- a/app/components/Views/TrendingView/tabs/NowTab.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.tsx
@@ -61,6 +61,8 @@ import {
   useWhatsHappening,
 } from '../../../UI/WhatsHappening/hooks';
 import { selectWhatsHappeningEnabled } from '../../../../selectors/featureFlagController/whatsHappening';
+import { ACTIONS } from '../../../../constants/deeplinks';
+import { endDeeplinkReadyTrace } from '../../../../core/Performance/DeeplinkReady';
 
 interface PerpsBlockProps {
   refresh: TabProps['refresh'];
@@ -272,6 +274,37 @@ const NowTabContent: React.FC<TabProps> = ({
     ),
     [],
   );
+
+  // Deeplink CUF end signal: the whole tab has stopped loading, so every section
+  // shows its final state rather than a skeleton. A feed that is flagged off or
+  // legitimately empty still reports `isLoading: false`, so it cannot stall the
+  // span. Safe against a mount-time close because crypto movers starts out
+  // loading (`useTrendingRequest` seeds `isLoading` true), so this cannot be true
+  // on the first render.
+  const isSettled =
+    !whatsHappening.isLoading &&
+    !displayedPredictions.isLoading &&
+    !perpsFeed.isLoading &&
+    !cryptoMovers.isLoading &&
+    !stocks.isLoading;
+
+  // Reads row counts rather than the `show*` flags below, which stay true while
+  // a section is still a skeleton.
+  const hasContent =
+    whatsHappening.items.length > 0 ||
+    displayedPredictions.data.length > 0 ||
+    perpsFeed.data.length > 0 ||
+    cryptoMovers.data.length > 0 ||
+    stocks.data.length > 0;
+
+  useEffect(() => {
+    if (isSettled) {
+      endDeeplinkReadyTrace({
+        route: ACTIONS.TRENDING,
+        contentState: hasContent ? 'filled' : 'empty',
+      });
+    }
+  }, [isSettled, hasContent]);
 
   const showWhatsHappening =
     isWhatsHappeningEnabled && isWhatsHappeningSectionVisible(whatsHappening);

--- a/app/core/AppStateEventListener.ts
+++ b/app/core/AppStateEventListener.ts
@@ -79,9 +79,20 @@ export class AppStateEventListener {
   private openedFromPushAt = 0;
   private openedFromPush: PushOpenDetails | null = null;
   private lastAppState: AppStateStatus = AppState.currentState;
+  private hasResumedFromBackground = false;
 
   constructor() {
     this.lastAppState = AppState.currentState;
+  }
+
+  /**
+   * True while the app is still in the session it was launched in — i.e. it has
+   * never come back from the background. Same distinction `App Opened` reports
+   * as {@link AppOpenedType.ColdStart} vs {@link AppOpenedType.WarmStart}, but
+   * readable synchronously instead of only inside the delayed event.
+   */
+  public get isColdStartSession(): boolean {
+    return !this.hasResumedFromBackground;
   }
 
   start() {
@@ -156,6 +167,7 @@ export class AppStateEventListener {
     // Transitioning from inactive (e.g. system permission dialogs, incoming calls)
     // back to active should NOT count as the user opening the app.
     if (nextAppState === 'active' && this.lastAppState === 'background') {
+      this.hasResumedFromBackground = true;
       // delay to allow time for the deeplink to be set
       setTimeout(() => {
         this.processAppStateChange(AppOpenedType.WarmStart);

--- a/app/core/DeeplinkManager/utils/startupDeeplinkNavigation.test.ts
+++ b/app/core/DeeplinkManager/utils/startupDeeplinkNavigation.test.ts
@@ -80,6 +80,16 @@ jest.mock('../../../util/Logger', () => ({
   error: jest.fn(),
 }));
 
+const mockStartDeeplinkReadyTrace = jest.fn();
+const mockCancelDeeplinkReadyTrace = jest.fn();
+
+jest.mock('../../Performance/DeeplinkReady', () => ({
+  startDeeplinkReadyTrace: (options: unknown) =>
+    mockStartDeeplinkReadyTrace(options),
+  cancelDeeplinkReadyTrace: (options: unknown) =>
+    mockCancelDeeplinkReadyTrace(options),
+}));
+
 describe('startupDeeplinkNavigation', () => {
   const intent: DeeplinkIntent = {
     target: {
@@ -157,6 +167,63 @@ describe('startupDeeplinkNavigation', () => {
 
     expect(mockExecuteStartupDeeplinkIntent).not.toHaveBeenCalled();
     expect(mockClearPendingDeeplink).toHaveBeenCalledTimes(1);
+  });
+
+  describe('deeplink CUF tracing', () => {
+    it('starts the CUF for unlocks that never render Login', async () => {
+      AppStateEventProcessor.pendingDeeplink =
+        'https://link.metamask.io/trending';
+
+      await navigateToPendingStartupDeeplink();
+
+      expect(mockStartDeeplinkReadyTrace).toHaveBeenCalledWith({
+        source: 'unlock',
+        appStartType: 'cold',
+      });
+      expect(mockCancelDeeplinkReadyTrace).not.toHaveBeenCalled();
+    });
+
+    it('does not start the CUF when there is nothing pending', async () => {
+      await navigateToPendingStartupDeeplink();
+
+      expect(mockStartDeeplinkReadyTrace).not.toHaveBeenCalled();
+    });
+
+    it('cancels the CUF when the user rejects the deeplink', async () => {
+      AppStateEventProcessor.pendingDeeplink =
+        'https://link.metamask.io/trending';
+      mockResolve.mockResolvedValueOnce(false);
+
+      await navigateToPendingStartupDeeplink();
+
+      expect(mockCancelDeeplinkReadyTrace).toHaveBeenCalledWith({
+        reason: 'rejected',
+      });
+    });
+
+    it('cancels the CUF when no intent resolves', async () => {
+      AppStateEventProcessor.pendingDeeplink =
+        'https://link.metamask.io/trending';
+      mockResolve.mockResolvedValueOnce(null);
+
+      await navigateToPendingStartupDeeplink();
+
+      expect(mockCancelDeeplinkReadyTrace).toHaveBeenCalledWith({
+        reason: 'unresolved',
+      });
+    });
+
+    it('cancels the CUF when resolution throws', async () => {
+      AppStateEventProcessor.pendingDeeplink =
+        'https://link.metamask.io/trending';
+      mockResolve.mockRejectedValueOnce(new Error('boom'));
+
+      await expect(navigateToPendingStartupDeeplink()).resolves.toBe(false);
+
+      expect(mockCancelDeeplinkReadyTrace).toHaveBeenCalledWith({
+        reason: 'error',
+      });
+    });
   });
 
   it('re-dispatches deeplink handling after default navigation when pending remains', () => {

--- a/app/core/DeeplinkManager/utils/startupDeeplinkNavigation.ts
+++ b/app/core/DeeplinkManager/utils/startupDeeplinkNavigation.ts
@@ -7,6 +7,10 @@ import NavigationService from '../../NavigationService';
 import ReduxService from '../../redux';
 import SharedDeeplinkManager from '../DeeplinkManager';
 import { executeStartupDeeplinkIntent } from './executeDeeplinkIntent';
+import {
+  cancelDeeplinkReadyTrace,
+  startDeeplinkReadyTrace,
+} from '../../Performance/DeeplinkReady';
 
 const scheduleAfterNavigation = (callback: () => void) => {
   if (typeof requestAnimationFrame === 'function') {
@@ -27,6 +31,10 @@ export const navigateToPendingStartupDeeplink = async (): Promise<boolean> => {
     AppStateEventProcessor.pendingDeeplinkSource ??
     AppConstants.DEEPLINKS.ORIGIN_DEEPLINK;
 
+  // Covers unlocks that never render Login — biometric auto-unlock is driven by
+  // the app-state saga. No-ops when an entry point already opened the span.
+  startDeeplinkReadyTrace({ source: 'unlock', appStartType: 'cold' });
+
   try {
     const intent = await SharedDeeplinkManager.resolve(deeplink, { origin });
     if (intent === false) {
@@ -34,10 +42,12 @@ export const navigateToPendingStartupDeeplink = async (): Promise<boolean> => {
       // rejected it. Clear the pending link so the Home fallback does not
       // redispatch the same deeplink and show the interstitial again.
       AppStateEventProcessor.clearPendingDeeplink();
+      cancelDeeplinkReadyTrace({ reason: 'rejected' });
       return false;
     }
 
     if (!intent) {
+      cancelDeeplinkReadyTrace({ reason: 'unresolved' });
       return false;
     }
 
@@ -48,6 +58,7 @@ export const navigateToPendingStartupDeeplink = async (): Promise<boolean> => {
 
     return handled;
   } catch (error) {
+    cancelDeeplinkReadyTrace({ reason: 'error' });
     Logger.error(
       error as Error,
       'DeeplinkManager: failed to navigate to pending startup deeplink',

--- a/app/core/Performance/DeeplinkReady.test.ts
+++ b/app/core/Performance/DeeplinkReady.test.ts
@@ -1,0 +1,250 @@
+import { endTrace, trace, TraceName, TraceOperation } from '../../util/trace';
+import { AppStateEventProcessor } from '../AppStateEventListener';
+import {
+  cancelDeeplinkReadyTrace,
+  endDeeplinkReadyTrace,
+  isDeeplinkReadyTraceActive,
+  resetDeeplinkReadyTraceForTesting,
+  startDeeplinkReadyTrace,
+} from './DeeplinkReady';
+
+jest.mock('../../util/trace', () => ({
+  trace: jest.fn(),
+  endTrace: jest.fn(),
+  TraceName: {
+    DeeplinkReady: 'Deeplink Ready',
+  },
+  TraceOperation: {
+    DeeplinkPerformance: 'deeplink.performance',
+  },
+  TRACES_CLEANUP_INTERVAL: 5 * 60 * 1000,
+}));
+
+jest.mock('../AppStateEventListener', () => ({
+  AppStateEventProcessor: {
+    isColdStartSession: true,
+    pendingDeeplink: null as string | null,
+  },
+}));
+
+const mockTrace = jest.mocked(trace);
+const mockEndTrace = jest.mocked(endTrace);
+const mockAppState = AppStateEventProcessor as unknown as {
+  isColdStartSession: boolean;
+  pendingDeeplink: string | null;
+};
+
+describe('DeeplinkReady', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetDeeplinkReadyTraceForTesting();
+    mockAppState.isColdStartSession = true;
+    mockAppState.pendingDeeplink = 'https://link.metamask.io/trending';
+  });
+
+  describe('startDeeplinkReadyTrace', () => {
+    it('starts an already-unlocked launch from the native launch timestamp', () => {
+      const startTime = 1_723_456_789_000;
+
+      const token = startDeeplinkReadyTrace({
+        source: 'app_open',
+        appStartType: 'cold',
+        startTime,
+      });
+
+      expect(token).not.toBeNull();
+      expect(mockTrace).toHaveBeenCalledWith({
+        name: TraceName.DeeplinkReady,
+        op: TraceOperation.DeeplinkPerformance,
+        startTime,
+        forceTransaction: true,
+        tags: {
+          start_source: 'app_open',
+          app_start_type: 'cold',
+          deeplink_route: 'trending',
+        },
+      });
+      expect(isDeeplinkReadyTraceActive()).toBe(true);
+    });
+
+    it('omits startTime for an unlock, so the span measures from submit', () => {
+      startDeeplinkReadyTrace({ source: 'unlock', appStartType: 'cold' });
+
+      expect(mockTrace.mock.calls[0][0]).not.toHaveProperty('startTime');
+      expect(mockTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tags: expect.objectContaining({ start_source: 'unlock' }),
+        }),
+      );
+    });
+
+    it('reads the route from a custom-scheme deeplink', () => {
+      mockAppState.pendingDeeplink = 'metamask://trending?tab=crypto';
+
+      startDeeplinkReadyTrace({ source: 'unlock', appStartType: 'cold' });
+
+      expect(mockTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tags: expect.objectContaining({ deeplink_route: 'trending' }),
+        }),
+      );
+    });
+
+    it.each([
+      ['no pending deeplink', null],
+      ['a route with no content marker', 'https://link.metamask.io/swap'],
+      ['an unparsable deeplink', 'not a url'],
+    ])('does not start for %s', (_label, pendingDeeplink) => {
+      mockAppState.pendingDeeplink = pendingDeeplink;
+
+      const token = startDeeplinkReadyTrace({
+        source: 'unlock',
+        appStartType: 'cold',
+      });
+
+      expect(token).toBeNull();
+      expect(mockTrace).not.toHaveBeenCalled();
+      expect(isDeeplinkReadyTraceActive()).toBe(false);
+    });
+
+    it('does not start outside the launch session', () => {
+      mockAppState.isColdStartSession = false;
+
+      expect(
+        startDeeplinkReadyTrace({ source: 'unlock', appStartType: 'cold' }),
+      ).toBeNull();
+      expect(mockTrace).not.toHaveBeenCalled();
+    });
+
+    it('lets a second entry point call in without replacing the open span', () => {
+      startDeeplinkReadyTrace({ source: 'unlock', appStartType: 'cold' });
+
+      const second = startDeeplinkReadyTrace({
+        source: 'app_open',
+        appStartType: 'cold',
+      });
+
+      expect(second).toBeNull();
+      expect(mockTrace).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('endDeeplinkReadyTrace', () => {
+    it('ends a filled destination successfully', () => {
+      startDeeplinkReadyTrace({ source: 'unlock', appStartType: 'cold' });
+
+      endDeeplinkReadyTrace({ route: 'trending', contentState: 'filled' });
+
+      expect(mockEndTrace).toHaveBeenCalledWith({
+        name: TraceName.DeeplinkReady,
+        data: {
+          success: true,
+          content_state: 'filled',
+          deeplink_route: 'trending',
+        },
+      });
+      expect(isDeeplinkReadyTraceActive()).toBe(false);
+    });
+
+    it('treats an empty destination as a completed flow', () => {
+      startDeeplinkReadyTrace({ source: 'unlock', appStartType: 'cold' });
+
+      endDeeplinkReadyTrace({ route: 'trending', contentState: 'empty' });
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            success: true,
+            content_state: 'empty',
+          }),
+        }),
+      );
+    });
+
+    it('reports an error state as a failure', () => {
+      startDeeplinkReadyTrace({ source: 'unlock', appStartType: 'cold' });
+
+      endDeeplinkReadyTrace({ route: 'trending', contentState: 'error' });
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            success: false,
+            content_state: 'error',
+          }),
+        }),
+      );
+    });
+
+    it('ignores a route other than the one being measured', () => {
+      startDeeplinkReadyTrace({ source: 'unlock', appStartType: 'cold' });
+
+      endDeeplinkReadyTrace({ route: 'rewards', contentState: 'filled' });
+
+      expect(mockEndTrace).not.toHaveBeenCalled();
+      expect(isDeeplinkReadyTraceActive()).toBe(true);
+    });
+
+    it('is a no-op when no span is open', () => {
+      endDeeplinkReadyTrace({ route: 'trending', contentState: 'filled' });
+
+      expect(mockEndTrace).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cancelDeeplinkReadyTrace', () => {
+    it('ends the span as a failure with a reason', () => {
+      startDeeplinkReadyTrace({ source: 'unlock', appStartType: 'cold' });
+
+      cancelDeeplinkReadyTrace({ reason: 'rejected' });
+
+      expect(mockEndTrace).toHaveBeenCalledWith({
+        name: TraceName.DeeplinkReady,
+        data: {
+          success: false,
+          reason: 'rejected',
+          deeplink_route: 'trending',
+        },
+      });
+      expect(isDeeplinkReadyTraceActive()).toBe(false);
+    });
+
+    it('only cancels the span its token belongs to', () => {
+      const token = startDeeplinkReadyTrace({
+        source: 'unlock',
+        appStartType: 'cold',
+      });
+
+      cancelDeeplinkReadyTrace({
+        reason: 'unlock_failed',
+        traceToken: (token as number) + 1,
+      });
+
+      expect(mockEndTrace).not.toHaveBeenCalled();
+      expect(isDeeplinkReadyTraceActive()).toBe(true);
+
+      cancelDeeplinkReadyTrace({ reason: 'unlock_failed', traceToken: token });
+
+      expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing when no span is open', () => {
+      cancelDeeplinkReadyTrace({ reason: 'error' });
+
+      expect(mockEndTrace).not.toHaveBeenCalled();
+    });
+
+    it('releases the guard so a retry can start its own span', () => {
+      startDeeplinkReadyTrace({ source: 'unlock', appStartType: 'cold' });
+      cancelDeeplinkReadyTrace({ reason: 'unlock_failed' });
+
+      const retry = startDeeplinkReadyTrace({
+        source: 'unlock',
+        appStartType: 'cold',
+      });
+
+      expect(retry).not.toBeNull();
+      expect(mockTrace).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/app/core/Performance/DeeplinkReady.ts
+++ b/app/core/Performance/DeeplinkReady.ts
@@ -1,0 +1,219 @@
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+  TRACES_CLEANUP_INTERVAL,
+} from '../../util/trace';
+import { AppStateEventProcessor } from '../AppStateEventListener';
+
+/**
+ * Deeplink Ready CUF — opening a deeplink while the app is closed, through to
+ * the destination showing usable content.
+ *
+ * Sibling of {@link ./HomepageReady}, which measures the same launch for users
+ * who land on Home. The two are mutually exclusive by construction: a cold
+ * launch that navigates elsewhere is discarded by
+ * `resolveColdHomepageReadyTrace({ isHomepageFocused: false })`.
+ *
+ * The unlock wait is excluded the same way Homepage Ready excludes it — the span
+ * starts at unlock submit rather than at process start, so the measurement stays
+ * machine time. Which entry point opened it is recorded as `start_source`.
+ *
+ * `app_open` (backdating to `Performance.appLaunchTime`) is intentionally not
+ * wired up. A cold launch always finds the vault locked by the time
+ * `SharedDeeplinkManager.start()` runs, so the only launches that would take that
+ * path are ones where Branch delivers the link *after* a manual unlock — where
+ * backdating would swallow the password wait, the exact thing this design
+ * excludes. Adding it back means mirroring Homepage Ready's queue/resolve pair
+ * (`queueColdHomepageReadyTrace` / `resolveColdHomepageReadyTrace`), not a
+ * one-line call. The trade-off is that a late-delivered deeplink goes
+ * unmeasured; under-measuring beats reporting a number inflated by human wait.
+ *
+ * Abandoned flows are deliberately left open rather than ended on a timer: the
+ * State of Quality query is `is_transaction:true transaction:"..."` with no
+ * `success` filter, so a span ended at an artificial timeout would be counted in
+ * the reported p90. `TRACES_CLEANUP_INTERVAL` marks those spans `trace.timed_out`
+ * and Sentry's `beforeSendTransaction` drops them.
+ */
+
+export type DeeplinkReadyContentState = 'filled' | 'empty' | 'error';
+export type DeeplinkReadyStartSource = 'app_open' | 'unlock';
+export type DeeplinkReadyAppStartType = 'cold' | 'warm';
+export type DeeplinkReadyTraceToken = number;
+
+/**
+ * Routes whose destination screen calls {@link endDeeplinkReadyTrace}.
+ *
+ * Starting the span for a route with no content marker would leave every one of
+ * its opens to expire unrecorded. Add a route here in the same change that adds
+ * its marker, never before.
+ */
+const INSTRUMENTED_ROUTES = new Set<string>(['trending']);
+
+interface StartDeeplinkReadyTraceOptions {
+  source: DeeplinkReadyStartSource;
+  appStartType: DeeplinkReadyAppStartType;
+  startTime?: number;
+}
+
+interface EndDeeplinkReadyTraceOptions {
+  route: string;
+  contentState: DeeplinkReadyContentState;
+}
+
+interface CancelDeeplinkReadyTraceOptions {
+  reason: 'unlock_failed' | 'rejected' | 'unresolved' | 'error';
+  traceToken?: DeeplinkReadyTraceToken | null;
+}
+
+let startedAt: number | null = null;
+let activeTraceToken: DeeplinkReadyTraceToken | null = null;
+let activeRoute: string | null = null;
+let nextTraceToken = 0;
+
+/**
+ * The action segment of the pending deeplink, when it is one we measure.
+ * `https://link.metamask.io/trending?tab=crypto` and `metamask://trending` both
+ * resolve to `trending`.
+ */
+const pendingInstrumentedRoute = (): string | null => {
+  const uri = AppStateEventProcessor.pendingDeeplink;
+  if (!uri) {
+    return null;
+  }
+
+  try {
+    const url = new URL(uri);
+    // Custom-scheme links carry the action as the host rather than the path.
+    const route = url.pathname.split('/')[1] || url.hostname;
+    return route && INSTRUMENTED_ROUTES.has(route) ? route : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Returns whether an entry point has already started the Deeplink Ready CUF.
+ */
+export const isDeeplinkReadyTraceActive = () => startedAt !== null;
+
+/**
+ * Starts the deeplink-to-content CUF, if the launch is one we measure.
+ *
+ * No-ops unless the app is still in the session it launched in and a pending
+ * deeplink targets an instrumented route. The in-flight guard lets the unlock
+ * and app-open entry points both call this without replacing each other's span,
+ * matching `startHomepageReadyTrace`.
+ */
+export const startDeeplinkReadyTrace = ({
+  source,
+  appStartType,
+  startTime,
+}: StartDeeplinkReadyTraceOptions): DeeplinkReadyTraceToken | null => {
+  if (!AppStateEventProcessor.isColdStartSession) {
+    return null;
+  }
+
+  const route = pendingInstrumentedRoute();
+  if (route === null) {
+    return null;
+  }
+
+  const now = Date.now();
+  if (startedAt !== null && now - startedAt < TRACES_CLEANUP_INTERVAL) {
+    return null;
+  }
+
+  startedAt = now;
+  activeRoute = route;
+  nextTraceToken += 1;
+  activeTraceToken = nextTraceToken;
+  trace({
+    name: TraceName.DeeplinkReady,
+    op: TraceOperation.DeeplinkPerformance,
+    ...(startTime === undefined ? {} : { startTime }),
+    // `UI Startup` is still open at this point in a cold launch, so the span
+    // has to be forced into its own trace to be queryable as a transaction.
+    forceTransaction: true,
+    tags: {
+      start_source: source,
+      app_start_type: appStartType,
+      deeplink_route: route,
+    },
+  });
+  return activeTraceToken;
+};
+
+/**
+ * Ends the CUF once the deeplink destination has rendered a usable filled,
+ * empty, or error state.
+ *
+ * Call this on data having settled, never on mount — a condition already true on
+ * the first render closes the span at ~0 ms and reads as a perfect score.
+ *
+ * @param route - The destination's route, matched against the one that opened
+ * the span so a later in-app navigation cannot close another route's flow.
+ */
+export const endDeeplinkReadyTrace = ({
+  route,
+  contentState,
+}: EndDeeplinkReadyTraceOptions) => {
+  if (startedAt === null || route !== activeRoute) {
+    return;
+  }
+
+  endTrace({
+    name: TraceName.DeeplinkReady,
+    data: {
+      success: contentState !== 'error',
+      content_state: contentState,
+      deeplink_route: route,
+    },
+  });
+  startedAt = null;
+  activeTraceToken = null;
+  activeRoute = null;
+};
+
+/**
+ * Ends an in-flight CUF that cannot reach the destination — a failed unlock, or
+ * a deeplink the app declined to act on.
+ *
+ * Releasing the guard matters as much as the span: a retry has to start from its
+ * own entry point rather than inheriting time from the failed attempt.
+ *
+ * @param traceToken - When given, the cancel only applies to that span. Omit it
+ * for terminal failures that are not tied to a specific entry point.
+ */
+export const cancelDeeplinkReadyTrace = ({
+  reason,
+  traceToken,
+}: CancelDeeplinkReadyTraceOptions) => {
+  if (startedAt === null) {
+    return;
+  }
+
+  if (traceToken !== undefined && traceToken !== activeTraceToken) {
+    return;
+  }
+
+  endTrace({
+    name: TraceName.DeeplinkReady,
+    data: {
+      success: false,
+      reason,
+      ...(activeRoute === null ? {} : { deeplink_route: activeRoute }),
+    },
+  });
+  startedAt = null;
+  activeTraceToken = null;
+  activeRoute = null;
+};
+
+export const resetDeeplinkReadyTraceForTesting = () => {
+  startedAt = null;
+  activeTraceToken = null;
+  activeRoute = null;
+  nextTraceToken = 0;
+};

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -273,6 +273,8 @@ export enum TraceName {
   MoneyHomeActivityTimeToContent = 'Money Home Activity Time To Content',
   MoneyHomeEarningsTimeToContent = 'Money Home Earnings Time To Content',
   MoneyHomeApyTimeToContent = 'Money Home APY Time To Content',
+  // Deeplink Performance
+  DeeplinkReady = 'Deeplink Ready',
 }
 
 export enum TraceOperation {
@@ -284,6 +286,7 @@ export enum TraceOperation {
   UIStartup = 'ui.startup',
   HomepagePerformance = 'homepage.performance',
   NavInit = 'navigation.initialization',
+  DeeplinkPerformance = 'deeplink.performance',
   NetworkSwitch = 'network.switch',
   SwitchBuiltInNetwork = 'switch.to.built.in.network',
   SwitchCustomNetwork = 'switch.to.custom.network',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

**Why:** Didier's mobile performance initiative expects every team to instrument one Critical User Flow (CUF). In the [State of Quality report](https://github.com/MetaMask/MetaMask-planning/blob/main/reports/state-of-quality/2026-08-11/state_of_quality.mobile.md), Engagement is currently listed as `no CUF mapped yet` — the only Growth team with no production performance signal. Christian proposed a deeplink navigation flow; Dylan agreed cold start alone is enough for v1.

Nothing on that path was instrumented: `app/util/trace.ts` had no deeplink or Explore trace name, and `app/components/Views/TrendingView/` contained zero `trace()` calls. What existed was analytics-only (`DEEP_LINK_USED`, `TRENDING_FEED_VIEWED` dwell time) — no timing.

**What:** a single Sentry transaction, `Deeplink Ready`, measuring a cold-start deeplink through to its destination showing usable content. It deliberately mirrors `app/core/Performance/HomepageReady.ts`, which is the direct sibling of this metric — same directory, same module-singleton shape, same guard/token mechanics, same tag and payload vocabulary. The two are mutually exclusive by construction: `resolveColdHomepageReadyTrace({ isHomepageFocused })` discards the Homepage Ready span when a cold launch navigates somewhere other than Home, which is exactly the deeplink case.

**The key design decision — excluding human wait.** A locked cold start puts the user on the Login screen, and that dwell would dominate p90 and make any budget meaningless. In one measured run the user sat on Login for **92 seconds**; measuring from process start would have reported ~104 s for a flow whose app-side work was 3.5 s. So the span starts where `HomepageReady` starts it — at unlock submit — and the entry point is recorded as a `start_source` tag rather than being split into a second transaction.

| Aspect | Value |
| --- | --- |
| Transaction | `Deeplink Ready` (`TraceName.DeeplinkReady`) |
| Operation | `deeplink.performance` |
| Start | unlock submit — `Login` (password + biometric), `OAuthRehydration`, and a `startupDeeplinkNavigation` fallback for unlocks that never render Login (saga-driven biometric auto-unlock) |
| End | all five Now-tab feeds report `!isLoading` |
| Tags | `start_source`, `app_start_type`, `deeplink_route` |
| End data | `success`, `content_state` (`filled`/`empty`/`error`) |
| Cancel | `success: false` + `reason`: `unlock_failed` / `rejected` / `unresolved` / `error` |

Notes for reviewers:

- **`forceTransaction: true`** is the one deliberate divergence from `HomepageReady`. `UI Startup` is still open when a cold-launch deeplink is handled, so the span needs its own trace to be queryable as `is_transaction:true` — which is what the State of Quality query filters on.
- **No self-scheduled timeout**, on purpose. The report query applies no `success` filter, so a span ended at an artificial timeout would land in the reported p90. Abandoned flows are left to `TRACES_CLEANUP_INTERVAL`, which marks them `trace.timed_out` so `beforeSendTransaction` drops them.
- **Route registry.** `INSTRUMENTED_ROUTES` currently holds only `trending`. A route is added in the same change that adds its `endDeeplinkReadyTrace` call, never before — otherwise its spans would open and never close.
- **End condition reads row counts, not the `show*` flags**, which stay true while a section renders a skeleton. Ending on those would close the span at mount and silently measure ~0 ms.

Follow-up, not in this PR: the `teams.csv` row in `Consensys/skills`, which needs a production p90 for `flow_budget_ms` and so has to ship first.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Instrumented cold-start deeplink navigation to Explore Trending with Sentry tracing

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

A dev build alone will not exercise this: `MM_SENTRY_DSN` is typically empty in `.js.env`, and the Expo dev-client intercepts `metamask://` links at launch. Point the DSN at the lab project (`test-metamask-mobile` / 2651591 — not prod 2299799, since the report query has no environment filter) and use the universal link, which arrives via `NSUserActivity`/Branch and bypasses the dev-launcher interception.

```gherkin
Feature: Deeplink Ready CUF

  Scenario: cold-start deeplink to Explore Trending emits a successful span
    Given MM_SENTRY_DSN points at test-metamask-mobile (2651591)
    And MetaMask is fully terminated (xcrun simctl terminate <udid> io.metamask.MetaMask)

    When user opens https://link.metamask.io/trending
    And user unlocks the wallet with their password
    Then the Explore Trending tab loads all of its sections
    And Sentry shows a "Deeplink Ready" transaction with is_transaction:true
    And the span carries start_source:unlock, app_start_type:cold, deeplink_route:trending
    And the span ends with success:true and content_state:filled
    And the duration excludes the time spent typing on the Login screen

  Scenario: failed unlock closes the span as a failure
    Given MetaMask is fully terminated
    And a cold-start deeplink to https://link.metamask.io/trending is pending

    When user submits an incorrect password
    Then a "Deeplink Ready" span ends with success:false and reason:unlock_failed
    And a subsequent successful unlock opens and completes its own span

  Scenario: deeplink to an uninstrumented route emits nothing
    Given MetaMask is fully terminated

    When user opens a deeplink for a route not in INSTRUMENTED_ROUTES
    Then no "Deeplink Ready" span is created
```

Verified over six cold-start runs on iOS (iPhone 17 simulator, iOS 26.5). Successful spans on the final definition: **4.93 s / 5.03 s / 5.30 s**, against a manual stopwatch of ~5 s — the instrumentation agrees with what a human sees. Two `unlock_failed` spans confirmed the cancel path and that the guard releases so a retry opens its own span. These are debug-build numbers (Metro-served JS) and are not a basis for `flow_budget_ms`.

Not yet exercised on Android or with a power-user wallet. The change is platform-agnostic JS with no native or list-rendering surface, so the risk is low, but the span boundaries have only been observed on iOS.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — no user-visible change. Before this PR the flow emitted no transaction; the State of Quality report shows `Growth | engagement | no CUF mapped yet`.

### **After**

N/A — no user-visible change. Evidence is the Sentry transaction:

```
https://metamask.sentry.io/explore/traces/?project=2651591&statsPeriod=24h&yAxes=p90%28span.duration%29&query=is_transaction%3Atrue+transaction%3A%22Deeplink+Ready%22
```

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
