### PR TITLE
feat(rewards): show lifetime equity-qualifying points on the VIP Total points card

### DIFF
--- a/app/components/UI/Rewards/Views/RewardsVipTiersView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipTiersView.test.tsx
@@ -259,8 +259,7 @@ const dashboardWithTiers: VipDashboardState = {
     },
   ],
   localizedText: {
-    equityLifetimePointsDescription:
-      'So far, a lifetime total of {points} points will contribute to your equity allocation.',
+    equityLifetimePointsDescription: 'Lifetime total: {points}',
     periodTitle: 'Jun 1 - Jun 30',
     memberIdTitle: 'Member ID',
     transactionsTitle: 'Transactions',

--- a/app/components/UI/Rewards/Views/RewardsVipTiersView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipTiersView.test.tsx
@@ -230,6 +230,7 @@ const dashboardWithTiers: VipDashboardState = {
     earned: 5_555_555,
     threshold: 7_777_777,
     percent: 71.4,
+    lifetimeQualifyingPoints: null,
   },
   tiers: [
     {
@@ -258,6 +259,8 @@ const dashboardWithTiers: VipDashboardState = {
     },
   ],
   localizedText: {
+    equityLifetimePointsDescription:
+      'So far, a lifetime total of {points} points will contribute to your equity allocation.',
     periodTitle: 'Jun 1 - Jun 30',
     memberIdTitle: 'Member ID',
     transactionsTitle: 'Transactions',

--- a/app/components/UI/Rewards/Views/RewardsVipView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipView.test.tsx
@@ -358,8 +358,7 @@ const defaultDashboard: VipDashboardState = {
     },
   ],
   localizedText: {
-    equityLifetimePointsDescription:
-      'So far, a lifetime total of {points} points will contribute to your equity allocation.',
+    equityLifetimePointsDescription: 'Lifetime total: {points}',
     periodTitle: 'Jun 1 - Jun 30',
     memberIdTitle: 'Member ID',
     transactionsTitle: 'Transactions',
@@ -772,8 +771,7 @@ describe('RewardsVipView', () => {
         ...defaultDashboard,
         program: { id: 'mock-vip-program', name: 'Acme Rewards Beta — Custom' },
         localizedText: {
-          equityLifetimePointsDescription:
-            'So far, a lifetime total of {points} points will contribute to your equity allocation.',
+          equityLifetimePointsDescription: 'Lifetime total: {points}',
           memberIdTitle: 'Member ID',
           transactionsTitle: 'Transactions',
           swapsFeeTitle: 'Swap fees',

--- a/app/components/UI/Rewards/Views/RewardsVipView.test.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipView.test.tsx
@@ -329,6 +329,7 @@ const defaultDashboard: VipDashboardState = {
     earned: 5_555_555,
     threshold: 7_777_777,
     percent: 71.4,
+    lifetimeQualifyingPoints: null,
   },
   tiers: [
     {
@@ -357,6 +358,8 @@ const defaultDashboard: VipDashboardState = {
     },
   ],
   localizedText: {
+    equityLifetimePointsDescription:
+      'So far, a lifetime total of {points} points will contribute to your equity allocation.',
     periodTitle: 'Jun 1 - Jun 30',
     memberIdTitle: 'Member ID',
     transactionsTitle: 'Transactions',
@@ -769,6 +772,8 @@ describe('RewardsVipView', () => {
         ...defaultDashboard,
         program: { id: 'mock-vip-program', name: 'Acme Rewards Beta — Custom' },
         localizedText: {
+          equityLifetimePointsDescription:
+            'So far, a lifetime total of {points} points will contribute to your equity allocation.',
           memberIdTitle: 'Member ID',
           transactionsTitle: 'Transactions',
           swapsFeeTitle: 'Swap fees',

--- a/app/components/UI/Rewards/Views/RewardsVipView.tsx
+++ b/app/components/UI/Rewards/Views/RewardsVipView.tsx
@@ -456,6 +456,9 @@ const RewardsVipViewContent: React.FC = () => {
                 equityUnlockedDescription={
                   dashboard.localizedText.equityUnlockedDescription
                 }
+                equityLifetimePointsDescription={
+                  dashboard.localizedText.equityLifetimePointsDescription
+                }
               />
               <VipEquityMultiplierSection
                 failedTitle={

--- a/app/components/UI/Rewards/components/Vip/VipPointsSection.test.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipPointsSection.test.tsx
@@ -42,10 +42,13 @@ const baseProps: React.ComponentProps<typeof VipPointsSection> = {
   equityLockedDescription: 'Keep earning to unlock equity.',
   equityUnlockedTitle: 'Unlocked allocation',
   equityUnlockedDescription: 'Your equity allocation is unlocked.',
+  equityLifetimePointsDescription:
+    'So far, a lifetime total of {points} points will contribute to your equity allocation.',
   pointsAllocation: {
     earned: 5_555_555,
     threshold: 7_777_777,
     percent: 71.4,
+    lifetimeQualifyingPoints: null,
   },
 };
 
@@ -77,6 +80,7 @@ describe('VipPointsSection', () => {
           earned: 7_777_777,
           threshold: 7_777_777,
           percent: 100,
+          lifetimeQualifyingPoints: null,
         }}
       />,
     );
@@ -96,6 +100,7 @@ describe('VipPointsSection', () => {
           earned: 9_999_999,
           threshold: 7_777_777,
           percent: 128.6,
+          lifetimeQualifyingPoints: null,
         }}
       />,
     );
@@ -113,6 +118,7 @@ describe('VipPointsSection', () => {
           earned: 9_999_999,
           threshold: 7_777_777,
           percent: 128.6,
+          lifetimeQualifyingPoints: null,
         }}
       />,
     );
@@ -129,5 +135,63 @@ describe('VipPointsSection', () => {
     const { getByTestId } = render(<VipPointsSection {...baseProps} />);
 
     expect(getByTestId(VIP_POINTS_SECTION_TEST_IDS.RADIAL)).toBeOnTheScreen();
+  });
+
+  describe('lifetime equity-qualifying points sub-row', () => {
+    const unlockedWithLifetime = (lifetimeQualifyingPoints: number | null) => ({
+      earned: 7_777_777,
+      threshold: 7_777_777,
+      percent: 100,
+      lifetimeQualifyingPoints,
+    });
+
+    it('renders the formatted lifetime total when equity is unlocked', () => {
+      const { getByTestId } = render(
+        <VipPointsSection
+          {...baseProps}
+          pointsAllocation={unlockedWithLifetime(12_345_678)}
+        />,
+      );
+
+      expect(
+        getByTestId(VIP_POINTS_SECTION_TEST_IDS.LIFETIME_POINTS),
+      ).toHaveTextContent(
+        'So far, a lifetime total of 12,345,678 points will contribute to your equity allocation.',
+      );
+    });
+
+    it('is hidden while equity is still locked, even with a positive lifetime total', () => {
+      const { queryByTestId } = render(
+        <VipPointsSection
+          {...baseProps}
+          pointsAllocation={{
+            earned: 5_555_555,
+            threshold: 7_777_777,
+            percent: 71.4,
+            lifetimeQualifyingPoints: 12_345_678,
+          }}
+        />,
+      );
+
+      expect(
+        queryByTestId(VIP_POINTS_SECTION_TEST_IDS.LIFETIME_POINTS),
+      ).toBeNull();
+    });
+
+    it.each([
+      ['null (legacy backend mode)', null],
+      ['zero', 0],
+    ])('is hidden when the lifetime total is %s', (_label, value) => {
+      const { queryByTestId } = render(
+        <VipPointsSection
+          {...baseProps}
+          pointsAllocation={unlockedWithLifetime(value)}
+        />,
+      );
+
+      expect(
+        queryByTestId(VIP_POINTS_SECTION_TEST_IDS.LIFETIME_POINTS),
+      ).toBeNull();
+    });
   });
 });

--- a/app/components/UI/Rewards/components/Vip/VipPointsSection.test.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipPointsSection.test.tsx
@@ -42,8 +42,7 @@ const baseProps: React.ComponentProps<typeof VipPointsSection> = {
   equityLockedDescription: 'Keep earning to unlock equity.',
   equityUnlockedTitle: 'Unlocked allocation',
   equityUnlockedDescription: 'Your equity allocation is unlocked.',
-  equityLifetimePointsDescription:
-    'So far, a lifetime total of {points} points will contribute to your equity allocation.',
+  equityLifetimePointsDescription: 'Lifetime total: {points}',
   pointsAllocation: {
     earned: 5_555_555,
     threshold: 7_777_777,
@@ -156,7 +155,7 @@ describe('VipPointsSection', () => {
       expect(
         getByTestId(VIP_POINTS_SECTION_TEST_IDS.LIFETIME_POINTS),
       ).toHaveTextContent(
-        'So far, a lifetime total of 12,345,678 points will contribute to your equity allocation.',
+        'Your equity allocation is unlocked. Lifetime total: 12.35M',
       );
     });
 

--- a/app/components/UI/Rewards/components/Vip/VipPointsSection.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipPointsSection.tsx
@@ -8,7 +8,7 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import { formatCompactValue } from '../../utils/formatUtils';
+import { formatCompactValue, formatNumber } from '../../utils/formatUtils';
 import type { VipEquityAllocation } from '../../../../../core/Engine/controllers/rewards-controller/types';
 import VipCircularProgress from './VipCircularProgress';
 
@@ -18,7 +18,12 @@ export const VIP_POINTS_SECTION_TEST_IDS = {
   RADIAL: 'vip-points-section-radial',
   RADIAL_PROGRESS: 'vip-points-section-radial-progress',
   RADIAL_LABEL: 'vip-points-section-radial-label',
+  LIFETIME_POINTS: 'vip-points-section-lifetime-points',
 } as const;
+
+/** Replaced client-side with the formatted lifetime figure — the server owns
+ * the copy, the client owns number formatting for this card. */
+const POINTS_PLACEHOLDER = '{points}';
 
 interface VipPointsSectionProps {
   pointsAllocation: VipEquityAllocation;
@@ -27,6 +32,7 @@ interface VipPointsSectionProps {
   equityLockedDescription: string;
   equityUnlockedTitle: string;
   equityUnlockedDescription: string;
+  equityLifetimePointsDescription: string;
 }
 
 const VipPointsSection: React.FC<VipPointsSectionProps> = ({
@@ -36,6 +42,7 @@ const VipPointsSection: React.FC<VipPointsSectionProps> = ({
   equityLockedDescription,
   equityUnlockedTitle,
   equityUnlockedDescription,
+  equityLifetimePointsDescription,
 }) => {
   const isEquityUnlocked =
     pointsAllocation.earned >= pointsAllocation.threshold;
@@ -43,6 +50,19 @@ const VipPointsSection: React.FC<VipPointsSectionProps> = ({
   const description = isEquityUnlocked
     ? equityUnlockedDescription
     : equityLockedDescription;
+
+  // Only meaningful once equity is unlocked, and only worth showing when the
+  // VIP has actually accrued something — a "lifetime total of 0" would read as
+  // a bug rather than as reassurance.
+  const lifetimeQualifyingPoints = pointsAllocation.lifetimeQualifyingPoints;
+  const lifetimePointsText =
+    isEquityUnlocked &&
+    lifetimeQualifyingPoints !== null &&
+    lifetimeQualifyingPoints > 0
+      ? equityLifetimePointsDescription
+          .split(POINTS_PLACEHOLDER)
+          .join(formatNumber(lifetimeQualifyingPoints))
+      : null;
 
   return (
     <Box
@@ -68,6 +88,15 @@ const VipPointsSection: React.FC<VipPointsSectionProps> = ({
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {description}
           </Text>
+          {lifetimePointsText ? (
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+              testID={VIP_POINTS_SECTION_TEST_IDS.LIFETIME_POINTS}
+            >
+              {lifetimePointsText}
+            </Text>
+          ) : null}
         </Box>
         <VipCircularProgress
           percent={pointsAllocation.percent}

--- a/app/components/UI/Rewards/components/Vip/VipPointsSection.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipPointsSection.tsx
@@ -8,7 +8,7 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import { formatCompactValue, formatNumber } from '../../utils/formatUtils';
+import { formatCompactValue } from '../../utils/formatUtils';
 import type { VipEquityAllocation } from '../../../../../core/Engine/controllers/rewards-controller/types';
 import VipCircularProgress from './VipCircularProgress';
 
@@ -47,9 +47,6 @@ const VipPointsSection: React.FC<VipPointsSectionProps> = ({
   const isEquityUnlocked =
     pointsAllocation.earned >= pointsAllocation.threshold;
   const subtitle = isEquityUnlocked ? equityUnlockedTitle : equityLockedTitle;
-  const description = isEquityUnlocked
-    ? equityUnlockedDescription
-    : equityLockedDescription;
 
   // Only meaningful once equity is unlocked, and only worth showing when the
   // VIP has actually accrued something — a "lifetime total of 0" would read as
@@ -61,8 +58,14 @@ const VipPointsSection: React.FC<VipPointsSectionProps> = ({
     lifetimeQualifyingPoints > 0
       ? equityLifetimePointsDescription
           .split(POINTS_PLACEHOLDER)
-          .join(formatNumber(lifetimeQualifyingPoints))
+          .join(formatCompactValue(lifetimeQualifyingPoints))
       : null;
+
+  const description = isEquityUnlocked
+    ? lifetimePointsText
+      ? `${equityUnlockedDescription} ${lifetimePointsText}`
+      : equityUnlockedDescription
+    : equityLockedDescription;
 
   return (
     <Box
@@ -85,18 +88,17 @@ const VipPointsSection: React.FC<VipPointsSectionProps> = ({
           <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
             {subtitle}
           </Text>
-          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+          <Text
+            variant={TextVariant.BodySm}
+            color={TextColor.TextAlternative}
+            testID={
+              lifetimePointsText
+                ? VIP_POINTS_SECTION_TEST_IDS.LIFETIME_POINTS
+                : undefined
+            }
+          >
             {description}
           </Text>
-          {lifetimePointsText ? (
-            <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.TextAlternative}
-              testID={VIP_POINTS_SECTION_TEST_IDS.LIFETIME_POINTS}
-            >
-              {lifetimePointsText}
-            </Text>
-          ) : null}
         </Box>
         <VipCircularProgress
           percent={pointsAllocation.percent}

--- a/app/components/UI/Rewards/hooks/useVipDashboard.test.ts
+++ b/app/components/UI/Rewards/hooks/useVipDashboard.test.ts
@@ -119,6 +119,7 @@ describe('useVipDashboard', () => {
       earned: 5555555,
       threshold: 7777777,
       percent: 71.4,
+      lifetimeQualifyingPoints: null,
     },
     tiers: [
       {
@@ -135,6 +136,8 @@ describe('useVipDashboard', () => {
       },
     ],
     localizedText: {
+      equityLifetimePointsDescription:
+        'So far, a lifetime total of {points} points will contribute to your equity allocation.',
       periodTitle: 'Jun 1 - Jun 30',
       memberIdTitle: 'Member ID',
       transactionsTitle: 'Transactions',

--- a/app/components/UI/Rewards/hooks/useVipDashboard.test.ts
+++ b/app/components/UI/Rewards/hooks/useVipDashboard.test.ts
@@ -136,8 +136,7 @@ describe('useVipDashboard', () => {
       },
     ],
     localizedText: {
-      equityLifetimePointsDescription:
-        'So far, a lifetime total of {points} points will contribute to your equity allocation.',
+      equityLifetimePointsDescription: 'Lifetime total: {points}',
       periodTitle: 'Jun 1 - Jun 30',
       memberIdTitle: 'Member ID',
       transactionsTitle: 'Transactions',

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -7461,8 +7461,7 @@ describe('RewardsController', () => {
         },
       ],
       localizedText: {
-        equityLifetimePointsDescription:
-          'So far, a lifetime total of {points} points will contribute to your equity allocation.',
+        equityLifetimePointsDescription: 'Lifetime total: {points}',
         periodTitle: 'Jun 1 - Jun 30',
         memberIdTitle: 'Member ID',
         transactionsTitle: 'Transactions',
@@ -10877,8 +10876,7 @@ describe('RewardsController', () => {
               },
               tiers: [],
               localizedText: {
-                equityLifetimePointsDescription:
-                  'So far, a lifetime total of {points} points will contribute to your equity allocation.',
+                equityLifetimePointsDescription: 'Lifetime total: {points}',
                 periodTitle: 'Jun 1 - Jun 30',
                 memberIdTitle: 'Member ID',
                 transactionsTitle: 'Transactions',

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.test.ts
@@ -7444,6 +7444,7 @@ describe('RewardsController', () => {
         earned: 5555555,
         threshold: 7777777,
         percent: 71.4,
+        lifetimeQualifyingPoints: null,
       },
       tiers: [
         {
@@ -7460,6 +7461,8 @@ describe('RewardsController', () => {
         },
       ],
       localizedText: {
+        equityLifetimePointsDescription:
+          'So far, a lifetime total of {points} points will contribute to your equity allocation.',
         periodTitle: 'Jun 1 - Jun 30',
         memberIdTitle: 'Member ID',
         transactionsTitle: 'Transactions',
@@ -10866,9 +10869,16 @@ describe('RewardsController', () => {
                 referrals: 3,
                 referralsCap: 7,
               },
-              pointsAllocation: { earned: 0, threshold: 1, percent: 0 },
+              pointsAllocation: {
+                earned: 0,
+                threshold: 1,
+                lifetimeQualifyingPoints: null,
+                percent: 0,
+              },
               tiers: [],
               localizedText: {
+                equityLifetimePointsDescription:
+                  'So far, a lifetime total of {points} points will contribute to your equity allocation.',
                 periodTitle: 'Jun 1 - Jun 30',
                 memberIdTitle: 'Member ID',
                 transactionsTitle: 'Transactions',

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -4449,6 +4449,7 @@ describe('RewardsDataService', () => {
         earned: 5555555,
         threshold: 7777777,
         percent: 71.4,
+        lifetimeQualifyingPoints: null,
       },
       tiers: [
         {
@@ -4465,6 +4466,8 @@ describe('RewardsDataService', () => {
         },
       ],
       localizedText: {
+        equityLifetimePointsDescription:
+          'So far, a lifetime total of {points} points will contribute to your equity allocation.',
         periodTitle: 'Jun 1 - Jun 30',
         memberIdTitle: 'Member ID',
         transactionsTitle: 'Transactions',

--- a/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
+++ b/app/core/Engine/controllers/rewards-controller/services/rewards-data-service.test.ts
@@ -4466,8 +4466,7 @@ describe('RewardsDataService', () => {
         },
       ],
       localizedText: {
-        equityLifetimePointsDescription:
-          'So far, a lifetime total of {points} points will contribute to your equity allocation.',
+        equityLifetimePointsDescription: 'Lifetime total: {points}',
         periodTitle: 'Jun 1 - Jun 30',
         memberIdTitle: 'Member ID',
         transactionsTitle: 'Transactions',

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -85,6 +85,12 @@ export type VipEquityAllocation = {
   earned: number;
   threshold: number;
   percent: number;
+  // LIFETIME total of points counting toward equity: the 30d window as it stood
+  // when the equity tier was first reached, plus every day since spent at that
+  // tier or above (a re-climb after dropping below it does not count). Unlike
+  // `earned` it is never clamped and never falls as the rolling window advances.
+  // Null when the backend pilot has no configured equity tier.
+  lifetimeQualifyingPoints: number | null;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -130,6 +136,13 @@ export type VipLocalizedTextDto = {
   equityLockedDescription: string;
   equityUnlockedTitle: string;
   equityUnlockedDescription: string;
+  /**
+   * Sub-row copy for the lifetime equity-qualifying points figure. Carries a
+   * `{points}` placeholder that the client interpolates with the formatted
+   * `pointsAllocation.lifetimeQualifyingPoints`, because number formatting for
+   * this card is client-side.
+   */
+  equityLifetimePointsDescription: string;
   /**
    * Copy for when the equity multiplier request itself fails. Carried here
    * rather than on that response, which returns no strings when it fails.

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -138,9 +138,9 @@ export type VipLocalizedTextDto = {
   equityUnlockedDescription: string;
   /**
    * Sub-row copy for the lifetime equity-qualifying points figure. Carries a
-   * `{points}` placeholder that the client interpolates with the formatted
-   * `pointsAllocation.lifetimeQualifyingPoints`, because number formatting for
-   * this card is client-side.
+   * `{points}` placeholder that the client interpolates with
+   * `formatCompactValue(pointsAllocation.lifetimeQualifyingPoints)`, matching
+   * the ring beside it — number formatting for this card is client-side.
    */
   equityLifetimePointsDescription: string;
   /**

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -4913,6 +4913,7 @@ describe('setVipDashboard', () => {
       earned: 5555555,
       threshold: 7777777,
       percent: 71.4,
+      lifetimeQualifyingPoints: null,
     },
     tiers: [
       {
@@ -4929,6 +4930,8 @@ describe('setVipDashboard', () => {
       },
     ],
     localizedText: {
+      equityLifetimePointsDescription:
+        'So far, a lifetime total of {points} points will contribute to your equity allocation.',
       periodTitle: 'Jun 1 - Jun 30',
       memberIdTitle: 'Member ID',
       transactionsTitle: 'Transactions',

--- a/app/reducers/rewards/index.test.ts
+++ b/app/reducers/rewards/index.test.ts
@@ -4930,8 +4930,7 @@ describe('setVipDashboard', () => {
       },
     ],
     localizedText: {
-      equityLifetimePointsDescription:
-        'So far, a lifetime total of {points} points will contribute to your equity allocation.',
+      equityLifetimePointsDescription: 'Lifetime total: {points}',
       periodTitle: 'Jun 1 - Jun 30',
       memberIdTitle: 'Member ID',
       transactionsTitle: 'Transactions',

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -3236,6 +3236,7 @@ describe('Rewards selectors', () => {
         earned: 5555555,
         threshold: 7777777,
         percent: 71.4,
+        lifetimeQualifyingPoints: null,
       },
       tiers: [
         {
@@ -3252,6 +3253,8 @@ describe('Rewards selectors', () => {
         },
       ],
       localizedText: {
+        equityLifetimePointsDescription:
+          'So far, a lifetime total of {points} points will contribute to your equity allocation.',
         periodTitle: 'Jun 1 - Jun 30',
         memberIdTitle: 'Member ID',
         transactionsTitle: 'Transactions',

--- a/app/reducers/rewards/selectors.test.ts
+++ b/app/reducers/rewards/selectors.test.ts
@@ -3253,8 +3253,7 @@ describe('Rewards selectors', () => {
         },
       ],
       localizedText: {
-        equityLifetimePointsDescription:
-          'So far, a lifetime total of {points} points will contribute to your equity allocation.',
+        equityLifetimePointsDescription: 'Lifetime total: {points}',
         periodTitle: 'Jun 1 - Jun 30',
         memberIdTitle: 'Member ID',
         transactionsTitle: 'Transactions',


### PR DESCRIPTION
## **Description**

[RWDS-1524](https://consensyssoftware.atlassian.net/browse/RWDS-1524). The Total points card on the VIP dashboard shows a rolling 30-day figure. When a big trading day falls out of that window the number drops, and VIPs have been reading it as their equity being taken away. This adds a line under the existing description showing the lifetime total that counts toward their equity allocation — a number that never goes down.

The row renders only when equity is unlocked **and** the lifetime figure is above zero. A "lifetime total of 0" would read as a bug rather than as reassurance, and the figure is meaningless before equity unlocks.

Consumes the new `pointsAllocation.lifetimeQualifyingPoints` field and the new `localizedText.equityLifetimePointsDescription` string from `GET /vip/me` (backend PR: https://github.com/consensys-vertical-apps/va-mmcx-rewards/pull/759). Copy is server-owned like the rest of this card; the client only substitutes the `{points}` placeholder with the locale-formatted number, matching how the card already owns its own number rendering.

**⚠️ The copy and placement here are provisional and have not been confirmed by design.** This implements the verbal spec captured in RWDS-1524 as a starting point so the shape can be reviewed against real data — final wording and placement are still pending design review. Both are cheap to change: the wording lives in Contentful (no app release needed), and the row is a single `Text` in `VipPointsSection`.

Until the backend field ships and the pilot has `config.equityTierNumber` set, the field is `null` and the row simply does not render, so this is safe to land ahead of the backend.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: RWDS-1524

## **Manual testing steps**

1. Open the Rewards VIP dashboard as a VIP whose tier is at or above the equity tier.
2. On the Total points card, confirm a new line appears under the existing description reading "So far, a lifetime total of N points will contribute to your equity allocation.", with `N` locale-formatted (e.g. `12,345,678`).
3. Confirm the number is larger than, and independent of, the figure in the ring — it must not change when the rolling 30-day window advances.
4. As a VIP below the equity tier (locked state), confirm the line is absent.
5. With a backend returning `lifetimeQualifyingPoints: null` or `0`, confirm the line is absent and the rest of the card is unchanged.

## **Screenshots/Recordings**

Screenshots were not captured for this PR: emulator use is currently disabled by standing preference, so no simulator or device run was performed. There **is** a visual change (a new text row on the Total points card) — it is covered by unit tests asserting the rendered string and the show/hide gating, but it has not been visually verified on device. Worth an extra look during review.

### **Before**

N/A — not captured (see above).

### **After**

N/A — not captured (see above).

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[RWDS-1524]: https://consensyssoftware.atlassian.net/browse/RWDS-1524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3a830d894003822d1af43ee80d07c4a6dad6b748. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->