### PR TITLE
feat: add excludeRwaTokens prop to asset picker

### DIFF
--- a/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.ts
+++ b/app/components/UI/Bridge/Views/BatchSellTokenSelect/useBatchSellTokens.ts
@@ -10,9 +10,8 @@ import { flow } from 'lodash/fp';
 import { selectBatchSellDestStablecoinsByChain } from '../../../../../core/redux/slices/bridge';
 import { useTokensWithBalance } from '../../hooks/useTokensWithBalance';
 import { BridgeToken } from '../../types';
+import { filterOutRwaTokens } from '../../utils/filterOutRwaTokens';
 import { SUPPORTED_BATCH_SELL_CHAIN_IDS } from './BatchSellTokenSelect.utils';
-
-const ONDO_TOKENIZED_TOKEN_NAME = 'Ondo Tokenized';
 
 function removeStablecoinsFromSourceTokens({
   tokens,
@@ -52,16 +51,6 @@ function removeStablecoinsFromSourceTokens({
   });
 }
 
-function removeOndoTokenizedTokens(tokens: BridgeToken[]): BridgeToken[] {
-  return tokens.filter(
-    (token) => !token.name?.includes(ONDO_TOKENIZED_TOKEN_NAME),
-  );
-}
-
-function removeRwaTokens(tokens: BridgeToken[]): BridgeToken[] {
-  return tokens.filter((token) => !token.rwaData);
-}
-
 export function useBatchSellTokens() {
   const allWalletTokens = useTokensWithBalance({
     chainIds: SUPPORTED_BATCH_SELL_CHAIN_IDS,
@@ -76,8 +65,7 @@ export function useBatchSellTokens() {
             tokens,
             stablecoinsByChain,
           }),
-        removeOndoTokenizedTokens,
-        removeRwaTokens,
+        filterOutRwaTokens,
       )(allWalletTokens),
     [allWalletTokens, stablecoinsByChain],
   );

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -1290,6 +1290,49 @@ describe('BridgeTokenSelector', () => {
       expect(queryByTestId('token-MSFTX')).toBeNull();
     });
 
+    it('hides empty state while an all-RWA page still has a cursor to auto-load', async () => {
+      mockRouteParams = { type: 'source', excludeRwaTokens: true };
+      mockSearchTokensState = {
+        ...mockSearchTokensState,
+        searchResults: [createRwaPopularToken('MSFTX', 'Microsoft Corp')],
+        searchCursor: 'next-cursor',
+        currentSearchQuery: 'MSF',
+      };
+
+      const { getByTestId, queryByTestId, UNSAFE_getByType } =
+        renderWithReduxProvider(<BridgeTokenSelector />);
+      fireEvent.changeText(getByTestId('bridge-token-search-input'), 'MSF');
+
+      const { FlatList } = jest.requireActual('react-native');
+      await act(async () => {
+        UNSAFE_getByType(FlatList).props.onLayout({
+          nativeEvent: { layout: { height: 500 } },
+        });
+      });
+
+      await waitFor(() => {
+        expect(mockSearchTokens).toHaveBeenCalledWith('MSF', 'next-cursor');
+      });
+      expect(queryByTestId('bridge-token-selector-empty-state')).toBeNull();
+    });
+
+    it('shows empty state once an all-RWA search exhausts its cursor', async () => {
+      mockRouteParams = { type: 'source', excludeRwaTokens: true };
+      mockSearchTokensState = {
+        ...mockSearchTokensState,
+        searchResults: [createRwaPopularToken('MSFTX', 'Microsoft Corp')],
+        searchCursor: undefined,
+        currentSearchQuery: 'MSF',
+      };
+
+      const { getByTestId } = renderWithReduxProvider(<BridgeTokenSelector />);
+      fireEvent.changeText(getByTestId('bridge-token-search-input'), 'MSF');
+
+      await waitFor(() =>
+        expect(getByTestId('bridge-token-selector-empty-state')).toBeTruthy(),
+      );
+    });
+
     it.each([
       { excludeRwaTokens: undefined, isRwaVisible: true },
       { excludeRwaTokens: true, isRwaVisible: false },

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.test.tsx
@@ -144,6 +144,7 @@ const mockNavigationDispatch = jest.fn();
 let mockRouteParams: {
   type: 'source' | 'dest';
   enabledChainIds?: CaipChainId[];
+  excludeRwaTokens?: boolean;
 } = { type: 'source' };
 
 jest.mock('@react-navigation/native', () => ({
@@ -1201,6 +1202,138 @@ describe('BridgeTokenSelector', () => {
       const { getByTestId } = renderWithReduxProvider(<BridgeTokenSelector />);
       await waitFor(() => expect(getByTestId('token-USDC')).toBeTruthy());
     });
+  });
+
+  describe('RWA filtering', () => {
+    const createRwaPopularToken = (symbol: string, name: string) =>
+      ({
+        ...createMockPopularToken({
+          assetId: `eip155:1/erc20:0x${symbol.toLowerCase()}` as never,
+          symbol,
+          name,
+        }),
+        rwaData: { instrumentType: 'stock' },
+      }) as never;
+
+    it('keeps RWA tokens when excludeRwaTokens is not set', async () => {
+      mockPopularTokensState = {
+        popularTokens: [
+          createMockPopularToken({ symbol: 'USDC', name: 'USD Coin' }),
+          createRwaPopularToken('AAPLX', 'Apple Inc'),
+        ],
+        isLoading: false,
+      };
+
+      const { getByTestId } = renderWithReduxProvider(<BridgeTokenSelector />);
+
+      await waitFor(() => expect(getByTestId('token-USDC')).toBeTruthy());
+      expect(getByTestId('token-AAPLX')).toBeTruthy();
+    });
+
+    it('hides RWA popular tokens when excludeRwaTokens is set', async () => {
+      mockRouteParams = { type: 'source', excludeRwaTokens: true };
+      mockPopularTokensState = {
+        popularTokens: [
+          createMockPopularToken({ symbol: 'USDC', name: 'USD Coin' }),
+          createRwaPopularToken('AAPLX', 'Apple Inc'),
+        ],
+        isLoading: false,
+      };
+
+      const { getByTestId, queryByTestId } = renderWithReduxProvider(
+        <BridgeTokenSelector />,
+      );
+
+      await waitFor(() => expect(getByTestId('token-USDC')).toBeTruthy());
+      expect(queryByTestId('token-AAPLX')).toBeNull();
+    });
+
+    it('hides Ondo Tokenized popular tokens matched by name', async () => {
+      mockRouteParams = { type: 'source', excludeRwaTokens: true };
+      mockPopularTokensState = {
+        popularTokens: [
+          createMockPopularToken({ symbol: 'USDC', name: 'USD Coin' }),
+          createMockPopularToken({
+            assetId: 'eip155:1/erc20:0xondo' as never,
+            symbol: 'TSLAon',
+            name: 'Ondo Tokenized Tesla',
+          }),
+        ],
+        isLoading: false,
+      };
+
+      const { getByTestId, queryByTestId } = renderWithReduxProvider(
+        <BridgeTokenSelector />,
+      );
+
+      await waitFor(() => expect(getByTestId('token-USDC')).toBeTruthy());
+      expect(queryByTestId('token-TSLAon')).toBeNull();
+    });
+
+    it('hides RWA search results when excludeRwaTokens is set', async () => {
+      mockRouteParams = { type: 'source', excludeRwaTokens: true };
+      mockSearchTokensState = {
+        ...mockSearchTokensState,
+        searchResults: [
+          createSearchToken('WETH'),
+          createRwaPopularToken('MSFTX', 'Microsoft Corp'),
+        ],
+        currentSearchQuery: 'WET',
+      };
+
+      const { getByTestId, queryByTestId } = renderWithReduxProvider(
+        <BridgeTokenSelector />,
+      );
+      fireEvent.changeText(getByTestId('bridge-token-search-input'), 'WET');
+
+      await waitFor(() => expect(getByTestId('token-WETH')).toBeTruthy());
+      expect(queryByTestId('token-MSFTX')).toBeNull();
+    });
+
+    it.each([
+      { excludeRwaTokens: undefined, isRwaVisible: true },
+      { excludeRwaTokens: true, isRwaVisible: false },
+    ])(
+      'renders Ondo Tokenized watchlist tokens: $isRwaVisible when excludeRwaTokens is $excludeRwaTokens',
+      async ({ excludeRwaTokens, isRwaVisible }) => {
+        mockRouteParams = { type: 'source', excludeRwaTokens };
+        mockIsWatchlistEnabled = true;
+        mockUseTokenWatchlistQuery.mockReturnValue({
+          data: [
+            {
+              assetId: 'eip155:1/slip44:60',
+              name: 'Ethereum',
+              symbol: 'ETH',
+              decimals: 18,
+              balance: '1.5',
+              balanceFiat: 3000,
+              fiatCurrency: 'usd',
+              isInWallet: true,
+            },
+            {
+              assetId: 'eip155:1/erc20:0xondo',
+              name: 'Ondo Tokenized Tesla',
+              symbol: 'TSLAon',
+              decimals: 18,
+              balance: '2',
+              balanceFiat: 500,
+              fiatCurrency: 'usd',
+              isInWallet: true,
+            },
+          ],
+          isLoading: false,
+        });
+
+        const { getByTestId, queryByTestId } = renderWithReduxProvider(
+          <BridgeTokenSelector />,
+        );
+
+        fireEvent.press(getByTestId('bridge-watchlist-filter-watchlist'));
+
+        await waitFor(() => expect(getByTestId('token-ETH')).toBeTruthy());
+        expect(Boolean(queryByTestId('token-TSLAon'))).toBe(isRwaVisible);
+      },
+    );
   });
 
   describe('chain selection', () => {

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -950,9 +950,23 @@ export const BridgeTokenSelector: React.FC = () => {
     [],
   );
 
+  // A page whose results are all filtered out (e.g. RWAs) leaves the
+  // filtered results empty while a cursor for the next page still exists.
+  // The auto-load effect will keep fetching in that case, so the empty
+  // state must stay hidden until either results appear or the cursor is
+  // exhausted, otherwise "no tokens found" flashes/sticks mid-fetch.
+  const isAwaitingMoreSearchResults =
+    searchResultsWithBalance.length === 0 && Boolean(searchCursor);
+
   const renderEmptyState = useCallback(() => {
     if (isWatchlistListMode && hasWatchlistItems) {
-      if (isWatchlistLoading || !isValidSearch || isSearchLoading) {
+      if (
+        isWatchlistLoading ||
+        !isValidSearch ||
+        isSearchLoading ||
+        isLoadingMore ||
+        isAwaitingMoreSearchResults
+      ) {
         return null;
       }
 
@@ -964,8 +978,14 @@ export const BridgeTokenSelector: React.FC = () => {
       );
     }
 
-    // Only show empty state when search is active and not loading
-    if (!isValidSearch || isSearchLoading) {
+    // Only show empty state when search is active, not loading, and not
+    // waiting on additional pages to fill in filtered-out results.
+    if (
+      !isValidSearch ||
+      isSearchLoading ||
+      isLoadingMore ||
+      isAwaitingMoreSearchResults
+    ) {
       return null;
     }
 
@@ -981,6 +1001,8 @@ export const BridgeTokenSelector: React.FC = () => {
     isWatchlistLoading,
     isValidSearch,
     isSearchLoading,
+    isLoadingMore,
+    isAwaitingMoreSearchResults,
     styles.emptyStateContainer,
     NoSearchResultsIcon,
   ]);

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/BridgeTokenSelector.tsx
@@ -90,6 +90,7 @@ import {
   mapWatchlistTokenToBridgeToken,
 } from '../../utils/mapWatchlistTokenToBridgeToken';
 import { mergeBridgeTokensWithBalances } from '../../utils/mergeBridgeTokensWithBalances';
+import { filterOutRwaTokens } from '../../utils/filterOutRwaTokens';
 import { filterWatchlistBridgeTokens } from '../../utils/filterWatchlistBridgeTokens';
 import { prependWatchlistToSearchResults } from '../../utils/prependWatchlistToSearchResults';
 import { trackTokenListItemClicked } from '../../../Assets/watchlist/utils/trackTokenListItemClicked';
@@ -109,6 +110,11 @@ export interface BridgeTokenSelectorRouteParams {
    * of the default allowed chainRanking.
    */
   enabledChainIds?: CaipChainId[];
+  /**
+   * When true, real-world asset tokens are hidden from every list this
+   * picker renders (popular, search, and watchlist results).
+   */
+  excludeRwaTokens?: boolean;
 }
 
 const MIN_SEARCH_LENGTH = 3;
@@ -172,6 +178,15 @@ interface BridgeTokenSelectorSearchEmptyStateProps {
   containerStyle: StyleProp<ViewStyle>;
   NoSearchResultsIcon: React.ComponentType<{ width: number; height: number }>;
 }
+
+const useRwaFilteredTokens = (
+  tokens: BridgeToken[],
+  excludeRwaTokens: boolean,
+) =>
+  useMemo(
+    () => (excludeRwaTokens ? filterOutRwaTokens(tokens) : tokens),
+    [tokens, excludeRwaTokens],
+  );
 
 const BridgeTokenSelectorSearchEmptyState = React.memo(
   ({
@@ -240,6 +255,7 @@ export const BridgeTokenSelector: React.FC = () => {
   );
 
   const enabledChainIds = route.params?.enabledChainIds;
+  const excludeRwaTokens = route.params?.excludeRwaTokens ?? false;
   const enabledChainRanking = useSelector((state: RootState) =>
     selectAllowedChainRanking(state, enabledChainIds),
   );
@@ -519,13 +535,13 @@ export const BridgeTokenSelector: React.FC = () => {
   ]);
 
   // Use custom hook for merging balances
-  const popularTokensWithBalance = useTokensWithBalances(
-    popularTokens,
-    balancesByAssetId,
+  const popularTokensWithBalance = useRwaFilteredTokens(
+    useTokensWithBalances(popularTokens, balancesByAssetId),
+    excludeRwaTokens,
   );
-  const searchResultsWithBalance = useTokensWithBalances(
-    searchResults,
-    balancesByAssetId,
+  const searchResultsWithBalance = useRwaFilteredTokens(
+    useTokensWithBalances(searchResults, balancesByAssetId),
+    excludeRwaTokens,
   );
 
   const watchlistBridgeTokens = useMemo(() => {
@@ -550,10 +566,13 @@ export const BridgeTokenSelector: React.FC = () => {
           !assetIdsMatch(token.assetId, ARC_NATIVE_ASSET_ID_LEGACY),
       );
 
-    return filterWatchlistBridgeTokens(mappedTokens, {
-      selectedChainId,
-      searchQuery: isValidSearch ? searchString : undefined,
-    });
+    return filterWatchlistBridgeTokens(
+      excludeRwaTokens ? filterOutRwaTokens(mappedTokens) : mappedTokens,
+      {
+        selectedChainId,
+        searchQuery: isValidSearch ? searchString : undefined,
+      },
+    );
   }, [
     isWatchlistListMode,
     isValidSearch,
@@ -562,6 +581,7 @@ export const BridgeTokenSelector: React.FC = () => {
     watchlistData,
     balancesByAssetId,
     currentCurrency,
+    excludeRwaTokens,
   ]);
 
   const watchlistMergedSearchResults = useMemo(() => {
@@ -714,8 +734,11 @@ export const BridgeTokenSelector: React.FC = () => {
       searchCursor &&
       flatListHeight > 0
     ) {
+      // Measure the rows actually rendered, not the raw API page. A page whose
+      // results are all filtered out (e.g. RWAs) would otherwise look full and
+      // never fetch the next one.
       const estimatedContentHeight =
-        searchResults.length * ESTIMATED_ITEM_HEIGHT;
+        searchResultsWithBalance.length * ESTIMATED_ITEM_HEIGHT;
 
       // If estimated content doesn't fill the view, load more
       if (estimatedContentHeight < flatListHeight) {
@@ -725,6 +748,7 @@ export const BridgeTokenSelector: React.FC = () => {
   }, [
     isValidSearch,
     searchResults.length,
+    searchResultsWithBalance.length,
     isSearchLoading,
     isLoadingMore,
     searchCursor,

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -195,6 +195,10 @@ interface TokenInputAreaProps {
    * of the default allowed chainRanking.
    */
   enabledChainIds?: CaipChainId[];
+  /**
+   * When true, the token selector hides real-world asset tokens.
+   */
+  excludeRwaTokens?: boolean;
 }
 
 export const TokenInputArea = forwardRef<
@@ -229,6 +233,7 @@ export const TokenInputArea = forwardRef<
       amountTypeToggleTestID,
       showFiatAmountAsPrimary = false,
       enabledChainIds,
+      excludeRwaTokens,
     },
     ref,
   ) => {
@@ -289,6 +294,7 @@ export const TokenInputArea = forwardRef<
       navigation.navigate(Routes.BRIDGE.TOKEN_SELECTOR, {
         type: TokenSelectorType.Dest,
         enabledChainIds,
+        excludeRwaTokens,
       });
     };
 
@@ -297,6 +303,7 @@ export const TokenInputArea = forwardRef<
       navigation.navigate(Routes.BRIDGE.TOKEN_SELECTOR, {
         type: TokenSelectorType.Source,
         enabledChainIds,
+        excludeRwaTokens,
       });
     };
 

--- a/app/components/UI/Bridge/hooks/useInitialDestToken/useInitialDestToken.test.ts
+++ b/app/components/UI/Bridge/hooks/useInitialDestToken/useInitialDestToken.test.ts
@@ -154,6 +154,55 @@ describe('useInitialDestToken', () => {
     });
   });
 
+  it('sets the bip44 default pair dest asset when no source token is anchored yet', async () => {
+    // Fresh Swaps entry: useInitialSourceToken applies the pair's source asset,
+    // so the pair's dest asset is the matching half.
+    (selectBridgeViewMode as unknown as jest.Mock).mockReturnValue(
+      BridgeViewMode.Unified,
+    );
+    (selectChainId as unknown as jest.Mock).mockReturnValue('0x1');
+    (selectSourceToken as unknown as jest.Mock).mockReturnValue(undefined);
+
+    renderHookWithProvider(() => useInitialDestToken(), {
+      state: initialState,
+    });
+
+    await waitFor(() => {
+      expect(setDestToken).toHaveBeenCalledWith(
+        expect.objectContaining({ symbol: 'mUSD', chainId: '0x1' }),
+      );
+    });
+  });
+
+  it('keeps the dest token on the source chain when the source is only set in Redux', async () => {
+    // Switching Bridge tabs clears the dest token but leaves the source
+    // anchored to the previous tab's chain. The bip44 pair's dest asset always
+    // lives on Ethereum, so pairing it with such a source would silently turn a
+    // same-chain swap into a cross-chain bridge.
+    (selectBridgeViewMode as unknown as jest.Mock).mockReturnValue(
+      BridgeViewMode.Unified,
+    );
+    (selectChainId as unknown as jest.Mock).mockReturnValue('0x1');
+    (selectSourceToken as unknown as jest.Mock).mockReturnValue({
+      address: '0x0000000000000000000000000000000000000000',
+      symbol: 'BNB',
+      decimals: 18,
+      name: 'BNB',
+      chainId: '0x38',
+    });
+
+    renderHookWithProvider(() => useInitialDestToken(), {
+      state: initialState,
+    });
+
+    await waitFor(() => {
+      expect(setDestToken).toHaveBeenCalledWith(getSwapDestToken('0x38'));
+    });
+    expect(setDestToken).not.toHaveBeenCalledWith(
+      expect.objectContaining({ chainId: '0x1' }),
+    );
+  });
+
   describe('BIP44 Bitcoin functionality', () => {
     it('should set bip44 default pair dest asset when source token is Bitcoin and bip44DefaultPair exists', async () => {
       // Arrange - Bitcoin source token from Asset Details page
@@ -180,6 +229,28 @@ describe('useInitialDestToken', () => {
             'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/slip44/60.png',
           chainId: '0x1',
         });
+      });
+    });
+
+    it('should set bip44 default pair dest asset when the Bitcoin source token only comes from Redux', async () => {
+      // Bitcoin has no same-chain swap dest, so its default pair is Ethereum's
+      // asset whether the source arrives on the route or is already in Redux.
+      (selectBridgeViewMode as unknown as jest.Mock).mockReturnValue(
+        BridgeViewMode.Unified,
+      );
+      (selectChainId as unknown as jest.Mock).mockReturnValue(BtcScope.Mainnet);
+      (selectSourceToken as unknown as jest.Mock).mockReturnValue(
+        mockBitcoinSourceToken,
+      );
+
+      renderHookWithProvider(() => useInitialDestToken(), {
+        state: initialState,
+      });
+
+      await waitFor(() => {
+        expect(setDestToken).toHaveBeenCalledWith(
+          expect.objectContaining({ symbol: 'ETH', chainId: '0x1' }),
+        );
       });
     });
   });

--- a/app/components/UI/Bridge/utils/filterOutRwaTokens.test.ts
+++ b/app/components/UI/Bridge/utils/filterOutRwaTokens.test.ts
@@ -1,0 +1,61 @@
+import { filterOutRwaTokens } from './filterOutRwaTokens';
+import type { BridgeToken } from '../types';
+
+const baseToken: BridgeToken = {
+  address: '0x1',
+  symbol: 'T',
+  decimals: 18,
+  chainId: '0x1',
+};
+
+describe('filterOutRwaTokens', () => {
+  it('removes tokens carrying rwaData', () => {
+    const plainToken = { ...baseToken, symbol: 'USDC' };
+    const rwaToken = {
+      ...baseToken,
+      address: '0x2',
+      symbol: 'AAPLx',
+      rwaData: { instrumentType: 'stock' } as BridgeToken['rwaData'],
+    };
+
+    expect(filterOutRwaTokens([plainToken, rwaToken])).toStrictEqual([
+      plainToken,
+    ]);
+  });
+
+  it('removes tokens with rwaData regardless of instrument type', () => {
+    const bondToken = {
+      ...baseToken,
+      rwaData: { instrumentType: 'bond' } as BridgeToken['rwaData'],
+    };
+
+    expect(filterOutRwaTokens([bondToken])).toStrictEqual([]);
+  });
+
+  it('removes Ondo Tokenized tokens matched by name', () => {
+    const ondoToken = { ...baseToken, name: 'Ondo Tokenized Tesla' };
+
+    expect(filterOutRwaTokens([ondoToken])).toStrictEqual([]);
+  });
+
+  it('keeps tokens without rwaData or an Ondo Tokenized name', () => {
+    const tokens = [
+      { ...baseToken, name: 'USD Coin' },
+      { ...baseToken, address: '0x2', name: undefined },
+    ];
+
+    expect(filterOutRwaTokens(tokens)).toStrictEqual(tokens);
+  });
+
+  it('returns an empty array for an empty list', () => {
+    expect(filterOutRwaTokens([])).toStrictEqual([]);
+  });
+
+  it('preserves extra properties on the token shape', () => {
+    const watchlistToken = { ...baseToken, assetId: 'eip155:1/slip44:60' };
+
+    expect(filterOutRwaTokens([watchlistToken])).toStrictEqual([
+      watchlistToken,
+    ]);
+  });
+});

--- a/app/components/UI/Bridge/utils/filterOutRwaTokens.ts
+++ b/app/components/UI/Bridge/utils/filterOutRwaTokens.ts
@@ -1,0 +1,19 @@
+import type { BridgeToken } from '../types';
+
+const ONDO_TOKENIZED_TOKEN_NAME = 'Ondo Tokenized';
+
+type RwaFilterableToken = Pick<BridgeToken, 'name' | 'rwaData'>;
+
+/**
+ * Removes real-world asset tokens from a token list.
+ *
+ * Ondo Tokenized assets are matched by name because they are not always
+ * accompanied by `rwaData`.
+ */
+export const filterOutRwaTokens = <Token extends RwaFilterableToken>(
+  tokens: readonly Token[],
+): Token[] =>
+  tokens.filter(
+    (token) =>
+      !token.rwaData && !token.name?.includes(ONDO_TOKENIZED_TOKEN_NAME),
+  );


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Limit-order and other restricted swap flows must not offer real-world asset (RWA) tokens in the asset picker. Today, RWA filtering lived only in batch-sell as inline helpers, and the shared `BridgeTokenSelector` had no way to opt out of showing RWAs.

This PR introduces a reusable `filterOutRwaTokens` utility and threads an `excludeRwaTokens` prop through `TokenInputArea` into `BridgeTokenSelector`. When enabled, RWA tokens (identified by `rwaData` or an "Ondo Tokenized" name match) are hidden from popular, search, and watchlist lists. Search pagination now measures filtered row counts so pages that are entirely RWA results still trigger the next fetch. Batch sell reuses the shared filter instead of duplicating logic.

Also adds regression tests for `useInitialDestToken` covering dest-token initialization when the source token is only present in Redux (e.g. after switching Bridge tabs).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4956

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Bridge token selector RWA filtering

  Background:
    Given I am logged into MetaMask Mobile
    And I am on a Bridge flow that passes excludeRwaTokens to TokenInputArea

  Scenario: RWA tokens are hidden from the source token picker
    Given the wallet holds or can search for both a standard token (e.g. USDC) and an RWA token (e.g. AAPLx or an Ondo Tokenized asset)

    When user opens the source token selector
    Then the standard token should appear in popular, search, and watchlist results
    And RWA tokens should not appear in any list

  Scenario: RWA tokens remain visible when excludeRwaTokens is not set
    Given I am on a standard Bridge or Swaps flow without excludeRwaTokens

    When user opens the token selector
    Then RWA tokens should still be visible alongside other tokens

  Scenario: search pagination continues when a page is entirely RWAs
    Given excludeRwaTokens is enabled
    And a search query returns a page of results that are all RWAs

    When user searches for tokens
    Then the selector should fetch additional pages until non-RWA results appear or pagination ends
    And the list should not appear stuck with no visible tokens while more pages exist
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 39626305d3e6df2b4991e04e858a02471d253245. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->