### PR TITLE
fix(ci): stop caching node_modules via Namespace in the setup workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,7 +256,8 @@ jobs:
            vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
           '/home/runner/_work/.gradle' || '/home/admin/_work/.gradle'
         }}
-      CACHE_GENERATION: v1
+      # Must match setup-node-modules.yml's CACHE_GENERATION; the two compose the same cache key.
+      CACHE_GENERATION: v2
     steps:
       - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
         if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -353,6 +353,12 @@ jobs:
             echo "❌ node_modules not found"
             exit 1
           fi
+          # A symlink here means the cache/tarball stored a stub instead of the real tree,
+          # which breaks Xcode subprojects that resolve paths relative to $(SRCROOT).
+          if [ -L "node_modules" ]; then
+            echo "❌ node_modules is a symlink to $(readlink node_modules), not a real directory"
+            exit 1
+          fi
           if [ ! -f "app/core/InpageBridgeWeb3.js" ]; then
             echo "❌ InpageBridgeWeb3.js not found"
             exit 1

--- a/.github/workflows/setup-node-modules.yml
+++ b/.github/workflows/setup-node-modules.yml
@@ -120,7 +120,8 @@ jobs:
            inputs.platform != 'ios' && inputs.platform != 'android' && vars.NAMESPACE_RUNNER_LINUX) ||
           vars.NAMESPACE_RUNNER_PROVIDER || 'current'
         }}
-      CACHE_GENERATION: v1
+      # Must match build.yml's CACHE_GENERATION; the two compose the same cache key.
+      CACHE_GENERATION: v2
     outputs:
       artifact-name: ${{ steps.set-artifact-name.outputs.artifact-name }}
       cache-key: ${{ steps.cache-key.outputs.key }}

--- a/.github/workflows/setup-node-modules.yml
+++ b/.github/workflows/setup-node-modules.yml
@@ -140,30 +140,16 @@ jobs:
           fetch-depth: ${{ inputs.fetch-depth }}
           submodules: ${{ inputs.checkout-submodules && 'recursive' || false }}
 
-      # iOS: node_modules is intentionally excluded here. nscloud-cache-action links
-      # cached paths via symlinks on macOS, so `node_modules` would resolve to a
-      # physical location under the Namespace cache volume (e.g. /Volumes/cache/node_modules)
-      # instead of the checkout. RCTAesForked.xcodeproj (react-native-aes-crypto-forked)
-      # computes its React header search paths relative to $(SRCROOT), assuming node_modules
-      # sits directly under the repo root; a symlinked node_modules breaks that assumption
-      # and fails the archive with "'React/RCTBridgeModule.h' file not found".
-      - name: Configure Namespace cache (iOS)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' && inputs.platform == 'ios' }}
-        uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
-        with:
-          path: |
-            ~/.cache/yarn
-            .metamask
-            .yarn/cache
-
+      # node_modules must not be cached here: nscloud-cache-action mounts cached paths as
+      # symlinks into /Volumes/cache, and the cache/tarball this workflow produces would
+      # then hold that symlink instead of the real tree.
       - name: Configure Namespace cache
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' && inputs.platform != 'ios' }}
+        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
         uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
         with:
           path: |
             ~/.cache/yarn
             .metamask
-            node_modules
             .yarn/cache
 
       # iOS: Only Node + Ruby needed (setup runs gem/bundle install, no pods/Xcode). Full iOS env is in build job.

--- a/.github/workflows/setup-node-modules.yml
+++ b/.github/workflows/setup-node-modules.yml
@@ -140,8 +140,24 @@ jobs:
           fetch-depth: ${{ inputs.fetch-depth }}
           submodules: ${{ inputs.checkout-submodules && 'recursive' || false }}
 
+      # iOS: node_modules is intentionally excluded here. nscloud-cache-action links
+      # cached paths via symlinks on macOS, so `node_modules` would resolve to a
+      # physical location under the Namespace cache volume (e.g. /Volumes/cache/node_modules)
+      # instead of the checkout. RCTAesForked.xcodeproj (react-native-aes-crypto-forked)
+      # computes its React header search paths relative to $(SRCROOT), assuming node_modules
+      # sits directly under the repo root; a symlinked node_modules breaks that assumption
+      # and fails the archive with "'React/RCTBridgeModule.h' file not found".
+      - name: Configure Namespace cache (iOS)
+        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' && inputs.platform == 'ios' }}
+        uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
+        with:
+          path: |
+            ~/.cache/yarn
+            .metamask
+            .yarn/cache
+
       - name: Configure Namespace cache
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
+        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' && inputs.platform != 'ios' }}
         uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
         with:
           path: |


### PR DESCRIPTION
## **Description**

iOS TestFlight/RC archives on Namespace runners fail in the `RCTAesForked` target with `'React/RCTBridgeModule.h' file not found`:

- [run 32142611336](https://github.com/MetaMask/metamask-mobile/actions/runs/32142611336) (beta)
- [run 32138428223](https://github.com/MetaMask/metamask-mobile/actions/runs/32138428223) (rc)

**Root cause.** `nscloud-cache-action` mounts cached paths as symlinks into the Namespace cache volume, so `node_modules` resolved to `/Volumes/cache/node_modules` instead of the checkout. `RCTAesForked.xcodeproj` is a hand-linked subproject vendored inside `node_modules` and computes its React header search paths relative to `$(SRCROOT)` (`$(SRCROOT)/../../../ios/Pods/Headers/Public/React-Core`, see `.yarn/patches/react-native-aes-crypto-forked-https-9ebec3d485.patch`). Xcode resolves `SRCROOT` to the physical path, so that traversal landed on `/Volumes/ios` rather than `<checkout>/ios`.

**Wider impact.** Neither transport dereferences the symlink — `actions/cache` and the explicit `tar -cf` both store the link, not its target — so the `node_modules` handoff from `setup-node-modules.yml` to the build job was reduced to ~200KB stubs, and builds silently read `node_modules` from the shared, mutable `/Volumes/cache` volume instead of the keyed artifact. `gh cache list` shows the two poisoned iOS entries at 205KB / 218KB against ~650MB for every healthy one. This also explains the intermittency: runs passed when their cache key already held a healthy entry saved from a non-Namespace runner.

**Fix.** Stop caching `node_modules` through Namespace in `setup-node-modules.yml` for every platform, not just iOS — this workflow's product *is* a portable `node_modules`, so caching it as a symlink defeats both its cache and tarball outputs. Yarn caches (`~/.cache/yarn`, `.yarn/cache`) and `.metamask` stay cached, and this matches the exclusion already used by `build-ios-e2e.yml`. Android is unaffected today only because it is not on Namespace runners yet; when that flips, Gradle would tolerate the symlink and the stub would become a silent hermeticity bug rather than a build failure.

The build job's verify step now also fails when `node_modules` is a symlink, so a regression surfaces in seconds instead of as an Xcode header error 25 minutes into the archive. Previously `[ -d node_modules ]` passed on a symlink and the `du -sh` output (`0B` in the failing runs, `3.4G` in the passing one) was cosmetic.

`CACHE_GENERATION` is bumped from `v1` to `v2` in both `setup-node-modules.yml` and `build.yml` so the existing stub entries are retired. Actions cache keys are immutable and this change alters none of the other key inputs, so without the bump the next iOS build off `main` would restore the same 205KB stub and fail identically. The variable is shared with the `gradle-release-*` keys, so this also costs one cold Android release build.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A — CI-only regression from the Namespace iOS runner rollout.

## **Manual testing steps**

```gherkin
Feature: iOS archive on Namespace runners

  Scenario: iOS build consumes a real node_modules tree
    Given CACHE_GENERATION is bumped so no stub cache entry can be hit
    When "Build and upload to TestFlight" runs on a Namespace iOS runner
    Then the setup job saves a node_modules cache entry of ~650MB, not ~200KB
    And the build job's verify step reports node_modules size in GB
    And the archive compiles past RCTAesForked without a header error

  Scenario: symlinked node_modules is rejected early
    Given node_modules is restored as a symlink
    When the build job runs "Verify artifacts and symlinks"
    Then it fails with "node_modules is a symlink to ..."

  Scenario: Android is unaffected
    When an Android build runs
    Then it restores node_modules as before and completes
```

`actionlint` is clean on both changed workflows.

## **Screenshots/Recordings**

N/A — CI configuration only.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b7f42a748a368b1572d55f48d7a3a405f6bccabd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->