### PR TITLE
fix(bridge): support zero-decimal tokens

### DIFF
--- a/app/components/UI/Bridge/hooks/useLatestBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useLatestBalance/index.ts
@@ -119,7 +119,7 @@ export const useLatestBalance = (token: {
   const handleFetchEvmAtomicBalance = useCallback(async () => {
     if (
       token.address &&
-      token.decimals &&
+      token.decimals !== undefined &&
       chainId &&
       !isCaipChainId(chainId) &&
       selectedAddress &&
@@ -144,7 +144,7 @@ export const useLatestBalance = (token: {
           token.address,
           chainId,
         );
-        if (atomicBalance && token.decimals) {
+        if (atomicBalance && token.decimals !== undefined) {
           setBalanceIfChanged({
             displayBalance: formatUnits(atomicBalance, token.decimals),
             atomicBalance,
@@ -171,7 +171,7 @@ export const useLatestBalance = (token: {
   const handleNonEvmAtomicBalance = useCallback(async () => {
     if (
       token.address &&
-      token.decimals &&
+      token.decimals !== undefined &&
       chainId &&
       isNonEvmChainId(chainId) &&
       selectedAddress
@@ -182,7 +182,7 @@ export const useLatestBalance = (token: {
           nonEvmToken.chainId === chainId,
       )?.balance;
 
-      if (displayBalance && token.decimals) {
+      if (displayBalance && token.decimals !== undefined) {
         setBalanceIfChanged({
           displayBalance,
           atomicBalance: parseUnits(displayBalance, token.decimals),
@@ -245,7 +245,7 @@ export const useLatestBalance = (token: {
   }, [token.balance, token.decimals]);
 
   const latestBalance = useMemo(() => {
-    if (!token.address || !token.decimals) {
+    if (!token.address || token.decimals === undefined) {
       return undefined;
     }
 


### PR DESCRIPTION
## **Description**

Tokens with zero decimals are valid, but truthiness checks in `useLatestBalance` treated `0` as missing. This change checks specifically for `undefined` so zero-decimal tokens can be fetched, formatted, and returned correctly.

## **Changelog**

CHANGELOG entry: Fixed bridge balances for tokens with zero decimals

## **Related issues**

Refs:

## **Manual testing steps**

N/A — No new tests were added per request. Automated tests could not be run because dependencies were not installed in the worktree.

## **Screenshots/Recordings**

### **Before**

N/A — Logic-only change; no visual changes.

### **After**

N/A — Logic-only change; no visual changes.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.com/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.com/wiki/spaces/TL1/pages/400085549067/Performance Guide for Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow guard change in bridge balance display logic with no auth or data-model impact.
> 
> **Overview**
> **Bridge balance hook** now treats `token.decimals` as present when it is `0`, instead of skipping paths that used truthiness (`token.decimals`).
> 
> Guards and formatting in `useLatestBalance` (EVM fetch, non-EVM balance mapping, and `latestBalance` memo) use `token.decimals !== undefined` so zero-decimal tokens get balances fetched, formatted with `formatUnits`/`parseUnits`, and returned instead of `undefined`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a890e53df9fd3d7a0f4162cd9d5d2ea6169e8924. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->