### PR TITLE
feat(predict): add football game event card

### DIFF
--- a/app/components/UI/PredictNext/adapters/remote/KalshiRemoteAdapter.test.ts
+++ b/app/components/UI/PredictNext/adapters/remote/KalshiRemoteAdapter.test.ts
@@ -16,7 +16,7 @@ const createEvent = (overrides = {}) => ({
     {
       id: 'market-1',
       question: 'Will the team win?',
-      status: 'open',
+      status: 'active',
       outcomes: [
         {
           id: 'market-1-yes',

--- a/app/components/UI/PredictNext/components/EventCard/EventCard.test.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCard.test.tsx
@@ -21,7 +21,7 @@ const outcome = (side: 'yes' | 'no', askPrice?: string): PredictOutcome => ({
 const market = (id: string): PredictMarket => ({
   id: id as PredictEntityId,
   question: `Question ${id}`,
-  status: 'open',
+  status: 'active',
   outcomes: [outcome('yes'), outcome('no')],
 });
 

--- a/app/components/UI/PredictNext/components/EventCard/EventCard.test.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCard.test.tsx
@@ -18,142 +18,66 @@ const outcome = (side: 'yes' | 'no', askPrice?: string): PredictOutcome => ({
   askPrice: askPrice as PredictDecimal | undefined,
 });
 
-const market = (id: string): PredictMarket => ({
-  id: id as PredictEntityId,
-  question: `Question ${id}`,
+const market = (): PredictMarket => ({
+  id: 'market-1' as PredictEntityId,
+  question: 'Question',
   status: 'active',
   outcomes: [outcome('yes'), outcome('no')],
 });
 
-const event = (overrides: Partial<PredictEvent> = {}): PredictEvent => ({
+const event = (): PredictEvent => ({
   id: 'event-1' as PredictEntityId,
   venueId: 'kalshi' as PredictVenueId,
   title: 'Election winner',
-  markets: [market('market-1')],
-  ...overrides,
+  markets: [market()],
 });
 
-describe('EventCard.Header', () => {
-  it('shows the event title', () => {
-    render(<EventCard.Header event={event()} />);
+describe('EventCard primitives', () => {
+  it('composes header content', () => {
+    render(
+      <EventCard.Header>
+        <EventCard.Image
+          source="https://example.com/event.png"
+          testID="event-image"
+        />
+        <EventCard.Title>Election winner</EventCard.Title>
+      </EventCard.Header>,
+    );
 
+    expect(screen.getByTestId('event-image')).toBeOnTheScreen();
     expect(screen.getByText('Election winner')).toBeOnTheScreen();
   });
 
-  it('shows the event image when an image URL is present', () => {
-    render(
-      <EventCard.Header
-        event={event({ imageUrl: 'https://example.com/event.png' })}
-      />,
-    );
-
-    expect(
-      screen.getByTestId('predict-next-event-image-event-1'),
-    ).toBeOnTheScreen();
-  });
-
-  it('omits the image when the event has no image URL', () => {
-    render(<EventCard.Header event={event()} />);
-
-    expect(screen.queryByTestId('predict-next-event-image-event-1')).toBeNull();
-  });
-});
-
-describe('EventCard.Footer', () => {
-  it('shows the category tag from the event', () => {
-    render(<EventCard.Footer event={event({ category: 'Senate' })} />);
-
-    expect(screen.getByText('Senate')).toBeOnTheScreen();
-  });
-
-  it('shows formatted volume from the event', () => {
-    render(<EventCard.Footer event={event({ volume: '1500000' })} />);
-
-    expect(screen.getByText('$1.5M Vol')).toBeOnTheScreen();
-  });
-
-  it('shows the hidden market count when more than three markets exist', () => {
-    render(
-      <EventCard.Footer
-        event={event({
-          markets: [
-            market('market-1'),
-            market('market-2'),
-            market('market-3'),
-            market('market-4'),
-            market('market-5'),
-          ],
-        })}
-      />,
-    );
-
-    expect(screen.getByLabelText('+2 more')).toBeOnTheScreen();
-  });
-
-  it('omits the hidden market count for a binary event', () => {
-    render(
-      <EventCard.Footer event={event({ category: 'Crypto', volume: '500' })} />,
-    );
-
-    expect(screen.queryByLabelText('+0 more')).toBeNull();
-    expect(screen.queryByTestId('predict-next-event-more-event-1')).toBeNull();
-  });
-
-  it('omits the hidden market count when three or fewer markets exist', () => {
-    render(
-      <EventCard.Footer
-        event={event({
-          category: 'Politics',
-          markets: [market('market-1'), market('market-2'), market('market-3')],
-        })}
-      />,
-    );
-
-    expect(screen.queryByTestId('predict-next-event-more-event-1')).toBeNull();
-  });
-
-  it('omits category and volume when those fields are missing', () => {
-    render(
-      <EventCard.Footer
-        event={event({
-          markets: [
-            market('market-1'),
-            market('market-2'),
-            market('market-3'),
-            market('market-4'),
-          ],
-        })}
-      />,
-    );
-
-    expect(
-      screen.queryByTestId('predict-next-event-category-event-1'),
-    ).toBeNull();
-    expect(
-      screen.queryByTestId('predict-next-event-volume-event-1'),
-    ).toBeNull();
-    expect(screen.getByLabelText('+1 more')).toBeOnTheScreen();
-  });
-
-  it('calls onPress when the hidden market count is pressed', () => {
+  it('composes footer metadata and its action', () => {
     const onPress = jest.fn();
-
     render(
-      <EventCard.Footer
-        event={event({
-          markets: [
-            market('market-1'),
-            market('market-2'),
-            market('market-3'),
-            market('market-4'),
-          ],
-        })}
-        onPress={onPress}
-      />,
+      <EventCard.Footer>
+        <EventCard.FooterLeading>
+          <EventCard.MetadataTag>Politics</EventCard.MetadataTag>
+          <EventCard.Volume value="1500000" />
+        </EventCard.FooterLeading>
+        <EventCard.MoreMarkets count={2} onPress={onPress} />
+      </EventCard.Footer>,
     );
-    fireEvent.press(screen.getByTestId('predict-next-event-more-event-1'));
 
+    expect(screen.getByText('Politics')).toBeOnTheScreen();
+    expect(screen.getByText('$1.5M Vol')).toBeOnTheScreen();
+    fireEvent.press(screen.getByLabelText('+2 more'));
     expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits absent volume and an empty market action', () => {
+    render(
+      <EventCard.Footer>
+        <EventCard.FooterLeading>
+          <EventCard.Volume />
+        </EventCard.FooterLeading>
+        <EventCard.MoreMarkets count={0} />
+      </EventCard.Footer>,
+    );
+
+    expect(screen.queryByText(/ Vol$/)).toBeNull();
+    expect(screen.queryByText(/more$/)).toBeNull();
   });
 });
 
@@ -164,54 +88,34 @@ describe('EventCard.OutcomeRow', () => {
     onOrder?: () => void,
   ) => {
     const value = event();
+    const valueOutcome = outcome('yes', askPrice);
 
     render(
       <EventCard.OutcomeRow
         event={value}
         market={value.markets[0]}
-        outcome={outcome('yes', askPrice)}
+        outcome={valueOutcome}
         color={color}
         onOrder={onOrder}
         testID="predict-next-outcome-event-1-yes"
       />,
     );
 
-    return value;
+    return { value, valueOutcome };
   };
 
-  it('shows the outcome label, multiplier, and Ask Price', () => {
+  it('shows the outcome label, multiplier, Ask Price, and chance', () => {
     renderRow('0.42');
 
     expect(screen.getByText('Yes')).toBeOnTheScreen();
     expect(screen.getByText('2.38x')).toBeOnTheScreen();
     expect(screen.getByText('42¢')).toBeOnTheScreen();
-  });
-
-  it('sizes the chance line from the Ask Price', () => {
-    renderRow('0.42');
-
     expect(
       screen.getByTestId('predict-next-outcome-event-1-yes-bar'),
     ).toHaveStyle({ width: '42%' });
   });
 
-  it('sizes the chance line from an Ask Price that is not an exact binary float', () => {
-    renderRow('0.58');
-
-    expect(
-      screen.getByTestId('predict-next-outcome-event-1-yes-bar'),
-    ).toHaveStyle({ width: '58%' });
-  });
-
-  it('uses a compact price button width', () => {
-    renderRow('0.42');
-
-    expect(screen.getByTestId('predict-next-outcome-event-1-yes')).toHaveStyle({
-      width: 64,
-    });
-  });
-
-  it('paints the chance line with the outcome color', () => {
+  it('uses the selected outcome color', () => {
     renderRow('0.5', 'red');
 
     expect(
@@ -219,7 +123,7 @@ describe('EventCard.OutcomeRow', () => {
     ).toHaveStyle({ backgroundColor: lightTheme.colors.error.default });
   });
 
-  it('omits the chance line and multiplier when Ask Price is missing', () => {
+  it('omits the chance and multiplier when Ask Price is missing', () => {
     renderRow();
 
     expect(
@@ -228,16 +132,12 @@ describe('EventCard.OutcomeRow', () => {
     expect(screen.queryByText(/x$/)).toBeNull();
   });
 
-  it('calls onOrder when the price control is pressed', () => {
+  it('emits the selected Event, Market, and Outcome', () => {
     const onOrder = jest.fn();
-    const value = renderRow('0.42', 'green', onOrder);
+    const { value, valueOutcome } = renderRow('0.42', 'green', onOrder);
 
     fireEvent.press(screen.getByTestId('predict-next-outcome-event-1-yes'));
 
-    expect(onOrder).toHaveBeenCalledWith(
-      value,
-      value.markets[0],
-      outcome('yes', '0.42'),
-    );
+    expect(onOrder).toHaveBeenCalledWith(value, value.markets[0], valueOutcome);
   });
 });

--- a/app/components/UI/PredictNext/components/EventCard/EventCard.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCard.tsx
@@ -57,10 +57,14 @@ const OUTCOME_ROW_TEXT: Record<OutcomeRowColor, TextColor> = {
 interface RootProps {
   children: React.ReactNode;
   testID?: string;
+  twClassName?: string;
 }
 
-const Root = ({ children, testID }: RootProps) => (
-  <Box twClassName="gap-3 rounded-2xl bg-section p-4 pt-3" testID={testID}>
+const Root = ({ children, testID, twClassName }: RootProps) => (
+  <Box
+    twClassName={twClassName ?? 'gap-3 rounded-2xl bg-section p-4 pt-3'}
+    testID={testID}
+  >
     {children}
   </Box>
 );
@@ -68,6 +72,138 @@ const Root = ({ children, testID }: RootProps) => (
 const Pressable = ({ children, ...props }: PressableProps) => (
   <NativePressable {...props}>{children}</NativePressable>
 );
+
+const Header = ({
+  children,
+  twClassName = 'flex-row items-center gap-3',
+}: {
+  children: React.ReactNode;
+  twClassName?: string;
+}) => <Box twClassName={twClassName}>{children}</Box>;
+
+const Title = ({
+  children,
+  numberOfLines = 2,
+  twClassName = 'flex-1',
+}: {
+  children: React.ReactNode;
+  numberOfLines?: number;
+  twClassName?: string;
+}) => (
+  <Text
+    variant={TextVariant.HeadingSm}
+    numberOfLines={numberOfLines}
+    twClassName={twClassName}
+  >
+    {children}
+  </Text>
+);
+
+const Image = ({ source, testID }: { source: string; testID?: string }) => {
+  const tw = useTailwind();
+  return (
+    <Box testID={testID}>
+      <ExpoImage
+        source={source}
+        style={tw.style('h-10 w-10 rounded-lg')}
+        contentFit="cover"
+        recyclingKey={source}
+      />
+    </Box>
+  );
+};
+
+const Body = ({
+  children,
+  twClassName,
+}: {
+  children: React.ReactNode;
+  twClassName?: string;
+}) => <Box twClassName={twClassName}>{children}</Box>;
+
+const Actions = ({ children }: { children: React.ReactNode }) => (
+  <Box twClassName="flex-row gap-2 pt-2">{children}</Box>
+);
+
+const Action = ({ children }: { children: React.ReactNode }) => (
+  <Box twClassName="min-w-0 flex-1">{children}</Box>
+);
+
+const Footer = ({ children, testID }: RootProps) => (
+  <Box twClassName="flex-row items-center justify-between" testID={testID}>
+    {children}
+  </Box>
+);
+
+const FooterLeading = ({ children }: { children: React.ReactNode }) => (
+  <Box twClassName="flex-1 flex-row items-center gap-3">{children}</Box>
+);
+
+const MetadataTag = ({
+  children,
+  testID,
+}: {
+  children: React.ReactNode;
+  testID?: string;
+}) => (
+  <Tag severity={TagSeverity.Neutral} testID={testID}>
+    <Text
+      variant={TextVariant.BodyXs}
+      fontWeight={FontWeight.Medium}
+      color={TextColor.TextAlternative}
+    >
+      {children}
+    </Text>
+  </Tag>
+);
+
+const Volume = ({ value, testID }: { value?: string; testID?: string }) => {
+  const volume = formatVolume(value);
+
+  return volume === undefined ? null : (
+    <Text
+      variant={TextVariant.BodyXs}
+      fontWeight={FontWeight.Medium}
+      color={TextColor.TextAlternative}
+      testID={testID}
+    >
+      ${volume} Vol
+    </Text>
+  );
+};
+
+const MoreMarkets = ({
+  count,
+  onPress,
+  testID,
+}: {
+  count: number;
+  onPress?: () => void;
+  testID?: string;
+}) =>
+  count > 0 ? (
+    <NativePressable
+      accessibilityLabel={`+${count} more`}
+      accessibilityRole="button"
+      onPress={onPress}
+      testID={testID}
+    >
+      <Box twClassName="flex-row items-center">
+        <Text
+          variant={TextVariant.BodyXs}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextAlternative}
+        >
+          +{count} more
+        </Text>
+        <Icon
+          name={IconName.ArrowRight}
+          size={IconSize.Xs}
+          color={IconColor.IconAlternative}
+        />
+      </Box>
+    </NativePressable>
+  ) : null;
 
 interface OutcomeRowProps {
   event: PredictEvent;
@@ -139,136 +275,19 @@ const OutcomeRow = ({
   );
 };
 
-const Title = ({ children }: { children: React.ReactNode }) => (
-  <Text variant={TextVariant.HeadingSm} numberOfLines={2} twClassName="flex-1">
-    {children}
-  </Text>
-);
-
-const Subtitle = ({ children }: { children: React.ReactNode }) => (
-  <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-    {children}
-  </Text>
-);
-
-const Image = ({ source, testID }: { source: string; testID?: string }) => {
-  const tw = useTailwind();
-  return (
-    <Box testID={testID}>
-      <ExpoImage
-        source={source}
-        style={tw.style('h-10 w-10 rounded-lg')}
-        contentFit="cover"
-        recyclingKey={source}
-      />
-    </Box>
-  );
-};
-
-interface HeaderProps {
-  event: PredictEvent;
-  testID?: string;
-}
-
-const Header = ({ event, testID }: HeaderProps) => (
-  <Box
-    twClassName="flex-row items-center gap-3"
-    testID={testID ?? `predict-next-event-header-${event.venueId}-${event.id}`}
-  >
-    {event.imageUrl ? (
-      <Image
-        source={event.imageUrl}
-        testID={`predict-next-event-image-${event.id}`}
-      />
-    ) : null}
-    <Title>{event.title}</Title>
-  </Box>
-);
-
-interface FooterProps {
-  event: PredictEvent;
-  onPress?: () => void;
-  testID?: string;
-}
-
-const Footer = ({ event, onPress, testID }: FooterProps) => {
-  const volume = formatVolume(event.volume);
-  const hiddenCount = Math.max(
-    0,
-    event.markets.length - EVENT_CARD_VISIBLE_MARKET_COUNT,
-  );
-
-  if (!event.category && volume === undefined && hiddenCount === 0) {
-    return null;
-  }
-
-  return (
-    <Box
-      twClassName="flex-row items-center justify-between"
-      testID={
-        testID ?? `predict-next-event-footer-${event.venueId}-${event.id}`
-      }
-    >
-      <Box twClassName="flex-1 flex-row items-center gap-3">
-        {event.category ? (
-          <Tag
-            severity={TagSeverity.Neutral}
-            testID={`predict-next-event-category-${event.id}`}
-          >
-            <Text
-              variant={TextVariant.BodyXs}
-              fontWeight={FontWeight.Medium}
-              color={TextColor.TextAlternative}
-            >
-              {event.category}
-            </Text>
-          </Tag>
-        ) : null}
-        {volume !== undefined ? (
-          <Text
-            variant={TextVariant.BodyXs}
-            fontWeight={FontWeight.Medium}
-            color={TextColor.TextAlternative}
-            testID={`predict-next-event-volume-${event.id}`}
-          >
-            ${volume} Vol
-          </Text>
-        ) : null}
-      </Box>
-      {hiddenCount > 0 ? (
-        <NativePressable
-          accessibilityLabel={`+${hiddenCount} more`}
-          accessibilityRole="button"
-          onPress={onPress}
-          testID={`predict-next-event-more-${event.id}`}
-        >
-          <Box twClassName="flex-row items-center">
-            <Text
-              variant={TextVariant.BodyXs}
-              fontWeight={FontWeight.Medium}
-              color={TextColor.TextAlternative}
-            >
-              +{hiddenCount} more
-            </Text>
-            <Icon
-              name={IconName.ArrowRight}
-              size={IconSize.Xs}
-              color={IconColor.IconAlternative}
-            />
-          </Box>
-        </NativePressable>
-      ) : null}
-    </Box>
-  );
-};
-
 export const EventCard = {
   Root,
   Pressable,
-  OutcomeRow,
-  Title,
-  Subtitle,
-  Image,
   Header,
+  Title,
+  Image,
+  Body,
+  Actions,
+  Action,
   Footer,
+  FooterLeading,
+  MetadataTag,
+  Volume,
+  MoreMarkets,
+  OutcomeRow,
 };

--- a/app/components/UI/PredictNext/components/EventCard/EventCardGame.test.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCardGame.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react-native';
-import { strings } from '../../../../../../locales/i18n';
+import I18n, { strings } from '../../../../../../locales/i18n';
 import type {
   PredictDecimal,
   PredictEntityId,
@@ -91,6 +91,16 @@ const renderCard = (
 ) => render(<EventCardGame event={event} onPress={jest.fn()} {...props} />);
 
 describe('EventCardGame', () => {
+  const originalLocale = I18n.locale;
+
+  beforeAll(() => {
+    I18n.locale = 'en-US';
+  });
+
+  afterAll(() => {
+    I18n.locale = originalLocale;
+  });
+
   it('defaults to the compact live layout', () => {
     const event = createEvent();
 
@@ -151,17 +161,8 @@ describe('EventCardGame', () => {
 
     renderCard(event, { variant: 'featured' });
 
-    const expectedDate = new Intl.DateTimeFormat(undefined, {
-      weekday: 'long',
-      month: 'long',
-      day: 'numeric',
-    }).format(new Date(event.startsAt as PredictTimestamp));
-    const expectedTime = new Intl.DateTimeFormat(undefined, {
-      hour: 'numeric',
-      minute: '2-digit',
-    }).format(new Date(event.startsAt as PredictTimestamp));
-    expect(screen.getByText(expectedDate)).toBeOnTheScreen();
-    expect(screen.getByText(expectedTime)).toBeOnTheScreen();
+    expect(screen.getByText('Thursday, September 10')).toBeOnTheScreen();
+    expect(screen.getByText('8:20 PM')).toBeOnTheScreen();
   });
 
   it('omits the featured bar when both Ask Prices are zero', () => {
@@ -223,6 +224,9 @@ describe('EventCardGame', () => {
     expect(
       screen.queryByTestId('predict-next-game-bar-game-event'),
     ).not.toBeOnTheScreen();
+    expect(
+      screen.getByTestId('predict-next-game-quote-game-event-home'),
+    ).toHaveStyle({ width: '100%' });
   });
 
   it('emits the Event, Market, and Outcome from an active quote', () => {

--- a/app/components/UI/PredictNext/components/EventCard/EventCardGame.test.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCardGame.test.tsx
@@ -285,16 +285,25 @@ describe('EventCardGame', () => {
     ).toHaveTextContent('CAR · 53¢');
   });
 
-  it('counts a linked Market without an Ask Price as more', () => {
+  it('disables a Team action without an Ask Price and counts its Market as more', () => {
     const event = createEvent({
       markets: [
         createMarket('away', 'away', null),
         createMarket('home', 'home', '0.53'),
       ],
     });
+    const onOrder = jest.fn();
 
-    renderCard(event);
+    renderCard(event, { onOrder });
 
+    const awayAction = screen.getByTestId(
+      'predict-next-game-quote-game-event-away',
+    );
+    expect(awayAction).toHaveTextContent('ARI');
+    expect(awayAction).not.toHaveTextContent('¢');
+    expect(awayAction).toBeDisabled();
+    fireEvent.press(awayAction);
+    expect(onOrder).not.toHaveBeenCalled();
     expect(
       screen.getByTestId('predict-next-event-more-game-event'),
     ).toHaveTextContent('+1 more');

--- a/app/components/UI/PredictNext/components/EventCard/EventCardGame.test.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCardGame.test.tsx
@@ -1,0 +1,315 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { strings } from '../../../../../../locales/i18n';
+import type {
+  PredictDecimal,
+  PredictEntityId,
+  PredictEvent,
+  PredictHexColor,
+  PredictHttpsUrl,
+  PredictMarket,
+  PredictOutcome,
+  PredictTimestamp,
+  PredictVenueId,
+} from '../../types';
+import { EventCardGame } from './EventCardGame';
+
+const createOutcome = (
+  id: string,
+  gameSelection: 'home' | 'away' | 'draw',
+  askPrice?: string,
+): PredictOutcome => ({
+  id: id as PredictEntityId,
+  side: 'yes',
+  label: id,
+  askPrice: askPrice as PredictDecimal | undefined,
+  gameSelection,
+});
+
+const createMarket = (
+  id: string,
+  selection: 'home' | 'away' | 'draw',
+  askPrice: string | null = '0.53',
+  status: PredictMarket['status'] = 'active',
+): PredictMarket => ({
+  id: id as PredictEntityId,
+  question: id,
+  status,
+  outcomes: [
+    createOutcome(`${id}-yes`, selection, askPrice ?? undefined),
+    {
+      id: `${id}-no` as PredictEntityId,
+      side: 'no',
+      label: 'No',
+    },
+  ],
+});
+
+const createEvent = (overrides: Partial<PredictEvent> = {}): PredictEvent => ({
+  venueId: 'kalshi' as PredictVenueId,
+  id: 'game-event' as PredictEntityId,
+  title: 'Cardinals vs Panthers',
+  startsAt: '2026-09-11T00:20:00Z' as PredictTimestamp,
+  volume: '125000',
+  sports: {
+    sport: {
+      id: 'american-football' as PredictEntityId,
+      label: 'American football',
+    },
+    competition: { id: 'nfl' as PredictEntityId, label: 'NFL' },
+    game: {
+      status: 'in_progress',
+      awayTeam: {
+        name: 'Arizona Cardinals',
+        abbreviation: 'ARI',
+        logoUrl: 'https://example.com/ari.png' as PredictHttpsUrl,
+        primaryColor: `#${'97233F'}` as PredictHexColor,
+      },
+      homeTeam: {
+        name: 'Carolina Panthers',
+        abbreviation: 'CAR',
+        primaryColor: `#${'0085CA'}` as PredictHexColor,
+      },
+      score: { away: '17', home: '21' },
+      period: 'Q4',
+      clock: '12:22',
+      observedAt: '2026-09-11T02:30:00Z' as PredictTimestamp,
+    },
+  },
+  markets: [
+    createMarket('away-market', 'away', '0.47'),
+    createMarket('home-market', 'home', '0.53'),
+    createMarket('draw-market', 'draw', '0'),
+    createMarket('prop-market', 'draw', undefined),
+  ],
+  ...overrides,
+});
+
+const renderCard = (
+  event = createEvent(),
+  props: Partial<React.ComponentProps<typeof EventCardGame>> = {},
+) => render(<EventCardGame event={event} onPress={jest.fn()} {...props} />);
+
+describe('EventCardGame', () => {
+  it('defaults to the compact live layout', () => {
+    const event = createEvent();
+
+    renderCard(event);
+
+    expect(
+      screen.getByText(strings('predict.game_status.live')),
+    ).toBeOnTheScreen();
+    expect(screen.getByText('Q4 · 12:22')).toBeOnTheScreen();
+    expect(
+      screen.getByTestId('predict-next-game-team-game-event-away'),
+    ).toHaveTextContent('Arizona Cardinals17');
+    expect(screen.getByText('Carolina Panthers')).toBeOnTheScreen();
+    expect(screen.getByText('21')).toBeOnTheScreen();
+    expect(
+      screen.getByTestId('predict-next-game-quote-game-event-away'),
+    ).toHaveTextContent('ARI · 47¢');
+    expect(
+      screen.getByTestId('predict-next-game-quote-game-event-away'),
+    ).toHaveStyle({ width: '100%' });
+    expect(
+      screen.getByTestId('predict-next-game-game-event-competition'),
+    ).toHaveTextContent('NFL');
+    expect(
+      screen.getByTestId('predict-next-event-more-game-event'),
+    ).toHaveTextContent('+2 more');
+    expect(screen.queryByText(event.title)).not.toBeOnTheScreen();
+  });
+
+  it('renders the featured matchup layout', () => {
+    const event = createEvent();
+
+    renderCard(event, { variant: 'featured' });
+
+    expect(screen.getByText(event.title)).toBeOnTheScreen();
+    expect(screen.getByText('Arizona Cardinals')).toHaveStyle({ width: 80 });
+    expect(
+      screen.getByTestId('predict-next-game-matchup-game-event'),
+    ).toHaveStyle({ height: 80, paddingBottom: 16 });
+    expect(
+      screen.getByTestId('predict-next-game-bar-game-event'),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId('predict-next-game-bar-game-event-away'),
+    ).toHaveStyle({ width: '47%' });
+    expect(
+      screen.queryByTestId('predict-next-game-event-footer'),
+    ).not.toBeOnTheScreen();
+    expect(screen.queryByText('2.13x')).not.toBeOnTheScreen();
+  });
+
+  it('splits the featured scheduled date and time', () => {
+    const event = createEvent();
+    if (!event.sports?.game) {
+      throw new Error('Game fixture missing');
+    }
+    event.sports.game.status = 'scheduled';
+
+    renderCard(event, { variant: 'featured' });
+
+    const expectedDate = new Intl.DateTimeFormat(undefined, {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+    }).format(new Date(event.startsAt as PredictTimestamp));
+    const expectedTime = new Intl.DateTimeFormat(undefined, {
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(new Date(event.startsAt as PredictTimestamp));
+    expect(screen.getByText(expectedDate)).toBeOnTheScreen();
+    expect(screen.getByText(expectedTime)).toBeOnTheScreen();
+  });
+
+  it('omits the featured bar when both Ask Prices are zero', () => {
+    const event = createEvent({
+      markets: [
+        createMarket('away', 'away', '0'),
+        createMarket('home', 'home', '0'),
+      ],
+    });
+
+    renderCard(event, { variant: 'featured' });
+
+    expect(
+      screen.queryByTestId('predict-next-game-bar-game-event'),
+    ).not.toBeOnTheScreen();
+  });
+
+  it.each([
+    ['scheduled', 'SCHEDULED'],
+    ['delayed', 'DELAYED · Q4 · 12:22'],
+    ['suspended', 'SUSPENDED · Q4 · 12:22'],
+    ['postponed', 'POSTPONED'],
+    ['completed', 'FINAL'],
+    ['canceled', 'CANCELED'],
+  ] as const)('renders %s Game status', (status, expected) => {
+    const event = createEvent({ startsAt: undefined });
+    if (!event.sports?.game) {
+      throw new Error('Game fixture missing');
+    }
+    event.sports.game.status = status;
+
+    renderCard(event);
+
+    const values = expected.split(' · ');
+
+    expect(screen.getByText(values[0])).toBeOnTheScreen();
+    if (values.length > 1) {
+      expect(screen.getByText(values.slice(1).join(' · '))).toBeOnTheScreen();
+    }
+  });
+
+  it('uses authoritative Game Selections and omits ambiguous Team quotes', () => {
+    const event = createEvent({
+      markets: [
+        createMarket('away-one', 'away', '0.47'),
+        createMarket('away-two', 'away', '0.48'),
+        createMarket('home', 'home', '0.53'),
+      ],
+    });
+
+    renderCard(event, { variant: 'featured' });
+
+    expect(
+      screen.queryByTestId('predict-next-game-quote-game-event-away'),
+    ).not.toBeOnTheScreen();
+    expect(
+      screen.getByTestId('predict-next-game-quote-game-event-home'),
+    ).toBeOnTheScreen();
+    expect(
+      screen.queryByTestId('predict-next-game-bar-game-event'),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('emits the Event, Market, and Outcome from an active quote', () => {
+    const event = createEvent();
+    const onOrder = jest.fn();
+    renderCard(event, { onOrder });
+
+    fireEvent.press(
+      screen.getByTestId('predict-next-game-quote-game-event-away'),
+    );
+
+    expect(onOrder).toHaveBeenCalledWith(
+      event,
+      event.markets[0],
+      event.markets[0].outcomes[0],
+    );
+  });
+
+  it('shows a non-interactive Ask Price from an inactive Market', () => {
+    const event = createEvent({
+      markets: [
+        createMarket('away', 'away', '0.47', 'inactive'),
+        createMarket('home', 'home', '0.53'),
+      ],
+    });
+    const onOrder = jest.fn();
+    renderCard(event, { onOrder });
+
+    fireEvent.press(
+      screen.getByTestId('predict-next-game-quote-game-event-away'),
+    );
+
+    expect(onOrder).not.toHaveBeenCalled();
+    expect(
+      screen.getByTestId('predict-next-game-quote-game-event-away'),
+    ).toHaveTextContent('ARI · 47¢');
+  });
+
+  it('uses the three-character display abbreviation for missing Team media', () => {
+    const event = createEvent();
+    if (!event.sports?.game) {
+      throw new Error('Game fixture missing');
+    }
+    event.sports.game.homeTeam.abbreviation = undefined;
+    event.sports.game.homeTeam.logoUrl = undefined;
+
+    renderCard(event);
+
+    expect(
+      screen.getByTestId('predict-next-game-logo-fallback-game-event-home', {
+        includeHiddenElements: true,
+      }),
+    ).toHaveTextContent('CAR');
+    expect(
+      screen.getByTestId('predict-next-game-quote-game-event-home'),
+    ).toHaveTextContent('CAR · 53¢');
+  });
+
+  it('counts a linked Market without an Ask Price as more', () => {
+    const event = createEvent({
+      markets: [
+        createMarket('away', 'away', null),
+        createMarket('home', 'home', '0.53'),
+      ],
+    });
+
+    renderCard(event);
+
+    expect(
+      screen.getByTestId('predict-next-event-more-game-event'),
+    ).toHaveTextContent('+1 more');
+  });
+
+  it('keeps non-quote navigation independent from quote actions', () => {
+    const event = createEvent();
+    const onPress = jest.fn();
+    const onOrder = jest.fn();
+    renderCard(event, { onPress, onOrder });
+
+    fireEvent.press(
+      screen.getByTestId('predict-next-event-content-kalshi-game-event'),
+    );
+    fireEvent.press(
+      screen.getByTestId('predict-next-game-quote-game-event-home'),
+    );
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(onOrder).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/UI/PredictNext/components/EventCard/EventCardGame.test.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCardGame.test.tsx
@@ -162,7 +162,7 @@ describe('EventCardGame', () => {
     renderCard(event, { variant: 'featured' });
 
     expect(screen.getByText('Thursday, September 10')).toBeOnTheScreen();
-    expect(screen.getByText('8:20 PM')).toBeOnTheScreen();
+    expect(screen.getByText(/^8:20\s*PM$/)).toBeOnTheScreen();
   });
 
   it('omits the featured bar when both Ask Prices are zero', () => {

--- a/app/components/UI/PredictNext/components/EventCard/EventCardGame.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCardGame.tsx
@@ -1,0 +1,690 @@
+import React, { useState } from 'react';
+import { Pressable as NativePressable } from 'react-native';
+import {
+  Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Tag,
+  TagSeverity,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { Image as ExpoImage } from 'expo-image';
+import BigNumber from 'bignumber.js';
+import I18n, { strings } from '../../../../../../locales/i18n';
+import { getIntlDateTimeFormatter } from '../../../../../util/intl';
+import { useTheme } from '../../../../../util/theme';
+import type {
+  PredictEntityId,
+  PredictEvent,
+  PredictGameStatus,
+  PredictMarket,
+  PredictOutcome,
+  PredictTeam,
+} from '../../types';
+import { formatAskPrice } from './formatAskPrice';
+import { formatMultiplier } from './formatMultiplier';
+import { formatVolume } from './formatVolume';
+import { getAskPricePercent } from './getAskPricePercent';
+import { parsePredictDecimal } from './parsePredictDecimal';
+
+export type EventCardGameVariant = 'compact' | 'featured';
+
+type GameSelection = 'away' | 'home';
+
+interface TeamQuote {
+  market: PredictMarket;
+  outcome: PredictOutcome;
+}
+
+interface EventCardGameProps {
+  event: PredictEvent;
+  variant?: EventCardGameVariant;
+  onPress: () => void;
+  onOrder?: (
+    event: PredictEvent,
+    market: PredictMarket,
+    outcome: PredictOutcome,
+  ) => void;
+}
+
+const STATUS_KEYS: Record<PredictGameStatus, string> = {
+  scheduled: 'scheduled',
+  in_progress: 'live',
+  delayed: 'delayed',
+  suspended: 'suspended',
+  postponed: 'postponed',
+  completed: 'final',
+  canceled: 'canceled',
+};
+
+const getDisplayAbbreviation = (team: PredictTeam) =>
+  (team.abbreviation ?? team.name.slice(0, 3)).toUpperCase();
+
+const getTeamQuote = (
+  event: PredictEvent,
+  selection: GameSelection,
+): TeamQuote | undefined => {
+  const matches = event.markets.flatMap((market) =>
+    market.outcomes
+      .filter((outcome) => outcome.gameSelection === selection)
+      .map((outcome) => ({ market, outcome })),
+  );
+
+  return matches.length === 1 ? matches[0] : undefined;
+};
+
+const formatScheduledTime = (startsAt?: string) => {
+  if (!startsAt) {
+    return undefined;
+  }
+
+  const date = new Date(startsAt);
+  const day = getIntlDateTimeFormatter(I18n.locale, {
+    month: 'long',
+    day: 'numeric',
+  }).format(date);
+  const time = getIntlDateTimeFormatter(I18n.locale, {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(date);
+
+  return `${day} · ${time}`;
+};
+
+const getStatusLabel = (status: PredictGameStatus) =>
+  strings(`predict.game_status.${STATUS_KEYS[status]}`);
+
+const getStatusLine = (
+  status: PredictGameStatus,
+  period?: string,
+  clock?: string,
+  startsAt?: string,
+  featured?: boolean,
+) => {
+  if (status === 'scheduled') {
+    if (!startsAt) {
+      return { label: getStatusLabel(status), metadata: '' };
+    }
+
+    const startsAtDate = new Date(startsAt);
+    return featured
+      ? {
+          label: getIntlDateTimeFormatter(I18n.locale, {
+            weekday: 'long',
+            month: 'long',
+            day: 'numeric',
+          }).format(startsAtDate),
+          metadata: getIntlDateTimeFormatter(I18n.locale, {
+            hour: 'numeric',
+            minute: '2-digit',
+          }).format(startsAtDate),
+        }
+      : { label: formatScheduledTime(startsAt), metadata: '' };
+  }
+
+  const metadata = ['in_progress', 'delayed', 'suspended'].includes(status)
+    ? [period, clock].filter(Boolean)
+    : [];
+
+  return {
+    label: getStatusLabel(status),
+    metadata: metadata.join(' · '),
+  };
+};
+
+const TeamLogo = ({
+  eventId,
+  selection,
+  team,
+  size = 'small',
+}: {
+  eventId: string;
+  selection: GameSelection;
+  team: PredictTeam;
+  size?: 'small' | 'large';
+}) => {
+  const tw = useTailwind();
+  const [failed, setFailed] = useState(false);
+  const showImage = team.logoUrl && !failed;
+  const sizeClassName = size === 'large' ? 'h-10 w-10' : 'h-8 w-8';
+  const imageSizeClassName = size === 'large' ? 'h-12 w-12' : 'h-9 w-9';
+
+  return (
+    <Box
+      twClassName={`${sizeClassName} items-center justify-center overflow-hidden rounded-full bg-muted`}
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+    >
+      {showImage ? (
+        <ExpoImage
+          source={team.logoUrl}
+          style={tw.style(imageSizeClassName)}
+          contentFit="contain"
+          recyclingKey={team.logoUrl}
+          onError={() => setFailed(true)}
+          testID={`predict-next-game-logo-${eventId}-${selection}`}
+        />
+      ) : (
+        <Text
+          variant={TextVariant.BodyXs}
+          fontWeight={FontWeight.Medium}
+          testID={`predict-next-game-logo-fallback-${eventId}-${selection}`}
+        >
+          {getDisplayAbbreviation(team)}
+        </Text>
+      )}
+    </Box>
+  );
+};
+
+const Quote = ({
+  event,
+  selection,
+  team,
+  quote,
+  onOrder,
+  fallbackColor,
+}: {
+  event: PredictEvent;
+  selection: GameSelection;
+  team: PredictTeam;
+  quote?: TeamQuote;
+  onOrder?: EventCardGameProps['onOrder'];
+  fallbackColor: string;
+}) => {
+  const { colors } = useTheme();
+  const formattedPrice = formatAskPrice(quote?.outcome.askPrice);
+
+  if (!quote || !formattedPrice) {
+    return null;
+  }
+
+  const label = `${getDisplayAbbreviation(team)} · ${formattedPrice}`;
+  const testID = `predict-next-game-quote-${event.id}-${selection}`;
+
+  if (quote.market.status !== 'active') {
+    return (
+      <Box
+        testID={testID}
+        twClassName="min-w-20 items-center rounded-lg px-3 py-2"
+        accessible
+        accessibilityLabel={`${team.name}, ${formattedPrice}`}
+      >
+        <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+          {label}
+        </Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Button
+      testID={testID}
+      variant={ButtonVariant.Secondary}
+      onPress={() => onOrder?.(event, quote.market, quote.outcome)}
+      accessibilityLabel={`${team.name}, ${formattedPrice}, buy`}
+      style={{ backgroundColor: team.primaryColor ?? fallbackColor }}
+      size={ButtonSize.Lg}
+      twClassName="w-full px-3"
+    >
+      <Text
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Medium}
+        numberOfLines={1}
+        style={{ color: colors.overlay.inverse }}
+      >
+        {label}
+      </Text>
+    </Button>
+  );
+};
+
+const CompactTeamRow = ({
+  event,
+  selection,
+  team,
+  score,
+  quote,
+  fallbackColor,
+  showMultiplier,
+}: {
+  event: PredictEvent;
+  selection: GameSelection;
+  team: PredictTeam;
+  score?: string;
+  quote?: TeamQuote;
+  fallbackColor: string;
+  showMultiplier: boolean;
+}) => {
+  const percent = getAskPricePercent(quote?.outcome.askPrice);
+  const multiplier = formatMultiplier(quote?.outcome.askPrice);
+  const color = team.primaryColor ?? fallbackColor;
+
+  return (
+    <Box
+      twClassName="flex-row items-center gap-3"
+      testID={`predict-next-game-team-${event.id}-${selection}`}
+    >
+      <TeamLogo eventId={event.id} selection={selection} team={team} />
+      <Box twClassName="min-w-0 flex-1 gap-2">
+        <Text
+          variant={TextVariant.HeadingSm}
+          fontWeight={FontWeight.Bold}
+          numberOfLines={1}
+        >
+          {team.name}
+        </Text>
+        {percent !== undefined ? (
+          <Box twClassName="h-0.5 overflow-hidden rounded-full bg-muted">
+            <Box
+              twClassName="h-full rounded-full"
+              style={{ width: `${percent}%`, backgroundColor: color }}
+            />
+          </Box>
+        ) : null}
+      </Box>
+      {showMultiplier && multiplier ? (
+        <Text
+          variant={TextVariant.BodySm}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextAlternative}
+          twClassName="w-12 text-right"
+        >
+          {multiplier}
+        </Text>
+      ) : score !== undefined ? (
+        <Box twClassName="h-8 w-8 items-center justify-center rounded-lg border border-muted p-1">
+          <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Bold}>
+            {score}
+          </Text>
+        </Box>
+      ) : (
+        <Box twClassName="w-8" />
+      )}
+    </Box>
+  );
+};
+
+const FeaturedTeam = ({
+  eventId,
+  selection,
+  team,
+}: {
+  eventId: string;
+  selection: GameSelection;
+  team: PredictTeam;
+}) => (
+  <Box twClassName="w-14 items-center gap-1">
+    <TeamLogo
+      eventId={eventId}
+      selection={selection}
+      team={team}
+      size="large"
+    />
+    <Text
+      variant={TextVariant.BodyXs}
+      fontWeight={FontWeight.Bold}
+      color={TextColor.TextAlternative}
+      numberOfLines={1}
+      twClassName="w-20 text-center"
+    >
+      {team.name}
+    </Text>
+  </Box>
+);
+
+const FeaturedBar = ({
+  eventId,
+  awayTeam,
+  homeTeam,
+  awayQuote,
+  homeQuote,
+  awayFallbackColor,
+  homeFallbackColor,
+}: {
+  eventId: string;
+  awayTeam: PredictTeam;
+  homeTeam: PredictTeam;
+  awayQuote?: TeamQuote;
+  homeQuote?: TeamQuote;
+  awayFallbackColor: string;
+  homeFallbackColor: string;
+}) => {
+  const away = parsePredictDecimal(awayQuote?.outcome.askPrice);
+  const home = parsePredictDecimal(homeQuote?.outcome.askPrice);
+
+  if (!away || !home) {
+    return null;
+  }
+
+  const total = away.plus(home);
+  if (total.lte(0)) {
+    return null;
+  }
+
+  const awayWidth = away.div(total).times(new BigNumber(100)).toNumber();
+
+  return (
+    <Box
+      testID={`predict-next-game-bar-${eventId}`}
+      twClassName="h-0.5 flex-row overflow-hidden rounded-full"
+    >
+      <Box
+        testID={`predict-next-game-bar-${eventId}-away`}
+        style={{
+          width: `${awayWidth}%`,
+          backgroundColor: awayTeam.primaryColor ?? awayFallbackColor,
+        }}
+      />
+      <Box
+        testID={`predict-next-game-bar-${eventId}-home`}
+        twClassName="flex-1"
+        style={{ backgroundColor: homeTeam.primaryColor ?? homeFallbackColor }}
+      />
+    </Box>
+  );
+};
+
+const GameStatus = ({
+  eventId,
+  status,
+  label,
+  metadata,
+  featured,
+}: {
+  eventId: string;
+  status: PredictGameStatus;
+  label: string;
+  metadata: string;
+  featured?: boolean;
+}) => (
+  <Box
+    twClassName={`${featured ? 'items-center' : 'flex-row pb-1'} gap-2`}
+    testID={`predict-next-game-status-${eventId}`}
+  >
+    <Box twClassName="flex-row items-center gap-2">
+      {status === 'in_progress' ? (
+        <Box twClassName="h-2.5 w-2.5 rounded-full bg-success-default" />
+      ) : null}
+      <Text
+        variant={TextVariant.BodyXs}
+        fontWeight={FontWeight.Bold}
+        color={
+          status === 'in_progress'
+            ? TextColor.SuccessDefault
+            : featured && status === 'scheduled'
+              ? TextColor.TextDefault
+              : TextColor.TextAlternative
+        }
+      >
+        {label}
+      </Text>
+    </Box>
+    {metadata ? (
+      <Text
+        variant={TextVariant.BodyXs}
+        fontWeight={FontWeight.Bold}
+        color={TextColor.TextAlternative}
+      >
+        {metadata}
+      </Text>
+    ) : null}
+  </Box>
+);
+
+const CompactFooter = ({
+  event,
+  representedMarketIds,
+  onPress,
+}: {
+  event: PredictEvent;
+  representedMarketIds: ReadonlySet<PredictEntityId>;
+  onPress: () => void;
+}) => {
+  const competition = event.sports?.competition?.label;
+  const volume = formatVolume(event.volume);
+  const hiddenCount = event.markets.filter(
+    (market) => !representedMarketIds.has(market.id),
+  ).length;
+
+  if (!competition && !volume && hiddenCount === 0) {
+    return null;
+  }
+
+  return (
+    <Box
+      testID={`predict-next-game-${event.id}-footer`}
+      twClassName="flex-row items-center justify-between"
+    >
+      <Box twClassName="flex-1 flex-row items-center gap-3">
+        {competition ? (
+          <Tag
+            severity={TagSeverity.Neutral}
+            testID={`predict-next-game-${event.id}-competition`}
+          >
+            <Text
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextAlternative}
+            >
+              {competition}
+            </Text>
+          </Tag>
+        ) : null}
+        {volume ? (
+          <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
+            ${volume} Vol
+          </Text>
+        ) : null}
+      </Box>
+      {hiddenCount > 0 ? (
+        <NativePressable
+          onPress={onPress}
+          accessibilityRole="button"
+          accessibilityLabel={`+${hiddenCount} more`}
+          testID={`predict-next-event-more-${event.id}`}
+        >
+          <Box twClassName="flex-row items-center">
+            <Text
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextAlternative}
+            >
+              +{hiddenCount} more
+            </Text>
+            <Icon
+              name={IconName.ArrowRight}
+              size={IconSize.Xs}
+              color={IconColor.IconAlternative}
+            />
+          </Box>
+        </NativePressable>
+      ) : null}
+    </Box>
+  );
+};
+
+export const EventCardGame = ({
+  event,
+  variant = 'compact',
+  onPress,
+  onOrder,
+}: EventCardGameProps) => {
+  const { colors } = useTheme();
+  const game = event.sports?.game;
+  if (!game) {
+    return null;
+  }
+
+  const awayQuote = getTeamQuote(event, 'away');
+  const homeQuote = getTeamQuote(event, 'home');
+  const statusLine = getStatusLine(
+    game.status,
+    game.period,
+    game.clock,
+    event.startsAt,
+    variant === 'featured',
+  );
+  const representedMarketIds = new Set<PredictEntityId>();
+  if (awayQuote && formatAskPrice(awayQuote.outcome.askPrice)) {
+    representedMarketIds.add(awayQuote.market.id);
+  }
+  if (homeQuote && formatAskPrice(homeQuote.outcome.askPrice)) {
+    representedMarketIds.add(homeQuote.market.id);
+  }
+
+  return (
+    <Box
+      twClassName={`rounded-2xl bg-section px-4 pb-4 ${
+        variant === 'featured' ? 'pt-4' : 'pt-3'
+      }`}
+      testID={`predict-next-event-${event.venueId}-${event.id}`}
+    >
+      <NativePressable
+        onPress={onPress}
+        accessibilityRole="button"
+        accessibilityLabel={event.title}
+        testID={`predict-next-event-content-${event.venueId}-${event.id}`}
+      >
+        <Box>
+          {variant === 'featured' ? (
+            <Box twClassName="items-center pb-1">
+              <Text
+                variant={TextVariant.HeadingSm}
+                fontWeight={FontWeight.Bold}
+                numberOfLines={1}
+                twClassName="w-68 text-center"
+              >
+                {event.title}
+              </Text>
+            </Box>
+          ) : null}
+          {variant === 'compact' ? (
+            <>
+              <GameStatus
+                eventId={event.id}
+                status={game.status}
+                label={statusLine.label}
+                metadata={statusLine.metadata}
+              />
+              <Box twClassName="gap-3 py-3">
+                <CompactTeamRow
+                  event={event}
+                  selection="away"
+                  team={game.awayTeam}
+                  score={game.score?.away}
+                  quote={awayQuote}
+                  fallbackColor={colors.info.default}
+                  showMultiplier={game.status === 'scheduled'}
+                />
+                <CompactTeamRow
+                  event={event}
+                  selection="home"
+                  team={game.homeTeam}
+                  score={game.score?.home}
+                  quote={homeQuote}
+                  fallbackColor={colors.success.default}
+                  showMultiplier={game.status === 'scheduled'}
+                />
+              </Box>
+            </>
+          ) : (
+            <Box>
+              <Box
+                twClassName="h-20 flex-row items-center justify-between pb-4"
+                testID={`predict-next-game-matchup-${event.id}`}
+              >
+                <FeaturedTeam
+                  eventId={event.id}
+                  selection="away"
+                  team={game.awayTeam}
+                />
+                {game.score ? (
+                  <Text
+                    variant={TextVariant.DisplayMd}
+                    fontWeight={FontWeight.Bold}
+                    twClassName="min-w-0 flex-1 text-center"
+                  >
+                    {game.score.away}
+                  </Text>
+                ) : null}
+                <GameStatus
+                  eventId={event.id}
+                  status={game.status}
+                  label={statusLine.label}
+                  metadata={statusLine.metadata}
+                  featured
+                />
+                {game.score ? (
+                  <Text
+                    variant={TextVariant.DisplayMd}
+                    fontWeight={FontWeight.Bold}
+                    twClassName="min-w-0 flex-1 text-center"
+                  >
+                    {game.score.home}
+                  </Text>
+                ) : null}
+                <FeaturedTeam
+                  eventId={event.id}
+                  selection="home"
+                  team={game.homeTeam}
+                />
+              </Box>
+              <Box twClassName="pb-2">
+                <FeaturedBar
+                  eventId={event.id}
+                  awayTeam={game.awayTeam}
+                  homeTeam={game.homeTeam}
+                  awayQuote={awayQuote}
+                  homeQuote={homeQuote}
+                  awayFallbackColor={colors.info.default}
+                  homeFallbackColor={colors.success.default}
+                />
+              </Box>
+            </Box>
+          )}
+        </Box>
+      </NativePressable>
+      {awayQuote || homeQuote ? (
+        <Box twClassName="flex-row gap-2 pt-2">
+          <Box twClassName="min-w-0 flex-1">
+            <Quote
+              event={event}
+              selection="away"
+              team={game.awayTeam}
+              quote={awayQuote}
+              onOrder={onOrder}
+              fallbackColor={colors.info.default}
+            />
+          </Box>
+          <Box twClassName="min-w-0 flex-1">
+            <Quote
+              event={event}
+              selection="home"
+              team={game.homeTeam}
+              quote={homeQuote}
+              onOrder={onOrder}
+              fallbackColor={colors.success.default}
+            />
+          </Box>
+        </Box>
+      ) : null}
+      {variant === 'compact' ? (
+        <Box twClassName="pt-3">
+          <CompactFooter
+            event={event}
+            representedMarketIds={representedMarketIds}
+            onPress={onPress}
+          />
+        </Box>
+      ) : null}
+    </Box>
+  );
+};

--- a/app/components/UI/PredictNext/components/EventCard/EventCardGame.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCardGame.tsx
@@ -1,49 +1,14 @@
-import React, { useState } from 'react';
-import { Pressable as NativePressable } from 'react-native';
-import {
-  Box,
-  Button,
-  ButtonSize,
-  ButtonVariant,
-  FontWeight,
-  Icon,
-  IconColor,
-  IconName,
-  IconSize,
-  Tag,
-  TagSeverity,
-  Text,
-  TextColor,
-  TextVariant,
-} from '@metamask/design-system-react-native';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { Image as ExpoImage } from 'expo-image';
-import BigNumber from 'bignumber.js';
-import I18n, { strings } from '../../../../../../locales/i18n';
-import { getIntlDateTimeFormatter } from '../../../../../util/intl';
-import { useTheme } from '../../../../../util/theme';
+import React from 'react';
 import type {
-  PredictEntityId,
   PredictEvent,
-  PredictGameStatus,
+  PredictGame,
   PredictMarket,
   PredictOutcome,
-  PredictTeam,
 } from '../../types';
-import { formatAskPrice } from './formatAskPrice';
-import { formatMultiplier } from './formatMultiplier';
-import { formatVolume } from './formatVolume';
-import { getAskPricePercent } from './getAskPricePercent';
-import { parsePredictDecimal } from './parsePredictDecimal';
+import { EventCard } from './EventCard';
+import { GameCard } from './EventCardGameParts';
 
 export type EventCardGameVariant = 'compact' | 'featured';
-
-type GameSelection = 'away' | 'home';
-
-interface TeamQuote {
-  market: PredictMarket;
-  outcome: PredictOutcome;
-}
 
 interface EventCardGameProps {
   event: PredictEvent;
@@ -56,460 +21,85 @@ interface EventCardGameProps {
   ) => void;
 }
 
-const STATUS_KEYS: Record<PredictGameStatus, string> = {
-  scheduled: 'scheduled',
-  in_progress: 'live',
-  delayed: 'delayed',
-  suspended: 'suspended',
-  postponed: 'postponed',
-  completed: 'final',
-  canceled: 'canceled',
-};
+interface GameCompositionProps extends EventCardGameProps {
+  game: PredictGame;
+}
 
-const getDisplayAbbreviation = (team: PredictTeam) =>
-  (team.abbreviation ?? team.name.slice(0, 3)).toUpperCase();
-
-const getTeamQuote = (
-  event: PredictEvent,
-  selection: GameSelection,
-): TeamQuote | undefined => {
-  const matches = event.markets.flatMap((market) =>
-    market.outcomes
-      .filter((outcome) => outcome.gameSelection === selection)
-      .map((outcome) => ({ market, outcome })),
-  );
-
-  return matches.length === 1 ? matches[0] : undefined;
-};
-
-const formatScheduledTime = (startsAt?: string) => {
-  if (!startsAt) {
-    return undefined;
-  }
-
-  const date = new Date(startsAt);
-  const day = getIntlDateTimeFormatter(I18n.locale, {
-    month: 'long',
-    day: 'numeric',
-  }).format(date);
-  const time = getIntlDateTimeFormatter(I18n.locale, {
-    hour: 'numeric',
-    minute: '2-digit',
-  }).format(date);
-
-  return `${day} · ${time}`;
-};
-
-const getStatusLabel = (status: PredictGameStatus) =>
-  strings(`predict.game_status.${STATUS_KEYS[status]}`);
-
-const getStatusLine = (
-  status: PredictGameStatus,
-  period?: string,
-  clock?: string,
-  startsAt?: string,
-  featured?: boolean,
-) => {
-  if (status === 'scheduled') {
-    if (!startsAt) {
-      return { label: getStatusLabel(status), metadata: '' };
-    }
-
-    const startsAtDate = new Date(startsAt);
-    return featured
-      ? {
-          label: getIntlDateTimeFormatter(I18n.locale, {
-            weekday: 'long',
-            month: 'long',
-            day: 'numeric',
-          }).format(startsAtDate),
-          metadata: getIntlDateTimeFormatter(I18n.locale, {
-            hour: 'numeric',
-            minute: '2-digit',
-          }).format(startsAtDate),
-        }
-      : { label: formatScheduledTime(startsAt), metadata: '' };
-  }
-
-  const metadata = ['in_progress', 'delayed', 'suspended'].includes(status)
-    ? [period, clock].filter(Boolean)
-    : [];
-
-  return {
-    label: getStatusLabel(status),
-    metadata: metadata.join(' · '),
-  };
-};
-
-const TeamLogo = ({
-  eventId,
-  selection,
-  team,
-  size = 'small',
-}: {
-  eventId: string;
-  selection: GameSelection;
-  team: PredictTeam;
-  size?: 'small' | 'large';
-}) => {
-  const tw = useTailwind();
-  const [failed, setFailed] = useState(false);
-  const showImage = team.logoUrl && !failed;
-  const sizeClassName = size === 'large' ? 'h-10 w-10' : 'h-8 w-8';
-  const imageSizeClassName = size === 'large' ? 'h-12 w-12' : 'h-9 w-9';
-
-  return (
-    <Box
-      twClassName={`${sizeClassName} items-center justify-center overflow-hidden rounded-full bg-muted`}
-      accessibilityElementsHidden
-      importantForAccessibility="no-hide-descendants"
-    >
-      {showImage ? (
-        <ExpoImage
-          source={team.logoUrl}
-          style={tw.style(imageSizeClassName)}
-          contentFit="contain"
-          recyclingKey={team.logoUrl}
-          onError={() => setFailed(true)}
-          testID={`predict-next-game-logo-${eventId}-${selection}`}
-        />
-      ) : (
-        <Text
-          variant={TextVariant.BodyXs}
-          fontWeight={FontWeight.Medium}
-          testID={`predict-next-game-logo-fallback-${eventId}-${selection}`}
-        >
-          {getDisplayAbbreviation(team)}
-        </Text>
-      )}
-    </Box>
-  );
-};
-
-const Quote = ({
+const CompactGameCard = ({
   event,
-  selection,
-  team,
-  quote,
-  onOrder,
-  fallbackColor,
-}: {
-  event: PredictEvent;
-  selection: GameSelection;
-  team: PredictTeam;
-  quote?: TeamQuote;
-  onOrder?: EventCardGameProps['onOrder'];
-  fallbackColor: string;
-}) => {
-  const { colors } = useTheme();
-  const formattedPrice = formatAskPrice(quote?.outcome.askPrice);
-
-  if (!quote || !formattedPrice) {
-    return null;
-  }
-
-  const label = `${getDisplayAbbreviation(team)} · ${formattedPrice}`;
-  const testID = `predict-next-game-quote-${event.id}-${selection}`;
-
-  if (quote.market.status !== 'active') {
-    return (
-      <Box
-        testID={testID}
-        twClassName="min-w-20 items-center rounded-lg px-3 py-2"
-        accessible
-        accessibilityLabel={`${team.name}, ${formattedPrice}`}
-      >
-        <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-          {label}
-        </Text>
-      </Box>
-    );
-  }
-
-  return (
-    <Button
-      testID={testID}
-      variant={ButtonVariant.Secondary}
-      onPress={() => onOrder?.(event, quote.market, quote.outcome)}
-      accessibilityLabel={`${team.name}, ${formattedPrice}, buy`}
-      style={{ backgroundColor: team.primaryColor ?? fallbackColor }}
-      size={ButtonSize.Lg}
-      twClassName="w-full px-3"
-    >
-      <Text
-        variant={TextVariant.BodyMd}
-        fontWeight={FontWeight.Medium}
-        numberOfLines={1}
-        style={{ color: colors.overlay.inverse }}
-      >
-        {label}
-      </Text>
-    </Button>
-  );
-};
-
-const CompactTeamRow = ({
-  event,
-  selection,
-  team,
-  score,
-  quote,
-  fallbackColor,
-  showMultiplier,
-}: {
-  event: PredictEvent;
-  selection: GameSelection;
-  team: PredictTeam;
-  score?: string;
-  quote?: TeamQuote;
-  fallbackColor: string;
-  showMultiplier: boolean;
-}) => {
-  const percent = getAskPricePercent(quote?.outcome.askPrice);
-  const multiplier = formatMultiplier(quote?.outcome.askPrice);
-  const color = team.primaryColor ?? fallbackColor;
-
-  return (
-    <Box
-      twClassName="flex-row items-center gap-3"
-      testID={`predict-next-game-team-${event.id}-${selection}`}
-    >
-      <TeamLogo eventId={event.id} selection={selection} team={team} />
-      <Box twClassName="min-w-0 flex-1 gap-2">
-        <Text
-          variant={TextVariant.HeadingSm}
-          fontWeight={FontWeight.Bold}
-          numberOfLines={1}
-        >
-          {team.name}
-        </Text>
-        {percent !== undefined ? (
-          <Box twClassName="h-0.5 overflow-hidden rounded-full bg-muted">
-            <Box
-              twClassName="h-full rounded-full"
-              style={{ width: `${percent}%`, backgroundColor: color }}
-            />
-          </Box>
-        ) : null}
-      </Box>
-      {showMultiplier && multiplier ? (
-        <Text
-          variant={TextVariant.BodySm}
-          fontWeight={FontWeight.Medium}
-          color={TextColor.TextAlternative}
-          twClassName="w-12 text-right"
-        >
-          {multiplier}
-        </Text>
-      ) : score !== undefined ? (
-        <Box twClassName="h-8 w-8 items-center justify-center rounded-lg border border-muted p-1">
-          <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Bold}>
-            {score}
-          </Text>
-        </Box>
-      ) : (
-        <Box twClassName="w-8" />
-      )}
-    </Box>
-  );
-};
-
-const FeaturedTeam = ({
-  eventId,
-  selection,
-  team,
-}: {
-  eventId: string;
-  selection: GameSelection;
-  team: PredictTeam;
-}) => (
-  <Box twClassName="w-14 items-center gap-1">
-    <TeamLogo
-      eventId={eventId}
-      selection={selection}
-      team={team}
-      size="large"
-    />
-    <Text
-      variant={TextVariant.BodyXs}
-      fontWeight={FontWeight.Bold}
-      color={TextColor.TextAlternative}
-      numberOfLines={1}
-      twClassName="w-20 text-center"
-    >
-      {team.name}
-    </Text>
-  </Box>
-);
-
-const FeaturedBar = ({
-  eventId,
-  awayTeam,
-  homeTeam,
-  awayQuote,
-  homeQuote,
-  awayFallbackColor,
-  homeFallbackColor,
-}: {
-  eventId: string;
-  awayTeam: PredictTeam;
-  homeTeam: PredictTeam;
-  awayQuote?: TeamQuote;
-  homeQuote?: TeamQuote;
-  awayFallbackColor: string;
-  homeFallbackColor: string;
-}) => {
-  const away = parsePredictDecimal(awayQuote?.outcome.askPrice);
-  const home = parsePredictDecimal(homeQuote?.outcome.askPrice);
-
-  if (!away || !home) {
-    return null;
-  }
-
-  const total = away.plus(home);
-  if (total.lte(0)) {
-    return null;
-  }
-
-  const awayWidth = away.div(total).times(new BigNumber(100)).toNumber();
-
-  return (
-    <Box
-      testID={`predict-next-game-bar-${eventId}`}
-      twClassName="h-0.5 flex-row overflow-hidden rounded-full"
-    >
-      <Box
-        testID={`predict-next-game-bar-${eventId}-away`}
-        style={{
-          width: `${awayWidth}%`,
-          backgroundColor: awayTeam.primaryColor ?? awayFallbackColor,
-        }}
-      />
-      <Box
-        testID={`predict-next-game-bar-${eventId}-home`}
-        twClassName="flex-1"
-        style={{ backgroundColor: homeTeam.primaryColor ?? homeFallbackColor }}
-      />
-    </Box>
-  );
-};
-
-const GameStatus = ({
-  eventId,
-  status,
-  label,
-  metadata,
-  featured,
-}: {
-  eventId: string;
-  status: PredictGameStatus;
-  label: string;
-  metadata: string;
-  featured?: boolean;
-}) => (
-  <Box
-    twClassName={`${featured ? 'items-center' : 'flex-row pb-1'} gap-2`}
-    testID={`predict-next-game-status-${eventId}`}
-  >
-    <Box twClassName="flex-row items-center gap-2">
-      {status === 'in_progress' ? (
-        <Box twClassName="h-2.5 w-2.5 rounded-full bg-success-default" />
-      ) : null}
-      <Text
-        variant={TextVariant.BodyXs}
-        fontWeight={FontWeight.Bold}
-        color={
-          status === 'in_progress'
-            ? TextColor.SuccessDefault
-            : featured && status === 'scheduled'
-              ? TextColor.TextDefault
-              : TextColor.TextAlternative
-        }
-      >
-        {label}
-      </Text>
-    </Box>
-    {metadata ? (
-      <Text
-        variant={TextVariant.BodyXs}
-        fontWeight={FontWeight.Bold}
-        color={TextColor.TextAlternative}
-      >
-        {metadata}
-      </Text>
-    ) : null}
-  </Box>
-);
-
-const CompactFooter = ({
-  event,
-  representedMarketIds,
+  game,
   onPress,
-}: {
-  event: PredictEvent;
-  representedMarketIds: ReadonlySet<PredictEntityId>;
-  onPress: () => void;
-}) => {
-  const competition = event.sports?.competition?.label;
-  const volume = formatVolume(event.volume);
-  const hiddenCount = event.markets.filter(
-    (market) => !representedMarketIds.has(market.id),
-  ).length;
-
-  if (!competition && !volume && hiddenCount === 0) {
-    return null;
-  }
-
-  return (
-    <Box
-      testID={`predict-next-game-${event.id}-footer`}
-      twClassName="flex-row items-center justify-between"
+  onOrder,
+}: GameCompositionProps) => (
+  <GameCard.Provider
+    event={event}
+    game={game}
+    onPress={onPress}
+    onOrder={onOrder}
+  >
+    <EventCard.Root
+      twClassName="rounded-2xl bg-section px-4 pb-4 pt-3"
+      testID={`predict-next-event-${event.venueId}-${event.id}`}
     >
-      <Box twClassName="flex-1 flex-row items-center gap-3">
-        {competition ? (
-          <Tag
-            severity={TagSeverity.Neutral}
-            testID={`predict-next-game-${event.id}-competition`}
-          >
-            <Text
-              variant={TextVariant.BodyXs}
-              color={TextColor.TextAlternative}
-            >
-              {competition}
-            </Text>
-          </Tag>
-        ) : null}
-        {volume ? (
-          <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
-            ${volume} Vol
-          </Text>
-        ) : null}
-      </Box>
-      {hiddenCount > 0 ? (
-        <NativePressable
-          onPress={onPress}
-          accessibilityRole="button"
-          accessibilityLabel={`+${hiddenCount} more`}
-          testID={`predict-next-event-more-${event.id}`}
-        >
-          <Box twClassName="flex-row items-center">
-            <Text
-              variant={TextVariant.BodyXs}
-              color={TextColor.TextAlternative}
-            >
-              +{hiddenCount} more
-            </Text>
-            <Icon
-              name={IconName.ArrowRight}
-              size={IconSize.Xs}
-              color={IconColor.IconAlternative}
-            />
-          </Box>
-        </NativePressable>
-      ) : null}
-    </Box>
-  );
-};
+      <GameCard.Navigation>
+        <GameCard.CompactStatus />
+        <EventCard.Body twClassName="gap-3 py-3">
+          <GameCard.CompactTeamRow selection="away" />
+          <GameCard.CompactTeamRow selection="home" />
+        </EventCard.Body>
+      </GameCard.Navigation>
+
+      <GameCard.Actions />
+
+      <GameCard.Footer>
+        <EventCard.FooterLeading>
+          <GameCard.Competition />
+          <EventCard.Volume value={event.volume} />
+        </EventCard.FooterLeading>
+        <GameCard.MoreMarkets />
+      </GameCard.Footer>
+    </EventCard.Root>
+  </GameCard.Provider>
+);
+
+const FeaturedGameCard = ({
+  event,
+  game,
+  onPress,
+  onOrder,
+}: GameCompositionProps) => (
+  <GameCard.Provider
+    event={event}
+    game={game}
+    onPress={onPress}
+    onOrder={onOrder}
+  >
+    <EventCard.Root
+      twClassName="rounded-2xl bg-section px-4 pb-4 pt-4"
+      testID={`predict-next-event-${event.venueId}-${event.id}`}
+    >
+      <GameCard.Navigation>
+        <EventCard.Header twClassName="items-center pb-1">
+          <EventCard.Title numberOfLines={1} twClassName="w-68 text-center">
+            {event.title}
+          </EventCard.Title>
+        </EventCard.Header>
+        <GameCard.Matchup>
+          <GameCard.FeaturedTeam selection="away" />
+          <GameCard.Score selection="away" />
+          <GameCard.FeaturedStatus />
+          <GameCard.Score selection="home" />
+          <GameCard.FeaturedTeam selection="home" />
+        </GameCard.Matchup>
+        <EventCard.Body twClassName="pb-2">
+          <GameCard.ProbabilityBar />
+        </EventCard.Body>
+      </GameCard.Navigation>
+
+      <GameCard.Actions />
+    </EventCard.Root>
+  </GameCard.Provider>
+);
 
 export const EventCardGame = ({
   event,
@@ -517,174 +107,15 @@ export const EventCardGame = ({
   onPress,
   onOrder,
 }: EventCardGameProps) => {
-  const { colors } = useTheme();
   const game = event.sports?.game;
   if (!game) {
     return null;
   }
 
-  const awayQuote = getTeamQuote(event, 'away');
-  const homeQuote = getTeamQuote(event, 'home');
-  const statusLine = getStatusLine(
-    game.status,
-    game.period,
-    game.clock,
-    event.startsAt,
-    variant === 'featured',
-  );
-  const representedMarketIds = new Set<PredictEntityId>();
-  if (awayQuote && formatAskPrice(awayQuote.outcome.askPrice)) {
-    representedMarketIds.add(awayQuote.market.id);
-  }
-  if (homeQuote && formatAskPrice(homeQuote.outcome.askPrice)) {
-    representedMarketIds.add(homeQuote.market.id);
-  }
-
-  return (
-    <Box
-      twClassName={`rounded-2xl bg-section px-4 pb-4 ${
-        variant === 'featured' ? 'pt-4' : 'pt-3'
-      }`}
-      testID={`predict-next-event-${event.venueId}-${event.id}`}
-    >
-      <NativePressable
-        onPress={onPress}
-        accessibilityRole="button"
-        accessibilityLabel={event.title}
-        testID={`predict-next-event-content-${event.venueId}-${event.id}`}
-      >
-        <Box>
-          {variant === 'featured' ? (
-            <Box twClassName="items-center pb-1">
-              <Text
-                variant={TextVariant.HeadingSm}
-                fontWeight={FontWeight.Bold}
-                numberOfLines={1}
-                twClassName="w-68 text-center"
-              >
-                {event.title}
-              </Text>
-            </Box>
-          ) : null}
-          {variant === 'compact' ? (
-            <>
-              <GameStatus
-                eventId={event.id}
-                status={game.status}
-                label={statusLine.label}
-                metadata={statusLine.metadata}
-              />
-              <Box twClassName="gap-3 py-3">
-                <CompactTeamRow
-                  event={event}
-                  selection="away"
-                  team={game.awayTeam}
-                  score={game.score?.away}
-                  quote={awayQuote}
-                  fallbackColor={colors.info.default}
-                  showMultiplier={game.status === 'scheduled'}
-                />
-                <CompactTeamRow
-                  event={event}
-                  selection="home"
-                  team={game.homeTeam}
-                  score={game.score?.home}
-                  quote={homeQuote}
-                  fallbackColor={colors.success.default}
-                  showMultiplier={game.status === 'scheduled'}
-                />
-              </Box>
-            </>
-          ) : (
-            <Box>
-              <Box
-                twClassName="h-20 flex-row items-center justify-between pb-4"
-                testID={`predict-next-game-matchup-${event.id}`}
-              >
-                <FeaturedTeam
-                  eventId={event.id}
-                  selection="away"
-                  team={game.awayTeam}
-                />
-                {game.score ? (
-                  <Text
-                    variant={TextVariant.DisplayMd}
-                    fontWeight={FontWeight.Bold}
-                    twClassName="min-w-0 flex-1 text-center"
-                  >
-                    {game.score.away}
-                  </Text>
-                ) : null}
-                <GameStatus
-                  eventId={event.id}
-                  status={game.status}
-                  label={statusLine.label}
-                  metadata={statusLine.metadata}
-                  featured
-                />
-                {game.score ? (
-                  <Text
-                    variant={TextVariant.DisplayMd}
-                    fontWeight={FontWeight.Bold}
-                    twClassName="min-w-0 flex-1 text-center"
-                  >
-                    {game.score.home}
-                  </Text>
-                ) : null}
-                <FeaturedTeam
-                  eventId={event.id}
-                  selection="home"
-                  team={game.homeTeam}
-                />
-              </Box>
-              <Box twClassName="pb-2">
-                <FeaturedBar
-                  eventId={event.id}
-                  awayTeam={game.awayTeam}
-                  homeTeam={game.homeTeam}
-                  awayQuote={awayQuote}
-                  homeQuote={homeQuote}
-                  awayFallbackColor={colors.info.default}
-                  homeFallbackColor={colors.success.default}
-                />
-              </Box>
-            </Box>
-          )}
-        </Box>
-      </NativePressable>
-      {awayQuote || homeQuote ? (
-        <Box twClassName="flex-row gap-2 pt-2">
-          <Box twClassName="min-w-0 flex-1">
-            <Quote
-              event={event}
-              selection="away"
-              team={game.awayTeam}
-              quote={awayQuote}
-              onOrder={onOrder}
-              fallbackColor={colors.info.default}
-            />
-          </Box>
-          <Box twClassName="min-w-0 flex-1">
-            <Quote
-              event={event}
-              selection="home"
-              team={game.homeTeam}
-              quote={homeQuote}
-              onOrder={onOrder}
-              fallbackColor={colors.success.default}
-            />
-          </Box>
-        </Box>
-      ) : null}
-      {variant === 'compact' ? (
-        <Box twClassName="pt-3">
-          <CompactFooter
-            event={event}
-            representedMarketIds={representedMarketIds}
-            onPress={onPress}
-          />
-        </Box>
-      ) : null}
-    </Box>
+  const props = { event, game, onPress, onOrder };
+  return variant === 'featured' ? (
+    <FeaturedGameCard {...props} />
+  ) : (
+    <CompactGameCard {...props} />
   );
 };

--- a/app/components/UI/PredictNext/components/EventCard/EventCardGameParts.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCardGameParts.tsx
@@ -1,0 +1,575 @@
+import React, { createContext, useContext, useMemo, useState } from 'react';
+import { Pressable as NativePressable } from 'react-native';
+import {
+  Box,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { Image as ExpoImage } from 'expo-image';
+import BigNumber from 'bignumber.js';
+import I18n, { strings } from '../../../../../../locales/i18n';
+import { getIntlDateTimeFormatter } from '../../../../../util/intl';
+import { useTheme } from '../../../../../util/theme';
+import type {
+  PredictEntityId,
+  PredictEvent,
+  PredictGame,
+  PredictGameStatus,
+  PredictMarket,
+  PredictOutcome,
+  PredictTeam,
+} from '../../types';
+import { EventCard } from './EventCard';
+import { formatAskPrice } from './formatAskPrice';
+import { formatMultiplier } from './formatMultiplier';
+import { getAskPricePercent } from './getAskPricePercent';
+import { parsePredictDecimal } from './parsePredictDecimal';
+
+type GameSelection = 'away' | 'home';
+
+type OrderHandler = (
+  event: PredictEvent,
+  market: PredictMarket,
+  outcome: PredictOutcome,
+) => void;
+
+interface TeamQuote {
+  market: PredictMarket;
+  outcome: PredictOutcome;
+}
+
+interface StatusLine {
+  label: string;
+  metadata: string;
+}
+
+interface GameCardContextValue {
+  event: PredictEvent;
+  game: PredictGame;
+  quotes: Record<GameSelection, TeamQuote | undefined>;
+  statusLines: Record<'compact' | 'featured', StatusLine>;
+  representedMarketIds: ReadonlySet<PredictEntityId>;
+  actions: {
+    openEvent: () => void;
+    order?: OrderHandler;
+  };
+  colors: Record<GameSelection, string>;
+}
+
+const GameCardContext = createContext<GameCardContextValue | undefined>(
+  undefined,
+);
+
+const useGameCard = () => {
+  const value = useContext(GameCardContext);
+  if (!value) {
+    throw new Error('GameCard parts must be rendered inside GameCard.Provider');
+  }
+  return value;
+};
+
+const useTeam = (selection: GameSelection) => {
+  const value = useGameCard();
+  return {
+    ...value,
+    team: selection === 'away' ? value.game.awayTeam : value.game.homeTeam,
+    quote: value.quotes[selection],
+    fallbackColor: value.colors[selection],
+  };
+};
+
+const STATUS_KEYS: Record<PredictGameStatus, string> = {
+  scheduled: 'scheduled',
+  in_progress: 'live',
+  delayed: 'delayed',
+  suspended: 'suspended',
+  postponed: 'postponed',
+  completed: 'final',
+  canceled: 'canceled',
+};
+
+const getDisplayAbbreviation = (team: PredictTeam) =>
+  (team.abbreviation ?? team.name.slice(0, 3)).toUpperCase();
+
+const getTeamQuote = (
+  event: PredictEvent,
+  selection: GameSelection,
+): TeamQuote | undefined => {
+  const matches = event.markets.flatMap((market) =>
+    market.outcomes
+      .filter((outcome) => outcome.gameSelection === selection)
+      .map((outcome) => ({ market, outcome })),
+  );
+
+  return matches.length === 1 ? matches[0] : undefined;
+};
+
+const getStatusLabel = (status: PredictGameStatus) =>
+  strings(`predict.game_status.${STATUS_KEYS[status]}`);
+
+const getStatusLine = (
+  game: PredictGame,
+  startsAt: string | undefined,
+  variant: 'compact' | 'featured',
+): StatusLine => {
+  if (game.status === 'scheduled') {
+    if (!startsAt) {
+      return { label: getStatusLabel(game.status), metadata: '' };
+    }
+
+    const date = new Date(startsAt);
+    if (variant === 'featured') {
+      return {
+        label: getIntlDateTimeFormatter(I18n.locale, {
+          weekday: 'long',
+          month: 'long',
+          day: 'numeric',
+        }).format(date),
+        metadata: getIntlDateTimeFormatter(I18n.locale, {
+          hour: 'numeric',
+          minute: '2-digit',
+        }).format(date),
+      };
+    }
+
+    const day = getIntlDateTimeFormatter(I18n.locale, {
+      month: 'long',
+      day: 'numeric',
+    }).format(date);
+    const time = getIntlDateTimeFormatter(I18n.locale, {
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(date);
+    return { label: `${day} · ${time}`, metadata: '' };
+  }
+
+  const metadata = ['in_progress', 'delayed', 'suspended'].includes(game.status)
+    ? [game.period, game.clock].filter(Boolean).join(' · ')
+    : '';
+
+  return { label: getStatusLabel(game.status), metadata };
+};
+
+interface ProviderProps {
+  children: React.ReactNode;
+  event: PredictEvent;
+  game: PredictGame;
+  onPress: () => void;
+  onOrder?: OrderHandler;
+}
+
+const Provider = ({
+  children,
+  event,
+  game,
+  onPress,
+  onOrder,
+}: ProviderProps) => {
+  const { colors } = useTheme();
+  const value = useMemo<GameCardContextValue>(() => {
+    const quotes = {
+      away: getTeamQuote(event, 'away'),
+      home: getTeamQuote(event, 'home'),
+    };
+    const representedMarketIds = new Set<PredictEntityId>();
+
+    for (const quote of Object.values(quotes)) {
+      if (quote && formatAskPrice(quote.outcome.askPrice)) {
+        representedMarketIds.add(quote.market.id);
+      }
+    }
+
+    return {
+      event,
+      game,
+      quotes,
+      representedMarketIds,
+      statusLines: {
+        compact: getStatusLine(game, event.startsAt, 'compact'),
+        featured: getStatusLine(game, event.startsAt, 'featured'),
+      },
+      actions: { openEvent: onPress, order: onOrder },
+      colors: {
+        away: colors.info.default,
+        home: colors.success.default,
+      },
+    };
+  }, [
+    colors.info.default,
+    colors.success.default,
+    event,
+    game,
+    onOrder,
+    onPress,
+  ]);
+
+  return (
+    <GameCardContext.Provider value={value}>
+      {children}
+    </GameCardContext.Provider>
+  );
+};
+
+const TeamLogo = ({
+  selection,
+  size = 'small',
+}: {
+  selection: GameSelection;
+  size?: 'small' | 'large';
+}) => {
+  const { event, team } = useTeam(selection);
+  const tw = useTailwind();
+  const [failed, setFailed] = useState(false);
+  const showImage = team.logoUrl && !failed;
+  const sizeClassName = size === 'large' ? 'h-10 w-10' : 'h-8 w-8';
+  const imageSizeClassName = size === 'large' ? 'h-12 w-12' : 'h-9 w-9';
+
+  return (
+    <Box
+      twClassName={`${sizeClassName} items-center justify-center overflow-hidden rounded-full bg-muted`}
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+    >
+      {showImage ? (
+        <ExpoImage
+          source={team.logoUrl}
+          style={tw.style(imageSizeClassName)}
+          contentFit="contain"
+          recyclingKey={team.logoUrl}
+          onError={() => setFailed(true)}
+          testID={`predict-next-game-logo-${event.id}-${selection}`}
+        />
+      ) : (
+        <Text
+          variant={TextVariant.BodyXs}
+          fontWeight={FontWeight.Medium}
+          testID={`predict-next-game-logo-fallback-${event.id}-${selection}`}
+        >
+          {getDisplayAbbreviation(team)}
+        </Text>
+      )}
+    </Box>
+  );
+};
+
+const StatusContent = ({ variant }: { variant: 'compact' | 'featured' }) => {
+  const { event, game, statusLines } = useGameCard();
+  const line = statusLines[variant];
+  const featured = variant === 'featured';
+
+  return (
+    <Box
+      twClassName={`${featured ? 'items-center' : 'flex-row pb-1'} gap-2`}
+      testID={`predict-next-game-status-${event.id}`}
+    >
+      <Box twClassName="flex-row items-center gap-2">
+        {game.status === 'in_progress' ? (
+          <Box twClassName="h-2.5 w-2.5 rounded-full bg-success-default" />
+        ) : null}
+        <Text
+          variant={TextVariant.BodyXs}
+          fontWeight={FontWeight.Bold}
+          color={
+            game.status === 'in_progress'
+              ? TextColor.SuccessDefault
+              : featured && game.status === 'scheduled'
+                ? TextColor.TextDefault
+                : TextColor.TextAlternative
+          }
+        >
+          {line.label}
+        </Text>
+      </Box>
+      {line.metadata ? (
+        <Text
+          variant={TextVariant.BodyXs}
+          fontWeight={FontWeight.Bold}
+          color={TextColor.TextAlternative}
+        >
+          {line.metadata}
+        </Text>
+      ) : null}
+    </Box>
+  );
+};
+
+const CompactStatus = () => <StatusContent variant="compact" />;
+const FeaturedStatus = () => <StatusContent variant="featured" />;
+
+const CompactTeamRow = ({ selection }: { selection: GameSelection }) => {
+  const { event, game, team, quote, fallbackColor } = useTeam(selection);
+  const score = game.score?.[selection];
+  const percent = getAskPricePercent(quote?.outcome.askPrice);
+  const multiplier = formatMultiplier(quote?.outcome.askPrice);
+  const color = team.primaryColor ?? fallbackColor;
+
+  return (
+    <Box
+      twClassName="flex-row items-center gap-3"
+      testID={`predict-next-game-team-${event.id}-${selection}`}
+    >
+      <TeamLogo selection={selection} />
+      <Box twClassName="min-w-0 flex-1 gap-2">
+        <Text
+          variant={TextVariant.HeadingSm}
+          fontWeight={FontWeight.Bold}
+          numberOfLines={1}
+        >
+          {team.name}
+        </Text>
+        {percent !== undefined ? (
+          <Box twClassName="h-0.5 overflow-hidden rounded-full bg-muted">
+            <Box
+              twClassName="h-full rounded-full"
+              style={{ width: `${percent}%`, backgroundColor: color }}
+            />
+          </Box>
+        ) : null}
+      </Box>
+      {game.status === 'scheduled' && multiplier ? (
+        <Text
+          variant={TextVariant.BodySm}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextAlternative}
+          twClassName="w-12 text-right"
+        >
+          {multiplier}
+        </Text>
+      ) : score !== undefined ? (
+        <Box twClassName="h-8 w-8 items-center justify-center rounded-lg border border-muted p-1">
+          <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Bold}>
+            {score}
+          </Text>
+        </Box>
+      ) : (
+        <Box twClassName="w-8" />
+      )}
+    </Box>
+  );
+};
+
+const FeaturedTeam = ({ selection }: { selection: GameSelection }) => {
+  const { team } = useTeam(selection);
+
+  return (
+    <Box twClassName="w-14 items-center gap-1">
+      <TeamLogo selection={selection} size="large" />
+      <Text
+        variant={TextVariant.BodyXs}
+        fontWeight={FontWeight.Bold}
+        color={TextColor.TextAlternative}
+        numberOfLines={1}
+        twClassName="w-20 text-center"
+      >
+        {team.name}
+      </Text>
+    </Box>
+  );
+};
+
+const Score = ({ selection }: { selection: GameSelection }) => {
+  const { game } = useGameCard();
+  return game.score ? (
+    <Text
+      variant={TextVariant.DisplayMd}
+      fontWeight={FontWeight.Bold}
+      twClassName="min-w-0 flex-1 text-center"
+    >
+      {game.score[selection]}
+    </Text>
+  ) : null;
+};
+
+const Matchup = ({ children }: { children: React.ReactNode }) => {
+  const { event } = useGameCard();
+  return (
+    <Box
+      twClassName="h-20 flex-row items-center justify-between pb-4"
+      testID={`predict-next-game-matchup-${event.id}`}
+    >
+      {children}
+    </Box>
+  );
+};
+
+const ProbabilityBar = () => {
+  const { event, game, quotes, colors } = useGameCard();
+  const away = parsePredictDecimal(quotes.away?.outcome.askPrice);
+  const home = parsePredictDecimal(quotes.home?.outcome.askPrice);
+
+  if (!away || !home) {
+    return null;
+  }
+
+  const total = away.plus(home);
+  if (total.lte(0)) {
+    return null;
+  }
+
+  const awayWidth = away.div(total).times(new BigNumber(100)).toNumber();
+
+  return (
+    <Box
+      testID={`predict-next-game-bar-${event.id}`}
+      twClassName="h-0.5 flex-row overflow-hidden rounded-full"
+    >
+      <Box
+        testID={`predict-next-game-bar-${event.id}-away`}
+        style={{
+          width: `${awayWidth}%`,
+          backgroundColor: game.awayTeam.primaryColor ?? colors.away,
+        }}
+      />
+      <Box
+        testID={`predict-next-game-bar-${event.id}-home`}
+        twClassName="flex-1"
+        style={{
+          backgroundColor: game.homeTeam.primaryColor ?? colors.home,
+        }}
+      />
+    </Box>
+  );
+};
+
+const Quote = ({ selection }: { selection: GameSelection }) => {
+  const { colors: themeColors } = useTheme();
+  const { event, team, quote, actions, fallbackColor } = useTeam(selection);
+  const formattedPrice = formatAskPrice(quote?.outcome.askPrice);
+
+  if (!quote || !formattedPrice) {
+    return null;
+  }
+
+  const label = `${getDisplayAbbreviation(team)} · ${formattedPrice}`;
+  const testID = `predict-next-game-quote-${event.id}-${selection}`;
+
+  if (quote.market.status !== 'active') {
+    return (
+      <Box
+        testID={testID}
+        twClassName="min-w-20 items-center rounded-lg px-3 py-2"
+        accessible
+        accessibilityLabel={`${team.name}, ${formattedPrice}`}
+      >
+        <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+          {label}
+        </Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Button
+      testID={testID}
+      variant={ButtonVariant.Secondary}
+      onPress={() => actions.order?.(event, quote.market, quote.outcome)}
+      accessibilityLabel={`${team.name}, ${formattedPrice}, buy`}
+      style={{ backgroundColor: team.primaryColor ?? fallbackColor }}
+      size={ButtonSize.Lg}
+      twClassName="w-full px-3"
+    >
+      <Text
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Medium}
+        numberOfLines={1}
+        style={{ color: themeColors.overlay.inverse }}
+      >
+        {label}
+      </Text>
+    </Button>
+  );
+};
+
+const Actions = () => {
+  const { quotes } = useGameCard();
+  return quotes.away || quotes.home ? (
+    <EventCard.Actions>
+      <EventCard.Action>
+        <Quote selection="away" />
+      </EventCard.Action>
+      <EventCard.Action>
+        <Quote selection="home" />
+      </EventCard.Action>
+    </EventCard.Actions>
+  ) : null;
+};
+
+const Footer = ({ children }: { children: React.ReactNode }) => {
+  const { event, representedMarketIds } = useGameCard();
+  const hiddenCount = event.markets.filter(
+    (market) => !representedMarketIds.has(market.id),
+  ).length;
+
+  if (!event.sports?.competition?.label && !event.volume && !hiddenCount) {
+    return null;
+  }
+
+  return (
+    <EventCard.Body twClassName="pt-3">
+      <EventCard.Footer testID={`predict-next-game-${event.id}-footer`}>
+        {children}
+      </EventCard.Footer>
+    </EventCard.Body>
+  );
+};
+
+const Competition = () => {
+  const { event } = useGameCard();
+  const competition = event.sports?.competition?.label;
+  return competition ? (
+    <EventCard.MetadataTag testID={`predict-next-game-${event.id}-competition`}>
+      {competition}
+    </EventCard.MetadataTag>
+  ) : null;
+};
+
+const MoreMarkets = () => {
+  const { event, representedMarketIds, actions } = useGameCard();
+  const count = event.markets.filter(
+    (market) => !representedMarketIds.has(market.id),
+  ).length;
+
+  return (
+    <EventCard.MoreMarkets
+      count={count}
+      onPress={actions.openEvent}
+      testID={`predict-next-event-more-${event.id}`}
+    />
+  );
+};
+
+const Navigation = ({ children }: { children: React.ReactNode }) => {
+  const { event, actions } = useGameCard();
+  return (
+    <NativePressable
+      onPress={actions.openEvent}
+      accessibilityRole="button"
+      accessibilityLabel={event.title}
+      testID={`predict-next-event-content-${event.venueId}-${event.id}`}
+    >
+      {children}
+    </NativePressable>
+  );
+};
+
+export const GameCard = {
+  Provider,
+  Navigation,
+  CompactStatus,
+  FeaturedStatus,
+  CompactTeamRow,
+  FeaturedTeam,
+  Score,
+  Matchup,
+  ProbabilityBar,
+  Actions,
+  Footer,
+  Competition,
+  MoreMarkets,
+};

--- a/app/components/UI/PredictNext/components/EventCard/EventCardGameParts.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCardGameParts.tsx
@@ -488,14 +488,19 @@ const Quote = ({ selection }: { selection: GameSelection }) => {
 
 const Actions = () => {
   const { quotes } = useGameCard();
-  return quotes.away || quotes.home ? (
+  const selections = (['away', 'home'] as const).filter(
+    (selection) =>
+      quotes[selection] &&
+      formatAskPrice(quotes[selection]?.outcome.askPrice) !== undefined,
+  );
+
+  return selections.length ? (
     <EventCard.Actions>
-      <EventCard.Action>
-        <Quote selection="away" />
-      </EventCard.Action>
-      <EventCard.Action>
-        <Quote selection="home" />
-      </EventCard.Action>
+      {selections.map((selection) => (
+        <EventCard.Action key={selection}>
+          <Quote selection={selection} />
+        </EventCard.Action>
+      ))}
     </EventCard.Actions>
   ) : null;
 };

--- a/app/components/UI/PredictNext/components/EventCard/EventCardGameParts.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCardGameParts.tsx
@@ -442,12 +442,30 @@ const Quote = ({ selection }: { selection: GameSelection }) => {
   const { event, team, quote, actions, fallbackColor } = useTeam(selection);
   const formattedPrice = formatAskPrice(quote?.outcome.askPrice);
 
-  if (!quote || !formattedPrice) {
+  if (!quote) {
     return null;
   }
 
-  const label = `${getDisplayAbbreviation(team)} · ${formattedPrice}`;
+  const abbreviation = getDisplayAbbreviation(team);
+  const label = formattedPrice
+    ? `${abbreviation} · ${formattedPrice}`
+    : abbreviation;
   const testID = `predict-next-game-quote-${event.id}-${selection}`;
+
+  if (!formattedPrice) {
+    return (
+      <Button
+        testID={testID}
+        variant={ButtonVariant.Secondary}
+        accessibilityLabel={`${team.name}, price unavailable`}
+        size={ButtonSize.Lg}
+        twClassName="w-full px-3"
+        disabled
+      >
+        {label}
+      </Button>
+    );
+  }
 
   if (quote.market.status !== 'active') {
     return (
@@ -489,9 +507,7 @@ const Quote = ({ selection }: { selection: GameSelection }) => {
 const Actions = () => {
   const { quotes } = useGameCard();
   const selections = (['away', 'home'] as const).filter(
-    (selection) =>
-      quotes[selection] &&
-      formatAskPrice(quotes[selection]?.outcome.askPrice) !== undefined,
+    (selection) => quotes[selection],
   );
 
   return selections.length ? (

--- a/app/components/UI/PredictNext/components/EventCard/EventCardGameParts.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCardGameParts.tsx
@@ -460,7 +460,7 @@ const Quote = ({ selection }: { selection: GameSelection }) => {
         accessibilityLabel={`${team.name}, price unavailable`}
         size={ButtonSize.Lg}
         twClassName="w-full px-3"
-        disabled
+        isDisabled
       >
         {label}
       </Button>

--- a/app/components/UI/PredictNext/components/EventCard/EventCardStandard.test.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCardStandard.test.tsx
@@ -25,7 +25,7 @@ const outcome = (
 const market = (id: string, askPrice = '0.42'): PredictMarket => ({
   id: id as PredictEntityId,
   question: `Question ${id}`,
-  status: 'open',
+  status: 'active',
   outcomes: [
     outcome('yes', askPrice, `Candidate ${id}`),
     outcome('no', '0.58'),

--- a/app/components/UI/PredictNext/components/EventCard/EventCardStandard.tsx
+++ b/app/components/UI/PredictNext/components/EventCard/EventCardStandard.tsx
@@ -31,6 +31,13 @@ export const EventCardStandard = ({
     0,
     EVENT_CARD_VISIBLE_MARKET_COUNT,
   );
+  const hiddenMarketCount = Math.max(
+    0,
+    event.markets.length - EVENT_CARD_VISIBLE_MARKET_COUNT,
+  );
+  const hasFooter = Boolean(
+    event.category || event.volume || hiddenMarketCount,
+  );
 
   return (
     <EventCard.Root testID={`predict-next-event-${event.venueId}-${event.id}`}>
@@ -38,41 +45,68 @@ export const EventCardStandard = ({
         onPress={onPress}
         testID={`predict-next-event-content-${event.venueId}-${event.id}`}
       >
-        <EventCard.Header event={event} />
+        <EventCard.Header>
+          {event.imageUrl ? (
+            <EventCard.Image
+              source={event.imageUrl}
+              testID={`predict-next-event-image-${event.id}`}
+            />
+          ) : null}
+          <EventCard.Title>{event.title}</EventCard.Title>
+        </EventCard.Header>
       </EventCard.Pressable>
 
-      {isSingleMarket ? (
-        <Box twClassName="gap-3">
-          {(['yes', 'no'] as const).map((side) => (
-            <EventCard.OutcomeRow
-              key={side}
-              event={event}
-              market={event.markets[0]}
-              outcome={getOutcome(event.markets[0], side)}
-              label={side === 'yes' ? 'Yes' : 'No'}
-              color={BINARY_OUTCOME_ROW_COLORS[side]}
-              onOrder={onOrder}
-              testID={`predict-next-outcome-${event.id}-${side}`}
-            />
-          ))}
-        </Box>
-      ) : (
-        <Box twClassName="gap-3">
-          {visibleMarkets.map((market, index) => (
-            <EventCard.OutcomeRow
-              key={market.id}
-              event={event}
-              market={market}
-              outcome={getOutcome(market, 'yes')}
-              color={MULTI_OUTCOME_ROW_COLORS[index]}
-              onOrder={onOrder}
-              testID={`predict-next-outcome-${event.id}-${market.id}-yes`}
-            />
-          ))}
-        </Box>
-      )}
+      <EventCard.Body twClassName="gap-3">
+        {isSingleMarket
+          ? (['yes', 'no'] as const).map((side) => (
+              <EventCard.OutcomeRow
+                key={side}
+                event={event}
+                market={event.markets[0]}
+                outcome={getOutcome(event.markets[0], side)}
+                label={side === 'yes' ? 'Yes' : 'No'}
+                color={BINARY_OUTCOME_ROW_COLORS[side]}
+                onOrder={onOrder}
+                testID={`predict-next-outcome-${event.id}-${side}`}
+              />
+            ))
+          : visibleMarkets.map((market, index) => (
+              <EventCard.OutcomeRow
+                key={market.id}
+                event={event}
+                market={market}
+                outcome={getOutcome(market, 'yes')}
+                color={MULTI_OUTCOME_ROW_COLORS[index]}
+                onOrder={onOrder}
+                testID={`predict-next-outcome-${event.id}-${market.id}-yes`}
+              />
+            ))}
+      </EventCard.Body>
 
-      <EventCard.Footer event={event} onPress={onPress} />
+      {hasFooter ? (
+        <EventCard.Footer
+          testID={`predict-next-event-footer-${event.venueId}-${event.id}`}
+        >
+          <EventCard.FooterLeading>
+            {event.category ? (
+              <EventCard.MetadataTag
+                testID={`predict-next-event-category-${event.id}`}
+              >
+                {event.category}
+              </EventCard.MetadataTag>
+            ) : null}
+            <EventCard.Volume
+              value={event.volume}
+              testID={`predict-next-event-volume-${event.id}`}
+            />
+          </EventCard.FooterLeading>
+          <EventCard.MoreMarkets
+            count={hiddenMarketCount}
+            onPress={onPress}
+            testID={`predict-next-event-more-${event.id}`}
+          />
+        </EventCard.Footer>
+      ) : null}
     </EventCard.Root>
   );
 };

--- a/app/components/UI/PredictNext/contracts/v1/marketData.test.ts
+++ b/app/components/UI/PredictNext/contracts/v1/marketData.test.ts
@@ -20,7 +20,7 @@ const createMarket = (overrides = {}) => ({
   id: 'market-1',
   question: 'Will the team win?',
   outcomes: [createOutcome('yes'), createOutcome('no')],
-  status: 'open' as const,
+  status: 'active' as const,
   ...overrides,
 });
 
@@ -191,6 +191,73 @@ describe('Predict API canonical response parsers', () => {
     'https:example.com/event.png',
   ])('rejects image URL %s', (imageUrl) => {
     const input = createEvent({ imageUrl });
+
+    expect(() => parsePredictEvent(input)).toThrow(
+      'Invalid Predict API response.',
+    );
+  });
+
+  it('parses an American-football Game Event', () => {
+    const input = createEvent({
+      startsAt: '2026-09-11T00:20:00Z',
+      sports: {
+        sport: { id: 'american-football', label: 'American football' },
+        competition: { id: 'nfl', label: 'NFL' },
+        game: {
+          status: 'in_progress',
+          awayTeam: {
+            name: 'Arizona Cardinals',
+            abbreviation: 'ARI',
+            logoUrl: 'https://example.com/ari.png',
+            primaryColor: `#${'97233F'}`,
+          },
+          homeTeam: { name: 'Carolina Panthers' },
+          score: { away: '17', home: '21' },
+          period: 'Q4',
+          clock: '12:22',
+          observedAt: '2026-09-11T02:30:00Z',
+        },
+      },
+      markets: [
+        createMarket({
+          status: 'active',
+          outcomes: [
+            createOutcome('yes', { gameSelection: 'away' }),
+            createOutcome('no', { gameSelection: 'draw' }),
+          ],
+        }),
+      ],
+    });
+
+    const result = parsePredictEvent(input);
+
+    expect(result).toEqual(input);
+  });
+
+  it.each([
+    { field: 'status', value: 'playing' },
+    { field: 'observedAt', value: 'yesterday' },
+    { field: 'primaryColor', value: 'red' },
+    { field: 'logoUrl', value: 'http://example.com/ari.png' },
+  ])('rejects Game data with malformed $field', ({ field, value }) => {
+    const game = {
+      status: 'scheduled',
+      awayTeam: { name: 'Arizona Cardinals' },
+      homeTeam: { name: 'Carolina Panthers' },
+      observedAt: '2026-09-11T00:00:00Z',
+    };
+    const input = createEvent({
+      sports: {
+        sport: { id: 'american-football', label: 'American football' },
+        game:
+          field === 'primaryColor' || field === 'logoUrl'
+            ? {
+                ...game,
+                awayTeam: { ...game.awayTeam, [field]: value },
+              }
+            : { ...game, [field]: value },
+      },
+    });
 
     expect(() => parsePredictEvent(input)).toThrow(
       'Invalid Predict API response.',

--- a/app/components/UI/PredictNext/contracts/v1/marketData.test.ts
+++ b/app/components/UI/PredictNext/contracts/v1/marketData.test.ts
@@ -41,6 +41,14 @@ describe('Predict API canonical response parsers', () => {
     expect(result).toEqual(input);
   });
 
+  it('parses a closed Market', () => {
+    const input = createEvent({
+      markets: [createMarket({ status: 'closed' })],
+    });
+
+    expect(parsePredictEvent(input).markets[0].status).toBe('closed');
+  });
+
   it('parses an event containing an ask without a bid', () => {
     const input = createEvent({
       markets: [

--- a/app/components/UI/PredictNext/contracts/v1/marketData.ts
+++ b/app/components/UI/PredictNext/contracts/v1/marketData.ts
@@ -41,6 +41,9 @@ const decimal = refine(
 const amount = refine(string(), 'PredictAmount', (value) =>
   /^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(value),
 );
+const hexColor = refine(string(), 'PredictHexColor', (value) =>
+  /^#[0-9a-f]{6}$/i.test(value),
+);
 const httpsUrl = refine(string(), 'PredictHttpsUrl', (value) => {
   if (!/^https:\/\//i.test(value)) {
     return false;
@@ -54,14 +57,54 @@ const httpsUrl = refine(string(), 'PredictHttpsUrl', (value) => {
   }
 });
 const status = enums([
-  'upcoming',
-  'open',
-  'closed',
-  'resolved',
-  'unavailable',
+  'initialized',
+  'active',
+  'inactive',
+  'determined',
+  'disputed',
+  'amended',
+  'finalized',
 ] as const);
 const venueStatus = enums(['available', 'degraded', 'unavailable'] as const);
 const side = enums(['yes', 'no'] as const);
+const gameSelection = enums(['home', 'away', 'draw'] as const);
+const gameStatus = enums([
+  'scheduled',
+  'in_progress',
+  'delayed',
+  'suspended',
+  'postponed',
+  'completed',
+  'canceled',
+] as const);
+
+const teamSchema = object({
+  name: string(),
+  abbreviation: optional(string()),
+  logoUrl: optional(httpsUrl),
+  primaryColor: optional(hexColor),
+});
+
+const gameSchema = object({
+  status: gameStatus,
+  homeTeam: teamSchema,
+  awayTeam: teamSchema,
+  score: optional(
+    object({
+      home: string(),
+      away: string(),
+    }),
+  ),
+  period: optional(string()),
+  clock: optional(string()),
+  observedAt: timestamp,
+});
+
+const sportsContextSchema = object({
+  sport: object({ id: entityId, label: string() }),
+  competition: optional(object({ id: entityId, label: string() })),
+  game: optional(gameSchema),
+});
 
 const outcomeSchema = object({
   id: entityId,
@@ -69,6 +112,7 @@ const outcomeSchema = object({
   label: string(),
   askPrice: optional(decimal),
   bidPrice: optional(decimal),
+  gameSelection: optional(gameSelection),
 });
 
 const binaryOutcomes = refine(
@@ -110,6 +154,7 @@ const eventSchema = object({
   volume: optional(amount),
   volume24h: optional(amount),
   imageUrl: optional(httpsUrl),
+  sports: optional(sportsContextSchema),
   markets: nonEmptyMarkets,
 });
 

--- a/app/components/UI/PredictNext/contracts/v1/marketData.ts
+++ b/app/components/UI/PredictNext/contracts/v1/marketData.ts
@@ -60,6 +60,7 @@ const status = enums([
   'initialized',
   'active',
   'inactive',
+  'closed',
   'determined',
   'disputed',
   'amended',

--- a/app/components/UI/PredictNext/controller/PredictNextController.test.ts
+++ b/app/components/UI/PredictNext/controller/PredictNextController.test.ts
@@ -26,6 +26,14 @@ const status: PredictVenueStatus = {
 };
 
 describe('PredictNextController', () => {
+  beforeAll(() => {
+    jest.useFakeTimers({ advanceTimers: true });
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/app/components/UI/PredictNext/services/PredictMarketDataService.integration.test.ts
+++ b/app/components/UI/PredictNext/services/PredictMarketDataService.integration.test.ts
@@ -16,7 +16,7 @@ const event = {
     {
       id: 'market-1',
       question: 'Will the team win?',
-      status: 'open',
+      status: 'active',
       outcomes: [
         { id: 'yes', side: 'yes', label: 'Yes', askPrice: '0.42' },
         { id: 'no', side: 'no', label: 'No', askPrice: '0.61' },

--- a/app/components/UI/PredictNext/services/PredictMarketDataService.test.ts
+++ b/app/components/UI/PredictNext/services/PredictMarketDataService.test.ts
@@ -29,8 +29,16 @@ const createMarketData = (): jest.Mocked<VenueMarketDataAdapter> => ({
 describe('PredictMarketDataService', () => {
   const services: PredictMarketDataService[] = [];
 
+  beforeAll(() => {
+    jest.useFakeTimers({ advanceTimers: true });
+  });
+
   afterEach(() => {
     services.splice(0).forEach((service) => service.destroy());
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
   });
 
   const buildService = (marketData: VenueMarketDataAdapter) => {

--- a/app/components/UI/PredictNext/types/index.ts
+++ b/app/components/UI/PredictNext/types/index.ts
@@ -4,17 +4,68 @@ export type PredictTimestamp = string & {
   readonly __brand: 'PredictTimestamp';
 };
 export type PredictDecimal = string & { readonly __brand: 'PredictDecimal' };
+export type PredictHttpsUrl = string & { readonly __brand: 'PredictHttpsUrl' };
+export type PredictHexColor = string & { readonly __brand: 'PredictHexColor' };
 
 export const KALSHI_VENUE_ID = 'kalshi' as PredictVenueId;
 
-export type PredictEntityStatus =
-  | 'upcoming'
-  | 'open'
+export type PredictMarketStatus =
+  | 'initialized'
+  | 'active'
+  | 'inactive'
   | 'closed'
-  | 'resolved'
-  | 'unavailable';
+  | 'determined'
+  | 'disputed'
+  | 'amended'
+  | 'finalized';
 
 export type PredictOutcomeSide = 'yes' | 'no';
+export type PredictGameSelection = 'home' | 'away' | 'draw';
+
+export interface PredictSport {
+  id: PredictEntityId;
+  label: string;
+}
+
+export interface PredictCompetition {
+  id: PredictEntityId;
+  label: string;
+}
+
+export interface PredictTeam {
+  name: string;
+  abbreviation?: string;
+  logoUrl?: PredictHttpsUrl;
+  primaryColor?: PredictHexColor;
+}
+
+export type PredictGameStatus =
+  | 'scheduled'
+  | 'in_progress'
+  | 'delayed'
+  | 'suspended'
+  | 'postponed'
+  | 'completed'
+  | 'canceled';
+
+export interface PredictGame {
+  status: PredictGameStatus;
+  homeTeam: PredictTeam;
+  awayTeam: PredictTeam;
+  score?: {
+    home: string;
+    away: string;
+  };
+  period?: string;
+  clock?: string;
+  observedAt: PredictTimestamp;
+}
+
+export interface PredictSportsContext {
+  sport: PredictSport;
+  competition?: PredictCompetition;
+  game?: PredictGame;
+}
 
 export interface PredictOutcome {
   id: PredictEntityId;
@@ -22,13 +73,14 @@ export interface PredictOutcome {
   label: string;
   askPrice?: PredictDecimal;
   bidPrice?: PredictDecimal;
+  gameSelection?: PredictGameSelection;
 }
 
 export interface PredictMarket {
   id: PredictEntityId;
   question: string;
   outcomes: readonly [PredictOutcome, PredictOutcome];
-  status: PredictEntityStatus;
+  status: PredictMarketStatus;
   volume?: string;
   volume24h?: string;
   createdAt?: PredictTimestamp;
@@ -51,6 +103,7 @@ export interface PredictEvent {
   volume?: string;
   volume24h?: string;
   imageUrl?: string;
+  sports?: PredictSportsContext;
   markets: readonly PredictMarket[];
 }
 

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.tsx
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.tsx
@@ -18,6 +18,7 @@ import { useEventList } from '../../hooks/useEventList';
 import { useVenueStatus } from '../../hooks/useVenueStatus';
 import { KALSHI_VENUE_ID, type PredictEvent } from '../../types';
 import { EventCardStandard } from '../../components/EventCard/EventCardStandard';
+import { EventCardGame } from '../../components/EventCard/EventCardGame';
 import type { PredictNextStackParamList } from '../../navigation/types';
 import { PredictNextRoutes } from '../../navigation/routes';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -66,9 +67,16 @@ export const PredictHome = () => {
     [navigation],
   );
   const renderEvent = useCallback(
-    ({ item }: ListRenderItemInfo<PredictEvent>) => (
-      <EventCardStandard event={item} onPress={() => openEvent(item)} />
-    ),
+    ({ item }: ListRenderItemInfo<PredictEvent>) =>
+      item.sports?.sport.id === 'american-football' && item.sports.game ? (
+        <EventCardGame
+          event={item}
+          onPress={() => openEvent(item)}
+          variant="featured"
+        />
+      ) : (
+        <EventCardStandard event={item} onPress={() => openEvent(item)} />
+      ),
     [openEvent],
   );
   const retryAll = () => {

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.tsx
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.tsx
@@ -69,11 +69,7 @@ export const PredictHome = () => {
   const renderEvent = useCallback(
     ({ item }: ListRenderItemInfo<PredictEvent>) =>
       item.sports?.sport.id === 'american-football' && item.sports.game ? (
-        <EventCardGame
-          event={item}
-          onPress={() => openEvent(item)}
-          variant="featured"
-        />
+        <EventCardGame event={item} onPress={() => openEvent(item)} />
       ) : (
         <EventCardStandard event={item} onPress={() => openEvent(item)} />
       ),

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.view.test.tsx
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.view.test.tsx
@@ -4,7 +4,7 @@ import Engine from '../../../../../core/Engine';
 import { fireEvent, waitFor, within } from '@testing-library/react-native';
 import { PredictHomeTestIds } from './PredictHome.testIds';
 import { PredictEventDetailTestIds } from '../PredictEventDetail/PredictEventDetail.testIds';
-import type { PredictEvent } from '../../types';
+import type { PredictEvent, PredictTimestamp } from '../../types';
 import { PredictEventValues } from '../../../Predict/constants/eventNames';
 
 const event: PredictEvent = {
@@ -19,7 +19,7 @@ const event: PredictEvent = {
     {
       id: 'market-1' as PredictEvent['markets'][number]['id'],
       question: 'Candidate A wins',
-      status: 'open',
+      status: 'active',
       outcomes: [
         {
           id: 'yes-1' as PredictEvent['markets'][number]['outcomes'][number]['id'],
@@ -35,6 +35,48 @@ const event: PredictEvent = {
           askPrice:
             '0.58' as PredictEvent['markets'][number]['outcomes'][number]['askPrice'],
         },
+      ],
+    },
+  ],
+};
+
+const gameEvent: PredictEvent = {
+  ...event,
+  id: 'game-event' as PredictEvent['id'],
+  title: 'Cardinals vs Panthers',
+  sports: {
+    sport: {
+      id: 'american-football' as PredictEvent['id'],
+      label: 'American football',
+    },
+    competition: { id: 'nfl' as PredictEvent['id'], label: 'NFL' },
+    game: {
+      status: 'in_progress',
+      awayTeam: { name: 'Arizona Cardinals', abbreviation: 'ARI' },
+      homeTeam: { name: 'Carolina Panthers', abbreviation: 'CAR' },
+      score: { away: '17', home: '21' },
+      period: 'Q4',
+      clock: '12:22',
+      observedAt: '2026-01-01T00:00:00Z' as PredictTimestamp,
+    },
+  },
+  markets: [
+    {
+      ...event.markets[0],
+      id: 'away-market' as PredictEvent['markets'][number]['id'],
+      status: 'active',
+      outcomes: [
+        { ...event.markets[0].outcomes[0], gameSelection: 'away' },
+        event.markets[0].outcomes[1],
+      ],
+    },
+    {
+      ...event.markets[0],
+      id: 'home-market' as PredictEvent['markets'][number]['id'],
+      status: 'active',
+      outcomes: [
+        { ...event.markets[0].outcomes[0], gameSelection: 'home' },
+        event.markets[0].outcomes[1],
       ],
     },
   ],
@@ -133,6 +175,51 @@ describe('PredictHome', () => {
     expect(
       within(card).getByTestId(PredictHomeTestIds.volume('event-1')),
     ).toHaveTextContent('$1.5M Vol');
+  });
+
+  it('opens American-football Game detail from the compact Game card', async () => {
+    configureQueries([event, gameEvent]);
+    const view = renderPredictNext();
+    const gameCard = await view.findByTestId(
+      PredictHomeTestIds.event('kalshi', 'game-event'),
+    );
+
+    expect(within(gameCard).getByText('Arizona Cardinals')).toBeOnTheScreen();
+    expect(within(gameCard).queryByText(gameEvent.title)).not.toBeOnTheScreen();
+    fireEvent.press(
+      within(gameCard).getByTestId(
+        PredictHomeTestIds.eventContent('kalshi', 'game-event'),
+      ),
+    );
+
+    expect(
+      await view.findByTestId(PredictEventDetailTestIds.VIEW),
+    ).toBeOnTheScreen();
+    expect(view.getByText(gameEvent.title)).toBeOnTheScreen();
+  });
+
+  it('renders a non-American-football Game with the standard card', async () => {
+    const soccerEvent: PredictEvent = {
+      ...gameEvent,
+      id: 'soccer-event' as PredictEvent['id'],
+      title: 'Soccer championship',
+      sports: {
+        ...gameEvent.sports,
+        sport: {
+          id: 'soccer' as PredictEvent['id'],
+          label: 'Soccer',
+        },
+      } as PredictEvent['sports'],
+    };
+    configureQueries([soccerEvent]);
+    const view = renderPredictNext();
+
+    const card = await view.findByTestId(
+      PredictHomeTestIds.event('kalshi', 'soccer-event'),
+    );
+
+    expect(within(card).getByText(soccerEvent.title)).toBeOnTheScreen();
+    expect(within(card).queryByText('Arizona Cardinals')).not.toBeOnTheScreen();
   });
 
   it('does not navigate when an Outcome is pressed', async () => {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -2725,6 +2725,15 @@
   },
   "predict": {
     "title": "MetaMask Predictions",
+    "game_status": {
+      "live": "LIVE",
+      "scheduled": "SCHEDULED",
+      "delayed": "DELAYED",
+      "suspended": "SUSPENDED",
+      "postponed": "POSTPONED",
+      "final": "FINAL",
+      "canceled": "CANCELED"
+    },
     "send_to_predictions": "Send to Predictions",
     "select_predict_account": "Select predict account",
     "search_account": "Search an account",


### PR DESCRIPTION
## **Description**

Adds the football Game Event card for PredictNext and renders it for canonical American-football Game Events on Predict Home.

The card supports explicit compact and featured compositions, scheduled and live/terminal Game states, authoritative Team quote association through `Outcome.gameSelection`, scores, localized status/date presentation, Team branding and fallbacks, quote actions, probability bars, competition/Volume metadata, and remaining-Market navigation. The implementation also extends the canonical PredictNext read contract with the temporary sports/Game fields needed by this vertical slice and refactors the shared Event card into children-based primitives with a narrowly scoped Game-card provider.

Non-Game Events and sports other than American football continue to use `EventCardStandard`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-1229

## **Manual testing steps**

```gherkin
Feature: Football Game Event cards

  Scenario: View a scheduled football Game Event
    Given Predict is enabled and the feed contains a scheduled American-football Game Event
    When the user opens Predict Home
    Then the compact Game Event card shows the localized start date and time, Away and Home Teams, Team quote controls, competition, Volume, and remaining Market count

  Scenario: View an in-progress football Game Event
    Given Predict is enabled and the feed contains an in-progress American-football Game Event
    When the user opens Predict Home
    Then the compact Game Event card shows LIVE status, period, clock, Away and Home scores, and Team quote controls

  Scenario: Open the Event and select a Team quote
    Given a football Game Event card is visible
    When the user presses a non-quote card region or the remaining Market count
    Then the app opens Event detail
    When the user presses an active Team quote
    Then the card emits the associated Event, Market, and Outcome independently of card navigation

  Scenario: View a non-football Event
    Given the feed contains an Event without an American-football Game
    When the user opens Predict Home
    Then the Event uses the standard Event card
```

## **Screenshots/Recordings**

### **Before**

N/A — this is a new card variant.

### **After**
<img width="350" alt="Simulator Screenshot - mm-red - 2026-08-18 at 17 16 47" src="https://github.com/user-attachments/assets/f8619525-c97c-4478-9a71-8fced26d6c6e" />
<img width="350" alt="Simulator Screenshot - mm-red - 2026-08-18 at 17 16 39" src="https://github.com/user-attachments/assets/05de289a-721d-4182-be4b-6c497f5bbe60" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - N/A — no performance-sensitive behavior was introduced; focused automated validation was used.
- [ ] I've tested with a power user scenario
  - N/A — the card renders a bounded Event snapshot and adds no polling or subscriptions.
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A — no long-running or asynchronous operation was introduced.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 23ab22b8ac74d899e09b8f4328b5b6c1712ea1c2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->