### PR TITLE
fix(tron): restore staked TRX on Token Details after assets unify

### DIFF
--- a/app/components/UI/TokenDetails/components/TronAssetOverviewSection.tsx
+++ b/app/components/UI/TokenDetails/components/TronAssetOverviewSection.tsx
@@ -11,7 +11,10 @@ import TronClaimableRewardsRow from '../../Earn/components/Tron/TronStakingRewar
 import TronEstimatedAnnualRewardsRow from '../../Earn/components/Tron/TronStakingRewardsRows/TronEstimatedAnnualRewardsRow';
 import TronErrorsBanner from '../../Earn/components/Tron/TronStakingRewardsRows/TronErrorsBanner';
 import useTronAssetOverviewSection from './useTronAssetOverviewSection';
-import type { TronNativeToken } from '../utils/isTronNativeToken';
+import {
+  getTronNativeChainId,
+  type TronNativeToken,
+} from '../utils/isTronNativeToken';
 
 export interface TronAssetOverviewSectionProps {
   token: TronNativeToken;
@@ -26,6 +29,7 @@ const TronAssetOverviewSection = ({
   inLockPeriodBalance,
   readyForWithdrawalBalance,
 }: TronAssetOverviewSectionProps) => {
+  const tronChainId = getTronNativeChainId(token);
   const {
     aprText,
     claimableRewardsRowProps,
@@ -34,7 +38,7 @@ const TronAssetOverviewSection = ({
   } = useTronAssetOverviewSection({
     enabled: true,
     tokenAddress: token.address,
-    tokenChainId: token.chainId,
+    tokenChainId: tronChainId,
   });
 
   return (
@@ -65,11 +69,11 @@ const TronAssetOverviewSection = ({
           ) : null}
         </Box>
       ) : null}
-      {readyForWithdrawalBalance ? (
+      {readyForWithdrawalBalance && tronChainId ? (
         <Box paddingTop={3} paddingHorizontal={4}>
           <TronUnstakedBanner
             amount={readyForWithdrawalBalance}
-            chainId={String(token.chainId) as CaipChainId}
+            chainId={tronChainId as CaipChainId}
           />
         </Box>
       ) : null}

--- a/app/components/UI/TokenDetails/hooks/useTokenBalance.test.ts
+++ b/app/components/UI/TokenDetails/hooks/useTokenBalance.test.ts
@@ -15,6 +15,16 @@ import {
 import { createStakedTrxAsset } from '../../AssetOverview/utils/createStakedTrxAsset';
 
 const TRON_MAINNET_CHAIN_ID = 'tron:728126428';
+const TRON_NATIVE_ASSET_ID = `${TRON_MAINNET_CHAIN_ID}/slip44:195`;
+
+const createTronNativeToken = (overrides: Partial<TokenI> = {}): TokenI =>
+  ({
+    address: TRON_NATIVE_ASSET_ID,
+    chainId: TRON_MAINNET_CHAIN_ID,
+    symbol: 'TRX',
+    isNative: true,
+    ...overrides,
+  }) as TokenI;
 
 const createMockTronAsset = (symbol: string, balance: string): Asset =>
   ({
@@ -142,12 +152,7 @@ describe('useTokenBalance', () => {
   });
 
   it('returns staked TRX asset for Tron native token', () => {
-    const tronToken = {
-      address: '',
-      chainId: TRON_MAINNET_CHAIN_ID,
-      ticker: 'TRX',
-      symbol: 'TRX',
-    } as TokenI;
+    const tronToken = createTronNativeToken();
 
     const mockStakedAsset = { symbol: 'sTRX', balance: '50' } as TokenI;
 
@@ -184,13 +189,30 @@ describe('useTokenBalance', () => {
     );
   });
 
-  it('returns in-lock-period balance for Tron native token', () => {
-    const tronToken = {
-      address: '',
-      chainId: TRON_MAINNET_CHAIN_ID,
-      ticker: 'TRX',
+  it('returns staked TRX when native token has CAIP-19 address and no ticker', () => {
+    const tronToken = createTronNativeToken({ ticker: undefined });
+    const mockStakedAsset = { symbol: 'sTRX', balance: '50' } as TokenI;
+
+    mockSelectAsset.mockReturnValue({
+      balance: '1000',
+      balanceFiat: '$100.00',
       symbol: 'TRX',
-    } as TokenI;
+    } as TokenI);
+    mockSelectTronResources.mockReturnValue({
+      ...createEmptySpecialAssetsMap(),
+      stakedTrxForEnergy: createMockTronAsset('strx-energy', '100'),
+      stakedTrxForBandwidth: createMockTronAsset('strx-bandwidth', '200'),
+    });
+    mockCreateStakedTrxAsset.mockReturnValue(mockStakedAsset);
+
+    const { result } = renderHookWithProvider(() => useTokenBalance(tronToken));
+
+    expect(result.current.isTronNative).toBe(true);
+    expect(result.current.stakedTrxAsset).toBe(mockStakedAsset);
+  });
+
+  it('returns in-lock-period balance for Tron native token', () => {
+    const tronToken = createTronNativeToken();
 
     mockSelectAsset.mockReturnValue({
       balance: '1000',
@@ -209,12 +231,7 @@ describe('useTokenBalance', () => {
   });
 
   it('returns undefined for in-lock-period when balance is zero', () => {
-    const tronToken = {
-      address: '',
-      chainId: TRON_MAINNET_CHAIN_ID,
-      ticker: 'TRX',
-      symbol: 'TRX',
-    } as TokenI;
+    const tronToken = createTronNativeToken();
 
     mockSelectAsset.mockReturnValue({
       balance: '1000',
@@ -233,12 +250,7 @@ describe('useTokenBalance', () => {
   });
 
   it('returns undefined for in-lock-period when balance is non-numeric', () => {
-    const tronToken = {
-      address: '',
-      chainId: TRON_MAINNET_CHAIN_ID,
-      ticker: 'TRX',
-      symbol: 'TRX',
-    } as TokenI;
+    const tronToken = createTronNativeToken();
 
     mockSelectAsset.mockReturnValue({
       balance: '1000',
@@ -260,12 +272,7 @@ describe('useTokenBalance', () => {
   });
 
   it('returns undefined for in-lock-period when balance is empty string', () => {
-    const tronToken = {
-      address: '',
-      chainId: TRON_MAINNET_CHAIN_ID,
-      ticker: 'TRX',
-      symbol: 'TRX',
-    } as TokenI;
+    const tronToken = createTronNativeToken();
 
     mockSelectAsset.mockReturnValue({
       balance: '1000',
@@ -284,12 +291,7 @@ describe('useTokenBalance', () => {
   });
 
   it('returns undefined for in-lock-period when resources are not available', () => {
-    const tronToken = {
-      address: '',
-      chainId: TRON_MAINNET_CHAIN_ID,
-      ticker: 'TRX',
-      symbol: 'TRX',
-    } as TokenI;
+    const tronToken = createTronNativeToken();
 
     mockSelectAsset.mockReturnValue({
       balance: '1000',
@@ -305,12 +307,7 @@ describe('useTokenBalance', () => {
   });
 
   it('returns ready-for-withdrawal balance for Tron native token', () => {
-    const tronToken = {
-      address: '',
-      chainId: TRON_MAINNET_CHAIN_ID,
-      ticker: 'TRX',
-      symbol: 'TRX',
-    } as TokenI;
+    const tronToken = createTronNativeToken();
 
     mockSelectAsset.mockReturnValue({
       balance: '1000',
@@ -332,12 +329,7 @@ describe('useTokenBalance', () => {
   });
 
   it('returns undefined for ready-for-withdrawal when balance is zero', () => {
-    const tronToken = {
-      address: '',
-      chainId: TRON_MAINNET_CHAIN_ID,
-      ticker: 'TRX',
-      symbol: 'TRX',
-    } as TokenI;
+    const tronToken = createTronNativeToken();
 
     mockSelectAsset.mockReturnValue({
       balance: '1000',
@@ -359,12 +351,7 @@ describe('useTokenBalance', () => {
   });
 
   it('returns undefined for ready-for-withdrawal when balance is non-numeric', () => {
-    const tronToken = {
-      address: '',
-      chainId: TRON_MAINNET_CHAIN_ID,
-      ticker: 'TRX',
-      symbol: 'TRX',
-    } as TokenI;
+    const tronToken = createTronNativeToken();
 
     mockSelectAsset.mockReturnValue({
       balance: '1000',
@@ -386,12 +373,7 @@ describe('useTokenBalance', () => {
   });
 
   it('returns undefined for ready-for-withdrawal when balance is empty string', () => {
-    const tronToken = {
-      address: '',
-      chainId: TRON_MAINNET_CHAIN_ID,
-      ticker: 'TRX',
-      symbol: 'TRX',
-    } as TokenI;
+    const tronToken = createTronNativeToken();
 
     mockSelectAsset.mockReturnValue({
       balance: '1000',
@@ -413,12 +395,7 @@ describe('useTokenBalance', () => {
   });
 
   it('returns undefined for ready-for-withdrawal when resources are not available', () => {
-    const tronToken = {
-      address: '',
-      chainId: TRON_MAINNET_CHAIN_ID,
-      ticker: 'TRX',
-      symbol: 'TRX',
-    } as TokenI;
+    const tronToken = createTronNativeToken();
 
     mockSelectAsset.mockReturnValue({
       balance: '1000',

--- a/app/components/UI/TokenDetails/utils/isTronNativeToken.test.ts
+++ b/app/components/UI/TokenDetails/utils/isTronNativeToken.test.ts
@@ -1,6 +1,10 @@
 import { TrxScope } from '@metamask/keyring-api';
 import type { TokenI } from '../../Tokens/types';
-import { isTronNativeAssetId, isTronNativeToken } from './isTronNativeToken';
+import {
+  getTronNativeChainId,
+  isTronNativeAssetId,
+  isTronNativeToken,
+} from './isTronNativeToken';
 
 const TRON_NATIVE_MAINNET = `${TrxScope.Mainnet}/slip44:195`;
 const TRON_NATIVE_HEX_CHAIN = 'tron:0x2b6653dc/slip44:195';
@@ -101,5 +105,38 @@ describe('isTronNativeToken', () => {
     });
 
     expect(isTronNativeToken(token)).toBe(false);
+  });
+});
+
+describe('getTronNativeChainId', () => {
+  it('returns decimal TrxScope when chainId is already decimal CAIP-2', () => {
+    expect(getTronNativeChainId(createToken())).toBe(TrxScope.Mainnet);
+  });
+
+  it('normalizes hex Tron chainId so stake APIs receive TrxScope form', () => {
+    const token = createToken({
+      chainId: 'tron:0x2b6653dc',
+      address: TRON_NATIVE_HEX_CHAIN,
+    });
+
+    expect(getTronNativeChainId(token)).toBe(TrxScope.Mainnet);
+  });
+
+  it('normalizes hex chain from native CAIP-19 address when chainId is missing', () => {
+    const token = createToken({
+      chainId: undefined,
+      address: TRON_NATIVE_HEX_CHAIN,
+    });
+
+    expect(getTronNativeChainId(token)).toBe(TrxScope.Mainnet);
+  });
+
+  it('returns undefined for non-Tron tokens', () => {
+    const token = createToken({
+      address: '0x0000000000000000000000000000000000000000',
+      chainId: '0x1',
+    });
+
+    expect(getTronNativeChainId(token)).toBeUndefined();
   });
 });

--- a/app/components/UI/TokenDetails/utils/isTronNativeToken.test.ts
+++ b/app/components/UI/TokenDetails/utils/isTronNativeToken.test.ts
@@ -1,0 +1,105 @@
+import { TrxScope } from '@metamask/keyring-api';
+import type { TokenI } from '../../Tokens/types';
+import { isTronNativeAssetId, isTronNativeToken } from './isTronNativeToken';
+
+const TRON_NATIVE_MAINNET = `${TrxScope.Mainnet}/slip44:195`;
+const TRON_NATIVE_HEX_CHAIN = 'tron:0x2b6653dc/slip44:195';
+const TRON_STAKED_ENERGY = `${TrxScope.Mainnet}/slip44:195-staked-for-energy`;
+const TRON_USDT = `${TrxScope.Mainnet}/token:TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t`;
+
+const createToken = (overrides: Partial<TokenI> = {}): TokenI =>
+  ({
+    address: TRON_NATIVE_MAINNET,
+    chainId: TrxScope.Mainnet,
+    symbol: 'TRX',
+    name: 'TRON',
+    decimals: 6,
+    balance: '1',
+    image: '',
+    logo: '',
+    isETH: false,
+    isNative: true,
+    ...overrides,
+  }) as TokenI;
+
+describe('isTronNativeAssetId', () => {
+  it('returns true for native TRX CAIP-19 on mainnet', () => {
+    expect(isTronNativeAssetId(TRON_NATIVE_MAINNET)).toBe(true);
+  });
+
+  it('returns true for native TRX CAIP-19 with hex chain reference', () => {
+    expect(isTronNativeAssetId(TRON_NATIVE_HEX_CHAIN)).toBe(true);
+  });
+
+  it('returns false for staked TRX synthetic CAIP-19', () => {
+    expect(isTronNativeAssetId(TRON_STAKED_ENERGY)).toBe(false);
+  });
+
+  it('returns false for TRC-20 CAIP-19', () => {
+    expect(isTronNativeAssetId(TRON_USDT)).toBe(false);
+  });
+
+  it('returns false for undefined and non-CAIP strings', () => {
+    expect(isTronNativeAssetId(undefined)).toBe(false);
+    expect(isTronNativeAssetId('TRX')).toBe(false);
+  });
+});
+
+describe('isTronNativeToken', () => {
+  it('returns true when address is native TRX CAIP-19 even without ticker', () => {
+    const token = createToken({ ticker: undefined, symbol: 'Tron' });
+
+    expect(isTronNativeToken(token)).toBe(true);
+  });
+
+  it('returns false when ticker is TRX but address is a TRC-20 CAIP-19', () => {
+    const token = createToken({
+      address: TRON_USDT,
+      ticker: 'TRX',
+      symbol: 'TRX',
+      isNative: false,
+    });
+
+    expect(isTronNativeToken(token)).toBe(false);
+  });
+
+  it('returns false when address is a staked TRX CAIP-19', () => {
+    const token = createToken({
+      address: TRON_STAKED_ENERGY,
+      ticker: 'TRX',
+      isNative: true,
+    });
+
+    expect(isTronNativeToken(token)).toBe(false);
+  });
+
+  it('returns true when caipAssetId is native TRX CAIP-19', () => {
+    const token = createToken({
+      address: '',
+      chainId: undefined,
+      caipAssetId: TRON_NATIVE_MAINNET,
+    } as TokenI & { caipAssetId: string });
+
+    expect(isTronNativeToken(token)).toBe(true);
+  });
+
+  it('returns true for legacy TokenI with empty address and CAIP-2 chainId', () => {
+    const token = createToken({
+      address: '',
+      chainId: TrxScope.Mainnet,
+    });
+
+    expect(isTronNativeToken(token)).toBe(true);
+  });
+
+  it('returns false for ETH native token', () => {
+    const token = createToken({
+      address: '0x0000000000000000000000000000000000000000',
+      chainId: '0x1',
+      ticker: 'ETH',
+      symbol: 'ETH',
+    });
+
+    expect(isTronNativeToken(token)).toBe(false);
+  });
+});

--- a/app/components/UI/TokenDetails/utils/isTronNativeToken.ts
+++ b/app/components/UI/TokenDetails/utils/isTronNativeToken.ts
@@ -5,6 +5,7 @@ import {
   parseCaipAssetType,
 } from '@metamask/utils';
 import type { TokenI } from '../../Tokens/types';
+import { toDecimalTronCaipChainId } from '../../../../core/Multichain/tronSpecialAssets';
 
 /** SLIP-44 coin type for TRX. Synthetic staking IDs use suffixes after this (e.g. `195-staked-for-energy`). */
 const TRX_SLIP44_REFERENCE = '195';
@@ -42,7 +43,7 @@ export const getTronNativeChainId = (
   token: TokenWithOptionalCaipAssetId,
 ): `tron:${string}` | undefined => {
   if (typeof token.chainId === 'string' && token.chainId.startsWith('tron:')) {
-    return token.chainId as `tron:${string}`;
+    return toDecimalTronCaipChainId(token.chainId);
   }
 
   const caipAssetId = isTronNativeAssetId(token.caipAssetId)
@@ -53,11 +54,7 @@ export const getTronNativeChainId = (
   }
 
   const { chainId } = parseCaipAssetType(caipAssetId as CaipAssetType);
-  if (chainId.startsWith('tron:')) {
-    return chainId as `tron:${string}`;
-  }
-
-  return undefined;
+  return toDecimalTronCaipChainId(chainId);
 };
 
 /**

--- a/app/components/UI/TokenDetails/utils/isTronNativeToken.ts
+++ b/app/components/UI/TokenDetails/utils/isTronNativeToken.ts
@@ -1,9 +1,82 @@
+import {
+  type CaipAssetType,
+  isCaipAssetType,
+  KnownCaipNamespace,
+  parseCaipAssetType,
+} from '@metamask/utils';
 import type { TokenI } from '../../Tokens/types';
 
-export type TronNativeToken = TokenI & {
-  chainId: `tron:${string}`;
-  ticker: 'TRX';
+/** SLIP-44 coin type for TRX. Synthetic staking IDs use suffixes after this (e.g. `195-staked-for-energy`). */
+const TRX_SLIP44_REFERENCE = '195';
+
+export type TronNativeToken = TokenI;
+
+type TokenWithOptionalCaipAssetId = TokenI & {
+  caipAssetId?: string;
 };
 
-export const isTronNativeToken = (token: TokenI): token is TronNativeToken =>
-  token.ticker === 'TRX' && String(token.chainId).startsWith('tron:');
+/**
+ * True when `assetId` is native TRX CAIP-19 (`tron:<chain>/slip44:195`).
+ *
+ * Exact `slip44:195` only — staking/resource IDs like `slip44:195-staked-for-energy`
+ * must not match. Symbols/tickers are unstable across AssetsController migrations.
+ */
+export const isTronNativeAssetId = (
+  assetId: string | undefined,
+): assetId is string => {
+  if (!assetId || !isCaipAssetType(assetId)) {
+    return false;
+  }
+
+  const { chain, assetNamespace, assetReference } = parseCaipAssetType(
+    assetId as CaipAssetType,
+  );
+  return (
+    chain.namespace === KnownCaipNamespace.Tron &&
+    assetNamespace === 'slip44' &&
+    assetReference === TRX_SLIP44_REFERENCE
+  );
+};
+
+export const getTronNativeChainId = (
+  token: TokenWithOptionalCaipAssetId,
+): `tron:${string}` | undefined => {
+  if (typeof token.chainId === 'string' && token.chainId.startsWith('tron:')) {
+    return token.chainId as `tron:${string}`;
+  }
+
+  const caipAssetId = isTronNativeAssetId(token.caipAssetId)
+    ? token.caipAssetId
+    : token.address;
+  if (!isCaipAssetType(caipAssetId)) {
+    return undefined;
+  }
+
+  const { chainId } = parseCaipAssetType(caipAssetId as CaipAssetType);
+  if (chainId.startsWith('tron:')) {
+    return chainId as `tron:${string}`;
+  }
+
+  return undefined;
+};
+
+/**
+ * True when `token` is native TRX, identified by CAIP-19 (or CAIP-2 chainId +
+ * native slip44:195), not by ticker/symbol.
+ */
+export const isTronNativeToken = (
+  token: TokenWithOptionalCaipAssetId,
+): token is TronNativeToken => {
+  const hasNativeCaip =
+    isTronNativeAssetId(token.address) ||
+    isTronNativeAssetId(token.caipAssetId);
+  const legacyChainNative =
+    !token.address && token.chainId
+      ? isTronNativeAssetId(`${token.chainId}/slip44:${TRX_SLIP44_REFERENCE}`)
+      : false;
+
+  return (
+    (hasNativeCaip && getTronNativeChainId(token) !== undefined) ||
+    legacyChainNative
+  );
+};

--- a/app/core/Multichain/tronSpecialAssets.test.ts
+++ b/app/core/Multichain/tronSpecialAssets.test.ts
@@ -1,0 +1,71 @@
+import { TrxScope } from '@metamask/keyring-api';
+import { KnownCaip19Id } from './constants';
+import {
+  getTronSpecialAssetMapKey,
+  getTronSpecialAssetUnit,
+  isTronSpecialAssetId,
+  toDecimalTronCaipChainId,
+} from './tronSpecialAssets';
+
+describe('tronSpecialAssets', () => {
+  it('maps every KnownCaip19Id to a special-asset key', () => {
+    for (const assetId of Object.values(KnownCaip19Id)) {
+      expect(getTronSpecialAssetMapKey(assetId)).toBeDefined();
+    }
+  });
+
+  it('matches hex and decimal Tron chain references for staking CAIP-19s', () => {
+    expect(
+      getTronSpecialAssetMapKey('tron:728126428/slip44:195-staked-for-energy'),
+    ).toBe('stakedTrxForEnergy');
+    expect(
+      getTronSpecialAssetMapKey('tron:0x2b6653dc/slip44:195-staked-for-energy'),
+    ).toBe('stakedTrxForEnergy');
+    expect(
+      getTronSpecialAssetMapKey(
+        'tron:0x2b6653dc/slip44:195-staked-for-bandwidth',
+      ),
+    ).toBe('stakedTrxForBandwidth');
+    expect(
+      getTronSpecialAssetMapKey('tron:728126428/slip44:195-staking-rewards'),
+    ).toBe('trxStakingRewards');
+    expect(getTronSpecialAssetMapKey('tron:728126428/slip44:energy')).toBe(
+      'energy',
+    );
+  });
+
+  it('does not treat native TRX or TRC-20 as special assets', () => {
+    expect(isTronSpecialAssetId('tron:728126428/slip44:195')).toBe(false);
+    expect(isTronSpecialAssetId('tron:0x2b6653dc/slip44:195')).toBe(false);
+    expect(
+      isTronSpecialAssetId(
+        'tron:728126428/trc20:TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+      ),
+    ).toBe(false);
+    expect(isTronSpecialAssetId('tron:728126428/slip44:strx-energy')).toBe(
+      false,
+    );
+    expect(isTronSpecialAssetId(undefined)).toBe(false);
+    expect(isTronSpecialAssetId('not-caip')).toBe(false);
+  });
+
+  it('returns the display unit for special assets', () => {
+    expect(
+      getTronSpecialAssetUnit('tron:728126428/slip44:195-staked-for-energy'),
+    ).toBe('TRX');
+    expect(getTronSpecialAssetUnit('tron:728126428/slip44:energy')).toBe(
+      'ENERGY',
+    );
+    expect(
+      getTronSpecialAssetUnit('tron:728126428/slip44:195'),
+    ).toBeUndefined();
+  });
+
+  it('normalizes hex Tron CAIP-2 chain ids to decimal TrxScope form', () => {
+    expect(toDecimalTronCaipChainId('tron:0x2b6653dc')).toBe(TrxScope.Mainnet);
+    expect(toDecimalTronCaipChainId(TrxScope.Mainnet)).toBe(TrxScope.Mainnet);
+    expect(toDecimalTronCaipChainId('eip155:1')).toBeUndefined();
+    expect(toDecimalTronCaipChainId('not-a-caip')).toBeUndefined();
+    expect(toDecimalTronCaipChainId(undefined)).toBeUndefined();
+  });
+});

--- a/app/core/Multichain/tronSpecialAssets.ts
+++ b/app/core/Multichain/tronSpecialAssets.ts
@@ -1,0 +1,90 @@
+import {
+  type CaipAssetType,
+  isCaipAssetType,
+  KnownCaipNamespace,
+  parseCaipAssetType,
+} from '@metamask/utils';
+
+/**
+ * Semantic keys for Tron Snap synthetic assets (resources + staking state).
+ * Matches {@link TronSpecialAssetsMap} in the assets-list selector, minus
+ * the computed `totalStakedTrx` field.
+ */
+export const TRON_SPECIAL_ASSET_REFERENCE_TO_KEY = {
+  energy: 'energy',
+  bandwidth: 'bandwidth',
+  'maximum-energy': 'maxEnergy',
+  'maximum-bandwidth': 'maxBandwidth',
+  '195-staked-for-energy': 'stakedTrxForEnergy',
+  '195-staked-for-bandwidth': 'stakedTrxForBandwidth',
+  '195-ready-for-withdrawal': 'trxReadyForWithdrawal',
+  '195-staking-rewards': 'trxStakingRewards',
+  '195-in-lock-period': 'trxInLockPeriod',
+} as const;
+
+export type TronSpecialAssetMapKey =
+  (typeof TRON_SPECIAL_ASSET_REFERENCE_TO_KEY)[keyof typeof TRON_SPECIAL_ASSET_REFERENCE_TO_KEY];
+
+const TRON_SPECIAL_ASSET_UNITS: Record<TronSpecialAssetMapKey, string> = {
+  energy: 'ENERGY',
+  bandwidth: 'BANDWIDTH',
+  maxEnergy: 'ENERGY',
+  maxBandwidth: 'BANDWIDTH',
+  stakedTrxForEnergy: 'TRX',
+  stakedTrxForBandwidth: 'TRX',
+  trxReadyForWithdrawal: 'TRX',
+  trxStakingRewards: 'TRX',
+  trxInLockPeriod: 'TRX',
+};
+
+/**
+ * Maps a CAIP-19 asset ID to its Tron special-asset key.
+ *
+ * Matching is by chain namespace `tron`, asset namespace `slip44`, and the
+ * asset reference (e.g. `195-staked-for-energy`). Chain reference may be
+ * decimal (`728126428`) or hex (`0x2b6653dc`). Native TRX (`slip44:195`)
+ * does not match.
+ */
+export const getTronSpecialAssetMapKey = (
+  assetId: string | undefined,
+): TronSpecialAssetMapKey | undefined => {
+  if (!assetId || !isCaipAssetType(assetId)) {
+    return undefined;
+  }
+
+  try {
+    const { chain, assetNamespace, assetReference } = parseCaipAssetType(
+      assetId as CaipAssetType,
+    );
+    if (
+      chain.namespace !== KnownCaipNamespace.Tron ||
+      assetNamespace !== 'slip44'
+    ) {
+      return undefined;
+    }
+
+    return TRON_SPECIAL_ASSET_REFERENCE_TO_KEY[
+      assetReference as keyof typeof TRON_SPECIAL_ASSET_REFERENCE_TO_KEY
+    ];
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * True when `assetId` is a Tron Snap synthetic resource or staking-state
+ * CAIP-19 (energy, bandwidth, staked TRX, lock period, etc.).
+ *
+ * Matching is by parsed CAIP-19, not an exact string catalog — hex and
+ * decimal chain references both count. Symbols are not used.
+ */
+export const isTronSpecialAssetId = (
+  assetId: string | undefined,
+): assetId is string => getTronSpecialAssetMapKey(assetId) !== undefined;
+
+export const getTronSpecialAssetUnit = (
+  assetId: string | undefined,
+): string | undefined => {
+  const key = getTronSpecialAssetMapKey(assetId);
+  return key ? TRON_SPECIAL_ASSET_UNITS[key] : undefined;
+};

--- a/app/core/Multichain/tronSpecialAssets.ts
+++ b/app/core/Multichain/tronSpecialAssets.ts
@@ -1,8 +1,10 @@
 import {
   type CaipAssetType,
+  type CaipChainId,
   isCaipAssetType,
   KnownCaipNamespace,
   parseCaipAssetType,
+  parseCaipChainId,
 } from '@metamask/utils';
 
 /**
@@ -87,4 +89,33 @@ export const getTronSpecialAssetUnit = (
 ): string | undefined => {
   const key = getTronSpecialAssetMapKey(assetId);
   return key ? TRON_SPECIAL_ASSET_UNITS[key] : undefined;
+};
+
+/**
+ * Normalize a Tron CAIP-2 chain id to decimal form (`tron:728126428`).
+ * Hex references (`tron:0x2b6653dc`) map to the same chain. Non-Tron IDs
+ * and invalid CAIP strings return `undefined`.
+ */
+export const toDecimalTronCaipChainId = (
+  chainId: string | undefined,
+): `tron:${string}` | undefined => {
+  if (!chainId) {
+    return undefined;
+  }
+
+  try {
+    const { namespace, reference } = parseCaipChainId(chainId as CaipChainId);
+    if (namespace !== KnownCaipNamespace.Tron) {
+      return undefined;
+    }
+    if (/^0x[0-9a-fA-F]+$/u.test(reference)) {
+      return `${namespace}:${Number.parseInt(
+        reference,
+        16,
+      )}` as `tron:${string}`;
+    }
+    return `${namespace}:${reference}` as `tron:${string}`;
+  } catch {
+    return undefined;
+  }
 };

--- a/app/core/Multichain/utils.ts
+++ b/app/core/Multichain/utils.ts
@@ -11,10 +11,8 @@ import { isAddress as isSolanaAddress } from '@solana/addresses';
 import Engine from '../Engine';
 import { CaipChainId, Hex } from '@metamask/utils';
 import { validate, Network } from 'bitcoin-address-validation';
-import {
-  MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP,
-  TRON_SPECIAL_ASSET_IDS_SET,
-} from './constants';
+import { MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP } from './constants';
+import { isTronSpecialAssetId } from './tronSpecialAssets';
 import { formatAddress, isEthAddress } from '../../util/address';
 import {
   formatBlockExplorerAddressUrl,
@@ -287,10 +285,8 @@ export function shortenTransactionId(txId: string) {
  * Checks if a token is a Tron special asset (resources, staking state, etc.)
  * that should be filtered out from user-facing asset lists.
  *
- * Matching is by CAIP-19 asset ID only — symbols are not stable across
- * AssetsController migrations.
+ * Matching is by parsed CAIP-19 (namespace + slip44 reference) — symbols
+ * are not stable across AssetsController migrations, and chain references
+ * may be decimal or hex.
  */
-export const isTronSpecialAsset = (
-  assetId: string | undefined,
-): assetId is string =>
-  Boolean(assetId && TRON_SPECIAL_ASSET_IDS_SET.has(assetId));
+export const isTronSpecialAsset = isTronSpecialAssetId;

--- a/app/selectors/assets/assets-list.test.ts
+++ b/app/selectors/assets/assets-list.test.ts
@@ -31,6 +31,10 @@ import {
 } from '@metamask/assets-controllers';
 import I18n from '../../../locales/i18n';
 import { ARC_USDC_ERC20_TOKEN_ADDRESS } from '../../enablement/assets/networks-customization';
+import {
+  ASSETS_UNIFY_STATE_FLAG,
+  ASSETS_UNIFY_STATE_FEATURE_VERSION_1,
+} from '../featureFlagController/assetsUnifyState';
 
 // Wrap the inner assets-controllers selector in a jest.fn so the Arc
 // filtering describe block can override its return value without affecting
@@ -2216,6 +2220,108 @@ describe('selectTronSpecialAssetsBySelectedAccountGroup', () => {
     // totalStakedTrx computed via BigNumber avoids floating-point errors
     // 65.48463 + 65.48463 = 130.96926 (not 130.96926000000002)
     expect(result.totalStakedTrx).toBe(130.96926);
+  });
+
+  it('still surfaces Snap-staked TRX when AssetsController unify omitted staking CAIP-19s', () => {
+    const accountId = '2d89e6a0-b4e6-45a8-a707-f10cef143b42';
+    const nativeTrx = 'tron:728126428/slip44:195';
+    const hexStakedEnergy = 'tron:0x2b6653dc/slip44:195-staked-for-energy';
+    const hexStakedBandwidth =
+      'tron:0x2b6653dc/slip44:195-staked-for-bandwidth';
+    const base = mockState();
+    const assetsController = base.engine.backgroundState.AssetsController;
+
+    const state = {
+      ...base,
+      engine: {
+        ...base.engine,
+        backgroundState: {
+          ...base.engine.backgroundState,
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              [ASSETS_UNIFY_STATE_FLAG]: {
+                enabled: true,
+                featureVersion: ASSETS_UNIFY_STATE_FEATURE_VERSION_1,
+              },
+            },
+          },
+          AssetsController: {
+            ...assetsController,
+            assetsInfo: {
+              ...assetsController.assetsInfo,
+              [nativeTrx]: {
+                type: 'native',
+                decimals: 6,
+                symbol: 'TRX',
+                name: 'TRON',
+              },
+            },
+            assetsBalance: {
+              ...assetsController.assetsBalance,
+              [accountId]: {
+                ...assetsController.assetsBalance[accountId],
+                [nativeTrx]: { amount: '1000' },
+              },
+            },
+          },
+          MultichainAssetsController: {
+            accountsAssets: {
+              [accountId]: [hexStakedEnergy, hexStakedBandwidth],
+            },
+            assetsMetadata: {
+              [hexStakedEnergy]: {
+                name: 'Staked TRX Energy',
+                symbol: 'sTRX-ENERGY',
+                fungible: true as const,
+                iconUrl: 'test-url',
+                units: [
+                  {
+                    name: 'Staked TRX Energy',
+                    symbol: 'sTRX-ENERGY',
+                    decimals: 6,
+                  },
+                ],
+              },
+              [hexStakedBandwidth]: {
+                name: 'Staked TRX Bandwidth',
+                symbol: 'sTRX-BANDWIDTH',
+                fungible: true as const,
+                iconUrl: 'test-url',
+                units: [
+                  {
+                    name: 'Staked TRX Bandwidth',
+                    symbol: 'sTRX-BANDWIDTH',
+                    decimals: 6,
+                  },
+                ],
+              },
+            },
+            allIgnoredAssets: {},
+          },
+          MultichainBalancesController: {
+            balances: {
+              [accountId]: {
+                [hexStakedEnergy]: { amount: '80', unit: 'TRX' },
+                [hexStakedBandwidth]: { amount: '20', unit: 'TRX' },
+              },
+            },
+          },
+          NetworkEnablementController: {
+            enabledNetworkMap: {
+              [KnownCaipNamespace.Tron]: {
+                [TrxScope.Mainnet]: true,
+              },
+            },
+          },
+        },
+      },
+    } as unknown as RootState;
+
+    const result = selectTronSpecialAssetsBySelectedAccountGroup(state);
+
+    expect(result.stakedTrxForEnergy?.balance).toBe('80');
+    expect(result.stakedTrxForBandwidth?.balance).toBe('20');
+    expect(result.totalStakedTrx).toBe(100);
   });
 
   it('returns empty object when Tron network is disabled', () => {

--- a/app/selectors/assets/assets-list.test.ts
+++ b/app/selectors/assets/assets-list.test.ts
@@ -2324,6 +2324,62 @@ describe('selectTronSpecialAssetsBySelectedAccountGroup', () => {
     expect(result.totalStakedTrx).toBe(100);
   });
 
+  it('builds staked TRX from Snap balances when the asset list omitted synthetics', () => {
+    const accountId = '2d89e6a0-b4e6-45a8-a707-f10cef143b42';
+    const state = {
+      ...mockState(),
+      engine: {
+        ...mockState().engine,
+        backgroundState: {
+          ...mockState().engine.backgroundState,
+          MultichainAssetsController: {
+            accountsAssets: {
+              [accountId]: ['tron:728126428/slip44:195'],
+            },
+            assetsMetadata: {
+              'tron:728126428/slip44:195': {
+                name: 'TRON',
+                symbol: 'TRX',
+                fungible: true as const,
+                iconUrl: 'test-url',
+                units: [{ name: 'TRON', symbol: 'TRX', decimals: 6 }],
+              },
+            },
+            allIgnoredAssets: {},
+          },
+          MultichainBalancesController: {
+            balances: {
+              [accountId]: {
+                'tron:728126428/slip44:195': { amount: '1000', unit: 'TRX' },
+                'tron:728126428/slip44:195-staked-for-energy': {
+                  amount: '40',
+                },
+                'tron:728126428/slip44:195-staked-for-bandwidth': {
+                  amount: '10',
+                  unit: 'TRX',
+                },
+              },
+            },
+          },
+          NetworkEnablementController: {
+            enabledNetworkMap: {
+              [KnownCaipNamespace.Tron]: {
+                [TrxScope.Mainnet]: true,
+              },
+            },
+          },
+        },
+      },
+    } as unknown as RootState;
+
+    const result = selectTronSpecialAssetsBySelectedAccountGroup(state);
+
+    expect(result.stakedTrxForEnergy?.balance).toBe('40');
+    expect(result.stakedTrxForEnergy?.symbol).toBe('TRX');
+    expect(result.stakedTrxForBandwidth?.balance).toBe('10');
+    expect(result.totalStakedTrx).toBe(50);
+  });
+
   it('returns empty object when Tron network is disabled', () => {
     const stateWithTronDisabled = {
       ...mockState(),

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -17,9 +17,7 @@ import {
   CaipChainId,
   Hex,
   isCaipChainId,
-  KnownCaipNamespace,
   parseCaipAssetType,
-  parseCaipChainId,
 } from '@metamask/utils';
 import { createSelector } from 'reselect';
 
@@ -31,6 +29,7 @@ import { isTronSpecialAsset } from '../../core/Multichain/utils';
 import {
   getTronSpecialAssetMapKey,
   getTronSpecialAssetUnit,
+  toDecimalTronCaipChainId,
 } from '../../core/Multichain/tronSpecialAssets';
 import { RootState } from '../../reducers';
 import { formatWithThreshold } from '../../util/assets';
@@ -101,31 +100,6 @@ export interface TronSpecialAssetsMap {
   trxInLockPeriod: Asset | undefined;
 }
 
-/**
- * Normalize a Tron CAIP-2 network ID to decimal form (`tron:728126428`).
- * Hex references (`tron:0x2b6653dc`) map to the same decimal chain.
- */
-const toDecimalTronChainId = (networkId: string): string | undefined => {
-  if (networkId.startsWith(`${KnownCaipNamespace.Tron}:`)) {
-    try {
-      const { namespace, reference } = parseCaipChainId(
-        networkId as CaipChainId,
-      );
-      if (namespace !== KnownCaipNamespace.Tron) {
-        return undefined;
-      }
-      if (/^0x[0-9a-fA-F]+$/u.test(reference)) {
-        return `${namespace}:${Number.parseInt(reference, 16)}`;
-      }
-      return networkId;
-    } catch {
-      return undefined;
-    }
-  }
-
-  return undefined;
-};
-
 interface AccountTreeSlice {
   selectedAccountGroup?: string;
   accountTree?: {
@@ -175,6 +149,7 @@ const specialAssetFromBalance = (
     name: unit,
     rawBalance: '0x0' as Hex,
     symbol: unit,
+    fiat: undefined,
   };
 };
 
@@ -741,8 +716,10 @@ export const selectTronSpecialAssetsBySelectedAccountGroup =
     [getStateForAssetSelector, selectEnabledNetworks],
     (assetsState, enabledNetworks): TronSpecialAssetsMap => {
       const enabledTronNetworks = enabledNetworks
-        .map(toDecimalTronChainId)
-        .filter((networkId): networkId is string => networkId !== undefined);
+        .map(toDecimalTronCaipChainId)
+        .filter(
+          (networkId): networkId is `tron:${string}` => networkId !== undefined,
+        );
 
       if (enabledTronNetworks.length === 0) {
         return EMPTY_TRON_SPECIAL_ASSETS_MAP;
@@ -771,7 +748,7 @@ export const selectTronSpecialAssetsBySelectedAccountGroup =
       };
 
       for (const [networkId, chainAssets] of Object.entries(allAssets)) {
-        const decimalTronChainId = toDecimalTronChainId(networkId);
+        const decimalTronChainId = toDecimalTronCaipChainId(networkId);
         const isEnabledTron = Boolean(
           decimalTronChainId && enabledTronNetworksSet.has(decimalTronChainId),
         );
@@ -801,7 +778,7 @@ export const selectTronSpecialAssetsBySelectedAccountGroup =
 
           try {
             const { chainId } = parseCaipAssetType(assetId as CaipAssetType);
-            const decimalTronChainId = toDecimalTronChainId(chainId);
+            const decimalTronChainId = toDecimalTronCaipChainId(chainId);
             if (
               !decimalTronChainId ||
               !enabledTronNetworksSet.has(decimalTronChainId)

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -12,15 +12,26 @@ import {
   MULTICHAIN_NETWORK_DECIMAL_PLACES,
   toEvmCaipChainId,
 } from '@metamask/multichain-network-controller';
-import { CaipChainId, Hex, isCaipChainId } from '@metamask/utils';
+import {
+  CaipAssetType,
+  CaipChainId,
+  Hex,
+  isCaipChainId,
+  KnownCaipNamespace,
+  parseCaipAssetType,
+  parseCaipChainId,
+} from '@metamask/utils';
 import { createSelector } from 'reselect';
 
 import I18n from '../../../locales/i18n';
 import { getLocaleLanguageCode } from '../../components/hooks/useFormatters';
 import { TokenI } from '../../components/UI/Tokens/types';
 import { sortAssetsWithPriority } from '../../components/UI/Tokens/util/sortAssetsWithPriority';
-import { KnownCaip19Id } from '../../core/Multichain/constants';
 import { isTronSpecialAsset } from '../../core/Multichain/utils';
+import {
+  getTronSpecialAssetMapKey,
+  getTronSpecialAssetUnit,
+} from '../../core/Multichain/tronSpecialAssets';
 import { RootState } from '../../reducers';
 import { formatWithThreshold } from '../../util/assets';
 import {
@@ -90,52 +101,82 @@ export interface TronSpecialAssetsMap {
   trxInLockPeriod: Asset | undefined;
 }
 
-type TronSpecialAssetKey = Exclude<
-  keyof TronSpecialAssetsMap,
-  'totalStakedTrx'
->;
-
 /**
- * Maps each Tron special-asset CAIP-19 ID to its semantic key in
- * {@link TronSpecialAssetsMap}. Network-specific IDs collapse to the same key.
+ * Normalize a Tron CAIP-2 network ID to decimal form (`tron:728126428`).
+ * Hex references (`tron:0x2b6653dc`) map to the same decimal chain.
  */
-const TRON_SPECIAL_ASSET_KEYS = {
-  [KnownCaip19Id.EnergyMainnet]: 'energy',
-  [KnownCaip19Id.EnergyNile]: 'energy',
-  [KnownCaip19Id.EnergyShasta]: 'energy',
+const toDecimalTronChainId = (networkId: string): string | undefined => {
+  if (networkId.startsWith(`${KnownCaipNamespace.Tron}:`)) {
+    try {
+      const { namespace, reference } = parseCaipChainId(
+        networkId as CaipChainId,
+      );
+      if (namespace !== KnownCaipNamespace.Tron) {
+        return undefined;
+      }
+      if (/^0x[0-9a-fA-F]+$/u.test(reference)) {
+        return `${namespace}:${Number.parseInt(reference, 16)}`;
+      }
+      return networkId;
+    } catch {
+      return undefined;
+    }
+  }
 
-  [KnownCaip19Id.BandwidthMainnet]: 'bandwidth',
-  [KnownCaip19Id.BandwidthNile]: 'bandwidth',
-  [KnownCaip19Id.BandwidthShasta]: 'bandwidth',
+  return undefined;
+};
 
-  [KnownCaip19Id.MaximumEnergyMainnet]: 'maxEnergy',
-  [KnownCaip19Id.MaximumEnergyNile]: 'maxEnergy',
-  [KnownCaip19Id.MaximumEnergyShasta]: 'maxEnergy',
+interface AccountTreeSlice {
+  selectedAccountGroup?: string;
+  accountTree?: {
+    wallets?: Record<
+      string,
+      {
+        groups?: Record<string, { accounts?: string[] }>;
+      }
+    >;
+  };
+  balances?: Record<string, Record<string, { amount?: string; unit?: string }>>;
+}
 
-  [KnownCaip19Id.MaximumBandwidthMainnet]: 'maxBandwidth',
-  [KnownCaip19Id.MaximumBandwidthNile]: 'maxBandwidth',
-  [KnownCaip19Id.MaximumBandwidthShasta]: 'maxBandwidth',
+const getSelectedAccountGroupAccountIds = (
+  assetsState: AssetListState,
+): string[] => {
+  const { selectedAccountGroup, accountTree } = assetsState as AssetListState &
+    AccountTreeSlice;
+  if (!selectedAccountGroup) {
+    return [];
+  }
+  for (const wallet of Object.values(accountTree?.wallets ?? {})) {
+    const group = wallet.groups?.[selectedAccountGroup];
+    if (group?.accounts) {
+      return group.accounts;
+    }
+  }
+  return [];
+};
 
-  [KnownCaip19Id.TrxStakedForEnergyMainnet]: 'stakedTrxForEnergy',
-  [KnownCaip19Id.TrxStakedForEnergyNile]: 'stakedTrxForEnergy',
-  [KnownCaip19Id.TrxStakedForEnergyShasta]: 'stakedTrxForEnergy',
-
-  [KnownCaip19Id.TrxStakedForBandwidthMainnet]: 'stakedTrxForBandwidth',
-  [KnownCaip19Id.TrxStakedForBandwidthNile]: 'stakedTrxForBandwidth',
-  [KnownCaip19Id.TrxStakedForBandwidthShasta]: 'stakedTrxForBandwidth',
-
-  [KnownCaip19Id.TrxReadyForWithdrawalMainnet]: 'trxReadyForWithdrawal',
-  [KnownCaip19Id.TrxReadyForWithdrawalNile]: 'trxReadyForWithdrawal',
-  [KnownCaip19Id.TrxReadyForWithdrawalShasta]: 'trxReadyForWithdrawal',
-
-  [KnownCaip19Id.TrxStakingRewardsMainnet]: 'trxStakingRewards',
-  [KnownCaip19Id.TrxStakingRewardsNile]: 'trxStakingRewards',
-  [KnownCaip19Id.TrxStakingRewardsShasta]: 'trxStakingRewards',
-
-  [KnownCaip19Id.TrxInLockPeriodMainnet]: 'trxInLockPeriod',
-  [KnownCaip19Id.TrxInLockPeriodNile]: 'trxInLockPeriod',
-  [KnownCaip19Id.TrxInLockPeriodShasta]: 'trxInLockPeriod',
-} as const satisfies Record<KnownCaip19Id, TronSpecialAssetKey>;
+const specialAssetFromBalance = (
+  accountId: string,
+  assetId: string,
+  amount: string,
+  unit: string,
+): Asset => {
+  const parsed = parseCaipAssetType(assetId as CaipAssetType);
+  return {
+    accountId,
+    accountType: 'tron:eoa',
+    assetId: assetId as CaipAssetType,
+    balance: amount,
+    chainId: parsed.chainId,
+    decimals: parsed.assetReference.startsWith('195') ? 6 : 0,
+    image: '',
+    isNative: false,
+    name: unit,
+    rawBalance: '0x0' as Hex,
+    symbol: unit,
+  };
+};
 
 /**
  * Empty constant to avoid creating new objects on each call when no Tron networks are enabled.
@@ -699,9 +740,9 @@ export const selectTronSpecialAssetsBySelectedAccountGroup =
   createDeepEqualSelector(
     [getStateForAssetSelector, selectEnabledNetworks],
     (assetsState, enabledNetworks): TronSpecialAssetsMap => {
-      const enabledTronNetworks = enabledNetworks.filter((networkId) =>
-        networkId.startsWith('tron:'),
-      );
+      const enabledTronNetworks = enabledNetworks
+        .map(toDecimalTronChainId)
+        .filter((networkId): networkId is string => networkId !== undefined);
 
       if (enabledTronNetworks.length === 0) {
         return EMPTY_TRON_SPECIAL_ASSETS_MAP;
@@ -712,6 +753,9 @@ export const selectTronSpecialAssetsBySelectedAccountGroup =
       });
 
       const enabledTronNetworksSet = new Set(enabledTronNetworks);
+      const selectedAccountIds = getSelectedAccountGroupAccountIds(assetsState);
+      const balances = (assetsState as AssetListState & AccountTreeSlice)
+        .balances;
 
       const specialAssetsMap: TronSpecialAssetsMap = {
         energy: undefined,
@@ -727,15 +771,58 @@ export const selectTronSpecialAssetsBySelectedAccountGroup =
       };
 
       for (const [networkId, chainAssets] of Object.entries(allAssets)) {
-        if (!enabledTronNetworksSet.has(networkId)) continue;
+        const decimalTronChainId = toDecimalTronChainId(networkId);
+        const isEnabledTron = Boolean(
+          decimalTronChainId && enabledTronNetworksSet.has(decimalTronChainId),
+        );
+        if (!isEnabledTron) continue;
 
         for (const asset of chainAssets) {
-          if (!Object.hasOwn(TRON_SPECIAL_ASSET_KEYS, asset.assetId)) {
+          const key = getTronSpecialAssetMapKey(asset.assetId);
+          if (!key || specialAssetsMap[key]) {
             continue;
           }
 
-          const key = TRON_SPECIAL_ASSET_KEYS[asset.assetId as KnownCaip19Id];
           specialAssetsMap[key] = asset;
+        }
+      }
+
+      for (const accountId of selectedAccountIds) {
+        const accountBalances = balances?.[accountId];
+        if (!accountBalances) {
+          continue;
+        }
+
+        for (const [assetId, balance] of Object.entries(accountBalances)) {
+          const key = getTronSpecialAssetMapKey(assetId);
+          if (!key || specialAssetsMap[key]) {
+            continue;
+          }
+
+          try {
+            const { chainId } = parseCaipAssetType(assetId as CaipAssetType);
+            const decimalTronChainId = toDecimalTronChainId(chainId);
+            if (
+              !decimalTronChainId ||
+              !enabledTronNetworksSet.has(decimalTronChainId)
+            ) {
+              continue;
+            }
+          } catch {
+            continue;
+          }
+
+          const amount = balance.amount;
+          if (amount === undefined) {
+            continue;
+          }
+
+          specialAssetsMap[key] = specialAssetFromBalance(
+            accountId,
+            assetId,
+            amount,
+            balance.unit ?? getTronSpecialAssetUnit(assetId) ?? '',
+          );
         }
       }
 

--- a/app/selectors/assets/assets-migration.test.ts
+++ b/app/selectors/assets/assets-migration.test.ts
@@ -1412,6 +1412,48 @@ describe('getMultiChainAssetsControllerAccountsAssets', () => {
         [mockAccountId2]: [solanaTokenAssetId],
       });
     });
+
+    it('merges Tron Snap staking CAIP-19s omitted from AssetsController', () => {
+      const tronAccountId = 'mock-tron-account-id';
+      const tronNativeAssetId = 'tron:728126428/slip44:195' as CaipAssetType;
+      const tronStakedEnergyAssetId =
+        'tron:728126428/slip44:195-staked-for-energy' as CaipAssetType;
+      const state = {
+        engine: {
+          backgroundState: {
+            ...enabledFeatureFlagControllerState,
+            MultichainAssetsController: {
+              accountsAssets: {
+                [tronAccountId]: [tronStakedEnergyAssetId],
+              },
+            },
+            AssetsController: {
+              assetsBalance: {
+                [tronAccountId]: {
+                  [tronNativeAssetId]: { amount: '1000' },
+                },
+              },
+              customAssets: {},
+            },
+            AccountsController: {
+              internalAccounts: {
+                accounts: {
+                  [tronAccountId]: {
+                    id: tronAccountId,
+                    type: 'tron:eoa',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = getMultiChainAssetsControllerAccountsAssets(state);
+
+      expect(result[tronAccountId]).toEqual(
+        expect.arrayContaining([tronNativeAssetId, tronStakedEnergyAssetId]),
+      );
+    });
   });
 
   describe('edge cases when enabled', () => {
@@ -1596,6 +1638,36 @@ describe('getMultiChainAssetsControllerAssetsMetadata', () => {
           name: 'USD Coin',
         },
       });
+    });
+
+    it('merges Tron Snap staking metadata omitted from AssetsController', () => {
+      const tronStakedEnergyAssetId =
+        'tron:728126428/slip44:195-staked-for-energy';
+      const snapMetadata = {
+        fungible: true as const,
+        iconUrl: '',
+        units: [{ decimals: 6, symbol: 'TRX', name: 'Staked TRX Energy' }],
+        symbol: 'sTRX-ENERGY',
+        name: 'Staked TRX Energy',
+      };
+      const state = {
+        engine: {
+          backgroundState: {
+            ...enabledFeatureFlagControllerState,
+            MultichainAssetsController: {
+              assetsMetadata: {
+                [tronStakedEnergyAssetId]: snapMetadata,
+              },
+            },
+            AssetsController: {
+              assetsInfo: {},
+            },
+          },
+        },
+      };
+      const result = getMultiChainAssetsControllerAssetsMetadata(state);
+
+      expect(result[tronStakedEnergyAssetId]).toStrictEqual(snapMetadata);
     });
   });
 
@@ -1881,6 +1953,61 @@ describe('getMultiChainBalancesControllerBalances', () => {
         [mockAccountId2]: {
           [solanaTokenAssetId]: { amount: '250.5', unit: 'USDC' },
         },
+      });
+    });
+
+    it('merges Tron Snap staking balances omitted from AssetsController', () => {
+      const tronAccountId = 'mock-tron-account-id';
+      const tronNativeAssetId = 'tron:728126428/slip44:195';
+      const tronStakedEnergyAssetId =
+        'tron:728126428/slip44:195-staked-for-energy';
+      const state = {
+        engine: {
+          backgroundState: {
+            ...enabledFeatureFlagControllerState,
+            MultichainBalancesController: {
+              balances: {
+                [tronAccountId]: {
+                  [tronStakedEnergyAssetId]: { amount: '50', unit: 'TRX' },
+                },
+              },
+            },
+            AssetsController: {
+              assetsInfo: {
+                [tronNativeAssetId]: {
+                  type: 'native',
+                  decimals: 6,
+                  symbol: 'TRX',
+                },
+              },
+              assetsBalance: {
+                [tronAccountId]: {
+                  [tronNativeAssetId]: { amount: '1000' },
+                },
+              },
+            },
+            AccountsController: {
+              internalAccounts: {
+                accounts: {
+                  [tronAccountId]: {
+                    id: tronAccountId,
+                    type: 'tron:eoa',
+                  },
+                },
+              },
+            },
+          },
+        },
+      };
+      const result = getMultiChainBalancesControllerBalances(state);
+
+      expect(result[tronAccountId][tronNativeAssetId]).toStrictEqual({
+        amount: '1000',
+        unit: 'TRX',
+      });
+      expect(result[tronAccountId][tronStakedEnergyAssetId]).toStrictEqual({
+        amount: '50',
+        unit: 'TRX',
       });
     });
   });

--- a/app/selectors/assets/assets-migration.ts
+++ b/app/selectors/assets/assets-migration.ts
@@ -29,6 +29,10 @@ import {
 } from '@metamask/assets-controller';
 import { AccountsControllerState } from '@metamask/accounts-controller';
 import { NetworkState } from '@metamask/network-controller';
+import {
+  getTronSpecialAssetMapKey,
+  getTronSpecialAssetUnit,
+} from '../../core/Multichain/tronSpecialAssets';
 
 // CAIP-19 asset identifiers (with checksummed addresses) for the pooled-staking
 // vault token that should never surface as regular ERC-20 tokens in the wallet
@@ -52,6 +56,42 @@ const isStakedTokenAssetId = (assetId: string): boolean => {
       assetReference,
     )}` as CaipAssetType,
   );
+};
+
+/**
+ * Accounts API / AssetsController does not model Tron Snap synthetic
+ * staking and resource CAIP-19s. When unify is on, copy those IDs from
+ * the Snap-backed Multichain* controllers so Token Details can still
+ * show staked TRX.
+ */
+const mergeTronSpecialAssetIds = (
+  targetIds: CaipAssetType[],
+  sourceIds: CaipAssetType[] | undefined,
+): void => {
+  if (!sourceIds) {
+    return;
+  }
+  const existing = new Set(targetIds);
+  for (const assetId of sourceIds) {
+    if (getTronSpecialAssetMapKey(assetId) && !existing.has(assetId)) {
+      targetIds.push(assetId);
+      existing.add(assetId);
+    }
+  }
+};
+
+const mergeTronSpecialAssetRecords = <T>(
+  target: Record<string, T>,
+  source: Record<string, T> | undefined,
+): void => {
+  if (!source) {
+    return;
+  }
+  for (const [assetId, value] of Object.entries(source)) {
+    if (getTronSpecialAssetMapKey(assetId) && target[assetId] === undefined) {
+      target[assetId] = value;
+    }
+  }
 };
 
 // ChainId (hex) -> AccountAddress (hex checksummed) -> Balance (hex)
@@ -473,6 +513,16 @@ export const getMultiChainAssetsControllerAccountsAssets =
         }
       }
 
+      for (const [accountId, assetIds] of Object.entries(accountsAssets)) {
+        const internalAccount = internalAccountsById[accountId];
+        if (!internalAccount || isEvmAccountType(internalAccount.type)) {
+          continue;
+        }
+
+        result[accountId] ??= [];
+        mergeTronSpecialAssetIds(result[accountId], assetIds);
+      }
+
       return result;
     },
   );
@@ -520,6 +570,8 @@ export const getMultiChainAssetsControllerAssetsMetadata =
           name: metadata.name,
         };
       }
+
+      mergeTronSpecialAssetRecords(result, assetsMetadata);
 
       return result;
     },
@@ -616,19 +668,31 @@ export const getMultiChainBalancesControllerBalances = createDeepEqualSelector(
       for (const [assetId, balance] of Object.entries(chainIdBalances)) {
         const assetType = parseCaipAssetType(assetId as CaipAssetType);
         const metadata = assetsInfo[assetId];
+        const specialKey = getTronSpecialAssetMapKey(assetId);
 
-        if (
-          !metadata ||
-          assetType.chain.namespace === KnownCaipNamespace.Eip155
-        ) {
+        if (assetType.chain.namespace === KnownCaipNamespace.Eip155) {
+          continue;
+        }
+
+        if (!metadata && !specialKey) {
           continue;
         }
 
         result[accountId][assetId] = {
           amount: balance.amount,
-          unit: metadata.symbol,
+          unit: metadata?.symbol ?? getTronSpecialAssetUnit(assetId) ?? '',
         };
       }
+    }
+
+    for (const [accountId, accountBalances] of Object.entries(balances)) {
+      const internalAccount = internalAccountsById[accountId];
+      if (!internalAccount || isEvmAccountType(internalAccount.type)) {
+        continue;
+      }
+
+      result[accountId] ??= {};
+      mergeTronSpecialAssetRecords(result[accountId], accountBalances);
     }
 
     return result;


### PR DESCRIPTION
Identify native TRX by CAIP-19 and keep Snap staking synthetics when AssetsController omits them, so Token Details can show staked energy/bandwidth balances.

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: restore staked TRX on Token Details after assets unify

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="427" height="916" alt="Screenshot 2026-08-18 at 18 25 29" src="https://github.com/user-attachments/assets/806e3404-b30c-428c-819f-1a32bd072703" />


### **After**

<!-- [screenshots/recordings] -->


<img width="434" height="915" alt="Screenshot 2026-08-18 at 18 40 41" src="https://github.com/user-attachments/assets/289fcd65-9dc7-4607-b58d-244eafd1da37" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b3303603ce18d79d6e37bca30081c54d843eb945. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->