### PR TITLE
feat(card): enrich Immersve Sentry exceptions with structured context

### DIFF
--- a/app/components/UI/Card/components/ImmersveKYCModal/ImmersveKYCModal.test.tsx
+++ b/app/components/UI/Card/components/ImmersveKYCModal/ImmersveKYCModal.test.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
 import { act, render, fireEvent } from '@testing-library/react-native';
+import Logger from '../../../../../util/Logger';
 import ImmersveKYCModal, {
   setImmersveKycOnClose,
   clearImmersveKycOnClose,
 } from './ImmersveKYCModal';
 
 const mockGoBack = jest.fn();
+
+jest.mock('../../../../../util/Logger', () => ({
+  __esModule: true,
+  default: { error: jest.fn() },
+}));
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ goBack: mockGoBack }),
@@ -73,6 +79,8 @@ jest.mock('../../../../../../locales/i18n', () => ({
 
 let capturedProps: {
   onNavigationStateChange?: (s: { url: string }) => void;
+  onError?: (e?: { nativeEvent?: { statusCode?: number } }) => void;
+  onHttpError?: (e?: { nativeEvent?: { statusCode?: number } }) => void;
   mediaPlaybackRequiresUserGesture?: boolean;
 } = {};
 
@@ -82,6 +90,8 @@ jest.mock('@metamask/react-native-webview', () => {
   return {
     WebView: (props: {
       onNavigationStateChange?: (s: { url: string }) => void;
+      onError?: (e?: { nativeEvent?: { statusCode?: number } }) => void;
+      onHttpError?: (e?: { nativeEvent?: { statusCode?: number } }) => void;
       mediaPlaybackRequiresUserGesture?: boolean;
       testID?: string;
     }) => {
@@ -150,5 +160,37 @@ describe('ImmersveKYCModal', () => {
     fireEvent.press(getByTestId('immersve-kyc-back-button'));
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(mockGoBack).toHaveBeenCalled();
+  });
+
+  it('reports webview load errors to Sentry with host context', async () => {
+    const { getByTestId } = render(<ImmersveKYCModal />);
+    await act(async () => {
+      capturedProps.onHttpError?.({ nativeEvent: { statusCode: 502 } });
+    });
+    expect(getByTestId('immersve-kyc-error-container')).toBeTruthy();
+    expect(Logger.error).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: { feature: 'card', provider: 'immersve' },
+        context: expect.objectContaining({
+          name: 'ImmersveKYCModal',
+          data: expect.objectContaining({
+            method: 'handleError',
+            urlHost: 'verify.immersve.com',
+            redirectHost: 'metamask.io',
+            httpStatus: 502,
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('dedupes onError and onHttpError for a single failure', async () => {
+    render(<ImmersveKYCModal />);
+    await act(async () => {
+      capturedProps.onError?.();
+      capturedProps.onHttpError?.({ nativeEvent: { statusCode: 500 } });
+    });
+    expect(Logger.error).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/UI/Card/components/ImmersveKYCModal/ImmersveKYCModal.tsx
+++ b/app/components/UI/Card/components/ImmersveKYCModal/ImmersveKYCModal.tsx
@@ -16,6 +16,7 @@ import { useParams } from '../../../../../util/navigation/navUtils';
 import { strings } from '../../../../../../locales/i18n';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
+import Logger from '../../../../../util/Logger';
 import { CardProviderIds } from '../../../../../core/Engine/controllers/card-controller/provider-types';
 import { CardActions, CardScreens, withCardProvider } from '../../util/metrics';
 
@@ -116,23 +117,56 @@ const ImmersveKYCModal: React.FC = () => {
     () => setStatus((s) => (s === 'error' ? s : 'loaded')),
     [],
   );
-  const handleError = useCallback(() => {
-    setStatus('error');
-    // onError + onHttpError often both fire for one failure.
-    if (hasTrackedLoadError.current) {
-      return;
-    }
-    hasTrackedLoadError.current = true;
-    trackEvent(
-      createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
-        .addProperties(
-          withCardProvider(CardProviderIds.Immersve, {
-            action: CardActions.KYC_WEBVIEW_LOAD_ERROR,
-          }),
-        )
-        .build(),
-    );
-  }, [trackEvent, createEventBuilder]);
+  const handleError = useCallback(
+    (event?: {
+      nativeEvent?: { statusCode?: number; description?: string };
+    }) => {
+      setStatus('error');
+      // onError + onHttpError often both fire for one failure.
+      if (hasTrackedLoadError.current) {
+        return;
+      }
+      hasTrackedLoadError.current = true;
+
+      let urlHost: string | undefined;
+      let redirectHost: string | undefined;
+      try {
+        urlHost = url ? new URL(url).host : undefined;
+      } catch {
+        urlHost = undefined;
+      }
+      try {
+        redirectHost = redirectUrl ? new URL(redirectUrl).host : undefined;
+      } catch {
+        redirectHost = undefined;
+      }
+
+      Logger.error(new Error('Immersve KYC webview load failed'), {
+        tags: { feature: 'card', provider: 'immersve' },
+        context: {
+          name: 'ImmersveKYCModal',
+          data: {
+            method: 'handleError',
+            urlHost,
+            redirectHost,
+            retryKey,
+            httpStatus: event?.nativeEvent?.statusCode,
+          },
+        },
+      });
+
+      trackEvent(
+        createEventBuilder(MetaMetricsEvents.CARD_BUTTON_CLICKED)
+          .addProperties(
+            withCardProvider(CardProviderIds.Immersve, {
+              action: CardActions.KYC_WEBVIEW_LOAD_ERROR,
+            }),
+          )
+          .build(),
+      );
+    },
+    [trackEvent, createEventBuilder, url, redirectUrl, retryKey],
+  );
 
   const handleNavigationStateChange = useCallback(
     (navState: WebViewNavigation) => {

--- a/app/components/UI/Card/components/Onboarding/VerifyIdentity.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/VerifyIdentity.test.tsx
@@ -566,7 +566,17 @@ describe('VerifyIdentity Component', () => {
       await waitFor(() => {
         expect(Logger.error).toHaveBeenCalledWith(
           expect.any(Error),
-          'Veriff verification failed with error=CAMERA_UNAVAILABLE',
+          expect.objectContaining({
+            tags: { feature: 'card', provider: 'baanx' },
+            context: expect.objectContaining({
+              name: 'VerifyIdentity',
+              data: expect.objectContaining({
+                method: 'veriffSdk',
+                status: 'error',
+                errorCode: 'CAMERA_UNAVAILABLE',
+              }),
+            }),
+          }),
         );
         expect(mockDispatch).not.toHaveBeenCalled();
       });

--- a/app/components/UI/Card/components/Onboarding/VerifyIdentity.tsx
+++ b/app/components/UI/Card/components/Onboarding/VerifyIdentity.tsx
@@ -105,19 +105,44 @@ const VerifyIdentity = () => {
           case VeriffSdk.statusCanceled:
             break;
           case VeriffSdk.statusError:
-            Logger.error(
-              new Error('Veriff verification failed'),
-              `Veriff verification failed with error=${result.error}`,
-            );
+            Logger.error(new Error('Veriff verification failed'), {
+              tags: { feature: 'card', provider: 'baanx' },
+              context: {
+                name: 'VerifyIdentity',
+                data: {
+                  method: 'veriffSdk',
+                  status: 'error',
+                  errorCode: result.error,
+                  country: selectedCountry?.key,
+                },
+              },
+            });
             break;
         }
       } catch (error) {
-        Logger.error(error as Error, 'Veriff SDK launch failed unexpectedly');
+        Logger.error(error as Error, {
+          tags: { feature: 'card', provider: 'baanx' },
+          context: {
+            name: 'VerifyIdentity',
+            data: {
+              method: 'veriffSdk',
+              status: 'launch_failed',
+              country: selectedCountry?.key,
+            },
+          },
+        });
       } finally {
         setIsLaunchingVeriff(false);
       }
     }
-  }, [navigation, sessionUrl, trackEvent, createEventBuilder, veriffBranding]);
+  }, [
+    navigation,
+    sessionUrl,
+    trackEvent,
+    createEventBuilder,
+    veriffBranding,
+    selectedCountry?.key,
+  ]);
 
   useEffect(() => {
     trackEvent(

--- a/app/components/UI/Card/hooks/useImmersveFunding.test.ts
+++ b/app/components/UI/Card/hooks/useImmersveFunding.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import Engine from '../../../../core/Engine';
 import { awaitTransactionConfirmed } from '../../../../core/Engine/controllers/card-controller/utils/awaitTransactionConfirmed';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
+import Logger from '../../../../util/Logger';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { useImmersveFunding } from './useImmersveFunding';
 import type { CardSmartContractWriteParams } from '../../../../core/Engine/controllers/card-controller/provider-types';
@@ -38,7 +39,7 @@ jest.mock('../../../../selectors/multichainAccounts/accounts', () => ({
 }));
 
 jest.mock('../../../../selectors/featureFlagController/card', () => ({
-  selectCardImmersveConfig: () => ({ network: 'base-sepolia' }),
+  selectCardImmersveConfig: jest.fn(() => ({ network: 'base-sepolia' })),
 }));
 
 jest.mock('./useEnsureCardNetworkExists', () => ({
@@ -65,6 +66,11 @@ const accountsModule = jest.requireMock(
   '../../../../selectors/multichainAccounts/accounts',
 ) as {
   selectSelectedInternalAccountByScope: jest.Mock;
+};
+const cardFeatureFlagsModule = jest.requireMock(
+  '../../../../selectors/featureFlagController/card',
+) as {
+  selectCardImmersveConfig: jest.Mock;
 };
 
 const mockTrackEvent = jest.fn();
@@ -111,10 +117,13 @@ describe('useImmersveFunding', () => {
         address: MOCK_ACCOUNT_ADDRESS,
       }),
     );
+    cardFeatureFlagsModule.selectCardImmersveConfig.mockReturnValue({
+      network: 'base-sepolia',
+    });
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   it('createFundingSource delegates to the controller', async () => {
@@ -235,5 +244,45 @@ describe('useImmersveFunding', () => {
 
     expect(mockTx.addTransaction).not.toHaveBeenCalled();
     expect(result.current.error).not.toBeNull();
+    expect(Logger.error).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        context: expect.objectContaining({
+          data: expect.objectContaining({
+            method: 'executeFunding',
+            step: 'approve',
+            network: 'base-sepolia',
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('executeFunding clears loading when network config is unsupported', async () => {
+    cardFeatureFlagsModule.selectCardImmersveConfig.mockReturnValue({
+      network: 'not-a-network',
+    });
+
+    const { result } = renderHook(() => useImmersveFunding());
+
+    await act(async () => {
+      await expect(
+        result.current.executeFunding(APPROVE_WRITE),
+      ).rejects.toThrow(/Unsupported Immersve funding network/);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).not.toBeNull();
+    expect(Logger.error).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        context: expect.objectContaining({
+          data: expect.objectContaining({
+            method: 'executeFunding',
+            network: 'not-a-network',
+          }),
+        }),
+      }),
+    );
   });
 });

--- a/app/components/UI/Card/hooks/useImmersveFunding.ts
+++ b/app/components/UI/Card/hooks/useImmersveFunding.ts
@@ -45,6 +45,19 @@ function getController() {
   return controller;
 }
 
+function getImmersveFundingErrorContext(
+  method: string,
+  data: Record<string, unknown>,
+) {
+  return {
+    tags: { feature: 'card', provider: 'immersve' },
+    context: {
+      name: 'useImmersveFunding',
+      data: { method, ...data },
+    },
+  };
+}
+
 export const useImmersveFunding = () => {
   const { TransactionController } = Engine.context;
   const { ensureNetworkExists } = useEnsureCardNetworkExists();
@@ -66,6 +79,7 @@ export const useImmersveFunding = () => {
         setState({ isLoading: false, error: null });
         return result;
       } catch (e) {
+        // Provider already reports API failures via reportAndMap.
         setState({ isLoading: false, error: getCardProviderErrorMessage(e) });
         throw e;
       }
@@ -80,7 +94,10 @@ export const useImmersveFunding = () => {
       const metricsProps = withCardProvider(CardProviderIds.Immersve, {
         step: 'approve',
       });
+      const network = immersveConfig?.network;
+      let caipChainId: string | undefined;
       try {
+        caipChainId = immersveNetworkToCaipChainId(network);
         trackEvent(
           createEventBuilder(MetaMetricsEvents.CARD_FUNDING_PROCESS_STARTED)
             .addProperties(metricsProps)
@@ -93,9 +110,6 @@ export const useImmersveFunding = () => {
           throw new Error('No account found for funding');
         }
 
-        const caipChainId = immersveNetworkToCaipChainId(
-          immersveConfig?.network,
-        );
         const networkClientId = await ensureNetworkExists(caipChainId);
         const writeToEncode = approveAmountBaseUnits
           ? withApproveAmount(write, approveAmountBaseUnits)
@@ -158,7 +172,12 @@ export const useImmersveFunding = () => {
         );
         Logger.error(
           e as Error,
-          'useImmersveFunding: funding execution failed',
+          getImmersveFundingErrorContext('executeFunding', {
+            step: 'approve',
+            network,
+            chainId: caipChainId,
+            contractMethod: write.method,
+          }),
         );
         setState({ isLoading: false, error: getCardProviderErrorMessage(e) });
         throw e;
@@ -192,6 +211,7 @@ export const useImmersveFunding = () => {
             .addProperties(metricsProps)
             .build(),
         );
+        // Provider already reports API failures via reportAndMap.
         setState({ isLoading: false, error: getCardProviderErrorMessage(e) });
         throw e;
       }

--- a/app/components/UI/Card/hooks/useImmersveSiweAuth.test.ts
+++ b/app/components/UI/Card/hooks/useImmersveSiweAuth.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import Engine from '../../../../core/Engine';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
+import Logger from '../../../../util/Logger';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { useImmersveSiweAuth } from './useImmersveSiweAuth';
 
@@ -114,5 +115,67 @@ describe('useImmersveSiweAuth', () => {
         error_type: 'unexpected_auth_step',
       }),
     );
+    expect(Logger.error).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: { feature: 'card', provider: 'immersve' },
+        context: expect.objectContaining({
+          name: 'useImmersveSiweAuth',
+          data: expect.objectContaining({
+            method: 'authenticate',
+            error_type: 'unexpected_auth_step',
+            country: 'GB',
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('does not report user cancellation to Sentry', async () => {
+    mockCard.initiateAuth.mockResolvedValue(undefined);
+    mockCard.getCurrentAuthStep.mockReturnValue({
+      type: 'siwe',
+      message: 'sign this',
+    });
+    (mockKeyring.signPersonalMessage as jest.Mock).mockRejectedValue(
+      new Error('User rejected the request'),
+    );
+
+    const { result } = renderHook(() => useImmersveSiweAuth());
+
+    await act(async () => {
+      await expect(
+        result.current.signIn({ country: 'GB', address: '0xabc' }),
+      ).rejects.toThrow();
+    });
+
+    expect(Logger.error).not.toHaveBeenCalled();
+    expect(mockAddProperties).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error_type: 'user_cancelled',
+      }),
+    );
+  });
+
+  it('does not report CardProviderError to Sentry (provider already logged)', async () => {
+    const { CardProviderError, CardProviderErrorCode } = jest.requireActual(
+      '../../../../core/Engine/controllers/card-controller/provider-types',
+    );
+    const providerError = new CardProviderError(
+      CardProviderErrorCode.InvalidCredentials,
+      'Authentication failed on initiateAuth',
+      401,
+    );
+    mockCard.initiateAuth.mockRejectedValue(providerError);
+
+    const { result } = renderHook(() => useImmersveSiweAuth());
+
+    await act(async () => {
+      await expect(
+        result.current.signIn({ country: 'GB', address: '0xabc' }),
+      ).rejects.toBe(providerError);
+    });
+
+    expect(Logger.error).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Card/hooks/useImmersveSiweAuth.ts
+++ b/app/components/UI/Card/hooks/useImmersveSiweAuth.ts
@@ -1,10 +1,12 @@
 import { useCallback, useState } from 'react';
 import Engine from '../../../../core/Engine';
 import {
+  CardProviderError,
   CardProviderIds,
   type CardAuthResult,
 } from '../../../../core/Engine/controllers/card-controller/provider-types';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
+import Logger from '../../../../util/Logger';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { getCardProviderErrorMessage } from '../util/getCardProviderErrorMessage';
 import { withCardProvider } from '../util/metrics';
@@ -88,15 +90,36 @@ export const useImmersveSiweAuth = () => {
 
         return result;
       } catch (e) {
+        const errorType = getSiweErrorType(e);
         trackEvent(
           createEventBuilder(MetaMetricsEvents.CARD_SIWE_AUTH_FAILED)
             .addProperties(
               withCardProvider(CardProviderIds.Immersve, {
-                error_type: getSiweErrorType(e),
+                error_type: errorType,
               }),
             )
             .build(),
         );
+        // Provider already reports API failures (and skips 401/auth-token noise).
+        // Only report UI-local failures here (e.g. unexpected auth step, sign errors).
+        if (
+          errorType !== 'user_cancelled' &&
+          !(e instanceof CardProviderError)
+        ) {
+          Logger.error(e as Error, {
+            tags: { feature: 'card', provider: 'immersve' },
+            context: {
+              name: 'useImmersveSiweAuth',
+              data: {
+                method: 'authenticate',
+                error_type: errorType,
+                country,
+                authStep:
+                  Engine.context?.CardController?.getCurrentAuthStep()?.type,
+              },
+            },
+          });
+        }
         setError(getCardProviderErrorMessage(e));
         throw e;
       } finally {

--- a/app/components/UI/Card/hooks/useImmersveSpendingPrerequisites.test.ts
+++ b/app/components/UI/Card/hooks/useImmersveSpendingPrerequisites.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import Engine from '../../../../core/Engine';
+import Logger from '../../../../util/Logger';
 import { useImmersveSpendingPrerequisites } from './useImmersveSpendingPrerequisites';
 
 jest.mock('../../../../core/Engine', () => ({
@@ -87,6 +88,8 @@ describe('useImmersveSpendingPrerequisites', () => {
     expect(action).toBeNull();
     expect(result.current.nextAction).toBeNull();
     expect(result.current.error).toBeTruthy();
+    // Provider owns Sentry for API failures; hook must not double-report.
+    expect(Logger.error).not.toHaveBeenCalled();
   });
 
   describe('polling while pending', () => {
@@ -143,6 +146,171 @@ describe('useImmersveSpendingPrerequisites', () => {
         await Promise.resolve();
       });
       expect(mockCard.getSpendingPrerequisites).toHaveBeenCalledTimes(2);
+    });
+
+    it('backs off after a failure then auto-retries after cooldown', async () => {
+      mockCard.getSpendingPrerequisites
+        .mockResolvedValueOnce({
+          prerequisites: [{ stage: 'aml', status: 'pending' }],
+        })
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce({
+          prerequisites: [
+            {
+              stage: 'funding',
+              status: 'action-required',
+              actionType: 'smart_contract_write',
+              params: {
+                abi: [],
+                contractAddress: '0xT',
+                method: 'approve',
+                params: { _spender: '0xS', _value: '1' },
+              },
+            },
+          ],
+        });
+
+      const { result } = renderHook(() =>
+        useImmersveSpendingPrerequisites({
+          fundingSourceId: 'fs-1',
+          pollIntervalMs: 1000,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.refresh();
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+      });
+
+      expect(result.current.error).toBeTruthy();
+      expect(mockCard.getSpendingPrerequisites).toHaveBeenCalledTimes(2);
+
+      // Fast interval must not fire while error is set.
+      await act(async () => {
+        jest.advanceTimersByTime(5000);
+        await Promise.resolve();
+      });
+      expect(mockCard.getSpendingPrerequisites).toHaveBeenCalledTimes(2);
+
+      // Cooldown retry (15s) recovers.
+      await act(async () => {
+        jest.advanceTimersByTime(15000);
+        await Promise.resolve();
+      });
+
+      expect(mockCard.getSpendingPrerequisites).toHaveBeenCalledTimes(3);
+      expect(result.current.error).toBeNull();
+      expect(result.current.nextAction?.type).toBe('funding');
+    });
+
+    it('does not restart fast polling while a cooldown retry is in flight', async () => {
+      let resolveRetry: (value: {
+        prerequisites: { stage: string; status: string }[];
+      }) => void = () => undefined;
+      const retryPromise = new Promise<{
+        prerequisites: { stage: string; status: string }[];
+      }>((resolve) => {
+        resolveRetry = resolve;
+      });
+
+      mockCard.getSpendingPrerequisites
+        .mockResolvedValueOnce({
+          prerequisites: [{ stage: 'aml', status: 'pending' }],
+        })
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockImplementationOnce(() => retryPromise);
+
+      const { result } = renderHook(() =>
+        useImmersveSpendingPrerequisites({
+          fundingSourceId: 'fs-1',
+          pollIntervalMs: 1000,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.refresh();
+      });
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+      });
+      expect(result.current.error).toBeTruthy();
+
+      await act(async () => {
+        jest.advanceTimersByTime(15000);
+        await Promise.resolve();
+      });
+
+      expect(result.current.isLoading).toBe(true);
+      expect(mockCard.getSpendingPrerequisites).toHaveBeenCalledTimes(3);
+
+      // Fast interval must stay off while the cooldown refresh is in flight.
+      await act(async () => {
+        jest.advanceTimersByTime(5000);
+        await Promise.resolve();
+      });
+      expect(mockCard.getSpendingPrerequisites).toHaveBeenCalledTimes(3);
+
+      await act(async () => {
+        resolveRetry({
+          prerequisites: [{ stage: 'aml', status: 'pending' }],
+        });
+        await retryPromise;
+      });
+
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('stops auto-retry after max consecutive poll failures', async () => {
+      mockCard.getSpendingPrerequisites
+        .mockResolvedValueOnce({
+          prerequisites: [{ stage: 'aml', status: 'pending' }],
+        })
+        .mockRejectedValue(new Error('boom'));
+
+      const { result } = renderHook(() =>
+        useImmersveSpendingPrerequisites({
+          fundingSourceId: 'fs-1',
+          pollIntervalMs: 1000,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.refresh();
+      });
+
+      // Failure 1 via interval
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+      });
+      // Failure 2 via cooldown
+      await act(async () => {
+        jest.advanceTimersByTime(15000);
+        await Promise.resolve();
+      });
+      // Failure 3 via cooldown
+      await act(async () => {
+        jest.advanceTimersByTime(15000);
+        await Promise.resolve();
+      });
+
+      const callsAfterMax = mockCard.getSpendingPrerequisites.mock.calls.length;
+      expect(result.current.error).toBeTruthy();
+
+      await act(async () => {
+        jest.advanceTimersByTime(60000);
+        await Promise.resolve();
+      });
+      expect(mockCard.getSpendingPrerequisites).toHaveBeenCalledTimes(
+        callsAfterMax,
+      );
     });
   });
 });

--- a/app/components/UI/Card/hooks/useImmersveSpendingPrerequisites.test.ts
+++ b/app/components/UI/Card/hooks/useImmersveSpendingPrerequisites.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
+import { CardSpendingPrerequisitesResult } from '../../../../core/Engine/controllers/card-controller/provider-types';
 import { useImmersveSpendingPrerequisites } from './useImmersveSpendingPrerequisites';
 
 jest.mock('../../../../core/Engine', () => ({
@@ -208,14 +209,13 @@ describe('useImmersveSpendingPrerequisites', () => {
     });
 
     it('does not restart fast polling while a cooldown retry is in flight', async () => {
-      let resolveRetry: (value: {
-        prerequisites: { stage: string; status: string }[];
-      }) => void = () => undefined;
-      const retryPromise = new Promise<{
-        prerequisites: { stage: string; status: string }[];
-      }>((resolve) => {
-        resolveRetry = resolve;
-      });
+      let resolveRetry: (value: CardSpendingPrerequisitesResult) => void = () =>
+        undefined;
+      const retryPromise = new Promise<CardSpendingPrerequisitesResult>(
+        (resolve) => {
+          resolveRetry = resolve;
+        },
+      );
 
       mockCard.getSpendingPrerequisites
         .mockResolvedValueOnce({

--- a/app/components/UI/Card/hooks/useImmersveSpendingPrerequisites.ts
+++ b/app/components/UI/Card/hooks/useImmersveSpendingPrerequisites.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Engine from '../../../../core/Engine';
 import type { CardSpendingPrerequisite } from '../../../../core/Engine/controllers/card-controller/provider-types';
 import {
@@ -8,6 +8,10 @@ import {
 import { getCardProviderErrorMessage } from '../util/getCardProviderErrorMessage';
 
 const DEFAULT_POLL_INTERVAL_MS = 5000;
+/** Cooldown before auto-retrying a failed pending poll (avoids Sentry spam). */
+const POLL_FAILURE_COOLDOWN_MS = 15000;
+/** Give up auto-retry after this many consecutive failures; manual refresh() resets. */
+const MAX_CONSECUTIVE_POLL_FAILURES = 3;
 
 function getController() {
   const controller = Engine.context?.CardController;
@@ -43,6 +47,7 @@ export const useImmersveSpendingPrerequisites = ({
     isLoading: false,
     error: null,
   });
+  const consecutiveFailuresRef = useRef(0);
 
   const refresh = useCallback(async (): Promise<ImmersveNextAction | null> => {
     if (!fundingSourceId) {
@@ -55,9 +60,13 @@ export const useImmersveSpendingPrerequisites = ({
         { kycRegion, kycRedirectUrl },
       );
       const nextAction = deriveNextImmersveAction(prerequisites);
+      consecutiveFailuresRef.current = 0;
       setState({ prerequisites, nextAction, isLoading: false, error: null });
       return nextAction;
     } catch (e) {
+      // Provider already reports API failures via reportAndMap. Setting error
+      // pauses the fast poll interval; a cooldown retry may resume below.
+      consecutiveFailuresRef.current += 1;
       const message = getCardProviderErrorMessage(e);
       setState((prev) => ({ ...prev, isLoading: false, error: message }));
       return null;
@@ -68,11 +77,38 @@ export const useImmersveSpendingPrerequisites = ({
     if (state.nextAction?.type !== 'pending') {
       return undefined;
     }
+
+    // Stay idle while a refresh is in flight. refresh() clears `error` at start;
+    // without this guard the effect would immediately re-enable the fast interval
+    // and overlap polls / Sentry during cooldown recovery.
+    if (state.isLoading) {
+      return undefined;
+    }
+
+    // After a failure: cool down, then auto-retry a few times so transient
+    // outages can recover (e.g. ImmersveKYCProcessing has no retry button).
+    // This avoids hitting the provider every pollInterval during an outage.
+    if (state.error) {
+      if (consecutiveFailuresRef.current >= MAX_CONSECUTIVE_POLL_FAILURES) {
+        return undefined;
+      }
+      const retryId = setTimeout(() => {
+        refresh().catch(() => undefined);
+      }, POLL_FAILURE_COOLDOWN_MS);
+      return () => clearTimeout(retryId);
+    }
+
     const id = setInterval(() => {
       refresh().catch(() => undefined);
     }, pollIntervalMs);
     return () => clearInterval(id);
-  }, [state.nextAction?.type, pollIntervalMs, refresh]);
+  }, [
+    state.nextAction?.type,
+    state.error,
+    state.isLoading,
+    pollIntervalMs,
+    refresh,
+  ]);
 
   return {
     prerequisites: state.prerequisites,

--- a/app/core/Engine/controllers/card-controller/providers/ImmersveProvider.test.ts
+++ b/app/core/Engine/controllers/card-controller/providers/ImmersveProvider.test.ts
@@ -236,6 +236,46 @@ describe('ImmersveProvider', () => {
       },
     );
 
+    it('reports non-auth initiateAuth failures to Sentry', async () => {
+      const { provider, service } = createProvider();
+      const apiError = new CardApiError(500, '/auth/login-init', 'fail');
+      service.post.mockRejectedValue(apiError);
+
+      await expect(
+        provider.initiateAuth('GB', { address: '0xabc' }),
+      ).rejects.toMatchObject({ code: CardProviderErrorCode.ServerError });
+
+      expect(Logger.error).toHaveBeenCalledWith(
+        apiError,
+        expect.objectContaining({
+          tags: { feature: 'card', provider: 'immersve' },
+          context: expect.objectContaining({
+            name: 'ImmersveProvider',
+            data: expect.objectContaining({
+              method: 'initiateAuth',
+              network: 'base-sepolia',
+              country: 'GB',
+              httpStatus: 500,
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('does not report 401 initiateAuth failures to Sentry', async () => {
+      const { provider, service } = createProvider();
+      service.post.mockRejectedValue(
+        new CardApiError(401, '/auth/login-init', 'unauthorized'),
+      );
+
+      await expect(
+        provider.initiateAuth('GB', { address: '0xabc' }),
+      ).rejects.toMatchObject({
+        code: CardProviderErrorCode.InvalidCredentials,
+      });
+      expect(Logger.error).not.toHaveBeenCalled();
+    });
+
     it('maps non-API errors to Unknown', async () => {
       const { provider, service } = createProvider();
       service.post.mockRejectedValue(new Error('boom'));
@@ -772,13 +812,24 @@ describe('ImmersveProvider', () => {
 
     it('createCard maps API failures', async () => {
       const { provider, service } = createProvider();
-      service.post.mockRejectedValue(
-        new CardApiError(500, '/api/cards', 'down'),
-      );
+      const apiError = new CardApiError(500, '/api/cards', 'down');
+      service.post.mockRejectedValue(apiError);
 
       await expect(provider.createCard('fs-1', TOKENS)).rejects.toMatchObject({
         code: CardProviderErrorCode.ServerError,
       });
+      expect(Logger.error).toHaveBeenCalledWith(
+        apiError,
+        expect.objectContaining({
+          context: expect.objectContaining({
+            data: expect.objectContaining({
+              method: 'createCard',
+              fundingSourceId: 'fs-1',
+              httpStatus: 500,
+            }),
+          }),
+        }),
+      );
     });
 
     it('getResumeCardInfo returns null when the account has no card', async () => {

--- a/app/core/Engine/controllers/card-controller/providers/ImmersveProvider.ts
+++ b/app/core/Engine/controllers/card-controller/providers/ImmersveProvider.ts
@@ -87,6 +87,33 @@ function getErrorContext(method: string, extra?: Record<string, unknown>) {
   };
 }
 
+/**
+ * Report non-auth API failures to Sentry, then rethrow as CardProviderError.
+ * Auth-token / 401 errors are intentionally excluded to avoid Sentry noise
+ * (matching setCardPin / getCardHomeData).
+ */
+function reportAndMap(
+  error: unknown,
+  method: string,
+  extra?: Record<string, unknown>,
+): never {
+  const isAuthFailure =
+    isCardAuthTokenError(error) ||
+    (error instanceof CardApiError && error.statusCode === 401);
+  if (!isAuthFailure) {
+    Logger.error(
+      error as Error,
+      getErrorContext(method, {
+        httpStatus:
+          error instanceof CardApiError ? error.statusCode : undefined,
+        errorCode: error instanceof CardApiError ? error.errorCode : undefined,
+        ...extra,
+      }),
+    );
+  }
+  throw mapApiError(error, method);
+}
+
 function mapApiError(error: unknown, operation: string): CardProviderError {
   if (error instanceof CardProviderError) return error;
   if (error instanceof CardApiError) {
@@ -375,7 +402,10 @@ export class ImmersveProvider implements ICardProvider {
         },
       };
     } catch (error) {
-      throw mapApiError(error, 'initiateAuth');
+      reportAndMap(error, 'initiateAuth', {
+        network: this.network,
+        country,
+      });
     }
   }
 
@@ -400,7 +430,13 @@ export class ImmersveProvider implements ICardProvider {
         },
       );
     } catch (error) {
-      throw mapApiError(error, 'submitCredentials');
+      reportAndMap(error, 'submitCredentials', {
+        network: this.network,
+        country:
+          typeof session._metadata?.country === 'string'
+            ? session._metadata.country
+            : undefined,
+      });
     }
 
     const tokenSet: CardAuthTokens = {
@@ -440,6 +476,8 @@ export class ImmersveProvider implements ICardProvider {
         { origin: this.appUrl },
       );
     } catch (error) {
+      // Auth refresh rejection (400/401/403) is expected session expiry —
+      // do not report to Sentry.
       if (
         error instanceof CardApiError &&
         [400, 401, 403].includes(error.statusCode)
@@ -450,7 +488,7 @@ export class ImmersveProvider implements ICardProvider {
           error.statusCode,
         );
       }
-      throw mapApiError(error, 'refreshTokens');
+      reportAndMap(error, 'refreshTokens');
     }
 
     const refreshToken = response.refreshToken ?? tokens.refreshToken;
@@ -526,7 +564,7 @@ export class ImmersveProvider implements ICardProvider {
         balanceCurrency: response.balanceCurrency,
       };
     } catch (error) {
-      throw mapApiError(error, 'createFundingSource');
+      reportAndMap(error, 'createFundingSource', { network: this.network });
     }
   }
 
@@ -554,7 +592,7 @@ export class ImmersveProvider implements ICardProvider {
         fundingChannelId: item.fundingChannelId,
       }));
     } catch (error) {
-      throw mapApiError(error, 'getFundingSources');
+      reportAndMap(error, 'getFundingSources');
     }
   }
 
@@ -584,7 +622,7 @@ export class ImmersveProvider implements ICardProvider {
         tokens,
       );
     } catch (error) {
-      throw mapApiError(error, 'patchContactDetails');
+      reportAndMap(error, 'patchContactDetails');
     }
   }
 
@@ -609,7 +647,10 @@ export class ImmersveProvider implements ICardProvider {
         tokens,
       );
     } catch (error) {
-      throw mapApiError(error, 'getSpendingPrerequisites');
+      reportAndMap(error, 'getSpendingPrerequisites', {
+        fundingSourceId,
+        kycRegion: params.kycRegion,
+      });
     }
   }
 
@@ -627,7 +668,7 @@ export class ImmersveProvider implements ICardProvider {
         tokens,
       );
     } catch (error) {
-      throw mapApiError(error, 'createCard');
+      reportAndMap(error, 'createCard', { fundingSourceId });
     }
   }
 
@@ -648,7 +689,7 @@ export class ImmersveProvider implements ICardProvider {
         fundingSourceIds: detail.fundingSourceIds ?? [],
       };
     } catch (error) {
-      throw mapApiError(error, 'getResumeCardInfo');
+      reportAndMap(error, 'getResumeCardInfo');
     }
   }
 
@@ -765,7 +806,7 @@ export class ImmersveProvider implements ICardProvider {
         regionCode: detail.regionCode ?? card.regionCode,
       });
     } catch (error) {
-      throw mapApiError(error, 'getCardDetails');
+      reportAndMap(error, 'getCardDetails');
     }
   }
 
@@ -773,7 +814,7 @@ export class ImmersveProvider implements ICardProvider {
     try {
       await this.service.post(`/api/cards/${cardId}/freeze`, {}, tokens);
     } catch (error) {
-      throw mapApiError(error, 'freezeCard');
+      reportAndMap(error, 'freezeCard');
     }
   }
 
@@ -781,7 +822,7 @@ export class ImmersveProvider implements ICardProvider {
     try {
       await this.service.post(`/api/cards/${cardId}/unfreeze`, {}, tokens);
     } catch (error) {
-      throw mapApiError(error, 'unfreezeCard');
+      reportAndMap(error, 'unfreezeCard');
     }
   }
 
@@ -798,18 +839,7 @@ export class ImmersveProvider implements ICardProvider {
         baseURL: this.secureApiBaseUrl,
       });
     } catch (error) {
-      if (!(error instanceof CardApiError && error.statusCode === 401)) {
-        Logger.error(
-          error as Error,
-          getErrorContext('setCardPin', {
-            httpStatus:
-              error instanceof CardApiError ? error.statusCode : undefined,
-            errorCode:
-              error instanceof CardApiError ? error.errorCode : undefined,
-          }),
-        );
-      }
-      throw mapApiError(error, 'setCardPin');
+      reportAndMap(error, 'setCardPin');
     }
   }
 
@@ -833,7 +863,7 @@ export class ImmersveProvider implements ICardProvider {
       );
       return await this.service.get<CardSensitiveDetails>(callbackUrl);
     } catch (error) {
-      throw mapApiError(error, 'getCardSensitiveDetails');
+      reportAndMap(error, 'getCardSensitiveDetails');
     }
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Immersve Card failures were hard to diagnose in Sentry: many provider and UI catch paths threw or set local error state with little or no structured context, and some Card paths still used legacy string `Logger.error` extras (display-only, not searchable).

This PR aligns Immersve (and related Card) error reporting with the existing Baanx / Card structured pattern (`tags` + `context`), while excluding auth-token noise and PII at the call site.

**What changed:**
- Added `reportAndMap` in `ImmersveProvider` to log-then-rethrow non-auth API failures with searchable `feature:card` / `provider:immersve` tags and method/network/httpStatus (and safe extras like `fundingSourceId` / `country`)
- Enriched UI-local Immersve failures in `useImmersveSiweAuth` (non-`CardProviderError` only), `useImmersveFunding` `executeFunding`, and `ImmersveKYCModal` webview load/HTTP errors (host + status only)
- Migrated `VerifyIdentity` Veriff `Logger.error` calls from legacy strings to structured `provider:baanx` context
- Hardened `useImmersveSpendingPrerequisites` pending polling with cooldown backoff + in-flight `isLoading` guard so outages do not spam the provider/Sentry while transient failures can still recover
- Unit tests for provider reporting/401 skip, hook/UI logging behavior, and poll backoff

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/CARD-499

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Immersve Card Sentry error context

  Background:
    Given Immersve Card flows are enabled
    And I can observe Sentry events for the build under test

  Scenario: Immersve API failure reports structured Card context
    Given I am in an Immersve Card flow that calls the provider API
    When an Immersve API request fails with a non-auth error
    Then a Sentry event is created with tags feature=card and provider=immersve
    And the event context includes the failing method and HTTP status when available
    And the event does not include email, phone, tokens, signatures, or wallet addresses

  Scenario: Auth token and user-cancelled SIWE failures stay quiet in Sentry
    Given I start Immersve SIWE authentication
    When authentication fails with a 401 auth-token error or the user cancels signing
    Then no noisy auth-token / user-cancelled Sentry event is created from those paths

  Scenario: KYC webview load failure is reported without full URLs
    Given I open the Immersve KYC webview
    When the webview fails to load or returns an HTTP error
    Then I see the KYC load error UI with retry
    And Sentry receives a structured ImmersveKYCModal error with URL host and HTTP status only

  Scenario: Pending prerequisites recover from a transient poll failure
    Given Immersve spending prerequisites are in a pending state
    When a poll request fails transiently
    Then fast polling pauses and a cooldown retry runs later
    And overlapping fast polls do not fire while the retry is in flight
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth, funding transactions, and broad Immersve provider error paths; behavior is mostly observability and poll backoff, but mis-filtered Sentry reporting could hide real failures or still duplicate noise.
> 
> **Overview**
> Improves **Sentry diagnosability** for Card flows by replacing legacy string `Logger.error` extras with searchable **`tags` + `context`** (`feature: card`, `provider: immersve` / `baanx`), while avoiding PII (e.g. URL hosts only in KYC webview errors).
> 
> **`ImmersveProvider`** adds **`reportAndMap`** to log non-auth API failures (skipping 401 / auth-token noise) then map to `CardProviderError`, applied across onboarding and card API methods; **`setCardPin`** logging is folded into the same path.
> 
> **UI hooks** log only **local** failures where the provider does not already report: **`useImmersveSiweAuth`** (not user cancel / `CardProviderError`), **`useImmersveFunding`** `executeFunding`, **`ImmersveKYCModal`** webview load/HTTP errors (deduped **`onError`/`onHttpError`**). **`VerifyIdentity`** Veriff errors use structured Baanx context.
> 
> **`useImmersveSpendingPrerequisites`** pending polling now **pauses fast polls on error**, **15s cooldown retries** (max 3), and an **`isLoading` guard** to prevent overlapping polls during recovery—reducing provider/Sentry spam without double-reporting API errors from the hook.
> 
> Tests cover provider 401 skip, structured logging, dedupe, funding errors, and poll backoff behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01028bdf1a3762ac6fb57d7cb99e02f81bb0f2f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->