### PR TITLE
fix(confirmations): restore scaled component-library network badges cp-8.8.0 

### DIFF
--- a/app/component-library/components-temp/Accounts/AccountBalance/AccountBalance.constants.ts
+++ b/app/component-library/components-temp/Accounts/AccountBalance/AccountBalance.constants.ts
@@ -1,11 +1,14 @@
 // Third party dependencies.
-import type { BadgeNetworkProps } from '@metamask/design-system-react-native';
 import { ImageSourcePropType } from 'react-native';
 import {
   AvatarProps,
   AvatarVariant,
 } from '../../../components/Avatars/Avatar/Avatar.types';
 import { AvatarAccountType } from '../../../components/Avatars/Avatar/variants/AvatarAccount';
+import {
+  BadgeVariant,
+  BadgeProps,
+} from '../../../components/Badges/Badge/Badge.types';
 
 const imageSource =
   'https://assets.coingecko.com/coins/images/279/small/ethereum.png?1595348880';
@@ -30,7 +33,8 @@ export const TEST_AVATAR_PROPS: AvatarProps = {
   type: AvatarAccountType.JazzIcon,
 };
 
-export const BADGE_PROPS: Pick<BadgeNetworkProps, 'name' | 'src'> = {
+export const BADGE_PROPS: BadgeProps = {
+  variant: BadgeVariant.Network,
   name: 'Ethereum',
-  src: TEST_REMOTE_IMAGE_SOURCE,
+  imageSource: TEST_REMOTE_IMAGE_SOURCE,
 };

--- a/app/component-library/components-temp/Accounts/AccountBase/AccountBase.test.tsx
+++ b/app/component-library/components-temp/Accounts/AccountBase/AccountBase.test.tsx
@@ -6,9 +6,11 @@ import {
   BADGE_PROPS,
 } from '../AccountBalance/AccountBalance.constants';
 import { AvatarAccountType } from '../../../components/Avatars/Avatar';
+import { BadgeVariant } from '../../../components/Badges/Badge';
+import { BADGENETWORK_TEST_ID } from '../../../components/Badges/Badge/variants/BadgeNetwork/BadgeNetwork.constants';
 
 describe('AccountBase', () => {
-  it('should render AccountBase', () => {
+  it('renders network badge when badgeProps.imageSource is provided', () => {
     render(
       <AccountBase
         accountBalance={0}
@@ -21,6 +23,29 @@ describe('AccountBase', () => {
         avatarAccountType={AvatarAccountType.Maskicon}
       />,
     );
-    expect(screen.getByTestId('account-base')).toBeTruthy();
+
+    expect(screen.getByTestId('account-base')).toBeOnTheScreen();
+    expect(screen.getByTestId(BADGENETWORK_TEST_ID)).toBeOnTheScreen();
+  });
+
+  it('renders without network badge when badgeProps.imageSource is missing', () => {
+    render(
+      <AccountBase
+        accountBalance={0}
+        accountNativeCurrency={''}
+        accountNetwork={''}
+        accountName={''}
+        accountBalanceLabel={''}
+        accountAddress={TEST_ACCOUNT_ADDRESS}
+        badgeProps={{
+          variant: BadgeVariant.Network,
+          name: 'Ethereum',
+        }}
+        avatarAccountType={AvatarAccountType.Maskicon}
+      />,
+    );
+
+    expect(screen.getByTestId('account-base')).toBeOnTheScreen();
+    expect(screen.queryByTestId(BADGENETWORK_TEST_ID)).not.toBeOnTheScreen();
   });
 });

--- a/app/component-library/components-temp/Accounts/AccountBase/AccountBase.test.tsx
+++ b/app/component-library/components-temp/Accounts/AccountBase/AccountBase.test.tsx
@@ -8,7 +8,7 @@ import {
 import { AvatarAccountType } from '../../../components/Avatars/Avatar';
 
 describe('AccountBase', () => {
-  it('renders AccountBase with network badge when badgeProps.src is provided', () => {
+  it('should render AccountBase', () => {
     render(
       <AccountBase
         accountBalance={0}
@@ -21,28 +21,6 @@ describe('AccountBase', () => {
         avatarAccountType={AvatarAccountType.Maskicon}
       />,
     );
-
-    expect(screen.getByTestId('account-base')).toBeOnTheScreen();
-    expect(screen.getByTestId('account-base-network-badge')).toBeOnTheScreen();
-  });
-
-  it('renders without network badge when badgeProps.src is missing', () => {
-    render(
-      <AccountBase
-        accountBalance={0}
-        accountNativeCurrency={''}
-        accountNetwork={''}
-        accountName={''}
-        accountBalanceLabel={''}
-        accountAddress={TEST_ACCOUNT_ADDRESS}
-        badgeProps={{ name: 'Ethereum' }}
-        avatarAccountType={AvatarAccountType.Maskicon}
-      />,
-    );
-
-    expect(screen.getByTestId('account-base')).toBeOnTheScreen();
-    expect(
-      screen.queryByTestId('account-base-network-badge'),
-    ).not.toBeOnTheScreen();
+    expect(screen.getByTestId('account-base')).toBeTruthy();
   });
 });

--- a/app/component-library/components-temp/Accounts/AccountBase/AccountBase.tsx
+++ b/app/component-library/components-temp/Accounts/AccountBase/AccountBase.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import { View } from 'react-native';
-import {
-  BadgeNetwork,
-  BadgeWrapper,
-  BadgeWrapperPosition,
-} from '@metamask/design-system-react-native';
 
+import Badge from '../../../../component-library/components/Badges/Badge';
 import Avatar, { AvatarVariant } from '../../../components/Avatars/Avatar';
+import BadgeWrapper from '../../../components/Badges/BadgeWrapper';
 import Text, { TextVariant } from '../../../components/Texts/Text';
 import {
   ACCOUNT_BALANCE_AVATAR_TEST_ID,
@@ -30,16 +27,7 @@ const AccountBase = ({
   <View style={styles.body} testID={ACCOUNT_BASE_TEST_ID}>
     <View style={styles.container}>
       <BadgeWrapper
-        position={BadgeWrapperPosition.BottomRight}
-        badge={
-          badgeProps.src ? (
-            <BadgeNetwork
-              src={badgeProps.src}
-              name={badgeProps.name}
-              testID="account-base-network-badge"
-            />
-          ) : null
-        }
+        badgeElement={<Badge {...badgeProps} />}
         style={styles.badgeWrapper}
         testID={ACCOUNT_BALANCE_AVATAR_TEST_ID}
       >

--- a/app/component-library/components-temp/Accounts/AccountBase/AccountBase.tsx
+++ b/app/component-library/components-temp/Accounts/AccountBase/AccountBase.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { View } from 'react-native';
 
-import Badge from '../../../../component-library/components/Badges/Badge';
+import Badge, {
+  BadgeVariant,
+} from '../../../../component-library/components/Badges/Badge';
 import Avatar, { AvatarVariant } from '../../../components/Avatars/Avatar';
 import BadgeWrapper from '../../../components/Badges/BadgeWrapper';
 import Text, { TextVariant } from '../../../components/Texts/Text';
@@ -27,7 +29,12 @@ const AccountBase = ({
   <View style={styles.body} testID={ACCOUNT_BASE_TEST_ID}>
     <View style={styles.container}>
       <BadgeWrapper
-        badgeElement={<Badge {...badgeProps} />}
+        badgeElement={
+          badgeProps.variant !== BadgeVariant.Network ||
+          badgeProps.imageSource ? (
+            <Badge {...badgeProps} />
+          ) : undefined
+        }
         style={styles.badgeWrapper}
         testID={ACCOUNT_BALANCE_AVATAR_TEST_ID}
       >

--- a/app/component-library/components-temp/Accounts/AccountBase/AccountBase.types.ts
+++ b/app/component-library/components-temp/Accounts/AccountBase/AccountBase.types.ts
@@ -1,5 +1,5 @@
-import type { BadgeNetworkProps } from '@metamask/design-system-react-native';
 import { AvatarAccountType } from '../../../components/Avatars/Avatar';
+import { BadgeProps } from '../../../components/Badges/Badge/Badge.types';
 
 export interface AccountBaseProps {
   /**
@@ -32,9 +32,9 @@ export interface AccountBaseProps {
    */
   accountAddress: string;
   /**
-   * Network badge props for the account avatar wrapper
+   * Avatar wrapper props
    */
-  badgeProps: Pick<BadgeNetworkProps, 'name' | 'src'>;
+  badgeProps: BadgeProps;
   /**
    * i18n string of account type label
    */

--- a/app/components/UI/AccountFromToInfoCard/AddressFrom.test.tsx
+++ b/app/components/UI/AccountFromToInfoCard/AddressFrom.test.tsx
@@ -114,15 +114,16 @@ describe('AddressFrom', () => {
     expect(getByText(MOCK_NETWORK_NAME)).toBeOnTheScreen();
   });
 
-  it('still renders account when network image is missing', () => {
+  it('hides network badge when network image is missing', () => {
     useNetworkInfoMock.mockReturnValue({
       networkName: MOCK_NETWORK_NAME,
       networkImage: undefined,
       networkNativeCurrency: 'ETH',
     } as unknown as ReturnType<typeof useNetworkInfo>);
 
-    const { getByText } = renderAddressFrom();
+    const { getByText, queryByTestId } = renderAddressFrom();
 
     expect(getByText(MOCK_NETWORK_NAME)).toBeOnTheScreen();
+    expect(queryByTestId('badgenetwork')).not.toBeOnTheScreen();
   });
 });

--- a/app/components/UI/AccountFromToInfoCard/AddressFrom.test.tsx
+++ b/app/components/UI/AccountFromToInfoCard/AddressFrom.test.tsx
@@ -110,20 +110,19 @@ describe('AddressFrom', () => {
   it('renders network badge when network image is provided', () => {
     const { getByTestId, getByText } = renderAddressFrom();
 
-    expect(getByTestId('account-base-network-badge')).toBeOnTheScreen();
+    expect(getByTestId('network-avatar-image')).toBeOnTheScreen();
     expect(getByText(MOCK_NETWORK_NAME)).toBeOnTheScreen();
   });
 
-  it('hides network badge when network image is missing', () => {
+  it('still renders account when network image is missing', () => {
     useNetworkInfoMock.mockReturnValue({
       networkName: MOCK_NETWORK_NAME,
       networkImage: undefined,
       networkNativeCurrency: 'ETH',
     } as unknown as ReturnType<typeof useNetworkInfo>);
 
-    const { queryByTestId, getByText } = renderAddressFrom();
+    const { getByText } = renderAddressFrom();
 
     expect(getByText(MOCK_NETWORK_NAME)).toBeOnTheScreen();
-    expect(queryByTestId('account-base-network-badge')).not.toBeOnTheScreen();
   });
 });

--- a/app/components/UI/AccountFromToInfoCard/AddressFrom.tsx
+++ b/app/components/UI/AccountFromToInfoCard/AddressFrom.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 
 import { strings } from '../../../../locales/i18n';
 import AccountBalance from '../../../component-library/components-temp/Accounts/AccountBalance';
+import { BadgeVariant } from '../../../component-library/components/Badges/Badge';
 import { useStyles } from '../../../component-library/hooks';
 import { selectAccountsByChainId } from '../../../selectors/accountTrackerController';
 import {
@@ -95,8 +96,9 @@ const AddressFrom = ({
         accountTypeLabel={accountTypeLabel as string}
         accountNetwork={String(displayNetworkName)}
         badgeProps={{
+          variant: BadgeVariant.Network,
           name: displayNetworkName,
-          src: displayNetworkImage,
+          imageSource: displayNetworkImage,
         }}
         avatarAccountType={avatarAccountType}
       />

--- a/app/components/Views/confirmations/components/UI/nft/nft.test.tsx
+++ b/app/components/Views/confirmations/components/UI/nft/nft.test.tsx
@@ -142,21 +142,6 @@ describe('Nft', () => {
     expect(mockOnPress).toHaveBeenCalledWith(mockNft);
   });
 
-  it('displays network badge when networkBadgeSource is provided', () => {
-    const mockNft = createMockNft({
-      networkBadgeSource: { uri: 'https://example.com/badge.png' },
-      collectionName: 'Badge Collection',
-      name: 'Badge NFT',
-      balance: '0',
-    });
-
-    const { getByTestId } = renderWithProvider(
-      <Nft asset={mockNft} onPress={mockOnPress} />,
-    );
-
-    expect(getByTestId('nft-network-badge')).toBeOnTheScreen();
-  });
-
   it('renders without network badge when networkBadgeSource is undefined', () => {
     const mockNft = createMockNft({
       networkBadgeSource: undefined,
@@ -165,13 +150,12 @@ describe('Nft', () => {
       balance: '0',
     });
 
-    const { getByText, queryByTestId } = renderWithProvider(
+    const { getByText } = renderWithProvider(
       <Nft asset={mockNft} onPress={mockOnPress} />,
     );
 
     expect(getByText('Simple Collection')).toBeOnTheScreen();
     // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     expect(getByText('#123')).toBeOnTheScreen();
-    expect(queryByTestId('nft-network-badge')).not.toBeOnTheScreen();
   });
 });

--- a/app/components/Views/confirmations/components/UI/nft/nft.tsx
+++ b/app/components/Views/confirmations/components/UI/nft/nft.tsx
@@ -1,19 +1,20 @@
 import React, { useCallback } from 'react';
 import { Pressable } from 'react-native';
 import {
-  AvatarToken,
-  BadgeNetwork,
-  BadgeWrapper,
-  BadgeWrapperPosition,
   Box,
   Text,
   TextVariant,
+  AvatarToken,
   FontWeight,
   TextColor,
-  type ImageOrSvgSrc,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 
+import { AvatarSize } from '../../../../../../component-library/components/Avatars/Avatar';
+import BadgeWrapper from '../../../../../../component-library/components/Badges/BadgeWrapper';
+import Badge from '../../../../../../component-library/components/Badges/Badge/Badge';
+import { BadgeVariant } from '../../../../../../component-library/components/Badges/Badge/Badge.types';
+import { BadgePosition } from '../../../../../../component-library/components/Badges/BadgeWrapper/BadgeWrapper.types';
 import { Nft as NftType } from '../../../types/token';
 
 interface NftProps {
@@ -44,15 +45,16 @@ export function Nft({ asset, onPress }: NftProps) {
       <Box twClassName="flex-row items-center px-4">
         <Box twClassName="h-12 justify-center">
           <BadgeWrapper
-            position={BadgeWrapperPosition.BottomRight}
-            badge={
+            badgePosition={BadgePosition.BottomRight}
+            badgeElement={
               asset.networkBadgeSource ? (
-                <BadgeNetwork
+                <Badge
+                  variant={BadgeVariant.Network}
                   name={asset.name || asset.collectionName || 'NFT'}
-                  src={asset.networkBadgeSource as ImageOrSvgSrc}
-                  testID="nft-network-badge"
+                  imageSource={asset.networkBadgeSource}
+                  size={AvatarSize.Xs}
                 />
-              ) : null
+              ) : undefined
             }
           >
             <AvatarToken

--- a/app/components/Views/confirmations/components/UI/token/token.test.tsx
+++ b/app/components/Views/confirmations/components/UI/token/token.test.tsx
@@ -86,12 +86,11 @@ describe('Token', () => {
       symbol: 'ETH',
     });
 
-    const { getByText, getByTestId } = renderWithProvider(
+    const { getByText } = renderWithProvider(
       <Token asset={mockToken} onPress={mockOnPress} />,
     );
 
     expect(getByText('Polygon ETH')).toBeOnTheScreen();
-    expect(getByTestId('token-network-badge')).toBeOnTheScreen();
   });
 
   it('displays balance in selected currency when provided', () => {

--- a/app/components/Views/confirmations/components/UI/token/token.tsx
+++ b/app/components/Views/confirmations/components/UI/token/token.tsx
@@ -1,15 +1,11 @@
 import React, { ReactNode, useCallback } from 'react';
 import { Pressable } from 'react-native';
 import {
-  BadgeNetwork,
-  BadgeWrapper,
-  BadgeWrapperPosition,
   Box,
   Text,
   TextVariant,
   FontWeight,
   TextColor,
-  type ImageOrSvgSrc,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { BigNumber } from 'bignumber.js';
@@ -17,6 +13,11 @@ import { KeyringAccountType } from '@metamask/keyring-api';
 
 import I18n from '../../../../../../../locales/i18n';
 import NetworkAssetLogo from '../../../../../../components/UI/NetworkAssetLogo';
+import { AvatarSize } from '../../../../../../component-library/components/Avatars/Avatar';
+import BadgeWrapper from '../../../../../../component-library/components/Badges/BadgeWrapper';
+import Badge from '../../../../../../component-library/components/Badges/Badge/Badge';
+import { BadgeVariant } from '../../../../../../component-library/components/Badges/Badge/Badge.types';
+import { BadgePosition } from '../../../../../../component-library/components/Badges/BadgeWrapper/BadgeWrapper.types';
 import { AccountTypeLabel } from '../account-type-label';
 import { AssetType } from '../../../types/token';
 import { getAssetTestId } from '../../../../../../../tests/selectors/Wallet/WalletView.selectors';
@@ -66,15 +67,16 @@ export function Token({ asset, tagRenderers, onPress }: TokenProps) {
       >
         <Box twClassName="h-12 justify-center">
           <BadgeWrapper
-            position={BadgeWrapperPosition.BottomRight}
-            badge={
+            badgePosition={BadgePosition.BottomRight}
+            badgeElement={
               asset.networkBadgeSource ? (
-                <BadgeNetwork
+                <Badge
+                  variant={BadgeVariant.Network}
                   name={asset.name || asset.symbol || 'Token'}
-                  src={asset.networkBadgeSource as ImageOrSvgSrc}
-                  testID="token-network-badge"
+                  imageSource={asset.networkBadgeSource}
+                  size={AvatarSize.Xs}
                 />
-              ) : null
+              ) : undefined
             }
           >
             {asset.isNative ? (

--- a/app/components/Views/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.test.tsx
@@ -109,8 +109,17 @@ describe('TransactionDetailsAccountRow', () => {
       transactionMeta: { ...TRANSACTION_META_MOCK, type },
     });
 
-    const { UNSAFE_getByProps } = render();
+    const { getByTestId, UNSAFE_getByProps } = render();
     expect(UNSAFE_getByProps({ accountAddress: ADDRESS_MOCK })).toBeDefined();
+    expect(getByTestId('badgenetwork')).toBeOnTheScreen();
+  });
+
+  it('hides network badge when network image is missing', () => {
+    useNetworkInfoMock.mockReturnValue({});
+
+    const { queryByTestId } = render();
+
+    expect(queryByTestId('badgenetwork')).not.toBeOnTheScreen();
   });
 
   it('renders "From" row with money account label for moneyAccountWithdraw', () => {

--- a/app/components/Views/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.test.tsx
@@ -109,11 +109,8 @@ describe('TransactionDetailsAccountRow', () => {
       transactionMeta: { ...TRANSACTION_META_MOCK, type },
     });
 
-    const { getByTestId, UNSAFE_getByProps } = render();
+    const { UNSAFE_getByProps } = render();
     expect(UNSAFE_getByProps({ accountAddress: ADDRESS_MOCK })).toBeDefined();
-    expect(
-      getByTestId('transaction-details-account-network-badge'),
-    ).toBeOnTheScreen();
   });
 
   it('renders "From" row with money account label for moneyAccountWithdraw', () => {

--- a/app/components/Views/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
@@ -161,11 +161,13 @@ export function TransactionDetailsAccountRow() {
     <BadgeWrapper
       badgePosition={BadgePosition.BottomRight}
       badgeElement={
-        <Badge
-          variant={BadgeVariant.Network}
-          imageSource={networkImage}
-          name={networkName}
-        />
+        networkImage ? (
+          <Badge
+            variant={BadgeVariant.Network}
+            imageSource={networkImage}
+            name={networkName}
+          />
+        ) : undefined
       }
     >
       <AvatarAccount accountAddress={avatarAddress} size={AvatarSize.Sm} />

--- a/app/components/Views/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
@@ -9,13 +9,14 @@ import {
 import Text, {
   TextColor,
 } from '../../../../../../component-library/components/Texts/Text';
-import {
-  BadgeNetwork,
-  BadgeWrapper,
-  BadgeWrapperPosition,
-} from '@metamask/design-system-react-native';
 import { AvatarSize } from '../../../../../../component-library/components/Avatars/Avatar';
 import AvatarAccount from '../../../../../../component-library/components/Avatars/Avatar/variants/AvatarAccount';
+import Badge, {
+  BadgeVariant,
+} from '../../../../../../component-library/components/Badges/Badge';
+import BadgeWrapper, {
+  BadgePosition,
+} from '../../../../../../component-library/components/Badges/BadgeWrapper';
 import { Box } from '../../../../../UI/Box/Box';
 import { AlignItems, FlexDirection } from '../../../../../UI/Box/box.types';
 import { NameType } from '../../../../../UI/Name/Name.types';
@@ -158,15 +159,13 @@ export function TransactionDetailsAccountRow() {
     </View>
   ) : (
     <BadgeWrapper
-      position={BadgeWrapperPosition.BottomRight}
-      badge={
-        networkImage ? (
-          <BadgeNetwork
-            src={networkImage}
-            name={networkName}
-            testID="transaction-details-account-network-badge"
-          />
-        ) : null
+      badgePosition={BadgePosition.BottomRight}
+      badgeElement={
+        <Badge
+          variant={BadgeVariant.Network}
+          imageSource={networkImage}
+          name={networkName}
+        />
       }
     >
       <AvatarAccount accountAddress={avatarAddress} size={AvatarSize.Sm} />

--- a/app/components/Views/confirmations/components/gas/gas-fee-token-icon/gas-fee-token-icon.test.tsx
+++ b/app/components/Views/confirmations/components/gas/gas-fee-token-icon/gas-fee-token-icon.test.tsx
@@ -72,20 +72,6 @@ describe('GasFeeTokenIcon', () => {
     );
 
     expect(getByTestId('token-icon')).toBeOnTheScreen();
-    expect(getByTestId('gas-fee-token-network-badge')).toBeOnTheScreen();
-  });
-
-  it('renders token icon without network badge when network image is missing', () => {
-    const tokenAddress = '0xTokenAddress' as Hex;
-    mockUseNetworkInfo.mockReturnValue({});
-
-    const { getByTestId, queryByTestId } = renderWithProvider(
-      <GasFeeTokenIcon tokenAddress={tokenAddress} />,
-      { state: transferTransactionStateMock },
-    );
-
-    expect(getByTestId('token-icon')).toBeOnTheScreen();
-    expect(queryByTestId('gas-fee-token-network-badge')).not.toBeOnTheScreen();
   });
 
   it('falls back to CDN token image when TokensController image is missing', () => {

--- a/app/components/Views/confirmations/components/gas/gas-fee-token-icon/gas-fee-token-icon.test.tsx
+++ b/app/components/Views/confirmations/components/gas/gas-fee-token-icon/gas-fee-token-icon.test.tsx
@@ -72,6 +72,20 @@ describe('GasFeeTokenIcon', () => {
     );
 
     expect(getByTestId('token-icon')).toBeOnTheScreen();
+    expect(getByTestId('badgenetwork')).toBeOnTheScreen();
+  });
+
+  it('renders token icon without network badge when network image is missing', () => {
+    const tokenAddress = '0xTokenAddress' as Hex;
+    mockUseNetworkInfo.mockReturnValue({});
+
+    const { getByTestId, queryByTestId } = renderWithProvider(
+      <GasFeeTokenIcon tokenAddress={tokenAddress} />,
+      { state: transferTransactionStateMock },
+    );
+
+    expect(getByTestId('token-icon')).toBeOnTheScreen();
+    expect(queryByTestId('badgenetwork')).not.toBeOnTheScreen();
   });
 
   it('falls back to CDN token image when TokensController image is missing', () => {

--- a/app/components/Views/confirmations/components/gas/gas-fee-token-icon/gas-fee-token-icon.tsx
+++ b/app/components/Views/confirmations/components/gas/gas-fee-token-icon/gas-fee-token-icon.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import { Hex } from '@metamask/utils';
-import {
-  BadgeNetwork,
-  BadgeWrapper,
-  BadgeWrapperPosition,
-} from '@metamask/design-system-react-native';
-import { View } from 'react-native';
 import { useStyles } from '../../../../../hooks/useStyles';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
 import styleSheet from './gas-fee-token-icon.styles';
 import { NATIVE_TOKEN_ADDRESS } from '../../../constants/tokens';
+import { View } from 'react-native';
 import useNetworkInfo from '../../../hooks/useNetworkInfo';
 import { AvatarSize } from '../../../../../../component-library/components/Avatars/Avatar';
 import AvatarToken from '../../../../../../component-library/components/Avatars/Avatar/variants/AvatarToken';
+import BadgeWrapper, {
+  BadgePosition,
+} from '../../../../../../component-library/components/Badges/BadgeWrapper';
+import Badge, {
+  BadgeVariant,
+} from '../../../../../../component-library/components/Badges/Badge';
 import NetworkAssetLogo from '../../../../../UI/NetworkAssetLogo';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { useTransactionBatchesMetadata } from '../../../hooks/transactions/useTransactionBatchesMetadata';
@@ -102,15 +103,13 @@ function TokenIconWithNetworkBadge({
   return (
     <View>
       <BadgeWrapper
-        position={BadgeWrapperPosition.BottomRight}
-        badge={
-          networkImage ? (
-            <BadgeNetwork
-              src={networkImage}
-              name={networkName}
-              testID="gas-fee-token-network-badge"
-            />
-          ) : null
+        badgePosition={BadgePosition.BottomRight}
+        badgeElement={
+          <Badge
+            variant={BadgeVariant.Network}
+            name={networkName}
+            imageSource={networkImage}
+          />
         }
         style={styles.badgeWrapper}
       >

--- a/app/components/Views/confirmations/components/gas/gas-fee-token-icon/gas-fee-token-icon.tsx
+++ b/app/components/Views/confirmations/components/gas/gas-fee-token-icon/gas-fee-token-icon.tsx
@@ -105,11 +105,13 @@ function TokenIconWithNetworkBadge({
       <BadgeWrapper
         badgePosition={BadgePosition.BottomRight}
         badgeElement={
-          <Badge
-            variant={BadgeVariant.Network}
-            name={networkName}
-            imageSource={networkImage}
-          />
+          networkImage ? (
+            <Badge
+              variant={BadgeVariant.Network}
+              name={networkName}
+              imageSource={networkImage}
+            />
+          ) : undefined
         }
         style={styles.badgeWrapper}
       >

--- a/app/components/Views/confirmations/components/hero-nft/hero-nft.test.tsx
+++ b/app/components/Views/confirmations/components/hero-nft/hero-nft.test.tsx
@@ -107,7 +107,7 @@ describe('HeroNft', () => {
     });
 
     expect(getByTestId('nft-image')).toBeDefined();
-    expect(getByTestId('hero-nft-badge-network')).toBeOnTheScreen();
+    expect(getByTestId('network-avatar-image')).toBeDefined();
     expect(getByText('Test Dapp NFTs')).toBeDefined();
     // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     expect(getByText('#12345')).toBeDefined();
@@ -158,7 +158,7 @@ describe('HeroNft', () => {
     });
 
     expect(getByTestId('nft-image')).toBeDefined();
-    expect(getByTestId('hero-nft-badge-network')).toBeOnTheScreen();
+    expect(getByTestId('network-avatar-image')).toBeDefined();
     expect(getByText('Test Dapp NFTs')).toBeDefined();
     // eslint-disable-next-line @metamask/design-tokens/color-no-hex
     expect(getByText('#12345')).toBeDefined();

--- a/app/components/Views/confirmations/components/hero-nft/hero-nft.test.tsx
+++ b/app/components/Views/confirmations/components/hero-nft/hero-nft.test.tsx
@@ -5,6 +5,7 @@ import { MOCK_ADDRESS_1 } from '../../../../../util/test/accountsControllerTestU
 import { MOCK_STATE_NFT } from '../../../../../util/test/mock-data/root-state/nft';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { useTransactionMetadataRequest } from '../../hooks/transactions/useTransactionMetadataRequest';
+import useNetworkInfo from '../../hooks/useNetworkInfo';
 import { HeroNft } from './hero-nft';
 
 const mockNft = MOCK_STATE_NFT.engine.backgroundState.NftController.allNfts[
@@ -31,9 +32,26 @@ jest.mock('../../hooks/ui/useFullScreenConfirmation', () => ({
   useFullScreenConfirmation: () => ({ isFullScreenConfirmation: false }),
 }));
 
+jest.mock('../../hooks/useNetworkInfo', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    networkName: 'Ethereum Mainnet',
+    networkImage: { uri: 'https://example.com/eth.png' },
+    networkNativeCurrency: 'ETH',
+  })),
+}));
+
 describe('HeroNft', () => {
+  const mockUseNetworkInfo = jest.mocked(useNetworkInfo);
+
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockUseNetworkInfo.mockReturnValue({
+      networkName: 'Ethereum Mainnet',
+      networkImage: { uri: 'https://example.com/eth.png' },
+      networkNativeCurrency: 'ETH',
+    });
 
     const mockTransaction =
       MOCK_STATE_NFT.engine.backgroundState.TransactionController
@@ -106,11 +124,11 @@ describe('HeroNft', () => {
       state: MOCK_STATE_NFT,
     });
 
-    expect(getByTestId('nft-image')).toBeDefined();
-    expect(getByTestId('network-avatar-image')).toBeDefined();
-    expect(getByText('Test Dapp NFTs')).toBeDefined();
+    expect(getByTestId('nft-image')).toBeOnTheScreen();
+    expect(getByTestId('network-avatar-image')).toBeOnTheScreen();
+    expect(getByText('Test Dapp NFTs')).toBeOnTheScreen();
     // eslint-disable-next-line @metamask/design-tokens/color-no-hex
-    expect(getByText('#12345')).toBeDefined();
+    expect(getByText('#12345')).toBeOnTheScreen();
 
     fireEvent.press(getByTestId('nft-image'));
 
@@ -157,11 +175,11 @@ describe('HeroNft', () => {
       }),
     });
 
-    expect(getByTestId('nft-image')).toBeDefined();
-    expect(getByTestId('network-avatar-image')).toBeDefined();
-    expect(getByText('Test Dapp NFTs')).toBeDefined();
+    expect(getByTestId('nft-image')).toBeOnTheScreen();
+    expect(getByTestId('network-avatar-image')).toBeOnTheScreen();
+    expect(getByText('Test Dapp NFTs')).toBeOnTheScreen();
     // eslint-disable-next-line @metamask/design-tokens/color-no-hex
-    expect(getByText('#12345')).toBeDefined();
+    expect(getByText('#12345')).toBeOnTheScreen();
 
     fireEvent.press(getByTestId('nft-image'));
 
@@ -172,5 +190,16 @@ describe('HeroNft', () => {
         collection: { imageUrl: 'testURI//:333' },
       },
     });
+  });
+
+  it('hides network badge when network image is missing', () => {
+    mockUseNetworkInfo.mockReturnValue({});
+
+    const { queryByTestId } = renderWithProvider(<HeroNft />, {
+      state: MOCK_STATE_NFT,
+    });
+
+    expect(queryByTestId('nft-image')).toBeOnTheScreen();
+    expect(queryByTestId('badgenetwork')).not.toBeOnTheScreen();
   });
 });

--- a/app/components/Views/confirmations/components/hero-nft/hero-nft.tsx
+++ b/app/components/Views/confirmations/components/hero-nft/hero-nft.tsx
@@ -3,12 +3,13 @@ import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import React, { useCallback } from 'react';
 import { TouchableOpacity, View } from 'react-native';
-import {
-  BadgeNetwork,
-  BadgeWrapper,
-  BadgeWrapperPosition,
-} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
+import Badge, {
+  BadgeVariant,
+} from '../../../../../component-library/components/Badges/Badge';
+import BadgeWrapper, {
+  BadgePosition,
+} from '../../../../../component-library/components/Badges/BadgeWrapper';
 import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
@@ -65,15 +66,14 @@ const NftImageAndNetworkBadge = ({
   return (
     <TouchableOpacity onPress={onPress} style={styles.touchableOpacity}>
       <BadgeWrapper
-        position={BadgeWrapperPosition.BottomRight}
-        badge={
-          networkImage ? (
-            <BadgeNetwork
-              src={networkImage}
-              name={networkName}
-              testID="hero-nft-badge-network"
-            />
-          ) : null
+        badgePosition={BadgePosition.BottomRight}
+        badgeElement={
+          <Badge
+            imageSource={networkImage}
+            name={networkName}
+            variant={BadgeVariant.Network}
+            testID="hero-nft-badge-network"
+          />
         }
       >
         <CollectibleMedia

--- a/app/components/Views/confirmations/components/hero-nft/hero-nft.tsx
+++ b/app/components/Views/confirmations/components/hero-nft/hero-nft.tsx
@@ -68,12 +68,14 @@ const NftImageAndNetworkBadge = ({
       <BadgeWrapper
         badgePosition={BadgePosition.BottomRight}
         badgeElement={
-          <Badge
-            imageSource={networkImage}
-            name={networkName}
-            variant={BadgeVariant.Network}
-            testID="hero-nft-badge-network"
-          />
+          networkImage ? (
+            <Badge
+              imageSource={networkImage}
+              name={networkName}
+              variant={BadgeVariant.Network}
+              testID="hero-nft-badge-network"
+            />
+          ) : undefined
         }
       >
         <CollectibleMedia

--- a/app/components/Views/confirmations/components/hero-token/avatar-token-with-network-badge/avatar-token-with-network-badge.test.tsx
+++ b/app/components/Views/confirmations/components/hero-token/avatar-token-with-network-badge/avatar-token-with-network-badge.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import initialRootState from '../../../../../../util/test/initial-root-state';
+import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
+import { useTokenAsset } from '../../../hooks/useTokenAsset';
+import useNetworkInfo from '../../../hooks/useNetworkInfo';
+import { AvatarTokenWithNetworkBadge } from './avatar-token-with-network-badge';
+
+jest.mock('../../../hooks/transactions/useTransactionMetadataRequest');
+jest.mock('../../../hooks/useTokenAsset');
+jest.mock('../../../hooks/useNetworkInfo');
+
+describe('AvatarTokenWithNetworkBadge', () => {
+  const mockUseTransactionMetadataRequest = jest.mocked(
+    useTransactionMetadataRequest,
+  );
+  const mockUseTokenAsset = jest.mocked(useTokenAsset);
+  const mockUseNetworkInfo = jest.mocked(useNetworkInfo);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    mockUseTransactionMetadataRequest.mockReturnValue({
+      chainId: '0x1',
+    } as ReturnType<typeof useTransactionMetadataRequest>);
+    mockUseTokenAsset.mockReturnValue({
+      asset: {
+        image: 'https://example.com/token.png',
+        isNative: false,
+      },
+      displayName: 'USDC',
+    } as ReturnType<typeof useTokenAsset>);
+    mockUseNetworkInfo.mockReturnValue({
+      networkName: 'Ethereum',
+      networkImage: { uri: 'https://example.com/eth.png' },
+      networkNativeCurrency: 'ETH',
+    });
+  });
+
+  it('renders network badge when network image is provided', () => {
+    const { getByTestId } = renderWithProvider(
+      <AvatarTokenWithNetworkBadge />,
+      { state: initialRootState },
+    );
+
+    expect(getByTestId('badgenetwork')).toBeOnTheScreen();
+  });
+
+  it('hides network badge when network image is missing', () => {
+    mockUseNetworkInfo.mockReturnValue({});
+
+    const { queryByTestId } = renderWithProvider(
+      <AvatarTokenWithNetworkBadge />,
+      { state: initialRootState },
+    );
+
+    expect(queryByTestId('badgenetwork')).not.toBeOnTheScreen();
+  });
+});

--- a/app/components/Views/confirmations/components/hero-token/avatar-token-with-network-badge/avatar-token-with-network-badge.test.tsx
+++ b/app/components/Views/confirmations/components/hero-token/avatar-token-with-network-badge/avatar-token-with-network-badge.test.tsx
@@ -23,7 +23,7 @@ describe('AvatarTokenWithNetworkBadge', () => {
 
     mockUseTransactionMetadataRequest.mockReturnValue({
       chainId: '0x1',
-    } as ReturnType<typeof useTransactionMetadataRequest>);
+    } as never);
     mockUseTokenAsset.mockReturnValue({
       asset: {
         image: 'https://example.com/token.png',

--- a/app/components/Views/confirmations/components/hero-token/avatar-token-with-network-badge/avatar-token-with-network-badge.tsx
+++ b/app/components/Views/confirmations/components/hero-token/avatar-token-with-network-badge/avatar-token-with-network-badge.tsx
@@ -2,16 +2,15 @@ import React from 'react';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 
-import {
-  BadgeNetwork,
-  BadgeWrapper,
-  BadgeWrapperPosition,
-} from '@metamask/design-system-react-native';
-import { View } from 'react-native';
-
 import { strings } from '../../../../../../../locales/i18n';
 import { AvatarSize } from '../../../../../../component-library/components/Avatars/Avatar/Avatar.types';
 import AvatarToken from '../../../../../../component-library/components/Avatars/Avatar/variants/AvatarToken/AvatarToken';
+import Badge, {
+  BadgeVariant,
+} from '../../../../../../component-library/components/Badges/Badge';
+import BadgeWrapper, {
+  BadgePosition,
+} from '../../../../../../component-library/components/Badges/BadgeWrapper';
 import { useStyles } from '../../../../../../component-library/hooks';
 import NetworkAssetLogo from '../../../../../UI/NetworkAssetLogo';
 import { NetworkBadgeSource } from '../../../../../UI/AssetOverview/Balance/Balance';
@@ -20,6 +19,7 @@ import useNetworkInfo from '../../../hooks/useNetworkInfo';
 import { useTokenAsset } from '../../../hooks/useTokenAsset';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
 import { styleSheet } from './avatar-token-with-network-badge.styles';
+import { View } from 'react-native';
 
 const AvatarTokenOrNetworkAssetLogo = ({
   asset,
@@ -68,15 +68,13 @@ export const AvatarTokenWithNetworkBadge = ({
   return (
     <View style={styles.base}>
       <BadgeWrapper
-        position={BadgeWrapperPosition.BottomRight}
-        badge={
-          networkImage ? (
-            <BadgeNetwork
-              src={networkImage}
-              name={networkName}
-              testID="avatar-token-network-badge"
-            />
-          ) : null
+        badgePosition={BadgePosition.BottomRight}
+        badgeElement={
+          <Badge
+            imageSource={networkImage}
+            name={networkName}
+            variant={BadgeVariant.Network}
+          />
         }
       >
         <AvatarTokenOrNetworkAssetLogo

--- a/app/components/Views/confirmations/components/hero-token/avatar-token-with-network-badge/avatar-token-with-network-badge.tsx
+++ b/app/components/Views/confirmations/components/hero-token/avatar-token-with-network-badge/avatar-token-with-network-badge.tsx
@@ -70,11 +70,13 @@ export const AvatarTokenWithNetworkBadge = ({
       <BadgeWrapper
         badgePosition={BadgePosition.BottomRight}
         badgeElement={
-          <Badge
-            imageSource={networkImage}
-            name={networkName}
-            variant={BadgeVariant.Network}
-          />
+          networkImage ? (
+            <Badge
+              imageSource={networkImage}
+              name={networkName}
+              variant={BadgeVariant.Network}
+            />
+          ) : undefined
         }
       >
         <AvatarTokenOrNetworkAssetLogo

--- a/app/components/Views/confirmations/components/hero-token/hero-token.test.tsx
+++ b/app/components/Views/confirmations/components/hero-token/hero-token.test.tsx
@@ -41,7 +41,6 @@ describe('HeroToken', () => {
 
     await waitFor(async () => {
       expect(queryByTestId('avatar-with-badge-avatar-token-ETH')).toBeTruthy();
-      expect(queryByTestId('avatar-token-network-badge')).toBeOnTheScreen();
       expect(getByText('0.0556 ETH')).toBeDefined();
       expect(getByText('$199.79')).toBeDefined();
     });

--- a/app/components/Views/confirmations/components/token-conversion-asset-header/token-conversion-asset-header.test.tsx
+++ b/app/components/Views/confirmations/components/token-conversion-asset-header/token-conversion-asset-header.test.tsx
@@ -128,6 +128,9 @@ describe('TokenConversionAssetHeader', () => {
       targetAmount: { usd: '1230.01', fiat: '1230.01' },
     } as ReturnType<typeof useTransactionPayTotals>);
     mockUseNetworkName.mockReturnValue('Ethereum');
+    jest.mocked(getNetworkImageSource).mockReturnValue({
+      uri: 'mock-network-image',
+    });
   });
 
   afterEach(() => {
@@ -263,6 +266,30 @@ describe('TokenConversionAssetHeader', () => {
     expect(
       getByTestId(TokenConversionAssetHeaderTestIds.OUTPUT_TOKEN_AVATAR),
     ).toBeOnTheScreen();
+  });
+
+  it('hides network badges when network image sources are missing', () => {
+    jest.mocked(getNetworkImageSource).mockReturnValue(undefined);
+
+    const token = createMockToken();
+    const formatFiat = createMockFormatFiat();
+
+    const { getByTestId, queryByTestId } = renderWithProvider(
+      <TokenConversionAssetHeader
+        inputToken={token}
+        outputToken={token}
+        formatFiat={formatFiat}
+      />,
+      { state: initialRootState },
+    );
+
+    expect(
+      getByTestId(TokenConversionAssetHeaderTestIds.INPUT_TOKEN_AVATAR),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(TokenConversionAssetHeaderTestIds.OUTPUT_TOKEN_AVATAR),
+    ).toBeOnTheScreen();
+    expect(queryByTestId('badgenetwork')).not.toBeOnTheScreen();
   });
 
   it('calls getNetworkImageSource with input and output token chainIds', () => {

--- a/app/components/Views/confirmations/components/token-conversion-asset-header/token-conversion-asset-header.test.tsx
+++ b/app/components/Views/confirmations/components/token-conversion-asset-header/token-conversion-asset-header.test.tsx
@@ -269,7 +269,7 @@ describe('TokenConversionAssetHeader', () => {
   });
 
   it('hides network badges when network image sources are missing', () => {
-    jest.mocked(getNetworkImageSource).mockReturnValue(undefined);
+    jest.mocked(getNetworkImageSource).mockReturnValue(undefined as never);
 
     const token = createMockToken();
     const formatFiat = createMockFormatFiat();

--- a/app/components/Views/confirmations/components/token-conversion-asset-header/token-conversion-asset-header.tsx
+++ b/app/components/Views/confirmations/components/token-conversion-asset-header/token-conversion-asset-header.tsx
@@ -1,16 +1,12 @@
 import React, { useCallback, useRef, useState } from 'react';
 import { NativeSyntheticEvent, TextLayoutEventData, View } from 'react-native';
-import {
-  BadgeNetwork,
-  BadgeWrapper,
-  BadgeWrapperPosition,
-  Icon,
-  IconColor,
-  IconName,
-  IconSize,
-} from '@metamask/design-system-react-native';
-import BigNumber from 'bignumber.js';
 import { useStyles } from '../../../../hooks/useStyles';
+import Badge, {
+  BadgeVariant,
+} from '../../../../../component-library/components/Badges/Badge';
+import BadgeWrapper, {
+  BadgePosition,
+} from '../../../../../component-library/components/Badges/BadgeWrapper';
 import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
 import AvatarToken from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarToken';
 import Text, {
@@ -18,6 +14,7 @@ import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import { getNetworkImageSource } from '../../../../../util/networks';
+import BigNumber from 'bignumber.js';
 import { Skeleton } from '../../../../../component-library/components-temp/Skeleton';
 import { AssetType } from '../../types/token';
 import styleSheet from './token-conversion-asset-header.styles';
@@ -25,6 +22,12 @@ import {
   useIsTransactionPayLoading,
   useTransactionPayTotals,
 } from '../../hooks/pay/useTransactionPayData';
+import {
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+} from '@metamask/design-system-react-native';
 import { Hex } from '@metamask/utils';
 import { useNetworkName } from '../../hooks/useNetworkName';
 
@@ -153,12 +156,6 @@ export const TokenConversionAssetHeader = ({
 
   const inputNetworkName = useNetworkName(inputToken?.chainId as Hex);
   const outputNetworkName = useNetworkName(outputToken?.chainId as Hex);
-  const inputNetworkImageSource = getNetworkImageSource({
-    chainId: inputToken?.chainId ?? '',
-  });
-  const outputNetworkImageSource = getNetworkImageSource({
-    chainId: outputToken?.chainId ?? '',
-  });
 
   const formatAmount = (amount?: string) => {
     if (!amount) {
@@ -213,14 +210,15 @@ export const TokenConversionAssetHeader = ({
         testID={TokenConversionAssetHeaderTestIds.ASSET_HEADER_INPUT}
       >
         <BadgeWrapper
-          position={BadgeWrapperPosition.BottomRight}
-          badge={
-            inputNetworkImageSource ? (
-              <BadgeNetwork
-                name={inputNetworkName}
-                src={inputNetworkImageSource}
-              />
-            ) : null
+          badgePosition={BadgePosition.BottomRight}
+          badgeElement={
+            <Badge
+              variant={BadgeVariant.Network}
+              name={inputNetworkName}
+              imageSource={getNetworkImageSource({
+                chainId: inputToken?.chainId ?? '',
+              })}
+            />
           }
         >
           <AvatarToken
@@ -273,14 +271,15 @@ export const TokenConversionAssetHeader = ({
         testID={TokenConversionAssetHeaderTestIds.ASSET_HEADER_OUTPUT}
       >
         <BadgeWrapper
-          position={BadgeWrapperPosition.BottomRight}
-          badge={
-            outputNetworkImageSource ? (
-              <BadgeNetwork
-                name={outputNetworkName}
-                src={outputNetworkImageSource}
-              />
-            ) : null
+          badgePosition={BadgePosition.BottomRight}
+          badgeElement={
+            <Badge
+              variant={BadgeVariant.Network}
+              name={outputNetworkName}
+              imageSource={getNetworkImageSource({
+                chainId: outputToken?.chainId ?? '',
+              })}
+            />
           }
         >
           <AvatarToken

--- a/app/components/Views/confirmations/components/token-conversion-asset-header/token-conversion-asset-header.tsx
+++ b/app/components/Views/confirmations/components/token-conversion-asset-header/token-conversion-asset-header.tsx
@@ -156,6 +156,12 @@ export const TokenConversionAssetHeader = ({
 
   const inputNetworkName = useNetworkName(inputToken?.chainId as Hex);
   const outputNetworkName = useNetworkName(outputToken?.chainId as Hex);
+  const inputNetworkImageSource = getNetworkImageSource({
+    chainId: inputToken?.chainId ?? '',
+  });
+  const outputNetworkImageSource = getNetworkImageSource({
+    chainId: outputToken?.chainId ?? '',
+  });
 
   const formatAmount = (amount?: string) => {
     if (!amount) {
@@ -212,13 +218,13 @@ export const TokenConversionAssetHeader = ({
         <BadgeWrapper
           badgePosition={BadgePosition.BottomRight}
           badgeElement={
-            <Badge
-              variant={BadgeVariant.Network}
-              name={inputNetworkName}
-              imageSource={getNetworkImageSource({
-                chainId: inputToken?.chainId ?? '',
-              })}
-            />
+            inputNetworkImageSource ? (
+              <Badge
+                variant={BadgeVariant.Network}
+                name={inputNetworkName}
+                imageSource={inputNetworkImageSource}
+              />
+            ) : undefined
           }
         >
           <AvatarToken
@@ -273,13 +279,13 @@ export const TokenConversionAssetHeader = ({
         <BadgeWrapper
           badgePosition={BadgePosition.BottomRight}
           badgeElement={
-            <Badge
-              variant={BadgeVariant.Network}
-              name={outputNetworkName}
-              imageSource={getNetworkImageSource({
-                chainId: outputToken?.chainId ?? '',
-              })}
-            />
+            outputNetworkImageSource ? (
+              <Badge
+                variant={BadgeVariant.Network}
+                name={outputNetworkName}
+                imageSource={outputNetworkImageSource}
+              />
+            ) : undefined
           }
         >
           <AvatarToken

--- a/app/components/Views/confirmations/components/token-icon/token-icon.styles.ts
+++ b/app/components/Views/confirmations/components/token-icon/token-icon.styles.ts
@@ -29,7 +29,10 @@ const styleSheet = (params: {
     borderRadius: 99,
   };
 
+  const badge: ViewStyle = {};
+
   return StyleSheet.create({
+    badge,
     container,
     tokenIcon,
   });

--- a/app/components/Views/confirmations/components/token-icon/token-icon.test.tsx
+++ b/app/components/Views/confirmations/components/token-icon/token-icon.test.tsx
@@ -107,7 +107,7 @@ describe('TokenIcon', () => {
   });
 
   it('hides network badge when network image is missing', () => {
-    mockGetNetworkImageSource.mockReturnValue(undefined);
+    mockGetNetworkImageSource.mockReturnValue(undefined as never);
 
     const { getByTestId, queryByTestId } = render({
       address: ADDRESS_MOCK,

--- a/app/components/Views/confirmations/components/token-icon/token-icon.test.tsx
+++ b/app/components/Views/confirmations/components/token-icon/token-icon.test.tsx
@@ -9,6 +9,16 @@ import {
 } from '../../__mocks__/controllers/other-controllers-mock';
 import { simpleSendTransactionControllerMock } from '../../__mocks__/controllers/transaction-controller-mock';
 import { transactionApprovalControllerMock } from '../../__mocks__/controllers/approval-controller-mock';
+import { getNetworkImageSource } from '../../../../../util/networks';
+
+jest.mock('../../../../../util/networks', () => ({
+  ...jest.requireActual('../../../../../util/networks'),
+  getNetworkImageSource: jest.fn((args: { chainId: string }) =>
+    jest
+      .requireActual('../../../../../util/networks')
+      .getNetworkImageSource(args),
+  ),
+}));
 
 jest.mock('../../../../Base/TokenIcon', () => {
   const ReactActual = jest.requireActual('react');
@@ -62,8 +72,15 @@ function render(props: TokenIconProps) {
 }
 
 describe('TokenIcon', () => {
+  const mockGetNetworkImageSource = jest.mocked(getNetworkImageSource);
+
   beforeEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
+    mockGetNetworkImageSource.mockImplementation((args) =>
+      jest
+        .requireActual('../../../../../util/networks')
+        .getNetworkImageSource(args),
+    );
   });
 
   it('renders token icon', () => {
@@ -75,6 +92,30 @@ describe('TokenIcon', () => {
     expect(getByTestId('token-icon').props.accessibilityLabel).toBe(
       TOKEN_ICON_URL_MOCK,
     );
+    expect(getByTestId('badgenetwork')).toBeOnTheScreen();
+  });
+
+  it('hides network badge when showNetwork is false', () => {
+    const { getByTestId, queryByTestId } = render({
+      address: ADDRESS_MOCK,
+      chainId: CHAIN_ID_MOCK,
+      showNetwork: false,
+    });
+
+    expect(getByTestId('token-icon')).toBeOnTheScreen();
+    expect(queryByTestId('badgenetwork')).not.toBeOnTheScreen();
+  });
+
+  it('hides network badge when network image is missing', () => {
+    mockGetNetworkImageSource.mockReturnValue(undefined);
+
+    const { getByTestId, queryByTestId } = render({
+      address: ADDRESS_MOCK,
+      chainId: CHAIN_ID_MOCK,
+    });
+
+    expect(getByTestId('token-icon')).toBeOnTheScreen();
+    expect(queryByTestId('badgenetwork')).not.toBeOnTheScreen();
   });
 
   it('renders nothing if token not found', () => {

--- a/app/components/Views/confirmations/components/token-icon/token-icon.test.tsx
+++ b/app/components/Views/confirmations/components/token-icon/token-icon.test.tsx
@@ -75,18 +75,6 @@ describe('TokenIcon', () => {
     expect(getByTestId('token-icon').props.accessibilityLabel).toBe(
       TOKEN_ICON_URL_MOCK,
     );
-    expect(getByTestId('token-icon-network-badge')).toBeOnTheScreen();
-  });
-
-  it('hides network badge when showNetwork is false', () => {
-    const { getByTestId, queryByTestId } = render({
-      address: ADDRESS_MOCK,
-      chainId: CHAIN_ID_MOCK,
-      showNetwork: false,
-    });
-
-    expect(getByTestId('token-icon')).toBeOnTheScreen();
-    expect(queryByTestId('token-icon-network-badge')).not.toBeOnTheScreen();
   });
 
   it('renders nothing if token not found', () => {

--- a/app/components/Views/confirmations/components/token-icon/token-icon.tsx
+++ b/app/components/Views/confirmations/components/token-icon/token-icon.tsx
@@ -55,13 +55,13 @@ export const TokenIcon: React.FC<TokenIconProps> = ({
       style={styles.container}
       badgePosition={BadgePosition.BottomRight}
       badgeElement={
-        showNetwork && (
+        showNetwork && networkImageSource ? (
           <Badge
             variant={BadgeVariant.Network}
             imageSource={networkImageSource}
             style={styles.badge}
           />
-        )
+        ) : undefined
       }
     >
       <BaseTokenIcon

--- a/app/components/Views/confirmations/components/token-icon/token-icon.tsx
+++ b/app/components/Views/confirmations/components/token-icon/token-icon.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
-import {
-  BadgeNetwork,
-  BadgeWrapper,
-  BadgeWrapperPosition,
-} from '@metamask/design-system-react-native';
 import { Hex } from '@metamask/utils';
 import BaseTokenIcon from '../../../../Base/TokenIcon';
 import styleSheet from './token-icon.styles';
 import { useStyles } from '../../../../hooks/useStyles';
+import BadgeWrapper, {
+  BadgePosition,
+} from '../../../../../component-library/components/Badges/BadgeWrapper';
+import Badge, {
+  BadgeVariant,
+} from '../../../../../component-library/components/Badges/Badge';
 import { getNetworkImageSource } from '../../../../../util/networks';
 import { useTokenWithBalance } from '../../hooks/tokens/useTokenWithBalance';
 import { getAssetImageUrl } from '../../../../UI/Bridge/hooks/useAssetMetadata/utils';
-import { useNetworkName } from '../../hooks/useNetworkName';
 
 export interface TokenIconProps {
   address: Hex;
@@ -39,10 +39,6 @@ export const TokenIcon: React.FC<TokenIconProps> = ({
 
   const token = useTokenWithBalance(address, chainId);
   const symbol = token?.symbol ?? symbolProp;
-  const networkName = useNetworkName(chainId);
-  const networkImageSource = getNetworkImageSource({
-    chainId,
-  });
 
   if (!token && !symbol) {
     return null;
@@ -50,18 +46,22 @@ export const TokenIcon: React.FC<TokenIconProps> = ({
 
   const icon = token?.image ?? getTokenIconUrl(address, chainId);
 
+  const networkImageSource = getNetworkImageSource({
+    chainId,
+  });
+
   return (
     <BadgeWrapper
       style={styles.container}
-      position={BadgeWrapperPosition.BottomRight}
-      badge={
-        showNetwork && networkImageSource ? (
-          <BadgeNetwork
-            src={networkImageSource}
-            name={networkName}
-            testID="token-icon-network-badge"
+      badgePosition={BadgePosition.BottomRight}
+      badgeElement={
+        showNetwork && (
+          <Badge
+            variant={BadgeVariant.Network}
+            imageSource={networkImageSource}
+            style={styles.badge}
           />
-        ) : null
+        )
       }
     >
       <BaseTokenIcon

--- a/app/components/Views/confirmations/legacy/components/AddressElement/AddressElement.test.tsx
+++ b/app/components/Views/confirmations/legacy/components/AddressElement/AddressElement.test.tsx
@@ -120,6 +120,7 @@ describe('AddressElement', () => {
       },
     );
 
-    expect(getByTestId('address-element-network-badge')).toBeOnTheScreen();
+    const networkBadge = getByTestId('network-avatar-image');
+    expect(networkBadge).toBeDefined();
   });
 });

--- a/app/components/Views/confirmations/legacy/components/AddressElement/AddressElement.test.tsx
+++ b/app/components/Views/confirmations/legacy/components/AddressElement/AddressElement.test.tsx
@@ -6,6 +6,7 @@ import { renderShortAddress } from '../../../../../../util/address';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
 import { mockNetworkState } from '../../../../../../util/test/network';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
 import { RootState } from '../../../../../../reducers';
 import { EngineState } from '../../../../../../core/Engine';
 
@@ -64,7 +65,7 @@ const renderComponent = (
   state: Partial<RootState> & { engine: { backgroundState: EngineState } },
   options?: {
     displayNetworkBadge?: boolean;
-    chainId?: string;
+    chainId?: Hex;
   },
 ) =>
   renderWithProvider(

--- a/app/components/Views/confirmations/legacy/components/AddressElement/AddressElement.test.tsx
+++ b/app/components/Views/confirmations/legacy/components/AddressElement/AddressElement.test.tsx
@@ -64,6 +64,7 @@ const renderComponent = (
   state: Partial<RootState> & { engine: { backgroundState: EngineState } },
   options?: {
     displayNetworkBadge?: boolean;
+    chainId?: string;
   },
 ) =>
   renderWithProvider(
@@ -73,7 +74,7 @@ const renderComponent = (
       onAccountLongPress={() => null}
       onIconPress={() => null}
       testID="address-element"
-      chainId="0x1"
+      chainId={options?.chainId ?? '0x1'}
       displayNetworkBadge={options?.displayNetworkBadge}
     />,
     { state },
@@ -120,7 +121,16 @@ describe('AddressElement', () => {
       },
     );
 
-    const networkBadge = getByTestId('network-avatar-image');
-    expect(networkBadge).toBeDefined();
+    expect(getByTestId('network-avatar-image')).toBeOnTheScreen();
+  });
+
+  it('does not render network badge when network image source is missing', () => {
+    const { getByTestId, queryByTestId } = renderComponent(initialState, {
+      displayNetworkBadge: true,
+      chainId: '0xdeadbeef',
+    });
+
+    expect(getByTestId('address-element')).toBeOnTheScreen();
+    expect(queryByTestId('badgenetwork')).not.toBeOnTheScreen();
   });
 });

--- a/app/components/Views/confirmations/legacy/components/AddressElement/AddressElement.tsx
+++ b/app/components/Views/confirmations/legacy/components/AddressElement/AddressElement.tsx
@@ -19,18 +19,19 @@ import Icon, {
   IconSize,
 } from '../../../../../../component-library/components/Icons/Icon';
 
-import {
-  BadgeNetwork,
-  BadgeWrapper,
-  BadgeWrapperPosition,
-} from '@metamask/design-system-react-native';
-import { Hex } from '@metamask/utils';
-import { useSelector } from 'react-redux';
-
 // Internal dependecies
 import styleSheet from './AddressElement.styles';
 import { AddressElementProps } from './AddressElement.types';
+import BadgeWrapper, {
+  BadgePosition,
+} from '../../../../../../component-library/components/Badges/BadgeWrapper';
 import { selectNetworkConfigurations } from '../../../../../../selectors/networkController';
+import { useSelector } from 'react-redux';
+
+import { Hex } from '@metamask/utils';
+import Badge, {
+  BadgeVariant,
+} from '../../../../../../component-library/components/Badges/Badge';
 import { NetworkBadgeSource } from '../../../../../UI/AssetOverview/Balance/Balance';
 
 const AddressElement: React.FC<AddressElementProps> = ({
@@ -58,20 +59,16 @@ const AddressElement: React.FC<AddressElementProps> = ({
 
   const renderIdenticon = useCallback(() => {
     if (shouldDisplayNetworkBadge) {
-      const networkImageSource = NetworkBadgeSource(chainId as Hex);
-
       return (
         <BadgeWrapper
-          position={BadgeWrapperPosition.BottomRight}
-          badge={
-            networkImageSource ? (
-              <BadgeNetwork
-                src={networkImageSource}
-                name={addressElementNetwork?.name}
-                testID="address-element-network-badge"
-              />
-            ) : null
+          badgeElement={
+            <Badge
+              variant={BadgeVariant.Network}
+              imageSource={NetworkBadgeSource(chainId as Hex)}
+              name={addressElementNetwork?.name}
+            />
           }
+          badgePosition={BadgePosition.BottomRight}
         >
           <Identicon address={address} diameter={28} />
         </BadgeWrapper>

--- a/app/components/Views/confirmations/legacy/components/AddressElement/AddressElement.tsx
+++ b/app/components/Views/confirmations/legacy/components/AddressElement/AddressElement.tsx
@@ -59,14 +59,18 @@ const AddressElement: React.FC<AddressElementProps> = ({
 
   const renderIdenticon = useCallback(() => {
     if (shouldDisplayNetworkBadge) {
+      const networkImageSource = NetworkBadgeSource(chainId as Hex);
+
       return (
         <BadgeWrapper
           badgeElement={
-            <Badge
-              variant={BadgeVariant.Network}
-              imageSource={NetworkBadgeSource(chainId as Hex)}
-              name={addressElementNetwork?.name}
-            />
+            networkImageSource ? (
+              <Badge
+                variant={BadgeVariant.Network}
+                imageSource={networkImageSource}
+                name={addressElementNetwork?.name}
+              />
+            ) : undefined
           }
           badgePosition={BadgePosition.BottomRight}
         >

--- a/app/components/Views/confirmations/legacy/components/ApproveTransactionHeader/ApproveTransactionHeader.tsx
+++ b/app/components/Views/confirmations/legacy/components/ApproveTransactionHeader/ApproveTransactionHeader.tsx
@@ -5,6 +5,7 @@ import { Hex } from '@metamask/utils';
 
 import { strings } from '../../../../../../../locales/i18n';
 import AccountBalance from '../../../../../../component-library/components-temp/Accounts/AccountBalance';
+import { BadgeVariant } from '../../../../../../component-library/components/Badges/Badge';
 import { useStyles } from '../../../../../../component-library/hooks';
 import { selectAccountsByChainId } from '../../../../../../selectors/accountTrackerController';
 import {
@@ -99,8 +100,9 @@ const ApproveTransactionHeader = ({
         accountTypeLabel={accountTypeLabel}
         accountNetwork={networkName}
         badgeProps={{
+          variant: BadgeVariant.Network,
           name: networkName,
-          src: networkImage,
+          imageSource: networkImage,
         }}
         avatarAccountType={avatarAccountType}
       />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Confirmation network badges were migrated to MMDS `BadgeNetwork` + `BadgeWrapper`. MMDS hardcodes `AvatarNetworkSize.Xs` with a border (18px) and does not scale to the parent token. The previous component-library `Badge` (`BadgeVariant.Network`) scaled to **50% of the wrapped token** (clamped 8–24px). On small surfaces like the Receive / Pay with row (`TokenIcon` variant `Row`, 20px token), the badge jumped from ~10px to 18px and looked oversized.

This PR restores those confirmation overlays to component-library `Badge` + `BadgeWrapper` (`badgeElement` / `badgePosition` / `imageSource`) so the old scaled sizing returns. Shared `AccountBase` / `AccountBalance` `badgeProps` go back to component-library `BadgeProps`, and `ApproveTransactionHeader` / `AddressFrom` are updated to match. The Pay With token-row `testID` (`chainId-symbol`) is unchanged. Staking’s standalone `AvatarNetwork` Xs is left as-is (not a badge overlay).

**What changed:**
- Restored scaled network badges on hero token/NFT, `TokenIcon`, gas fee token icon, token conversion header, send token/NFT rows, transaction details account row, and `AddressElement`
- Reverted `AccountBase` badge rendering and `badgeProps` to component-library `BadgeProps`; updated `ApproveTransactionHeader` and `AddressFrom`
- Adjusted unit tests to query the component-library network avatar (`network-avatar-image`) instead of MMDS badge `testID`s

**Breaking change:** `AccountBase` / `AccountBalance` `badgeProps` no longer accept MMDS `{ name?; src }`. Callers must pass component-library `BadgeProps` (`variant: BadgeVariant.Network`, `imageSource`, `name`).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed oversized network badges on confirmation screens

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-1069

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: confirmation network badges use scaled component-library size

  Scenario: user reviews a withdraw confirmation Receive row
    Given the app is unlocked with a token that can be withdrawn
    When the user starts a withdraw and reaches the confirmation screen
    Then the Receive / Pay with row shows a bottom-right network badge that is about half the token icon, not nearly as large as the token

  Scenario: user reviews a send confirmation with a network badge on the token hero
    Given the app is unlocked with an account that has ETH on a network with a known network image
    When the user starts a send of native ETH and reaches the confirmation screen
    Then the token hero shows a bottom-right network badge sized to about half the token avatar

  Scenario: user opens NFT send confirmation
    Given the app has an NFT on a network with a network image
    When the user starts an NFT send and reaches confirmation
    Then the NFT hero shows a scaled network badge overlay and collection/token id remain visible

  Scenario: user opens legacy approve confirmation header
    Given a dapp approval confirmation that uses the legacy approve header
    When the confirmation is shown
    Then the account avatar still shows a network badge and the balance row renders as before
```

Unit tests:

```bash
yarn jest app/components/Views/confirmations/components/hero-nft
yarn jest app/components/Views/confirmations/components/hero-token
yarn jest app/components/Views/confirmations/components/UI/token
yarn jest app/components/Views/confirmations/components/UI/nft
yarn jest app/components/Views/confirmations/components/token-icon
yarn jest app/components/Views/confirmations/legacy/components/AddressElement
yarn jest app/components/Views/confirmations/components/activity/transaction-details-account-row
yarn jest app/component-library/components-temp/Accounts/AccountBase
yarn jest app/components/UI/AccountFromToInfoCard/AddressFrom.test.tsx
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- MMDS BadgeNetwork: fixed ~18px badge on the Receive-row 20px token -->

### **After**

<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 15 Pro Max - 2026-08-18 at 11 28 05" src="https://github.com/user-attachments/assets/10192838-521a-4630-9776-cb4c42e61679" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for-Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide UI swap across confirmations with a breaking `AccountBase`/`badgeProps` API change; behavior is mostly visual sizing and conditional badge rendering when images are absent.
> 
> **Overview**
> Replaces **MMDS** `BadgeNetwork` / `BadgeWrapper` with component-library **`Badge`** (`BadgeVariant.Network`) and **`BadgeWrapper`** (`badgeElement`, `badgePosition`, `imageSource`) across confirmation and related UI so network overlays scale with the parent token (~50% size) instead of a fixed ~18px badge.
> 
> Touches hero token/NFT, `TokenIcon`, gas fee token icon, token conversion header, send token/NFT rows, transaction details account row, legacy `AddressElement`, and shared **`AccountBase`** / **`AccountBalance`**. **`badgeProps`** is again component-library **`BadgeProps`** (`variant`, `imageSource`, `name`); callers like **`AddressFrom`** and **`ApproveTransactionHeader`** are updated accordingly.
> 
> Tests now assert component-library badge test IDs (e.g. `badgenetwork`, `network-avatar-image`) and add cases for missing network images where relevant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c56b8e6f5745d1526baaf0e15ecfce3159fea6f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->