### PR TITLE
test(perps): add reusable visible-pipeline probe

### DIFF
--- a/app/components/UI/Perps/adapters/mobileInfrastructure.ts
+++ b/app/components/UI/Perps/adapters/mobileInfrastructure.ts
@@ -49,6 +49,8 @@ import {
   getTerminalGlobalSnapshotUrl,
   resolveTerminalApiUrl,
 } from '../constants/terminalApi';
+import { PERPS_DISK_CACHE_USER_DATA } from '../constants/perpsConfig';
+import { markHomepagePerpsDiskCacheHydrated } from '../utils/homepagePerformanceProbe';
 
 /**
  * Resolves the Terminal API base URL based on build environment.
@@ -319,7 +321,13 @@ export function createMobileInfrastructure(): PerpsPlatformDependencies {
     // === Disk Cache (cold-start persistence via MMKV) ===
     diskCache: {
       getItem: (key: string) => StorageWrapper.getItem(key),
-      getItemSync: (key: string) => StorageWrapper.getItemSync(key),
+      getItemSync: (key: string) => {
+        const value = StorageWrapper.getItemSync(key);
+        if (__DEV__ && key === PERPS_DISK_CACHE_USER_DATA && value !== null) {
+          markHomepagePerpsDiskCacheHydrated(value);
+        }
+        return value;
+      },
       setItem: (key: string, value: string) =>
         StorageWrapper.setItem(key, value),
       removeItem: (key: string) =>

--- a/app/components/UI/Perps/adapters/mobileInfrastructure.ts
+++ b/app/components/UI/Perps/adapters/mobileInfrastructure.ts
@@ -49,8 +49,6 @@ import {
   getTerminalGlobalSnapshotUrl,
   resolveTerminalApiUrl,
 } from '../constants/terminalApi';
-import { PERPS_DISK_CACHE_USER_DATA } from '../constants/perpsConfig';
-import { markHomepagePerpsDiskCacheHydrated } from '../utils/homepagePerformanceProbe';
 
 /**
  * Resolves the Terminal API base URL based on build environment.
@@ -321,13 +319,7 @@ export function createMobileInfrastructure(): PerpsPlatformDependencies {
     // === Disk Cache (cold-start persistence via MMKV) ===
     diskCache: {
       getItem: (key: string) => StorageWrapper.getItem(key),
-      getItemSync: (key: string) => {
-        const value = StorageWrapper.getItemSync(key);
-        if (__DEV__ && key === PERPS_DISK_CACHE_USER_DATA && value !== null) {
-          markHomepagePerpsDiskCacheHydrated(value);
-        }
-        return value;
-      },
+      getItemSync: (key: string) => StorageWrapper.getItemSync(key),
       setItem: (key: string, value: string) =>
         StorageWrapper.setItem(key, value),
       removeItem: (key: string) =>

--- a/app/components/UI/Perps/hooks/stream/usePerpsLiveAccount.test.ts
+++ b/app/components/UI/Perps/hooks/stream/usePerpsLiveAccount.test.ts
@@ -32,6 +32,23 @@ jest.mock('../../../../../core/Engine', () => ({
 
 // Mock PerpsStreamManager
 const mockSubscribe = jest.fn();
+const mockCreateHomepagePerpsDelivery = jest.fn((_input: unknown) => ({
+  deliveryId: 'account-delivery',
+  stream: 'account',
+  source: 'provider_snapshot',
+  itemCount: 1,
+  receivedAtMonotonicMs: 1,
+  dataAgeMs: 0,
+  lifecycle: 'cold_no_cache',
+  accountGeneration: 0,
+  contextGeneration: 0,
+}));
+jest.mock('../../utils/homepagePerformanceProbe', () => ({
+  createHomepagePerpsDelivery: (input: unknown) =>
+    mockCreateHomepagePerpsDelivery(input),
+  isHomepagePerformanceProbeActive: () => true,
+  logHomepagePerformanceStage: jest.fn(),
+}));
 jest.mock('../../providers/PerpsStreamManager', () => ({
   usePerpsStream: jest.fn(() => ({
     account: {
@@ -88,6 +105,45 @@ describe('usePerpsLiveAccount', () => {
   });
 
   describe('state from PerpsController', () => {
+    it('preserves provider-snapshot provenance for the account delivery', async () => {
+      const accountState = {
+        spendableBalance: '1',
+        withdrawableBalance: '1',
+        marginUsed: '0',
+        unrealizedPnl: '0',
+        returnOnEquity: '0',
+        totalBalance: '1',
+      } as AccountState;
+      let callback!: (
+        account: AccountState | null,
+        source?: 'provider_snapshot',
+      ) => void;
+      mockSubscribe.mockImplementation((params) => {
+        callback = params.callback;
+        return jest.fn();
+      });
+      const { result } = renderHookWithProvider(
+        () => usePerpsLiveAccount({ includeDeliveryMetadata: true }),
+        { state: {} },
+      );
+
+      act(() => callback(accountState, 'provider_snapshot'));
+
+      await waitFor(() =>
+        expect(result.current.latestDelivery?.deliveryId).toBe(
+          'account-delivery',
+        ),
+      );
+      expect(mockCreateHomepagePerpsDelivery).toHaveBeenCalledWith({
+        stream: 'account',
+        source: 'provider_snapshot',
+        itemCount: 1,
+      });
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        expect.objectContaining({ includeDeliverySource: true }),
+      );
+    });
+
     it('returns account state from the channel snapshot before controller cache', () => {
       const mockAccountState: AccountState = {
         spendableBalance: '7000',

--- a/app/components/UI/Perps/hooks/stream/usePerpsLiveAccount.ts
+++ b/app/components/UI/Perps/hooks/stream/usePerpsLiveAccount.ts
@@ -1,15 +1,25 @@
 import { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { usePerpsStream } from '../../providers/PerpsStreamManager';
+import {
+  usePerpsStream,
+  type StreamUpdateSource,
+} from '../../providers/PerpsStreamManager';
 import { type AccountState } from '@metamask/perps-controller';
 import { hasPreloadedData, getPreloadedData } from './hasCachedPerpsData';
 import { selectSelectedAccountGroupEvmInternalAccount } from '../../../../../selectors/multichainAccounts/accountTreeController';
+import {
+  createHomepagePerpsDelivery,
+  isHomepagePerformanceProbeActive,
+  logHomepagePerformanceStage,
+  type HomepagePerpsDeliveryMetadata,
+} from '../../utils/homepagePerformanceProbe';
 
 export interface UsePerpsLiveAccountOptions {
   /** Whether to subscribe to account updates. */
   enabled?: boolean;
   /** Throttle delay in milliseconds (default: 1000ms for balance updates) */
   throttleMs?: number;
+  includeDeliveryMetadata?: boolean;
 }
 
 export interface UsePerpsLiveAccountReturn {
@@ -17,6 +27,7 @@ export interface UsePerpsLiveAccountReturn {
   account: AccountState | null;
   /** Whether we're waiting for the first real WebSocket data */
   isInitialLoading: boolean;
+  latestDelivery?: HomepagePerpsDeliveryMetadata;
 }
 
 /**
@@ -32,7 +43,11 @@ export interface UsePerpsLiveAccountReturn {
 export function usePerpsLiveAccount(
   options: UsePerpsLiveAccountOptions = {},
 ): UsePerpsLiveAccountReturn {
-  const { enabled = true, throttleMs = 1000 } = options;
+  const {
+    enabled = true,
+    throttleMs = 1000,
+    includeDeliveryMetadata = false,
+  } = options;
   const streamManager = usePerpsStream();
   const selectedAddress = useSelector(
     selectSelectedAccountGroupEvmInternalAccount,
@@ -52,17 +67,37 @@ export function usePerpsLiveAccount(
     const hasCached = hasPreloadedData('cachedAccountState');
     return !hasCached;
   });
+  const [latestDelivery, setLatestDelivery] =
+    useState<HomepagePerpsDeliveryMetadata>();
 
   useEffect(() => {
     if (!enabled || !streamManager) return;
 
     // Mark as no longer loading once we get first update
-    const handleAccountUpdate = (newAccount: AccountState | null) => {
+    const handleAccountUpdate = (
+      newAccount: AccountState | null,
+      source?: StreamUpdateSource,
+    ) => {
       setAccount(newAccount);
       setAccountAddress(selectedAddress);
       if (newAccount === null) {
         setIsInitialLoading(true);
+        setLatestDelivery(undefined);
         return;
+      }
+      if (
+        includeDeliveryMetadata &&
+        source !== undefined &&
+        source !== 'optimistic' &&
+        isHomepagePerformanceProbeActive()
+      ) {
+        const delivery = createHomepagePerpsDelivery({
+          stream: 'account',
+          source,
+          itemCount: 1,
+        });
+        logHomepagePerformanceStage('subscriber_delivery', delivery);
+        setLatestDelivery(delivery);
       }
       // Only set loading to false if we have actual data
       setIsInitialLoading(false);
@@ -71,14 +106,22 @@ export function usePerpsLiveAccount(
     const unsubscribe = streamManager.account.subscribe({
       callback: handleAccountUpdate,
       throttleMs,
+      ...(includeDeliveryMetadata && { includeDeliverySource: true }),
     });
 
     return unsubscribe;
-  }, [enabled, selectedAddress, streamManager, throttleMs]);
+  }, [
+    enabled,
+    includeDeliveryMetadata,
+    selectedAddress,
+    streamManager,
+    throttleMs,
+  ]);
 
   const identityMatches = accountAddress === selectedAddress;
   return {
     account: identityMatches ? account : null,
     isInitialLoading: !identityMatches || isInitialLoading,
+    ...(identityMatches && latestDelivery ? { latestDelivery } : {}),
   };
 }

--- a/app/components/UI/Perps/hooks/stream/usePerpsLiveOrders.ts
+++ b/app/components/UI/Perps/hooks/stream/usePerpsLiveOrders.ts
@@ -4,6 +4,12 @@ import { usePerpsStream } from '../../providers/PerpsStreamManager';
 import { isTPSLOrder, type Order } from '@metamask/perps-controller';
 import { hasPreloadedData, getPreloadedData } from './hasCachedPerpsData';
 import { selectSelectedInternalAccountAddress } from '../../../../../selectors/accountsController';
+import {
+  createHomepagePerpsDelivery,
+  isHomepagePerformanceProbeActive,
+  logHomepagePerformanceStage,
+  type HomepagePerpsDeliveryMetadata,
+} from '../../utils/homepagePerformanceProbe';
 
 // Stable empty array reference to prevent re-renders
 const EMPTY_ORDERS: Order[] = [];
@@ -15,6 +21,7 @@ export interface UsePerpsLiveOrdersOptions {
   hideTpSl?: boolean;
   /** Filter out all reduce-only orders */
   hideReduceOnly?: boolean;
+  includeDeliveryMetadata?: boolean;
 }
 
 export interface UsePerpsLiveOrdersReturn {
@@ -22,6 +29,7 @@ export interface UsePerpsLiveOrdersReturn {
   orders: Order[];
   /** Whether we're waiting for the first real WebSocket data (not cached) */
   isInitialLoading: boolean;
+  latestDelivery?: HomepagePerpsDeliveryMetadata;
 }
 
 /**
@@ -37,7 +45,12 @@ export interface UsePerpsLiveOrdersReturn {
 export function usePerpsLiveOrders(
   options: UsePerpsLiveOrdersOptions = {},
 ): UsePerpsLiveOrdersReturn {
-  const { throttleMs = 0, hideTpSl = false, hideReduceOnly = false } = options; // No throttling by default for instant updates
+  const {
+    throttleMs = 0,
+    hideTpSl = false,
+    hideReduceOnly = false,
+    includeDeliveryMetadata = false,
+  } = options;
   const stream = usePerpsStream();
   const selectedAddress = useSelector(
     selectSelectedInternalAccountAddress,
@@ -60,10 +73,12 @@ export function usePerpsLiveOrders(
   });
   const lastOrdersRef = useRef<Order[]>(EMPTY_ORDERS);
   const hasReceivedFirstUpdate = useRef(false);
+  const [latestDelivery, setLatestDelivery] =
+    useState<HomepagePerpsDeliveryMetadata>();
 
   useEffect(() => {
     const unsubscribe = stream.orders.subscribe({
-      callback: (newOrders) => {
+      callback: (newOrders, source) => {
         if (newOrders === null || newOrders === undefined) {
           // Cleared on account switch — show skeleton until first update for new account
           hasReceivedFirstUpdate.current = false;
@@ -71,7 +86,22 @@ export function usePerpsLiveOrders(
           lastOrdersRef.current = EMPTY_ORDERS;
           setOrders(EMPTY_ORDERS);
           setOrdersAddress(selectedAddress);
+          setLatestDelivery(undefined);
           return;
+        }
+
+        if (
+          includeDeliveryMetadata &&
+          source !== undefined &&
+          isHomepagePerformanceProbeActive()
+        ) {
+          const delivery = createHomepagePerpsDelivery({
+            stream: 'orders',
+            source: source === 'fresh' ? 'fresh_socket' : 'memory_cache',
+            itemCount: newOrders.length,
+          });
+          logHomepagePerformanceStage('subscriber_delivery', delivery);
+          setLatestDelivery(delivery);
         }
 
         // We have real data now (either empty array or orders)
@@ -96,12 +126,13 @@ export function usePerpsLiveOrders(
         }
       },
       throttleMs,
+      ...(includeDeliveryMetadata && { includeDeliverySource: true }),
     });
 
     return () => {
       unsubscribe();
     };
-  }, [selectedAddress, stream, throttleMs]);
+  }, [includeDeliveryMetadata, selectedAddress, stream, throttleMs]);
 
   // Filter orders based on requested display options
   const filteredOrders = useMemo(() => {
@@ -130,5 +161,7 @@ export function usePerpsLiveOrders(
   return {
     orders: ordersAddress === selectedAddress ? filteredOrders : EMPTY_ORDERS,
     isInitialLoading: ordersAddress !== selectedAddress || isInitialLoading,
+    latestDelivery:
+      ordersAddress === selectedAddress ? latestDelivery : undefined,
   };
 }

--- a/app/components/UI/Perps/hooks/stream/usePerpsLiveOrders.ts
+++ b/app/components/UI/Perps/hooks/stream/usePerpsLiveOrders.ts
@@ -93,11 +93,12 @@ export function usePerpsLiveOrders(
         if (
           includeDeliveryMetadata &&
           source !== undefined &&
+          source !== 'optimistic' &&
           isHomepagePerformanceProbeActive()
         ) {
           const delivery = createHomepagePerpsDelivery({
             stream: 'orders',
-            source: source === 'fresh' ? 'fresh_socket' : 'memory_cache',
+            source,
             itemCount: newOrders.length,
           });
           logHomepagePerformanceStage('subscriber_delivery', delivery);

--- a/app/components/UI/Perps/hooks/stream/usePerpsLivePositions.ts
+++ b/app/components/UI/Perps/hooks/stream/usePerpsLivePositions.ts
@@ -177,11 +177,12 @@ export function usePerpsLivePositions(
         if (
           includeDeliveryMetadata &&
           source !== undefined &&
+          source !== 'optimistic' &&
           isHomepagePerformanceProbeActive()
         ) {
           const delivery = createHomepagePerpsDelivery({
             stream: 'positions',
-            source: source === 'fresh' ? 'fresh_socket' : 'memory_cache',
+            source,
             itemCount: newPositions.length,
           });
           logHomepagePerformanceStage('subscriber_delivery', delivery);

--- a/app/components/UI/Perps/hooks/stream/usePerpsLivePositions.ts
+++ b/app/components/UI/Perps/hooks/stream/usePerpsLivePositions.ts
@@ -6,6 +6,12 @@ import { type Position, type PriceUpdate } from '@metamask/perps-controller';
 import { calculateRoEForPrice } from '../../utils/tpslValidation';
 import { hasPreloadedData, getPreloadedData } from './hasCachedPerpsData';
 import { selectSelectedInternalAccountAddress } from '../../../../../selectors/accountsController';
+import {
+  createHomepagePerpsDelivery,
+  isHomepagePerformanceProbeActive,
+  logHomepagePerformanceStage,
+  type HomepagePerpsDeliveryMetadata,
+} from '../../utils/homepagePerformanceProbe';
 
 // Stable empty array reference to prevent re-renders
 const EMPTY_POSITIONS: Position[] = [];
@@ -15,6 +21,7 @@ export interface UsePerpsLivePositionsOptions {
   throttleMs?: number;
   /** Whether to subscribe to price updates for live PnL calculations (default: false) */
   useLivePnl?: boolean;
+  includeDeliveryMetadata?: boolean;
 }
 
 export interface UsePerpsLivePositionsReturn {
@@ -22,6 +29,7 @@ export interface UsePerpsLivePositionsReturn {
   positions: Position[];
   /** Whether we're waiting for the first real WebSocket data (not cached) */
   isInitialLoading: boolean;
+  latestDelivery?: HomepagePerpsDeliveryMetadata;
 }
 
 /**
@@ -104,7 +112,11 @@ export function enrichPositionsWithLivePnL(
 export function usePerpsLivePositions(
   options: UsePerpsLivePositionsOptions = {},
 ): UsePerpsLivePositionsReturn {
-  const { throttleMs = 0, useLivePnl = false } = options; // No live PnL by default to avoid unnecessary re-renders
+  const {
+    throttleMs = 0,
+    useLivePnl = false,
+    includeDeliveryMetadata = false,
+  } = options;
   const stream = usePerpsStream();
   const selectedAddress = useSelector(
     selectSelectedInternalAccountAddress,
@@ -133,6 +145,8 @@ export function usePerpsLivePositions(
   const [rawPositionsAddress, setRawPositionsAddress] =
     useState(selectedAddress);
   const [priceData, setPriceData] = useState<Record<string, PriceUpdate>>({});
+  const [latestDelivery, setLatestDelivery] =
+    useState<HomepagePerpsDeliveryMetadata>();
 
   // Derive enriched positions synchronously to avoid one-frame flash
   // where isInitialLoading is false but positions haven't been enriched yet
@@ -149,14 +163,29 @@ export function usePerpsLivePositions(
   // Subscribe to position updates
   useEffect(() => {
     const unsubscribe = stream.positions.subscribe({
-      callback: (newPositions) => {
+      callback: (newPositions, source) => {
         if (newPositions === null) {
           // Cleared on account switch — show skeleton until first update for new account
           hasReceivedFirstUpdate.current = false;
           setIsInitialLoading(true);
           setRawPositions(EMPTY_POSITIONS);
           setRawPositionsAddress(selectedAddress);
+          setLatestDelivery(undefined);
           return;
+        }
+
+        if (
+          includeDeliveryMetadata &&
+          source !== undefined &&
+          isHomepagePerformanceProbeActive()
+        ) {
+          const delivery = createHomepagePerpsDelivery({
+            stream: 'positions',
+            source: source === 'fresh' ? 'fresh_socket' : 'memory_cache',
+            itemCount: newPositions.length,
+          });
+          logHomepagePerformanceStage('subscriber_delivery', delivery);
+          setLatestDelivery(delivery);
         }
 
         if (!hasReceivedFirstUpdate.current) {
@@ -172,12 +201,13 @@ export function usePerpsLivePositions(
         setRawPositionsAddress(selectedAddress);
       },
       throttleMs,
+      ...(includeDeliveryMetadata && { includeDeliverySource: true }),
     });
 
     return () => {
       unsubscribe();
     };
-  }, [selectedAddress, stream, throttleMs]);
+  }, [includeDeliveryMetadata, selectedAddress, stream, throttleMs]);
 
   // Derive the unique set of symbols from the current positions so we only
   // subscribe to the prices we actually need (instead of the full price channel).
@@ -232,5 +262,7 @@ export function usePerpsLivePositions(
     positions,
     isInitialLoading:
       rawPositionsAddress !== selectedAddress || isInitialLoading,
+    latestDelivery:
+      rawPositionsAddress === selectedAddress ? latestDelivery : undefined,
   };
 }

--- a/app/components/UI/Perps/hooks/usePerpsMarkets.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarkets.ts
@@ -7,6 +7,29 @@ import {
   getPreloadedData,
 } from './stream/hasCachedPerpsData';
 import { filterAndSortMarkets } from '../utils/filterAndSortMarkets';
+import {
+  createHomepagePerpsDelivery,
+  isHomepagePerformanceProbeActive,
+  logHomepagePerformanceStage,
+  type HomepagePerpsDeliveryMetadata,
+  type HomepagePerpsDeliverySource,
+} from '../utils/homepagePerformanceProbe';
+
+const resolveMarketDeliveryOrigin = (
+  marketData: PerpsMarketData[] | null | undefined,
+): HomepagePerpsDeliverySource => {
+  if (!marketData?.length) return 'unknown';
+  if (
+    marketData.every(
+      (market) => market.dataSource === 'terminal-global-snapshot-mark',
+    )
+  ) {
+    return 'terminal_global_snapshot_v2';
+  }
+  return marketData.every((market) => !market.dataSource)
+    ? 'provider'
+    : 'unknown';
+};
 
 export type PerpsMarketDataWithVolumeNumber = PerpsMarketData & {
   volumeNumber: number;
@@ -33,6 +56,7 @@ export interface UsePerpsMarketsResult {
    * Indicates if data is being refreshed
    */
   isRefreshing: boolean;
+  latestDelivery?: HomepagePerpsDeliveryMetadata;
 }
 
 export interface UsePerpsMarketsOptions {
@@ -109,6 +133,8 @@ export const usePerpsMarkets = (
   });
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [latestDelivery, setLatestDelivery] =
+    useState<HomepagePerpsDeliveryMetadata>();
 
   // Helper function to filter and sort markets by volume
   const sortMarketsByVolume = useCallback(
@@ -152,9 +178,22 @@ export const usePerpsMarkets = (
     const subscriptionStartTime = Date.now();
 
     const unsubscribe = streamManager.marketData.subscribe({
-      callback: (marketData) => {
+      callback: (marketData, source) => {
         const receiveTime = Date.now();
         const timeToData = receiveTime - subscriptionStartTime;
+        const originSource = resolveMarketDeliveryOrigin(marketData);
+        const deliverySource =
+          source === 'cache' ? 'memory_cache' : originSource;
+        if (isHomepagePerformanceProbeActive()) {
+          const delivery = createHomepagePerpsDelivery({
+            stream: 'markets',
+            source: deliverySource,
+            itemCount: marketData?.length ?? 0,
+            ...(source === 'cache' && { originSource }),
+          });
+          logHomepagePerformanceStage('subscriber_delivery', delivery);
+          setLatestDelivery(delivery);
+        }
         if (marketData && marketData.length > 0) {
           const sortedMarkets = sortMarketsByVolume(marketData);
           setMarkets(sortedMarkets);
@@ -187,6 +226,7 @@ export const usePerpsMarkets = (
         }
       },
       throttleMs: 0, // No throttle for market data updates
+      includeDeliverySource: true,
     });
 
     return () => {
@@ -215,5 +255,6 @@ export const usePerpsMarkets = (
     error,
     refresh,
     isRefreshing,
+    latestDelivery,
   };
 };

--- a/app/components/UI/Perps/hooks/usePerpsMarkets.ts
+++ b/app/components/UI/Perps/hooks/usePerpsMarkets.ts
@@ -12,23 +12,21 @@ import {
   isHomepagePerformanceProbeActive,
   logHomepagePerformanceStage,
   type HomepagePerpsDeliveryMetadata,
-  type HomepagePerpsDeliverySource,
 } from '../utils/homepagePerformanceProbe';
+import { TERMINAL_GLOBAL_SNAPSHOT_DATA_SOURCE } from '../constants/terminalApi';
 
 const resolveMarketDeliveryOrigin = (
   marketData: PerpsMarketData[] | null | undefined,
-): HomepagePerpsDeliverySource => {
-  if (!marketData?.length) return 'unknown';
+): 'terminal_global_snapshot_v2' | 'provider' => {
   if (
+    marketData?.length &&
     marketData.every(
-      (market) => market.dataSource === 'terminal-global-snapshot-mark',
+      (market) => market.dataSource === TERMINAL_GLOBAL_SNAPSHOT_DATA_SOURCE,
     )
   ) {
     return 'terminal_global_snapshot_v2';
   }
-  return marketData.every((market) => !market.dataSource)
-    ? 'provider'
-    : 'unknown';
+  return 'provider';
 };
 
 export type PerpsMarketDataWithVolumeNumber = PerpsMarketData & {
@@ -181,15 +179,15 @@ export const usePerpsMarkets = (
       callback: (marketData, source) => {
         const receiveTime = Date.now();
         const timeToData = receiveTime - subscriptionStartTime;
-        const originSource = resolveMarketDeliveryOrigin(marketData);
-        const deliverySource =
-          source === 'cache' ? 'memory_cache' : originSource;
-        if (isHomepagePerformanceProbeActive()) {
+        if (isHomepagePerformanceProbeActive() && marketData?.length) {
+          const originSource = resolveMarketDeliveryOrigin(marketData);
+          const deliverySource =
+            source === 'memory_cache' ? 'memory_cache' : originSource;
           const delivery = createHomepagePerpsDelivery({
             stream: 'markets',
             source: deliverySource,
             itemCount: marketData?.length ?? 0,
-            ...(source === 'cache' && { originSource }),
+            ...(source === 'memory_cache' && { originSource }),
           });
           logHomepagePerformanceStage('subscriber_delivery', delivery);
           setLatestDelivery(delivery);
@@ -226,7 +224,7 @@ export const usePerpsMarkets = (
         }
       },
       throttleMs: 0, // No throttle for market data updates
-      includeDeliverySource: true,
+      includeDeliverySource: __DEV__,
     });
 
     return () => {

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -107,7 +107,23 @@ interface StreamSubscription<T> {
   symbols?: string[];
 }
 
-type StreamUpdateSource = 'fresh' | 'cache' | 'optimistic';
+export type StreamUpdateSource =
+  | 'fresh_socket'
+  | 'memory_cache'
+  | 'provider_snapshot'
+  | 'optimistic';
+
+function deliverStreamUpdate<T>(
+  subscriber: StreamSubscription<T>,
+  data: T,
+  source: StreamUpdateSource,
+): void {
+  if (subscriber.includeDeliverySource) {
+    subscriber.callback(data, source);
+  } else {
+    subscriber.callback(data);
+  }
+}
 const DYNAMIC_DEX_SNAPSHOT_UNAVAILABLE =
   'User data snapshot DEX identity is not static';
 
@@ -167,7 +183,7 @@ abstract class StreamChannel<T> {
 
   protected notifySubscribers(
     updates: T,
-    source: StreamUpdateSource = 'fresh',
+    source: StreamUpdateSource = 'fresh_socket',
   ) {
     this.deliveryRevision += 1;
     // Block emission while any pause is held (WebSocket continues receiving updates)
@@ -242,7 +258,7 @@ abstract class StreamChannel<T> {
           return;
         }
         notifiedIds.add(id);
-        this.deliverToSubscriber(subscriber, updates, 'fresh');
+        this.deliverToSubscriber(subscriber, updates, 'fresh_socket');
       });
     }
   }
@@ -257,11 +273,6 @@ abstract class StreamChannel<T> {
     updates: T,
     source: StreamUpdateSource,
   ) {
-    const deliver = (data: T, deliverySource: StreamUpdateSource) =>
-      subscriber.includeDeliverySource
-        ? subscriber.callback(data, deliverySource)
-        : subscriber.callback(data);
-
     if (source === 'optimistic') {
       if (subscriber.timer) {
         clearTimeout(subscriber.timer);
@@ -269,24 +280,24 @@ abstract class StreamChannel<T> {
       }
       subscriber.pendingUpdate = undefined;
       subscriber.pendingSource = undefined;
-      deliver(updates, source);
+      deliverStreamUpdate(subscriber, updates, source);
       return;
     }
 
-    if (source === 'cache') {
-      deliver(updates, source);
+    if (source === 'memory_cache' || source === 'provider_snapshot') {
+      deliverStreamUpdate(subscriber, updates, source);
       return;
     }
 
     if (!subscriber.hasReceivedFirstFreshUpdate) {
-      deliver(updates, source);
+      deliverStreamUpdate(subscriber, updates, source);
       subscriber.hasReceivedFirstFreshUpdate = true;
       return;
     }
 
     // If no throttling (throttleMs is 0 or undefined), notify immediately
     if (!subscriber.throttleMs) {
-      deliver(updates, source);
+      deliverStreamUpdate(subscriber, updates, source);
       return;
     }
 
@@ -301,7 +312,11 @@ abstract class StreamChannel<T> {
     // The conditional check prevents timer accumulation - no memory leaks
     subscriber.timer ??= setTimeout(() => {
       if (subscriber.pendingUpdate) {
-        deliver(subscriber.pendingUpdate, subscriber.pendingSource ?? 'fresh');
+        deliverStreamUpdate(
+          subscriber,
+          subscriber.pendingUpdate,
+          subscriber.pendingSource ?? 'fresh_socket',
+        );
         subscriber.pendingUpdate = undefined;
         subscriber.pendingSource = undefined;
       }
@@ -330,7 +345,7 @@ abstract class StreamChannel<T> {
         if (subscriber.includeDeliverySource) {
           subscriber.callback(
             subscriber.pendingUpdate,
-            subscriber.pendingSource ?? 'fresh',
+            subscriber.pendingSource ?? 'fresh_socket',
           );
         } else {
           subscriber.callback(subscriber.pendingUpdate);
@@ -400,7 +415,7 @@ abstract class StreamChannel<T> {
     const cached = this.getCachedData();
     if (cached != null) {
       if (params.includeDeliverySource) {
-        params.callback(cached, 'cache');
+        params.callback(cached, 'memory_cache');
       } else {
         params.callback(cached);
       }
@@ -626,7 +641,7 @@ abstract class StreamChannel<T> {
     );
   }
 
-  public publish(data: T, source: StreamUpdateSource = 'fresh'): void {
+  public publish(data: T, source: StreamUpdateSource = 'fresh_socket'): void {
     this.notifySubscribers(data, source);
   }
 
@@ -2305,7 +2320,7 @@ class MarketDataChannel extends StreamChannel<PerpsMarketData[]> {
             'memory_cache',
             cachedForProvider.length,
           );
-          this.notifySubscribers(cachedForProvider, 'cache');
+          this.notifySubscribers(cachedForProvider, 'memory_cache');
           return;
         }
 
@@ -2392,7 +2407,7 @@ class MarketDataChannel extends StreamChannel<PerpsMarketData[]> {
               marketCount: existing.length,
             },
           );
-          this.notifySubscribers(existing, 'cache');
+          this.notifySubscribers(existing, 'memory_cache');
         }
       }
     })();
@@ -2570,7 +2585,7 @@ export class PerpsStreamManager {
 
   private publishUserDataSnapshot(
     snapshot: PerpsUserDataBundle,
-    source: Extract<StreamUpdateSource, 'cache' | 'fresh'>,
+    source: Extract<StreamUpdateSource, 'memory_cache' | 'provider_snapshot'>,
   ): void {
     const address = getEvmAccountFromSelectedAccountGroup()?.address ?? null;
     this.positions.setAccountContext(address);
@@ -2580,8 +2595,7 @@ export class PerpsStreamManager {
     this.orders.seedCache('orders', snapshot.orders);
     this.account.seedCache('account', snapshot.accountState);
 
-    const proofSource =
-      source === 'cache' ? 'memory_cache' : 'provider_snapshot';
+    const proofSource = source;
     recordPerpsLoadingSessionValuesReady(
       'positions',
       proofSource,
@@ -2631,7 +2645,7 @@ export class PerpsStreamManager {
       if (cachedSnapshot?.accountState) {
         this.publishUserDataSnapshot(
           cachedSnapshot as PerpsUserDataBundle,
-          'cache',
+          'memory_cache',
         );
         this.acceptedUserDataSnapshotKey = requestKey;
       }
@@ -2668,7 +2682,7 @@ export class PerpsStreamManager {
           return;
         }
 
-        this.publishUserDataSnapshot(snapshot, 'fresh');
+        this.publishUserDataSnapshot(snapshot, 'provider_snapshot');
         this.acceptedUserDataSnapshotKey = requestKey;
       })
       .catch((error) => {

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -65,11 +65,13 @@ function getEvmAccountFromSelectedAccountGroup() {
 // Generic subscription parameters
 interface StreamSubscription<T> {
   id: string;
-  callback: (data: T) => void;
+  callback: (data: T, source?: StreamUpdateSource) => void;
   throttleMs?: number;
   timer?: NodeJS.Timeout;
   pendingUpdate?: T;
+  pendingSource?: StreamUpdateSource;
   hasReceivedFirstFreshUpdate?: boolean;
+  includeDeliverySource?: boolean;
   // Symbols this subscriber cares about. When present, the channel can dispatch
   // an update only to subscribers registered for the symbols that changed,
   // instead of iterating every subscriber on every tick. Used by the price channel.
@@ -224,36 +226,43 @@ abstract class StreamChannel<T> {
     updates: T,
     source: StreamUpdateSource,
   ) {
+    const deliver = (data: T, deliverySource: StreamUpdateSource) =>
+      subscriber.includeDeliverySource
+        ? subscriber.callback(data, deliverySource)
+        : subscriber.callback(data);
+
     if (source === 'optimistic') {
       if (subscriber.timer) {
         clearTimeout(subscriber.timer);
         subscriber.timer = undefined;
       }
       subscriber.pendingUpdate = undefined;
-      subscriber.callback(updates);
+      subscriber.pendingSource = undefined;
+      deliver(updates, source);
       return;
     }
 
     if (source === 'cache') {
-      subscriber.callback(updates);
+      deliver(updates, source);
       return;
     }
 
     if (!subscriber.hasReceivedFirstFreshUpdate) {
-      subscriber.callback(updates);
+      deliver(updates, source);
       subscriber.hasReceivedFirstFreshUpdate = true;
       return;
     }
 
     // If no throttling (throttleMs is 0 or undefined), notify immediately
     if (!subscriber.throttleMs) {
-      subscriber.callback(updates);
+      deliver(updates, source);
       return;
     }
 
     // For subsequent updates with throttling, use throttle logic
     // Store pending update
     subscriber.pendingUpdate = updates;
+    subscriber.pendingSource = source;
 
     // Throttle pattern: Only set timer if one isn't already running
     // This ensures callbacks fire at most once per throttleMs interval
@@ -261,8 +270,9 @@ abstract class StreamChannel<T> {
     // The conditional check prevents timer accumulation - no memory leaks
     subscriber.timer ??= setTimeout(() => {
       if (subscriber.pendingUpdate) {
-        subscriber.callback(subscriber.pendingUpdate);
+        deliver(subscriber.pendingUpdate, subscriber.pendingSource ?? 'fresh');
         subscriber.pendingUpdate = undefined;
+        subscriber.pendingSource = undefined;
       }
       subscriber.timer = undefined;
     }, subscriber.throttleMs);
@@ -286,8 +296,16 @@ abstract class StreamChannel<T> {
       clearTimeout(subscriber.timer);
       subscriber.timer = undefined;
       if (subscriber.pendingUpdate !== undefined) {
-        subscriber.callback(subscriber.pendingUpdate);
+        if (subscriber.includeDeliverySource) {
+          subscriber.callback(
+            subscriber.pendingUpdate,
+            subscriber.pendingSource ?? 'fresh',
+          );
+        } else {
+          subscriber.callback(subscriber.pendingUpdate);
+        }
         subscriber.pendingUpdate = undefined;
+        subscriber.pendingSource = undefined;
       }
     });
   }
@@ -332,9 +350,10 @@ abstract class StreamChannel<T> {
   }
 
   subscribe(params: {
-    callback: (data: T) => void;
+    callback: (data: T, source?: StreamUpdateSource) => void;
     throttleMs?: number;
     symbols?: string[];
+    includeDeliverySource?: boolean;
   }): () => void {
     const id = Math.random().toString(36);
 
@@ -349,7 +368,11 @@ abstract class StreamChannel<T> {
     // Give immediate cached data if available
     const cached = this.getCachedData();
     if (cached != null) {
-      params.callback(cached);
+      if (params.includeDeliverySource) {
+        params.callback(cached, 'cache');
+      } else {
+        params.callback(cached);
+      }
       // Cached data renders immediately but must not consume the first fresh
       // update exemption. The first live snapshot should also bypass throttling.
     }

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -33,9 +33,7 @@ import {
 import {
   logHomepageConnectionStage,
   markHomepagePerpsAccountSwitch,
-  markHomepagePerpsNetworkRecovery,
   markHomepagePerpsNetworkSwitch,
-  markHomepagePerpsProviderSwitch,
 } from '../utils/homepagePerformanceProbe';
 import Logger from '../../../../util/Logger';
 import {
@@ -172,12 +170,12 @@ class PerpsConnectionManagerClass {
         });
       }
 
-      if (hasAccountChanged) {
-        markHomepagePerpsAccountSwitch();
-      } else if (hasProviderChanged) {
-        markHomepagePerpsProviderSwitch();
-      } else if (hasPerpsNetworkChanged || hasHip3Changed) {
-        markHomepagePerpsNetworkSwitch();
+      if (__DEV__) {
+        if (hasPerpsNetworkChanged) {
+          markHomepagePerpsNetworkSwitch();
+        } else if (hasAccountChanged) {
+          markHomepagePerpsAccountSwitch();
+        }
       }
 
       // If account, network, provider, or HIP-3 config changed and we're connected, trigger reconnection
@@ -318,7 +316,6 @@ class PerpsConnectionManagerClass {
             netState.isInternetReachable ?? netState.isConnected ?? false;
 
           if (isOnline && this.wasOffline) {
-            markHomepagePerpsNetworkRecovery();
             DevLogger.log(
               'PerpsConnectionManager: Network restored - validating connection',
             );
@@ -916,10 +913,12 @@ class PerpsConnectionManagerClass {
           data: loadingSessionTraceData,
         });
 
-        logHomepageConnectionStage('connection_attempt_started', {
-          connection_id: traceId,
-          source,
-        });
+        if (__DEV__) {
+          logHomepageConnectionStage('connection_attempt_started', {
+            connection_id: traceId,
+            source,
+          });
+        }
 
         DevLogger.log('PerpsConnectionManager: Initializing connection');
 
@@ -938,11 +937,13 @@ class PerpsConnectionManagerClass {
           'millisecond',
           traceSpan,
         );
-        logHomepageConnectionStage('provider_initialized', {
-          connection_id: traceId,
-          duration_ms: performance.now() - initStart,
-          elapsed_ms: performance.now() - connectionStartTime,
-        });
+        if (__DEV__) {
+          logHomepageConnectionStage('provider_initialized', {
+            connection_id: traceId,
+            duration_ms: performance.now() - initStart,
+            elapsed_ms: performance.now() - connectionStartTime,
+          });
+        }
 
         // Validate connection with WebSocket health check ping before marking as connected
         // This ensures the WebSocket connection is actually responsive without expensive API calls
@@ -958,11 +959,13 @@ class PerpsConnectionManagerClass {
           'millisecond',
           traceSpan,
         );
-        logHomepageConnectionStage('health_check_completed', {
-          connection_id: traceId,
-          duration_ms: performance.now() - healthCheckStart,
-          elapsed_ms: performance.now() - connectionStartTime,
-        });
+        if (__DEV__) {
+          logHomepageConnectionStage('health_check_completed', {
+            connection_id: traceId,
+            duration_ms: performance.now() - healthCheckStart,
+            elapsed_ms: performance.now() - connectionStartTime,
+          });
+        }
 
         // Check if timeout fired during health check - respect timeout decision.
         // The timeout handler always sets isConnecting=false (even when
@@ -1006,10 +1009,12 @@ class PerpsConnectionManagerClass {
           'millisecond',
           traceSpan,
         );
-        logHomepageConnectionStage('connection_established', {
-          connection_id: traceId,
-          elapsed_ms: connectionDuration,
-        });
+        if (__DEV__) {
+          logHomepageConnectionStage('connection_established', {
+            connection_id: traceId,
+            elapsed_ms: connectionDuration,
+          });
+        }
 
         DevLogger.log('PerpsConnectionManager: Successfully connected');
 
@@ -1022,11 +1027,13 @@ class PerpsConnectionManagerClass {
           'millisecond',
           traceSpan,
         );
-        logHomepageConnectionStage('subscriptions_preloaded', {
-          connection_id: traceId,
-          duration_ms: performance.now() - preloadStart,
-          elapsed_ms: performance.now() - connectionStartTime,
-        });
+        if (__DEV__) {
+          logHomepageConnectionStage('subscriptions_preloaded', {
+            connection_id: traceId,
+            duration_ms: performance.now() - preloadStart,
+            elapsed_ms: performance.now() - connectionStartTime,
+          });
+        }
 
         // Track total connection time including preload (user-perceived performance)
         const totalConnectionDuration = performance.now() - connectionStartTime;
@@ -1046,10 +1053,12 @@ class PerpsConnectionManagerClass {
           'millisecond',
           traceSpan,
         );
-        logHomepageConnectionStage('connection_with_preload_completed', {
-          connection_id: traceId,
-          elapsed_ms: totalConnectionDuration,
-        });
+        if (__DEV__) {
+          logHomepageConnectionStage('connection_with_preload_completed', {
+            connection_id: traceId,
+            elapsed_ms: totalConnectionDuration,
+          });
+        }
 
         traceData = {
           success: true,

--- a/app/components/UI/Perps/services/PerpsConnectionManager.ts
+++ b/app/components/UI/Perps/services/PerpsConnectionManager.ts
@@ -30,6 +30,13 @@ import {
   PERPS_CUF_END_REASON,
   PERPS_CUF_STREAM_TIMEOUT_MS,
 } from '../constants/perpsCufTags';
+import {
+  logHomepageConnectionStage,
+  markHomepagePerpsAccountSwitch,
+  markHomepagePerpsNetworkRecovery,
+  markHomepagePerpsNetworkSwitch,
+  markHomepagePerpsProviderSwitch,
+} from '../utils/homepagePerformanceProbe';
 import Logger from '../../../../util/Logger';
 import {
   PERPS_CONSTANTS,
@@ -139,6 +146,14 @@ class PerpsConnectionManagerClass {
         this.previousProvider !== undefined &&
         this.previousProvider !== currentProvider;
       const hasHip3Changed = this.previousHip3Version !== currentHip3Version;
+
+      if (hasAccountChanged) {
+        markHomepagePerpsAccountSwitch();
+      } else if (hasProviderChanged) {
+        markHomepagePerpsProviderSwitch();
+      } else if (hasPerpsNetworkChanged || hasHip3Changed) {
+        markHomepagePerpsNetworkSwitch();
+      }
 
       // If account, network, provider, or HIP-3 config changed and we're connected, trigger reconnection
       if (
@@ -284,6 +299,7 @@ class PerpsConnectionManagerClass {
             netState.isInternetReachable ?? netState.isConnected ?? false;
 
           if (isOnline && this.wasOffline) {
+            markHomepagePerpsNetworkRecovery();
             DevLogger.log(
               'PerpsConnectionManager: Network restored - validating connection',
             );
@@ -879,6 +895,11 @@ class PerpsConnectionManagerClass {
           op: TraceOperation.PerpsOperation,
         });
 
+        logHomepageConnectionStage('connection_attempt_started', {
+          connection_id: traceId,
+          source,
+        });
+
         DevLogger.log('PerpsConnectionManager: Initializing connection');
 
         // Stage 1: Initialize providers
@@ -896,6 +917,11 @@ class PerpsConnectionManagerClass {
           'millisecond',
           traceSpan,
         );
+        logHomepageConnectionStage('provider_initialized', {
+          connection_id: traceId,
+          duration_ms: performance.now() - initStart,
+          elapsed_ms: performance.now() - connectionStartTime,
+        });
         // Validate connection with WebSocket health check ping before marking as connected
         // This ensures the WebSocket connection is actually responsive without expensive API calls
         DevLogger.log(
@@ -910,6 +936,11 @@ class PerpsConnectionManagerClass {
           'millisecond',
           traceSpan,
         );
+        logHomepageConnectionStage('health_check_completed', {
+          connection_id: traceId,
+          duration_ms: performance.now() - healthCheckStart,
+          elapsed_ms: performance.now() - connectionStartTime,
+        });
         // Check if timeout fired during health check - respect timeout decision.
         // The timeout handler always sets isConnecting=false (even when
         // suppressError is true), so checking that flag detects the timeout
@@ -952,6 +983,10 @@ class PerpsConnectionManagerClass {
           'millisecond',
           traceSpan,
         );
+        logHomepageConnectionStage('connection_established', {
+          connection_id: traceId,
+          elapsed_ms: connectionDuration,
+        });
         DevLogger.log('PerpsConnectionManager: Successfully connected');
 
         // Stage 3: Pre-load positions and orders subscriptions to populate cache
@@ -963,6 +998,11 @@ class PerpsConnectionManagerClass {
           'millisecond',
           traceSpan,
         );
+        logHomepageConnectionStage('subscriptions_preloaded', {
+          connection_id: traceId,
+          duration_ms: performance.now() - preloadStart,
+          elapsed_ms: performance.now() - connectionStartTime,
+        });
         // Track total connection time including preload (user-perceived performance)
         const totalConnectionDuration = performance.now() - connectionStartTime;
 
@@ -981,6 +1021,10 @@ class PerpsConnectionManagerClass {
           'millisecond',
           traceSpan,
         );
+        logHomepageConnectionStage('connection_with_preload_completed', {
+          connection_id: traceId,
+          elapsed_ms: totalConnectionDuration,
+        });
         traceData = {
           success: true,
         };

--- a/app/components/UI/Perps/utils/homepagePerformanceProbe.test.ts
+++ b/app/components/UI/Perps/utils/homepagePerformanceProbe.test.ts
@@ -9,6 +9,7 @@ import {
   handleHomepagePerformanceAppStateChange,
   logHomepagePerformanceStage,
   markHomepagePerpsAccountSwitch,
+  markHomepagePerpsNavigateReturn,
   markHomepagePerformanceDemandComplete,
   recordHomepagePerpsVisibleFrame,
   resetHomepagePerformanceProbeForTests,
@@ -18,9 +19,8 @@ jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
   DevLogger: { log: jest.fn() },
 }));
 
-jest.mock('uuid', () => ({
-  v4: jest.fn(() => 'demand-1'),
-}));
+const mockUuid = jest.fn();
+jest.mock('uuid', () => ({ v4: () => mockUuid() }));
 
 jest.mock('react-native-performance', () => ({
   __esModule: true,
@@ -55,6 +55,8 @@ describe('homepagePerformanceProbe', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    let uuidSequence = 0;
+    mockUuid.mockImplementation(() => `probe-id-${uuidSequence++}`);
     jest.mocked(performance.now).mockReturnValue(1000);
     resetHomepagePerformanceProbeForTests();
     activateHomepagePerformanceProbe();
@@ -99,6 +101,53 @@ describe('homepagePerformanceProbe', () => {
       'surface_resolved_recorded',
       'surface_live_recorded',
     ]);
+  });
+
+  it('rejects account deliveries from different atomic bundles', () => {
+    const demand = createHomepagePerformanceDemand();
+    const positions = createHomepagePerpsDelivery({
+      stream: 'positions',
+      source: 'provider_snapshot',
+      itemCount: 1,
+    });
+    const orders = createHomepagePerpsDelivery({
+      stream: 'orders',
+      source: 'provider_snapshot',
+      itemCount: 0,
+    });
+    createHomepagePerpsDelivery({
+      stream: 'positions',
+      source: 'provider_snapshot',
+      itemCount: 1,
+    });
+    const account = createHomepagePerpsDelivery({
+      stream: 'account',
+      source: 'provider_snapshot',
+      itemCount: 1,
+    });
+
+    recordHomepagePerpsVisibleFrame({
+      demand,
+      deliveries: [positions, orders, account],
+      contentVariant: 'positions',
+      reactCommitAtMonotonicMs: 1100,
+      frameCheckpointAtMonotonicMs: 1200,
+    });
+
+    expect(stages().map(({ stage }) => stage)).toEqual(['surface_demand']);
+  });
+
+  it('advances context generation for repeated lifecycle occurrences', () => {
+    const first = createHomepagePerformanceDemand();
+    markHomepagePerformanceDemandComplete(first);
+    const firstReturn = createHomepagePerformanceDemand();
+    markHomepagePerpsNavigateReturn();
+    const secondReturn = createHomepagePerformanceDemand();
+
+    expect(secondReturn.lifecycle).toBe('navigate_return');
+    expect(secondReturn.contextGeneration).toBeGreaterThan(
+      firstReturn.contextGeneration,
+    );
   });
 
   it('does not satisfy a demand with a prior-account delivery', () => {
@@ -199,7 +248,6 @@ describe('homepagePerformanceProbe', () => {
     expect(stages().map(({ stage }) => stage)).toEqual([
       'surface_demand',
       'surface_resolved_recorded',
-      'surface_live_recorded',
     ]);
   });
 

--- a/app/components/UI/Perps/utils/homepagePerformanceProbe.test.ts
+++ b/app/components/UI/Perps/utils/homepagePerformanceProbe.test.ts
@@ -1,11 +1,15 @@
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import performance from 'react-native-performance';
 import {
   activateHomepagePerformanceProbe,
   createHomepagePerformanceDemand,
   createHomepagePerpsDelivery,
   createHomepagePerpsResidentDelivery,
   isHomepagePerpsDeliveryFreshForDemand,
+  handleHomepagePerformanceAppStateChange,
+  logHomepagePerformanceStage,
   markHomepagePerpsAccountSwitch,
+  markHomepagePerformanceDemandComplete,
   recordHomepagePerpsVisibleFrame,
   resetHomepagePerformanceProbeForTests,
 } from './homepagePerformanceProbe';
@@ -51,6 +55,7 @@ describe('homepagePerformanceProbe', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(performance.now).mockReturnValue(1000);
     resetHomepagePerformanceProbeForTests();
     activateHomepagePerformanceProbe();
   });
@@ -75,10 +80,15 @@ describe('homepagePerformanceProbe', () => {
       source: 'fresh_socket',
       itemCount: 0,
     });
+    const account = createHomepagePerpsDelivery({
+      stream: 'account',
+      source: 'fresh_socket',
+      itemCount: 1,
+    });
 
     recordHomepagePerpsVisibleFrame({
       demand,
-      deliveries: [positions, orders],
+      deliveries: [positions, orders, account],
       contentVariant: 'positions',
       reactCommitAtMonotonicMs: 1100,
       frameCheckpointAtMonotonicMs: 1200,
@@ -144,5 +154,120 @@ describe('homepagePerformanceProbe', () => {
 
     expect(resident.originSource).toBe('memory_cache');
     expect(isHomepagePerpsDeliveryFreshForDemand(resident, demand)).toBe(false);
+  });
+
+  it('does not require an unrelated price delivery for trending', () => {
+    const stalePrice = createHomepagePerpsDelivery({
+      stream: 'prices',
+      source: 'fresh_socket',
+      itemCount: 1,
+    });
+    markHomepagePerpsAccountSwitch();
+    const demand = createHomepagePerformanceDemand();
+    const deliveries = [
+      createHomepagePerpsDelivery({
+        stream: 'positions',
+        source: 'fresh_socket',
+        itemCount: 0,
+      }),
+      createHomepagePerpsDelivery({
+        stream: 'orders',
+        source: 'fresh_socket',
+        itemCount: 0,
+      }),
+      createHomepagePerpsDelivery({
+        stream: 'account',
+        source: 'fresh_socket',
+        itemCount: 1,
+      }),
+      createHomepagePerpsDelivery({
+        stream: 'markets',
+        source: 'provider',
+        itemCount: 2,
+      }),
+      stalePrice,
+    ];
+
+    recordHomepagePerpsVisibleFrame({
+      demand,
+      deliveries,
+      contentVariant: 'trending',
+      reactCommitAtMonotonicMs: 1100,
+      frameCheckpointAtMonotonicMs: 1200,
+    });
+
+    expect(stages().map(({ stage }) => stage)).toEqual([
+      'surface_demand',
+      'surface_resolved_recorded',
+      'surface_live_recorded',
+    ]);
+  });
+
+  it('does not let an old demand complete a new account generation', () => {
+    const demand = createHomepagePerformanceDemand();
+    markHomepagePerpsAccountSwitch();
+    const deliveries = ['positions', 'orders', 'account'].map((stream) =>
+      createHomepagePerpsDelivery({
+        stream: stream as 'positions' | 'orders' | 'account',
+        source: 'fresh_socket',
+        itemCount: 1,
+      }),
+    );
+
+    recordHomepagePerpsVisibleFrame({
+      demand,
+      deliveries,
+      contentVariant: 'positions',
+      reactCommitAtMonotonicMs: 1100,
+      frameCheckpointAtMonotonicMs: 1200,
+    });
+    markHomepagePerformanceDemandComplete(demand);
+
+    expect(stages().map(({ stage }) => stage)).toEqual(['surface_demand']);
+    expect(createHomepagePerformanceDemand().lifecycle).toBe('account_switch');
+  });
+
+  it('ages chained resident deliveries without double counting', () => {
+    const origin = createHomepagePerpsDelivery({
+      stream: 'markets',
+      source: 'memory_cache',
+      itemCount: 2,
+      dataAgeMs: 50,
+    });
+    jest.mocked(performance.now).mockReturnValue(1010);
+    const first = createHomepagePerpsResidentDelivery({
+      stream: 'markets',
+      itemCount: 2,
+      previousDelivery: origin,
+    });
+    jest.mocked(performance.now).mockReturnValue(1020);
+    const second = createHomepagePerpsResidentDelivery({
+      stream: 'markets',
+      itemCount: 2,
+      previousDelivery: first,
+    });
+
+    expect(first.dataAgeMs).toBe(60);
+    expect(second.dataAgeMs).toBe(70);
+  });
+
+  it('ignores iOS inactive when classifying a background lifecycle', () => {
+    handleHomepagePerformanceAppStateChange('inactive');
+    jest.mocked(performance.now).mockReturnValue(30_000);
+    handleHomepagePerformanceAppStateChange('active');
+
+    expect(createHomepagePerformanceDemand().lifecycle).toBe('cold_no_cache');
+  });
+
+  it('allowlists detail fields and preserves the canonical stage', () => {
+    logHomepagePerformanceStage('react_commit', undefined, {
+      stage: 'overridden',
+      wallet_address: '0xprivate',
+      duration_ms: 12,
+    });
+
+    const record = stages()[0] as Record<string, unknown>;
+    expect(record).toMatchObject({ stage: 'react_commit', duration_ms: 12 });
+    expect(record).not.toHaveProperty('wallet_address');
   });
 });

--- a/app/components/UI/Perps/utils/homepagePerformanceProbe.test.ts
+++ b/app/components/UI/Perps/utils/homepagePerformanceProbe.test.ts
@@ -1,0 +1,148 @@
+import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import {
+  activateHomepagePerformanceProbe,
+  createHomepagePerformanceDemand,
+  createHomepagePerpsDelivery,
+  createHomepagePerpsResidentDelivery,
+  isHomepagePerpsDeliveryFreshForDemand,
+  markHomepagePerpsAccountSwitch,
+  recordHomepagePerpsVisibleFrame,
+  resetHomepagePerformanceProbeForTests,
+} from './homepagePerformanceProbe';
+
+jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
+  DevLogger: { log: jest.fn() },
+}));
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'demand-1'),
+}));
+
+jest.mock('react-native-performance', () => ({
+  __esModule: true,
+  default: {
+    now: jest.fn(() => 1000),
+  },
+}));
+
+const stages = () =>
+  jest
+    .mocked(DevLogger.log)
+    .mock.calls.map(([message]) => String(message))
+    .filter((message) => message.includes('[PerpsPerf]'))
+    .map(
+      (message) =>
+        JSON.parse(message.replace('[PerpsPerf] ', '')) as {
+          stage: string;
+        },
+    );
+
+describe('homepagePerformanceProbe', () => {
+  const devGlobal = global as typeof global & { __DEV__: boolean };
+  const previousDev = devGlobal.__DEV__;
+
+  beforeAll(() => {
+    devGlobal.__DEV__ = true;
+  });
+
+  afterAll(() => {
+    devGlobal.__DEV__ = previousDev;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetHomepagePerformanceProbeForTests();
+    activateHomepagePerformanceProbe();
+  });
+
+  it('emits the canonical surface_demand stage', () => {
+    createHomepagePerformanceDemand();
+
+    expect(stages()).toEqual([
+      expect.objectContaining({ stage: 'surface_demand' }),
+    ]);
+  });
+
+  it('records resolved and live surface stages from a fresh demand', () => {
+    const demand = createHomepagePerformanceDemand();
+    const positions = createHomepagePerpsDelivery({
+      stream: 'positions',
+      source: 'fresh_socket',
+      itemCount: 1,
+    });
+    const orders = createHomepagePerpsDelivery({
+      stream: 'orders',
+      source: 'fresh_socket',
+      itemCount: 0,
+    });
+
+    recordHomepagePerpsVisibleFrame({
+      demand,
+      deliveries: [positions, orders],
+      contentVariant: 'positions',
+      reactCommitAtMonotonicMs: 1100,
+      frameCheckpointAtMonotonicMs: 1200,
+    });
+
+    expect(stages().map(({ stage }) => stage)).toEqual([
+      'surface_demand',
+      'surface_resolved_recorded',
+      'surface_live_recorded',
+    ]);
+  });
+
+  it('does not satisfy a demand with a prior-account delivery', () => {
+    const stale = createHomepagePerpsDelivery({
+      stream: 'positions',
+      source: 'fresh_socket',
+      itemCount: 1,
+    });
+    markHomepagePerpsAccountSwitch();
+    const demand = createHomepagePerformanceDemand();
+
+    recordHomepagePerpsVisibleFrame({
+      demand,
+      deliveries: [stale],
+      contentVariant: 'positions',
+      reactCommitAtMonotonicMs: 1100,
+      frameCheckpointAtMonotonicMs: 1200,
+    });
+
+    expect(stages().map(({ stage }) => stage)).toEqual(['surface_demand']);
+  });
+
+  it('treats resident Terminal-origin markets as fresh in the current lifecycle', () => {
+    const cached = createHomepagePerpsDelivery({
+      stream: 'markets',
+      source: 'memory_cache',
+      originSource: 'terminal_global_snapshot_v2',
+      itemCount: 2,
+    });
+    const resident = createHomepagePerpsResidentDelivery({
+      stream: 'markets',
+      itemCount: 2,
+      previousDelivery: cached,
+    });
+    const demand = createHomepagePerformanceDemand();
+
+    expect(resident.originSource).toBe('terminal_global_snapshot_v2');
+    expect(isHomepagePerpsDeliveryFreshForDemand(resident, demand)).toBe(true);
+  });
+
+  it('does not treat resident markets without a fresh origin as fresh', () => {
+    const cached = createHomepagePerpsDelivery({
+      stream: 'markets',
+      source: 'memory_cache',
+      itemCount: 2,
+    });
+    const resident = createHomepagePerpsResidentDelivery({
+      stream: 'markets',
+      itemCount: 2,
+      previousDelivery: cached,
+    });
+    const demand = createHomepagePerformanceDemand();
+
+    expect(resident.originSource).toBe('memory_cache');
+    expect(isHomepagePerpsDeliveryFreshForDemand(resident, demand)).toBe(false);
+  });
+});

--- a/app/components/UI/Perps/utils/homepagePerformanceProbe.ts
+++ b/app/components/UI/Perps/utils/homepagePerformanceProbe.ts
@@ -3,28 +3,15 @@ import performance from 'react-native-performance';
 import { PERPS_CONSTANTS } from '@metamask/perps-controller';
 import { v4 as uuidv4 } from 'uuid';
 import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+import type {
+  PerpsLoadingLifecycle,
+  PerpsLoadingSource,
+  PerpsLoadingStream,
+} from './perpsLoadingSession';
 
-export type HomepagePerpsStream = 'positions' | 'orders' | 'markets' | 'prices';
-export type HomepagePerpsDeliverySource =
-  | 'memory_cache'
-  | 'disk_cache'
-  | 'provider_snapshot'
-  | 'terminal_global_snapshot_v2'
-  | 'provider'
-  | 'resident_state'
-  | 'fresh_socket'
-  | 'unknown';
-export type HomepagePerformanceLifecycle =
-  | 'cold_no_cache'
-  | 'cold_disk_cache'
-  | 'warm_foreground'
-  | 'navigate_return'
-  | 'background_short'
-  | 'background_reconnect'
-  | 'network_recovery'
-  | 'account_switch'
-  | 'perps_network_switch'
-  | 'provider_switch';
+export type HomepagePerpsStream = PerpsLoadingStream;
+export type HomepagePerpsDeliverySource = PerpsLoadingSource | 'resident_state';
+export type HomepagePerformanceLifecycle = PerpsLoadingLifecycle;
 export type HomepagePerpsContentVariant =
   | 'empty'
   | 'positions'
@@ -41,7 +28,7 @@ export interface HomepagePerpsDeliveryMetadata {
   originSource?: HomepagePerpsDeliverySource;
   itemCount: number;
   receivedAtMonotonicMs: number;
-  subscriberDeliveredAtMonotonicMs?: number;
+  residentWrappedAtMonotonicMs?: number;
   dataAgeMs: number;
   lifecycle: HomepagePerformanceLifecycle;
   accountGeneration: number;
@@ -57,10 +44,6 @@ export interface HomepagePerformanceDemand {
   contextGeneration: number;
   firstVisibleRecorded: boolean;
   firstFreshVisibleRecorded: boolean;
-  cachedVisibleAtMonotonicMs?: number;
-  cachedVisibleSource?: string;
-  recordedFreshPipelineStreams: Set<HomepagePerpsStream>;
-  recordedSocketPipelineStreams: Set<HomepagePerpsStream>;
 }
 
 type HomepagePerformanceStage =
@@ -83,11 +66,46 @@ type HomepagePerformanceStage =
   | 'cache_write'
   | 'subscriber_delivery'
   | 'react_commit'
-  | 'values_visible'
-  | 'first_frame_checkpoint'
+  | 'surface_initial_ui_recorded'
   | 'next_frame_checkpoint'
   | 'surface_resolved_recorded'
   | 'surface_live_recorded';
+
+const SAFE_DETAIL_KEYS = new Set([
+  'account_generation',
+  'cache_age_ms',
+  'connection_id',
+  'content_variant',
+  'context_generation',
+  'data_ready_at_demand',
+  'demand_id',
+  'duration_ms',
+  'elapsed_ms',
+  'frame_checkpoint_monotonic_ms',
+  'frame_boundary',
+  'fresh_for_lifecycle',
+  'freshness_source',
+  'instrumentation_schema',
+  'lifecycle',
+  'markets_source',
+  'orders_source',
+  'positions_source',
+  'delivery_source',
+  'source',
+  'success',
+  'visible_item_count',
+]);
+
+const sanitizeDetail = (detail: Record<string, unknown>) =>
+  Object.fromEntries(
+    Object.entries(detail).filter(
+      ([key, value]) =>
+        SAFE_DETAIL_KEYS.has(key) &&
+        (typeof value === 'string' ||
+          typeof value === 'number' ||
+          typeof value === 'boolean'),
+    ),
+  );
 
 let diskCacheTimestampMs: number | null = null;
 let firstDemand = true;
@@ -102,6 +120,7 @@ export const isHomepagePerformanceProbeActive = () =>
   activeObservationCount > 0;
 
 export const activateHomepagePerformanceProbe = () => {
+  if (!__DEV__) return () => undefined;
   activeObservationCount += 1;
   let released = false;
 
@@ -121,6 +140,7 @@ export const logHomepagePerformanceStage = (
 
   DevLogger.log(
     `[PerpsPerf] ${JSON.stringify({
+      ...sanitizeDetail(detail),
       stage,
       monotonic_ms: Number(performance.now().toFixed(3)),
       ...(delivery && {
@@ -134,7 +154,6 @@ export const logHomepagePerformanceStage = (
         account_generation: delivery.accountGeneration,
         context_generation: delivery.contextGeneration,
       }),
-      ...detail,
     })}`,
   );
 };
@@ -173,6 +192,7 @@ const notifyLifecycleChange = () =>
 export const subscribeHomepagePerformanceLifecycleChange = (
   listener: () => void,
 ) => {
+  if (!__DEV__) return () => undefined;
   lifecycleListeners.add(listener);
   return () => {
     lifecycleListeners.delete(listener);
@@ -182,7 +202,8 @@ export const subscribeHomepagePerformanceLifecycleChange = (
 export const handleHomepagePerformanceAppStateChange = (
   nextState: AppStateStatus,
 ) => {
-  if (nextState === 'background' || nextState === 'inactive') {
+  if (!__DEV__) return;
+  if (nextState === 'background') {
     backgroundStartedAt ??= performance.now();
     return;
   }
@@ -208,6 +229,7 @@ export const getHomepagePerpsDiskCacheAgeMs = () =>
     : Math.max(0, Date.now() - diskCacheTimestampMs);
 
 export const markHomepagePerpsDiskCacheHydrated = (rawValue: string) => {
+  if (!__DEV__) return;
   try {
     const parsed = JSON.parse(rawValue) as {
       timestamp?: number;
@@ -243,26 +265,23 @@ const setLifecycle = (
 };
 
 export const markHomepagePerpsNavigateReturn = () => {
+  if (!__DEV__) return;
   if (
     lifecycle === 'cold_no_cache' ||
     lifecycle === 'cold_disk_cache' ||
-    lifecycle === 'warm_foreground' ||
     lifecycle === 'navigate_return'
   ) {
     setLifecycle('navigate_return');
   }
 };
 
-export const markHomepagePerpsNetworkRecovery = () =>
-  setLifecycle('network_recovery');
-
-export const markHomepagePerpsNetworkSwitch = () =>
-  setLifecycle('perps_network_switch', { advancesContext: true });
-
-export const markHomepagePerpsProviderSwitch = () =>
-  setLifecycle('provider_switch', { advancesContext: true });
+export const markHomepagePerpsNetworkSwitch = () => {
+  if (!__DEV__) return;
+  setLifecycle('network_switch', { advancesContext: true });
+};
 
 export const markHomepagePerpsAccountSwitch = () => {
+  if (!__DEV__) return;
   accountGeneration += 1;
   setLifecycle('account_switch', { advancesContext: true });
 };
@@ -309,10 +328,12 @@ export const createHomepagePerpsResidentDelivery = ({
     originSource: previousDelivery?.originSource ?? previousDelivery?.source,
     itemCount,
     receivedAtMonotonicMs: previousDelivery?.receivedAtMonotonicMs ?? now,
+    residentWrappedAtMonotonicMs: now,
     dataAgeMs: previousDelivery
       ? previousDelivery.dataAgeMs +
         now -
-        previousDelivery.receivedAtMonotonicMs
+        (previousDelivery.residentWrappedAtMonotonicMs ??
+          previousDelivery.receivedAtMonotonicMs)
       : 0,
     lifecycle,
     accountGeneration: previousDelivery?.accountGeneration ?? accountGeneration,
@@ -331,8 +352,6 @@ export const createHomepagePerformanceDemand =
       contextGeneration,
       firstVisibleRecorded: false,
       firstFreshVisibleRecorded: false,
-      recordedFreshPipelineStreams: new Set<HomepagePerpsStream>(),
-      recordedSocketPipelineStreams: new Set<HomepagePerpsStream>(),
     };
     firstDemand = false;
     logHomepagePerformanceStage('surface_demand', undefined, {
@@ -343,6 +362,11 @@ export const createHomepagePerformanceDemand =
     });
     return demand;
   };
+
+const isDemandCurrent = (demand: HomepagePerformanceDemand) =>
+  demand.lifecycle === lifecycle &&
+  demand.accountGeneration === accountGeneration &&
+  demand.contextGeneration === contextGeneration;
 
 export const isHomepagePerpsDeliveryFreshForDemand = (
   delivery: HomepagePerpsDeliveryMetadata,
@@ -373,7 +397,7 @@ const hasRequiredStreams = (
 ) => {
   const streams = new Set(deliveries.map(({ stream }) => stream));
   const hasAccountResolution =
-    streams.has('positions') && streams.has('orders');
+    streams.has('positions') && streams.has('orders') && streams.has('account');
   return contentVariant === 'trending' || contentVariant === 'pills'
     ? hasAccountResolution && streams.has('markets')
     : hasAccountResolution;
@@ -385,34 +409,24 @@ const getRequiredDeliveries = (
 ) => {
   const requiresMarkets =
     contentVariant === 'trending' || contentVariant === 'pills';
-  return deliveries.filter(
-    ({ stream }) =>
-      stream === 'positions' || stream === 'orders' || requiresMarkets,
-  );
+  const requiredStreams = new Set<HomepagePerpsStream>([
+    'positions',
+    'orders',
+    'account',
+  ]);
+  if (requiresMarkets) requiredStreams.add('markets');
+  return deliveries.filter(({ stream }) => requiredStreams.has(stream));
 };
 
 const getVisibleDeliveries = (
   deliveries: HomepagePerpsDeliveryMetadata[],
   contentVariant: HomepagePerpsContentVariant,
-) => {
-  if (contentVariant === 'positions') {
-    return deliveries.filter(({ stream }) => stream === 'positions');
-  }
-  if (contentVariant === 'orders') {
-    return deliveries.filter(({ stream }) => stream === 'orders');
-  }
-  return getRequiredDeliveries(deliveries, contentVariant);
-};
+) => getRequiredDeliveries(deliveries, contentVariant);
 
 const hasVisibleStreams = (
   deliveries: HomepagePerpsDeliveryMetadata[],
   contentVariant: HomepagePerpsContentVariant,
-) => {
-  const streams = new Set(deliveries.map(({ stream }) => stream));
-  if (contentVariant === 'positions') return streams.has('positions');
-  if (contentVariant === 'orders') return streams.has('orders');
-  return hasRequiredStreams(deliveries, contentVariant);
-};
+) => hasRequiredStreams(deliveries, contentVariant);
 
 const getEffectiveSource = (delivery: HomepagePerpsDeliveryMetadata) =>
   delivery.source === 'resident_state' || delivery.source === 'memory_cache'
@@ -424,6 +438,7 @@ export const recordHomepagePerpsVisibleFrame = ({
   deliveries,
   contentVariant,
   isConnectionLive = false,
+  reactCommitAtMonotonicMs,
   frameCheckpointAtMonotonicMs,
 }: {
   demand: HomepagePerformanceDemand;
@@ -433,6 +448,15 @@ export const recordHomepagePerpsVisibleFrame = ({
   reactCommitAtMonotonicMs: number;
   frameCheckpointAtMonotonicMs: number;
 }) => {
+  if (
+    !isDemandCurrent(demand) ||
+    !Number.isFinite(reactCommitAtMonotonicMs) ||
+    !Number.isFinite(frameCheckpointAtMonotonicMs) ||
+    reactCommitAtMonotonicMs < demand.startedAtMonotonicMs ||
+    frameCheckpointAtMonotonicMs < reactCommitAtMonotonicMs
+  ) {
+    return;
+  }
   const visibleDeliveries = getVisibleDeliveries(deliveries, contentVariant);
   if (!hasVisibleStreams(visibleDeliveries, contentVariant)) {
     return;
@@ -487,19 +511,6 @@ export const recordHomepagePerpsVisibleFrame = ({
       ),
       ...visibleTags,
     });
-    if (
-      visibleDeliveries.some(
-        (delivery) =>
-          !isHomepagePerpsDeliveryFreshForDemand(
-            delivery,
-            demand,
-            isConnectionLive,
-          ),
-      )
-    ) {
-      demand.cachedVisibleAtMonotonicMs = frameCheckpointAtMonotonicMs;
-      demand.cachedVisibleSource = visibleTags.delivery_source;
-    }
   }
 
   const requiredDeliveries = getRequiredDeliveries(deliveries, contentVariant);
@@ -550,6 +561,13 @@ export const recordHomepagePerpsErrorFrame = ({
   demand: HomepagePerformanceDemand;
   frameCheckpointAtMonotonicMs: number;
 }) => {
+  if (
+    !isDemandCurrent(demand) ||
+    !Number.isFinite(frameCheckpointAtMonotonicMs) ||
+    frameCheckpointAtMonotonicMs < demand.startedAtMonotonicMs
+  ) {
+    return;
+  }
   if (demand.firstVisibleRecorded) return;
   demand.firstVisibleRecorded = true;
   logHomepagePerformanceStage('surface_resolved_recorded', undefined, {
@@ -563,9 +581,12 @@ export const recordHomepagePerpsErrorFrame = ({
   });
 };
 
-export const markHomepagePerformanceDemandComplete = () => {
-  lifecycle = 'warm_foreground';
-  lifecycleStartedAtMonotonicMs = performance.now();
+export const markHomepagePerformanceDemandComplete = (
+  demand: HomepagePerformanceDemand,
+) => {
+  if (!__DEV__) return;
+  if (!isDemandCurrent(demand)) return;
+  setLifecycle('navigate_return');
 };
 
 export const resetHomepagePerformanceProbeForTests = () => {

--- a/app/components/UI/Perps/utils/homepagePerformanceProbe.ts
+++ b/app/components/UI/Perps/utils/homepagePerformanceProbe.ts
@@ -1,0 +1,581 @@
+import type { AppStateStatus } from 'react-native';
+import performance from 'react-native-performance';
+import { PERPS_CONSTANTS } from '@metamask/perps-controller';
+import { v4 as uuidv4 } from 'uuid';
+import { DevLogger } from '../../../../core/SDKConnect/utils/DevLogger';
+
+export type HomepagePerpsStream = 'positions' | 'orders' | 'markets' | 'prices';
+export type HomepagePerpsDeliverySource =
+  | 'memory_cache'
+  | 'disk_cache'
+  | 'provider_snapshot'
+  | 'terminal_global_snapshot_v2'
+  | 'provider'
+  | 'resident_state'
+  | 'fresh_socket'
+  | 'unknown';
+export type HomepagePerformanceLifecycle =
+  | 'cold_no_cache'
+  | 'cold_disk_cache'
+  | 'warm_foreground'
+  | 'navigate_return'
+  | 'background_short'
+  | 'background_reconnect'
+  | 'network_recovery'
+  | 'account_switch'
+  | 'perps_network_switch'
+  | 'provider_switch';
+export type HomepagePerpsContentVariant =
+  | 'empty'
+  | 'positions'
+  | 'orders'
+  | 'positions_and_orders'
+  | 'trending'
+  | 'pills'
+  | 'error';
+
+export interface HomepagePerpsDeliveryMetadata {
+  deliveryId: string;
+  stream: HomepagePerpsStream;
+  source: HomepagePerpsDeliverySource;
+  originSource?: HomepagePerpsDeliverySource;
+  itemCount: number;
+  receivedAtMonotonicMs: number;
+  subscriberDeliveredAtMonotonicMs?: number;
+  dataAgeMs: number;
+  lifecycle: HomepagePerformanceLifecycle;
+  accountGeneration: number;
+  contextGeneration: number;
+}
+
+export interface HomepagePerformanceDemand {
+  demandId: string;
+  startedAtMonotonicMs: number;
+  lifecycleStartedAtMonotonicMs: number;
+  lifecycle: HomepagePerformanceLifecycle;
+  accountGeneration: number;
+  contextGeneration: number;
+  firstVisibleRecorded: boolean;
+  firstFreshVisibleRecorded: boolean;
+  cachedVisibleAtMonotonicMs?: number;
+  cachedVisibleSource?: string;
+  recordedFreshPipelineStreams: Set<HomepagePerpsStream>;
+  recordedSocketPipelineStreams: Set<HomepagePerpsStream>;
+}
+
+type HomepagePerformanceStage =
+  | 'disk_cache_hydrated'
+  | 'surface_demand'
+  | 'connection_attempt_started'
+  | 'provider_initialized'
+  | 'health_check_completed'
+  | 'connection_established'
+  | 'subscriptions_preloaded'
+  | 'connection_with_preload_completed'
+  | 'account_bundle_request_started'
+  | 'account_bundle_cache_accepted'
+  | 'account_bundle_accepted'
+  | 'account_bundle_discarded'
+  | 'market_snapshot_request_started'
+  | 'market_snapshot_resolved'
+  | 'market_snapshot_error'
+  | 'socket_received'
+  | 'cache_write'
+  | 'subscriber_delivery'
+  | 'react_commit'
+  | 'values_visible'
+  | 'first_frame_checkpoint'
+  | 'next_frame_checkpoint'
+  | 'surface_resolved_recorded'
+  | 'surface_live_recorded';
+
+let diskCacheTimestampMs: number | null = null;
+let firstDemand = true;
+let accountGeneration = 0;
+let contextGeneration = 0;
+let lifecycle: HomepagePerformanceLifecycle = 'cold_no_cache';
+let lifecycleStartedAtMonotonicMs = performance.now();
+let backgroundStartedAt: number | null = null;
+let activeObservationCount = 0;
+const lifecycleListeners = new Set<() => void>();
+export const isHomepagePerformanceProbeActive = () =>
+  activeObservationCount > 0;
+
+export const activateHomepagePerformanceProbe = () => {
+  activeObservationCount += 1;
+  let released = false;
+
+  return () => {
+    if (released) return;
+    released = true;
+    activeObservationCount = Math.max(0, activeObservationCount - 1);
+  };
+};
+
+export const logHomepagePerformanceStage = (
+  stage: HomepagePerformanceStage,
+  delivery?: HomepagePerpsDeliveryMetadata,
+  detail: Record<string, unknown> = {},
+) => {
+  if (!__DEV__ || !isHomepagePerformanceProbeActive()) return;
+
+  DevLogger.log(
+    `[PerpsPerf] ${JSON.stringify({
+      stage,
+      monotonic_ms: Number(performance.now().toFixed(3)),
+      ...(delivery && {
+        delivery_id: delivery.deliveryId,
+        stream: delivery.stream,
+        source: delivery.source,
+        ...(delivery.originSource && { origin_source: delivery.originSource }),
+        item_count: delivery.itemCount,
+        data_age_ms: Math.round(delivery.dataAgeMs),
+        lifecycle: delivery.lifecycle,
+        account_generation: delivery.accountGeneration,
+        context_generation: delivery.contextGeneration,
+      }),
+      ...detail,
+    })}`,
+  );
+};
+
+export const logHomepageConnectionStage = (
+  stage: Extract<
+    HomepagePerformanceStage,
+    | 'connection_attempt_started'
+    | 'provider_initialized'
+    | 'health_check_completed'
+    | 'connection_established'
+    | 'subscriptions_preloaded'
+    | 'connection_with_preload_completed'
+  >,
+  detail: Record<string, unknown>,
+) => {
+  logHomepagePerformanceStage(stage, undefined, detail);
+};
+
+export const logHomepageAccountStage = (
+  stage: Extract<
+    HomepagePerformanceStage,
+    | 'account_bundle_request_started'
+    | 'account_bundle_cache_accepted'
+    | 'account_bundle_accepted'
+    | 'account_bundle_discarded'
+  >,
+  detail: Record<string, unknown>,
+) => {
+  logHomepagePerformanceStage(stage, undefined, detail);
+};
+
+const notifyLifecycleChange = () =>
+  lifecycleListeners.forEach((listener) => listener());
+
+export const subscribeHomepagePerformanceLifecycleChange = (
+  listener: () => void,
+) => {
+  lifecycleListeners.add(listener);
+  return () => {
+    lifecycleListeners.delete(listener);
+  };
+};
+
+export const handleHomepagePerformanceAppStateChange = (
+  nextState: AppStateStatus,
+) => {
+  if (nextState === 'background' || nextState === 'inactive') {
+    backgroundStartedAt ??= performance.now();
+    return;
+  }
+  if (nextState !== 'active' || backgroundStartedAt === null) return;
+
+  const foregroundedAt = performance.now();
+  lifecycle =
+    foregroundedAt - backgroundStartedAt <
+    PERPS_CONSTANTS.ConnectionGracePeriodMs
+      ? 'background_short'
+      : 'background_reconnect';
+  lifecycleStartedAtMonotonicMs = foregroundedAt;
+  backgroundStartedAt = null;
+  queueMicrotask(notifyLifecycleChange);
+};
+
+export const wasHomepagePerpsDiskCacheHydrated = () =>
+  diskCacheTimestampMs !== null;
+
+export const getHomepagePerpsDiskCacheAgeMs = () =>
+  diskCacheTimestampMs === null
+    ? 0
+    : Math.max(0, Date.now() - diskCacheTimestampMs);
+
+export const markHomepagePerpsDiskCacheHydrated = (rawValue: string) => {
+  try {
+    const parsed = JSON.parse(rawValue) as {
+      timestamp?: number;
+      entries?: { timestamp?: number }[];
+    };
+    const timestamps = [
+      parsed.timestamp,
+      ...(parsed.entries?.map((entry) => entry.timestamp) ?? []),
+    ].filter((value): value is number => typeof value === 'number');
+    diskCacheTimestampMs =
+      timestamps.length > 0 ? Math.min(...timestamps) : null;
+  } catch {
+    diskCacheTimestampMs = null;
+  }
+  if (firstDemand && diskCacheTimestampMs !== null) {
+    lifecycle = 'cold_disk_cache';
+    lifecycleStartedAtMonotonicMs = performance.now();
+  }
+  logHomepagePerformanceStage('disk_cache_hydrated', undefined, {
+    cache_age_ms: getHomepagePerpsDiskCacheAgeMs(),
+  });
+};
+
+const setLifecycle = (
+  next: HomepagePerformanceLifecycle,
+  { advancesContext = false }: { advancesContext?: boolean } = {},
+) => {
+  if (lifecycle === next && !advancesContext) return;
+  if (advancesContext) contextGeneration += 1;
+  lifecycle = next;
+  lifecycleStartedAtMonotonicMs = performance.now();
+  notifyLifecycleChange();
+};
+
+export const markHomepagePerpsNavigateReturn = () => {
+  if (
+    lifecycle === 'cold_no_cache' ||
+    lifecycle === 'cold_disk_cache' ||
+    lifecycle === 'warm_foreground' ||
+    lifecycle === 'navigate_return'
+  ) {
+    setLifecycle('navigate_return');
+  }
+};
+
+export const markHomepagePerpsNetworkRecovery = () =>
+  setLifecycle('network_recovery');
+
+export const markHomepagePerpsNetworkSwitch = () =>
+  setLifecycle('perps_network_switch', { advancesContext: true });
+
+export const markHomepagePerpsProviderSwitch = () =>
+  setLifecycle('provider_switch', { advancesContext: true });
+
+export const markHomepagePerpsAccountSwitch = () => {
+  accountGeneration += 1;
+  setLifecycle('account_switch', { advancesContext: true });
+};
+
+export const createHomepagePerpsDelivery = ({
+  stream,
+  source,
+  itemCount,
+  dataAgeMs = 0,
+  originSource,
+}: {
+  stream: HomepagePerpsStream;
+  source: HomepagePerpsDeliverySource;
+  itemCount: number;
+  dataAgeMs?: number;
+  originSource?: HomepagePerpsDeliverySource;
+}): HomepagePerpsDeliveryMetadata => ({
+  deliveryId: uuidv4(),
+  stream,
+  source,
+  ...(originSource && { originSource }),
+  itemCount,
+  receivedAtMonotonicMs: performance.now(),
+  dataAgeMs,
+  lifecycle,
+  accountGeneration,
+  contextGeneration,
+});
+
+export const createHomepagePerpsResidentDelivery = ({
+  stream,
+  itemCount,
+  previousDelivery,
+}: {
+  stream: HomepagePerpsStream;
+  itemCount: number;
+  previousDelivery?: HomepagePerpsDeliveryMetadata;
+}): HomepagePerpsDeliveryMetadata => {
+  const now = performance.now();
+  return {
+    deliveryId: uuidv4(),
+    stream,
+    source: 'resident_state',
+    originSource: previousDelivery?.originSource ?? previousDelivery?.source,
+    itemCount,
+    receivedAtMonotonicMs: previousDelivery?.receivedAtMonotonicMs ?? now,
+    dataAgeMs: previousDelivery
+      ? previousDelivery.dataAgeMs +
+        now -
+        previousDelivery.receivedAtMonotonicMs
+      : 0,
+    lifecycle,
+    accountGeneration: previousDelivery?.accountGeneration ?? accountGeneration,
+    contextGeneration: previousDelivery?.contextGeneration ?? contextGeneration,
+  };
+};
+
+export const createHomepagePerformanceDemand =
+  (): HomepagePerformanceDemand => {
+    const demand: HomepagePerformanceDemand = {
+      demandId: uuidv4(),
+      startedAtMonotonicMs: performance.now(),
+      lifecycleStartedAtMonotonicMs,
+      lifecycle,
+      accountGeneration,
+      contextGeneration,
+      firstVisibleRecorded: false,
+      firstFreshVisibleRecorded: false,
+      recordedFreshPipelineStreams: new Set<HomepagePerpsStream>(),
+      recordedSocketPipelineStreams: new Set<HomepagePerpsStream>(),
+    };
+    firstDemand = false;
+    logHomepagePerformanceStage('surface_demand', undefined, {
+      demand_id: demand.demandId,
+      lifecycle: demand.lifecycle,
+      account_generation: demand.accountGeneration,
+      context_generation: demand.contextGeneration,
+    });
+    return demand;
+  };
+
+export const isHomepagePerpsDeliveryFreshForDemand = (
+  delivery: HomepagePerpsDeliveryMetadata,
+  demand: HomepagePerformanceDemand,
+  isConnectionLive = false,
+) =>
+  (delivery.receivedAtMonotonicMs >= demand.lifecycleStartedAtMonotonicMs ||
+    (demand.lifecycle === 'navigate_return' &&
+      isConnectionLive &&
+      delivery.source === 'resident_state' &&
+      delivery.originSource === 'fresh_socket')) &&
+  delivery.accountGeneration === demand.accountGeneration &&
+  delivery.contextGeneration === demand.contextGeneration &&
+  (delivery.source === 'fresh_socket' ||
+    delivery.source === 'provider_snapshot' ||
+    delivery.source === 'terminal_global_snapshot_v2' ||
+    delivery.source === 'provider' ||
+    ((delivery.source === 'resident_state' ||
+      delivery.source === 'memory_cache') &&
+      (delivery.originSource === 'fresh_socket' ||
+        delivery.originSource === 'provider_snapshot' ||
+        delivery.originSource === 'terminal_global_snapshot_v2' ||
+        delivery.originSource === 'provider')));
+
+const hasRequiredStreams = (
+  deliveries: HomepagePerpsDeliveryMetadata[],
+  contentVariant: HomepagePerpsContentVariant,
+) => {
+  const streams = new Set(deliveries.map(({ stream }) => stream));
+  const hasAccountResolution =
+    streams.has('positions') && streams.has('orders');
+  return contentVariant === 'trending' || contentVariant === 'pills'
+    ? hasAccountResolution && streams.has('markets')
+    : hasAccountResolution;
+};
+
+const getRequiredDeliveries = (
+  deliveries: HomepagePerpsDeliveryMetadata[],
+  contentVariant: HomepagePerpsContentVariant,
+) => {
+  const requiresMarkets =
+    contentVariant === 'trending' || contentVariant === 'pills';
+  return deliveries.filter(
+    ({ stream }) =>
+      stream === 'positions' || stream === 'orders' || requiresMarkets,
+  );
+};
+
+const getVisibleDeliveries = (
+  deliveries: HomepagePerpsDeliveryMetadata[],
+  contentVariant: HomepagePerpsContentVariant,
+) => {
+  if (contentVariant === 'positions') {
+    return deliveries.filter(({ stream }) => stream === 'positions');
+  }
+  if (contentVariant === 'orders') {
+    return deliveries.filter(({ stream }) => stream === 'orders');
+  }
+  return getRequiredDeliveries(deliveries, contentVariant);
+};
+
+const hasVisibleStreams = (
+  deliveries: HomepagePerpsDeliveryMetadata[],
+  contentVariant: HomepagePerpsContentVariant,
+) => {
+  const streams = new Set(deliveries.map(({ stream }) => stream));
+  if (contentVariant === 'positions') return streams.has('positions');
+  if (contentVariant === 'orders') return streams.has('orders');
+  return hasRequiredStreams(deliveries, contentVariant);
+};
+
+const getEffectiveSource = (delivery: HomepagePerpsDeliveryMetadata) =>
+  delivery.source === 'resident_state' || delivery.source === 'memory_cache'
+    ? (delivery.originSource ?? delivery.source)
+    : delivery.source;
+
+export const recordHomepagePerpsVisibleFrame = ({
+  demand,
+  deliveries,
+  contentVariant,
+  isConnectionLive = false,
+  frameCheckpointAtMonotonicMs,
+}: {
+  demand: HomepagePerformanceDemand;
+  deliveries: HomepagePerpsDeliveryMetadata[];
+  contentVariant: HomepagePerpsContentVariant;
+  isConnectionLive?: boolean;
+  reactCommitAtMonotonicMs: number;
+  frameCheckpointAtMonotonicMs: number;
+}) => {
+  const visibleDeliveries = getVisibleDeliveries(deliveries, contentVariant);
+  if (!hasVisibleStreams(visibleDeliveries, contentVariant)) {
+    return;
+  }
+  if (
+    visibleDeliveries.some(
+      (delivery) =>
+        delivery.accountGeneration !== demand.accountGeneration ||
+        delivery.contextGeneration !== demand.contextGeneration,
+    )
+  ) {
+    return;
+  }
+
+  const tagsFor = (tagDeliveries: HomepagePerpsDeliveryMetadata[]) => {
+    const sources = new Set(tagDeliveries.map(({ source }) => source));
+    const deliverySource =
+      sources.size === 1 ? tagDeliveries[0].source : 'mixed';
+    const sourceFor = (stream: HomepagePerpsStream) => {
+      const delivery = tagDeliveries.find(
+        (candidate) => candidate.stream === stream,
+      );
+      return delivery ? getEffectiveSource(delivery) : 'not_required';
+    };
+    return {
+      instrumentation_schema: 'homepage_perps_visible_v4',
+      lifecycle: demand.lifecycle,
+      account_generation: String(demand.accountGeneration),
+      context_generation: String(demand.contextGeneration),
+      content_variant: contentVariant,
+      delivery_source: deliverySource,
+      positions_source: sourceFor('positions'),
+      orders_source: sourceFor('orders'),
+      markets_source: sourceFor('markets'),
+      data_ready_at_demand: tagDeliveries.every(
+        ({ receivedAtMonotonicMs }) =>
+          receivedAtMonotonicMs <= demand.startedAtMonotonicMs,
+      ),
+      frame_boundary: 'next_frame_checkpoint',
+      success: true,
+    };
+  };
+  const visibleTags = tagsFor(visibleDeliveries);
+
+  if (!demand.firstVisibleRecorded) {
+    demand.firstVisibleRecorded = true;
+    logHomepagePerformanceStage('surface_resolved_recorded', undefined, {
+      demand_id: demand.demandId,
+      frame_checkpoint_monotonic_ms: frameCheckpointAtMonotonicMs,
+      duration_ms: Number(
+        (frameCheckpointAtMonotonicMs - demand.startedAtMonotonicMs).toFixed(3),
+      ),
+      ...visibleTags,
+    });
+    if (
+      visibleDeliveries.some(
+        (delivery) =>
+          !isHomepagePerpsDeliveryFreshForDemand(
+            delivery,
+            demand,
+            isConnectionLive,
+          ),
+      )
+    ) {
+      demand.cachedVisibleAtMonotonicMs = frameCheckpointAtMonotonicMs;
+      demand.cachedVisibleSource = visibleTags.delivery_source;
+    }
+  }
+
+  const requiredDeliveries = getRequiredDeliveries(deliveries, contentVariant);
+  const hasCompleteRequiredStreams = hasRequiredStreams(
+    requiredDeliveries,
+    contentVariant,
+  );
+
+  if (
+    !hasCompleteRequiredStreams ||
+    requiredDeliveries.some(
+      (delivery) =>
+        delivery.accountGeneration !== demand.accountGeneration ||
+        delivery.contextGeneration !== demand.contextGeneration,
+    )
+  ) {
+    return;
+  }
+
+  const allFresh = requiredDeliveries.every((delivery) =>
+    isHomepagePerpsDeliveryFreshForDemand(delivery, demand, isConnectionLive),
+  );
+  if (!allFresh || demand.firstFreshVisibleRecorded) return;
+
+  const freshnessSources = new Set(requiredDeliveries.map(getEffectiveSource));
+  const freshnessSource =
+    freshnessSources.size === 1
+      ? (freshnessSources.values().next().value ?? 'mixed')
+      : 'mixed';
+  const freshTags = tagsFor(requiredDeliveries);
+
+  demand.firstFreshVisibleRecorded = true;
+  logHomepagePerformanceStage('surface_live_recorded', undefined, {
+    demand_id: demand.demandId,
+    frame_checkpoint_monotonic_ms: frameCheckpointAtMonotonicMs,
+    duration_ms: Number(
+      (frameCheckpointAtMonotonicMs - demand.startedAtMonotonicMs).toFixed(3),
+    ),
+    ...freshTags,
+    freshness_source: freshnessSource,
+  });
+};
+
+export const recordHomepagePerpsErrorFrame = ({
+  demand,
+  frameCheckpointAtMonotonicMs,
+}: {
+  demand: HomepagePerformanceDemand;
+  frameCheckpointAtMonotonicMs: number;
+}) => {
+  if (demand.firstVisibleRecorded) return;
+  demand.firstVisibleRecorded = true;
+  logHomepagePerformanceStage('surface_resolved_recorded', undefined, {
+    demand_id: demand.demandId,
+    frame_checkpoint_monotonic_ms: frameCheckpointAtMonotonicMs,
+    duration_ms: Number(
+      (frameCheckpointAtMonotonicMs - demand.startedAtMonotonicMs).toFixed(3),
+    ),
+    content_variant: 'error',
+    success: false,
+  });
+};
+
+export const markHomepagePerformanceDemandComplete = () => {
+  lifecycle = 'warm_foreground';
+  lifecycleStartedAtMonotonicMs = performance.now();
+};
+
+export const resetHomepagePerformanceProbeForTests = () => {
+  diskCacheTimestampMs = null;
+  firstDemand = true;
+  accountGeneration = 0;
+  contextGeneration = 0;
+  lifecycle = 'cold_no_cache';
+  lifecycleStartedAtMonotonicMs = performance.now();
+  backgroundStartedAt = null;
+  activeObservationCount = 0;
+  lifecycleListeners.clear();
+};

--- a/app/components/UI/Perps/utils/homepagePerformanceProbe.ts
+++ b/app/components/UI/Perps/utils/homepagePerformanceProbe.ts
@@ -33,6 +33,7 @@ export interface HomepagePerpsDeliveryMetadata {
   lifecycle: HomepagePerformanceLifecycle;
   accountGeneration: number;
   contextGeneration: number;
+  bundleId?: string;
 }
 
 export interface HomepagePerformanceDemand {
@@ -102,7 +103,7 @@ const sanitizeDetail = (detail: Record<string, unknown>) =>
       ([key, value]) =>
         SAFE_DETAIL_KEYS.has(key) &&
         (typeof value === 'string' ||
-          typeof value === 'number' ||
+          (typeof value === 'number' && Number.isFinite(value) && value >= 0) ||
           typeof value === 'boolean'),
     ),
   );
@@ -115,6 +116,13 @@ let lifecycle: HomepagePerformanceLifecycle = 'cold_no_cache';
 let lifecycleStartedAtMonotonicMs = performance.now();
 let backgroundStartedAt: number | null = null;
 let activeObservationCount = 0;
+let pendingAccountBundle:
+  | {
+      key: string;
+      id: string;
+      streams: Set<HomepagePerpsStream>;
+    }
+  | undefined;
 const lifecycleListeners = new Set<() => void>();
 export const isHomepagePerformanceProbeActive = () =>
   activeObservationCount > 0;
@@ -210,6 +218,8 @@ export const handleHomepagePerformanceAppStateChange = (
   if (nextState !== 'active' || backgroundStartedAt === null) return;
 
   const foregroundedAt = performance.now();
+  contextGeneration += 1;
+  pendingAccountBundle = undefined;
   lifecycle =
     foregroundedAt - backgroundStartedAt <
     PERPS_CONSTANTS.ConnectionGracePeriodMs
@@ -255,10 +265,11 @@ export const markHomepagePerpsDiskCacheHydrated = (rawValue: string) => {
 
 const setLifecycle = (
   next: HomepagePerformanceLifecycle,
-  { advancesContext = false }: { advancesContext?: boolean } = {},
+  { advancesContext = true }: { advancesContext?: boolean } = {},
 ) => {
   if (lifecycle === next && !advancesContext) return;
   if (advancesContext) contextGeneration += 1;
+  pendingAccountBundle = undefined;
   lifecycle = next;
   lifecycleStartedAtMonotonicMs = performance.now();
   notifyLifecycleChange();
@@ -286,6 +297,32 @@ export const markHomepagePerpsAccountSwitch = () => {
   setLifecycle('account_switch', { advancesContext: true });
 };
 
+const getAccountBundleId = (
+  stream: HomepagePerpsStream,
+  source: HomepagePerpsDeliverySource,
+): string | undefined => {
+  if (
+    (source !== 'provider_snapshot' && source !== 'memory_cache') ||
+    (stream !== 'positions' && stream !== 'orders' && stream !== 'account')
+  ) {
+    return undefined;
+  }
+  const key = `${accountGeneration}|${contextGeneration}|${source}`;
+  if (
+    !pendingAccountBundle ||
+    pendingAccountBundle.key !== key ||
+    pendingAccountBundle.streams.has(stream)
+  ) {
+    pendingAccountBundle = { key, id: uuidv4(), streams: new Set() };
+  }
+  pendingAccountBundle.streams.add(stream);
+  const bundleId = pendingAccountBundle.id;
+  if (pendingAccountBundle.streams.size === 3) {
+    pendingAccountBundle = undefined;
+  }
+  return bundleId;
+};
+
 export const createHomepagePerpsDelivery = ({
   stream,
   source,
@@ -298,18 +335,22 @@ export const createHomepagePerpsDelivery = ({
   itemCount: number;
   dataAgeMs?: number;
   originSource?: HomepagePerpsDeliverySource;
-}): HomepagePerpsDeliveryMetadata => ({
-  deliveryId: uuidv4(),
-  stream,
-  source,
-  ...(originSource && { originSource }),
-  itemCount,
-  receivedAtMonotonicMs: performance.now(),
-  dataAgeMs,
-  lifecycle,
-  accountGeneration,
-  contextGeneration,
-});
+}): HomepagePerpsDeliveryMetadata => {
+  const bundleId = getAccountBundleId(stream, source);
+  return {
+    deliveryId: uuidv4(),
+    stream,
+    source,
+    ...(originSource && { originSource }),
+    ...(bundleId && { bundleId }),
+    itemCount,
+    receivedAtMonotonicMs: performance.now(),
+    dataAgeMs,
+    lifecycle,
+    accountGeneration,
+    contextGeneration,
+  };
+};
 
 export const createHomepagePerpsResidentDelivery = ({
   stream,
@@ -321,11 +362,14 @@ export const createHomepagePerpsResidentDelivery = ({
   previousDelivery?: HomepagePerpsDeliveryMetadata;
 }): HomepagePerpsDeliveryMetadata => {
   const now = performance.now();
+  const bundleId =
+    previousDelivery?.bundleId ?? getAccountBundleId(stream, 'memory_cache');
   return {
     deliveryId: uuidv4(),
     stream,
     source: 'resident_state',
     originSource: previousDelivery?.originSource ?? previousDelivery?.source,
+    ...(bundleId && { bundleId }),
     itemCount,
     receivedAtMonotonicMs: previousDelivery?.receivedAtMonotonicMs ?? now,
     residentWrappedAtMonotonicMs: now,
@@ -398,9 +442,20 @@ const hasRequiredStreams = (
   const streams = new Set(deliveries.map(({ stream }) => stream));
   const hasAccountResolution =
     streams.has('positions') && streams.has('orders') && streams.has('account');
+  const accountDeliveries = deliveries.filter(
+    ({ stream }) =>
+      stream === 'positions' || stream === 'orders' || stream === 'account',
+  );
+  const bundledDeliveries = accountDeliveries.filter(({ bundleId }) =>
+    Boolean(bundleId),
+  );
+  const hasCoherentBundle =
+    bundledDeliveries.length === 0 ||
+    (bundledDeliveries.length === 3 &&
+      new Set(bundledDeliveries.map(({ bundleId }) => bundleId)).size === 1);
   return contentVariant === 'trending' || contentVariant === 'pills'
-    ? hasAccountResolution && streams.has('markets')
-    : hasAccountResolution;
+    ? hasAccountResolution && hasCoherentBundle && streams.has('markets')
+    : hasAccountResolution && hasCoherentBundle;
 };
 
 const getRequiredDeliveries = (
@@ -449,6 +504,8 @@ export const recordHomepagePerpsVisibleFrame = ({
   frameCheckpointAtMonotonicMs: number;
 }) => {
   if (
+    !__DEV__ ||
+    !isHomepagePerformanceProbeActive() ||
     !isDemandCurrent(demand) ||
     !Number.isFinite(reactCommitAtMonotonicMs) ||
     !Number.isFinite(frameCheckpointAtMonotonicMs) ||
@@ -513,6 +570,10 @@ export const recordHomepagePerpsVisibleFrame = ({
     });
   }
 
+  if (contentVariant === 'trending' || contentVariant === 'pills') {
+    return;
+  }
+
   const requiredDeliveries = getRequiredDeliveries(deliveries, contentVariant);
   const hasCompleteRequiredStreams = hasRequiredStreams(
     requiredDeliveries,
@@ -562,6 +623,8 @@ export const recordHomepagePerpsErrorFrame = ({
   frameCheckpointAtMonotonicMs: number;
 }) => {
   if (
+    !__DEV__ ||
+    !isHomepagePerformanceProbeActive() ||
     !isDemandCurrent(demand) ||
     !Number.isFinite(frameCheckpointAtMonotonicMs) ||
     frameCheckpointAtMonotonicMs < demand.startedAtMonotonicMs
@@ -584,7 +647,7 @@ export const recordHomepagePerpsErrorFrame = ({
 export const markHomepagePerformanceDemandComplete = (
   demand: HomepagePerformanceDemand,
 ) => {
-  if (!__DEV__) return;
+  if (!__DEV__ || !isHomepagePerformanceProbeActive()) return;
   if (!isDemandCurrent(demand)) return;
   setLifecycle('navigate_return');
 };
@@ -598,5 +661,6 @@ export const resetHomepagePerformanceProbeForTests = () => {
   lifecycleStartedAtMonotonicMs = performance.now();
   backgroundStartedAt = null;
   activeObservationCount = 0;
+  pendingAccountBundle = undefined;
   lifecycleListeners.clear();
 };

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSection.test.tsx
@@ -18,12 +18,19 @@ const mockStartPerpsLoadingSession = jest.fn(
   (_options: unknown) => 'session-id-1',
 );
 const mockFinishPerpsLoadingSession = jest.fn((_data: unknown) => undefined);
-const mockGetActivePerpsLoadingSessionContext = jest.fn(() => ({
-  id: 'session-id-1',
-  marketSource: 'provider',
-  accountSource: 'memory_cache',
-  lifecycle: 'cold_no_cache',
-}));
+const mockGetActivePerpsLoadingSessionContext = jest.fn(
+  (): {
+    id: string;
+    marketSource: string;
+    accountSource: string;
+    lifecycle: string;
+  } | null => ({
+    id: 'session-id-1',
+    marketSource: 'provider',
+    accountSource: 'memory_cache',
+    lifecycle: 'cold_no_cache',
+  }),
+);
 
 jest.mock('../../hooks/useSectionPerformance', () => ({
   useSectionPerformance: (config: unknown) => mockUseSectionPerformance(config),

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
@@ -109,13 +109,17 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
       latestDelivery: positionsDelivery,
     } = usePerpsLivePositions({
       throttleMs: HOMEPAGE_THROTTLE_MS,
-      includeDeliveryMetadata: true,
+      includeDeliveryMetadata: __DEV__,
     });
 
-    const { account: perpsAccount, isInitialLoading: perpsAccountLoading } =
-      usePerpsLiveAccount({
-        throttleMs: HOMEPAGE_THROTTLE_MS,
-      });
+    const {
+      account: perpsAccount,
+      isInitialLoading: perpsAccountLoading,
+      latestDelivery: accountDelivery,
+    } = usePerpsLiveAccount({
+      throttleMs: HOMEPAGE_THROTTLE_MS,
+      includeDeliveryMetadata: __DEV__,
+    });
 
     const {
       orders,
@@ -124,7 +128,7 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
     } = usePerpsLiveOrders({
       hideTpSl: true,
       throttleMs: 0,
-      includeDeliveryMetadata: true,
+      includeDeliveryMetadata: __DEV__,
     });
 
     const hookLoading = positionsLoading || ordersLoading;
@@ -181,6 +185,7 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
       data: perpsPillsData,
       isLoading: isPerpsPillsLoading,
       refetch: refetchPerpsPills,
+      latestDelivery: perpsPillsDelivery,
     } = usePerpsFeed({
       variant: 'all',
       withTileExtras: false,
@@ -392,10 +397,16 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
           : 0,
       positionsCount: positions.length,
       ordersCount: orders.length,
-      marketsCount: markets.length,
+      accountResolved: perpsAccount !== null,
+      marketsCount:
+        contentVariant === 'pills'
+          ? perpsPillsData.length
+          : allCarouselMarkets.length,
       positionsDelivery,
       ordersDelivery,
-      marketsDelivery,
+      accountDelivery,
+      marketsDelivery:
+        contentVariant === 'pills' ? perpsPillsDelivery : marketsDelivery,
     });
     const handleSectionLayout = useCallback(() => {
       onLayout();

--- a/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
+++ b/app/components/Views/Homepage/Sections/Perpetuals/PerpsSectionMain.tsx
@@ -64,6 +64,7 @@ import {
   getActivePerpsLoadingSessionContext,
   resolvePerpsMarketSource,
 } from '../../../../UI/Perps/utils/perpsLoadingSession';
+import { useHomepagePerpsVisiblePerformance } from './hooks/useHomepagePerpsVisiblePerformance';
 
 /**
  * PerpsSection — single "Perps" section on the homepage.
@@ -86,25 +87,36 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
     const sectionViewRef = useRef<View>(null);
     const baseTitle = strings('homepage.sections.perps');
     const usesPillsEmptyState = emptyStateContent === 'pills';
-    const { error: connectionError, reconnectWithNewContext } =
-      usePerpsConnection();
+    const {
+      error: connectionError,
+      isConnected,
+      reconnectWithNewContext,
+    } = usePerpsConnection();
     const { track } = usePerpsEventTracking();
     const privacyMode = useSelector(selectPrivacyMode);
 
-    const { positions, isInitialLoading: positionsLoading } =
-      usePerpsLivePositions({
-        throttleMs: HOMEPAGE_THROTTLE_MS,
-      });
+    const {
+      positions,
+      isInitialLoading: positionsLoading,
+      latestDelivery: positionsDelivery,
+    } = usePerpsLivePositions({
+      throttleMs: HOMEPAGE_THROTTLE_MS,
+      includeDeliveryMetadata: true,
+    });
 
     const { account: perpsAccount, isInitialLoading: perpsAccountLoading } =
       usePerpsLiveAccount({
         throttleMs: HOMEPAGE_THROTTLE_MS,
       });
 
-    const { orders, isInitialLoading: ordersLoading } = usePerpsLiveOrders({
+    const {
+      orders,
+      isInitialLoading: ordersLoading,
+      latestDelivery: ordersDelivery,
+    } = usePerpsLiveOrders({
       hideTpSl: true,
-      // Orders are low-frequency user state and should render immediately.
       throttleMs: 0,
+      includeDeliveryMetadata: true,
     });
 
     const hookLoading = positionsLoading || ordersLoading;
@@ -139,10 +151,15 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
       usesPillsEmptyState && !showSkeleton && !hasItems;
     const shouldLoadMarkets = !shouldShowPillsEmptyState;
 
-    const { markets, marketsLoading, allCarouselMarkets, watchlistSymbolSet } =
-      usePerpsTrendingCarouselData({
-        skipInitialFetch: !shouldLoadMarkets,
-      });
+    const {
+      markets,
+      marketsLoading,
+      allCarouselMarkets,
+      watchlistSymbolSet,
+      marketsDelivery,
+    } = usePerpsTrendingCarouselData({
+      skipInitialFetch: !shouldLoadMarkets,
+    });
     const title =
       shouldShowPillsEmptyState && !connectionError
         ? (emptyStateTitleOverride ?? baseTitle)
@@ -325,6 +342,29 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
     const accountSource = sessionContext?.accountSource ?? 'unknown';
     const lifecycleContext = getPerpsLifecycleContext();
 
+    const onPerformanceLayout = useHomepagePerpsVisiblePerformance({
+      sectionRef: sectionViewRef,
+      willRender,
+      hasConnectionError: Boolean(connectionError),
+      isConnectionLive: isConnected,
+      contentVariant,
+      itemCount: hasItems
+        ? displayPositions.length + displayOrders.length
+        : showTrending
+          ? allCarouselMarkets.length
+          : 0,
+      positionsCount: positions.length,
+      ordersCount: orders.length,
+      marketsCount: markets.length,
+      positionsDelivery,
+      ordersDelivery,
+      marketsDelivery,
+    });
+    const handleSectionLayout = useCallback(() => {
+      onLayout();
+      onPerformanceLayout();
+    }, [onLayout, onPerformanceLayout]);
+
     useSectionPerformance({
       sectionId: HomeSectionNames.PERPS,
       contentReady: !isLoadingSection,
@@ -370,7 +410,7 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
 
     if (connectionError) {
       return (
-        <View ref={sectionViewRef} onLayout={onLayout}>
+        <View ref={sectionViewRef} onLayout={handleSectionLayout}>
           <Box paddingBottom={3}>
             <SectionDivider />
             <SectionHeader
@@ -460,7 +500,7 @@ const PerpsSectionMain = forwardRef<SectionRefreshHandle, PerpsSectionProps>(
     );
 
     return (
-      <View ref={sectionViewRef} onLayout={onLayout}>
+      <View ref={sectionViewRef} onLayout={handleSectionLayout}>
         {showsVerticalPositions ? (
           sectionContent
         ) : (

--- a/app/components/Views/Homepage/Sections/Perpetuals/hooks/useHomepagePerpsVisiblePerformance.test.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/hooks/useHomepagePerpsVisiblePerformance.test.ts
@@ -1,0 +1,139 @@
+import React from 'react';
+import { act, renderHook } from '@testing-library/react-native';
+import { useHomepagePerpsVisiblePerformanceDev } from './useHomepagePerpsVisiblePerformance';
+
+const mockRelease = jest.fn();
+const mockRecordVisible = jest.fn();
+const mockRecordError = jest.fn((_input: unknown) => undefined);
+const mockMarkComplete = jest.fn((_demand: unknown) => undefined);
+const mockLifecycleListeners: (() => void)[] = [];
+let mockIsFocused = true;
+
+const demand = {
+  demandId: 'demand-1',
+  startedAtMonotonicMs: 0,
+  lifecycleStartedAtMonotonicMs: 0,
+  lifecycle: 'cold_no_cache' as const,
+  accountGeneration: 0,
+  contextGeneration: 0,
+  firstVisibleRecorded: false,
+  firstFreshVisibleRecorded: false,
+};
+
+jest.mock('@react-navigation/native', () => ({
+  useIsFocused: () => mockIsFocused,
+}));
+
+jest.mock('../../../hooks/useSectionViewportVisible', () => () => ({
+  isVisible: true,
+  onLayout: jest.fn(),
+}));
+
+jest.mock('../../../../../UI/Perps/utils/homepagePerformanceProbe', () => ({
+  activateHomepagePerformanceProbe: () => mockRelease,
+  createHomepagePerformanceDemand: () => ({ ...demand }),
+  createHomepagePerpsResidentDelivery: ({
+    stream,
+    itemCount,
+  }: {
+    stream: string;
+    itemCount: number;
+  }) => ({
+    deliveryId: `resident-${stream}`,
+    stream,
+    source: 'resident_state',
+    itemCount,
+    receivedAtMonotonicMs: 0,
+    dataAgeMs: 0,
+    lifecycle: 'cold_no_cache',
+    accountGeneration: 0,
+    contextGeneration: 0,
+  }),
+  handleHomepagePerformanceAppStateChange: jest.fn(),
+  isHomepagePerpsDeliveryFreshForDemand: () => false,
+  logHomepagePerformanceStage: jest.fn(),
+  markHomepagePerformanceDemandComplete: (input: unknown) =>
+    mockMarkComplete(input),
+  markHomepagePerpsNavigateReturn: jest.fn(),
+  recordHomepagePerpsErrorFrame: (input: unknown) => mockRecordError(input),
+  recordHomepagePerpsVisibleFrame: (input: unknown) => mockRecordVisible(input),
+  subscribeHomepagePerformanceLifecycleChange: (listener: () => void) => {
+    mockLifecycleListeners.push(listener);
+    return jest.fn();
+  },
+}));
+
+jest.mock('react-native-performance', () => ({
+  __esModule: true,
+  default: { now: jest.fn(() => 100) },
+}));
+
+describe('useHomepagePerpsVisiblePerformance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLifecycleListeners.length = 0;
+    mockIsFocused = true;
+    global.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    };
+  });
+
+  it('requires account metadata in the visible delivery bundle', () => {
+    renderHook(() =>
+      useHomepagePerpsVisiblePerformanceDev({
+        sectionRef: { current: null },
+        willRender: true,
+        hasConnectionError: false,
+        contentVariant: 'trending',
+        itemCount: 1,
+        positionsCount: 0,
+        ordersCount: 0,
+        accountResolved: true,
+        marketsCount: 1,
+        marketsDelivery: {
+          deliveryId: 'markets-1',
+          stream: 'markets',
+          source: 'provider',
+          itemCount: 1,
+          receivedAtMonotonicMs: 1,
+          dataAgeMs: 0,
+          lifecycle: 'cold_no_cache',
+          accountGeneration: 0,
+          contextGeneration: 0,
+        },
+      }),
+    );
+
+    expect(mockRecordVisible).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deliveries: expect.arrayContaining([
+          expect.objectContaining({ stream: 'positions' }),
+          expect.objectContaining({ stream: 'orders' }),
+          expect.objectContaining({ stream: 'account' }),
+          expect.objectContaining({ stream: 'markets' }),
+        ]),
+      }),
+    );
+  });
+
+  it('releases observation when Homepage loses focus', () => {
+    const { rerender } = renderHook(() =>
+      useHomepagePerpsVisiblePerformanceDev({
+        sectionRef: { current: null },
+        willRender: true,
+        hasConnectionError: false,
+        contentVariant: 'trending',
+        itemCount: 0,
+        positionsCount: 0,
+        ordersCount: 0,
+        accountResolved: false,
+      }),
+    );
+
+    mockIsFocused = false;
+    act(() => rerender(undefined));
+
+    expect(mockRelease).toHaveBeenCalled();
+  });
+});

--- a/app/components/Views/Homepage/Sections/Perpetuals/hooks/useHomepagePerpsVisiblePerformance.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/hooks/useHomepagePerpsVisiblePerformance.ts
@@ -35,13 +35,15 @@ interface UseHomepagePerpsVisiblePerformanceOptions {
   itemCount: number;
   positionsCount: number;
   ordersCount: number;
+  accountResolved: boolean;
   marketsCount?: number;
   positionsDelivery?: HomepagePerpsDeliveryMetadata;
   ordersDelivery?: HomepagePerpsDeliveryMetadata;
+  accountDelivery?: HomepagePerpsDeliveryMetadata;
   marketsDelivery?: HomepagePerpsDeliveryMetadata;
 }
 
-const useHomepagePerpsVisiblePerformanceDev = ({
+export const useHomepagePerpsVisiblePerformanceDev = ({
   sectionRef,
   willRender,
   hasConnectionError,
@@ -50,9 +52,11 @@ const useHomepagePerpsVisiblePerformanceDev = ({
   itemCount,
   positionsCount,
   ordersCount,
+  accountResolved,
   marketsCount = 0,
   positionsDelivery,
   ordersDelivery,
+  accountDelivery,
   marketsDelivery,
 }: UseHomepagePerpsVisiblePerformanceOptions) => {
   const isHomeFocused = useIsFocused();
@@ -64,27 +68,36 @@ const useHomepagePerpsVisiblePerformanceDev = ({
   );
   const releaseObservationRef = useRef<(() => void) | undefined>(undefined);
   const loggedDeliveryIdsRef = useRef(new Set<string>());
+  const residentDeliveriesRef = useRef(
+    new Map<string, HomepagePerpsDeliveryMetadata>(),
+  );
   const valuesRef = useRef({
     willRender,
+    hasConnectionError,
     contentVariant,
     itemCount,
     positionsCount,
     ordersCount,
+    accountResolved,
     marketsCount,
     positionsDelivery,
     ordersDelivery,
+    accountDelivery,
     marketsDelivery,
     isConnectionLive,
   });
   valuesRef.current = {
     willRender,
+    hasConnectionError,
     contentVariant,
     itemCount,
     positionsCount,
     ordersCount,
+    accountResolved,
     marketsCount,
     positionsDelivery,
     ordersDelivery,
+    accountDelivery,
     marketsDelivery,
     isConnectionLive,
   };
@@ -112,6 +125,7 @@ const useHomepagePerpsVisiblePerformanceDev = ({
     releaseObservation();
     releaseObservationRef.current = activateHomepagePerformanceProbe();
     loggedDeliveryIdsRef.current.clear();
+    residentDeliveriesRef.current.clear();
     currentDemandRef.current = createHomepagePerformanceDemand();
   }, [releaseObservation]);
 
@@ -123,34 +137,36 @@ const useHomepagePerpsVisiblePerformanceDev = ({
       const values = valuesRef.current;
       if ((!isVisible && !forceVisible) || !values.willRender) return;
 
-      const renderDeliveries = deliveries.filter(
+      const incomingDeliveries = deliveries.filter(
         (delivery): delivery is HomepagePerpsDeliveryMetadata =>
           delivery !== undefined,
       );
-      if (
-        values.contentVariant === 'trending' ||
-        values.contentVariant === 'pills'
-      ) {
-        const streams = new Set(
-          renderDeliveries.map((delivery) => delivery.stream),
-        );
-        if (!streams.has('positions')) {
-          renderDeliveries.push(
+      incomingDeliveries.forEach((delivery) =>
+        residentDeliveriesRef.current.set(delivery.stream, delivery),
+      );
+      const ensureResident = (
+        stream: 'positions' | 'orders' | 'account',
+        residentItemCount: number,
+      ) => {
+        if (
+          values.accountResolved &&
+          !residentDeliveriesRef.current.has(stream)
+        ) {
+          residentDeliveriesRef.current.set(
+            stream,
             createHomepagePerpsResidentDelivery({
-              stream: 'positions',
-              itemCount: values.positionsCount,
+              stream,
+              itemCount: residentItemCount,
             }),
           );
         }
-        if (!streams.has('orders')) {
-          renderDeliveries.push(
-            createHomepagePerpsResidentDelivery({
-              stream: 'orders',
-              itemCount: values.ordersCount,
-            }),
-          );
-        }
-      }
+      };
+      ensureResident('positions', values.positionsCount);
+      ensureResident('orders', values.ordersCount);
+      ensureResident('account', 1);
+      const renderDeliveries = Array.from(
+        residentDeliveriesRef.current.values(),
+      );
       const newDeliveries = renderDeliveries.filter(
         ({ deliveryId }) => !loggedDeliveryIdsRef.current.has(deliveryId),
       );
@@ -177,25 +193,22 @@ const useHomepagePerpsVisiblePerformanceDev = ({
           fresh_for_lifecycle: isHomepagePerpsDeliveryFreshForDemand(
             delivery,
             demand,
+            values.isConnectionLive,
           ),
         });
-        logHomepagePerformanceStage('values_visible', delivery, {
+        logHomepagePerformanceStage('surface_initial_ui_recorded', delivery, {
           ...detail,
           data_ready_at_demand:
             delivery.receivedAtMonotonicMs <= demand.startedAtMonotonicMs,
           fresh_for_lifecycle: isHomepagePerpsDeliveryFreshForDemand(
             delivery,
             demand,
+            values.isConnectionLive,
           ),
         });
       });
 
       requestAnimationFrame(() => {
-        logHomepagePerformanceStage(
-          'first_frame_checkpoint',
-          undefined,
-          detail,
-        );
         requestAnimationFrame(() => {
           if (currentDemandRef.current?.demandId !== demand.demandId) return;
 
@@ -206,6 +219,7 @@ const useHomepagePerpsVisiblePerformanceDev = ({
               fresh_for_lifecycle: isHomepagePerpsDeliveryFreshForDemand(
                 delivery,
                 demand,
+                values.isConnectionLive,
               ),
               frame_checkpoint_monotonic_ms: Number(
                 frameCheckpointAtMonotonicMs.toFixed(3),
@@ -221,7 +235,7 @@ const useHomepagePerpsVisiblePerformanceDev = ({
             frameCheckpointAtMonotonicMs,
           });
           if (demand.firstFreshVisibleRecorded) {
-            markHomepagePerformanceDemandComplete();
+            markHomepagePerformanceDemandComplete(demand);
             releaseObservation(demand.demandId);
           }
         });
@@ -233,71 +247,43 @@ const useHomepagePerpsVisiblePerformanceDev = ({
   const startDemandWithResidentState = useCallback(() => {
     startDemand();
     const values = valuesRef.current;
-    const requiresResolvedEmptyAccount =
-      values.contentVariant === 'trending' || values.contentVariant === 'pills';
     [
       values.positionsDelivery,
       values.ordersDelivery,
+      values.accountDelivery,
       values.marketsDelivery,
     ].forEach((delivery) => {
       if (delivery) loggedDeliveryIdsRef.current.add(delivery.deliveryId);
     });
     observeVisibleDeliveries(
       [
-        values.positionsDelivery
-          ? createHomepagePerpsResidentDelivery({
-              stream: 'positions',
-              itemCount: values.positionsCount,
-              previousDelivery: values.positionsDelivery,
-            })
-          : values.positionsCount > 0 || requiresResolvedEmptyAccount
-            ? createHomepagePerpsResidentDelivery({
-                stream: 'positions',
-                itemCount: values.positionsCount,
-              })
-            : undefined,
-        values.ordersDelivery
-          ? createHomepagePerpsResidentDelivery({
-              stream: 'orders',
-              itemCount: values.ordersCount,
-              previousDelivery: values.ordersDelivery,
-            })
-          : values.ordersCount > 0 || requiresResolvedEmptyAccount
-            ? createHomepagePerpsResidentDelivery({
-                stream: 'orders',
-                itemCount: values.ordersCount,
-              })
-            : undefined,
-        values.marketsDelivery
-          ? createHomepagePerpsResidentDelivery({
-              stream: 'markets',
-              itemCount: values.marketsCount,
-              previousDelivery: values.marketsDelivery,
-            })
-          : values.marketsCount > 0
-            ? createHomepagePerpsResidentDelivery({
-                stream: 'markets',
-                itemCount: values.marketsCount,
-              })
-            : undefined,
+        values.positionsDelivery,
+        values.ordersDelivery,
+        values.accountDelivery,
+        values.marketsDelivery,
       ],
       true,
     );
   }, [observeVisibleDeliveries, startDemand]);
 
   const lostHomeFocusRef = useRef(false);
+  const wasVisibleRef = useRef(false);
   useLayoutEffect(() => {
     if (!isHomeFocused) {
       lostHomeFocusRef.current = true;
+      releaseObservation();
+      currentDemandRef.current = undefined;
+      loggedDeliveryIdsRef.current.clear();
+      residentDeliveriesRef.current.clear();
+      wasVisibleRef.current = false;
     } else if (lostHomeFocusRef.current) {
       lostHomeFocusRef.current = false;
       markHomepagePerpsNavigateReturn();
     }
-  }, [isHomeFocused]);
+  }, [isHomeFocused, releaseObservation]);
 
-  const wasVisibleRef = useRef(false);
   useLayoutEffect(() => {
-    if (isVisible && !wasVisibleRef.current) {
+    if (isHomeFocused && isVisible && !wasVisibleRef.current) {
       startDemandWithResidentState();
     } else if (!isVisible && wasVisibleRef.current) {
       releaseObservation();
@@ -305,55 +291,85 @@ const useHomepagePerpsVisiblePerformanceDev = ({
       loggedDeliveryIdsRef.current.clear();
     }
     wasVisibleRef.current = isVisible;
-  }, [isVisible, releaseObservation, startDemandWithResidentState]);
+  }, [
+    isHomeFocused,
+    isVisible,
+    releaseObservation,
+    startDemandWithResidentState,
+  ]);
+
+  const scheduleErrorFrame = useCallback(
+    (demand: HomepagePerformanceDemand) => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (
+            currentDemandRef.current?.demandId !== demand.demandId ||
+            !isHomeFocused ||
+            !isVisible
+          ) {
+            return;
+          }
+          recordHomepagePerpsErrorFrame({
+            demand,
+            frameCheckpointAtMonotonicMs: performance.now(),
+          });
+          markHomepagePerformanceDemandComplete(demand);
+          releaseObservation(demand.demandId);
+        });
+      });
+    },
+    [isHomeFocused, isVisible, releaseObservation],
+  );
 
   useEffect(
     () =>
       subscribeHomepagePerformanceLifecycleChange(() => {
-        if (isVisible && currentDemandRef.current) {
+        if (isHomeFocused && isVisible && currentDemandRef.current) {
           startDemandWithResidentState();
+          const demand = currentDemandRef.current;
+          if (valuesRef.current.hasConnectionError && demand) {
+            scheduleErrorFrame(demand);
+          }
         }
       }),
-    [isVisible, startDemandWithResidentState],
+    [
+      isHomeFocused,
+      isVisible,
+      scheduleErrorFrame,
+      startDemandWithResidentState,
+    ],
   );
 
   useLayoutEffect(() => {
     observeVisibleDeliveries([
       positionsDelivery,
       ordersDelivery,
+      accountDelivery,
       marketsDelivery,
     ]);
   }, [
     marketsDelivery,
     observeVisibleDeliveries,
     ordersDelivery,
+    accountDelivery,
     positionsDelivery,
   ]);
 
   useLayoutEffect(() => {
     const demand = currentDemandRef.current;
     if (!isVisible || !hasConnectionError || !demand) return;
-
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        recordHomepagePerpsErrorFrame({
-          demand,
-          frameCheckpointAtMonotonicMs: performance.now(),
-        });
-        markHomepagePerformanceDemandComplete();
-        releaseObservation(demand.demandId);
-      });
-    });
-  }, [hasConnectionError, isVisible, releaseObservation]);
+    scheduleErrorFrame(demand);
+  }, [hasConnectionError, isVisible, scheduleErrorFrame]);
 
   useEffect(() => () => releaseObservation(), [releaseObservation]);
 
   return onLayout;
 };
 
-const useHomepagePerpsVisiblePerformanceDisabled =
-  (_options: UseHomepagePerpsVisiblePerformanceOptions) => () =>
-    undefined;
+const NOOP_LAYOUT = () => undefined;
+const useHomepagePerpsVisiblePerformanceDisabled = (
+  _options: UseHomepagePerpsVisiblePerformanceOptions,
+) => NOOP_LAYOUT;
 
 export const useHomepagePerpsVisiblePerformance = __DEV__
   ? useHomepagePerpsVisiblePerformanceDev

--- a/app/components/Views/Homepage/Sections/Perpetuals/hooks/useHomepagePerpsVisiblePerformance.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/hooks/useHomepagePerpsVisiblePerformance.ts
@@ -1,0 +1,360 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  type RefObject,
+} from 'react';
+import { AppState, type View } from 'react-native';
+import { useIsFocused } from '@react-navigation/native';
+import performance from 'react-native-performance';
+import useSectionViewportVisible from '../../../hooks/useSectionViewportVisible';
+import {
+  activateHomepagePerformanceProbe,
+  createHomepagePerformanceDemand,
+  createHomepagePerpsResidentDelivery,
+  handleHomepagePerformanceAppStateChange,
+  isHomepagePerpsDeliveryFreshForDemand,
+  logHomepagePerformanceStage,
+  markHomepagePerformanceDemandComplete,
+  markHomepagePerpsNavigateReturn,
+  recordHomepagePerpsErrorFrame,
+  recordHomepagePerpsVisibleFrame,
+  subscribeHomepagePerformanceLifecycleChange,
+  type HomepagePerpsContentVariant,
+  type HomepagePerformanceDemand,
+  type HomepagePerpsDeliveryMetadata,
+} from '../../../../../UI/Perps/utils/homepagePerformanceProbe';
+
+interface UseHomepagePerpsVisiblePerformanceOptions {
+  sectionRef: RefObject<View | null>;
+  willRender: boolean;
+  hasConnectionError: boolean;
+  isConnectionLive?: boolean;
+  contentVariant: HomepagePerpsContentVariant;
+  itemCount: number;
+  positionsCount: number;
+  ordersCount: number;
+  marketsCount?: number;
+  positionsDelivery?: HomepagePerpsDeliveryMetadata;
+  ordersDelivery?: HomepagePerpsDeliveryMetadata;
+  marketsDelivery?: HomepagePerpsDeliveryMetadata;
+}
+
+const useHomepagePerpsVisiblePerformanceDev = ({
+  sectionRef,
+  willRender,
+  hasConnectionError,
+  isConnectionLive = false,
+  contentVariant,
+  itemCount,
+  positionsCount,
+  ordersCount,
+  marketsCount = 0,
+  positionsDelivery,
+  ordersDelivery,
+  marketsDelivery,
+}: UseHomepagePerpsVisiblePerformanceOptions) => {
+  const isHomeFocused = useIsFocused();
+  const { isVisible, onLayout } = useSectionViewportVisible(sectionRef, {
+    isLoading: false,
+  });
+  const currentDemandRef = useRef<HomepagePerformanceDemand | undefined>(
+    undefined,
+  );
+  const releaseObservationRef = useRef<(() => void) | undefined>(undefined);
+  const loggedDeliveryIdsRef = useRef(new Set<string>());
+  const valuesRef = useRef({
+    willRender,
+    contentVariant,
+    itemCount,
+    positionsCount,
+    ordersCount,
+    marketsCount,
+    positionsDelivery,
+    ordersDelivery,
+    marketsDelivery,
+    isConnectionLive,
+  });
+  valuesRef.current = {
+    willRender,
+    contentVariant,
+    itemCount,
+    positionsCount,
+    ordersCount,
+    marketsCount,
+    positionsDelivery,
+    ordersDelivery,
+    marketsDelivery,
+    isConnectionLive,
+  };
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener(
+      'change',
+      handleHomepagePerformanceAppStateChange,
+    );
+    return () => subscription.remove();
+  }, []);
+
+  const releaseObservation = useCallback((demandId?: string) => {
+    if (
+      demandId !== undefined &&
+      currentDemandRef.current?.demandId !== demandId
+    ) {
+      return;
+    }
+    releaseObservationRef.current?.();
+    releaseObservationRef.current = undefined;
+  }, []);
+
+  const startDemand = useCallback(() => {
+    releaseObservation();
+    releaseObservationRef.current = activateHomepagePerformanceProbe();
+    loggedDeliveryIdsRef.current.clear();
+    currentDemandRef.current = createHomepagePerformanceDemand();
+  }, [releaseObservation]);
+
+  const observeVisibleDeliveries = useCallback(
+    (
+      deliveries: (HomepagePerpsDeliveryMetadata | undefined)[],
+      forceVisible = false,
+    ) => {
+      const values = valuesRef.current;
+      if ((!isVisible && !forceVisible) || !values.willRender) return;
+
+      const renderDeliveries = deliveries.filter(
+        (delivery): delivery is HomepagePerpsDeliveryMetadata =>
+          delivery !== undefined,
+      );
+      if (
+        values.contentVariant === 'trending' ||
+        values.contentVariant === 'pills'
+      ) {
+        const streams = new Set(
+          renderDeliveries.map((delivery) => delivery.stream),
+        );
+        if (!streams.has('positions')) {
+          renderDeliveries.push(
+            createHomepagePerpsResidentDelivery({
+              stream: 'positions',
+              itemCount: values.positionsCount,
+            }),
+          );
+        }
+        if (!streams.has('orders')) {
+          renderDeliveries.push(
+            createHomepagePerpsResidentDelivery({
+              stream: 'orders',
+              itemCount: values.ordersCount,
+            }),
+          );
+        }
+      }
+      const newDeliveries = renderDeliveries.filter(
+        ({ deliveryId }) => !loggedDeliveryIdsRef.current.has(deliveryId),
+      );
+      const demand = currentDemandRef.current;
+      if (!demand || newDeliveries.length === 0) return;
+
+      newDeliveries.forEach(({ deliveryId }) =>
+        loggedDeliveryIdsRef.current.add(deliveryId),
+      );
+      const reactCommitAtMonotonicMs = performance.now();
+      const detail = {
+        demand_id: demand.demandId,
+        content_variant: values.contentVariant,
+        visible_item_count: values.itemCount,
+        elapsed_ms: Number(
+          (reactCommitAtMonotonicMs - demand.startedAtMonotonicMs).toFixed(3),
+        ),
+      };
+      newDeliveries.forEach((delivery) => {
+        logHomepagePerformanceStage('react_commit', delivery, {
+          ...detail,
+          data_ready_at_demand:
+            delivery.receivedAtMonotonicMs <= demand.startedAtMonotonicMs,
+          fresh_for_lifecycle: isHomepagePerpsDeliveryFreshForDemand(
+            delivery,
+            demand,
+          ),
+        });
+        logHomepagePerformanceStage('values_visible', delivery, {
+          ...detail,
+          data_ready_at_demand:
+            delivery.receivedAtMonotonicMs <= demand.startedAtMonotonicMs,
+          fresh_for_lifecycle: isHomepagePerpsDeliveryFreshForDemand(
+            delivery,
+            demand,
+          ),
+        });
+      });
+
+      requestAnimationFrame(() => {
+        logHomepagePerformanceStage(
+          'first_frame_checkpoint',
+          undefined,
+          detail,
+        );
+        requestAnimationFrame(() => {
+          if (currentDemandRef.current?.demandId !== demand.demandId) return;
+
+          const frameCheckpointAtMonotonicMs = performance.now();
+          newDeliveries.forEach((delivery) =>
+            logHomepagePerformanceStage('next_frame_checkpoint', delivery, {
+              ...detail,
+              fresh_for_lifecycle: isHomepagePerpsDeliveryFreshForDemand(
+                delivery,
+                demand,
+              ),
+              frame_checkpoint_monotonic_ms: Number(
+                frameCheckpointAtMonotonicMs.toFixed(3),
+              ),
+            }),
+          );
+          recordHomepagePerpsVisibleFrame({
+            demand,
+            deliveries: renderDeliveries,
+            contentVariant: values.contentVariant,
+            isConnectionLive: values.isConnectionLive,
+            reactCommitAtMonotonicMs,
+            frameCheckpointAtMonotonicMs,
+          });
+          if (demand.firstFreshVisibleRecorded) {
+            markHomepagePerformanceDemandComplete();
+            releaseObservation(demand.demandId);
+          }
+        });
+      });
+    },
+    [isVisible, releaseObservation],
+  );
+
+  const startDemandWithResidentState = useCallback(() => {
+    startDemand();
+    const values = valuesRef.current;
+    const requiresResolvedEmptyAccount =
+      values.contentVariant === 'trending' || values.contentVariant === 'pills';
+    [
+      values.positionsDelivery,
+      values.ordersDelivery,
+      values.marketsDelivery,
+    ].forEach((delivery) => {
+      if (delivery) loggedDeliveryIdsRef.current.add(delivery.deliveryId);
+    });
+    observeVisibleDeliveries(
+      [
+        values.positionsDelivery
+          ? createHomepagePerpsResidentDelivery({
+              stream: 'positions',
+              itemCount: values.positionsCount,
+              previousDelivery: values.positionsDelivery,
+            })
+          : values.positionsCount > 0 || requiresResolvedEmptyAccount
+            ? createHomepagePerpsResidentDelivery({
+                stream: 'positions',
+                itemCount: values.positionsCount,
+              })
+            : undefined,
+        values.ordersDelivery
+          ? createHomepagePerpsResidentDelivery({
+              stream: 'orders',
+              itemCount: values.ordersCount,
+              previousDelivery: values.ordersDelivery,
+            })
+          : values.ordersCount > 0 || requiresResolvedEmptyAccount
+            ? createHomepagePerpsResidentDelivery({
+                stream: 'orders',
+                itemCount: values.ordersCount,
+              })
+            : undefined,
+        values.marketsDelivery
+          ? createHomepagePerpsResidentDelivery({
+              stream: 'markets',
+              itemCount: values.marketsCount,
+              previousDelivery: values.marketsDelivery,
+            })
+          : values.marketsCount > 0
+            ? createHomepagePerpsResidentDelivery({
+                stream: 'markets',
+                itemCount: values.marketsCount,
+              })
+            : undefined,
+      ],
+      true,
+    );
+  }, [observeVisibleDeliveries, startDemand]);
+
+  const lostHomeFocusRef = useRef(false);
+  useLayoutEffect(() => {
+    if (!isHomeFocused) {
+      lostHomeFocusRef.current = true;
+    } else if (lostHomeFocusRef.current) {
+      lostHomeFocusRef.current = false;
+      markHomepagePerpsNavigateReturn();
+    }
+  }, [isHomeFocused]);
+
+  const wasVisibleRef = useRef(false);
+  useLayoutEffect(() => {
+    if (isVisible && !wasVisibleRef.current) {
+      startDemandWithResidentState();
+    } else if (!isVisible && wasVisibleRef.current) {
+      releaseObservation();
+      currentDemandRef.current = undefined;
+      loggedDeliveryIdsRef.current.clear();
+    }
+    wasVisibleRef.current = isVisible;
+  }, [isVisible, releaseObservation, startDemandWithResidentState]);
+
+  useEffect(
+    () =>
+      subscribeHomepagePerformanceLifecycleChange(() => {
+        if (isVisible && currentDemandRef.current) {
+          startDemandWithResidentState();
+        }
+      }),
+    [isVisible, startDemandWithResidentState],
+  );
+
+  useLayoutEffect(() => {
+    observeVisibleDeliveries([
+      positionsDelivery,
+      ordersDelivery,
+      marketsDelivery,
+    ]);
+  }, [
+    marketsDelivery,
+    observeVisibleDeliveries,
+    ordersDelivery,
+    positionsDelivery,
+  ]);
+
+  useLayoutEffect(() => {
+    const demand = currentDemandRef.current;
+    if (!isVisible || !hasConnectionError || !demand) return;
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        recordHomepagePerpsErrorFrame({
+          demand,
+          frameCheckpointAtMonotonicMs: performance.now(),
+        });
+        markHomepagePerformanceDemandComplete();
+        releaseObservation(demand.demandId);
+      });
+    });
+  }, [hasConnectionError, isVisible, releaseObservation]);
+
+  useEffect(() => () => releaseObservation(), [releaseObservation]);
+
+  return onLayout;
+};
+
+const useHomepagePerpsVisiblePerformanceDisabled =
+  (_options: UseHomepagePerpsVisiblePerformanceOptions) => () =>
+    undefined;
+
+export const useHomepagePerpsVisiblePerformance = __DEV__
+  ? useHomepagePerpsVisiblePerformanceDev
+  : useHomepagePerpsVisiblePerformanceDisabled;

--- a/app/components/Views/Homepage/Sections/Perpetuals/hooks/usePerpsTrendingCarouselData.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/hooks/usePerpsTrendingCarouselData.ts
@@ -13,9 +13,11 @@ export interface UsePerpsTrendingCarouselDataArgs {
 export function usePerpsTrendingCarouselData({
   skipInitialFetch = false,
 }: UsePerpsTrendingCarouselDataArgs = {}) {
-  const { markets, isLoading: marketsLoading } = usePerpsMarkets({
-    skipInitialFetch,
-  });
+  const {
+    markets,
+    isLoading: marketsLoading,
+    latestDelivery: marketsDelivery,
+  } = usePerpsMarkets({ skipInitialFetch });
   const watchlistSymbols = useSelector(selectPerpsWatchlistMarkets);
 
   const safeWatchlistSymbols = useMemo(
@@ -62,7 +64,14 @@ export function usePerpsTrendingCarouselData({
       marketsLoading,
       allCarouselMarkets,
       watchlistSymbolSet,
+      marketsDelivery,
     }),
-    [markets, marketsLoading, allCarouselMarkets, watchlistSymbolSet],
+    [
+      markets,
+      marketsLoading,
+      allCarouselMarkets,
+      watchlistSymbolSet,
+      marketsDelivery,
+    ],
   );
 }

--- a/app/components/Views/TrendingView/feeds/perps/usePerpsFeed.ts
+++ b/app/components/Views/TrendingView/feeds/perps/usePerpsFeed.ts
@@ -10,6 +10,7 @@ import {
 import { isEquityAsset } from '../../../../UI/Perps/utils/marketHours';
 import { usePerpsMarkets } from '../../../../UI/Perps/hooks';
 import type { PerpsMarketDataWithVolumeNumber } from '../../../../UI/Perps/hooks/usePerpsMarkets';
+import type { HomepagePerpsDeliveryMetadata } from '../../../../UI/Perps/utils/homepagePerformanceProbe';
 import { PerpsConnectionContext } from '../../../../UI/Perps/providers/PerpsConnectionProvider';
 import { selectPerpsWatchlistMarkets } from '../../../../UI/Perps/selectors/perpsController';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
@@ -47,6 +48,7 @@ export interface UsePerpsFeedResult {
   refetch: () => Promise<void>;
   /** The sort option ID that matches this feed's sort order — pass to `navigateToPerpsMarketList` so the market list opens consistently sorted. */
   defaultSortOptionId: SortOptionId;
+  latestDelivery?: HomepagePerpsDeliveryMetadata;
 }
 
 /**
@@ -154,6 +156,7 @@ export const usePerpsFeed = ({
     isLoading,
     refresh: refetch,
     isRefreshing,
+    latestDelivery,
   } = usePerpsMarkets({ skipInitialFetch });
 
   useFeedRefresh(refresh, refetch);
@@ -203,5 +206,6 @@ export const usePerpsFeed = ({
     isLoading: connectionContext?.error ? false : isLoading || isRefreshing,
     refetch,
     defaultSortOptionId: PERPS_VARIANT_SORT_OPTION[variant],
+    ...(latestDelivery ? { latestDelivery } : {}),
   };
 };


### PR DESCRIPTION
## Description

Adds one reusable, development-only, platform-neutral visible-pipeline probe on top of #34948. The same `perps.performance` recipe runs on Android or iOS; `--device` selects the platform.

The probe records canonical demand, cache/provider/socket delivery, subscriber, React commit, next-frame, resolved, live, and error boundaries while preserving account/context generations. It requires coherent account + positions + orders, uses the pills feed’s own market delivery, never claims trending live-price readiness, and rejects stale demands or mixed atomic bundles.

Production call sites are compile-time gated with `__DEV__`; semantic delivery metadata is requested only for dev validation. No AgenticBridge performance API, wallet address, order/position ID, platform-specific recipe branch, or raw cache payload is added.

## Dependency chain

- Product behavior: #34934
- Production instrumentation: #34948
- This PR: complete dev-only probe state machine + UI wiring

## Validation

- Probe state machine: 12/12 PASS.
- Visible-pipeline hook: 2/2 PASS.
- Account, orders, positions, markets, StreamManager, PerpsSection, and Perps feed focused suites: PASS.
- Targeted ESLint: 0 errors; Prettier and diff-check: PASS.
- Full typecheck reports only current-base Lighter and generated Terms errors outside this PR.
- Independent Claude and Codex consolidated review runs against the final SHA.

## Recipe

`perps.performance` remains the single recipe. Lifecycle, source strategy, account, provider, network, and content variant are parameters; platform is not.

Jira: https://consensyssoftware.atlassian.net/browse/TAT-3662
