### PR TITLE
feat: recurring schedule input and interval bottom sheet

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
@@ -61,9 +61,8 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
         .props.accessibilityState?.invalid,
     ).toBe(false);
     expect(
-      renderResult.getByTestId(
-        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
-      ).props.accessibilityState?.invalid,
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT)
+        .props.accessibilityState?.invalid,
     ).toBe(false);
   });
 
@@ -207,9 +206,8 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
       ),
     ).toHaveDisplayValue('0');
     expect(
-      renderResult.getByTestId(
-        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
-      ).props.accessibilityState?.invalid,
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT)
+        .props.accessibilityState?.invalid,
     ).toBe(true);
   });
 
@@ -229,7 +227,9 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
       ).toHaveDisplayValue('0');
     });
 
-    fireEvent.press(renderResult.getByTestId(BridgeViewSelectorsIDs.MARKET_TAB));
+    fireEvent.press(
+      renderResult.getByTestId(BridgeViewSelectorsIDs.MARKET_TAB),
+    );
     await waitFor(() => {
       expect(
         renderResult.queryByTestId(
@@ -402,9 +402,8 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
         .props.accessibilityState?.invalid,
     ).toBe(true);
     expect(
-      renderResult.getByTestId(
-        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
-      ).props.accessibilityState?.invalid,
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT)
+        .props.accessibilityState?.invalid,
     ).toBe(false);
   });
 
@@ -438,9 +437,8 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
     });
 
     expect(
-      renderResult.getByTestId(
-        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
-      ).props.accessibilityState?.invalid,
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT)
+        .props.accessibilityState?.invalid,
     ).toBe(true);
     expect(
       renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT)

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
@@ -120,6 +120,77 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
     });
   });
 
+  it('snaps every back to 1 when the keypad is closed on 0', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+    await openEveryKeypad(renderResult);
+    fireEvent.press(
+      renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+    );
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(
+          RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT,
+        ),
+      ).toHaveDisplayValue('0');
+    });
+    fireEvent(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.CONTAINER),
+      'responderRelease',
+    );
+
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(
+          RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT,
+        ),
+      ).toHaveDisplayValue('1');
+    });
+  });
+
+  it('snaps repeat back to 1 when the keypad is closed on 0', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+    fireEvent(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+      ),
+      'pressIn',
+    );
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+      ).toBeOnTheScreen();
+    });
+    fireEvent.press(
+      renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+    );
+    fireEvent.press(
+      renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+    );
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(
+          RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+        ),
+      ).toHaveDisplayValue('0');
+    });
+    fireEvent(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.CONTAINER),
+      'responderRelease',
+    );
+
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(
+          RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+        ),
+      ).toHaveDisplayValue('1');
+    });
+  });
+
   it('does not add a decimal when the period key is pressed', async () => {
     const renderResult = renderBridgeView();
 

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
@@ -1,0 +1,337 @@
+import '../../../../../../../tests/component-view/mocks';
+import { fireEvent, waitFor } from '@testing-library/react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import { renderBridgeView } from '../../../../../../../tests/component-view/renderers/bridge';
+import { describeForPlatforms } from '../../../../../../../tests/component-view/platform';
+import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
+import { RecurringScheduleFieldsSelectorsIDs } from '../../../components/RecurringScheduleFields';
+import { RecurringIntervalSheetSelectorsIDs } from '../../../components/RecurringIntervalSheet';
+import { BuildQuoteSelectors } from '../../../../Ramp/Aggregator/Views/BuildQuote/BuildQuote.testIds';
+
+async function openRecurringTab(
+  renderResult: ReturnType<typeof renderBridgeView>,
+) {
+  fireEvent.press(
+    renderResult.getByTestId(BridgeViewSelectorsIDs.RECURRING_TAB),
+  );
+
+  await waitFor(() => {
+    expect(
+      renderResult.getByTestId(BridgeViewSelectorsIDs.RECURRING_BUY_CONTAINER),
+    ).toBeOnTheScreen();
+  });
+}
+
+async function openEveryKeypad(
+  renderResult: ReturnType<typeof renderBridgeView>,
+) {
+  fireEvent(
+    renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
+    'pressIn',
+  );
+
+  await waitFor(() => {
+    expect(
+      renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+    ).toBeOnTheScreen();
+  });
+}
+
+describeForPlatforms('BridgeRecurringBuyView', () => {
+  it('shows default every 1 hour and repeat 10 after opening the recurring tab', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+
+    expect(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
+    ).toHaveDisplayValue('1');
+    expect(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
+      ),
+    ).toHaveTextContent(strings('bridge.recurring.unit.hour'));
+    expect(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+      ),
+    ).toHaveDisplayValue('10');
+  });
+
+  it('appends keypad digits to the every value', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+    await openEveryKeypad(renderResult);
+    fireEvent.press(renderResult.getByTestId('keypad-key-2'));
+
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(
+          RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT,
+        ),
+      ).toHaveDisplayValue('12');
+    });
+  });
+
+  it('updates only the repeat value when the repeat input is focused', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+    fireEvent(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+      ),
+      'pressIn',
+    );
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+      ).toBeOnTheScreen();
+    });
+    fireEvent.press(renderResult.getByTestId('keypad-key-1'));
+
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(
+          RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+        ),
+      ).toHaveDisplayValue('101');
+    });
+    expect(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
+    ).toHaveDisplayValue('1');
+  });
+
+  it('closes the keypad when tapping outside it', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+    await openEveryKeypad(renderResult);
+    fireEvent(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.CONTAINER),
+      'responderRelease',
+    );
+
+    await waitFor(() => {
+      expect(
+        renderResult.queryByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+      ).not.toBeOnTheScreen();
+    });
+  });
+
+  it('does not add a decimal when the period key is pressed', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+    await openEveryKeypad(renderResult);
+    fireEvent.press(renderResult.getByTestId('keypad-key-dot'));
+
+    expect(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
+    ).toHaveDisplayValue('1');
+    expect(renderResult.queryByText('25%')).not.toBeOnTheScreen();
+    expect(renderResult.queryByText('Max')).not.toBeOnTheScreen();
+  });
+
+  it('commits the selected interval unit on confirm', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
+      ),
+    );
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(RecurringIntervalSheetSelectorsIDs.SHEET),
+      ).toBeOnTheScreen();
+    });
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringIntervalSheetSelectorsIDs.OPTION('day'),
+      ),
+    );
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringIntervalSheetSelectorsIDs.CONFIRM_BUTTON,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(
+          RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
+        ),
+      ).toHaveTextContent(strings('bridge.recurring.unit.day'));
+    });
+  });
+
+  it('keeps the previous interval unit when the sheet is dismissed', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
+      ),
+    );
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(RecurringIntervalSheetSelectorsIDs.SHEET),
+      ).toBeOnTheScreen();
+    });
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringIntervalSheetSelectorsIDs.OPTION('week'),
+      ),
+    );
+    fireEvent.press(
+      renderResult.getByTestId(RecurringIntervalSheetSelectorsIDs.CLOSE_BUTTON),
+    );
+
+    await waitFor(() => {
+      expect(
+        renderResult.queryByTestId(RecurringIntervalSheetSelectorsIDs.SHEET),
+      ).not.toBeOnTheScreen();
+    });
+    expect(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
+      ),
+    ).toHaveTextContent(strings('bridge.recurring.unit.hour'));
+  });
+
+  it('resets every to 1 when confirming a unit whose max the value exceeds', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+    await openEveryKeypad(renderResult);
+    fireEvent.press(
+      renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+    );
+    fireEvent.press(renderResult.getByTestId('keypad-key-6'));
+    fireEvent.press(renderResult.getByTestId('keypad-key-0'));
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(
+          RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT,
+        ),
+      ).toHaveDisplayValue('60');
+    });
+
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
+      ),
+    );
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(RecurringIntervalSheetSelectorsIDs.SHEET),
+      ).toBeOnTheScreen();
+    });
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringIntervalSheetSelectorsIDs.OPTION('minute'),
+      ),
+    );
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringIntervalSheetSelectorsIDs.CONFIRM_BUTTON,
+      ),
+    );
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(
+          RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
+        ),
+      ).toHaveTextContent(strings('bridge.recurring.unit.minute'));
+    });
+    expect(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
+    ).toHaveDisplayValue('60');
+
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
+      ),
+    );
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(RecurringIntervalSheetSelectorsIDs.SHEET),
+      ).toBeOnTheScreen();
+    });
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringIntervalSheetSelectorsIDs.OPTION('hour'),
+      ),
+    );
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringIntervalSheetSelectorsIDs.CONFIRM_BUTTON,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(
+          RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
+        ),
+      ).toHaveTextContent(strings('bridge.recurring.unit.hour'));
+    });
+    expect(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
+    ).toHaveDisplayValue('1');
+  });
+
+  it('keeps the every value when confirming a unit that still fits', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+    await openEveryKeypad(renderResult);
+    fireEvent.press(
+      renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+    );
+    fireEvent.press(renderResult.getByTestId('keypad-key-2'));
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(
+          RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT,
+        ),
+      ).toHaveDisplayValue('2');
+    });
+
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
+      ),
+    );
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(RecurringIntervalSheetSelectorsIDs.SHEET),
+      ).toBeOnTheScreen();
+    });
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringIntervalSheetSelectorsIDs.OPTION('day'),
+      ),
+    );
+    fireEvent.press(
+      renderResult.getByTestId(
+        RecurringIntervalSheetSelectorsIDs.CONFIRM_BUTTON,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(
+          RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
+        ),
+      ).toHaveTextContent(strings('bridge.recurring.unit.day'));
+    });
+    expect(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
+    ).toHaveDisplayValue('2');
+  });
+});

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
@@ -56,6 +56,15 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
         RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
       ),
     ).toHaveDisplayValue('10');
+    expect(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT)
+        .props.accessibilityState?.invalid,
+    ).toBe(false);
+    expect(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+      ).props.accessibilityState?.invalid,
+    ).toBe(false);
   });
 
   it('appends keypad digits to the every value', async () => {
@@ -120,7 +129,7 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
     });
   });
 
-  it('snaps every back to 1 when the keypad is closed on 0', async () => {
+  it('keeps every at 0 and invalid after the keypad is closed', async () => {
     const renderResult = renderBridgeView();
 
     await openRecurringTab(renderResult);
@@ -142,14 +151,19 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
 
     await waitFor(() => {
       expect(
-        renderResult.getByTestId(
-          RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT,
-        ),
-      ).toHaveDisplayValue('1');
+        renderResult.queryByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+      ).not.toBeOnTheScreen();
     });
+    expect(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
+    ).toHaveDisplayValue('0');
+    expect(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT)
+        .props.accessibilityState?.invalid,
+    ).toBe(true);
   });
 
-  it('snaps repeat back to 1 when the keypad is closed on 0', async () => {
+  it('keeps repeat at 0 and invalid after the keypad is closed', async () => {
     const renderResult = renderBridgeView();
 
     await openRecurringTab(renderResult);
@@ -184,11 +198,55 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
 
     await waitFor(() => {
       expect(
-        renderResult.getByTestId(
-          RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
-        ),
-      ).toHaveDisplayValue('1');
+        renderResult.queryByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+      ).not.toBeOnTheScreen();
     });
+    expect(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+      ),
+    ).toHaveDisplayValue('0');
+    expect(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+      ).props.accessibilityState?.invalid,
+    ).toBe(true);
+  });
+
+  it('keeps a 0 every value after leaving and returning to the recurring tab', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+    await openEveryKeypad(renderResult);
+    fireEvent.press(
+      renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+    );
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(
+          RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT,
+        ),
+      ).toHaveDisplayValue('0');
+    });
+
+    fireEvent.press(renderResult.getByTestId(BridgeViewSelectorsIDs.MARKET_TAB));
+    await waitFor(() => {
+      expect(
+        renderResult.queryByTestId(
+          RecurringScheduleFieldsSelectorsIDs.CONTAINER,
+        ),
+      ).not.toBeOnTheScreen();
+    });
+
+    await openRecurringTab(renderResult);
+
+    expect(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
+    ).toHaveDisplayValue('0');
+    expect(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT)
+        .props.accessibilityState?.invalid,
+    ).toBe(true);
   });
 
   it('does not add a decimal when the period key is pressed', async () => {
@@ -322,5 +380,71 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
     expect(
       renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
     ).toHaveDisplayValue('1');
+  });
+
+  it('marks the every value invalid when it exceeds the unit max', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+    await openEveryKeypad(renderResult);
+    fireEvent.press(renderResult.getByTestId('keypad-key-5'));
+    fireEvent.press(renderResult.getByTestId('keypad-key-5'));
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(
+          RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT,
+        ),
+      ).toHaveDisplayValue('155');
+    });
+
+    expect(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT)
+        .props.accessibilityState?.invalid,
+    ).toBe(true);
+    expect(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+      ).props.accessibilityState?.invalid,
+    ).toBe(false);
+  });
+
+  it('marks the repeat value invalid when it is 0', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+    fireEvent(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+      ),
+      'pressIn',
+    );
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+      ).toBeOnTheScreen();
+    });
+    fireEvent.press(
+      renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+    );
+    fireEvent.press(
+      renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
+    );
+    await waitFor(() => {
+      expect(
+        renderResult.getByTestId(
+          RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+        ),
+      ).toHaveDisplayValue('0');
+    });
+
+    expect(
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+      ).props.accessibilityState?.invalid,
+    ).toBe(true);
+    expect(
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT)
+        .props.accessibilityState?.invalid,
+    ).toBe(false);
   });
 });

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
@@ -1,5 +1,6 @@
 import '../../../../../../../tests/component-view/mocks';
 import { fireEvent, waitFor } from '@testing-library/react-native';
+import { lightTheme } from '@metamask/design-tokens';
 import { strings } from '../../../../../../../locales/i18n';
 import { renderBridgeView } from '../../../../../../../tests/component-view/renderers/bridge';
 import { describeForPlatforms } from '../../../../../../../tests/component-view/platform';
@@ -7,6 +8,8 @@ import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
 import { RecurringScheduleFieldsSelectorsIDs } from '../../../components/RecurringScheduleFields';
 import { RecurringIntervalSheetSelectorsIDs } from '../../../components/RecurringIntervalSheet';
 import { BuildQuoteSelectors } from '../../../../Ramp/Aggregator/Views/BuildQuote/BuildQuote.testIds';
+
+const errorColor = lightTheme.colors.error.default;
 
 async function openRecurringTab(
   renderResult: ReturnType<typeof renderBridgeView>,
@@ -57,13 +60,13 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
       ),
     ).toHaveDisplayValue('10');
     expect(
-      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT)
-        .props.accessibilityState?.invalid,
-    ).toBe(false);
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
+    ).not.toHaveStyle({ color: errorColor });
     expect(
-      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT)
-        .props.accessibilityState?.invalid,
-    ).toBe(false);
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+      ),
+    ).not.toHaveStyle({ color: errorColor });
   });
 
   it('appends keypad digits to the every value', async () => {
@@ -157,9 +160,8 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
       renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
     ).toHaveDisplayValue('0');
     expect(
-      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT)
-        .props.accessibilityState?.invalid,
-    ).toBe(true);
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
+    ).toHaveStyle({ color: errorColor });
   });
 
   it('keeps repeat at 0 and invalid after the keypad is closed', async () => {
@@ -206,9 +208,10 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
       ),
     ).toHaveDisplayValue('0');
     expect(
-      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT)
-        .props.accessibilityState?.invalid,
-    ).toBe(true);
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+      ),
+    ).toHaveStyle({ color: errorColor });
   });
 
   it('keeps a 0 every value after leaving and returning to the recurring tab', async () => {
@@ -244,9 +247,8 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
       renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
     ).toHaveDisplayValue('0');
     expect(
-      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT)
-        .props.accessibilityState?.invalid,
-    ).toBe(true);
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
+    ).toHaveStyle({ color: errorColor });
   });
 
   it('does not add a decimal when the period key is pressed', async () => {
@@ -398,13 +400,13 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
     });
 
     expect(
-      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT)
-        .props.accessibilityState?.invalid,
-    ).toBe(true);
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
+    ).toHaveStyle({ color: errorColor });
     expect(
-      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT)
-        .props.accessibilityState?.invalid,
-    ).toBe(false);
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+      ),
+    ).not.toHaveStyle({ color: errorColor });
   });
 
   it('marks the repeat value invalid when it is 0', async () => {
@@ -437,12 +439,12 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
     });
 
     expect(
-      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT)
-        .props.accessibilityState?.invalid,
-    ).toBe(true);
+      renderResult.getByTestId(
+        RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT,
+      ),
+    ).toHaveStyle({ color: errorColor });
     expect(
-      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT)
-        .props.accessibilityState?.invalid,
-    ).toBe(false);
+      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
+    ).not.toHaveStyle({ color: errorColor });
   });
 });

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
@@ -203,89 +203,7 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
     ).toHaveTextContent(strings('bridge.recurring.unit.hour'));
   });
 
-  it('resets every to 1 when confirming a unit whose max the value exceeds', async () => {
-    const renderResult = renderBridgeView();
-
-    await openRecurringTab(renderResult);
-    await openEveryKeypad(renderResult);
-    fireEvent.press(
-      renderResult.getByTestId(BuildQuoteSelectors.KEYPAD_DELETE_BUTTON),
-    );
-    fireEvent.press(renderResult.getByTestId('keypad-key-6'));
-    fireEvent.press(renderResult.getByTestId('keypad-key-0'));
-    await waitFor(() => {
-      expect(
-        renderResult.getByTestId(
-          RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT,
-        ),
-      ).toHaveDisplayValue('60');
-    });
-
-    fireEvent.press(
-      renderResult.getByTestId(
-        RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
-      ),
-    );
-    await waitFor(() => {
-      expect(
-        renderResult.getByTestId(RecurringIntervalSheetSelectorsIDs.SHEET),
-      ).toBeOnTheScreen();
-    });
-    fireEvent.press(
-      renderResult.getByTestId(
-        RecurringIntervalSheetSelectorsIDs.OPTION('minute'),
-      ),
-    );
-    fireEvent.press(
-      renderResult.getByTestId(
-        RecurringIntervalSheetSelectorsIDs.CONFIRM_BUTTON,
-      ),
-    );
-    await waitFor(() => {
-      expect(
-        renderResult.getByTestId(
-          RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
-        ),
-      ).toHaveTextContent(strings('bridge.recurring.unit.minute'));
-    });
-    expect(
-      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
-    ).toHaveDisplayValue('60');
-
-    fireEvent.press(
-      renderResult.getByTestId(
-        RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
-      ),
-    );
-    await waitFor(() => {
-      expect(
-        renderResult.getByTestId(RecurringIntervalSheetSelectorsIDs.SHEET),
-      ).toBeOnTheScreen();
-    });
-    fireEvent.press(
-      renderResult.getByTestId(
-        RecurringIntervalSheetSelectorsIDs.OPTION('hour'),
-      ),
-    );
-    fireEvent.press(
-      renderResult.getByTestId(
-        RecurringIntervalSheetSelectorsIDs.CONFIRM_BUTTON,
-      ),
-    );
-
-    await waitFor(() => {
-      expect(
-        renderResult.getByTestId(
-          RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON,
-        ),
-      ).toHaveTextContent(strings('bridge.recurring.unit.hour'));
-    });
-    expect(
-      renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
-    ).toHaveDisplayValue('1');
-  });
-
-  it('keeps the every value when confirming a unit that still fits', async () => {
+  it('resets every to 1 when confirming a unit change', async () => {
     const renderResult = renderBridgeView();
 
     await openRecurringTab(renderResult);
@@ -332,6 +250,6 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
     });
     expect(
       renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
-    ).toHaveDisplayValue('2');
+    ).toHaveDisplayValue('1');
   });
 });

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/index.tsx
@@ -1,20 +1,15 @@
 import React from 'react';
 import { Box } from '@metamask/design-system-react-native';
 import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
-
-// === ATTENTION ===
-//
-// Access recurring buy feature flags like this:
-//
-// const recurringBuyFeatureFlags = useSelector(selectBridgeRecurringBuyFeatureFlags);
-//
-// ===
+import RecurringScheduleFields from '../../../components/RecurringScheduleFields';
 
 const BridgeRecurringBuyView = () => (
   <Box
     twClassName="flex-1 bg-default"
     testID={BridgeViewSelectorsIDs.RECURRING_BUY_CONTAINER}
-  />
+  >
+    <RecurringScheduleFields />
+  </Box>
 );
 
 export default BridgeRecurringBuyView;

--- a/app/components/UI/Bridge/_mocks_/bridgeReducerState.ts
+++ b/app/components/UI/Bridge/_mocks_/bridgeReducerState.ts
@@ -1,6 +1,7 @@
 import type { BridgeState } from '../../../../core/redux/slices/bridge';
 import { initialHardwareWalletsSwapsState } from '../../HardwareWallet/Swaps/HardwareWalletsSwaps.state';
 import { BridgeViewMode } from '../types';
+import { initialRecurringState } from '../utils/recurringSchedule';
 
 export const mockBridgeReducerState: BridgeState = {
   sourceAmount: '1000000000000000000',
@@ -46,4 +47,5 @@ export const mockBridgeReducerState: BridgeState = {
   batchSellSourceTokenAmounts: {},
   batchSellDestToken: undefined,
   batchSellSlippages: {},
+  recurring: initialRecurringState,
 };

--- a/app/components/UI/Bridge/_mocks_/initialState.ts
+++ b/app/components/UI/Bridge/_mocks_/initialState.ts
@@ -1,4 +1,5 @@
 import { defaultBridgeControllerState } from './bridgeControllerState';
+import { initialRecurringState } from '../utils/recurringSchedule';
 import { CaipAssetId, Hex } from '@metamask/utils';
 import {
   SolScope,
@@ -830,5 +831,6 @@ export const initialState = {
     bridgeViewMode: undefined,
     isSelectingRecipient: false,
     isSelectingToken: false,
+    recurring: initialRecurringState,
   },
 };

--- a/app/components/UI/Bridge/components/RecurringIntervalSheet/RecurringIntervalSheet.testIds.ts
+++ b/app/components/UI/Bridge/components/RecurringIntervalSheet/RecurringIntervalSheet.testIds.ts
@@ -1,0 +1,8 @@
+import type { RecurringIntervalUnit } from '../../utils/recurringSchedule';
+
+export const RecurringIntervalSheetSelectorsIDs = {
+  SHEET: 'recurring-interval-sheet',
+  CLOSE_BUTTON: 'recurring-interval-sheet-close',
+  CONFIRM_BUTTON: 'recurring-interval-sheet-confirm',
+  OPTION: (unit: RecurringIntervalUnit) => `recurring-interval-option-${unit}`,
+} as const;

--- a/app/components/UI/Bridge/components/RecurringIntervalSheet/RecurringIntervalSheet.tsx
+++ b/app/components/UI/Bridge/components/RecurringIntervalSheet/RecurringIntervalSheet.tsx
@@ -1,0 +1,84 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  BottomSheet,
+  BottomSheetFooter,
+  BottomSheetHeader,
+  Box,
+  ListItemSelect,
+  type BottomSheetRef,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../locales/i18n';
+import {
+  RECURRING_INTERVAL_UNITS,
+  type RecurringIntervalUnit,
+} from '../../utils/recurringSchedule';
+import { RecurringIntervalSheetSelectorsIDs } from './RecurringIntervalSheet.testIds';
+import type { RecurringIntervalSheetProps } from './RecurringIntervalSheet.types';
+
+const RecurringIntervalSheet = ({
+  isVisible,
+  currentUnit,
+  onClose,
+  onConfirm,
+}: RecurringIntervalSheetProps) => {
+  const sheetRef = useRef<BottomSheetRef>(null);
+  const [pendingUnit, setPendingUnit] =
+    useState<RecurringIntervalUnit>(currentUnit);
+
+  useEffect(() => {
+    if (isVisible) {
+      setPendingUnit(currentUnit);
+    }
+  }, [currentUnit, isVisible]);
+
+  const closeSheet = useCallback(() => {
+    sheetRef.current?.onCloseBottomSheet();
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    onConfirm(pendingUnit);
+    closeSheet();
+  }, [closeSheet, onConfirm, pendingUnit]);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <BottomSheet
+      ref={sheetRef}
+      testID={RecurringIntervalSheetSelectorsIDs.SHEET}
+      onClose={onClose}
+    >
+      <BottomSheetHeader
+        onClose={closeSheet}
+        closeButtonProps={{
+          testID: RecurringIntervalSheetSelectorsIDs.CLOSE_BUTTON,
+        }}
+      >
+        {strings('bridge.recurring.every')}
+      </BottomSheetHeader>
+      <Box paddingHorizontal={4} paddingBottom={2}>
+        {RECURRING_INTERVAL_UNITS.map((unit) => (
+          <ListItemSelect
+            key={unit}
+            title={strings(`bridge.recurring.unit_option.${unit}`)}
+            isSelected={pendingUnit === unit}
+            showSelectedIcon
+            onPress={() => setPendingUnit(unit)}
+            testID={RecurringIntervalSheetSelectorsIDs.OPTION(unit)}
+          />
+        ))}
+      </Box>
+      <BottomSheetFooter
+        primaryButtonProps={{
+          children: strings('bridge.recurring.confirm'),
+          onPress: handleConfirm,
+          testID: RecurringIntervalSheetSelectorsIDs.CONFIRM_BUTTON,
+        }}
+      />
+    </BottomSheet>
+  );
+};
+
+export default RecurringIntervalSheet;

--- a/app/components/UI/Bridge/components/RecurringIntervalSheet/RecurringIntervalSheet.types.ts
+++ b/app/components/UI/Bridge/components/RecurringIntervalSheet/RecurringIntervalSheet.types.ts
@@ -1,0 +1,8 @@
+import type { RecurringIntervalUnit } from '../../utils/recurringSchedule';
+
+export interface RecurringIntervalSheetProps {
+  isVisible: boolean;
+  currentUnit: RecurringIntervalUnit;
+  onClose: () => void;
+  onConfirm: (unit: RecurringIntervalUnit) => void;
+}

--- a/app/components/UI/Bridge/components/RecurringIntervalSheet/index.ts
+++ b/app/components/UI/Bridge/components/RecurringIntervalSheet/index.ts
@@ -1,0 +1,3 @@
+export { default } from './RecurringIntervalSheet';
+export type { RecurringIntervalSheetProps } from './RecurringIntervalSheet.types';
+export { RecurringIntervalSheetSelectorsIDs } from './RecurringIntervalSheet.testIds';

--- a/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.testIds.ts
+++ b/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.testIds.ts
@@ -1,0 +1,12 @@
+export const RecurringScheduleFieldsSelectorsIDs = {
+  CONTAINER: 'recurring-schedule-fields',
+  EVERY_CARD: 'recurring-every-card',
+  EVERY_INPUT: 'recurring-every-input',
+  EVERY_UNIT_BUTTON: 'recurring-every-unit-button',
+  REPEAT_CARD: 'recurring-repeat-card',
+  REPEAT_INPUT: 'recurring-repeat-input',
+  REPEAT_TIMES_LABEL: 'recurring-repeat-times',
+} as const;
+
+export type RecurringScheduleFieldsSelectorsIDsType =
+  typeof RecurringScheduleFieldsSelectorsIDs;

--- a/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.tsx
+++ b/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import type { AccessibilityState } from 'react-native';
 import {
   Box,
   BoxAlignItems,
@@ -65,9 +64,6 @@ function RecurringNumberCard({
   hasError: boolean;
 }) {
   const tw = useTailwind();
-  const accessibilityState: AccessibilityState & { invalid: boolean } = {
-    invalid: hasError,
-  };
 
   return (
     <Box
@@ -100,7 +96,6 @@ function RecurringNumberCard({
           }`}
           testID={inputTestID}
           accessibilityLabel={label}
-          accessibilityState={accessibilityState}
         />
         {accessory}
       </Box>

--- a/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.tsx
+++ b/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.tsx
@@ -20,6 +20,7 @@ import {
   selectRecurringEveryUnit,
   selectRecurringEveryValue,
   selectRecurringRepeatCount,
+  selectRecurringScheduleValidation,
   setRecurringEveryUnit,
   setRecurringEveryValue,
   setRecurringRepeatCount,
@@ -30,9 +31,9 @@ import type { SwapsKeypadRef } from '../SwapsKeypad/types';
 import RecurringIntervalSheet from '../RecurringIntervalSheet';
 import {
   capRecurringKeypadValue,
-  restoreRecurringValueIfInvalid,
   RECURRING_EVERY_MAX_DIGITS,
   RECURRING_REPEAT_MAX_DIGITS,
+  RecurringScheduleErrorCode,
   type RecurringIntervalUnit,
 } from '../../utils/recurringSchedule';
 import { RecurringScheduleFieldsSelectorsIDs } from './RecurringScheduleFields.testIds';
@@ -52,6 +53,7 @@ function RecurringNumberCard({
   inputTestID,
   onInputPress,
   accessory,
+  hasError,
 }: {
   label: string;
   value: string;
@@ -59,6 +61,7 @@ function RecurringNumberCard({
   inputTestID: string;
   onInputPress: () => void;
   accessory: React.ReactNode;
+  hasError: boolean;
 }) {
   const tw = useTailwind();
 
@@ -88,9 +91,12 @@ function RecurringNumberCard({
           onPressIn={onInputPress}
           onFocus={onInputPress}
           placeholderTextColor={tw.color('text-muted')}
-          twClassName="h-8 min-w-0 flex-1 border-0 bg-transparent p-0 font-semibold"
+          twClassName={`h-8 min-w-0 flex-1 border-0 bg-transparent p-0 font-semibold${
+            hasError ? ' text-error-default' : ''
+          }`}
           testID={inputTestID}
           accessibilityLabel={label}
+          accessibilityState={{ invalid: hasError }}
         />
         {accessory}
       </Box>
@@ -108,6 +114,20 @@ const RecurringScheduleFields = () => {
   const everyValue = useSelector(selectRecurringEveryValue);
   const everyUnit = useSelector(selectRecurringEveryUnit);
   const repeatCount = useSelector(selectRecurringRepeatCount);
+  const { errors: scheduleErrors } = useSelector(
+    selectRecurringScheduleValidation,
+  );
+  const hasEveryError = scheduleErrors.some(
+    (error) =>
+      error === RecurringScheduleErrorCode.EveryInvalid ||
+      error === RecurringScheduleErrorCode.EveryExceedsUnitMax ||
+      error === RecurringScheduleErrorCode.DurationExceedsMax,
+  );
+  const hasRepeatError = scheduleErrors.some(
+    (error) =>
+      error === RecurringScheduleErrorCode.RepeatInvalid ||
+      error === RecurringScheduleErrorCode.DurationExceedsMax,
+  );
 
   const keypadValue =
     focusedField === FocusedScheduleField.Repeat ? repeatCount : everyValue;
@@ -115,17 +135,7 @@ const RecurringScheduleFields = () => {
   const closeKeypad = useCallback(() => {
     keypadRef.current?.close();
     setFocusedField(null);
-
-    const restoredEveryValue = restoreRecurringValueIfInvalid(everyValue);
-    if (restoredEveryValue !== everyValue) {
-      dispatch(setRecurringEveryValue(restoredEveryValue));
-    }
-
-    const restoredRepeatCount = restoreRecurringValueIfInvalid(repeatCount);
-    if (restoredRepeatCount !== repeatCount) {
-      dispatch(setRecurringRepeatCount(restoredRepeatCount));
-    }
-  }, [dispatch, everyValue, repeatCount]);
+  }, []);
 
   const handleEveryPress = useCallback(() => {
     setFocusedField(FocusedScheduleField.Every);
@@ -197,6 +207,7 @@ const RecurringScheduleFields = () => {
           testID={RecurringScheduleFieldsSelectorsIDs.EVERY_CARD}
           inputTestID={RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT}
           onInputPress={handleEveryPress}
+          hasError={hasEveryError}
           accessory={
             <ButtonBase
               size={ButtonBaseSize.Sm}
@@ -218,6 +229,7 @@ const RecurringScheduleFields = () => {
           testID={RecurringScheduleFieldsSelectorsIDs.REPEAT_CARD}
           inputTestID={RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT}
           onInputPress={handleRepeatPress}
+          hasError={hasRepeatError}
           accessory={
             <Text
               variant={TextVariant.BodyMd}

--- a/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.tsx
+++ b/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import type { AccessibilityState } from 'react-native';
 import {
   Box,
   BoxAlignItems,
@@ -64,6 +65,9 @@ function RecurringNumberCard({
   hasError: boolean;
 }) {
   const tw = useTailwind();
+  const accessibilityState: AccessibilityState & { invalid: boolean } = {
+    invalid: hasError,
+  };
 
   return (
     <Box
@@ -96,7 +100,7 @@ function RecurringNumberCard({
           }`}
           testID={inputTestID}
           accessibilityLabel={label}
-          accessibilityState={{ invalid: hasError }}
+          accessibilityState={accessibilityState}
         />
         {accessory}
       </Box>

--- a/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.tsx
+++ b/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.tsx
@@ -30,6 +30,7 @@ import type { SwapsKeypadRef } from '../SwapsKeypad/types';
 import RecurringIntervalSheet from '../RecurringIntervalSheet';
 import {
   capRecurringKeypadValue,
+  restoreRecurringValueIfInvalid,
   RECURRING_EVERY_MAX_DIGITS,
   RECURRING_REPEAT_MAX_DIGITS,
   type RecurringIntervalUnit,
@@ -114,7 +115,17 @@ const RecurringScheduleFields = () => {
   const closeKeypad = useCallback(() => {
     keypadRef.current?.close();
     setFocusedField(null);
-  }, []);
+
+    const restoredEveryValue = restoreRecurringValueIfInvalid(everyValue);
+    if (restoredEveryValue !== everyValue) {
+      dispatch(setRecurringEveryValue(restoredEveryValue));
+    }
+
+    const restoredRepeatCount = restoreRecurringValueIfInvalid(repeatCount);
+    if (restoredRepeatCount !== repeatCount) {
+      dispatch(setRecurringRepeatCount(restoredRepeatCount));
+    }
+  }, [dispatch, everyValue, repeatCount]);
 
   const handleEveryPress = useCallback(() => {
     setFocusedField(FocusedScheduleField.Every);

--- a/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.tsx
+++ b/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.tsx
@@ -1,0 +1,239 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  ButtonBase,
+  ButtonBaseSize,
+  IconName,
+  IconSize,
+  Input,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { strings } from '../../../../../../locales/i18n';
+import {
+  selectRecurringEveryUnit,
+  selectRecurringEveryValue,
+  selectRecurringRepeatCount,
+  setRecurringEveryUnit,
+  setRecurringEveryValue,
+  setRecurringRepeatCount,
+} from '../../../../../core/redux/slices/bridge';
+import type { KeypadChangeData } from '../../../../Base/Keypad';
+import { SwapsKeypad } from '../SwapsKeypad';
+import type { SwapsKeypadRef } from '../SwapsKeypad/types';
+import RecurringIntervalSheet from '../RecurringIntervalSheet';
+import {
+  capRecurringKeypadValue,
+  RECURRING_EVERY_MAX_DIGITS,
+  RECURRING_REPEAT_MAX_DIGITS,
+  type RecurringIntervalUnit,
+} from '../../utils/recurringSchedule';
+import { RecurringScheduleFieldsSelectorsIDs } from './RecurringScheduleFields.testIds';
+
+enum FocusedScheduleField {
+  Every = 'every',
+  Repeat = 'repeat',
+}
+
+// SwapsKeypad requires a currency code; Recurring isn't a currency input.
+const DUMMY_KEYPAD_CURRENCY = '';
+
+function RecurringNumberCard({
+  label,
+  value,
+  testID,
+  inputTestID,
+  onInputPress,
+  accessory,
+}: {
+  label: string;
+  value: string;
+  testID: string;
+  inputTestID: string;
+  onInputPress: () => void;
+  accessory: React.ReactNode;
+}) {
+  const tw = useTailwind();
+
+  return (
+    <Box
+      testID={testID}
+      gap={2}
+      padding={3}
+      twClassName="min-w-px flex-1 rounded-2xl bg-muted"
+    >
+      <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+        {label}
+      </Text>
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Between}
+        gap={2}
+      >
+        <Input
+          value={value}
+          showSoftInputOnFocus={false}
+          caretHidden={false}
+          keyboardType="number-pad"
+          isStateStylesDisabled
+          textVariant={TextVariant.HeadingLg}
+          onPressIn={onInputPress}
+          onFocus={onInputPress}
+          placeholderTextColor={tw.color('text-muted')}
+          twClassName="h-8 min-w-0 flex-1 border-0 bg-transparent p-0 font-semibold"
+          testID={inputTestID}
+          accessibilityLabel={label}
+        />
+        {accessory}
+      </Box>
+    </Box>
+  );
+}
+
+const RecurringScheduleFields = () => {
+  const dispatch = useDispatch();
+  const keypadRef = useRef<SwapsKeypadRef>(null);
+  const [focusedField, setFocusedField] = useState<FocusedScheduleField | null>(
+    null,
+  );
+  const [isIntervalSheetVisible, setIsIntervalSheetVisible] = useState(false);
+  const everyValue = useSelector(selectRecurringEveryValue);
+  const everyUnit = useSelector(selectRecurringEveryUnit);
+  const repeatCount = useSelector(selectRecurringRepeatCount);
+
+  const keypadValue =
+    focusedField === FocusedScheduleField.Repeat ? repeatCount : everyValue;
+
+  const closeKeypad = useCallback(() => {
+    keypadRef.current?.close();
+    setFocusedField(null);
+  }, []);
+
+  const handleEveryPress = useCallback(() => {
+    setFocusedField(FocusedScheduleField.Every);
+    keypadRef.current?.open();
+  }, []);
+
+  const handleRepeatPress = useCallback(() => {
+    setFocusedField(FocusedScheduleField.Repeat);
+    keypadRef.current?.open();
+  }, []);
+
+  const handleUnitPress = useCallback(() => {
+    closeKeypad();
+    setIsIntervalSheetVisible(true);
+  }, [closeKeypad]);
+
+  const handleIntervalSheetClosed = useCallback(() => {
+    setIsIntervalSheetVisible(false);
+  }, []);
+
+  const handleIntervalConfirm = useCallback(
+    (unit: RecurringIntervalUnit) => {
+      dispatch(setRecurringEveryUnit(unit));
+    },
+    [dispatch],
+  );
+
+  const handleKeypadChange = useCallback(
+    ({ value }: KeypadChangeData) => {
+      if (focusedField === FocusedScheduleField.Every) {
+        dispatch(
+          setRecurringEveryValue(
+            capRecurringKeypadValue(
+              everyValue,
+              value,
+              RECURRING_EVERY_MAX_DIGITS,
+            ),
+          ),
+        );
+        return;
+      }
+
+      if (focusedField === FocusedScheduleField.Repeat) {
+        dispatch(
+          setRecurringRepeatCount(
+            capRecurringKeypadValue(
+              repeatCount,
+              value,
+              RECURRING_REPEAT_MAX_DIGITS,
+            ),
+          ),
+        );
+      }
+    },
+    [dispatch, everyValue, focusedField, repeatCount],
+  );
+
+  return (
+    <Box
+      twClassName="flex-1"
+      testID={RecurringScheduleFieldsSelectorsIDs.CONTAINER}
+      onStartShouldSetResponder={() => true}
+      onResponderRelease={closeKeypad}
+    >
+      <Box padding={4} flexDirection={BoxFlexDirection.Row} gap={2}>
+        <RecurringNumberCard
+          label={strings('bridge.recurring.every')}
+          value={everyValue}
+          testID={RecurringScheduleFieldsSelectorsIDs.EVERY_CARD}
+          inputTestID={RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT}
+          onInputPress={handleEveryPress}
+          accessory={
+            <ButtonBase
+              size={ButtonBaseSize.Sm}
+              endIconName={IconName.ArrowDown}
+              endIconProps={{ size: IconSize.Sm }}
+              onPress={handleUnitPress}
+              testID={RecurringScheduleFieldsSelectorsIDs.EVERY_UNIT_BUTTON}
+              accessibilityLabel={strings(
+                `bridge.recurring.unit_option.${everyUnit}`,
+              )}
+            >
+              {strings(`bridge.recurring.unit.${everyUnit}`)}
+            </ButtonBase>
+          }
+        />
+        <RecurringNumberCard
+          label={strings('bridge.recurring.repeat')}
+          value={repeatCount}
+          testID={RecurringScheduleFieldsSelectorsIDs.REPEAT_CARD}
+          inputTestID={RecurringScheduleFieldsSelectorsIDs.REPEAT_INPUT}
+          onInputPress={handleRepeatPress}
+          accessory={
+            <Text
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
+              testID={RecurringScheduleFieldsSelectorsIDs.REPEAT_TIMES_LABEL}
+            >
+              {strings('bridge.recurring.times')}
+            </Text>
+          }
+        />
+      </Box>
+      <SwapsKeypad
+        ref={keypadRef}
+        value={keypadValue}
+        onChange={handleKeypadChange}
+        currency={DUMMY_KEYPAD_CURRENCY}
+        decimals={0}
+        periodButtonProps={{ isDisabled: true }}
+      />
+      <RecurringIntervalSheet
+        isVisible={isIntervalSheetVisible}
+        currentUnit={everyUnit}
+        onClose={handleIntervalSheetClosed}
+        onConfirm={handleIntervalConfirm}
+      />
+    </Box>
+  );
+};
+
+export default RecurringScheduleFields;

--- a/app/components/UI/Bridge/components/RecurringScheduleFields/index.ts
+++ b/app/components/UI/Bridge/components/RecurringScheduleFields/index.ts
@@ -1,0 +1,2 @@
+export { default } from './RecurringScheduleFields';
+export { RecurringScheduleFieldsSelectorsIDs } from './RecurringScheduleFields.testIds';

--- a/app/components/UI/Bridge/components/SwapsKeypad/index.tsx
+++ b/app/components/UI/Bridge/components/SwapsKeypad/index.tsx
@@ -11,7 +11,10 @@ import {
   type BottomSheetDialogRef,
   Box,
 } from '@metamask/design-system-react-native';
-import Keypad, { KeypadChangeData } from '../../../../Base/Keypad';
+import Keypad, {
+  KeypadChangeData,
+  type KeypadComponentProps,
+} from '../../../../Base/Keypad';
 import { SwapsKeypadRef } from './types';
 
 interface SwapsKeypadProps {
@@ -19,63 +22,70 @@ interface SwapsKeypadProps {
   currency: string;
   decimals: number;
   onChange: (data: KeypadChangeData) => void;
+  periodButtonProps?: KeypadComponentProps['periodButtonProps'];
 }
 
 export const SwapsKeypad = forwardRef<
   SwapsKeypadRef,
   PropsWithChildren<SwapsKeypadProps>
->(({ value, currency, decimals, onChange, children }, ref) => {
-  const bottomSheetRef = useRef<BottomSheetDialogRef>(null);
-  const isOpenRef = useRef(false);
-  const [isRendered, setIsRendered] = useState(false);
+>(
+  (
+    { value, currency, decimals, onChange, periodButtonProps, children },
+    ref,
+  ) => {
+    const bottomSheetRef = useRef<BottomSheetDialogRef>(null);
+    const isOpenRef = useRef(false);
+    const [isRendered, setIsRendered] = useState(false);
 
-  const handleClose = useCallback(() => {
-    isOpenRef.current = false;
-    setIsRendered(false);
-  }, []);
+    const handleClose = useCallback(() => {
+      isOpenRef.current = false;
+      setIsRendered(false);
+    }, []);
 
-  useImperativeHandle(ref, () => ({
-    open: () => {
-      if (!isOpenRef.current) {
-        setIsRendered(true);
-        isOpenRef.current = true;
-      }
-    },
-    close: () => {
-      if (isOpenRef.current) {
-        bottomSheetRef.current?.onCloseDialog();
-      }
-    },
-    isOpen: () => isOpenRef.current,
-  }));
+    useImperativeHandle(ref, () => ({
+      open: () => {
+        if (!isOpenRef.current) {
+          setIsRendered(true);
+          isOpenRef.current = true;
+        }
+      },
+      close: () => {
+        if (isOpenRef.current) {
+          bottomSheetRef.current?.onCloseDialog();
+        }
+      },
+      isOpen: () => isOpenRef.current,
+    }));
 
-  if (!isRendered) {
-    return null;
-  }
+    if (!isRendered) {
+      return null;
+    }
 
-  return (
-    <BottomSheetDialog
-      ref={bottomSheetRef}
-      isInteractable={false}
-      onClose={handleClose}
-      onStartShouldSetResponder={() =>
-        // Prevents the native gesture system from bubbling up
-        // the event to BottomSheetDialog, causing keypad to close
-        // when user click anywhere inside the keypad area that is
-        // not a pressable component.
-        // This is required because
-        true
-      }
-    >
-      <Box twClassName="content-end px-4 gap-4 pt-4">
-        {children}
-        <Keypad
-          value={value}
-          onChange={onChange}
-          currency={currency}
-          decimals={decimals}
-        />
-      </Box>
-    </BottomSheetDialog>
-  );
-});
+    return (
+      <BottomSheetDialog
+        ref={bottomSheetRef}
+        isInteractable={false}
+        onClose={handleClose}
+        onStartShouldSetResponder={() =>
+          // Prevents the native gesture system from bubbling up
+          // the event to BottomSheetDialog, causing keypad to close
+          // when user click anywhere inside the keypad area that is
+          // not a pressable component.
+          // This is required because
+          true
+        }
+      >
+        <Box twClassName="content-end px-4 gap-4 pt-4">
+          {children}
+          <Keypad
+            value={value}
+            onChange={onChange}
+            currency={currency}
+            decimals={decimals}
+            periodButtonProps={periodButtonProps}
+          />
+        </Box>
+      </BottomSheetDialog>
+    );
+  },
+);

--- a/app/components/UI/Bridge/utils/recurringSchedule.test.ts
+++ b/app/components/UI/Bridge/utils/recurringSchedule.test.ts
@@ -1,6 +1,7 @@
 import {
   capRecurringKeypadValue,
   parsePositiveInteger,
+  restoreRecurringValueIfInvalid,
   RECURRING_MAX_DURATION_MINUTES,
   validateRecurringSchedule,
   type RecurringState,
@@ -32,6 +33,24 @@ describe('parsePositiveInteger', () => {
       expect(result).toBeUndefined();
     },
   );
+});
+
+describe('restoreRecurringValueIfInvalid', () => {
+  it('returns 1 when the value is not a positive integer', () => {
+    const value = '0';
+
+    const result = restoreRecurringValueIfInvalid(value);
+
+    expect(result).toBe('1');
+  });
+
+  it('keeps a valid positive integer', () => {
+    const value = '12';
+
+    const result = restoreRecurringValueIfInvalid(value);
+
+    expect(result).toBe('12');
+  });
 });
 
 describe('capRecurringKeypadValue', () => {

--- a/app/components/UI/Bridge/utils/recurringSchedule.test.ts
+++ b/app/components/UI/Bridge/utils/recurringSchedule.test.ts
@@ -1,6 +1,5 @@
 import {
   capRecurringKeypadValue,
-  getEveryValueAfterUnitChange,
   parsePositiveInteger,
   RECURRING_MAX_DURATION_MINUTES,
   validateRecurringSchedule,
@@ -33,32 +32,6 @@ describe('parsePositiveInteger', () => {
       expect(result).toBeUndefined();
     },
   );
-});
-
-describe('getEveryValueAfterUnitChange', () => {
-  it('keeps the every value when it fits the new unit max', () => {
-    const everyValue = '2';
-
-    const result = getEveryValueAfterUnitChange(everyValue, 'day');
-
-    expect(result).toBe('2');
-  });
-
-  it('resets every value to 1 when it exceeds the new unit max', () => {
-    const everyValue = '60';
-
-    const result = getEveryValueAfterUnitChange(everyValue, 'hour');
-
-    expect(result).toBe('1');
-  });
-
-  it('resets every value to 1 when the current value is empty', () => {
-    const everyValue = '';
-
-    const result = getEveryValueAfterUnitChange(everyValue, 'minute');
-
-    expect(result).toBe('1');
-  });
 });
 
 describe('capRecurringKeypadValue', () => {

--- a/app/components/UI/Bridge/utils/recurringSchedule.test.ts
+++ b/app/components/UI/Bridge/utils/recurringSchedule.test.ts
@@ -1,7 +1,7 @@
 import {
   capRecurringKeypadValue,
   parsePositiveInteger,
-  restoreRecurringValueIfInvalid,
+  RecurringScheduleErrorCode,
   RECURRING_MAX_DURATION_MINUTES,
   validateRecurringSchedule,
   type RecurringState,
@@ -33,24 +33,6 @@ describe('parsePositiveInteger', () => {
       expect(result).toBeUndefined();
     },
   );
-});
-
-describe('restoreRecurringValueIfInvalid', () => {
-  it('returns 1 when the value is not a positive integer', () => {
-    const value = '0';
-
-    const result = restoreRecurringValueIfInvalid(value);
-
-    expect(result).toBe('1');
-  });
-
-  it('keeps a valid positive integer', () => {
-    const value = '12';
-
-    const result = restoreRecurringValueIfInvalid(value);
-
-    expect(result).toBe('12');
-  });
 });
 
 describe('capRecurringKeypadValue', () => {
@@ -85,7 +67,7 @@ describe('validateRecurringSchedule', () => {
 
     const result = validateRecurringSchedule(schedule);
 
-    expect(result.errors).toContain('every_invalid');
+    expect(result.errors).toContain(RecurringScheduleErrorCode.EveryInvalid);
     expect(result.isValid).toBe(false);
   });
 
@@ -94,7 +76,7 @@ describe('validateRecurringSchedule', () => {
 
     const result = validateRecurringSchedule(schedule);
 
-    expect(result.errors).toContain('every_invalid');
+    expect(result.errors).toContain(RecurringScheduleErrorCode.EveryInvalid);
   });
 
   it('returns repeat_invalid for an empty repeat count', () => {
@@ -102,7 +84,7 @@ describe('validateRecurringSchedule', () => {
 
     const result = validateRecurringSchedule(schedule);
 
-    expect(result.errors).toContain('repeat_invalid');
+    expect(result.errors).toContain(RecurringScheduleErrorCode.RepeatInvalid);
     expect(result.isValid).toBe(false);
   });
 
@@ -111,7 +93,9 @@ describe('validateRecurringSchedule', () => {
 
     const result = validateRecurringSchedule(schedule);
 
-    expect(result.errors).toContain('every_exceeds_unit_max');
+    expect(result.errors).toContain(
+      RecurringScheduleErrorCode.EveryExceedsUnitMax,
+    );
     expect(result.isValid).toBe(false);
   });
 
@@ -129,7 +113,9 @@ describe('validateRecurringSchedule', () => {
 
     const result = validateRecurringSchedule(schedule);
 
-    expect(result.errors).not.toContain('every_exceeds_unit_max');
+    expect(result.errors).not.toContain(
+      RecurringScheduleErrorCode.EveryExceedsUnitMax,
+    );
   });
 
   it('accepts 1 day repeated 180 times', () => {
@@ -153,7 +139,9 @@ describe('validateRecurringSchedule', () => {
 
     const result = validateRecurringSchedule(schedule);
 
-    expect(result.errors).toContain('duration_exceeds_max');
+    expect(result.errors).toContain(
+      RecurringScheduleErrorCode.DurationExceedsMax,
+    );
     expect(result.isValid).toBe(false);
   });
 
@@ -166,7 +154,9 @@ describe('validateRecurringSchedule', () => {
 
     const result = validateRecurringSchedule(schedule);
 
-    expect(result.errors).toContain('duration_exceeds_max');
+    expect(result.errors).toContain(
+      RecurringScheduleErrorCode.DurationExceedsMax,
+    );
   });
 
   it('returns both unit max and duration errors when both limits are exceeded', () => {
@@ -179,8 +169,8 @@ describe('validateRecurringSchedule', () => {
     const result = validateRecurringSchedule(schedule);
 
     expect(result.errors).toEqual([
-      'every_exceeds_unit_max',
-      'duration_exceeds_max',
+      RecurringScheduleErrorCode.EveryExceedsUnitMax,
+      RecurringScheduleErrorCode.DurationExceedsMax,
     ]);
   });
 });

--- a/app/components/UI/Bridge/utils/recurringSchedule.test.ts
+++ b/app/components/UI/Bridge/utils/recurringSchedule.test.ts
@@ -1,0 +1,194 @@
+import {
+  capRecurringKeypadValue,
+  getEveryValueAfterUnitChange,
+  parsePositiveInteger,
+  RECURRING_MAX_DURATION_MINUTES,
+  validateRecurringSchedule,
+  type RecurringState,
+} from './recurringSchedule';
+
+const makeSchedule = (
+  overrides: Partial<RecurringState> = {},
+): RecurringState => ({
+  everyValue: '1',
+  everyUnit: 'hour',
+  repeatCount: '10',
+  ...overrides,
+});
+
+describe('parsePositiveInteger', () => {
+  it('returns the number for a positive integer string', () => {
+    const value = '24';
+
+    const result = parsePositiveInteger(value);
+
+    expect(result).toBe(24);
+  });
+
+  it.each(['', '0', '01', '1.5', 'abc', '-2'])(
+    'returns undefined for %s',
+    (value) => {
+      const result = parsePositiveInteger(value);
+
+      expect(result).toBeUndefined();
+    },
+  );
+});
+
+describe('getEveryValueAfterUnitChange', () => {
+  it('keeps the every value when it fits the new unit max', () => {
+    const everyValue = '2';
+
+    const result = getEveryValueAfterUnitChange(everyValue, 'day');
+
+    expect(result).toBe('2');
+  });
+
+  it('resets every value to 1 when it exceeds the new unit max', () => {
+    const everyValue = '60';
+
+    const result = getEveryValueAfterUnitChange(everyValue, 'hour');
+
+    expect(result).toBe('1');
+  });
+
+  it('resets every value to 1 when the current value is empty', () => {
+    const everyValue = '';
+
+    const result = getEveryValueAfterUnitChange(everyValue, 'minute');
+
+    expect(result).toBe('1');
+  });
+});
+
+describe('capRecurringKeypadValue', () => {
+  it('keeps the current value when the next value exceeds the digit cap', () => {
+    const currentValue = '60';
+
+    const result = capRecurringKeypadValue(currentValue, '6000', 3);
+
+    expect(result).toBe('60');
+  });
+
+  it('returns the next value when it is within the digit cap', () => {
+    const currentValue = '6';
+
+    const result = capRecurringKeypadValue(currentValue, '60', 3);
+
+    expect(result).toBe('60');
+  });
+});
+
+describe('validateRecurringSchedule', () => {
+  it('returns valid for the default 1 hour times 10 schedule', () => {
+    const schedule = makeSchedule();
+
+    const result = validateRecurringSchedule(schedule);
+
+    expect(result).toEqual({ isValid: true, errors: [] });
+  });
+
+  it('returns every_invalid for an empty every value', () => {
+    const schedule = makeSchedule({ everyValue: '' });
+
+    const result = validateRecurringSchedule(schedule);
+
+    expect(result.errors).toContain('every_invalid');
+    expect(result.isValid).toBe(false);
+  });
+
+  it('returns every_invalid for a zero every value', () => {
+    const schedule = makeSchedule({ everyValue: '0' });
+
+    const result = validateRecurringSchedule(schedule);
+
+    expect(result.errors).toContain('every_invalid');
+  });
+
+  it('returns repeat_invalid for an empty repeat count', () => {
+    const schedule = makeSchedule({ repeatCount: '' });
+
+    const result = validateRecurringSchedule(schedule);
+
+    expect(result.errors).toContain('repeat_invalid');
+    expect(result.isValid).toBe(false);
+  });
+
+  it('returns every_exceeds_unit_max when hours exceed 24', () => {
+    const schedule = makeSchedule({ everyValue: '25', everyUnit: 'hour' });
+
+    const result = validateRecurringSchedule(schedule);
+
+    expect(result.errors).toContain('every_exceeds_unit_max');
+    expect(result.isValid).toBe(false);
+  });
+
+  it.each([
+    { unit: 'minute' as const, max: '60' },
+    { unit: 'hour' as const, max: '24' },
+    { unit: 'day' as const, max: '7' },
+    { unit: 'week' as const, max: '25' },
+  ])('accepts the max every value of $max for $unit', ({ unit, max }) => {
+    const schedule = makeSchedule({
+      everyValue: max,
+      everyUnit: unit,
+      repeatCount: '1',
+    });
+
+    const result = validateRecurringSchedule(schedule);
+
+    expect(result.errors).not.toContain('every_exceeds_unit_max');
+  });
+
+  it('accepts 1 day repeated 180 times', () => {
+    const schedule = makeSchedule({
+      everyValue: '1',
+      everyUnit: 'day',
+      repeatCount: '180',
+    });
+
+    const result = validateRecurringSchedule(schedule);
+
+    expect(result).toEqual({ isValid: true, errors: [] });
+  });
+
+  it('returns duration_exceeds_max for 1 day repeated 181 times', () => {
+    const schedule = makeSchedule({
+      everyValue: '1',
+      everyUnit: 'day',
+      repeatCount: '181',
+    });
+
+    const result = validateRecurringSchedule(schedule);
+
+    expect(result.errors).toContain('duration_exceeds_max');
+    expect(result.isValid).toBe(false);
+  });
+
+  it('returns duration_exceeds_max when the product exceeds 180 days in minutes', () => {
+    const schedule = makeSchedule({
+      everyValue: '1',
+      everyUnit: 'minute',
+      repeatCount: String(RECURRING_MAX_DURATION_MINUTES + 1),
+    });
+
+    const result = validateRecurringSchedule(schedule);
+
+    expect(result.errors).toContain('duration_exceeds_max');
+  });
+
+  it('returns both unit max and duration errors when both limits are exceeded', () => {
+    const schedule = makeSchedule({
+      everyValue: '61',
+      everyUnit: 'minute',
+      repeatCount: '10000',
+    });
+
+    const result = validateRecurringSchedule(schedule);
+
+    expect(result.errors).toEqual([
+      'every_exceeds_unit_max',
+      'duration_exceeds_max',
+    ]);
+  });
+});

--- a/app/components/UI/Bridge/utils/recurringSchedule.ts
+++ b/app/components/UI/Bridge/utils/recurringSchedule.ts
@@ -13,11 +13,12 @@ export interface RecurringState {
   repeatCount: string;
 }
 
-export type RecurringScheduleErrorCode =
-  | 'every_invalid'
-  | 'repeat_invalid'
-  | 'every_exceeds_unit_max'
-  | 'duration_exceeds_max';
+export enum RecurringScheduleErrorCode {
+  EveryInvalid = 'every_invalid',
+  RepeatInvalid = 'repeat_invalid',
+  EveryExceedsUnitMax = 'every_exceeds_unit_max',
+  DurationExceedsMax = 'duration_exceeds_max',
+}
 
 export interface RecurringScheduleValidation {
   isValid: boolean;
@@ -67,14 +68,6 @@ export function parsePositiveInteger(value: string): number | undefined {
   return Number(value);
 }
 
-export function restoreRecurringValueIfInvalid(value: string): string {
-  if (parsePositiveInteger(value) === undefined) {
-    return DEFAULT_RECURRING_EVERY_VALUE;
-  }
-
-  return value;
-}
-
 export function capRecurringKeypadValue(
   currentValue: string,
   nextValue: string,
@@ -95,13 +88,13 @@ export function validateRecurringSchedule(
   const repeat = parsePositiveInteger(recurring.repeatCount);
 
   if (every === undefined) {
-    errors.push('every_invalid');
+    errors.push(RecurringScheduleErrorCode.EveryInvalid);
   } else if (every > RECURRING_EVERY_MAX_BY_UNIT[recurring.everyUnit]) {
-    errors.push('every_exceeds_unit_max');
+    errors.push(RecurringScheduleErrorCode.EveryExceedsUnitMax);
   }
 
   if (repeat === undefined) {
-    errors.push('repeat_invalid');
+    errors.push(RecurringScheduleErrorCode.RepeatInvalid);
   }
 
   if (every !== undefined && repeat !== undefined) {
@@ -109,7 +102,7 @@ export function validateRecurringSchedule(
       every * RECURRING_INTERVAL_MINUTES[recurring.everyUnit] * repeat;
 
     if (durationMinutes > RECURRING_MAX_DURATION_MINUTES) {
-      errors.push('duration_exceeds_max');
+      errors.push(RecurringScheduleErrorCode.DurationExceedsMax);
     }
   }
 

--- a/app/components/UI/Bridge/utils/recurringSchedule.ts
+++ b/app/components/UI/Bridge/utils/recurringSchedule.ts
@@ -67,6 +67,14 @@ export function parsePositiveInteger(value: string): number | undefined {
   return Number(value);
 }
 
+export function restoreRecurringValueIfInvalid(value: string): string {
+  if (parsePositiveInteger(value) === undefined) {
+    return DEFAULT_RECURRING_EVERY_VALUE;
+  }
+
+  return value;
+}
+
 export function capRecurringKeypadValue(
   currentValue: string,
   nextValue: string,

--- a/app/components/UI/Bridge/utils/recurringSchedule.ts
+++ b/app/components/UI/Bridge/utils/recurringSchedule.ts
@@ -1,0 +1,126 @@
+export const RECURRING_INTERVAL_UNITS = [
+  'minute',
+  'hour',
+  'day',
+  'week',
+] as const;
+
+export type RecurringIntervalUnit = (typeof RECURRING_INTERVAL_UNITS)[number];
+
+export interface RecurringState {
+  everyValue: string;
+  everyUnit: RecurringIntervalUnit;
+  repeatCount: string;
+}
+
+export type RecurringScheduleErrorCode =
+  | 'every_invalid'
+  | 'repeat_invalid'
+  | 'every_exceeds_unit_max'
+  | 'duration_exceeds_max';
+
+export interface RecurringScheduleValidation {
+  isValid: boolean;
+  errors: RecurringScheduleErrorCode[];
+}
+
+export const RECURRING_EVERY_MAX_BY_UNIT: Record<
+  RecurringIntervalUnit,
+  number
+> = {
+  minute: 60,
+  hour: 24,
+  day: 7,
+  week: 25,
+};
+
+export const RECURRING_INTERVAL_MINUTES: Record<RecurringIntervalUnit, number> =
+  {
+    minute: 1,
+    hour: 60,
+    day: 1440,
+    week: 10080,
+  };
+
+export const RECURRING_MAX_DURATION_DAYS = 180;
+export const RECURRING_MAX_DURATION_MINUTES =
+  RECURRING_MAX_DURATION_DAYS * 24 * 60;
+
+export const DEFAULT_RECURRING_EVERY_VALUE = '1';
+export const DEFAULT_RECURRING_EVERY_UNIT: RecurringIntervalUnit = 'hour';
+export const DEFAULT_RECURRING_REPEAT_COUNT = '10';
+
+export const RECURRING_EVERY_MAX_DIGITS = 3;
+export const RECURRING_REPEAT_MAX_DIGITS = 6;
+
+export const initialRecurringState: RecurringState = {
+  everyValue: DEFAULT_RECURRING_EVERY_VALUE,
+  everyUnit: DEFAULT_RECURRING_EVERY_UNIT,
+  repeatCount: DEFAULT_RECURRING_REPEAT_COUNT,
+};
+
+export function parsePositiveInteger(value: string): number | undefined {
+  if (!/^[1-9]\d*$/.test(value)) {
+    return undefined;
+  }
+
+  return Number(value);
+}
+
+export function getEveryValueAfterUnitChange(
+  everyValue: string,
+  nextUnit: RecurringIntervalUnit,
+): string {
+  const parsed = parsePositiveInteger(everyValue);
+  const max = RECURRING_EVERY_MAX_BY_UNIT[nextUnit];
+
+  if (parsed === undefined || parsed > max) {
+    return DEFAULT_RECURRING_EVERY_VALUE;
+  }
+
+  return everyValue;
+}
+
+export function capRecurringKeypadValue(
+  currentValue: string,
+  nextValue: string,
+  maxDigits: number,
+): string {
+  if (nextValue.length > maxDigits) {
+    return currentValue;
+  }
+
+  return nextValue;
+}
+
+export function validateRecurringSchedule(
+  recurring: RecurringState,
+): RecurringScheduleValidation {
+  const errors: RecurringScheduleErrorCode[] = [];
+  const every = parsePositiveInteger(recurring.everyValue);
+  const repeat = parsePositiveInteger(recurring.repeatCount);
+
+  if (every === undefined) {
+    errors.push('every_invalid');
+  } else if (every > RECURRING_EVERY_MAX_BY_UNIT[recurring.everyUnit]) {
+    errors.push('every_exceeds_unit_max');
+  }
+
+  if (repeat === undefined) {
+    errors.push('repeat_invalid');
+  }
+
+  if (every !== undefined && repeat !== undefined) {
+    const durationMinutes =
+      every * RECURRING_INTERVAL_MINUTES[recurring.everyUnit] * repeat;
+
+    if (durationMinutes > RECURRING_MAX_DURATION_MINUTES) {
+      errors.push('duration_exceeds_max');
+    }
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+}

--- a/app/components/UI/Bridge/utils/recurringSchedule.ts
+++ b/app/components/UI/Bridge/utils/recurringSchedule.ts
@@ -67,20 +67,6 @@ export function parsePositiveInteger(value: string): number | undefined {
   return Number(value);
 }
 
-export function getEveryValueAfterUnitChange(
-  everyValue: string,
-  nextUnit: RecurringIntervalUnit,
-): string {
-  const parsed = parsePositiveInteger(everyValue);
-  const max = RECURRING_EVERY_MAX_BY_UNIT[nextUnit];
-
-  if (parsed === undefined || parsed > max) {
-    return DEFAULT_RECURRING_EVERY_VALUE;
-  }
-
-  return everyValue;
-}
-
 export function capRecurringKeypadValue(
   currentValue: string,
   nextValue: string,

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -1550,6 +1550,20 @@ describe('bridge slice', () => {
       expect(newState.recurring).toEqual(initialState.recurring);
     });
 
+    it('defaults to the initial recurring state when it is missing', () => {
+      const mockState = {
+        ...mockRootState,
+        bridge: {
+          ...initialState,
+          recurring: undefined,
+        },
+      } as unknown as RootState;
+
+      const result = selectRecurring(mockState);
+
+      expect(result).toEqual(initialState.recurring);
+    });
+
     it('selects the recurring object from state', () => {
       const mockState = {
         ...mockRootState,

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -63,6 +63,7 @@ import {
 import { RootState } from '../../../../reducers';
 import { cloneDeep } from 'lodash';
 import { BridgeTokenMetadata } from '../../../../components/UI/Bridge/constants/tokens';
+import { RecurringScheduleErrorCode } from '../../../../components/UI/Bridge/utils/recurringSchedule';
 import {
   HardwareWalletsSwapsEventType,
   HardwareWalletsSwapsStatus,
@@ -1587,7 +1588,9 @@ describe('bridge slice', () => {
       const result = selectRecurringScheduleValidation(mockState);
 
       expect(result.isValid).toBe(false);
-      expect(result.errors).toContain('duration_exceeds_max');
+      expect(result.errors).toContain(
+        RecurringScheduleErrorCode.DurationExceedsMax,
+      );
     });
   });
 });

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -1529,29 +1529,16 @@ describe('bridge slice', () => {
       expect(newState.recurring.repeatCount).toBe('20');
     });
 
-    it('keeps the every value when the new unit max still fits', () => {
+    it('resets the every value to 1 when the unit changes', () => {
       const state = reducer(initialState, setRecurringEveryValue('2'));
 
       const newState = reducer(state, setRecurringEveryUnit('day'));
 
       expect(newState.recurring).toEqual({
-        everyValue: '2',
+        everyValue: '1',
         everyUnit: 'day',
         repeatCount: '10',
       });
-    });
-
-    it('resets the every value to 1 when the new unit max is exceeded', () => {
-      const withMinutes = reducer(
-        initialState,
-        setRecurringEveryUnit('minute'),
-      );
-      const withValue = reducer(withMinutes, setRecurringEveryValue('60'));
-
-      const newState = reducer(withValue, setRecurringEveryUnit('hour'));
-
-      expect(newState.recurring.everyUnit).toBe('hour');
-      expect(newState.recurring.everyValue).toBe('1');
     });
 
     it('resets recurring fields when bridge state resets', () => {

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -43,6 +43,11 @@ import reducer, {
   setBatchSellTokenSlippage,
   setBatchSellTokenSlippages,
   selectIsNonEvmSourced,
+  setRecurringEveryValue,
+  setRecurringRepeatCount,
+  setRecurringEveryUnit,
+  selectRecurring,
+  selectRecurringScheduleValidation,
 } from '.';
 import { FEATURE_FLAG_NAME } from '../../../../selectors/featureFlagController/rwa';
 import {
@@ -141,6 +146,11 @@ describe('bridge slice', () => {
         batchSellSourceTokenAmounts: {},
         batchSellDestToken: undefined,
         batchSellSlippages: {},
+        recurring: {
+          everyValue: '1',
+          everyUnit: 'hour',
+          repeatCount: '10',
+        },
       });
     });
   });
@@ -1499,6 +1509,98 @@ describe('bridge slice', () => {
     it('returns a falsy value when there is no source token', () => {
       const state = buildState(undefined);
       expect(selectIsNonEvmSourced(state)).toBeFalsy();
+    });
+  });
+
+  describe('recurring', () => {
+    it('sets the every value', () => {
+      const action = setRecurringEveryValue('6');
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.recurring.everyValue).toBe('6');
+    });
+
+    it('sets the repeat count', () => {
+      const action = setRecurringRepeatCount('20');
+
+      const newState = reducer(initialState, action);
+
+      expect(newState.recurring.repeatCount).toBe('20');
+    });
+
+    it('keeps the every value when the new unit max still fits', () => {
+      const state = reducer(initialState, setRecurringEveryValue('2'));
+
+      const newState = reducer(state, setRecurringEveryUnit('day'));
+
+      expect(newState.recurring).toEqual({
+        everyValue: '2',
+        everyUnit: 'day',
+        repeatCount: '10',
+      });
+    });
+
+    it('resets the every value to 1 when the new unit max is exceeded', () => {
+      const withMinutes = reducer(
+        initialState,
+        setRecurringEveryUnit('minute'),
+      );
+      const withValue = reducer(withMinutes, setRecurringEveryValue('60'));
+
+      const newState = reducer(withValue, setRecurringEveryUnit('hour'));
+
+      expect(newState.recurring.everyUnit).toBe('hour');
+      expect(newState.recurring.everyValue).toBe('1');
+    });
+
+    it('resets recurring fields when bridge state resets', () => {
+      const withValue = reducer(initialState, setRecurringEveryValue('8'));
+
+      const newState = reducer(withValue, resetBridgeState());
+
+      expect(newState.recurring).toEqual(initialState.recurring);
+    });
+
+    it('selects the recurring object from state', () => {
+      const mockState = {
+        ...mockRootState,
+        bridge: {
+          ...initialState,
+          recurring: {
+            everyValue: '3',
+            everyUnit: 'day' as const,
+            repeatCount: '4',
+          },
+        },
+      } as unknown as RootState;
+
+      const result = selectRecurring(mockState);
+
+      expect(result).toEqual({
+        everyValue: '3',
+        everyUnit: 'day',
+        repeatCount: '4',
+      });
+    });
+
+    it('selects duration_exceeds_max when every times repeat is over 180 days', () => {
+      const mockState = {
+        ...mockRootState,
+        bridge: {
+          ...initialState,
+          recurring: {
+            everyValue: '1',
+            everyUnit: 'day' as const,
+            repeatCount: '181',
+          },
+        },
+      } as unknown as RootState;
+
+      const result = selectRecurringScheduleValidation(mockState);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain('duration_exceeds_max');
     });
   });
 });

--- a/app/core/redux/slices/bridge/index.ts
+++ b/app/core/redux/slices/bridge/index.ts
@@ -61,7 +61,7 @@ import { selectRWAEnabledFlag } from '../../../../selectors/featureFlagControlle
 import { BridgeTokenMetadata } from '../../../../components/UI/Bridge/constants/tokens';
 import { selectAnalyticsEnabled } from '../../../../selectors/analyticsController';
 import {
-  getEveryValueAfterUnitChange,
+  DEFAULT_RECURRING_EVERY_VALUE,
   initialRecurringState,
   validateRecurringSchedule,
   type RecurringIntervalUnit,
@@ -225,10 +225,7 @@ const slice = createSlice({
       action: PayloadAction<RecurringIntervalUnit>,
     ) => {
       state.recurring.everyUnit = action.payload;
-      state.recurring.everyValue = getEveryValueAfterUnitChange(
-        state.recurring.everyValue,
-        action.payload,
-      );
+      state.recurring.everyValue = DEFAULT_RECURRING_EVERY_VALUE;
     },
     setSelectedSourceChainIds: (
       state,

--- a/app/core/redux/slices/bridge/index.ts
+++ b/app/core/redux/slices/bridge/index.ts
@@ -451,7 +451,7 @@ export const selectDestAmount = createSelector(
 
 export const selectRecurring = createSelector(
   selectBridgeState,
-  (bridgeState) => bridgeState.recurring,
+  (bridgeState) => bridgeState.recurring ?? initialRecurringState,
 );
 
 export const selectRecurringEveryValue = createSelector(

--- a/app/core/redux/slices/bridge/index.ts
+++ b/app/core/redux/slices/bridge/index.ts
@@ -60,6 +60,13 @@ import { isStockRwaBridgeToken } from '../../../../components/UI/Bridge/utils/is
 import { selectRWAEnabledFlag } from '../../../../selectors/featureFlagController/rwa';
 import { BridgeTokenMetadata } from '../../../../components/UI/Bridge/constants/tokens';
 import { selectAnalyticsEnabled } from '../../../../selectors/analyticsController';
+import {
+  getEveryValueAfterUnitChange,
+  initialRecurringState,
+  validateRecurringSchedule,
+  type RecurringIntervalUnit,
+  type RecurringState,
+} from '../../../../components/UI/Bridge/utils/recurringSchedule';
 
 export const selectBridgeControllerState = (state: RootState) =>
   state.engine.backgroundState?.BridgeController;
@@ -114,6 +121,7 @@ export interface BridgeState {
   >;
   batchSellDestToken: BridgeToken | undefined;
   batchSellSlippages: Partial<Record<CaipAssetType, string | undefined>>;
+  recurring: RecurringState;
 }
 
 export const initialState: BridgeState = {
@@ -146,6 +154,7 @@ export const initialState: BridgeState = {
   batchSellSourceTokenAmounts: {},
   batchSellDestToken: undefined,
   batchSellSlippages: {},
+  recurring: initialRecurringState,
 };
 
 const name = 'bridge';
@@ -204,6 +213,22 @@ const slice = createSlice({
     },
     setDestAmount: (state, action: PayloadAction<string | undefined>) => {
       state.destAmount = action.payload;
+    },
+    setRecurringEveryValue: (state, action: PayloadAction<string>) => {
+      state.recurring.everyValue = action.payload;
+    },
+    setRecurringRepeatCount: (state, action: PayloadAction<string>) => {
+      state.recurring.repeatCount = action.payload;
+    },
+    setRecurringEveryUnit: (
+      state,
+      action: PayloadAction<RecurringIntervalUnit>,
+    ) => {
+      state.recurring.everyUnit = action.payload;
+      state.recurring.everyValue = getEveryValueAfterUnitChange(
+        state.recurring.everyValue,
+        action.payload,
+      );
     },
     setSelectedSourceChainIds: (
       state,
@@ -425,6 +450,31 @@ export const selectSourceAmount = createSelector(
 export const selectDestAmount = createSelector(
   selectBridgeState,
   (bridgeState) => bridgeState.destAmount,
+);
+
+export const selectRecurring = createSelector(
+  selectBridgeState,
+  (bridgeState) => bridgeState.recurring,
+);
+
+export const selectRecurringEveryValue = createSelector(
+  selectRecurring,
+  (recurring) => recurring.everyValue,
+);
+
+export const selectRecurringEveryUnit = createSelector(
+  selectRecurring,
+  (recurring) => recurring.everyUnit,
+);
+
+export const selectRecurringRepeatCount = createSelector(
+  selectRecurring,
+  (recurring) => recurring.repeatCount,
+);
+
+export const selectRecurringScheduleValidation = createSelector(
+  selectRecurring,
+  validateRecurringSchedule,
 );
 
 export const selectIsMaxSourceAmount = createSelector(
@@ -1066,6 +1116,9 @@ export const {
   setSourceAmount,
   setSourceAmountAsMax,
   setDestAmount,
+  setRecurringEveryValue,
+  setRecurringRepeatCount,
+  setRecurringEveryUnit,
   resetBridgeState,
   resetBridgeTokenInputs,
   resetBridgeDestToken,

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8481,6 +8481,24 @@
       "limit": "Limit",
       "recurring": "Recurring"
     },
+    "recurring": {
+      "every": "Every",
+      "repeat": "Repeat",
+      "times": "times",
+      "confirm": "Confirm",
+      "unit": {
+        "minute": "minute",
+        "hour": "hour",
+        "day": "day",
+        "week": "week"
+      },
+      "unit_option": {
+        "minute": "Minute",
+        "hour": "Hour",
+        "day": "Day",
+        "week": "Week"
+      }
+    },
     "continue": "Continue",
     "confirm_bridge": "Bridge",
     "confirm_swap": "Swap",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Recurring swaps tab was a placeholder. This adds the Every and Repeat schedule fields at the top of that tab so users can set how often a swap repeats and how many times it runs.

Every defaults to `1 hour` and Repeat to `10 times`. The number fields share Market's `SwapsKeypad` (no 25/50/Max, decimal key disabled). The unit picker is an MMDS `BottomSheet` (Minute / Hour / Day / Week) that slides down on overlay tap, X, and Confirm. Confirming a unit always resets Every to `1`. Backspacing Every or Repeat to `0` keeps `0` in Redux and turns that number red; closing the keypad or switching tabs does not snap it back to `1`. Invalid values also go red when Every exceeds the per-unit max (minute 60, hour 24, day 7, week 25) or when Every × Repeat exceeds 180 days. Error copy is not shown yet.

Schedule state lives on a nested `bridge.recurring` Redux object. Token pickers, price range, orders, and Preview are out of scope.

`SwapsKeypad` now forwards optional `periodButtonProps` so Recurring can disable the decimal key; Market is unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

The Recurring tab is still behind `swapsRecurringBuy` (off by default) and this slice does not complete the user-facing Recurring flow.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: SWAPS-4911

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

Enable the Recurring tab (`swapsRecurringBuy` / local Recurring flag), then:

```gherkin
Feature: Recurring Every and Repeat schedule fields

  Background:
    Given I am logged into MetaMask Mobile
    And the Recurring swaps tab is enabled
    And I open Swap and switch to the Recurring tab

  Scenario: user sees default Every and Repeat values
    Then Every shows 1
    And the unit is hour
    And Repeat shows 10 times

  Scenario: user edits Every and Repeat with the keypad
    When user taps the Every value
    Then the keypad opens at the bottom of the screen
    And the decimal key does nothing
    And 25% / 50% / Max are not shown
    When user types 2
    Then Every shows 12
    When user taps Repeat
    And user types 1
    Then Repeat shows 101
    And Every is still 12

  Scenario: user dismisses the keypad by tapping outside
    Given the keypad is open
    When user taps outside the keypad
    Then the keypad slides closed

  Scenario: user confirms a new interval unit
    Given Every is 2 hours
    When user taps the hour unit
    Then the Every bottom sheet opens at the bottom of the screen
    When user selects Day
    And user taps Confirm
    Then the unit is day
    And Every is 1

  Scenario: user dismisses the interval sheet without confirming
    Given the unit is hour
    When user opens the Every bottom sheet
    And user selects Week
    And user taps X or the overlay
    Then the sheet slides closed
    And the unit is still hour

  Scenario: user backspaces Every or Repeat to 0
    When user opens the Every keypad
    And user deletes until the value is 0
    Then Every shows 0 in red
    When user taps outside the keypad
    Then Every is still 0 and still red
    When user opens the Repeat keypad
    And user deletes until the value is 0
    And user taps outside the keypad
    Then Repeat is 0 and red

  Scenario: user leaves Recurring with Every at 0 and comes back
    Given Every is 0
    When user switches to the Market tab
    And user switches back to Recurring
    Then Every is still 0 and still red

  Scenario: user types an Every value over the unit max
    Given the unit is hour
    When user types 155
    Then Every shows 155 in red
    And Repeat is not red
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — Recurring tab was an empty placeholder. No screenshot captured in this session.

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/3a65715d-7eea-44d4-a04e-f7cf691c4d11



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and local bridge Redux schedule state only; no transaction submission or auth changes, and the tab remains behind the recurring-buy feature flag.
> 
> **Overview**
> Replaces the empty **Recurring** tab with **Every** / **Repeat** schedule inputs wired to new `bridge.recurring` Redux state (defaults: 1 hour, 10 times).
> 
> Users edit integers via the shared **SwapsKeypad** (decimal disabled); interval units use a new **RecurringIntervalSheet** bottom sheet. Validation covers per-unit maxima, zero/invalid values (red styling), and a 180-day total duration cap via `validateRecurringSchedule`. Confirming a unit change resets **Every** to `1`; dismissing the sheet keeps the prior unit.
> 
> **SwapsKeypad** gains optional `periodButtonProps` passthrough for Recurring only. Adds i18n under `bridge.recurring`, unit/component tests, and bridge slice tests for recurring actions/selectors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eccfc10288eebf336e573e365a95da3649e0287b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->