### PR TITLE
feat: identify automated RC OTA updates by commit in app info

### DIFF
--- a/app/components/Views/Settings/AppInformation/EnvironmentInfo.tsx
+++ b/app/components/Views/Settings/AppInformation/EnvironmentInfo.tsx
@@ -8,7 +8,7 @@ import {
   updateId,
   checkAutomatically,
 } from 'expo-updates';
-import { OTA_VERSION } from '../../../../constants/ota';
+import { OTA_RC_AUTO_COMMIT, OTA_VERSION } from '../../../../constants/ota';
 import {
   getFeatureFlagAppDistribution,
   getFeatureFlagAppEnvironment,
@@ -69,6 +69,11 @@ export const EnvironmentInfo = ({
             {`OTA Update status: ${otaUpdateMessage}`}
           </Text>
           <Text style={styles.branchInfo}>{`OTA Version: ${OTA_VERSION}`}</Text>
+          {OTA_RC_AUTO_COMMIT ? (
+            <Text style={styles.branchInfo}>
+              {`Auto RC OTA commit: ${OTA_RC_AUTO_COMMIT}`}
+            </Text>
+          ) : null}
         </>
       ) : null}
       {preinstalledSnaps.map((snap) => (

--- a/app/components/Views/Settings/AppInformation/index.test.tsx
+++ b/app/components/Views/Settings/AppInformation/index.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { waitFor, fireEvent } from '@testing-library/react-native';
 import { Image, InteractionManager, TouchableOpacity } from 'react-native';
+// Namespace import so jest.replaceProperty can override a value on the same expo-updates
+// module instance the components read from.
+// eslint-disable-next-line import-x/no-namespace
+import * as ExpoUpdates from 'expo-updates';
 import renderWithProvider, {
   DeepPartial,
   renderScreen,
@@ -44,8 +48,12 @@ jest.mock(
   }),
 );
 
+let mockOtaRcAutoCommit = '';
 jest.mock('../../../../constants/ota', () => ({
   OTA_VERSION: 'v0',
+  get OTA_RC_AUTO_COMMIT() {
+    return mockOtaRcAutoCommit;
+  },
 }));
 
 const MOCK_STATE = {
@@ -73,6 +81,7 @@ const MOCK_STATE = {
 describe('AppInformation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockOtaRcAutoCommit = '';
     jest
       .spyOn(InteractionManager, 'runAfterInteractions')
       .mockImplementation((task) => {
@@ -598,6 +607,99 @@ describe('AppInformation', () => {
         expect(getByText(/OTA Update runtime version: 1.0.0/)).toBeTruthy();
         expect(getByText(/Check Automatically: NEVER/)).toBeTruthy();
         expect(getByText(/OTA Update status:/)).toBeTruthy();
+      });
+    });
+
+    it('displays the Auto RC OTA commit after long-pressing the fox icon when CI set one', async () => {
+      mockOtaRcAutoCommit = 'a1b2c3d';
+
+      const { getByText, UNSAFE_getAllByType } = renderScreen(
+        AppInformation,
+        { name: 'AppInformation' },
+        { state: MOCK_STATE },
+      );
+
+      const foxTouchable = UNSAFE_getAllByType(TouchableOpacity).find(
+        (item) => item.props.onLongPress !== undefined,
+      );
+      if (foxTouchable) {
+        fireEvent(foxTouchable, 'longPress');
+      }
+
+      await waitFor(() => {
+        expect(getByText('Auto RC OTA commit: a1b2c3d')).toBeOnTheScreen();
+      });
+    });
+
+    it('omits the Auto RC OTA commit line when CI did not set one', async () => {
+      const { getByText, queryByText, UNSAFE_getAllByType } = renderScreen(
+        AppInformation,
+        { name: 'AppInformation' },
+        { state: MOCK_STATE },
+      );
+
+      const foxTouchable = UNSAFE_getAllByType(TouchableOpacity).find(
+        (item) => item.props.onLongPress !== undefined,
+      );
+      if (foxTouchable) {
+        fireEvent(foxTouchable, 'longPress');
+      }
+
+      await waitFor(() => {
+        expect(getByText('OTA Version: v0')).toBeOnTheScreen();
+      });
+      expect(queryByText(/Auto RC OTA commit:/)).not.toBeOnTheScreen();
+    });
+  });
+
+  describe('Version Display', () => {
+    // The version line only shows an OTA identity when the app is running a downloaded
+    // update rather than the bundle embedded in the binary. restoreAllMocks puts the
+    // shared expo-updates mock back afterwards.
+    const runningAnUpdate = () => {
+      jest.replaceProperty(ExpoUpdates, 'isEmbeddedLaunch', false);
+    };
+
+    it('identifies an Auto RC OTA update by its commit', async () => {
+      runningAnUpdate();
+      mockOtaRcAutoCommit = 'a1b2c3d';
+
+      const { getByText } = renderScreen(
+        AppInformation,
+        { name: 'AppInformation' },
+        { state: MOCK_STATE },
+      );
+
+      await waitFor(() => {
+        expect(getByText('MetaMask ota a1b2c3d (1000)')).toBeOnTheScreen();
+      });
+    });
+
+    it('falls back to OTA_VERSION for updates published outside the Auto RC path', async () => {
+      runningAnUpdate();
+
+      const { getByText } = renderScreen(
+        AppInformation,
+        { name: 'AppInformation' },
+        { state: MOCK_STATE },
+      );
+
+      await waitFor(() => {
+        expect(getByText('MetaMask ota v0 (1000)')).toBeOnTheScreen();
+      });
+    });
+
+    it('shows the native version when running the embedded bundle, even with a commit set', async () => {
+      mockOtaRcAutoCommit = 'a1b2c3d';
+
+      const { getByText } = renderScreen(
+        AppInformation,
+        { name: 'AppInformation' },
+        { state: MOCK_STATE },
+      );
+
+      await waitFor(() => {
+        expect(getByText('MetaMask v7.0.0 (1000)')).toBeOnTheScreen();
       });
     });
   });

--- a/app/components/Views/Settings/AppInformation/index.tsx
+++ b/app/components/Views/Settings/AppInformation/index.tsx
@@ -13,7 +13,7 @@ import {
   isEnabled as isOTAUpdatesEnabled,
 } from 'expo-updates';
 import { connect } from 'react-redux';
-import { OTA_VERSION } from '../../../../constants/ota';
+import { OTA_RC_AUTO_COMMIT, OTA_VERSION } from '../../../../constants/ota';
 import { strings } from '../../../../../locales/i18n';
 import AppConstants from '../../../../core/AppConstants';
 import { useTheme } from '../../../../util/theme';
@@ -123,10 +123,13 @@ const AppInformation = ({ navigation, preinstalledSnaps }: Props) => {
   /**
    * Returns the version string to display (native app version or OTA version).
    * When OTA is disabled we're always on embedded code; native isEmbeddedLaunch can be false in that case.
+   * Automated RC OTAs don't bump OTA_VERSION, so they identify themselves by commit instead.
    */
   const getVersionDisplay = () => {
     const appInfo = `${appName} v${appVersion} (${buildNumber})`;
-    const appInfoOta = `${appName} ota ${OTA_VERSION} (${buildNumber})`;
+    const appInfoOta = `${appName} ota ${
+      OTA_RC_AUTO_COMMIT || OTA_VERSION
+    } (${buildNumber})`;
     const isRunningEmbedded = isEmbeddedLaunch || !isOTAUpdatesEnabled;
     return __DEV__ || isRunningEmbedded ? appInfo : appInfoOta;
   };

--- a/app/constants/ota.ts
+++ b/app/constants/ota.ts
@@ -13,6 +13,17 @@ import otaConfig from '../../ota.config.js';
  * Kept here (not only in ota.config.js) so changes there do not alter the Expo fingerprint and break CI.
  */
 export const OTA_VERSION: string = 'vX.XX.X';
+
+/**
+ * Short commit SHA the running automated release-candidate OTA update was published from.
+ *
+ * The automated RC path publishes on every JS-only push to a `release/*` branch, so it never
+ * bumps `OTA_VERSION` and the commit is the only thing that identifies which update a tester is
+ * on. Set by CI at publish time and inlined into the bundle by babel's
+ * `transform-inline-environment-variables`; empty for native builds and every other OTA flow.
+ */
+export const OTA_RC_AUTO_COMMIT: string = process.env.OTA_RC_AUTO_COMMIT || '';
+
 export const RUNTIME_VERSION = otaConfig.RUNTIME_VERSION;
 export const PROJECT_ID = otaConfig.PROJECT_ID;
 export const UPDATE_URL = otaConfig.UPDATE_URL;


### PR DESCRIPTION
## What

Adds `OTA_RC_AUTO_COMMIT` and shows it in Settings > About MetaMask.

PR 1 of 3 for the simplified Auto RC OTA flow, which publishes an OTA update on every JS-only push to a `release/*` branch instead of a native build. That path never bumps `OTA_VERSION`, so the commit is the only thing that identifies which update a tester is running.

- [`app/constants/ota.ts`](https://github.com/MetaMask/metamask-mobile/blob/feat/rc-auto-ota/1-app-commit-display/app/constants/ota.ts): new `OTA_RC_AUTO_COMMIT`, read from `process.env` and inlined by babel's `transform-inline-environment-variables` (no allowlist change needed, that plugin inlines everything not in its `exclude` list).
- [`AppInformation/index.tsx`](https://github.com/MetaMask/metamask-mobile/blob/feat/rc-auto-ota/1-app-commit-display/app/components/Views/Settings/AppInformation/index.tsx): the always-visible version line prefers the commit over `OTA_VERSION`, so testers see `MetaMask ota a1b2c3d (1234)`.
- [`EnvironmentInfo.tsx`](https://github.com/MetaMask/metamask-mobile/blob/feat/rc-auto-ota/1-app-commit-display/app/components/Views/Settings/AppInformation/EnvironmentInfo.tsx): adds an `Auto RC OTA commit` line to the long-press panel.

## Why it is safe to merge alone

`OTA_RC_AUTO_COMMIT` is empty for native builds and for every existing OTA flow (Runway RC, production, exp), so behaviour is unchanged until CI starts setting it in PR 3. The version line still falls back to `OTA_VERSION`, and the panel line is omitted entirely when unset.

## Testing

`yarn jest app/components/Views/Settings/AppInformation`

<details>
<summary>28 passed, including 5 new cases</summary>

```
✓ displays the Auto RC OTA commit after long-pressing the fox icon when CI set one
✓ omits the Auto RC OTA commit line when CI did not set one
✓ identifies an Auto RC OTA update by its commit
✓ falls back to OTA_VERSION for updates published outside the Auto RC path
✓ shows the native version when running the embedded bundle, even with a commit set

Test Suites: 1 passed, 1 total
Tests:       28 passed, 28 total
```

</details>

Also clean: `eslint`, `prettier --check` and `tsc --noEmit` on all four files.

The version line only renders an OTA identity when the app is running a downloaded update, so the new tests use `jest.replaceProperty` to flip `isEmbeddedLaunch` on the shared `expo-updates` mock. `restoreAllMocks` in the existing `afterEach` puts it back.

## Manual verification

Not done, and it cannot be until PR 3 lands, since nothing sets the variable yet. Once the stack is merged this is covered by the end-to-end check in PR 3: push a JS-only commit to a `release/*` branch, install the RC build, and confirm Settings > About MetaMask shows `ota <short sha>`.

Made with [Cursor](https://cursor.com)