### PR TITLE
feat(predict): remove Live now pagination dots

### DIFF
--- a/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarousel.test.tsx
+++ b/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarousel.test.tsx
@@ -184,7 +184,7 @@ describe('FeaturedCarousel', () => {
     ).toBeOnTheScreen();
   });
 
-  it('renders pagination dots matching market count', () => {
+  it('does not render pagination dots', () => {
     mockUseFeaturedCarouselData.mockReturnValue({
       markets: [
         mockMarket,
@@ -196,13 +196,13 @@ describe('FeaturedCarousel', () => {
       refetch: jest.fn(),
     });
 
-    const { getByTestId } = renderWithProvider(<FeaturedCarousel />, {
+    const { queryByTestId } = renderWithProvider(<FeaturedCarousel />, {
       state: initialState,
     });
 
     expect(
-      getByTestId(FEATURED_CAROUSEL_TEST_IDS.PAGINATION_DOTS),
-    ).toBeOnTheScreen();
+      queryByTestId(FEATURED_CAROUSEL_TEST_IDS.PAGINATION_DOTS),
+    ).not.toBeOnTheScreen();
   });
 
   it('renders the expected number of carousel cards', () => {
@@ -230,7 +230,7 @@ describe('FeaturedCarousel', () => {
     ).not.toBeOnTheScreen();
   });
 
-  it('resets activeIndex when refetch returns fewer markets', () => {
+  it('still renders cards when refetch returns fewer markets', () => {
     mockUseFeaturedCarouselData.mockReturnValue({
       markets: [
         mockMarket,
@@ -245,10 +245,6 @@ describe('FeaturedCarousel', () => {
     const { rerender, getByTestId } = renderWithProvider(<FeaturedCarousel />, {
       state: initialState,
     });
-
-    expect(
-      getByTestId(FEATURED_CAROUSEL_TEST_IDS.PAGINATION_DOTS),
-    ).toBeOnTheScreen();
 
     mockUseFeaturedCarouselData.mockReturnValue({
       markets: [mockMarket],

--- a/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarousel.tsx
+++ b/app/components/UI/Predict/components/FeaturedCarousel/FeaturedCarousel.tsx
@@ -1,15 +1,5 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import {
-  NativeScrollEvent,
-  NativeSyntheticEvent,
-  useWindowDimensions,
-} from 'react-native';
+import React, { useCallback, useMemo, useRef } from 'react';
+import { useWindowDimensions } from 'react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { Box } from '@metamask/design-system-react-native';
 import { FlashList, FlashListRef } from '@shopify/flash-list';
@@ -17,7 +7,6 @@ import { Skeleton } from '../../../../../component-library/components-temp/Skele
 import { PredictMarket } from '../../types';
 import { PredictEventValues } from '../../constants/eventNames';
 import { useFeaturedCarouselData } from '../../hooks/useFeaturedCarouselData';
-import { PaginationDots } from '../PaginationDots/PaginationDots';
 import FeaturedCarouselCard from './FeaturedCarouselCard';
 import { FEATURED_CAROUSEL_TEST_IDS } from './FeaturedCarousel.testIds';
 
@@ -51,26 +40,9 @@ const FeaturedCarouselSkeleton: React.FC = () => {
 const FeaturedCarousel: React.FC = () => {
   const tw = useTailwind();
   const flashListRef = useRef<FlashListRef<PredictMarket>>(null);
-  const [activeIndex, setActiveIndex] = useState(0);
   const { cardWidth, snapInterval } = useCarouselLayout();
 
   const { markets, isLoading, error } = useFeaturedCarouselData();
-
-  useEffect(() => {
-    setActiveIndex((prev) => (prev >= markets.length ? 0 : prev));
-  }, [markets.length]);
-
-  const handleScroll = useCallback(
-    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      const offsetX = event.nativeEvent.contentOffset.x;
-      const newIndex = Math.min(
-        Math.max(0, Math.round(offsetX / snapInterval)),
-        markets.length - 1,
-      );
-      setActiveIndex(newIndex);
-    },
-    [markets.length, snapInterval],
-  );
 
   const renderItem = useCallback(
     ({ item: market, index: idx }: { item: PredictMarket; index: number }) => (
@@ -116,11 +88,8 @@ const FeaturedCarousel: React.FC = () => {
         showsHorizontalScrollIndicator={false}
         snapToInterval={snapInterval}
         decelerationRate="fast"
-        onScroll={handleScroll}
-        scrollEventThrottle={16}
         contentContainerStyle={tw.style(`px-[${HORIZONTAL_PADDING}px]`)}
       />
-      <PaginationDots count={markets.length} activeIndex={activeIndex} />
     </Box>
   );
 };

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.test.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.test.tsx
@@ -322,18 +322,8 @@ describe('PredictLiveNowSection', () => {
     expect(mockTrackHomeSectionInteraction).not.toHaveBeenCalled();
   });
 
-  it('renders pagination dots when there are 2+ items after load', () => {
+  it('does not render pagination dots after load', () => {
     setSection({ items: [createLiveMarket('L1'), createLiveMarket('L2')] });
-
-    const { getByTestId } = renderSection();
-
-    expect(
-      getByTestId(PREDICT_LIVE_NOW_SECTION_TEST_IDS.PAGINATION_DOTS),
-    ).toBeOnTheScreen();
-  });
-
-  it('does not render pagination dots when there is fewer than 2 items', () => {
-    setSection({ items: [createLiveMarket('L1')] });
 
     const { queryByTestId } = renderSection();
 

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx
@@ -1,9 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  useWindowDimensions,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
-} from 'react-native';
+import React, { useCallback, useMemo } from 'react';
+import { useWindowDimensions } from 'react-native';
 import {
   Box,
   BoxBorderColor,
@@ -21,7 +17,6 @@ import SharedDeeplinkManager from '../../../../../../../core/DeeplinkManager/Dee
 import Logger from '../../../../../../../util/Logger';
 import PredictMarket from '../../../../components/PredictMarket';
 import PredictMarketSkeleton from '../../../../components/PredictMarketSkeleton';
-import { PaginationDots } from '../../../../components/PaginationDots/PaginationDots';
 import { PredictEventValues } from '../../../../constants/eventNames';
 import type { PredictMarket as PredictMarketType } from '../../../../types';
 import { PREDICT_LIVE_NOW_SECTION_TEST_IDS } from './PredictLiveNowSection.testIds';
@@ -61,7 +56,6 @@ const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
   // interval (not just cardWidth) to stay in sync with the snapped card.
   const snapInterval = useMemo(() => cardWidth + CARD_GAP, [cardWidth]);
   const { items, isLoading, isEmpty, config } = usePredictLiveNowSection();
-  const [activeIndex, setActiveIndex] = useState(0);
   const isCustom = config.mode === 'custom';
   const isHeaderInteractive = !isCustom || Boolean(config.deeplink);
 
@@ -92,33 +86,10 @@ const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
     });
   }, [config.deeplink, isCustom, navigation]);
 
-  useEffect(() => {
-    const lastIndex = items.length - 1;
-    setActiveIndex((prev) =>
-      lastIndex < 0 ? 0 : Math.min(Math.max(prev, 0), lastIndex),
-    );
-  }, [items.length]);
-
   const carouselData = useMemo<CarouselItem[]>(
     () =>
       isLoading ? Array.from<CarouselItem>({ length: SKELETON_COUNT }) : items,
     [isLoading, items],
-  );
-
-  const handleScroll = useCallback(
-    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      const lastIndex = items.length - 1;
-      if (lastIndex < 0) {
-        return;
-      }
-      const offsetX = event.nativeEvent.contentOffset.x;
-      const newIndex = Math.min(
-        Math.max(0, Math.round(offsetX / snapInterval)),
-        lastIndex,
-      );
-      setActiveIndex(newIndex);
-    },
-    [snapInterval, items.length],
   );
 
   const renderItem: ListRenderItem<CarouselItem> = useCallback(
@@ -192,18 +163,8 @@ const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
           showsHorizontalScrollIndicator={false}
           snapToInterval={snapInterval}
           decelerationRate="fast"
-          onScroll={handleScroll}
-          scrollEventThrottle={16}
         />
       </Box>
-
-      {!isLoading && (
-        <PaginationDots
-          count={items.length}
-          activeIndex={activeIndex}
-          testID={PREDICT_LIVE_NOW_SECTION_TEST_IDS.PAGINATION_DOTS}
-        />
-      )}
     </Box>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Design requested removing the pagination indicators (pill + dots) under the Predict Live now carousel. Cards still swipe horizontally; only the page indicator is gone.

The Live now rail on Predict home is `PredictLiveNowSection`. `FeaturedCarousel` no longer renders dots either so the older carousel path stays consistent.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Removed pagination dots from the Predict Live now carousel

## **Related issues**

Fixes:

No issue: design-requested UI change on Predict home Live now (no GitHub or Jira ticket)

## **Manual testing steps**

```gherkin
Feature: Predict Live now carousel

  Scenario: user views Live now without pagination dots
    Given the user is on Predict home with Live now markets

    When the Live now carousel is visible
    Then pagination dots are not shown under the cards
    And the user can still swipe between cards
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
https://github.com/user-attachments/assets/f033dfb1-1d7d-4cd1-a0ec-144e435c6322



Pagination pill and dots under Live now (design review on Simulator). Upload screenshots in the GitHub PR conversation if needed.

### **After**
https://github.com/user-attachments/assets/62a2cd93-8302-4a62-9946-2a8103deab1d





Live now cards with no indicator row (verified on iOS Simulator 8.6.0). Upload screenshots in the GitHub PR conversation if needed.

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4a9c30d83ea89d525c3cefc286a971c3e3605e0e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->