### PR TITLE
feat: MUSD-1257 add earn asset model and ranking (3/6)

### DIFF
--- a/app/components/UI/Earn/types/earnAssets.ts
+++ b/app/components/UI/Earn/types/earnAssets.ts
@@ -1,0 +1,38 @@
+import type { LendingMarket } from '@metamask/stake-sdk';
+import type { CaipAssetType } from '@metamask/utils';
+import type { AssetType } from '../../../Views/confirmations/types/token';
+import type { EARN_EXPERIENCES } from '../constants/experiences';
+
+export type EarnAssetId = CaipAssetType;
+
+export type EarnRateStatus = 'loading' | 'ready' | 'error' | 'unavailable';
+
+export interface EarnRate {
+  type: 'APR' | 'APY';
+  percentage?: number;
+  status: EarnRateStatus;
+}
+
+export type EarnExperienceType = EARN_EXPERIENCES | 'MONEY_ACCOUNT_DEPOSIT';
+
+export type EarnAssetRole = 'funding' | 'underlying' | 'output';
+
+export interface EarnExperience {
+  id: string;
+  type: EarnExperienceType;
+  role: EarnAssetRole;
+  rate: EarnRate;
+  isFeeSubsidized: boolean;
+  market?: LendingMarket;
+}
+
+export interface EarnAsset
+  extends Omit<AssetType, 'assetId' | 'experience' | 'experiences'> {
+  assetId: EarnAssetId;
+  experiences: readonly EarnExperience[];
+  balanceFormatted?: string;
+  balanceMinimalUnit?: string;
+  balanceFiatNumber?: number;
+  isBalanceFiatAvailable?: boolean;
+  tokenUsdExchangeRate?: number;
+}

--- a/app/components/UI/Earn/utils/earnAssets/buildEarnAssets.test.ts
+++ b/app/components/UI/Earn/utils/earnAssets/buildEarnAssets.test.ts
@@ -1,0 +1,164 @@
+import { EARN_EXPERIENCES } from '../../constants/experiences';
+import type { EarnAsset, EarnAssetId } from '../../types/earnAssets';
+import { buildEarnAssets } from './buildEarnAssets';
+
+const assetId =
+  'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as EarnAssetId;
+
+const createAsset = (overrides: Partial<EarnAsset> = {}): EarnAsset => ({
+  assetId,
+  address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  chainId: '0x1',
+  decimals: 6,
+  image: 'usdc.png',
+  name: 'USD Coin',
+  symbol: 'USDC',
+  ticker: 'USDC',
+  balance: '10',
+  logo: 'usdc.png',
+  isETH: false,
+  experiences: [
+    {
+      id: 'money:usdc',
+      type: 'MONEY_ACCOUNT_DEPOSIT',
+      role: 'funding',
+      rate: { type: 'APY', percentage: 6.2, status: 'ready' },
+      isFeeSubsidized: false,
+    },
+  ],
+  ...overrides,
+});
+
+describe('buildEarnAssets', () => {
+  it('returns one asset for each CAIP-19 identity', () => {
+    const usdt = createAsset({
+      assetId:
+        'eip155:1/erc20:0xdac17f958d2ee523a2206206994597c13d831ec7' as EarnAssetId,
+      address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+      symbol: 'USDT',
+    });
+
+    const result = buildEarnAssets([createAsset(), usdt]);
+
+    expect(result.map(({ symbol }) => symbol)).toEqual(['USDC', 'USDT']);
+  });
+
+  it('keeps metadata from the first candidate', () => {
+    const held = createAsset({ name: 'Held USD Coin' });
+    const discovery = createAsset({ name: 'Remote USD Coin', balance: '0' });
+
+    const [result] = buildEarnAssets([held, discovery]);
+
+    expect(result.name).toBe('Held USD Coin');
+    expect(result.balance).toBe('10');
+  });
+
+  it('adds fields missing from the first candidate', () => {
+    const held = createAsset({ fiat: undefined });
+    const money = createAsset({
+      fiat: { balance: 10, currency: 'usd' },
+    });
+
+    const [result] = buildEarnAssets([held, money]);
+
+    expect(result.fiat).toEqual({ balance: 10, currency: 'usd' });
+  });
+
+  it('merges experiences by stable experience ID', () => {
+    const lending = createAsset({
+      experiences: [
+        {
+          id: 'lending:1:aave:usdc',
+          type: EARN_EXPERIENCES.STABLECOIN_LENDING,
+          role: 'underlying',
+          rate: { type: 'APY', percentage: 4.2, status: 'ready' },
+          isFeeSubsidized: false,
+        },
+      ],
+    });
+
+    const [result] = buildEarnAssets([createAsset(), lending, lending]);
+
+    expect(result.experiences.map(({ id }) => id)).toEqual([
+      'money:usdc',
+      'lending:1:aave:usdc',
+    ]);
+  });
+
+  it('orders merged experiences by strategy priority', () => {
+    const lending = createAsset({
+      experiences: [
+        {
+          id: 'lending:1:aave:usdc',
+          type: EARN_EXPERIENCES.STABLECOIN_LENDING,
+          role: 'underlying',
+          rate: { type: 'APY', percentage: 4.2, status: 'ready' },
+          isFeeSubsidized: false,
+        },
+      ],
+    });
+    const staking = createAsset({
+      experiences: [
+        {
+          id: 'pooled:eth',
+          type: EARN_EXPERIENCES.POOLED_STAKING,
+          role: 'underlying',
+          rate: { type: 'APR', percentage: 3.8, status: 'ready' },
+          isFeeSubsidized: false,
+        },
+        {
+          id: 'trx:trx',
+          type: EARN_EXPERIENCES.TRX_STAKING,
+          role: 'underlying',
+          rate: { type: 'APR', percentage: 4.5, status: 'ready' },
+          isFeeSubsidized: false,
+        },
+      ],
+    });
+
+    const [result] = buildEarnAssets([staking, lending, createAsset()]);
+
+    expect(result.experiences.map(({ id }) => id)).toEqual([
+      'money:usdc',
+      'lending:1:aave:usdc',
+      'pooled:eth',
+      'trx:trx',
+    ]);
+  });
+
+  it('orders experiences from a single candidate by strategy priority', () => {
+    const asset = createAsset({
+      experiences: [
+        {
+          id: 'trx:trx',
+          type: EARN_EXPERIENCES.TRX_STAKING,
+          role: 'underlying',
+          rate: { type: 'APR', percentage: 4.5, status: 'ready' },
+          isFeeSubsidized: false,
+        },
+        {
+          id: 'lending:1:aave:usdc',
+          type: EARN_EXPERIENCES.STABLECOIN_LENDING,
+          role: 'underlying',
+          rate: { type: 'APY', percentage: 4.2, status: 'ready' },
+          isFeeSubsidized: false,
+        },
+        {
+          id: 'money:usdc',
+          type: 'MONEY_ACCOUNT_DEPOSIT',
+          role: 'funding',
+          rate: { type: 'APY', percentage: 6.2, status: 'ready' },
+          isFeeSubsidized: false,
+        },
+      ],
+    });
+
+    const [result] = buildEarnAssets([asset]);
+
+    expect(result.experiences.map(({ id }) => id)).toEqual([
+      'money:usdc',
+      'lending:1:aave:usdc',
+      'trx:trx',
+    ]);
+  });
+});

--- a/app/components/UI/Earn/utils/earnAssets/buildEarnAssets.ts
+++ b/app/components/UI/Earn/utils/earnAssets/buildEarnAssets.ts
@@ -1,0 +1,101 @@
+import { EARN_EXPERIENCES } from '../../constants/experiences';
+import type { EarnAsset, EarnExperience } from '../../types/earnAssets';
+
+const experienceOrder: Record<EarnExperience['type'], number> = {
+  MONEY_ACCOUNT_DEPOSIT: 0,
+  [EARN_EXPERIENCES.STABLECOIN_LENDING]: 1,
+  [EARN_EXPERIENCES.POOLED_STAKING]: 2,
+  [EARN_EXPERIENCES.TRX_STAKING]: 2,
+};
+
+const orderExperiencesByRank = (
+  experiences: readonly EarnExperience[],
+): EarnExperience[] =>
+  experiences
+    .map((experience, index) => ({ experience, index }))
+    .sort(
+      (first, second) =>
+        experienceOrder[first.experience.type] -
+          experienceOrder[second.experience.type] || first.index - second.index,
+    )
+    .map(({ experience }) => experience);
+
+/**
+ * Merges Earn experiences while preserving their first-seen order.
+ *
+ * @param current - Experiences already associated with an asset.
+ * @param incoming - Experiences from a later asset candidate.
+ * @returns Combined experiences with duplicate IDs removed.
+ */
+const mergeExperiences = (
+  current: readonly EarnExperience[],
+  incoming: readonly EarnExperience[],
+): EarnExperience[] => {
+  const experiencesById = new Map(
+    current.map((experience) => [experience.id, experience]),
+  );
+  incoming.forEach((experience) => {
+    if (!experiencesById.has(experience.id)) {
+      experiencesById.set(experience.id, experience);
+    }
+  });
+  return [...experiencesById.values()];
+};
+
+/**
+ * Adds undefined fields from an incoming candidate without overwriting fields
+ * owned by the current candidate.
+ *
+ * @param current - Candidate with precedence for already-defined fields.
+ * @param incoming - Candidate that may provide missing fields.
+ * @returns Asset containing the current fields and any missing incoming fields.
+ */
+const fillMissingTokenFields = (
+  current: EarnAsset,
+  incoming: EarnAsset,
+): EarnAsset => {
+  const merged = { ...current };
+  (Object.keys(incoming) as (keyof EarnAsset)[]).forEach((key) => {
+    if (merged[key] === undefined) {
+      Object.assign(merged, { [key]: incoming[key] });
+    }
+  });
+  return merged;
+};
+
+/**
+ * Builds one asset per CAIP-19 identity.
+ *
+ * Earlier candidates own conflicting token fields; later candidates can only
+ * fill fields that are absent. Experiences are merged by stable experience ID
+ * and ordered by strategy priority.
+ *
+ * @param candidates - Asset candidates contributed by Earn data sources.
+ * @returns Deduplicated Earn assets in first-seen candidate order.
+ */
+export const buildEarnAssets = (
+  candidates: readonly EarnAsset[],
+): EarnAsset[] =>
+  Array.from(
+    candidates
+      .reduce((assetsById, candidate) => {
+        const identity = candidate.assetId.toLowerCase();
+        const current = assetsById.get(identity);
+        if (!current) {
+          assetsById.set(identity, {
+            ...candidate,
+            experiences: orderExperiencesByRank(candidate.experiences),
+          });
+          return assetsById;
+        }
+
+        assetsById.set(identity, {
+          ...fillMissingTokenFields(current, candidate),
+          experiences: orderExperiencesByRank(
+            mergeExperiences(current.experiences, candidate.experiences),
+          ),
+        });
+        return assetsById;
+      }, new Map<string, EarnAsset>())
+      .values(),
+  );

--- a/app/components/UI/Earn/utils/earnAssets/earnAssetBalance.test.ts
+++ b/app/components/UI/Earn/utils/earnAssets/earnAssetBalance.test.ts
@@ -1,0 +1,135 @@
+import type { EarnAsset, EarnAssetId } from '../../types/earnAssets';
+import {
+  getEarnAssetFiatDisplay,
+  getEarnAssetFiatNumber,
+  hasEarnAssetBalance,
+} from './earnAssetBalance';
+
+const createAsset = (overrides: Partial<EarnAsset> = {}): EarnAsset => ({
+  assetId:
+    'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as EarnAssetId,
+  address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  chainId: '0x1',
+  decimals: 6,
+  image: 'usdc.png',
+  name: 'USD Coin',
+  symbol: 'USDC',
+  ticker: 'USDC',
+  balance: '0',
+  logo: 'usdc.png',
+  isETH: false,
+  experiences: [],
+  ...overrides,
+});
+
+describe('hasEarnAssetBalance', () => {
+  it('uses balanceMinimalUnit when it is available', () => {
+    const asset = createAsset({
+      balance: '0',
+      balanceMinimalUnit: '1000000',
+    });
+
+    const result = hasEarnAssetBalance(asset);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false for a zero balanceMinimalUnit', () => {
+    const asset = createAsset({
+      balance: '100',
+      balanceMinimalUnit: '0',
+    });
+
+    const result = hasEarnAssetBalance(asset);
+
+    expect(result).toBe(false);
+  });
+
+  it('uses rawBalance when balanceMinimalUnit is unavailable', () => {
+    const asset = createAsset({
+      rawBalance: '0x1',
+    });
+
+    const result = hasEarnAssetBalance(asset);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false for an empty raw balance', () => {
+    const asset = createAsset({
+      rawBalance: '0x0',
+    });
+
+    const result = hasEarnAssetBalance(asset);
+
+    expect(result).toBe(false);
+  });
+
+  it('uses decimal balance when higher-priority balances are unavailable', () => {
+    const asset = createAsset({
+      balance: '0.01',
+    });
+
+    const result = hasEarnAssetBalance(asset);
+
+    expect(result).toBe(true);
+  });
+});
+
+describe('getEarnAssetFiatNumber', () => {
+  it('returns an available balanceFiatNumber', () => {
+    const asset = createAsset({
+      balanceFiatNumber: 12.34,
+      fiat: { balance: 56.78, currency: 'USD' },
+    });
+
+    const result = getEarnAssetFiatNumber(asset);
+
+    expect(result).toBe(12.34);
+  });
+
+  it('uses fiat balance when balanceFiatNumber is unavailable', () => {
+    const asset = createAsset({
+      balanceFiatNumber: undefined,
+      fiat: { balance: 56.78, currency: 'USD' },
+    });
+
+    const result = getEarnAssetFiatNumber(asset);
+
+    expect(result).toBe(56.78);
+  });
+
+  it('does not expose balanceFiatNumber when fiat is unavailable', () => {
+    const asset = createAsset({
+      isBalanceFiatAvailable: false,
+      balanceFiatNumber: 12.34,
+    });
+
+    const result = getEarnAssetFiatNumber(asset);
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('getEarnAssetFiatDisplay', () => {
+  it('prefers formatted balanceFiat over selected-currency balance', () => {
+    const asset = createAsset({
+      balanceFiat: '$12.34',
+      balanceInSelectedCurrency: '$56.78',
+    });
+
+    const result = getEarnAssetFiatDisplay(asset);
+
+    expect(result).toBe('$12.34');
+  });
+
+  it('uses selected-currency balance when formatted balanceFiat is unavailable', () => {
+    const asset = createAsset({
+      balanceInSelectedCurrency: '$56.78',
+    });
+
+    const result = getEarnAssetFiatDisplay(asset);
+
+    expect(result).toBe('$56.78');
+  });
+});

--- a/app/components/UI/Earn/utils/earnAssets/earnAssetBalance.ts
+++ b/app/components/UI/Earn/utils/earnAssets/earnAssetBalance.ts
@@ -1,0 +1,25 @@
+import BigNumber from 'bignumber.js';
+import type { EarnAsset } from '../../types/earnAssets';
+
+export const hasEarnAssetBalance = (asset: EarnAsset) => {
+  if (asset.balanceMinimalUnit !== undefined) {
+    return new BigNumber(asset.balanceMinimalUnit).isGreaterThan(0);
+  }
+  if (asset.rawBalance !== undefined) {
+    return asset.rawBalance !== '0x0';
+  }
+  return new BigNumber(asset.balance || 0).isGreaterThan(0);
+};
+
+export const getEarnAssetFiatNumber = (asset: EarnAsset) => {
+  if (
+    asset.isBalanceFiatAvailable !== false &&
+    Number.isFinite(asset.balanceFiatNumber)
+  ) {
+    return asset.balanceFiatNumber;
+  }
+  return Number.isFinite(asset.fiat?.balance) ? asset.fiat?.balance : undefined;
+};
+
+export const getEarnAssetFiatDisplay = (asset: EarnAsset) =>
+  asset.balanceFiat ?? asset.balanceInSelectedCurrency;

--- a/app/components/UI/Earn/utils/earnAssets/earnAssetBalance.ts
+++ b/app/components/UI/Earn/utils/earnAssets/earnAssetBalance.ts
@@ -22,4 +22,6 @@ export const getEarnAssetFiatNumber = (asset: EarnAsset) => {
 };
 
 export const getEarnAssetFiatDisplay = (asset: EarnAsset) =>
-  asset.balanceFiat ?? asset.balanceInSelectedCurrency;
+  asset.isBalanceFiatAvailable !== false
+    ? (asset.balanceFiat ?? asset.balanceInSelectedCurrency)
+    : asset.balanceInSelectedCurrency;

--- a/app/components/UI/Earn/utils/earnAssets/index.ts
+++ b/app/components/UI/Earn/utils/earnAssets/index.ts
@@ -1,0 +1,6 @@
+export { buildEarnAssets } from './buildEarnAssets';
+export {
+  getEarnAssetFiatDisplay,
+  getEarnAssetFiatNumber,
+  hasEarnAssetBalance,
+} from './earnAssetBalance';

--- a/app/components/UI/Earn/utils/earnSection/index.ts
+++ b/app/components/UI/Earn/utils/earnSection/index.ts
@@ -1,0 +1,1 @@
+export * from './rankEarnSectionAssets';

--- a/app/components/UI/Earn/utils/earnSection/rankEarnSectionAssets.test.ts
+++ b/app/components/UI/Earn/utils/earnSection/rankEarnSectionAssets.test.ts
@@ -1,0 +1,155 @@
+import { EARN_EXPERIENCES } from '../../constants/experiences';
+import type { EarnAsset, EarnAssetId } from '../../types/earnAssets';
+import {
+  EARN_SECTION_ASSET_LIMIT,
+  rankEarnSectionAssets,
+} from './rankEarnSectionAssets';
+
+const createAsset = (
+  symbol: string,
+  overrides: Partial<EarnAsset> = {},
+): EarnAsset => ({
+  assetId:
+    `eip155:1/erc20:0x${symbol.toLowerCase().padEnd(40, '0')}` as EarnAssetId,
+  address: `0x${symbol.toLowerCase().padEnd(40, '0')}`,
+  chainId: '0x1',
+  decimals: 6,
+  image: `${symbol}.png`,
+  name: symbol,
+  symbol,
+  balance: '0',
+  balanceMinimalUnit: '0',
+  logo: `${symbol}.png`,
+  isETH: false,
+  experiences: [
+    {
+      id: `lending:1:aave:${symbol}`,
+      type: EARN_EXPERIENCES.STABLECOIN_LENDING,
+      role: 'underlying',
+      rate: {
+        type: 'APR',
+        percentage: 3,
+        status: 'ready',
+      },
+      isFeeSubsidized: false,
+    },
+  ],
+  ...overrides,
+});
+
+describe('rankEarnSectionAssets', () => {
+  it('ranks held assets by descending fiat balance before unheld assets', () => {
+    const unheld = createAsset('USDT');
+    const smallerHeld = createAsset('DAI', {
+      balanceMinimalUnit: '1',
+      balanceFiatNumber: 10,
+    });
+    const largerHeld = createAsset('USDC', {
+      balanceMinimalUnit: '1',
+      balanceFiatNumber: 20,
+    });
+
+    const result = rankEarnSectionAssets([unheld, smallerHeld, largerHeld]);
+
+    expect(
+      result.flatMap((slot) =>
+        slot.kind === 'asset' ? [slot.asset.symbol] : [],
+      ),
+    ).toEqual(['USDC', 'DAI', 'USDT']);
+  });
+
+  it('ranks unheld assets by descending highest rate', () => {
+    const lowerRate = createAsset('USDT');
+    const higherRate = createAsset('USDC', {
+      experiences: [
+        {
+          id: 'money:usdc',
+          type: 'MONEY_ACCOUNT_DEPOSIT',
+          role: 'funding',
+          rate: {
+            type: 'APY',
+            percentage: 6.2,
+            status: 'ready',
+          },
+          isFeeSubsidized: false,
+        },
+      ],
+    });
+
+    const result = rankEarnSectionAssets([lowerRate, higherRate]);
+
+    expect(
+      result.flatMap((slot) =>
+        slot.kind === 'asset' ? [slot.asset.symbol] : [],
+      ),
+    ).toEqual(['USDC', 'USDT']);
+  });
+
+  it('selects the experience with the highest available rate', () => {
+    const asset = createAsset('USDC', {
+      experiences: [
+        {
+          id: 'lending:usdc',
+          type: EARN_EXPERIENCES.STABLECOIN_LENDING,
+          role: 'underlying',
+          rate: { type: 'APR', percentage: 4, status: 'ready' },
+          isFeeSubsidized: false,
+        },
+        {
+          id: 'money:usdc',
+          type: 'MONEY_ACCOUNT_DEPOSIT',
+          role: 'funding',
+          rate: { type: 'APY', percentage: 6.2, status: 'ready' },
+          isFeeSubsidized: false,
+        },
+      ],
+    });
+
+    const [result] = rankEarnSectionAssets([asset]);
+
+    expect(result.kind).toBe('asset');
+    if (result.kind === 'asset') {
+      expect(result.asset.highestRatePercent).toBe(6.2);
+      expect(result.asset.highestRateExperience?.id).toBe('money:usdc');
+    }
+  });
+
+  it('pads missing assets to the fixed section limit', () => {
+    const result = rankEarnSectionAssets([createAsset('USDC')]);
+
+    expect(result).toHaveLength(EARN_SECTION_ASSET_LIMIT);
+    expect(result.filter(({ kind }) => kind === 'unavailable')).toHaveLength(4);
+  });
+
+  it('truncates ranked assets to the fixed section limit', () => {
+    const assets = ['USDC', 'USDT', 'DAI', 'ETH', 'TRX', 'MUSD'].map((symbol) =>
+      createAsset(symbol),
+    );
+
+    const result = rankEarnSectionAssets(assets);
+
+    expect(result).toHaveLength(EARN_SECTION_ASSET_LIMIT);
+    expect(result.every(({ kind }) => kind === 'asset')).toBe(true);
+  });
+
+  it('reports an error rate when no experience has a value', () => {
+    const asset = createAsset('USDC', {
+      experiences: [
+        {
+          id: 'lending:usdc',
+          type: EARN_EXPERIENCES.STABLECOIN_LENDING,
+          role: 'underlying',
+          rate: { type: 'APR', status: 'error' },
+          isFeeSubsidized: false,
+        },
+      ],
+    });
+
+    const [result] = rankEarnSectionAssets([asset]);
+
+    expect(result.kind).toBe('asset');
+    if (result.kind === 'asset') {
+      expect(result.asset.rateStatus).toBe('error');
+    }
+  });
+});

--- a/app/components/UI/Earn/utils/earnSection/rankEarnSectionAssets.ts
+++ b/app/components/UI/Earn/utils/earnSection/rankEarnSectionAssets.ts
@@ -1,0 +1,137 @@
+import type {
+  EarnAsset,
+  EarnExperience,
+  EarnRateStatus,
+} from '../../types/earnAssets';
+import { getEarnAssetFiatNumber, hasEarnAssetBalance } from '../earnAssets';
+
+export const EARN_SECTION_ASSET_LIMIT = 5;
+
+export interface EarnSectionRankedAsset extends EarnAsset {
+  highestRatePercent?: number;
+  highestRateExperience?: EarnExperience;
+  rateStatus: EarnRateStatus;
+}
+
+export type EarnSectionAssetSlot =
+  | {
+      kind: 'asset';
+      key: string;
+      asset: EarnSectionRankedAsset;
+    }
+  | {
+      kind: 'unavailable';
+      key: string;
+    };
+
+const getRateStatus = (
+  experiences: readonly EarnExperience[],
+): EarnRateStatus => {
+  if (experiences.some(({ rate }) => rate.percentage !== undefined)) {
+    return 'ready';
+  }
+  if (experiences.some(({ rate }) => rate.status === 'loading')) {
+    return 'loading';
+  }
+  if (experiences.some(({ rate }) => rate.status === 'error')) {
+    return 'error';
+  }
+  return 'unavailable';
+};
+
+const getHighestRatePercent = (experiences: readonly EarnExperience[]) =>
+  experiences.reduce<number | undefined>((highest, { rate }) => {
+    if (rate.percentage === undefined || !Number.isFinite(rate.percentage)) {
+      return highest;
+    }
+    return highest === undefined
+      ? rate.percentage
+      : Math.max(highest, rate.percentage);
+  }, undefined);
+
+const getHighestRateExperience = (experiences: readonly EarnExperience[]) =>
+  experiences.reduce<EarnExperience | undefined>((highest, experience) => {
+    if (
+      experience.rate.percentage === undefined ||
+      !Number.isFinite(experience.rate.percentage)
+    ) {
+      return highest;
+    }
+    return highest?.rate.percentage !== undefined &&
+      highest.rate.percentage >= experience.rate.percentage
+      ? highest
+      : experience;
+  }, undefined);
+
+const compareKnownNumbersDescending = (
+  first: number | undefined,
+  second: number | undefined,
+) => {
+  if (first === undefined && second === undefined) return 0;
+  if (first === undefined) return 1;
+  if (second === undefined) return -1;
+  return second - first;
+};
+
+const compareByKey = (
+  first: EarnSectionRankedAsset,
+  second: EarnSectionRankedAsset,
+) => first.assetId.localeCompare(second.assetId);
+
+/**
+ * Projects the CAIP-19-deduplicated catalogue produced by buildEarnAssets into
+ * fixed homepage slots. Held assets rank before discovery assets, and missing
+ * assets are padded so the section always renders five slots by default.
+ *
+ * Rates are compared as displayed numeric percentages; APR and APY values are
+ * not normalized to a common yield type.
+ */
+export const rankEarnSectionAssets = (
+  assets: readonly EarnAsset[],
+  limit = EARN_SECTION_ASSET_LIMIT,
+): EarnSectionAssetSlot[] => {
+  const rankedAssets = assets.map(
+    (asset): EarnSectionRankedAsset => ({
+      ...asset,
+      highestRatePercent: getHighestRatePercent(asset.experiences),
+      highestRateExperience: getHighestRateExperience(asset.experiences),
+      rateStatus: getRateStatus(asset.experiences),
+    }),
+  );
+
+  const held = rankedAssets
+    .filter(hasEarnAssetBalance)
+    .sort(
+      (first, second) =>
+        compareKnownNumbersDescending(
+          getEarnAssetFiatNumber(first),
+          getEarnAssetFiatNumber(second),
+        ) || compareByKey(first, second),
+    );
+  const unheld = rankedAssets
+    .filter((asset) => !hasEarnAssetBalance(asset))
+    .sort(
+      (first, second) =>
+        compareKnownNumbersDescending(
+          first.highestRatePercent,
+          second.highestRatePercent,
+        ) || compareByKey(first, second),
+    );
+
+  const slots: EarnSectionAssetSlot[] = [...held, ...unheld]
+    .slice(0, limit)
+    .map((asset) => ({
+      kind: 'asset',
+      key: asset.assetId,
+      asset,
+    }));
+
+  while (slots.length < limit) {
+    slots.push({
+      kind: 'unavailable',
+      key: `earn-section-unavailable-${slots.length}`,
+    });
+  }
+
+  return slots;
+};


### PR DESCRIPTION
# PR Title

feat(earn): add earn asset model and ranking

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
PR 3/6 for this [MUSD-1257](https://consensyssoftware.atlassian.net/browse/MUSD-1257).

Introduces canonical CAIP-19 Earn asset types, deterministic experience merging, balance helpers, and Homepage asset ranking. This isolates critical transformations before catalogue fetching and UI integration.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added canonical Earn asset construction and ranking logic

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1257: Home – Implement Earn module and empty state](https://consensyssoftware.atlassian.net/browse/MUSD-1257)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — pure transformations are covered by focused Jest tests.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — no UI changes.

### **After**

N/A — no UI changes.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ab3b8718f294c266410f5ed64309b77a2e2f8ee5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[MUSD-1257]: https://consensyssoftware.atlassian.net/browse/MUSD-1257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ