### PR TITLE
fix(card): render KYC failed artwork as full-bleed background

### DIFF
--- a/app/components/UI/Card/components/Onboarding/KYCFailed.test.tsx
+++ b/app/components/UI/Card/components/Onboarding/KYCFailed.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import { render, fireEvent } from '@testing-library/react-native';
 import { useNavigation } from '@react-navigation/native';
 import KYCFailed from './KYCFailed';
@@ -286,6 +287,24 @@ describe('KYCFailed Component', () => {
       const image = getByTestId('kyc-failed-image');
 
       expect(image).toBeTruthy();
+    });
+
+    it('renders the image as a full-bleed background', () => {
+      const { getByTestId } = render(<KYCFailed />);
+
+      const image = getByTestId('kyc-failed-image');
+      const style = StyleSheet.flatten(image.props.style);
+
+      // The asset has its own purple backdrop baked in, so any area it leaves
+      // uncovered shows the screen's flat fallback color as a visible seam.
+      expect(image.props.resizeMode).toBe('cover');
+      expect(style).toMatchObject({
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+      });
     });
   });
 

--- a/app/components/UI/Card/components/Onboarding/KYCFailed.tsx
+++ b/app/components/UI/Card/components/Onboarding/KYCFailed.tsx
@@ -1,12 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import {
-  Image,
-  View,
-  StyleSheet,
-  useWindowDimensions,
-  ViewStyle,
-  ImageStyle,
-} from 'react-native';
+import React, { useCallback, useEffect, useRef } from 'react';
+import { Image, StyleSheet } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import { useDispatch, useSelector } from 'react-redux';
@@ -35,10 +28,14 @@ import { brandColor } from '@metamask/design-tokens';
 import { colors as importedColors } from '../../../../../styles/common';
 import { resetOnboardingState } from '../../../../../core/redux/slices/card';
 
-// Threshold for small screen adjustments
-const SMALL_SCREEN_THRESHOLD = 700;
-
 const staticStyles = StyleSheet.create({
+  backgroundImage: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+  },
   headerContainer: {
     zIndex: 2,
   },
@@ -58,36 +55,6 @@ const KYCFailed = () => {
   const { trackEvent, createEventBuilder } = useAnalytics();
   const activeProviderId = useSelector(selectCardActiveProviderId);
   const hasTrackedView = useRef(false);
-  const { width: screenWidth, height: screenHeight } = useWindowDimensions();
-
-  const dynamicStyles = useMemo<{
-    imageContainer: ViewStyle;
-    image: ImageStyle;
-  }>(() => {
-    const isSmallScreen = screenHeight < SMALL_SCREEN_THRESHOLD;
-    const imageTop = isSmallScreen ? '28%' : '25%';
-    const imageWidth = isSmallScreen ? screenWidth * 1.5 : screenWidth * 1.2;
-    const imageHeight = isSmallScreen
-      ? screenHeight * 0.8
-      : screenHeight * 0.75;
-
-    return {
-      imageContainer: {
-        position: 'absolute',
-        top: imageTop,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        alignItems: 'center',
-        justifyContent: 'flex-start',
-        zIndex: 1,
-      },
-      image: {
-        width: imageWidth,
-        height: imageHeight,
-      },
-    };
-  }, [screenWidth, screenHeight]);
 
   useEffect(() => {
     dispatch(resetOnboardingState());
@@ -117,6 +84,13 @@ const KYCFailed = () => {
 
   return (
     <Box twClassName="flex-1" style={tw.style(`bg-[${brandColor.purple800}]`)}>
+      <Image
+        source={MM_CARD_ONBOARDING_FAILED}
+        resizeMode="cover"
+        style={staticStyles.backgroundImage}
+        testID="kyc-failed-image"
+      />
+
       {/* Header with back button */}
       <SafeAreaView edges={['top']} style={staticStyles.headerContainer}>
         <Box twClassName="px-4 py-2 items-start">
@@ -140,23 +114,13 @@ const KYCFailed = () => {
           </Text>
           <Text
             variant={TextVariant.BodyMd}
-            twClassName="text-white opacity-80 mt-4"
+            twClassName="text-white opacity-80 mt-2"
             testID="kyc-failed-description"
           >
             {strings('card.card_onboarding.kyc_failed.description')}
           </Text>
         </Box>
       </SafeAreaView>
-
-      {/* Image - positioned absolutely to extend behind footer */}
-      <View style={dynamicStyles.imageContainer}>
-        <Image
-          source={MM_CARD_ONBOARDING_FAILED}
-          resizeMode="contain"
-          style={dynamicStyles.image}
-          testID="kyc-failed-image"
-        />
-      </View>
 
       {/* Footer */}
       <SafeAreaView


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The KYC failed screen showed a hard horizontal color seam because the onboarding-failed artwork was rendered with `resizeMode="contain"` and a dynamic inset (`top` ~25%, oversized width/height). That left uncovered areas filled by the screen's flat `purple800` fallback, which does not match the purple gradient baked into the asset.

This PR renders the artwork as a full-bleed `cover` background (`absolute`, `100%` width/height) behind the header and footer, removes the small-screen dynamic sizing path, and tightens the description spacing (`mt-4` → `mt-2`) so title/description match the design mock. Adds a unit regression that asserts `resizeMode="cover"` and full-container fill styles.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a background color seam on the MetaMask Card KYC failed screen

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/CARD-550

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Card KYC failed background

  Scenario: KYC failed screen shows a continuous purple backdrop
    Given the user reaches the Card KYC failed screen

    When the screen is displayed
    Then the character artwork fills the screen as a background
    And there is no horizontal color split between the asset backdrop and the screen background
    And the description text sits above the character hat without overlapping it
    And the "Back to home" button remains usable
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="299" alt="b" src="https://github.com/user-attachments/assets/baa57344-3948-4078-bc4b-d8651cdb1315" />


### **After**

<img width="299" alt="a" src="https://github.com/user-attachments/assets/740f5e65-c82e-46db-af21-d089bc77c314" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c9646d1f5f94eff5805281f163dca46aafaef149. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->