### PR TITLE
refactor(card): remove address text from card image

### DIFF
--- a/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
@@ -1352,19 +1352,6 @@ describe('CardHome Component', () => {
     expect(screen.getByTestId('card-view-title')).toBeOnTheScreen();
   });
 
-  it('does not render wallet address on the card image when unauthenticated', () => {
-    // Given: unauthenticated user with primary asset wallet address
-    setupMockSelectors({ isAuthenticated: false });
-
-    // When: component renders
-    render();
-
-    // Then: card image should not include the wallet address
-    expect(
-      screen.queryByTestId(CardHomeSelectors.CARD_WALLET_ADDRESS),
-    ).not.toBeOnTheScreen();
-  });
-
   it('resets to authentication when onboarding token is revoked', async () => {
     setupMockSelectors({
       isAuthenticated: false,
@@ -1396,20 +1383,6 @@ describe('CardHome Component', () => {
       }),
     );
     expect(mockClearLastUnauthenticatedReason).toHaveBeenCalledTimes(1);
-  });
-
-  it('renders wallet address on the card image when authenticated', () => {
-    // Given: authenticated user with primary asset wallet address
-    setupMockSelectors({ isAuthenticated: true });
-    setupLoadCardDataMock({ isAuthenticated: true });
-
-    // When: component renders
-    render();
-
-    // Then: card image should include the wallet address
-    expect(
-      screen.getByTestId(CardHomeSelectors.CARD_WALLET_ADDRESS),
-    ).toBeOnTheScreen();
   });
 
   it('navigates to add funds modal when add funds button is pressed with USDC token', async () => {
@@ -1502,51 +1475,6 @@ describe('CardHome Component', () => {
       ...mockPriorityToken,
       isMoneyAccountEntry: true,
     } as typeof mockPriorityToken;
-
-    it('passes the Money Account i18n label as the address to the card image when authenticated', () => {
-      setupMockSelectors({ isAuthenticated: true });
-      setupLoadCardDataMock({
-        priorityToken: moneyAccountPriorityToken,
-        allTokens: [moneyAccountPriorityToken],
-        isAuthenticated: true,
-      });
-
-      render();
-
-      const cardImage = screen.getByTestId(
-        CardHomeSelectors.CARD_WALLET_ADDRESS,
-      );
-      // The SVG `Svg` element receives `address` via `{...props}`; this is
-      // the same prop that drives the rendered SVG `<Text>` content. In
-      // the test environment `strings()` returns the i18n key.
-      expect(cardImage.props.address).toBe(
-        'card.card_spending_limit.money_account_label',
-      );
-    });
-
-    it('passes the truncated wallet hex (not the Money Account label) when the primary token is not a money account entry', () => {
-      setupMockSelectors({ isAuthenticated: true });
-      const walletPriorityToken = {
-        ...mockPriorityToken,
-        isMoneyAccountEntry: false,
-      } as typeof mockPriorityToken;
-      setupLoadCardDataMock({
-        priorityToken: walletPriorityToken,
-        allTokens: [mockPriorityToken],
-        isAuthenticated: true,
-      });
-
-      render();
-
-      const cardImage = screen.getByTestId(
-        CardHomeSelectors.CARD_WALLET_ADDRESS,
-      );
-      // CardImage truncates the hex; what matters here is that the Money
-      // Account label is NOT used when the flag is false.
-      expect(cardImage.props.address).not.toBe(
-        'card.card_spending_limit.money_account_label',
-      );
-    });
 
     it('shows the unlink row when the active primary Money Account owns the Money Account spending source', () => {
       setupMockSelectors({ isAuthenticated: true });

--- a/app/components/UI/Card/Views/CardHome/CardHome.testIds.ts
+++ b/app/components/UI/Card/Views/CardHome/CardHome.testIds.ts
@@ -38,7 +38,6 @@ export const CardHomeSelectors = {
   FREEZE_CARD_TOGGLE: 'freeze-card-toggle',
   VIEW_PIN_BUTTON: 'view-pin-button',
   SET_PIN_BUTTON: 'set-pin-button',
-  CARD_WALLET_ADDRESS: 'card-wallet-address',
   LINK_MONEY_ACCOUNT_DIVIDER_BOTTOM: 'link-money-account-divider-bottom',
   CREDIT_BALANCE_INFO_BUTTON: 'credit-balance-info-button',
   CREDIT_BANNER: 'credit-banner',

--- a/app/components/UI/Card/Views/CardHome/CardHome.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.tsx
@@ -607,13 +607,6 @@ const CardHome = () => {
                 onCopyDetail={actions.copyCardDetail}
                 cardType={data?.card?.type}
                 cardStatus={data?.card?.status}
-                walletAddress={
-                  isAuthenticated
-                    ? primaryToken?.isMoneyAccountEntry
-                      ? strings('card.card_spending_limit.money_account_label')
-                      : data?.primaryFundingAsset?.walletAddress
-                    : undefined
-                }
               />
             )}
           </Animated.View>

--- a/app/components/UI/Card/Views/CardHome/components/CardImageSection.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/components/CardImageSection.test.tsx
@@ -31,7 +31,6 @@ const baseProps = {
   onImageError: jest.fn(),
   cardType: CardType.VIRTUAL,
   cardStatus: CardStatus.ACTIVE,
-  walletAddress: undefined,
 };
 
 describe('CardImageSection', () => {

--- a/app/components/UI/Card/Views/CardHome/components/CardImageSection.tsx
+++ b/app/components/UI/Card/Views/CardHome/components/CardImageSection.tsx
@@ -32,7 +32,6 @@ interface CardImageSectionProps {
   onImageError: () => void;
   cardType: CardType | undefined;
   cardStatus: CardStatus | undefined;
-  walletAddress: string | undefined;
   cardSensitiveDetails?: CardSensitiveDetails | null;
   onCopyDetail?: (value: string) => void;
 }
@@ -85,7 +84,6 @@ const CardImageSection = ({
   onImageError,
   cardType,
   cardStatus,
-  walletAddress,
   cardSensitiveDetails,
   onCopyDetail,
 }: CardImageSectionProps) => {
@@ -214,8 +212,6 @@ const CardImageSection = ({
     <CardImage
       type={cardType ?? CardType.VIRTUAL}
       status={cardStatus ?? CardStatus.ACTIVE}
-      address={walletAddress}
-      testID={walletAddress ? CardHomeSelectors.CARD_WALLET_ADDRESS : undefined}
     />
   );
 };

--- a/app/components/UI/Card/components/CardImage/CardImage.test.tsx
+++ b/app/components/UI/Card/components/CardImage/CardImage.test.tsx
@@ -4,15 +4,6 @@ import { CardType, CardStatus } from '../../types';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 
-jest.mock('../../util/truncateAddress', () => ({
-  truncateAddress: jest.fn((address: string | undefined) => {
-    if (address) {
-      return `${address.slice(0, 6)}...${address.slice(-4)}`;
-    }
-    return undefined;
-  }),
-}));
-
 function renderWithProvider(component: React.ComponentType) {
   return renderScreen(
     component,
@@ -100,31 +91,6 @@ describe('CardImage Component', () => {
     ));
 
     expect(getByTestId('active-card')).toBeOnTheScreen();
-  });
-
-  it('renders with truncated address when address prop provided', () => {
-    const { getByTestId } = renderWithProvider(() => (
-      <CardImage
-        type={CardType.VIRTUAL}
-        status={CardStatus.ACTIVE}
-        address="0x1234567890123456789012345678901234567890"
-        testID="card-with-address"
-      />
-    ));
-
-    expect(getByTestId('card-with-address')).toBeOnTheScreen();
-  });
-
-  it('renders without address when address prop not provided', () => {
-    const { getByTestId } = renderWithProvider(() => (
-      <CardImage
-        type={CardType.VIRTUAL}
-        status={CardStatus.ACTIVE}
-        testID="card-without-address"
-      />
-    ));
-
-    expect(getByTestId('card-without-address')).toBeOnTheScreen();
   });
 
   it.each([CardType.VIRTUAL, CardType.PHYSICAL, CardType.METAL] as const)(

--- a/app/components/UI/Card/components/CardImage/CardImage.tsx
+++ b/app/components/UI/Card/components/CardImage/CardImage.tsx
@@ -10,10 +10,8 @@ import Svg, {
   ClipPath,
   LinearGradient,
   Stop,
-  Text,
 } from 'react-native-svg';
 import { CardStatus, CardType } from '../../types';
-import { truncateAddress } from '../../util/truncateAddress';
 
 const cardImageOriginalWidth = 851;
 const cardImageOriginalHeight = 540;
@@ -22,12 +20,9 @@ const cardImageAspectRatio = cardImageOriginalWidth / cardImageOriginalHeight;
 type CardImageProps = {
   type: CardType;
   status: CardStatus;
-  address?: string;
 } & SvgProps;
 
-const VirtualCardImage = (
-  props: SvgProps & { address?: string; hasLowerOpacity: boolean },
-) => (
+const VirtualCardImage = (props: SvgProps & { hasLowerOpacity: boolean }) => (
   <View style={{ aspectRatio: cardImageAspectRatio }}>
     <Svg
       fill="none"
@@ -105,11 +100,6 @@ const VirtualCardImage = (
           fill="#661800"
         />
       </G>
-      {props.address && (
-        <Text x={40} y={500} fontSize="40px" fontWeight={800} fill="#fff">
-          {props.address}
-        </Text>
-      )}
       <Defs>
         <ClipPath id="clip0_4219_2177">
           <Rect width={850.7} height={540} rx={31.8} fill="#fff" />
@@ -126,9 +116,7 @@ const VirtualCardImage = (
   </View>
 );
 
-const MetalCardImage = (
-  props: SvgProps & { address?: string; hasLowerOpacity: boolean },
-) => (
+const MetalCardImage = (props: SvgProps & { hasLowerOpacity: boolean }) => (
   <View style={{ aspectRatio: cardImageAspectRatio }}>
     <Svg
       fill="none"
@@ -219,11 +207,6 @@ const MetalCardImage = (
           fill="#EEE"
         />
       </G>
-      {props.address && (
-        <Text x={40} y={500} fontSize="40px" fontWeight={800} fill="#EEE">
-          {props.address}
-        </Text>
-      )}
       <Defs>
         <LinearGradient
           id="paint0_linear_4219_2151"
@@ -490,29 +473,16 @@ const MetalCardImage = (
 );
 
 const CardImage = (props: CardImageProps) => {
-  const { type, address: rawAddress, status } = props;
-  const address = truncateAddress(rawAddress);
+  const { type, status } = props;
   const hasLowerOpacity =
     status === CardStatus.FROZEN || status === CardStatus.BLOCKED;
 
   switch (type) {
     case CardType.VIRTUAL:
-      return (
-        <VirtualCardImage
-          {...props}
-          address={address}
-          hasLowerOpacity={hasLowerOpacity}
-        />
-      );
+      return <VirtualCardImage {...props} hasLowerOpacity={hasLowerOpacity} />;
     case CardType.PHYSICAL:
     case CardType.METAL:
-      return (
-        <MetalCardImage
-          {...props}
-          address={address}
-          hasLowerOpacity={hasLowerOpacity}
-        />
-      );
+      return <MetalCardImage {...props} hasLowerOpacity={hasLowerOpacity} />;
   }
 };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!-- mms-check: type=text required=true -->

The card artwork previously overlaid a truncated wallet address (or the "Money account" label when that was the funding source) on both the virtual and metal CardImage SVGs.

This PR removes that overlay text and cleans up the dead wiring:
- Drop the SVG `<Text>` address blocks and `address` prop from `CardImage`
- Stop passing `walletAddress` from `CardHome` → `CardImageSection`
- Remove the `CARD_WALLET_ADDRESS` test ID and address-focused unit tests

`truncateAddress` is kept — it is still used by asset selection.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Removed the wallet address and Money account label overlay from the MetaMask Card artwork on Card Home

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: internal UI cleanup — no tracking issue

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Card Home card artwork

  Scenario: authenticated user with a wallet funding source sees card without address overlay
    Given the user is authenticated for Card
    And the primary funding asset is a wallet address (not Money account)

    When the user opens Card Home
    Then the card artwork is shown
    And no truncated wallet address is displayed on the card image

  Scenario: authenticated user with Money account funding source sees card without label overlay
    Given the user is authenticated for Card
    And the primary funding asset is a Money account entry

    When the user opens Card Home
    Then the card artwork is shown
    And the "Money account" label is not displayed on the card image

  Scenario: frozen or blocked card still shows reduced opacity
    Given the user's card status is FROZEN or BLOCKED

    When the user opens Card Home
    Then the card artwork renders with lower opacity
    And no address or Money account text appears on the card
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ba0a170acf8d0636068262f6489224cc1144a9aa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->