### PR TITLE
fix(predict): tighten feed filter and card spacing

### DIFF
--- a/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
@@ -1084,7 +1084,7 @@ const PredictCryptoUpDownMarketCardSkeleton = ({
       twClassName={
         compact
           ? 'h-full rounded-xl bg-section p-4 justify-between'
-          : 'my-2 rounded-xl bg-section p-4'
+          : 'mb-3 rounded-xl bg-section p-4'
       }
     >
       <Box
@@ -1389,7 +1389,7 @@ const PredictCryptoUpDownMarketCard: React.FC<
   }
 
   return (
-    <Box twClassName="my-2 h-[319px] rounded-xl bg-muted overflow-hidden">
+    <Box twClassName="mb-3 h-[319px] rounded-xl bg-muted overflow-hidden">
       <Pressable
         testID={testID ?? PredictCryptoUpDownMarketCardSelectorsIDs.CARD}
         onPress={handleCardPress}

--- a/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.styles.ts
+++ b/app/components/UI/Predict/components/PredictMarketMultiple/PredictMarketMultiple.styles.ts
@@ -14,7 +14,8 @@ const styleSheet = (params: {
       backgroundColor: theme.colors.background.section,
       borderRadius: 12,
       padding: 16,
-      marginVertical: vars.isCarousel ? 0 : 8,
+      marginTop: 0,
+      marginBottom: vars.isCarousel ? 0 : 12,
       ...(vars.isCarousel && {
         flexDirection: 'column',
         justifyContent: 'space-between',

--- a/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.styles.ts
+++ b/app/components/UI/Predict/components/PredictMarketSingle/PredictMarketSingle.styles.ts
@@ -17,7 +17,8 @@ const styleSheet = (params: {
       backgroundColor: theme.colors.background.section,
       borderRadius: 12,
       padding: 16,
-      marginVertical: vars.isCarousel ? 0 : 8,
+      marginTop: 0,
+      marginBottom: vars.isCarousel ? 0 : 12,
     },
     marketHeader: {
       flexDirection: 'row',

--- a/app/components/UI/Predict/components/PredictMarketSkeleton/PredictMarketSkeleton.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSkeleton/PredictMarketSkeleton.tsx
@@ -25,7 +25,7 @@ const PredictMarketSkeleton: React.FC<PredictMarketSkeletonProps> = ({
   return (
     <Box
       testID={testID}
-      twClassName={`bg-section rounded-xl ${isCarousel ? 'p-4 h-full' : 'p-4 my-2'}`}
+      twClassName={`bg-section rounded-xl ${isCarousel ? 'p-4 h-full' : 'p-4 mb-3'}`}
     >
       {/* Header: Circle Avatar + Title Bar */}
       <Box

--- a/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
+++ b/app/components/UI/Predict/components/PredictMarketSportCard/PredictMarketSportCard.tsx
@@ -286,7 +286,7 @@ const PredictMarketSportCard: React.FC<PredictMarketSportCardProps> = ({
 
   return (
     <TouchableOpacity
-      style={tw.style(isCarousel ? 'h-full' : 'my-[8px]')}
+      style={tw.style(isCarousel ? 'h-full' : 'mb-3')}
       testID={testID}
       onPress={handleCardPress}
       activeOpacity={0.9}

--- a/app/components/UI/Predict/views/PredictFeedView/PredictFeedView.tsx
+++ b/app/components/UI/Predict/views/PredictFeedView/PredictFeedView.tsx
@@ -297,7 +297,7 @@ const PredictFeedView: React.FC = () => {
   const renderContent = () => {
     if (isLoading) {
       return (
-        <Box twClassName="flex-1 px-4">
+        <Box twClassName={`flex-1 px-4 ${showFilterBar ? 'pt-1' : ''}`}>
           {Array.from({ length: INITIAL_SKELETON_COUNT }).map((_, index) => (
             <PredictMarketSkeleton
               key={`skeleton-${index}`}
@@ -353,7 +353,11 @@ const PredictFeedView: React.FC = () => {
           onEndReached={handleEndReached}
           onEndReachedThreshold={0.7}
           ListFooterComponent={renderFooter}
-          contentContainerStyle={tw.style('px-4 pb-4')}
+          contentContainerStyle={tw.style(
+            'px-4 pb-4',
+            // Chip row is pb-3 (12px); 4px here makes 16px to the first card.
+            showFilterBar && 'pt-1',
+          )}
           showsVerticalScrollIndicator={false}
         />
       </Box>
@@ -406,6 +410,10 @@ const PredictFeedView: React.FC = () => {
             activeChipKey={activeFilterId ?? ''}
             onChipSelect={handleFilterSelect}
             testID={PredictFeedViewSelectorsIDs.FILTERS}
+            // No tabs: flush under the header like Explore Trending.
+            // With tabs: 16px (pt-4) between the tab underline and chips.
+            // pb-3 = 12px between chips and the first feed card.
+            containerTwClassName={showTabBar ? 'pt-4 pb-3' : 'pb-3'}
           />
         )}
 

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.tsx
@@ -67,7 +67,8 @@ const PredictTrendingSection: React.FC<PredictTrendingSectionProps> = ({
       />
 
       {isLoading ? (
-        <Box twClassName="gap-3">
+        // No list gap: skeletons already use mb-3 (12px), matching feed cards.
+        <Box>
           {Array.from({ length: TRENDING_DISPLAY_LIMIT }).map((_, index) => (
             <PredictMarketSkeleton
               key={`${PREDICT_TRENDING_SECTION_TEST_IDS.SKELETON_PREFIX}-${index}`}
@@ -89,7 +90,7 @@ const PredictTrendingSection: React.FC<PredictTrendingSectionProps> = ({
           </Text>
         </Box>
       ) : (
-        <Box twClassName="gap-1">
+        <Box>
           {markets.map((market) => (
             <PredictMarket
               key={market.id}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adjusting spacing in Tab, ButtonFilter, and between cards for better vertical rhythm as users scroll.

Filter bar (`PredictFeedView` + `PredictChipList`):
- No tabs (e.g. Trending with All / topic chips): no extra space above the chips (aligned to Explore Trending’s filter row).
- With tabs (e.g. Sports All / Soccer above Games / Props): 16px (`pt-4`) between the tab underline and the chips.
- 12px (`pb-3`) below the chips so the filter row keeps even padding. The list may use `pt-1` so the space under the chips to the first card is 16px.

Cards:
- Cards no longer use equal top and bottom margin on every card. That stacked 6px + 6px between items and also leaked 6px above the first card.
- Spacing between cards is a **12px gap**. FlashList cannot set CSS `gap`, so this is implemented as 12px bottom margin (`mb-3` / `marginBottom: 12`) with **0 top margin** on the first card (list-gap equivalent).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Tightened spacing between Predict feed filters and market cards

## **Related issues**

Fixes:

No issue: design-requested Predict feed spacing (no GitHub or Jira ticket)

## **Manual testing steps**

```gherkin
Feature: Predict feed filter and card spacing

  Scenario: user opens Trending with chips and no tabs
    Given the user is on Predict Trending with filter chips (All, topics)

    When the feed is visible
    Then there is a tight gap from the header to the chips
    And there is 16px from the chips to the first card
    And cards in the list are 12px apart

  Scenario: user opens a tabbed Predict feed
    Given the user is on a Predict feed with tabs and chips (e.g. Sports)

    When the Games or Props chips are visible under the tabs
    Then there is 16px between the tab underline and the chips
    And card spacing below matches the Trending feed
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/b761df48-cb90-4b86-9dc2-f6c2fed553cc


Add screenshots of Predict Trending (chips → first card) and a tabbed feed (tabs → chips).

### **After**

https://github.com/user-attachments/assets/7114c530-c3ba-4390-9b51-a78610971b7a


Same two screens after the spacing pass (design review on iOS Simulator).

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual layout and Tailwind/StyleSheet spacing only; no business logic, navigation, or data changes.
> 
> **Overview**
> Tightens **vertical rhythm** on Predict feeds and home trending so filters, skeletons, and cards align with design (Explore Trending–style filter row, **12px** between cards, **16px** from chips to the first card).
> 
> **Filter bar (`PredictFeedView` + `PredictChipList`):** Chips sit flush under the header when there are no tabs; with tabs, **16px** (`pt-4`) sits between the tab underline and the chip row. The chip row uses **12px** bottom padding (`pb-3`); the list adds **`pt-1`** when filters are shown so chip-to-first-card spacing totals **16px** (loading skeletons use the same top padding).
> 
> **Cards and skeletons:** Replaces symmetric vertical margin (`my-2` / `marginVertical: 8`) with **bottom-only 12px** (`mb-3` / `marginBottom: 12`, `marginTop: 0`) on feed market cards (single, multiple, sport, crypto up/down) and skeletons—FlashList-friendly “gap” without extra space above the first item. **PredictTrendingSection** drops wrapper `gap-*` classes so spacing comes from each card’s `mb-3` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba4834adba27532dbb2df2eea3e1b1cd2d577c02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->