### PR TITLE
fix(predict): align Trending header arrow with other home sections

### DIFF
--- a/app/components/UI/Predict/views/PredictHome/components/PredictCategoriesSection/PredictCategoriesSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictCategoriesSection/PredictCategoriesSection.tsx
@@ -3,6 +3,7 @@ import { TouchableOpacity } from 'react-native';
 import {
   Box,
   FontWeight,
+  SectionHeader,
   Text,
   TextColor,
   TextVariant,
@@ -18,7 +19,6 @@ import type { AppNavigationProp } from '../../../../../../../core/NavigationServ
 import { strings } from '../../../../../../../../locales/i18n';
 import Routes from '../../../../../../../constants/navigation/Routes';
 import Engine from '../../../../../../../core/Engine';
-import SectionHeader from '../../../../../../../component-library/components-temp/SectionHeader';
 import { PredictEventValues } from '../../../../constants/eventNames';
 import {
   PREDICT_HOME_CATEGORIES,
@@ -77,7 +77,7 @@ const PredictCategoriesSection: React.FC<PredictCategoriesSectionProps> = ({
       <SectionHeader
         testID={PREDICT_CATEGORIES_SECTION_TEST_IDS.HEADER}
         title={strings('predict.home.categories_title')}
-        twClassName="px-0 mb-2"
+        twClassName="px-0 pt-0 mb-1"
       />
 
       <Box twClassName="flex-row gap-3">

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx
@@ -174,7 +174,7 @@ const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
         endIconProps={{
           testID: PREDICT_LIVE_NOW_SECTION_TEST_IDS.HEADER_CHEVRON,
         }}
-        twClassName="p-0 mb-2"
+        twClassName="px-0 pt-0 mb-1"
       />
 
       <Box twClassName="-mx-4">

--- a/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
@@ -185,7 +185,7 @@ const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
         title={strings('predict.feed.popular_today')}
         isInteractive
         onPress={handleSeeAll}
-        twClassName="px-0 pt-0 mb-2"
+        twClassName="px-0 pt-0 mb-1"
       />
 
       {isLoading ? (

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.test.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.test.tsx
@@ -157,8 +157,9 @@ describe('PredictTrendingSection', () => {
     const header = getByTestId(PREDICT_TRENDING_SECTION_TEST_IDS.HEADER);
     expect(header).toBeOnTheScreen();
     expect(getByText(strings('predict.home.trending_title'))).toBeOnTheScreen();
-    // The chevron renders only when the header is pressable (onPress set).
-    expect(getByTestId('section-header-arrow-icon')).toBeOnTheScreen();
+    expect(
+      getByTestId(PREDICT_TRENDING_SECTION_TEST_IDS.HEADER_CHEVRON),
+    ).toBeOnTheScreen();
 
     fireEvent.press(header);
 

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.testIds.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.testIds.ts
@@ -8,6 +8,7 @@ import { PredictHomeSelectorsIDs } from '../../../../Predict.testIds';
 export const PREDICT_TRENDING_SECTION_TEST_IDS = {
   SECTION: PredictHomeSelectorsIDs.TRENDING_SECTION,
   HEADER: 'predict-home-trending-header',
+  HEADER_CHEVRON: 'predict-home-trending-header-chevron',
   CARD_PREFIX: 'predict-home-trending-card',
   SKELETON_PREFIX: 'predict-home-trending-skeleton',
   ERROR_STATE: 'predict-home-trending-error-state',

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.tsx
@@ -4,13 +4,13 @@ import {
   Text,
   TextColor,
   TextVariant,
+  SectionHeader,
 } from '@metamask/design-system-react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../../../core/NavigationService/types';
 import { strings } from '../../../../../../../../locales/i18n';
 import Routes from '../../../../../../../constants/navigation/Routes';
 import Engine from '../../../../../../../core/Engine';
-import SectionHeader from '../../../../../../../component-library/components-temp/SectionHeader';
 import PredictMarket from '../../../../components/PredictMarket';
 import PredictMarketSkeleton from '../../../../components/PredictMarketSkeleton';
 import { PredictEventValues } from '../../../../constants/eventNames';
@@ -57,13 +57,17 @@ const PredictTrendingSection: React.FC<PredictTrendingSectionProps> = ({
 
   return (
     <Box testID={testID}>
-      {/* "See all" navigates to the generic PredictFeedView (feedId 'trending').
-          Passing `onPress` is what renders the chevron + touchable. */}
+      {/* Same design-system SectionHeader as Live now / Popular today so the
+          trailing arrow uses the shared icon size. */}
       <SectionHeader
         testID={PREDICT_TRENDING_SECTION_TEST_IDS.HEADER}
         title={strings('predict.home.trending_title')}
+        isInteractive
         onPress={handleSeeAll}
-        twClassName="px-0 mb-2"
+        endIconProps={{
+          testID: PREDICT_TRENDING_SECTION_TEST_IDS.HEADER_CHEVRON,
+        }}
+        twClassName="px-0 pt-0 mb-1"
       />
 
       {isLoading ? (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Predict home Trending title used the temp `SectionHeader`, which draws a medium trailing arrow. Live now and Popular today already use the design-system `SectionHeader`, so their arrows are smaller.

Trending now uses the same design-system header (`isInteractive`, `onPress`, `endIconProps`) so the chevron size matches those sections. The title is still pressable and still opens the Trending feed.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Aligned the Predict Trending section header arrow with other Predict home titles

## **Related issues**

Fixes:

No issue: design-requested header arrow alignment on Predict home (no GitHub or Jira ticket)

## **Manual testing steps**

```gherkin
Feature: Predict home section headers

  Scenario: user compares Trending and Live now title arrows
    Given the user is on Predict home with Trending and Live now visible

    When the section titles are on screen
    Then the Trending trailing arrow matches the Live now arrow size
    And tapping Trending still opens the Trending feed
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/dadffd04-4771-4d46-8333-2c9f29676ddd


Trending title with a larger temp-header arrow vs Live now / Popular today.

### **After**

https://github.com/user-attachments/assets/359fe826-a5e0-4970-8537-144608392a08

Trending title arrow matching Live now / Popular today (design review on Simulator).

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2d78d385f5d2161d40105ed36e99193a02cb1610. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->