### PR TITLE
fix(predict): use DS SectionHeader and 32px home section gaps

### DIFF
--- a/app/components/UI/Predict/views/PredictHome/PredictHome.tsx
+++ b/app/components/UI/Predict/views/PredictHome/PredictHome.tsx
@@ -186,7 +186,7 @@ const PredictHome: React.FC = () => {
               </Text>
             </Box>
 
-            <Box twClassName="gap-6">
+            <Box twClassName="gap-8">
               <PredictFeedBanner
                 position={PredictFeedBannerPosition.BeforePortfolio}
               />

--- a/app/components/UI/Predict/views/PredictHome/components/PredictCategoriesSection/PredictCategoriesSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictCategoriesSection/PredictCategoriesSection.tsx
@@ -3,6 +3,7 @@ import { TouchableOpacity } from 'react-native';
 import {
   Box,
   FontWeight,
+  SectionHeader,
   Text,
   TextColor,
   TextVariant,
@@ -18,7 +19,6 @@ import type { AppNavigationProp } from '../../../../../../../core/NavigationServ
 import { strings } from '../../../../../../../../locales/i18n';
 import Routes from '../../../../../../../constants/navigation/Routes';
 import Engine from '../../../../../../../core/Engine';
-import SectionHeader from '../../../../../../../component-library/components-temp/SectionHeader';
 import { PredictEventValues } from '../../../../constants/eventNames';
 import {
   PREDICT_HOME_CATEGORIES,
@@ -77,7 +77,7 @@ const PredictCategoriesSection: React.FC<PredictCategoriesSectionProps> = ({
       <SectionHeader
         testID={PREDICT_CATEGORIES_SECTION_TEST_IDS.HEADER}
         title={strings('predict.home.categories_title')}
-        twClassName="px-0 mb-2"
+        twClassName="px-0 pt-0 mb-1"
       />
 
       <Box twClassName="flex-row gap-3">

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/PredictLiveNowSection.tsx
@@ -174,7 +174,7 @@ const PredictLiveNowSection: React.FC<PredictLiveNowSectionProps> = ({
         endIconProps={{
           testID: PREDICT_LIVE_NOW_SECTION_TEST_IDS.HEADER_CHEVRON,
         }}
-        twClassName="p-0 mb-2"
+        twClassName="px-0 pt-0 mb-1"
       />
 
       <Box twClassName="-mx-4">

--- a/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
@@ -189,11 +189,7 @@ const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
       />
 
       {isLoading ? (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={tw.style('pb-1')}
-        >
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
           <Box twClassName="gap-2">
             {skeletonRows.map((row, rowIndex) => (
               <Box
@@ -216,11 +212,7 @@ const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
       ) : null}
 
       {!isLoading && chips.length > 0 ? (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={tw.style('pb-1')}
-        >
+        <ScrollView horizontal showsHorizontalScrollIndicator={false}>
           <Box twClassName="gap-2">
             {chipRows.map((row, rowIndex) => (
               <Box

--- a/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
@@ -185,7 +185,7 @@ const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
         title={strings('predict.feed.popular_today')}
         isInteractive
         onPress={handleSeeAll}
-        twClassName="px-0 pt-0 mb-2"
+        twClassName="px-0 pt-0 mb-1"
       />
 
       {isLoading ? (

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.test.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.test.tsx
@@ -157,8 +157,9 @@ describe('PredictTrendingSection', () => {
     const header = getByTestId(PREDICT_TRENDING_SECTION_TEST_IDS.HEADER);
     expect(header).toBeOnTheScreen();
     expect(getByText(strings('predict.home.trending_title'))).toBeOnTheScreen();
-    // The chevron renders only when the header is pressable (onPress set).
-    expect(getByTestId('section-header-arrow-icon')).toBeOnTheScreen();
+    expect(
+      getByTestId(PREDICT_TRENDING_SECTION_TEST_IDS.HEADER_CHEVRON),
+    ).toBeOnTheScreen();
 
     fireEvent.press(header);
 

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.testIds.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.testIds.ts
@@ -8,6 +8,7 @@ import { PredictHomeSelectorsIDs } from '../../../../Predict.testIds';
 export const PREDICT_TRENDING_SECTION_TEST_IDS = {
   SECTION: PredictHomeSelectorsIDs.TRENDING_SECTION,
   HEADER: 'predict-home-trending-header',
+  HEADER_CHEVRON: 'predict-home-trending-header-chevron',
   CARD_PREFIX: 'predict-home-trending-card',
   SKELETON_PREFIX: 'predict-home-trending-skeleton',
   ERROR_STATE: 'predict-home-trending-error-state',

--- a/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictTrendingSection/PredictTrendingSection.tsx
@@ -4,13 +4,13 @@ import {
   Text,
   TextColor,
   TextVariant,
+  SectionHeader,
 } from '@metamask/design-system-react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../../../core/NavigationService/types';
 import { strings } from '../../../../../../../../locales/i18n';
 import Routes from '../../../../../../../constants/navigation/Routes';
 import Engine from '../../../../../../../core/Engine';
-import SectionHeader from '../../../../../../../component-library/components-temp/SectionHeader';
 import PredictMarket from '../../../../components/PredictMarket';
 import PredictMarketSkeleton from '../../../../components/PredictMarketSkeleton';
 import { PredictEventValues } from '../../../../constants/eventNames';
@@ -57,13 +57,17 @@ const PredictTrendingSection: React.FC<PredictTrendingSectionProps> = ({
 
   return (
     <Box testID={testID}>
-      {/* "See all" navigates to the generic PredictFeedView (feedId 'trending').
-          Passing `onPress` is what renders the chevron + touchable. */}
+      {/* Same design-system SectionHeader as Live now / Popular today so the
+          trailing arrow uses the shared icon size. */}
       <SectionHeader
         testID={PREDICT_TRENDING_SECTION_TEST_IDS.HEADER}
         title={strings('predict.home.trending_title')}
+        isInteractive
         onPress={handleSeeAll}
-        twClassName="px-0 mb-2"
+        endIconProps={{
+          testID: PREDICT_TRENDING_SECTION_TEST_IDS.HEADER_CHEVRON,
+        }}
+        twClassName="px-0 pt-0 mb-1"
       />
 
       {isLoading ? (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Predict home section titles were split across two `SectionHeader` implementations, and section-to-section spacing was 24px (`gap-6`) with an extra Popular today `pb-1` that made Popular→Trending 36px.

This PR:

1. Puts every Predict home section on the design-system `SectionHeader` with the same layout override: `px-0 pt-0 mb-1` (keep default 8px bottom padding, 4px margin under the header).
   - **Trending:** migrate to DS header (interactive, smaller chevron matching Live now / Popular today).
   - **Categories:** migrate to DS header (static, no chevron).
   - **Live now / Popular today:** already DS; header classes aligned with the others.
2. Sets the home section stack to `gap-8` (32px) and removes Popular today ScrollView `contentContainerStyle pb-1` so every measured section-to-section gap is 32px.

Does not include pagination dots, chip press, crypto card padding, or Popular bleed.

Supersedes #34971.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Aligned Predict home section headers to the design-system SectionHeader and set 32px section spacing

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

No issue: design-requested Predict home header consistency and 32px section gaps (no GitHub or Jira ticket)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Predict home section headers and spacing

  Scenario: user compares section titles on Predict home
    Given the user is on Predict home

    When Live now, Categories, Popular today, and Trending are visible
    Then all four titles use the same header treatment
    And Trending and Popular today show matching chevron sizes
    And Categories has no trailing chevron
    And tapping Trending still opens the Trending feed

  Scenario: user checks section-to-section spacing
    Given the user is on Predict home

    When adjacent sections are visible
    Then the gap between each pair of sections is 32px
    And Popular today to Trending is not larger than the other gaps
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/851d61d8-1385-441d-8327-4199a79006cc




Trending used a larger temp-header arrow; Categories sat tighter under the title; section stack used 24px gap plus Popular `pb-1`.

### **Afte

https://github.com/user-attachments/assets/d4d5c017-d5c6-4f9f-a730-4a051a74d43e

r**



All four Predict home section headers on design-system SectionHeader; section-to-section gap is 32px (Simulator).

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8bdad9cd98c74ad5593592957397960ff430d4b4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->