### PR TITLE
fix(predict): add Popular today bleed and chip pressed states

### DIFF
--- a/app/components/UI/Predict/components/PredictChipList/PredictChipList.test.tsx
+++ b/app/components/UI/Predict/components/PredictChipList/PredictChipList.test.tsx
@@ -7,7 +7,7 @@ import {
   waitFor,
 } from '@testing-library/react-native';
 import type { LayoutChangeEvent, ScrollView } from 'react-native';
-import PredictChipList from './PredictChipList';
+import PredictChipList, { getPredictChipTwArgs } from './PredictChipList';
 import { calculateChipScrollX } from './calculateChipScrollX';
 import { useChipScrollList } from './useChipScrollList';
 import {
@@ -148,6 +148,30 @@ describe('PredictChipList', () => {
   });
 
   describe('selection', () => {
+    it('applies muted-pressed background when an inactive chip is pressed', () => {
+      const restArgs = getPredictChipTwArgs('rounded-xl px-4 py-2', false, false);
+      const pressedArgs = getPredictChipTwArgs(
+        'rounded-xl px-4 py-2',
+        false,
+        true,
+      );
+
+      expect(restArgs).toContain('bg-muted');
+      expect(restArgs).not.toContain('bg-muted-pressed');
+      expect(pressedArgs).toContain('bg-muted-pressed');
+    });
+
+    it('keeps the selected chip icon-default background while pressed', () => {
+      const pressedArgs = getPredictChipTwArgs(
+        'rounded-xl px-4 py-2',
+        true,
+        true,
+      );
+
+      expect(pressedArgs).toContain('bg-icon-default');
+      expect(pressedArgs).not.toContain('bg-muted-pressed');
+    });
+
     it('marks the active chip with accessibilityState selected', () => {
       const chips = createMockChips();
 

--- a/app/components/UI/Predict/components/PredictChipList/PredictChipList.test.tsx
+++ b/app/components/UI/Predict/components/PredictChipList/PredictChipList.test.tsx
@@ -149,7 +149,11 @@ describe('PredictChipList', () => {
 
   describe('selection', () => {
     it('applies muted-pressed background when an inactive chip is pressed', () => {
-      const restArgs = getPredictChipTwArgs('rounded-xl px-4 py-2', false, false);
+      const restArgs = getPredictChipTwArgs(
+        'rounded-xl px-4 py-2',
+        false,
+        false,
+      );
       const pressedArgs = getPredictChipTwArgs(
         'rounded-xl px-4 py-2',
         false,

--- a/app/components/UI/Predict/components/PredictChipList/PredictChipList.tsx
+++ b/app/components/UI/Predict/components/PredictChipList/PredictChipList.tsx
@@ -25,6 +25,17 @@ export { calculateChipScrollX } from './calculateChipScrollX';
 const DEFAULT_CONTAINER_CLASS = 'pt-3 pb-3';
 const DEFAULT_CHIP_CLASS = 'rounded-xl px-4 py-2';
 
+export const getPredictChipTwArgs = (
+  chipTwClassName: string,
+  isActive: boolean,
+  pressed: boolean,
+) =>
+  [
+    chipTwClassName,
+    isActive ? 'bg-icon-default' : 'bg-muted',
+    pressed && !isActive && 'bg-muted-pressed',
+  ] as const;
+
 const PredictChipList: React.FC<PredictChipListProps> = ({
   chips,
   activeChipKey,
@@ -66,10 +77,9 @@ const PredictChipList: React.FC<PredictChipListProps> = ({
         key={chip.key}
         onPress={() => handlePress(chip.key, index)}
         onLayout={(event) => handleChipLayout(index, event)}
-        style={tw.style(
-          chipTwClassName,
-          isActive ? 'bg-icon-default' : 'bg-muted',
-        )}
+        style={({ pressed }) =>
+          tw.style(...getPredictChipTwArgs(chipTwClassName, isActive, pressed))
+        }
         testID={getChipTestId(chip.key)}
         accessibilityRole="button"
         accessibilityState={{ selected: isActive }}

--- a/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.test.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.test.tsx
@@ -8,6 +8,7 @@ import { PredictEventValues } from '../../../../constants/eventNames';
 import { usePredictFilterOptions } from '../../../../hooks/usePredictFilterOptions';
 import type { PredictFilterOption } from '../../../../types';
 import PredictPopularTodaySection, {
+  getPopularTodayChipTwArgs,
   PREDICT_POPULAR_TODAY_SECTION_TEST_IDS,
 } from './PredictPopularTodaySection';
 
@@ -119,6 +120,15 @@ describe('PredictPopularTodaySection', () => {
         `${PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.SKELETON_PREFIX}-0`,
       ),
     ).toBeOnTheScreen();
+  });
+
+  it('applies muted-pressed background when a chip is pressed', () => {
+    const restArgs = getPopularTodayChipTwArgs(false);
+    const pressedArgs = getPopularTodayChipTwArgs(true);
+
+    expect(restArgs).toContain('rounded-xl bg-muted px-4 py-2');
+    expect(restArgs).not.toContain('bg-muted-pressed');
+    expect(pressedArgs).toContain('bg-muted-pressed');
   });
 
   it('renders a chip for each popular filter option', () => {

--- a/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
@@ -189,11 +189,12 @@ const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
       />
 
       {isLoading ? (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={tw.style('pb-1')}
-        >
+        <Box twClassName="-mx-4">
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={tw.style('px-4 pb-1')}
+          >
           <Box twClassName="gap-2">
             {skeletonRows.map((row, rowIndex) => (
               <Box
@@ -212,15 +213,17 @@ const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
               </Box>
             ))}
           </Box>
-        </ScrollView>
+          </ScrollView>
+        </Box>
       ) : null}
 
       {!isLoading && chips.length > 0 ? (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={tw.style('pb-1')}
-        >
+        <Box twClassName="-mx-4">
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={tw.style('px-4 pb-1')}
+          >
           <Box twClassName="gap-2">
             {chipRows.map((row, rowIndex) => (
               <Box
@@ -249,7 +252,8 @@ const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
               </Box>
             ))}
           </Box>
-        </ScrollView>
+          </ScrollView>
+        </Box>
       ) : null}
     </Box>
   );

--- a/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
@@ -61,6 +61,9 @@ export const PREDICT_POPULAR_TODAY_SECTION_TEST_IDS = {
   SKELETON_PREFIX: 'predict-home-popular-today-skeleton',
 } as const;
 
+export const getPopularTodayChipTwArgs = (pressed: boolean) =>
+  ['rounded-xl bg-muted px-4 py-2', pressed && 'bg-muted-pressed'] as const;
+
 const normalizeRowCount = (rowCount: number) =>
   Math.max(1, Math.floor(rowCount));
 
@@ -238,7 +241,9 @@ const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
                     onPress={() => handleChipPress(option)}
                     accessibilityRole="button"
                     accessibilityLabel={label}
-                    style={tw.style('rounded-xl bg-muted px-4 py-2')}
+                    style={({ pressed }) =>
+                      tw.style(...getPopularTodayChipTwArgs(pressed))
+                    }
                   >
                     <Text
                       variant={TextVariant.BodySm}

--- a/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictPopularTodaySection/PredictPopularTodaySection.tsx
@@ -198,24 +198,24 @@ const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
             showsHorizontalScrollIndicator={false}
             contentContainerStyle={tw.style('px-4 pb-1')}
           >
-          <Box twClassName="gap-2">
-            {skeletonRows.map((row, rowIndex) => (
-              <Box
-                key={`popular-today-skeleton-row-${rowIndex}`}
-                twClassName="flex-row gap-2"
-              >
-                {row.map((index) => (
-                  <Skeleton
-                    key={`popular-today-skeleton-${index}`}
-                    width={104}
-                    height={40}
-                    style={tw.style('rounded-xl')}
-                    testID={`${PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.SKELETON_PREFIX}-${index}`}
-                  />
-                ))}
-              </Box>
-            ))}
-          </Box>
+            <Box twClassName="gap-2">
+              {skeletonRows.map((row, rowIndex) => (
+                <Box
+                  key={`popular-today-skeleton-row-${rowIndex}`}
+                  twClassName="flex-row gap-2"
+                >
+                  {row.map((index) => (
+                    <Skeleton
+                      key={`popular-today-skeleton-${index}`}
+                      width={104}
+                      height={40}
+                      style={tw.style('rounded-xl')}
+                      testID={`${PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.SKELETON_PREFIX}-${index}`}
+                    />
+                  ))}
+                </Box>
+              ))}
+            </Box>
           </ScrollView>
         </Box>
       ) : null}
@@ -227,36 +227,36 @@ const PredictPopularTodaySection: React.FC<PredictPopularTodaySectionProps> = ({
             showsHorizontalScrollIndicator={false}
             contentContainerStyle={tw.style('px-4 pb-1')}
           >
-          <Box twClassName="gap-2">
-            {chipRows.map((row, rowIndex) => (
-              <Box
-                key={`popular-today-row-${rowIndex}`}
-                testID={`${PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.ROW_PREFIX}-${rowIndex}`}
-                twClassName="flex-row gap-2"
-              >
-                {row.map(({ key, label, option }) => (
-                  <Pressable
-                    key={key}
-                    testID={`${PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.CHIP_PREFIX}-${key}`}
-                    onPress={() => handleChipPress(option)}
-                    accessibilityRole="button"
-                    accessibilityLabel={label}
-                    style={({ pressed }) =>
-                      tw.style(...getPopularTodayChipTwArgs(pressed))
-                    }
-                  >
-                    <Text
-                      variant={TextVariant.BodySm}
-                      color={TextColor.TextDefault}
-                      fontWeight={FontWeight.Medium}
+            <Box twClassName="gap-2">
+              {chipRows.map((row, rowIndex) => (
+                <Box
+                  key={`popular-today-row-${rowIndex}`}
+                  testID={`${PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.ROW_PREFIX}-${rowIndex}`}
+                  twClassName="flex-row gap-2"
+                >
+                  {row.map(({ key, label, option }) => (
+                    <Pressable
+                      key={key}
+                      testID={`${PREDICT_POPULAR_TODAY_SECTION_TEST_IDS.CHIP_PREFIX}-${key}`}
+                      onPress={() => handleChipPress(option)}
+                      accessibilityRole="button"
+                      accessibilityLabel={label}
+                      style={({ pressed }) =>
+                        tw.style(...getPopularTodayChipTwArgs(pressed))
+                      }
                     >
-                      {label}
-                    </Text>
-                  </Pressable>
-                ))}
-              </Box>
-            ))}
-          </Box>
+                      <Text
+                        variant={TextVariant.BodySm}
+                        color={TextColor.TextDefault}
+                        fontWeight={FontWeight.Medium}
+                      >
+                        {label}
+                      </Text>
+                    </Pressable>
+                  ))}
+                </Box>
+              ))}
+            </Box>
           </ScrollView>
         </Box>
       ) : null}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Predict home Popular today chip rail was clipped at the page padding, and the pills had no pressed/tap feedback. Feed chip rails (`PredictChipList`) had the same missing press state.

This PR does two things:

1. Full-bleed chip rails on Popular today, matching Live now: `-mx-4` on the rail wrapper and `px-4` on the `ScrollView` content. Chips stay 16px inset at rest and can move into the edge gutters while scrolling. The section title stays page-aligned.
2. Pressed/tap state on Popular today pills and matching `PredictChipList` / feed chips. Custom `Pressable`s now use a function style with `pressed && 'bg-muted-pressed'` (same token as DS Button Secondary). Chip size, radius, and type stay the same — these are not swapped to DS Button.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Allowed Popular today chips to scroll to the screen edges and added a pressed state to Predict chips

## **Related issues**

Fixes:

No issue: design-requested Popular today chip rail bleed and pressed states (no GitHub or Jira ticket)

## **Manual testing steps**

```gherkin
Feature: Predict chip rails

  Scenario: user scrolls Popular today chips
    Given the user is on Predict home with Popular today chips

    When the chip rail is visible
    Then the first chips are inset from the screen edge
    And scrolling the rail lets chips move into the edge gutters without clipping
    And the Popular today title stays aligned with other section titles

  Scenario: user presses a Popular today chip
    Given the user is on Predict home with Popular today chips

    When the user presses a chip
    Then the chip background uses the muted-pressed token
    And the chip keeps BodySm / Medium / rounded-xl / px-4 py-2

  Scenario: user presses a feed chip
    Given the user is on a Predict feed with a chip rail

    When the user presses an unselected chip
    Then the chip background uses the muted-pressed token
    And a selected chip stays icon-default while pressed
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/1a40bdc1-d428-41f2-a85b-9d4e775c92ea



Popular today chips clipped flush to the page padding, with no pressed/tap feedback on home pills or feed chips.

### **After**

https://github.com/user-attachments/assets/2a8eba15-9463-4ab0-a9eb-5c9989db28eb



Same rail as Live now: inset at rest, full-bleed while scrolling. Chips use `bg-muted-pressed` on press (design review on Simulator).

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->