### PR TITLE
fix(predict): match Live now crypto card inset to sports

### DIFF
--- a/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.test.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.test.tsx
@@ -772,6 +772,16 @@ describe('PredictCryptoUpDownMarketCard', () => {
       ).toBeOnTheScreen();
     });
 
+    it('uses 12px inset and Md button radius on live-now cards', () => {
+      const { toJSON } = renderCard(createMarket(), { isCarousel: true });
+
+      const tree = JSON.stringify(toJSON());
+
+      expect(tree).toContain('"paddingLeft":12');
+      expect(tree).toContain('"paddingRight":12');
+      expect(tree).toContain('"borderRadius":12');
+    });
+
     it('still opens the buy sheet for the Up and Down outcomes in the carousel', () => {
       const liveMarket = createMarket();
       mockUsePredictSeries.mockReturnValue({

--- a/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownMarketCard/PredictCryptoUpDownMarketCard.tsx
@@ -1016,12 +1016,16 @@ const OutcomeButtons = React.memo(
       restPrices,
     );
 
+    // Live-now compact buttons match sports Md `Button` radius (`rounded-xl` /
+    // 12px). Feed cards keep `rounded-lg` so this stays isolated.
+    const buttonRadiusClass = compact ? 'rounded-xl' : 'rounded-lg';
+
     const buttons = (
       <>
         <ButtonBase
           testID={PredictCryptoUpDownMarketCardSelectorsIDs.UP_BUTTON}
           onPress={() => onBuyPress(upToken)}
-          twClassName="h-10 flex-1 rounded-lg bg-success-muted"
+          twClassName={`h-10 flex-1 ${buttonRadiusClass} bg-success-muted`}
           disabled={!upToken || !isMarketOpen}
         >
           <Text
@@ -1035,7 +1039,7 @@ const OutcomeButtons = React.memo(
         <ButtonBase
           testID={PredictCryptoUpDownMarketCardSelectorsIDs.DOWN_BUTTON}
           onPress={() => onBuyPress(downToken)}
-          twClassName="h-10 flex-1 rounded-lg bg-error-muted"
+          twClassName={`h-10 flex-1 ${buttonRadiusClass} bg-error-muted`}
           disabled={!downToken || !isMarketOpen}
         >
           <Text
@@ -1083,8 +1087,8 @@ const PredictCryptoUpDownMarketCardSkeleton = ({
       testID={testID}
       twClassName={
         compact
-          ? 'h-full rounded-xl bg-section p-4 justify-between'
-          : 'my-2 rounded-xl bg-section p-4'
+          ? 'h-full rounded-xl bg-section p-3 justify-between'
+          : 'mb-3 rounded-xl bg-section p-4'
       }
     >
       <Box
@@ -1097,8 +1101,16 @@ const PredictCryptoUpDownMarketCardSkeleton = ({
           <Skeleton width="100%" height={120} style={tw.style('rounded-xl')} />
         )}
         <Box flexDirection={BoxFlexDirection.Row} twClassName="w-full gap-2">
-          <Skeleton width="48%" height={40} style={tw.style('rounded-lg')} />
-          <Skeleton width="48%" height={40} style={tw.style('rounded-lg')} />
+          <Skeleton
+            width="48%"
+            height={40}
+            style={tw.style(compact ? 'rounded-xl' : 'rounded-lg')}
+          />
+          <Skeleton
+            width="48%"
+            height={40}
+            style={tw.style(compact ? 'rounded-xl' : 'rounded-lg')}
+          />
         </Box>
       </Box>
     </Box>
@@ -1345,7 +1357,7 @@ const PredictCryptoUpDownMarketCard: React.FC<
         accessibilityRole="button"
         style={tw.style('h-full rounded-xl bg-muted overflow-hidden')}
       >
-        <Box twClassName="flex-1 p-4 items-center justify-between">
+        <Box twClassName="flex-1 p-3 items-center justify-between">
           <Box twClassName="items-center">
             <LiveStatus
               compact
@@ -1389,7 +1401,7 @@ const PredictCryptoUpDownMarketCard: React.FC<
   }
 
   return (
-    <Box twClassName="my-2 h-[319px] rounded-xl bg-muted overflow-hidden">
+    <Box twClassName="mb-3 h-[319px] rounded-xl bg-muted overflow-hidden">
       <Pressable
         testID={testID ?? PredictCryptoUpDownMarketCardSelectorsIDs.CARD}
         onPress={handleCardPress}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Live now sports and crypto carousel cards had mismatched outer insets. Sports compact cards already use 12px (`p-3`); crypto compact cards used 16px (`p-4`), so buttons sat farther from the card edge.

This aligns compact crypto padding to sports (`p-3` / 12px). Compact Up/Down buttons also used `rounded-lg` (8px) while sports Md `Button` uses the DS Md radius `rounded-xl` (12px); compact crypto buttons now use `rounded-xl`. Feed (non-carousel) crypto cards are unchanged.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Live now crypto card padding so it matches sports cards

## **Related issues**

No issue: isolated Live now carousel padding/radius alignment from design review. Separate from Popular today bleed/press work.

## **Manual testing steps**

```gherkin
Feature: Predict Live now carousel card padding

  Scenario: sports and crypto live cards share the same outer inset
    Given the Predict home Live now carousel is visible
    And a sports live card and a crypto Up/Down live card are both present

    When the user compares left/right inset from card edge to the buy buttons
    Then both cards use a 12px inset
    And compact crypto Up/Down buttons use 12px corner radius (rounded-xl)
```

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/a67e9f97-4149-40ea-8c60-d5d5a3243716



### **After**

https://github.com/user-attachments/assets/a7a54856-f7c7-4f57-9d51-484de698cab2






## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebd-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)