### PR TITLE
fix(predict): make crypto up/down details footer full-bleed

### DIFF
--- a/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx
+++ b/app/components/UI/Predict/components/PredictCryptoUpDownDetails/PredictCryptoUpDownDetails.tsx
@@ -694,7 +694,7 @@ const PredictCryptoUpDownDetails: React.FC<PredictCryptoUpDownDetailsProps> = ({
       </ScrollView>
 
       {shouldRenderActions && (
-        <Box twClassName="px-4 pb-8">
+        <Box twClassName="w-full bg-default pb-8">
           <PredictMarketDetailsActions
             isClaimablePositionsLoading={isClaimablePositionsLoading}
             hasPositivePnl={canClaim}


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

The BTC Up or Down **detail** sticky footer used `px-4` on the wrapper around `PredictMarketDetailsActions`. That inset the white footer bar from the screen edges. The wrapper is now full-width (`w-full bg-default`) so the bar is edge-to-edge. Buttons keep their own inner padding from `PredictMarketDetailsActions` (`px-3`). Bottom home-indicator spacing (`pb-8`) is unchanged; only horizontal inset is removed.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed the Predict crypto up/down details footer so the white action bar spans the full screen width

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: N/A (design polish: detail footer full-bleed)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Predict crypto up/down details footer

  Scenario: user opens a BTC Up or Down market details screen
    Given Predictions is enabled
    And a BTC Up or Down market is available

    When user opens that market details screen
    Then the sticky footer white bar spans the full screen width with no side inset
    And the Yes/No action buttons still have their inner horizontal padding
    And the home-indicator bottom inset remains
```

## **Screenshots/Recordings**
<img width="1206" height="2622" alt="IMG_8516" src="https://github.com/user-attachments/assets/201e0dc1-d8c0-412d-a290-252b2c6ff09d" />

<!-- mms-check: type=screenshot required=true -->

N/A — layout-only change: remove `px-4` from the sticky footer wrapper so `bg-default` is edge-to-edge. Verify on device/simulator against the existing inset screenshot.

### **Before**

Footer white bar inset from both screen edges (parent `px-4`).

### **Afte

https://github.com/user-attachments/assets/55f37eaf-847c-4349-a40e-6f73b1a51bd4

r**


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)