### PR TITLE
test(onboarding): add Telegram seedless Appium smoke

### DIFF
--- a/tests/api-mocking/seedless-onboarding/OAuthMockttpService.ts
+++ b/tests/api-mocking/seedless-onboarding/OAuthMockttpService.ts
@@ -268,15 +268,22 @@ export class OAuthMockttpService {
    *
    */
   private async setupAuthServerProxy(server: Mockttp): Promise<void> {
-    // Proxy token requests to backend QA mock
+    // Proxy token/mint requests to backend QA mock.
+    // Google/Apple use /oauth/token; Telegram's mock handler uses /oauth/mint.
     const tokenEndpoint = `${AUTH_SERVICE_BASE_URL}/api/v1/oauth/token`;
     console.log(`[E2E MockServer] Registering mock for: ${tokenEndpoint}`);
+    console.log(
+      `[E2E MockServer] Registering mock for: ${AUTH_SERVICE_BASE_URL}/api/v1/oauth/mint`,
+    );
 
     await server
       .forPost('/proxy')
       .matching((request) => {
         const url = this.getDecodedProxiedURL(request.url);
-        return url.includes('/api/v1/oauth/token');
+        return (
+          url.includes('/api/v1/oauth/token') ||
+          url.includes('/api/v1/oauth/mint')
+        );
       })
       .asPriority(1000)
       .thenCallback(async (request) => {

--- a/tests/smoke-appium/seedless/helpers/seedless-helpers.ts
+++ b/tests/smoke-appium/seedless/helpers/seedless-helpers.ts
@@ -239,8 +239,23 @@ export const completeSocialLoginOnboarding = async (
   }
 
   if (PlatformDetector.isIOS()) {
-    await SocialLoginView.isIosNewUserScreenVisible();
-    await SocialLoginView.tapIosNewUserSetPinButton();
+    if (provider === 'telegram') {
+      try {
+        await Assertions.expectElementToBeVisible(
+          SocialLoginView.iosNewUserTitle,
+          {
+            timeout: 8000,
+            description: 'iOS set-PIN screen may appear after Telegram login',
+          },
+        );
+        await SocialLoginView.tapIosNewUserSetPinButton();
+      } catch {
+        // Telegram can skip SocialLoginIosUser and land on create-password.
+      }
+    } else {
+      await SocialLoginView.isIosNewUserScreenVisible();
+      await SocialLoginView.tapIosNewUserSetPinButton();
+    }
   }
 
   await waitForCreatePasswordScreenPlaywright(resolveE2EWaitTimeoutMs(60_000));

--- a/tests/smoke-appium/seedless/helpers/seedless-helpers.ts
+++ b/tests/smoke-appium/seedless/helpers/seedless-helpers.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../framework/PlaywrightUtilities.js';
 import { ChoosePasswordSelectorsIDs } from '../../../../app/components/Views/ChoosePassword/ChoosePassword.testIds.js';
 import { OnboardingSelectorIDs } from '../../../../app/components/Views/Onboarding/Onboarding.testIds.js';
+import { setupRemoteFeatureFlagsMock } from '../../../api-mocking/helpers/remoteFeatureFlagsHelper.js';
 import { createOAuthMockttpService } from '../../../api-mocking/seedless-onboarding/index.js';
 import { E2EOAuthHelpers } from '../../../module-mocking/oauth/index.js';
 import { resolveE2EWaitTimeoutMs } from '../../../framework/Constants.js';
@@ -188,13 +189,31 @@ export async function setupAppleExistingUserOAuthMock(
   await oAuthMockttpService.setup(mockServer);
 }
 
+export async function setupTelegramNewUserOAuthMock(
+  mockServer: Mockttp,
+): Promise<void> {
+  E2EOAuthHelpers.reset();
+  E2EOAuthHelpers.configureTelegramNewUser();
+  const oAuthMockttpService = createOAuthMockttpService();
+  oAuthMockttpService.configureTelegramNewUser();
+  await oAuthMockttpService.setup(mockServer);
+  // main-e2e does not bake MM_TELEGRAM_LOGIN_ENABLED; e2e/test LD defaults
+  // Telegram off. Override the client-config mock so the onboarding sheet
+  // renders the Telegram button.
+  await setupRemoteFeatureFlagsMock(mockServer, {
+    telegram_login_enabled: true,
+  });
+}
+
+type SocialLoginProvider = 'google' | 'apple' | 'telegram';
+
 /**
  * Social login new-user smoke.
  * Intermediate screen UI is covered by component-view / unit tests; this
  * helper only drives the device path.
  */
 export const completeSocialLoginOnboarding = async (
-  provider: 'google' | 'apple',
+  provider: SocialLoginProvider,
 ): Promise<void> => {
   await waitForOnboardingScreenPlaywright(resolveE2EWaitTimeoutMs(60_000));
 
@@ -206,8 +225,17 @@ export const completeSocialLoginOnboarding = async (
 
   if (provider === 'google') {
     await OnboardingSheet.tapGoogleLoginButton();
-  } else {
+  } else if (provider === 'apple') {
     await OnboardingSheet.tapAppleLoginButton();
+  } else {
+    await Assertions.expectElementToBeVisible(
+      OnboardingSheet.telegramLoginButton,
+      {
+        description:
+          'Telegram login button should be visible when telegram_login_enabled is mocked true',
+      },
+    );
+    await OnboardingSheet.tapTelegramLoginButton();
   }
 
   if (PlatformDetector.isIOS()) {
@@ -282,6 +310,9 @@ export const completeGoogleNewUserOnboarding = (): Promise<void> =>
 
 export const completeAppleNewUserOnboarding = (): Promise<void> =>
   completeSocialLoginOnboarding('apple');
+
+export const completeTelegramNewUserOnboarding = (): Promise<void> =>
+  completeSocialLoginOnboarding('telegram');
 
 /**
  * Confirms the native lock alert. On iOS the confirm button can go stale before

--- a/tests/smoke-appium/seedless/telegram-login-new-user.spec.ts
+++ b/tests/smoke-appium/seedless/telegram-login-new-user.spec.ts
@@ -11,21 +11,24 @@ import {
  * Device smoke: Telegram OAuth mock → password → wallet home.
  * Screen-level UI belongs in component-view tests.
  */
-appiumTest.describe(SmokeSeedlessOnboarding('Telegram Login - New User'), () => {
-  appiumTest(
-    'creates a new wallet with Telegram login',
-    async ({ driver: _driver, currentDeviceDetails }) => {
-      await withFixtures(
-        {
-          fixture: new FixtureBuilder({ onboarding: true }).build(),
-          restartDevice: true,
-          currentDeviceDetails,
-          testSpecificMock: setupTelegramNewUserOAuthMock,
-        },
-        async () => {
-          await completeTelegramNewUserOnboarding();
-        },
-      );
-    },
-  );
-});
+appiumTest.describe(
+  SmokeSeedlessOnboarding('Telegram Login - New User'),
+  () => {
+    appiumTest(
+      'creates a new wallet with Telegram login',
+      async ({ driver: _driver, currentDeviceDetails }) => {
+        await withFixtures(
+          {
+            fixture: new FixtureBuilder({ onboarding: true }).build(),
+            restartDevice: true,
+            currentDeviceDetails,
+            testSpecificMock: setupTelegramNewUserOAuthMock,
+          },
+          async () => {
+            await completeTelegramNewUserOnboarding();
+          },
+        );
+      },
+    );
+  },
+);

--- a/tests/smoke-appium/seedless/telegram-login-new-user.spec.ts
+++ b/tests/smoke-appium/seedless/telegram-login-new-user.spec.ts
@@ -1,0 +1,31 @@
+import { test as appiumTest } from '../../framework/fixtures/playwright/index.js';
+import { SmokeSeedlessOnboarding } from '../../tags.js';
+import FixtureBuilder from '../../framework/fixtures/FixtureBuilder.js';
+import { withFixtures } from '../../framework/fixtures/FixtureHelper.js';
+import {
+  completeTelegramNewUserOnboarding,
+  setupTelegramNewUserOAuthMock,
+} from './helpers/seedless-helpers.js';
+
+/**
+ * Device smoke: Telegram OAuth mock → password → wallet home.
+ * Screen-level UI belongs in component-view tests.
+ */
+appiumTest.describe(SmokeSeedlessOnboarding('Telegram Login - New User'), () => {
+  appiumTest(
+    'creates a new wallet with Telegram login',
+    async ({ driver: _driver, currentDeviceDetails }) => {
+      await withFixtures(
+        {
+          fixture: new FixtureBuilder({ onboarding: true }).build(),
+          restartDevice: true,
+          currentDeviceDetails,
+          testSpecificMock: setupTelegramNewUserOAuthMock,
+        },
+        async () => {
+          await completeTelegramNewUserOnboarding();
+        },
+      );
+    },
+  );
+});


### PR DESCRIPTION
## **Description**

Adds device smoke coverage for Telegram seedless onboarding so the provider is exercised the same way as Google and Apple.

Telegram already had OAuth mocks, page-object helpers, and performance coverage (TO-916). Appium smoke still only covered Google and Apple. This adds a new-user Telegram spec that reuses the shared social-login helper, and mocks `telegram_login_enabled` so the Telegram button appears on `main-e2e` (that binary does not bake `MM_TELEGRAM_LOGIN_ENABLED`, and the e2e/test LaunchDarkly environment defaults the flag off).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TO-682

## **Manual testing steps**

```gherkin
Feature: Telegram seedless onboarding Appium smoke

  Scenario: create a new Telegram seedless wallet
    Given MetaMask Mobile is freshly installed with a main-e2e build
    And Telegram OAuth is mocked for a new user
    And telegram_login_enabled is mocked true

    When the smoke spec creates a new wallet via Telegram
    And the user completes password creation and dismisses optional post-onboarding prompts
    Then the Wallet screen should become usable

  Scenario: Telegram button is missing when the flag is off
    Given telegram_login_enabled is not enabled
    When the onboarding sheet is opened
    Then the Telegram login button should not be visible
```

Authoritative validation is the Appium `SmokeSeedlessOnboarding` suite on this PR, not a production UI change.

## **Screenshots/Recordings**

### **Before**

N/A — automated smoke coverage only.

### **After**

N/A — automated smoke coverage only.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Not applicable to this test-only change; Appium CI is the validation path.
- [x] I've tested with a power user scenario
  - Not applicable to Telegram new-user smoke.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - Not applicable; no production code changes.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test the code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)