### PR TITLE
test: Activity Overview list-row component-view coverage (MMQA-2080)

### DIFF
--- a/app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx
+++ b/app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx
@@ -14,13 +14,24 @@ import {
   ACTIVITY_CV_NFT_COLLECTION_NAME,
   ACTIVITY_CV_NFT_CONTRACT,
   ACTIVITY_CV_PREDICT_MARKET_TITLE,
+  ACTIVITY_CV_RAMP_BUY_TX_HASH,
+  ACTIVITY_CV_RAMP_SELL_TX_HASH,
   ACTIVITY_CV_RECIPIENT,
+  ACTIVITY_CV_PERPS_DEPOSIT_HASH,
+  ACTIVITY_CV_PERPS_WITHDRAWAL_HASH,
   LINEA_ACTIVITY_HASH,
   MAINNET_ACTIVITY_HASH,
   activityCvBridgeHistoryEntry,
   activityCvCrossChainSwapBridgeHistoryEntry,
+  activityCvPerpsCanceledTakeProfitRowHash,
+  activityCvPerpsFundingRowHash,
+  activityCvPerpsTradeRowHash,
   activityLineaNetworkOverride,
+  activityPerpsTradingEnabledFlag,
   activityPredictTradingEnabledFlag,
+  buildActivityCvPerpsOverviewEngineSeed,
+  buildActivityCvRampBuyMusdOrder,
+  buildActivityCvRampSellEthOrder,
   buildConfirmedLocalBridgeTransaction,
   buildConfirmedLocalContractInteractionTransaction,
   buildConfirmedLocalCrossChainSwapTransaction,
@@ -37,6 +48,8 @@ import {
   buildPredictSellActivity,
   initialStateActivityWithAccountsApi,
   initialStateActivityWithLocalTransactions,
+  initialStateActivityWithPerpsDetails,
+  initialStateActivityWithRampOrders,
 } from '../../../../tests/component-view/presets/activity';
 import {
   clearAccountsTransactionsApiMocks,
@@ -62,6 +75,18 @@ const activityListRowAvatarSingleTestId = (hash: string): string =>
   `activity-row-avatar-single-${hash}`;
 const activityListRowAvatarStackTestId = (hash: string): string =>
   `activity-row-avatar-stack-${hash}`;
+
+/** Trade fills append `-${index}` in transformFillsToTransactions. */
+const activityListRowTitleTestIdPattern = (hashPrefix: string): RegExp =>
+  new RegExp(`^activity-title-${hashPrefix}-\\d+$`);
+const activityListRowSubtitleTestIdPattern = (hashPrefix: string): RegExp =>
+  new RegExp(`^activity-subtitle-${hashPrefix}-\\d+$`);
+const activityListRowPrimaryAmountTestIdPattern = (
+  hashPrefix: string,
+): RegExp => new RegExp(`^activity-primary-amount-${hashPrefix}-\\d+$`);
+const activityListRowSecondaryAmountTestIdPattern = (
+  hashPrefix: string,
+): RegExp => new RegExp(`^activity-secondary-amount-${hashPrefix}-\\d+$`);
 
 const USDC_MAINNET = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 
@@ -566,52 +591,37 @@ describeForPlatforms('ActivityScreen — transaction rows', () => {
   });
 
   // Default type filter is Transactions (`All` is off the sheet for now).
-  it('shows Send ETH under Transactions filter with negative primary amount and a single avatar', async () => {
-    const sendTransaction = buildConfirmedLocalSendTransaction();
-    const sendHash = sendTransaction.hash as string;
-    const state = initialStateActivityWithLocalTransactions([
-      sendTransaction,
-    ]).build();
+  it('shows send, receive, swap, bridge, approval, contract, and NFT rows under Transactions after load', async () => {
+    const sendEth = buildConfirmedLocalSendTransaction();
+    const sendUsdc = buildConfirmedLocalUsdcSendTransaction();
+    const bridge = buildConfirmedLocalBridgeTransaction();
+    const crossChainSwap = buildConfirmedLocalCrossChainSwapTransaction();
+    const approve = buildConfirmedLocalUsdcApproveTransaction();
+    const increase = buildConfirmedLocalUsdcIncreaseAllowanceTransaction();
+    const unlimitedApprove =
+      buildConfirmedLocalUsdcUnlimitedApproveTransaction();
+    const revoke = buildConfirmedLocalUsdcRevokeTransaction();
+    const contract = buildConfirmedLocalContractInteractionTransaction();
 
-    const { findByTestId, getAllByText } = renderActivityScreenView({ state });
+    const sendEthHash = sendEth.hash as string;
+    const sendUsdcHash = sendUsdc.hash as string;
+    const bridgeHash = bridge.hash as string;
+    const crossChainSwapHash = crossChainSwap.hash as string;
+    const approveHash = approve.hash as string;
+    const increaseHash = increase.hash as string;
+    const unlimitedApproveHash = unlimitedApprove.hash as string;
+    const revokeHash = revoke.hash as string;
+    const contractHash = contract.hash as string;
+    const receiveEthHash = '0xactivitycvreceiveeth';
+    const receiveUsdcHash = '0xactivitycvreceiveusdc';
+    const apiSwapHash = '0xactivitycvswapethusdc';
+    const mintHash = '0xactivitycvnftmint';
+    const zeroAddress = '0x0000000000000000000000000000000000000000';
 
-    await waitFor(() => {
-      expect(
-        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Transactions))
-          .length,
-      ).toBeGreaterThan(0);
-    });
-
-    const title = await findByTestId(activityListRowTitleTestId(sendHash));
-    expect(title).toHaveTextContent('Sent ETH');
-
-    const subtitle = await findByTestId(
-      activityListRowSubtitleTestId(sendHash),
-    );
-    expect(subtitle).toBeOnTheScreen();
-    expect(subtitle).toHaveTextContent('To: 0x80181...229cC');
-
-    const primaryAmount = await findByTestId(
-      activityListRowPrimaryAmountTestId(sendHash),
-    );
-    expect(primaryAmount).toHaveTextContent(/^-.*ETH/);
-
-    const secondaryAmount = await findByTestId(
-      activityListRowSecondaryAmountTestId(sendHash),
-    );
-    expect(secondaryAmount).toHaveTextContent(/^-\$2,500\.00/);
-
-    expect(
-      await findByTestId(activityListRowAvatarSingleTestId(sendHash)),
-    ).toBeOnTheScreen();
-  });
-
-  it('shows Receive ETH under Transactions filter with positive primary amount and a single avatar', async () => {
-    const receiveHash = '0xactivitycvreceiveeth';
     setupAccountsTransactionsApiMock([
       {
-        hash: receiveHash,
-        timestamp: new Date().toISOString(),
+        hash: receiveEthHash,
+        timestamp: new Date(1_716_367_800_000).toISOString(),
         chainId: 1,
         from: ACTIVITY_CV_RECIPIENT,
         to: ACTIVITY_CV_ACCOUNT,
@@ -623,81 +633,14 @@ describeForPlatforms('ActivityScreen — transaction rows', () => {
             amount: '1000000000000000000',
             symbol: 'ETH',
             decimal: 18,
-            // Omit transferType so shouldSkipTransaction keeps this inbound row.
           },
         ],
         isError: false,
         transactionCategory: 'STANDARD',
       },
-    ]);
-
-    const state = initialStateActivityWithAccountsApi().build();
-    const { findByTestId, getAllByText } = renderActivityScreenView({ state });
-
-    await waitFor(() => {
-      expect(
-        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Transactions))
-          .length,
-      ).toBeGreaterThan(0);
-    });
-
-    const title = await waitFor(
-      () => findByTestId(activityListRowTitleTestId(receiveHash)),
-      { timeout: 10000 },
-    );
-    expect(title).toHaveTextContent('Received ETH');
-
-    const subtitle = await findByTestId(
-      activityListRowSubtitleTestId(receiveHash),
-    );
-    expect(subtitle).toBeOnTheScreen();
-    expect(subtitle).toHaveTextContent('From: 0x80181...229cC');
-
-    const primaryAmount = await findByTestId(
-      activityListRowPrimaryAmountTestId(receiveHash),
-    );
-    expect(primaryAmount).toHaveTextContent(/^\+.*ETH/);
-
-    expect(
-      await findByTestId(activityListRowAvatarSingleTestId(receiveHash)),
-    ).toBeOnTheScreen();
-  });
-
-  it('shows Send USDC under Transactions filter with negative primary amount and a single avatar', async () => {
-    const sendTransaction = buildConfirmedLocalUsdcSendTransaction();
-    const sendHash = sendTransaction.hash as string;
-    const state = initialStateActivityWithLocalTransactions([
-      sendTransaction,
-    ]).build();
-
-    const { findByTestId, getAllByText } = renderActivityScreenView({ state });
-
-    await waitFor(() => {
-      expect(
-        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Transactions))
-          .length,
-      ).toBeGreaterThan(0);
-    });
-
-    const title = await findByTestId(activityListRowTitleTestId(sendHash));
-    expect(title).toHaveTextContent('Sent USDC');
-
-    const primaryAmount = await findByTestId(
-      activityListRowPrimaryAmountTestId(sendHash),
-    );
-    expect(primaryAmount).toHaveTextContent(/^-.*USDC/);
-
-    expect(
-      await findByTestId(activityListRowAvatarSingleTestId(sendHash)),
-    ).toBeOnTheScreen();
-  });
-
-  it('shows Receive USDC under Transactions filter with positive primary amount and a single avatar', async () => {
-    const receiveHash = '0xactivitycvreceiveusdc';
-    setupAccountsTransactionsApiMock([
       {
-        hash: receiveHash,
-        timestamp: new Date().toISOString(),
+        hash: receiveUsdcHash,
+        timestamp: new Date(1_716_367_801_000).toISOString(),
         chainId: 1,
         from: ACTIVITY_CV_RECIPIENT,
         to: ACTIVITY_CV_ACCOUNT,
@@ -709,7 +652,6 @@ describeForPlatforms('ActivityScreen — transaction rows', () => {
             amount: '1000000',
             symbol: 'USDC',
             decimal: 6,
-            // Omit contractAddress so shouldSkipTransaction keeps this inbound row.
             name: 'USD Coin',
             transferType: 'ERC20',
           },
@@ -717,41 +659,9 @@ describeForPlatforms('ActivityScreen — transaction rows', () => {
         isError: false,
         transactionCategory: 'TRANSFER',
       },
-    ]);
-
-    const state = initialStateActivityWithAccountsApi().build();
-    const { findByTestId, getAllByText } = renderActivityScreenView({ state });
-
-    await waitFor(() => {
-      expect(
-        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Transactions))
-          .length,
-      ).toBeGreaterThan(0);
-    });
-
-    const title = await waitFor(
-      () => findByTestId(activityListRowTitleTestId(receiveHash)),
-      { timeout: 10000 },
-    );
-    expect(title).toHaveTextContent('Received USDC');
-
-    const primaryAmount = await findByTestId(
-      activityListRowPrimaryAmountTestId(receiveHash),
-    );
-    expect(primaryAmount).toHaveTextContent(/^\+.*USDC/);
-
-    expect(
-      await findByTestId(activityListRowAvatarSingleTestId(receiveHash)),
-    ).toBeOnTheScreen();
-  });
-
-  it('shows Swap ETH to USDC under Transactions filter with dual avatar and negative spent amount', async () => {
-    const swapHash = '0xactivitycvswapethusdc';
-    const aggregator = ACTIVITY_CV_RECIPIENT;
-    setupAccountsTransactionsApiMock([
       {
-        hash: swapHash,
-        timestamp: new Date().toISOString(),
+        hash: apiSwapHash,
+        timestamp: new Date(1_716_367_802_000).toISOString(),
         chainId: 1,
         from: ACTIVITY_CV_ACCOUNT,
         to: ACTIVITY_CV_ACCOUNT,
@@ -759,7 +669,7 @@ describeForPlatforms('ActivityScreen — transaction rows', () => {
         valueTransfers: [
           {
             from: ACTIVITY_CV_ACCOUNT,
-            to: aggregator,
+            to: ACTIVITY_CV_RECIPIENT,
             amount: '1000000000000000000',
             decimal: 18,
             symbol: 'ETH',
@@ -767,7 +677,7 @@ describeForPlatforms('ActivityScreen — transaction rows', () => {
             transferType: 'normal',
           },
           {
-            from: aggregator,
+            from: ACTIVITY_CV_RECIPIENT,
             to: ACTIVITY_CV_ACCOUNT,
             amount: '1000000',
             decimal: 6,
@@ -780,54 +690,50 @@ describeForPlatforms('ActivityScreen — transaction rows', () => {
         isError: false,
         transactionCategory: 'EXCHANGE',
       },
+      {
+        hash: mintHash,
+        timestamp: new Date(1_716_367_803_000).toISOString(),
+        chainId: 1,
+        from: ACTIVITY_CV_ACCOUNT,
+        to: ACTIVITY_CV_NFT_CONTRACT,
+        value: '0',
+        valueTransfers: [
+          {
+            from: zeroAddress,
+            to: ACTIVITY_CV_ACCOUNT,
+            contractAddress: ACTIVITY_CV_NFT_CONTRACT,
+            tokenId: '1',
+            name: ACTIVITY_CV_NFT_COLLECTION_NAME,
+            symbol: 'PUNK',
+            transferType: 'erc721',
+          },
+        ],
+        isError: false,
+        transactionCategory: 'TRANSFER',
+      },
     ]);
 
-    const state = initialStateActivityWithAccountsApi().build();
-    const { findByTestId, getAllByText } = renderActivityScreenView({ state });
-
-    await waitFor(() => {
-      expect(
-        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Transactions))
-          .length,
-      ).toBeGreaterThan(0);
-    });
-
-    const title = await waitFor(
-      () => findByTestId(activityListRowTitleTestId(swapHash)),
-      { timeout: 10000 },
-    );
-    // Title "Swapped"; pair in subtitle ("ETH → USDC").
-    expect(title).toHaveTextContent('Swapped');
-    expect(
-      await findByTestId(activityListRowSubtitleTestId(swapHash)),
-    ).toHaveTextContent('ETH → USDC');
-
-    // Destination (+USDC) primary; spent ETH secondary.
-    const primaryAmount = await findByTestId(
-      activityListRowPrimaryAmountTestId(swapHash),
-    );
-    expect(primaryAmount).toHaveTextContent(/^\+.*USDC/);
-
-    const secondaryAmount = await findByTestId(
-      activityListRowSecondaryAmountTestId(swapHash),
-    );
-    expect(secondaryAmount).toHaveTextContent(/^-.*ETH/);
-
-    expect(
-      await findByTestId(activityListRowAvatarStackTestId(swapHash)),
-    ).toBeOnTheScreen();
-  });
-
-  it('shows Bridge under Transactions filter with dual avatar, primary amount and secondary amount', async () => {
-    const bridgeTransaction = buildConfirmedLocalBridgeTransaction();
-    const bridgeHash = bridgeTransaction.hash as string;
-    const state = initialStateActivityWithLocalTransactions([bridgeTransaction])
+    const state = initialStateActivityWithLocalTransactions([
+      sendEth,
+      sendUsdc,
+      bridge,
+      crossChainSwap,
+      approve,
+      increase,
+      unlimitedApprove,
+      revoke,
+      contract,
+    ])
       .withOverrides({
         engine: {
           backgroundState: {
+            PreferencesController: {
+              privacyMode: false,
+            },
             BridgeStatusController: {
               txHistory: {
-                [bridgeTransaction.id]: activityCvBridgeHistoryEntry,
+                [bridge.id]: activityCvBridgeHistoryEntry,
+                [crossChainSwap.id]: activityCvCrossChainSwapBridgeHistoryEntry,
               },
             },
           },
@@ -835,7 +741,8 @@ describeForPlatforms('ActivityScreen — transaction rows', () => {
       } as never)
       .build();
 
-    const { findByTestId, getAllByText } = renderActivityScreenView({ state });
+    const { findByTestId, queryByTestId, getAllByText } =
+      renderActivityScreenView({ state });
 
     await waitFor(() => {
       expect(
@@ -844,74 +751,197 @@ describeForPlatforms('ActivityScreen — transaction rows', () => {
       ).toBeGreaterThan(0);
     });
 
-    const title = await findByTestId(activityListRowTitleTestId(bridgeHash));
-    expect(title).toHaveTextContent('Bridged USDC');
+    const sendEthTitle = await waitFor(
+      () => findByTestId(activityListRowTitleTestId(sendEthHash)),
+      { timeout: 10000 },
+    );
+    expect(sendEthTitle).toHaveTextContent('Sent ETH');
+    expect(
+      await findByTestId(activityListRowSubtitleTestId(sendEthHash)),
+    ).toHaveTextContent('To: 0x80181...229cC');
+    expect(
+      await findByTestId(activityListRowPrimaryAmountTestId(sendEthHash)),
+    ).toHaveTextContent(/^-.*ETH/);
+    expect(
+      await findByTestId(activityListRowSecondaryAmountTestId(sendEthHash)),
+    ).toHaveTextContent(/^-\$2,500\.00/);
+    expect(
+      await findByTestId(activityListRowAvatarSingleTestId(sendEthHash)),
+    ).toBeOnTheScreen();
+
+    const receiveEthTitle = await findByTestId(
+      activityListRowTitleTestId(receiveEthHash),
+    );
+    expect(receiveEthTitle).toHaveTextContent('Received ETH');
+    expect(
+      await findByTestId(activityListRowSubtitleTestId(receiveEthHash)),
+    ).toHaveTextContent('From: 0x80181...229cC');
+    expect(
+      await findByTestId(activityListRowPrimaryAmountTestId(receiveEthHash)),
+    ).toHaveTextContent(/^\+.*ETH/);
+    expect(
+      await findByTestId(activityListRowAvatarSingleTestId(receiveEthHash)),
+    ).toBeOnTheScreen();
+
+    expect(
+      await findByTestId(activityListRowTitleTestId(sendUsdcHash)),
+    ).toHaveTextContent('Sent USDC');
+    expect(
+      await findByTestId(activityListRowPrimaryAmountTestId(sendUsdcHash)),
+    ).toHaveTextContent(/^-.*USDC/);
+    expect(
+      await findByTestId(activityListRowAvatarSingleTestId(sendUsdcHash)),
+    ).toBeOnTheScreen();
+
+    expect(
+      await findByTestId(activityListRowTitleTestId(receiveUsdcHash)),
+    ).toHaveTextContent('Received USDC');
+    expect(
+      await findByTestId(activityListRowPrimaryAmountTestId(receiveUsdcHash)),
+    ).toHaveTextContent(/^\+.*USDC/);
+    expect(
+      await findByTestId(activityListRowAvatarSingleTestId(receiveUsdcHash)),
+    ).toBeOnTheScreen();
+
+    expect(
+      await findByTestId(activityListRowTitleTestId(apiSwapHash)),
+    ).toHaveTextContent('Swapped');
+    expect(
+      await findByTestId(activityListRowSubtitleTestId(apiSwapHash)),
+    ).toHaveTextContent('ETH → USDC');
+    expect(
+      await findByTestId(activityListRowPrimaryAmountTestId(apiSwapHash)),
+    ).toHaveTextContent(/^\+.*USDC/);
+    expect(
+      await findByTestId(activityListRowSecondaryAmountTestId(apiSwapHash)),
+    ).toHaveTextContent(/^-.*ETH/);
+    expect(
+      await findByTestId(activityListRowAvatarStackTestId(apiSwapHash)),
+    ).toBeOnTheScreen();
+
+    expect(
+      await findByTestId(activityListRowTitleTestId(bridgeHash)),
+    ).toHaveTextContent('Bridged USDC');
     expect(
       await findByTestId(activityListRowSubtitleTestId(bridgeHash)),
     ).toHaveTextContent('Ethereum → Linea');
-
-    // Dest amount present → +USDC primary, -ETH secondary.
-    const primaryAmount = await findByTestId(
-      activityListRowPrimaryAmountTestId(bridgeHash),
-    );
-    expect(primaryAmount).toHaveTextContent(/^\+.*USDC/);
-
-    const secondaryAmount = await findByTestId(
-      activityListRowSecondaryAmountTestId(bridgeHash),
-    );
-    expect(secondaryAmount).toHaveTextContent(/^-.*ETH/);
-
+    expect(
+      await findByTestId(activityListRowPrimaryAmountTestId(bridgeHash)),
+    ).toHaveTextContent(/^\+.*USDC/);
+    expect(
+      await findByTestId(activityListRowSecondaryAmountTestId(bridgeHash)),
+    ).toHaveTextContent(/^-.*ETH/);
     expect(
       await findByTestId(activityListRowAvatarStackTestId(bridgeHash)),
     ).toBeOnTheScreen();
-  });
 
-  it('shows Swapped under Transactions filter with dual avatar with bridged tokens in the subtitle, primary amount and secondary amount, when bridging different tokens on different networks', async () => {
-    const swapTransaction = buildConfirmedLocalCrossChainSwapTransaction();
-    const swapHash = swapTransaction.hash as string;
-    const state = initialStateActivityWithLocalTransactions([swapTransaction])
-      .withOverrides({
-        engine: {
-          backgroundState: {
-            BridgeStatusController: {
-              txHistory: {
-                [swapTransaction.id]:
-                  activityCvCrossChainSwapBridgeHistoryEntry,
-              },
-            },
-          },
-        },
-      } as never)
-      .build();
-
-    const { findByTestId, getAllByText } = renderActivityScreenView({ state });
-
-    await waitFor(() => {
-      expect(
-        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Transactions))
-          .length,
-      ).toBeGreaterThan(0);
-    });
-
-    const title = await findByTestId(activityListRowTitleTestId(swapHash));
-    // Cross-chain different-token unified swap: "Swapped" + token-pair subtitle.
-    expect(title).toHaveTextContent('Swapped');
     expect(
-      await findByTestId(activityListRowSubtitleTestId(swapHash)),
+      await findByTestId(activityListRowTitleTestId(crossChainSwapHash)),
+    ).toHaveTextContent('Swapped');
+    expect(
+      await findByTestId(activityListRowSubtitleTestId(crossChainSwapHash)),
     ).toHaveTextContent('ETH → USDC');
-
-    const primaryAmount = await findByTestId(
-      activityListRowPrimaryAmountTestId(swapHash),
-    );
-    expect(primaryAmount).toHaveTextContent(/^\+.*USDC/);
-
-    const secondaryAmount = await findByTestId(
-      activityListRowSecondaryAmountTestId(swapHash),
-    );
-    expect(secondaryAmount).toHaveTextContent(/^-.*ETH/);
+    expect(
+      await findByTestId(
+        activityListRowPrimaryAmountTestId(crossChainSwapHash),
+      ),
+    ).toHaveTextContent(/^\+.*USDC/);
+    expect(
+      await findByTestId(
+        activityListRowSecondaryAmountTestId(crossChainSwapHash),
+      ),
+    ).toHaveTextContent(/^-.*ETH/);
+    expect(
+      await findByTestId(activityListRowAvatarStackTestId(crossChainSwapHash)),
+    ).toBeOnTheScreen();
 
     expect(
-      await findByTestId(activityListRowAvatarStackTestId(swapHash)),
+      await findByTestId(activityListRowTitleTestId(approveHash)),
+    ).toHaveTextContent('Approved spending cap');
+    expect(
+      await findByTestId(activityListRowSubtitleTestId(approveHash)),
+    ).toHaveTextContent('USDC');
+    expect(
+      await findByTestId(activityListRowPrimaryAmountTestId(approveHash)),
+    ).toHaveTextContent('100 USDC');
+    expect(
+      await findByTestId(activityListRowPrimaryAmountTestId(approveHash)),
+    ).not.toHaveTextContent(/^[+-]/);
+    expect(
+      await findByTestId(activityListRowAvatarSingleTestId(approveHash)),
+    ).toBeOnTheScreen();
+
+    expect(
+      await findByTestId(activityListRowTitleTestId(increaseHash)),
+    ).toHaveTextContent('Increased spending cap');
+    expect(
+      await findByTestId(activityListRowSubtitleTestId(increaseHash)),
+    ).toHaveTextContent('USDC');
+    expect(
+      await findByTestId(activityListRowPrimaryAmountTestId(increaseHash)),
+    ).toHaveTextContent('100 USDC');
+    expect(
+      await findByTestId(activityListRowPrimaryAmountTestId(increaseHash)),
+    ).not.toHaveTextContent(/^[+-]/);
+    expect(
+      await findByTestId(activityListRowAvatarSingleTestId(increaseHash)),
+    ).toBeOnTheScreen();
+
+    expect(
+      await findByTestId(activityListRowTitleTestId(contractHash)),
+    ).toHaveTextContent(strings('transactions.smart_contract_interaction'));
+    expect(
+      queryByTestId(activityListRowPrimaryAmountTestId(contractHash)),
+    ).toBeNull();
+    expect(
+      await findByTestId(activityListRowAvatarSingleTestId(contractHash)),
+    ).toBeOnTheScreen();
+
+    expect(
+      await findByTestId(activityListRowTitleTestId(unlimitedApproveHash)),
+    ).toHaveTextContent('Approved spending cap');
+    expect(
+      await findByTestId(activityListRowSubtitleTestId(unlimitedApproveHash)),
+    ).toHaveTextContent('USDC');
+    expect(
+      await findByTestId(
+        activityListRowPrimaryAmountTestId(unlimitedApproveHash),
+      ),
+    ).toHaveTextContent(`${strings('confirm.unlimited')} USDC`);
+    expect(
+      await findByTestId(
+        activityListRowPrimaryAmountTestId(unlimitedApproveHash),
+      ),
+    ).not.toHaveTextContent(/^[+-]/);
+    expect(
+      await findByTestId(
+        activityListRowAvatarSingleTestId(unlimitedApproveHash),
+      ),
+    ).toBeOnTheScreen();
+
+    expect(
+      await findByTestId(activityListRowTitleTestId(revokeHash)),
+    ).toHaveTextContent(strings('transactions.activity_revoke_spending_cap'));
+    expect(
+      await findByTestId(activityListRowSubtitleTestId(revokeHash)),
+    ).toHaveTextContent('USDC');
+    expect(
+      await findByTestId(activityListRowPrimaryAmountTestId(revokeHash)),
+    ).toHaveTextContent('0 USDC');
+    expect(
+      await findByTestId(activityListRowPrimaryAmountTestId(revokeHash)),
+    ).not.toHaveTextContent(/^[+-]/);
+    expect(
+      await findByTestId(activityListRowAvatarSingleTestId(revokeHash)),
+    ).toBeOnTheScreen();
+
+    expect(
+      await findByTestId(activityListRowTitleTestId(mintHash)),
+    ).toHaveTextContent(
+      `${strings('transactions.activity_nft_mint')} ${ACTIVITY_CV_NFT_COLLECTION_NAME}`,
+    );
+    expect(
+      await findByTestId(activityListRowAvatarSingleTestId(mintHash)),
     ).toBeOnTheScreen();
   });
 
@@ -978,228 +1008,6 @@ describeForPlatforms('ActivityScreen — transaction rows', () => {
       await findByTestId(activityListRowSubtitleTestId(swapHash)),
     ).toHaveTextContent('ETH → USDC');
   });
-
-  it('shows Approve USDC under Transactions filter with unsigned primary amount and a single avatar', async () => {
-    const approveTransaction = buildConfirmedLocalUsdcApproveTransaction();
-    const approveHash = approveTransaction.hash as string;
-    const state = initialStateActivityWithLocalTransactions([
-      approveTransaction,
-    ]).build();
-
-    const { findByTestId, getAllByText } = renderActivityScreenView({ state });
-
-    await waitFor(() => {
-      expect(
-        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Transactions))
-          .length,
-      ).toBeGreaterThan(0);
-    });
-
-    const title = await findByTestId(activityListRowTitleTestId(approveHash));
-    expect(title).toHaveTextContent('Approved spending cap');
-    expect(
-      await findByTestId(activityListRowSubtitleTestId(approveHash)),
-    ).toHaveTextContent('USDC');
-
-    const primaryAmount = await findByTestId(
-      activityListRowPrimaryAmountTestId(approveHash),
-    );
-    expect(primaryAmount).toHaveTextContent('100 USDC');
-    expect(primaryAmount).not.toHaveTextContent(/^[+-]/);
-
-    expect(
-      await findByTestId(activityListRowAvatarSingleTestId(approveHash)),
-    ).toBeOnTheScreen();
-  });
-
-  it('shows increased spending cap under Transactions filter with amount and a single avatar with subtitle of token', async () => {
-    const increaseTransaction =
-      buildConfirmedLocalUsdcIncreaseAllowanceTransaction();
-    const increaseHash = increaseTransaction.hash as string;
-    const state = initialStateActivityWithLocalTransactions([
-      increaseTransaction,
-    ]).build();
-
-    const { findByTestId, getAllByText } = renderActivityScreenView({ state });
-
-    await waitFor(() => {
-      expect(
-        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Transactions))
-          .length,
-      ).toBeGreaterThan(0);
-    });
-
-    const title = await findByTestId(activityListRowTitleTestId(increaseHash));
-    expect(title).toHaveTextContent('Increased spending cap');
-    expect(
-      await findByTestId(activityListRowSubtitleTestId(increaseHash)),
-    ).toHaveTextContent('USDC');
-
-    const primaryAmount = await findByTestId(
-      activityListRowPrimaryAmountTestId(increaseHash),
-    );
-    expect(primaryAmount).toHaveTextContent('100 USDC');
-    expect(primaryAmount).not.toHaveTextContent(/^[+-]/);
-
-    expect(
-      await findByTestId(activityListRowAvatarSingleTestId(increaseHash)),
-    ).toBeOnTheScreen();
-  });
-
-  it('shows Contract interaction under Transactions filter with no amount sign and a single avatar', async () => {
-    const contractTransaction =
-      buildConfirmedLocalContractInteractionTransaction();
-    const contractHash = contractTransaction.hash as string;
-    const state = initialStateActivityWithLocalTransactions([
-      contractTransaction,
-    ]).build();
-
-    const { findByTestId, queryByTestId, getAllByText } =
-      renderActivityScreenView({ state });
-
-    await waitFor(() => {
-      expect(
-        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Transactions))
-          .length,
-      ).toBeGreaterThan(0);
-    });
-
-    const title = await findByTestId(activityListRowTitleTestId(contractHash));
-    expect(title).toHaveTextContent(
-      strings('transactions.smart_contract_interaction'),
-    );
-
-    // Zero-value interaction has no primary amount.
-    expect(
-      queryByTestId(activityListRowPrimaryAmountTestId(contractHash)),
-    ).toBeNull();
-
-    expect(
-      await findByTestId(activityListRowAvatarSingleTestId(contractHash)),
-    ).toBeOnTheScreen();
-  });
-
-  it('shows Unlimited Approval of USDC under Transactions filter with unsigned primary amount and a single avatar', async () => {
-    const approveTransaction =
-      buildConfirmedLocalUsdcUnlimitedApproveTransaction();
-    const approveHash = approveTransaction.hash as string;
-    const state = initialStateActivityWithLocalTransactions([
-      approveTransaction,
-    ]).build();
-
-    const { findByTestId, getAllByText } = renderActivityScreenView({ state });
-
-    await waitFor(() => {
-      expect(
-        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Transactions))
-          .length,
-      ).toBeGreaterThan(0);
-    });
-
-    const title = await findByTestId(activityListRowTitleTestId(approveHash));
-    expect(title).toHaveTextContent('Approved spending cap');
-    expect(
-      await findByTestId(activityListRowSubtitleTestId(approveHash)),
-    ).toHaveTextContent('USDC');
-
-    const primaryAmount = await findByTestId(
-      activityListRowPrimaryAmountTestId(approveHash),
-    );
-    expect(primaryAmount).toHaveTextContent(
-      `${strings('confirm.unlimited')} USDC`,
-    );
-    expect(primaryAmount).not.toHaveTextContent(/^[+-]/);
-
-    expect(
-      await findByTestId(activityListRowAvatarSingleTestId(approveHash)),
-    ).toBeOnTheScreen();
-  });
-
-  it('shows revoke approval of USDC under Transactions filter with unsigned primary amount and a single avatar', async () => {
-    const revokeTransaction = buildConfirmedLocalUsdcRevokeTransaction();
-    const revokeHash = revokeTransaction.hash as string;
-    const state = initialStateActivityWithLocalTransactions([
-      revokeTransaction,
-    ]).build();
-
-    const { findByTestId, getAllByText } = renderActivityScreenView({ state });
-
-    await waitFor(() => {
-      expect(
-        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Transactions))
-          .length,
-      ).toBeGreaterThan(0);
-    });
-
-    const title = await findByTestId(activityListRowTitleTestId(revokeHash));
-    expect(title).toHaveTextContent(
-      strings('transactions.activity_revoke_spending_cap'),
-    );
-    expect(
-      await findByTestId(activityListRowSubtitleTestId(revokeHash)),
-    ).toHaveTextContent('USDC');
-
-    const primaryAmount = await findByTestId(
-      activityListRowPrimaryAmountTestId(revokeHash),
-    );
-    expect(primaryAmount).toHaveTextContent('0 USDC');
-    expect(primaryAmount).not.toHaveTextContent(/^[+-]/);
-
-    expect(
-      await findByTestId(activityListRowAvatarSingleTestId(revokeHash)),
-    ).toBeOnTheScreen();
-  });
-
-  it('shows NFT mint under Transactions filter with the collection name in the title', async () => {
-    const mintHash = '0xactivitycvnftmint';
-    const zeroAddress = '0x0000000000000000000000000000000000000000';
-    setupAccountsTransactionsApiMock([
-      {
-        hash: mintHash,
-        timestamp: new Date().toISOString(),
-        chainId: 1,
-        // from = selected account so shouldSkipTransaction does not drop this mint.
-        from: ACTIVITY_CV_ACCOUNT,
-        to: ACTIVITY_CV_NFT_CONTRACT,
-        value: '0',
-        valueTransfers: [
-          {
-            from: zeroAddress,
-            to: ACTIVITY_CV_ACCOUNT,
-            contractAddress: ACTIVITY_CV_NFT_CONTRACT,
-            tokenId: '1',
-            name: ACTIVITY_CV_NFT_COLLECTION_NAME,
-            symbol: 'PUNK',
-            transferType: 'erc721',
-          },
-        ],
-        isError: false,
-        transactionCategory: 'TRANSFER',
-      },
-    ]);
-
-    const state = initialStateActivityWithAccountsApi().build();
-    const { findByTestId, getAllByText } = renderActivityScreenView({ state });
-
-    await waitFor(() => {
-      expect(
-        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Transactions))
-          .length,
-      ).toBeGreaterThan(0);
-    });
-
-    const title = await waitFor(
-      () => findByTestId(activityListRowTitleTestId(mintHash)),
-      { timeout: 10000 },
-    );
-    expect(title).toHaveTextContent(
-      `${strings('transactions.activity_nft_mint')} ${ACTIVITY_CV_NFT_COLLECTION_NAME}`,
-    );
-
-    expect(
-      await findByTestId(activityListRowAvatarSingleTestId(mintHash)),
-    ).toBeOnTheScreen();
-  });
 });
 
 describeForPlatforms('ActivityScreen — prediction rows', () => {
@@ -1210,10 +1018,21 @@ describeForPlatforms('ActivityScreen — prediction rows', () => {
     ).mockResolvedValue([]);
   });
 
-  it('shows Account funded under Predictions with balance subtitle, + fiat, and USDC secondary', async () => {
+  it('shows deposit, withdrawal, claim, cash-out, and placed rows under Predictions after load', async () => {
     const deposit = buildConfirmedLocalPredictDepositTransaction();
+    const withdraw = buildConfirmedLocalPredictWithdrawTransaction();
+    const claim = buildPredictClaimActivity();
+    const sell = buildPredictSellActivity();
+    const buy = buildPredictBuyActivity();
     const depositHash = deposit.hash as string;
-    const state = initialStateActivityWithLocalTransactions([deposit])
+    const withdrawHash = withdraw.hash as string;
+
+    setupAccountsTransactionsApiMock([]);
+    (
+      Engine.context.PredictController.getActivity as jest.Mock
+    ).mockResolvedValue([claim, sell, buy]);
+
+    const state = initialStateActivityWithLocalTransactions([deposit, withdraw])
       .withRemoteFeatureFlags(activityPredictTradingEnabledFlag)
       .build();
 
@@ -1239,17 +1058,17 @@ describeForPlatforms('ActivityScreen — prediction rows', () => {
       await findByTestId(activityListRowSubtitleTestId(depositHash)),
     ).toHaveTextContent(strings('transactions.activity_predictions_balance'));
 
-    const primaryAmount = await findByTestId(
+    const depositPrimary = await findByTestId(
       activityListRowPrimaryAmountTestId(depositHash),
     );
-    expect(primaryAmount).toHaveTextContent(/^\+/);
-    expect(primaryAmount).toHaveTextContent(/USD|\$/);
+    expect(depositPrimary).toHaveTextContent(/^\+/);
+    expect(depositPrimary).toHaveTextContent(/USD|\$/);
 
-    const secondaryAmount = await findByTestId(
+    const depositSecondary = await findByTestId(
       activityListRowSecondaryAmountTestId(depositHash),
     );
-    expect(secondaryAmount).toHaveTextContent(/4,?000 USDC/);
-    expect(secondaryAmount).not.toHaveTextContent(/^\+/);
+    expect(depositSecondary).toHaveTextContent(/4,?000 USDC/);
+    expect(depositSecondary).not.toHaveTextContent(/^\+/);
 
     expect(
       await findByTestId(activityListRowAvatarSingleTestId(depositHash)),
@@ -1257,26 +1076,6 @@ describeForPlatforms('ActivityScreen — prediction rows', () => {
     expect(
       queryByTestId(activityListRowAvatarStackTestId(depositHash)),
     ).toBeNull();
-  });
-
-  it('shows Prediction withdrawal under Predictions with balance subtitle and negative amounts', async () => {
-    const withdraw = buildConfirmedLocalPredictWithdrawTransaction();
-    const withdrawHash = withdraw.hash as string;
-    const state = initialStateActivityWithLocalTransactions([withdraw])
-      .withRemoteFeatureFlags(activityPredictTradingEnabledFlag)
-      .build();
-
-    const { findByTestId, getAllByText } = renderActivityScreenView({
-      state,
-      params: { initialTypeFilter: ActivityTypeFilter.Predictions },
-    });
-
-    await waitFor(() => {
-      expect(
-        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Predictions))
-          .length,
-      ).toBeGreaterThan(0);
-    });
 
     expect(
       await findByTestId(activityListRowTitleTestId(withdrawHash)),
@@ -1285,61 +1084,37 @@ describeForPlatforms('ActivityScreen — prediction rows', () => {
       await findByTestId(activityListRowSubtitleTestId(withdrawHash)),
     ).toHaveTextContent(strings('transactions.activity_predictions_balance'));
 
-    const primaryAmount = await findByTestId(
+    const withdrawPrimary = await findByTestId(
       activityListRowPrimaryAmountTestId(withdrawHash),
     );
-    expect(primaryAmount).toHaveTextContent(/^-/);
-    expect(primaryAmount).toHaveTextContent(/USD|\$/);
+    expect(withdrawPrimary).toHaveTextContent(/^-/);
+    expect(withdrawPrimary).toHaveTextContent(/USD|\$/);
 
-    const secondaryAmount = await findByTestId(
+    const withdrawSecondary = await findByTestId(
       activityListRowSecondaryAmountTestId(withdrawHash),
     );
-    expect(secondaryAmount).toHaveTextContent(/^-.*4,?000 USDC/);
+    expect(withdrawSecondary).toHaveTextContent(/^-.*4,?000 USDC/);
 
     expect(
       await findByTestId(activityListRowAvatarSingleTestId(withdrawHash)),
     ).toBeOnTheScreen();
-  });
 
-  it('shows Claimed winnings under Predictions with market subtitle and + fiat primary', async () => {
-    const claim = buildPredictClaimActivity();
-    (
-      Engine.context.PredictController.getActivity as jest.Mock
-    ).mockResolvedValue([claim]);
-
-    const state = initialStateActivityWithAccountsApi()
-      .withRemoteFeatureFlags(activityPredictTradingEnabledFlag)
-      .build();
-
-    const { findByTestId, getAllByText, queryByTestId } =
-      renderActivityScreenView({
-        state,
-        params: { initialTypeFilter: ActivityTypeFilter.Predictions },
-      });
-
-    await waitFor(() => {
-      expect(
-        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Predictions))
-          .length,
-      ).toBeGreaterThan(0);
-    });
-
-    const title = await waitFor(
+    const claimTitle = await waitFor(
       () => findByTestId(activityListRowTitleTestId(claim.id)),
       { timeout: 10000 },
     );
-    expect(title).toHaveTextContent(
+    expect(claimTitle).toHaveTextContent(
       strings('predict.transactions.claim_title'),
     );
     expect(
       await findByTestId(activityListRowSubtitleTestId(claim.id)),
     ).toHaveTextContent(ACTIVITY_CV_PREDICT_MARKET_TITLE);
 
-    const primaryAmount = await findByTestId(
+    const claimPrimary = await findByTestId(
       activityListRowPrimaryAmountTestId(claim.id),
     );
-    expect(primaryAmount).toHaveTextContent(/^\+/);
-    expect(primaryAmount).toHaveTextContent(/\$/);
+    expect(claimPrimary).toHaveTextContent(/^\+/);
+    expect(claimPrimary).toHaveTextContent(/\$/);
 
     expect(
       queryByTestId(activityListRowSecondaryAmountTestId(claim.id)),
@@ -1347,45 +1122,19 @@ describeForPlatforms('ActivityScreen — prediction rows', () => {
     expect(
       await findByTestId(activityListRowAvatarSingleTestId(claim.id)),
     ).toBeOnTheScreen();
-  });
 
-  it('shows Cashed out under Predictions with market subtitle and + fiat primary', async () => {
-    const sell = buildPredictSellActivity();
-    (
-      Engine.context.PredictController.getActivity as jest.Mock
-    ).mockResolvedValue([sell]);
-
-    const state = initialStateActivityWithAccountsApi()
-      .withRemoteFeatureFlags(activityPredictTradingEnabledFlag)
-      .build();
-
-    const { findByTestId, getAllByText, queryByTestId } =
-      renderActivityScreenView({
-        state,
-        params: { initialTypeFilter: ActivityTypeFilter.Predictions },
-      });
-
-    await waitFor(() => {
-      expect(
-        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Predictions))
-          .length,
-      ).toBeGreaterThan(0);
-    });
-
-    const title = await waitFor(
-      () => findByTestId(activityListRowTitleTestId(sell.id)),
-      { timeout: 10000 },
-    );
-    expect(title).toHaveTextContent(strings('predict.transactions.sell_title'));
+    expect(
+      await findByTestId(activityListRowTitleTestId(sell.id)),
+    ).toHaveTextContent(strings('predict.transactions.sell_title'));
     expect(
       await findByTestId(activityListRowSubtitleTestId(sell.id)),
     ).toHaveTextContent(ACTIVITY_CV_PREDICT_MARKET_TITLE);
 
-    const primaryAmount = await findByTestId(
+    const sellPrimary = await findByTestId(
       activityListRowPrimaryAmountTestId(sell.id),
     );
-    expect(primaryAmount).toHaveTextContent(/^\+/);
-    expect(primaryAmount).toHaveTextContent(/\$/);
+    expect(sellPrimary).toHaveTextContent(/^\+/);
+    expect(sellPrimary).toHaveTextContent(/\$/);
 
     expect(
       queryByTestId(activityListRowSecondaryAmountTestId(sell.id)),
@@ -1393,47 +1142,19 @@ describeForPlatforms('ActivityScreen — prediction rows', () => {
     expect(
       await findByTestId(activityListRowAvatarSingleTestId(sell.id)),
     ).toBeOnTheScreen();
-  });
 
-  it('shows Prediction placed under Predictions with market subtitle and - fiat primary', async () => {
-    const buy = buildPredictBuyActivity();
-    (
-      Engine.context.PredictController.getActivity as jest.Mock
-    ).mockResolvedValue([buy]);
-
-    const state = initialStateActivityWithAccountsApi()
-      .withRemoteFeatureFlags(activityPredictTradingEnabledFlag)
-      .build();
-
-    const { findByTestId, getAllByText, queryByTestId } =
-      renderActivityScreenView({
-        state,
-        params: { initialTypeFilter: ActivityTypeFilter.Predictions },
-      });
-
-    await waitFor(() => {
-      expect(
-        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.Predictions))
-          .length,
-      ).toBeGreaterThan(0);
-    });
-
-    const title = await waitFor(
-      () => findByTestId(activityListRowTitleTestId(buy.id)),
-      { timeout: 10000 },
-    );
-    expect(title).toHaveTextContent(
-      strings('transactions.activity_prediction_placed'),
-    );
+    expect(
+      await findByTestId(activityListRowTitleTestId(buy.id)),
+    ).toHaveTextContent(strings('transactions.activity_prediction_placed'));
     expect(
       await findByTestId(activityListRowSubtitleTestId(buy.id)),
     ).toHaveTextContent(ACTIVITY_CV_PREDICT_MARKET_TITLE);
 
-    const primaryAmount = await findByTestId(
+    const buyPrimary = await findByTestId(
       activityListRowPrimaryAmountTestId(buy.id),
     );
-    expect(primaryAmount).toHaveTextContent(/^-/);
-    expect(primaryAmount).toHaveTextContent(/\$/);
+    expect(buyPrimary).toHaveTextContent(/^-/);
+    expect(buyPrimary).toHaveTextContent(/\$/);
 
     expect(
       queryByTestId(activityListRowSecondaryAmountTestId(buy.id)),
@@ -1441,5 +1162,392 @@ describeForPlatforms('ActivityScreen — prediction rows', () => {
     expect(
       await findByTestId(activityListRowAvatarSingleTestId(buy.id)),
     ).toBeOnTheScreen();
+  });
+});
+
+interface PerpsControllerOverviewStubs {
+  getActiveProvider: jest.Mock;
+  getActiveProviderOrNull: jest.Mock;
+  getOrderFills: jest.Mock;
+  getOrders: jest.Mock;
+  getFunding: jest.Mock;
+}
+
+const stubPerpsOverviewEngine = () => {
+  const seed = buildActivityCvPerpsOverviewEngineSeed();
+  const perpsController = Engine.context
+    .PerpsController as unknown as PerpsControllerOverviewStubs;
+  const provider = {
+    ping: jest.fn().mockResolvedValue(true),
+    getUserHistory: jest.fn().mockResolvedValue(seed.userHistory),
+    getFunding: jest.fn().mockResolvedValue(seed.funding),
+    getOrderFills: jest.fn().mockResolvedValue(seed.fills),
+  };
+
+  perpsController.getActiveProvider.mockReturnValue(provider);
+  perpsController.getActiveProviderOrNull.mockReturnValue(provider);
+  perpsController.getOrderFills.mockResolvedValue(seed.fills);
+  perpsController.getOrders.mockResolvedValue(seed.orders);
+  perpsController.getFunding.mockResolvedValue(seed.funding);
+
+  return { perpsController, seed };
+};
+
+const restorePerpsOverviewEngine = (
+  perpsController: PerpsControllerOverviewStubs,
+) => {
+  perpsController.getActiveProviderOrNull.mockReturnValue(null);
+  perpsController.getOrderFills.mockResolvedValue([]);
+  perpsController.getOrders.mockResolvedValue([]);
+  perpsController.getFunding.mockResolvedValue([]);
+};
+
+const renderPerpsOverview = (initialPerpsFilter?: PerpsActivityFilter) => {
+  const state = initialStateActivityWithPerpsDetails()
+    .withRemoteFeatureFlags(activityPerpsTradingEnabledFlag)
+    .build();
+
+  return renderActivityScreenView({
+    state,
+    params: {
+      initialTypeFilter: ActivityTypeFilter.Perps,
+      ...(initialPerpsFilter ? { initialPerpsFilter } : {}),
+    },
+  });
+};
+
+describeForPlatforms('ActivityScreen — buy/sell rows', () => {
+  afterEach(() => {
+    clearAccountsTransactionsApiMocks();
+  });
+
+  it('shows Bought mUSD and Sold ETH under Buy/Sell after load, and hides a Transactions send', async () => {
+    const sendTransaction = buildConfirmedLocalSendTransaction();
+    const sendHash = sendTransaction.hash as string;
+    setupAccountsTransactionsApiMock([]);
+    const state = initialStateActivityWithRampOrders([
+      buildActivityCvRampBuyMusdOrder(),
+      buildActivityCvRampSellEthOrder(),
+    ])
+      .withOverrides({
+        engine: {
+          backgroundState: {
+            TransactionController: {
+              transactions: [sendTransaction],
+              swapsTransactions: {},
+            },
+          },
+        },
+      } as never)
+      .build();
+
+    const { findByTestId, getAllByText, queryByTestId } =
+      renderActivityScreenView({
+        state,
+        params: { initialTypeFilter: ActivityTypeFilter.BuySell },
+      });
+
+    await waitFor(() => {
+      expect(
+        getAllByText(selectedTypeFilterLabel(ActivityTypeFilter.BuySell))
+          .length,
+      ).toBeGreaterThan(0);
+    });
+
+    const buyTitle = await findByTestId(
+      activityListRowTitleTestId(ACTIVITY_CV_RAMP_BUY_TX_HASH),
+    );
+    expect(buyTitle).toHaveTextContent('Bought mUSD');
+    expect(
+      await findByTestId(
+        activityListRowPrimaryAmountTestId(ACTIVITY_CV_RAMP_BUY_TX_HASH),
+      ),
+    ).toHaveTextContent(/^\+5\.01 mUSD/);
+    expect(
+      await findByTestId(
+        activityListRowAvatarSingleTestId(ACTIVITY_CV_RAMP_BUY_TX_HASH),
+      ),
+    ).toBeOnTheScreen();
+
+    const sellTitle = await findByTestId(
+      activityListRowTitleTestId(ACTIVITY_CV_RAMP_SELL_TX_HASH),
+    );
+    expect(sellTitle).toHaveTextContent('Sold ETH');
+    expect(
+      await findByTestId(
+        activityListRowPrimaryAmountTestId(ACTIVITY_CV_RAMP_SELL_TX_HASH),
+      ),
+    ).toHaveTextContent(/^-0\.085 ETH/);
+    expect(
+      await findByTestId(
+        activityListRowAvatarSingleTestId(ACTIVITY_CV_RAMP_SELL_TX_HASH),
+      ),
+    ).toBeOnTheScreen();
+
+    expect(
+      queryByTestId(activityListRowTitleTestId(sendHash)),
+    ).not.toBeOnTheScreen();
+  });
+});
+
+describeForPlatforms('ActivityScreen — perps funds', () => {
+  let perpsController: PerpsControllerOverviewStubs;
+
+  beforeEach(() => {
+    ({ perpsController } = stubPerpsOverviewEngine());
+    setupAccountsTransactionsApiMock([]);
+  });
+
+  afterEach(() => {
+    restorePerpsOverviewEngine(perpsController);
+    clearAccountsTransactionsApiMocks();
+  });
+
+  it('shows Account funded and Perps withdrawal under Perps Deposits after load, and hides a Perps trade', async () => {
+    const { findByTestId, getAllByText, queryByTestId } = renderPerpsOverview(
+      PerpsActivityFilter.Deposits,
+    );
+
+    await waitFor(() => {
+      expect(
+        getAllByText(perpsFilterLabel(PerpsActivityFilter.Deposits)).length,
+      ).toBeGreaterThan(0);
+    });
+
+    const depositTitle = await waitFor(
+      () =>
+        findByTestId(
+          activityListRowTitleTestId(ACTIVITY_CV_PERPS_DEPOSIT_HASH),
+        ),
+      { timeout: 10000 },
+    );
+    expect(depositTitle).toHaveTextContent(
+      strings('transactions.activity_perps_account_funded'),
+    );
+    expect(
+      await findByTestId(
+        activityListRowSubtitleTestId(ACTIVITY_CV_PERPS_DEPOSIT_HASH),
+      ),
+    ).toHaveTextContent(strings('transactions.activity_perps_balance'));
+    expect(
+      await findByTestId(
+        activityListRowPrimaryAmountTestId(ACTIVITY_CV_PERPS_DEPOSIT_HASH),
+      ),
+    ).toHaveTextContent(/^\+/);
+    expect(
+      await findByTestId(
+        activityListRowSecondaryAmountTestId(ACTIVITY_CV_PERPS_DEPOSIT_HASH),
+      ),
+    ).toHaveTextContent(/1,?000 USDC/);
+    expect(
+      await findByTestId(
+        activityListRowAvatarSingleTestId(ACTIVITY_CV_PERPS_DEPOSIT_HASH),
+      ),
+    ).toBeOnTheScreen();
+
+    expect(
+      await findByTestId(
+        activityListRowTitleTestId(ACTIVITY_CV_PERPS_WITHDRAWAL_HASH),
+      ),
+    ).toHaveTextContent(strings('transactions.activity_perps_withdrawal'));
+    expect(
+      await findByTestId(
+        activityListRowPrimaryAmountTestId(ACTIVITY_CV_PERPS_WITHDRAWAL_HASH),
+      ),
+    ).toHaveTextContent(/^-/);
+    expect(
+      await findByTestId(
+        activityListRowSecondaryAmountTestId(ACTIVITY_CV_PERPS_WITHDRAWAL_HASH),
+      ),
+    ).toHaveTextContent(/^-.*1,?000 USDC/);
+
+    expect(
+      queryByTestId(
+        activityListRowTitleTestIdPattern(
+          activityCvPerpsTradeRowHash('openLong'),
+        ),
+      ),
+    ).not.toBeOnTheScreen();
+  });
+});
+
+describeForPlatforms('ActivityScreen — perps trades', () => {
+  let perpsController: PerpsControllerOverviewStubs;
+
+  beforeEach(() => {
+    ({ perpsController } = stubPerpsOverviewEngine());
+    setupAccountsTransactionsApiMock([]);
+  });
+
+  afterEach(() => {
+    restorePerpsOverviewEngine(perpsController);
+    clearAccountsTransactionsApiMocks();
+  });
+
+  it('shows open and close long and short under Perps Trades after load, and hides a Perps order', async () => {
+    const openLongHash = activityCvPerpsTradeRowHash('openLong');
+    const openShortHash = activityCvPerpsTradeRowHash('openShort');
+    const closeLongHash = activityCvPerpsTradeRowHash('closeLong');
+    const closeShortHash = activityCvPerpsTradeRowHash('closeShort');
+    const orderHash = activityCvPerpsCanceledTakeProfitRowHash();
+
+    const { findByTestId, getAllByText, queryByTestId } = renderPerpsOverview();
+
+    await waitFor(() => {
+      expect(
+        getAllByText(perpsFilterLabel(PerpsActivityFilter.Trades)).length,
+      ).toBeGreaterThan(0);
+    });
+
+    const openLongTitle = await waitFor(
+      () => findByTestId(activityListRowTitleTestIdPattern(openLongHash)),
+      { timeout: 10000 },
+    );
+    expect(openLongTitle).toHaveTextContent(
+      strings('transactions.activity_perps_open_long'),
+    );
+    expect(
+      await findByTestId(activityListRowSubtitleTestIdPattern(openLongHash)),
+    ).toHaveTextContent('0.0001 BTC');
+    expect(
+      await findByTestId(
+        activityListRowPrimaryAmountTestIdPattern(openLongHash),
+      ),
+    ).toHaveTextContent(/^-\$0\.50/);
+    expect(
+      queryByTestId(activityListRowSecondaryAmountTestIdPattern(openLongHash)),
+    ).toBeNull();
+
+    expect(
+      await findByTestId(activityListRowTitleTestIdPattern(openShortHash)),
+    ).toHaveTextContent(strings('transactions.activity_perps_open_short'));
+    expect(
+      await findByTestId(
+        activityListRowPrimaryAmountTestIdPattern(openShortHash),
+      ),
+    ).toHaveTextContent(/^-\$0\.50/);
+
+    expect(
+      await findByTestId(activityListRowTitleTestIdPattern(closeLongHash)),
+    ).toHaveTextContent(strings('transactions.activity_perps_close_long'));
+    expect(
+      await findByTestId(
+        activityListRowPrimaryAmountTestIdPattern(closeLongHash),
+      ),
+    ).toHaveTextContent(/^\+\$45\.67/);
+
+    expect(
+      await findByTestId(activityListRowTitleTestIdPattern(closeShortHash)),
+    ).toHaveTextContent(strings('transactions.activity_perps_close_short'));
+    expect(
+      await findByTestId(
+        activityListRowPrimaryAmountTestIdPattern(closeShortHash),
+      ),
+    ).toHaveTextContent(/^-\$12\.34/);
+
+    expect(
+      queryByTestId(activityListRowTitleTestId(orderHash)),
+    ).not.toBeOnTheScreen();
+  });
+});
+
+describeForPlatforms('ActivityScreen — perps orders', () => {
+  let perpsController: PerpsControllerOverviewStubs;
+
+  beforeEach(() => {
+    ({ perpsController } = stubPerpsOverviewEngine());
+    setupAccountsTransactionsApiMock([]);
+  });
+
+  afterEach(() => {
+    restorePerpsOverviewEngine(perpsController);
+    clearAccountsTransactionsApiMocks();
+  });
+
+  it('shows canceled take-profit close short under Perps Orders after load, and hides a Perps trade', async () => {
+    const orderHash = activityCvPerpsCanceledTakeProfitRowHash();
+    const tradeHash = activityCvPerpsTradeRowHash('openLong');
+
+    const { findByTestId, getAllByText, queryByTestId } = renderPerpsOverview(
+      PerpsActivityFilter.Orders,
+    );
+
+    await waitFor(() => {
+      expect(
+        getAllByText(perpsFilterLabel(PerpsActivityFilter.Orders)).length,
+      ).toBeGreaterThan(0);
+    });
+
+    const title = await waitFor(
+      () => findByTestId(activityListRowTitleTestId(orderHash)),
+      { timeout: 10000 },
+    );
+    expect(title).toHaveTextContent(
+      strings('transactions.activity_limit_close_short'),
+    );
+    expect(
+      await findByTestId(activityListRowPrimaryAmountTestId(orderHash)),
+    ).toHaveTextContent(strings('transactions.activity_order_status_canceled'));
+
+    expect(
+      queryByTestId(activityListRowTitleTestIdPattern(tradeHash)),
+    ).not.toBeOnTheScreen();
+  });
+});
+
+describeForPlatforms('ActivityScreen — perps funding', () => {
+  let perpsController: PerpsControllerOverviewStubs;
+
+  beforeEach(() => {
+    ({ perpsController } = stubPerpsOverviewEngine());
+    setupAccountsTransactionsApiMock([]);
+  });
+
+  afterEach(() => {
+    restorePerpsOverviewEngine(perpsController);
+    clearAccountsTransactionsApiMocks();
+  });
+
+  it('shows Paid and Received funding fees under Perps Fundings after load, and hides a Perps trade', async () => {
+    const paidHash = activityCvPerpsFundingRowHash('paid');
+    const receivedHash = activityCvPerpsFundingRowHash('received');
+    const tradeHash = activityCvPerpsTradeRowHash('openLong');
+
+    const { findByTestId, getAllByText, queryByTestId } = renderPerpsOverview(
+      PerpsActivityFilter.Fundings,
+    );
+
+    await waitFor(() => {
+      expect(
+        getAllByText(perpsFilterLabel(PerpsActivityFilter.Fundings)).length,
+      ).toBeGreaterThan(0);
+    });
+
+    const paidTitle = await waitFor(
+      () => findByTestId(activityListRowTitleTestId(paidHash)),
+      { timeout: 10000 },
+    );
+    expect(paidTitle).toHaveTextContent(
+      strings('transactions.activity_perps_paid_funding_fees'),
+    );
+    expect(
+      await findByTestId(activityListRowSubtitleTestId(paidHash)),
+    ).toHaveTextContent('BTC');
+    expect(
+      await findByTestId(activityListRowPrimaryAmountTestId(paidHash)),
+    ).toHaveTextContent(/^-/);
+
+    expect(
+      await findByTestId(activityListRowTitleTestId(receivedHash)),
+    ).toHaveTextContent(
+      strings('transactions.activity_perps_received_funding_fees'),
+    );
+    expect(
+      await findByTestId(activityListRowPrimaryAmountTestId(receivedHash)),
+    ).toHaveTextContent(/^\+/);
+
+    expect(
+      queryByTestId(activityListRowTitleTestIdPattern(tradeHash)),
+    ).not.toBeOnTheScreen();
   });
 });

--- a/tests/component-view/mocks.ts
+++ b/tests/component-view/mocks.ts
@@ -467,6 +467,7 @@ jest.mock('../../app/core/Engine', () => {
           },
         ]),
         getOrders: jest.fn().mockResolvedValue([]),
+        getFunding: jest.fn().mockResolvedValue([]),
         getOpenOrders: jest.fn().mockResolvedValue([]),
         getAccountState: jest.fn().mockResolvedValue(null),
         depositWithOrder: jest.fn().mockResolvedValue({

--- a/tests/component-view/presets/activity.ts
+++ b/tests/component-view/presets/activity.ts
@@ -2192,6 +2192,7 @@ export const buildActivityCvPerpsOverviewUserHistory =
       asset: 'USDC',
       txHash: ACTIVITY_CV_PERPS_DEPOSIT_HASH,
       status: 'completed',
+      details: { source: 'activity-cv' },
     },
     {
       id: 'activity-cv-perps-withdrawal',
@@ -2201,6 +2202,7 @@ export const buildActivityCvPerpsOverviewUserHistory =
       asset: 'USDC',
       txHash: ACTIVITY_CV_PERPS_WITHDRAWAL_HASH,
       status: 'completed',
+      details: { source: 'activity-cv' },
     },
   ];
 

--- a/tests/component-view/presets/activity.ts
+++ b/tests/component-view/presets/activity.ts
@@ -14,6 +14,12 @@ import { createStateFixture } from '../stateFixture';
 import type { DeepPartial } from '../../../app/util/test/renderWithProvider';
 import type { RootState } from '../../../app/reducers';
 import type { PredictActivity } from '../../../app/components/UI/Predict/types';
+import type {
+  Funding,
+  Order,
+  OrderFill,
+  UserHistoryItem,
+} from '@metamask/perps-controller';
 import {
   FillType,
   PerpsOrderTransactionStatus,
@@ -275,6 +281,7 @@ export const ACTIVITY_CV_NFT_COLLECTION_NAME = 'CryptoPunks';
 /**
  * Confirmed zero-value contract interaction for ActivityScreen transaction-row CV.
  * Uses a non-wrap method id so it stays `contractInteraction` (no token amount).
+ * Nonce is unique among local CV txs — Activity groups by chain + from + nonce.
  */
 export const buildConfirmedLocalContractInteractionTransaction =
   (): TransactionMeta =>
@@ -283,13 +290,13 @@ export const buildConfirmedLocalContractInteractionTransaction =
       hash: '0xactivitycvconfirmedcontract',
       chainId: '0x1',
       status: TransactionStatus.confirmed,
-      time: 1_716_367_786_000,
+      time: 1_716_367_784_000,
       type: TransactionType.contractInteraction,
       txParams: {
         from: ACTIVITY_CV_ACCOUNT,
         to: ACTIVITY_CV_RECIPIENT,
         value: '0x0',
-        nonce: '0x5',
+        nonce: '0x9',
         data: '0xabcdef12',
       },
       txReceipt: { status: '0x1' },
@@ -1111,6 +1118,13 @@ export const buildPredictClaimActivity = (): PredictActivity => ({
 /** Remote flag shape that enables PredictActivitySource on ActivityScreen CV. */
 export const activityPredictTradingEnabledFlag = {
   predictTradingEnabled: {
+    enabled: true,
+    minimumVersion: '0.0.0',
+  },
+} as const;
+
+export const activityPerpsTradingEnabledFlag = {
+  perpsPerpTradingEnabled: {
     enabled: true,
     minimumVersion: '0.0.0',
   },
@@ -2059,3 +2073,145 @@ export const initialStateActivityWithPerpsDetails = (
         },
       },
     } as unknown as DeepPartial<RootState>);
+
+const ACTIVITY_CV_PERPS_TRADE_FILL_TIMESTAMPS: Record<
+  ActivityCvPerpsTradeKind,
+  number
+> = {
+  openLong: ACTIVITY_CV_PERPS_DEPOSIT_TIMESTAMP_MS + 3000,
+  openShort: ACTIVITY_CV_PERPS_DEPOSIT_TIMESTAMP_MS + 2000,
+  closeLong: ACTIVITY_CV_PERPS_DEPOSIT_TIMESTAMP_MS + 1000,
+  closeShort: ACTIVITY_CV_PERPS_DEPOSIT_TIMESTAMP_MS,
+};
+
+const ACTIVITY_CV_PERPS_TRADE_FILL_DIRECTION: Record<
+  ActivityCvPerpsTradeKind,
+  OrderFill['direction']
+> = {
+  openLong: 'Open Long',
+  openShort: 'Open Short',
+  closeLong: 'Close Long',
+  closeShort: 'Close Short',
+};
+
+const ACTIVITY_CV_PERPS_TRADE_FILL_SIDE: Record<
+  ActivityCvPerpsTradeKind,
+  OrderFill['side']
+> = {
+  openLong: 'buy',
+  openShort: 'sell',
+  closeLong: 'sell',
+  closeShort: 'buy',
+};
+
+export const buildActivityCvPerpsOverviewOrderFill = (
+  kind: ActivityCvPerpsTradeKind,
+): OrderFill => {
+  const spec = ACTIVITY_CV_PERPS_TRADE_SPECS[kind];
+  const isOpen = spec.action === 'Opened';
+
+  return {
+    orderId: spec.id,
+    symbol: ACTIVITY_CV_PERPS_TRADE_ASSET,
+    side: ACTIVITY_CV_PERPS_TRADE_FILL_SIDE[kind],
+    size: ACTIVITY_CV_PERPS_TRADE_SIZE,
+    price: ACTIVITY_CV_PERPS_TRADE_PRICE,
+    pnl: isOpen ? '0' : String(spec.amountNumber),
+    direction: ACTIVITY_CV_PERPS_TRADE_FILL_DIRECTION[kind],
+    fee: isOpen ? ACTIVITY_CV_PERPS_TRADE_FEE : '0',
+    feeToken: 'USDC',
+    timestamp: ACTIVITY_CV_PERPS_TRADE_FILL_TIMESTAMPS[kind],
+    startPosition: ACTIVITY_CV_PERPS_TRADE_SIZE,
+    success: true,
+  };
+};
+
+export const activityCvPerpsTradeRowHash = (
+  kind: ActivityCvPerpsTradeKind,
+): string =>
+  `${ACTIVITY_CV_PERPS_TRADE_SPECS[kind].id}-${ACTIVITY_CV_PERPS_TRADE_FILL_TIMESTAMPS[kind]}`;
+
+const ACTIVITY_CV_PERPS_ORDER_TIMESTAMP_MS =
+  ACTIVITY_CV_PERPS_DEPOSIT_TIMESTAMP_MS + 6000;
+
+export const buildActivityCvPerpsOverviewCanceledTakeProfitOrder =
+  (): Order => {
+    const spec = ACTIVITY_CV_PERPS_ORDER_SPECS.takeProfitCanceled;
+
+    return {
+      orderId: spec.id,
+      symbol: ACTIVITY_CV_PERPS_TRADE_ASSET,
+      side: 'buy',
+      orderType: 'limit',
+      detailedOrderType: 'Take Profit Limit',
+      size: ACTIVITY_CV_PERPS_TRADE_SIZE,
+      originalSize: ACTIVITY_CV_PERPS_TRADE_SIZE,
+      price: ACTIVITY_CV_PERPS_TRADE_PRICE,
+      filledSize: '0',
+      remainingSize: ACTIVITY_CV_PERPS_TRADE_SIZE,
+      status: 'canceled',
+      timestamp: ACTIVITY_CV_PERPS_ORDER_TIMESTAMP_MS,
+      reduceOnly: true,
+      isTrigger: true,
+    };
+  };
+
+export const activityCvPerpsCanceledTakeProfitRowHash = (): string =>
+  `${ACTIVITY_CV_PERPS_ORDER_SPECS.takeProfitCanceled.id}-${ACTIVITY_CV_PERPS_ORDER_TIMESTAMP_MS}`;
+
+const ACTIVITY_CV_PERPS_FUNDING_TIMESTAMPS = {
+  received: ACTIVITY_CV_PERPS_DEPOSIT_TIMESTAMP_MS + 5000,
+  paid: ACTIVITY_CV_PERPS_DEPOSIT_TIMESTAMP_MS + 4000,
+} as const;
+
+export const buildActivityCvPerpsOverviewFunding = (
+  kind: ActivityCvPerpsFundingKind,
+): Funding => {
+  const spec = ACTIVITY_CV_PERPS_FUNDING_SPECS[kind];
+
+  return {
+    symbol: ACTIVITY_CV_PERPS_TRADE_ASSET,
+    amountUsd: String(spec.feeNumber),
+    rate: kind === 'received' ? '-0.000125' : '0.0001',
+    timestamp: ACTIVITY_CV_PERPS_FUNDING_TIMESTAMPS[kind],
+  };
+};
+
+export const activityCvPerpsFundingRowHash = (
+  kind: ActivityCvPerpsFundingKind,
+): string =>
+  `funding-${ACTIVITY_CV_PERPS_FUNDING_TIMESTAMPS[kind]}-${ACTIVITY_CV_PERPS_TRADE_ASSET}`;
+
+export const buildActivityCvPerpsOverviewUserHistory =
+  (): UserHistoryItem[] => [
+    {
+      id: 'activity-cv-perps-deposit',
+      timestamp: ACTIVITY_CV_PERPS_DEPOSIT_TIMESTAMP_MS + 8000,
+      type: 'deposit',
+      amount: '1000',
+      asset: 'USDC',
+      txHash: ACTIVITY_CV_PERPS_DEPOSIT_HASH,
+      status: 'completed',
+    },
+    {
+      id: 'activity-cv-perps-withdrawal',
+      timestamp: ACTIVITY_CV_PERPS_DEPOSIT_TIMESTAMP_MS + 7000,
+      type: 'withdrawal',
+      amount: '1000',
+      asset: 'USDC',
+      txHash: ACTIVITY_CV_PERPS_WITHDRAWAL_HASH,
+      status: 'completed',
+    },
+  ];
+
+/** Mixed Engine payloads so Overview Perps sub-filters can assert isolation. */
+export const buildActivityCvPerpsOverviewEngineSeed = () => ({
+  fills: (['openLong', 'openShort', 'closeLong', 'closeShort'] as const).map(
+    buildActivityCvPerpsOverviewOrderFill,
+  ),
+  orders: [buildActivityCvPerpsOverviewCanceledTakeProfitOrder()],
+  funding: (['paid', 'received'] as const).map(
+    buildActivityCvPerpsOverviewFunding,
+  ),
+  userHistory: buildActivityCvPerpsOverviewUserHistory(),
+});


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Adds and consolidates Activity Overview list-row component-view coverage in `ActivityScreen.view.test.tsx` for [MMQA-2080](https://consensyssoftware.atlassian.net/browse/MMQA-2080). Transaction and Predictions kinds are merged into one mixed-seed completeness `it` per async flow (plus a dedicated SCI/swap same-hash collision test). Buy/Sell and Perps Overview describes use one completeness `it` each with paired hidden distractors where applicable.

Supporting presets and Engine stubs live in `tests/component-view/presets/activity.ts` and `tests/component-view/mocks.ts` (Perps `getFunding`). Card list rows remain out of scope ([MMQA-2118](https://consensyssoftware.atlassian.net/browse/MMQA-2118) cancelled).

**Jira:** [MMQA-2080](https://consensyssoftware.atlassian.net/browse/MMQA-2080) — [Mobile] Write automation coverage for the activity overview

**Sub-tasks covered in this PR:**

| Sub-task | Summary | Status |
| --- | --- | --- |
| [MMQA-2114](https://consensyssoftware.atlassian.net/browse/MMQA-2114) | Transactions | Done |
| [MMQA-2115](https://consensyssoftware.atlassian.net/browse/MMQA-2115) | Buy/Sell | In Progress |
| [MMQA-2116](https://consensyssoftware.atlassian.net/browse/MMQA-2116) | Perps | In Progress |
| [MMQA-2117](https://consensyssoftware.atlassian.net/browse/MMQA-2117) | Predictions | Done |

### Tests added / consolidated

| Case | Suite | Regression prevented |
| --- | --- | --- |
| Send ETH | `ActivityScreen — transaction rows` | Wrong title, missing recipient subtitle, or incorrect negative ETH/fiat amounts on outbound rows |
| Receive ETH (Accounts API) | `ActivityScreen — transaction rows` | Inbound ETH row missing, wrong sender subtitle, or positive amount not shown |
| Send USDC | `ActivityScreen — transaction rows` | ERC-20 send mislabeled or negative USDC primary missing |
| Receive USDC (Accounts API) | `ActivityScreen — transaction rows` | ERC-20 receive row missing or positive USDC primary wrong |
| Swap ETH → USDC (Accounts API) | `ActivityScreen — transaction rows` | Swap pair subtitle, dual avatar, or +/- leg amounts regress |
| Bridge USDC | `ActivityScreen — transaction rows` | Bridge title/subtitle (Ethereum → Linea) or dual-avatar swap-style amounts break |
| Cross-chain swap | `ActivityScreen — transaction rows` | Local swap row renders as plain send or loses ETH → USDC subtitle |
| Approve USDC | `ActivityScreen — transaction rows` | Spending-cap approve shows signed amount or wrong title |
| Increase spending cap | `ActivityScreen — transaction rows` | Increase-allowance confused with approve or unsigned cap wrong |
| Smart contract interaction | `ActivityScreen — transaction rows` | SCI row shows token amount or wrong title |
| Unlimited approve | `ActivityScreen — transaction rows` | Unlimited cap label missing or amount incorrectly signed |
| Revoke spending cap | `ActivityScreen — transaction rows` | Revoke title/subtitle or `0 USDC` primary regress |
| NFT mint (Accounts API) | `ActivityScreen — transaction rows` | Mint title/collection name or avatar missing |
| SCI vs swap same hash | `ActivityScreen — transaction rows` | Accounts API swap wins dedup and SCI title incorrectly shown |
| Account funded (deposit) | `ActivityScreen — prediction rows` | Predictions deposit title, balance subtitle, + fiat / USDC secondary wrong |
| Prediction withdrawal | `ActivityScreen — prediction rows` | Withdrawal negative fiat/USDC amounts or balance subtitle missing |
| Claimed winnings | `ActivityScreen — prediction rows` | Provider claim row missing market subtitle or + fiat primary |
| Cashed out | `ActivityScreen — prediction rows` | Sell/cash-out row title or + fiat primary wrong under Predictions |
| Prediction placed | `ActivityScreen — prediction rows` | Buy/placed row missing market subtitle or - fiat primary |
| Bought mUSD | `ActivityScreen — buy/sell rows` | Ramp buy row title or + mUSD amount wrong under Buy/Sell |
| Sold ETH | `ActivityScreen — buy/sell rows` | Ramp sell row title or - ETH amount wrong under Buy/Sell |
| Transactions send hidden | `ActivityScreen — buy/sell rows` | Buy/Sell filter leaks Transactions send rows |
| Perps deposit | `ActivityScreen — perps funds` | Account funded row missing under Perps Deposits |
| Perps withdrawal | `ActivityScreen — perps funds` | Withdrawal row missing or Perps trade not hidden on Deposits |
| Open/close long & short | `ActivityScreen — perps trades` | Trade fill rows (indexed hash) lose title, PnL subtitle, or amounts |
| Canceled TP close short | `ActivityScreen — perps orders` | Canceled order row or `Canceled` status chip missing |
| Perps trade hidden on Orders | `ActivityScreen — perps orders` | Orders sub-filter shows trade fills |
| Paid / received funding | `ActivityScreen — perps funding` | Funding fee rows missing paid/received labels or amounts |
| Perps trade hidden on Fundings | `ActivityScreen — perps funding` | Fundings sub-filter shows trade fills |

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: [MMQA-2080](https://consensyssoftware.atlassian.net/browse/MMQA-2080), [MMQA-2114](https://consensyssoftware.atlassian.net/browse/MMQA-2114), [MMQA-2115](https://consensyssoftware.atlassian.net/browse/MMQA-2115), [MMQA-2116](https://consensyssoftware.atlassian.net/browse/MMQA-2116), [MMQA-2117](https://consensyssoftware.atlassian.net/browse/MMQA-2117)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — coverage is component-view only; verified with:

```bash
yarn jest -c jest.config.view.js app/components/Views/ActivityScreen/ActivityScreen.view.test.tsx --runInBand --silent --coverage=false
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — test-only change; no UI or end-user behavior modified.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MMQA-2080]: https://consensyssoftware.atlassian.net/browse/MMQA-2080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6f4c542a516587ad3743f3df3e1155f3576dc731. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->