### PR TITLE
feat(analytics): implement navigation analytics context for enhanced tracking across components

### DIFF
--- a/app/components/Nav/Main/types/navigation.ts
+++ b/app/components/Nav/Main/types/navigation.ts
@@ -1,4 +1,5 @@
 import type { NavigatorScreenParams } from '@react-navigation/native';
+import type { NavigationAnalyticsRouteParams } from '../../../../util/analytics/navigationAnalyticsAttribution';
 import type {
   AssetLoaderParams,
   AssetViewParams,
@@ -172,7 +173,7 @@ export type ImportPrivateKeyStackParamList = {
 // ParamListBase requires `type`; `interface` cannot satisfy it.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type MoneyTabStackParamList = {
-  MoneyHome: { entryPoint?: string } | undefined;
+  MoneyHome: NavigationAnalyticsRouteParams | undefined;
   MoneyActivity: undefined;
   MoneyHowItWorks: undefined;
 };

--- a/app/components/UI/Assets/DeFiPositions/components/DeFiPositionsListV2.test.tsx
+++ b/app/components/UI/Assets/DeFiPositions/components/DeFiPositionsListV2.test.tsx
@@ -101,16 +101,10 @@ const makeHookResult = (
   ...overrides,
 });
 
-const renderComponent = (isFullView = true, analyticsSource?: string) =>
-  renderWithProvider(
-    <DeFiPositionsListV2
-      isFullView={isFullView}
-      analyticsSource={analyticsSource}
-    />,
-    {
-      state: mockInitialState,
-    },
-  );
+const renderComponent = (isFullView = true) =>
+  renderWithProvider(<DeFiPositionsListV2 isFullView={isFullView} />, {
+    state: mockInitialState,
+  });
 
 describe('DeFiPositionsListV2', () => {
   beforeEach(() => {
@@ -379,24 +373,6 @@ describe('DeFiPositionsListV2', () => {
           location: 'homepage',
           is_empty: true,
           screen_type: 'defi',
-        })
-        .build(),
-    );
-  });
-
-  it('attributes the screen viewed event to the homepage balance breakdown', () => {
-    renderComponent(true, 'homescreen_balance_breakdown');
-
-    expect(mockTrackEvent).toHaveBeenCalledWith(
-      AnalyticsEventBuilder.createEventBuilder(
-        MetaMetricsEvents.POSITION_SCREEN_VIEWED,
-      )
-        .addProperties({
-          item_count: 0,
-          location: 'homepage',
-          is_empty: true,
-          screen_type: 'defi',
-          source: 'homescreen_balance_breakdown',
         })
         .build(),
     );

--- a/app/components/UI/Assets/DeFiPositions/components/DeFiPositionsListV2.tsx
+++ b/app/components/UI/Assets/DeFiPositions/components/DeFiPositionsListV2.tsx
@@ -38,7 +38,6 @@ import { filterDeFiPositionsByEnabledNetworks } from '../utils/filter-defi-posit
 
 interface DeFiPositionsListV2Props {
   isFullView: boolean;
-  analyticsSource?: string;
 }
 
 /**
@@ -48,7 +47,6 @@ interface DeFiPositionsListV2Props {
  */
 const DeFiPositionsListV2: React.FC<DeFiPositionsListV2Props> = ({
   isFullView,
-  analyticsSource,
 }) => {
   const { styles } = useStyles(styleSheet, undefined);
   const { trackEvent, createEventBuilder } = useAnalytics();
@@ -146,18 +144,10 @@ const DeFiPositionsListV2: React.FC<DeFiPositionsListV2Props> = ({
           location: 'homepage',
           is_empty: listLength === 0,
           screen_type: 'defi',
-          ...(analyticsSource ? { source: analyticsSource } : {}),
         })
         .build(),
     );
-  }, [
-    isFullView,
-    isReady,
-    listLength,
-    analyticsSource,
-    trackEvent,
-    createEventBuilder,
-  ]);
+  }, [isFullView, isReady, listLength, trackEvent, createEventBuilder]);
 
   if (isLoading || showIdlePlaceholder) {
     return (

--- a/app/components/UI/DeFiPositions/DeFiPositionsList.test.tsx
+++ b/app/components/UI/DeFiPositions/DeFiPositionsList.test.tsx
@@ -636,26 +636,6 @@ describe('DeFiPositionsList', () => {
       );
     });
 
-    it('attributes Position Screen Viewed to the homepage balance breakdown', async () => {
-      const { findByTestId } = renderWithProvider(
-        <DeFiPositionsList
-          tabLabel="DeFi"
-          isFullView
-          analyticsSource="homescreen_balance_breakdown"
-        />,
-        { state: mockInitialState },
-      );
-
-      await findByTestId(WalletViewSelectorsIDs.DEFI_POSITIONS_LIST);
-
-      expect(mockAddProperties).toHaveBeenCalledWith(
-        expect.objectContaining({
-          screen_type: 'defi',
-          source: 'homescreen_balance_breakdown',
-        }),
-      );
-    });
-
     it('tracks Position Screen Viewed with is_empty true when no positions are present', async () => {
       const defiPositionsModule = jest.requireMock(
         '../../../selectors/defiPositionsController',

--- a/app/components/UI/DeFiPositions/DeFiPositionsList.tsx
+++ b/app/components/UI/DeFiPositions/DeFiPositionsList.tsx
@@ -47,12 +47,10 @@ import DeFiPositionsListV2 from '../Assets/DeFiPositions/components/DeFiPosition
 export interface DeFiPositionsListProps {
   tabLabel: string;
   isFullView?: boolean;
-  analyticsSource?: string;
 }
 
 const DeFiPositionsListV1: React.FC<DeFiPositionsListProps> = ({
   isFullView = false,
-  analyticsSource,
 }) => {
   const { styles } = useStyles(styleSheet, undefined);
   const { trackEvent, createEventBuilder } = useAnalytics();
@@ -159,17 +157,10 @@ const DeFiPositionsListV1: React.FC<DeFiPositionsListProps> = ({
           location: 'homepage',
           is_empty: formattedDeFiPositions.length === 0,
           screen_type: 'defi',
-          ...(analyticsSource ? { source: analyticsSource } : {}),
         })
         .build(),
     );
-  }, [
-    isFullView,
-    formattedDeFiPositions,
-    analyticsSource,
-    trackEvent,
-    createEventBuilder,
-  ]);
+  }, [isFullView, formattedDeFiPositions, trackEvent, createEventBuilder]);
 
   if (!formattedDeFiPositions) {
     if (formattedDeFiPositions === undefined) {
@@ -250,10 +241,7 @@ const DeFiPositionsList: React.FC<DeFiPositionsListProps> = (props) => {
   const isV2Enabled = useSelector(selectDeFiPositionsV2SectionEnabled);
 
   return isV2Enabled ? (
-    <DeFiPositionsListV2
-      isFullView={props.isFullView ?? false}
-      analyticsSource={props.analyticsSource}
-    />
+    <DeFiPositionsListV2 isFullView={props.isFullView ?? false} />
   ) : (
     <DeFiPositionsListV1 {...props} />
   );

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.test.tsx
@@ -77,7 +77,6 @@ const mockCreateEventBuilder = jest.fn((_eventName?: unknown) => ({
 const mockMoneyFormatUsd = moneyFormatUsd as jest.MockedFunction<
   typeof moneyFormatUsd
 >;
-let mockRouteParams: { entryPoint?: string } | undefined;
 
 jest.mock('@react-navigation/native', () => {
   const actualReactNavigation = jest.requireActual('@react-navigation/native');
@@ -89,7 +88,7 @@ jest.mock('@react-navigation/native', () => {
       setParams: jest.fn(),
     }),
     useFocusEffect: (callback: () => void) => callback(),
-    useRoute: () => ({ params: mockRouteParams }),
+    useRoute: () => ({ params: undefined }),
   };
 });
 
@@ -478,7 +477,6 @@ describe('MoneyHomeView', () => {
   let defaultMoneyVaultApy: ReturnType<typeof useMoneyVaultApy>;
 
   beforeEach(() => {
-    mockRouteParams = undefined;
     jest.clearAllMocks();
     global.alert = jest.fn();
 
@@ -603,16 +601,6 @@ describe('MoneyHomeView', () => {
     const { getByTestId } = renderWithProvider(<MoneyHomeView />);
 
     expect(getByTestId(MoneyHomeViewTestIds.CONTAINER)).toBeOnTheScreen();
-  });
-
-  it('tracks the Money home entry point from route params', () => {
-    mockRouteParams = { entryPoint: 'homescreen_balance_breakdown' };
-
-    renderWithProvider(<MoneyHomeView />);
-
-    expect(mockTrackScreenViewed).toHaveBeenCalledWith({
-      entry_point: 'homescreen_balance_breakdown',
-    });
   });
 
   it('renders the scroll view', () => {

--- a/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
+++ b/app/components/UI/Money/Views/MoneyHomeView/MoneyHomeView.tsx
@@ -7,14 +7,8 @@ import React, {
 } from 'react';
 import { RefreshControl, ScrollView } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import {
-  type RouteProp,
-  useFocusEffect,
-  useNavigation,
-  useRoute,
-} from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
-import type { MoneyNavigationParamList } from '../../types/navigation';
 import { navigateWithDetails } from '../../../../../util/navigation/navUtils';
 import { useSelector } from 'react-redux';
 import BigNumber from 'bignumber.js';
@@ -112,7 +106,6 @@ const ACTION_BUTTON_ROW_BUTTON_COUNT = 3;
 
 const MoneyHomeView = () => {
   const navigation = useNavigation<AppNavigationProp>();
-  const route = useRoute<RouteProp<MoneyNavigationParamList, 'MoneyHome'>>();
   const insets = useSafeAreaInsets();
   const { styles } = useStyles(styleSheet, {});
   const { colors } = useTheme();
@@ -150,24 +143,10 @@ const MoneyHomeView = () => {
   // Pull-to-refresh state
   const [refreshing, setRefreshing] = useState(false);
 
-  const trackMoneyHomeViewed = useCallback(
-    () =>
-      trackScreenViewed({
-        entry_point: route.params?.entryPoint,
-      }),
-    [route.params?.entryPoint, trackScreenViewed],
-  );
-
   useFocusEffect(
     useCallback(() => {
-      trackMoneyHomeViewed();
-
-      return () => {
-        if (route.params?.entryPoint) {
-          navigation.setParams({ entryPoint: undefined });
-        }
-      };
-    }, [navigation, route.params?.entryPoint, trackMoneyHomeViewed]),
+      trackScreenViewed();
+    }, [trackScreenViewed]),
   );
 
   const handlePullRefresh = useCallback(async () => {

--- a/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx
+++ b/app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx
@@ -263,7 +263,7 @@ const MoneyOnboardingView = () => {
   const navigation = useNavigation<AppNavigationProp>();
   const route = useRoute<MoneyOnboardingRouteProp>();
   const postOnboardingRedirect = route.params?.postOnboardingRedirect;
-  const entryPoint = route.params?.entryPoint;
+  const analyticsContext = route.params?.analyticsContext;
 
   const isUsUnauthenticatedNonCardholder = useSelector(
     selectIsUsUnauthenticatedNonCardholder,
@@ -370,12 +370,12 @@ const MoneyOnboardingView = () => {
         screen: Routes.MONEY.ROOT,
         params: {
           screen: Routes.MONEY.HOME,
-          ...(entryPoint ? { params: { entryPoint } } : {}),
+          ...(analyticsContext ? { params: { analyticsContext } } : {}),
         },
       },
       { pop: true },
     );
-  }, [entryPoint, navigation]);
+  }, [analyticsContext, navigation]);
 
   const navigateToPostOnboardingDestination = useCallback(async () => {
     if (

--- a/app/components/UI/Money/hooks/useMoneyNavigation.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyNavigation.test.ts
@@ -10,6 +10,10 @@ import { selectMoneyOnboardingStepperAnimationEnabled } from '../../../../select
 import { MoneyPostOnboardingRedirectType } from '../types/navigation';
 
 const mockNavigate = jest.fn();
+const analyticsContext = {
+  id: 'balance-breakdown-navigation',
+  attribution: 'homescreen_balance_breakdown' as const,
+};
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -66,15 +70,13 @@ describe('useMoneyNavigation', () => {
       expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.ONBOARDING);
     });
 
-    it('forwards the entry point through Money onboarding', () => {
+    it('forwards analytics context through Money onboarding', () => {
       const { result } = renderHook(() => useMoneyNavigation());
 
-      act(() =>
-        result.current.navigateToMoneyHome('homescreen_balance_breakdown'),
-      );
+      act(() => result.current.navigateToMoneyHome(analyticsContext));
 
       expect(mockNavigate).toHaveBeenCalledWith(Routes.MONEY.ONBOARDING, {
-        entryPoint: 'homescreen_balance_breakdown',
+        analyticsContext,
       });
     });
 
@@ -99,16 +101,14 @@ describe('useMoneyNavigation', () => {
       );
     });
 
-    it('forwards the entry point to Money home', () => {
+    it('forwards analytics context to Money home', () => {
       setupSelectorMocks({
         hasSeenOnboarding: true,
         isOnboardingEnabled: true,
       });
       const { result } = renderHook(() => useMoneyNavigation());
 
-      act(() =>
-        result.current.navigateToMoneyHome('homescreen_balance_breakdown'),
-      );
+      act(() => result.current.navigateToMoneyHome(analyticsContext));
 
       expect(mockNavigate).toHaveBeenCalledWith(
         Routes.HOME_TABS,
@@ -116,7 +116,7 @@ describe('useMoneyNavigation', () => {
           screen: Routes.MONEY.ROOT,
           params: {
             screen: Routes.MONEY.HOME,
-            params: { entryPoint: 'homescreen_balance_breakdown' },
+            params: { analyticsContext },
           },
         },
         { pop: true },

--- a/app/components/UI/Money/hooks/useMoneyNavigation.ts
+++ b/app/components/UI/Money/hooks/useMoneyNavigation.ts
@@ -5,6 +5,7 @@ import Routes from '../../../../constants/navigation/Routes';
 import NavigationService from '../../../../core/NavigationService/NavigationService';
 import { selectMoneyOnboardingStepperAnimationEnabled } from '../../../../selectors/featureFlagController/moneyAccount';
 import type { MoneyOnboardingParams } from '../types/navigation';
+import type { NavigationAnalyticsContext } from '../../../../util/analytics/navigationAnalyticsAttribution';
 
 /**
  * Why NavigationService instead of useNavigation():
@@ -56,9 +57,11 @@ export const useMoneyNavigation = () => {
     useMoneyOnboardingNavigation();
 
   const navigateToMoneyHome = useCallback(
-    (entryPoint?: string) => {
+    (analyticsContext?: NavigationAnalyticsContext) => {
       if (
-        redirectToOnboardingIfNeeded(entryPoint ? { entryPoint } : undefined)
+        redirectToOnboardingIfNeeded(
+          analyticsContext ? { analyticsContext } : undefined,
+        )
       ) {
         return;
       }
@@ -69,7 +72,7 @@ export const useMoneyNavigation = () => {
           screen: Routes.MONEY.ROOT,
           params: {
             screen: Routes.MONEY.HOME,
-            ...(entryPoint ? { params: { entryPoint } } : {}),
+            ...(analyticsContext ? { params: { analyticsContext } } : {}),
           },
         },
         { pop: true },

--- a/app/components/UI/Money/types/navigation.ts
+++ b/app/components/UI/Money/types/navigation.ts
@@ -3,6 +3,7 @@ import type { Hex } from '@metamask/utils';
 import type { AccountsApiActivity } from './moneyActivity';
 import type { CardTransaction } from '../../../../core/Engine/controllers/card-controller/provider-types';
 import type { ConfirmationParams } from '../../../Views/confirmations/components/confirm/confirm-component';
+import type { NavigationAnalyticsRouteParams } from '../../../../util/analytics/navigationAnalyticsAttribution';
 
 export enum MoneyPostOnboardingRedirectType {
   DEPOSIT = 'deposit',
@@ -13,8 +14,7 @@ export interface MoneyPreferredPaymentToken {
   chainId: Hex;
 }
 
-export interface MoneyOnboardingParams {
-  entryPoint?: string;
+export interface MoneyOnboardingParams extends NavigationAnalyticsRouteParams {
   postOnboardingRedirect?: {
     type: MoneyPostOnboardingRedirectType;
     preferredPaymentToken?: MoneyPreferredPaymentToken;
@@ -27,7 +27,7 @@ export interface MoneyOnboardingParams {
 // ParamListBase requires `type`; `interface` cannot satisfy it.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type MoneyScreensStackParamList = {
-  MoneyHome: { entryPoint?: string } | undefined;
+  MoneyHome: NavigationAnalyticsRouteParams | undefined;
   MoneyActivity: undefined;
   MoneyHowItWorks: undefined;
 };

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
@@ -1328,6 +1328,22 @@ describe('PerpsHomeView', () => {
       jest.clearAllMocks();
     });
 
+    it('omits the default source when navigation analytics context is present', () => {
+      mockRouteParams = {
+        analyticsContext: {
+          id: 'balance-breakdown-navigation',
+          attribution: 'homescreen_balance_breakdown',
+        },
+      };
+
+      render(<PerpsHomeView />);
+
+      const properties = getBaseEventProperties(
+        mockUsePerpsEventTracking.mock.calls,
+      );
+      expect(properties?.source).toBeUndefined();
+    });
+
     it('includes sections_displayed containing balance and explore sections when markets exist', () => {
       mockUsePerpsHomeData.mockReturnValue({
         ...mockDefaultData,

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
@@ -1328,7 +1328,7 @@ describe('PerpsHomeView', () => {
       jest.clearAllMocks();
     });
 
-    it('omits the default source when navigation analytics context is present', () => {
+    it('uses navigation analytics attribution as the source', () => {
       mockRouteParams = {
         analyticsContext: {
           id: 'balance-breakdown-navigation',
@@ -1341,7 +1341,7 @@ describe('PerpsHomeView', () => {
       const properties = getBaseEventProperties(
         mockUsePerpsEventTracking.mock.calls,
       );
-      expect(properties?.source).toBeUndefined();
+      expect(properties?.source).toBe('homescreen_balance_breakdown');
     });
 
     it('includes sections_displayed containing balance and explore sections when markets exist', () => {

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
@@ -1332,7 +1332,7 @@ describe('PerpsHomeView', () => {
       jest.clearAllMocks();
     });
 
-    it('delegates one-time source attribution to Perps event tracking', () => {
+    it('delegates source attribution to Perps event tracking', () => {
       mockRouteParams = {
         analyticsContext: {
           id: 'balance-breakdown-navigation',

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
@@ -1312,6 +1312,10 @@ describe('PerpsHomeView', () => {
 
     interface TrackingOptions {
       properties?: Record<string, unknown>;
+      navigationAnalyticsContext?: {
+        id: string;
+        attribution: string;
+      };
     }
 
     const getBaseEventProperties = (
@@ -1328,7 +1332,7 @@ describe('PerpsHomeView', () => {
       jest.clearAllMocks();
     });
 
-    it('uses navigation analytics attribution as the source', () => {
+    it('delegates one-time source attribution to Perps event tracking', () => {
       mockRouteParams = {
         analyticsContext: {
           id: 'balance-breakdown-navigation',
@@ -1341,7 +1345,12 @@ describe('PerpsHomeView', () => {
       const properties = getBaseEventProperties(
         mockUsePerpsEventTracking.mock.calls,
       );
-      expect(properties?.source).toBe('homescreen_balance_breakdown');
+      expect(properties?.source).toBe('main_action_button');
+      expect(mockUsePerpsEventTracking).toHaveBeenCalledWith(
+        expect.objectContaining({
+          navigationAnalyticsContext: mockRouteParams.analyticsContext,
+        }),
+      );
     });
 
     it('includes sections_displayed containing balance and explore sections when markets exist', () => {

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -430,9 +430,7 @@ const PerpsHomeView = () => {
 
   // Track home screen viewed event
   const source =
-    route.params?.source ||
-    analyticsContext?.attribution ||
-    PERPS_EVENT_VALUE.SOURCE.MAIN_ACTION_BUTTON;
+    route.params?.source || PERPS_EVENT_VALUE.SOURCE.MAIN_ACTION_BUTTON;
 
   // Get perp balance status for tracking
   const livePositions = usePerpsLivePositions({ throttleMs: 5000 });
@@ -507,6 +505,9 @@ const PerpsHomeView = () => {
   usePerpsEventTracking({
     eventName: MetaMetricsEvents.PERPS_SCREEN_VIEWED,
     conditions: [!isAnyLoading],
+    navigationAnalyticsContext: route.params?.source
+      ? undefined
+      : analyticsContext,
     properties: {
       [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
         PERPS_EVENT_VALUE.SCREEN_TYPE.PERPS_HOME,

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -110,6 +110,7 @@ import styleSheet from './PerpsHomeView.styles';
 import { TraceName } from '../../../../../util/trace';
 import { buildPerpsCufStartTags } from '../../utils/perpsCufTrace';
 import { PERPS_CUF_TAG, PERPS_CUF_VARIANT } from '../../constants/perpsCufTags';
+import type { NavigationAnalyticsRouteParams } from '../../../../../util/analytics/navigationAnalyticsAttribution';
 import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
@@ -143,6 +144,9 @@ const PerpsHomeView = () => {
   const route =
     useRoute<RouteProp<PerpsNavigationParamList, 'PerpsMarketListView'>>();
   const transactionActiveAbTests = route.params?.transactionActiveAbTests;
+  const analyticsContext = (
+    route.params as NavigationAnalyticsRouteParams | undefined
+  )?.analyticsContext;
   const { trackEvent, createEventBuilder } = useAnalytics();
   const { openSupportWithConsent } = useSupportConsent();
 
@@ -426,7 +430,10 @@ const PerpsHomeView = () => {
 
   // Track home screen viewed event
   const source =
-    route.params?.source || PERPS_EVENT_VALUE.SOURCE.MAIN_ACTION_BUTTON;
+    route.params?.source ||
+    (analyticsContext
+      ? undefined
+      : PERPS_EVENT_VALUE.SOURCE.MAIN_ACTION_BUTTON);
 
   // Get perp balance status for tracking
   const livePositions = usePerpsLivePositions({ throttleMs: 5000 });
@@ -504,7 +511,9 @@ const PerpsHomeView = () => {
     properties: {
       [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
         PERPS_EVENT_VALUE.SCREEN_TYPE.PERPS_HOME,
-      [PERPS_EVENT_PROPERTY.SOURCE]: source,
+      ...(source && {
+        [PERPS_EVENT_PROPERTY.SOURCE]: source,
+      }),
       [PERPS_EVENT_PROPERTY.HAS_PERP_BALANCE]: hasPerpBalance,
       [PERPS_EVENT_PROPERTY.OPEN_POSITION]: livePositions.positions.length,
       [PERPS_EVENT_PROPERTY.OPEN_ORDER]: orders?.length || 0,

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -431,9 +431,8 @@ const PerpsHomeView = () => {
   // Track home screen viewed event
   const source =
     route.params?.source ||
-    (analyticsContext
-      ? undefined
-      : PERPS_EVENT_VALUE.SOURCE.MAIN_ACTION_BUTTON);
+    analyticsContext?.attribution ||
+    PERPS_EVENT_VALUE.SOURCE.MAIN_ACTION_BUTTON;
 
   // Get perp balance status for tracking
   const livePositions = usePerpsLivePositions({ throttleMs: 5000 });
@@ -511,9 +510,7 @@ const PerpsHomeView = () => {
     properties: {
       [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
         PERPS_EVENT_VALUE.SCREEN_TYPE.PERPS_HOME,
-      ...(source && {
-        [PERPS_EVENT_PROPERTY.SOURCE]: source,
-      }),
+      [PERPS_EVENT_PROPERTY.SOURCE]: source,
       [PERPS_EVENT_PROPERTY.HAS_PERP_BALANCE]: hasPerpBalance,
       [PERPS_EVENT_PROPERTY.OPEN_POSITION]: livePositions.positions.length,
       [PERPS_EVENT_PROPERTY.OPEN_ORDER]: orders?.length || 0,

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -998,7 +998,7 @@ describe('PerpsMarketDetailsView', () => {
     jest.useRealTimers();
   });
 
-  it('uses navigation analytics attribution as the source', () => {
+  it('delegates one-time source attribution to Perps event tracking', () => {
     mockRouteParams.analyticsContext = {
       id: 'balance-breakdown-navigation',
       attribution: 'homescreen_balance_breakdown',
@@ -1014,8 +1014,9 @@ describe('PerpsMarketDetailsView', () => {
     expect(jest.mocked(usePerpsEventTracking)).toHaveBeenCalledWith(
       expect.objectContaining({
         eventName: MetaMetricsEvents.PERPS_SCREEN_VIEWED,
+        navigationAnalyticsContext: mockRouteParams.analyticsContext,
         properties: expect.objectContaining({
-          [PERPS_EVENT_PROPERTY.SOURCE]: 'homescreen_balance_breakdown',
+          [PERPS_EVENT_PROPERTY.SOURCE]: PERPS_EVENT_VALUE.SOURCE.PERP_MARKETS,
         }),
       }),
     );

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -998,7 +998,7 @@ describe('PerpsMarketDetailsView', () => {
     jest.useRealTimers();
   });
 
-  it('delegates one-time source attribution to Perps event tracking', () => {
+  it('delegates source attribution to Perps event tracking', () => {
     mockRouteParams.analyticsContext = {
       id: 'balance-breakdown-navigation',
       attribution: 'homescreen_balance_breakdown',

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -998,7 +998,7 @@ describe('PerpsMarketDetailsView', () => {
     jest.useRealTimers();
   });
 
-  it('omits the default source when navigation analytics context is present', () => {
+  it('uses navigation analytics attribution as the source', () => {
     mockRouteParams.analyticsContext = {
       id: 'balance-breakdown-navigation',
       attribution: 'homescreen_balance_breakdown',
@@ -1014,8 +1014,8 @@ describe('PerpsMarketDetailsView', () => {
     expect(jest.mocked(usePerpsEventTracking)).toHaveBeenCalledWith(
       expect.objectContaining({
         eventName: MetaMetricsEvents.PERPS_SCREEN_VIEWED,
-        properties: expect.not.objectContaining({
-          [PERPS_EVENT_PROPERTY.SOURCE]: expect.anything(),
+        properties: expect.objectContaining({
+          [PERPS_EVENT_PROPERTY.SOURCE]: 'homescreen_balance_breakdown',
         }),
       }),
     );

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.test.tsx
@@ -35,6 +35,7 @@ import {
   PERPS_EVENT_PROPERTY as PERPS_CHART_EVENT_PROPERTY,
   PERPS_EVENT_VALUE as PERPS_CHART_EVENT_VALUE,
 } from '@metamask/perps-controller/constants';
+import { usePerpsEventTracking } from '../../hooks/usePerpsEventTracking';
 
 const mockPerpsAdvancedChartMount = jest.fn();
 const mockPerpsAdvancedChartUnmount = jest.fn();
@@ -244,7 +245,12 @@ const mockRouteParams: {
     asset: string;
     monitor: 'orders' | 'positions' | 'both';
   };
+  source?: string;
   source_section?: string;
+  analyticsContext?: {
+    id: string;
+    attribution: 'homescreen_balance_breakdown';
+  };
   transactionActiveAbTests?: {
     key: string;
     value: string;
@@ -964,7 +970,9 @@ describe('PerpsMarketDetailsView', () => {
       maxLeverage: '40x',
     };
     mockRouteParams.transactionActiveAbTests = undefined;
+    mockRouteParams.source = undefined;
     mockRouteParams.source_section = undefined;
+    mockRouteParams.analyticsContext = undefined;
 
     // Reset order fills mock to default
     mockUsePerpsLiveFillsImpl.mockReturnValue({
@@ -988,6 +996,29 @@ describe('PerpsMarketDetailsView', () => {
     mockPerpsModeValue = 'lite';
     mockHasCompletedPerpsModeSelection.mockResolvedValue(true);
     jest.useRealTimers();
+  });
+
+  it('omits the default source when navigation analytics context is present', () => {
+    mockRouteParams.analyticsContext = {
+      id: 'balance-breakdown-navigation',
+      attribution: 'homescreen_balance_breakdown',
+    };
+
+    renderWithProvider(
+      <PerpsConnectionProvider>
+        <PerpsMarketDetailsView />
+      </PerpsConnectionProvider>,
+      { state: initialState },
+    );
+
+    expect(jest.mocked(usePerpsEventTracking)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventName: MetaMetricsEvents.PERPS_SCREEN_VIEWED,
+        properties: expect.not.objectContaining({
+          [PERPS_EVENT_PROPERTY.SOURCE]: expect.anything(),
+        }),
+      }),
+    );
   });
 
   it('renders correctly', () => {

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -737,9 +737,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
         PERPS_EVENT_VALUE.SCREEN_TYPE.ASSET_DETAILS,
       [PERPS_EVENT_PROPERTY.ASSET]: market?.symbol || '',
       [PERPS_EVENT_PROPERTY.SOURCE]:
-        source ||
-        analyticsContext?.attribution ||
-        PERPS_EVENT_VALUE.SOURCE.PERP_MARKETS,
+        source || PERPS_EVENT_VALUE.SOURCE.PERP_MARKETS,
       ...chartAnalyticsProperties,
       ...(source_section && {
         [PERPS_EVENT_PROPERTY.SOURCE_SECTION]: source_section,
@@ -759,7 +757,6 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     [
       market?.symbol,
       source,
-      analyticsContext,
       chartAnalyticsProperties,
       source_section,
       existingPosition,
@@ -797,6 +794,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     eventName: MetaMetricsEvents.PERPS_SCREEN_VIEWED,
     resetKey: marketDetailsScreenViewResetKey,
     conditions: [isMarketDetailsScreenViewReady],
+    navigationAnalyticsContext: source ? undefined : analyticsContext,
     properties: marketDetailsScreenViewedProperties,
   });
 

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -179,12 +179,13 @@ import {
   type TransactionActiveAbTestEntry,
   withPendingTransactionActiveAbTests,
 } from '../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
+import type { NavigationAnalyticsRouteParams } from '../../../../../util/analytics/navigationAnalyticsAttribution';
 import PerpsSelectAdjustMarginActionView from '../PerpsSelectAdjustMarginActionView';
 import PerpsSelectModifyActionView from '../PerpsSelectModifyActionView';
 import { createStyles } from './PerpsMarketDetailsView.styles';
 import type { PerpsMarketDetailsViewProps } from './PerpsMarketDetailsView.types';
 
-interface MarketDetailsRouteParams {
+interface MarketDetailsRouteParams extends NavigationAnalyticsRouteParams {
   market: PerpsMarketData;
   monitoringIntent?: Partial<DataMonitorParams>;
   isNavigationFromOrderSuccess?: boolean;
@@ -227,6 +228,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     source,
     source_section,
     transactionActiveAbTests,
+    analyticsContext,
   } = route.params || {};
   const { track } = usePerpsEventTracking();
   const isRelatedMarketsEnabled = useSelector(
@@ -734,8 +736,10 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
       [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
         PERPS_EVENT_VALUE.SCREEN_TYPE.ASSET_DETAILS,
       [PERPS_EVENT_PROPERTY.ASSET]: market?.symbol || '',
-      [PERPS_EVENT_PROPERTY.SOURCE]:
-        source || PERPS_EVENT_VALUE.SOURCE.PERP_MARKETS,
+      ...((source || !analyticsContext) && {
+        [PERPS_EVENT_PROPERTY.SOURCE]:
+          source || PERPS_EVENT_VALUE.SOURCE.PERP_MARKETS,
+      }),
       ...chartAnalyticsProperties,
       ...(source_section && {
         [PERPS_EVENT_PROPERTY.SOURCE_SECTION]: source_section,
@@ -755,6 +759,7 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
     [
       market?.symbol,
       source,
+      analyticsContext,
       chartAnalyticsProperties,
       source_section,
       existingPosition,

--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.tsx
@@ -736,10 +736,10 @@ const PerpsMarketDetailsView: React.FC<PerpsMarketDetailsViewProps> = () => {
       [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
         PERPS_EVENT_VALUE.SCREEN_TYPE.ASSET_DETAILS,
       [PERPS_EVENT_PROPERTY.ASSET]: market?.symbol || '',
-      ...((source || !analyticsContext) && {
-        [PERPS_EVENT_PROPERTY.SOURCE]:
-          source || PERPS_EVENT_VALUE.SOURCE.PERP_MARKETS,
-      }),
+      [PERPS_EVENT_PROPERTY.SOURCE]:
+        source ||
+        analyticsContext?.attribution ||
+        PERPS_EVENT_VALUE.SOURCE.PERP_MARKETS,
       ...chartAnalyticsProperties,
       ...(source_section && {
         [PERPS_EVENT_PROPERTY.SOURCE_SECTION]: source_section,

--- a/app/components/UI/Perps/hooks/usePerpsEventTracking.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsEventTracking.test.ts
@@ -105,6 +105,7 @@ describe('usePerpsEventTracking', () => {
       const { result } = renderHook(() => usePerpsEventTracking());
       const customProps = {
         screen_type: 'home',
+        source: 'homescreen_balance_breakdown',
         [PERPS_EVENT_PROPERTY.OPEN_POSITION]: 2,
       };
 
@@ -134,6 +135,7 @@ describe('usePerpsEventTracking', () => {
       expect(assetViewedProperties).toEqual({
         [PERPS_EVENT_PROPERTY.TIMESTAMP]: 1234567890,
         screen_type: 'home',
+        source: 'homescreen_balance_breakdown',
         open_positions_count: 2,
         trade_type: 'Perps',
         implementation_type: 'native',

--- a/app/components/UI/Perps/hooks/usePerpsEventTracking.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsEventTracking.test.ts
@@ -258,7 +258,7 @@ describe('usePerpsEventTracking', () => {
       });
     });
 
-    it('uses navigation attribution once, then restores the default source', () => {
+    it('keeps navigation attribution across reset-key emissions', () => {
       const navigationAnalyticsContext: NavigationAnalyticsContext = {
         id: 'balance-breakdown-navigation',
         attribution: 'homescreen_balance_breakdown',
@@ -299,12 +299,12 @@ describe('usePerpsEventTracking', () => {
       const secondAssetBuilder = mockCreateEventBuilder.mock.results[3].value;
       expect(secondScreenBuilder.addProperties).toHaveBeenCalledWith(
         expect.objectContaining({
-          source: PERPS_EVENT_VALUE.SOURCE.PERP_MARKETS,
+          source: 'homescreen_balance_breakdown',
         }),
       );
       expect(secondAssetBuilder.addProperties).toHaveBeenCalledWith(
         expect.objectContaining({
-          source: PERPS_EVENT_VALUE.SOURCE.PERP_MARKETS,
+          source: 'homescreen_balance_breakdown',
         }),
       );
     });

--- a/app/components/UI/Perps/hooks/usePerpsEventTracking.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsEventTracking.test.ts
@@ -9,6 +9,10 @@ import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { getPerpsUtmAttributionProperties } from '../utils/perpsAnalyticsAttribution';
 import { PERPS_MODE_ANALYTICS_PROPERTY } from '../utils/perpsModeAnalytics';
+import {
+  resetNavigationAnalyticsAttributionForTests,
+  type NavigationAnalyticsContext,
+} from '../../../../util/analytics/navigationAnalyticsAttribution';
 
 const mockTrackEvent = jest.fn();
 const mockCreateEventBuilder = jest.fn();
@@ -28,6 +32,7 @@ const mockGetPerpsUtmAttributionProperties = jest.mocked(
 describe('usePerpsEventTracking', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resetNavigationAnalyticsAttributionForTests();
     jest.spyOn(Date, 'now').mockReturnValue(1234567890);
     mockGetPerpsUtmAttributionProperties.mockReturnValue({});
 
@@ -251,6 +256,57 @@ describe('usePerpsEventTracking', () => {
         [PERPS_EVENT_PROPERTY.TIMESTAMP]: 1234567890,
         asset: 'ETH',
       });
+    });
+
+    it('uses navigation attribution once, then restores the default source', () => {
+      const navigationAnalyticsContext: NavigationAnalyticsContext = {
+        id: 'balance-breakdown-navigation',
+        attribution: 'homescreen_balance_breakdown',
+      };
+      const { rerender } = renderHook(
+        ({ resetKey }: { resetKey: string }) =>
+          usePerpsEventTracking({
+            eventName: MetaMetricsEvents.PERPS_SCREEN_VIEWED,
+            resetKey,
+            conditions: [true],
+            navigationAnalyticsContext,
+            properties: {
+              asset: resetKey,
+              source: PERPS_EVENT_VALUE.SOURCE.PERP_MARKETS,
+            },
+          }),
+        {
+          initialProps: { resetKey: 'BTC' },
+        },
+      );
+
+      const firstScreenBuilder = mockCreateEventBuilder.mock.results[0].value;
+      const firstAssetBuilder = mockCreateEventBuilder.mock.results[1].value;
+      expect(firstScreenBuilder.addProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'homescreen_balance_breakdown',
+        }),
+      );
+      expect(firstAssetBuilder.addProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: 'homescreen_balance_breakdown',
+        }),
+      );
+
+      rerender({ resetKey: 'ETH' });
+
+      const secondScreenBuilder = mockCreateEventBuilder.mock.results[2].value;
+      const secondAssetBuilder = mockCreateEventBuilder.mock.results[3].value;
+      expect(secondScreenBuilder.addProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: PERPS_EVENT_VALUE.SOURCE.PERP_MARKETS,
+        }),
+      );
+      expect(secondAssetBuilder.addProperties).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: PERPS_EVENT_VALUE.SOURCE.PERP_MARKETS,
+        }),
+      );
     });
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsEventTracking.ts
+++ b/app/components/UI/Perps/hooks/usePerpsEventTracking.ts
@@ -9,6 +9,10 @@ import {
   PERPS_EVENT_VALUE,
 } from '@metamask/perps-controller';
 import { getPerpsUtmAttributionProperties } from '../utils/perpsAnalyticsAttribution';
+import {
+  consumeNavigationAnalyticsAttribution,
+  type NavigationAnalyticsContext,
+} from '../../../../util/analytics/navigationAnalyticsAttribution';
 
 // Static helper function - moved outside component to avoid recreation
 const allTrue = (conditionArray: boolean[]): boolean =>
@@ -46,6 +50,7 @@ interface EventTrackingOptions {
 
   // Advanced API - full control (for future extensibility)
   resetConditions?: boolean[];
+  navigationAnalyticsContext?: NavigationAnalyticsContext;
 }
 
 /**
@@ -80,6 +85,7 @@ interface EventTrackingOptions {
  */
 export const usePerpsEventTracking = (options?: EventTrackingOptions) => {
   const { trackEvent, createEventBuilder } = useAnalytics();
+  const navigationAnalyticsContext = options?.navigationAnalyticsContext;
 
   /**
    * Track an event with automatic timestamp (imperative API)
@@ -89,16 +95,28 @@ export const usePerpsEventTracking = (options?: EventTrackingOptions) => {
       eventName: (typeof MetaMetricsEvents)[keyof typeof MetaMetricsEvents],
       properties: Record<string, unknown> = {},
     ) => {
+      const isScreenViewed =
+        eventName === MetaMetricsEvents.PERPS_SCREEN_VIEWED;
+      const navigationAttribution =
+        isScreenViewed && navigationAnalyticsContext
+          ? consumeNavigationAnalyticsAttribution(
+              navigationAnalyticsContext,
+              eventName.category,
+            )
+          : undefined;
+
       // Timestamp on every event. Lite/Pro `perps_mode` is injected later by
       // enrichWithPerpsMode in analytics.trackEvent (caller props still win).
-      // UTM is Screen Viewed only.
+      // Navigation attribution is resolved here so both Perp Screen Viewed and
+      // its companion Asset Viewed receive the same one-time source.
       const props = {
         [PERPS_EVENT_PROPERTY.TIMESTAMP]: Date.now(),
         ...properties,
+        ...(navigationAttribution && {
+          [navigationAttribution.property]:
+            navigationAnalyticsContext?.attribution,
+        }),
       };
-
-      const isScreenViewed =
-        eventName === MetaMetricsEvents.PERPS_SCREEN_VIEWED;
 
       // attach stored UTM attribution to every Perp Screen Viewed
       // event. Explicit props win over attribution, so it never overrides a
@@ -119,7 +137,7 @@ export const usePerpsEventTracking = (options?: EventTrackingOptions) => {
         );
       }
     },
-    [trackEvent, createEventBuilder],
+    [trackEvent, createEventBuilder, navigationAnalyticsContext],
   );
 
   // Declarative API implementation (similar to usePerpsMeasurement)

--- a/app/components/UI/Perps/hooks/usePerpsEventTracking.ts
+++ b/app/components/UI/Perps/hooks/usePerpsEventTracking.ts
@@ -97,25 +97,26 @@ export const usePerpsEventTracking = (options?: EventTrackingOptions) => {
     ) => {
       const isScreenViewed =
         eventName === MetaMetricsEvents.PERPS_SCREEN_VIEWED;
-      const navigationAttribution =
-        isScreenViewed && navigationAnalyticsContext
-          ? consumeNavigationAnalyticsAttribution(
-              navigationAnalyticsContext,
-              eventName.category,
-            )
-          : undefined;
+      if (isScreenViewed && navigationAnalyticsContext) {
+        consumeNavigationAnalyticsAttribution(
+          navigationAnalyticsContext,
+          eventName.category,
+        );
+      }
 
       // Timestamp on every event. Lite/Pro `perps_mode` is injected later by
       // enrichWithPerpsMode in analytics.trackEvent (caller props still win).
       // Navigation attribution is resolved here so both Perp Screen Viewed and
-      // its companion Asset Viewed receive the same one-time source.
+      // its companion Asset Viewed retain the navigation source across every
+      // reset-key emission.
       const props = {
         [PERPS_EVENT_PROPERTY.TIMESTAMP]: Date.now(),
         ...properties,
-        ...(navigationAttribution && {
-          [navigationAttribution.property]:
-            navigationAnalyticsContext?.attribution,
-        }),
+        ...(isScreenViewed &&
+          navigationAnalyticsContext && {
+            [PERPS_EVENT_PROPERTY.SOURCE]:
+              navigationAnalyticsContext.attribution,
+          }),
       };
 
       // attach stored UTM attribution to every Perp Screen Viewed

--- a/app/components/UI/Tokens/index.test.tsx
+++ b/app/components/UI/Tokens/index.test.tsx
@@ -186,7 +186,6 @@ const renderComponent = (
   isFullView: boolean = false,
   showOnlyMusd: boolean = false,
   hasMusdBalanceOnAnyChain?: boolean,
-  analyticsSource?: string,
 ) =>
   renderWithProvider(
     <Stack.Navigator>
@@ -196,7 +195,6 @@ const renderComponent = (
             isFullView={isFullView}
             showOnlyMusd={showOnlyMusd}
             hasMusdBalanceOnAnyChain={hasMusdBalanceOnAnyChain}
-            analyticsSource={analyticsSource}
           />
         )}
       </Stack.Screen>
@@ -343,25 +341,6 @@ describe('Tokens', () => {
             location: 'homepage',
             is_empty: false,
             screen_type: 'tokens',
-          }),
-        );
-      });
-    });
-
-    it('attributes Position Screen Viewed to the homepage balance breakdown', async () => {
-      renderComponent(
-        initialState,
-        true,
-        false,
-        undefined,
-        'homescreen_balance_breakdown',
-      );
-
-      await waitFor(() => {
-        expect(mockAddProperties).toHaveBeenCalledWith(
-          expect.objectContaining({
-            screen_type: 'tokens',
-            source: 'homescreen_balance_breakdown',
           }),
         );
       });

--- a/app/components/UI/Tokens/index.tsx
+++ b/app/components/UI/Tokens/index.tsx
@@ -52,8 +52,6 @@ interface TokensProps {
    * Whether this is the full view (with header and safe area) or tab view
    */
   isFullView?: boolean;
-  /** Source used to attribute full-view analytics events. */
-  analyticsSource?: string;
   /**
    * When true, show only mUSD token positions (for Cash full view).
    * Hides add-token bar and uses cash-specific empty state when empty.
@@ -90,7 +88,6 @@ const Tokens = forwardRef<TabRefreshHandle, TokensProps>(
   (
     {
       isFullView = false,
-      analyticsSource,
       showOnlyMusd = false,
       hasMusdBalanceOnAnyChain: hasMusdBalanceOnAnyChainProp,
       listHeaderComponent,
@@ -179,7 +176,6 @@ const Tokens = forwardRef<TabRefreshHandle, TokensProps>(
             location: 'homepage',
             is_empty: tokenKeysForList.length === 0,
             screen_type: showOnlyMusd ? 'cash' : 'tokens',
-            ...(analyticsSource ? { source: analyticsSource } : {}),
           })
           .build(),
       );
@@ -188,7 +184,6 @@ const Tokens = forwardRef<TabRefreshHandle, TokensProps>(
       hasInitialLoad,
       tokenKeysForList.length,
       showOnlyMusd,
-      analyticsSource,
       trackEvent,
       createEventBuilder,
     ]);

--- a/app/components/Views/DeFiFullView/DeFiFullView.tsx
+++ b/app/components/Views/DeFiFullView/DeFiFullView.tsx
@@ -1,14 +1,6 @@
 import React, { useCallback } from 'react';
-import {
-  type RouteProp,
-  useFocusEffect,
-  useNavigation,
-  useRoute,
-} from '@react-navigation/native';
-import type {
-  AppNavigationProp,
-  RootStackParamList,
-} from '../../../core/NavigationService/types';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import {
   SafeAreaView,
   useSafeAreaInsets,
@@ -29,7 +21,6 @@ import { DEFAULT_TOKEN_SORT_CONFIG } from '../../UI/Tokens/util/sortAssets';
 
 const DeFiFullView = () => {
   const navigation = useNavigation<AppNavigationProp>();
-  const route = useRoute<RouteProp<RootStackParamList, 'DeFiFullView'>>();
   const tw = useTailwind();
   const insets = useSafeAreaInsets();
 
@@ -73,7 +64,6 @@ const DeFiFullView = () => {
         <DeFiPositionsList
           tabLabel={strings('homepage.sections.defi')}
           isFullView
-          analyticsSource={route.params?.source}
         />
       </Box>
     </SafeAreaView>

--- a/app/components/Views/Homepage/Sections/Perpetuals/hooks/usePerpsNavigationHandlers.test.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/hooks/usePerpsNavigationHandlers.test.ts
@@ -1,0 +1,73 @@
+import { act, renderHook } from '@testing-library/react-native';
+import Routes from '../../../../../../constants/navigation/Routes';
+import type { NavigationAnalyticsContext } from '../../../../../../util/analytics/navigationAnalyticsAttribution';
+import { usePerpsNavigationHandlers } from './usePerpsNavigationHandlers';
+
+const mockNavigate = jest.fn();
+const mockGetPerpsHomeNavigationTarget = jest.fn();
+let mockIsFirstTimePerpsUser = false;
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+  }),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: () => mockIsFirstTimePerpsUser,
+}));
+
+jest.mock('../../../../../UI/Perps/utils/perpsModeSwitch', () => ({
+  useGetPerpsHomeNavigationTarget: () => mockGetPerpsHomeNavigationTarget,
+  toPerpsNavigatorScreenParams: (target: unknown) => target,
+}));
+
+const analyticsContext: NavigationAnalyticsContext = {
+  id: 'balance-breakdown-navigation',
+  attribution: 'homescreen_balance_breakdown',
+};
+
+describe('usePerpsNavigationHandlers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsFirstTimePerpsUser = false;
+    mockGetPerpsHomeNavigationTarget.mockImplementation((params) => ({
+      screen: Routes.PERPS.PERPS_HOME,
+      params,
+    }));
+  });
+
+  it('attributes the tutorial and preserves context for the post-tutorial destination', () => {
+    mockIsFirstTimePerpsUser = true;
+    const { result } = renderHook(() => usePerpsNavigationHandlers());
+
+    act(() => result.current.navigateToPerpsHome(analyticsContext));
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.TUTORIAL, {
+      source: 'homescreen_balance_breakdown',
+      redirectScreen: Routes.PERPS.PERPS_HOME,
+      redirectParams: { analyticsContext },
+    });
+  });
+
+  it('passes navigation analytics context to returning users', () => {
+    const { result } = renderHook(() => usePerpsNavigationHandlers());
+
+    act(() => result.current.navigateToPerpsHome(analyticsContext));
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.ROOT, {
+      screen: Routes.PERPS.PERPS_HOME,
+      params: { analyticsContext },
+    });
+  });
+
+  it('uses the existing source when navigation context is absent', () => {
+    const { result } = renderHook(() => usePerpsNavigationHandlers());
+
+    act(() => result.current.navigateToPerpsHome());
+
+    expect(mockGetPerpsHomeNavigationTarget).toHaveBeenCalledWith({
+      source: 'home_section',
+    });
+  });
+});

--- a/app/components/Views/Homepage/Sections/Perpetuals/hooks/usePerpsNavigationHandlers.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/hooks/usePerpsNavigationHandlers.ts
@@ -78,7 +78,7 @@ export const usePerpsNavigationHandlers = ({
 
       if (isFirstTimePerpsUser) {
         navigation.navigate(Routes.PERPS.TUTORIAL, {
-          source,
+          source: analyticsContext?.attribution ?? source,
           redirectScreen: target.screen,
           redirectParams: target.params,
         });

--- a/app/components/Views/Homepage/Sections/Perpetuals/hooks/usePerpsNavigationHandlers.ts
+++ b/app/components/Views/Homepage/Sections/Perpetuals/hooks/usePerpsNavigationHandlers.ts
@@ -20,6 +20,7 @@ import type {
   PerpsStackParamList,
 } from '../../../../../UI/Perps/types/navigation';
 import type { TransactionActiveAbTestEntry } from '../../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
+import type { NavigationAnalyticsContext } from '../../../../../../util/analytics/navigationAnalyticsAttribution';
 
 interface UsePerpsNavigationHandlersArgs {
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
@@ -59,41 +60,49 @@ export const usePerpsNavigationHandlers = ({
     [isFirstTimePerpsUser, navigation],
   );
 
-  const handleViewAllPerps = useCallback(() => {
-    const homeParams = {
+  const navigateToPerpsHome = useCallback(
+    (analyticsContext?: NavigationAnalyticsContext) => {
+      const homeParams = {
+        ...(analyticsContext ? { analyticsContext } : { source }),
+        ...(marketDetailsTransactionActiveAbTests?.length
+          ? {
+              transactionActiveAbTests: marketDetailsTransactionActiveAbTests,
+            }
+          : {}),
+      };
+
+      // Resolve the Pro-aware target up front (Home vs. default Pro market)
+      // so first-time users are redirected consistently with returning users
+      // once they complete the tutorial (TAT-3612).
+      const target = getPerpsHomeNavigationTarget(homeParams);
+
+      if (isFirstTimePerpsUser) {
+        navigation.navigate(Routes.PERPS.TUTORIAL, {
+          source,
+          redirectScreen: target.screen,
+          redirectParams: target.params,
+        });
+        return;
+      }
+
+      navigation.navigate(
+        Routes.PERPS.ROOT,
+        toPerpsNavigatorScreenParams(target),
+      );
+    },
+    [
+      isFirstTimePerpsUser,
+      navigation,
+      marketDetailsTransactionActiveAbTests,
+      getPerpsHomeNavigationTarget,
       source,
-      ...(marketDetailsTransactionActiveAbTests?.length
-        ? {
-            transactionActiveAbTests: marketDetailsTransactionActiveAbTests,
-          }
-        : {}),
-    };
+    ],
+  );
 
-    // Resolve the Pro-aware target up front (Home vs. default Pro market)
-    // so first-time users are redirected consistently with returning users
-    // once they complete the tutorial (TAT-3612).
-    const target = getPerpsHomeNavigationTarget(homeParams);
-
-    if (isFirstTimePerpsUser) {
-      navigation.navigate(Routes.PERPS.TUTORIAL, {
-        source,
-        redirectScreen: target.screen,
-        redirectParams: target.params,
-      });
-      return;
-    }
-
-    navigation.navigate(
-      Routes.PERPS.ROOT,
-      toPerpsNavigatorScreenParams(target),
-    );
-  }, [
-    isFirstTimePerpsUser,
-    navigation,
-    marketDetailsTransactionActiveAbTests,
-    getPerpsHomeNavigationTarget,
-    source,
-  ]);
+  const handleViewAllPerps = useCallback(
+    () => navigateToPerpsHome(),
+    [navigateToPerpsHome],
+  );
 
   const handleViewMorePerps = useCallback(() => {
     navigateToTutorialOrScreen(Routes.PERPS.MARKET_LIST, {
@@ -124,6 +133,7 @@ export const usePerpsNavigationHandlers = ({
   return {
     marketDetailsTransactionActiveAbTests,
     navigateToTutorialOrScreen,
+    navigateToPerpsHome,
     handleViewAllPerps,
     handleViewMorePerps,
     handleTilePress,

--- a/app/components/Views/Homepage/components/HomepageBalanceBreakdown/HomepageBalanceBreakdown.test.tsx
+++ b/app/components/Views/Homepage/components/HomepageBalanceBreakdown/HomepageBalanceBreakdown.test.tsx
@@ -24,9 +24,9 @@ import { createActiveABTestAssignment } from '../../../../../util/analytics/acti
 
 const mockNavigate = jest.fn();
 const mockNavigateToMoneyHome = jest.fn();
-const mockHandleViewAllPerps = jest.fn();
+const mockNavigateToPerpsHome = jest.fn();
 const mockUsePerpsNavigationHandlers = jest.fn((_options?: unknown) => ({
-  handleViewAllPerps: mockHandleViewAllPerps,
+  navigateToPerpsHome: mockNavigateToPerpsHome,
 }));
 const mockTrackEvent = jest.fn();
 const mockBuild = jest.fn(() => ({ name: 'Home Viewed' }));
@@ -556,18 +556,31 @@ describe('HomepageBalanceBreakdown', () => {
     fireEvent.press(getByTestId(HomepageBalanceBreakdownTestIds.ROW('defi')));
 
     expect(mockNavigateToMoneyHome).toHaveBeenCalledWith(
-      'homescreen_balance_breakdown',
+      expect.objectContaining({
+        attribution: 'homescreen_balance_breakdown',
+        id: expect.any(String),
+      }),
     );
     expect(mockNavigate).toHaveBeenNthCalledWith(
       1,
       Routes.WALLET.TOKENS_FULL_VIEW,
-      { source: 'homescreen_balance_breakdown' },
+      {
+        analyticsContext: expect.objectContaining({
+          attribution: 'homescreen_balance_breakdown',
+          id: expect.any(String),
+        }),
+      },
     );
     expect(mockUsePerpsNavigationHandlers).toHaveBeenCalledWith({
-      source: 'homescreen_balance_breakdown',
       transactionActiveAbTests,
     });
-    expect(mockHandleViewAllPerps).toHaveBeenCalledTimes(1);
+    expect(mockNavigateToPerpsHome).toHaveBeenCalledTimes(1);
+    expect(mockNavigateToPerpsHome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attribution: 'homescreen_balance_breakdown',
+        id: expect.any(String),
+      }),
+    );
     expect(mockNavigate).toHaveBeenNthCalledWith(2, Routes.PREDICT.ROOT, {
       screen: Routes.PREDICT.MARKET_LIST,
       params: {
@@ -578,7 +591,12 @@ describe('HomepageBalanceBreakdown', () => {
     expect(mockNavigate).toHaveBeenNthCalledWith(
       3,
       Routes.WALLET.DEFI_FULL_VIEW,
-      { source: 'homescreen_balance_breakdown' },
+      {
+        analyticsContext: expect.objectContaining({
+          attribution: 'homescreen_balance_breakdown',
+          id: expect.any(String),
+        }),
+      },
     );
     expect(mockCreateEventBuilder).toHaveBeenCalledTimes(5);
     expect(mockCreateEventBuilder).toHaveBeenCalledWith(

--- a/app/components/Views/Homepage/components/HomepageBalanceBreakdown/useHomepageBalanceBreakdownNavigation.ts
+++ b/app/components/Views/Homepage/components/HomepageBalanceBreakdown/useHomepageBalanceBreakdownNavigation.ts
@@ -9,6 +9,10 @@ import type { SliceKey } from '../../BalanceBreakdown/types';
 import { useHomepageScrollContext } from '../../context/HomepageScrollContext';
 import { HOMEPAGE_BALANCE_BREAKDOWN_ENTRY_POINT } from '../../abTestConfig';
 import type { TransactionActiveAbTestEntry } from '../../../../../util/transactions/transaction-active-ab-test-attribution-registry';
+import {
+  createNavigationAnalyticsContext,
+  NavigationAnalyticsAttribution,
+} from '../../../../../util/analytics/navigationAnalyticsAttribution';
 
 const BALANCE_BREAKDOWN_SECTION_NAMES: Record<SliceKey, string> = {
   money: 'money',
@@ -28,14 +32,16 @@ export function useHomepageBalanceBreakdownNavigation({
   const navigation = useNavigation();
   const { entryPoint, appSessionId, visitId } = useHomepageScrollContext();
   const { navigateToMoneyHome } = useMoneyNavigation();
-  const { handleViewAllPerps } = usePerpsNavigationHandlers({
-    source: HOMEPAGE_BALANCE_BREAKDOWN_ENTRY_POINT,
+  const { navigateToPerpsHome } = usePerpsNavigationHandlers({
     transactionActiveAbTests,
   });
   const { trackEvent, createEventBuilder } = useAnalytics();
 
   const openSlice = useCallback(
     (key: SliceKey, position: number) => {
+      const analyticsContext = createNavigationAnalyticsContext(
+        NavigationAnalyticsAttribution.HomepageBalanceBreakdown,
+      );
       trackEvent(
         createEventBuilder(MetaMetricsEvents.HOME_VIEWED)
           .addProperties({
@@ -52,15 +58,15 @@ export function useHomepageBalanceBreakdownNavigation({
 
       switch (key) {
         case 'money':
-          navigateToMoneyHome(HOMEPAGE_BALANCE_BREAKDOWN_ENTRY_POINT);
+          navigateToMoneyHome(analyticsContext);
           break;
         case 'tokens':
           navigation.navigate(Routes.WALLET.TOKENS_FULL_VIEW, {
-            source: HOMEPAGE_BALANCE_BREAKDOWN_ENTRY_POINT,
+            analyticsContext,
           });
           break;
         case 'perps':
-          handleViewAllPerps();
+          navigateToPerpsHome(analyticsContext);
           break;
         case 'predict':
           navigation.navigate(Routes.PREDICT.ROOT, {
@@ -75,7 +81,7 @@ export function useHomepageBalanceBreakdownNavigation({
           break;
         case 'defi':
           navigation.navigate(Routes.WALLET.DEFI_FULL_VIEW, {
-            source: HOMEPAGE_BALANCE_BREAKDOWN_ENTRY_POINT,
+            analyticsContext,
           });
           break;
       }
@@ -84,7 +90,7 @@ export function useHomepageBalanceBreakdownNavigation({
       createEventBuilder,
       entryPoint,
       appSessionId,
-      handleViewAllPerps,
+      navigateToPerpsHome,
       navigateToMoneyHome,
       navigation,
       trackEvent,

--- a/app/components/Views/TokensFullView/TokensFullView.tsx
+++ b/app/components/Views/TokensFullView/TokensFullView.tsx
@@ -1,13 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
-import {
-  type RouteProp,
-  useNavigation,
-  useRoute,
-} from '@react-navigation/native';
-import type {
-  AppNavigationProp,
-  RootStackParamList,
-} from '../../../core/NavigationService/types';
+import { useNavigation } from '@react-navigation/native';
+import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import { Box, HeaderStandard } from '@metamask/design-system-react-native';
 import { strings } from '../../../../locales/i18n';
 import Tokens from '../../UI/Tokens';
@@ -17,7 +10,6 @@ import { DEFAULT_TOKEN_SORT_CONFIG } from '../../UI/Tokens/util/sortAssets';
 
 const TokensFullView = () => {
   const navigation = useNavigation<AppNavigationProp>();
-  const route = useRoute<RouteProp<RootStackParamList, 'TokensFullView'>>();
 
   useEffect(
     () => () => {
@@ -44,7 +36,7 @@ const TokensFullView = () => {
           backButtonProps={{ testID: 'back-button' }}
           includesTopInset
         />
-        <Tokens isFullView analyticsSource={route.params?.source} />
+        <Tokens isFullView />
       </Box>
     </>
   );

--- a/app/core/NavigationService/NavigationService.test.ts
+++ b/app/core/NavigationService/NavigationService.test.ts
@@ -272,6 +272,19 @@ describe('NavigationService', () => {
       expect(route).toEqual({ name: 'Home', key: 'home-key' });
     });
 
+    it('safely returns the focused route for shared services', () => {
+      NavigationService.navigation = mockNavigation;
+
+      expect(NavigationService.getCurrentRoute()).toEqual({
+        name: 'Home',
+        key: 'home-key',
+      });
+    });
+
+    it('returns undefined when shared services read before navigation is ready', () => {
+      expect(NavigationService.getCurrentRoute()).toBeUndefined();
+    });
+
     it('getRootState returns the root navigation state', () => {
       NavigationService.navigation = mockNavigation;
 

--- a/app/core/NavigationService/NavigationService.ts
+++ b/app/core/NavigationService/NavigationService.ts
@@ -115,6 +115,16 @@ class NavigationService {
   }
 
   /**
+   * Returns the focused route when navigation is ready.
+   *
+   * Unlike the navigation getter, analytics callers can safely use this during
+   * app startup without logging or throwing when the container is not mounted.
+   */
+  static getCurrentRoute() {
+    return this.#navigation?.getCurrentRoute();
+  }
+
+  /**
    * Resets the navigation reference. Only for testing purposes.
    * @internal
    */

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -5,6 +5,7 @@ import type {
 } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { Position } from '@metamask/social-controllers';
+import type { NavigationAnalyticsRouteParams } from '../../util/analytics/navigationAnalyticsAttribution';
 
 // ============================================================================
 // Import types from their source files
@@ -854,9 +855,9 @@ export type RootStackParamList = {
     | NavigatorScreenParams<WalletTabStackParamList>
     | undefined;
   WalletConnectSessionsView: undefined;
-  DeFiFullView: { source?: string } | undefined;
+  DeFiFullView: NavigationAnalyticsRouteParams | undefined;
   NftFullView: undefined;
-  TokensFullView: { source?: string } | undefined;
+  TokensFullView: NavigationAnalyticsRouteParams | undefined;
   CashTokensFullView: undefined;
   WatchlistFullView: undefined;
 

--- a/app/util/analytics/analytics.ts
+++ b/app/util/analytics/analytics.ts
@@ -19,6 +19,7 @@ import {
   getFeatureFlagThresholdGroupsFromState,
 } from './enrichWithABTests';
 import { enrichWithPerpsMode } from './enrichWithPerpsMode';
+import { enrichWithNavigationAttribution } from './navigationAnalyticsAttribution';
 
 /**
  * Analytics helper interface
@@ -56,22 +57,23 @@ const queueManager = createAnalyticsQueueManager({
  * @param event - AnalyticsTrackingEvent to track
  */
 const trackEvent = (event: AnalyticsTrackingEvent): void => {
-  let enrichedEvent: AnalyticsTrackingEvent;
+  let enrichedEvent = event;
+
+  try {
+    enrichedEvent = enrichWithNavigationAttribution(enrichWithPerpsMode(event));
+  } catch {
+    // Best-effort shared enrichment — never block event emission.
+  }
 
   try {
     const state = store.getState();
     enrichedEvent = enrichWithABTests(
-      enrichWithPerpsMode(event),
+      enrichedEvent,
       getRemoteFeatureFlagsFromState(state),
       getFeatureFlagThresholdGroupsFromState(state),
     );
   } catch {
-    // Best-effort enrichment — never block emission if mode/AB lookup fails.
-    try {
-      enrichedEvent = enrichWithPerpsMode(event);
-    } catch {
-      enrichedEvent = event;
-    }
+    // Best-effort A/B enrichment — retain successful shared enrichment.
   }
 
   queueManager.queueOperation('trackEvent', enrichedEvent).catch((error) => {

--- a/app/util/analytics/navigationAnalyticsAttribution.test.ts
+++ b/app/util/analytics/navigationAnalyticsAttribution.test.ts
@@ -73,15 +73,23 @@ describe('navigation analytics attribution', () => {
     expect(result.properties.entry_point).toBe('homescreen_balance_breakdown');
   });
 
-  it('preserves an explicit callsite property', () => {
+  it('preserves an explicit callsite property without consuming attribution', () => {
+    const route = createRoute();
     const event = createEvent(EVENT_NAME.PERPS_SCREEN_VIEWED, {
       source: 'explicit_source',
     });
 
-    const result = enrichWithNavigationAttribution(event, createRoute());
+    const result = enrichWithNavigationAttribution(event, route);
+    const destinationResult = enrichWithNavigationAttribution(
+      createEvent(EVENT_NAME.PERPS_SCREEN_VIEWED),
+      route,
+    );
 
     expect(result).toBe(event);
     expect(result.properties.source).toBe('explicit_source');
+    expect(destinationResult.properties.source).toBe(
+      'homescreen_balance_breakdown',
+    );
   });
 
   it('ignores events outside the attribution allowlist', () => {

--- a/app/util/analytics/navigationAnalyticsAttribution.test.ts
+++ b/app/util/analytics/navigationAnalyticsAttribution.test.ts
@@ -30,15 +30,48 @@ describe('navigation analytics attribution', () => {
   });
 
   it.each([
-    [EVENT_NAME.MONEY_SURFACE_VIEWED, 'entry_point'],
-    [EVENT_NAME.PERPS_SCREEN_VIEWED, 'source'],
-    [EVENT_NAME.POSITION_SCREEN_VIEWED, 'source'],
-  ])('injects the delegated property into %s', (eventName, property) => {
-    const event = createEvent(eventName);
+    [
+      EVENT_NAME.MONEY_SURFACE_VIEWED,
+      'entry_point',
+      { screen_name: 'money_home', surface_type: 'screen' },
+    ],
+    [EVENT_NAME.PERPS_SCREEN_VIEWED, 'source', {}],
+    [EVENT_NAME.POSITION_SCREEN_VIEWED, 'source', {}],
+  ])(
+    'injects the delegated property into %s',
+    (eventName, property, properties) => {
+      const event = createEvent(eventName, properties);
 
-    const result = enrichWithNavigationAttribution(event, createRoute());
+      const result = enrichWithNavigationAttribution(event, createRoute());
 
-    expect(result.properties[property]).toBe('homescreen_balance_breakdown');
+      expect(result.properties[property]).toBe('homescreen_balance_breakdown');
+    },
+  );
+
+  it('preserves Money attribution until the Money home screen event', () => {
+    const route = createRoute();
+    const intermediateEvent = createEvent(EVENT_NAME.MONEY_SURFACE_VIEWED, {
+      screen_name: 'money_onboarding',
+      surface_type: 'screen',
+    });
+    const moneyHomeEvent = createEvent(EVENT_NAME.MONEY_SURFACE_VIEWED, {
+      screen_name: 'money_home',
+      surface_type: 'screen',
+    });
+
+    const intermediateResult = enrichWithNavigationAttribution(
+      intermediateEvent,
+      route,
+    );
+    const moneyHomeResult = enrichWithNavigationAttribution(
+      moneyHomeEvent,
+      route,
+    );
+
+    expect(intermediateResult.properties.entry_point).toBeUndefined();
+    expect(moneyHomeResult.properties.entry_point).toBe(
+      'homescreen_balance_breakdown',
+    );
   });
 
   it('consumes attribution after the first matching event', () => {
@@ -62,11 +95,17 @@ describe('navigation analytics attribution', () => {
     const secondRoute = createRoute();
 
     enrichWithNavigationAttribution(
-      createEvent(EVENT_NAME.MONEY_SURFACE_VIEWED),
+      createEvent(EVENT_NAME.MONEY_SURFACE_VIEWED, {
+        screen_name: 'money_home',
+        surface_type: 'screen',
+      }),
       firstRoute,
     );
     const result = enrichWithNavigationAttribution(
-      createEvent(EVENT_NAME.MONEY_SURFACE_VIEWED),
+      createEvent(EVENT_NAME.MONEY_SURFACE_VIEWED, {
+        screen_name: 'money_home',
+        surface_type: 'screen',
+      }),
       secondRoute,
     );
 

--- a/app/util/analytics/navigationAnalyticsAttribution.test.ts
+++ b/app/util/analytics/navigationAnalyticsAttribution.test.ts
@@ -1,0 +1,94 @@
+import { EVENT_NAME } from '../../core/Analytics/MetaMetrics.events';
+import {
+  createNavigationAnalyticsContext,
+  enrichWithNavigationAttribution,
+  NavigationAnalyticsAttribution,
+  resetNavigationAnalyticsAttributionForTests,
+} from './navigationAnalyticsAttribution';
+
+const createRoute = (
+  analyticsContext = createNavigationAnalyticsContext(
+    NavigationAnalyticsAttribution.HomepageBalanceBreakdown,
+  ),
+) => ({
+  key: 'destination-route',
+  name: 'Destination',
+  params: { analyticsContext },
+});
+
+const createEvent = (
+  name: string,
+  properties: Record<string, unknown> = {},
+) => ({
+  name,
+  properties,
+});
+
+describe('navigation analytics attribution', () => {
+  beforeEach(() => {
+    resetNavigationAnalyticsAttributionForTests();
+  });
+
+  it.each([
+    [EVENT_NAME.MONEY_SURFACE_VIEWED, 'entry_point'],
+    [EVENT_NAME.PERPS_SCREEN_VIEWED, 'source'],
+    [EVENT_NAME.POSITION_SCREEN_VIEWED, 'source'],
+  ])('injects the delegated property into %s', (eventName, property) => {
+    const event = createEvent(eventName);
+
+    const result = enrichWithNavigationAttribution(event, createRoute());
+
+    expect(result.properties[property]).toBe('homescreen_balance_breakdown');
+  });
+
+  it('consumes attribution after the first matching event', () => {
+    const route = createRoute();
+
+    const first = enrichWithNavigationAttribution(
+      createEvent(EVENT_NAME.POSITION_SCREEN_VIEWED),
+      route,
+    );
+    const second = enrichWithNavigationAttribution(
+      createEvent(EVENT_NAME.POSITION_SCREEN_VIEWED),
+      route,
+    );
+
+    expect(first.properties.source).toBe('homescreen_balance_breakdown');
+    expect(second.properties.source).toBeUndefined();
+  });
+
+  it('allows a new navigation context to attribute the same reused route', () => {
+    const firstRoute = createRoute();
+    const secondRoute = createRoute();
+
+    enrichWithNavigationAttribution(
+      createEvent(EVENT_NAME.MONEY_SURFACE_VIEWED),
+      firstRoute,
+    );
+    const result = enrichWithNavigationAttribution(
+      createEvent(EVENT_NAME.MONEY_SURFACE_VIEWED),
+      secondRoute,
+    );
+
+    expect(result.properties.entry_point).toBe('homescreen_balance_breakdown');
+  });
+
+  it('preserves an explicit callsite property', () => {
+    const event = createEvent(EVENT_NAME.PERPS_SCREEN_VIEWED, {
+      source: 'explicit_source',
+    });
+
+    const result = enrichWithNavigationAttribution(event, createRoute());
+
+    expect(result).toBe(event);
+    expect(result.properties.source).toBe('explicit_source');
+  });
+
+  it('ignores events outside the attribution allowlist', () => {
+    const event = createEvent(EVENT_NAME.HOME_VIEWED);
+
+    const result = enrichWithNavigationAttribution(event, createRoute());
+
+    expect(result).toBe(event);
+  });
+});

--- a/app/util/analytics/navigationAnalyticsAttribution.ts
+++ b/app/util/analytics/navigationAnalyticsAttribution.ts
@@ -67,6 +67,14 @@ const rememberConsumption = (consumptionKey: string) => {
   }
 };
 
+const getNavigationAnalyticsAttribution = (
+  analyticsContext: NavigationAnalyticsContext,
+  eventName: string,
+): NavigationAttributionMapping | undefined =>
+  NAVIGATION_ATTRIBUTION_MAPPINGS[analyticsContext.attribution]?.find(
+    ({ eventName: mappedEventName }) => mappedEventName === eventName,
+  );
+
 /**
  * Consumes the attribution mapping for one navigation context and event.
  *
@@ -78,9 +86,10 @@ export const consumeNavigationAnalyticsAttribution = (
   analyticsContext: NavigationAnalyticsContext,
   eventName: string,
 ): NavigationAttributionMapping | undefined => {
-  const mapping = NAVIGATION_ATTRIBUTION_MAPPINGS[
-    analyticsContext.attribution
-  ]?.find(({ eventName: mappedEventName }) => mappedEventName === eventName);
+  const mapping = getNavigationAnalyticsAttribution(
+    analyticsContext,
+    eventName,
+  );
   if (!mapping) {
     return undefined;
   }
@@ -110,7 +119,7 @@ export const enrichWithNavigationAttribution = <
     return event;
   }
 
-  const mapping = consumeNavigationAnalyticsAttribution(
+  const mapping = getNavigationAnalyticsAttribution(
     analyticsContext,
     event.name,
   );
@@ -119,6 +128,10 @@ export const enrichWithNavigationAttribution = <
   }
 
   if (event.properties[mapping.property] !== undefined) {
+    return event;
+  }
+
+  if (!consumeNavigationAnalyticsAttribution(analyticsContext, event.name)) {
     return event;
   }
 

--- a/app/util/analytics/navigationAnalyticsAttribution.ts
+++ b/app/util/analytics/navigationAnalyticsAttribution.ts
@@ -21,6 +21,7 @@ export interface NavigationAnalyticsRouteParams {
 interface NavigationAttributionMapping {
   eventName: string;
   property: 'entry_point' | 'source';
+  requiredProperties?: Readonly<Record<string, unknown>>;
 }
 
 const NAVIGATION_ATTRIBUTION_MAPPINGS: Record<
@@ -31,6 +32,10 @@ const NAVIGATION_ATTRIBUTION_MAPPINGS: Record<
     {
       eventName: EVENT_NAME.MONEY_SURFACE_VIEWED,
       property: 'entry_point',
+      requiredProperties: {
+        screen_name: 'money_home',
+        surface_type: 'screen',
+      },
     },
     {
       eventName: EVENT_NAME.PERPS_SCREEN_VIEWED,
@@ -73,6 +78,15 @@ const getNavigationAnalyticsAttribution = (
 ): NavigationAttributionMapping | undefined =>
   NAVIGATION_ATTRIBUTION_MAPPINGS[analyticsContext.attribution]?.find(
     ({ eventName: mappedEventName }) => mappedEventName === eventName,
+  );
+
+const hasRequiredProperties = (
+  mapping: NavigationAttributionMapping,
+  properties: Record<string, unknown>,
+): boolean =>
+  !mapping.requiredProperties ||
+  Object.entries(mapping.requiredProperties).every(
+    ([property, value]) => properties[property] === value,
   );
 
 /**
@@ -124,6 +138,10 @@ export const enrichWithNavigationAttribution = <
     event.name,
   );
   if (!mapping) {
+    return event;
+  }
+
+  if (!hasRequiredProperties(mapping, event.properties)) {
     return event;
   }
 

--- a/app/util/analytics/navigationAnalyticsAttribution.ts
+++ b/app/util/analytics/navigationAnalyticsAttribution.ts
@@ -67,6 +67,33 @@ const rememberConsumption = (consumptionKey: string) => {
   }
 };
 
+/**
+ * Consumes the attribution mapping for one navigation context and event.
+ *
+ * Callers that emit related events from the same property set can use the
+ * returned value before building those events. Later emissions for the same
+ * context and event return `undefined`.
+ */
+export const consumeNavigationAnalyticsAttribution = (
+  analyticsContext: NavigationAnalyticsContext,
+  eventName: string,
+): NavigationAttributionMapping | undefined => {
+  const mapping = NAVIGATION_ATTRIBUTION_MAPPINGS[
+    analyticsContext.attribution
+  ]?.find(({ eventName: mappedEventName }) => mappedEventName === eventName);
+  if (!mapping) {
+    return undefined;
+  }
+
+  const consumptionKey = `${analyticsContext.id}:${eventName}`;
+  if (consumedAttributions.has(consumptionKey)) {
+    return undefined;
+  }
+
+  rememberConsumption(consumptionKey);
+  return mapping;
+};
+
 export const enrichWithNavigationAttribution = <
   T extends {
     name: string;
@@ -83,18 +110,13 @@ export const enrichWithNavigationAttribution = <
     return event;
   }
 
-  const mapping = NAVIGATION_ATTRIBUTION_MAPPINGS[
-    analyticsContext.attribution
-  ]?.find(({ eventName }) => eventName === event.name);
+  const mapping = consumeNavigationAnalyticsAttribution(
+    analyticsContext,
+    event.name,
+  );
   if (!mapping) {
     return event;
   }
-
-  const consumptionKey = `${analyticsContext.id}:${event.name}`;
-  if (consumedAttributions.has(consumptionKey)) {
-    return event;
-  }
-  rememberConsumption(consumptionKey);
 
   if (event.properties[mapping.property] !== undefined) {
     return event;

--- a/app/util/analytics/navigationAnalyticsAttribution.ts
+++ b/app/util/analytics/navigationAnalyticsAttribution.ts
@@ -1,0 +1,117 @@
+import type { Route } from '@react-navigation/native';
+import { EVENT_NAME } from '../../core/Analytics/MetaMetrics.events';
+import NavigationService from '../../core/NavigationService';
+
+export const NavigationAnalyticsAttribution = {
+  HomepageBalanceBreakdown: 'homescreen_balance_breakdown',
+} as const;
+
+export type NavigationAnalyticsAttributionValue =
+  (typeof NavigationAnalyticsAttribution)[keyof typeof NavigationAnalyticsAttribution];
+
+export interface NavigationAnalyticsContext {
+  id: string;
+  attribution: NavigationAnalyticsAttributionValue;
+}
+
+export interface NavigationAnalyticsRouteParams {
+  analyticsContext?: NavigationAnalyticsContext;
+}
+
+interface NavigationAttributionMapping {
+  eventName: string;
+  property: 'entry_point' | 'source';
+}
+
+const NAVIGATION_ATTRIBUTION_MAPPINGS: Record<
+  NavigationAnalyticsAttributionValue,
+  readonly NavigationAttributionMapping[]
+> = {
+  [NavigationAnalyticsAttribution.HomepageBalanceBreakdown]: [
+    {
+      eventName: EVENT_NAME.MONEY_SURFACE_VIEWED,
+      property: 'entry_point',
+    },
+    {
+      eventName: EVENT_NAME.PERPS_SCREEN_VIEWED,
+      property: 'source',
+    },
+    {
+      eventName: EVENT_NAME.POSITION_SCREEN_VIEWED,
+      property: 'source',
+    },
+  ],
+};
+
+const MAX_CONSUMED_ATTRIBUTIONS = 500;
+const consumedAttributions = new Set<string>();
+let contextSequence = 0;
+
+export const createNavigationAnalyticsContext = (
+  attribution: NavigationAnalyticsAttributionValue,
+): NavigationAnalyticsContext => ({
+  id: `${attribution}-${Date.now()}-${contextSequence++}`,
+  attribution,
+});
+
+const getCurrentRoute = (): Route<string> | undefined =>
+  NavigationService.getCurrentRoute();
+
+const rememberConsumption = (consumptionKey: string) => {
+  consumedAttributions.add(consumptionKey);
+  if (consumedAttributions.size > MAX_CONSUMED_ATTRIBUTIONS) {
+    const oldestKey = consumedAttributions.values().next().value;
+    if (oldestKey) {
+      consumedAttributions.delete(oldestKey);
+    }
+  }
+};
+
+export const enrichWithNavigationAttribution = <
+  T extends {
+    name: string;
+    properties: Record<string, unknown>;
+  },
+>(
+  event: T,
+  route: Route<string> | undefined = getCurrentRoute(),
+): T => {
+  const analyticsContext = (
+    route?.params as NavigationAnalyticsRouteParams | undefined
+  )?.analyticsContext;
+  if (!analyticsContext) {
+    return event;
+  }
+
+  const mapping = NAVIGATION_ATTRIBUTION_MAPPINGS[
+    analyticsContext.attribution
+  ]?.find(({ eventName }) => eventName === event.name);
+  if (!mapping) {
+    return event;
+  }
+
+  const consumptionKey = `${analyticsContext.id}:${event.name}`;
+  if (consumedAttributions.has(consumptionKey)) {
+    return event;
+  }
+  rememberConsumption(consumptionKey);
+
+  if (event.properties[mapping.property] !== undefined) {
+    return event;
+  }
+
+  const clonedEvent = Object.create(
+    Object.getPrototypeOf(event),
+    Object.getOwnPropertyDescriptors(event),
+  ) as T;
+  clonedEvent.properties = {
+    ...event.properties,
+    [mapping.property]: analyticsContext.attribution,
+  };
+  return clonedEvent;
+};
+
+export const resetNavigationAnalyticsAttributionForTests = () => {
+  consumedAttributions.clear();
+  contextSequence = 0;
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Homepage balance breakdown destinations previously needed destination-specific props and route cleanup to attribute their first analytics event. This duplicated attribution logic across Money, Perps, Tokens, and DeFi, and made reused navigation routes vulnerable to stale attribution.

This change introduces a navigation-scoped analytics context. Each balance breakdown row tap creates a unique context that travels through route params, including through Money onboarding and Perps redirects. Shared analytics enrichment reads the focused route, injects the allowlisted `entry_point` or `source` property once per context and event, preserves explicit event properties, and bounds consumed-context memory. Destination screens can now emit their normal analytics events without custom source props or cleanup logic.

It also adds a safe `NavigationService.getCurrentRoute()` accessor and unit coverage for attribution injection, one-time consumption, route reuse, explicit-property precedence, navigation forwarding, and destination selection.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: TMCU-1209

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Homepage balance breakdown analytics attribution

  Background:
    Given I am logged into MetaMask Mobile
    And the homepage balance breakdown experiment is set to "icons" or "allocation"
    And analytics events are visible in the analytics debugger

  Scenario Outline: attribute the first destination event
    Given I am on the Wallet home screen

    When user taps the "<row>" balance breakdown row
    Then the "<destination>" screen should open
    And the first "<event>" event should contain "<property>" with value "homescreen_balance_breakdown"
    And a repeated "<event>" event on the same navigation context should not inherit that value

    Examples:
      | row    | destination | event                  | property    |
      | Money  | Money home  | Money Surface Viewed   | entry_point |
      | Perps  | Perps home  | Perp Screen Viewed     | source      |
      | Tokens | Tokens view | Position Screen Viewed | source      |
      | DeFi   | DeFi view   | Position Screen Viewed | source      |

  Scenario: preserve attribution through Money onboarding
    Given Money onboarding has not been completed
    And I am on the Wallet home screen

    When user taps the "Money" balance breakdown row
    And user completes Money onboarding
    Then the Money home screen should open
    And the first "Money Surface Viewed" event should contain "entry_point" with value "homescreen_balance_breakdown"

  Scenario Outline: do not attribute direct destination navigation
    Given I navigate to "<destination>" without using the balance breakdown

    Then the first "<event>" event should not contain "homescreen_balance_breakdown"

    Examples:
      | destination | event                  |
      | Money home  | Money Surface Viewed   |
      | Perps home  | Perp Screen Viewed     |
      | Tokens view | Position Screen Viewed |
      | DeFi view   | Position Screen Viewed |
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared analytics emission path and navigation params across Money, Perps, Tokens, and DeFi. Incorrect consumption or enrichment could mis-attribute events or drop explicit source properties.
> 
> **Overview**
> Centralizes homepage balance-breakdown attribution so destination screens no longer take custom `source`/`entryPoint` props or clean up stale route params.
> 
> Each breakdown row tap now creates a unique `analyticsContext` that travels through Money onboarding, Perps tutorial redirects, and full-view routes. Shared `enrichWithNavigationAttribution` reads the focused route and injects allowlisted `entry_point` or `source` **once** per context/event, leaving explicit caller properties alone.
> 
> Perps still applies the same source on companion Asset Viewed events via `usePerpsEventTracking`. Tokens/DeFi/Money home drop destination-side attribution plumbing. `NavigationService.getCurrentRoute()` is a non-throwing accessor for this enrichment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c162dc0fe3309ef9b2fe2fd89310bc5b1835f22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->