### PR TITLE
fix(swaps): set 8px spacing for slippage error row

### DIFF
--- a/app/components/UI/Bridge/components/InputStepper/InputStepperDescriptionRow.tsx
+++ b/app/components/UI/Bridge/components/InputStepper/InputStepperDescriptionRow.tsx
@@ -26,7 +26,7 @@ export const InputStepperDescriptionRow = ({
       testID="input-stepper-description-row"
     >
       {description.icon && (
-        <View>
+        <View style={inputStepperDescriptionRow.iconWrapper}>
           <Icon
             testID="input-stepper-description-icon"
             name={description.icon.name}

--- a/app/components/UI/Bridge/components/InputStepper/styles.tsx
+++ b/app/components/UI/Bridge/components/InputStepper/styles.tsx
@@ -40,11 +40,16 @@ export const inputStepperStyles = ({
 export const inputStepperDescriptionRow = StyleSheet.create({
   descriptionRow: {
     flexDirection: 'row',
-    width: '75%',
-    marginHorizontal: 'auto',
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  iconWrapper: {
+    // Matches the design requirement: 8px gap between the warning icon and text.
+    marginRight: 8,
   },
   descriptionTextWrapper: {
-    flex: 1,
+    flexShrink: 1,
   },
   descriptionText: {
     textAlign: 'center',


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

The slippage custom bottom sheet showed the warning/error icon too far from the validation message (for example, "Enter a value …"), making the row feel misaligned and cramped.

This change updates `InputStepperDescriptionRow` layout so the icon and message sit together with an **8px horizontal gap**, and the full icon+text group is **center-aligned** in the sheet. Specifically:

- Added `iconWrapper` with `marginRight: 8` between the icon and description text
- Set the description row to `width: '100%'` with `justifyContent: 'center'` and `alignItems: 'center'`
- Changed the text wrapper from `flex: 1` to `flexShrink: 1` so centering treats icon and text as one unit

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed slippage custom settings error message spacing in Swaps

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: UI polish — no linked GitHub issue

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Swaps slippage custom settings error layout

  Scenario: user sees centered slippage validation error with 8px icon gap
    Given I am logged into MetaMask Mobile on a network that supports Swaps
    And I open the Swaps flow
    And I tap the settings (cog) icon
    And I open the Slippage bottom sheet
    And I select the Custom slippage option

    When I clear the custom slippage input or enter an invalid value
    Then the warning/error icon and validation message appear on the same row
    And the horizontal gap between the icon and message is 8px
    And the icon and message group is centered in the bottom sheet
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — screenshots attached in the PR thread, not committed to the repo.

### **After**

N/A — screenshots attached in the PR thread, not committed to the repo.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only styling in a shared Bridge InputStepper description row; no logic, data, or security impact.
> 
> **Overview**
> **InputStepper** description rows (including Swaps custom slippage validation) now lay out the warning icon and message as a single centered group instead of a wide, misaligned row.
> 
> The description row goes from **75% width** with horizontal auto margins to **full width** with `alignItems` / `justifyContent` **center**. An **`iconWrapper`** adds **8px** `marginRight` between icon and text, and the text container switches from **`flex: 1`** to **`flexShrink: 1`** so the icon+text block centers together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cc33d9f8c472eda125562a0bcda9933bd7b0aab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->