### PR TITLE
fix(money): match Get card and Link card thumbnail size (MUSD-1295)

### DIFF
--- a/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.test.tsx
+++ b/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.test.tsx
@@ -676,7 +676,7 @@ describe('MoneyMetaMaskCard', () => {
       expect(mockTiltAnimationCalls).toEqual([{ isMetalCard: false }]);
     });
 
-    it('renders the tilt animation in link mode, sized for the link layout', () => {
+    it('leaves the link row on the default thumbnail size', () => {
       const { getByTestId } = render(
         <MoneyMetaMaskCard mode="link" onGetNowPress={jest.fn()} />,
       );
@@ -687,8 +687,8 @@ describe('MoneyMetaMaskCard', () => {
       expect(mockTiltAnimationProps).toEqual([
         {
           isMetalCard: false,
-          width: 111,
-          height: 70,
+          width: undefined,
+          height: undefined,
           testID: MoneyMetaMaskCardTestIds.LINK_CARD_IMAGE,
         },
       ]);
@@ -749,6 +749,33 @@ describe('MoneyMetaMaskCard', () => {
           testID: undefined,
         },
       ]);
+    });
+
+    it('renders the same thumbnail size in upsell, link and manage modes', () => {
+      const sizeFor = (element: React.ReactElement) => {
+        mockTiltAnimationProps.length = 0;
+        render(element);
+        const { width, height } = mockTiltAnimationProps[0];
+        return { width, height };
+      };
+
+      const upsellSize = sizeFor(
+        <MoneyMetaMaskCard onGetNowPress={jest.fn()} />,
+      );
+      const linkSize = sizeFor(
+        <MoneyMetaMaskCard mode="link" onGetNowPress={jest.fn()} />,
+      );
+      const manageSize = sizeFor(
+        <MoneyMetaMaskCard
+          mode="manage"
+          onGetNowPress={jest.fn()}
+          onManagePress={jest.fn()}
+          cardBalance="$0.00"
+        />,
+      );
+
+      expect(linkSize).toEqual(upsellSize);
+      expect(manageSize).toEqual(upsellSize);
     });
 
     it('does not render the tilt animation in verifying mode', () => {

--- a/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.tsx
+++ b/app/components/UI/Money/components/MoneyMetaMaskCard/MoneyMetaMaskCard.tsx
@@ -38,11 +38,6 @@ import {
 
 import { FLAT_BANNER_ALERT_STYLE } from '../../../shared/flatBannerAlertStyle';
 
-// The link layout gives the card slightly more room than the upsell and manage
-// rows, which use the component's default thumbnail size.
-const LINK_CARD_WIDTH = 111;
-const LINK_CARD_HEIGHT = 70;
-
 interface MoneyMetaMaskCardProps {
   /**
    * 'upsell' (default): virtual/metal card rows.
@@ -222,8 +217,6 @@ const LinkContent = ({
         >
           <MoneyCardTiltAnimation
             isMetalCard={showMetalCard}
-            width={LINK_CARD_WIDTH}
-            height={LINK_CARD_HEIGHT}
             testID={MoneyMetaMaskCardTestIds.LINK_CARD_IMAGE}
           />
           <Box twClassName="gap-2 flex-1 justify-center">


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The MetaMask card thumbnail on Money home renders at the same size in every state: the Get card (upsell) row, the Link card module, and the Manage row all use `MoneyCardTiltAnimation`'s default 104 × 66 thumbnail.

Bug: the Link card module passed an explicit `111 × 70` override while the upsell and manage rows fell through to the component default, so the card visibly changed size when moving between the unauthenticated (Get card) and cardholder-unlinked (Link card) states. The override was introduced in #34459 to give the link layout slightly more room; that extra room is not worth the inconsistency.

The fix drops the `LINK_CARD_WIDTH` / `LINK_CARD_HEIGHT` constants and the two props at the link-mode call site, so all three rows share one size. The freed 7pt of width goes to the adjacent `flex-1` bullet column. `Fit.Contain` keeps the card art's aspect ratio unchanged. Card Home is unaffected — it renders link mode with `hideCardImage`.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the MetaMask card thumbnail rendering at a different size in the Get card and Link card modules on Money home

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1295](https://consensyssoftware.atlassian.net/browse/MUSD-1295)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: MetaMask card thumbnail sizing on Money home

  Scenario: user without a MetaMask card sees the Get card module
    Given the user has a Money account and no MetaMask card
    When user opens Money home
    Then the Get card module shows the card thumbnail at 104 x 66

  Scenario: cardholder with an unlinked card sees the Link card module
    Given the user holds a MetaMask card that is not linked to the Money account
    When user opens Money home
    Then the Link card module shows the card thumbnail at 104 x 66
    And the thumbnail is the same size as in the Get card module

  Scenario: cardholder with a linked card sees the Manage module
    Given the user holds a MetaMask card linked to the Money account
    When user opens Money home
    Then the Manage module shows the card thumbnail at the same size as the other two modules
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — pending device capture. Link card thumbnail rendered at 111 × 70 against 104 × 66 in the Get card module.

### **After**
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-19 at 15 47 07" src="https://github.com/user-attachments/assets/051e5d24-8f49-4fc3-91ba-cf5c237e9a72" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-19 at 14 48 12" src="https://github.com/user-attachments/assets/6260312b-ba58-48d0-ae9e-99e49d86c10c" />

<!-- [screenshots/recordings] -->

N/A — pending device capture. All Money home card thumbnails render at 104 × 66.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-1295]: https://consensyssoftware.atlassian.net/browse/MUSD-1295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Money home UI sizing with no auth, data, or API changes; behavior is covered by unit tests.
> 
> **Overview**
> **Unifies the MetaMask card thumbnail size** on Money home so Get card (upsell), Link card, and Manage rows all use `MoneyCardTiltAnimation`'s default **104 × 66** instead of link mode overriding to **111 × 70**.
> 
> The change removes `LINK_CARD_WIDTH` / `LINK_CARD_HEIGHT` and stops passing `width` / `height` on the link-layout `MoneyCardTiltAnimation`. Tests now assert link mode passes `undefined` dimensions and add coverage that upsell, link, and manage share the same thumbnail props.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e490cf9e0ebe0c7e17c3097ecdd5eae1b2f98b8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->