### PR TITLE
refactor: extract composable swaps banner components

### DIFF
--- a/app/components/UI/Bridge/components/SwapsBanners/SwapsBanners.constants.ts
+++ b/app/components/UI/Bridge/components/SwapsBanners/SwapsBanners.constants.ts
@@ -1,0 +1,4 @@
+export const ERROR_BANNER_TW_CLASSNAME =
+  'border-l-4 border-error-default bg-error-muted pl-2';
+export const WARNING_BANNER_TW_CLASSNAME =
+  'border-l-4 border-warning-default bg-warning-muted pl-2';

--- a/app/components/UI/Bridge/components/SwapsBanners/SwapsBanners.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsBanners/SwapsBanners.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { MetaMetricsSwapsEventSource } from '@metamask/bridge-controller';
+import { BigNumber } from 'ethers';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import { createBridgeTestState, createMockToken } from '../../testUtils';
+import { SwapsBanners } from './SwapsBanners';
+import { SwapsBannersSelectorsIDs } from './SwapsBanners.testIds';
+import { useSwapsBannersContext } from './SwapsBannersContext';
+
+const sourceToken = createMockToken({
+  address: '0x0000000000000000000000000000000000000000',
+  symbol: 'ETH',
+});
+const destToken = createMockToken({ address: '0xdest', symbol: 'USDC' });
+
+const state = createBridgeTestState({
+  bridgeReducerOverrides: { sourceAmount: '1.5', sourceToken, destToken },
+});
+
+const ContextProbe = () => {
+  const context = useSwapsBannersContext();
+
+  return <Text testID="context-probe">{JSON.stringify(context)}</Text>;
+};
+
+const mockOnAdjustSourceAmount = jest.fn();
+
+describe('SwapsBanners', () => {
+  it('lays out the banners the order type composes', () => {
+    const { getByTestId, getByText } = renderWithProvider(
+      <SwapsBanners onAdjustSourceAmount={mockOnAdjustSourceAmount}>
+        <Text>first banner</Text>
+        <Text>second banner</Text>
+      </SwapsBanners>,
+      { state },
+    );
+
+    expect(getByTestId(SwapsBannersSelectorsIDs.CONTAINER)).toBeOnTheScreen();
+    expect(getByText('first banner')).toBeOnTheScreen();
+    expect(getByText('second banner')).toBeOnTheScreen();
+  });
+
+  it('shares the swap being quoted with the banners', () => {
+    const { getByTestId } = renderWithProvider(
+      <SwapsBanners
+        latestSourceAtomicBalance={BigNumber.from('1000')}
+        location={MetaMetricsSwapsEventSource.TokenView}
+        onAdjustSourceAmount={mockOnAdjustSourceAmount}
+      >
+        <ContextProbe />
+      </SwapsBanners>,
+      { state },
+    );
+
+    const context = JSON.parse(getByTestId('context-probe').props.children);
+
+    expect(context).toEqual(
+      expect.objectContaining({
+        sourceAmount: '1.5',
+        sourceToken: expect.objectContaining({ symbol: 'ETH' }),
+        destToken: expect.objectContaining({ symbol: 'USDC' }),
+        location: MetaMetricsSwapsEventSource.TokenView,
+      }),
+    );
+  });
+
+  it('reports the main view to analytics unless the order type says otherwise', () => {
+    const { getByTestId } = renderWithProvider(
+      <SwapsBanners onAdjustSourceAmount={mockOnAdjustSourceAmount}>
+        <ContextProbe />
+      </SwapsBanners>,
+      { state },
+    );
+
+    const context = JSON.parse(getByTestId('context-probe').props.children);
+
+    expect(context.location).toBe(MetaMetricsSwapsEventSource.MainView);
+  });
+
+  it('tells the engineer when a banner is rendered outside the container', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    expect(() => renderWithProvider(<ContextProbe />, { state })).toThrow(
+      'useSwapsBannersContext must be used within SwapsBannersProvider',
+    );
+  });
+});

--- a/app/components/UI/Bridge/components/SwapsBanners/SwapsBanners.testIds.ts
+++ b/app/components/UI/Bridge/components/SwapsBanners/SwapsBanners.testIds.ts
@@ -1,0 +1,13 @@
+import { BridgeViewSelectorsIDs } from '../../Views/BridgeView/BridgeView.testIds';
+
+export const SwapsBannersSelectorsIDs = {
+  CONTAINER: 'swaps-banners',
+  // The quote error and missing price banners keep the Market view IDs so
+  // existing E2E selectors still match once that view renders this component.
+  QUOTE_ERROR: BridgeViewSelectorsIDs.NO_QUOTES_BANNER,
+  MISSING_PRICE: BridgeViewSelectorsIDs.MISSING_PRICE_BANNER,
+  TOKEN_WARNING: 'swaps-banners-token-warning',
+  INSUFFICIENT_NATIVE_RESERVE: 'swaps-banners-insufficient-native-reserve',
+  HARDWARE_WALLET_UNSUPPORTED: 'swaps-banners-hardware-wallet-unsupported',
+  BLOCKAID_ERROR: 'swaps-banners-blockaid-error',
+} as const;

--- a/app/components/UI/Bridge/components/SwapsBanners/SwapsBanners.tsx
+++ b/app/components/UI/Bridge/components/SwapsBanners/SwapsBanners.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Box } from '@metamask/design-system-react-native';
+import { SwapsBannersSelectorsIDs } from './SwapsBanners.testIds';
+import { SwapsBannersProvider } from './SwapsBannersContext';
+import type { SwapsBannersProps } from './SwapsBanners.types';
+
+/**
+ * Lays out the warning and error banners an order type composes, and shares the
+ * swap being quoted with them. Banners read the active quote, so this must be
+ * rendered within a `BridgeQuoteDataProvider`.
+ *
+ * Each banner decides on its own whether it applies, so an order type only has
+ * to list the ones it wants:
+ *
+ * ```tsx
+ * <SwapsBanners onAdjustSourceAmount={handleAmountChange}>
+ *   <QuoteErrorBanner />
+ *   <TokenWarningBanner />
+ * </SwapsBanners>
+ * ```
+ */
+export const SwapsBanners = ({
+  children,
+  latestSourceAtomicBalance,
+  location,
+  onAdjustSourceAmount,
+}: SwapsBannersProps) => (
+  <SwapsBannersProvider
+    latestSourceAtomicBalance={latestSourceAtomicBalance}
+    location={location}
+    onAdjustSourceAmount={onAdjustSourceAmount}
+  >
+    <Box gap={3} twClassName="mx-4" testID={SwapsBannersSelectorsIDs.CONTAINER}>
+      {children}
+    </Box>
+  </SwapsBannersProvider>
+);

--- a/app/components/UI/Bridge/components/SwapsBanners/SwapsBanners.types.ts
+++ b/app/components/UI/Bridge/components/SwapsBanners/SwapsBanners.types.ts
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react';
+import type { MetaMetricsSwapsEventSource } from '@metamask/bridge-controller';
+import type { BigNumber } from 'ethers';
+import type { BridgeToken } from '../../types';
+
+export interface SwapsBannersProps {
+  /**
+   * The banners to show, in the order the order type wants them.
+   */
+  children: ReactNode;
+  /**
+   * Source token balance in atomic units, used to work out whether the entered
+   * amount would eat into the native balance kept in reserve for gas.
+   */
+  latestSourceAtomicBalance?: BigNumber;
+  /**
+   * Entry point reported to analytics when a banner opens a modal.
+   */
+  location?: MetaMetricsSwapsEventSource;
+  /**
+   * Called with a new source amount when a banner offers to correct the amount.
+   * Must be referentially stable, otherwise every banner re-renders whenever the
+   * hosting screen does.
+   */
+  onAdjustSourceAmount: (amount: string) => void;
+}
+
+export type SwapsBannersProviderProps = SwapsBannersProps;
+
+/**
+ * The swap the banners describe, plus the callbacks the hosting screen owns.
+ * Banner specific state (quote errors, token security, native reserve) is
+ * derived by each banner instead, so composing a banner is enough to opt into
+ * the work it does.
+ */
+export interface SwapsBannersContextValue {
+  sourceAmount?: string;
+  sourceToken?: BridgeToken;
+  destToken?: BridgeToken;
+  walletAddress?: string;
+  latestSourceAtomicBalance?: BigNumber;
+  location: MetaMetricsSwapsEventSource;
+  onAdjustSourceAmount: (amount: string) => void;
+}

--- a/app/components/UI/Bridge/components/SwapsBanners/SwapsBannersContext.tsx
+++ b/app/components/UI/Bridge/components/SwapsBanners/SwapsBannersContext.tsx
@@ -1,0 +1,68 @@
+import React, { createContext, useContext, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { MetaMetricsSwapsEventSource } from '@metamask/bridge-controller';
+import {
+  selectDestToken,
+  selectSourceAmount,
+  selectSourceToken,
+} from '../../../../../core/redux/slices/bridge';
+import { selectSourceWalletAddress } from '../../../../../selectors/bridge';
+import type {
+  SwapsBannersContextValue,
+  SwapsBannersProviderProps,
+} from './SwapsBanners.types';
+
+const SwapsBannersContext = createContext<SwapsBannersContextValue | null>(
+  null,
+);
+
+export function SwapsBannersProvider({
+  children,
+  latestSourceAtomicBalance,
+  location = MetaMetricsSwapsEventSource.MainView,
+  onAdjustSourceAmount,
+}: SwapsBannersProviderProps) {
+  const sourceAmount = useSelector(selectSourceAmount);
+  const sourceToken = useSelector(selectSourceToken);
+  const destToken = useSelector(selectDestToken);
+  const walletAddress = useSelector(selectSourceWalletAddress);
+
+  const value = useMemo(
+    () => ({
+      sourceAmount,
+      sourceToken,
+      destToken,
+      walletAddress,
+      latestSourceAtomicBalance,
+      location,
+      onAdjustSourceAmount,
+    }),
+    [
+      sourceAmount,
+      sourceToken,
+      destToken,
+      walletAddress,
+      latestSourceAtomicBalance,
+      location,
+      onAdjustSourceAmount,
+    ],
+  );
+
+  return (
+    <SwapsBannersContext.Provider value={value}>
+      {children}
+    </SwapsBannersContext.Provider>
+  );
+}
+
+export function useSwapsBannersContext(): SwapsBannersContextValue {
+  const context = useContext(SwapsBannersContext);
+
+  if (!context) {
+    throw new Error(
+      'useSwapsBannersContext must be used within SwapsBannersProvider',
+    );
+  }
+
+  return context;
+}

--- a/app/components/UI/Bridge/components/SwapsBanners/banners/BlockaidErrorBanner.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsBanners/banners/BlockaidErrorBanner.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { strings } from '../../../../../../../locales/i18n';
+import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import { useBridgeQuoteDataContext } from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
+import { SwapsBannersSelectorsIDs } from '../SwapsBanners.testIds';
+import { BlockaidErrorBanner } from './BlockaidErrorBanner';
+import { createBannerState } from './testUtils';
+
+jest.mock('../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => ({
+  useBridgeQuoteDataContext: jest.fn(),
+}));
+
+type QuoteContextValue = ReturnType<typeof useBridgeQuoteDataContext>;
+
+const setQuoteData = (overrides: Partial<QuoteContextValue> = {}) => {
+  jest.mocked(useBridgeQuoteDataContext).mockReturnValue({
+    blockaidError: null,
+    ...overrides,
+  } as unknown as QuoteContextValue);
+};
+
+// Rendered next to the confirm button rather than in the banner stack, so it
+// works without the SwapsBanners container.
+const renderBlockaidErrorBanner = () =>
+  renderWithProvider(<BlockaidErrorBanner />, { state: createBannerState() });
+
+describe('BlockaidErrorBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setQuoteData();
+  });
+
+  it('reports the security risk found in the transaction', () => {
+    setQuoteData({ blockaidError: 'This transaction may be a security risk' });
+
+    const { getByText } = renderBlockaidErrorBanner();
+
+    expect(getByText(strings('bridge.blockaid_error_title'))).toBeOnTheScreen();
+    expect(
+      getByText('This transaction may be a security risk'),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders nothing when the transaction raises no security risk', () => {
+    const { queryByTestId } = renderBlockaidErrorBanner();
+
+    expect(queryByTestId(SwapsBannersSelectorsIDs.BLOCKAID_ERROR)).toBeNull();
+  });
+});

--- a/app/components/UI/Bridge/components/SwapsBanners/banners/BlockaidErrorBanner.tsx
+++ b/app/components/UI/Bridge/components/SwapsBanners/banners/BlockaidErrorBanner.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import {
+  BannerAlert,
+  BannerAlertSeverity,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import { useBridgeQuoteDataContext } from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
+import { SwapsBannersSelectorsIDs } from '../SwapsBanners.testIds';
+
+/**
+ * Surfaces the security risk the transaction security check found in the quote.
+ */
+export const BlockaidErrorBanner = () => {
+  const { blockaidError } = useBridgeQuoteDataContext();
+
+  if (!blockaidError) {
+    return null;
+  }
+
+  return (
+    <BannerAlert
+      severity={BannerAlertSeverity.Danger}
+      title={strings('bridge.blockaid_error_title')}
+      description={blockaidError}
+      testID={SwapsBannersSelectorsIDs.BLOCKAID_ERROR}
+    />
+  );
+};

--- a/app/components/UI/Bridge/components/SwapsBanners/banners/HardwareWalletSolanaSignUnsupportedBanner.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsBanners/banners/HardwareWalletSolanaSignUnsupportedBanner.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { SolScope } from '@metamask/keyring-api';
+import type { Hex } from '@metamask/utils';
+import { strings } from '../../../../../../../locales/i18n';
+import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import { selectSelectedInternalAccountFormattedAddress } from '../../../../../../selectors/accountsController';
+import { isHardwareAccount } from '../../../../../../util/address';
+import { createBridgeTestState } from '../../../testUtils';
+import type { BridgeToken } from '../../../types';
+import { SwapsBannersSelectorsIDs } from '../SwapsBanners.testIds';
+import { HardwareWalletSolanaSignUnsupportedBanner } from './HardwareWalletSolanaSignUnsupportedBanner';
+
+jest.mock('../../../../../../util/address', () => ({
+  ...jest.requireActual('../../../../../../util/address'),
+  isHardwareAccount: jest.fn(),
+}));
+
+jest.mock('../../../../../../selectors/accountsController', () => ({
+  ...jest.requireActual('../../../../../../selectors/accountsController'),
+  selectSelectedInternalAccountFormattedAddress: jest.fn(),
+}));
+
+const solanaToken: BridgeToken = {
+  address: 'So11111111111111111111111111111111111111112',
+  chainId: SolScope.Mainnet,
+  decimals: 9,
+  image: '',
+  name: 'Solana',
+  symbol: 'SOL',
+};
+
+const ethereumToken: BridgeToken = {
+  address: '0x0000000000000000000000000000000000000000',
+  chainId: '0x1' as Hex,
+  decimals: 18,
+  image: '',
+  name: 'Ether',
+  symbol: 'ETH',
+};
+
+// Rendered next to the confirm button rather than in the banner stack, so it
+// works without the SwapsBanners container.
+const renderHardwareWalletBanner = (sourceToken: BridgeToken) =>
+  renderWithProvider(<HardwareWalletSolanaSignUnsupportedBanner />, {
+    state: createBridgeTestState({
+      bridgeReducerOverrides: { sourceAmount: '1', sourceToken },
+    }),
+  });
+
+describe('HardwareWalletSolanaSignUnsupportedBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest
+      .mocked(selectSelectedInternalAccountFormattedAddress)
+      .mockReturnValue('0x1234567890123456789012345678901234567890');
+  });
+
+  it('tells hardware wallet users that Solana swaps are unsupported', () => {
+    jest.mocked(isHardwareAccount).mockReturnValue(true);
+
+    const { getByText } = renderHardwareWalletBanner(solanaToken);
+
+    expect(
+      getByText(strings('bridge.hardware_wallet_not_supported_solana')),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders nothing for a software account swapping from Solana', () => {
+    jest.mocked(isHardwareAccount).mockReturnValue(false);
+
+    const { queryByTestId } = renderHardwareWalletBanner(solanaToken);
+
+    expect(
+      queryByTestId(SwapsBannersSelectorsIDs.HARDWARE_WALLET_UNSUPPORTED),
+    ).toBeNull();
+  });
+
+  it('renders nothing for a hardware wallet swapping from an EVM chain', () => {
+    jest.mocked(isHardwareAccount).mockReturnValue(true);
+
+    const { queryByTestId } = renderHardwareWalletBanner(ethereumToken);
+
+    expect(
+      queryByTestId(SwapsBannersSelectorsIDs.HARDWARE_WALLET_UNSUPPORTED),
+    ).toBeNull();
+  });
+
+  it('renders nothing while no account is selected', () => {
+    jest
+      .mocked(selectSelectedInternalAccountFormattedAddress)
+      .mockReturnValue(undefined);
+
+    const { queryByTestId } = renderHardwareWalletBanner(solanaToken);
+
+    expect(
+      queryByTestId(SwapsBannersSelectorsIDs.HARDWARE_WALLET_UNSUPPORTED),
+    ).toBeNull();
+  });
+});

--- a/app/components/UI/Bridge/components/SwapsBanners/banners/HardwareWalletSolanaSignUnsupportedBanner.tsx
+++ b/app/components/UI/Bridge/components/SwapsBanners/banners/HardwareWalletSolanaSignUnsupportedBanner.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import {
+  BannerAlert,
+  BannerAlertSeverity,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import { selectIsSolanaSourced } from '../../../../../../core/redux/slices/bridge';
+import { selectSelectedInternalAccountFormattedAddress } from '../../../../../../selectors/accountsController';
+import { isHardwareAccount } from '../../../../../../util/address';
+import { SwapsBannersSelectorsIDs } from '../SwapsBanners.testIds';
+
+/**
+ * Tells the user that hardware wallets cannot sign the Solana swap they set up.
+ */
+export const HardwareWalletSolanaSignUnsupportedBanner = () => {
+  const selectedAddress = useSelector(
+    selectSelectedInternalAccountFormattedAddress,
+  );
+  const isSolanaSourced = useSelector(selectIsSolanaSourced);
+
+  const isHardwareAddress = selectedAddress
+    ? Boolean(isHardwareAccount(selectedAddress))
+    : false;
+
+  if (!isHardwareAddress || !isSolanaSourced) {
+    return null;
+  }
+
+  return (
+    <BannerAlert
+      severity={BannerAlertSeverity.Danger}
+      description={strings('bridge.hardware_wallet_not_supported_solana')}
+      testID={SwapsBannersSelectorsIDs.HARDWARE_WALLET_UNSUPPORTED}
+    />
+  );
+};

--- a/app/components/UI/Bridge/components/SwapsBanners/banners/InsufficientNativeReserveBanner.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsBanners/banners/InsufficientNativeReserveBanner.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import { useBridgeQuoteDataContext } from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
+import useIsInsufficientBalance from '../../../hooks/useInsufficientBalance';
+import { useInsufficientNativeReserveError } from '../../../hooks/useInsufficientNativeReserveError';
+import { SwapsBannersSelectorsIDs } from '../SwapsBanners.testIds';
+import { InsufficientNativeReserveBanner } from './InsufficientNativeReserveBanner';
+import { renderBanner } from './testUtils';
+
+jest.mock('../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => ({
+  useBridgeQuoteDataContext: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useInsufficientBalance', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useInsufficientNativeReserveError', () => ({
+  useInsufficientNativeReserveError: jest.fn(),
+}));
+
+describe('InsufficientNativeReserveBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useBridgeQuoteDataContext).mockReturnValue({
+      activeQuote: undefined,
+      quoteFetchError: null,
+    } as unknown as ReturnType<typeof useBridgeQuoteDataContext>);
+    jest.mocked(useIsInsufficientBalance).mockReturnValue(false);
+    jest.mocked(useInsufficientNativeReserveError).mockReturnValue({
+      minimumNativeBalanceToBeKeptInAccount: '10',
+      maxSwappableNativeBalance: '5',
+    });
+  });
+
+  it('offers to lower the amount to the maximum swappable balance', () => {
+    const onAdjustSourceAmount = jest.fn();
+
+    const { getByText } = renderBanner(<InsufficientNativeReserveBanner />, {
+      onAdjustSourceAmount,
+    });
+
+    fireEvent.press(
+      getByText(strings('bridge.insufficient_native_reserve_cta')),
+    );
+
+    expect(onAdjustSourceAmount).toHaveBeenCalledWith('5');
+  });
+
+  it('gives way to the insufficient balance state', () => {
+    jest.mocked(useIsInsufficientBalance).mockReturnValue(true);
+
+    const { queryByTestId } = renderBanner(<InsufficientNativeReserveBanner />);
+
+    expect(
+      queryByTestId(SwapsBannersSelectorsIDs.INSUFFICIENT_NATIVE_RESERVE),
+    ).toBeNull();
+  });
+
+  it('renders nothing when the amount leaves the reserve untouched', () => {
+    jest.mocked(useInsufficientNativeReserveError).mockReturnValue(undefined);
+
+    const { queryByTestId } = renderBanner(<InsufficientNativeReserveBanner />);
+
+    expect(
+      queryByTestId(SwapsBannersSelectorsIDs.INSUFFICIENT_NATIVE_RESERVE),
+    ).toBeNull();
+  });
+});

--- a/app/components/UI/Bridge/components/SwapsBanners/banners/InsufficientNativeReserveBanner.tsx
+++ b/app/components/UI/Bridge/components/SwapsBanners/banners/InsufficientNativeReserveBanner.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {
+  BannerBase,
+  ButtonSize,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import { useBridgeQuoteDataContext } from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
+import useIsInsufficientBalance from '../../../hooks/useInsufficientBalance';
+import { useInsufficientNativeReserveError } from '../../../hooks/useInsufficientNativeReserveError';
+import { WARNING_BANNER_TW_CLASSNAME } from '../SwapsBanners.constants';
+import { SwapsBannersSelectorsIDs } from '../SwapsBanners.testIds';
+import { useSwapsBannersContext } from '../SwapsBannersContext';
+
+/**
+ * Warns when the entered amount would spend the native balance that has to stay
+ * in the account, and offers to lower it to the maximum swappable amount.
+ */
+export const InsufficientNativeReserveBanner = () => {
+  const {
+    sourceAmount,
+    sourceToken,
+    walletAddress,
+    latestSourceAtomicBalance,
+    onAdjustSourceAmount,
+  } = useSwapsBannersContext();
+  const { activeQuote } = useBridgeQuoteDataContext();
+
+  const hasInsufficientBalance = useIsInsufficientBalance({
+    amount: sourceAmount,
+    token: sourceToken,
+    latestAtomicBalance: latestSourceAtomicBalance,
+  });
+
+  const insufficientNativeReserveError = useInsufficientNativeReserveError({
+    amount: sourceAmount,
+    token: sourceToken,
+    latestAtomicBalance: latestSourceAtomicBalance,
+    walletAddress,
+    activeQuote,
+  });
+
+  if (!insufficientNativeReserveError || hasInsufficientBalance) {
+    return null;
+  }
+
+  const { maxSwappableNativeBalance, minimumNativeBalanceToBeKeptInAccount } =
+    insufficientNativeReserveError;
+
+  return (
+    <BannerBase
+      testID={SwapsBannersSelectorsIDs.INSUFFICIENT_NATIVE_RESERVE}
+      twClassName={WARNING_BANNER_TW_CLASSNAME}
+      startAccessory={
+        <Icon
+          name={IconName.Warning}
+          color={IconColor.WarningDefault}
+          size={IconSize.Lg}
+        />
+      }
+      title={strings('bridge.insufficient_native_reserve_title', {
+        ticker: sourceToken?.symbol,
+      })}
+      description={strings('bridge.insufficient_native_reserve_message', {
+        ticker: sourceToken?.symbol,
+        minimumReserve: minimumNativeBalanceToBeKeptInAccount,
+        maxSwappable: maxSwappableNativeBalance,
+      })}
+      actionButtonLabel={strings('bridge.insufficient_native_reserve_cta')}
+      actionButtonOnPress={() =>
+        onAdjustSourceAmount(maxSwappableNativeBalance)
+      }
+      actionButtonProps={{
+        size: ButtonSize.Sm,
+        twClassName: 'mt-1.5',
+      }}
+    />
+  );
+};

--- a/app/components/UI/Bridge/components/SwapsBanners/banners/MissingPriceDataBanner.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsBanners/banners/MissingPriceDataBanner.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { useBridgeQuoteDataContext } from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
+import { SwapsBannersSelectorsIDs } from '../SwapsBanners.testIds';
+import { MissingPriceDataBanner } from './MissingPriceDataBanner';
+import { createBannerState, renderBanner } from './testUtils';
+
+jest.mock('../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => ({
+  useBridgeQuoteDataContext: jest.fn(),
+}));
+
+type QuoteContextValue = ReturnType<typeof useBridgeQuoteDataContext>;
+
+const setQuoteData = (overrides: Partial<QuoteContextValue> = {}) => {
+  jest.mocked(useBridgeQuoteDataContext).mockReturnValue({
+    activeQuote: undefined,
+    quoteFetchError: null,
+    ...overrides,
+  } as unknown as QuoteContextValue);
+};
+
+describe('MissingPriceDataBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setQuoteData();
+  });
+
+  it('is shown when the active quote has no price impact data', () => {
+    setQuoteData({
+      activeQuote: { quote: {} } as QuoteContextValue['activeQuote'],
+    });
+
+    const { getByTestId } = renderBanner(<MissingPriceDataBanner />);
+
+    expect(
+      getByTestId(SwapsBannersSelectorsIDs.MISSING_PRICE),
+    ).toBeOnTheScreen();
+  });
+
+  it('is hidden while no amount has been entered', () => {
+    setQuoteData({
+      activeQuote: { quote: {} } as QuoteContextValue['activeQuote'],
+    });
+
+    const { queryByTestId } = renderBanner(<MissingPriceDataBanner />, {
+      state: createBannerState({ sourceAmount: '0' }),
+    });
+
+    expect(queryByTestId(SwapsBannersSelectorsIDs.MISSING_PRICE)).toBeNull();
+  });
+
+  it('is hidden when the quote carries price impact data', () => {
+    setQuoteData({
+      activeQuote: {
+        quote: { priceData: { priceImpact: { amount: '0.01' } } },
+      } as QuoteContextValue['activeQuote'],
+    });
+
+    const { queryByTestId } = renderBanner(<MissingPriceDataBanner />);
+
+    expect(queryByTestId(SwapsBannersSelectorsIDs.MISSING_PRICE)).toBeNull();
+  });
+});

--- a/app/components/UI/Bridge/components/SwapsBanners/banners/MissingPriceDataBanner.tsx
+++ b/app/components/UI/Bridge/components/SwapsBanners/banners/MissingPriceDataBanner.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import {
+  BannerAlert,
+  BannerAlertSeverity,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import { useBridgeQuoteDataContext } from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
+import { hasMissingPriceData } from '../../../utils/hasMissingPriceData';
+import { SwapsBannersSelectorsIDs } from '../SwapsBanners.testIds';
+import { useSwapsBannersContext } from '../SwapsBannersContext';
+
+/**
+ * Tells the user the quote came back without the market price data needed to
+ * work out the price impact.
+ */
+export const MissingPriceDataBanner = () => {
+  const { sourceAmount } = useSwapsBannersContext();
+  const { activeQuote } = useBridgeQuoteDataContext();
+
+  const hasEnteredAmount = Boolean(sourceAmount) && Number(sourceAmount) > 0;
+
+  if (!hasEnteredAmount || !activeQuote || !hasMissingPriceData(activeQuote)) {
+    return null;
+  }
+
+  return (
+    <BannerAlert
+      severity={BannerAlertSeverity.Danger}
+      description={strings('swaps.market_price_unavailable')}
+      testID={SwapsBannersSelectorsIDs.MISSING_PRICE}
+    />
+  );
+};

--- a/app/components/UI/Bridge/components/SwapsBanners/banners/QuoteErrorBanner.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsBanners/banners/QuoteErrorBanner.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { QuoteStreamCompleteReason } from '@metamask/bridge-controller';
+import { strings } from '../../../../../../../locales/i18n';
+import { useBridgeQuoteDataContext } from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
+import { SwapsBannersSelectorsIDs } from '../SwapsBanners.testIds';
+import { QuoteErrorBanner } from './QuoteErrorBanner';
+import { createBannerState, renderBanner } from './testUtils';
+
+jest.mock('../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext', () => ({
+  useBridgeQuoteDataContext: jest.fn(),
+}));
+
+type QuoteContextValue = ReturnType<typeof useBridgeQuoteDataContext>;
+
+const setQuoteData = (overrides: Partial<QuoteContextValue> = {}) => {
+  jest.mocked(useBridgeQuoteDataContext).mockReturnValue({
+    activeQuote: undefined,
+    quoteFetchError: null,
+    ...overrides,
+  } as unknown as QuoteContextValue);
+};
+
+describe('QuoteErrorBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setQuoteData();
+  });
+
+  it('explains why the quote stream completed without a quote', () => {
+    const { getByText } = renderBanner(<QuoteErrorBanner />, {
+      state: createBannerState({
+        quoteStreamComplete: {
+          quoteCount: 0,
+          hasQuotes: false,
+          reason: QuoteStreamCompleteReason.AMOUNT_TOO_HIGH,
+        },
+      }),
+    });
+
+    expect(
+      getByText(strings('bridge.quote_stream_complete_amount_too_high')),
+    ).toBeOnTheScreen();
+  });
+
+  it('falls back to the retry message when the quote fetch fails', () => {
+    setQuoteData({ quoteFetchError: 'Network error' });
+
+    const { getByText } = renderBanner(<QuoteErrorBanner />);
+
+    expect(
+      getByText(strings('bridge.quote_stream_complete_retry')),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders nothing while quotes are being fetched without error', () => {
+    const { queryByTestId } = renderBanner(<QuoteErrorBanner />);
+
+    expect(queryByTestId(SwapsBannersSelectorsIDs.QUOTE_ERROR)).toBeNull();
+  });
+});

--- a/app/components/UI/Bridge/components/SwapsBanners/banners/QuoteErrorBanner.tsx
+++ b/app/components/UI/Bridge/components/SwapsBanners/banners/QuoteErrorBanner.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import {
+  BannerBase,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { selectQuoteStreamComplete } from '../../../../../../core/redux/slices/bridge';
+import { useBridgeQuoteDataContext } from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
+import { getQuoteStreamReasonString } from '../../../utils/getQuoteStreamReasonString';
+import { ERROR_BANNER_TW_CLASSNAME } from '../SwapsBanners.constants';
+import { SwapsBannersSelectorsIDs } from '../SwapsBanners.testIds';
+
+/**
+ * Explains why the quote stream ended without a quote the user can take.
+ */
+export const QuoteErrorBanner = () => {
+  const quoteStreamComplete = useSelector(selectQuoteStreamComplete);
+  const { quoteFetchError } = useBridgeQuoteDataContext();
+
+  if (!quoteStreamComplete?.reason && !quoteFetchError) {
+    return null;
+  }
+
+  return (
+    <BannerBase
+      twClassName={ERROR_BANNER_TW_CLASSNAME}
+      startAccessory={
+        <Icon
+          name={IconName.Error}
+          color={IconColor.ErrorDefault}
+          size={IconSize.Lg}
+        />
+      }
+      description={
+        <Text
+          testID={SwapsBannersSelectorsIDs.QUOTE_ERROR}
+          variant={TextVariant.BodySm}
+        >
+          {getQuoteStreamReasonString(quoteStreamComplete?.reason)}
+        </Text>
+      }
+    />
+  );
+};

--- a/app/components/UI/Bridge/components/SwapsBanners/banners/QuoteErrorBanner.tsx
+++ b/app/components/UI/Bridge/components/SwapsBanners/banners/QuoteErrorBanner.tsx
@@ -11,7 +11,7 @@ import {
 } from '@metamask/design-system-react-native';
 import { selectQuoteStreamComplete } from '../../../../../../core/redux/slices/bridge';
 import { useBridgeQuoteDataContext } from '../../../hooks/useBridgeQuoteData/BridgeQuoteDataContext';
-import { getQuoteStreamReasonString } from '../../../utils/getQuoteStreamReasonString';
+import { getQuoteStreamReasonString } from '../../../Views/BridgeView/BridgeMarketView/BridgeMarketView.utils.ts';
 import { ERROR_BANNER_TW_CLASSNAME } from '../SwapsBanners.constants';
 import { SwapsBannersSelectorsIDs } from '../SwapsBanners.testIds';
 

--- a/app/components/UI/Bridge/components/SwapsBanners/banners/TokenWarningBanner.test.tsx
+++ b/app/components/UI/Bridge/components/SwapsBanners/banners/TokenWarningBanner.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import Routes from '../../../../../../constants/navigation/Routes';
+import { createMockToken } from '../../../testUtils';
+import { SecurityDataType, type SecurityData } from '../../../types';
+import { TokenWarningModalMode } from '../../TokenWarningModal/constants';
+import { SwapsBannersSelectorsIDs } from '../SwapsBanners.testIds';
+import { TokenWarningBanner } from './TokenWarningBanner';
+import { createBannerState, renderBanner } from './testUtils';
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+const renderWithSecurityData = (securityData: SecurityData) =>
+  renderBanner(<TokenWarningBanner />, {
+    state: createBannerState({
+      destToken: createMockToken({
+        address: '0xdest',
+        symbol: 'USDC',
+        securityData,
+      }),
+    }),
+  });
+
+const renderWithSecurityType = (type: SecurityDataType) =>
+  renderWithSecurityData({ type, metadata: { features: [] } });
+
+describe('TokenWarningBanner', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('warns about a suspicious destination token', () => {
+    const { getByText } = renderWithSecurityType(SecurityDataType.Warning);
+
+    expect(
+      getByText(
+        strings('bridge.token_warning_suspicious_banner', { token: 'USDC' }),
+      ),
+    ).toBeOnTheScreen();
+  });
+
+  it('warns about a malicious destination token', () => {
+    const { getByText } = renderWithSecurityType(SecurityDataType.Malicious);
+
+    expect(
+      getByText(
+        strings('bridge.token_warning_malicious_banner', { token: 'USDC' }),
+      ),
+    ).toBeOnTheScreen();
+  });
+
+  it('is not shown for a token without a negative security type', () => {
+    const { queryByTestId } = renderWithSecurityType(SecurityDataType.Verified);
+
+    expect(queryByTestId(SwapsBannersSelectorsIDs.TOKEN_WARNING)).toBeNull();
+  });
+
+  it('opens the token warning modal with the flagged features when pressed', () => {
+    const features = [
+      {
+        featureId: 'honeypot',
+        type: SecurityDataType.Warning,
+        description: 'Cannot be sold',
+      },
+    ];
+    const { getByTestId } = renderWithSecurityData({
+      type: SecurityDataType.Warning,
+      metadata: { features },
+    });
+
+    fireEvent.press(getByTestId(SwapsBannersSelectorsIDs.TOKEN_WARNING));
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.MODALS.ROOT, {
+      screen: Routes.BRIDGE.MODALS.TOKEN_WARNING_MODAL,
+      params: expect.objectContaining({
+        warningType: SecurityDataType.Warning,
+        features,
+        mode: TokenWarningModalMode.Info,
+      }),
+    });
+  });
+
+  it('opens the token warning modal without features when none were reported', () => {
+    const { getByTestId } = renderWithSecurityData({
+      type: SecurityDataType.Malicious,
+    });
+
+    fireEvent.press(getByTestId(SwapsBannersSelectorsIDs.TOKEN_WARNING));
+
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.MODALS.ROOT, {
+      screen: Routes.BRIDGE.MODALS.TOKEN_WARNING_MODAL,
+      params: expect.objectContaining({ features: [] }),
+    });
+  });
+});

--- a/app/components/UI/Bridge/components/SwapsBanners/banners/TokenWarningBanner.tsx
+++ b/app/components/UI/Bridge/components/SwapsBanners/banners/TokenWarningBanner.tsx
@@ -1,0 +1,90 @@
+import React, { useMemo } from 'react';
+import { Pressable } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import {
+  BannerBase,
+  Icon,
+  IconSize,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import Routes from '../../../../../../constants/navigation/Routes';
+import type { AppNavigationProp } from '../../../../../../core/NavigationService/types';
+import {
+  getBridgeTokenSecurityConfig,
+  isNegativeSecurityType,
+} from '../../../utils/tokenSecurityUtils';
+import { SecurityDataType } from '../../../types';
+import { TokenWarningModalMode } from '../../TokenWarningModal/constants';
+import {
+  ERROR_BANNER_TW_CLASSNAME,
+  WARNING_BANNER_TW_CLASSNAME,
+} from '../SwapsBanners.constants';
+import { SwapsBannersSelectorsIDs } from '../SwapsBanners.testIds';
+import { useSwapsBannersContext } from '../SwapsBannersContext';
+
+/**
+ * Flags a destination token the security provider considers suspicious or
+ * malicious, and opens the warning modal with the details.
+ */
+export const TokenWarningBanner = () => {
+  const navigation = useNavigation<AppNavigationProp>();
+  const { destToken, location } = useSwapsBannersContext();
+
+  const securityData = destToken?.securityData;
+  const tokenWarning = useMemo(
+    () =>
+      securityData && isNegativeSecurityType(securityData.type)
+        ? // Spread to keep the narrowed warning type the modal params expect.
+          { ...securityData, type: securityData.type }
+        : undefined,
+    [securityData],
+  );
+
+  if (!tokenWarning) {
+    return null;
+  }
+
+  const securityConfig = getBridgeTokenSecurityConfig(tokenWarning.type);
+  const isMalicious = tokenWarning.type === SecurityDataType.Malicious;
+
+  const openWarningModal = () =>
+    navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
+      screen: Routes.BRIDGE.MODALS.TOKEN_WARNING_MODAL,
+      params: {
+        warningType: tokenWarning.type,
+        features: tokenWarning.metadata?.features ?? [],
+        mode: TokenWarningModalMode.Info,
+        location,
+      },
+    });
+
+  return (
+    <Pressable
+      onPress={openWarningModal}
+      testID={SwapsBannersSelectorsIDs.TOKEN_WARNING}
+    >
+      <BannerBase
+        twClassName={
+          isMalicious ? ERROR_BANNER_TW_CLASSNAME : WARNING_BANNER_TW_CLASSNAME
+        }
+        startAccessory={
+          <Icon
+            name={securityConfig.iconName}
+            color={securityConfig.iconColor}
+            size={IconSize.Lg}
+          />
+        }
+        description={
+          isMalicious
+            ? strings('bridge.token_warning_malicious_banner', {
+                token: destToken?.symbol,
+              })
+            : strings('bridge.token_warning_suspicious_banner', {
+                token: destToken?.symbol,
+              })
+        }
+        onClose={openWarningModal}
+      />
+    </Pressable>
+  );
+};

--- a/app/components/UI/Bridge/components/SwapsBanners/banners/testUtils.tsx
+++ b/app/components/UI/Bridge/components/SwapsBanners/banners/testUtils.tsx
@@ -1,0 +1,58 @@
+import React, { type ReactNode } from 'react';
+import { QuoteStreamCompleteReason } from '@metamask/bridge-controller';
+import renderWithProvider from '../../../../../../util/test/renderWithProvider';
+import { createBridgeTestState, createMockToken } from '../../../testUtils';
+import type { BridgeToken } from '../../../types';
+import { SwapsBanners } from '../SwapsBanners';
+
+export const mockSourceToken = createMockToken({
+  address: '0x0000000000000000000000000000000000000000',
+  symbol: 'ETH',
+});
+
+export const createBannerState = ({
+  sourceAmount = '1',
+  destToken = createMockToken({ address: '0xdest', symbol: 'USDC' }),
+  quoteStreamComplete,
+}: {
+  sourceAmount?: string;
+  destToken?: BridgeToken;
+  quoteStreamComplete?: {
+    quoteCount: number;
+    hasQuotes: boolean;
+    reason?: QuoteStreamCompleteReason;
+  };
+} = {}) =>
+  createBridgeTestState({
+    // Always set explicitly: the controller state helper merges into the shared
+    // default state object, so an omitted value leaks across test cases.
+    bridgeControllerOverrides: {
+      quoteStreamComplete: quoteStreamComplete ?? null,
+    },
+    bridgeReducerOverrides: {
+      sourceAmount,
+      sourceToken: mockSourceToken,
+      destToken,
+    },
+  });
+
+/**
+ * Renders a banner the way an order type would: inside the container that
+ * provides the swap being quoted.
+ */
+export const renderBanner = (
+  banner: ReactNode,
+  {
+    state = createBannerState(),
+    onAdjustSourceAmount = jest.fn(),
+  }: {
+    state?: ReturnType<typeof createBannerState>;
+    onAdjustSourceAmount?: (amount: string) => void;
+  } = {},
+) =>
+  renderWithProvider(
+    <SwapsBanners onAdjustSourceAmount={onAdjustSourceAmount}>
+      {banner}
+    </SwapsBanners>,
+    { state },
+  );

--- a/app/components/UI/Bridge/components/SwapsBanners/index.ts
+++ b/app/components/UI/Bridge/components/SwapsBanners/index.ts
@@ -1,0 +1,13 @@
+export { SwapsBanners } from './SwapsBanners';
+export { SwapsBannersSelectorsIDs } from './SwapsBanners.testIds';
+export { useSwapsBannersContext } from './SwapsBannersContext';
+export { BlockaidErrorBanner } from './banners/BlockaidErrorBanner';
+export { HardwareWalletSolanaSignUnsupportedBanner } from './banners/HardwareWalletSolanaSignUnsupportedBanner';
+export { InsufficientNativeReserveBanner } from './banners/InsufficientNativeReserveBanner';
+export { MissingPriceDataBanner } from './banners/MissingPriceDataBanner';
+export { QuoteErrorBanner } from './banners/QuoteErrorBanner';
+export { TokenWarningBanner } from './banners/TokenWarningBanner';
+export type {
+  SwapsBannersContextValue,
+  SwapsBannersProps,
+} from './SwapsBanners.types';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Swaps and bridge order types (market, limit, recurring) need the same warning and error banners — quote failures, suspicious tokens, native reserve, missing price data, Blockaid alerts, hardware-wallet-on-Solana — but each order type may show a different subset. Today that logic lives inline in `BridgeMarketView`, which makes reuse in limit order (and future order types) a copy-paste job.

This PR introduces a composable `SwapsBanners` architecture under `app/components/UI/Bridge/components/SwapsBanners/`:

- **`SwapsBanners` container** — provides layout (`Box gap={3} mx-4`) and a `SwapsBannersProvider` that shares swap context (source/dest tokens, amount, wallet address, balance, analytics location, amount-adjust callback) with child banners.
- **Individual banner components** — each owns its visibility logic and returns `null` when it does not apply:
  - `QuoteErrorBanner`
  - `TokenWarningBanner`
  - `InsufficientNativeReserveBanner`
  - `MissingPriceDataBanner`
  - `BlockaidErrorBanner`
  - `HardwareWalletSolanaSignUnsupportedBanner`
- **Shared utility** — `getQuoteStreamReasonString` moved from `BridgeMarketView.utils` to `app/components/UI/Bridge/utils/` for reuse across order types.

Order types compose only the banners they need:

```tsx
<SwapsBanners onAdjustSourceAmount={handleAmountChange}>
  <QuoteErrorBanner />
  <TokenWarningBanner />
</SwapsBanners>
```

Footer-only banners (`BlockaidErrorBanner`, `HardwareWalletSolanaSignUnsupportedBanner`) work standalone without the container since they do not need screen-owned context.

This commit is infrastructure-only; wiring into `BridgeMarketView` and `BridgeLimitOrderView` will follow in separate PRs.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4960

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — this PR adds composable banner components and unit tests only; no views are wired up yet, so there is no user-facing behavior to exercise manually. Follow-up PRs that integrate `SwapsBanners` into market and limit order views will include manual testing steps.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---