### PR TITLE
fix(money): invert Perps and Predictions account naming in activity (MUSD-1297)

### DIFF
--- a/app/components/Views/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.test.tsx
@@ -172,7 +172,7 @@ describe('TransactionDetailsAccountRow', () => {
       useIsMoneyAccountContextMock.mockReturnValue(false);
     });
 
-    it('renders "From" with "Perps Account 1" for perpsWithdraw in money context', () => {
+    it('renders "From" with "Account 1 Perps" for perpsWithdraw in money context', () => {
       useIsMoneyAccountContextMock.mockReturnValue(true);
 
       useTransactionDetailsMock.mockReturnValue({
@@ -191,7 +191,7 @@ describe('TransactionDetailsAccountRow', () => {
       ).toBeDefined();
     });
 
-    it('renders "From" with "Predictions Account 1" for predictWithdraw in money context', () => {
+    it('renders "From" with "Account 1 Predictions" for predictWithdraw in money context', () => {
       useIsMoneyAccountContextMock.mockReturnValue(true);
 
       useTransactionDetailsMock.mockReturnValue({

--- a/app/components/Views/confirmations/components/activity/transaction-details-to-row/transaction-details-to-row.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-to-row/transaction-details-to-row.test.tsx
@@ -97,22 +97,22 @@ describe('TransactionDetailsToRow', () => {
     expect(getByText(RECIPIENT_MOCK)).toBeDefined();
   });
 
-  it('renders "Perps Account 1" label for perpsDeposit', () => {
+  it('renders "Account 1 Perps" label for perpsDeposit', () => {
     useTransactionDetailsMock.mockReturnValue({
       transactionMeta: createTransactionMeta(TransactionType.perpsDeposit),
     });
 
     const { getByText } = render();
-    expect(getByText('Perps Account 1')).toBeDefined();
+    expect(getByText('Account 1 Perps')).toBeDefined();
   });
 
-  it('renders "Predictions Account 1" label for predictDeposit', () => {
+  it('renders "Account 1 Predictions" label for predictDeposit', () => {
     useTransactionDetailsMock.mockReturnValue({
       transactionMeta: createTransactionMeta(TransactionType.predictDeposit),
     });
 
     const { getByText } = render();
-    expect(getByText('Predictions Account 1')).toBeDefined();
+    expect(getByText('Account 1 Predictions')).toBeDefined();
   });
 
   it('renders nothing when no recipient can be decoded', () => {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -10455,8 +10455,8 @@
       "you_received": "You received",
       "token_received": "Token received",
       "money_account": "Money account",
-      "perps_account": "Perps Account 1",
-      "predictions_account": "Predictions Account 1",
+      "perps_account": "Account 1 Perps",
+      "predictions_account": "Account 1 Predictions",
       "steps_completed": "Steps ({{count}} completed)",
       "summary": "Summary"
     },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Perps and Predictions account labels on the Money activity list and activity details read `Account 1 Perps` and `Account 1 Predictions`, putting the account ahead of the service to reflect the hierarchy — the account is the higher abstraction.

Bug: the labels read `Perps Account 1` and `Predictions Account 1`, leading with the service.

This is a copy-only change to `locales/languages/en.json`. The two labels are frozen literals rather than templates, so the inversion is a value edit on the existing `transaction_details.label.perps_account` / `predictions_account` keys; all three consumers (the Money activity row subtitle and the activity-details From/To rows) read them through `strings()` and need no change. Other locales are left to the localisation pipeline.

Note on the second AC bullet: the Money Account withdraw screen renders `Account 1 (Perps)` — parenthesised, and built from the real account-group name in `usePerpsSubAccounts`. The activity labels are hardcoded English placeholders, so the two surfaces cannot be made byte-identical without also wiring real account names into activity. This PR implements the word order from the ticket title and first AC bullet (`Account 1 Perps`, no parentheses) and leaves the withdraw screen untouched. Making activity use the real account name is a larger follow-up.

`Predictions Account 1` is the identical sibling string rendered by the same rows, so it is inverted here too rather than left in the old word order next to the new one.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated Perps and Predictions account labels in activity to read "Account 1 Perps" and "Account 1 Predictions"

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1297](https://consensyssoftware.atlassian.net/browse/MUSD-1297)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps and Predictions account naming in activity

  Scenario: user views a Perps deposit in the activity list
    Given the user has a Money account with a Perps deposit transaction
    When user opens Money activity
    Then the transaction row subtitle reads "Account 1 Perps"

  Scenario: user opens activity details for a Perps deposit
    Given the user has a Perps deposit transaction
    When user taps the transaction to open activity details
    Then the "To" row reads "Account 1 Perps"

  Scenario: user opens activity details for a Perps withdrawal
    Given the user has a Perps withdrawal transaction
    When user taps the transaction to open activity details
    Then the "From" row reads "Account 1 Perps"

  Scenario: user views a Predictions transaction
    Given the user has a Predictions deposit or withdrawal transaction
    When user opens activity details
    Then the service row reads "Account 1 Predictions"
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — pending device capture. Activity surfaces read `Perps Account 1` / `Predictions Account 1`.

### **After**

<!-- [screenshots/recordings] -->

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/e0521779-4ac4-4540-931b-1780aac70293" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-1297]: https://consensyssoftware.atlassian.net/browse/MUSD-1297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> English string-only change with matching test updates; no logic, auth, or data handling.
> 
> **Overview**
> Updates Money activity copy so Perps and Predictions account names lead with **Account 1** instead of the service name.
> 
> In `locales/languages/en.json`, `transaction_details.label.perps_account` and `predictions_account` change from **Perps Account 1** / **Predictions Account 1** to **Account 1 Perps** / **Account 1 Predictions**. Activity list subtitles and transaction-details From/To rows already use these keys via `strings()`, so no UI code changes.
> 
> Unit tests in `transaction-details-account-row` and `transaction-details-to-row` are updated to assert the new wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ed669f7bc7770ff659136744463ca98eee4347a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->