### PR TITLE
fix(money): pin activity details fiat amounts to two decimals (MUSD-1299)

### DIFF
--- a/app/components/UI/SimulationDetails/FiatDisplay/useFiatFormatter.test.ts
+++ b/app/components/UI/SimulationDetails/FiatDisplay/useFiatFormatter.test.ts
@@ -36,7 +36,7 @@ describe('useFiatFormatter', () => {
     const formattedResult = formatter(amount);
 
     expect(selectCurrentCurrency).toHaveBeenCalledTimes(1);
-    expect(formatFiat).toHaveBeenCalledWith(amount, 'USD');
+    expect(formatFiat).toHaveBeenCalledWith(amount, 'USD', undefined);
     expect(formattedResult).toBe('$1,000');
   });
 
@@ -51,7 +51,7 @@ describe('useFiatFormatter', () => {
     formatter(amount);
 
     expect(selectCurrentCurrency).toHaveBeenCalledTimes(1);
-    expect(formatFiat).toHaveBeenCalledWith(amount, 'EUR');
+    expect(formatFiat).toHaveBeenCalledWith(amount, 'EUR', undefined);
   });
 
   it('overrides the currency from Redux when currency parameter is provided', () => {
@@ -65,7 +65,22 @@ describe('useFiatFormatter', () => {
     formatter(amount);
 
     expect(selectCurrentCurrency).toHaveBeenCalledTimes(1);
-    expect(formatFiat).toHaveBeenCalledWith(amount, 'GBP');
+    expect(formatFiat).toHaveBeenCalledWith(amount, 'GBP', undefined);
+  });
+
+  it('forwards fractionDigits to formatFiat when provided', () => {
+    mockSelectCurrentCurrency.mockReturnValue('USD');
+    mockFormatFiat.mockReturnValue('$1,000.00');
+
+    const { result } = renderHook(() =>
+      useFiatFormatter({ fractionDigits: 2 }),
+    );
+    const formatter = result.current;
+
+    const amount = new BigNumber(1000);
+    formatter(amount);
+
+    expect(formatFiat).toHaveBeenCalledWith(amount, 'USD', 2);
   });
 
   it('passes the correct currency to formatFiat for each call', () => {
@@ -81,7 +96,17 @@ describe('useFiatFormatter', () => {
     formatter(new BigNumber(200));
 
     expect(formatFiat).toHaveBeenCalledTimes(2);
-    expect(formatFiat).toHaveBeenNthCalledWith(1, new BigNumber(100), 'JPY');
-    expect(formatFiat).toHaveBeenNthCalledWith(2, new BigNumber(200), 'JPY');
+    expect(formatFiat).toHaveBeenNthCalledWith(
+      1,
+      new BigNumber(100),
+      'JPY',
+      undefined,
+    );
+    expect(formatFiat).toHaveBeenNthCalledWith(
+      2,
+      new BigNumber(200),
+      'JPY',
+      undefined,
+    );
   });
 });

--- a/app/components/UI/SimulationDetails/FiatDisplay/useFiatFormatter.ts
+++ b/app/components/UI/SimulationDetails/FiatDisplay/useFiatFormatter.ts
@@ -18,13 +18,16 @@ type FiatFormatter = (fiatAmount: BigNumber) => string;
  */
 const useFiatFormatter = ({
   currency,
+  fractionDigits,
 }: {
   currency?: string;
+  fractionDigits?: number;
 } = {}): FiatFormatter => {
   const currencyCurrency = useSelector(selectCurrentCurrency);
   const fiatCurrency = currency ?? currencyCurrency;
 
-  return (fiatAmount: BigNumber) => formatFiat(fiatAmount, fiatCurrency);
+  return (fiatAmount: BigNumber) =>
+    formatFiat(fiatAmount, fiatCurrency, fractionDigits);
 };
 
 export default useFiatFormatter;

--- a/app/components/Views/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.tsx
@@ -10,9 +10,13 @@ import { strings } from '../../../../../../../locales/i18n';
 import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 import { BigNumber } from 'bignumber.js';
 import { TransactionDetailsSelectorIDs } from '../TransactionDetailsModal.testIds';
+import { ACTIVITY_FIAT_FRACTION_DIGITS } from '../../../constants/confirmations';
 
 export function TransactionDetailsBridgeFeeRow() {
-  const formatFiat = useFiatFormatter({ currency: 'usd' });
+  const formatFiat = useFiatFormatter({
+    currency: 'usd',
+    fractionDigits: ACTIVITY_FIAT_FRACTION_DIGITS,
+  });
   const { transactionMeta } = useTransactionDetails();
   const { metamaskPay } = transactionMeta;
   const { bridgeFeeFiat } = metamaskPay || {};

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.test.tsx
@@ -434,7 +434,7 @@ describe('TransactionDetailsHero', () => {
 
         const { getByText, queryByText } = render();
 
-        expect(getByText(/^-\$1$/)).toBeDefined();
+        expect(getByText(/^-\$1\.00$/)).toBeDefined();
         expect(getByText(/\+\$0\.75/)).toBeDefined();
         expect(queryByText(/\$1\.25/)).toBeNull();
       });
@@ -534,7 +534,7 @@ describe('TransactionDetailsHero', () => {
 
       const { getByText, queryByText } = render();
 
-      expect(getByText(/-\$1$/)).toBeDefined();
+      expect(getByText(/-\$1\.00$/)).toBeDefined();
       expect(queryByText(/\$0/)).toBeNull();
     });
 
@@ -621,6 +621,23 @@ describe('TransactionDetailsHero', () => {
       expect(getByText(/\+\$100/)).toBeDefined();
       expect(queryByText('You sent')).toBeNull();
       expect(queryByText('You received')).toBeNull();
+    });
+
+    it('keeps two decimals on a whole-dollar deposit', () => {
+      useTransactionDetailsMock.mockReturnValue({
+        transactionMeta: {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.moneyAccountDeposit,
+          metamaskPay: {
+            targetFiat: '1',
+            fiat: { orderId: 'order-123' },
+          },
+        } as unknown as TransactionMeta,
+      });
+
+      const { getByText } = render();
+
+      expect(getByText(/^\+\$1\.00$/)).toBeDefined();
     });
 
     it('renders single-row mUSD deposit hero with Money Account icon', () => {

--- a/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -49,7 +49,10 @@ import {
   MUSD_DECIMALS,
 } from '../../../../../UI/Earn/constants/musd';
 import { selectTransactionsByIds } from '../../../../../../selectors/transactionController';
-import { RELAY_DEPOSIT_TYPES } from '../../../constants/confirmations';
+import {
+  ACTIVITY_FIAT_FRACTION_DIGITS,
+  RELAY_DEPOSIT_TYPES,
+} from '../../../constants/confirmations';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { strings } from '../../../../../../../locales/i18n';
 import MoneyIcon from '../../../../../../images/money.png';
@@ -175,8 +178,13 @@ function AssetLine({
 }
 
 export function TransactionDetailsHero() {
-  const formatFiatPerps = useFiatFormatter({ currency: PERPS_CURRENCY });
-  const formatFiatUser = useFiatFormatter();
+  const formatFiatPerps = useFiatFormatter({
+    currency: PERPS_CURRENCY,
+    fractionDigits: ACTIVITY_FIAT_FRACTION_DIGITS,
+  });
+  const formatFiatUser = useFiatFormatter({
+    fractionDigits: ACTIVITY_FIAT_FRACTION_DIGITS,
+  });
   const formatFiatPay = usePayFiatFormatter();
   const { styles } = useStyles(styleSheet, {});
   const decodedAmount = useDecodedAmount();

--- a/app/components/Views/confirmations/components/activity/transaction-details-status/transaction-details-status.test.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status/transaction-details-status.test.tsx
@@ -175,7 +175,7 @@ describe('TransactionDetailsStatus', () => {
     });
 
     useTokenAmountMock.mockReturnValue({
-      fiat: '$123.45',
+      fiatUnformatted: '123.45',
     } as ReturnType<typeof useTokenAmount>);
 
     const { getByText } = render({
@@ -187,6 +187,43 @@ describe('TransactionDetailsStatus', () => {
       getByText(
         strings('transaction_details.perps_deposit_solution', {
           fiat: '$123.45',
+        }),
+      ),
+    ).toBeDefined();
+  });
+
+  it('keeps two decimals in the solution text for a whole-dollar amount', () => {
+    selectBridgeHistoryForAccountMock.mockReturnValue({
+      '1': {
+        quote: {
+          destAsset: { address: ARBITRUM_USDC.address },
+        },
+        status: {
+          status: StatusTypes.COMPLETE,
+        },
+      },
+    } as never);
+
+    useTransactionDetailsMock.mockReturnValue({
+      transactionMeta: {
+        requiredTransactionIds: ['1'],
+        type: TransactionType.perpsDeposit,
+      } as TransactionMeta,
+    });
+
+    useTokenAmountMock.mockReturnValue({
+      fiatUnformatted: '100',
+    } as ReturnType<typeof useTokenAmount>);
+
+    const { getByText } = render({
+      status: TransactionStatus.failed,
+      type: TransactionType.perpsDeposit,
+    });
+
+    expect(
+      getByText(
+        strings('transaction_details.perps_deposit_solution', {
+          fiat: '$100.00',
         }),
       ),
     ).toBeDefined();

--- a/app/components/Views/confirmations/components/activity/transaction-details-status/transaction-details-status.tsx
+++ b/app/components/Views/confirmations/components/activity/transaction-details-status/transaction-details-status.tsx
@@ -20,6 +20,9 @@ import { useTokenAmount } from '../../../hooks/useTokenAmount';
 import { ARBITRUM_USDC } from '../../../constants/perps';
 import { StatusIcon } from '../../status-icon';
 import { getErrorMessage, getSeverity } from '../../../utils/transaction';
+import { BigNumber } from 'bignumber.js';
+import useFiatFormatter from '../../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
+import { ACTIVITY_FIAT_FRACTION_DIGITS } from '../../../constants/confirmations';
 
 export function TransactionDetailsStatus({
   gap,
@@ -35,15 +38,20 @@ export function TransactionDetailsStatus({
   const { status } = transactionMeta;
   const isMoneyContext = useIsMoneyAccountContext();
   const hasSuccessfulPerpsBridge = useHasSuccessfulPerpsBridge();
-  const { fiat } = useTokenAmount({ transactionMeta });
+  const { fiatUnformatted } = useTokenAmount({ transactionMeta });
   const errorMessage = getErrorMessage(transactionMeta);
+  // useTokenAmount's own `fiat` lets the decimals follow the amount, which would
+  // disagree with the pinned rows elsewhere on this screen.
+  const formatFiat = useFiatFormatter({
+    fractionDigits: ACTIVITY_FIAT_FRACTION_DIGITS,
+  });
 
   const statusText = text ?? getStatusText(status);
 
   const solutionText =
     !text && status === TransactionStatus.failed && hasSuccessfulPerpsBridge
       ? strings('transaction_details.perps_deposit_solution', {
-          fiat: fiat ?? '0.00',
+          fiat: formatFiat(new BigNumber(fiatUnformatted ?? 0)),
         })
       : undefined;
 

--- a/app/components/Views/confirmations/constants/confirmations.ts
+++ b/app/components/Views/confirmations/constants/confirmations.ts
@@ -99,6 +99,14 @@ export const POST_QUOTE_TRANSACTION_TYPES = [
 export const USER_CURRENCY_TYPES = [TransactionType.musdClaim] as const;
 
 /**
+ * Decimals every fiat amount on the activity details screen renders with.
+ * Pinned so the same value reads identically whichever row or transaction type
+ * produced it, rather than dropping decimals whenever the amount is a whole
+ * number.
+ */
+export const ACTIVITY_FIAT_FRACTION_DIGITS = 2;
+
+/**
  * Transaction types that participate in the pay flow (deposits, orders,
  * conversions, withdrawals). Token/amount displays inside these confirmations
  * are priced in USD unless the type is also in {@link USER_CURRENCY_TYPES}.

--- a/app/components/Views/confirmations/hooks/pay/usePayFiatFormatter.ts
+++ b/app/components/Views/confirmations/hooks/pay/usePayFiatFormatter.ts
@@ -1,7 +1,10 @@
 import { hasTransactionType } from '@metamask/transaction-controller';
 
 import { useTransactionDetails } from '../activity/useTransactionDetails';
-import { USER_CURRENCY_TYPES } from '../../constants/confirmations';
+import {
+  ACTIVITY_FIAT_FRACTION_DIGITS,
+  USER_CURRENCY_TYPES,
+} from '../../constants/confirmations';
 import useFiatFormatter from '../../../../UI/SimulationDetails/FiatDisplay/useFiatFormatter';
 
 /**
@@ -13,8 +16,13 @@ import useFiatFormatter from '../../../../UI/SimulationDetails/FiatDisplay/useFi
  * @returns A fiat formatter function
  */
 export function usePayFiatFormatter() {
-  const formatFiatUsd = useFiatFormatter({ currency: 'usd' });
-  const formatFiatUser = useFiatFormatter();
+  const formatFiatUsd = useFiatFormatter({
+    currency: 'usd',
+    fractionDigits: ACTIVITY_FIAT_FRACTION_DIGITS,
+  });
+  const formatFiatUser = useFiatFormatter({
+    fractionDigits: ACTIVITY_FIAT_FRACTION_DIGITS,
+  });
   const { transactionMeta } = useTransactionDetails();
 
   const useUserCurrency = hasTransactionType(

--- a/app/util/formatFiat.test.ts
+++ b/app/util/formatFiat.test.ts
@@ -35,6 +35,26 @@ describe('formatFiat', () => {
     });
   });
 
+  describe('pinned fraction digits', () => {
+    it('keeps decimals on whole numbers when fraction digits are pinned', () => {
+      expect(formatFiat(new BigNumber(1), 'USD', 2)).toBe('$1.00');
+      expect(formatFiat(new BigNumber(1000), 'USD', 2)).toBe('$1,000.00');
+      expect(formatFiat(new BigNumber(0), 'USD', 2)).toBe('$0.00');
+    });
+
+    it('rounds longer decimals down to the pinned digits', () => {
+      expect(formatFiat(new BigNumber('1.0021'), 'USD', 2)).toBe('$1.00');
+    });
+
+    it('pins digits for currencies that default to zero decimals', () => {
+      expect(formatFiat(new BigNumber(1), 'JPY', 2)).toBe('¥1.00');
+    });
+
+    it('leaves the value-driven default in place when not pinned', () => {
+      expect(formatFiat(new BigNumber(1), 'USD')).toBe('$1');
+    });
+  });
+
   describe('small amount handling', () => {
     it('displays "<$0.01" for amounts less than 0.01', () => {
       expect(formatFiat(new BigNumber(0.005), 'USD')).toBe('<$0.01');

--- a/app/util/formatFiat.ts
+++ b/app/util/formatFiat.ts
@@ -3,6 +3,30 @@ import I18n from '../../locales/i18n';
 import { getIntlNumberFormatter } from './intl';
 
 /**
+ * Resolves the fraction-digit options passed to Intl.
+ *
+ * By default the decimals follow the value: integers render bare ("$1") and
+ * everything else gets two decimals ("$1.23"). When `fractionDigits` is given
+ * the amount always renders with exactly that many decimals, which callers use
+ * to keep a screen consistent regardless of the values it happens to receive.
+ * Both bounds are pinned because currencies whose Intl default is zero decimals
+ * (e.g. JPY) reject a minimum above their maximum.
+ */
+const getFractionDigitOptions = (
+  hasDecimals: boolean,
+  fractionDigits?: number,
+) => {
+  if (fractionDigits === undefined) {
+    return { minimumFractionDigits: hasDecimals ? 2 : 0 };
+  }
+
+  return {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  };
+};
+
+/**
  * Formats a fiat amount as a localized string.
  *
  * Example usage:
@@ -13,7 +37,11 @@ import { getIntlNumberFormatter } from './intl';
  *
  * @returns A formatted string.
  */
-const formatFiat = (fiatAmount: BigNumber, currency?: string) => {
+const formatFiat = (
+  fiatAmount: BigNumber,
+  currency?: string,
+  fractionDigits?: number,
+) => {
   const hasDecimals = !fiatAmount.isInteger();
 
   const isSmall =
@@ -28,7 +56,7 @@ const formatFiat = (fiatAmount: BigNumber, currency?: string) => {
       style: 'currency',
       currency,
       currencyDisplay: 'narrowSymbol',
-      minimumFractionDigits: hasDecimals ? 2 : 0,
+      ...getFractionDigitOptions(hasDecimals, fractionDigits),
       // string is valid parameter for format function
       // for some reason it gives TS issue
       // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/format#number


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Every fiat amount on the activity details screen renders with two decimals, so the same value reads identically whichever row or transaction type produced it.

Bug: the decimals depended on whether the amount happened to be a whole number. `app/util/formatFiat.ts` set `minimumFractionDigits: hasDecimals ? 2 : 0`, so a $1 deposit — whose `targetFiat` is exactly `1` — rendered "$1", while a $1 send rendered "$1.00" because fees make its total non-integral. Same screen, same currency, two different shapes.

`formatFiat` is shared by roughly thirty callers across the app (gas fees, simulation details, staking, bridge), so its default is deliberately left alone. Instead it takes an optional `fractionDigits`, threaded through `useFiatFormatter`, and only the activity-details surfaces opt in via `ACTIVITY_FIAT_FRACTION_DIGITS`:

- `usePayFiatFormatter` — used by the hero, the total row and the network fee row, and by nothing outside activity details
- the hero's two direct `useFiatFormatter` calls (the perps-currency and user-currency fallbacks, which the hero's third render path uses)
- the bridge fee row
- the perps-deposit failure "solution" text, which reached its amount through `useTokenAmount`'s pre-formatted `fiat` and so kept the old value-driven decimals; it now reformats from `fiatUnformatted`

Both `minimumFractionDigits` and `maximumFractionDigits` are pinned when the option is passed. Pinning only the minimum throws a `RangeError` for currencies whose Intl default maximum is zero (JPY), which the existing `try`/`catch` would have swallowed into the unformatted `"1 JPY"` fallback. There is a unit test covering that case.

The hero had two assertions that locked in the old behaviour (`/^-\$1$/`), which now assert the two-decimal form.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed currency amounts in activity details showing inconsistent decimal places, where a whole-dollar amount rendered as "$1" instead of "$1.00"

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1299](https://consensyssoftware.atlassian.net/browse/MUSD-1299)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Consistent decimal places in activity details

  Scenario: user opens activity details for a whole-dollar deposit
    Given the user has a $1 deposit into their Money account
    When user opens the transaction in activity details
    Then the amount reads "+$1.00"

  Scenario: user opens activity details for a whole-dollar send
    Given the user has a $1 send from their Money account
    When user opens the transaction in activity details
    Then the amount reads "-$1.00"
    And it has the same number of decimals as the deposit

  Scenario: fee and total rows stay consistent
    Given the user opens any Money transaction in activity details
    When user reads the total, network fee and bridge fee rows
    Then every fiat amount shows two decimal places
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — pending device capture. A $1 deposit rendered "$1" while a $1 send rendered "$1.00".

### **After**

<!-- [screenshots/recordings] -->

N/A — pending device capture. Both render with two decimals: "+$1.00" and "-$1.00".

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-1299]: https://consensyssoftware.atlassian.net/browse/MUSD-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped display-formatting change with default `formatFiat` behavior preserved; activity details surfaces opt in via a single constant.
> 
> **Overview**
> Activity details fiat amounts now always show **two decimal places** (e.g. `$1.00` instead of `$1`) so hero, fee rows, and status copy stay consistent.
> 
> `formatFiat` gains an optional `fractionDigits` argument that pins both min and max Intl fraction digits (needed for currencies like JPY). Default formatting elsewhere is unchanged. `useFiatFormatter` passes the option through, and confirmations define `ACTIVITY_FIAT_FRACTION_DIGITS = 2` for activity-details formatters (`usePayFiatFormatter`, hero, bridge fee row). **Transaction details status** formats perps-deposit solution text via `fiatUnformatted` + the pinned formatter instead of `useTokenAmount`’s variable-decimal `fiat`.
> 
> Tests cover pinned formatting, hook forwarding, and updated hero/status expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ff45e7d022548ee2a3047bd813f5cde1e82b3ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

