### PR TITLE
fix(rewards): show lifetime equity points regardless of current tier standing

### DIFF
--- a/app/components/UI/Rewards/components/Vip/VipPointsSection.test.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipPointsSection.test.tsx
@@ -159,8 +159,8 @@ describe('VipPointsSection', () => {
       );
     });
 
-    it('is hidden while equity is still locked, even with a positive lifetime total', () => {
-      const { queryByTestId } = render(
+    it('still shows the lifetime total while equity is currently locked (e.g. dropped below the equity tier)', () => {
+      const { getByTestId } = render(
         <VipPointsSection
           {...baseProps}
           pointsAllocation={{
@@ -173,24 +173,43 @@ describe('VipPointsSection', () => {
       );
 
       expect(
-        queryByTestId(VIP_POINTS_SECTION_TEST_IDS.LIFETIME_POINTS),
-      ).toBeNull();
+        getByTestId(VIP_POINTS_SECTION_TEST_IDS.LIFETIME_POINTS),
+      ).toHaveTextContent(
+        'Keep earning to unlock equity. Lifetime total: 12.35M',
+      );
     });
 
     it.each([
       ['null (legacy backend mode)', null],
       ['zero', 0],
-    ])('is hidden when the lifetime total is %s', (_label, value) => {
-      const { queryByTestId } = render(
-        <VipPointsSection
-          {...baseProps}
-          pointsAllocation={unlockedWithLifetime(value)}
-        />,
-      );
+    ])(
+      'is hidden when the lifetime total is %s, regardless of lock state',
+      (_label, value) => {
+        const { queryByTestId: queryUnlocked } = render(
+          <VipPointsSection
+            {...baseProps}
+            pointsAllocation={unlockedWithLifetime(value)}
+          />,
+        );
+        expect(
+          queryUnlocked(VIP_POINTS_SECTION_TEST_IDS.LIFETIME_POINTS),
+        ).toBeNull();
 
-      expect(
-        queryByTestId(VIP_POINTS_SECTION_TEST_IDS.LIFETIME_POINTS),
-      ).toBeNull();
-    });
+        const { queryByTestId: queryLocked } = render(
+          <VipPointsSection
+            {...baseProps}
+            pointsAllocation={{
+              earned: 5_555_555,
+              threshold: 7_777_777,
+              percent: 71.4,
+              lifetimeQualifyingPoints: value,
+            }}
+          />,
+        );
+        expect(
+          queryLocked(VIP_POINTS_SECTION_TEST_IDS.LIFETIME_POINTS),
+        ).toBeNull();
+      },
+    );
   });
 });

--- a/app/components/UI/Rewards/components/Vip/VipPointsSection.tsx
+++ b/app/components/UI/Rewards/components/Vip/VipPointsSection.tsx
@@ -48,24 +48,25 @@ const VipPointsSection: React.FC<VipPointsSectionProps> = ({
     pointsAllocation.earned >= pointsAllocation.threshold;
   const subtitle = isEquityUnlocked ? equityUnlockedTitle : equityLockedTitle;
 
-  // Only meaningful once equity is unlocked, and only worth showing when the
-  // VIP has actually accrued something — a "lifetime total of 0" would read as
-  // a bug rather than as reassurance.
+  // Lifetime total is never clamped and never shrinks once accrued — a VIP
+  // who has since dropped below the equity tier still keeps it, so this is
+  // NOT gated on `isEquityUnlocked`. Only worth showing when the VIP has
+  // actually accrued something — a "lifetime total of 0" would read as a bug
+  // rather than as reassurance.
   const lifetimeQualifyingPoints = pointsAllocation.lifetimeQualifyingPoints;
   const lifetimePointsText =
-    isEquityUnlocked &&
-    lifetimeQualifyingPoints !== null &&
-    lifetimeQualifyingPoints > 0
+    lifetimeQualifyingPoints !== null && lifetimeQualifyingPoints > 0
       ? equityLifetimePointsDescription
           .split(POINTS_PLACEHOLDER)
           .join(formatCompactValue(lifetimeQualifyingPoints))
       : null;
 
-  const description = isEquityUnlocked
-    ? lifetimePointsText
-      ? `${equityUnlockedDescription} ${lifetimePointsText}`
-      : equityUnlockedDescription
+  const baseDescription = isEquityUnlocked
+    ? equityUnlockedDescription
     : equityLockedDescription;
+  const description = lifetimePointsText
+    ? `${baseDescription} ${lifetimePointsText}`
+    : baseDescription;
 
   return (
     <Box


### PR DESCRIPTION
## **Description**

`lifetimeQualifyingPoints` is a lifetime-cumulative, never-decreasing backend value, but `VipPointsSection` only rendered it while `isEquityUnlocked` (VIP currently at/above the equity tier). A VIP who reached the equity tier and has since dropped below it kept a positive lifetime total but the UI hid it — exactly the case this figure exists to reassure. This drops the `isEquityUnlocked` gate so the lifetime line shows whenever the value is positive, appended to whichever base description (locked or unlocked) is currently showing.

## **Changelog**

CHANGELOG entry: fix VIP lifetime equity points being hidden after dropping below the equity tier

## **Related issues**

Refs: RWDS-1524

## **Manual testing steps**

1. As a VIP who has previously reached the equity tier (e.g. Platinum) and since dropped below it (e.g. back to Gold), open the VIP dashboard.
2. Confirm the "Lifetime total: {points}" line now appears alongside the locked-state copy, using the VIP's positive `lifetimeQualifyingPoints` value.
3. As a VIP currently at/above the equity tier, confirm the line still appears alongside the unlocked-state copy (unchanged from before).
4. As a VIP who has never reached the equity tier (`lifetimeQualifyingPoints` is `0` or `null`), confirm the line still does not appear.

## **Screenshots/Recordings**

### **Before**

N/A — no simulator run for this fix (visibility-condition change only, not a rendering change; the rendered text itself was already screenshotted in #34923 / RWDS-1524).

### **After**

N/A — same as above.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small rewards UI copy/visibility change with no auth, data, or API changes; behavior is covered by updated unit tests.
> 
> **Overview**
> Fixes **VIP lifetime equity points** being hidden after a user drops back below the equity tier. `VipPointsSection` no longer ties the lifetime line to `isEquityUnlocked`; it shows whenever `lifetimeQualifyingPoints` is present and **> 0**, appended to the locked or unlocked base description.
> 
> Tests now cover the locked-but-positive-lifetime case and assert **null/zero** lifetime totals stay hidden in both lock states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dabfe6ee11abbea6ee308e8f390d22821c7cd9da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->