### PR TITLE
refactor(predict): deepen game card projection

### DIFF
--- a/app/components/UI/PredictNext/events/cards/internal/EventCardGameParts.tsx
+++ b/app/components/UI/PredictNext/events/cards/internal/EventCardGameParts.tsx
@@ -12,26 +12,19 @@ import {
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { Image as ExpoImage } from 'expo-image';
-import BigNumber from 'bignumber.js';
-import I18n, { strings } from '../../../../../../../locales/i18n';
-import { getIntlDateTimeFormatter } from '../../../../../../util/intl';
 import { useTheme } from '../../../../../../util/theme';
 import type {
-  PredictEntityId,
   PredictEvent,
   PredictGame,
-  PredictGameStatus,
   PredictMarket,
   PredictOutcome,
-  PredictTeam,
 } from '../../../types';
 import { EventCard } from './EventCard';
-import { formatAskPrice } from './formatAskPrice';
-import { formatMultiplier } from './formatMultiplier';
-import { getAskPricePercent } from './getAskPricePercent';
-import { parsePredictDecimal } from './parsePredictDecimal';
-
-type GameSelection = 'away' | 'home';
+import {
+  createGameCardProjection,
+  type GameCardProjection,
+  type GameSelection,
+} from './createGameCardProjection';
 
 type OrderHandler = (
   event: PredictEvent,
@@ -39,22 +32,10 @@ type OrderHandler = (
   outcome: PredictOutcome,
 ) => void;
 
-interface TeamQuote {
-  market: PredictMarket;
-  outcome: PredictOutcome;
-}
-
-interface StatusLine {
-  label: string;
-  metadata: string;
-}
-
 interface GameCardContextValue {
   event: PredictEvent;
   game: PredictGame;
-  quotes: Record<GameSelection, TeamQuote | undefined>;
-  statusLines: Record<'compact' | 'featured', StatusLine>;
-  representedMarketIds: ReadonlySet<PredictEntityId>;
+  projection: GameCardProjection;
   actions: {
     openEvent: () => void;
     order?: OrderHandler;
@@ -78,82 +59,9 @@ const useTeam = (selection: GameSelection) => {
   const value = useGameCard();
   return {
     ...value,
-    team: selection === 'away' ? value.game.awayTeam : value.game.homeTeam,
-    quote: value.quotes[selection],
+    ...value.projection.teams[selection],
     fallbackColor: value.colors[selection],
   };
-};
-
-const STATUS_KEYS: Record<PredictGameStatus, string> = {
-  scheduled: 'scheduled',
-  in_progress: 'live',
-  delayed: 'delayed',
-  suspended: 'suspended',
-  postponed: 'postponed',
-  completed: 'final',
-  canceled: 'canceled',
-};
-
-const getDisplayAbbreviation = (team: PredictTeam) =>
-  (team.abbreviation ?? team.name.slice(0, 3)).toUpperCase();
-
-const getTeamQuote = (
-  event: PredictEvent,
-  selection: GameSelection,
-): TeamQuote | undefined => {
-  const matches = event.markets.flatMap((market) =>
-    market.outcomes
-      .filter((outcome) => outcome.gameSelection === selection)
-      .map((outcome) => ({ market, outcome })),
-  );
-
-  return matches.length === 1 ? matches[0] : undefined;
-};
-
-const getStatusLabel = (status: PredictGameStatus) =>
-  strings(`predict.game_status.${STATUS_KEYS[status]}`);
-
-const getStatusLine = (
-  game: PredictGame,
-  startsAt: string | undefined,
-  variant: 'compact' | 'featured',
-): StatusLine => {
-  if (game.status === 'scheduled') {
-    if (!startsAt) {
-      return { label: getStatusLabel(game.status), metadata: '' };
-    }
-
-    const date = new Date(startsAt);
-    if (variant === 'featured') {
-      return {
-        label: getIntlDateTimeFormatter(I18n.locale, {
-          weekday: 'long',
-          month: 'long',
-          day: 'numeric',
-        }).format(date),
-        metadata: getIntlDateTimeFormatter(I18n.locale, {
-          hour: 'numeric',
-          minute: '2-digit',
-        }).format(date),
-      };
-    }
-
-    const day = getIntlDateTimeFormatter(I18n.locale, {
-      month: 'long',
-      day: 'numeric',
-    }).format(date);
-    const time = getIntlDateTimeFormatter(I18n.locale, {
-      hour: 'numeric',
-      minute: '2-digit',
-    }).format(date);
-    return { label: `${day} · ${time}`, metadata: '' };
-  }
-
-  const metadata = ['in_progress', 'delayed', 'suspended'].includes(game.status)
-    ? [game.period, game.clock].filter(Boolean).join(' · ')
-    : '';
-
-  return { label: getStatusLabel(game.status), metadata };
 };
 
 interface ProviderProps {
@@ -172,42 +80,26 @@ const Provider = ({
   onOrder,
 }: ProviderProps) => {
   const { colors } = useTheme();
-  const value = useMemo<GameCardContextValue>(() => {
-    const quotes = {
-      away: getTeamQuote(event, 'away'),
-      home: getTeamQuote(event, 'home'),
-    };
-    const representedMarketIds = new Set<PredictEntityId>();
-
-    for (const quote of Object.values(quotes)) {
-      if (quote && formatAskPrice(quote.outcome.askPrice)) {
-        representedMarketIds.add(quote.market.id);
-      }
-    }
-
-    return {
+  const value = useMemo<GameCardContextValue>(
+    () => ({
       event,
       game,
-      quotes,
-      representedMarketIds,
-      statusLines: {
-        compact: getStatusLine(game, event.startsAt, 'compact'),
-        featured: getStatusLine(game, event.startsAt, 'featured'),
-      },
+      projection: createGameCardProjection(event, game),
       actions: { openEvent: onPress, order: onOrder },
       colors: {
         away: colors.info.default,
         home: colors.success.default,
       },
-    };
-  }, [
-    colors.info.default,
-    colors.success.default,
-    event,
-    game,
-    onOrder,
-    onPress,
-  ]);
+    }),
+    [
+      colors.info.default,
+      colors.success.default,
+      event,
+      game,
+      onOrder,
+      onPress,
+    ],
+  );
 
   return (
     <GameCardContext.Provider value={value}>
@@ -223,7 +115,7 @@ const TeamLogo = ({
   selection: GameSelection;
   size?: 'small' | 'large';
 }) => {
-  const { event, team } = useTeam(selection);
+  const { event, team, abbreviation } = useTeam(selection);
   const tw = useTailwind();
   const [failed, setFailed] = useState(false);
   const showImage = team.logoUrl && !failed;
@@ -251,7 +143,7 @@ const TeamLogo = ({
           fontWeight={FontWeight.Medium}
           testID={`predict-next-game-logo-fallback-${event.id}-${selection}`}
         >
-          {getDisplayAbbreviation(team)}
+          {abbreviation}
         </Text>
       )}
     </Box>
@@ -259,8 +151,8 @@ const TeamLogo = ({
 };
 
 const StatusContent = ({ variant }: { variant: 'compact' | 'featured' }) => {
-  const { event, game, statusLines } = useGameCard();
-  const line = statusLines[variant];
+  const { event, game, projection } = useGameCard();
+  const line = projection.status[variant];
   const featured = variant === 'featured';
 
   return (
@@ -303,10 +195,9 @@ const CompactStatus = () => <StatusContent variant="compact" />;
 const FeaturedStatus = () => <StatusContent variant="featured" />;
 
 const CompactTeamRow = ({ selection }: { selection: GameSelection }) => {
-  const { event, game, team, quote, fallbackColor } = useTeam(selection);
+  const { event, game, team, percent, multiplier, fallbackColor } =
+    useTeam(selection);
   const score = game.score?.[selection];
-  const percent = getAskPricePercent(quote?.outcome.askPrice);
-  const multiplier = formatMultiplier(quote?.outcome.askPrice);
   const color = team.primaryColor ?? fallbackColor;
 
   return (
@@ -399,20 +290,12 @@ const Matchup = ({ children }: { children: React.ReactNode }) => {
 };
 
 const ProbabilityBar = () => {
-  const { event, game, quotes, colors } = useGameCard();
-  const away = parsePredictDecimal(quotes.away?.outcome.askPrice);
-  const home = parsePredictDecimal(quotes.home?.outcome.askPrice);
+  const { event, game, projection, colors } = useGameCard();
+  const awayWidth = projection.awayProbabilityPercent;
 
-  if (!away || !home) {
+  if (awayWidth === undefined) {
     return null;
   }
-
-  const total = away.plus(home);
-  if (total.lte(0)) {
-    return null;
-  }
-
-  const awayWidth = away.div(total).times(new BigNumber(100)).toNumber();
 
   return (
     <Box
@@ -439,14 +322,21 @@ const ProbabilityBar = () => {
 
 const Quote = ({ selection }: { selection: GameSelection }) => {
   const { colors: themeColors } = useTheme();
-  const { event, team, quote, actions, fallbackColor } = useTeam(selection);
-  const formattedPrice = formatAskPrice(quote?.outcome.askPrice);
+  const {
+    event,
+    team,
+    quote,
+    abbreviation,
+    formattedPrice,
+    canOrder,
+    actions,
+    fallbackColor,
+  } = useTeam(selection);
 
   if (!quote) {
     return null;
   }
 
-  const abbreviation = getDisplayAbbreviation(team);
   const label = formattedPrice
     ? `${abbreviation} · ${formattedPrice}`
     : abbreviation;
@@ -467,7 +357,7 @@ const Quote = ({ selection }: { selection: GameSelection }) => {
     );
   }
 
-  if (quote.market.status !== 'active') {
+  if (!canOrder) {
     return (
       <Box
         testID={testID}
@@ -505,9 +395,9 @@ const Quote = ({ selection }: { selection: GameSelection }) => {
 };
 
 const Actions = () => {
-  const { quotes } = useGameCard();
+  const { projection } = useGameCard();
   const selections = (['away', 'home'] as const).filter(
-    (selection) => quotes[selection],
+    (selection) => projection.teams[selection].quote,
   );
 
   return selections.length ? (
@@ -522,12 +412,13 @@ const Actions = () => {
 };
 
 const Footer = ({ children }: { children: React.ReactNode }) => {
-  const { event, representedMarketIds } = useGameCard();
-  const hiddenCount = event.markets.filter(
-    (market) => !representedMarketIds.has(market.id),
-  ).length;
+  const { event, projection } = useGameCard();
 
-  if (!event.sports?.competition?.label && !event.volume && !hiddenCount) {
+  if (
+    !event.sports?.competition?.label &&
+    !event.volume &&
+    !projection.hiddenMarketCount
+  ) {
     return null;
   }
 
@@ -551,14 +442,11 @@ const Competition = () => {
 };
 
 const MoreMarkets = () => {
-  const { event, representedMarketIds, actions } = useGameCard();
-  const count = event.markets.filter(
-    (market) => !representedMarketIds.has(market.id),
-  ).length;
+  const { event, projection, actions } = useGameCard();
 
   return (
     <EventCard.MoreMarkets
-      count={count}
+      count={projection.hiddenMarketCount}
       onPress={actions.openEvent}
       testID={`predict-next-event-more-${event.id}`}
     />

--- a/app/components/UI/PredictNext/events/cards/internal/createGameCardProjection.test.ts
+++ b/app/components/UI/PredictNext/events/cards/internal/createGameCardProjection.test.ts
@@ -1,0 +1,174 @@
+import I18n from '../../../../../../../locales/i18n';
+import type {
+  PredictDecimal,
+  PredictEntityId,
+  PredictEvent,
+  PredictGame,
+  PredictMarket,
+  PredictOutcome,
+  PredictTimestamp,
+  PredictVenueId,
+} from '../../../types';
+import { createGameCardProjection } from './createGameCardProjection';
+
+const createOutcome = (
+  id: string,
+  gameSelection?: PredictOutcome['gameSelection'],
+  askPrice?: string,
+): PredictOutcome => ({
+  id: id as PredictEntityId,
+  side: gameSelection ? 'yes' : 'no',
+  label: id,
+  gameSelection,
+  askPrice: askPrice as PredictDecimal | undefined,
+});
+
+const createMarket = (
+  id: string,
+  selection: PredictOutcome['gameSelection'],
+  askPrice?: string,
+  status: PredictMarket['status'] = 'active',
+): PredictMarket => ({
+  id: id as PredictEntityId,
+  question: id,
+  status,
+  outcomes: [
+    createOutcome(`${id}-yes`, selection, askPrice),
+    createOutcome(`${id}-no`),
+  ],
+});
+
+const game: PredictGame = {
+  status: 'in_progress',
+  awayTeam: { name: 'Arizona Cardinals', abbreviation: 'ARI' },
+  homeTeam: { name: 'Carolina Panthers', abbreviation: 'CAR' },
+  score: { away: '17', home: '21' },
+  period: 'Q4',
+  clock: '12:22',
+  observedAt: '2026-09-11T02:30:00Z' as PredictTimestamp,
+};
+
+const createEvent = (
+  markets: readonly PredictMarket[],
+  overrides: Partial<PredictEvent> = {},
+): PredictEvent => ({
+  venueId: 'kalshi' as PredictVenueId,
+  id: 'game-event' as PredictEntityId,
+  title: 'Cardinals vs Panthers',
+  startsAt: '2026-09-11T00:20:00Z' as PredictTimestamp,
+  sports: {
+    sport: {
+      id: 'american-football' as PredictEntityId,
+      label: 'American football',
+    },
+    game,
+  },
+  markets,
+  ...overrides,
+});
+
+describe('createGameCardProjection', () => {
+  const originalLocale = I18n.locale;
+
+  beforeAll(() => {
+    I18n.locale = 'en-US';
+  });
+
+  afterAll(() => {
+    I18n.locale = originalLocale;
+  });
+
+  it('projects authoritative Team quotes and price presentation', () => {
+    const event = createEvent([
+      createMarket('away', 'away', '0.47'),
+      createMarket('home', 'home', '0.53'),
+    ]);
+
+    const result = createGameCardProjection(event, game);
+
+    expect(result.teams.away).toMatchObject({
+      abbreviation: 'ARI',
+      formattedPrice: '47¢',
+      multiplier: '2.13x',
+      percent: 47,
+      canOrder: true,
+    });
+    expect(result.teams.home).toMatchObject({
+      abbreviation: 'CAR',
+      formattedPrice: '53¢',
+      multiplier: '1.89x',
+      percent: 53,
+      canOrder: true,
+    });
+  });
+
+  it('omits a Team quote when multiple Outcomes claim its Game Selection', () => {
+    const event = createEvent([
+      createMarket('away-one', 'away', '0.47'),
+      createMarket('away-two', 'away', '0.48'),
+      createMarket('home', 'home', '0.53'),
+    ]);
+
+    const result = createGameCardProjection(event, game);
+
+    expect(result.teams.away.quote).toBeUndefined();
+    expect(result.teams.home.quote?.market.id).toBe('home');
+    expect(result.hiddenMarketCount).toBe(2);
+  });
+
+  it('keeps an unavailable Team quote visible but excludes its Market representation', () => {
+    const event = createEvent([
+      createMarket('away', 'away'),
+      createMarket('home', 'home', '0.53'),
+    ]);
+
+    const result = createGameCardProjection(event, game);
+
+    expect(result.teams.away.quote?.market.id).toBe('away');
+    expect(result.teams.away.formattedPrice).toBeUndefined();
+    expect(result.teams.away.canOrder).toBe(false);
+    expect(result.hiddenMarketCount).toBe(1);
+  });
+
+  it('marks an inactive Market quote as non-orderable', () => {
+    const event = createEvent([
+      createMarket('away', 'away', '0.47', 'inactive'),
+    ]);
+
+    const result = createGameCardProjection(event, game);
+
+    expect(result.teams.away.formattedPrice).toBe('47¢');
+    expect(result.teams.away.canOrder).toBe(false);
+  });
+
+  it('projects Game status for compact and featured variants', () => {
+    const scheduledGame: PredictGame = { ...game, status: 'scheduled' };
+    const event = createEvent([]);
+    if (!event.sports) {
+      throw new Error('Sports context fixture missing');
+    }
+    event.sports.game = scheduledGame;
+
+    const result = createGameCardProjection(event, scheduledGame);
+
+    expect(result.status.compact).toEqual({
+      label: 'September 10 · 8:20 PM',
+      metadata: '',
+    });
+    expect(result.status.featured).toEqual({
+      label: 'Thursday, September 10',
+      metadata: '8:20 PM',
+    });
+  });
+
+  it('projects no probability when Team prices total zero', () => {
+    const event = createEvent([
+      createMarket('away', 'away', '0'),
+      createMarket('home', 'home', '0'),
+    ]);
+
+    const result = createGameCardProjection(event, game);
+
+    expect(result.awayProbabilityPercent).toBeUndefined();
+  });
+});

--- a/app/components/UI/PredictNext/events/cards/internal/createGameCardProjection.ts
+++ b/app/components/UI/PredictNext/events/cards/internal/createGameCardProjection.ts
@@ -1,0 +1,167 @@
+import BigNumber from 'bignumber.js';
+import I18n, { strings } from '../../../../../../../locales/i18n';
+import { getIntlDateTimeFormatter } from '../../../../../../util/intl';
+import type {
+  PredictEvent,
+  PredictGame,
+  PredictGameStatus,
+  PredictMarket,
+  PredictOutcome,
+  PredictTeam,
+} from '../../../types';
+import { formatAskPrice } from './formatAskPrice';
+import { formatMultiplier } from './formatMultiplier';
+import { getAskPricePercent } from './getAskPricePercent';
+import { parsePredictDecimal } from './parsePredictDecimal';
+
+export type GameSelection = 'away' | 'home';
+
+export interface GameCardQuote {
+  market: PredictMarket;
+  outcome: PredictOutcome;
+}
+
+interface GameCardStatusLine {
+  label: string;
+  metadata: string;
+}
+
+export interface GameCardTeamProjection {
+  team: PredictTeam;
+  quote?: GameCardQuote;
+  abbreviation: string;
+  formattedPrice?: string;
+  multiplier?: string;
+  percent?: number;
+  canOrder: boolean;
+}
+
+export interface GameCardProjection {
+  teams: Record<GameSelection, GameCardTeamProjection>;
+  status: Record<'compact' | 'featured', GameCardStatusLine>;
+  hiddenMarketCount: number;
+  awayProbabilityPercent?: number;
+}
+
+const STATUS_KEYS: Record<PredictGameStatus, string> = {
+  scheduled: 'scheduled',
+  in_progress: 'live',
+  delayed: 'delayed',
+  suspended: 'suspended',
+  postponed: 'postponed',
+  completed: 'final',
+  canceled: 'canceled',
+};
+
+const getStatusLabel = (status: PredictGameStatus) =>
+  strings(`predict.game_status.${STATUS_KEYS[status]}`);
+
+const getStatusLine = (
+  game: PredictGame,
+  startsAt: string | undefined,
+  variant: 'compact' | 'featured',
+): GameCardStatusLine => {
+  if (game.status === 'scheduled') {
+    if (!startsAt) {
+      return { label: getStatusLabel(game.status), metadata: '' };
+    }
+
+    const date = new Date(startsAt);
+    if (variant === 'featured') {
+      return {
+        label: getIntlDateTimeFormatter(I18n.locale, {
+          weekday: 'long',
+          month: 'long',
+          day: 'numeric',
+        }).format(date),
+        metadata: getIntlDateTimeFormatter(I18n.locale, {
+          hour: 'numeric',
+          minute: '2-digit',
+        }).format(date),
+      };
+    }
+
+    const day = getIntlDateTimeFormatter(I18n.locale, {
+      month: 'long',
+      day: 'numeric',
+    }).format(date);
+    const time = getIntlDateTimeFormatter(I18n.locale, {
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(date);
+    return { label: `${day} · ${time}`, metadata: '' };
+  }
+
+  const metadata = ['in_progress', 'delayed', 'suspended'].includes(game.status)
+    ? [game.period, game.clock].filter(Boolean).join(' · ')
+    : '';
+
+  return { label: getStatusLabel(game.status), metadata };
+};
+
+const findQuote = (
+  event: PredictEvent,
+  selection: GameSelection,
+): GameCardQuote | undefined => {
+  const matches = event.markets.flatMap((market) =>
+    market.outcomes
+      .filter((outcome) => outcome.gameSelection === selection)
+      .map((outcome) => ({ market, outcome })),
+  );
+
+  return matches.length === 1 ? matches[0] : undefined;
+};
+
+const createTeamProjection = (
+  event: PredictEvent,
+  game: PredictGame,
+  selection: GameSelection,
+): GameCardTeamProjection => {
+  const team = selection === 'away' ? game.awayTeam : game.homeTeam;
+  const quote = findQuote(event, selection);
+  const formattedPrice = formatAskPrice(quote?.outcome.askPrice);
+
+  return {
+    team,
+    quote,
+    abbreviation: (team.abbreviation ?? team.name.slice(0, 3)).toUpperCase(),
+    formattedPrice,
+    multiplier: formatMultiplier(quote?.outcome.askPrice),
+    percent: getAskPricePercent(quote?.outcome.askPrice),
+    canOrder: Boolean(formattedPrice && quote?.market.status === 'active'),
+  };
+};
+
+export const createGameCardProjection = (
+  event: PredictEvent,
+  game: PredictGame,
+): GameCardProjection => {
+  const teams = {
+    away: createTeamProjection(event, game, 'away'),
+    home: createTeamProjection(event, game, 'home'),
+  };
+  const representedMarkets = new Set(
+    Object.values(teams)
+      .filter((team) => team.formattedPrice)
+      .map((team) => team.quote?.market.id),
+  );
+  const away = parsePredictDecimal(teams.away.quote?.outcome.askPrice);
+  const home = parsePredictDecimal(teams.home.quote?.outcome.askPrice);
+  const total = away && home ? away.plus(home) : undefined;
+  const awayProbabilityPercent =
+    away && total?.gt(0)
+      ? away.div(total).times(new BigNumber(100)).toNumber()
+      : undefined;
+
+  return {
+    teams,
+    status: {
+      compact: getStatusLine(game, event.startsAt, 'compact'),
+      featured: getStatusLine(game, event.startsAt, 'featured'),
+    },
+    hiddenMarketCount: event.markets.filter(
+      (market) => !representedMarkets.has(market.id),
+    ).length,
+    awayProbabilityPercent,
+  };
+};


### PR DESCRIPTION
## **Description**

Deepens the PredictNext Game card projection so canonical Event interpretation is concentrated in one internal module. Team quote selection, price presentation, Game status display, order eligibility, represented Market counting, and probability calculation are now computed once and consumed by the compact and featured card compositions.

This reduces the rendering module's interface and keeps Game-domain rules local without changing the public Event card interface or user-visible behavior.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: Internal PredictNext architecture improvement

## **Manual testing steps**

```gherkin
Feature: PredictNext football Game cards

  Scenario: user views football Game Events
    Given PredictNext returns football Game Events with canonical Team quotes

    When the user opens the PredictNext home screen
    Then compact Game cards show the same Teams, status, scores, quotes, and remaining Market count
    And featured Game cards show the same matchup and probability presentation
    And active quotes remain orderable independently from Event navigation
```

Automated verification:

1. `yarn jest app/components/UI/PredictNext/events/cards --runInBand --coverage=false`
2. `yarn test:view:one app/components/UI/PredictNext/views/PredictHome/PredictHome.view.test.tsx --runInBand`
3. `yarn lint:tsc`
4. ESLint on all changed files

## **Screenshots/Recordings**

N/A — internal architecture refactor with no intended visual changes.

### **Before**

N/A — no visual change.

### **After**

N/A — no visual change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - N/A — no runtime behavior or rendering structure changed; focused automated coverage passed.
- [ ] I've tested with a power user scenario
  - N/A — no data-fetching, list, or state-subscription behavior changed.
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A — no new operation or performance-critical workflow was introduced.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 70b6b13381489313af3990476a04e329b866af53. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->