### PR TITLE
ci: run Appium smoke and fixture validation on the runner-provider switch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1513,12 +1513,8 @@ jobs:
 
   appium-smoke-tests-android:
     name: 'Appium Smoke Tests (Android)'
-    # Pinned to Cirrus until artifact-store parity. Run only when the Android build
-    # provider also resolves to current so this job can consume its artifacts.
     if: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-         vars.NAMESPACE_RUNNER_ANDROID || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'current' &&
         !cancelled() &&
         needs.build-android-apks.result == 'success'
       }}
@@ -1531,8 +1527,13 @@ jobs:
     with:
       build_type: 'main'
       metamask_environment: 'e2e'
-      # Pinned to Cirrus until Namespace artifact-store parity.
-      runner_provider: current
+      # Mirrors build-android-apks' resolution chain so this consumer always matches
+      # the builder's artifact store (GitHub on current, Namespace store on namespace).
+      runner_provider: >-
+        ${{
+          inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
+          vars.NAMESPACE_RUNNER_ANDROID || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+        }}
       selected_tags: >-
         ${{
           (fromJSON(needs.smart-e2e-selection.outputs.ai_confidence || '0') >= 85 &&
@@ -1543,16 +1544,12 @@ jobs:
 
   appium-smoke-tests-ios:
     name: 'Appium Smoke Tests (iOS)'
-    # Pinned to Cirrus until artifact-store parity. Run only when the iOS build
-    # provider also resolves to current so this job can consume its artifacts.
     # Main/release push and main schedule: always run when the iOS build succeeded.
     # PRs: skipped by default; add run-appium-ios-tests, or change
     # page-objects/selectors/locators/framework/smoke-appium
     # (same smart-selected tags as other E2E jobs).
     if: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-         vars.NAMESPACE_RUNNER_IOS || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'current' &&
         !cancelled() &&
         needs.ios-tests-ready.result == 'success' &&
         (
@@ -1582,8 +1579,13 @@ jobs:
     with:
       build_type: 'main'
       metamask_environment: 'e2e'
-      # Pinned to Cirrus until Namespace artifact-store parity.
-      runner_provider: current
+      # Mirrors build-ios-apps' resolution chain so this consumer always matches
+      # the builder's artifact store (GitHub on current, Namespace store on namespace).
+      runner_provider: >-
+        ${{
+          inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
+          vars.NAMESPACE_RUNNER_IOS || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+        }}
       selected_tags: >-
         ${{
           (fromJSON(needs.smart-e2e-selection.outputs.ai_confidence || '0') >= 85 &&
@@ -1595,12 +1597,8 @@ jobs:
   # Fixture validation — ensures committed E2E fixtures match the live app state schema
   validate-e2e-fixtures:
     name: 'Validate E2E Fixtures'
-    # Pinned to Cirrus until artifact-store parity. Run only when the iOS build
-    # provider also resolves to current so this job can consume its artifacts.
     if: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-         vars.NAMESPACE_RUNNER_IOS || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'current' &&
         needs.ios-tests-ready.result == 'success' &&
         github.event_name == 'pull_request'
       }}
@@ -1619,8 +1617,13 @@ jobs:
       test-timeout-minutes: 25
       build_type: 'main'
       metamask_environment: 'e2e'
-      # Pinned to Cirrus until Namespace artifact-store parity (same as Appium smoke).
-      runner_provider: current
+      # Mirrors build-ios-apps' resolution chain so this consumer always matches
+      # the builder's artifact store (GitHub on current, Namespace store on namespace).
+      runner_provider: >-
+        ${{
+          inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
+          vars.NAMESPACE_RUNNER_IOS || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+        }}
     secrets: inherit
 
   report-fixture-validation:
@@ -1647,9 +1650,9 @@ jobs:
       - uses: actions/checkout@v6
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
 
-      # validate-e2e-fixtures is pinned to runner_provider: current, so results always
-      # land in the GitHub Actions artifact store — download via actions/* regardless
-      # of where this reporting job runs.
+      # run-appium-e2e-workflow uploads fixture validation results unconditionally via
+      # actions/upload-artifact (no Namespace-store arm), so results always land in the
+      # GitHub Actions artifact store — download via actions/* regardless of provider.
       - name: Download fixture validation results
         continue-on-error: true
         uses: actions/download-artifact@v4

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -170,7 +170,20 @@ jobs:
 
       - name: Download iOS build artifacts (Namespace)
         if: ${{ inputs.platform == 'ios' && inputs.runner_provider == 'namespace' }}
+        id: download-ios-app-namespace
+        continue-on-error: true
         uses: namespace-actions/download-artifact@7cbad919e4b0e09f17e9d6311a444ff002992b5b # v2.0.1
+        with:
+          name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app
+          path: artifacts/${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app
+      - name: Download iOS build artifacts (GitHub — build may be on Cirrus)
+        if: >-
+          ${{
+            inputs.platform == 'ios' &&
+            inputs.runner_provider == 'namespace' &&
+            steps.download-ios-app-namespace.outcome != 'success'
+          }}
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app
           path: artifacts/${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -112,14 +112,18 @@ jobs:
           install-applesimutils: 'false'
           runner_provider: ${{ inputs.runner_provider }}
 
+      # The cache key must be provider-scoped: runner.os is macOS on both Cirrus and
+      # Namespace, but their images carry different Homebrew installations — a snapshot
+      # created on one crashes brew on the other (Utils::Bottles.load_tab NoMethodError
+      # while pouring a cached bottle). Both buckets rebuild once from empty.
       - name: Cache ffmpeg (Homebrew)
         if: ${{ inputs.platform == 'ios' }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/mms-ffmpeg
-          key: brew-ffmpeg-${{ runner.os }}-v1
+          key: brew-ffmpeg-${{ runner.os }}-${{ inputs.runner_provider == 'namespace' && 'namespace' || 'current' }}-v1
           restore-keys: |
-            brew-ffmpeg-${{ runner.os }}-
+            brew-ffmpeg-${{ runner.os }}-${{ inputs.runner_provider == 'namespace' && 'namespace' || 'current' }}-
 
       - name: Install ffmpeg for XCUITest screen recording
         if: ${{ inputs.platform == 'ios' }}
@@ -176,6 +180,18 @@ jobs:
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app
           path: artifacts/${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app
+      # actions/download-artifact merges into its target directory rather than
+      # replacing it (same caveat as in build-ios-e2e.yml) — clear any residue from
+      # the failed Namespace attempt so the fallback starts from an empty bundle dir.
+      - name: Clear any partial iOS app before the fallback download
+        if: >-
+          ${{
+            inputs.platform == 'ios' &&
+            inputs.runner_provider == 'namespace' &&
+            steps.download-ios-app-namespace.outcome != 'success'
+          }}
+        shell: bash
+        run: rm -rf "artifacts/${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app"
       - name: Download iOS build artifacts (GitHub — build may be on Cirrus)
         if: >-
           ${{

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -112,18 +112,14 @@ jobs:
           install-applesimutils: 'false'
           runner_provider: ${{ inputs.runner_provider }}
 
-      # The cache key must be provider-scoped: runner.os is macOS on both Cirrus and
-      # Namespace, but their images carry different Homebrew installations — a snapshot
-      # created on one crashes brew on the other (Utils::Bottles.load_tab NoMethodError
-      # while pouring a cached bottle). Both buckets rebuild once from empty.
       - name: Cache ffmpeg (Homebrew)
         if: ${{ inputs.platform == 'ios' }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/mms-ffmpeg
-          key: brew-ffmpeg-${{ runner.os }}-${{ inputs.runner_provider == 'namespace' && 'namespace' || 'current' }}-v1
+          key: brew-ffmpeg-${{ runner.os }}-v1
           restore-keys: |
-            brew-ffmpeg-${{ runner.os }}-${{ inputs.runner_provider == 'namespace' && 'namespace' || 'current' }}-
+            brew-ffmpeg-${{ runner.os }}-
 
       - name: Install ffmpeg for XCUITest screen recording
         if: ${{ inputs.platform == 'ios' }}

--- a/scripts/e2e/ensure-ffmpeg-ci.sh
+++ b/scripts/e2e/ensure-ffmpeg-ci.sh
@@ -63,7 +63,15 @@ if command -v ffmpeg >/dev/null 2>&1; then
 fi
 
 echo "Installing ffmpeg via Homebrew (bottles cached under ${BREW_CACHE_DIR})..."
-brew install ffmpeg
+if ! brew install ffmpeg; then
+  # A Homebrew older than the bottles it downloads cannot read their metadata and
+  # crashes (Utils::Bottles.load_tab NoMethodError) — brew's own error text says to
+  # run `brew update` and retry. Only reached when the plain install fails, so
+  # runners with a current brew never pay the update cost.
+  echo "brew install failed — updating Homebrew once and retrying..." >&2
+  brew update --quiet
+  brew install ffmpeg
+fi
 
 if ! command -v ffmpeg >/dev/null 2>&1; then
   echo "ffmpeg install finished but binary is not on PATH" >&2


### PR DESCRIPTION
## **Description**

Unpins the last PR-CI consumers from `runner_provider: current`: `appium-smoke-tests-android`, `appium-smoke-tests-ios` and `validate-e2e-fixtures`.

- Each call site now mirrors its build job's resolution chain (per-run input → platform variable → fleet variable → `current`), so the consumer always lands on the same provider as its builder and reads the matching artifact store (GitHub store on `current`, Namespace store on `namespace`). The provider-equality `if:` gates become unnecessary and are removed.
- Adds a GitHub-store fallback to the iOS artifact download in `run-appium-e2e-workflow.yml`, mirroring the existing Android fallback, for mixed-provider variable states.

Context: with the platform variables engaged (`NAMESPACE_RUNNER_ANDROID/IOS=namespace`), the old gates have been skipping these suites entirely — no Appium smoke or fixture-validation coverage on any PR/push/schedule since the flip. This PR restores that coverage, now on the Namespace e2e profiles. All the Namespace plumbing already exists in `run-appium-e2e-workflow.yml` (profile labels, dual checkout/downloads, provider-aware setup-e2e-env, emulator baked into the Android image); this PR only switches it on at the call sites.

Draft on purpose: this PR's own CI is the runtime trial of Appium-on-Namespace (its workflow changes are `e2e_relevant_workflows`, so the native e2e builds run; the `run-appium-ios-tests` label forces iOS Appium; fixture validation runs on any PR with a successful iOS build).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Relates to: [INFRA-3841](https://consensyssoftware.atlassian.net/browse/INFRA-3841) (Appium/fixture artifact-store carve-out)

## **Manual testing steps**

```gherkin
Feature: Appium smoke and fixture validation follow the fleet

  Scenario: PR CI with ANDROID/IOS=namespace
    Given NAMESPACE_RUNNER_ANDROID and NAMESPACE_RUNNER_IOS are namespace
    When this PR's CI runs
    Then Appium Android smoke runs on namespace-profile-metamask-android-build
    And Appium iOS smoke and fixture validation run on namespace-profile-metamask-ios-e2e
    And app artifacts are consumed from the Namespace artifact store

  Scenario: rollback without a revert
    Given NAMESPACE_RUNNER_ANDROID=current (or IOS)
    When PR CI runs
    Then the corresponding builds and Appium consumers both return to Cirrus together
```

## **Screenshots/Recordings**

N/A

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[INFRA-3841]: https://consensyssoftware.atlassian.net/browse/INFRA-3841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI orchestration and artifact download paths for E2E; wrong provider pairing could break smoke runs, but behavior mirrors existing Android fallback and build-job resolution.
> 
> **Overview**
> **Restores PR CI Appium coverage** when Android/iOS builds run on Namespace by unpinned the last jobs that were hard-coded to `runner_provider: current`. **Appium Android smoke**, **iOS smoke**, and **validate-e2e-fixtures** now pass the same provider resolution as their build jobs (input → platform var → fleet var → `current`) and drop the `if` gates that skipped them whenever builders were on Namespace.
> 
> **`run-appium-e2e-workflow.yml`** adds an iOS artifact path aligned with Android: try Namespace download, clear a partial bundle on failure, then fall back to GitHub Actions artifacts when the build still uploaded to Cirrus.
> 
> **`ensure-ffmpeg-ci.sh`** retries `brew install ffmpeg` after a one-time `brew update` when bottle metadata breaks on stale Homebrew (iOS XCUITest recording).
> 
> Fixture-validation reporting comments are updated to note results always land in the GitHub artifact store via unconditional `actions/upload-artifact`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ae94daf75f332ecf2fa759873302233762a2332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->