### PR TITLE
feat(homepage): add new variant for balance breakdown with row arrows

### DIFF
--- a/app/components/Views/Homepage/abTestConfig.ts
+++ b/app/components/Views/Homepage/abTestConfig.ts
@@ -267,6 +267,7 @@ export const HOMEPAGE_BALANCE_BREAKDOWN_ENTRY_POINT =
 export enum HomepageBalanceBreakdownVariant {
   Control = 'control',
   Icons = 'icons',
+  IconsWithArrows = 'iconsWithArrows',
   Allocation = 'allocation',
 }
 
@@ -274,6 +275,7 @@ export type HomepageBalanceBreakdownLayout = 'icons' | 'allocation';
 
 interface HomepageBalanceBreakdownVariantConfig {
   layout: HomepageBalanceBreakdownLayout | null;
+  showRowArrows: boolean;
 }
 
 export const HOMEPAGE_BALANCE_BREAKDOWN_VARIANTS: Record<
@@ -282,12 +284,19 @@ export const HOMEPAGE_BALANCE_BREAKDOWN_VARIANTS: Record<
 > = {
   [HomepageBalanceBreakdownVariant.Control]: {
     layout: null,
+    showRowArrows: false,
   },
   [HomepageBalanceBreakdownVariant.Icons]: {
     layout: 'icons',
+    showRowArrows: false,
+  },
+  [HomepageBalanceBreakdownVariant.IconsWithArrows]: {
+    layout: 'icons',
+    showRowArrows: true,
   },
   [HomepageBalanceBreakdownVariant.Allocation]: {
     layout: 'allocation',
+    showRowArrows: false,
   },
 };
 
@@ -296,6 +305,7 @@ export const HOMEPAGE_BALANCE_BREAKDOWN_AB_TEST_EXPOSURE_OPTIONS = {
   variationNames: {
     control: 'Current homepage without balance breakdown',
     icons: 'Primitive breakdown with icons',
+    iconsWithArrows: 'Primitive breakdown with icons and row arrows',
     allocation: 'Primitive allocation breakdown',
   },
 } as const;

--- a/app/components/Views/Homepage/components/HomepageBalanceBreakdown/HomepageBalanceBreakdown.test.tsx
+++ b/app/components/Views/Homepage/components/HomepageBalanceBreakdown/HomepageBalanceBreakdown.test.tsx
@@ -186,7 +186,7 @@ describe('HomepageBalanceBreakdown', () => {
   });
 
   it('renders the aggregate hero and rows in screenshot order', () => {
-    const { getByTestId, getAllByRole } = render(
+    const { getByTestId, getAllByRole, queryByTestId } = render(
       <HomepageBalanceBreakdown layout="icons" />,
     );
 
@@ -236,6 +236,9 @@ describe('HomepageBalanceBreakdown', () => {
       getByTestId(HomepageBalanceBreakdownTestIds.ICON('defi')),
     ).toHaveTextContent('%');
     expect(
+      queryByTestId(HomepageBalanceBreakdownTestIds.ARROW('money')),
+    ).not.toBeOnTheScreen();
+    expect(
       getByTestId(HomepageBalanceBreakdownTestIds.HERO).props
         .accessibilityLabel,
     ).toContain('USD 50.00');
@@ -257,6 +260,23 @@ describe('HomepageBalanceBreakdown', () => {
       getByTestId(HomepageBalanceBreakdownTestIds.ROW('perps')).props
         .accessibilityLabel,
     ).toBe('Perps, USD 10.00, 20%');
+  });
+
+  it('renders a right arrow on every icon row when enabled', () => {
+    const { getByTestId } = render(
+      <HomepageBalanceBreakdown layout="icons" showRowArrows />,
+    );
+
+    (['money', 'tokens', 'perps', 'predict', 'defi'] as const).forEach(
+      (key) => {
+        expect(
+          getByTestId(HomepageBalanceBreakdownTestIds.ARROW(key)).props.name,
+        ).toBe('ArrowRight');
+        expect(
+          getByTestId(HomepageBalanceBreakdownTestIds.ICON(key)),
+        ).toBeOnTheScreen();
+      },
+    );
   });
 
   it('localizes allocation percentages and APY numbers', () => {

--- a/app/components/Views/Homepage/components/HomepageBalanceBreakdown/HomepageBalanceBreakdown.testIds.ts
+++ b/app/components/Views/Homepage/components/HomepageBalanceBreakdown/HomepageBalanceBreakdown.testIds.ts
@@ -15,6 +15,7 @@ export const HomepageBalanceBreakdownTestIds = {
     `homepage-balance-breakdown-allocation-segment-${key}`,
   ROW: (key: SliceKey) => `homepage-balance-breakdown-row-${key}`,
   ICON: (key: SliceKey) => `homepage-balance-breakdown-icon-${key}`,
+  ARROW: (key: SliceKey) => `homepage-balance-breakdown-arrow-${key}`,
   DOT: (key: SliceKey) => `homepage-balance-breakdown-dot-${key}`,
   PERCENTAGE: (key: SliceKey) => `homepage-balance-breakdown-percentage-${key}`,
   VALUE: (key: SliceKey) => `homepage-balance-breakdown-value-${key}`,

--- a/app/components/Views/Homepage/components/HomepageBalanceBreakdown/HomepageBalanceBreakdown.tsx
+++ b/app/components/Views/Homepage/components/HomepageBalanceBreakdown/HomepageBalanceBreakdown.tsx
@@ -17,6 +17,7 @@ export interface HomepageBalanceBreakdownProps {
   hideRows?: boolean;
   accountGroupBalanceProps?: React.ComponentProps<typeof AccountGroupBalance>;
   layout: HomepageBalanceBreakdownLayout;
+  showRowArrows?: boolean;
   transactionActiveAbTests?: TransactionActiveAbTestEntry[];
   children?: React.ReactNode;
 }
@@ -25,6 +26,7 @@ const HomepageBalanceBreakdown = ({
   hideRows = false,
   accountGroupBalanceProps,
   layout,
+  showRowArrows = false,
   transactionActiveAbTests,
   children,
 }: HomepageBalanceBreakdownProps) => {
@@ -58,6 +60,7 @@ const HomepageBalanceBreakdown = ({
               key={key}
               layout={layout}
               onPress={() => openSlice(key, SLICE_ORDER.indexOf(key))}
+              showArrow={showRowArrows}
               slice={slices[key]}
               userCurrency={hero.userCurrency}
             />

--- a/app/components/Views/Homepage/components/HomepageBalanceBreakdown/HomepageBalanceBreakdownRow.tsx
+++ b/app/components/Views/Homepage/components/HomepageBalanceBreakdown/HomepageBalanceBreakdownRow.tsx
@@ -9,6 +9,7 @@ import {
   FontWeight,
   Icon,
   IconColor,
+  IconName,
   IconSize,
   ListItem,
   ListItemVariant,
@@ -49,6 +50,7 @@ export interface HomepageBalanceBreakdownRowProps {
   userCurrency: string;
   onPress: () => void;
   layout: HomepageBalanceBreakdownLayout;
+  showArrow: boolean;
 }
 
 const HomepageBalanceBreakdownRow = ({
@@ -56,6 +58,7 @@ const HomepageBalanceBreakdownRow = ({
   userCurrency,
   onPress,
   layout,
+  showArrow,
 }: HomepageBalanceBreakdownRowProps) => {
   const privacyMode = useSelector(selectPrivacyMode);
   const { formatCurrency } = useFormatters();
@@ -224,6 +227,17 @@ const HomepageBalanceBreakdownRow = ({
     <ListItem
       accessibilityLabel={accessibilityLabel}
       avatar={avatar}
+      endAccessory={
+        showArrow ? (
+          <Icon
+            color={IconColor.IconAlternative}
+            name={IconName.ArrowRight}
+            size={IconSize.Sm}
+            testID={HomepageBalanceBreakdownTestIds.ARROW(slice.key)}
+            twClassName="ml-1"
+          />
+        ) : undefined
+      }
       isInteractive
       onPress={onPress}
       testID={HomepageBalanceBreakdownTestIds.ROW(slice.key)}

--- a/app/components/Views/Wallet/index.test.tsx
+++ b/app/components/Views/Wallet/index.test.tsx
@@ -125,9 +125,12 @@ jest.mock('../../../hooks', () => ({
         variant: {
           layout:
             mockBalanceBreakdownVariantName === 'icons' ||
-            mockBalanceBreakdownVariantName === 'allocation'
-              ? mockBalanceBreakdownVariantName
-              : null,
+            mockBalanceBreakdownVariantName === 'iconsWithArrows'
+              ? 'icons'
+              : mockBalanceBreakdownVariantName === 'allocation'
+                ? 'allocation'
+                : null,
+          showRowArrows: mockBalanceBreakdownVariantName === 'iconsWithArrows',
         },
         isActive: mockBalanceBreakdownVariantName !== 'unresolved',
       };
@@ -1961,30 +1964,39 @@ describe('Homepage balance breakdown ABC test', () => {
   });
 
   it.each([
-    ['icons', 'icons'],
-    ['allocation', 'allocation'],
-  ])('maps %s assignment to the %s layout', (variantName, layout) => {
-    mockBalanceBreakdownVariantName = variantName;
+    { variantName: 'icons', layout: 'icons', showRowArrows: false },
+    {
+      variantName: 'iconsWithArrows',
+      layout: 'icons',
+      showRowArrows: true,
+    },
+    { variantName: 'allocation', layout: 'allocation', showRowArrows: false },
+  ] as const)(
+    'maps $variantName assignment to the $layout layout',
+    ({ variantName, layout, showRowArrows }) => {
+      mockBalanceBreakdownVariantName = variantName;
 
-    render(Wallet);
+      render(Wallet);
 
-    expect(mockHomepage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        balanceBreakdownSectionProps: expect.objectContaining({
-          children: expect.anything(),
-          hideRows: false,
-          layout,
-          transactionActiveAbTests: [
-            {
-              key: 'homeTMCU1209AbtestHomepageBalanceBreakdown',
-              value: variantName,
-              key_value_pair: `homeTMCU1209AbtestHomepageBalanceBreakdown=${variantName}`,
-            },
-          ],
+      expect(mockHomepage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          balanceBreakdownSectionProps: expect.objectContaining({
+            children: expect.anything(),
+            hideRows: false,
+            layout,
+            showRowArrows,
+            transactionActiveAbTests: [
+              {
+                key: 'homeTMCU1209AbtestHomepageBalanceBreakdown',
+                value: variantName,
+                key_value_pair: `homeTMCU1209AbtestHomepageBalanceBreakdown=${variantName}`,
+              },
+            ],
+          }),
         }),
-      }),
-    );
-  });
+      );
+    },
+  );
 
   it('does not reserve banner spacing when treatment banners are hidden', () => {
     mockBalanceBreakdownVariantName = 'icons';

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -1076,6 +1076,7 @@ const Wallet = ({
         accountGroupBalanceProps: walletHomeAccountGroupBalanceProps,
         hideRows: inWalletHomePostOnboardingFlow,
         layout: balanceBreakdownLayout,
+        showRowArrows: balanceBreakdownVariant.showRowArrows,
         transactionActiveAbTests: balanceBreakdownTransactionActiveAbTests,
         children: contentBeforeBalanceBreakdown,
       }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds the `iconsWithArrows` variant to the homepage balance breakdown A/B test. It reuses the existing icon layout and adds a right-arrow accessory to every visible row while preserving existing navigation and analytics attribution.

Includes coverage for variant mapping, arrow rendering, and ensuring the original icon variant remains unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added navigation arrows to a homepage balance breakdown experiment variant

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Homepage balance breakdown with navigation arrows

  Scenario: User receives the iconsWithArrows variant
    Given the balance breakdown experiment returns "iconsWithArrows"
    And the wallet contains a selected account
    And the post-onboarding checklist is not active

    When the user opens the wallet homepage

    Then the balance breakdown uses the existing icon layout
    And every visible balance row displays a right arrow
    And the standard four-button action layout is displayed
    And tapping each row opens its corresponding destination
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="376" height="560" alt="Screenshot 2026-08-19 at 12 50 14" src="https://github.com/user-attachments/assets/4ea8cafa-c74e-4555-a117-2c5018430a44" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only experiment wiring with existing navigation and analytics paths; covered by unit tests and no changes to auth or data handling.
> 
> **Overview**
> Adds a new **`iconsWithArrows`** arm to the homepage balance breakdown experiment. It keeps the existing **icons** layout and toggles optional **right-arrow** accessories on each breakdown row via a `showRowArrows` flag on variant config and UI props.
> 
> **Wallet** maps the new assignment to `layout: 'icons'` with `showRowArrows: true` and passes that into `HomepageBalanceBreakdown`. **Rows** render an `ArrowRight` `ListItem` end accessory when enabled; navigation and analytics attribution are unchanged. Tests cover arrow visibility, default icon variant behavior, and Wallet variant mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50ac90dd6a124f72e4c4050695b1b99991409698. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->