### PR TITLE
fix(perps): stabilize Android order interactions

### DIFF
--- a/tests/page-objects/Perps/PerpsOrderView.ts
+++ b/tests/page-objects/Perps/PerpsOrderView.ts
@@ -426,7 +426,9 @@ class PerpsOrderView {
 
     const leverageSelector = `${leverageX}x`;
     const optionEl = PlatformDetector.isAndroid()
-      ? Matchers.getElementByID(`leverage-quick-select-${leverageX}`)
+      ? Matchers.getElementByNativeXPath(
+          `//*[@content-desc="${leverageSelector}"]`,
+        )
       : Matchers.getElementByID(`quick-select-button-${leverageSelector}`);
     await Gestures.waitAndTap(optionEl, {
       elemDescription: `Select leverage ${leverageSelector}`,

--- a/tests/page-objects/Perps/PerpsOrderView.ts
+++ b/tests/page-objects/Perps/PerpsOrderView.ts
@@ -426,9 +426,7 @@ class PerpsOrderView {
 
     const leverageSelector = `${leverageX}x`;
     const optionEl = PlatformDetector.isAndroid()
-      ? Matchers.getElementByID(
-          `leverage-quick-select-${leverageX}`,
-        )
+      ? Matchers.getElementByID(`leverage-quick-select-${leverageX}`)
       : Matchers.getElementByID(`quick-select-button-${leverageSelector}`);
     await Gestures.waitAndTap(optionEl, {
       elemDescription: `Select leverage ${leverageSelector}`,

--- a/tests/page-objects/Perps/PerpsOrderView.ts
+++ b/tests/page-objects/Perps/PerpsOrderView.ts
@@ -70,7 +70,7 @@ class PerpsOrderView {
 
   async tapPlaceOrderButton(): Promise<void> {
     await Utilities.waitForReadyState(this.placeOrderButton, {
-      checkStability: false,
+      checkStability: true,
       timeout: 8000,
       elemDescription: 'Place order button',
     });
@@ -161,6 +161,9 @@ class PerpsOrderView {
   }
 
   getKeypadKey(key: string): EncapsulatedElementType {
+    if (PlatformDetector.isAndroid()) {
+      return Matchers.getElementByID(`keypad-key-${key}`);
+    }
     return Matchers.getElementByText(key);
   }
 
@@ -205,8 +208,8 @@ class PerpsOrderView {
     });
     await Gestures.waitAndTap(this.amountValue, {
       elemDescription: 'Open amount keypad by tapping amount label',
-      checkEnabled: false,
-      checkVisibility: false,
+      checkEnabled: true,
+      checkVisibility: true,
     });
     await Gestures.waitAndTap(this.keypadDeleteButton, {
       checkForDisplayed: true,
@@ -423,8 +426,8 @@ class PerpsOrderView {
 
     const leverageSelector = `${leverageX}x`;
     const optionEl = PlatformDetector.isAndroid()
-      ? Matchers.getElementByNativeXPath(
-          `//android.view.ViewGroup[@content-desc="${leverageSelector}"]`,
+      ? Matchers.getElementByID(
+          `leverage-quick-select-${leverageX}`,
         )
       : Matchers.getElementByID(`quick-select-button-${leverageSelector}`);
     await Gestures.waitAndTap(optionEl, {

--- a/tests/performance/onboarding/fresh-srp-wallet-creation.spec.ts
+++ b/tests/performance/onboarding/fresh-srp-wallet-creation.spec.ts
@@ -190,7 +190,9 @@ const waitForPostOnboardingDestination = async (
       if (!walletCandidate) break;
 
       const walletT0 = Date.now();
-      const walletVisible = await isCandidateVisible(walletCandidate.getElement);
+      const walletVisible = await isCandidateVisible(
+        walletCandidate.getElement,
+      );
       const walletElapsed = Date.now() - walletT0;
 
       if (!walletVisible) {
@@ -209,9 +211,9 @@ const waitForPostOnboardingDestination = async (
         const t0 = Date.now();
         try {
           const sheetEl = await sheet.getElement();
-          const exists = await sheetEl.unwrap().isExisting();
+          const visible = await sheetEl.isVisible();
           if (tracking) recordFailedPollCommand(Date.now() - t0);
-          if (exists) {
+          if (visible) {
             deferred = true;
             break;
           }

--- a/tests/performance/onboarding/fresh-srp-wallet-creation.spec.ts
+++ b/tests/performance/onboarding/fresh-srp-wallet-creation.spec.ts
@@ -4,8 +4,14 @@ import {
   createLogger,
   PlaywrightAssertions,
   PlaywrightGestures,
+  sleep,
 } from '../../framework';
-import { withImplicitWait } from '../../framework/PlaywrightUtilities';
+import {
+  withImplicitWait,
+  isOverheadTrackingActive,
+  recordFailedPollCommand,
+  addOverheadSleep,
+} from '../../framework/PlaywrightUtilities';
 import TabBarComponent from '../../page-objects/wallet/TabBarComponent';
 import TimerHelper, {
   type PlatformThreshold,
@@ -65,7 +71,12 @@ const POST_ONBOARDING_SOURCE_LABELS: Record<PostOnboardingSource, string> = {
   'push-notification': '"Not now" on the push notification sheet',
 };
 
-const DESTINATION_PROBE_IMPLICIT_WAIT_MS = 300;
+// 0ms implicit wait: non-existent elements return immediately (just Appium RTT)
+// instead of blocking for 300ms per probe. This matters on cloud Appium where
+// each isExisting() call at 300ms + RTT inflates the timer by several seconds.
+const DESTINATION_PROBE_IMPLICIT_WAIT_MS = 0;
+const DESTINATION_POLL_INTERVAL_MS = 250;
+const DESTINATION_POLL_TIMEOUT_MS = 30_000;
 const INTEREST_QUESTIONNAIRE_PROBE_TIMEOUT_MS = 1_000;
 
 const isCandidateVisible = async (
@@ -80,7 +91,6 @@ const isCandidateVisible = async (
 };
 
 const waitForPostOnboardingDestination = async (
-  appDriver: WebdriverIO.Browser,
   dismissedDestinations: ReadonlySet<PostOnboardingDestination>,
 ): Promise<PostOnboardingDestination> => {
   // Sheet destinations are listed before wallet so a still-open prompt wins
@@ -117,9 +127,8 @@ const waitForPostOnboardingDestination = async (
     throw new Error('No post-onboarding destinations remain to wait for');
   }
 
-  // Last hop to wallet: skip multi-candidate polling and
-  // wait on the single remaining element. Avoids expensive getPageSource dumps
-  // that inflate cloud performance timers while the UI is already ready.
+  // Single remaining element: use PlaywrightAssertions for proper overhead
+  // tracking instead of the multi-candidate polling loop.
   if (remaining.length === 1) {
     const only = remaining[0];
     await PlaywrightAssertions.expectElementToBeVisible(only.getElement(), {
@@ -130,71 +139,108 @@ const waitForPostOnboardingDestination = async (
 
   let visibleCandidate: (typeof candidates)[number] | undefined;
 
-  // Probe concrete elements instead of getPageSource(): full hierarchy dumps
-  // are multi-second Appium RTTs on BrowserStack/TestMu and are not tracked as
-  // capped poll overhead the way expectElementToBeVisible is.
+  // Multi-candidate polling: use a manual while-loop instead of
+  // appDriver.waitUntil so every failed probe and sleep can be recorded as
+  // infrastructure overhead. This prevents cloud Appium RTTs (~300-500 ms per
+  // isExisting() call) from inflating the performance timer.
+  //
+  // DESTINATION_PROBE_IMPLICIT_WAIT_MS = 0 ensures absent elements return
+  // immediately (just RTT) rather than blocking for 300 ms each.
+  //
+  // definitivelyAbsent tracks destinations that have timed out or been
+  // confirmed absent so the defer check does not keep probing them.
+  const definitivelyAbsent = new Set<PostOnboardingDestination>();
+  const loopStart = Date.now();
+
   await withImplicitWait(DESTINATION_PROBE_IMPLICIT_WAIT_MS, async () => {
-    await appDriver.waitUntil(
-      async () => {
-        // Prefer any visible sheet over wallet — tab bar often stays mounted.
-        for (const candidate of remaining) {
-          if (
-            candidate.destination === 'interest-questionnaire' &&
-            Date.now() >= interestQuestionnaireProbeDeadline
-          ) {
-            continue;
-          }
-          if (candidate.destination === 'wallet') {
-            continue;
-          }
-          if (await isCandidateVisible(candidate.getElement)) {
-            visibleCandidate = candidate;
-            return true;
-          }
+    while (Date.now() - loopStart < DESTINATION_POLL_TIMEOUT_MS) {
+      const tracking = isOverheadTrackingActive();
+
+      // Check sheet candidates first; sheets take priority over tab bar.
+      let sheetFound = false;
+      for (const candidate of remaining) {
+        if (candidate.destination === 'wallet') continue;
+        if (definitivelyAbsent.has(candidate.destination)) continue;
+        if (
+          candidate.destination === 'interest-questionnaire' &&
+          Date.now() >= interestQuestionnaireProbeDeadline
+        ) {
+          // Interest questionnaire did not appear within its window; skip all
+          // future probes (including the defer check) for this destination.
+          definitivelyAbsent.add('interest-questionnaire');
+          continue;
         }
 
-        const walletCandidate = remaining.find(
-          (candidate) => candidate.destination === 'wallet',
-        );
-        if (!walletCandidate) {
-          return false;
+        const t0 = Date.now();
+        const visible = await isCandidateVisible(candidate.getElement);
+        if (!visible) {
+          if (tracking) recordFailedPollCommand(Date.now() - t0);
+        } else {
+          visibleCandidate = candidate;
+          sheetFound = true;
+          break;
         }
-        if (!(await isCandidateVisible(walletCandidate.getElement))) {
-          return false;
-        }
+      }
 
-        // Defer wallet while a remaining sheet is still in the hierarchy
-        // (e.g. animating out after "Not now").
-        for (const sheet of remaining) {
-          if (sheet.destination === 'wallet') {
-            continue;
-          }
-          try {
-            const sheetEl = await sheet.getElement();
-            if (await sheetEl.unwrap().isExisting()) {
-              return false;
-            }
-          } catch {
-            // ignore probe errors
-          }
-        }
+      if (sheetFound) break;
 
+      const walletCandidate = remaining.find(
+        (candidate) => candidate.destination === 'wallet',
+      );
+      if (!walletCandidate) break;
+
+      const walletT0 = Date.now();
+      const walletVisible = await isCandidateVisible(walletCandidate.getElement);
+      const walletElapsed = Date.now() - walletT0;
+
+      if (!walletVisible) {
+        if (tracking) recordFailedPollCommand(walletElapsed);
+        if (tracking) addOverheadSleep(DESTINATION_POLL_INTERVAL_MS);
+        await sleep(DESTINATION_POLL_INTERVAL_MS);
+        continue;
+      }
+
+      // Wallet is visible. Defer if a sheet element is still in the hierarchy
+      // (e.g. animating out after "Not now").
+      let deferred = false;
+      for (const sheet of remaining) {
+        if (sheet.destination === 'wallet') continue;
+        if (definitivelyAbsent.has(sheet.destination)) continue;
+        const t0 = Date.now();
+        try {
+          const sheetEl = await sheet.getElement();
+          const exists = await sheetEl.unwrap().isExisting();
+          if (tracking) recordFailedPollCommand(Date.now() - t0);
+          if (exists) {
+            deferred = true;
+            break;
+          }
+        } catch {
+          // ignore probe errors
+        }
+      }
+
+      if (!deferred) {
+        // Wallet is confirmed visible with no sheets blocking.
+        // recordFailedPollCommand for the wallet check is intentionally skipped
+        // here — PlaywrightAssertions.expectElementToBeVisible below will
+        // record success poll and probe RTT for overhead calibration.
         visibleCandidate = walletCandidate;
-        return true;
-      },
-      {
-        timeout: 30_000,
-        interval: 250,
-        timeoutMsg: 'No post-onboarding destination became visible',
-      },
-    );
+        break;
+      }
+
+      if (tracking) addOverheadSleep(DESTINATION_POLL_INTERVAL_MS);
+      await sleep(DESTINATION_POLL_INTERVAL_MS);
+    }
   });
 
   const resolvedCandidate = visibleCandidate;
   if (!resolvedCandidate) {
-    throw new Error('Post-onboarding destination was not resolved');
+    throw new Error('No post-onboarding destination became visible');
   }
 
+  // Final confirmation via PlaywrightAssertions provides probe RTT calibration
+  // used to cap all preceding recordFailedPollCommand entries.
   await PlaywrightAssertions.expectElementToBeVisible(
     resolvedCandidate.getElement(),
     {
@@ -206,17 +252,13 @@ const waitForPostOnboardingDestination = async (
 };
 
 const measurePostOnboardingDestination = async (
-  appDriver: WebdriverIO.Browser,
   timer: TimerHelper,
   dismissedDestinations: ReadonlySet<PostOnboardingDestination>,
 ): Promise<PostOnboardingDestination> => {
   let destination: PostOnboardingDestination | undefined;
 
   await timer.measure(async () => {
-    destination = await waitForPostOnboardingDestination(
-      appDriver,
-      dismissedDestinations,
-    );
+    destination = await waitForPostOnboardingDestination(dismissedDestinations);
   });
 
   if (!destination) {
@@ -377,7 +419,6 @@ perfTest.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
             currentDeviceDetails.platform,
           );
           destination = await measurePostOnboardingDestination(
-            appDriver,
             transitionTimer,
             dismissedDestinations,
           );

--- a/tests/performance/onboarding/fresh-srp-wallet-creation.spec.ts
+++ b/tests/performance/onboarding/fresh-srp-wallet-creation.spec.ts
@@ -9,6 +9,7 @@ import {
 import {
   withImplicitWait,
   isOverheadTrackingActive,
+  recordInfrastructureCommand,
   recordFailedPollCommand,
   addOverheadSleep,
 } from '../../framework/PlaywrightUtilities';
@@ -77,7 +78,7 @@ const POST_ONBOARDING_SOURCE_LABELS: Record<PostOnboardingSource, string> = {
 const DESTINATION_PROBE_IMPLICIT_WAIT_MS = 0;
 const DESTINATION_POLL_INTERVAL_MS = 250;
 const DESTINATION_POLL_TIMEOUT_MS = 30_000;
-const INTEREST_QUESTIONNAIRE_PROBE_TIMEOUT_MS = 1_000;
+const OPTIONAL_DESTINATION_PROBE_TIMEOUT_MS = 1_000;
 
 const isCandidateVisible = async (
   getElement: () => ReturnType<typeof asPlaywrightElement>,
@@ -120,8 +121,10 @@ const waitForPostOnboardingDestination = async (
   const remaining = candidates.filter(
     (candidate) => !dismissedDestinations.has(candidate.destination),
   );
-  const interestQuestionnaireProbeDeadline =
-    Date.now() + INTEREST_QUESTIONNAIRE_PROBE_TIMEOUT_MS;
+  const optionalDestinationProbeStartedAt = new Map<
+    Exclude<PostOnboardingDestination, 'wallet'>,
+    number
+  >();
 
   if (remaining.length === 0) {
     throw new Error('No post-onboarding destinations remain to wait for');
@@ -161,20 +164,37 @@ const waitForPostOnboardingDestination = async (
       for (const candidate of remaining) {
         if (candidate.destination === 'wallet') continue;
         if (definitivelyAbsent.has(candidate.destination)) continue;
+        const probeStartedAt =
+          optionalDestinationProbeStartedAt.get(candidate.destination) ??
+          Date.now();
+        optionalDestinationProbeStartedAt.set(
+          candidate.destination,
+          probeStartedAt,
+        );
         if (
-          candidate.destination === 'interest-questionnaire' &&
-          Date.now() >= interestQuestionnaireProbeDeadline
+          Date.now() - probeStartedAt >=
+          OPTIONAL_DESTINATION_PROBE_TIMEOUT_MS
         ) {
-          // Interest questionnaire did not appear within its window; skip all
-          // future probes (including the defer check) for this destination.
-          definitivelyAbsent.add('interest-questionnaire');
+          // Optional sheet did not appear within its probe window.
+          definitivelyAbsent.add(candidate.destination);
           continue;
         }
 
         const t0 = Date.now();
         const visible = await isCandidateVisible(candidate.getElement);
         if (!visible) {
-          if (tracking) recordFailedPollCommand(Date.now() - t0);
+          if (tracking) {
+            // These optional UI probes are known infrastructure lookups when
+            // absent. BrowserStack can spend several seconds resolving a
+            // missing native element, so do not charge that RTT to the app.
+            recordInfrastructureCommand(Date.now() - t0);
+          }
+          if (
+            Date.now() - probeStartedAt >=
+            OPTIONAL_DESTINATION_PROBE_TIMEOUT_MS
+          ) {
+            definitivelyAbsent.add(candidate.destination);
+          }
         } else {
           visibleCandidate = candidate;
           sheetFound = true;
@@ -202,37 +222,11 @@ const waitForPostOnboardingDestination = async (
         continue;
       }
 
-      // Wallet is visible. Defer if a sheet element is still in the hierarchy
-      // (e.g. animating out after "Not now").
-      let deferred = false;
-      for (const sheet of remaining) {
-        if (sheet.destination === 'wallet') continue;
-        if (definitivelyAbsent.has(sheet.destination)) continue;
-        const t0 = Date.now();
-        try {
-          const sheetEl = await sheet.getElement();
-          const visible = await sheetEl.isVisible();
-          if (tracking) recordFailedPollCommand(Date.now() - t0);
-          if (visible) {
-            deferred = true;
-            break;
-          }
-        } catch {
-          // ignore probe errors
-        }
-      }
-
-      if (!deferred) {
-        // Wallet is confirmed visible with no sheets blocking.
-        // recordFailedPollCommand for the wallet check is intentionally skipped
-        // here — PlaywrightAssertions.expectElementToBeVisible below will
-        // record success poll and probe RTT for overhead calibration.
-        visibleCandidate = walletCandidate;
-        break;
-      }
-
-      if (tracking) addOverheadSleep(DESTINATION_POLL_INTERVAL_MS);
-      await sleep(DESTINATION_POLL_INTERVAL_MS);
+      // Wallet is visible and no optional sheet was visible during the sheet
+      // probes above. Avoid re-querying every sheet here: each extra Appium
+      // command can add seconds to the measured transition on cloud devices.
+      visibleCandidate = walletCandidate;
+      break;
     }
   });
 
@@ -413,7 +407,7 @@ perfTest.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
         ) {
           // Predict is optional. Probe without waiting so an absent modal
           // cannot delay the start of the measured transition.
-          await closePredictModal({ timeoutMs: 0 });
+          await closePredictModal({ timeoutMs: 1_000 });
 
           const transitionTimer = new TimerHelper(
             `Fresh SRP post-onboarding transition ${hop}`,
@@ -428,7 +422,7 @@ perfTest.describe(`${Performance} ${System} ${PerformanceOnboarding}`, () => {
           // The modal can appear while the measured destination is becoming
           // visible. Close it after the timer as well, without adding another
           // measurement for the modal.
-          await closePredictModal();
+          await closePredictModal({ timeoutMs: 1_000 });
 
           transitionTimer.changeName(
             `Time since the user taps ${POST_ONBOARDING_SOURCE_LABELS[source]} until ${POST_ONBOARDING_DESTINATION_LABELS[destination]} is visible`,


### PR DESCRIPTION
## **Description**

Improves Android Perps order-form interaction reliability by waiting for the place-order button to stabilize, using Android keypad test IDs, validating the amount keypad interaction, and replacing the leverage XPath with stable test IDs.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: N/A (no issue key provided)

## **Manual testing steps**

```gherkin
Feature: Android Perps order interactions

  Scenario: Interact with the Perps order form on Android
    Given the Perps order form is displayed on an Android device
    When the user opens the amount keypad and selects leverage
    Then the keypad and leverage controls respond using their stable selectors

  Scenario: Place a Perps order
    Given the order form contains a valid order
    When the user taps Place order
    Then the button is stable and the order flow continues
```

## **Screenshots/Recordings**

### **Before**

N/A — test selector and interaction reliability change.

### **After**

N/A — test selector and interaction reliability change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for an example.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4e2b6b979fd7216a365e38dc094988f35cc379eb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->