### PR TITLE
perf(predict): batch Gamma /teams calls and skip feed child fetches

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -429,7 +429,7 @@ describe('PolymarketProvider', () => {
       expect(mockSearchEventsFromPolymarketApi).not.toHaveBeenCalled();
     });
 
-    it('adds World Cup child markets to the original feed event before parsing', async () => {
+    it('parses feed events without fetching World Cup child markets', async () => {
       const provider = createProvider({
         extendedSportsMarketsLeagues: ['fifwc'],
         enabledSportsMarketTypes: ['moneyline', 'soccer_team_to_advance'],
@@ -437,10 +437,6 @@ describe('PolymarketProvider', () => {
       const moneylineMarket = {
         id: 'moneyline-market',
         sportsMarketType: 'moneyline',
-      };
-      const teamToAdvanceMarket = {
-        id: 'team-to-advance-market',
-        sportsMarketType: 'soccer_team_to_advance',
       };
       const parentEvent = {
         id: 'parent-event',
@@ -456,20 +452,10 @@ describe('PolymarketProvider', () => {
         ],
         markets: [moneylineMarket],
       };
-      const fetchedParentEvent = {
-        ...parentEvent,
-        title: 'Fetched parent title should not replace feed title',
-        markets: [],
-      };
-      const childEvent = {
-        id: 'child-event',
-        parentEventId: parentEvent.id,
-        markets: [teamToAdvanceMarket],
-      };
       const markets = [
         {
           id: 'market-1',
-          outcomes: [{ id: 'team-to-advance-outcome' }],
+          outcomes: [{ id: 'moneyline-outcome' }],
         },
       ];
 
@@ -478,10 +464,6 @@ describe('PolymarketProvider', () => {
         category: 'trending',
         nextCursor: null,
       } as never);
-      mockFetchChildEventsFromGammaApi.mockResolvedValue([
-        fetchedParentEvent,
-        childEvent,
-      ] as never);
       mockParsePolymarketEvents.mockReturnValue(markets as never);
 
       await expect(
@@ -490,17 +472,9 @@ describe('PolymarketProvider', () => {
         markets,
         nextCursor: null,
       });
-      expect(mockFetchChildEventsFromGammaApi).toHaveBeenCalledWith({
-        parentEventId: parentEvent.id,
-      });
+      expect(mockFetchChildEventsFromGammaApi).not.toHaveBeenCalled();
       expect(mockParsePolymarketEvents).toHaveBeenCalledWith(
-        [
-          expect.objectContaining({
-            id: parentEvent.id,
-            title: parentEvent.title,
-            markets: [moneylineMarket, teamToAdvanceMarket],
-          }),
-        ],
+        [parentEvent],
         expect.any(Object),
       );
     });

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -28,7 +28,6 @@ import {
 } from '../../constants/eventNames';
 import { filterSupportedLeagues } from '../../constants/sports';
 import { getPrimarySportsCardOutcomes } from '../../utils/sports';
-import { resolveWorldCupFeedEvents } from './sportsUtils';
 import { PREDICT_ACTIVITY_PAGE_SIZE } from '../../constants/transactions';
 import { SERIES_MAX_EVENTS } from '../../utils/series';
 import {
@@ -433,11 +432,7 @@ export class PolymarketProvider implements PredictProvider {
 
     const neededTeams = extractNeededTeamsFromEvents(events, supportedLeagues);
 
-    await Promise.all(
-      [...neededTeams.entries()].map(([league, abbreviations]) =>
-        TeamsCache.getInstance().ensureTeamsLoaded(league, abbreviations),
-      ),
-    );
+    await TeamsCache.getInstance().ensureTeamsLoadedForLeagues(neededTeams);
   }
 
   async #parseEventsToMarkets({
@@ -1062,12 +1057,9 @@ export class PolymarketProvider implements PredictProvider {
     try {
       const { events, category, nextCursor } =
         await fetchEventsFromPolymarketApi(params);
-      const resolvedEvents = await resolveWorldCupFeedEvents(events, {
-        extendedSportsMarketsLeagues: this.#getExtendedSportsMarketsLeagues(),
-      });
 
       const markets = await this.#parseEventsToMarkets({
-        events: resolvedEvents,
+        events,
         category,
       });
 

--- a/app/components/UI/Predict/providers/polymarket/TeamsCache.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/TeamsCache.test.ts
@@ -389,6 +389,207 @@ describe('TeamsCache', () => {
     });
   });
 
+  describe('ensureTeamsLoadedForLeagues', () => {
+    const mockNbaTeams: PolymarketApiTeam[] = [
+      createMockTeam({
+        id: 'team-lal',
+        name: 'Los Angeles Lakers',
+        abbreviation: 'LAL',
+        color: TEST_HEX_COLORS.TEAM_LAL,
+        alias: 'Lakers',
+        league: 'nba',
+      }),
+      createMockTeam({
+        id: 'team-bos',
+        name: 'Boston Celtics',
+        abbreviation: 'BOS',
+        color: TEST_HEX_COLORS.TEAM_BOS,
+        alias: 'Celtics',
+        league: 'nba',
+      }),
+    ];
+
+    const nflTeamsWithLeague = mockNflTeams.map((team) => ({
+      ...team,
+      league: 'nfl',
+    }));
+
+    it('fetches all requested leagues in one request', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [...nflTeamsWithLeague, ...mockNbaTeams],
+      });
+      const cache = TeamsCache.getInstance();
+
+      await cache.ensureTeamsLoadedForLeagues(
+        new Map([
+          ['nfl', ['sea', 'den']],
+          ['nba', ['lal', 'bos']],
+        ]),
+      );
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const callUrl = mockFetch.mock.calls[0][0] as string;
+      expect(callUrl).toContain('league=nba');
+      expect(callUrl).toContain('league=nfl');
+      expect(callUrl).toContain('abbreviation=sea');
+      expect(callUrl).toContain('abbreviation=den');
+      expect(callUrl).toContain('abbreviation=lal');
+      expect(callUrl).toContain('abbreviation=bos');
+    });
+
+    it('caches teams into the league matching team.league', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [...nflTeamsWithLeague, ...mockNbaTeams],
+      });
+      const cache = TeamsCache.getInstance();
+
+      await cache.ensureTeamsLoadedForLeagues(
+        new Map([
+          ['nfl', ['sea']],
+          ['nba', ['lal']],
+        ]),
+      );
+
+      expect(cache.getTeam('nfl', 'sea')?.name).toBe('Seattle Seahawks');
+      expect(cache.getTeam('nba', 'lal')?.name).toBe('Los Angeles Lakers');
+      expect(cache.getTeam('nfl', 'lal')).toBeUndefined();
+      expect(cache.getTeam('nba', 'sea')).toBeUndefined();
+    });
+
+    it('uses team API aliases when batching leagues', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      });
+      const cache = TeamsCache.getInstance();
+
+      await cache.ensureTeamsLoadedForLeagues(
+        new Map([
+          ['cs2', ['navi']],
+          ['val', ['sen']],
+        ]),
+      );
+
+      const callUrl = mockFetch.mock.calls[0][0] as string;
+      expect(callUrl).toContain('league=csgo');
+      expect(callUrl).toContain('league=valorant');
+    });
+
+    it('skips fetch when every requested team is already cached', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => nflTeamsWithLeague,
+      });
+      const cache = TeamsCache.getInstance();
+      await cache.ensureLeagueLoaded('nfl');
+      mockFetch.mockClear();
+
+      await cache.ensureTeamsLoadedForLeagues(new Map([['nfl', ['sea']]]));
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('fetches only leagues that still have uncached teams', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => nflTeamsWithLeague,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => mockNbaTeams,
+        });
+      const cache = TeamsCache.getInstance();
+      await cache.ensureLeagueLoaded('nfl');
+      mockFetch.mockClear();
+
+      await cache.ensureTeamsLoadedForLeagues(
+        new Map([
+          ['nfl', ['sea']],
+          ['nba', ['lal']],
+        ]),
+      );
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const callUrl = mockFetch.mock.calls[0][0] as string;
+      expect(callUrl).toContain('league=nba');
+      expect(callUrl).not.toContain('league=nfl');
+      expect(cache.getTeam('nba', 'lal')?.name).toBe('Los Angeles Lakers');
+    });
+
+    it('caches teams without league onto the league that requested the abbreviation', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [mockNflTeams[0]],
+      });
+      const cache = TeamsCache.getInstance();
+
+      await cache.ensureTeamsLoadedForLeagues(new Map([['nfl', ['sea']]]));
+
+      expect(cache.getTeam('nfl', 'sea')?.name).toBe('Seattle Seahawks');
+    });
+
+    it('deduplicates concurrent requests for the same batch', async () => {
+      let resolvePromise: (value: unknown) => void = () => undefined;
+      const fetchPromise = new Promise((resolve) => {
+        resolvePromise = resolve;
+      });
+
+      mockFetch.mockReturnValue(fetchPromise);
+      const cache = TeamsCache.getInstance();
+
+      const promise1 = cache.ensureTeamsLoadedForLeagues(
+        new Map([
+          ['nfl', ['sea']],
+          ['nba', ['lal']],
+        ]),
+      );
+      const promise2 = cache.ensureTeamsLoadedForLeagues(
+        new Map([
+          ['nba', ['lal']],
+          ['nfl', ['sea']],
+        ]),
+      );
+
+      resolvePromise({
+        ok: true,
+        json: async () => [...nflTeamsWithLeague, ...mockNbaTeams],
+      });
+
+      await Promise.all([promise1, promise2]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fetch when the needed map is empty', async () => {
+      const cache = TeamsCache.getInstance();
+
+      await cache.ensureTeamsLoadedForLeagues(new Map());
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('leaves teams uncached when the API returns an error', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      });
+      const cache = TeamsCache.getInstance();
+
+      await cache.ensureTeamsLoadedForLeagues(
+        new Map([
+          ['nfl', ['sea']],
+          ['nba', ['lal']],
+        ]),
+      );
+
+      expect(cache.getTeam('nfl', 'sea')).toBeUndefined();
+      expect(cache.getTeam('nba', 'lal')).toBeUndefined();
+    });
+  });
+
   describe('getTeam', () => {
     beforeEach(async () => {
       mockFetch.mockResolvedValueOnce({

--- a/app/components/UI/Predict/providers/polymarket/TeamsCache.ts
+++ b/app/components/UI/Predict/providers/polymarket/TeamsCache.ts
@@ -77,33 +77,32 @@ export class TeamsCache {
     league: PredictSportsLeague,
     abbreviations: string[],
   ): Promise<void> {
-    const uncached = [
-      ...new Set(abbreviations.map((a) => a.toLowerCase())),
-    ].filter((abbr) => !this.getTeam(league, abbr));
+    await this.ensureTeamsLoadedForLeagues(new Map([[league, abbreviations]]));
+  }
 
-    if (uncached.length === 0) {
+  /**
+   * Load the given team abbreviations across one or more leagues in a single
+   * Gamma `/teams` request. Repeated `league=` and `abbreviation=` params are
+   * valid; the response is partitioned back into per-league cache maps.
+   */
+  async ensureTeamsLoadedForLeagues(
+    neededTeams: Map<PredictSportsLeague, string[]>,
+  ): Promise<void> {
+    const uncached = this.collectUncachedTeams(neededTeams);
+    if (uncached.size === 0) {
       return;
     }
 
-    const key = `${league}:${uncached.sort((a, b) => a.localeCompare(b)).join(',')}`;
+    const key = this.buildBatchKey(uncached);
     const existingPromise = this.teamBatchLoadingPromises.get(key);
     if (existingPromise) {
       return existingPromise;
     }
 
-    const { GAMMA_API_ENDPOINT } = getPolymarketEndpoints();
-    const teamLeague = getPolymarketTeamLeague(league);
-    const params = new URLSearchParams({ league: teamLeague });
-    uncached.forEach((abbr) => params.append('abbreviation', abbr));
-    const url = `${GAMMA_API_ENDPOINT}/teams?${params.toString()}`;
-
-    const loadPromise = this.fetchAndCacheFromUrl(
-      league,
-      url,
-      'merge',
-      'TeamsCache.ensureTeamsLoaded',
-      uncached,
-    ).then(() => undefined as void);
+    const url = this.buildTeamsUrl(uncached);
+    const loadPromise = this.fetchAndCacheBatchedTeams(uncached, url).then(
+      () => undefined as void,
+    );
     this.teamBatchLoadingPromises.set(key, loadPromise);
 
     try {
@@ -139,6 +138,132 @@ export class TeamsCache {
     return this.cache.get(league)?.size ?? 0;
   }
 
+  private collectUncachedTeams(
+    neededTeams: Map<PredictSportsLeague, string[]>,
+  ): Map<PredictSportsLeague, string[]> {
+    const uncached = new Map<PredictSportsLeague, string[]>();
+
+    for (const [league, abbreviations] of neededTeams) {
+      const missing = [
+        ...new Set(
+          abbreviations.map((abbreviation) => abbreviation.toLowerCase()),
+        ),
+      ]
+        .filter((abbreviation) => !this.getTeam(league, abbreviation))
+        .sort((left, right) => left.localeCompare(right));
+
+      if (missing.length > 0) {
+        uncached.set(league, missing);
+      }
+    }
+
+    return uncached;
+  }
+
+  private buildBatchKey(uncached: Map<PredictSportsLeague, string[]>): string {
+    return [...uncached.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([league, abbreviations]) => `${league}:${abbreviations.join(',')}`)
+      .join('|');
+  }
+
+  private buildTeamsUrl(uncached: Map<PredictSportsLeague, string[]>): string {
+    const { GAMMA_API_ENDPOINT } = getPolymarketEndpoints();
+    const params = new URLSearchParams();
+
+    for (const [league, abbreviations] of [...uncached.entries()].sort(
+      ([left], [right]) => left.localeCompare(right),
+    )) {
+      params.append('league', getPolymarketTeamLeague(league));
+      abbreviations.forEach((abbreviation) => {
+        params.append('abbreviation', abbreviation);
+      });
+    }
+
+    return `${GAMMA_API_ENDPOINT}/teams?${params.toString()}`;
+  }
+
+  private async fetchAndCacheBatchedTeams(
+    uncached: Map<PredictSportsLeague, string[]>,
+    url: string,
+  ): Promise<boolean> {
+    const leagues = [...uncached.keys()];
+    const abbreviations = [...uncached.values()].flat();
+
+    DevLogger.log(
+      `[TeamsCache] Fetching teams for leagues: ${leagues.join(', ')}, teams: ${abbreviations.join(', ')}`,
+    );
+
+    const teams = await this.fetchTeamsFromUrl(
+      url,
+      'TeamsCache.ensureTeamsLoadedForLeagues',
+      { leagues, abbreviations },
+    );
+    if (!teams) {
+      return false;
+    }
+
+    this.cacheBatchedTeams(teams, uncached);
+
+    DevLogger.log(
+      `[TeamsCache] Cached ${teams.length} teams for leagues: ${leagues.join(', ')}`,
+    );
+
+    return true;
+  }
+
+  private cacheBatchedTeams(
+    teams: PolymarketApiTeam[],
+    uncached: Map<PredictSportsLeague, string[]>,
+  ): void {
+    const requestedLeagues = [...uncached.keys()];
+
+    for (const team of teams) {
+      if (!team.abbreviation) {
+        continue;
+      }
+
+      const abbreviation = team.abbreviation.toLowerCase();
+      team.color = TEAM_COLOR_OVERRIDES[abbreviation] ?? team.color;
+
+      const targetLeagues = this.resolveLeaguesForTeam(
+        team,
+        requestedLeagues,
+        uncached,
+      );
+
+      for (const league of targetLeagues) {
+        const leagueCache =
+          this.cache.get(league) ?? new Map<string, PolymarketApiTeam>();
+        leagueCache.set(abbreviation, team);
+        this.cache.set(league, leagueCache);
+      }
+    }
+  }
+
+  /**
+   * Map a Gamma team onto the Predict league caches that requested it.
+   * Prefer `team.league` (including API aliases like csgo → cs2). If Gamma
+   * omits league, fall back to the league that asked for this abbreviation.
+   */
+  private resolveLeaguesForTeam(
+    team: PolymarketApiTeam,
+    requestedLeagues: PredictSportsLeague[],
+    uncached: Map<PredictSportsLeague, string[]>,
+  ): PredictSportsLeague[] {
+    if (team.league) {
+      const apiLeague = team.league.toLowerCase();
+      return requestedLeagues.filter(
+        (league) => getPolymarketTeamLeague(league).toLowerCase() === apiLeague,
+      );
+    }
+
+    const abbreviation = team.abbreviation.toLowerCase();
+    return requestedLeagues.filter((league) =>
+      uncached.get(league)?.includes(abbreviation),
+    );
+  }
+
   /**
    * Shared fetch+cache logic for both full-league and specific-team loading.
    *
@@ -159,71 +284,84 @@ export class TeamsCache {
       `[TeamsCache] Fetching teams for league: ${league}${abbreviations ? `, teams: ${abbreviations.join(', ')}` : ''}`,
     );
 
+    const teams = await this.fetchTeamsFromUrl(url, callerMethod, {
+      league,
+      ...(abbreviations && { abbreviations }),
+    });
+    if (!teams) {
+      return false;
+    }
+
+    const leagueCache =
+      mode === 'merge'
+        ? (this.cache.get(league) ?? new Map<string, PolymarketApiTeam>())
+        : new Map<string, PolymarketApiTeam>();
+
+    for (const team of teams) {
+      if (team.abbreviation) {
+        team.color =
+          TEAM_COLOR_OVERRIDES[team.abbreviation.toLowerCase()] ?? team.color;
+        leagueCache.set(team.abbreviation.toLowerCase(), team);
+      }
+    }
+
+    this.cache.set(league, leagueCache);
+
+    DevLogger.log(
+      `[TeamsCache] Cached ${teams.length} teams for league: ${league}`,
+    );
+
+    return true;
+  }
+
+  private async fetchTeamsFromUrl(
+    url: string,
+    callerMethod: string,
+    extra: Record<string, unknown>,
+  ): Promise<PolymarketApiTeam[] | null> {
     try {
       const response = await fetchWithTimeout(url);
 
       if (!response.ok) {
-        const errorMessage = `Failed to fetch teams for ${league}: ${response.status}`;
+        const errorMessage = `Failed to fetch teams: ${response.status}`;
         DevLogger.log(`[TeamsCache] ${errorMessage}`);
         Logger.error(new Error(errorMessage), {
           feature: 'predict',
           provider: POLYMARKET_PROVIDER_ID,
           method: callerMethod,
-          league,
-          ...(abbreviations && { abbreviations }),
+          ...extra,
           statusCode: response.status,
         });
-        return false;
+        return null;
       }
 
       const teams: PolymarketApiTeam[] = await response.json();
 
       if (!Array.isArray(teams)) {
-        const errorMessage = `Invalid response format for ${league} teams`;
+        const errorMessage = 'Invalid response format for teams';
         DevLogger.log(`[TeamsCache] ${errorMessage}`);
         Logger.error(new Error(errorMessage), {
           feature: 'predict',
           provider: POLYMARKET_PROVIDER_ID,
           method: callerMethod,
-          league,
-          ...(abbreviations && { abbreviations }),
+          ...extra,
         });
-        return false;
+        return null;
       }
 
-      const leagueCache =
-        mode === 'merge'
-          ? (this.cache.get(league) ?? new Map<string, PolymarketApiTeam>())
-          : new Map<string, PolymarketApiTeam>();
-
-      for (const team of teams) {
-        if (team.abbreviation) {
-          team.color =
-            TEAM_COLOR_OVERRIDES[team.abbreviation.toLowerCase()] ?? team.color;
-          leagueCache.set(team.abbreviation.toLowerCase(), team);
-        }
-      }
-
-      this.cache.set(league, leagueCache);
-
-      DevLogger.log(
-        `[TeamsCache] Cached ${teams.length} teams for league: ${league}`,
-      );
-
-      return true;
+      return teams;
     } catch (error) {
       DevLogger.log(
-        `[TeamsCache] Error fetching teams for ${league}:`,
+        '[TeamsCache] Error fetching teams:',
         error instanceof Error ? error.message : 'Unknown error',
       );
       Logger.error(error instanceof Error ? error : new Error(String(error)), {
         feature: 'predict',
         provider: POLYMARKET_PROVIDER_ID,
         method: callerMethod,
-        league,
-        ...(abbreviations && { abbreviations }),
+        ...extra,
       });
-      return false;
+      return null;
     }
   }
 }

--- a/app/components/UI/Predict/providers/polymarket/sportsUtils.ts
+++ b/app/components/UI/Predict/providers/polymarket/sportsUtils.ts
@@ -8,7 +8,6 @@ import { getMatchingSportTeam } from '../../utils/sports';
 import { getEventLeague } from '../../utils/gameParser';
 import type { PredictMarketGame } from '../../types';
 import type { PolymarketApiEvent } from './types';
-import { fetchChildEventsFromGammaApi } from './utils';
 
 interface NegRiskSportsMarket {
   negRisk?: boolean;
@@ -31,11 +30,13 @@ interface SportsFeedEvent {
   markets?: SportsFeedMarket[];
 }
 
-type FetchChildEvents = typeof fetchChildEventsFromGammaApi;
+type FetchChildEvents = (params: {
+  parentEventId: string | number;
+}) => Promise<PolymarketApiEvent[]>;
 
 interface ResolveWorldCupFeedEventsParams {
   extendedSportsMarketsLeagues: string[];
-  fetchChildEvents?: FetchChildEvents;
+  fetchChildEvents: FetchChildEvents;
 }
 
 const normalizeTeamLabel = (value?: string): string | undefined =>
@@ -199,7 +200,7 @@ export const resolveWorldCupFeedEvents = async (
   events: PolymarketApiEvent[],
   {
     extendedSportsMarketsLeagues,
-    fetchChildEvents = fetchChildEventsFromGammaApi,
+    fetchChildEvents,
   }: ResolveWorldCupFeedEventsParams,
 ): Promise<PolymarketApiEvent[]> => {
   if (

--- a/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/usePredictLiveNowSection.ts
+++ b/app/components/UI/Predict/views/PredictHome/components/PredictLiveNowSection/usePredictLiveNowSection.ts
@@ -21,11 +21,10 @@ import { interleaveLiveNowMarkets } from './liveNowInterleave';
  * only) still leaves enough to fill the rail.
  *
  * Kept deliberately modest: `listMarkets` does not resolve until the provider
- * has loaded the team rosters for every sports league present in the batch
- * (one `/teams` request per league, all awaited before any market returns).
- * A larger limit pulls in more leagues and makes the whole live list wait on
- * the slowest roster fetch, so this is tuned to roughly 2x the display cap
- * rather than a blanket over-fetch.
+ * has loaded team metadata for sports markets in the batch (one batched
+ * `/teams` request, awaited before any market returns). A larger limit pulls
+ * in more leagues and more abbreviations, so this is tuned to roughly 2x the
+ * display cap rather than a blanket over-fetch.
  */
 export const LIVE_NOW_FETCH_LIMIT = 15;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

Predict Explore and Predict home were firing more Gamma requests than those screens need:

1. **`/teams`** — `TeamsCache` sent one request per league while parsing a page of sports markets, and `listMarkets` waited on all of them before returning.
2. **Child events** — `getMarkets` called `resolveWorldCupFeedEvents`, which hits `/events/keyset?parent_event_id&include_children=true` for World Cup feed cards. That extra call belongs on market details for extended sports, not the feed/carousel.

This change:

- Batches uncached team abbreviations across leagues into a **single** `/teams` request using repeated `league=` and `abbreviation=` params, then partitions the response back into per-league caches.
- Stops the category feed (`getMarkets`) from fetching child events. `getMarketDetails` still fetches children for extended-sports games.
- Breaks the `sportsUtils` → `utils` import cycle by making `fetchChildEvents` a required argument of `resolveWorldCupFeedEvents` (feed no longer uses that helper).

Highlight market details (`getMarketsByIds` / event `567958`) are unchanged, as agreed on PRED-1215.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Reduced Predict sports API calls so Explore and Predict home load faster

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-1215

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Predict Gamma request volume

  Scenario: Explore and Predict home batch team metadata
    Given a user with Predict enabled and live sports leagues on
    And Charles / the network inspector is capturing Gamma traffic
    When the user opens Explore and the Predict home tab
    Then Gamma receives at most one `/teams` request for that page load (or zero if the cache is already warm)
    And that request may include repeated `league=` and `abbreviation=` params
    And sports cards still show team logos and abbreviations

  Scenario: Feed does not fetch event children
    Given the same network inspector session
    When the user stays on Explore / Predict home without opening a market
    Then there are no `/events/keyset` calls with `parent_event_id` and `include_children=true`

  Scenario: Market details still load extended-sports children
    Given a World Cup or other extended-sports market
    When the user opens that market's details screen
    Then child markets (for example team-to-advance) still load
    And sports team metadata still renders
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — request-volume change with no UI. Confirm via network inspector using the steps above.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff649647-8c64-4c59-9ee3-d904e11a0110?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff649647-8c64-4c59-9ee3-d904e11a0110&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

