### PR TITLE
fix(social): unclip Following/All labels on the feed audience toggle

### DIFF
--- a/app/components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.tsx
+++ b/app/components/Views/SocialLeaderboard/FeedView/components/FeedAudienceToggle.tsx
@@ -52,6 +52,10 @@ const styles = StyleSheet.create({
     position: 'relative',
     alignItems: 'center',
     justifyContent: 'center',
+    overflow: 'visible',
+  },
+  touchable: {
+    overflow: 'visible',
   },
   labelActive: {
     ...StyleSheet.absoluteFillObject,
@@ -206,26 +210,29 @@ const FeedAudienceToggle: React.FC<FeedAudienceToggleProps> = ({
           accessibilityRole="button"
           accessibilityState={{ selected: displayValue === 'following' }}
           testID={getFeedAudienceOptionTestId('following')}
+          style={styles.touchable}
         >
           <Box twClassName="rounded-xl px-4 h-8 items-center justify-center">
             <Box style={styles.labelWrap}>
-              <Animated.View style={followingBaseStyle}>
+              {/* In-flow Medium label sets the segment width so the wider
+                  selected weight never clips (e.g. Android "Followin[g]"). */}
+              <Animated.View style={followingActiveStyle}>
                 <Text
                   variant={TextVariant.BodyMd}
-                  fontWeight={FontWeight.Regular}
-                  color={TextColor.TextAlternative}
+                  fontWeight={FontWeight.Medium}
+                  color={TextColor.TextDefault}
                 >
                   {strings('social_leaderboard.feed.following')}
                 </Text>
               </Animated.View>
               <Animated.View
-                style={[styles.labelActive, followingActiveStyle]}
+                style={[styles.labelActive, followingBaseStyle]}
                 pointerEvents="none"
               >
                 <Text
                   variant={TextVariant.BodyMd}
-                  fontWeight={FontWeight.Medium}
-                  color={TextColor.TextDefault}
+                  fontWeight={FontWeight.Regular}
+                  color={TextColor.TextAlternative}
                 >
                   {strings('social_leaderboard.feed.following')}
                 </Text>
@@ -244,26 +251,27 @@ const FeedAudienceToggle: React.FC<FeedAudienceToggleProps> = ({
           accessibilityRole="button"
           accessibilityState={{ selected: displayValue === 'all' }}
           testID={getFeedAudienceOptionTestId('all')}
+          style={styles.touchable}
         >
           <Box twClassName="rounded-xl px-4 h-8 items-center justify-center">
             <Box style={styles.labelWrap}>
-              <Animated.View style={allBaseStyle}>
+              <Animated.View style={allActiveStyle}>
                 <Text
                   variant={TextVariant.BodyMd}
-                  fontWeight={FontWeight.Regular}
-                  color={TextColor.TextAlternative}
+                  fontWeight={FontWeight.Medium}
+                  color={TextColor.TextDefault}
                 >
                   {strings('social_leaderboard.feed.all')}
                 </Text>
               </Animated.View>
               <Animated.View
-                style={[styles.labelActive, allActiveStyle]}
+                style={[styles.labelActive, allBaseStyle]}
                 pointerEvents="none"
               >
                 <Text
                   variant={TextVariant.BodyMd}
-                  fontWeight={FontWeight.Medium}
-                  color={TextColor.TextDefault}
+                  fontWeight={FontWeight.Regular}
+                  color={TextColor.TextAlternative}
                 >
                   {strings('social_leaderboard.feed.all')}
                 </Text>


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

On narrower Android phones (reported on Galaxy A32), the Feed **Following / All** segmented control clipped the last glyph of “Following” (`Followin`). Each segment was sized from the in-flow Regular-weight label, while the selected Medium-weight label was absolutely overlaid and slightly wider. Android `TouchableOpacity` clips overflow, so the extra width was cut off.

This change sizes each segment from the Medium-weight string (in-flow), overlays the Regular-weight label, and sets `overflow: 'visible'` on the segment touchables so the full locale string stays visible without ellipsis.

<img height="800" alt="Screenshot_1787147953" src="https://github.com/user-attachments/assets/d8f67835-ac12-4492-9373-f2fd5d60f55f" />
<img height="800" alt="Screenshot_1787147850" src="https://github.com/user-attachments/assets/9324dcb4-5e1c-4707-a015-451e58c63915" />
<img height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-19 at 15 29 03" src="https://github.com/user-attachments/assets/26b02ff6-32ef-410f-9a27-fd8a3495bbcb" />


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: TSA-1007

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Feed audience toggle labels

  Background:
    Given I am logged into MetaMask Mobile
    And social Top traders is available
    And I open Top traders and select the Feed tab

  Scenario: Following and All labels are fully visible
    Given the Following/All toggle is shown next to All types

    Then the Following label shows the full string with no clipped glyph
    And the All label shows the full string

  Scenario: user switches audience without clipping
    Given Following is selected

    When user taps All
    Then the sliding pill moves to All
    And both labels remain fully visible

    When user taps Following
    Then the sliding pill moves to Following
    And both labels remain fully visible
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- Author will attach before/after screenshots before marking ready for review. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI layout fix in FeedAudienceToggle with no auth, data, or API changes.
> 
> **Overview**
> Fixes **Following** / **All** label clipping on narrow Android devices (e.g. Galaxy A32), where **Following** could render as **Followin**.
> 
> Each segment now sizes from the **in-flow Medium-weight** label (wider when selected) instead of Regular, with the Regular label absolutely overlaid for the inactive state. **`overflow: 'visible'`** is applied on the label wrapper and segment **`TouchableOpacity`** so Android no longer clips the extra glyph width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d7e556145e19961f8f75bb40af3329314295a65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->