### PR TITLE
fix: run Appium E2E with Namespace builds

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Push-, schedule- and `merge_group`-triggered workflows have no dispatch inputs, 
 
 The production build chain (`build.yml`, `setup-node-modules.yml`, `upload-to-testflight.yml` and their callers) and PR CI (`ci.yml` plus the Android/iOS e2e build workflows) are on the switch. BrowserStack native builds go through `build.yml` and follow the fleet. OTA (`eas-update-platform.yml`) and iOS BrowserStack upload follow `NAMESPACE_RUNNER_LINUX` (`ci-linux` vs `ubuntu-latest`). Android BrowserStack upload/repack follows `NAMESPACE_RUNNER_ANDROID` (`metamask-android-build`, which has JDK and `/opt/android-sdk`) and keeps Cirrus / `ubuntu-latest` only for `current` rollback. Do not put that job on `ci-linux`.
 
-Appium jobs, fixture validation, and the scheduled arm64 E2E APK build stay pinned to Cirrus (`runner_provider: current`) until Namespace artifact-store parity. A workflow that hardcodes `current` at its call site is opted out on purpose.
+Appium jobs and fixture validation follow the same platform runner variables as their native E2E builds and use Namespace artifacts when those builds run on Namespace. The scheduled arm64 E2E APK build stays pinned to Cirrus (`runner_provider: current`) because it has no Namespace artifact consumer.
 
 A few short GitHub-hosted jobs stay on `ubuntu-latest` on purpose and do not follow `NAMESPACE_RUNNER_LINUX`: `get-requirements.yml`, `native-build-fingerprint`, `prepare-e2e-timings`, `ios-tests-ready`, and `cleanup-ci-js-deps`.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1521,12 +1521,9 @@ jobs:
 
   appium-smoke-tests-android:
     name: 'Appium Smoke Tests (Android)'
-    # Pinned to Cirrus until artifact-store parity. Run only when the Android build
-    # provider also resolves to current so this job can consume its artifacts.
+    # Use the same provider as the Android build so Appium can consume its artifacts.
     if: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-         vars.NAMESPACE_RUNNER_ANDROID || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'current' &&
         !cancelled() &&
         needs.build-android-apks.result == 'success'
       }}
@@ -1539,8 +1536,11 @@ jobs:
     with:
       build_type: 'main'
       metamask_environment: 'e2e'
-      # Pinned to Cirrus until Namespace artifact-store parity.
-      runner_provider: current
+      runner_provider: >-
+        ${{
+          inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
+          vars.NAMESPACE_RUNNER_ANDROID || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+        }}
       selected_tags: >-
         ${{
           (fromJSON(needs.smart-e2e-selection.outputs.ai_confidence || '0') >= 85 &&
@@ -1551,16 +1551,13 @@ jobs:
 
   appium-smoke-tests-ios:
     name: 'Appium Smoke Tests (iOS)'
-    # Pinned to Cirrus until artifact-store parity. Run only when the iOS build
-    # provider also resolves to current so this job can consume its artifacts.
+    # Use the same provider as the iOS build so Appium can consume its artifacts.
     # Main/release push and main schedule: always run when the iOS build succeeded.
     # PRs: skipped by default; add run-appium-ios-tests, or change
     # page-objects/selectors/locators/framework/smoke-appium
     # (same smart-selected tags as other E2E jobs).
     if: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-         vars.NAMESPACE_RUNNER_IOS || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'current' &&
         !cancelled() &&
         needs.ios-tests-ready.result == 'success' &&
         (
@@ -1590,8 +1587,11 @@ jobs:
     with:
       build_type: 'main'
       metamask_environment: 'e2e'
-      # Pinned to Cirrus until Namespace artifact-store parity.
-      runner_provider: current
+      runner_provider: >-
+        ${{
+          inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
+          vars.NAMESPACE_RUNNER_IOS || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+        }}
       selected_tags: >-
         ${{
           (fromJSON(needs.smart-e2e-selection.outputs.ai_confidence || '0') >= 85 &&
@@ -1603,12 +1603,8 @@ jobs:
   # Fixture validation — ensures committed E2E fixtures match the live app state schema
   validate-e2e-fixtures:
     name: 'Validate E2E Fixtures'
-    # Pinned to Cirrus until artifact-store parity. Run only when the iOS build
-    # provider also resolves to current so this job can consume its artifacts.
     if: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-         vars.NAMESPACE_RUNNER_IOS || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'current' &&
         needs.ios-tests-ready.result == 'success' &&
         github.event_name == 'pull_request'
       }}
@@ -1627,8 +1623,11 @@ jobs:
       test-timeout-minutes: 25
       build_type: 'main'
       metamask_environment: 'e2e'
-      # Pinned to Cirrus until Namespace artifact-store parity (same as Appium smoke).
-      runner_provider: current
+      runner_provider: >-
+        ${{
+          inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
+          vars.NAMESPACE_RUNNER_IOS || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+        }}
     secrets: inherit
 
   report-fixture-validation:
@@ -1655,10 +1654,15 @@ jobs:
       - uses: actions/checkout@v6
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
 
-      # validate-e2e-fixtures is pinned to runner_provider: current, so results always
-      # land in the GitHub Actions artifact store — download via actions/* regardless
-      # of where this reporting job runs.
-      - name: Download fixture validation results
+      - name: Download fixture validation results (Namespace)
+        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
+        continue-on-error: true
+        uses: namespace-actions/download-artifact@7cbad919e4b0e09f17e9d6311a444ff002992b5b # v2.0.1
+        with:
+          name: fixture-validation-results-validate-e2e-fixtures
+          path: fixture-results/
+      - name: Download fixture validation results (current)
+        if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1644,6 +1644,11 @@ jobs:
         ${{
           (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
         }}
+      IOS_E2E_ARTIFACT_PROVIDER: >-
+        ${{
+          inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
+          vars.NAMESPACE_RUNNER_IOS || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+        }}
     if: ${{ inputs.runner_provider != 'bitrise' && !cancelled() && needs.validate-e2e-fixtures.result != 'skipped' }}
     needs: [validate-e2e-fixtures]
     permissions:
@@ -1655,14 +1660,14 @@ jobs:
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
 
       - name: Download fixture validation results (Namespace)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
+        if: ${{ env.IOS_E2E_ARTIFACT_PROVIDER == 'namespace' }}
         continue-on-error: true
         uses: namespace-actions/download-artifact@7cbad919e4b0e09f17e9d6311a444ff002992b5b # v2.0.1
         with:
           name: fixture-validation-results-validate-e2e-fixtures
           path: fixture-results/
       - name: Download fixture validation results (current)
-        if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
+        if: ${{ env.IOS_E2E_ARTIFACT_PROVIDER != 'namespace' }}
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -426,8 +426,18 @@ jobs:
           list-suites: all
           list-tests: failed
 
-      - name: Upload fixture validation reports
-        if: ${{ always() && inputs.test_suite_tag == 'FixtureValidation' }}
+      - name: Upload fixture validation reports (Namespace)
+        if: ${{ always() && inputs.test_suite_tag == 'FixtureValidation' && inputs.runner_provider == 'namespace' }}
+        uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
+        with:
+          name: fixture-validation-results-${{ inputs.test-suite-name }}
+          path: |
+            tests/reports/fixture-validation-result.json
+            tests/reports/fixture-validation-diff.txt
+          if-no-files-found: ignore
+          retention-days: 7
+      - name: Upload fixture validation reports (current)
+        if: ${{ always() && inputs.test_suite_tag == 'FixtureValidation' && inputs.runner_provider != 'namespace' }}
         uses: actions/upload-artifact@v4
         with:
           name: fixture-validation-results-${{ inputs.test-suite-name }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

PR #34898 moved native E2E builds to Namespace but left Appium smoke tests and fixture validation gated on `runner_provider == current`. As a result, the builds completed successfully while the Appium jobs were skipped.

This change keeps the Namespace runner migration and makes Appium Android/iOS plus fixture validation follow the same platform provider as their corresponding native E2E build. Namespace runs download and upload artifacts through the Namespace artifact store; `current` runs retain the existing GitHub Actions artifact path for rollback compatibility.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #34898

## **Manual testing steps**

```gherkin
Feature: Appium E2E on Namespace runners

  Scenario: Android Appium tests use the Namespace Android build
    Given the Android E2E build resolves to the Namespace runner
    When the CI workflow runs after the Android build succeeds
    Then Android Appium smoke tests are scheduled on the Namespace Android runner
    And the tests download the APK from the Namespace artifact store

  Scenario: iOS Appium tests use the Namespace iOS build
    Given the iOS E2E build resolves to the Namespace runner
    When the CI workflow runs after the iOS build succeeds
    Then iOS Appium smoke tests are scheduled on the Namespace iOS runner
    And the tests download the app bundle from the Namespace artifact store

  Scenario: Current runner rollback remains supported
    Given the platform runner variable resolves to current
    When the CI workflow runs
    Then Appium uses the existing GitHub Actions artifact path

  Scenario: Fixture validation reports are preserved
    Given iOS fixture validation runs on Namespace
    When validation reports are uploaded
    Then the reporting job downloads them from the Namespace artifact store
```

## **Screenshots/Recordings**

### **Before**

N/A — CI workflow-only change.

### **After**

N/A — CI workflow-only change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android — not applicable; this is a CI workflow change.
- [x] I've tested with a power user scenario — not applicable; this is a CI workflow change.
- [x] I've instrumented key operations with Sentry traces for production performance metrics — not applicable; this is a CI workflow change.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4421bee-b874-4cb3-9ce6-95b470d2b56c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4421bee-b874-4cb3-9ce6-95b470d2b56c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

