### PR TITLE
fix(assets): source Tron special assets from unified AssetsController state

### DIFF
--- a/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/TronEnergyBandwidthDetail.test.tsx
+++ b/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/TronEnergyBandwidthDetail.test.tsx
@@ -54,13 +54,17 @@ const createEmptySpecialAssetsMap = (): TronSpecialAssetsMap => ({
 });
 
 interface Resource {
+  assetId: string;
   symbol: string;
-  balance: number | string;
+  balance: string;
+  fiat: undefined;
 }
 
 const res = (symbol: string, balance: number | string): Resource => ({
+  assetId: symbol,
   symbol,
-  balance,
+  balance: String(balance),
+  fiat: undefined,
 });
 
 const ResourceRingMock = jest.mocked(ResourceRing);

--- a/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/TronEnergyBandwidthDetail.test.tsx
+++ b/app/components/UI/AssetOverview/TronEnergyBandwidthDetail/TronEnergyBandwidthDetail.test.tsx
@@ -82,6 +82,7 @@ describe('TronEnergyBandwidthDetail', () => {
 
   it('renders values, coverage counts, and passes correct progress to ResourceRing', () => {
     jest.mocked(selectTronSpecialAssetsBySelectedAccountGroup).mockReturnValue({
+      ...createEmptySpecialAssetsMap(),
       energy: res('energy', 130000),
       bandwidth: res('bandwidth', 560),
       maxEnergy: res('max-energy', 200000),
@@ -114,6 +115,7 @@ describe('TronEnergyBandwidthDetail', () => {
 
   it('parses balances and caps progress', () => {
     jest.mocked(selectTronSpecialAssetsBySelectedAccountGroup).mockReturnValue({
+      ...createEmptySpecialAssetsMap(),
       energy: res('energy', '1000'),
       bandwidth: res('bandwidth', '2000'),
       maxEnergy: res('max-energy', '400'),

--- a/app/selectors/assets/assets-list.test.ts
+++ b/app/selectors/assets/assets-list.test.ts
@@ -2074,6 +2074,43 @@ describe('selectTronSpecialAssetsBySelectedAccountGroup', () => {
       trxInLockPeriod: undefined,
     });
   });
+
+  it('ignores special assets whose Tron network is not enabled', () => {
+    const stateWithDisabledNetworkAssets = {
+      ...mockState(),
+      engine: {
+        ...mockState().engine,
+        backgroundState: {
+          ...mockState().engine.backgroundState,
+          AssetsController: {
+            selectedCurrency: 'USD',
+            assetsBalance: {
+              '2d89e6a0-b4e6-45a8-a707-f10cef143b42': {
+                'tron:728126428/slip44:energy': { amount: '400' },
+                [`${TrxScope.Nile}/slip44:energy`]: { amount: '999' },
+              },
+            },
+            assetsPrice: {},
+          },
+          NetworkEnablementController: {
+            enabledNetworkMap: {
+              [KnownCaipNamespace.Tron]: {
+                [TrxScope.Mainnet]: true,
+                [TrxScope.Nile]: false,
+              },
+            },
+          },
+        },
+      },
+    } as unknown as RootState;
+
+    const result = selectTronSpecialAssetsBySelectedAccountGroup(
+      stateWithDisabledNetworkAssets,
+    );
+
+    expect(result.energy?.assetId).toBe('tron:728126428/slip44:energy');
+    expect(result.energy?.balance).toBe('400');
+  });
 });
 
 describe('selectAssetsByAccountGroupId', () => {

--- a/app/selectors/assets/assets-list.test.ts
+++ b/app/selectors/assets/assets-list.test.ts
@@ -1902,61 +1902,21 @@ describe('selectTronSpecialAssetsBySelectedAccountGroup', () => {
         ...mockState().engine,
         backgroundState: {
           ...mockState().engine.backgroundState,
-          MultichainAssetsController: {
-            accountsAssets: {
-              '2d89e6a0-b4e6-45a8-a707-f10cef143b42': [
-                'tron:728126428/slip44:energy',
-                'tron:728126428/slip44:bandwidth',
-                'tron:728126428/slip44:195',
-              ],
-            },
-            assetsMetadata: {
-              'tron:728126428/slip44:energy': {
-                name: 'Energy',
-                symbol: 'ENERGY',
-                fungible: true as const,
-                iconUrl: 'test-url',
-                units: [{ name: 'Energy', symbol: 'ENERGY', decimals: 0 }],
-              },
-              'tron:728126428/slip44:bandwidth': {
-                name: 'Bandwidth',
-                symbol: 'BANDWIDTH',
-                fungible: true as const,
-                iconUrl: 'test-url',
-                units: [
-                  { name: 'Bandwidth', symbol: 'BANDWIDTH', decimals: 0 },
-                ],
-              },
-              'tron:728126428/slip44:195': {
-                name: 'TRON',
-                symbol: 'TRX',
-                fungible: true as const,
-                iconUrl: 'test-url',
-                units: [{ name: 'TRON', symbol: 'TRX', decimals: 6 }],
-              },
-            },
-            allIgnoredAssets: {},
-          },
-          MultichainBalancesController: {
-            balances: {
+          AssetsController: {
+            selectedCurrency: 'USD',
+            assetsBalance: {
               '2d89e6a0-b4e6-45a8-a707-f10cef143b42': {
-                'tron:728126428/slip44:energy': {
-                  amount: '400',
-                  unit: 'ENERGY',
-                },
-                'tron:728126428/slip44:bandwidth': {
-                  amount: '604',
-                  unit: 'BANDWIDTH',
-                },
-                'tron:728126428/slip44:195': { amount: '1000', unit: 'TRX' },
+                'tron:728126428/slip44:energy': { amount: '400' },
+                'tron:728126428/slip44:bandwidth': { amount: '604' },
+                'tron:728126428/slip44:195': { amount: '1000' },
               },
             },
-          },
-          MultichainAssetsRatesController: {
-            conversionRates: {
+            assetsPrice: {
               'tron:728126428/slip44:195': {
-                rate: '0.12',
-                currency: 'swift:0/iso4217:USD',
+                assetPriceType: 'fungible',
+                price: 0.12,
+                usdPrice: 0.12,
+                lastUpdated: 0,
               },
             },
           },
@@ -1990,186 +1950,36 @@ describe('selectTronSpecialAssetsBySelectedAccountGroup', () => {
         ...mockState().engine,
         backgroundState: {
           ...mockState().engine.backgroundState,
-          MultichainAssetsController: {
-            accountsAssets: {
-              '2d89e6a0-b4e6-45a8-a707-f10cef143b42': [
-                'tron:728126428/slip44:energy',
-                'tron:728126428/slip44:bandwidth',
-                'tron:728126428/slip44:maximum-energy',
-                'tron:728126428/slip44:maximum-bandwidth',
-                'tron:728126428/slip44:195-staked-for-energy',
-                'tron:728126428/slip44:195-staked-for-bandwidth',
-                'tron:728126428/slip44:195-ready-for-withdrawal',
-                'tron:728126428/slip44:195-staking-rewards',
-                'tron:728126428/slip44:195-in-lock-period',
-                'tron:728126428/slip44:195',
-              ],
-            },
-            assetsMetadata: {
-              'tron:728126428/slip44:energy': {
-                name: 'Energy',
-                symbol: 'ENERGY',
-                fungible: true as const,
-                iconUrl: 'test-url',
-                units: [{ name: 'Energy', symbol: 'ENERGY', decimals: 0 }],
-              },
-              'tron:728126428/slip44:bandwidth': {
-                name: 'Bandwidth',
-                symbol: 'BANDWIDTH',
-                fungible: true as const,
-                iconUrl: 'test-url',
-                units: [
-                  { name: 'Bandwidth', symbol: 'BANDWIDTH', decimals: 0 },
-                ],
-              },
-              'tron:728126428/slip44:maximum-energy': {
-                name: 'Max Energy',
-                symbol: 'MAX-ENERGY',
-                fungible: true as const,
-                iconUrl: 'test-url',
-                units: [
-                  { name: 'Max Energy', symbol: 'MAX-ENERGY', decimals: 0 },
-                ],
-              },
-              'tron:728126428/slip44:maximum-bandwidth': {
-                name: 'Max Bandwidth',
-                symbol: 'MAX-BANDWIDTH',
-                fungible: true as const,
-                iconUrl: 'test-url',
-                units: [
-                  {
-                    name: 'Max Bandwidth',
-                    symbol: 'MAX-BANDWIDTH',
-                    decimals: 0,
-                  },
-                ],
-              },
-              'tron:728126428/slip44:195-staked-for-energy': {
-                name: 'Staked TRX Energy',
-                symbol: 'sTRX-ENERGY',
-                fungible: true as const,
-                iconUrl: 'test-url',
-                units: [
-                  {
-                    name: 'Staked TRX Energy',
-                    symbol: 'sTRX-ENERGY',
-                    decimals: 6,
-                  },
-                ],
-              },
-              'tron:728126428/slip44:195-staked-for-bandwidth': {
-                name: 'Staked TRX Bandwidth',
-                symbol: 'sTRX-BANDWIDTH',
-                fungible: true as const,
-                iconUrl: 'test-url',
-                units: [
-                  {
-                    name: 'Staked TRX Bandwidth',
-                    symbol: 'sTRX-BANDWIDTH',
-                    decimals: 6,
-                  },
-                ],
-              },
-              'tron:728126428/slip44:195-ready-for-withdrawal': {
-                name: 'Ready for Withdrawal',
-                symbol: 'TRX-READY-FOR-WITHDRAWAL',
-                fungible: true as const,
-                iconUrl: 'test-url',
-                units: [
-                  {
-                    name: 'Ready for Withdrawal',
-                    symbol: 'TRX-READY-FOR-WITHDRAWAL',
-                    decimals: 6,
-                  },
-                ],
-              },
-              'tron:728126428/slip44:195-staking-rewards': {
-                name: 'Staking Rewards',
-                symbol: 'TRX-STAKING-REWARDS',
-                fungible: true as const,
-                iconUrl: 'test-url',
-                units: [
-                  {
-                    name: 'Staking Rewards',
-                    symbol: 'TRX-STAKING-REWARDS',
-                    decimals: 6,
-                  },
-                ],
-              },
-              'tron:728126428/slip44:195-in-lock-period': {
-                name: 'In Lock Period',
-                symbol: 'TRX-IN-LOCK-PERIOD',
-                fungible: true as const,
-                iconUrl: 'test-url',
-                units: [
-                  {
-                    name: 'In Lock Period',
-                    symbol: 'TRX-IN-LOCK-PERIOD',
-                    decimals: 6,
-                  },
-                ],
-              },
-              'tron:728126428/slip44:195': {
-                name: 'TRON',
-                symbol: 'TRX',
-                fungible: true as const,
-                iconUrl: 'test-url',
-                units: [{ name: 'TRON', symbol: 'TRX', decimals: 6 }],
-              },
-            },
-            allIgnoredAssets: {},
-          },
-          MultichainBalancesController: {
-            balances: {
+          AssetsController: {
+            selectedCurrency: 'USD',
+            assetsBalance: {
               '2d89e6a0-b4e6-45a8-a707-f10cef143b42': {
-                'tron:728126428/slip44:energy': {
-                  amount: '130000',
-                  unit: 'ENERGY',
-                },
-                'tron:728126428/slip44:bandwidth': {
-                  amount: '560',
-                  unit: 'BANDWIDTH',
-                },
-                'tron:728126428/slip44:maximum-energy': {
-                  amount: '200000',
-                  unit: 'MAX-ENERGY',
-                },
-                'tron:728126428/slip44:maximum-bandwidth': {
-                  amount: '1000',
-                  unit: 'MAX-BANDWIDTH',
-                },
+                'tron:728126428/slip44:energy': { amount: '130000' },
+                'tron:728126428/slip44:bandwidth': { amount: '560' },
+                'tron:728126428/slip44:maximum-energy': { amount: '200000' },
+                'tron:728126428/slip44:maximum-bandwidth': { amount: '1000' },
                 'tron:728126428/slip44:195-staked-for-energy': {
                   amount: '65.48463',
-                  unit: 'sTRX-ENERGY',
                 },
                 'tron:728126428/slip44:195-staked-for-bandwidth': {
                   amount: '65.48463',
-                  unit: 'sTRX-BANDWIDTH',
                 },
                 'tron:728126428/slip44:195-ready-for-withdrawal': {
                   amount: '25.5',
-                  unit: 'TRX-READY-FOR-WITHDRAWAL',
                 },
                 'tron:728126428/slip44:195-staking-rewards': {
                   amount: '12.3',
-                  unit: 'TRX-STAKING-REWARDS',
                 },
-                'tron:728126428/slip44:195-in-lock-period': {
-                  amount: '50',
-                  unit: 'TRX-IN-LOCK-PERIOD',
-                },
-                'tron:728126428/slip44:195': {
-                  amount: '1000',
-                  unit: 'TRX',
-                },
+                'tron:728126428/slip44:195-in-lock-period': { amount: '50' },
+                'tron:728126428/slip44:195': { amount: '1000' },
               },
             },
-          },
-          MultichainAssetsRatesController: {
-            conversionRates: {
+            assetsPrice: {
               'tron:728126428/slip44:195': {
-                rate: '0.12',
-                currency: 'swift:0/iso4217:USD',
+                assetPriceType: 'fungible',
+                price: 0.12,
+                usdPrice: 0.12,
+                lastUpdated: 0,
               },
             },
           },
@@ -2225,46 +2035,15 @@ describe('selectTronSpecialAssetsBySelectedAccountGroup', () => {
         ...mockState().engine,
         backgroundState: {
           ...mockState().engine.backgroundState,
-          MultichainAssetsController: {
-            accountsAssets: {
-              '2d89e6a0-b4e6-45a8-a707-f10cef143b42': [
-                'tron:728126428/slip44:energy',
-                'tron:728126428/slip44:bandwidth',
-              ],
-            },
-            assetsMetadata: {
-              'tron:728126428/slip44:energy': {
-                name: 'Energy',
-                symbol: 'ENERGY',
-                fungible: true as const,
-                iconUrl: 'test-url',
-                units: [{ name: 'Energy', symbol: 'ENERGY', decimals: 0 }],
-              },
-              'tron:728126428/slip44:bandwidth': {
-                name: 'Bandwidth',
-                symbol: 'BANDWIDTH',
-                fungible: true as const,
-                iconUrl: 'test-url',
-                units: [
-                  { name: 'Bandwidth', symbol: 'BANDWIDTH', decimals: 0 },
-                ],
-              },
-            },
-            allIgnoredAssets: {},
-          },
-          MultichainBalancesController: {
-            balances: {
+          AssetsController: {
+            selectedCurrency: 'USD',
+            assetsBalance: {
               '2d89e6a0-b4e6-45a8-a707-f10cef143b42': {
-                'tron:728126428/slip44:energy': {
-                  amount: '400',
-                  unit: 'ENERGY',
-                },
-                'tron:728126428/slip44:bandwidth': {
-                  amount: '604',
-                  unit: 'BANDWIDTH',
-                },
+                'tron:728126428/slip44:energy': { amount: '400' },
+                'tron:728126428/slip44:bandwidth': { amount: '604' },
               },
             },
+            assetsPrice: {},
           },
           NetworkEnablementController: {
             enabledNetworkMap: {

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -708,80 +708,6 @@ function assetToToken(
 }
 
 /**
- * @deprecated Legacy implementation kept for comparison/testing only.
- *
- * Selects Tron special assets for the currently selected account group by
- * routing through the assets-controllers `selectAssetsBySelectedAccountGroup`
- * selector and the `assets-migration` compatibility layer
- * (see {@link getStateForAssetSelector}).
- *
- * Prefer {@link selectTronSpecialAssetsBySelectedAccountGroup}, which reads Tron
- * data directly from the Multichain controllers without the migration work.
- */
-export const selectTronSpecialAssetsBySelectedAccountGroupLegacy =
-  createDeepEqualSelector(
-    [getStateForAssetSelector, selectEnabledNetworks],
-    (assetsState, enabledNetworks): TronSpecialAssetsMap => {
-      const enabledTronNetworks = enabledNetworks.filter((networkId) =>
-        networkId.startsWith('tron:'),
-      );
-
-      if (enabledTronNetworks.length === 0) {
-        return EMPTY_TRON_SPECIAL_ASSETS_MAP;
-      }
-
-      const allAssets = callSelectAssetsBySelectedAccountGroup(assetsState, {
-        filterTronStakedTokens: false,
-      });
-
-      const enabledTronNetworksSet = new Set(enabledTronNetworks);
-
-      const specialAssetsMap: TronSpecialAssetsMap = {
-        energy: undefined,
-        bandwidth: undefined,
-        maxEnergy: undefined,
-        maxBandwidth: undefined,
-        stakedTrxForEnergy: undefined,
-        stakedTrxForBandwidth: undefined,
-        totalStakedTrx: 0,
-        trxReadyForWithdrawal: undefined,
-        trxStakingRewards: undefined,
-        trxInLockPeriod: undefined,
-      };
-
-      for (const [networkId, chainAssets] of Object.entries(allAssets)) {
-        if (!enabledTronNetworksSet.has(networkId)) continue;
-
-        for (const asset of chainAssets) {
-          if (!Object.hasOwn(TRON_SPECIAL_ASSET_KEYS, asset.assetId)) {
-            continue;
-          }
-
-          const key = TRON_SPECIAL_ASSET_KEYS[asset.assetId as KnownCaip19Id];
-          specialAssetsMap[key] = asset;
-        }
-      }
-
-      /**
-       * Compute total staked TRX using BigNumber to avoid floating-point precision errors
-       */
-      const stakedTrxForEnergyBN = safeParseBigNumber(
-        specialAssetsMap.stakedTrxForEnergy?.balance,
-      );
-      const stakedTrxForBandwidthBN = safeParseBigNumber(
-        specialAssetsMap.stakedTrxForBandwidth?.balance,
-      );
-      const totalStakedTrxBN = stakedTrxForEnergyBN.plus(
-        stakedTrxForBandwidthBN,
-      );
-
-      specialAssetsMap.totalStakedTrx = totalStakedTrxBN.toNumber();
-
-      return specialAssetsMap;
-    },
-  );
-
-/**
  * Selects Tron special assets for the currently selected account group.
  *
  * This includes:
@@ -789,11 +715,10 @@ export const selectTronSpecialAssetsBySelectedAccountGroupLegacy =
  * - **Staking assets**: TRX staked for Energy/Bandwidth and a pre-computed `totalStakedTrx` sum.
  * - **Staking lifecycle assets**: TRX Ready for Withdrawal, Staking Rewards, and TRX In Lock Period.
  *
- * Unlike {@link selectTronSpecialAssetsBySelectedAccountGroupLegacy}, this reads
- * Tron balances and prices **directly** from the unified `AssetsController`
- * state (`assetsBalance` + `assetsPrice`) for the accounts in the selected
- * account group. It does not go through the assets-controllers selector or the
- * `assets-migration` compatibility layer, nor the deprecated
+ * This reads Tron balances and prices **directly** from the unified
+ * `AssetsController` state (`assetsBalance` + `assetsPrice`) for the accounts in
+ * the selected account group. It does not go through the assets-controllers
+ * selector or the `assets-migration` compatibility layer, nor the deprecated
  * `MultichainBalancesController` / `MultichainAssetsController` /
  * `MultichainAssetsRatesController` controllers.
  *

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -12,7 +12,7 @@ import {
   MULTICHAIN_NETWORK_DECIMAL_PLACES,
   toEvmCaipChainId,
 } from '@metamask/multichain-network-controller';
-import { CaipChainId, Hex, isCaipChainId } from '@metamask/utils';
+import { CaipAssetType, CaipChainId, Hex, isCaipChainId } from '@metamask/utils';
 import { createSelector } from 'reselect';
 
 import I18n from '../../../locales/i18n';
@@ -36,6 +36,12 @@ import {
   selectCurrentCurrency,
 } from '../currencyRateController';
 import { selectSelectedInternalAccountByScope } from '../multichainAccounts/accounts';
+import { selectSelectedAccountGroup } from '../multichainAccounts/accountTreeController';
+import {
+  getAssetsBalance,
+  getAssetsPrice,
+  getSelectedCurrency,
+} from './assets-controller';
 import { selectEvmNetworkConfigurationsByChainId } from '../networkController';
 import { selectEnabledNetworksByNamespace } from '../networkEnablementController';
 import { selectTokenSortConfig } from '../preferencesController';
@@ -67,27 +73,44 @@ import { filterExcludedAssets } from '../../enablement/assets/networks-customiza
  * and additional staking lifecycle assets (Ready for Withdrawal, Staking
  * Rewards, In Lock Period).
  */
+/**
+ * Minimal representation of a Tron special asset consumed by the wallet UI.
+ *
+ * Only the fields actually read by consumers are modeled here so the selector
+ * can build these objects straight from unified `AssetsController` state
+ * (`assetsBalance` + `assetsInfo` + `assetsPrice`) without reconstructing the
+ * full assets-controllers `Asset` shape.
+ */
+export interface TronSpecialAsset {
+  /** CAIP-19 asset id (e.g. `tron:728126428/slip44:energy`) */
+  assetId: string;
+  /** Human-readable balance amount (e.g. `"65.48463"`) */
+  balance: string;
+  /** Fiat conversion in the user's selected currency, if a price is known */
+  fiat: { balance: number; currency: string } | undefined;
+}
+
 export interface TronSpecialAssetsMap {
   /** Current available energy */
-  energy: Asset | undefined;
+  energy: TronSpecialAsset | undefined;
   /** Current available bandwidth */
-  bandwidth: Asset | undefined;
+  bandwidth: TronSpecialAsset | undefined;
   /** Maximum energy capacity */
-  maxEnergy: Asset | undefined;
+  maxEnergy: TronSpecialAsset | undefined;
   /** Maximum bandwidth capacity */
-  maxBandwidth: Asset | undefined;
+  maxBandwidth: TronSpecialAsset | undefined;
   /** TRX staked for energy (sTRX-Energy) */
-  stakedTrxForEnergy: Asset | undefined;
+  stakedTrxForEnergy: TronSpecialAsset | undefined;
   /** TRX staked for bandwidth (sTRX-Bandwidth) */
-  stakedTrxForBandwidth: Asset | undefined;
+  stakedTrxForBandwidth: TronSpecialAsset | undefined;
   /** Total staked TRX (sum of energy + bandwidth staking) */
   totalStakedTrx: number;
   /** TRX ready for withdrawal (unstaked TRX that has completed the lock period) */
-  trxReadyForWithdrawal: Asset | undefined;
+  trxReadyForWithdrawal: TronSpecialAsset | undefined;
   /** TRX staking rewards */
-  trxStakingRewards: Asset | undefined;
+  trxStakingRewards: TronSpecialAsset | undefined;
   /** TRX in lock period (unstaked but waiting for lock period to end) */
-  trxInLockPeriod: Asset | undefined;
+  trxInLockPeriod: TronSpecialAsset | undefined;
 }
 
 type TronSpecialAssetKey = Exclude<
@@ -685,17 +708,17 @@ function assetToToken(
 }
 
 /**
- * Selects Tron special assets for the currently selected account group.
+ * @deprecated Legacy implementation kept for comparison/testing only.
  *
- * This includes:
- * - **Network resources**: Energy, Bandwidth, and their maximum capacities.
- * - **Staking assets**: TRX staked for Energy/Bandwidth and a pre-computed `totalStakedTrx` sum.
- * - **Staking lifecycle assets**: TRX Ready for Withdrawal, Staking Rewards, and TRX In Lock Period.
+ * Selects Tron special assets for the currently selected account group by
+ * routing through the assets-controllers `selectAssetsBySelectedAccountGroup`
+ * selector and the `assets-migration` compatibility layer
+ * (see {@link getStateForAssetSelector}).
  *
- * Returns a structured {@link TronSpecialAssetsMap} with all assets pre-mapped by type
- * for efficient access, eliminating the need for consumers to iterate or search the array.
+ * Prefer {@link selectTronSpecialAssetsBySelectedAccountGroup}, which reads Tron
+ * data directly from the Multichain controllers without the migration work.
  */
-export const selectTronSpecialAssetsBySelectedAccountGroup =
+export const selectTronSpecialAssetsBySelectedAccountGroupLegacy =
   createDeepEqualSelector(
     [getStateForAssetSelector, selectEnabledNetworks],
     (assetsState, enabledNetworks): TronSpecialAssetsMap => {
@@ -751,6 +774,118 @@ export const selectTronSpecialAssetsBySelectedAccountGroup =
       const totalStakedTrxBN = stakedTrxForEnergyBN.plus(
         stakedTrxForBandwidthBN,
       );
+
+      specialAssetsMap.totalStakedTrx = totalStakedTrxBN.toNumber();
+
+      return specialAssetsMap;
+    },
+  );
+
+/**
+ * Selects Tron special assets for the currently selected account group.
+ *
+ * This includes:
+ * - **Network resources**: Energy, Bandwidth, and their maximum capacities.
+ * - **Staking assets**: TRX staked for Energy/Bandwidth and a pre-computed `totalStakedTrx` sum.
+ * - **Staking lifecycle assets**: TRX Ready for Withdrawal, Staking Rewards, and TRX In Lock Period.
+ *
+ * Unlike {@link selectTronSpecialAssetsBySelectedAccountGroupLegacy}, this reads
+ * Tron balances and prices **directly** from the unified `AssetsController`
+ * state (`assetsBalance` + `assetsPrice`) for the accounts in the selected
+ * account group. It does not go through the assets-controllers selector or the
+ * `assets-migration` compatibility layer, nor the deprecated
+ * `MultichainBalancesController` / `MultichainAssetsController` /
+ * `MultichainAssetsRatesController` controllers.
+ *
+ * Returns a structured {@link TronSpecialAssetsMap} with all assets pre-mapped by type
+ * for efficient access, eliminating the need for consumers to iterate or search the array.
+ */
+export const selectTronSpecialAssetsBySelectedAccountGroup =
+  createDeepEqualSelector(
+    [
+      selectSelectedAccountGroup,
+      selectEnabledNetworks,
+      getAssetsBalance,
+      getAssetsPrice,
+      getSelectedCurrency,
+    ],
+    (
+      selectedGroup,
+      enabledNetworks,
+      assetsBalance,
+      assetsPrice,
+      selectedCurrency,
+    ): TronSpecialAssetsMap => {
+      const enabledTronNetworks = enabledNetworks.filter((networkId) =>
+        networkId.startsWith('tron:'),
+      );
+
+      if (!selectedGroup || enabledTronNetworks.length === 0) {
+        return EMPTY_TRON_SPECIAL_ASSETS_MAP;
+      }
+
+      const enabledTronNetworksSet = new Set(enabledTronNetworks);
+
+      const specialAssetsMap: TronSpecialAssetsMap = {
+        energy: undefined,
+        bandwidth: undefined,
+        maxEnergy: undefined,
+        maxBandwidth: undefined,
+        stakedTrxForEnergy: undefined,
+        stakedTrxForBandwidth: undefined,
+        totalStakedTrx: 0,
+        trxReadyForWithdrawal: undefined,
+        trxStakingRewards: undefined,
+        trxInLockPeriod: undefined,
+      };
+
+      for (const accountId of selectedGroup.accounts) {
+        const accountBalances = assetsBalance[accountId];
+        if (!accountBalances) {
+          continue;
+        }
+
+        // Look up each known Tron special asset id directly rather than
+        // scanning every balance the account holds.
+        for (const [assetId, key] of Object.entries(TRON_SPECIAL_ASSET_KEYS)) {
+          const balanceData = accountBalances[assetId as CaipAssetType];
+          if (!balanceData) {
+            continue;
+          }
+
+          // The CAIP-2 chain id is the portion of the CAIP-19 asset id before
+          // the first '/'. Skip assets whose Tron network is not enabled.
+          const chainId = assetId.slice(0, assetId.indexOf('/'));
+          if (!enabledTronNetworksSet.has(chainId)) {
+            continue;
+          }
+
+          const amount = balanceData.amount ?? '0';
+          const price = assetsPrice[assetId as CaipAssetType]?.price;
+          const fiat =
+            price !== undefined
+              ? {
+                  balance: safeParseBigNumber(amount)
+                    .multipliedBy(price)
+                    .toNumber(),
+                  currency: selectedCurrency,
+                }
+              : undefined;
+
+          specialAssetsMap[key] = {
+            assetId,
+            balance: amount,
+            fiat,
+          };
+        }
+      }
+
+      /**
+       * Compute total staked TRX using BigNumber to avoid floating-point precision errors
+       */
+      const totalStakedTrxBN = safeParseBigNumber(
+        specialAssetsMap.stakedTrxForEnergy?.balance,
+      ).plus(safeParseBigNumber(specialAssetsMap.stakedTrxForBandwidth?.balance));
 
       specialAssetsMap.totalStakedTrx = totalStakedTrxBN.toNumber();
 

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -12,7 +12,13 @@ import {
   MULTICHAIN_NETWORK_DECIMAL_PLACES,
   toEvmCaipChainId,
 } from '@metamask/multichain-network-controller';
-import { CaipAssetType, CaipChainId, Hex, isCaipChainId } from '@metamask/utils';
+import {
+  CaipAssetType,
+  CaipChainId,
+  Hex,
+  isCaipChainId,
+  parseCaipAssetType,
+} from '@metamask/utils';
 import { createSelector } from 'reselect';
 
 import I18n from '../../../locales/i18n';
@@ -770,21 +776,17 @@ export const selectTronSpecialAssetsBySelectedAccountGroup =
           continue;
         }
 
-        // Look up each known Tron special asset id directly rather than
-        // scanning every balance the account holds.
-        for (const [assetId, key] of Object.entries(TRON_SPECIAL_ASSET_KEYS)) {
-          const balanceData = accountBalances[assetId as CaipAssetType];
-          if (!balanceData) {
+        for (const [assetId, balanceData] of Object.entries(accountBalances)) {
+          if (!Object.hasOwn(TRON_SPECIAL_ASSET_KEYS, assetId)) {
             continue;
           }
 
-          // The CAIP-2 chain id is the portion of the CAIP-19 asset id before
-          // the first '/'. Skip assets whose Tron network is not enabled.
-          const chainId = assetId.slice(0, assetId.indexOf('/'));
+          const { chainId } = parseCaipAssetType(assetId as CaipAssetType);
           if (!enabledTronNetworksSet.has(chainId)) {
             continue;
           }
 
+          const key = TRON_SPECIAL_ASSET_KEYS[assetId as KnownCaip19Id];
           const amount = balanceData.amount ?? '0';
           const price = assetsPrice[assetId as CaipAssetType]?.price;
           const fiat =
@@ -808,9 +810,15 @@ export const selectTronSpecialAssetsBySelectedAccountGroup =
       /**
        * Compute total staked TRX using BigNumber to avoid floating-point precision errors
        */
-      const totalStakedTrxBN = safeParseBigNumber(
+      const stakedTrxForEnergyBN = safeParseBigNumber(
         specialAssetsMap.stakedTrxForEnergy?.balance,
-      ).plus(safeParseBigNumber(specialAssetsMap.stakedTrxForBandwidth?.balance));
+      );
+      const stakedTrxForBandwidthBN = safeParseBigNumber(
+        specialAssetsMap.stakedTrxForBandwidth?.balance,
+      );
+      const totalStakedTrxBN = stakedTrxForEnergyBN.plus(
+        stakedTrxForBandwidthBN,
+      );
 
       specialAssetsMap.totalStakedTrx = totalStakedTrxBN.toNumber();
 

--- a/app/selectors/assets/assets-list.ts
+++ b/app/selectors/assets/assets-list.ts
@@ -776,8 +776,11 @@ export const selectTronSpecialAssetsBySelectedAccountGroup =
           continue;
         }
 
-        for (const [assetId, balanceData] of Object.entries(accountBalances)) {
-          if (!Object.hasOwn(TRON_SPECIAL_ASSET_KEYS, assetId)) {
+        // Look up each known Tron special asset id directly rather than
+        // scanning every balance the account holds.
+        for (const [assetId, key] of Object.entries(TRON_SPECIAL_ASSET_KEYS)) {
+          const balanceData = accountBalances[assetId as CaipAssetType];
+          if (!balanceData) {
             continue;
           }
 
@@ -786,7 +789,6 @@ export const selectTronSpecialAssetsBySelectedAccountGroup =
             continue;
           }
 
-          const key = TRON_SPECIAL_ASSET_KEYS[assetId as KnownCaip19Id];
           const amount = balanceData.amount ?? '0';
           const price = assetsPrice[assetId as CaipAssetType]?.price;
           const fiat =


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

This fixes an issue where staked TRX balances were not showing up in the TRX details view. It moves `selectTronSpecialAssetsBySelectedAccountGroup` to the unified `AssetsController` state, reading balances and prices directly for accounts in the selected account group instead of routing through the deprecated multichain controllers, the legacy assets selector, or the `assets-migration` compatibility layer.

The selector now returns a focused `TronSpecialAsset` shape containing the CAIP-19 asset ID, balance, and optional fiat value. It continues to map energy, bandwidth, capacity, staking, withdrawal, reward, and lock-period assets; only enabled Tron networks are included; and the total staked TRX value is calculated with `BigNumber` arithmetic.

Tests were updated to use `AssetsController` fixtures, cover assets on disabled Tron networks, and align the Tron resource component fixtures with the new asset shape.

<!-- mms-check: type=text required=true -->

## **Changelog**

CHANGELOG entry: null

<!-- mms-check: type=changelog required=true blocking=true -->

## **Related issues**

Refs: N/A — No linked issue; this is an internal selector and test-fixture refactor.

<!-- mms-check: type=issue-link required=true -->

## **Manual testing steps**

N/A — This change is limited to selector logic and automated test fixtures; it does not change user-facing flows.

<!-- mms-check: type=manual-testing required=true -->

## **Screenshots/Recordings**

N/A — There are no user-facing or visual changes.

<!-- mms-check: type=screenshot required=true -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android — N/A: selector-only refactor with no platform-specific behavior.
- [x] I've tested with a power user scenario — N/A: no wallet/account flow or user-facing performance behavior changed.
- [x] I've instrumented key operations with Sentry traces for production performance metrics — N/A: no new production operation requiring instrumentation was introduced.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5f83ee39381905bbc9706daa48a7549580665098. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->