### PR TITLE
fix(browser): sync URL bar with committed page after back/forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Security
+### Fixed
 
-- Fixed the in-app browser so back/forward navigation uses the WebView's committed URL for origin, rather than a page-supplied value (#35021)
+- Fixed the in-app browser address bar so it matches the page shown after back/forward navigation (#35021)
 
 ## [8.7.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Fixed the in-app browser so back/forward navigation uses the WebView's committed URL for origin, rather than a page-supplied value
+- Fixed the in-app browser so back/forward navigation uses the WebView's committed URL for origin, rather than a page-supplied value (#35021)
 
 ## [8.7.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Fixed the in-app browser so back/forward navigation uses the WebView's committed URL for origin, rather than a page-supplied value
+
 ## [8.7.0]
 
 ### Added

--- a/app/components/Views/BrowserTab/BrowserTab.tsx
+++ b/app/components/Views/BrowserTab/BrowserTab.tsx
@@ -124,6 +124,7 @@ import {
   isDisallowedExplicitPort,
   isDocumentUrlForUrlBarPayload,
   isENSUrl,
+  resolveCommittedDocumentUrl,
 } from './utils';
 import { getURLProtocol } from '../../../util/general';
 import { PROTOCOLS } from '../../../constants/deeplinks';
@@ -826,6 +827,9 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(
      * Resolves the URL bar from a document URL reported by the WebView after a
      * back/forward navigation. Only the message matching the pending request is
      * applied; messages without a matching request are ignored.
+     *
+     * The native WebView URL captured at request time is authoritative for
+     * origin. A page-supplied URL is used only when it shares that origin.
      */
     const handleDocumentUrlForUrlBar = useCallback(
       (payload: unknown) => {
@@ -840,9 +844,30 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(
 
         pendingBackForwardNavRef.current = null;
 
+        const committedUrl = resolveCommittedDocumentUrl(
+          pendingNav.url,
+          payload.url,
+        );
+
+        if (!committedUrl) {
+          Logger.log(
+            `Ignoring back/forward document URL that cannot be committed. Native: ${pendingNav.url} Reported: ${payload.url}`,
+          );
+          return;
+        }
+
+        const usedPageReportedUrl = committedUrl === payload.url;
+        if (!usedPageReportedUrl) {
+          Logger.log(
+            `Ignoring page-reported document URL with mismatched origin. Native: ${pendingNav.url} Reported: ${payload.url}`,
+          );
+        }
+
         handleSuccessfulPageResolution({
-          title: payload.title ?? titleRef.current,
-          url: payload.url,
+          title: usedPageReportedUrl
+            ? (payload.title ?? pendingNav.title ?? titleRef.current)
+            : (pendingNav.title ?? titleRef.current),
+          url: committedUrl,
           icon: favicon,
           canGoBack: pendingNav.canGoBack,
           canGoForward: pendingNav.canGoForward,
@@ -1180,6 +1205,10 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(
             return;
           }
           if (dataParsed.name) {
+            // Do not overwrite `origin`. BackgroundBridge already rejects
+            // messages whose origin does not match the bridge origin. Stamping
+            // `resolvedUrlRef` would also attribute traffic to a stale origin
+            // during back/forward before this document-URL sync completes.
             backgroundBridgeRef.current?.onMessage(dataParsed);
             return;
           }
@@ -1611,7 +1640,8 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(
 
     const handleOnNavigationStateChange = useCallback(
       (event: WebViewNavigation) => {
-        const { canGoForward, canGoBack, navigationType, loading } = event;
+        const { canGoForward, canGoBack, navigationType, loading, url, title } =
+          event;
         Logger.log(
           `WEBVIEW NAVIGATING: OnNavigationStateChange \n Values: ${JSON.stringify(
             event,
@@ -1624,11 +1654,18 @@ export const BrowserTab: React.FC<BrowserTabProps> = React.memo(
             return;
           }
 
+          if (!url) {
+            return;
+          }
+
           // Sync the URL bar from the document; navigation events are not always
-          // aligned with window.location after back/forward transitions.
+          // aligned with window.location after back/forward transitions. The
+          // native URL is stored so a page-supplied response cannot change origin.
           const requestId = createRequestId();
           pendingBackForwardNavRef.current = {
             requestId,
+            url,
+            title,
             canGoBack,
             canGoForward,
           };

--- a/app/components/Views/BrowserTab/index.test.tsx
+++ b/app/components/Views/BrowserTab/index.test.tsx
@@ -720,7 +720,7 @@ describe('BrowserTab', () => {
       expect(mockInjectJavaScript).not.toHaveBeenCalled();
     });
 
-    it('updates the URL bar from the document URL after backforward navigation', async () => {
+    it('updates the URL bar from the document URL when origin matches the native WebView URL', async () => {
       renderWithProvider(<BrowserTab {...mockProps} />, {
         state: mockInitialState,
       });
@@ -757,8 +757,8 @@ describe('BrowserTab', () => {
               type: DOCUMENT_URL_FOR_URL_BAR,
               payload: {
                 requestId,
-                url: 'https://example.com/page',
-                title: 'Example',
+                url: 'https://example.org/app',
+                title: 'Example Org App',
               },
             }),
           },
@@ -768,15 +768,167 @@ describe('BrowserTab', () => {
       await waitFor(() =>
         expect(mockNavigation.setParams).toHaveBeenCalledWith(
           expect.objectContaining({
-            url: expect.stringContaining('example.com'),
+            url: expect.stringContaining('example.org'),
+          }),
+        ),
+      );
+    });
+
+    it('keeps the native WebView origin when the page reports a different origin', async () => {
+      renderWithProvider(<BrowserTab {...mockProps} />, {
+        state: mockInitialState,
+      });
+
+      await waitFor(() =>
+        expect(screen.getByTestId('browser-webview')).toBeVisible(),
+      );
+
+      const webView = screen.getByTestId('browser-webview');
+      const { onNavigationStateChange, onMessage } = webView.props;
+
+      mockNavigation.setParams.mockClear();
+
+      await act(async () => {
+        onNavigationStateChange({
+          url: 'https://example.org/page',
+          title: 'Example Org',
+          loading: false,
+          canGoBack: true,
+          canGoForward: false,
+          navigationType: 'backforward',
+        });
+      });
+
+      const requestId = extractRequestIdFromInjectScript();
+
+      await act(async () => {
+        onMessage({
+          nativeEvent: {
+            data: JSON.stringify({
+              type: DOCUMENT_URL_FOR_URL_BAR,
+              payload: {
+                requestId,
+                url: 'https://example.com/page',
+                title: 'Spoofed',
+              },
+            }),
+          },
+        });
+      });
+
+      await waitFor(() =>
+        expect(mockNavigation.setParams).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: expect.stringContaining('example.org'),
           }),
         ),
       );
       expect(mockNavigation.setParams).not.toHaveBeenCalledWith(
         expect.objectContaining({
-          url: expect.stringContaining('example.org'),
+          url: expect.stringContaining('example.com'),
         }),
       );
+    });
+
+    it('keeps the native WebView origin when the page reports a URL with a disallowed explicit port', async () => {
+      renderWithProvider(<BrowserTab {...mockProps} />, {
+        state: mockInitialState,
+      });
+
+      await waitFor(() =>
+        expect(screen.getByTestId('browser-webview')).toBeVisible(),
+      );
+
+      const webView = screen.getByTestId('browser-webview');
+      const { onNavigationStateChange, onMessage } = webView.props;
+
+      mockNavigation.setParams.mockClear();
+
+      await act(async () => {
+        onNavigationStateChange({
+          url: 'https://attacker.example/poc',
+          title: 'Attacker',
+          loading: false,
+          canGoBack: true,
+          canGoForward: false,
+          navigationType: 'backforward',
+        });
+      });
+
+      const requestId = extractRequestIdFromInjectScript();
+
+      await act(async () => {
+        onMessage({
+          nativeEvent: {
+            data: JSON.stringify({
+              type: DOCUMENT_URL_FOR_URL_BAR,
+              payload: {
+                requestId,
+                url: 'https://metamask.io:8443',
+                title: 'MetaMask',
+              },
+            }),
+          },
+        });
+      });
+
+      await waitFor(() =>
+        expect(mockNavigation.setParams).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url: expect.stringContaining('attacker.example'),
+          }),
+        ),
+      );
+      expect(mockNavigation.setParams).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: expect.stringContaining('metamask.io'),
+        }),
+      );
+    });
+
+    it('does not commit a backforward URL when the native WebView URL has a disallowed explicit port', async () => {
+      renderWithProvider(<BrowserTab {...mockProps} />, {
+        state: mockInitialState,
+      });
+
+      await waitFor(() =>
+        expect(screen.getByTestId('browser-webview')).toBeVisible(),
+      );
+
+      const webView = screen.getByTestId('browser-webview');
+      const { onNavigationStateChange, onMessage } = webView.props;
+
+      mockNavigation.setParams.mockClear();
+
+      await act(async () => {
+        onNavigationStateChange({
+          url: 'https://metamask.io:8443',
+          title: 'MetaMask',
+          loading: false,
+          canGoBack: true,
+          canGoForward: false,
+          navigationType: 'backforward',
+        });
+      });
+
+      const requestId = extractRequestIdFromInjectScript();
+
+      await act(async () => {
+        onMessage({
+          nativeEvent: {
+            data: JSON.stringify({
+              type: DOCUMENT_URL_FOR_URL_BAR,
+              payload: {
+                requestId,
+                url: 'https://metamask.io:8443',
+                title: 'MetaMask',
+              },
+            }),
+          },
+        });
+      });
+
+      expect(mockNavigation.setParams).not.toHaveBeenCalled();
     });
 
     it('ignores document URL sync messages without a matching pending request', async () => {

--- a/app/components/Views/BrowserTab/types.ts
+++ b/app/components/Views/BrowserTab/types.ts
@@ -25,11 +25,14 @@ export enum WebViewNavigationEventName {
 
 /**
  * A back/forward navigation awaiting its committed document URL. We keep the
- * navigation state captured at request time so the URL bar can be resolved once
- * the WebView reports back the actual `window.location` for that request.
+ * native WebView URL captured at request time so origin state is never taken
+ * solely from a page-supplied `postMessage` payload.
  */
 export interface PendingBackForwardNav {
   requestId: string;
+  /** Native WebView URL at the time of the back/forward navigation event. */
+  url: string;
+  title?: string;
   canGoBack: boolean;
   canGoForward: boolean;
 }

--- a/app/components/Views/BrowserTab/utils.test.ts
+++ b/app/components/Views/BrowserTab/utils.test.ts
@@ -3,6 +3,7 @@ import {
   isENSUrl,
   getMaskedUrl,
   isDisallowedExplicitPort,
+  resolveCommittedDocumentUrl,
 } from './utils';
 import URLParse from 'url-parse';
 import AppConstants from '../../../core/AppConstants';
@@ -24,6 +25,82 @@ describe('BrowserTab utils', () => {
         const parsedUrl = new URLParse(url);
         expect(isValidUrl(parsedUrl)).toBe(expected);
       });
+    });
+  });
+
+  describe('resolveCommittedDocumentUrl', () => {
+    it('returns the page-reported URL when origin matches the native WebView URL', () => {
+      const nativeUrl = 'https://example.org/page';
+      const pageReportedUrl = 'https://example.org/app';
+
+      const result = resolveCommittedDocumentUrl(nativeUrl, pageReportedUrl);
+
+      expect(result).toBe(pageReportedUrl);
+    });
+
+    it('returns the native WebView URL when the page reports a different origin', () => {
+      const nativeUrl = 'https://example.org/page';
+      const pageReportedUrl = 'https://example.com/page';
+
+      const result = resolveCommittedDocumentUrl(nativeUrl, pageReportedUrl);
+
+      expect(result).toBe(nativeUrl);
+    });
+
+    it('returns the native WebView URL when the page reports a URL with a disallowed explicit port', () => {
+      const nativeUrl = 'https://attacker.example/poc';
+      const pageReportedUrl = 'https://metamask.io:8443';
+
+      const result = resolveCommittedDocumentUrl(nativeUrl, pageReportedUrl);
+
+      expect(result).toBe(nativeUrl);
+    });
+
+    it('returns the native WebView URL when the page-reported URL cannot be parsed', () => {
+      const nativeUrl = 'https://example.org/page';
+      const pageReportedUrl = 'not-a-url';
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      const result = resolveCommittedDocumentUrl(nativeUrl, pageReportedUrl);
+
+      expect(result).toBe(nativeUrl);
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('returns the page-reported URL when origins match except for a default HTTPS port', () => {
+      const nativeUrl = 'https://example.org/page';
+      const pageReportedUrl = 'https://example.org:443/app';
+
+      const result = resolveCommittedDocumentUrl(nativeUrl, pageReportedUrl);
+
+      expect(result).toBe(pageReportedUrl);
+    });
+
+    it('returns the native WebView URL when the page-reported URL uses userinfo to impersonate another host', () => {
+      const nativeUrl = 'https://attacker.example/poc';
+      const pageReportedUrl = 'https://attacker.example@metamask.io/';
+
+      const result = resolveCommittedDocumentUrl(nativeUrl, pageReportedUrl);
+
+      expect(result).toBe(nativeUrl);
+    });
+
+    it('returns null when the native WebView URL has a disallowed explicit port', () => {
+      const nativeUrl = 'https://metamask.io:8443';
+      const pageReportedUrl = 'https://metamask.io:8443';
+
+      const result = resolveCommittedDocumentUrl(nativeUrl, pageReportedUrl);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when origin mismatches and the native WebView URL has a disallowed explicit port', () => {
+      const nativeUrl = 'https://metamask.io:8443';
+      const pageReportedUrl = 'https://attacker.example/poc';
+
+      const result = resolveCommittedDocumentUrl(nativeUrl, pageReportedUrl);
+
+      expect(result).toBeNull();
     });
   });
 

--- a/app/components/Views/BrowserTab/utils.ts
+++ b/app/components/Views/BrowserTab/utils.ts
@@ -1,5 +1,6 @@
 import AppConstants from '../../../core/AppConstants';
 import URLParse from 'url-parse';
+import { isSameOrigin } from '../../../util/url';
 import { DocumentUrlForUrlBarPayload, SessionENSNames } from './types';
 
 const DEFAULT_HTTP_PORTS: Record<string, string> = {
@@ -61,6 +62,38 @@ export const isDocumentUrlForUrlBarPayload = (
     url.length > 0 &&
     (title === undefined || typeof title === 'string')
   );
+};
+
+/**
+ * Chooses the committed document URL after a back/forward document-URL sync.
+ *
+ * The native WebView URL is authoritative for origin. A page-supplied URL is
+ * used only when it shares that origin, so same-origin SPA path updates from
+ * `window.location` still apply (MCWP-595). Origin mismatches never take the
+ * page-supplied value, so a hooked `postMessage` cannot change origin.
+ *
+ * URLs that would not be allowed to load (`isDisallowedExplicitPort`) are not
+ * committed. That covers the case where the native event reports a navigation
+ * that `onShouldStartLoadWithRequest` already blocked.
+ *
+ * @param nativeUrl - URL from the native WebView navigation event
+ * @param pageReportedUrl - URL posted back from untrusted page JavaScript
+ * @returns The URL to use for bridge, permissions, and URL-bar state, or
+ * `null` when neither candidate is safe to commit
+ */
+export const resolveCommittedDocumentUrl = (
+  nativeUrl: string,
+  pageReportedUrl: string,
+): string | null => {
+  const candidate = isSameOrigin(nativeUrl, pageReportedUrl)
+    ? pageReportedUrl
+    : nativeUrl;
+
+  if (isDisallowedExplicitPort(candidate)) {
+    return null;
+  }
+
+  return candidate;
 };
 
 /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Back/forward in the in-app browser can leave the address bar out of sync with the page that is actually displayed, especially on iOS where `onLoadEnd` is not always fired.

This change resolves the address bar from the WebView navigation event after the load has finished, while still applying same-origin document path updates so SPA history continues to work. URLs that the browser would not load are not written into the address bar.

Internal details are in MCWP-800.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the in-app browser address bar so it matches the page shown after back/forward navigation

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: MCWP-800

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: in-app browser address bar after back/forward

  Background:
    Given I am logged into MetaMask Mobile
    And I have opened the in-app browser

  Scenario: address bar after back and forward between two sites
    Given I have opened two pages in the in-app browser

    When I navigate back and then forward
    Then the address bar shows the page that is displayed

  Scenario: SPA path update after back/forward
    Given I have opened a same-origin SPA that uses history navigation

    When I navigate within the SPA and then use back/forward
    Then the address bar still reflects the path of the displayed document
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
