### PR TITLE
fix(quick-buy): compute gasless flags from the source chain cp-8.8.0

### DIFF
--- a/app/components/UI/QuickBuy/hooks/useQuickBuyController.test.ts
+++ b/app/components/UI/QuickBuy/hooks/useQuickBuyController.test.ts
@@ -190,6 +190,7 @@ jest.mock('../../../../core/Engine', () => ({
       BridgeStatusController: { submitTx: jest.fn() },
       NetworkController: {
         findNetworkClientIdByChainId: jest.fn(() => 'mainnet'),
+        getEIP1559Compatibility: jest.fn().mockResolvedValue(true),
       },
     },
   },

--- a/app/components/UI/QuickBuy/hooks/useQuickBuyController.test.ts
+++ b/app/components/UI/QuickBuy/hooks/useQuickBuyController.test.ts
@@ -8,6 +8,7 @@ import {
   selectBridgeFeatureFlags,
   selectDestAddress,
   selectIsEvmNonEvmBridge,
+  selectIsGasIncludedSTXSendBundleSupported,
   selectIsNonEvmNonEvmBridge,
   selectIsNonEvmSourced,
   selectIsSolanaSourced,
@@ -22,7 +23,6 @@ import {
   selectCurrencyRates,
 } from '../../../../selectors/currencyRateController';
 import { selectNetworkConfigurations } from '../../../../selectors/networkController';
-import { selectShouldUseSmartTransaction } from '../../../../selectors/smartTransactionsController';
 import {
   ImpactMoment,
   playErrorNotification,
@@ -30,6 +30,8 @@ import {
 } from '../../../../util/haptics';
 import Logger from '../../../../util/Logger';
 import { useHasSufficientGas } from '../../Bridge/hooks/useHasSufficientGas';
+import { useIsGasIncluded7702Supported } from '../../Bridge/hooks/useIsGasIncluded7702Supported';
+import { useIsGasIncludedSTXSendBundleSupported } from '../../Bridge/hooks/useIsGasIncludedSTXSendBundleSupported';
 import useIsInsufficientBalance from '../../Bridge/hooks/useInsufficientBalance';
 import { useLatestBalance } from '../../Bridge/hooks/useLatestBalance';
 import { toAssetId } from '../../Bridge/hooks/useAssetMetadata/utils';
@@ -170,8 +172,8 @@ jest.mock('../../Bridge/hooks/useIsGasIncludedSTXSendBundleSupported', () => ({
   useIsGasIncludedSTXSendBundleSupported: jest.fn(),
 }));
 
-jest.mock('../../../../selectors/smartTransactionsController', () => ({
-  selectShouldUseSmartTransaction: jest.fn(),
+jest.mock('../../Bridge/hooks/useIsGasIncluded7702Supported', () => ({
+  useIsGasIncluded7702Supported: jest.fn(),
 }));
 
 jest.mock('../../../hooks/useRefreshSmartTransactionsLiveness', () => ({
@@ -190,7 +192,6 @@ jest.mock('../../../../core/Engine', () => ({
       BridgeStatusController: { submitTx: jest.fn() },
       NetworkController: {
         findNetworkClientIdByChainId: jest.fn(() => 'mainnet'),
-        getEIP1559Compatibility: jest.fn().mockResolvedValue(true),
       },
     },
   },
@@ -220,6 +221,7 @@ jest.mock('../../../../core/redux/slices/bridge', () => ({
   selectIsSolanaSourced: jest.fn(),
   selectIsNonEvmSourced: jest.fn(),
   selectBridgeFeatureFlags: jest.fn(),
+  selectIsGasIncludedSTXSendBundleSupported: jest.fn(),
 }));
 
 jest.mock('../../../../selectors/bridge', () => ({
@@ -453,9 +455,9 @@ const setupDefaultMocks = () => {
 
   (useIsInsufficientBalance as jest.Mock).mockReturnValue(false);
   (useHasSufficientGas as jest.Mock).mockReturnValue(true);
-  (selectShouldUseSmartTransaction as unknown as jest.Mock).mockReturnValue(
-    false,
-  );
+  (
+    selectIsGasIncludedSTXSendBundleSupported as unknown as jest.Mock
+  ).mockReturnValue(false);
   (
     Engine.context.BridgeStatusController.submitTx as jest.Mock
   ).mockResolvedValue(undefined);
@@ -3557,6 +3559,15 @@ describe('useQuickBuyController', () => {
   });
 
   describe('handleConfirm', () => {
+    it('syncs STX and 7702 gas-included flags for the source chain', () => {
+      renderHook(() => useQuickBuyController(createTarget(), jest.fn()));
+
+      expect(useIsGasIncludedSTXSendBundleSupported).toHaveBeenCalledWith(
+        '0x1',
+      );
+      expect(useIsGasIncluded7702Supported).toHaveBeenCalledWith('0x1');
+    });
+
     it('submits via BridgeStatusController.submitTx with normalised approval and stxEnabled', async () => {
       const activeQuote = {
         ...createActiveQuote(),
@@ -3579,9 +3590,9 @@ describe('useQuickBuyController', () => {
         maxRefreshCount: 5,
         refetchQuotes: jest.fn(),
       });
-      (selectShouldUseSmartTransaction as unknown as jest.Mock).mockReturnValue(
-        true,
-      );
+      (
+        selectIsGasIncludedSTXSendBundleSupported as unknown as jest.Mock
+      ).mockReturnValue(true);
 
       const onClose = jest.fn();
       const { result } = renderHook(() =>

--- a/app/components/UI/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/UI/QuickBuy/hooks/useQuickBuyController.ts
@@ -68,6 +68,7 @@ import {
   selectBridgeFeatureFlags,
   selectDestAddress,
   selectIsEvmNonEvmBridge,
+  selectIsGasIncludedSTXSendBundleSupported,
   selectIsNonEvmNonEvmBridge,
   selectIsNonEvmSourced,
   selectIsSolanaSourced,
@@ -81,7 +82,6 @@ import {
 } from '../../../../core/redux/slices/bridge';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../../selectors/accountsController';
 import { selectSourceWalletAddress } from '../../../../selectors/bridge';
-import { selectShouldUseSmartTransaction } from '../../../../selectors/smartTransactionsController';
 import { isHardwareAccount } from '../../../../util/address';
 import Logger from '../../../../util/Logger';
 import { buildSocialLoggerErrorOptions } from '../../../../util/social/socialServiceTelemetry';
@@ -93,6 +93,7 @@ import { useRampNavigation } from '../../Ramp/hooks/useRampNavigation';
 import { useHasSufficientGas } from '../../Bridge/hooks/useHasSufficientGas';
 import { useInitialSlippage } from '../../Bridge/hooks/useInitialSlippage';
 import useIsInsufficientBalance from '../../Bridge/hooks/useInsufficientBalance';
+import { useIsGasIncluded7702Supported } from '../../Bridge/hooks/useIsGasIncluded7702Supported';
 import { useIsGasIncludedSTXSendBundleSupported } from '../../Bridge/hooks/useIsGasIncludedSTXSendBundleSupported';
 import { useIsNetworkFeeUnavailable } from '../../Bridge/hooks/useIsNetworkFeeUnavailable';
 import { useLatestBalance } from '../../Bridge/hooks/useLatestBalance';
@@ -590,6 +591,11 @@ export function useQuickBuyController(
 
   useRefreshSmartTransactionsLiveness(sourceChainId);
   useIsGasIncludedSTXSendBundleSupported(sourceChainId);
+  // Same as BridgeView: keep `selectGasIncludedQuoteParams` in sync with the
+  // *source* chain. Without this, a leftover 7702 flag from Ethereum makes
+  // QuickBuy request gas-included quotes (maxFeePerGas) for Robinhood sells
+  // that TransactionController then rejects (TSA-1008).
+  useIsGasIncluded7702Supported(sourceChainId);
 
   useEffect(() => {
     if (sourceToken && destToken) {
@@ -964,7 +970,11 @@ export function useQuickBuyController(
   const hasInsufficientGas =
     !isNetworkFeeUnavailable && hasSufficientGas === false;
 
-  const stxEnabled = useSelector(selectShouldUseSmartTransaction);
+  // Same flag Swap's `useSubmitBridgeTx` uses: STX + sendBundle on the *source*
+  // chain. `selectShouldUseSmartTransaction()` without a chainId is the
+  // currently selected network, which is wrong when QuickBuy sells on
+  // Robinhood while the wallet is still on Ethereum (TSA-1008).
+  const stxEnabled = useSelector(selectIsGasIncludedSTXSendBundleSupported);
   const hasDestinationPicker = isEvmNonEvmBridge || isNonEvmNonEvmBridge;
   const isDestinationAddressMissing = hasDestinationPicker && !destAddress;
 
@@ -1542,26 +1552,6 @@ export function useQuickBuyController(
       // notification once submitTx resolves.
       beginQuickBuySubmission();
       dispatch(setIsSubmittingTx(true));
-      // TSA-1008: prime the source chain's EIP-1559 metadata before submit.
-      // `TransactionController.addTransaction` calls
-      // `NetworkController.getEIP1559Compatibility(networkClientId)` and
-      // coerces `undefined` → `false`, which then trips
-      // `validateEIP1559Compatibility` because bridge-status-controller always
-      // attaches `maxFeePerGas` / `maxPriorityFeePerGas` from the quote's
-      // `txFee`. The regular Swap flow gets away with it because the
-      // full-screen Bridge view stays mounted long enough for the network
-      // client to be probed and cached. QuickBuy is a bottom sheet that can be
-      // submitted before that probe runs, so we force it here. Errors are
-      // swallowed — worst case we fall back to the pre-fix behaviour.
-      if (sourceNetworkClientId) {
-        try {
-          await Engine.context.NetworkController.getEIP1559Compatibility(
-            sourceNetworkClientId,
-          );
-        } catch {
-          // Non-fatal: submitTx below will surface the real error if any.
-        }
-      }
       const submitResult = await Engine.context.BridgeStatusController.submitTx(
         walletAddress,
         activeQuote,
@@ -1645,7 +1635,6 @@ export function useQuickBuyController(
     activeQuote,
     walletAddress,
     stxEnabled,
-    sourceNetworkClientId,
     dispatch,
     onClose,
     toastRef,

--- a/app/components/UI/QuickBuy/hooks/useQuickBuyController.ts
+++ b/app/components/UI/QuickBuy/hooks/useQuickBuyController.ts
@@ -1542,6 +1542,26 @@ export function useQuickBuyController(
       // notification once submitTx resolves.
       beginQuickBuySubmission();
       dispatch(setIsSubmittingTx(true));
+      // TSA-1008: prime the source chain's EIP-1559 metadata before submit.
+      // `TransactionController.addTransaction` calls
+      // `NetworkController.getEIP1559Compatibility(networkClientId)` and
+      // coerces `undefined` → `false`, which then trips
+      // `validateEIP1559Compatibility` because bridge-status-controller always
+      // attaches `maxFeePerGas` / `maxPriorityFeePerGas` from the quote's
+      // `txFee`. The regular Swap flow gets away with it because the
+      // full-screen Bridge view stays mounted long enough for the network
+      // client to be probed and cached. QuickBuy is a bottom sheet that can be
+      // submitted before that probe runs, so we force it here. Errors are
+      // swallowed — worst case we fall back to the pre-fix behaviour.
+      if (sourceNetworkClientId) {
+        try {
+          await Engine.context.NetworkController.getEIP1559Compatibility(
+            sourceNetworkClientId,
+          );
+        } catch {
+          // Non-fatal: submitTx below will surface the real error if any.
+        }
+      }
       const submitResult = await Engine.context.BridgeStatusController.submitTx(
         walletAddress,
         activeQuote,
@@ -1625,6 +1645,7 @@ export function useQuickBuyController(
     activeQuote,
     walletAddress,
     stxEnabled,
+    sourceNetworkClientId,
     dispatch,
     onClose,
     toastRef,


### PR DESCRIPTION
## **Description**

QuickBuy sells on Robinhood Chain failed immediately with a "Couldn't sell ETH" toast, while the regular Swap flow succeeded on the exact same pair and account.

Root cause: QuickBuy derived both "gasless" flags from state that isn't tied to the chain being traded.

- `stxEnabled` came from `selectShouldUseSmartTransaction` with no `chainId`, i.e. the **currently selected network**. Swap's `useSubmitBridgeTx` uses `selectIsGasIncludedSTXSendBundleSupported`, which is source-chain STX **and** sendBundle support.
- QuickBuy never called `useIsGasIncluded7702Supported(sourceChainId)`. Every Swap screen does, and that hook is what keeps the Redux 7702 flag — read by `selectGasIncludedQuoteParams` — in sync with the source chain. Without it QuickBuy inherits whatever the last Bridge view left behind (typically `true` from Ethereum).

The consequence is that QuickBuy asks the Bridge API for a **gas-included** quote on a chain where Swap would not. `submitEvmHandler` then attaches `maxFeePerGas` / `maxPriorityFeePerGas` from `quote.feeData.txFee`, making it an EIP-1559 transaction, and `TransactionController.validateEIP1559Compatibility` rejects it before publish. Swap, computing the same flags against the source chain, gets a non-gas-included quote; `getGasFeeEstimates` returns `undefined` for anything that isn't a FeeMarket estimate, so its transaction carries no 1559 fields and goes through.

This PR aligns QuickBuy with Swap on both flags.

Two earlier theories on this branch were ruled out and are not part of the final diff:

- Routing through `submitIntent` — instrumented logs showed `hasIntent: false`, so the intent branch was never the one being missed.
- Priming EIP-1559 metadata before submit — `NetworkController.get1559CompatibilityWithNetworkClientId` already awaits `lookupNetwork` when `EIPS[1559]` is missing, and `addTransaction` goes through that same path, so priming a moment earlier cannot change the outcome.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TSA-1008

## **Manual testing steps**

Requires a build with working RPC access to Robinhood Chain (4663). Local dev builds without an Infura project entitled for that chain, and without `QUICKNODE_ROBINHOOD_URL` failover configured, cannot reach it — both Swap and QuickBuy fail there for an unrelated reason.

```
Feature: QuickBuy sell on Robinhood Chain

  Scenario: user sells ETH for USDe from QuickBuy while the wallet is on Ethereum
    Given smart transactions are enabled in Settings
    And the wallet is currently on Ethereum Mainnet
    And the account holds ETH on Robinhood Chain
    When the user opens the QuickBuy sheet from an ETH position and switches to Sell
    And selects USDe as the receive token and commits a small non-zero amount
    And taps Sell
    Then a pending "Selling ETH" toast appears
    And after the swap settles a "Sell complete" toast is shown
    And the ETH balance decreases and the USDe balance increases

  Scenario: regression - gas-included Buy on a chain that supports it still works
    Given the account holds USDC on a chain with STX or 7702 relay support
    When the user commits an amount in QuickBuy and taps Buy
    Then the quote is still gas-included and submission succeeds as before
```

## **Screenshots/Recordings**

### **Before**

Selling ETH to USDe from QuickBuy on Robinhood Chain surfaces an immediate "Couldn't sell ETH" toast (reproduction screenshots on TSA-1008). The standard Swap flow with the same tokens succeeds on the same account.

### **After**

Pending toast followed by "Sell complete", matching the standard Swap flow. Screenshots to be attached once verified on an RC build.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit dbbdd5a38f31fa4cd64fba7c77df37cf3bdb20b6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->