### PR TITLE
feat: order and history tabs + empty state for recurring and limit

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.view.test.tsx
@@ -1,0 +1,42 @@
+import '../../../../../../../tests/component-view/mocks';
+import { fireEvent, waitFor } from '@testing-library/react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import { renderBridgeView } from '../../../../../../../tests/component-view/renderers/bridge';
+import { describeForPlatforms } from '../../../../../../../tests/component-view/platform';
+import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
+import { OrdersTabsSelectorsIDs } from '../../../components/OrdersTabs';
+
+async function openLimitTab(renderResult: ReturnType<typeof renderBridgeView>) {
+  fireEvent.press(renderResult.getByTestId(BridgeViewSelectorsIDs.LIMIT_TAB));
+
+  await waitFor(() => {
+    expect(
+      renderResult.getByTestId(BridgeViewSelectorsIDs.LIMIT_ORDER_CONTAINER),
+    ).toBeOnTheScreen();
+  });
+}
+
+describeForPlatforms('BridgeLimitOrderView', () => {
+  it('shows history empty copy after pressing the History tab', async () => {
+    const renderResult = renderBridgeView();
+
+    await openLimitTab(renderResult);
+
+    expect(
+      renderResult.getByText(strings('bridge.orders.empty.open_orders')),
+    ).toBeOnTheScreen();
+
+    fireEvent.press(
+      renderResult.getByTestId(OrdersTabsSelectorsIDs.HISTORY_TAB),
+    );
+
+    await waitFor(() => {
+      expect(
+        renderResult.getByText(strings('bridge.orders.empty.history')),
+      ).toBeOnTheScreen();
+    });
+    expect(
+      renderResult.queryByText(strings('bridge.orders.empty.open_orders')),
+    ).toBeNull();
+  });
+});

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { Box } from '@metamask/design-system-react-native';
 import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
+import OrdersTabs from '../../../components/OrdersTabs';
 
 const BridgeLimitOrderView = () => (
   <Box
     twClassName="flex-1 bg-default"
     testID={BridgeViewSelectorsIDs.LIMIT_ORDER_CONTAINER}
-  />
+  >
+    <OrdersTabs openOrders={{ items: [] }} history={{ items: [] }} />
+  </Box>
 );
 
 export default BridgeLimitOrderView;

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
@@ -7,6 +7,7 @@ import { describeForPlatforms } from '../../../../../../../tests/component-view/
 import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
 import { RecurringScheduleFieldsSelectorsIDs } from '../../../components/RecurringScheduleFields';
 import { RecurringIntervalSheetSelectorsIDs } from '../../../components/RecurringIntervalSheet';
+import { OrdersTabsSelectorsIDs } from '../../../components/OrdersTabs';
 import { BuildQuoteSelectors } from '../../../../Ramp/Aggregator/Views/BuildQuote/BuildQuote.testIds';
 
 const errorColor = lightTheme.colors.error.default;
@@ -446,5 +447,28 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
     expect(
       renderResult.getByTestId(RecurringScheduleFieldsSelectorsIDs.EVERY_INPUT),
     ).not.toHaveStyle({ color: errorColor });
+  });
+
+  it('shows history empty copy after pressing the History tab', async () => {
+    const renderResult = renderBridgeView();
+
+    await openRecurringTab(renderResult);
+
+    expect(
+      renderResult.getByText(strings('bridge.orders.empty.open_orders')),
+    ).toBeOnTheScreen();
+
+    fireEvent.press(
+      renderResult.getByTestId(OrdersTabsSelectorsIDs.HISTORY_TAB),
+    );
+
+    await waitFor(() => {
+      expect(
+        renderResult.getByText(strings('bridge.orders.empty.history')),
+      ).toBeOnTheScreen();
+    });
+    expect(
+      renderResult.queryByText(strings('bridge.orders.empty.open_orders')),
+    ).toBeNull();
   });
 });

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box } from '@metamask/design-system-react-native';
 import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
 import RecurringScheduleFields from '../../../components/RecurringScheduleFields';
+import OrdersTabs from '../../../components/OrdersTabs';
 
 const BridgeRecurringBuyView = () => (
   <Box
@@ -9,6 +10,7 @@ const BridgeRecurringBuyView = () => (
     testID={BridgeViewSelectorsIDs.RECURRING_BUY_CONTAINER}
   >
     <RecurringScheduleFields />
+    <OrdersTabs openOrders={{ items: [] }} history={{ items: [] }} />
   </Box>
 );
 

--- a/app/components/UI/Bridge/components/OrdersTabs/OrdersEmptyState.tsx
+++ b/app/components/UI/Bridge/components/OrdersTabs/OrdersEmptyState.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Image } from 'react-native';
+import {
+  Box,
+  BoxAlignItems,
+  BoxJustifyContent,
+  TabEmptyState,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import { useAssetFromTheme } from '../../../../../util/theme';
+import emptyStatePerpsLight from '../../../../../images/empty-state-perps-light.png';
+import emptyStatePerpsDark from '../../../../../images/empty-state-perps-dark.png';
+import { OrdersTabsSelectorsIDs } from './OrdersTabs.testIds';
+
+interface OrdersEmptyStateProps {
+  description: string;
+}
+
+export function OrdersEmptyState({ description }: OrdersEmptyStateProps) {
+  const tw = useTailwind();
+  const emptyStateIcon = useAssetFromTheme(
+    emptyStatePerpsLight,
+    emptyStatePerpsDark,
+  );
+
+  return (
+    <Box
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Center}
+      twClassName="flex-1"
+    >
+      <TabEmptyState
+        testID={OrdersTabsSelectorsIDs.EMPTY_STATE}
+        icon={
+          <Image
+            source={emptyStateIcon}
+            resizeMode="contain"
+            style={tw.style('h-[72px] w-[72px]')}
+            accessible={false}
+          />
+        }
+        description={description}
+      />
+    </Box>
+  );
+}

--- a/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.test.tsx
+++ b/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import { strings } from '../../../../../../locales/i18n';
+import { initialState } from '../../_mocks_/initialState';
+import OrdersTabs from './OrdersTabs';
+import { OrdersTabsSelectorsIDs } from './OrdersTabs.testIds';
+
+function renderOrdersTabs(
+  props?: Partial<React.ComponentProps<typeof OrdersTabs>>,
+) {
+  return renderWithProvider(
+    <OrdersTabs
+      openOrders={{ items: [] }}
+      history={{ items: [] }}
+      {...props}
+    />,
+    { state: initialState },
+  );
+}
+
+describe('OrdersTabs', () => {
+  it('shows open orders empty copy then history empty copy after pressing History', () => {
+    const { getByTestId, getByText, queryByText } = renderOrdersTabs();
+
+    expect(getByTestId(OrdersTabsSelectorsIDs.EMPTY_STATE)).toBeOnTheScreen();
+    expect(
+      getByText(strings('bridge.orders.empty.open_orders')),
+    ).toBeOnTheScreen();
+
+    fireEvent.press(getByTestId(OrdersTabsSelectorsIDs.HISTORY_TAB));
+
+    expect(getByText(strings('bridge.orders.empty.history'))).toBeOnTheScreen();
+    expect(queryByText(strings('bridge.orders.empty.open_orders'))).toBeNull();
+  });
+
+  it('renders feature-specific open order and history items from distinct data shapes', () => {
+    const { getByTestId, queryByTestId } = renderOrdersTabs({
+      openOrders: {
+        items: [{ id: 'limit-1', price: '2500' }],
+        renderItem: (item: { id: string; price: string }) => (
+          <Text testID="limit-open-order">{item.price}</Text>
+        ),
+        keyExtractor: (item: { id: string }) => item.id,
+      },
+      history: {
+        items: [{ hash: '0xabc', executedAt: 1_700_000_000 }],
+        renderItem: (item: { hash: string; executedAt: number }) => (
+          <Text testID="recurring-history">{item.hash}</Text>
+        ),
+        keyExtractor: (item: { hash: string }) => item.hash,
+      },
+    });
+
+    expect(getByTestId('limit-open-order')).toHaveTextContent('2500');
+    expect(queryByTestId(OrdersTabsSelectorsIDs.EMPTY_STATE)).toBeNull();
+    expect(queryByTestId('recurring-history')).toBeNull();
+
+    fireEvent.press(getByTestId(OrdersTabsSelectorsIDs.HISTORY_TAB));
+
+    expect(getByTestId('recurring-history')).toHaveTextContent('0xabc');
+    expect(queryByTestId('limit-open-order')).toBeNull();
+    expect(queryByTestId(OrdersTabsSelectorsIDs.EMPTY_STATE)).toBeNull();
+  });
+});

--- a/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.test.tsx
+++ b/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.test.tsx
@@ -6,23 +6,22 @@ import { strings } from '../../../../../../locales/i18n';
 import { initialState } from '../../_mocks_/initialState';
 import OrdersTabs from './OrdersTabs';
 import { OrdersTabsSelectorsIDs } from './OrdersTabs.testIds';
+import type { OrdersTabsProps } from './OrdersTabs.types';
 
-function renderOrdersTabs(
-  props?: Partial<React.ComponentProps<typeof OrdersTabs>>,
+function renderOrdersTabs<TOpen, THistory>(
+  props: OrdersTabsProps<TOpen, THistory>,
 ) {
-  return renderWithProvider(
-    <OrdersTabs
-      openOrders={{ items: [] }}
-      history={{ items: [] }}
-      {...props}
-    />,
-    { state: initialState },
-  );
+  return renderWithProvider(<OrdersTabs {...props} />, {
+    state: initialState,
+  });
 }
 
 describe('OrdersTabs', () => {
   it('shows open orders empty copy then history empty copy after pressing History', () => {
-    const { getByTestId, getByText, queryByText } = renderOrdersTabs();
+    const { getByTestId, getByText, queryByText } = renderOrdersTabs({
+      openOrders: { items: [] },
+      history: { items: [] },
+    });
 
     expect(getByTestId(OrdersTabsSelectorsIDs.EMPTY_STATE)).toBeOnTheScreen();
     expect(
@@ -39,17 +38,17 @@ describe('OrdersTabs', () => {
     const { getByTestId, queryByTestId } = renderOrdersTabs({
       openOrders: {
         items: [{ id: 'limit-1', price: '2500' }],
-        renderItem: (item: { id: string; price: string }) => (
+        renderItem: (item) => (
           <Text testID="limit-open-order">{item.price}</Text>
         ),
-        keyExtractor: (item: { id: string }) => item.id,
+        keyExtractor: (item) => item.id,
       },
       history: {
         items: [{ hash: '0xabc', executedAt: 1_700_000_000 }],
-        renderItem: (item: { hash: string; executedAt: number }) => (
+        renderItem: (item) => (
           <Text testID="recurring-history">{item.hash}</Text>
         ),
-        keyExtractor: (item: { hash: string }) => item.hash,
+        keyExtractor: (item) => item.hash,
       },
     });
 

--- a/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.testIds.ts
+++ b/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.testIds.ts
@@ -1,0 +1,10 @@
+export const OrdersTabsSelectorsIDs = {
+  CONTAINER: 'bridge-orders-tabs',
+  TABS_BAR: 'bridge-orders-tabs-bar',
+  OPEN_ORDERS_TAB: 'bridge-orders-open-orders-tab',
+  HISTORY_TAB: 'bridge-orders-history-tab',
+  EMPTY_STATE: 'bridge-orders-empty-state',
+  CONTENT: 'bridge-orders-content',
+} as const;
+
+export type OrdersTabsSelectorsIDsType = typeof OrdersTabsSelectorsIDs;

--- a/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.tsx
+++ b/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.tsx
@@ -1,0 +1,97 @@
+import React, { useMemo, useState } from 'react';
+import { Box } from '@metamask/design-system-react-native';
+import {
+  TabsBar,
+  type TabItem,
+} from '../../../../../component-library/components-temp/Tabs';
+import { strings } from '../../../../../../locales/i18n';
+import { OrdersEmptyState } from './OrdersEmptyState';
+import { OrdersTabsSelectorsIDs } from './OrdersTabs.testIds';
+import { OrdersTabKey, type OrdersTabsProps } from './OrdersTabs.types';
+
+function OrdersTabPanel<T>({
+  items,
+  renderItem,
+  keyExtractor,
+  emptyDescription,
+}: {
+  items: T[];
+  renderItem?: (item: T, index: number) => React.ReactElement;
+  keyExtractor?: (item: T, index: number) => string;
+  emptyDescription: string;
+}) {
+  if (items.length === 0 || !renderItem) {
+    return <OrdersEmptyState description={emptyDescription} />;
+  }
+
+  return (
+    <Box testID={OrdersTabsSelectorsIDs.CONTENT} twClassName="flex-1">
+      {items.map((item, index) => (
+        <React.Fragment key={keyExtractor?.(item, index) ?? String(index)}>
+          {renderItem(item, index)}
+        </React.Fragment>
+      ))}
+    </Box>
+  );
+}
+
+function OrdersTabs<TOpen, THistory>({
+  openOrders,
+  history,
+  initialTab = OrdersTabKey.OpenOrders,
+}: OrdersTabsProps<TOpen, THistory>) {
+  const [selectedTab, setSelectedTab] = useState<OrdersTabKey>(initialTab);
+
+  const tabs = useMemo<TabItem[]>(
+    () => [
+      {
+        key: OrdersTabKey.OpenOrders,
+        label: strings('bridge.orders.tabs.open_orders'),
+        content: null,
+        testID: OrdersTabsSelectorsIDs.OPEN_ORDERS_TAB,
+      },
+      {
+        key: OrdersTabKey.History,
+        label: strings('bridge.orders.tabs.history'),
+        content: null,
+        testID: OrdersTabsSelectorsIDs.HISTORY_TAB,
+      },
+    ],
+    [],
+  );
+
+  const activeIndex = selectedTab === OrdersTabKey.History ? 1 : 0;
+
+  return (
+    <Box testID={OrdersTabsSelectorsIDs.CONTAINER} twClassName="flex-1">
+      <Box twClassName="mx-4 h-px bg-border-muted" />
+      <TabsBar
+        tabs={tabs}
+        activeIndex={activeIndex}
+        onTabPress={(index) =>
+          setSelectedTab(
+            index === 1 ? OrdersTabKey.History : OrdersTabKey.OpenOrders,
+          )
+        }
+        testID={OrdersTabsSelectorsIDs.TABS_BAR}
+      />
+      {selectedTab === OrdersTabKey.OpenOrders ? (
+        <OrdersTabPanel
+          items={openOrders.items}
+          renderItem={openOrders.renderItem}
+          keyExtractor={openOrders.keyExtractor}
+          emptyDescription={strings('bridge.orders.empty.open_orders')}
+        />
+      ) : (
+        <OrdersTabPanel
+          items={history.items}
+          renderItem={history.renderItem}
+          keyExtractor={history.keyExtractor}
+          emptyDescription={strings('bridge.orders.empty.history')}
+        />
+      )}
+    </Box>
+  );
+}
+
+export default OrdersTabs;

--- a/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.types.ts
+++ b/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.types.ts
@@ -1,0 +1,18 @@
+import type { ReactElement } from 'react';
+
+export enum OrdersTabKey {
+  OpenOrders = 'openOrders',
+  History = 'history',
+}
+
+export interface OrdersTabConfig<T> {
+  items: T[];
+  renderItem?: (item: T, index: number) => ReactElement;
+  keyExtractor?: (item: T, index: number) => string;
+}
+
+export interface OrdersTabsProps<TOpen, THistory> {
+  openOrders: OrdersTabConfig<TOpen>;
+  history: OrdersTabConfig<THistory>;
+  initialTab?: OrdersTabKey;
+}

--- a/app/components/UI/Bridge/components/OrdersTabs/index.ts
+++ b/app/components/UI/Bridge/components/OrdersTabs/index.ts
@@ -1,0 +1,5 @@
+export { default } from './OrdersTabs';
+export { OrdersEmptyState } from './OrdersEmptyState';
+export { OrdersTabsSelectorsIDs } from './OrdersTabs.testIds';
+export { OrdersTabKey } from './OrdersTabs.types';
+export type { OrdersTabConfig, OrdersTabsProps } from './OrdersTabs.types';

--- a/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.tsx
+++ b/app/components/UI/Bridge/components/RecurringScheduleFields/RecurringScheduleFields.tsx
@@ -194,7 +194,6 @@ const RecurringScheduleFields = () => {
 
   return (
     <Box
-      twClassName="flex-1"
       testID={RecurringScheduleFieldsSelectorsIDs.CONTAINER}
       onStartShouldSetResponder={() => true}
       onResponderRelease={closeKeypad}

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8489,6 +8489,16 @@
       "limit": "Limit",
       "recurring": "Recurring"
     },
+    "orders": {
+      "tabs": {
+        "open_orders": "Open orders",
+        "history": "History"
+      },
+      "empty": {
+        "open_orders": "Open orders appear here",
+        "history": "Order history appears here"
+      }
+    },
     "recurring": {
       "every": "Every",
       "repeat": "Repeat",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR adds a shared `OrdersTabs` shell and mounts it on both Limit and Recurring with empty lists. The shell owns the Open orders / History tabs, empty copy, and empty icon. Each feature later supplies its own `items` plus `renderItem` / `keyExtractor`, so Limit and Recurring can keep distinct row shapes instead of sharing one unified order model.

Empty state shows when `items` is empty or `renderItem` is omitted, which is the current mount (`items: []` on both views). Recurring also drops `flex-1` from `RecurringScheduleFields` so the schedule inputs stay at the top and the orders panel can sit below them.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added empty state tabs for Open Orders and History for Limit and Recurring Swaps

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

Refs: SWAPS-4913

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Open orders and History empty states

  Background:
    Given I am logged into MetaMask Mobile
    And the swapsLimitOrder and swapsRecurringBuy feature flags are enabled

  Scenario: Recurring shows empty Open orders then empty History
    Given I am on the Swap / Bridge screen
    And I have opened the Recurring tab

    Then I should see the Every and Repeat schedule fields
    And I should see Open orders and History tabs
    And Open orders should be selected
    And I should see "Open orders appear here"

    When user taps History
    Then I should see "Order history appears here"
    And I should not see "Open orders appear here"
    And the schedule fields should still be visible

  Scenario: Limit shows empty Open orders then empty History
    Given I am on the Swap / Bridge screen
    And I have opened the Limit tab

    Then I should see Open orders and History tabs
    And Open orders should be selected
    And I should see "Open orders appear here"

    When user taps History
    Then I should see "Order history appears here"
    And I should not see "Open orders appear here"
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — Limit and Recurring had no Open orders / History panel.

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/f83c02b7-1b68-45d9-b5e6-8ffbfa5663d1



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 514784f1c904be3564733f2890608636442532d7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->