### PR TITLE
fix(perps): restore bottom safe-area inset in modal-wrapped sheets (TAT-3758)

### DIFF
--- a/app/component-library/components-temp/ModalSafeAreaProvider/ModalSafeAreaProvider.test.tsx
+++ b/app/component-library/components-temp/ModalSafeAreaProvider/ModalSafeAreaProvider.test.tsx
@@ -1,0 +1,41 @@
+// Third party dependencies.
+import React from 'react';
+import { Platform, Text } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+// Internal dependencies.
+import ModalSafeAreaProvider from './ModalSafeAreaProvider';
+
+describe('ModalSafeAreaProvider', () => {
+  const originalPlatform = Platform.OS;
+
+  afterEach(() => {
+    Platform.OS = originalPlatform;
+  });
+
+  it('wraps children in a SafeAreaProvider on Android', () => {
+    Platform.OS = 'android';
+
+    const { getByTestId, getByText } = render(
+      <ModalSafeAreaProvider testID="modal-safe-area">
+        <Text>content</Text>
+      </ModalSafeAreaProvider>,
+    );
+
+    expect(getByTestId('modal-safe-area')).toBeOnTheScreen();
+    expect(getByText('content')).toBeOnTheScreen();
+  });
+
+  it('renders children without a provider on iOS', () => {
+    Platform.OS = 'ios';
+
+    const { queryByTestId, getByText } = render(
+      <ModalSafeAreaProvider testID="modal-safe-area">
+        <Text>content</Text>
+      </ModalSafeAreaProvider>,
+    );
+
+    expect(queryByTestId('modal-safe-area')).toBeNull();
+    expect(getByText('content')).toBeOnTheScreen();
+  });
+});

--- a/app/component-library/components-temp/ModalSafeAreaProvider/ModalSafeAreaProvider.tsx
+++ b/app/component-library/components-temp/ModalSafeAreaProvider/ModalSafeAreaProvider.tsx
@@ -1,0 +1,40 @@
+// Third party dependencies.
+import React from 'react';
+import { Platform } from 'react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+export interface ModalSafeAreaProviderProps {
+  children: React.ReactNode;
+  testID?: string;
+}
+
+/**
+ * Restores real safe-area insets for content rendered inside a react-native
+ * `Modal` on Android.
+ *
+ * On Android a `Modal` is its own window, and `statusBarTranslucent` makes it
+ * draw under the system bars. The root `SafeAreaProvider` measures the activity
+ * window — which is not edge-to-edge below Android 15 — so `useSafeAreaInsets()`
+ * reports a bottom inset of 0 inside the modal. Any sheet whose bottom padding
+ * derives from that inset then collapses, leaving its footer button under the
+ * navigation bar. A nested provider measures the modal's own window instead.
+ *
+ * iOS does not have this problem: a modal covers the full screen and the root
+ * provider already reports the correct insets. The nested provider is therefore
+ * applied on Android only, so iOS keeps its existing (correct) inset source.
+ *
+ * @param props.children Modal content that reads safe-area insets.
+ * @param props.testID Optional test ID applied to the Android provider.
+ */
+const ModalSafeAreaProvider: React.FC<ModalSafeAreaProviderProps> = ({
+  children,
+  testID,
+}) => {
+  if (Platform.OS !== 'android') {
+    return <>{children}</>;
+  }
+
+  return <SafeAreaProvider testID={testID}>{children}</SafeAreaProvider>;
+};
+
+export default ModalSafeAreaProvider;

--- a/app/component-library/components-temp/ModalSafeAreaProvider/index.ts
+++ b/app/component-library/components-temp/ModalSafeAreaProvider/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ModalSafeAreaProvider';
+export type { ModalSafeAreaProviderProps } from './ModalSafeAreaProvider';

--- a/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
+++ b/app/components/UI/MarketInsights/Views/MarketInsightsView/MarketInsightsView.tsx
@@ -89,6 +89,7 @@ import { usePerpsEventTracking } from '../../../Perps/hooks/usePerpsEventTrackin
 import TokenDetailsStickyFooter from '../../../TokenDetails/components/TokenDetailsStickyFooter';
 import type { TokenDetailsRouteParams } from '../../../TokenDetails/constants/constants';
 import { useStickyQuickBuy } from '../../../TokenDetails/hooks/useStickyQuickBuy';
+import ModalSafeAreaProvider from '../../../../../component-library/components-temp/ModalSafeAreaProvider';
 
 const feedbackByDigest = new Map<string, 'up' | 'down'>();
 
@@ -910,12 +911,14 @@ const MarketInsightsView: React.FC = () => {
         // Android Compatibility: Wrap the <Modal> in a plain <View> component to prevent rendering issues and freezing.
         <View>
           <Modal visible transparent animationType="none" statusBarTranslucent>
-            <PerpsBottomSheetTooltip
-              isVisible
-              onClose={closeEligibilityModal}
-              contentKey="geo_block"
-              testID="market-insights-geo-block-tooltip"
-            />
+            <ModalSafeAreaProvider>
+              <PerpsBottomSheetTooltip
+                isVisible
+                onClose={closeEligibilityModal}
+                contentKey="geo_block"
+                testID="market-insights-geo-block-tooltip"
+              />
+            </ModalSafeAreaProvider>
           </Modal>
         </View>
       )}

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsDisclaimerBottomSheet.test.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsDisclaimerBottomSheet.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent } from '@testing-library/react-native';
+import { Platform } from 'react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import MarketInsightsDisclaimerBottomSheet from './MarketInsightsDisclaimerBottomSheet';
 
@@ -77,14 +78,38 @@ describe('MarketInsightsDisclaimerBottomSheet', () => {
   // measures the activity window and reports a bottom inset of 0, collapsing
   // BottomSheetDialog's bottom padding and leaving "Got it" under the
   // navigation bar.
-  it('nests a SafeAreaProvider inside the Modal so the bottom inset is measured against the modal window', () => {
-    const { getByTestId } = renderWithProvider(
-      <MarketInsightsDisclaimerBottomSheet onClose={jest.fn()} />,
-    );
+  describe('modal safe-area inset (TAT-3758)', () => {
+    const originalPlatform = Platform.OS;
 
-    expect(
-      getByTestId('market-insights-disclaimer-safe-area-provider'),
-    ).toBeOnTheScreen();
+    afterEach(() => {
+      Platform.OS = originalPlatform;
+    });
+
+    it('nests a SafeAreaProvider on Android so the bottom inset is measured against the modal window', () => {
+      Platform.OS = 'android';
+
+      const { getByTestId } = renderWithProvider(
+        <MarketInsightsDisclaimerBottomSheet onClose={jest.fn()} />,
+      );
+
+      expect(
+        getByTestId('market-insights-disclaimer-safe-area-provider'),
+      ).toBeOnTheScreen();
+    });
+
+    it('does not nest a SafeAreaProvider on iOS, where the root provider already reports correct insets', () => {
+      Platform.OS = 'ios';
+
+      const { queryByTestId, getByText } = renderWithProvider(
+        <MarketInsightsDisclaimerBottomSheet onClose={jest.fn()} />,
+      );
+
+      expect(
+        queryByTestId('market-insights-disclaimer-safe-area-provider'),
+      ).toBeNull();
+      // The sheet still renders normally on iOS.
+      expect(getByText('AI generated content')).toBeOnTheScreen();
+    });
   });
 
   it('does not call onClose before the button is pressed', () => {

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsDisclaimerBottomSheet.test.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsDisclaimerBottomSheet.test.tsx
@@ -72,6 +72,21 @@ describe('MarketInsightsDisclaimerBottomSheet', () => {
     ).toBeOnTheScreen();
   });
 
+  // TAT-3758: on Android this sheet renders inside a react-native <Modal>, which
+  // is its own window. Without a nested SafeAreaProvider the root provider
+  // measures the activity window and reports a bottom inset of 0, collapsing
+  // BottomSheetDialog's bottom padding and leaving "Got it" under the
+  // navigation bar.
+  it('nests a SafeAreaProvider inside the Modal so the bottom inset is measured against the modal window', () => {
+    const { getByTestId } = renderWithProvider(
+      <MarketInsightsDisclaimerBottomSheet onClose={jest.fn()} />,
+    );
+
+    expect(
+      getByTestId('market-insights-disclaimer-safe-area-provider'),
+    ).toBeOnTheScreen();
+  });
+
   it('does not call onClose before the button is pressed', () => {
     const onClose = jest.fn();
 

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsDisclaimerBottomSheet.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsDisclaimerBottomSheet.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useRef } from 'react';
 import { Modal, View } from 'react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import {
   BottomSheet,
   BottomSheetFooter,
@@ -47,26 +48,36 @@ const MarketInsightsDisclaimerBottomSheet: React.FC<
         statusBarTranslucent
         onRequestClose={handleClose}
       >
-        <BottomSheet ref={bottomSheetRef} onClose={onClose}>
-          <BottomSheetHeader onClose={handleClose}>
-            {strings('market_insights.disclaimer_modal.title')}
-          </BottomSheetHeader>
+        {/*
+          On Android a Modal is its own window, and `statusBarTranslucent` makes
+          it draw under the system bars. The root SafeAreaProvider measures the
+          activity window, so it reports a bottom inset of 0 here and
+          BottomSheetDialog's bottom padding collapses — leaving the footer
+          button under the navigation bar. A nested provider measures this
+          window instead, so the inset is right on every Android version.
+        */}
+        <SafeAreaProvider testID="market-insights-disclaimer-safe-area-provider">
+          <BottomSheet ref={bottomSheetRef} onClose={onClose}>
+            <BottomSheetHeader onClose={handleClose}>
+              {strings('market_insights.disclaimer_modal.title')}
+            </BottomSheetHeader>
 
-          <Box paddingHorizontal={4}>
-            <Text
-              variant={TextVariant.BodyMd}
-              color={TextColor.TextAlternative}
-            >
-              {strings('market_insights.disclaimer_modal.body')}
-            </Text>
-          </Box>
+            <Box paddingHorizontal={4}>
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+              >
+                {strings('market_insights.disclaimer_modal.body')}
+              </Text>
+            </Box>
 
-          <BottomSheetFooter
-            buttonsAlignment={ButtonsAlignment.Horizontal}
-            primaryButtonProps={primaryButtonProps}
-            twClassName="pt-6"
-          />
-        </BottomSheet>
+            <BottomSheetFooter
+              buttonsAlignment={ButtonsAlignment.Horizontal}
+              primaryButtonProps={primaryButtonProps}
+              twClassName="pt-6"
+            />
+          </BottomSheet>
+        </SafeAreaProvider>
       </Modal>
     </View>
   );

--- a/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsDisclaimerBottomSheet.tsx
+++ b/app/components/UI/MarketInsights/components/MarketInsightsEntryCard/MarketInsightsDisclaimerBottomSheet.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useRef } from 'react';
 import { Modal, View } from 'react-native';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
+import ModalSafeAreaProvider from '../../../../../component-library/components-temp/ModalSafeAreaProvider';
 import {
   BottomSheet,
   BottomSheetFooter,
@@ -48,15 +48,7 @@ const MarketInsightsDisclaimerBottomSheet: React.FC<
         statusBarTranslucent
         onRequestClose={handleClose}
       >
-        {/*
-          On Android a Modal is its own window, and `statusBarTranslucent` makes
-          it draw under the system bars. The root SafeAreaProvider measures the
-          activity window, so it reports a bottom inset of 0 here and
-          BottomSheetDialog's bottom padding collapses — leaving the footer
-          button under the navigation bar. A nested provider measures this
-          window instead, so the inset is right on every Android version.
-        */}
-        <SafeAreaProvider testID="market-insights-disclaimer-safe-area-provider">
+        <ModalSafeAreaProvider testID="market-insights-disclaimer-safe-area-provider">
           <BottomSheet ref={bottomSheetRef} onClose={onClose}>
             <BottomSheetHeader onClose={handleClose}>
               {strings('market_insights.disclaimer_modal.title')}
@@ -77,7 +69,7 @@ const MarketInsightsDisclaimerBottomSheet: React.FC<
               twClassName="pt-6"
             />
           </BottomSheet>
-        </SafeAreaProvider>
+        </ModalSafeAreaProvider>
       </Modal>
     </View>
   );

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -130,6 +130,7 @@ import PerpsCompetitionBanner from '../../components/PerpsCompetitionBanner';
 import PerpsProducts from '../../components/PerpsProducts';
 import PerpsTopMoversSection from '../../components/PerpsTopMoversSection';
 import PerpsRecentlyAddedSection from '../../components/PerpsRecentlyAddedSection';
+import ModalSafeAreaProvider from '../../../../../component-library/components-temp/ModalSafeAreaProvider';
 import {
   isPerpsTopMoversSectionVisible,
   usePerpsTopMovers,
@@ -1235,12 +1236,14 @@ const PerpsHomeView = () => {
         // Android Compatibility: Wrap the <Modal> in a plain <View> component to prevent rendering issues and freezing.
         <View>
           <Modal visible transparent animationType="none" statusBarTranslucent>
-            <PerpsBottomSheetTooltip
-              isVisible
-              onClose={closeEligibilityModal}
-              contentKey={'geo_block'}
-              testID={'perps-home-geo-block-tooltip'}
-            />
+            <ModalSafeAreaProvider>
+              <PerpsBottomSheetTooltip
+                isVisible
+                onClose={closeEligibilityModal}
+                contentKey={'geo_block'}
+                testID={'perps-home-geo-block-tooltip'}
+              />
+            </ModalSafeAreaProvider>
           </Modal>
         </View>
       )}
@@ -1249,12 +1252,14 @@ const PerpsHomeView = () => {
       {isCloseAllGeoBlockVisible && (
         <View>
           <Modal visible transparent animationType="none" statusBarTranslucent>
-            <PerpsBottomSheetTooltip
-              isVisible
-              onClose={() => setIsCloseAllGeoBlockVisible(false)}
-              contentKey={'geo_block'}
-              testID={'perps-home-close-all-geo-block-tooltip'}
-            />
+            <ModalSafeAreaProvider>
+              <PerpsBottomSheetTooltip
+                isVisible
+                onClose={() => setIsCloseAllGeoBlockVisible(false)}
+                contentKey={'geo_block'}
+                testID={'perps-home-close-all-geo-block-tooltip'}
+              />
+            </ModalSafeAreaProvider>
           </Modal>
         </View>
       )}

--- a/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderBookView/PerpsOrderBookView.tsx
@@ -94,6 +94,7 @@ import {
 } from '../../utils/orderBookGrouping';
 import PerpsSelectModifyActionView from '../PerpsSelectModifyActionView';
 import styleSheet from './PerpsOrderBookView.styles';
+import ModalSafeAreaProvider from '../../../../../component-library/components-temp/ModalSafeAreaProvider';
 import type {
   OrderBookRouteParams,
   PerpsOrderBookViewProps,
@@ -821,13 +822,15 @@ const PerpsOrderBookView: React.FC<PerpsOrderBookViewProps> = ({
       {selectedTooltip && (
         <View>
           <Modal visible transparent animationType="none" statusBarTranslucent>
-            <PerpsBottomSheetTooltip
-              isVisible
-              onClose={handleTooltipClose}
-              contentKey={selectedTooltip}
-              testID={PerpsOrderBookViewSelectorsIDs.BOTTOM_SHEET_TOOLTIP}
-              buttonLocation={PERPS_EVENT_VALUE.BUTTON_LOCATION.ORDER_BOOK}
-            />
+            <ModalSafeAreaProvider>
+              <PerpsBottomSheetTooltip
+                isVisible
+                onClose={handleTooltipClose}
+                contentKey={selectedTooltip}
+                testID={PerpsOrderBookViewSelectorsIDs.BOTTOM_SHEET_TOOLTIP}
+                buttonLocation={PERPS_EVENT_VALUE.BUTTON_LOCATION.ORDER_BOOK}
+              />
+            </ModalSafeAreaProvider>
           </Modal>
         </View>
       )}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProModalPortal.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProModalPortal.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Modal, View } from 'react-native';
+import { Modal, Platform, Text, View } from 'react-native';
 import { render, screen, within } from '@testing-library/react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import PerpsProModalPortal, {
   PERPS_PRO_MODAL_GESTURE_ROOT_TEST_ID,
 } from './PerpsProModalPortal';
@@ -32,6 +33,62 @@ describe('PerpsProModalPortal', () => {
     UNSAFE_getByType(Modal).props.onRequestClose();
 
     expect(onRequestClose).toHaveBeenCalledTimes(1);
+  });
+
+  // TAT-3758: Android gives this Modal its own window, so the root
+  // SafeAreaProvider reports a bottom inset of 0 here and BottomSheetDialog's
+  // bottom padding collapses, leaving sheet footers under the navigation bar.
+  // Every Pro sheet (order form, positions panel, geo-block tooltip) renders
+  // through this portal, so the nested provider belongs here.
+  describe('modal safe-area inset (TAT-3758)', () => {
+    const originalPlatform = Platform.OS;
+
+    afterEach(() => {
+      Platform.OS = originalPlatform;
+    });
+
+    it('nests a SafeAreaProvider on Android so children measure this modal window', () => {
+      Platform.OS = 'android';
+
+      const { UNSAFE_getAllByType } = render(
+        <PerpsProModalPortal>
+          <View testID="modal-content" />
+        </PerpsProModalPortal>,
+      );
+
+      expect(UNSAFE_getAllByType(SafeAreaProvider).length).toBe(1);
+      expect(screen.getByTestId('modal-content')).toBeOnTheScreen();
+    });
+
+    it('does not nest a SafeAreaProvider on iOS, where the root provider is already correct', () => {
+      Platform.OS = 'ios';
+
+      const { UNSAFE_queryAllByType } = render(
+        <PerpsProModalPortal>
+          <View testID="modal-content" />
+        </PerpsProModalPortal>,
+      );
+
+      expect(UNSAFE_queryAllByType(SafeAreaProvider).length).toBe(0);
+      expect(screen.getByTestId('modal-content')).toBeOnTheScreen();
+    });
+
+    it('keeps the gesture root filling the provider so sheet layout is unchanged', () => {
+      Platform.OS = 'android';
+
+      render(
+        <PerpsProModalPortal>
+          <Text>sheet</Text>
+        </PerpsProModalPortal>,
+      );
+
+      const gestureRoot = screen.getByTestId(
+        PERPS_PRO_MODAL_GESTURE_ROOT_TEST_ID,
+      );
+
+      expect(gestureRoot).toHaveStyle({ flex: 1 });
+      expect(within(gestureRoot).getByText('sheet')).toBeOnTheScreen();
+    });
   });
 
   it('uses the requested modal animation', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProModalPortal.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProModalPortal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Modal, type ModalProps, StyleSheet, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import ModalSafeAreaProvider from '../../../../../../component-library/components-temp/ModalSafeAreaProvider';
 
 export const PERPS_PRO_MODAL_GESTURE_ROOT_TEST_ID =
   'perps-pro-modal-gesture-root';
@@ -24,6 +25,12 @@ const styles = StyleSheet.create({
  * app-level GestureHandlerRootView does not cover modal content. The nested
  * gesture root keeps BottomSheet swipe gestures and controls such as Slider
  * interactive on Android.
+ *
+ * For the same reason the root SafeAreaProvider measures the activity window
+ * rather than this modal's window, reporting a bottom inset of 0 and collapsing
+ * BottomSheetDialog's bottom padding — which leaves sheet footers under the
+ * navigation bar. ModalSafeAreaProvider measures this window instead (Android
+ * only; iOS already reports correct insets here).
  */
 const PerpsProModalPortal = ({
   children,
@@ -40,12 +47,14 @@ const PerpsProModalPortal = ({
       statusBarTranslucent
       onRequestClose={onRequestClose}
     >
-      <GestureHandlerRootView
-        style={styles.gestureRoot}
-        testID={PERPS_PRO_MODAL_GESTURE_ROOT_TEST_ID}
-      >
-        {children}
-      </GestureHandlerRootView>
+      <ModalSafeAreaProvider>
+        <GestureHandlerRootView
+          style={styles.gestureRoot}
+          testID={PERPS_PRO_MODAL_GESTURE_ROOT_TEST_ID}
+        >
+          {children}
+        </GestureHandlerRootView>
+      </ModalSafeAreaProvider>
     </Modal>
   </View>
 );

--- a/app/components/UI/Perps/components/PerpsBalanceBottomSheet/PerpsBalanceBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsBalanceBottomSheet/PerpsBalanceBottomSheet.tsx
@@ -35,6 +35,7 @@ import {
 import PerpsBottomSheetTooltip from '../PerpsBottomSheetTooltip';
 import { PerpsBalanceBottomSheetSelectorsIDs } from '../../Perps.testIds';
 import { PerpsBalanceBottomSheetProps } from './PerpsBalanceBottomSheet.types';
+import ModalSafeAreaProvider from '../../../../../component-library/components-temp/ModalSafeAreaProvider';
 
 /**
  * Perps account balance bottom sheet.
@@ -235,14 +236,16 @@ const PerpsBalanceBottomSheet: React.FC<PerpsBalanceBottomSheetProps> = ({
         // Android Compatibility: Wrap the <Modal> in a plain <View> component to prevent rendering issues and freezing.
         <View>
           <Modal visible transparent animationType="none" statusBarTranslucent>
-            <PerpsBottomSheetTooltip
-              isVisible
-              onClose={closeEligibilityModal}
-              contentKey="geo_block"
-              testID={
-                PerpsBalanceBottomSheetSelectorsIDs.GEO_BLOCK_BOTTOM_SHEET_TOOLTIP
-              }
-            />
+            <ModalSafeAreaProvider>
+              <PerpsBottomSheetTooltip
+                isVisible
+                onClose={closeEligibilityModal}
+                contentKey="geo_block"
+                testID={
+                  PerpsBalanceBottomSheetSelectorsIDs.GEO_BLOCK_BOTTOM_SHEET_TOOLTIP
+                }
+              />
+            </ModalSafeAreaProvider>
           </Modal>
         </View>
       )}

--- a/app/components/UI/Perps/components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.test.tsx
+++ b/app/components/UI/Perps/components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.test.tsx
@@ -1,6 +1,5 @@
 import { fireEvent, waitFor } from '@testing-library/react-native';
 import React from 'react';
-import { Platform } from 'react-native';
 import { Metrics, SafeAreaProvider } from 'react-native-safe-area-context';
 import { PerpsBottomSheetTooltipSelectorsIDs } from '../../Perps.testIds';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
@@ -256,50 +255,27 @@ describe('PerpsBottomSheetTooltip', () => {
     expect(getByText('0.045%')).toBeTruthy();
   });
 
-  // TAT-3758: callers render this tooltip inside a react-native <Modal>, which
-  // on Android is its own window. Without a nested SafeAreaProvider the root
-  // provider measures the activity window and reports a bottom inset of 0,
-  // collapsing BottomSheetDialog's bottom padding and leaving the footer button
-  // under the navigation bar.
-  describe('modal safe-area inset (TAT-3758)', () => {
-    const originalPlatform = Platform.OS;
+  // TAT-3758: this component must NOT wrap itself in a SafeAreaProvider. Many
+  // call sites (PerpsOrderView, PerpsAdjustMarginView, PerpsMarketDetailsView,
+  // PerpsProOrderFormPanel, ...) render it inline with no Modal. SafeAreaProvider
+  // applies flex: 1, so wrapping here would inject a flex sibling into those
+  // screens and shrink their content whenever a tooltip opens. The provider
+  // belongs at the Modal roots that actually need it.
+  it('does not wrap itself in a SafeAreaProvider, so inline call sites keep their layout', () => {
+    const customTestID = 'geo-block-tooltip';
 
-    afterEach(() => {
-      Platform.OS = originalPlatform;
+    const { queryByTestId, getByTestId } = renderBottomSheetTooltip({
+      isVisible: true,
+      onClose: mockOnClose,
+      contentKey: 'geo_block',
+      testID: customTestID,
     });
 
-    it('nests a SafeAreaProvider on Android so the bottom inset is measured against the modal window', () => {
-      Platform.OS = 'android';
-      const customTestID = 'geo-block-tooltip';
-
-      const { getByTestId } = renderBottomSheetTooltip({
-        isVisible: true,
-        onClose: mockOnClose,
-        contentKey: 'geo_block',
-        testID: customTestID,
-      });
-
-      expect(getByTestId(`${customTestID}-safe-area-provider`)).toBeTruthy();
-    });
-
-    it('does not nest a SafeAreaProvider on iOS, where the root provider already reports correct insets', () => {
-      Platform.OS = 'ios';
-      const customTestID = 'geo-block-tooltip';
-
-      const { queryByTestId, getByTestId } = renderBottomSheetTooltip({
-        isVisible: true,
-        onClose: mockOnClose,
-        contentKey: 'geo_block',
-        testID: customTestID,
-      });
-
-      expect(queryByTestId(`${customTestID}-safe-area-provider`)).toBeNull();
-      // The tooltip still renders normally on iOS.
-      expect(getByTestId(customTestID)).toBeTruthy();
-      expect(
-        getByTestId(PerpsBottomSheetTooltipSelectorsIDs.GOT_IT_BUTTON),
-      ).toBeTruthy();
-    });
+    expect(queryByTestId(`${customTestID}-safe-area-provider`)).toBeNull();
+    expect(getByTestId(customTestID)).toBeTruthy();
+    expect(
+      getByTestId(PerpsBottomSheetTooltipSelectorsIDs.GOT_IT_BUTTON),
+    ).toBeTruthy();
   });
 
   it('uses custom testID when provided', () => {

--- a/app/components/UI/Perps/components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.test.tsx
+++ b/app/components/UI/Perps/components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, waitFor } from '@testing-library/react-native';
 import React from 'react';
+import { Platform } from 'react-native';
 import { Metrics, SafeAreaProvider } from 'react-native-safe-area-context';
 import { PerpsBottomSheetTooltipSelectorsIDs } from '../../Perps.testIds';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
@@ -260,16 +261,45 @@ describe('PerpsBottomSheetTooltip', () => {
   // provider measures the activity window and reports a bottom inset of 0,
   // collapsing BottomSheetDialog's bottom padding and leaving the footer button
   // under the navigation bar.
-  it('nests a SafeAreaProvider so the bottom inset is measured against the modal window', () => {
-    const customTestID = 'geo-block-tooltip';
-    const { getByTestId } = renderBottomSheetTooltip({
-      isVisible: true,
-      onClose: mockOnClose,
-      contentKey: 'geo_block',
-      testID: customTestID,
+  describe('modal safe-area inset (TAT-3758)', () => {
+    const originalPlatform = Platform.OS;
+
+    afterEach(() => {
+      Platform.OS = originalPlatform;
     });
 
-    expect(getByTestId(`${customTestID}-safe-area-provider`)).toBeTruthy();
+    it('nests a SafeAreaProvider on Android so the bottom inset is measured against the modal window', () => {
+      Platform.OS = 'android';
+      const customTestID = 'geo-block-tooltip';
+
+      const { getByTestId } = renderBottomSheetTooltip({
+        isVisible: true,
+        onClose: mockOnClose,
+        contentKey: 'geo_block',
+        testID: customTestID,
+      });
+
+      expect(getByTestId(`${customTestID}-safe-area-provider`)).toBeTruthy();
+    });
+
+    it('does not nest a SafeAreaProvider on iOS, where the root provider already reports correct insets', () => {
+      Platform.OS = 'ios';
+      const customTestID = 'geo-block-tooltip';
+
+      const { queryByTestId, getByTestId } = renderBottomSheetTooltip({
+        isVisible: true,
+        onClose: mockOnClose,
+        contentKey: 'geo_block',
+        testID: customTestID,
+      });
+
+      expect(queryByTestId(`${customTestID}-safe-area-provider`)).toBeNull();
+      // The tooltip still renders normally on iOS.
+      expect(getByTestId(customTestID)).toBeTruthy();
+      expect(
+        getByTestId(PerpsBottomSheetTooltipSelectorsIDs.GOT_IT_BUTTON),
+      ).toBeTruthy();
+    });
   });
 
   it('uses custom testID when provided', () => {

--- a/app/components/UI/Perps/components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.test.tsx
+++ b/app/components/UI/Perps/components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.test.tsx
@@ -255,6 +255,23 @@ describe('PerpsBottomSheetTooltip', () => {
     expect(getByText('0.045%')).toBeTruthy();
   });
 
+  // TAT-3758: callers render this tooltip inside a react-native <Modal>, which
+  // on Android is its own window. Without a nested SafeAreaProvider the root
+  // provider measures the activity window and reports a bottom inset of 0,
+  // collapsing BottomSheetDialog's bottom padding and leaving the footer button
+  // under the navigation bar.
+  it('nests a SafeAreaProvider so the bottom inset is measured against the modal window', () => {
+    const customTestID = 'geo-block-tooltip';
+    const { getByTestId } = renderBottomSheetTooltip({
+      isVisible: true,
+      onClose: mockOnClose,
+      contentKey: 'geo_block',
+      testID: customTestID,
+    });
+
+    expect(getByTestId(`${customTestID}-safe-area-provider`)).toBeTruthy();
+  });
+
   it('uses custom testID when provided', () => {
     const customTestID = 'custom-tooltip-test-id';
     const { getByTestId } = renderBottomSheetTooltip({

--- a/app/components/UI/Perps/components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.tsx
+++ b/app/components/UI/Perps/components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.tsx
@@ -12,6 +12,7 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { strings } from '../../../../../../locales/i18n';
 import { PerpsBottomSheetTooltipProps } from './PerpsBottomSheetTooltip.types';
 import { tooltipContentRegistry } from './content/contentRegistry';
@@ -122,23 +123,35 @@ const PerpsBottomSheetTooltip = React.memo<PerpsBottomSheetTooltipProps>(
     if (!isVisible || !title) return null;
 
     return (
-      <BottomSheet ref={bottomSheetRef} onClose={onClose} testID={testID}>
-        {!hasCustomHeader && (
-          <BottomSheetHeader
-            onClose={handleClose}
-            testID={PerpsBottomSheetTooltipSelectorsIDs.TITLE}
-          >
-            {title}
-          </BottomSheetHeader>
-        )}
-        <Box paddingHorizontal={4}>{renderContent()}</Box>
-        <BottomSheetFooter
-          buttonsAlignment={ButtonsAlignment.Horizontal}
-          primaryButtonProps={primaryButtonProps}
-          secondaryButtonProps={secondaryButtonProps}
-          twClassName="pt-6"
-        />
-      </BottomSheet>
+      /*
+        Callers render this tooltip inside a react-native <Modal>, which on
+        Android is its own window. `statusBarTranslucent` makes that window draw
+        under the system bars, but the root SafeAreaProvider measures the
+        activity window, so it reports a bottom inset of 0 here and
+        BottomSheetDialog's bottom padding collapses — leaving the footer button
+        under the navigation bar. A nested provider measures this window
+        instead, so the inset is right on every Android version. Same approach
+        as FilterOptionSheet and the scam questionnaire modal.
+      */
+      <SafeAreaProvider testID={`${testID}-safe-area-provider`}>
+        <BottomSheet ref={bottomSheetRef} onClose={onClose} testID={testID}>
+          {!hasCustomHeader && (
+            <BottomSheetHeader
+              onClose={handleClose}
+              testID={PerpsBottomSheetTooltipSelectorsIDs.TITLE}
+            >
+              {title}
+            </BottomSheetHeader>
+          )}
+          <Box paddingHorizontal={4}>{renderContent()}</Box>
+          <BottomSheetFooter
+            buttonsAlignment={ButtonsAlignment.Horizontal}
+            primaryButtonProps={primaryButtonProps}
+            secondaryButtonProps={secondaryButtonProps}
+            twClassName="pt-6"
+          />
+        </BottomSheet>
+      </SafeAreaProvider>
     );
   },
 );

--- a/app/components/UI/Perps/components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.tsx
+++ b/app/components/UI/Perps/components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.tsx
@@ -12,7 +12,7 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
+import ModalSafeAreaProvider from '../../../../../component-library/components-temp/ModalSafeAreaProvider';
 import { strings } from '../../../../../../locales/i18n';
 import { PerpsBottomSheetTooltipProps } from './PerpsBottomSheetTooltip.types';
 import { tooltipContentRegistry } from './content/contentRegistry';
@@ -123,17 +123,7 @@ const PerpsBottomSheetTooltip = React.memo<PerpsBottomSheetTooltipProps>(
     if (!isVisible || !title) return null;
 
     return (
-      /*
-        Callers render this tooltip inside a react-native <Modal>, which on
-        Android is its own window. `statusBarTranslucent` makes that window draw
-        under the system bars, but the root SafeAreaProvider measures the
-        activity window, so it reports a bottom inset of 0 here and
-        BottomSheetDialog's bottom padding collapses — leaving the footer button
-        under the navigation bar. A nested provider measures this window
-        instead, so the inset is right on every Android version. Same approach
-        as FilterOptionSheet and the scam questionnaire modal.
-      */
-      <SafeAreaProvider testID={`${testID}-safe-area-provider`}>
+      <ModalSafeAreaProvider testID={`${testID}-safe-area-provider`}>
         <BottomSheet ref={bottomSheetRef} onClose={onClose} testID={testID}>
           {!hasCustomHeader && (
             <BottomSheetHeader
@@ -151,7 +141,7 @@ const PerpsBottomSheetTooltip = React.memo<PerpsBottomSheetTooltipProps>(
             twClassName="pt-6"
           />
         </BottomSheet>
-      </SafeAreaProvider>
+      </ModalSafeAreaProvider>
     );
   },
 );

--- a/app/components/UI/Perps/components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.tsx
+++ b/app/components/UI/Perps/components/PerpsBottomSheetTooltip/PerpsBottomSheetTooltip.tsx
@@ -12,7 +12,6 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import ModalSafeAreaProvider from '../../../../../component-library/components-temp/ModalSafeAreaProvider';
 import { strings } from '../../../../../../locales/i18n';
 import { PerpsBottomSheetTooltipProps } from './PerpsBottomSheetTooltip.types';
 import { tooltipContentRegistry } from './content/contentRegistry';
@@ -123,25 +122,23 @@ const PerpsBottomSheetTooltip = React.memo<PerpsBottomSheetTooltipProps>(
     if (!isVisible || !title) return null;
 
     return (
-      <ModalSafeAreaProvider testID={`${testID}-safe-area-provider`}>
-        <BottomSheet ref={bottomSheetRef} onClose={onClose} testID={testID}>
-          {!hasCustomHeader && (
-            <BottomSheetHeader
-              onClose={handleClose}
-              testID={PerpsBottomSheetTooltipSelectorsIDs.TITLE}
-            >
-              {title}
-            </BottomSheetHeader>
-          )}
-          <Box paddingHorizontal={4}>{renderContent()}</Box>
-          <BottomSheetFooter
-            buttonsAlignment={ButtonsAlignment.Horizontal}
-            primaryButtonProps={primaryButtonProps}
-            secondaryButtonProps={secondaryButtonProps}
-            twClassName="pt-6"
-          />
-        </BottomSheet>
-      </ModalSafeAreaProvider>
+      <BottomSheet ref={bottomSheetRef} onClose={onClose} testID={testID}>
+        {!hasCustomHeader && (
+          <BottomSheetHeader
+            onClose={handleClose}
+            testID={PerpsBottomSheetTooltipSelectorsIDs.TITLE}
+          >
+            {title}
+          </BottomSheetHeader>
+        )}
+        <Box paddingHorizontal={4}>{renderContent()}</Box>
+        <BottomSheetFooter
+          buttonsAlignment={ButtonsAlignment.Horizontal}
+          primaryButtonProps={primaryButtonProps}
+          secondaryButtonProps={secondaryButtonProps}
+          twClassName="pt-6"
+        />
+      </BottomSheet>
     );
   },
 );

--- a/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketBalanceActions/PerpsMarketBalanceActions.tsx
@@ -39,6 +39,7 @@ import PerpsEmptyBalance from '../PerpsEmptyBalance';
 import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 import { PerpsProgressBar } from '../PerpsProgressBar';
 import { selectWithdrawalRequestsBySelectedAccount } from '../../../../../selectors/perps';
+import ModalSafeAreaProvider from '../../../../../component-library/components-temp/ModalSafeAreaProvider';
 
 interface PerpsMarketBalanceActionsProps {
   showActionButtons?: boolean;
@@ -362,14 +363,16 @@ const PerpsMarketBalanceActions: React.FC<PerpsMarketBalanceActionsProps> = ({
         // Android Compatibility: Wrap the <Modal> in a plain <View> component to prevent rendering issues and freezing.
         <View>
           <Modal visible transparent animationType="none" statusBarTranslucent>
-            <PerpsBottomSheetTooltip
-              isVisible
-              onClose={closeEligibilityModal}
-              contentKey={'geo_block'}
-              testID={
-                PerpsMarketBalanceActionsSelectorsIDs.GEO_BLOCK_BOTTOM_SHEET_TOOLTIP
-              }
-            />
+            <ModalSafeAreaProvider>
+              <PerpsBottomSheetTooltip
+                isVisible
+                onClose={closeEligibilityModal}
+                contentKey={'geo_block'}
+                testID={
+                  PerpsMarketBalanceActionsSelectorsIDs.GEO_BLOCK_BOTTOM_SHEET_TOOLTIP
+                }
+              />
+            </ModalSafeAreaProvider>
           </Modal>
         </View>
       )}

--- a/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
+++ b/app/components/UI/TokenDetails/components/AssetOverviewContent.tsx
@@ -94,6 +94,7 @@ import { IconName as ComponentLibraryIconName } from '../../../../component-libr
 import { useRWAToken } from '../../Bridge/hooks/useRWAToken';
 import { BridgeToken } from '../../Bridge/types';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
+import ModalSafeAreaProvider from '../../../../component-library/components-temp/ModalSafeAreaProvider';
 import {
   endTrace,
   trace,
@@ -747,12 +748,14 @@ const AssetOverviewContent: React.FC<AssetOverviewContentProps> = ({
                 animationType="none"
                 statusBarTranslucent
               >
-                <PerpsBottomSheetTooltip
-                  isVisible
-                  onClose={closeEligibilityModal}
-                  contentKey="geo_block"
-                  testID="token-details-geo-block-tooltip"
-                />
+                <ModalSafeAreaProvider>
+                  <PerpsBottomSheetTooltip
+                    isVisible
+                    onClose={closeEligibilityModal}
+                    contentKey="geo_block"
+                    testID="token-details-geo-block-tooltip"
+                  />
+                </ModalSafeAreaProvider>
               </Modal>
             </View>
           )}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Bottom sheet footer buttons were covered by the Android navigation bar. These
sheets render inside a react-native `Modal`, which on Android is its own window,
so the root `SafeAreaProvider` reports a bottom inset of 0 and
`BottomSheetDialog`'s bottom padding collapses to 16dp — under the ~48dp
3-button navigation bar.

The fix nests a `SafeAreaProvider` inside the Modal so it measures that window
instead, via a small `ModalSafeAreaProvider` helper applied **on Android only**
(iOS modals cover the full screen and the root provider already reports correct
insets there).

The provider is applied at the **Modal roots** — seven direct roots plus the
shared `PerpsProModalPortal`, which alone backs 15 Pro sheet usages (order form
panel, positions panel, order-edit sheets, side filter, order book config,
positions option sheet) — not inside `PerpsBottomSheetTooltip` itself. That component has 17 call sites and
most render it inline with no Modal (`PerpsOrderView`, `PerpsAdjustMarginView`,
`PerpsMarketDetailsView`, `PerpsProOrderFormPanel`, `PerpsWithdrawView`, the Pro
positions panel). Wrapping the component would make `SafeAreaProvider`'s
`flex: 1` a flex sibling in those screens, shrinking their content and
constraining the absolutely positioned sheet whenever a tooltip opened.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where the button on some Perps bottom sheets was hidden behind the Android navigation bar

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: TAT-3758

## **Manual testing steps**

<!-- recipe-evidence summary: keep reviewer-facing checks concise; full paths stay in pr-package/evidence.md. -->
Device: Pixel 6a (physical), Android 17 / API 37, **3-button navigation mode**
(`settings get secure navigation_mode` = `0`) — the defect only manifests there;
gesture navigation has a much thinner inset. Build: main, dev client. Wallet:
harness fixture, unlocked, account `dev1`.

1. Open Perps → any market (e.g. ETH) → tap the Market insights info icon.
2. Observe the "Got it" button on the disclaimer sheet.
3. Before: the button is overlapped by the navigation bar. After: it renders
   fully above it and dismisses the sheet when tapped.

Recipe run (10/10 nodes pass): `pr-package/runs/artifacts-recipe-run/`

Also verified on device:
- an **inline** (non-Modal) tooltip (market details oracle price) opens with the
  underlying screen layout intact — no flex regression at call sites that were
  never affected by the original bug;
- a **Pro** sheet through `PerpsProModalPortal` (order type sheet) renders with
  the correct bottom inset.

Out of scope: `PerpsChartFullscreenModal` is also a translucent Modal without the
provider, but it reads `useSafeAreaInsets()` directly and is a fullscreen chart
rather than a footer-bearing sheet. Pre-existing and unrelated to this bug.

**iOS:** not exercised at runtime — no iOS simulator was available on this slot
(`mm-1` not booted; the other booted sims belong to different slots). The change
is a no-op on iOS by construction (`Platform.OS !== 'android'` renders children
unwrapped), and unit tests assert that on both platforms. Worth a reviewer
sanity-check on an iOS build that these sheets are unchanged.

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps bottom sheet respects the Android navigation bar

  Scenario: user opens a Modal-wrapped Perps bottom sheet on Android
    Given the device uses 3-button navigation
    And the user is on a Perps market screen

    When the user opens a bottom sheet with a footer button
    Then the footer button renders fully above the navigation bar
    And tapping the footer button dismisses the sheet
```

## **Screenshots/Recordings**

<table>
<tr><td colspan="2"><strong>Recipe visual evidence</strong><br/>Screenshots are grouped for quick reviewer comparison.</td></tr>
<tr>
<td align="center" width="50%"><strong>00 before got it under navbar</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/TAT-3758-fix-perps-bottom-sheet-android-nav-inset-1410/00-before-got-it-under-navbar.png" alt="00 before got it under navbar" width="400" /></td>
<td align="center" width="50%"><strong>ui.screenshot screenshot</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/TAT-3758-fix-perps-bottom-sheet-android-nav-inset-1410/01-ui-screenshot-screenshot.png" alt="ui.screenshot screenshot" width="400" /></td>
</tr>
<tr>
<td align="center" width="50%"><strong>02 after got it above navbar</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/TAT-3758-fix-perps-bottom-sheet-android-nav-inset-1410/02-after-got-it-above-navbar.png" alt="02 after got it above navbar" width="400" /></td>
<td width="50%"></td>
</tr>
</table>

### **Before**

"Got it" is overlapped by the Android navigation bar — only a sliver is visible.

<!-- IMAGE_SLOT_00: drag/drop pr-package/images/00-before-got-it-under-navbar.png here. -->
`pr-package/images/00-before-got-it-under-navbar.png`

### **After**

"Got it" renders fully, clear of the navigation bar.

<!-- IMAGE_SLOT_02: drag/drop pr-package/images/02-after-got-it-above-navbar.png here. -->
`pr-package/images/02-after-got-it-above-navbar.png`

### **Recipe evidence**

<!-- Generated from .github/pull-request-template.md. Drag/drop each local image file at its marker so GitHub uploads and renders it. -->

<table>
<tr><td colspan="2"><strong>Recipe visual evidence</strong><br/>Use concise captions; edit into a clearer before/after table when that helps review.</td></tr>
<tr>
<td align="center" width="50%"><strong>ui.screenshot screenshot</strong><br/><!-- IMAGE_SLOT_01: drag/drop pr-package/images/01-ui-screenshot-screenshot.png here. --><br/><code>pr-package/images/01-ui-screenshot-screenshot.png</code></td>
<td width="50%"></td>
</tr>
</table>


## **Recipe artifact package**

Task path: `/Users/deeeed/dev/metamask/metamask-mobile-1/temp/tasks/recipe-cook/20260819T134249Z-perps-bottom-sheet-android-nav-inset`
PR package: `/Users/deeeed/dev/metamask/metamask-mobile-1/temp/tasks/recipe-cook/20260819T134249Z-perps-bottom-sheet-android-nav-inset/pr-package`
- Report: `artifacts/report.md` · Coverage: `artifacts/recipe-coverage.md`
- Quality: `artifacts/recipe-quality.json` (verdict: **warn** — see note below)
- Image files: `pr-package/images/`
- Checklist: `pr-package/checklist.md`
- Recipe run: `pr-package/runs/artifacts-recipe-run/`

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

**Note on the recipe's regression strength.** The recipe passes with the fix
reverted (verified by stashing the change and rerunning). `ui.press` invokes
`onPress` on the fiber node regardless of what visually covers it, so the
automated assertions cannot detect the occlusion itself. The regression signal
for the visual AC is the before/after screenshots above; the self-checking guard
is the added unit tests, which fail when the nested `SafeAreaProvider` is
removed. Details in `artifacts/recipe-coverage.md`.
