### PR TITLE
fix(perps): open historic fills in Activity details

### DIFF
--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.test.tsx
@@ -47,6 +47,7 @@ jest.mock('../../hooks', () => ({
   usePerpsConnection: jest.fn(),
   usePerpsTransactionHistory: jest.fn(),
   usePerpsEventTracking: jest.fn(),
+  usePerpsNetwork: jest.fn(() => 'mainnet'),
 }));
 
 // Mock the asset metadata hook to avoid network calls

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
@@ -28,6 +28,7 @@ import { TabEmptyState } from '../../../../../component-library/components-temp/
 import ButtonFilter from '../../../../../component-library/components-temp/ButtonFilter';
 import { selectSelectedAccountGroupEvmInternalAccount } from '../../../../../selectors/multichainAccounts/accountTreeController';
 import { selectChainId } from '../../../../../selectors/networkController';
+import { selectIsTransactionsRedesignEnabled } from '../../../../../selectors/featureFlagController/activityRedesign';
 import {
   formatAccountToCaipAccountId,
   PERPS_TRANSACTIONS_HISTORY_CONSTANTS,
@@ -75,6 +76,9 @@ const PerpsTransactionsView: React.FC = () => {
   const evmAccount = useSelector(selectSelectedAccountGroupEvmInternalAccount);
   const selectedAddress = evmAccount?.address;
   const currentChainId = useSelector(selectChainId);
+  const isTransactionsRedesignEnabled = useSelector(
+    selectIsTransactionsRedesignEnabled,
+  );
   const accountId = useMemo(() => {
     if (!selectedAddress || !currentChainId) {
       return undefined;
@@ -326,7 +330,11 @@ const PerpsTransactionsView: React.FC = () => {
         .build(),
     );
 
-    navigateToPerpsTransactionDetails(navigation, transaction);
+    navigateToPerpsTransactionDetails(
+      navigation,
+      transaction,
+      isTransactionsRedesignEnabled,
+    );
   };
 
   // Render right content based on transaction type

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
@@ -26,7 +26,6 @@ import {
 import { useStyles } from '../../../../../component-library/hooks';
 import { TabEmptyState } from '../../../../../component-library/components-temp/TabEmptyState';
 import ButtonFilter from '../../../../../component-library/components-temp/ButtonFilter';
-import Routes from '../../../../../constants/navigation/Routes';
 import { selectSelectedAccountGroupEvmInternalAccount } from '../../../../../selectors/multichainAccounts/accountTreeController';
 import { selectChainId } from '../../../../../selectors/networkController';
 import {
@@ -52,6 +51,7 @@ import {
   TransactionSection,
 } from '../../types/transactionHistory';
 import { formatDateSection } from '../../utils/formatUtils';
+import { navigateToPerpsTransactionDetails } from '../../utils/navigateToPerpsTransactionDetails';
 import { PerpsTransactionsViewSelectorsIDs } from '../../Perps.testIds';
 import { styleSheet } from './PerpsTransactionsView.styles';
 import { usePerpsMeasurement } from '../../hooks/usePerpsMeasurement';
@@ -326,26 +326,7 @@ const PerpsTransactionsView: React.FC = () => {
         .build(),
     );
 
-    switch (transaction.type) {
-      case 'trade':
-        navigation.navigate(Routes.PERPS.POSITION_TRANSACTION, {
-          transaction,
-        });
-        break;
-      case 'order':
-        navigation.navigate(Routes.PERPS.ORDER_TRANSACTION, {
-          transaction,
-        });
-        break;
-      case 'funding':
-        navigation.navigate(Routes.PERPS.FUNDING_TRANSACTION, {
-          transaction,
-        });
-        break;
-      default:
-        // Unknown transaction type - do nothing
-        break;
-    }
+    navigateToPerpsTransactionDetails(navigation, transaction);
   };
 
   // Render right content based on transaction type

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsTransactionsView.tsx
@@ -37,7 +37,11 @@ import {
 // Import PerpsController hooks
 import PerpsTransactionItem from '../../components/PerpsTransactionItem';
 import PerpsTransactionsSkeleton from '../../components/PerpsTransactionsSkeleton';
-import { usePerpsConnection, usePerpsTransactionHistory } from '../../hooks';
+import {
+  usePerpsConnection,
+  usePerpsNetwork,
+  usePerpsTransactionHistory,
+} from '../../hooks';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MonetizedPrimitive } from '../../../../../core/Analytics/MetaMetrics.types';
 import {
@@ -79,6 +83,7 @@ const PerpsTransactionsView: React.FC = () => {
   const isTransactionsRedesignEnabled = useSelector(
     selectIsTransactionsRedesignEnabled,
   );
+  const isTestnet = usePerpsNetwork() === 'testnet';
   const accountId = useMemo(() => {
     if (!selectedAddress || !currentChainId) {
       return undefined;
@@ -334,6 +339,7 @@ const PerpsTransactionsView: React.FC = () => {
       navigation,
       transaction,
       isTransactionsRedesignEnabled,
+      isTestnet,
     );
   };
 

--- a/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.test.tsx
@@ -14,6 +14,11 @@ const mockBuild = jest.fn(() => ({ name: 'test-event' }));
 const mockCreateEventBuilder = jest.fn();
 
 // Mock dependencies
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(() => true),
+}));
+
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(() => ({
     navigate: jest.fn(),
@@ -201,6 +206,9 @@ describe('PerpsMarketTradesList', () => {
       trackEvent: mockTrackEvent,
       createEventBuilder: mockCreateEventBuilder,
     });
+
+    const { useSelector } = jest.requireMock('react-redux');
+    useSelector.mockImplementation(() => true);
   });
 
   afterEach(() => {
@@ -398,6 +406,29 @@ describe('PerpsMarketTradesList', () => {
         expect.objectContaining({
           txIdentifier: expect.stringContaining('fill-2'),
           preloadKey: expect.any(String),
+        }),
+      );
+    });
+
+    it('navigates to the legacy position screen when redesign is disabled', () => {
+      const { useSelector } = jest.requireMock('react-redux');
+      useSelector.mockImplementation(() => false);
+      mockUsePerpsMarketFills.mockReturnValue(
+        createMockFillsReturn(mockOrderFills),
+      );
+
+      render(<PerpsMarketTradesList symbol="ETH" />);
+
+      const tradeItem = screen.getByText('Opened long');
+      fireEvent.press(tradeItem.parent?.parent || tradeItem);
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.PERPS.POSITION_TRANSACTION,
+        expect.objectContaining({
+          transaction: expect.objectContaining({
+            type: 'trade',
+            id: expect.stringContaining('fill-1'),
+          }),
         }),
       );
     });

--- a/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.test.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.test.tsx
@@ -359,7 +359,7 @@ describe('PerpsMarketTradesList', () => {
       });
     });
 
-    it('navigates to position transaction detail when trade item is pressed', () => {
+    it('navigates to Activity details when trade item is pressed', () => {
       mockUsePerpsMarketFills.mockReturnValue(
         createMockFillsReturn(mockOrderFills),
       );
@@ -373,15 +373,10 @@ describe('PerpsMarketTradesList', () => {
       // Verify navigation to correct route with transaction param
       // ID format: {orderId}-{timestamp}-{index}
       expect(mockNavigate).toHaveBeenCalledWith(
-        Routes.PERPS.POSITION_TRANSACTION,
+        Routes.ACTIVITY_DETAILS,
         expect.objectContaining({
-          transaction: expect.objectContaining({
-            id: expect.stringContaining('fill-1'),
-            type: 'trade',
-            category: 'position_open',
-            title: 'Opened long',
-            asset: 'ETH',
-          }),
+          txIdentifier: expect.stringContaining('fill-1'),
+          preloadKey: expect.any(String),
         }),
       );
     });
@@ -399,15 +394,10 @@ describe('PerpsMarketTradesList', () => {
       // Verify navigation with correct transformed transaction data
       // ID format: {orderId}-{timestamp}-{index}
       expect(mockNavigate).toHaveBeenCalledWith(
-        Routes.PERPS.POSITION_TRANSACTION,
+        Routes.ACTIVITY_DETAILS,
         expect.objectContaining({
-          transaction: expect.objectContaining({
-            id: expect.stringContaining('fill-2'),
-            type: 'trade',
-            category: 'position_close',
-            title: 'Closed long',
-            asset: 'ETH',
-          }),
+          txIdentifier: expect.stringContaining('fill-2'),
+          preloadKey: expect.any(String),
         }),
       );
     });

--- a/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.tsx
@@ -39,6 +39,7 @@ import {
 } from '../../constants/perpsConfig';
 import { navigateToPerpsTransactionDetails } from '../../utils/navigateToPerpsTransactionDetails';
 import { selectIsTransactionsRedesignEnabled } from '../../../../../selectors/featureFlagController/activityRedesign';
+import { usePerpsNetwork } from '../../hooks/usePerpsNetwork';
 
 interface PerpsMarketTradesListProps {
   symbol: string; // Market symbol to filter trades
@@ -54,6 +55,7 @@ const PerpsMarketTradesList: React.FC<PerpsMarketTradesListProps> = ({
   const isTransactionsRedesignEnabled = useSelector(
     selectIsTransactionsRedesignEnabled,
   );
+  const isTestnet = usePerpsNetwork() === 'testnet';
   const { trackEvent, createEventBuilder } = useAnalytics();
 
   // Fetch order fills via WebSocket + REST API for complete history
@@ -98,9 +100,16 @@ const PerpsMarketTradesList: React.FC<PerpsMarketTradesListProps> = ({
         navigation,
         transaction,
         isTransactionsRedesignEnabled,
+        isTestnet,
       );
     },
-    [navigation, isTransactionsRedesignEnabled, trackEvent, createEventBuilder],
+    [
+      navigation,
+      isTransactionsRedesignEnabled,
+      isTestnet,
+      trackEvent,
+      createEventBuilder,
+    ],
   );
 
   // Render right content for trades

--- a/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.tsx
@@ -36,6 +36,7 @@ import {
   PERPS_BALANCE_CHAIN_ID,
   HOME_SCREEN_CONFIG,
 } from '../../constants/perpsConfig';
+import { navigateToPerpsTransactionDetails } from '../../utils/navigateToPerpsTransactionDetails';
 
 interface PerpsMarketTradesListProps {
   symbol: string; // Market symbol to filter trades
@@ -88,10 +89,7 @@ const PerpsMarketTradesList: React.FC<PerpsMarketTradesListProps> = ({
           .build(),
       );
 
-      // Navigate to the position transaction detail screen
-      navigation.navigate(Routes.PERPS.POSITION_TRANSACTION, {
-        transaction,
-      });
+      navigateToPerpsTransactionDetails(navigation, transaction);
     },
     [navigation, trackEvent, createEventBuilder],
   );

--- a/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.tsx
+++ b/app/components/UI/Perps/components/PerpsMarketTradesList/PerpsMarketTradesList.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { View, TouchableOpacity, FlatList } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 
 import {
@@ -37,6 +38,7 @@ import {
   HOME_SCREEN_CONFIG,
 } from '../../constants/perpsConfig';
 import { navigateToPerpsTransactionDetails } from '../../utils/navigateToPerpsTransactionDetails';
+import { selectIsTransactionsRedesignEnabled } from '../../../../../selectors/featureFlagController/activityRedesign';
 
 interface PerpsMarketTradesListProps {
   symbol: string; // Market symbol to filter trades
@@ -49,6 +51,9 @@ const PerpsMarketTradesList: React.FC<PerpsMarketTradesListProps> = ({
 }) => {
   const { styles } = useStyles(styleSheet, {});
   const navigation = useNavigation<AppNavigationProp>();
+  const isTransactionsRedesignEnabled = useSelector(
+    selectIsTransactionsRedesignEnabled,
+  );
   const { trackEvent, createEventBuilder } = useAnalytics();
 
   // Fetch order fills via WebSocket + REST API for complete history
@@ -89,9 +94,13 @@ const PerpsMarketTradesList: React.FC<PerpsMarketTradesListProps> = ({
           .build(),
       );
 
-      navigateToPerpsTransactionDetails(navigation, transaction);
+      navigateToPerpsTransactionDetails(
+        navigation,
+        transaction,
+        isTransactionsRedesignEnabled,
+      );
     },
-    [navigation, trackEvent, createEventBuilder],
+    [navigation, isTransactionsRedesignEnabled, trackEvent, createEventBuilder],
   );
 
   // Render right content for trades

--- a/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.test.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.test.tsx
@@ -305,7 +305,7 @@ describe('PerpsRecentActivityList', () => {
       });
     });
 
-    it('navigates to position transaction detail when transaction item is pressed', () => {
+    it('navigates to Activity details when transaction item is pressed', () => {
       render(<PerpsRecentActivityList transactions={mockTransactions} />);
 
       const transactionItem = screen.getByText('Opened long');
@@ -313,10 +313,12 @@ describe('PerpsRecentActivityList', () => {
 
       expect(mockNavigate).toHaveBeenCalledTimes(1);
       expect(mockNavigate).toHaveBeenCalledWith(
-        Routes.PERPS.POSITION_TRANSACTION,
-        {
-          transaction: mockTransactions[0],
-        },
+        Routes.ACTIVITY_DETAILS,
+        expect.objectContaining({
+          chainId: 'eip155:42161',
+          txIdentifier: mockTransactions[0].id,
+          preloadKey: expect.any(String),
+        }),
       );
     });
 
@@ -327,10 +329,12 @@ describe('PerpsRecentActivityList', () => {
       fireEvent.press(ethTransaction.parent?.parent || ethTransaction);
 
       expect(mockNavigate).toHaveBeenCalledWith(
-        Routes.PERPS.POSITION_TRANSACTION,
-        {
-          transaction: mockTransactions[1],
-        },
+        Routes.ACTIVITY_DETAILS,
+        expect.objectContaining({
+          chainId: 'eip155:42161',
+          txIdentifier: mockTransactions[1].id,
+          preloadKey: expect.any(String),
+        }),
       );
     });
 

--- a/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.test.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.test.tsx
@@ -12,6 +12,11 @@ const mockBuild = jest.fn(() => ({ name: 'test-event' }));
 const mockCreateEventBuilder = jest.fn();
 
 // Mock dependencies
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(() => true),
+}));
+
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(() => ({
     navigate: jest.fn(),
@@ -137,6 +142,9 @@ describe('PerpsRecentActivityList', () => {
       trackEvent: mockTrackEvent,
       createEventBuilder: mockCreateEventBuilder,
     });
+
+    const { useSelector } = jest.requireMock('react-redux');
+    useSelector.mockImplementation(() => true);
   });
 
   afterEach(() => {
@@ -335,6 +343,21 @@ describe('PerpsRecentActivityList', () => {
           txIdentifier: mockTransactions[1].id,
           preloadKey: expect.any(String),
         }),
+      );
+    });
+
+    it('navigates to the legacy position screen when redesign is disabled', () => {
+      const { useSelector } = jest.requireMock('react-redux');
+      useSelector.mockImplementation(() => false);
+
+      render(<PerpsRecentActivityList transactions={mockTransactions} />);
+
+      const transactionItem = screen.getByText('Opened long');
+      fireEvent.press(transactionItem.parent?.parent || transactionItem);
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        Routes.PERPS.POSITION_TRANSACTION,
+        { transaction: mockTransactions[0] },
       );
     });
 

--- a/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { FlatList } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import {
   Box,
@@ -29,6 +30,7 @@ import {
   TransactionDetailLocation,
 } from '../../../../../core/Analytics/events/transactions';
 import { navigateToPerpsTransactionDetails } from '../../utils/navigateToPerpsTransactionDetails';
+import { selectIsTransactionsRedesignEnabled } from '../../../../../selectors/featureFlagController/activityRedesign';
 
 interface PerpsRecentActivityListProps {
   transactions: PerpsTransaction[];
@@ -42,6 +44,9 @@ const PerpsRecentActivityList: React.FC<PerpsRecentActivityListProps> = ({
   iconSize = HOME_SCREEN_CONFIG.DefaultIconSize,
 }) => {
   const navigation = useNavigation<AppNavigationProp>();
+  const isTransactionsRedesignEnabled = useSelector(
+    selectIsTransactionsRedesignEnabled,
+  );
   const { trackEvent, createEventBuilder } = useAnalytics();
   const activityTitle = strings('perps.home.recent_activity');
 
@@ -68,10 +73,14 @@ const PerpsRecentActivityList: React.FC<PerpsRecentActivityListProps> = ({
             .build(),
         );
 
-        navigateToPerpsTransactionDetails(navigation, transaction);
+        navigateToPerpsTransactionDetails(
+          navigation,
+          transaction,
+          isTransactionsRedesignEnabled,
+        );
       }
     },
-    [navigation, trackEvent, createEventBuilder],
+    [navigation, isTransactionsRedesignEnabled, trackEvent, createEventBuilder],
   );
 
   const renderItem = useCallback(

--- a/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.tsx
@@ -31,6 +31,7 @@ import {
 } from '../../../../../core/Analytics/events/transactions';
 import { navigateToPerpsTransactionDetails } from '../../utils/navigateToPerpsTransactionDetails';
 import { selectIsTransactionsRedesignEnabled } from '../../../../../selectors/featureFlagController/activityRedesign';
+import { usePerpsNetwork } from '../../hooks/usePerpsNetwork';
 
 interface PerpsRecentActivityListProps {
   transactions: PerpsTransaction[];
@@ -47,6 +48,7 @@ const PerpsRecentActivityList: React.FC<PerpsRecentActivityListProps> = ({
   const isTransactionsRedesignEnabled = useSelector(
     selectIsTransactionsRedesignEnabled,
   );
+  const isTestnet = usePerpsNetwork() === 'testnet';
   const { trackEvent, createEventBuilder } = useAnalytics();
   const activityTitle = strings('perps.home.recent_activity');
 
@@ -77,10 +79,17 @@ const PerpsRecentActivityList: React.FC<PerpsRecentActivityListProps> = ({
           navigation,
           transaction,
           isTransactionsRedesignEnabled,
+          isTestnet,
         );
       }
     },
-    [navigation, isTransactionsRedesignEnabled, trackEvent, createEventBuilder],
+    [
+      navigation,
+      isTransactionsRedesignEnabled,
+      isTestnet,
+      trackEvent,
+      createEventBuilder,
+    ],
   );
 
   const renderItem = useCallback(

--- a/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.tsx
+++ b/app/components/UI/Perps/components/PerpsRecentActivityList/PerpsRecentActivityList.tsx
@@ -28,6 +28,7 @@ import {
   ACTIVITY_DETAIL_EVENTS,
   TransactionDetailLocation,
 } from '../../../../../core/Analytics/events/transactions';
+import { navigateToPerpsTransactionDetails } from '../../utils/navigateToPerpsTransactionDetails';
 
 interface PerpsRecentActivityListProps {
   transactions: PerpsTransaction[];
@@ -67,9 +68,7 @@ const PerpsRecentActivityList: React.FC<PerpsRecentActivityListProps> = ({
             .build(),
         );
 
-        navigation.navigate(Routes.PERPS.POSITION_TRANSACTION, {
-          transaction,
-        });
+        navigateToPerpsTransactionDetails(navigation, transaction);
       }
     },
     [navigation, trackEvent, createEventBuilder],

--- a/app/components/UI/Perps/utils/navigateToPerpsTransactionDetails.test.ts
+++ b/app/components/UI/Perps/utils/navigateToPerpsTransactionDetails.test.ts
@@ -29,10 +29,10 @@ const tradeTransaction: PerpsTransaction = {
 };
 
 describe('navigateToPerpsTransactionDetails', () => {
-  it('opens Activity details for a mapped historic fill', () => {
+  it('opens Activity details for a mapped historic fill when redesign is enabled', () => {
     const navigation = createNavigation();
 
-    navigateToPerpsTransactionDetails(navigation, tradeTransaction);
+    navigateToPerpsTransactionDetails(navigation, tradeTransaction, true);
 
     expect(navigation.navigate).toHaveBeenCalledWith(
       Routes.ACTIVITY_DETAILS,
@@ -41,6 +41,17 @@ describe('navigateToPerpsTransactionDetails', () => {
         txIdentifier: 'order-1',
         preloadKey: expect.any(String),
       }),
+    );
+  });
+
+  it('opens the legacy position screen for a mapped fill when redesign is disabled', () => {
+    const navigation = createNavigation();
+
+    navigateToPerpsTransactionDetails(navigation, tradeTransaction, false);
+
+    expect(navigation.navigate).toHaveBeenCalledWith(
+      Routes.PERPS.POSITION_TRANSACTION,
+      { transaction: tradeTransaction },
     );
   });
 
@@ -58,7 +69,7 @@ describe('navigateToPerpsTransactionDetails', () => {
       },
     };
 
-    navigateToPerpsTransactionDetails(navigation, unmappedTrade);
+    navigateToPerpsTransactionDetails(navigation, unmappedTrade, true);
 
     expect(navigation.navigate).toHaveBeenCalledWith(
       Routes.PERPS.POSITION_TRANSACTION,
@@ -78,7 +89,7 @@ describe('navigateToPerpsTransactionDetails', () => {
       asset: 'ETH',
     };
 
-    navigateToPerpsTransactionDetails(navigation, unmappedOrder);
+    navigateToPerpsTransactionDetails(navigation, unmappedOrder, true);
 
     expect(navigation.navigate).toHaveBeenCalledWith(
       Routes.PERPS.ORDER_TRANSACTION,
@@ -98,7 +109,7 @@ describe('navigateToPerpsTransactionDetails', () => {
       asset: 'ETH',
     };
 
-    navigateToPerpsTransactionDetails(navigation, unmappedFunding);
+    navigateToPerpsTransactionDetails(navigation, unmappedFunding, true);
 
     expect(navigation.navigate).toHaveBeenCalledWith(
       Routes.PERPS.FUNDING_TRANSACTION,

--- a/app/components/UI/Perps/utils/navigateToPerpsTransactionDetails.test.ts
+++ b/app/components/UI/Perps/utils/navigateToPerpsTransactionDetails.test.ts
@@ -28,11 +28,35 @@ const tradeTransaction: PerpsTransaction = {
   },
 };
 
+const depositTransaction: PerpsTransaction = {
+  id: 'deposit-1',
+  type: 'deposit',
+  category: 'deposit',
+  title: 'Deposit',
+  subtitle: 'USDC',
+  timestamp: 1698700000000,
+  asset: 'USDC',
+  depositWithdrawal: {
+    amount: '+$500',
+    amountNumber: 500,
+    isPositive: true,
+    asset: 'USDC',
+    txHash: '0xdeadbeef',
+    status: 'completed',
+    type: 'deposit',
+  },
+};
+
 describe('navigateToPerpsTransactionDetails', () => {
   it('opens Activity details for a mapped historic fill when redesign is enabled', () => {
     const navigation = createNavigation();
 
-    navigateToPerpsTransactionDetails(navigation, tradeTransaction, true);
+    navigateToPerpsTransactionDetails(
+      navigation,
+      tradeTransaction,
+      true,
+      false,
+    );
 
     expect(navigation.navigate).toHaveBeenCalledWith(
       Routes.ACTIVITY_DETAILS,
@@ -44,10 +68,34 @@ describe('navigateToPerpsTransactionDetails', () => {
     );
   });
 
+  it('tags testnet deposits with Arbitrum Sepolia', () => {
+    const navigation = createNavigation();
+
+    navigateToPerpsTransactionDetails(
+      navigation,
+      depositTransaction,
+      true,
+      true,
+    );
+
+    expect(navigation.navigate).toHaveBeenCalledWith(
+      Routes.ACTIVITY_DETAILS,
+      expect.objectContaining({
+        chainId: 'eip155:421614',
+        txIdentifier: '0xdeadbeef',
+      }),
+    );
+  });
+
   it('opens the legacy position screen for a mapped fill when redesign is disabled', () => {
     const navigation = createNavigation();
 
-    navigateToPerpsTransactionDetails(navigation, tradeTransaction, false);
+    navigateToPerpsTransactionDetails(
+      navigation,
+      tradeTransaction,
+      false,
+      false,
+    );
 
     expect(navigation.navigate).toHaveBeenCalledWith(
       Routes.PERPS.POSITION_TRANSACTION,
@@ -69,7 +117,7 @@ describe('navigateToPerpsTransactionDetails', () => {
       },
     };
 
-    navigateToPerpsTransactionDetails(navigation, unmappedTrade, true);
+    navigateToPerpsTransactionDetails(navigation, unmappedTrade, true, false);
 
     expect(navigation.navigate).toHaveBeenCalledWith(
       Routes.PERPS.POSITION_TRANSACTION,
@@ -89,7 +137,7 @@ describe('navigateToPerpsTransactionDetails', () => {
       asset: 'ETH',
     };
 
-    navigateToPerpsTransactionDetails(navigation, unmappedOrder, true);
+    navigateToPerpsTransactionDetails(navigation, unmappedOrder, true, false);
 
     expect(navigation.navigate).toHaveBeenCalledWith(
       Routes.PERPS.ORDER_TRANSACTION,
@@ -109,7 +157,7 @@ describe('navigateToPerpsTransactionDetails', () => {
       asset: 'ETH',
     };
 
-    navigateToPerpsTransactionDetails(navigation, unmappedFunding, true);
+    navigateToPerpsTransactionDetails(navigation, unmappedFunding, true, false);
 
     expect(navigation.navigate).toHaveBeenCalledWith(
       Routes.PERPS.FUNDING_TRANSACTION,

--- a/app/components/UI/Perps/utils/navigateToPerpsTransactionDetails.test.ts
+++ b/app/components/UI/Perps/utils/navigateToPerpsTransactionDetails.test.ts
@@ -1,0 +1,108 @@
+import Routes from '../../../../constants/navigation/Routes';
+import { FillType, type PerpsTransaction } from '../types/transactionHistory';
+import { navigateToPerpsTransactionDetails } from './navigateToPerpsTransactionDetails';
+
+const createNavigation = () => ({ navigate: jest.fn() });
+
+const tradeTransaction: PerpsTransaction = {
+  id: 'order-1',
+  type: 'trade',
+  category: 'position_close',
+  title: 'Closed short',
+  subtitle: '0.00016 BTC',
+  timestamp: 1698700000000,
+  asset: 'BTC',
+  fill: {
+    shortTitle: 'Closed short',
+    amount: '-$0.02',
+    amountNumber: -0.02,
+    isPositive: false,
+    size: '0.00016',
+    entryPrice: '63479',
+    pnl: '-0.02',
+    fee: '0.01',
+    points: '0',
+    feeToken: 'USDC',
+    action: 'Closed',
+    fillType: FillType.Standard,
+  },
+};
+
+describe('navigateToPerpsTransactionDetails', () => {
+  it('opens Activity details for a mapped historic fill', () => {
+    const navigation = createNavigation();
+
+    navigateToPerpsTransactionDetails(navigation, tradeTransaction);
+
+    expect(navigation.navigate).toHaveBeenCalledWith(
+      Routes.ACTIVITY_DETAILS,
+      expect.objectContaining({
+        chainId: 'eip155:42161',
+        txIdentifier: 'order-1',
+        preloadKey: expect.any(String),
+      }),
+    );
+  });
+
+  it('falls back to the legacy position screen when a trade cannot be mapped', () => {
+    const navigation = createNavigation();
+    const fill = tradeTransaction.fill;
+    if (!fill) {
+      throw new Error('expected fill on tradeTransaction');
+    }
+    const unmappedTrade: PerpsTransaction = {
+      ...tradeTransaction,
+      fill: {
+        ...fill,
+        shortTitle: 'Unknown fill',
+      },
+    };
+
+    navigateToPerpsTransactionDetails(navigation, unmappedTrade);
+
+    expect(navigation.navigate).toHaveBeenCalledWith(
+      Routes.PERPS.POSITION_TRANSACTION,
+      { transaction: unmappedTrade },
+    );
+  });
+
+  it('falls back to the legacy order screen when an order cannot be mapped', () => {
+    const navigation = createNavigation();
+    const unmappedOrder: PerpsTransaction = {
+      id: 'order-open-1',
+      type: 'order',
+      category: 'limit_order',
+      title: 'Limit long',
+      subtitle: '1 ETH',
+      timestamp: 1698700000000,
+      asset: 'ETH',
+    };
+
+    navigateToPerpsTransactionDetails(navigation, unmappedOrder);
+
+    expect(navigation.navigate).toHaveBeenCalledWith(
+      Routes.PERPS.ORDER_TRANSACTION,
+      { transaction: unmappedOrder },
+    );
+  });
+
+  it('falls back to the legacy funding screen when funding cannot be mapped', () => {
+    const navigation = createNavigation();
+    const unmappedFunding: PerpsTransaction = {
+      id: 'funding-1',
+      type: 'funding',
+      category: 'funding_fee',
+      title: 'Funding fee',
+      subtitle: 'ETH',
+      timestamp: 1698700000000,
+      asset: 'ETH',
+    };
+
+    navigateToPerpsTransactionDetails(navigation, unmappedFunding);
+
+    expect(navigation.navigate).toHaveBeenCalledWith(
+      Routes.PERPS.FUNDING_TRANSACTION,
+      { transaction: unmappedFunding },
+    );
+  });
+});

--- a/app/components/UI/Perps/utils/navigateToPerpsTransactionDetails.ts
+++ b/app/components/UI/Perps/utils/navigateToPerpsTransactionDetails.ts
@@ -1,37 +1,50 @@
 import type { NavigationProp, ParamListBase } from '@react-navigation/native';
-import { ARBITRUM_MAINNET_CAIP_CHAIN_ID } from '@metamask/perps-controller';
-import { USDC_ARBITRUM_MAINNET_ADDRESS } from '@metamask/perps-controller/constants/hyperLiquidConfig';
+import {
+  getCaipChainId,
+  USDC_ARBITRUM_MAINNET_ADDRESS,
+  USDC_ARBITRUM_TESTNET_ADDRESS,
+} from '@metamask/perps-controller/constants/hyperLiquidConfig';
 import type { CaipChainId } from '@metamask/utils';
 import Routes from '../../../../constants/navigation/Routes';
 import { mapPerpsTransaction } from '../../../../util/activity-adapters';
 import { getActivityDetailsRoute } from '../../../Views/ActivityList/getActivityDetailsRoute';
 import type { PerpsTransaction } from '../types/transactionHistory';
 
-/**
- * HyperLiquid settles on Arbitrum; same chain/collateral ids as
- * `usePerpsActivityItems` so a fill from Perps home/TDP resolves the same
- * Activity row as the unified list.
- */
-const PERPS_ACTIVITY_CHAIN_ID = ARBITRUM_MAINNET_CAIP_CHAIN_ID as CaipChainId;
-const PERPS_COLLATERAL_ASSET_ID = `${PERPS_ACTIVITY_CHAIN_ID}/erc20:${USDC_ARBITRUM_MAINNET_ADDRESS.toLowerCase()}`;
+function getPerpsActivityMappingIds(isTestnet: boolean): {
+  chainId: CaipChainId;
+  collateralAssetId: string;
+} {
+  const chainId = getCaipChainId(isTestnet) as CaipChainId;
+  const usdcAddress = (
+    isTestnet ? USDC_ARBITRUM_TESTNET_ADDRESS : USDC_ARBITRUM_MAINNET_ADDRESS
+  ).toLowerCase();
+  return {
+    chainId,
+    collateralAssetId: `${chainId}/erc20:${usdcAddress}`,
+  };
+}
 
 /**
  * Opens Activity details for a mapped Perps history row when
  * `selectIsTransactionsRedesignEnabled` is true. Callers pass that selector
- * result so this module stays store-free. Falls back to the legacy Perps
- * transaction screens when the flag is off or the row cannot be mapped
- * (open orders, unrecognized trades).
+ * result and the active Perps network (`usePerpsNetwork`) so this module stays
+ * store-free. Settlement chain and collateral follow HyperLiquid mainnet vs
+ * testnet. Falls back to the legacy Perps transaction screens when the flag is
+ * off or the row cannot be mapped (open orders, unrecognized trades).
  */
 export function navigateToPerpsTransactionDetails(
   navigation: Pick<NavigationProp<ParamListBase>, 'navigate'>,
   transaction: PerpsTransaction,
   isTransactionsRedesignEnabled: boolean,
+  isTestnet: boolean,
 ): void {
   if (isTransactionsRedesignEnabled) {
+    const { chainId, collateralAssetId } =
+      getPerpsActivityMappingIds(isTestnet);
     const item = mapPerpsTransaction({
       transaction,
-      chainId: PERPS_ACTIVITY_CHAIN_ID,
-      collateralAssetId: PERPS_COLLATERAL_ASSET_ID,
+      chainId,
+      collateralAssetId,
     });
     const detailsRoute = item ? getActivityDetailsRoute(item) : null;
     if (detailsRoute) {

--- a/app/components/UI/Perps/utils/navigateToPerpsTransactionDetails.ts
+++ b/app/components/UI/Perps/utils/navigateToPerpsTransactionDetails.ts
@@ -16,23 +16,28 @@ const PERPS_ACTIVITY_CHAIN_ID = ARBITRUM_MAINNET_CAIP_CHAIN_ID as CaipChainId;
 const PERPS_COLLATERAL_ASSET_ID = `${PERPS_ACTIVITY_CHAIN_ID}/erc20:${USDC_ARBITRUM_MAINNET_ADDRESS.toLowerCase()}`;
 
 /**
- * Opens Activity details for a mapped Perps history row. Falls back to the
- * legacy Perps transaction screens when the row cannot be mapped (open orders,
- * unrecognized trades).
+ * Opens Activity details for a mapped Perps history row when
+ * `selectIsTransactionsRedesignEnabled` is true. Callers pass that selector
+ * result so this module stays store-free. Falls back to the legacy Perps
+ * transaction screens when the flag is off or the row cannot be mapped
+ * (open orders, unrecognized trades).
  */
 export function navigateToPerpsTransactionDetails(
   navigation: Pick<NavigationProp<ParamListBase>, 'navigate'>,
   transaction: PerpsTransaction,
+  isTransactionsRedesignEnabled: boolean,
 ): void {
-  const item = mapPerpsTransaction({
-    transaction,
-    chainId: PERPS_ACTIVITY_CHAIN_ID,
-    collateralAssetId: PERPS_COLLATERAL_ASSET_ID,
-  });
-  const detailsRoute = item ? getActivityDetailsRoute(item) : null;
-  if (detailsRoute) {
-    navigation.navigate(Routes.ACTIVITY_DETAILS, detailsRoute);
-    return;
+  if (isTransactionsRedesignEnabled) {
+    const item = mapPerpsTransaction({
+      transaction,
+      chainId: PERPS_ACTIVITY_CHAIN_ID,
+      collateralAssetId: PERPS_COLLATERAL_ASSET_ID,
+    });
+    const detailsRoute = item ? getActivityDetailsRoute(item) : null;
+    if (detailsRoute) {
+      navigation.navigate(Routes.ACTIVITY_DETAILS, detailsRoute);
+      return;
+    }
   }
 
   if (transaction.type === 'trade') {

--- a/app/components/UI/Perps/utils/navigateToPerpsTransactionDetails.ts
+++ b/app/components/UI/Perps/utils/navigateToPerpsTransactionDetails.ts
@@ -1,0 +1,49 @@
+import type { NavigationProp, ParamListBase } from '@react-navigation/native';
+import { ARBITRUM_MAINNET_CAIP_CHAIN_ID } from '@metamask/perps-controller';
+import { USDC_ARBITRUM_MAINNET_ADDRESS } from '@metamask/perps-controller/constants/hyperLiquidConfig';
+import type { CaipChainId } from '@metamask/utils';
+import Routes from '../../../../constants/navigation/Routes';
+import { mapPerpsTransaction } from '../../../../util/activity-adapters';
+import { getActivityDetailsRoute } from '../../../Views/ActivityList/getActivityDetailsRoute';
+import type { PerpsTransaction } from '../types/transactionHistory';
+
+/**
+ * HyperLiquid settles on Arbitrum; same chain/collateral ids as
+ * `usePerpsActivityItems` so a fill from Perps home/TDP resolves the same
+ * Activity row as the unified list.
+ */
+const PERPS_ACTIVITY_CHAIN_ID = ARBITRUM_MAINNET_CAIP_CHAIN_ID as CaipChainId;
+const PERPS_COLLATERAL_ASSET_ID = `${PERPS_ACTIVITY_CHAIN_ID}/erc20:${USDC_ARBITRUM_MAINNET_ADDRESS.toLowerCase()}`;
+
+/**
+ * Opens Activity details for a mapped Perps history row. Falls back to the
+ * legacy Perps transaction screens when the row cannot be mapped (open orders,
+ * unrecognized trades).
+ */
+export function navigateToPerpsTransactionDetails(
+  navigation: Pick<NavigationProp<ParamListBase>, 'navigate'>,
+  transaction: PerpsTransaction,
+): void {
+  const item = mapPerpsTransaction({
+    transaction,
+    chainId: PERPS_ACTIVITY_CHAIN_ID,
+    collateralAssetId: PERPS_COLLATERAL_ASSET_ID,
+  });
+  const detailsRoute = item ? getActivityDetailsRoute(item) : null;
+  if (detailsRoute) {
+    navigation.navigate(Routes.ACTIVITY_DETAILS, detailsRoute);
+    return;
+  }
+
+  if (transaction.type === 'trade') {
+    navigation.navigate(Routes.PERPS.POSITION_TRANSACTION, { transaction });
+    return;
+  }
+  if (transaction.type === 'order') {
+    navigation.navigate(Routes.PERPS.ORDER_TRANSACTION, { transaction });
+    return;
+  }
+  if (transaction.type === 'funding') {
+    navigation.navigate(Routes.PERPS.FUNDING_TRANSACTION, { transaction });
+  }
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

In lite mode, tapping a historic Perps fill from home, market details, or the Perps activity list opened `PerpsPositionTransactionView`. Mapped fills now open the same Activity details screen as the Activity tab (status pill, amount header, View on block explorer, then Trade again).

Navigation stays behind `selectIsTransactionsRedesignEnabled`. Flag-off cohorts keep the legacy Perps detail screens.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed historic Perps trades in lite mode opening the old details screen instead of Activity details

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3790

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: lite Perps historic trade details

  Scenario: tap a closed fill from Perps home (flag on)
    Given lite mode, Activity details rollout enabled, and a closed ETH fill in Recent Activity
    When the user taps Closed long
    Then Activity details shows Status Confirmed, size, close price, fees, net P&L, View on block explorer, and Trade again

  Scenario: tap a closed fill from market details (flag on)
    Given the ETH market details screen with historic trades
    When the user taps Closed long
    Then the same Activity details screen opens

  Scenario: flag off
    Given selectIsTransactionsRedesignEnabled is false
    When the user taps the same fill
    Then the legacy Perps position details screen opens
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<table>
<tr>
<td align="center" width="50%"><strong>Before</strong><br/>Old Perps trade details<br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/TAT-3790-dev-recent-trade-tdp-activity-2245/00-before-old-trade-details.png" alt="Before: old Perps trade details" width="400" /></td>
<td align="center" width="50%"><strong>After</strong><br/>Activity details for the same fill<br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/TAT-3790-dev-recent-trade-tdp-activity-2245/01-ui-screenshot-screenshot.png" alt="After: Activity details" width="400" /></td>
</tr>
</table>

Market details uses the same after screen.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - N/A: navigation routing only, proved on iOS mm-2
- [ ] I've tested with a power user scenario
  - N/A
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ef399500dbae7ee55d75d2a9996c1b963f57cddb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->