### PR TITLE
feat(rewards): show Money Sweepstakes outcome draw rank

### DIFF
--- a/app/components/UI/Rewards/Views/MoneyAccountSweepstakesCampaignWinningView.test.tsx
+++ b/app/components/UI/Rewards/Views/MoneyAccountSweepstakesCampaignWinningView.test.tsx
@@ -34,7 +34,7 @@ jest.mock('@react-navigation/native', () => ({
 }));
 
 jest.mock('../utils/formatUtils', () => ({
-  formatUsd: (value: number) => `$${value.toFixed(2)}`,
+  formatOrdinalRank: (rank: number) => `${rank}-rank`,
 }));
 
 const mockUseOutcome = useMoneyAccountSweepstakesOutcome as jest.MockedFunction<
@@ -53,6 +53,7 @@ describe('MoneyAccountSweepstakesCampaignWinningView', () => {
         outcomeStatus: 'pending',
         winnerVerificationCode: 'MAS-WIN-42',
         prizeAmountUsd: 250,
+        rank: 2,
       },
       isLoading: false,
       hasError: false,
@@ -86,7 +87,7 @@ describe('MoneyAccountSweepstakesCampaignWinningView', () => {
         winningCode: 'MAS-WIN-42',
         hasOutcomeLoaded: true,
         isLoading: false,
-        rankDisplay: '$250.00',
+        rankDisplay: '2-rank',
         isRankLoading: false,
         fallbackRoute: {
           route: Routes.REWARDS_MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_DETAILS_VIEW,
@@ -97,13 +98,14 @@ describe('MoneyAccountSweepstakesCampaignWinningView', () => {
     );
   });
 
-  it('passes null winning code and rank when outcome has no prize data', () => {
+  it('passes null winning code and rank when outcome has no winner data', () => {
     mockUseOutcome.mockReturnValue({
       outcome: {
         subscriptionId: 'sub-1',
         outcomeStatus: 'finalized',
         winnerVerificationCode: null,
         prizeAmountUsd: null,
+        rank: null,
       },
       isLoading: false,
       hasError: false,

--- a/app/components/UI/Rewards/Views/MoneyAccountSweepstakesCampaignWinningView.tsx
+++ b/app/components/UI/Rewards/Views/MoneyAccountSweepstakesCampaignWinningView.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { useRoute, RouteProp } from '@react-navigation/native';
 import { useMoneyAccountSweepstakesOutcome } from '../hooks/useMoneyAccountSweepstakesOutcome';
-import { formatUsd } from '../utils/formatUtils';
+import { formatOrdinalRank } from '../utils/formatUtils';
 import CampaignWinningView from './CampaignWinningView';
 import Routes from '../../../../constants/navigation/Routes';
 import { REWARDS_WINNER_CONTACT_EMAIL } from '../constants/campaignWinnerContact';
@@ -33,11 +33,11 @@ const MoneyAccountSweepstakesCampaignWinningView: React.FC = () => {
   const winningCode = outcome?.winnerVerificationCode ?? null;
 
   const rankDisplay = useMemo(() => {
-    if (outcome?.prizeAmountUsd == null) {
+    if (!outcome?.rank) {
       return null;
     }
-    return formatUsd(outcome.prizeAmountUsd);
-  }, [outcome?.prizeAmountUsd]);
+    return formatOrdinalRank(outcome.rank);
+  }, [outcome?.rank]);
 
   const fallbackRoute = useMemo(
     () => ({

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -1643,6 +1643,8 @@ export interface MoneyAccountSweepstakesDrawProofDto {
 export interface MoneyAccountSweepstakesOutcomeDto
   extends BaseCampaignParticipantOutcomeDto {
   prizeAmountUsd?: number | null;
+  /** 1-based draw position; same as draw-proof originalRank / drawOrder. */
+  rank?: number | null;
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Adds `rank` to the Money Account Sweepstakes outcome client type and shows it as an ordinal on the winning screen. Previously `rankDisplay` incorrectly showed `prizeAmountUsd`; prize amount is no longer rendered on this view.

Depends on the API change that exposes `rank` from `winner.draw_order` (same value as draw-proof `originalRank`).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: Money Account Sweepstakes winning UX / outcome rank wiring

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money Sweepstakes winning rank

  Scenario: winner sees ordinal draw rank
    Given the user has a Money Sweepstakes winner outcome with rank and verification code
    When the user opens the Money Sweepstakes campaign winning view
    Then an ordinal rank (for example "2nd") is shown
    And prize amount is not shown as the rank

  Scenario: missing rank
    Given the outcome has no rank
    When the user opens the winning view
    Then no rank display is shown
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — unit-covered wiring; visual verification pending once API rank is available in the environment under test.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)