### PR TITLE
feat(predict-next): add football feed previews

### DIFF
--- a/app/components/UI/PredictNext/CONTEXT.md
+++ b/app/components/UI/PredictNext/CONTEXT.md
@@ -44,6 +44,10 @@ _Avoid_: Venue Account, sub-wallet
 A product-owned, ordered selection of Events for a navigation surface. A Feed may represent a Category, curated collection, or supported filter combination.
 _Avoid_: Venue series, raw Event query, client-side category
 
+**Feed Screen**:
+A product navigation surface that presents one or more related Feeds. Each selectable tab on a Feed Screen identifies one Feed; the first tab is the default when no tab is requested.
+_Avoid_: Feed, Competition screen, backend Feed hierarchy
+
 **Event**:
 A grouping of one or more related binary Markets from exactly one Venue Event, such as "2026 NBA Finals" or "Will ETH hit $5k?". An Event may have one Category and one Series.
 _Avoid_: Market, PredictMarket, composite Venue Events
@@ -236,6 +240,7 @@ _Avoid_: New Venue, backend provider, opaque proxy
 - Account Setup can change Account Readiness from setup-required to ready.
 - Account Readiness is distinct from Balance and Venue Status; a Predict User can be ready with zero Balance, or funded while a Venue is unavailable.
 - A Feed contains zero or more Events and owns their membership, ordering, and pagination semantics.
+- A Feed Screen contains one or more ordered tabs, and each tab identifies exactly one Feed.
 - Each Event maps to exactly one Venue Event and contains one or more Markets; Predict never combines Markets from multiple Venue Events into one Event.
 - Each Event may have one primary Category and one Series.
 - A Category is product-owned and is distinct from Venue tags and future Topics.

--- a/app/components/UI/PredictNext/navigation/PredictNextStack.tsx
+++ b/app/components/UI/PredictNext/navigation/PredictNextStack.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { PredictHome } from '../views/PredictHome/PredictHome';
 import { PredictEventDetail } from '../views/PredictEventDetail/PredictEventDetail';
+import { PredictFeedScreen } from '../views/PredictFeedScreen/PredictFeedScreen';
 import type { PredictNextHomeParams, PredictNextStackParamList } from './types';
 import { PredictNextRoutes } from './routes';
 
@@ -21,6 +22,7 @@ const PredictNextStack = ({ initialParams }: PredictNextStackProps) => (
       component={PredictHome}
       initialParams={initialParams}
     />
+    <Stack.Screen name={PredictNextRoutes.FEED} component={PredictFeedScreen} />
     <Stack.Screen
       name={PredictNextRoutes.EVENT_DETAIL}
       component={PredictEventDetail}

--- a/app/components/UI/PredictNext/navigation/feedScreens.ts
+++ b/app/components/UI/PredictNext/navigation/feedScreens.ts
@@ -1,0 +1,54 @@
+import type { PredictFeedId } from '../types';
+
+export const NFL_FEED_SCREEN_ID = 'sports-football-nfl';
+export const NCAA_FEED_SCREEN_ID = 'sports-football-ncaa';
+
+interface FeedScreenTabDefinition {
+  id: string;
+  label: string;
+  feedId: PredictFeedId;
+}
+
+export interface FeedScreenDefinition {
+  title: string;
+  selectionLabel?: string;
+  tabs: readonly FeedScreenTabDefinition[];
+}
+
+export const FEED_SCREENS = {
+  [NFL_FEED_SCREEN_ID]: {
+    title: 'Sports',
+    selectionLabel: 'NFL',
+    tabs: [
+      {
+        id: 'games',
+        label: 'Games',
+        feedId: 'sports-football-nfl-games' as PredictFeedId,
+      },
+    ],
+  },
+  [NCAA_FEED_SCREEN_ID]: {
+    title: 'Sports',
+    selectionLabel: 'NCAAF',
+    tabs: [
+      {
+        id: 'games',
+        label: 'Games',
+        feedId: 'sports-football-ncaa-games' as PredictFeedId,
+      },
+    ],
+  },
+} as const satisfies Record<string, FeedScreenDefinition>;
+
+export type FeedScreenId = keyof typeof FEED_SCREENS;
+
+export const getFeedScreen = (
+  feedScreenId: string,
+): FeedScreenDefinition | undefined =>
+  FEED_SCREENS[feedScreenId as FeedScreenId];
+
+export const getFeedScreenTab = (
+  definition: FeedScreenDefinition,
+  selectedTabId?: string,
+): FeedScreenTabDefinition =>
+  definition.tabs.find(({ id }) => id === selectedTabId) ?? definition.tabs[0];

--- a/app/components/UI/PredictNext/navigation/routes.ts
+++ b/app/components/UI/PredictNext/navigation/routes.ts
@@ -1,4 +1,5 @@
 export const PredictNextRoutes = {
   HOME: 'PredictNextHome',
+  FEED: 'PredictNextFeed',
   EVENT_DETAIL: 'PredictNextEventDetail',
 } as const;

--- a/app/components/UI/PredictNext/navigation/types.ts
+++ b/app/components/UI/PredictNext/navigation/types.ts
@@ -1,5 +1,6 @@
 import type { PredictEntityId, PredictVenueId } from '../types';
 import type { PredictEntryPoint } from '../../Predict/types/navigation';
+import type { FeedScreenId } from './feedScreens';
 
 export interface PredictNextHomeParams {
   entryPoint?: PredictEntryPoint;
@@ -11,9 +12,16 @@ export interface PredictNextEventDetailParams {
   title: string;
 }
 
+export interface PredictNextFeedParams {
+  venueId: PredictVenueId;
+  feedScreenId: FeedScreenId;
+  selectedTabId?: string;
+}
+
 // ParamListBase requires a type alias.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type PredictNextStackParamList = {
   PredictNextHome: PredictNextHomeParams | undefined;
+  PredictNextFeed: PredictNextFeedParams;
   PredictNextEventDetail: PredictNextEventDetailParams;
 };

--- a/app/components/UI/PredictNext/views/PredictFeedScreen/PredictFeedScreen.testIds.ts
+++ b/app/components/UI/PredictNext/views/PredictFeedScreen/PredictFeedScreen.testIds.ts
@@ -1,0 +1,5 @@
+export const PredictFeedScreenTestIds = {
+  VIEW: 'predict-next-feed-screen',
+  BACK: 'predict-next-feed-screen-back',
+  UNAVAILABLE: 'predict-next-feed-screen-unavailable',
+} as const;

--- a/app/components/UI/PredictNext/views/PredictFeedScreen/PredictFeedScreen.tsx
+++ b/app/components/UI/PredictNext/views/PredictFeedScreen/PredictFeedScreen.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {
+  useNavigation,
+  useRoute,
+  type RouteProp,
+} from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import {
+  Box,
+  Button,
+  ButtonVariant,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { getFeedScreen } from '../../navigation/feedScreens';
+import { PredictNextRoutes } from '../../navigation/routes';
+import type { PredictNextStackParamList } from '../../navigation/types';
+import { PredictFeedScreenTestIds } from './PredictFeedScreen.testIds';
+
+export const PredictFeedScreen = () => {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<PredictNextStackParamList>>();
+  const { feedScreenId } =
+    useRoute<RouteProp<PredictNextStackParamList, 'PredictNextFeed'>>().params;
+  const definition = getFeedScreen(feedScreenId);
+
+  const handleBack = () =>
+    navigation.canGoBack()
+      ? navigation.goBack()
+      : navigation.navigate(PredictNextRoutes.HOME);
+
+  if (!definition) {
+    return (
+      <Box
+        testID={PredictFeedScreenTestIds.UNAVAILABLE}
+        twClassName="flex-1 gap-6 p-4 pt-12"
+      >
+        <Button
+          testID={PredictFeedScreenTestIds.BACK}
+          variant={ButtonVariant.Tertiary}
+          onPress={handleBack}
+        >
+          Back
+        </Button>
+        <Text>This feed is unavailable.</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      testID={PredictFeedScreenTestIds.VIEW}
+      twClassName="flex-1 gap-3 p-4 pt-12"
+    >
+      <Button
+        testID={PredictFeedScreenTestIds.BACK}
+        variant={ButtonVariant.Tertiary}
+        onPress={handleBack}
+      >
+        Back
+      </Button>
+      <Text variant={TextVariant.HeadingLg}>{definition.title}</Text>
+      {definition.selectionLabel ? (
+        <Text variant={TextVariant.HeadingMd}>{definition.selectionLabel}</Text>
+      ) : null}
+    </Box>
+  );
+};

--- a/app/components/UI/PredictNext/views/PredictFeedScreen/PredictFeedScreen.view.test.tsx
+++ b/app/components/UI/PredictNext/views/PredictFeedScreen/PredictFeedScreen.view.test.tsx
@@ -1,0 +1,24 @@
+import '../../../../../../tests/component-view/mocks';
+import { renderPredictFeedScreen } from '../../../../../../tests/component-view/renderers/predictNext';
+import { fireEvent } from '@testing-library/react-native';
+import { KALSHI_VENUE_ID } from '../../types';
+import { PredictHomeTestIds } from '../PredictHome/PredictHome.testIds';
+import { PredictFeedScreenTestIds } from './PredictFeedScreen.testIds';
+
+const invalidFeedScreenParams = {
+  venueId: KALSHI_VENUE_ID,
+  feedScreenId: 'missing-feed-screen',
+} as unknown as Parameters<typeof renderPredictFeedScreen>[0];
+
+describe('PredictFeedScreen', () => {
+  it('shows an unavailable state for an unknown Feed Screen and returns Home', async () => {
+    const view = renderPredictFeedScreen(invalidFeedScreenParams);
+
+    expect(
+      await view.findByTestId(PredictFeedScreenTestIds.UNAVAILABLE),
+    ).toBeOnTheScreen();
+    fireEvent.press(view.getByTestId(PredictFeedScreenTestIds.BACK));
+
+    expect(await view.findByTestId(PredictHomeTestIds.HOME)).toBeOnTheScreen();
+  });
+});

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.testIds.ts
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.testIds.ts
@@ -1,11 +1,18 @@
 export const PredictHomeTestIds = {
   HOME: 'predict-next-home',
-  LOADING: 'predict-next-loading',
-  ERROR: 'predict-next-error',
-  EMPTY: 'predict-next-empty',
-  FEED: 'predict-next-event-feed',
-  FOOTER_LOADING: 'predict-next-footer-loading',
-  FOOTER_RETRY: 'predict-next-footer-retry',
+  SCROLL: 'predict-next-home-scroll',
+  section: (feedScreenId: string) =>
+    `predict-next-home-section-${feedScreenId}`,
+  sectionHeader: (feedScreenId: string) =>
+    `predict-next-home-section-header-${feedScreenId}`,
+  sectionLoading: (feedScreenId: string) =>
+    `predict-next-home-section-loading-${feedScreenId}`,
+  sectionError: (feedScreenId: string) =>
+    `predict-next-home-section-error-${feedScreenId}`,
+  sectionEmpty: (feedScreenId: string) =>
+    `predict-next-home-section-empty-${feedScreenId}`,
+  sectionRetry: (feedScreenId: string) =>
+    `predict-next-home-section-retry-${feedScreenId}`,
   event: (venueId: string, eventId: string) =>
     `predict-next-event-${venueId}-${eventId}`,
   eventContent: (venueId: string, eventId: string) =>

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.testIds.ts
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.testIds.ts
@@ -19,6 +19,8 @@ export const PredictHomeTestIds = {
     `predict-next-event-content-${venueId}-${eventId}`,
   outcome: (eventId: string, side: 'yes' | 'no') =>
     `predict-next-outcome-${eventId}-${side}`,
+  gameQuote: (eventId: string, selection: 'away' | 'home') =>
+    `predict-next-game-quote-${eventId}-${selection}`,
   image: (eventId: string) => `predict-next-event-image-${eventId}`,
   category: (eventId: string) => `predict-next-event-category-${eventId}`,
   volume: (eventId: string) => `predict-next-event-volume-${eventId}`,

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.tsx
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { FlashList, type ListRenderItemInfo } from '@shopify/flash-list';
+import React, { useCallback } from 'react';
+import { ScrollView } from 'react-native';
 import {
   type RouteProp,
   useFocusEffect,
@@ -7,59 +7,31 @@ import {
   useRoute,
 } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import {
-  Box,
-  Button,
-  ButtonVariant,
-  Text,
-  TextVariant,
-} from '@metamask/design-system-react-native';
-import { useFeed } from '../../hooks/useFeed';
+import { Box, Text, TextVariant } from '@metamask/design-system-react-native';
 import { usePredictNextMeasurement } from '../../hooks/usePredictNextMeasurement';
-import { useVenueStatus } from '../../hooks/useVenueStatus';
+import { useFeed } from '../../hooks/useFeed';
 import {
-  KALSHI_VENUE_ID,
-  type PredictEvent,
-  type PredictFeedId,
-} from '../../types';
-import { EventCardGame, EventCardStandard } from '../../events/cards';
-import type { PredictNextStackParamList } from '../../navigation/types';
+  FEED_SCREENS,
+  NCAA_FEED_SCREEN_ID,
+  NFL_FEED_SCREEN_ID,
+  getFeedScreenTab,
+  type FeedScreenId,
+} from '../../navigation/feedScreens';
 import { PredictNextRoutes } from '../../navigation/routes';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import type { PredictNextStackParamList } from '../../navigation/types';
+import { KALSHI_VENUE_ID, type PredictEvent } from '../../types';
 import Engine from '../../../../../core/Engine';
 import { TraceName } from '../../../../../util/trace';
+import { FeedPreviewSection } from './internal/FeedPreviewSection';
+import { PredictHomeTestIds } from './PredictHome.testIds';
 
-const PAGE_SIZE = 20;
-const NFL_GAMES_FEED_ID = 'sports-football-nfl-games' as PredictFeedId;
-
-const EventSeparator = () => <Box twClassName="h-3" />;
-
-const isAmericanFootballGameEvent = (event: PredictEvent): boolean =>
-  event.sports?.sport.id === 'american-football' && Boolean(event.sports.game);
-
-const getEventItemType = (event: PredictEvent): 'game' | 'standard' =>
-  isAmericanFootballGameEvent(event) ? 'game' : 'standard';
-
-interface EventFeedItemProps {
-  event: PredictEvent;
-  onOpenEvent: (event: PredictEvent) => void;
-}
-
-const EventFeedItem = React.memo(
-  ({ event, onOpenEvent }: EventFeedItemProps) => {
-    const handlePress = useCallback(
-      () => onOpenEvent(event),
-      [event, onOpenEvent],
-    );
-
-    return isAmericanFootballGameEvent(event) ? (
-      <EventCardGame event={event} onPress={handlePress} />
-    ) : (
-      <EventCardStandard event={event} onPress={handlePress} />
-    );
-  },
-);
-EventFeedItem.displayName = 'EventFeedItem';
+const PREVIEW_LIMIT = 2;
+const NFL_GAMES_FEED_ID = getFeedScreenTab(
+  FEED_SCREENS[NFL_FEED_SCREEN_ID],
+).feedId;
+const NCAA_GAMES_FEED_ID = getFeedScreenTab(
+  FEED_SCREENS[NCAA_FEED_SCREEN_ID],
+).feedId;
 
 export const PredictHome = () => {
   const navigation =
@@ -67,31 +39,25 @@ export const PredictHome = () => {
   const route =
     useRoute<RouteProp<PredictNextStackParamList, 'PredictNextHome'>>();
   const entryPoint = route.params?.entryPoint;
-  const eventsQuery = useFeed(KALSHI_VENUE_ID, NFL_GAMES_FEED_ID, {
-    limit: PAGE_SIZE,
+  const nflQuery = useFeed(KALSHI_VENUE_ID, NFL_GAMES_FEED_ID, {
+    limit: PREVIEW_LIMIT,
   });
-  const events = useMemo(
-    () => eventsQuery.data?.pages.flatMap((page) => page.events) ?? [],
-    [eventsQuery.data],
-  );
-  const needsVenueStatus =
-    !eventsQuery.isLoading && !eventsQuery.isError && events.length === 0;
-  const statusQuery = useVenueStatus(KALSHI_VENUE_ID, {
-    enabled: needsVenueStatus,
+  const ncaaQuery = useFeed(KALSHI_VENUE_ID, NCAA_GAMES_FEED_ID, {
+    limit: PREVIEW_LIMIT,
   });
-  const endReached = useRef(false);
-  const [paginationError, setPaginationError] = useState(false);
+  const nflEvents =
+    nflQuery.data?.pages[0]?.events.slice(0, PREVIEW_LIMIT) ?? [];
+  const ncaaEvents =
+    ncaaQuery.data?.pages[0]?.events.slice(0, PREVIEW_LIMIT) ?? [];
 
   usePredictNextMeasurement({
     traceName: TraceName.PredictNextHomeView,
-    conditions: [
-      !eventsQuery.isLoading,
-      events.length > 0 || eventsQuery.isError || !statusQuery.isLoading,
-    ],
+    conditions: [!nflQuery.isLoading, !ncaaQuery.isLoading],
     debugContext: {
-      eventCount: events.length,
-      eventsError: eventsQuery.isError,
-      venueStatus: statusQuery.data?.status ?? 'unknown',
+      nflEventCount: nflEvents.length,
+      nflError: nflQuery.isError,
+      ncaaEventCount: ncaaEvents.length,
+      ncaaError: ncaaQuery.isError,
     },
   });
 
@@ -107,8 +73,14 @@ export const PredictHome = () => {
     }, [entryPoint, navigation]),
   );
 
-  const tw = useTailwind();
-
+  const openFeedScreen = useCallback(
+    (feedScreenId: FeedScreenId) =>
+      navigation.navigate(PredictNextRoutes.FEED, {
+        venueId: KALSHI_VENUE_ID,
+        feedScreenId,
+      }),
+    [navigation],
+  );
   const openEvent = useCallback(
     (event: PredictEvent) =>
       navigation.navigate(PredictNextRoutes.EVENT_DETAIL, {
@@ -118,96 +90,34 @@ export const PredictHome = () => {
       }),
     [navigation],
   );
-  const renderEvent = useCallback(
-    ({ item }: ListRenderItemInfo<PredictEvent>) => (
-      <EventFeedItem event={item} onOpenEvent={openEvent} />
-    ),
-    [openEvent],
-  );
-  const retryAll = () => {
-    eventsQuery.refetch();
-    if (needsVenueStatus) {
-      statusQuery.refetch();
-    }
-  };
-  const loadNextPage = () => {
-    if (
-      !endReached.current &&
-      eventsQuery.hasNextPage &&
-      !eventsQuery.isFetchingNextPage
-    ) {
-      endReached.current = true;
-      eventsQuery
-        .fetchNextPage()
-        .then((result) => setPaginationError(result.isError))
-        .catch(() => setPaginationError(true))
-        .finally(() => {
-          endReached.current = false;
-        });
-    }
-  };
-
-  let blockingContent: React.ReactNode;
-  if (eventsQuery.isLoading) {
-    blockingContent = (
-      <Box testID="predict-next-loading" twClassName="gap-4 p-4">
-        <Box twClassName="h-32 rounded-xl bg-muted" />
-        <Box twClassName="h-32 rounded-xl bg-muted" />
-      </Box>
-    );
-  } else if (events.length === 0 && eventsQuery.isError) {
-    blockingContent = (
-      <Box testID="predict-next-error" twClassName="items-center gap-4 p-8">
-        <Text>Predictions could not be loaded.</Text>
-        <Button onPress={retryAll}>Retry</Button>
-      </Box>
-    );
-  } else if (events.length === 0) {
-    blockingContent = (
-      <Box testID="predict-next-empty" twClassName="items-center gap-4 p-8">
-        <Text>
-          {statusQuery.data?.status === 'unavailable'
-            ? 'Predictions are unavailable.'
-            : 'No predictions yet.'}
-        </Text>
-        {statusQuery.data?.status === 'unavailable' ? (
-          <Button onPress={retryAll}>Retry</Button>
-        ) : null}
-      </Box>
-    );
-  }
 
   return (
-    <Box twClassName="flex-1 pt-12" testID="predict-next-home">
-      <Box twClassName="px-4 pb-2">
-        <Text variant={TextVariant.HeadingLg}>Predictions</Text>
-      </Box>
-      {blockingContent ?? (
-        <FlashList
-          testID="predict-next-event-feed"
-          data={events}
-          renderItem={renderEvent}
-          getItemType={getEventItemType}
-          keyExtractor={(event) => `${event.venueId}:${event.id}`}
-          onEndReached={loadNextPage}
-          onEndReachedThreshold={0.5}
-          ItemSeparatorComponent={EventSeparator}
-          contentContainerStyle={tw.style('px-4')}
-          ListFooterComponent={
-            eventsQuery.isFetchingNextPage ? (
-              <Text testID="predict-next-footer-loading">Loading…</Text>
-            ) : paginationError ? (
-              <Button
-                testID="predict-next-footer-retry"
-                variant={ButtonVariant.Tertiary}
-                onPress={loadNextPage}
-              >
-                Retry
-              </Button>
-            ) : null
-          }
-        />
-      )}
+    <Box twClassName="flex-1 pt-12" testID={PredictHomeTestIds.HOME}>
+      <ScrollView testID={PredictHomeTestIds.SCROLL}>
+        <Box twClassName="gap-6 px-4 pb-8">
+          <Text variant={TextVariant.HeadingLg}>Predictions</Text>
+          <FeedPreviewSection
+            feedScreenId={NFL_FEED_SCREEN_ID}
+            title={FEED_SCREENS[NFL_FEED_SCREEN_ID].selectionLabel}
+            events={nflEvents}
+            isLoading={nflQuery.isLoading}
+            isError={nflQuery.isError}
+            onOpen={() => openFeedScreen(NFL_FEED_SCREEN_ID)}
+            onOpenEvent={openEvent}
+            onRetry={() => nflQuery.refetch()}
+          />
+          <FeedPreviewSection
+            feedScreenId={NCAA_FEED_SCREEN_ID}
+            title={FEED_SCREENS[NCAA_FEED_SCREEN_ID].selectionLabel}
+            events={ncaaEvents}
+            isLoading={ncaaQuery.isLoading}
+            isError={ncaaQuery.isError}
+            onOpen={() => openFeedScreen(NCAA_FEED_SCREEN_ID)}
+            onOpenEvent={openEvent}
+            onRetry={() => ncaaQuery.refetch()}
+          />
+        </Box>
+      </ScrollView>
     </Box>
   );
 };

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.view.test.tsx
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.view.test.tsx
@@ -5,7 +5,12 @@ import { fireEvent, waitFor, within } from '@testing-library/react-native';
 import { PredictHomeTestIds } from './PredictHome.testIds';
 import { PredictEventDetailTestIds } from '../PredictEventDetail/PredictEventDetail.testIds';
 import { PredictFeedScreenTestIds } from '../PredictFeedScreen/PredictFeedScreen.testIds';
-import type { PredictEvent, PredictFeedId } from '../../types';
+import type {
+  PredictEntityId,
+  PredictEvent,
+  PredictFeedId,
+  PredictTimestamp,
+} from '../../types';
 import { PredictEventValues } from '../../../Predict/constants/eventNames';
 import {
   NCAA_FEED_SCREEN_ID,
@@ -43,13 +48,69 @@ const makeEvent = (id: string, title: string): PredictEvent => ({
   ],
 });
 
+const makeGameEvent = (
+  id: string,
+  awayTeam: string,
+  homeTeam: string,
+  competition: string,
+): PredictEvent => ({
+  ...makeEvent(id, `${awayTeam} vs ${homeTeam}`),
+  sports: {
+    sport: {
+      id: 'american-football' as PredictEntityId,
+      label: 'American football',
+    },
+    competition: {
+      id: competition.toLowerCase() as PredictEntityId,
+      label: competition,
+    },
+    game: {
+      status: 'in_progress',
+      awayTeam: { name: awayTeam, abbreviation: awayTeam.slice(0, 3) },
+      homeTeam: { name: homeTeam, abbreviation: homeTeam.slice(0, 3) },
+      score: { away: '17', home: '21' },
+      period: 'Q4',
+      clock: '12:22',
+      observedAt: '2026-08-19T12:00:00Z' as PredictTimestamp,
+    },
+  },
+  markets: [
+    {
+      ...makeEvent(id, '').markets[0],
+      id: `${id}-away-market` as PredictEntityId,
+      outcomes: [
+        {
+          ...makeEvent(id, '').markets[0].outcomes[0],
+          gameSelection: 'away',
+        },
+        makeEvent(id, '').markets[0].outcomes[1],
+      ],
+    },
+    {
+      ...makeEvent(id, '').markets[0],
+      id: `${id}-home-market` as PredictEntityId,
+      outcomes: [
+        {
+          ...makeEvent(id, '').markets[0].outcomes[0],
+          id: `${id}-home-yes` as PredictEntityId,
+          gameSelection: 'home',
+        },
+        {
+          ...makeEvent(id, '').markets[0].outcomes[1],
+          id: `${id}-home-no` as PredictEntityId,
+        },
+      ],
+    },
+  ],
+});
+
 const nflEvents = [
-  makeEvent('nfl-1', 'Packers vs Steelers'),
-  makeEvent('nfl-2', 'Panthers vs Cardinals'),
+  makeGameEvent('nfl-1', 'Packers', 'Steelers', 'NFL'),
+  makeGameEvent('nfl-2', 'Panthers', 'Cardinals', 'NFL'),
 ];
 const ncaaEvents = [
-  makeEvent('ncaa-1', 'Pittsburgh vs Miami'),
-  makeEvent('ncaa-2', 'Georgia vs Florida'),
+  makeGameEvent('ncaa-1', 'Pittsburgh', 'Miami', 'NCAAF'),
+  makeGameEvent('ncaa-2', 'Georgia', 'Florida', 'NCAAF'),
 ];
 
 const messengerCall = Engine.controllerMessenger.call as unknown as jest.Mock;
@@ -112,17 +173,41 @@ describe('PredictHome', () => {
       { limit: 2 },
       undefined,
     );
-    expect(await view.findByText('Packers vs Steelers')).toBeOnTheScreen();
-    expect(view.getByText('Panthers vs Cardinals')).toBeOnTheScreen();
+    const firstNflCard = await view.findByTestId(
+      PredictHomeTestIds.event('kalshi', 'nfl-1'),
+    );
+    expect(within(firstNflCard).getByText('Packers')).toBeOnTheScreen();
+    expect(within(firstNflCard).getByText('Steelers')).toBeOnTheScreen();
+    expect(within(firstNflCard).getByText('17')).toBeOnTheScreen();
+    expect(within(firstNflCard).getByText('21')).toBeOnTheScreen();
+    expect(within(firstNflCard).getByText('NFL')).toBeOnTheScreen();
+    expect(within(firstNflCard).getByText('$1.5M Vol')).toBeOnTheScreen();
+
+    const secondNflCard = view.getByTestId(
+      PredictHomeTestIds.event('kalshi', 'nfl-2'),
+    );
+    expect(within(secondNflCard).getByText('Panthers')).toBeOnTheScreen();
+    expect(within(secondNflCard).getByText('Cardinals')).toBeOnTheScreen();
     expect(view.queryByText('Hidden NFL Game')).not.toBeOnTheScreen();
-    expect(view.getByText('Pittsburgh vs Miami')).toBeOnTheScreen();
-    expect(view.getByText('Georgia vs Florida')).toBeOnTheScreen();
+
+    const firstNcaaCard = view.getByTestId(
+      PredictHomeTestIds.event('kalshi', 'ncaa-1'),
+    );
+    expect(within(firstNcaaCard).getByText('Pittsburgh')).toBeOnTheScreen();
+    expect(within(firstNcaaCard).getByText('Miami')).toBeOnTheScreen();
+    expect(within(firstNcaaCard).getByText('NCAAF')).toBeOnTheScreen();
+
+    const secondNcaaCard = view.getByTestId(
+      PredictHomeTestIds.event('kalshi', 'ncaa-2'),
+    );
+    expect(within(secondNcaaCard).getByText('Georgia')).toBeOnTheScreen();
+    expect(within(secondNcaaCard).getByText('Florida')).toBeOnTheScreen();
     expect(view.queryByText('Hidden College Game')).not.toBeOnTheScreen();
   });
 
   it('opens the NFL Feed Screen and returns without refetching previews', async () => {
     const view = renderPredictNext();
-    await view.findByText('Packers vs Steelers');
+    await view.findByTestId(PredictHomeTestIds.event('kalshi', 'nfl-1'));
     messengerCall.mockClear();
 
     fireEvent.press(
@@ -177,7 +262,9 @@ describe('PredictHome', () => {
     );
     const view = renderPredictNext();
 
-    expect(await view.findByText('Pittsburgh vs Miami')).toBeOnTheScreen();
+    expect(
+      await view.findByTestId(PredictHomeTestIds.event('kalshi', 'ncaa-1')),
+    ).toBeOnTheScreen();
     expect(
       view.getByTestId(PredictHomeTestIds.sectionLoading(NFL_FEED_SCREEN_ID)),
     ).toBeOnTheScreen();
@@ -188,7 +275,9 @@ describe('PredictHome', () => {
       title: 'NFL Games',
       events: nflEvents,
     });
-    expect(await view.findByText('Packers vs Steelers')).toBeOnTheScreen();
+    expect(
+      await view.findByTestId(PredictHomeTestIds.event('kalshi', 'nfl-1')),
+    ).toBeOnTheScreen();
   });
 
   it('keeps an errored NFL preview independent from a successful NCAAF preview', async () => {
@@ -200,7 +289,9 @@ describe('PredictHome', () => {
         PredictHomeTestIds.sectionError(NFL_FEED_SCREEN_ID),
       ),
     ).toBeOnTheScreen();
-    expect(view.getByText('Pittsburgh vs Miami')).toBeOnTheScreen();
+    expect(
+      view.getByTestId(PredictHomeTestIds.event('kalshi', 'ncaa-1')),
+    ).toBeOnTheScreen();
     expect(
       view.queryByTestId(PredictHomeTestIds.sectionError(NCAA_FEED_SCREEN_ID)),
     ).not.toBeOnTheScreen();
@@ -209,7 +300,9 @@ describe('PredictHome', () => {
     fireEvent.press(
       view.getByTestId(PredictHomeTestIds.sectionRetry(NFL_FEED_SCREEN_ID)),
     );
-    expect(await view.findByText('Packers vs Steelers')).toBeOnTheScreen();
+    expect(
+      await view.findByTestId(PredictHomeTestIds.event('kalshi', 'nfl-1')),
+    ).toBeOnTheScreen();
   });
 
   it('keeps an empty NFL preview independent from a successful NCAAF preview', async () => {
@@ -221,7 +314,9 @@ describe('PredictHome', () => {
         PredictHomeTestIds.sectionEmpty(NFL_FEED_SCREEN_ID),
       ),
     ).toBeOnTheScreen();
-    expect(view.getByText('Pittsburgh vs Miami')).toBeOnTheScreen();
+    expect(
+      view.getByTestId(PredictHomeTestIds.event('kalshi', 'ncaa-1')),
+    ).toBeOnTheScreen();
   });
 
   it('opens immutable Event detail from a card', async () => {
@@ -251,7 +346,7 @@ describe('PredictHome', () => {
     );
 
     fireEvent.press(
-      within(card).getByTestId(PredictHomeTestIds.outcome('nfl-1', 'yes')),
+      within(card).getByTestId(PredictHomeTestIds.gameQuote('nfl-1', 'away')),
     );
 
     expect(view.getByTestId(PredictHomeTestIds.HOME)).toBeOnTheScreen();

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.view.test.tsx
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.view.test.tsx
@@ -4,32 +4,35 @@ import Engine from '../../../../../core/Engine';
 import { fireEvent, waitFor, within } from '@testing-library/react-native';
 import { PredictHomeTestIds } from './PredictHome.testIds';
 import { PredictEventDetailTestIds } from '../PredictEventDetail/PredictEventDetail.testIds';
-import type { PredictEvent, PredictTimestamp } from '../../types';
+import { PredictFeedScreenTestIds } from '../PredictFeedScreen/PredictFeedScreen.testIds';
+import type { PredictEvent, PredictFeedId } from '../../types';
 import { PredictEventValues } from '../../../Predict/constants/eventNames';
+import {
+  NCAA_FEED_SCREEN_ID,
+  NFL_FEED_SCREEN_ID,
+} from '../../navigation/feedScreens';
 
-const event: PredictEvent = {
+const makeEvent = (id: string, title: string): PredictEvent => ({
   venueId: 'kalshi' as PredictEvent['venueId'],
-  id: 'event-1' as PredictEvent['id'],
-  title: 'Who wins the election?',
-  subtitle: 'Election 2028',
-  category: 'Politics',
+  id: id as PredictEvent['id'],
+  title,
+  category: 'Sports',
   volume: '1500000',
-  imageUrl: 'https://example.com/event.png',
   markets: [
     {
-      id: 'market-1' as PredictEvent['markets'][number]['id'],
-      question: 'Candidate A wins',
+      id: `${id}-market` as PredictEvent['markets'][number]['id'],
+      question: title,
       status: 'active',
       outcomes: [
         {
-          id: 'yes-1' as PredictEvent['markets'][number]['outcomes'][number]['id'],
+          id: `${id}-yes` as PredictEvent['markets'][number]['outcomes'][number]['id'],
           side: 'yes',
           label: 'Yes',
           askPrice:
             '0.42' as PredictEvent['markets'][number]['outcomes'][number]['askPrice'],
         },
         {
-          id: 'no-1' as PredictEvent['markets'][number]['outcomes'][number]['id'],
+          id: `${id}-no` as PredictEvent['markets'][number]['outcomes'][number]['id'],
           side: 'no',
           label: 'No',
           askPrice:
@@ -38,97 +41,227 @@ const event: PredictEvent = {
       ],
     },
   ],
-};
+});
 
-const gameEvent: PredictEvent = {
-  ...event,
-  id: 'game-event' as PredictEvent['id'],
-  title: 'Cardinals vs Panthers',
-  sports: {
-    sport: {
-      id: 'american-football' as PredictEvent['id'],
-      label: 'American football',
-    },
-    competition: { id: 'nfl' as PredictEvent['id'], label: 'NFL' },
-    game: {
-      status: 'in_progress',
-      awayTeam: { name: 'Arizona Cardinals', abbreviation: 'ARI' },
-      homeTeam: { name: 'Carolina Panthers', abbreviation: 'CAR' },
-      score: { away: '17', home: '21' },
-      period: 'Q4',
-      clock: '12:22',
-      observedAt: '2026-01-01T00:00:00Z' as PredictTimestamp,
-    },
-  },
-  markets: [
-    {
-      ...event.markets[0],
-      id: 'away-market' as PredictEvent['markets'][number]['id'],
-      status: 'active',
-      outcomes: [
-        { ...event.markets[0].outcomes[0], gameSelection: 'away' },
-        event.markets[0].outcomes[1],
-      ],
-    },
-    {
-      ...event.markets[0],
-      id: 'home-market' as PredictEvent['markets'][number]['id'],
-      status: 'active',
-      outcomes: [
-        { ...event.markets[0].outcomes[0], gameSelection: 'home' },
-        event.markets[0].outcomes[1],
-      ],
-    },
-  ],
-};
-
-const multiMarketEvent: PredictEvent = {
-  ...event,
-  id: 'event-2' as PredictEvent['id'],
-  title: 'Multi-market election',
-  markets: [
-    ...event.markets,
-    ...(['market-2', 'market-3', 'market-4'] as const).map((marketId) => ({
-      ...event.markets[0],
-      id: marketId as PredictEvent['markets'][number]['id'],
-    })),
-  ],
-};
+const nflEvents = [
+  makeEvent('nfl-1', 'Packers vs Steelers'),
+  makeEvent('nfl-2', 'Panthers vs Cardinals'),
+];
+const ncaaEvents = [
+  makeEvent('ncaa-1', 'Pittsburgh vs Miami'),
+  makeEvent('ncaa-2', 'Georgia vs Florida'),
+];
 
 const messengerCall = Engine.controllerMessenger.call as unknown as jest.Mock;
 
-const configureQueries = (
-  events: readonly PredictEvent[] = [event],
-  status: 'available' | 'degraded' | 'unavailable' = 'available',
-) => {
-  messengerCall.mockImplementation((action: string) => {
-    if (action === 'PredictMarketDataService:getVenueStatus') {
+const configureFeeds = ({
+  nfl = nflEvents,
+  ncaa = ncaaEvents,
+}: {
+  nfl?: readonly PredictEvent[] | Error;
+  ncaa?: readonly PredictEvent[] | Error;
+} = {}) => {
+  messengerCall.mockImplementation(
+    (action: string, _venueId: string, feedId: PredictFeedId) => {
+      if (action !== 'PredictMarketDataService:getFeed') {
+        return Promise.resolve(undefined);
+      }
+
+      const result = feedId === 'sports-football-nfl-games' ? nfl : ncaa;
+      if (result instanceof Error) {
+        return Promise.reject(result);
+      }
+
       return Promise.resolve({
         venueId: 'kalshi',
-        status,
-        checkedAt: '2026-01-01T00:00:00Z',
+        id: feedId,
+        title:
+          feedId === 'sports-football-nfl-games' ? 'NFL Games' : 'NCAAF Games',
+        events: result,
       });
-    }
-    if (action === 'PredictMarketDataService:getFeed') {
-      return Promise.resolve({
-        venueId: 'kalshi',
-        id: 'sports-football-nfl-games',
-        title: 'NFL Games',
-        events,
-      });
-    }
-    return Promise.resolve(undefined);
-  });
+    },
+  );
 };
 
 describe('PredictHome', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    configureQueries();
+    configureFeeds();
   });
 
-  it('tracks the homepage balance breakdown entry point', async () => {
-    const view = renderPredictNext({
+  it('loads the first two backend-ordered Games for both previews', async () => {
+    configureFeeds({
+      nfl: [...nflEvents, makeEvent('nfl-3', 'Hidden NFL Game')],
+      ncaa: [...ncaaEvents, makeEvent('ncaa-3', 'Hidden College Game')],
+    });
+    const view = renderPredictNext();
+
+    await waitFor(() => expect(messengerCall).toHaveBeenCalledTimes(2));
+
+    expect(messengerCall).toHaveBeenCalledWith(
+      'PredictMarketDataService:getFeed',
+      'kalshi',
+      'sports-football-nfl-games',
+      { limit: 2 },
+      undefined,
+    );
+    expect(messengerCall).toHaveBeenCalledWith(
+      'PredictMarketDataService:getFeed',
+      'kalshi',
+      'sports-football-ncaa-games',
+      { limit: 2 },
+      undefined,
+    );
+    expect(await view.findByText('Packers vs Steelers')).toBeOnTheScreen();
+    expect(view.getByText('Panthers vs Cardinals')).toBeOnTheScreen();
+    expect(view.queryByText('Hidden NFL Game')).not.toBeOnTheScreen();
+    expect(view.getByText('Pittsburgh vs Miami')).toBeOnTheScreen();
+    expect(view.getByText('Georgia vs Florida')).toBeOnTheScreen();
+    expect(view.queryByText('Hidden College Game')).not.toBeOnTheScreen();
+  });
+
+  it('opens the NFL Feed Screen and returns without refetching previews', async () => {
+    const view = renderPredictNext();
+    await view.findByText('Packers vs Steelers');
+    messengerCall.mockClear();
+
+    fireEvent.press(
+      view.getByTestId(PredictHomeTestIds.sectionHeader(NFL_FEED_SCREEN_ID)),
+    );
+
+    expect(
+      await view.findByTestId(PredictFeedScreenTestIds.VIEW),
+    ).toBeOnTheScreen();
+    expect(view.getByText('Sports')).toBeOnTheScreen();
+    expect(view.getByText('NFL')).toBeOnTheScreen();
+    fireEvent.press(view.getByTestId(PredictFeedScreenTestIds.BACK));
+    await view.findByTestId(PredictHomeTestIds.HOME);
+    expect(messengerCall).not.toHaveBeenCalled();
+  });
+
+  it('opens the NCAAF Feed Screen', async () => {
+    const view = renderPredictNext();
+
+    fireEvent.press(
+      await view.findByTestId(
+        PredictHomeTestIds.sectionHeader(NCAA_FEED_SCREEN_ID),
+      ),
+    );
+
+    expect(
+      await view.findByTestId(PredictFeedScreenTestIds.VIEW),
+    ).toBeOnTheScreen();
+    expect(view.getByText('Sports')).toBeOnTheScreen();
+    expect(view.getByText('NCAAF')).toBeOnTheScreen();
+  });
+
+  it('renders a successful NCAAF preview while NFL is still loading', async () => {
+    let resolveNfl: (value: unknown) => void = () => undefined;
+    messengerCall.mockImplementation(
+      (action: string, _venueId: string, feedId: PredictFeedId) => {
+        if (action !== 'PredictMarketDataService:getFeed') {
+          return Promise.resolve(undefined);
+        }
+        if (feedId === 'sports-football-nfl-games') {
+          return new Promise((resolve) => {
+            resolveNfl = resolve;
+          });
+        }
+        return Promise.resolve({
+          venueId: 'kalshi',
+          id: feedId,
+          title: 'NCAAF Games',
+          events: ncaaEvents,
+        });
+      },
+    );
+    const view = renderPredictNext();
+
+    expect(await view.findByText('Pittsburgh vs Miami')).toBeOnTheScreen();
+    expect(
+      view.getByTestId(PredictHomeTestIds.sectionLoading(NFL_FEED_SCREEN_ID)),
+    ).toBeOnTheScreen();
+
+    resolveNfl({
+      venueId: 'kalshi',
+      id: 'sports-football-nfl-games',
+      title: 'NFL Games',
+      events: nflEvents,
+    });
+    expect(await view.findByText('Packers vs Steelers')).toBeOnTheScreen();
+  });
+
+  it('keeps an errored NFL preview independent from a successful NCAAF preview', async () => {
+    configureFeeds({ nfl: new Error('NFL failed') });
+    const view = renderPredictNext();
+
+    expect(
+      await view.findByTestId(
+        PredictHomeTestIds.sectionError(NFL_FEED_SCREEN_ID),
+      ),
+    ).toBeOnTheScreen();
+    expect(view.getByText('Pittsburgh vs Miami')).toBeOnTheScreen();
+    expect(
+      view.queryByTestId(PredictHomeTestIds.sectionError(NCAA_FEED_SCREEN_ID)),
+    ).not.toBeOnTheScreen();
+
+    configureFeeds();
+    fireEvent.press(
+      view.getByTestId(PredictHomeTestIds.sectionRetry(NFL_FEED_SCREEN_ID)),
+    );
+    expect(await view.findByText('Packers vs Steelers')).toBeOnTheScreen();
+  });
+
+  it('keeps an empty NFL preview independent from a successful NCAAF preview', async () => {
+    configureFeeds({ nfl: [] });
+    const view = renderPredictNext();
+
+    expect(
+      await view.findByTestId(
+        PredictHomeTestIds.sectionEmpty(NFL_FEED_SCREEN_ID),
+      ),
+    ).toBeOnTheScreen();
+    expect(view.getByText('Pittsburgh vs Miami')).toBeOnTheScreen();
+  });
+
+  it('opens immutable Event detail from a card', async () => {
+    const view = renderPredictNext();
+
+    fireEvent.press(
+      await view.findByTestId(
+        PredictHomeTestIds.eventContent('kalshi', 'nfl-1'),
+      ),
+    );
+
+    expect(
+      await view.findByTestId(PredictEventDetailTestIds.VIEW),
+    ).toBeOnTheScreen();
+    expect(view.getByText('Packers vs Steelers')).toBeOnTheScreen();
+    expect(messengerCall).not.toHaveBeenCalledWith(
+      'PredictMarketDataService:getEvent',
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it('does not navigate when a disabled Outcome is pressed', async () => {
+    const view = renderPredictNext();
+    const card = await view.findByTestId(
+      PredictHomeTestIds.event('kalshi', 'nfl-1'),
+    );
+
+    fireEvent.press(
+      within(card).getByTestId(PredictHomeTestIds.outcome('nfl-1', 'yes')),
+    );
+
+    expect(view.getByTestId(PredictHomeTestIds.HOME)).toBeOnTheScreen();
+    expect(
+      view.queryByTestId(PredictEventDetailTestIds.VIEW),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('tracks the homepage entry point', async () => {
+    renderPredictNext({
       entryPoint: PredictEventValues.ENTRY_POINT.HOMESCREEN_BALANCE_BREAKDOWN,
     });
 
@@ -139,280 +272,5 @@ describe('PredictHome', () => {
         entryPoint: 'homescreen_balance_breakdown',
       }),
     );
-
-    fireEvent.press(
-      await view.findByTestId(
-        PredictHomeTestIds.eventContent('kalshi', 'event-1'),
-      ),
-    );
-    await view.findByTestId(PredictEventDetailTestIds.VIEW);
-    fireEvent.press(view.getByTestId(PredictEventDetailTestIds.BACK));
-
-    await waitFor(() =>
-      expect(
-        Engine.context.PredictController.trackHomeViewed,
-      ).toHaveBeenLastCalledWith({
-        entryPoint: undefined,
-      }),
-    );
-  });
-
-  it('loads complete Event data through the Engine messenger', async () => {
-    const view = renderPredictNext();
-
-    const card = await view.findByTestId(
-      PredictHomeTestIds.event('kalshi', 'event-1'),
-    );
-
-    expect(within(card).getByText('Who wins the election?')).toBeOnTheScreen();
-    expect(within(card).getByText('Yes')).toBeOnTheScreen();
-    expect(within(card).getByText('2.38x')).toBeOnTheScreen();
-    expect(within(card).getByText('42¢')).toBeOnTheScreen();
-    expect(within(card).getByText('No')).toBeOnTheScreen();
-    expect(within(card).getByText('1.72x')).toBeOnTheScreen();
-    expect(within(card).getByText('58¢')).toBeOnTheScreen();
-    expect(
-      within(card).getByTestId(PredictHomeTestIds.image('event-1')),
-    ).toBeOnTheScreen();
-    expect(
-      within(card).getByTestId(PredictHomeTestIds.category('event-1')),
-    ).toBeOnTheScreen();
-    expect(
-      within(card).getByTestId(PredictHomeTestIds.volume('event-1')),
-    ).toHaveTextContent('$1.5M Vol');
-  });
-
-  it('opens American-football Game detail from the compact Game card', async () => {
-    configureQueries([event, gameEvent]);
-    const view = renderPredictNext();
-    const gameCard = await view.findByTestId(
-      PredictHomeTestIds.event('kalshi', 'game-event'),
-    );
-
-    expect(within(gameCard).getByText('Arizona Cardinals')).toBeOnTheScreen();
-    expect(within(gameCard).queryByText(gameEvent.title)).not.toBeOnTheScreen();
-    fireEvent.press(
-      within(gameCard).getByTestId(
-        PredictHomeTestIds.eventContent('kalshi', 'game-event'),
-      ),
-    );
-
-    expect(
-      await view.findByTestId(PredictEventDetailTestIds.VIEW),
-    ).toBeOnTheScreen();
-    expect(view.getByText(gameEvent.title)).toBeOnTheScreen();
-  });
-
-  it('renders a non-American-football Game with the standard card', async () => {
-    const soccerEvent: PredictEvent = {
-      ...gameEvent,
-      id: 'soccer-event' as PredictEvent['id'],
-      title: 'Soccer championship',
-      sports: {
-        ...gameEvent.sports,
-        sport: {
-          id: 'soccer' as PredictEvent['id'],
-          label: 'Soccer',
-        },
-      } as PredictEvent['sports'],
-    };
-    configureQueries([soccerEvent]);
-    const view = renderPredictNext();
-
-    const card = await view.findByTestId(
-      PredictHomeTestIds.event('kalshi', 'soccer-event'),
-    );
-
-    expect(within(card).getByText(soccerEvent.title)).toBeOnTheScreen();
-    expect(within(card).queryByText('Arizona Cardinals')).not.toBeOnTheScreen();
-  });
-
-  it('does not navigate when an Outcome is pressed', async () => {
-    const view = renderPredictNext();
-    const card = await view.findByTestId(
-      PredictHomeTestIds.event('kalshi', 'event-1'),
-    );
-
-    fireEvent.press(
-      within(card).getByTestId(PredictHomeTestIds.outcome('event-1', 'yes')),
-    );
-
-    expect(view.getByTestId(PredictHomeTestIds.HOME)).toBeOnTheScreen();
-    expect(
-      view.queryByTestId(PredictEventDetailTestIds.VIEW),
-    ).not.toBeOnTheScreen();
-  });
-
-  it('opens detail from More for a multi-market Event', async () => {
-    configureQueries([event, multiMarketEvent]);
-    const view = renderPredictNext();
-
-    expect(
-      await view.findByTestId(
-        PredictHomeTestIds.event('kalshi', multiMarketEvent.id),
-      ),
-    ).toBeOnTheScreen();
-    expect(
-      view.queryByTestId(PredictHomeTestIds.more('event-1')),
-    ).not.toBeOnTheScreen();
-
-    fireEvent.press(
-      view.getByTestId(PredictHomeTestIds.more(multiMarketEvent.id)),
-    );
-
-    expect(
-      await view.findByTestId(PredictEventDetailTestIds.VIEW),
-    ).toBeOnTheScreen();
-    expect(view.getByText(multiMarketEvent.title)).toBeOnTheScreen();
-  });
-
-  it('opens detail and returns without fetching Event detail', async () => {
-    const view = renderPredictNext();
-    fireEvent.press(
-      await view.findByTestId(
-        PredictHomeTestIds.eventContent('kalshi', 'event-1'),
-      ),
-    );
-
-    expect(
-      await view.findByTestId(PredictEventDetailTestIds.VIEW),
-    ).toBeOnTheScreen();
-    expect(view.getByText('Who wins the election?')).toBeOnTheScreen();
-    expect(messengerCall).not.toHaveBeenCalledWith(
-      'PredictMarketDataService:getEvent',
-      expect.anything(),
-      expect.anything(),
-    );
-
-    fireEvent.press(view.getByTestId(PredictEventDetailTestIds.BACK));
-
-    await waitFor(() =>
-      expect(view.getByTestId(PredictHomeTestIds.HOME)).toBeOnTheScreen(),
-    );
-  });
-
-  it('shows an empty state after an empty Event response', async () => {
-    configureQueries([]);
-
-    const view = renderPredictNext();
-
-    expect(await view.findByText('No predictions yet.')).toBeOnTheScreen();
-    expect(
-      messengerCall.mock.calls.some(
-        (call) => call[0] === 'PredictMarketDataService:getVenueStatus',
-      ),
-    ).toBe(true);
-  });
-
-  it('does not fetch Venue Status when Events are available', async () => {
-    const view = renderPredictNext();
-
-    expect(
-      await view.findByTestId(PredictHomeTestIds.event('kalshi', 'event-1')),
-    ).toBeOnTheScreen();
-    expect(
-      messengerCall.mock.calls.filter(
-        (call) => call[0] === 'PredictMarketDataService:getVenueStatus',
-      ),
-    ).toHaveLength(0);
-  });
-
-  it('retries the Feed after a first-page error', async () => {
-    configureQueries();
-    messengerCall.mockImplementation((action: string) => {
-      if (action === 'PredictMarketDataService:getFeed') {
-        return Promise.reject(new Error('feed failed'));
-      }
-      return Promise.resolve(undefined);
-    });
-    const view = renderPredictNext();
-    const retry = await view.findByText('Retry');
-    configureQueries();
-    messengerCall.mockClear();
-
-    fireEvent.press(retry);
-
-    await waitFor(() =>
-      expect(messengerCall).toHaveBeenCalledWith(
-        'PredictMarketDataService:getFeed',
-        expect.anything(),
-        expect.anything(),
-        expect.anything(),
-        undefined,
-      ),
-    );
-    expect(
-      messengerCall.mock.calls.filter(
-        (call) => call[0] === 'PredictMarketDataService:getVenueStatus',
-      ),
-    ).toHaveLength(0);
-    expect(
-      await view.findByTestId(PredictHomeTestIds.event('kalshi', 'event-1')),
-    ).toBeOnTheScreen();
-  });
-
-  it('shows unavailable when no Events can be displayed', async () => {
-    configureQueries([], 'unavailable');
-
-    const view = renderPredictNext();
-
-    expect(
-      await view.findByText('Predictions are unavailable.'),
-    ).toBeOnTheScreen();
-  });
-
-  it('preserves Events and retries a failed next page from the footer', async () => {
-    configureQueries();
-    let eventRequest = 0;
-    messengerCall.mockImplementation((action: string) => {
-      if (action === 'PredictMarketDataService:getVenueStatus') {
-        return Promise.resolve({
-          venueId: 'kalshi',
-          status: 'available',
-          checkedAt: '2026-01-01T00:00:00Z',
-        });
-      }
-      if (action === 'PredictMarketDataService:getFeed') {
-        eventRequest += 1;
-        if (eventRequest === 1) {
-          return Promise.resolve({
-            venueId: 'kalshi',
-            id: 'sports-football-nfl-games',
-            title: 'NFL Games',
-            events: [event],
-            nextCursor: 'next',
-          });
-        }
-        if (eventRequest === 2) {
-          return Promise.reject(new Error('next page failed'));
-        }
-        return Promise.resolve({
-          venueId: 'kalshi',
-          id: 'sports-football-nfl-games',
-          title: 'NFL Games',
-          events: [{ ...event, id: 'event-2', title: 'Second Event' }],
-        });
-      }
-      return Promise.resolve(undefined);
-    });
-    const view = renderPredictNext();
-    const feed = await view.findByTestId(PredictHomeTestIds.FEED);
-
-    fireEvent(feed, 'onEndReached');
-    const retry = await view.findByTestId(PredictHomeTestIds.FOOTER_RETRY);
-
-    expect(view.getByText('Who wins the election?')).toBeOnTheScreen();
-    fireEvent.press(retry);
-    expect(await view.findByText('Second Event')).toBeOnTheScreen();
-  });
-
-  it('renders Events when Venue Status is unavailable', async () => {
-    configureQueries([event], 'unavailable');
-
-    const view = renderPredictNext();
-
-    expect(
-      await view.findByTestId(PredictHomeTestIds.event('kalshi', 'event-1')),
-    ).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.view.test.tsx
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.view.test.tsx
@@ -53,8 +53,16 @@ const makeGameEvent = (
   awayTeam: string,
   homeTeam: string,
   competition: string,
+  {
+    volume = '1500000',
+    score = { away: '17', home: '21' },
+  }: {
+    volume?: string;
+    score?: { away: string; home: string };
+  } = {},
 ): PredictEvent => ({
   ...makeEvent(id, `${awayTeam} vs ${homeTeam}`),
+  volume,
   sports: {
     sport: {
       id: 'american-football' as PredictEntityId,
@@ -68,7 +76,7 @@ const makeGameEvent = (
       status: 'in_progress',
       awayTeam: { name: awayTeam, abbreviation: awayTeam.slice(0, 3) },
       homeTeam: { name: homeTeam, abbreviation: homeTeam.slice(0, 3) },
-      score: { away: '17', home: '21' },
+      score,
       period: 'Q4',
       clock: '12:22',
       observedAt: '2026-08-19T12:00:00Z' as PredictTimestamp,
@@ -106,11 +114,20 @@ const makeGameEvent = (
 
 const nflEvents = [
   makeGameEvent('nfl-1', 'Packers', 'Steelers', 'NFL'),
-  makeGameEvent('nfl-2', 'Panthers', 'Cardinals', 'NFL'),
+  makeGameEvent('nfl-2', 'Panthers', 'Cardinals', 'NFL', {
+    volume: '2500',
+    score: { away: '10', home: '7' },
+  }),
 ];
 const ncaaEvents = [
-  makeGameEvent('ncaa-1', 'Pittsburgh', 'Miami', 'NCAAF'),
-  makeGameEvent('ncaa-2', 'Georgia', 'Florida', 'NCAAF'),
+  makeGameEvent('ncaa-1', 'Pittsburgh', 'Miami', 'NCAAF', {
+    volume: '500',
+    score: { away: '24', home: '31' },
+  }),
+  makeGameEvent('ncaa-2', 'Georgia', 'Florida', 'NCAAF', {
+    volume: '900000',
+    score: { away: '3', home: '0' },
+  }),
 ];
 
 const messengerCall = Engine.controllerMessenger.call as unknown as jest.Mock;
@@ -144,6 +161,44 @@ const configureFeeds = ({
   );
 };
 
+const expectGameCard = (
+  section: Parameters<typeof within>[0],
+  eventId: string,
+  {
+    away,
+    home,
+    awayScore,
+    homeScore,
+    competition,
+    volume,
+  }: {
+    away: string;
+    home: string;
+    awayScore: string;
+    homeScore: string;
+    competition: string;
+    volume: string;
+  },
+) => {
+  const card = within(section).getByTestId(
+    PredictHomeTestIds.event('kalshi', eventId),
+  );
+  const scoped = within(card);
+
+  expect(scoped.getByText(away)).toBeOnTheScreen();
+  expect(scoped.getByText(home)).toBeOnTheScreen();
+  expect(scoped.getByText(awayScore)).toBeOnTheScreen();
+  expect(scoped.getByText(homeScore)).toBeOnTheScreen();
+  expect(scoped.getByText(competition)).toBeOnTheScreen();
+  expect(scoped.getByText(volume)).toBeOnTheScreen();
+  expect(
+    scoped.getByTestId(PredictHomeTestIds.gameQuote(eventId, 'away')),
+  ).toBeOnTheScreen();
+  expect(
+    scoped.getByTestId(PredictHomeTestIds.gameQuote(eventId, 'home')),
+  ).toBeOnTheScreen();
+};
+
 describe('PredictHome', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -173,36 +228,65 @@ describe('PredictHome', () => {
       { limit: 2 },
       undefined,
     );
-    const firstNflCard = await view.findByTestId(
-      PredictHomeTestIds.event('kalshi', 'nfl-1'),
-    );
-    expect(within(firstNflCard).getByText('Packers')).toBeOnTheScreen();
-    expect(within(firstNflCard).getByText('Steelers')).toBeOnTheScreen();
-    expect(within(firstNflCard).getByText('17')).toBeOnTheScreen();
-    expect(within(firstNflCard).getByText('21')).toBeOnTheScreen();
-    expect(within(firstNflCard).getByText('NFL')).toBeOnTheScreen();
-    expect(within(firstNflCard).getByText('$1.5M Vol')).toBeOnTheScreen();
 
-    const secondNflCard = view.getByTestId(
-      PredictHomeTestIds.event('kalshi', 'nfl-2'),
-    );
-    expect(within(secondNflCard).getByText('Panthers')).toBeOnTheScreen();
-    expect(within(secondNflCard).getByText('Cardinals')).toBeOnTheScreen();
-    expect(view.queryByText('Hidden NFL Game')).not.toBeOnTheScreen();
+    await view.findByTestId(PredictHomeTestIds.event('kalshi', 'nfl-1'));
+    await view.findByTestId(PredictHomeTestIds.event('kalshi', 'ncaa-2'));
 
-    const firstNcaaCard = view.getByTestId(
-      PredictHomeTestIds.event('kalshi', 'ncaa-1'),
+    const nflSection = view.getByTestId(
+      PredictHomeTestIds.section(NFL_FEED_SCREEN_ID),
     );
-    expect(within(firstNcaaCard).getByText('Pittsburgh')).toBeOnTheScreen();
-    expect(within(firstNcaaCard).getByText('Miami')).toBeOnTheScreen();
-    expect(within(firstNcaaCard).getByText('NCAAF')).toBeOnTheScreen();
+    expectGameCard(nflSection, 'nfl-1', {
+      away: 'Packers',
+      home: 'Steelers',
+      awayScore: '17',
+      homeScore: '21',
+      competition: 'NFL',
+      volume: '$1.5M Vol',
+    });
+    expectGameCard(nflSection, 'nfl-2', {
+      away: 'Panthers',
+      home: 'Cardinals',
+      awayScore: '10',
+      homeScore: '7',
+      competition: 'NFL',
+      volume: '$2.5k Vol',
+    });
+    expect(
+      within(nflSection).queryByText('Hidden NFL Game'),
+    ).not.toBeOnTheScreen();
+    expect(
+      within(nflSection).queryByTestId(
+        PredictHomeTestIds.event('kalshi', 'ncaa-1'),
+      ),
+    ).not.toBeOnTheScreen();
 
-    const secondNcaaCard = view.getByTestId(
-      PredictHomeTestIds.event('kalshi', 'ncaa-2'),
+    const ncaaSection = view.getByTestId(
+      PredictHomeTestIds.section(NCAA_FEED_SCREEN_ID),
     );
-    expect(within(secondNcaaCard).getByText('Georgia')).toBeOnTheScreen();
-    expect(within(secondNcaaCard).getByText('Florida')).toBeOnTheScreen();
-    expect(view.queryByText('Hidden College Game')).not.toBeOnTheScreen();
+    expectGameCard(ncaaSection, 'ncaa-1', {
+      away: 'Pittsburgh',
+      home: 'Miami',
+      awayScore: '24',
+      homeScore: '31',
+      competition: 'NCAAF',
+      volume: '$500 Vol',
+    });
+    expectGameCard(ncaaSection, 'ncaa-2', {
+      away: 'Georgia',
+      home: 'Florida',
+      awayScore: '3',
+      homeScore: '0',
+      competition: 'NCAAF',
+      volume: '$900k Vol',
+    });
+    expect(
+      within(ncaaSection).queryByText('Hidden College Game'),
+    ).not.toBeOnTheScreen();
+    expect(
+      within(ncaaSection).queryByTestId(
+        PredictHomeTestIds.event('kalshi', 'nfl-1'),
+      ),
+    ).not.toBeOnTheScreen();
   });
 
   it('opens the NFL Feed Screen and returns without refetching previews', async () => {

--- a/app/components/UI/PredictNext/views/PredictHome/internal/FeedPreviewSection.tsx
+++ b/app/components/UI/PredictNext/views/PredictHome/internal/FeedPreviewSection.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { Pressable } from 'react-native';
+import {
+  Box,
+  Button,
+  ButtonVariant,
+  Icon,
+  IconName,
+  IconSize,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { EventCardGame, EventCardStandard } from '../../../events/cards';
+import type { FeedScreenId } from '../../../navigation/feedScreens';
+import type { PredictEvent } from '../../../types';
+import { PredictHomeTestIds } from '../PredictHome.testIds';
+
+interface FeedPreviewSectionProps {
+  feedScreenId: FeedScreenId;
+  title: string;
+  events: readonly PredictEvent[];
+  isLoading: boolean;
+  isError: boolean;
+  onOpen: () => void;
+  onOpenEvent: (event: PredictEvent) => void;
+  onRetry: () => void;
+}
+
+const isAmericanFootballGameEvent = (event: PredictEvent): boolean =>
+  event.sports?.sport.id === 'american-football' && Boolean(event.sports.game);
+
+export const FeedPreviewSection = ({
+  feedScreenId,
+  title,
+  events,
+  isLoading,
+  isError,
+  onOpen,
+  onOpenEvent,
+  onRetry,
+}: FeedPreviewSectionProps) => {
+  const renderEvent = (event: PredictEvent) => {
+    const handlePress = () => onOpenEvent(event);
+    return isAmericanFootballGameEvent(event) ? (
+      <EventCardGame key={event.id} event={event} onPress={handlePress} />
+    ) : (
+      <EventCardStandard key={event.id} event={event} onPress={handlePress} />
+    );
+  };
+
+  return (
+    <Box testID={PredictHomeTestIds.section(feedScreenId)} twClassName="gap-3">
+      <Pressable
+        testID={PredictHomeTestIds.sectionHeader(feedScreenId)}
+        accessibilityRole="button"
+        accessibilityLabel={`View ${title}`}
+        onPress={onOpen}
+      >
+        <Box twClassName="flex-row items-center gap-1">
+          <Text variant={TextVariant.HeadingMd}>{title}</Text>
+          <Icon name={IconName.ArrowRight} size={IconSize.Sm} />
+        </Box>
+      </Pressable>
+
+      {isLoading ? (
+        <Box
+          testID={PredictHomeTestIds.sectionLoading(feedScreenId)}
+          twClassName="gap-3"
+        >
+          <Box twClassName="h-32 rounded-xl bg-muted" />
+          <Box twClassName="h-32 rounded-xl bg-muted" />
+        </Box>
+      ) : isError ? (
+        <Box
+          testID={PredictHomeTestIds.sectionError(feedScreenId)}
+          twClassName="items-start gap-2 py-4"
+        >
+          <Text>Games couldn’t be loaded.</Text>
+          <Button
+            testID={PredictHomeTestIds.sectionRetry(feedScreenId)}
+            variant={ButtonVariant.Tertiary}
+            onPress={onRetry}
+          >
+            Retry
+          </Button>
+        </Box>
+      ) : events.length === 0 ? (
+        <Box
+          testID={PredictHomeTestIds.sectionEmpty(feedScreenId)}
+          twClassName="py-4"
+        >
+          <Text>No games available.</Text>
+        </Box>
+      ) : (
+        <Box twClassName="gap-3">{events.map(renderEvent)}</Box>
+      )}
+    </Box>
+  );
+};

--- a/app/components/UI/PredictNext/views/PredictHome/internal/FeedPreviewSection.tsx
+++ b/app/components/UI/PredictNext/views/PredictHome/internal/FeedPreviewSection.tsx
@@ -70,7 +70,7 @@ export const FeedPreviewSection = ({
           <Box twClassName="h-32 rounded-xl bg-muted" />
           <Box twClassName="h-32 rounded-xl bg-muted" />
         </Box>
-      ) : isError ? (
+      ) : isError && events.length === 0 ? (
         <Box
           testID={PredictHomeTestIds.sectionError(feedScreenId)}
           twClassName="items-start gap-2 py-4"

--- a/tests/component-view/renderers/predictNext.ts
+++ b/tests/component-view/renderers/predictNext.ts
@@ -4,8 +4,12 @@ import { renderScreenWithRoutes } from '../render';
 import { initialStatePredictNext } from '../presets/predictNext';
 import { PredictHome } from '../../../app/components/UI/PredictNext/views/PredictHome/PredictHome';
 import { PredictEventDetail } from '../../../app/components/UI/PredictNext/views/PredictEventDetail/PredictEventDetail';
+import { PredictFeedScreen } from '../../../app/components/UI/PredictNext/views/PredictFeedScreen/PredictFeedScreen';
 import { PredictNextRoutes } from '../../../app/components/UI/PredictNext/navigation/routes';
-import type { PredictNextHomeParams } from '../../../app/components/UI/PredictNext/navigation/types';
+import type {
+  PredictNextFeedParams,
+  PredictNextHomeParams,
+} from '../../../app/components/UI/PredictNext/navigation/types';
 
 export const renderPredictNext = (initialParams?: PredictNextHomeParams) =>
   renderScreenWithRoutes(
@@ -13,10 +17,23 @@ export const renderPredictNext = (initialParams?: PredictNextHomeParams) =>
     { name: PredictNextRoutes.HOME },
     [
       {
+        name: PredictNextRoutes.FEED,
+        Component: PredictFeedScreen as unknown as React.ComponentType<object>,
+      },
+      {
         name: PredictNextRoutes.EVENT_DETAIL,
         Component: PredictEventDetail as unknown as React.ComponentType<object>,
       },
     ],
     { state: initialStatePredictNext().build() },
     initialParams ? { ...initialParams } : undefined,
+  );
+
+export const renderPredictFeedScreen = (initialParams: PredictNextFeedParams) =>
+  renderScreenWithRoutes(
+    PredictFeedScreen as unknown as React.ComponentType,
+    { name: PredictNextRoutes.FEED },
+    [{ name: PredictNextRoutes.HOME, Component: PredictHome }],
+    { state: initialStatePredictNext().build() },
+    { ...initialParams },
   );


### PR DESCRIPTION
## **Description**

Adds the American-football MVP sections to PredictNext Home. NFL and NCAAF now load independent two-Event previews from their backend Feeds, preserve backend ordering, and expose independent loading, error/retry, and empty states.

Section headers navigate to a new generic Feed Screen route backed by local Feed Screen configuration. This PR intentionally scaffolds only the route, title, selection label, and Back behavior; Games/Props tabs and paginated Feed UI remain in PRED-1231. Event cards continue to open immutable Event detail, and disabled Outcome controls remain independent from navigation.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/PRED-1230

## **Manual testing steps**

```gherkin
Feature: Predict Home football previews

  Scenario: user views NFL and NCAAF previews
    Given PredictNext is enabled for Kalshi
    And both configured Games Feeds return Events
    When the user opens Predict Home
    Then the NFL section shows the first two backend-ordered NFL Games
    And the NCAAF section shows the first two backend-ordered college football Games

  Scenario: user opens a Feed Screen
    Given Predict Home has loaded
    When the user presses the NFL or NCAAF section header
    Then the generic Sports Feed Screen placeholder opens for that selection
    And Back returns to Predict Home without discarding usable preview data

  Scenario: one preview fails independently
    Given one Games Feed fails and the other succeeds
    When the user opens Predict Home
    Then the failed section shows its own error and Retry action
    And the successful section remains available

  Scenario: user opens Event detail
    Given a preview Event card is visible
    When the user presses the Event card
    Then immutable Event detail opens
    And pressing a disabled Outcome control does not navigate
```

Automated verification:
- `yarn lint:tsc`
- ESLint for the touched scope
- PredictNext unit suite: 152 tests passed
- PredictNext component-view tests: 10 tests passed
- Full unit suite was attempted once but exhausted the Node heap after approximately six minutes; no test failure was reported before the OOM.

## **Screenshots/Recordings**

N/A — no simulator/device was available in this session. Visual/device review remains required before marking the PR ready for review.

### **Before**

N/A

### **After**


https://github.com/user-attachments/assets/d6422105-a4e6-403c-896e-5efd27ec5890



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Not performed in this session; consciously assessed and called out above before draft review.
- [ ] I've tested with a power user scenario
  - Not applicable to two fixed previews containing at most four cards.
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - Existing PredictNext Home TTI instrumentation was preserved and now completes after both initial Feed requests settle.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 497892d058d3b75d7e822f24a48e8ea67a4f5005. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->