### PR TITLE
fix(activity): pass subject address when mapping non-EVM details

### DIFF
--- a/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.test.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.test.ts
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { useSelector } from 'react-redux';
 import {
   mapRampOrder,
   type ActivityListItem,
@@ -9,6 +10,7 @@ import {
   FIAT_ORDER_STATES,
 } from '../../../../constants/on-ramp';
 import type { FiatOrder } from '../../../../reducers/fiatOrders/types';
+import { selectSelectedAccountGroupInternalAccounts } from '../../../../selectors/multichainAccounts/accountTreeController';
 import { useActivityDetailsItem } from './useActivityDetailsItem';
 /* eslint-disable import-x/no-restricted-paths -- TODO(ADR-0020): mirrors the resolver hook's data sources; route-isolation backlog */
 import { useLocalActivityItems } from '../../ActivityList/hooks/useLocalActivityItems';
@@ -18,13 +20,19 @@ import { mapNonEvmTransactions } from '../../ActivityList/helpers/transformation
 /* eslint-enable import-x/no-restricted-paths */
 
 jest.mock('react-redux', () => ({
-  useSelector: jest.fn(() => ({ transactions: [] })),
+  useSelector: jest.fn(),
 }));
 jest.mock('../../ActivityList/hooks/useLocalActivityItems');
 jest.mock('../../ActivityList/hooks/useRampActivityItems');
 jest.mock('../../ActivityList/useTransactionsQuery');
 jest.mock('../../ActivityList/helpers/transformations', () => ({
   mapNonEvmTransactions: jest.fn(() => []),
+}));
+jest.mock('../../../UI/Bridge/hooks/useBridgeHistoryItemBySrcTxHash', () => ({
+  useBridgeHistoryItemBySrcTxHash: jest.fn(() => ({
+    bridgeHistoryItemsBySrcTxHash: {},
+  })),
+  findBridgeHistoryItemBySrcTxHash: jest.fn(),
 }));
 
 const useLocalActivityItemsMock = jest.mocked(useLocalActivityItems);
@@ -82,7 +90,15 @@ function setSources({
 }
 
 describe('useActivityDetailsItem', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useSelector).mockImplementation((selector) => {
+      if (selector === selectSelectedAccountGroupInternalAccounts) {
+        return [];
+      }
+      return { transactions: [] };
+    });
+  });
 
   it('returns undefined when no identifier is provided', () => {
     setSources({});
@@ -104,6 +120,32 @@ describe('useActivityDetailsItem', () => {
 
     const { result } = renderHook(() => useActivityDetailsItem('0xsol'));
     expect(result.current).toBe(nonEvm);
+  });
+
+  it('forwards bridge history and subject address into non-EVM mapping', () => {
+    const transaction = { id: 'sol-tx', account: 'account-1' };
+    const subjectAddress = 'So11111111111111111111111111111111111111112';
+    jest.mocked(useSelector).mockImplementation((selector) => {
+      if (selector === selectSelectedAccountGroupInternalAccounts) {
+        return [{ id: 'account-1', address: subjectAddress }];
+      }
+      return { transactions: [transaction] };
+    });
+    mapNonEvmTransactionsMock.mockReturnValue([
+      makeItem({ type: 'receive', hash: 'sol-tx' }),
+    ]);
+
+    renderHook(() => useActivityDetailsItem('sol-tx'));
+
+    expect(mapNonEvmTransactionsMock).toHaveBeenCalledWith(
+      [transaction],
+      expect.any(Function),
+      expect.any(Function),
+    );
+    const getSubjectAddress = mapNonEvmTransactionsMock.mock.calls[0][2] as (
+      tx: { account: string },
+    ) => string | undefined;
+    expect(getSubjectAddress(transaction)).toBe(subjectAddress);
   });
 
   it('prefers the API item over a generic local contractInteraction', () => {

--- a/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.test.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.test.ts
@@ -142,9 +142,8 @@ describe('useActivityDetailsItem', () => {
       expect.any(Function),
       expect.any(Function),
     );
-    const getSubjectAddress = mapNonEvmTransactionsMock.mock.calls[0][2] as (
-      tx: { account: string },
-    ) => string | undefined;
+    const getSubjectAddress = mapNonEvmTransactionsMock.mock
+      .calls[0][2] as (tx: { account: string }) => string | undefined;
     expect(getSubjectAddress(transaction)).toBe(subjectAddress);
   });
 

--- a/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.ts
@@ -6,12 +6,17 @@ import {
   preferLocalOrApiActivityItem,
 } from '../../../../util/activity-adapters';
 import { selectNonEvmTransactionsForSelectedAccountGroup } from '../../../../selectors/multichain/multichain';
+import { selectSelectedAccountGroupInternalAccounts } from '../../../../selectors/multichainAccounts/accountTreeController';
 /* eslint-disable import-x/no-restricted-paths -- TODO(ADR-0020): reuses the activity list's data sources; route-isolation backlog */
 import { useLocalActivityItems } from '../../ActivityList/hooks/useLocalActivityItems';
 import { useRampActivityItems } from '../../ActivityList/hooks/useRampActivityItems';
 import { useTransactionsQuery } from '../../ActivityList/useTransactionsQuery';
 import { mapNonEvmTransactions } from '../../ActivityList/helpers/transformations';
 /* eslint-enable import-x/no-restricted-paths */
+import {
+  findBridgeHistoryItemBySrcTxHash,
+  useBridgeHistoryItemBySrcTxHash,
+} from '../../../UI/Bridge/hooks/useBridgeHistoryItemBySrcTxHash';
 
 /**
  * Re-resolves a single {@link ActivityListItem} by its transaction identifier
@@ -159,6 +164,10 @@ export function useActivityDetailsItem(
   const nonEvmState = useSelector(
     selectNonEvmTransactionsForSelectedAccountGroup,
   );
+  const selectedAccountGroupInternalAccounts = useSelector(
+    selectSelectedAccountGroupInternalAccounts,
+  );
+  const { bridgeHistoryItemsBySrcTxHash } = useBridgeHistoryItemBySrcTxHash();
 
   const confirmedEvmItems = useMemo<ActivityListItem[]>(
     () => evmTransactions?.pages.flatMap((page) => page.data) ?? [],
@@ -166,8 +175,21 @@ export function useActivityDetailsItem(
   );
 
   const nonEvmItems = useMemo<ActivityListItem[]>(
-    () => mapNonEvmTransactions(nonEvmState?.transactions ?? []),
-    [nonEvmState?.transactions],
+    () =>
+      mapNonEvmTransactions(
+        nonEvmState?.transactions ?? [],
+        (txId) =>
+          findBridgeHistoryItemBySrcTxHash(bridgeHistoryItemsBySrcTxHash, txId),
+        (transaction) =>
+          selectedAccountGroupInternalAccounts.find(
+            (account) => account.id === transaction.account,
+          )?.address,
+      ),
+    [
+      nonEvmState?.transactions,
+      bridgeHistoryItemsBySrcTxHash,
+      selectedAccountGroupInternalAccounts,
+    ],
   );
 
   const chainedLocalItems = useMemo(

--- a/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.ts
+++ b/app/components/Views/ActivityDetails/hooks/useActivityDetailsItem.ts
@@ -164,9 +164,7 @@ export function useActivityDetailsItem(
   const nonEvmState = useSelector(
     selectNonEvmTransactionsForSelectedAccountGroup,
   );
-  const selectedAccountGroupInternalAccounts = useSelector(
-    selectSelectedAccountGroupInternalAccounts,
-  );
+  const accounts = useSelector(selectSelectedAccountGroupInternalAccounts);
   const { bridgeHistoryItemsBySrcTxHash } = useBridgeHistoryItemBySrcTxHash();
 
   const confirmedEvmItems = useMemo<ActivityListItem[]>(
@@ -181,15 +179,10 @@ export function useActivityDetailsItem(
         (txId) =>
           findBridgeHistoryItemBySrcTxHash(bridgeHistoryItemsBySrcTxHash, txId),
         (transaction) =>
-          selectedAccountGroupInternalAccounts.find(
-            (account) => account.id === transaction.account,
-          )?.address,
+          accounts.find((account) => account.id === transaction.account)
+            ?.address,
       ),
-    [
-      nonEvmState?.transactions,
-      bridgeHistoryItemsBySrcTxHash,
-      selectedAccountGroupInternalAccounts,
-    ],
+    [nonEvmState?.transactions, bridgeHistoryItemsBySrcTxHash, accounts],
   );
 
   const chainedLocalItems = useMemo(


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Follow-up to #34682. Activity details remaps non-EVM transactions without the wallet address or bridge history that the list already passes into `mapNonEvmTransactions`.


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed non-EVM activity details showing the wrong party or a send instead of a bridge

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #34682

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: non-EVM activity details mapping

  Scenario: Solana receive details match the list
    Given a wallet with Solana activity in a multi-account group

    When the user opens a Solana receive from the Activity list
    Then details uses the selected account as the subject address
    And the row type and party match the list

  Scenario: Bridge details stay a bridge
    Given a cross-chain bridge in activity

    When the user opens that row from the list
    Then details still shows a bridge, not a send
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — same mapping the list already uses; no UI design changes

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9a2ed8d4068118a8acbdfdc619baca62330bfd1d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->