### PR TITLE
fix: respect securityAlertsEnabled in trust-signals middleware

### DIFF
--- a/app/core/BackgroundBridge/BackgroundBridge.js
+++ b/app/core/BackgroundBridge/BackgroundBridge.js
@@ -693,6 +693,7 @@ export class BackgroundBridge extends EventEmitter {
       createTrustSignalsMiddleware({
         phishingController: Engine.context.PhishingController,
         networkController: Engine.context.NetworkController,
+        preferencesController: Engine.context.PreferencesController,
       }),
     );
 

--- a/app/core/RPCMethods/TrustSignalsMiddleware.test.ts
+++ b/app/core/RPCMethods/TrustSignalsMiddleware.test.ts
@@ -2,6 +2,7 @@ import { JsonRpcEngine } from '@metamask/json-rpc-engine';
 import type { JsonRpcRequest, JsonRpcParams } from '@metamask/utils';
 import type { PhishingController } from '@metamask/phishing-controller';
 import type { NetworkController } from '@metamask/network-controller';
+import type { PreferencesController } from '@metamask/preferences-controller';
 import Logger from '../../util/Logger';
 import { createTrustSignalsMiddleware } from './TrustSignalsMiddleware';
 import {
@@ -96,6 +97,14 @@ function createMockNetworkController(options?: {
   } as unknown as NetworkController;
 }
 
+function createMockPreferencesController(
+  securityAlertsEnabled = true,
+): PreferencesController {
+  return {
+    state: { securityAlertsEnabled },
+  } as unknown as PreferencesController;
+}
+
 function createNetworkControllerWithoutChain(): NetworkController {
   return {
     state: {},
@@ -150,6 +159,7 @@ describe('createTrustSignalsMiddleware', () => {
     const middleware = createTrustSignalsMiddleware({
       phishingController,
       networkController,
+      preferencesController: createMockPreferencesController(),
     });
 
     await callThroughMiddleware({
@@ -176,6 +186,7 @@ describe('createTrustSignalsMiddleware', () => {
     const middleware = createTrustSignalsMiddleware({
       phishingController,
       networkController,
+      preferencesController: createMockPreferencesController(),
     });
 
     await callThroughMiddleware({
@@ -202,6 +213,7 @@ describe('createTrustSignalsMiddleware', () => {
     const middleware = createTrustSignalsMiddleware({
       phishingController,
       networkController,
+      preferencesController: createMockPreferencesController(),
     });
 
     await callThroughMiddleware({
@@ -230,6 +242,7 @@ describe('createTrustSignalsMiddleware', () => {
     const middleware = createTrustSignalsMiddleware({
       phishingController,
       networkController,
+      preferencesController: createMockPreferencesController(),
     });
 
     await callThroughMiddleware({
@@ -271,6 +284,7 @@ describe('createTrustSignalsMiddleware', () => {
     const middleware = createTrustSignalsMiddleware({
       phishingController,
       networkController,
+      preferencesController: createMockPreferencesController(),
     });
 
     await callThroughMiddleware({
@@ -296,6 +310,97 @@ describe('createTrustSignalsMiddleware', () => {
     );
   });
 
+  it('does not scan the origin URL when security alerts are disabled', async () => {
+    const phishingController = createMockPhishingController();
+    const networkController = createMockNetworkController();
+
+    mockIsEthSendTransaction.mockReturnValue(false);
+    mockIsEthSignTypedData.mockReturnValue(false);
+
+    const middleware = createTrustSignalsMiddleware({
+      phishingController,
+      networkController,
+      preferencesController: createMockPreferencesController(false),
+    });
+
+    const { nextMiddleware } = await callThroughMiddleware({
+      middleware,
+      request: {
+        jsonrpc,
+        id: 1,
+        method: 'eth_chainId',
+        origin: 'https://example.com',
+        params: [] as JsonRpcParams,
+      },
+    });
+
+    expect(mockScanUrl).not.toHaveBeenCalled();
+    expect(nextMiddleware).toHaveBeenCalled();
+  });
+
+  it('does not scan addresses when security alerts are disabled', async () => {
+    const phishingController = createMockPhishingController();
+    const networkController = createMockNetworkController({ chainId: '0x1' });
+
+    mockIsEthSendTransaction.mockReturnValue(true);
+    mockHasValidTransactionParams.mockReturnValue(true);
+    mockExtractSpenderFromApprovalData.mockReturnValue('0xspender');
+
+    const middleware = createTrustSignalsMiddleware({
+      phishingController,
+      networkController,
+      preferencesController: createMockPreferencesController(false),
+    });
+
+    await callThroughMiddleware({
+      middleware,
+      request: {
+        jsonrpc,
+        id: 1,
+        method: 'eth_sendTransaction',
+        params: [{ to: '0xabc', data: '0xdata' }] as JsonRpcParams,
+      },
+    });
+
+    expect(mockScanAddress).not.toHaveBeenCalled();
+  });
+
+  it('picks up preference changes without rebuilding the middleware', async () => {
+    const phishingController = createMockPhishingController();
+    const networkController = createMockNetworkController();
+    const preferencesState = { securityAlertsEnabled: false };
+
+    mockIsEthSendTransaction.mockReturnValue(false);
+    mockIsEthSignTypedData.mockReturnValue(false);
+
+    const middleware = createTrustSignalsMiddleware({
+      phishingController,
+      networkController,
+      preferencesController: {
+        state: preferencesState,
+      } as unknown as PreferencesController,
+    });
+
+    const request: TrustSignalsTestRequest = {
+      jsonrpc,
+      id: 1,
+      method: 'eth_chainId',
+      origin: 'https://example.com',
+      params: [] as JsonRpcParams,
+    };
+
+    await callThroughMiddleware({ middleware, request });
+    expect(mockScanUrl).not.toHaveBeenCalled();
+
+    preferencesState.securityAlertsEnabled = true;
+
+    await callThroughMiddleware({ middleware, request });
+    expect(mockScanUrl).toHaveBeenCalledWith(
+      phishingController,
+      'https://example.com',
+    );
+  });
+
   it('logs unexpected error and still calls next middleware', async () => {
     const phishingController = createMockPhishingController();
     const networkController = createMockNetworkController();
@@ -308,6 +413,7 @@ describe('createTrustSignalsMiddleware', () => {
     const middleware = createTrustSignalsMiddleware({
       phishingController,
       networkController,
+      preferencesController: createMockPreferencesController(),
     });
 
     const { response, nextMiddleware } = await callThroughMiddleware({

--- a/app/core/RPCMethods/TrustSignalsMiddleware.ts
+++ b/app/core/RPCMethods/TrustSignalsMiddleware.ts
@@ -2,6 +2,7 @@ import { createAsyncMiddleware } from '@metamask/json-rpc-engine';
 import type { Hex, Json, JsonRpcRequest } from '@metamask/utils';
 import type { PhishingController } from '@metamask/phishing-controller';
 import type { NetworkController } from '@metamask/network-controller';
+import type { PreferencesController } from '@metamask/preferences-controller';
 import Logger from '../../util/Logger';
 import {
   parseTypedDataMessage,
@@ -30,6 +31,7 @@ interface TrustSignalsRequest extends JsonRpcRequest {
 interface TrustSignalsMiddlewareConfig {
   phishingController: PhishingController;
   networkController: NetworkController;
+  preferencesController: PreferencesController;
 }
 
 /**
@@ -144,9 +146,16 @@ async function handleEthSignTypedData(
 export function createTrustSignalsMiddleware({
   phishingController,
   networkController,
+  preferencesController,
 }: TrustSignalsMiddlewareConfig) {
   return createAsyncMiddleware(async (req: TrustSignalsRequest, _res, next) => {
     try {
+      // Read per request rather than at construction time, so toggling the
+      // preference takes effect without rebuilding the RPC pipeline.
+      if (!preferencesController.state.securityAlertsEnabled) {
+        return;
+      }
+
       if (req.origin) {
         scanUrl(phishingController, req.origin);
       }


### PR DESCRIPTION
## **Description**

The mobile trust-signals middleware scans every request origin and every transaction / typed-data address without ever checking the user's `securityAlertsEnabled` preference. Users who turn security alerts off still have their browsing origins and transaction counterparties sent to the Blockaid scan API.

The extension's equivalent middleware has always gated on this preference (`isSecurityAlertsEnabledByUser` in `app/scripts/lib/trust-signals/trust-signals-middleware.ts`). Mobile's `createTrustSignalsMiddleware` has no equivalent check, and neither does its install site in `BackgroundBridge.js`. This was found while auditing the two implementations for [PSAFE-613](https://consensyssoftware.atlassian.net/browse/PSAFE-613) (pulling this middleware into core).

**Solution:** inject `PreferencesController` into the middleware factory and return early when `securityAlertsEnabled` is false. The `finally { next() }` block is unchanged, so the RPC pipeline is unaffected either way.

Two notes on the approach:

- The preference is read **per request** rather than captured at construction time, so toggling the setting takes effect without rebuilding the RPC pipeline. There is a test covering this specifically.
- The existing `isBlockaidFeatureEnabled()` helper in `app/util/blockaid/index.ts` was deliberately not used. It is `async` and reaches into `Engine.context` directly, which would have added an `await` before `next()` on every RPC call and made the middleware harder to extract in PSAFE-613. Injecting the controller matches how `phishingController` and `networkController` are already passed in.

This is independently shippable and does not block or depend on any other trust-signals work.

## **Changelog**

CHANGELOG entry: Fixed an issue where turning off the security alerts setting did not stop origins and addresses from being sent to the security scanning API

## **Related issues**

Fixes: [PSAFE-620](https://consensyssoftware.atlassian.net/browse/PSAFE-620)

## **Manual testing steps**

Feature: security alerts preference gates trust-signals scanning

 Scenario: user disables security alerts
 Given the user has Settings > Security & Privacy > Security alerts enabled
 And the user opens a dapp in the in-app browser and submits a transaction
 Then origin and address scan requests are sent to the Blockaid API

 When the user turns Security alerts off
 And the user reloads the dapp and submits another transaction
 Then no origin or address scan requests are sent
 And the confirmation still renders and can be submitted normally

 When the user turns Security alerts back on
 Then scan requests resume without restarting the app

## **Screenshots/Recordings**

### Security Alerts On
https://github.com/user-attachments/assets/f3e54948-1960-48ea-bb5f-e656c7723af1


### Security Alerts Off
https://github.com/user-attachments/assets/67a22fdb-4825-4d8d-8403-5396d02ee453


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[PSAFE-613]: https://consensyssoftware.atlassian.net/browse/PSAFE-613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PSAFE-620]: https://consensyssoftware.atlassian.net/browse/PSAFE-620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7be6abfe1a410ed29e6b79ab521399da0680d0c8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->