### PR TITLE
feat: MUSD-1258 Add earn section to explore now and crypto tabs (doesn't include explore search)

### DIFF
--- a/.js.env.example
+++ b/.js.env.example
@@ -115,6 +115,7 @@ export MM_STABLE_COIN_SERVICE_INTERRUPTION_BANNER_ENABLED="true"
 export MM_POOLED_STAKING_ENABLED="true"
 export MM_POOLED_STAKING_SERVICE_INTERRUPTION_BANNER_ENABLED="true"
 export MM_EARN_HOME_SECTION_ENABLED="false"
+export MM_EXPLORE_EARN_SECTION_ENABLED="false"
 # mUSD
 export MM_MUSD_CONVERSION_FLOW_ENABLED="false"
 # See app/components/UI/Earn/docs/wildcard-token-list.md for more information.

--- a/app/components/UI/Earn/components/EarnSection/EarnSection.test.tsx
+++ b/app/components/UI/Earn/components/EarnSection/EarnSection.test.tsx
@@ -9,7 +9,7 @@ import {
   waitFor,
 } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useIsFocused } from '@react-navigation/native';
 import {
   Icon,
   IconColor,
@@ -53,6 +53,9 @@ jest.mock(
 
 const mockUseNavigation = useNavigation as jest.MockedFunction<
   typeof useNavigation
+>;
+const mockUseIsFocused = useIsFocused as jest.MockedFunction<
+  typeof useIsFocused
 >;
 const mockUseTailwind = useTailwind as jest.MockedFunction<typeof useTailwind>;
 const mockUseEarnSectionAssets = jest.mocked(useEarnSectionAssets);
@@ -186,6 +189,7 @@ describe('EarnSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     resetEarnSectionRefreshForTests();
+    mockUseIsFocused.mockReturnValue(true);
     mockMoneyAccountVisible = false;
     mockUseSelector.mockImplementation((selector) =>
       selector === selectIsMoneyAccountVisible
@@ -251,6 +255,22 @@ describe('EarnSection', () => {
     );
     expect(mockUseSectionPerformance).toHaveBeenCalledWith(
       expect.objectContaining({ enabled: true }),
+    );
+  });
+
+  it('disables Homepage telemetry while Home is unfocused', () => {
+    mockUseIsFocused.mockReturnValue(false);
+
+    render(<HomepageEarnSection sectionIndex={2} totalSectionsLoaded={5} />);
+
+    expect(mockUseHomeViewedEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sectionRef: null,
+        fireImmediateWhenNoView: false,
+      }),
+    );
+    expect(mockUseSectionPerformance).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
     );
   });
 

--- a/app/components/UI/Earn/components/EarnSection/EarnSection.test.tsx
+++ b/app/components/UI/Earn/components/EarnSection/EarnSection.test.tsx
@@ -1,7 +1,13 @@
 import React, { createRef } from 'react';
 import type { Asset } from '@metamask/assets-controllers';
 import { EthAccountType } from '@metamask/keyring-api';
-import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
 import {
@@ -140,20 +146,24 @@ const navigate = jest.fn();
 const mockRefetchBalance = jest.fn();
 let mockMoneyAccountVisible = false;
 
+const createSectionResult = (
+  overrides: Partial<ReturnType<typeof useEarnSectionAssets>> = {},
+): ReturnType<typeof useEarnSectionAssets> => ({
+  assetSlots: [assetSlot],
+  hasMoreAssets: false,
+  moneyApyPercent: 6.2,
+  moneyRateStatus: 'ready',
+  isLoading: false,
+  hasError: false,
+  errors: [],
+  refresh: jest.fn(),
+  ...overrides,
+});
+
 const mockSectionResult = (
   overrides: Partial<ReturnType<typeof useEarnSectionAssets>> = {},
 ) => {
-  mockUseEarnSectionAssets.mockReturnValue({
-    assetSlots: [assetSlot],
-    hasMoreAssets: false,
-    moneyApyPercent: 6.2,
-    moneyRateStatus: 'ready',
-    isLoading: false,
-    hasError: false,
-    errors: [],
-    refresh: jest.fn(),
-    ...overrides,
-  });
+  mockUseEarnSectionAssets.mockReturnValue(createSectionResult(overrides));
 };
 
 const getSuccessArrowIcons = () =>
@@ -521,7 +531,9 @@ describe('EarnSection', () => {
     const refresh = jest.fn().mockResolvedValue(undefined);
     mockSectionResult({ refresh });
 
-    renderEarnSection({ refreshTrigger: 0 });
+    renderEarnSection({
+      refresh: { trigger: 0, silentRefresh: true },
+    });
 
     expect(refresh).not.toHaveBeenCalled();
     expect(mockRefetchBalance).not.toHaveBeenCalled();
@@ -531,7 +543,9 @@ describe('EarnSection', () => {
     const refresh = jest.fn().mockResolvedValue(undefined);
     mockSectionResult({ refresh });
 
-    renderEarnSection({ refreshTrigger: 1 });
+    renderEarnSection({
+      refresh: { trigger: 1, silentRefresh: true },
+    });
 
     await act(async () => {
       await Promise.resolve();
@@ -541,21 +555,54 @@ describe('EarnSection', () => {
     expect(mockRefetchBalance).toHaveBeenCalledTimes(1);
   });
 
-  it('logs an Explore refresh failure', async () => {
-    const refreshError = new Error('Earn refresh failed');
-    const refresh = jest.fn().mockRejectedValue(refreshError);
+  it('logs when an Explore refresh fails', async () => {
+    const error = new Error('Explore refresh failed');
+    const refresh = jest.fn().mockRejectedValue(error);
     mockSectionResult({ refresh });
 
-    renderEarnSection({ refreshTrigger: 1 });
+    renderEarnSection({
+      refresh: { trigger: 1, silentRefresh: true },
+    });
+
+    await waitFor(() => {
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        error,
+        'EarnSection: Failed to refresh section data',
+      );
+    });
+  });
+
+  it('coalesces concurrent Explore refreshes across EarnSection instances', async () => {
+    const firstRefresh = jest.fn().mockResolvedValue(undefined);
+    const secondRefresh = jest.fn().mockResolvedValue(undefined);
+    mockUseEarnSectionAssets
+      .mockImplementationOnce(() =>
+        createSectionResult({ refresh: firstRefresh }),
+      )
+      .mockImplementationOnce(() =>
+        createSectionResult({ refresh: secondRefresh }),
+      );
+
+    render(
+      <>
+        <EarnSection
+          tokenDetailsSource={TokenDetailsSource.ExploreEarn}
+          refresh={{ trigger: 1, silentRefresh: true }}
+        />
+        <EarnSection
+          tokenDetailsSource={TokenDetailsSource.ExploreEarn}
+          refresh={{ trigger: 1, silentRefresh: true }}
+        />
+      </>,
+    );
 
     await act(async () => {
       await Promise.resolve();
     });
 
-    expect(mockLoggerError).toHaveBeenCalledWith(
-      refreshError,
-      'EarnSection: Failed to refresh Earn data',
-    );
+    expect(firstRefresh).toHaveBeenCalledTimes(1);
+    expect(secondRefresh).not.toHaveBeenCalled();
+    expect(mockRefetchBalance).toHaveBeenCalledTimes(1);
   });
 
   it('refreshes catalogue sources from the error action', async () => {

--- a/app/components/UI/Earn/components/EarnSection/EarnSection.test.tsx
+++ b/app/components/UI/Earn/components/EarnSection/EarnSection.test.tsx
@@ -12,22 +12,23 @@ import {
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
-import useMoneyAccountBalance from '../../../../UI/Money/hooks/useMoneyAccountBalance';
-import { selectIsMoneyAccountVisible } from '../../../../UI/Money/selectors/visibility';
-import { useMoneyNavigation } from '../../../../UI/Money/hooks/useMoneyNavigation';
-import useEarnSectionAssets from '../../../../UI/Earn/hooks/useEarnSectionAssets';
-import useHomeViewedEvent from '../../hooks/useHomeViewedEvent';
-import { useSectionPerformance } from '../../hooks/useSectionPerformance';
-import { TokenDetailsSource } from '../../../../UI/TokenDetails/constants/constants';
-import type { SectionRefreshHandle } from '../../types';
-import type { EarnAssetId } from '../../../../UI/Earn/types/earnAssets';
+import useMoneyAccountBalance from '../../../Money/hooks/useMoneyAccountBalance';
+import { selectIsMoneyAccountVisible } from '../../../Money/selectors/visibility';
+import { useMoneyNavigation } from '../../../Money/hooks/useMoneyNavigation';
+import useEarnSectionAssets from '../../hooks/useEarnSectionAssets';
+import useHomeViewedEvent from '../../../../Views/Homepage/hooks/useHomeViewedEvent';
+import { useSectionPerformance } from '../../../../Views/Homepage/hooks/useSectionPerformance';
+import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
+import type { SectionRefreshHandle } from '../../../../Views/Homepage/types';
+import type { EarnAssetId } from '../../types/earnAssets';
 import type {
   EarnSectionAssetSlot,
   EarnSectionRankedAsset,
-} from '../../../../UI/Earn/utils/earnSection';
-import { EARN_EXPERIENCES } from '../../../../UI/Earn/constants/experiences';
+} from '../../utils/earnSection';
+import { EARN_EXPERIENCES } from '../../constants/experiences';
 import EarnSection from './EarnSection';
-import HomepageEarnSection from './HomepageEarnSection';
+import HomepageEarnSection from '../../../../Views/Homepage/Sections/EarnSection/HomepageEarnSection';
+import Logger from '../../../../../util/Logger';
 
 jest.mock('@react-navigation/native');
 jest.mock('react-redux', () => ({
@@ -41,6 +42,7 @@ jest.mock('../../../../UI/Money/selectors/visibility');
 jest.mock('../../../../UI/Money/hooks/useMoneyNavigation');
 jest.mock('../../../../Views/Homepage/hooks/useHomeViewedEvent');
 jest.mock('../../../../Views/Homepage/hooks/useSectionPerformance');
+jest.mock('../../../../../util/Logger');
 jest.mock(
   '../../../../UI/Assets/components/AssetLogo/AssetLogo',
   () => () => null,
@@ -63,6 +65,7 @@ const mockUseHomeViewedEvent = useHomeViewedEvent as jest.MockedFunction<
 const mockUseSectionPerformance = useSectionPerformance as jest.MockedFunction<
   typeof useSectionPerformance
 >;
+const mockLoggerError = jest.mocked(Logger.error);
 
 const assetId =
   'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as EarnAssetId;
@@ -162,6 +165,16 @@ const getSuccessArrowIcons = () =>
         props.color === IconColor.SuccessDefault,
     );
 
+const renderEarnSection = (
+  props: Partial<React.ComponentProps<typeof EarnSection>> = {},
+) =>
+  render(
+    <EarnSection
+      tokenDetailsSource={TokenDetailsSource.ExploreEarn}
+      {...props}
+    />,
+  );
+
 describe('EarnSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -195,7 +208,7 @@ describe('EarnSection', () => {
   });
 
   it('renders the Earn section title', () => {
-    render(<EarnSection />);
+    renderEarnSection();
 
     expect(
       screen.getByText(strings('homepage.sections.earn')),
@@ -203,7 +216,7 @@ describe('EarnSection', () => {
   });
 
   it('disables Homepage telemetry for shared Explore rendering', () => {
-    render(<EarnSection />);
+    renderEarnSection();
 
     expect(mockUseHomeViewedEvent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -234,7 +247,7 @@ describe('EarnSection', () => {
   });
 
   it('renders funded lending assets with Get APY copy', () => {
-    render(<EarnSection />);
+    renderEarnSection();
 
     expect(screen.getByTestId('earn-section-asset-0-card')).toBeOnTheScreen();
     expect(
@@ -269,7 +282,7 @@ describe('EarnSection', () => {
       ],
     });
 
-    render(<EarnSection />);
+    renderEarnSection();
 
     expect(
       screen.getByText(
@@ -306,7 +319,7 @@ describe('EarnSection', () => {
       ],
     });
 
-    render(<EarnSection />);
+    renderEarnSection();
 
     expect(
       screen.getByTestId('earn-section-asset-0-no-fee-tag'),
@@ -314,7 +327,7 @@ describe('EarnSection', () => {
   });
 
   it('hides No fee when asset experiences are not subsidized', () => {
-    render(<EarnSection />);
+    renderEarnSection();
 
     expect(
       screen.queryByTestId('earn-section-asset-0-no-fee-tag'),
@@ -325,7 +338,7 @@ describe('EarnSection', () => {
     mockMoneyAccountVisible = true;
     mockSectionResult({ assetSlots: [] });
 
-    render(<EarnSection />);
+    renderEarnSection();
 
     expect(
       screen.getByTestId('earn-section-money-account-card'),
@@ -341,7 +354,7 @@ describe('EarnSection', () => {
     } as ReturnType<typeof useMoneyAccountBalance>);
     mockSectionResult({ assetSlots: [] });
 
-    render(<EarnSection />);
+    renderEarnSection();
 
     expect(
       screen.queryByText(strings('earn_module.new_tag')),
@@ -356,7 +369,7 @@ describe('EarnSection', () => {
     } as ReturnType<typeof useMoneyAccountBalance>);
     mockSectionResult({ assetSlots: [] });
 
-    render(<EarnSection />);
+    renderEarnSection();
 
     expect(
       screen.queryByText(strings('earn_module.new_tag')),
@@ -375,7 +388,7 @@ describe('EarnSection', () => {
     } as ReturnType<typeof useMoneyAccountBalance>);
     mockSectionResult({ assetSlots: [] });
 
-    render(<EarnSection />);
+    renderEarnSection();
 
     expect(
       screen.getByTestId('earn-section-money-account-balance-skeleton'),
@@ -393,7 +406,7 @@ describe('EarnSection', () => {
       moneyRateStatus: 'loading',
     });
 
-    render(<EarnSection />);
+    renderEarnSection();
 
     expect(
       screen.getByTestId('earn-section-money-account-apy-skeleton'),
@@ -411,7 +424,7 @@ describe('EarnSection', () => {
       moneyRateStatus: 'unavailable',
     });
 
-    render(<EarnSection />);
+    renderEarnSection();
 
     expect(
       screen.getByText(strings('earn_module.rate_unavailable')),
@@ -424,7 +437,7 @@ describe('EarnSection', () => {
   it('uses the asset name for zero-balance tiles', () => {
     mockSectionResult({ assetSlots: [zeroBalanceAssetSlot] });
 
-    render(<EarnSection />);
+    renderEarnSection();
 
     expect(screen.getByTestId('earn-section-asset-0-card')).toBeOnTheScreen();
     expect(
@@ -438,13 +451,13 @@ describe('EarnSection', () => {
   it('removes green arrows from Money and asset tiles', () => {
     mockMoneyAccountVisible = true;
 
-    render(<EarnSection />);
+    renderEarnSection();
 
     expect(getSuccessArrowIcons()).toHaveLength(0);
   });
 
   it('navigates with the selected CAIP-19 asset ID', () => {
-    render(<EarnSection />);
+    renderEarnSection();
 
     fireEvent.press(screen.getByTestId('earn-section-asset-0-card'));
 
@@ -457,7 +470,7 @@ describe('EarnSection', () => {
   it('navigates zero-balance assets to Asset Overview', () => {
     mockSectionResult({ assetSlots: [zeroBalanceAssetSlot] });
 
-    render(<EarnSection />);
+    render(<HomepageEarnSection sectionIndex={0} totalSectionsLoaded={1} />);
 
     fireEvent.press(screen.getByTestId('earn-section-asset-0-card'));
 
@@ -483,7 +496,7 @@ describe('EarnSection', () => {
   });
 
   it('navigates funded assets to Earn strategy selection', () => {
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    renderEarnSection();
 
     fireEvent.press(screen.getByTestId('earn-section-asset-0-card'));
 
@@ -498,10 +511,51 @@ describe('EarnSection', () => {
       hasError: true,
     });
 
-    render(<EarnSection />);
+    renderEarnSection();
 
     expect(screen.getByTestId('earn-section-error')).toBeOnTheScreen();
     expect(screen.getByTestId('earn-section-asset-0-card')).toBeOnTheScreen();
+  });
+
+  it('does not refresh for the initial Explore trigger', () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    mockSectionResult({ refresh });
+
+    renderEarnSection({ refreshTrigger: 0 });
+
+    expect(refresh).not.toHaveBeenCalled();
+    expect(mockRefetchBalance).not.toHaveBeenCalled();
+  });
+
+  it('refreshes catalogue and Money balance for an Explore trigger', async () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    mockSectionResult({ refresh });
+
+    renderEarnSection({ refreshTrigger: 1 });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(mockRefetchBalance).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs an Explore refresh failure', async () => {
+    const refreshError = new Error('Earn refresh failed');
+    const refresh = jest.fn().mockRejectedValue(refreshError);
+    mockSectionResult({ refresh });
+
+    renderEarnSection({ refreshTrigger: 1 });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      refreshError,
+      'EarnSection: Failed to refresh Earn data',
+    );
   });
 
   it('refreshes catalogue sources from the error action', async () => {
@@ -510,7 +564,7 @@ describe('EarnSection', () => {
       hasError: true,
       refresh,
     });
-    render(<EarnSection />);
+    renderEarnSection();
 
     await act(async () => {
       fireEvent.press(screen.getByTestId('earn-section-error-retry-button'));
@@ -524,7 +578,13 @@ describe('EarnSection', () => {
     mockSectionResult({ refresh });
     const ref = createRef<SectionRefreshHandle>();
 
-    render(<EarnSection ref={ref} sectionIndex={0} totalSectionsLoaded={1} />);
+    render(
+      <HomepageEarnSection
+        ref={ref}
+        sectionIndex={0}
+        totalSectionsLoaded={1}
+      />,
+    );
 
     await act(async () => {
       await ref.current?.refresh();
@@ -546,7 +606,7 @@ describe('EarnSection', () => {
       hasError: true,
       refresh,
     });
-    render(<EarnSection />);
+    renderEarnSection();
 
     const retryButton = screen.getByTestId('earn-section-error-retry-button');
     fireEvent.press(retryButton);
@@ -566,7 +626,7 @@ describe('EarnSection', () => {
   it('renders skeleton slots while catalogue data loads', () => {
     mockSectionResult({ isLoading: true });
 
-    render(<EarnSection />);
+    renderEarnSection();
 
     expect(screen.getByTestId(assetId)).toBeOnTheScreen();
     expect(

--- a/app/components/UI/Earn/components/EarnSection/EarnSection.test.tsx
+++ b/app/components/UI/Earn/components/EarnSection/EarnSection.test.tsx
@@ -27,12 +27,9 @@ import { useSectionPerformance } from '../../../../Views/Homepage/hooks/useSecti
 import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
 import type { SectionRefreshHandle } from '../../../../Views/Homepage/types';
 import type { EarnAssetId } from '../../types/earnAssets';
-import type {
-  EarnSectionAssetSlot,
-  EarnSectionRankedAsset,
-} from '../../utils/earnSection';
+import type { EarnSectionRankedAsset } from '../../utils/earnSection';
 import { EARN_EXPERIENCES } from '../../constants/experiences';
-import EarnSection from './EarnSection';
+import EarnSection, { resetEarnSectionRefreshForTests } from './EarnSection';
 import HomepageEarnSection from '../../../../Views/Homepage/Sections/EarnSection/HomepageEarnSection';
 import Logger from '../../../../../util/Logger';
 
@@ -188,6 +185,7 @@ const renderEarnSection = (
 describe('EarnSection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resetEarnSectionRefreshForTests();
     mockMoneyAccountVisible = false;
     mockUseSelector.mockImplementation((selector) =>
       selector === selectIsMoneyAccountVisible
@@ -539,6 +537,27 @@ describe('EarnSection', () => {
     expect(mockRefetchBalance).not.toHaveBeenCalled();
   });
 
+  it('does not refresh or query Money balance while disabled', async () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    mockSectionResult({ refresh });
+
+    renderEarnSection({
+      enabled: false,
+      refresh: { trigger: 1, silentRefresh: true },
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockUseEarnSectionAssets).toHaveBeenCalledWith({ enabled: false });
+    expect(mockUseMoneyAccountBalance).toHaveBeenCalledWith({
+      enabled: false,
+    });
+    expect(refresh).not.toHaveBeenCalled();
+    expect(mockRefetchBalance).not.toHaveBeenCalled();
+  });
+
   it('refreshes catalogue and Money balance for an Explore trigger', async () => {
     const refresh = jest.fn().mockResolvedValue(undefined);
     mockSectionResult({ refresh });
@@ -643,12 +662,13 @@ describe('EarnSection', () => {
 
   it('prevents duplicate retries while a refresh is pending', async () => {
     let resolveRefresh: (() => void) | undefined;
-    const refresh = jest.fn(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveRefresh = resolve;
-        }),
-    );
+    let refreshPromise: Promise<void> | undefined;
+    const refresh = jest.fn(() => {
+      refreshPromise = new Promise<void>((resolve) => {
+        resolveRefresh = resolve;
+      });
+      return refreshPromise;
+    });
     mockSectionResult({
       hasError: true,
       refresh,
@@ -663,11 +683,20 @@ describe('EarnSection', () => {
 
     await act(async () => {
       resolveRefresh?.();
+      await refreshPromise;
     });
 
-    fireEvent.press(retryButton);
+    await act(async () => {
+      fireEvent.press(retryButton);
+      await Promise.resolve();
+    });
 
     expect(refresh).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      resolveRefresh?.();
+      await refreshPromise;
+    });
   });
 
   it('renders skeleton slots while catalogue data loads', () => {

--- a/app/components/UI/Earn/components/EarnSection/EarnSection.tsx
+++ b/app/components/UI/Earn/components/EarnSection/EarnSection.tsx
@@ -1,6 +1,7 @@
 import React, {
   forwardRef,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -32,37 +33,37 @@ import {
 import { getNetworkImageSource } from '../../../../../util/networks';
 import MoneyBalanceIcon from '../../../../../images/money-balance.svg';
 import { strings } from '../../../../../../locales/i18n';
-import type { TokenI } from '../../../../UI/Tokens/types';
-import AssetLogo from '../../../../UI/Assets/components/AssetLogo/AssetLogo';
-import EarnSectionAssetCard from '../../../../UI/Earn/components/EarnSectionAssetCard';
-import EarnSectionCard from '../../../../UI/Earn/components/EarnSectionCard';
+import type { TokenI } from '../../../Tokens/types';
+import AssetLogo from '../../../Assets/components/AssetLogo/AssetLogo';
+import EarnSectionAssetCard from '../EarnSectionAssetCard';
+import EarnSectionCard from '../EarnSectionCard';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
-import { homepageSectionTitleTestId } from '../../Homepage.testIds';
+import { homepageSectionTitleTestId } from '../../../../Views/Homepage/Homepage.testIds';
 import useHomeViewedEvent, {
   HomeSectionNames,
-} from '../../hooks/useHomeViewedEvent';
-import { useSectionPerformance } from '../../hooks/useSectionPerformance';
-import type { SectionRefreshHandle } from '../../types';
+} from '../../../../Views/Homepage/hooks/useHomeViewedEvent';
+import { useSectionPerformance } from '../../../../Views/Homepage/hooks/useSectionPerformance';
+import type { SectionRefreshHandle } from '../../../../Views/Homepage/types';
 import { useNavigation } from '@react-navigation/native';
-import useEarnSectionAssets from '../../../../UI/Earn/hooks/useEarnSectionAssets';
-import { truncateNumber } from '../../../../UI/Earn/utils';
+import useEarnSectionAssets from '../../hooks/useEarnSectionAssets';
+import { truncateNumber } from '../../utils';
 import {
   earnAssetToToken,
   getEarnAssetFiatDisplay,
   getEarnAssetMetadata,
-} from '../../../../UI/Earn/utils/earnAssets';
-import useMoneyAccountBalance from '../../../../UI/Money/hooks/useMoneyAccountBalance';
-import { useMoneyNavigation } from '../../../../UI/Money/hooks/useMoneyNavigation';
-import { selectIsMoneyAccountVisible } from '../../../../UI/Money/selectors/visibility';
-import { TokenDetailsSource } from '../../../../UI/TokenDetails/constants/constants';
-import type { EarnAsset } from '../../../../UI/Earn/types/earnAssets';
-import EarnNewTag from '../../../../UI/Earn/components/EarnNewTag';
-import EarnNoFeeTag from '../../../../UI/Earn/components/EarnNoFeeTag';
+} from '../../utils/earnAssets';
+import useMoneyAccountBalance from '../../../Money/hooks/useMoneyAccountBalance';
+import { useMoneyNavigation } from '../../../Money/hooks/useMoneyNavigation';
+import { selectIsMoneyAccountVisible } from '../../../Money/selectors/visibility';
+import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
+import type { EarnAsset } from '../../types/earnAssets';
+import EarnNewTag from '../EarnNewTag';
+import EarnNoFeeTag from '../EarnNoFeeTag';
 import Logger from '../../../../../util/Logger';
-import { isEarnAssetBalanceBelowMinDepositAmount } from '../../../../UI/Earn/utils/earnAssets/earnAssetBalance';
+import { isEarnAssetBalanceBelowMinDepositAmount } from '../../utils/earnAssets/earnAssetBalance';
 import Routes from '../../../../../constants/navigation/Routes';
 
-export interface EarnSectionHomeAnalytics {
+interface EarnSectionHomeAnalytics {
   sectionIndex: number;
   totalSectionsLoaded: number;
 }
@@ -146,8 +147,8 @@ const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
       moneyRateStatus,
       isLoading,
       hasError,
-      refresh,
-    } = useEarnSectionAssets({ refreshTrigger });
+      refresh: refreshEarnSectionAssets,
+    } = useEarnSectionAssets();
 
     const {
       totalFiatFormatted: moneyAccountBalanceFiat,
@@ -165,9 +166,32 @@ const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
       (!isLoading && hasMoreAssets ? 1 : 0);
 
     const refresh = useCallback(async () => {
-      refetchMoneyAccountBalance();
-      await refreshEarnSectionAssets();
+      await Promise.all([
+        refetchMoneyAccountBalance(),
+        refreshEarnSectionAssets(),
+      ]);
     }, [refetchMoneyAccountBalance, refreshEarnSectionAssets]);
+
+    /**
+     * Refreshes Earn data when the parent requests a page refresh.
+     * Currently used for Explore pull-to-refresh.
+     */
+    useEffect(() => {
+      if (refreshTrigger === undefined || refreshTrigger <= 0) return;
+
+      const refreshEarnSection = async () => {
+        try {
+          await refresh();
+        } catch (error: unknown) {
+          Logger.error(
+            error instanceof Error ? error : new Error(String(error)),
+            'EarnSection: Failed to refresh Earn data',
+          );
+        }
+      };
+
+      refreshEarnSection();
+    }, [refresh, refreshTrigger]);
 
     useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 

--- a/app/components/UI/Earn/components/EarnSection/EarnSection.tsx
+++ b/app/components/UI/Earn/components/EarnSection/EarnSection.tsx
@@ -147,6 +147,7 @@ const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
     const tw = useTailwind();
     const navigation = useNavigation<AppNavigationProp>();
     const isHomepageSection = homeAnalytics !== undefined;
+    const homepageTelemetryEnabled = isHomepageSection && enabled;
     const sectionIndex = homeAnalytics?.sectionIndex ?? -1;
     const totalSectionsLoaded = homeAnalytics?.totalSectionsLoaded ?? 0;
 
@@ -215,14 +216,14 @@ const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
     useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 
     const { onLayout } = useHomeViewedEvent({
-      sectionRef: isHomepageSection ? sectionViewRef : null,
+      sectionRef: homepageTelemetryEnabled ? sectionViewRef : null,
       isLoading,
       sectionName: HomeSectionNames.EARN,
       sectionIndex,
       totalSectionsLoaded,
       isEmpty: false,
       itemCount: earnSectionItemCount,
-      fireImmediateWhenNoView: isHomepageSection,
+      fireImmediateWhenNoView: homepageTelemetryEnabled,
     });
 
     useSectionPerformance({
@@ -230,7 +231,7 @@ const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
       contentReady: !isLoading,
       isEmpty: false,
       isLoading,
-      enabled: isHomepageSection,
+      enabled: homepageTelemetryEnabled,
     });
 
     const handleHeaderPress = () => {

--- a/app/components/UI/Earn/components/EarnSection/EarnSection.tsx
+++ b/app/components/UI/Earn/components/EarnSection/EarnSection.tsx
@@ -1,7 +1,6 @@
 import React, {
   forwardRef,
   useCallback,
-  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -62,6 +61,8 @@ import EarnNoFeeTag from '../EarnNoFeeTag';
 import Logger from '../../../../../util/Logger';
 import { isEarnAssetBalanceBelowMinDepositAmount } from '../../utils/earnAssets/earnAssetBalance';
 import Routes from '../../../../../constants/navigation/Routes';
+import { RefreshConfig } from '../../../../Views/TrendingView/hooks/useExploreRefresh';
+import { useFeedRefresh } from '../../../../Views/TrendingView/hooks/useFeedRefresh';
 
 interface EarnSectionHomeAnalytics {
   sectionIndex: number;
@@ -72,7 +73,7 @@ export interface EarnSectionProps {
   tokenDetailsSource: TokenDetailsSource;
   homeAnalytics?: EarnSectionHomeAnalytics;
   showDividers?: boolean;
-  refreshTrigger?: number;
+  refresh?: RefreshConfig;
 }
 
 const renderEarnAssetIcon = (token: TokenI) => {
@@ -124,9 +125,17 @@ const renderUnavailableAssetCard = (key: string) => (
   />
 );
 
+// Module-level promise to prevent multiple concurrent refreshes.
+let refreshPromise: Promise<void> | undefined;
+
 const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
   (
-    { tokenDetailsSource, homeAnalytics, showDividers = false, refreshTrigger },
+    {
+      tokenDetailsSource,
+      homeAnalytics,
+      showDividers = false,
+      refresh: exploreFeedRefreshConfig,
+    },
     ref,
   ) => {
     const tw = useTailwind();
@@ -166,32 +175,34 @@ const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
       (!isLoading && hasMoreAssets ? 1 : 0);
 
     const refresh = useCallback(async () => {
-      await Promise.all([
+      refreshPromise ??= Promise.all([
         refetchMoneyAccountBalance(),
         refreshEarnSectionAssets(),
-      ]);
+      ])
+        .then(() => undefined)
+        .finally(() => {
+          refreshPromise = undefined;
+        });
+
+      return refreshPromise;
     }, [refetchMoneyAccountBalance, refreshEarnSectionAssets]);
+
+    const handleExploreFeedRefresh = useCallback(async () => {
+      try {
+        await refresh();
+      } catch (error: unknown) {
+        Logger.error(
+          error instanceof Error ? error : new Error(String(error)),
+          'EarnSection: Failed to refresh section data',
+        );
+      }
+    }, [refresh]);
 
     /**
      * Refreshes Earn data when the parent requests a page refresh.
      * Currently used for Explore pull-to-refresh.
      */
-    useEffect(() => {
-      if (refreshTrigger === undefined || refreshTrigger <= 0) return;
-
-      const refreshEarnSection = async () => {
-        try {
-          await refresh();
-        } catch (error: unknown) {
-          Logger.error(
-            error instanceof Error ? error : new Error(String(error)),
-            'EarnSection: Failed to refresh Earn data',
-          );
-        }
-      };
-
-      refreshEarnSection();
-    }, [refresh, refreshTrigger]);
+    useFeedRefresh(exploreFeedRefreshConfig, handleExploreFeedRefresh);
 
     useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 

--- a/app/components/UI/Earn/components/EarnSection/EarnSection.tsx
+++ b/app/components/UI/Earn/components/EarnSection/EarnSection.tsx
@@ -74,6 +74,7 @@ export interface EarnSectionProps {
   homeAnalytics?: EarnSectionHomeAnalytics;
   showDividers?: boolean;
   refresh?: RefreshConfig;
+  enabled?: boolean;
 }
 
 const renderEarnAssetIcon = (token: TokenI) => {
@@ -128,6 +129,10 @@ const renderUnavailableAssetCard = (key: string) => (
 // Module-level promise to prevent multiple concurrent refreshes.
 let refreshPromise: Promise<void> | undefined;
 
+export const resetEarnSectionRefreshForTests = () => {
+  refreshPromise = undefined;
+};
+
 const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
   (
     {
@@ -135,6 +140,7 @@ const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
       homeAnalytics,
       showDividers = false,
       refresh: exploreFeedRefreshConfig,
+      enabled = true,
     },
     ref,
   ) => {
@@ -157,14 +163,16 @@ const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
       isLoading,
       hasError,
       refresh: refreshEarnSectionAssets,
-    } = useEarnSectionAssets();
+    } = useEarnSectionAssets({ enabled });
 
     const {
       totalFiatFormatted: moneyAccountBalanceFiat,
       totalFiatRaw: moneyAccountBalanceRaw,
       isBalanceLoading: isMoneyAccountBalanceLoading,
       refetchBalance: refetchMoneyAccountBalance,
-    } = useMoneyAccountBalance({ enabled: isMoneyAccountVisible });
+    } = useMoneyAccountBalance({
+      enabled: enabled && isMoneyAccountVisible,
+    });
 
     const { isOnboardingRedirectNeeded, navigateToMoneyHome } =
       useMoneyNavigation();
@@ -202,7 +210,10 @@ const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
      * Refreshes Earn data when the parent requests a page refresh.
      * Currently used for Explore pull-to-refresh.
      */
-    useFeedRefresh(exploreFeedRefreshConfig, handleExploreFeedRefresh);
+    useFeedRefresh(
+      enabled ? exploreFeedRefreshConfig : undefined,
+      handleExploreFeedRefresh,
+    );
 
     useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 

--- a/app/components/UI/Earn/components/EarnSection/EarnSection.tsx
+++ b/app/components/UI/Earn/components/EarnSection/EarnSection.tsx
@@ -210,10 +210,7 @@ const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
      * Refreshes Earn data when the parent requests a page refresh.
      * Currently used for Explore pull-to-refresh.
      */
-    useFeedRefresh(
-      enabled ? exploreFeedRefreshConfig : undefined,
-      handleExploreFeedRefresh,
-    );
+    useFeedRefresh(exploreFeedRefreshConfig, handleExploreFeedRefresh, enabled);
 
     useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 

--- a/app/components/UI/Earn/components/EarnSection/index.ts
+++ b/app/components/UI/Earn/components/EarnSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from './EarnSection';

--- a/app/components/UI/Earn/hooks/useEarnAssetCatalogue.test.ts
+++ b/app/components/UI/Earn/hooks/useEarnAssetCatalogue.test.ts
@@ -41,7 +41,9 @@ jest.mock('../../../../core/Engine', () => ({
 
 const USDC_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
 const AUSDC_ADDRESS = '0xbcca60bb61934080951369a648fb03df4f96263c';
+const DAI_ADDRESS = '0x6b175474e89094c44da98b954eedeac495271d0f';
 const USDC_ASSET_ID = `eip155:1/erc20:${USDC_ADDRESS}`;
+const DAI_ASSET_ID = `eip155:1/erc20:${DAI_ADDRESS}`;
 const ETH_ASSET_ID = 'eip155:1/slip44:60';
 const POL_ASSET_ID = 'eip155:137/slip44:966';
 const TRON_CHAIN_ID = 'tron:728126428';
@@ -80,6 +82,15 @@ const market: LendingMarket = {
   },
   outputToken: {
     address: AUSDC_ADDRESS,
+    chainId: 1,
+  },
+};
+const unheldMarket: LendingMarket = {
+  ...market,
+  id: 'mainnet-aave-dai',
+  name: 'Aave DAI',
+  underlying: {
+    address: DAI_ADDRESS,
     chainId: 1,
   },
 };
@@ -300,6 +311,64 @@ describe('useEarnAssetCatalogue', () => {
     mockDependencies();
   });
 
+  it('disables catalogue data sources when disabled', async () => {
+    const { result } = renderHook(() =>
+      useEarnAssetCatalogue({ enabled: false }),
+    );
+
+    expect(mockUseMoneyVaultApy).toHaveBeenCalledWith({ enabled: false });
+    expect(mockUseTronStakeApy).toHaveBeenCalledWith({
+      fetchOnMount: false,
+      chainId: expect.anything(),
+    });
+    expect(mockUseEarnSectionLendingMarkets).toHaveBeenCalledWith({
+      enabled: false,
+    });
+    expect(mockUseEarnSectionTokenMetadata).toHaveBeenCalledWith([], false);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(refetchMoneyApy).not.toHaveBeenCalled();
+    expect(refreshLendingMarkets).not.toHaveBeenCalled();
+    expect(refreshLendingMetadata).not.toHaveBeenCalled();
+    expect(refetchTrxApy).not.toHaveBeenCalled();
+    expect(
+      Engine.context.EarnController.refreshPooledStakingVaultApyAverages,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('does not report loading while cached lending markets refresh', () => {
+    mockUseEarnSectionLendingMarkets.mockReturnValue({
+      markets: [market],
+      isLoading: true,
+      error: null,
+      refresh: refreshLendingMarkets,
+    });
+    mockSelectorValues({
+      earnTokens: [createEarnToken(USDC_ADDRESS, 'underlying')],
+      assets: [moneyToken],
+    });
+
+    const { result } = renderHook(() => useEarnAssetCatalogue());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.assets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          assetId: USDC_ASSET_ID,
+          kind: 'held',
+          experiences: expect.arrayContaining([
+            expect.objectContaining({
+              type: EARN_EXPERIENCES.STABLECOIN_LENDING,
+            }),
+          ]),
+        }),
+      ]),
+    );
+  });
+
   it('merges Money and lending experiences for the same underlying asset', () => {
     const { result } = renderHook(() => useEarnAssetCatalogue());
 
@@ -319,6 +388,51 @@ describe('useEarnAssetCatalogue', () => {
     expect(
       usdc?.experiences.map(({ isFeeSubsidized }) => isFeeSubsidized),
     ).toEqual([false, false]);
+  });
+
+  it('fetches metadata only for lending assets absent from wallet assets', () => {
+    mockUseEarnSectionLendingMarkets.mockReturnValue({
+      markets: [market, unheldMarket],
+      isLoading: false,
+      error: null,
+      refresh: refreshLendingMarkets,
+    });
+    mockSelectorValues({
+      earnTokens: [createEarnToken(USDC_ADDRESS, 'underlying')],
+    });
+
+    renderHook(() => useEarnAssetCatalogue());
+
+    expect(mockUseEarnSectionTokenMetadata).toHaveBeenLastCalledWith(
+      [DAI_ASSET_ID],
+      true,
+    );
+  });
+
+  it('retains held Earn lending experience without lending metadata', () => {
+    mockUseEarnSectionTokenMetadata.mockReturnValue({
+      tokensByAssetId: {},
+      isLoading: false,
+      isSettled: true,
+      error: null,
+      refresh: refreshLendingMetadata,
+    });
+    mockSelectorValues({
+      earnTokens: [createEarnToken(USDC_ADDRESS, 'underlying')],
+      assets: [moneyToken],
+    });
+
+    const { result } = renderHook(() => useEarnAssetCatalogue());
+    const usdc = result.current.assets.find(
+      ({ assetId }) => assetId === USDC_ASSET_ID,
+    );
+
+    expect(usdc).toMatchObject({ kind: 'held' });
+    expect(
+      usdc?.experiences.some(
+        ({ type }) => type === EARN_EXPERIENCES.STABLECOIN_LENDING,
+      ),
+    ).toBe(true);
   });
 
   it('marks Money deposit experiences with subsidized routes', () => {
@@ -766,6 +880,16 @@ describe('useEarnAssetCatalogue', () => {
   });
 
   it('reports initial lending metadata work as loading without an error', () => {
+    mockUseEarnSectionLendingMarkets.mockReturnValue({
+      markets: [market, unheldMarket],
+      isLoading: false,
+      error: null,
+      refresh: refreshLendingMarkets,
+    });
+    mockSelectorValues({
+      earnTokens: [createEarnToken(USDC_ADDRESS, 'underlying')],
+      assets: [moneyToken],
+    });
     mockUseEarnSectionTokenMetadata.mockReturnValue({
       tokensByAssetId: {},
       isLoading: true,

--- a/app/components/UI/Earn/hooks/useEarnAssetCatalogue.test.ts
+++ b/app/components/UI/Earn/hooks/useEarnAssetCatalogue.test.ts
@@ -12,11 +12,9 @@ import Engine from '../../../../core/Engine';
 import { selectEarnAssetCatalogueInputs } from '../../../../selectors/earnController/earn';
 import { selectRelayFixedSpread } from '../../../../selectors/featureFlagController/confirmations';
 import type { RelayFixedSpreadConfig } from '../../../Views/confirmations/utils/relayFixedSpread';
-import useMoneyAccountInfo from '../../Money/hooks/useMoneyAccountInfo';
-import useMoneyAccountVisibility from '../../Money/hooks/useMoneyAccountVisibility';
 import useMoneyVaultApy from '../../Money/hooks/useMoneyVaultApy';
 import type { MoneyDepositAsset } from '../../Money/selectors/depositTokens';
-import { invalidateMoneyAccountBalanceCaches } from '../../Money/utils/invalidateMoneyAccountBalanceCaches';
+import { selectIsMoneyAccountVisible } from '../../Money/selectors/visibility';
 import useEarnSectionLendingMarkets from './useEarnSectionLendingMarkets';
 import useEarnSectionTokenMetadata from './useEarnSectionTokenMetadata';
 import useTronStakeApy, { FetchStatus } from './useTronStakeApy';
@@ -26,12 +24,7 @@ jest.mock('react-redux');
 jest.mock('@metamask/bridge-controller', () => ({
   formatAddressToAssetId: jest.fn(),
 }));
-jest.mock('../../Money/hooks/useMoneyAccountVisibility');
-jest.mock('../../Money/hooks/useMoneyAccountInfo');
 jest.mock('../../Money/hooks/useMoneyVaultApy');
-jest.mock('../../Money/utils/invalidateMoneyAccountBalanceCaches', () => ({
-  invalidateMoneyAccountBalanceCaches: jest.fn(),
-}));
 jest.mock('./useEarnSectionLendingMarkets');
 jest.mock('./useEarnSectionTokenMetadata');
 jest.mock('./useTronStakeApy');
@@ -56,19 +49,9 @@ const TRX_ASSET_ID = `${TRON_CHAIN_ID}/slip44:195`;
 
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 const mockFormatAddressToAssetId = jest.mocked(formatAddressToAssetId);
-const mockUseMoneyAccountVisibility =
-  useMoneyAccountVisibility as jest.MockedFunction<
-    typeof useMoneyAccountVisibility
-  >;
-const mockUseMoneyAccountInfo = useMoneyAccountInfo as jest.MockedFunction<
-  typeof useMoneyAccountInfo
->;
 const mockUseMoneyVaultApy = useMoneyVaultApy as jest.MockedFunction<
   typeof useMoneyVaultApy
 >;
-const mockInvalidateMoneyAccountBalanceCaches = jest.mocked(
-  invalidateMoneyAccountBalanceCaches,
-);
 const mockUseEarnSectionLendingMarkets =
   useEarnSectionLendingMarkets as jest.MockedFunction<
     typeof useEarnSectionLendingMarkets
@@ -206,9 +189,9 @@ const refreshLendingMarkets = jest.fn();
 const refreshLendingMetadata = jest.fn();
 const refetchMoneyApy = jest.fn();
 const refetchTrxApy = jest.fn();
-const MONEY_ACCOUNT_ADDRESS = '0x1234567890123456789012345678901234567890';
-
 const mockSelectorValues = ({
+  isMoneyAccountVisible = true,
+  isEarnEligible = true,
   isPooledStakingEnabled = true,
   isStablecoinLendingEnabled = true,
   isTrxStakingEnabled = false,
@@ -218,6 +201,8 @@ const mockSelectorValues = ({
   assets,
   relayFixedSpread = EMPTY_RELAY_FIXED_SPREAD_CONFIG,
 }: {
+  isMoneyAccountVisible?: boolean;
+  isEarnEligible?: boolean;
   isPooledStakingEnabled?: boolean;
   isStablecoinLendingEnabled?: boolean;
   isTrxStakingEnabled?: boolean;
@@ -228,6 +213,9 @@ const mockSelectorValues = ({
   relayFixedSpread?: RelayFixedSpreadConfig;
 } = {}) => {
   mockUseSelector.mockImplementation((selector) => {
+    if (selector === selectIsMoneyAccountVisible) {
+      return isMoneyAccountVisible;
+    }
     if (selector === selectRelayFixedSpread) return relayFixedSpread;
     if (selector === selectEarnAssetCatalogueInputs) {
       return {
@@ -240,7 +228,7 @@ const mockSelectorValues = ({
           ...earnTokens.map(earnTokenToAsset),
           ...earnOutputTokens.map(earnTokenToAsset),
         ],
-        isEarnEligible: true,
+        isEarnEligible,
         isPooledStakingEnabled,
         isStablecoinLendingEnabled,
         isTrxStakingEnabled,
@@ -252,16 +240,6 @@ const mockSelectorValues = ({
 
 const mockDependencies = () => {
   mockSelectorValues();
-  mockUseMoneyAccountVisibility.mockReturnValue({
-    isMoneyAccountVisible: true,
-  });
-  mockUseMoneyAccountInfo.mockReturnValue({
-    isMoneyAccountFeatureEnabled: true,
-    hasMoneyAccount: true,
-    primaryMoneyAccount: {
-      address: MONEY_ACCOUNT_ADDRESS,
-    },
-  } as ReturnType<typeof useMoneyAccountInfo>);
   mockUseMoneyVaultApy.mockReturnValue({
     apyDecimal: 0.062,
     apyPercent: 6.2,
@@ -313,7 +291,6 @@ describe('useEarnAssetCatalogue', () => {
     refreshLendingMetadata.mockResolvedValue(undefined);
     refetchMoneyApy.mockResolvedValue(undefined);
     refetchTrxApy.mockResolvedValue(undefined);
-    mockInvalidateMoneyAccountBalanceCaches.mockResolvedValue(undefined);
     (
       Engine.context.EarnController
         .refreshPooledStakingVaultApyAverages as jest.MockedFunction<
@@ -358,6 +335,52 @@ describe('useEarnAssetCatalogue', () => {
       usdc?.experiences.find(({ type }) => type === 'MONEY_ACCOUNT_DEPOSIT')
         ?.isFeeSubsidized,
     ).toBe(true);
+  });
+
+  it('keeps Money funding while Earn strategies are ineligible', () => {
+    mockSelectorValues({ isEarnEligible: false });
+
+    const { result } = renderHook(() => useEarnAssetCatalogue());
+
+    expect(result.current.assets).toHaveLength(1);
+    expect(result.current.assets[0].experiences).toEqual([
+      expect.objectContaining({ type: 'MONEY_ACCOUNT_DEPOSIT' }),
+    ]);
+  });
+
+  it('omits Money funding when the Money account is hidden', () => {
+    mockSelectorValues({ isMoneyAccountVisible: false });
+
+    const { result } = renderHook(() => useEarnAssetCatalogue());
+
+    expect(
+      result.current.assets.some(({ experiences }) =>
+        experiences.some(({ type }) => type === 'MONEY_ACCOUNT_DEPOSIT'),
+      ),
+    ).toBe(false);
+  });
+
+  it('reports Money assets that cannot be converted to CAIP-19', () => {
+    const unresolvedMoneyAsset = {
+      ...moneyToken,
+      address: '0x0000000000000000000000000000000000000000',
+      assetId: '0x0000000000000000000000000000000000000000',
+      chainId: '0x999',
+      isNative: true,
+    } as MoneyDepositAsset;
+    mockFormatAddressToAssetId.mockReturnValue(undefined);
+    mockSelectorValues({ moneyDepositAssets: [unresolvedMoneyAsset] });
+
+    const { result } = renderHook(() => useEarnAssetCatalogue());
+
+    expect(result.current.hasError).toBe(true);
+    expect(result.current.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: 'Money deposit asset has no valid CAIP-19 identity',
+        }),
+      ]),
+    );
   });
 
   it('adds Money funding to every deposit token including native assets', () => {
@@ -710,7 +733,7 @@ describe('useEarnAssetCatalogue', () => {
     expect(refetchTrxApy).toHaveBeenCalledTimes(1);
   });
 
-  it('refreshes the Money APY and balance when Money is visible', async () => {
+  it('refreshes the Money APY when Money is visible', async () => {
     const { result } = renderHook(() => useEarnAssetCatalogue());
 
     await act(async () => {
@@ -718,42 +741,10 @@ describe('useEarnAssetCatalogue', () => {
     });
 
     expect(refetchMoneyApy).toHaveBeenCalledTimes(1);
-    expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledWith(
-      MONEY_ACCOUNT_ADDRESS,
-    );
-  });
-
-  it('skips the Money balance refresh when Money is hidden', async () => {
-    mockUseMoneyAccountVisibility.mockReturnValue({
-      isMoneyAccountVisible: false,
-    });
-
-    const { result } = renderHook(() => useEarnAssetCatalogue());
-
-    await act(async () => {
-      await result.current.refresh();
-    });
-
-    expect(mockInvalidateMoneyAccountBalanceCaches).not.toHaveBeenCalled();
-  });
-
-  it('skips the Money balance refresh when no Money account address exists', async () => {
-    mockUseMoneyAccountInfo.mockReturnValue({
-      isMoneyAccountFeatureEnabled: true,
-      hasMoneyAccount: false,
-      primaryMoneyAccount: undefined,
-    } as ReturnType<typeof useMoneyAccountInfo>);
-
-    const { result } = renderHook(() => useEarnAssetCatalogue());
-
-    await act(async () => {
-      await result.current.refresh();
-    });
-
-    expect(mockInvalidateMoneyAccountBalanceCaches).not.toHaveBeenCalled();
   });
 
   it('reports missing lending decimals as an error', () => {
+    mockSelectorValues({ assets: [] });
     mockUseEarnSectionTokenMetadata.mockReturnValue({
       tokensByAssetId: {
         [USDC_ASSET_ID]: {
@@ -806,16 +797,5 @@ describe('useEarnAssetCatalogue', () => {
     const refreshPromise = act(async () => result.current.refresh());
 
     await expect(refreshPromise).rejects.toThrow('Lending unavailable');
-  });
-
-  it('rejects refresh when the Money balance refresh fails', async () => {
-    mockInvalidateMoneyAccountBalanceCaches.mockRejectedValue(
-      new Error('Money balance unavailable'),
-    );
-    const { result } = renderHook(() => useEarnAssetCatalogue());
-
-    const refreshPromise = act(async () => result.current.refresh());
-
-    await expect(refreshPromise).rejects.toThrow('Money balance unavailable');
   });
 });

--- a/app/components/UI/Earn/hooks/useEarnAssetCatalogue.test.ts
+++ b/app/components/UI/Earn/hooks/useEarnAssetCatalogue.test.ts
@@ -12,9 +12,11 @@ import Engine from '../../../../core/Engine';
 import { selectEarnAssetCatalogueInputs } from '../../../../selectors/earnController/earn';
 import { selectRelayFixedSpread } from '../../../../selectors/featureFlagController/confirmations';
 import type { RelayFixedSpreadConfig } from '../../../Views/confirmations/utils/relayFixedSpread';
+import useMoneyAccountInfo from '../../Money/hooks/useMoneyAccountInfo';
+import useMoneyAccountVisibility from '../../Money/hooks/useMoneyAccountVisibility';
 import useMoneyVaultApy from '../../Money/hooks/useMoneyVaultApy';
 import type { MoneyDepositAsset } from '../../Money/selectors/depositTokens';
-import { selectIsMoneyAccountVisible } from '../../Money/selectors/visibility';
+import { invalidateMoneyAccountBalanceCaches } from '../../Money/utils/invalidateMoneyAccountBalanceCaches';
 import useEarnSectionLendingMarkets from './useEarnSectionLendingMarkets';
 import useEarnSectionTokenMetadata from './useEarnSectionTokenMetadata';
 import useTronStakeApy, { FetchStatus } from './useTronStakeApy';
@@ -24,7 +26,12 @@ jest.mock('react-redux');
 jest.mock('@metamask/bridge-controller', () => ({
   formatAddressToAssetId: jest.fn(),
 }));
+jest.mock('../../Money/hooks/useMoneyAccountVisibility');
+jest.mock('../../Money/hooks/useMoneyAccountInfo');
 jest.mock('../../Money/hooks/useMoneyVaultApy');
+jest.mock('../../Money/utils/invalidateMoneyAccountBalanceCaches', () => ({
+  invalidateMoneyAccountBalanceCaches: jest.fn(),
+}));
 jest.mock('./useEarnSectionLendingMarkets');
 jest.mock('./useEarnSectionTokenMetadata');
 jest.mock('./useTronStakeApy');
@@ -41,9 +48,7 @@ jest.mock('../../../../core/Engine', () => ({
 
 const USDC_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
 const AUSDC_ADDRESS = '0xbcca60bb61934080951369a648fb03df4f96263c';
-const DAI_ADDRESS = '0x6b175474e89094c44da98b954eedeac495271d0f';
 const USDC_ASSET_ID = `eip155:1/erc20:${USDC_ADDRESS}`;
-const DAI_ASSET_ID = `eip155:1/erc20:${DAI_ADDRESS}`;
 const ETH_ASSET_ID = 'eip155:1/slip44:60';
 const POL_ASSET_ID = 'eip155:137/slip44:966';
 const TRON_CHAIN_ID = 'tron:728126428';
@@ -51,9 +56,19 @@ const TRX_ASSET_ID = `${TRON_CHAIN_ID}/slip44:195`;
 
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 const mockFormatAddressToAssetId = jest.mocked(formatAddressToAssetId);
+const mockUseMoneyAccountVisibility =
+  useMoneyAccountVisibility as jest.MockedFunction<
+    typeof useMoneyAccountVisibility
+  >;
+const mockUseMoneyAccountInfo = useMoneyAccountInfo as jest.MockedFunction<
+  typeof useMoneyAccountInfo
+>;
 const mockUseMoneyVaultApy = useMoneyVaultApy as jest.MockedFunction<
   typeof useMoneyVaultApy
 >;
+const mockInvalidateMoneyAccountBalanceCaches = jest.mocked(
+  invalidateMoneyAccountBalanceCaches,
+);
 const mockUseEarnSectionLendingMarkets =
   useEarnSectionLendingMarkets as jest.MockedFunction<
     typeof useEarnSectionLendingMarkets
@@ -82,15 +97,6 @@ const market: LendingMarket = {
   },
   outputToken: {
     address: AUSDC_ADDRESS,
-    chainId: 1,
-  },
-};
-const unheldMarket: LendingMarket = {
-  ...market,
-  id: 'mainnet-aave-dai',
-  name: 'Aave DAI',
-  underlying: {
-    address: DAI_ADDRESS,
     chainId: 1,
   },
 };
@@ -200,10 +206,9 @@ const refreshLendingMarkets = jest.fn();
 const refreshLendingMetadata = jest.fn();
 const refetchMoneyApy = jest.fn();
 const refetchTrxApy = jest.fn();
+const MONEY_ACCOUNT_ADDRESS = '0x1234567890123456789012345678901234567890';
 
 const mockSelectorValues = ({
-  isMoneyAccountVisible = true,
-  isEarnEligible = true,
   isPooledStakingEnabled = true,
   isStablecoinLendingEnabled = true,
   isTrxStakingEnabled = false,
@@ -213,8 +218,6 @@ const mockSelectorValues = ({
   assets,
   relayFixedSpread = EMPTY_RELAY_FIXED_SPREAD_CONFIG,
 }: {
-  isMoneyAccountVisible?: boolean;
-  isEarnEligible?: boolean;
   isPooledStakingEnabled?: boolean;
   isStablecoinLendingEnabled?: boolean;
   isTrxStakingEnabled?: boolean;
@@ -225,9 +228,6 @@ const mockSelectorValues = ({
   relayFixedSpread?: RelayFixedSpreadConfig;
 } = {}) => {
   mockUseSelector.mockImplementation((selector) => {
-    if (selector === selectIsMoneyAccountVisible) {
-      return isMoneyAccountVisible;
-    }
     if (selector === selectRelayFixedSpread) return relayFixedSpread;
     if (selector === selectEarnAssetCatalogueInputs) {
       return {
@@ -240,18 +240,28 @@ const mockSelectorValues = ({
           ...earnTokens.map(earnTokenToAsset),
           ...earnOutputTokens.map(earnTokenToAsset),
         ],
-        isEarnEligible,
+        isEarnEligible: true,
         isPooledStakingEnabled,
         isStablecoinLendingEnabled,
         isTrxStakingEnabled,
       };
     }
-    return { apyPercentString: '3.1%' };
+    return { apyPercentString: '3.1' };
   });
 };
 
 const mockDependencies = () => {
   mockSelectorValues();
+  mockUseMoneyAccountVisibility.mockReturnValue({
+    isMoneyAccountVisible: true,
+  });
+  mockUseMoneyAccountInfo.mockReturnValue({
+    isMoneyAccountFeatureEnabled: true,
+    hasMoneyAccount: true,
+    primaryMoneyAccount: {
+      address: MONEY_ACCOUNT_ADDRESS,
+    },
+  } as ReturnType<typeof useMoneyAccountInfo>);
   mockUseMoneyVaultApy.mockReturnValue({
     apyDecimal: 0.062,
     apyPercent: 6.2,
@@ -303,6 +313,7 @@ describe('useEarnAssetCatalogue', () => {
     refreshLendingMetadata.mockResolvedValue(undefined);
     refetchMoneyApy.mockResolvedValue(undefined);
     refetchTrxApy.mockResolvedValue(undefined);
+    mockInvalidateMoneyAccountBalanceCaches.mockResolvedValue(undefined);
     (
       Engine.context.EarnController
         .refreshPooledStakingVaultApyAverages as jest.MockedFunction<
@@ -313,18 +324,6 @@ describe('useEarnAssetCatalogue', () => {
   });
 
   it('merges Money and lending experiences for the same underlying asset', () => {
-    mockSelectorValues({
-      earnTokens: [createEarnToken(USDC_ADDRESS, 'underlying')],
-      assets: [moneyToken],
-    });
-    mockUseEarnSectionTokenMetadata.mockReturnValue({
-      tokensByAssetId: {},
-      isLoading: false,
-      isSettled: true,
-      error: null,
-      refresh: refreshLendingMetadata,
-    });
-
     const { result } = renderHook(() => useEarnAssetCatalogue());
 
     const usdc = result.current.assets.find(
@@ -343,50 +342,6 @@ describe('useEarnAssetCatalogue', () => {
     expect(
       usdc?.experiences.map(({ isFeeSubsidized }) => isFeeSubsidized),
     ).toEqual([false, false]);
-  });
-
-  it('fetches metadata only for lending assets absent from wallet assets', () => {
-    mockUseEarnSectionLendingMarkets.mockReturnValue({
-      markets: [market, unheldMarket],
-      isLoading: false,
-      error: null,
-      refresh: refreshLendingMarkets,
-    });
-    mockSelectorValues({
-      earnTokens: [createEarnToken(USDC_ADDRESS, 'underlying')],
-    });
-
-    renderHook(() => useEarnAssetCatalogue());
-
-    expect(mockUseEarnSectionTokenMetadata).toHaveBeenLastCalledWith([
-      DAI_ASSET_ID,
-    ]);
-  });
-
-  it('retains held Earn lending experience without lending metadata', () => {
-    mockUseEarnSectionTokenMetadata.mockReturnValue({
-      tokensByAssetId: {},
-      isLoading: false,
-      isSettled: true,
-      error: null,
-      refresh: refreshLendingMetadata,
-    });
-    mockSelectorValues({
-      earnTokens: [createEarnToken(USDC_ADDRESS, 'underlying')],
-      assets: [moneyToken],
-    });
-
-    const { result } = renderHook(() => useEarnAssetCatalogue());
-    const usdc = result.current.assets.find(
-      ({ assetId }) => assetId === USDC_ASSET_ID,
-    );
-
-    expect(usdc).toMatchObject({ kind: 'held' });
-    expect(
-      usdc?.experiences.some(
-        ({ type }) => type === EARN_EXPERIENCES.STABLECOIN_LENDING,
-      ),
-    ).toBe(true);
   });
 
   it('marks Money deposit experiences with subsidized routes', () => {
@@ -441,52 +396,6 @@ describe('useEarnAssetCatalogue', () => {
         asset?.experiences.some(({ type }) => type === 'MONEY_ACCOUNT_DEPOSIT'),
       ).toBe(true);
     });
-  });
-
-  it('keeps Money funding while Earn strategies are ineligible', () => {
-    mockSelectorValues({ isEarnEligible: false });
-
-    const { result } = renderHook(() => useEarnAssetCatalogue());
-
-    expect(result.current.assets).toHaveLength(1);
-    expect(result.current.assets[0].experiences).toEqual([
-      expect.objectContaining({ type: 'MONEY_ACCOUNT_DEPOSIT' }),
-    ]);
-  });
-
-  it('omits Money funding when the Money account is hidden', () => {
-    mockSelectorValues({ isMoneyAccountVisible: false });
-
-    const { result } = renderHook(() => useEarnAssetCatalogue());
-
-    expect(
-      result.current.assets.some(({ experiences }) =>
-        experiences.some(({ type }) => type === 'MONEY_ACCOUNT_DEPOSIT'),
-      ),
-    ).toBe(false);
-  });
-
-  it('reports Money assets that cannot be converted to CAIP-19', () => {
-    const unresolvedMoneyAsset = {
-      ...moneyToken,
-      address: '0x0000000000000000000000000000000000000000',
-      assetId: '0x0000000000000000000000000000000000000000',
-      chainId: '0x999',
-      isNative: true,
-    } as MoneyDepositAsset;
-    mockFormatAddressToAssetId.mockReturnValue(undefined);
-    mockSelectorValues({ moneyDepositAssets: [unresolvedMoneyAsset] });
-
-    const { result } = renderHook(() => useEarnAssetCatalogue());
-
-    expect(result.current.hasError).toBe(true);
-    expect(result.current.errors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          message: 'Money deposit asset has no valid CAIP-19 identity',
-        }),
-      ]),
-    );
   });
 
   it('omits unheld lending output tokens', () => {
@@ -577,7 +486,6 @@ describe('useEarnAssetCatalogue', () => {
       kind: 'discovery',
       assetId: ETH_ASSET_ID,
       metadata: {
-        symbol: 'ETH',
         ticker: 'ETH',
       },
     });
@@ -586,11 +494,6 @@ describe('useEarnAssetCatalogue', () => {
         id: `pooled:${ETH_ASSET_ID}`,
         role: 'underlying',
         type: EARN_EXPERIENCES.POOLED_STAKING,
-        rate: {
-          type: 'APR',
-          percentage: 3.1,
-          status: 'ready',
-        },
       }),
     ]);
   });
@@ -807,11 +710,50 @@ describe('useEarnAssetCatalogue', () => {
     expect(refetchTrxApy).toHaveBeenCalledTimes(1);
   });
 
-  it('reports missing lending decimals as an error', () => {
-    mockSelectorValues({
-      assets: [],
-      moneyDepositAssets: [],
+  it('refreshes the Money APY and balance when Money is visible', async () => {
+    const { result } = renderHook(() => useEarnAssetCatalogue());
+
+    await act(async () => {
+      await result.current.refresh();
     });
+
+    expect(refetchMoneyApy).toHaveBeenCalledTimes(1);
+    expect(mockInvalidateMoneyAccountBalanceCaches).toHaveBeenCalledWith(
+      MONEY_ACCOUNT_ADDRESS,
+    );
+  });
+
+  it('skips the Money balance refresh when Money is hidden', async () => {
+    mockUseMoneyAccountVisibility.mockReturnValue({
+      isMoneyAccountVisible: false,
+    });
+
+    const { result } = renderHook(() => useEarnAssetCatalogue());
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockInvalidateMoneyAccountBalanceCaches).not.toHaveBeenCalled();
+  });
+
+  it('skips the Money balance refresh when no Money account address exists', async () => {
+    mockUseMoneyAccountInfo.mockReturnValue({
+      isMoneyAccountFeatureEnabled: true,
+      hasMoneyAccount: false,
+      primaryMoneyAccount: undefined,
+    } as ReturnType<typeof useMoneyAccountInfo>);
+
+    const { result } = renderHook(() => useEarnAssetCatalogue());
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(mockInvalidateMoneyAccountBalanceCaches).not.toHaveBeenCalled();
+  });
+
+  it('reports missing lending decimals as an error', () => {
     mockUseEarnSectionTokenMetadata.mockReturnValue({
       tokensByAssetId: {
         [USDC_ASSET_ID]: {
@@ -833,10 +775,6 @@ describe('useEarnAssetCatalogue', () => {
   });
 
   it('reports initial lending metadata work as loading without an error', () => {
-    mockSelectorValues({
-      assets: [],
-      moneyDepositAssets: [],
-    });
     mockUseEarnSectionTokenMetadata.mockReturnValue({
       tokensByAssetId: {},
       isLoading: true,
@@ -868,7 +806,16 @@ describe('useEarnAssetCatalogue', () => {
     const refreshPromise = act(async () => result.current.refresh());
 
     await expect(refreshPromise).rejects.toThrow('Lending unavailable');
-    expect(refreshLendingMetadata).toHaveBeenCalledTimes(1);
-    expect(refetchMoneyApy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects refresh when the Money balance refresh fails', async () => {
+    mockInvalidateMoneyAccountBalanceCaches.mockRejectedValue(
+      new Error('Money balance unavailable'),
+    );
+    const { result } = renderHook(() => useEarnAssetCatalogue());
+
+    const refreshPromise = act(async () => result.current.refresh());
+
+    await expect(refreshPromise).rejects.toThrow('Money balance unavailable');
   });
 });

--- a/app/components/UI/Earn/hooks/useEarnAssetCatalogue.ts
+++ b/app/components/UI/Earn/hooks/useEarnAssetCatalogue.ts
@@ -11,11 +11,9 @@ import { selectEarnAssetCatalogueInputs } from '../../../../selectors/earnContro
 import { pooledStakingSelectors } from '../../../../selectors/earnController/pooledStaking';
 import { selectRelayFixedSpread } from '../../../../selectors/featureFlagController/confirmations';
 import { buildEvmCaip19AssetId } from '../../../../util/multichain/buildEvmCaip19AssetId';
-import useMoneyAccountInfo from '../../Money/hooks/useMoneyAccountInfo';
 import useMoneyVaultApy from '../../Money/hooks/useMoneyVaultApy';
 import { selectIsMoneyAccountVisible } from '../../Money/selectors/visibility';
 import { isMoneyDepositFeeSubsidized } from '../../Money/utils/isMoneyDepositFeeSubsidized';
-import { invalidateMoneyAccountBalanceCaches } from '../../Money/utils/invalidateMoneyAccountBalanceCaches';
 import type { TokenI } from '../../Tokens/types';
 import { EARN_EXPERIENCES } from '../constants/experiences';
 import type {
@@ -226,9 +224,7 @@ const getHeldEarnExperiences = ({
  */
 const useEarnAssetCatalogue = () => {
   const relayFixedSpread = useSelector(selectRelayFixedSpread);
-    const isMoneyAccountVisible = useSelector(selectIsMoneyAccountVisible);
-    const { primaryMoneyAccount } = useMoneyAccountInfo();
-  const moneyAccountAddress = primaryMoneyAccount?.address;
+  const isMoneyAccountVisible = useSelector(selectIsMoneyAccountVisible);
   const {
     earnTokens,
     earnOutputTokens,
@@ -574,15 +570,11 @@ const useEarnAssetCatalogue = () => {
       refreshLendingMetadata(),
       isTrxStakingEnabled ? refetchTrxApy() : Promise.resolve(),
       isMoneyAccountVisible ? refetchMoneyApy() : Promise.resolve(),
-      isMoneyAccountVisible && moneyAccountAddress
-        ? invalidateMoneyAccountBalanceCaches(moneyAccountAddress)
-        : Promise.resolve(),
     ]);
   }, [
     isMoneyAccountVisible,
     isPooledStakingEnabled,
     isTrxStakingEnabled,
-    moneyAccountAddress,
     refetchMoneyApy,
     refetchTrxApy,
     refreshLendingMetadata,

--- a/app/components/UI/Earn/hooks/useEarnAssetCatalogue.ts
+++ b/app/components/UI/Earn/hooks/useEarnAssetCatalogue.ts
@@ -11,9 +11,11 @@ import { selectEarnAssetCatalogueInputs } from '../../../../selectors/earnContro
 import { pooledStakingSelectors } from '../../../../selectors/earnController/pooledStaking';
 import { selectRelayFixedSpread } from '../../../../selectors/featureFlagController/confirmations';
 import { buildEvmCaip19AssetId } from '../../../../util/multichain/buildEvmCaip19AssetId';
+import useMoneyAccountInfo from '../../Money/hooks/useMoneyAccountInfo';
 import useMoneyVaultApy from '../../Money/hooks/useMoneyVaultApy';
 import { selectIsMoneyAccountVisible } from '../../Money/selectors/visibility';
 import { isMoneyDepositFeeSubsidized } from '../../Money/utils/isMoneyDepositFeeSubsidized';
+import { invalidateMoneyAccountBalanceCaches } from '../../Money/utils/invalidateMoneyAccountBalanceCaches';
 import type { TokenI } from '../../Tokens/types';
 import { EARN_EXPERIENCES } from '../constants/experiences';
 import type {
@@ -224,7 +226,9 @@ const getHeldEarnExperiences = ({
  */
 const useEarnAssetCatalogue = () => {
   const relayFixedSpread = useSelector(selectRelayFixedSpread);
-  const isMoneyAccountVisible = useSelector(selectIsMoneyAccountVisible);
+    const isMoneyAccountVisible = useSelector(selectIsMoneyAccountVisible);
+    const { primaryMoneyAccount } = useMoneyAccountInfo();
+  const moneyAccountAddress = primaryMoneyAccount?.address;
   const {
     earnTokens,
     earnOutputTokens,
@@ -570,11 +574,15 @@ const useEarnAssetCatalogue = () => {
       refreshLendingMetadata(),
       isTrxStakingEnabled ? refetchTrxApy() : Promise.resolve(),
       isMoneyAccountVisible ? refetchMoneyApy() : Promise.resolve(),
+      isMoneyAccountVisible && moneyAccountAddress
+        ? invalidateMoneyAccountBalanceCaches(moneyAccountAddress)
+        : Promise.resolve(),
     ]);
   }, [
     isMoneyAccountVisible,
     isPooledStakingEnabled,
     isTrxStakingEnabled,
+    moneyAccountAddress,
     refetchMoneyApy,
     refetchTrxApy,
     refreshLendingMetadata,

--- a/app/components/UI/Earn/hooks/useEarnAssetCatalogue.ts
+++ b/app/components/UI/Earn/hooks/useEarnAssetCatalogue.ts
@@ -43,6 +43,10 @@ const ETH_MAINNET_ASSET_ID = 'eip155:1/slip44:60' as CaipAssetType;
 const selectMainnetPooledStakingVaultApy =
   pooledStakingSelectors.selectVaultApyForChain(ChainId.ETHEREUM);
 
+interface UseEarnAssetCatalogueOptions {
+  enabled?: boolean;
+}
+
 const parseRatePercent = (value: string | number | null | undefined) => {
   if (value === null || value === undefined || String(value).trim() === '') {
     return undefined;
@@ -222,7 +226,9 @@ const getHeldEarnExperiences = ({
  * Builds the shared Earn asset catalogue from existing asset, Earn, Money,
  * lending, and staking authorities.
  */
-const useEarnAssetCatalogue = () => {
+const useEarnAssetCatalogue = ({
+  enabled = true,
+}: UseEarnAssetCatalogueOptions = {}) => {
   const relayFixedSpread = useSelector(selectRelayFixedSpread);
   const isMoneyAccountVisible = useSelector(selectIsMoneyAccountVisible);
   const {
@@ -243,7 +249,7 @@ const useEarnAssetCatalogue = () => {
       error: moneyApyError,
       refetch: refetchMoneyApy,
     },
-  } = useMoneyVaultApy({ enabled: isMoneyAccountVisible });
+  } = useMoneyVaultApy({ enabled: enabled && isMoneyAccountVisible });
   const mainnetVaultApy = useSelector(selectMainnetPooledStakingVaultApy);
   const {
     apyDecimal: trxApyPercent,
@@ -251,7 +257,7 @@ const useEarnAssetCatalogue = () => {
     errorMessage: trxErrorMessage,
     refetch: refetchTrxApy,
   } = useTronStakeApy({
-    fetchOnMount: isTrxStakingEnabled,
+    fetchOnMount: enabled && isTrxStakingEnabled,
     chainId: TRON_MAINNET_CHAIN_ID,
   });
   const {
@@ -260,7 +266,7 @@ const useEarnAssetCatalogue = () => {
     error: lendingMarketsError,
     refresh: refreshLendingMarkets,
   } = useEarnSectionLendingMarkets({
-    enabled: isStablecoinLendingEnabled && isEarnEligible,
+    enabled: enabled && isStablecoinLendingEnabled && isEarnEligible,
   });
 
   const walletAssetsById = useMemo(
@@ -300,7 +306,7 @@ const useEarnAssetCatalogue = () => {
     isSettled: isLendingMetadataSettled,
     error: lendingMetadataError,
     refresh: refreshLendingMetadata,
-  } = useEarnSectionTokenMetadata(discoveryLendingAssetIds);
+  } = useEarnSectionTokenMetadata(discoveryLendingAssetIds, enabled);
 
   const trxRatePercent = parseRatePercent(trxApyPercent);
   const ethRatePercent = parseRatePercent(mainnetVaultApy?.apyPercentString);
@@ -508,15 +514,19 @@ const useEarnAssetCatalogue = () => {
       return assetId !== undefined && !walletAssetsById.has(assetId);
     });
   const isLendingLoading =
+    enabled &&
     isStablecoinLendingEnabled &&
     isEarnEligible &&
-    (isLendingMarketsLoading || isLendingMetadataLoading);
+    ((isLendingMarketsLoading && lendingMarkets.length === 0) ||
+      (isLendingMetadataLoading && discoveryLendingAssetIds.length > 0));
   const isLoading =
-    (isMoneyAccountVisible && isMoneyApyLoading) ||
+    (enabled && isMoneyAccountVisible && isMoneyApyLoading) ||
     isLendingLoading ||
-    (isTrxStakingEnabled &&
+    (enabled &&
+      isTrxStakingEnabled &&
       (trxFetchStatus === FetchStatus.Initial ||
-        trxFetchStatus === FetchStatus.Fetching));
+        (trxFetchStatus === FetchStatus.Fetching &&
+          trxRatePercent === undefined)));
   const errors = useMemo(
     () =>
       [
@@ -560,6 +570,8 @@ const useEarnAssetCatalogue = () => {
   const hasError = errors.length > 0;
 
   const refresh = useCallback(async () => {
+    if (!enabled) return;
+
     await Promise.all([
       isPooledStakingEnabled
         ? Engine.context.EarnController.refreshPooledStakingVaultApyAverages(
@@ -572,6 +584,7 @@ const useEarnAssetCatalogue = () => {
       isMoneyAccountVisible ? refetchMoneyApy() : Promise.resolve(),
     ]);
   }, [
+    enabled,
     isMoneyAccountVisible,
     isPooledStakingEnabled,
     isTrxStakingEnabled,

--- a/app/components/UI/Earn/hooks/useEarnSectionAssets.test.ts
+++ b/app/components/UI/Earn/hooks/useEarnSectionAssets.test.ts
@@ -1,0 +1,82 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import Logger from '../../../../util/Logger';
+import useEarnAssetCatalogue from './useEarnAssetCatalogue';
+import useEarnSectionAssets from './useEarnSectionAssets';
+
+jest.mock('../../../../util/Logger');
+jest.mock('./useEarnAssetCatalogue');
+
+const mockUseEarnAssetCatalogue = useEarnAssetCatalogue as jest.MockedFunction<
+  typeof useEarnAssetCatalogue
+>;
+const mockLoggerError = jest.mocked(Logger.error);
+
+type EarnAssetCatalogueResult = ReturnType<typeof useEarnAssetCatalogue>;
+
+const createCatalogueResult = (
+  overrides: Partial<EarnAssetCatalogueResult> = {},
+): EarnAssetCatalogueResult => ({
+  assets: [],
+  assetsById: {},
+  isLoading: false,
+  hasError: false,
+  errors: [],
+  refresh: jest.fn().mockResolvedValue(undefined),
+  moneyApyPercent: undefined,
+  moneyRateStatus: 'unavailable',
+  ...overrides,
+});
+
+describe('useEarnSectionAssets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseEarnAssetCatalogue.mockReturnValue(createCatalogueResult());
+  });
+
+  it('does not refresh the catalogue for the initial trigger', () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    mockUseEarnAssetCatalogue.mockReturnValue(
+      createCatalogueResult({ refresh }),
+    );
+
+    renderHook(() => useEarnSectionAssets({ refreshTrigger: 0 }));
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it('refreshes the catalogue when the trigger increments', async () => {
+    const refresh = jest.fn().mockResolvedValue(undefined);
+    mockUseEarnAssetCatalogue.mockReturnValue(
+      createCatalogueResult({ refresh }),
+    );
+
+    const { rerender } = renderHook(
+      ({ refreshTrigger }: { refreshTrigger: number }) =>
+        useEarnSectionAssets({ refreshTrigger }),
+      { initialProps: { refreshTrigger: 0 } },
+    );
+
+    rerender({ refreshTrigger: 1 });
+
+    await waitFor(() => {
+      expect(refresh).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('logs a rejected catalogue refresh', async () => {
+    const refreshError = new Error('Catalogue refresh failed');
+    const refresh = jest.fn().mockRejectedValue(refreshError);
+    mockUseEarnAssetCatalogue.mockReturnValue(
+      createCatalogueResult({ refresh }),
+    );
+
+    renderHook(() => useEarnSectionAssets({ refreshTrigger: 1 }));
+
+    await waitFor(() => {
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        refreshError,
+        'EarnSection: Failed to refresh Earn data',
+      );
+    });
+  });
+});

--- a/app/components/UI/Earn/hooks/useEarnSectionAssets.test.ts
+++ b/app/components/UI/Earn/hooks/useEarnSectionAssets.test.ts
@@ -1,15 +1,12 @@
-import { renderHook, waitFor } from '@testing-library/react-native';
-import Logger from '../../../../util/Logger';
+import { renderHook } from '@testing-library/react-native';
 import useEarnAssetCatalogue from './useEarnAssetCatalogue';
 import useEarnSectionAssets from './useEarnSectionAssets';
 
-jest.mock('../../../../util/Logger');
 jest.mock('./useEarnAssetCatalogue');
 
 const mockUseEarnAssetCatalogue = useEarnAssetCatalogue as jest.MockedFunction<
   typeof useEarnAssetCatalogue
 >;
-const mockLoggerError = jest.mocked(Logger.error);
 
 type EarnAssetCatalogueResult = ReturnType<typeof useEarnAssetCatalogue>;
 
@@ -33,50 +30,25 @@ describe('useEarnSectionAssets', () => {
     mockUseEarnAssetCatalogue.mockReturnValue(createCatalogueResult());
   });
 
-  it('does not refresh the catalogue for the initial trigger', () => {
+  it('does not refresh the catalogue when rendered', () => {
     const refresh = jest.fn().mockResolvedValue(undefined);
     mockUseEarnAssetCatalogue.mockReturnValue(
       createCatalogueResult({ refresh }),
     );
 
-    renderHook(() => useEarnSectionAssets({ refreshTrigger: 0 }));
+    renderHook(() => useEarnSectionAssets());
 
     expect(refresh).not.toHaveBeenCalled();
   });
 
-  it('refreshes the catalogue when the trigger increments', async () => {
+  it('returns the catalogue refresh function', () => {
     const refresh = jest.fn().mockResolvedValue(undefined);
     mockUseEarnAssetCatalogue.mockReturnValue(
       createCatalogueResult({ refresh }),
     );
 
-    const { rerender } = renderHook(
-      ({ refreshTrigger }: { refreshTrigger: number }) =>
-        useEarnSectionAssets({ refreshTrigger }),
-      { initialProps: { refreshTrigger: 0 } },
-    );
+    const { result } = renderHook(() => useEarnSectionAssets());
 
-    rerender({ refreshTrigger: 1 });
-
-    await waitFor(() => {
-      expect(refresh).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it('logs a rejected catalogue refresh', async () => {
-    const refreshError = new Error('Catalogue refresh failed');
-    const refresh = jest.fn().mockRejectedValue(refreshError);
-    mockUseEarnAssetCatalogue.mockReturnValue(
-      createCatalogueResult({ refresh }),
-    );
-
-    renderHook(() => useEarnSectionAssets({ refreshTrigger: 1 }));
-
-    await waitFor(() => {
-      expect(mockLoggerError).toHaveBeenCalledWith(
-        refreshError,
-        'EarnSection: Failed to refresh Earn data',
-      );
-    });
+    expect(result.current.refresh).toBe(refresh);
   });
 });

--- a/app/components/UI/Earn/hooks/useEarnSectionAssets.test.ts
+++ b/app/components/UI/Earn/hooks/useEarnSectionAssets.test.ts
@@ -51,4 +51,10 @@ describe('useEarnSectionAssets', () => {
 
     expect(result.current.refresh).toBe(refresh);
   });
+
+  it('forwards enabled state to the catalogue hook', () => {
+    renderHook(() => useEarnSectionAssets({ enabled: false }));
+
+    expect(mockUseEarnAssetCatalogue).toHaveBeenCalledWith({ enabled: false });
+  });
 });

--- a/app/components/UI/Earn/hooks/useEarnSectionAssets.ts
+++ b/app/components/UI/Earn/hooks/useEarnSectionAssets.ts
@@ -1,14 +1,21 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import {
   EARN_SECTION_ASSET_LIMIT,
   rankEarnSectionAssets,
 } from '../utils/earnSection';
 import useEarnAssetCatalogue from './useEarnAssetCatalogue';
+import Logger from '../../../../util/Logger';
 
 /**
- * Projects the shared Earn asset catalogue into fixed homepage card slots.
+ * Projects the shared Earn asset catalogue into fixed card slots.
  */
-const useEarnSectionAssets = () => {
+interface UseEarnSectionAssetsOptions {
+  refreshTrigger?: number;
+}
+
+const useEarnSectionAssets = ({
+  refreshTrigger,
+}: UseEarnSectionAssetsOptions = {}) => {
   const {
     assets,
     moneyApyPercent,
@@ -18,6 +25,23 @@ const useEarnSectionAssets = () => {
     errors,
     refresh,
   } = useEarnAssetCatalogue();
+
+  useEffect(() => {
+    if (refreshTrigger === undefined || refreshTrigger <= 0) return;
+
+    const refreshEarnAssets = async () => {
+      try {
+        await refresh();
+      } catch (error: unknown) {
+        Logger.error(
+          error instanceof Error ? error : new Error(String(error)),
+          'EarnSection: Failed to refresh Earn data',
+        );
+      }
+    };
+
+    refreshEarnAssets();
+  }, [refresh, refreshTrigger]);
 
   const assetSlots = useMemo(() => rankEarnSectionAssets(assets), [assets]);
   const hasMoreAssets = assets.length > EARN_SECTION_ASSET_LIMIT;

--- a/app/components/UI/Earn/hooks/useEarnSectionAssets.ts
+++ b/app/components/UI/Earn/hooks/useEarnSectionAssets.ts
@@ -5,10 +5,16 @@ import {
 } from '../utils/earnSection';
 import useEarnAssetCatalogue from './useEarnAssetCatalogue';
 
+interface UseEarnSectionAssetsOptions {
+  enabled?: boolean;
+}
+
 /**
  * Projects the shared Earn asset catalogue into fixed card slots.
  */
-const useEarnSectionAssets = () => {
+const useEarnSectionAssets = ({
+  enabled = true,
+}: UseEarnSectionAssetsOptions = {}) => {
   const {
     assets,
     moneyApyPercent,
@@ -17,7 +23,7 @@ const useEarnSectionAssets = () => {
     hasError,
     errors,
     refresh,
-  } = useEarnAssetCatalogue();
+  } = useEarnAssetCatalogue({ enabled });
 
   const assetSlots = useMemo(() => rankEarnSectionAssets(assets), [assets]);
   const hasMoreAssets = assets.length > EARN_SECTION_ASSET_LIMIT;

--- a/app/components/UI/Earn/hooks/useEarnSectionAssets.ts
+++ b/app/components/UI/Earn/hooks/useEarnSectionAssets.ts
@@ -1,21 +1,14 @@
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import {
   EARN_SECTION_ASSET_LIMIT,
   rankEarnSectionAssets,
 } from '../utils/earnSection';
 import useEarnAssetCatalogue from './useEarnAssetCatalogue';
-import Logger from '../../../../util/Logger';
 
 /**
  * Projects the shared Earn asset catalogue into fixed card slots.
  */
-interface UseEarnSectionAssetsOptions {
-  refreshTrigger?: number;
-}
-
-const useEarnSectionAssets = ({
-  refreshTrigger,
-}: UseEarnSectionAssetsOptions = {}) => {
+const useEarnSectionAssets = () => {
   const {
     assets,
     moneyApyPercent,
@@ -25,23 +18,6 @@ const useEarnSectionAssets = ({
     errors,
     refresh,
   } = useEarnAssetCatalogue();
-
-  useEffect(() => {
-    if (refreshTrigger === undefined || refreshTrigger <= 0) return;
-
-    const refreshEarnAssets = async () => {
-      try {
-        await refresh();
-      } catch (error: unknown) {
-        Logger.error(
-          error instanceof Error ? error : new Error(String(error)),
-          'EarnSection: Failed to refresh Earn data',
-        );
-      }
-    };
-
-    refreshEarnAssets();
-  }, [refresh, refreshTrigger]);
 
   const assetSlots = useMemo(() => rankEarnSectionAssets(assets), [assets]);
   const hasMoreAssets = assets.length > EARN_SECTION_ASSET_LIMIT;

--- a/app/components/UI/Earn/hooks/useEarnSectionTokenMetadata.test.ts
+++ b/app/components/UI/Earn/hooks/useEarnSectionTokenMetadata.test.ts
@@ -73,6 +73,50 @@ describe('useEarnSectionTokenMetadata', () => {
     expect(result.current.isSettled).toBe(true);
   });
 
+  it('does not fetch metadata when disabled', () => {
+    const { result } = renderHook(() =>
+      useEarnSectionTokenMetadata([USDC_ASSET_ID], false),
+    );
+
+    expect(mockFetchTokenAssets).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('preserves current metadata while a refresh is in flight', async () => {
+    const token = createTokenAsset();
+    let resolveRefresh: (tokens: TokenAsset[]) => void = () => undefined;
+    mockFetchTokenAssets.mockResolvedValueOnce([token]).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+
+    const { result } = renderHook(() =>
+      useEarnSectionTokenMetadata([USDC_ASSET_ID]),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSettled).toBe(true);
+    });
+
+    let refreshPromise: Promise<void> | undefined;
+    await act(async () => {
+      refreshPromise = result.current.refresh();
+      await Promise.resolve();
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.tokensByAssetId).toEqual({
+      [USDC_ASSET_ID]: token,
+    });
+
+    await act(async () => {
+      resolveRefresh([token]);
+      await refreshPromise;
+    });
+  });
+
   it('deduplicates asset IDs that differ only by casing', async () => {
     mockFetchTokenAssets.mockResolvedValue([]);
 

--- a/app/components/UI/Earn/hooks/useEarnSectionTokenMetadata.ts
+++ b/app/components/UI/Earn/hooks/useEarnSectionTokenMetadata.ts
@@ -24,7 +24,7 @@ const EMPTY_STATE: EarnSectionTokenMetadataState = {
  * Loads metadata for unheld lending assets while preserving an explicit error
  * state so EarnSection never silently substitutes incomplete token data.
  */
-const useEarnSectionTokenMetadata = (assetIds: string[]) => {
+const useEarnSectionTokenMetadata = (assetIds: string[], enabled = true) => {
   const assetIdsKey = useMemo(
     () =>
       [...new Set(assetIds.map((assetId) => assetId.toLowerCase()))].join(','),
@@ -39,6 +39,8 @@ const useEarnSectionTokenMetadata = (assetIds: string[]) => {
   const requestIdRef = useRef(0);
 
   const loadMetadata = useCallback(async (): Promise<Error | null> => {
+    if (!enabled) return null;
+
     const requestId = ++requestIdRef.current;
     if (!assetIdsKey) {
       setState(EMPTY_STATE);
@@ -85,15 +87,17 @@ const useEarnSectionTokenMetadata = (assetIds: string[]) => {
       });
       return normalizedError;
     }
-  }, [assetIdsKey]);
+  }, [assetIdsKey, enabled]);
 
   useEffect(() => {
+    if (!enabled) return;
+
     loadMetadata();
 
     return () => {
       requestIdRef.current += 1;
     };
-  }, [loadMetadata]);
+  }, [enabled, loadMetadata]);
 
   const refresh = useCallback(async () => {
     const error = await loadMetadata();
@@ -103,10 +107,20 @@ const useEarnSectionTokenMetadata = (assetIds: string[]) => {
   }, [loadMetadata]);
 
   const isCurrentRequest = state.assetIdsKey === assetIdsKey;
+  const hasMetadataForCurrentAssetIds =
+    isCurrentRequest &&
+    Boolean(assetIdsKey) &&
+    assetIdsKey
+      .split(',')
+      .every((assetId) => state.tokensByAssetId[assetId] !== undefined);
 
   return {
     tokensByAssetId: isCurrentRequest ? state.tokensByAssetId : {},
-    isLoading: Boolean(assetIdsKey) && (!isCurrentRequest || state.isLoading),
+    isLoading:
+      enabled &&
+      Boolean(assetIdsKey) &&
+      (!isCurrentRequest ||
+        (state.isLoading && !hasMetadataForCurrentAssetIds)),
     isSettled: isCurrentRequest && state.isSettled,
     error: isCurrentRequest ? state.error : null,
     refresh,

--- a/app/components/UI/Earn/selectors/featureFlags/index.test.ts
+++ b/app/components/UI/Earn/selectors/featureFlags/index.test.ts
@@ -17,6 +17,7 @@ import {
   MUSD_TOKEN_REGISTRATION_CHAIN_IDS_FALLBACK,
   selectMusdBalanceChainIds,
   MUSD_BALANCE_CHAIN_IDS_FALLBACK,
+  selectExploreEarnSectionEnabledFlag,
 } from '.';
 import mockedEngine from '../../../../../core/__mocks__/MockedEngine';
 import type { Json } from '@metamask/utils';
@@ -2195,6 +2196,82 @@ describe('Earn Feature Flag Selectors', () => {
       const result = selectMusdBalanceChainIds(stateWithMissingChainIds);
 
       expect(result).toEqual(MUSD_BALANCE_CHAIN_IDS_FALLBACK);
+    });
+  });
+
+  describe('selectExploreEarnSectionEnabledFlag', () => {
+    it('returns true when remote flag is enabled and version check passes', () => {
+      process.env.MM_EXPLORE_EARN_SECTION_ENABLED = 'false';
+
+      const stateWithEnabledRemoteFlag = createStateWithRemoteFlags({
+        earnExploreSectionEnabled: {
+          enabled: true,
+          minimumVersion: '1.0.0',
+        },
+      });
+
+      const result = selectExploreEarnSectionEnabledFlag(
+        stateWithEnabledRemoteFlag,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when remote flag is disabled', () => {
+      process.env.MM_EXPLORE_EARN_SECTION_ENABLED = 'true';
+
+      const stateWithDisabledRemoteFlag = createStateWithRemoteFlags({
+        earnExploreSectionEnabled: {
+          enabled: false,
+          minimumVersion: '1.0.0',
+        },
+      });
+
+      const result = selectExploreEarnSectionEnabledFlag(
+        stateWithDisabledRemoteFlag,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when remote flag minimum version exceeds app version', () => {
+      process.env.MM_EXPLORE_EARN_SECTION_ENABLED = 'true';
+      mockHasMinimumRequiredVersion.mockReturnValue(false);
+
+      const stateWithVersionMismatch = createStateWithRemoteFlags({
+        earnExploreSectionEnabled: {
+          enabled: true,
+          minimumVersion: '99.0.0',
+        },
+      });
+
+      const result = selectExploreEarnSectionEnabledFlag(
+        stateWithVersionMismatch,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('falls back to local flag when remote flag is invalid', () => {
+      process.env.MM_EXPLORE_EARN_SECTION_ENABLED = 'true';
+
+      const stateWithInvalidRemoteFlag = createStateWithRemoteFlags({
+        earnExploreSectionEnabled: null,
+      });
+
+      const result = selectExploreEarnSectionEnabledFlag(
+        stateWithInvalidRemoteFlag,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('falls back to false when remote flag is unavailable and local flag is disabled', () => {
+      process.env.MM_EXPLORE_EARN_SECTION_ENABLED = 'false';
+
+      const result = selectExploreEarnSectionEnabledFlag(mockedEmptyFlagsState);
+
+      expect(result).toBe(false);
     });
   });
 });

--- a/app/components/UI/Earn/selectors/featureFlags/index.ts
+++ b/app/components/UI/Earn/selectors/featureFlags/index.ts
@@ -382,3 +382,17 @@ export const selectEarnHomeSectionEnabledFlag = createSelector(
     return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
   },
 );
+
+/**
+ * Selects whether the static Earn section is shown on Explore page.
+ */
+export const selectExploreEarnSectionEnabledFlag = createSelector(
+  selectRemoteFeatureFlags,
+  (remoteFeatureFlags) => {
+    const localFlag = process.env.MM_EXPLORE_EARN_SECTION_ENABLED === 'true';
+    const remoteFlag =
+      remoteFeatureFlags?.earnExploreSectionEnabled as unknown as VersionGatedFeatureFlag;
+
+    return validatedVersionGatedFeatureFlag(remoteFlag) ?? localFlag;
+  },
+);

--- a/app/components/UI/Earn/selectors/featureFlags/index.ts
+++ b/app/components/UI/Earn/selectors/featureFlags/index.ts
@@ -370,7 +370,7 @@ export const selectMusdBalanceChainIds = createSelector(
 );
 
 /**
- * Selects whether the static Earn section is shown on Wallet Home.
+ * Selects whether the Earn section is rendered on Wallet Home.
  */
 export const selectEarnHomeSectionEnabledFlag = createSelector(
   selectRemoteFeatureFlags,
@@ -384,7 +384,7 @@ export const selectEarnHomeSectionEnabledFlag = createSelector(
 );
 
 /**
- * Selects whether the static Earn section is shown on Explore page.
+ * Selects whether the Earn section is rendered on Explore page.
  */
 export const selectExploreEarnSectionEnabledFlag = createSelector(
   selectRemoteFeatureFlags,

--- a/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
@@ -45,7 +45,7 @@ interface UseMoneyAccountBalanceResult {
   /** Whether the last successful balance used the secondary source. */
   usedFallback: boolean;
   lastKnownTotalFiatFormatted: string | undefined;
-  refetchBalance: () => void;
+  refetchBalance: () => Promise<void>;
   tokenTotal: BigNumber | undefined;
   totalFiatFormatted: string | undefined;
   totalFiatRaw: string | undefined;

--- a/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
+++ b/app/components/UI/Money/hooks/useMoneyAccountBalance.ts
@@ -186,7 +186,7 @@ const useMoneyAccountBalance = ({
   const withdrawableMusdRaw = moneyBalanceQuery.data?.vmusdValueInMusd;
 
   useEffect(() => {
-    if (isBalanceFetchError || isBalanceLoading) {
+    if (!enabled || isBalanceFetchError || isBalanceLoading) {
       return;
     }
     dispatch(
@@ -200,6 +200,7 @@ const useMoneyAccountBalance = ({
     dispatch,
     moneyAccountAddress,
     withdrawableMusdRaw,
+    enabled,
     isBalanceFetchError,
     isBalanceLoading,
   ]);

--- a/app/components/UI/TokenDetails/constants/constants.ts
+++ b/app/components/UI/TokenDetails/constants/constants.ts
@@ -25,6 +25,8 @@ export enum TokenDetailsSource {
   ExploreRwasStocks = 'explore_rwas_stocks',
   /** Explore omni-search result tap */
   ExploreSearch = 'explore_search',
+  /** Explore Earn section */
+  ExploreEarn = 'explore_earn',
   /** Trending tokens section on the Swaps / Bridge view */
   TrendingSwaps = 'trending-swaps',
   /** Swap discovery feed — hot tokens / movers pills */
@@ -59,6 +61,7 @@ const EXPLORE_TOKEN_DETAILS_SOURCES = new Set<TokenDetailsSource>([
   TokenDetailsSource.ExploreCryptoTrending,
   TokenDetailsSource.ExploreRwasStocks,
   TokenDetailsSource.ExploreSearch,
+  TokenDetailsSource.ExploreEarn,
   TokenDetailsSource.Trending,
   TokenDetailsSource.BannerRobinhoodExplore,
 ]);

--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -33,7 +33,7 @@ import { PerpsStreamProvider } from '../../UI/Perps/providers/PerpsStreamManager
 import BalanceBreakdownSection, {
   type BalanceBreakdownSectionProps,
 } from './Sections/BalanceBreakdown';
-import EarnSection from './Sections/EarnSection';
+import { HomepageEarnSection } from '../../UI/Earn/components/EarnSection';
 import { selectEarnHomeSectionEnabledFlag } from '../../UI/Earn/selectors/featureFlags';
 
 /**
@@ -170,10 +170,11 @@ const Homepage = forwardRef<SectionRefreshHandle, HomepageProps>(
               />
             )}
             {isEarnSectionEnabled && (
-              <EarnSection
+              <HomepageEarnSection
                 ref={earnSectionRef}
                 sectionIndex={getSectionIndex(HomeSectionNames.EARN)}
                 totalSectionsLoaded={totalSectionsLoaded}
+                showDividers
               />
             )}
             <PredictionsSection

--- a/app/components/Views/Homepage/Homepage.tsx
+++ b/app/components/Views/Homepage/Homepage.tsx
@@ -33,8 +33,8 @@ import { PerpsStreamProvider } from '../../UI/Perps/providers/PerpsStreamManager
 import BalanceBreakdownSection, {
   type BalanceBreakdownSectionProps,
 } from './Sections/BalanceBreakdown';
-import { HomepageEarnSection } from '../../UI/Earn/components/EarnSection';
 import { selectEarnHomeSectionEnabledFlag } from '../../UI/Earn/selectors/featureFlags';
+import { HomepageEarnSection } from './Sections/EarnSection';
 
 /**
  * Homepage component - Main view for the redesigned wallet homepage.

--- a/app/components/Views/Homepage/Sections/EarnSection/EarnSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/EarnSection/EarnSection.test.tsx
@@ -27,6 +27,7 @@ import type {
 } from '../../../../UI/Earn/utils/earnSection';
 import { EARN_EXPERIENCES } from '../../../../UI/Earn/constants/experiences';
 import EarnSection from './EarnSection';
+import HomepageEarnSection from './HomepageEarnSection';
 
 jest.mock('@react-navigation/native');
 jest.mock('react-redux', () => ({
@@ -194,15 +195,46 @@ describe('EarnSection', () => {
   });
 
   it('renders the Earn section title', () => {
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    render(<EarnSection />);
 
     expect(
       screen.getByText(strings('homepage.sections.earn')),
     ).toBeOnTheScreen();
   });
 
+  it('disables Homepage telemetry for shared Explore rendering', () => {
+    render(<EarnSection />);
+
+    expect(mockUseHomeViewedEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sectionRef: null,
+        sectionIndex: -1,
+        totalSectionsLoaded: 0,
+        fireImmediateWhenNoView: false,
+      }),
+    );
+    expect(mockUseSectionPerformance).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it('passes required section metadata to Homepage telemetry', () => {
+    render(<HomepageEarnSection sectionIndex={2} totalSectionsLoaded={5} />);
+
+    expect(mockUseHomeViewedEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sectionIndex: 2,
+        totalSectionsLoaded: 5,
+        fireImmediateWhenNoView: true,
+      }),
+    );
+    expect(mockUseSectionPerformance).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true }),
+    );
+  });
+
   it('renders funded lending assets with Get APY copy', () => {
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    render(<EarnSection />);
 
     expect(screen.getByTestId('earn-section-asset-0-card')).toBeOnTheScreen();
     expect(
@@ -237,7 +269,7 @@ describe('EarnSection', () => {
       ],
     });
 
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    render(<EarnSection />);
 
     expect(
       screen.getByText(
@@ -274,7 +306,7 @@ describe('EarnSection', () => {
       ],
     });
 
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    render(<EarnSection />);
 
     expect(
       screen.getByTestId('earn-section-asset-0-no-fee-tag'),
@@ -282,7 +314,7 @@ describe('EarnSection', () => {
   });
 
   it('hides No fee when asset experiences are not subsidized', () => {
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    render(<EarnSection />);
 
     expect(
       screen.queryByTestId('earn-section-asset-0-no-fee-tag'),
@@ -293,7 +325,7 @@ describe('EarnSection', () => {
     mockMoneyAccountVisible = true;
     mockSectionResult({ assetSlots: [] });
 
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    render(<EarnSection />);
 
     expect(
       screen.getByTestId('earn-section-money-account-card'),
@@ -309,7 +341,7 @@ describe('EarnSection', () => {
     } as ReturnType<typeof useMoneyAccountBalance>);
     mockSectionResult({ assetSlots: [] });
 
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    render(<EarnSection />);
 
     expect(
       screen.queryByText(strings('earn_module.new_tag')),
@@ -324,7 +356,7 @@ describe('EarnSection', () => {
     } as ReturnType<typeof useMoneyAccountBalance>);
     mockSectionResult({ assetSlots: [] });
 
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    render(<EarnSection />);
 
     expect(
       screen.queryByText(strings('earn_module.new_tag')),
@@ -343,7 +375,7 @@ describe('EarnSection', () => {
     } as ReturnType<typeof useMoneyAccountBalance>);
     mockSectionResult({ assetSlots: [] });
 
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    render(<EarnSection />);
 
     expect(
       screen.getByTestId('earn-section-money-account-balance-skeleton'),
@@ -361,7 +393,7 @@ describe('EarnSection', () => {
       moneyRateStatus: 'loading',
     });
 
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    render(<EarnSection />);
 
     expect(
       screen.getByTestId('earn-section-money-account-apy-skeleton'),
@@ -379,7 +411,7 @@ describe('EarnSection', () => {
       moneyRateStatus: 'unavailable',
     });
 
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    render(<EarnSection />);
 
     expect(
       screen.getByText(strings('earn_module.rate_unavailable')),
@@ -392,7 +424,7 @@ describe('EarnSection', () => {
   it('uses the asset name for zero-balance tiles', () => {
     mockSectionResult({ assetSlots: [zeroBalanceAssetSlot] });
 
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    render(<EarnSection />);
 
     expect(screen.getByTestId('earn-section-asset-0-card')).toBeOnTheScreen();
     expect(
@@ -406,15 +438,26 @@ describe('EarnSection', () => {
   it('removes green arrows from Money and asset tiles', () => {
     mockMoneyAccountVisible = true;
 
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    render(<EarnSection />);
 
     expect(getSuccessArrowIcons()).toHaveLength(0);
+  });
+
+  it('navigates with the selected CAIP-19 asset ID', () => {
+    render(<EarnSection />);
+
+    fireEvent.press(screen.getByTestId('earn-section-asset-0-card'));
+
+    expect(navigate).toHaveBeenCalledWith(Routes.EARN.ROOT, {
+      screen: Routes.EARN.STRATEGY_SELECTION,
+      params: { assetId },
+    });
   });
 
   it('navigates zero-balance assets to Asset Overview', () => {
     mockSectionResult({ assetSlots: [zeroBalanceAssetSlot] });
 
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    render(<EarnSection />);
 
     fireEvent.press(screen.getByTestId('earn-section-asset-0-card'));
 
@@ -455,7 +498,7 @@ describe('EarnSection', () => {
       hasError: true,
     });
 
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    render(<EarnSection />);
 
     expect(screen.getByTestId('earn-section-error')).toBeOnTheScreen();
     expect(screen.getByTestId('earn-section-asset-0-card')).toBeOnTheScreen();
@@ -467,7 +510,7 @@ describe('EarnSection', () => {
       hasError: true,
       refresh,
     });
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    render(<EarnSection />);
 
     await act(async () => {
       fireEvent.press(screen.getByTestId('earn-section-error-retry-button'));
@@ -503,7 +546,7 @@ describe('EarnSection', () => {
       hasError: true,
       refresh,
     });
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    render(<EarnSection />);
 
     const retryButton = screen.getByTestId('earn-section-error-retry-button');
     fireEvent.press(retryButton);
@@ -523,7 +566,7 @@ describe('EarnSection', () => {
   it('renders skeleton slots while catalogue data loads', () => {
     mockSectionResult({ isLoading: true });
 
-    render(<EarnSection sectionIndex={0} totalSectionsLoaded={1} />);
+    render(<EarnSection />);
 
     expect(screen.getByTestId(assetId)).toBeOnTheScreen();
     expect(

--- a/app/components/Views/Homepage/Sections/EarnSection/EarnSection.tsx
+++ b/app/components/Views/Homepage/Sections/EarnSection/EarnSection.tsx
@@ -62,9 +62,14 @@ import Logger from '../../../../../util/Logger';
 import { isEarnAssetBalanceBelowMinDepositAmount } from '../../../../UI/Earn/utils/earnAssets/earnAssetBalance';
 import Routes from '../../../../../constants/navigation/Routes';
 
-interface EarnSectionProps {
+export interface EarnSectionHomeAnalytics {
   sectionIndex: number;
   totalSectionsLoaded: number;
+}
+
+export interface EarnSectionProps {
+  homeAnalytics?: EarnSectionHomeAnalytics;
+  showDividers?: boolean;
 }
 
 const renderEarnAssetIcon = (token: TokenI) => {
@@ -117,9 +122,12 @@ const renderUnavailableAssetCard = (key: string) => (
 );
 
 const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
-  ({ sectionIndex, totalSectionsLoaded }, ref) => {
+  ({ homeAnalytics, showDividers = false }, ref) => {
     const tw = useTailwind();
     const navigation = useNavigation<AppNavigationProp>();
+    const isHomepageSection = homeAnalytics !== undefined;
+    const sectionIndex = homeAnalytics?.sectionIndex ?? -1;
+    const totalSectionsLoaded = homeAnalytics?.totalSectionsLoaded ?? 0;
 
     const isMoneyAccountVisible = useSelector(selectIsMoneyAccountVisible);
 
@@ -159,13 +167,14 @@ const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
     useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 
     const { onLayout } = useHomeViewedEvent({
-      sectionRef: sectionViewRef,
+      sectionRef: isHomepageSection ? sectionViewRef : null,
       isLoading,
       sectionName: HomeSectionNames.EARN,
       sectionIndex,
       totalSectionsLoaded,
       isEmpty: false,
       itemCount: earnSectionItemCount,
+      fireImmediateWhenNoView: isHomepageSection,
     });
 
     useSectionPerformance({
@@ -173,13 +182,13 @@ const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
       contentReady: !isLoading,
       isEmpty: false,
       isLoading,
-      enabled: true,
+      enabled: isHomepageSection,
     });
 
     const handleHeaderPress = () => {
       // eslint-disable-next-line no-alert
       alert(
-        'Under construction 🚧 - Implement when adding Earn Section to Explore page',
+        'Under construction 🚧 - Implement when adding Earn Section to Explore search page',
       );
     };
 
@@ -215,7 +224,7 @@ const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
     const handleViewMoreCardPress = () => {
       // eslint-disable-next-line no-alert
       alert(
-        'Under construction 🚧 - Implement when adding Earn Section to Explore page',
+        'Under construction 🚧 - Implement when adding Earn Section to Explore search page',
       );
     };
 
@@ -323,7 +332,7 @@ const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
     return (
       <View ref={sectionViewRef} onLayout={onLayout}>
         <Box testID="earn-section">
-          <SectionDivider />
+          {showDividers && <SectionDivider />}
           <SectionHeader
             title={strings('homepage.sections.earn')}
             isInteractive

--- a/app/components/Views/Homepage/Sections/EarnSection/EarnSection.tsx
+++ b/app/components/Views/Homepage/Sections/EarnSection/EarnSection.tsx
@@ -68,8 +68,10 @@ export interface EarnSectionHomeAnalytics {
 }
 
 export interface EarnSectionProps {
+  tokenDetailsSource: TokenDetailsSource;
   homeAnalytics?: EarnSectionHomeAnalytics;
   showDividers?: boolean;
+  refreshTrigger?: number;
 }
 
 const renderEarnAssetIcon = (token: TokenI) => {
@@ -122,7 +124,10 @@ const renderUnavailableAssetCard = (key: string) => (
 );
 
 const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
-  ({ homeAnalytics, showDividers = false }, ref) => {
+  (
+    { tokenDetailsSource, homeAnalytics, showDividers = false, refreshTrigger },
+    ref,
+  ) => {
     const tw = useTailwind();
     const navigation = useNavigation<AppNavigationProp>();
     const isHomepageSection = homeAnalytics !== undefined;
@@ -141,8 +146,8 @@ const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
       moneyRateStatus,
       isLoading,
       hasError,
-      refresh: refreshEarnSectionAssets,
-    } = useEarnSectionAssets();
+      refresh,
+    } = useEarnSectionAssets({ refreshTrigger });
 
     const {
       totalFiatFormatted: moneyAccountBalanceFiat,
@@ -208,7 +213,7 @@ const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
             isETH: token.isETH,
             aggregators: token.aggregators,
             rwaData: token.rwaData,
-            source: TokenDetailsSource.HomeSection,
+            source: tokenDetailsSource,
           });
           return;
         }
@@ -218,7 +223,7 @@ const EarnSection = forwardRef<SectionRefreshHandle, EarnSectionProps>(
           params: { assetId: asset.assetId },
         });
       },
-      [navigation],
+      [navigation, tokenDetailsSource],
     );
 
     const handleViewMoreCardPress = () => {

--- a/app/components/Views/Homepage/Sections/EarnSection/HomepageEarnSection.tsx
+++ b/app/components/Views/Homepage/Sections/EarnSection/HomepageEarnSection.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef } from 'react';
 import type { SectionRefreshHandle } from '../../../../Views/Homepage/types';
+import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
 import EarnSection from './EarnSection';
 
 interface HomepageEarnSectionProps {
@@ -21,6 +22,7 @@ const HomepageEarnSection = forwardRef<
 >(({ sectionIndex, totalSectionsLoaded, showDividers }, ref) => (
   <EarnSection
     ref={ref}
+    tokenDetailsSource={TokenDetailsSource.HomeSection}
     homeAnalytics={{ sectionIndex, totalSectionsLoaded }}
     showDividers={showDividers}
   />

--- a/app/components/Views/Homepage/Sections/EarnSection/HomepageEarnSection.tsx
+++ b/app/components/Views/Homepage/Sections/EarnSection/HomepageEarnSection.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import type { SectionRefreshHandle } from '../../../../Views/Homepage/types';
-import { TokenDetailsSource } from '../../../TokenDetails/constants/constants';
-import EarnSection from './EarnSection';
+import { TokenDetailsSource } from '../../../../UI/TokenDetails/constants/constants';
+import EarnSection from '../../../../UI/Earn/components/EarnSection';
 
 interface HomepageEarnSectionProps {
   sectionIndex: number;

--- a/app/components/Views/Homepage/Sections/EarnSection/HomepageEarnSection.tsx
+++ b/app/components/Views/Homepage/Sections/EarnSection/HomepageEarnSection.tsx
@@ -1,0 +1,29 @@
+import React, { forwardRef } from 'react';
+import type { SectionRefreshHandle } from '../../../../Views/Homepage/types';
+import EarnSection from './EarnSection';
+
+interface HomepageEarnSectionProps {
+  sectionIndex: number;
+  totalSectionsLoaded: number;
+  showDividers?: boolean;
+}
+
+/**
+ * Homepage adapter for EarnSection.
+ *
+ * EarnSection is shared with Explore, where Homepage section metadata does not
+ * apply. Keeping this wrapper preserves required analytics props for Homepage
+ * callers without making the shared component's Explore contract ambiguous.
+ */
+const HomepageEarnSection = forwardRef<
+  SectionRefreshHandle,
+  HomepageEarnSectionProps
+>(({ sectionIndex, totalSectionsLoaded, showDividers }, ref) => (
+  <EarnSection
+    ref={ref}
+    homeAnalytics={{ sectionIndex, totalSectionsLoaded }}
+    showDividers={showDividers}
+  />
+));
+
+export default React.memo(HomepageEarnSection);

--- a/app/components/Views/Homepage/Sections/EarnSection/HomepageEarnSection.tsx
+++ b/app/components/Views/Homepage/Sections/EarnSection/HomepageEarnSection.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef } from 'react';
 import type { SectionRefreshHandle } from '../../../../Views/Homepage/types';
 import { TokenDetailsSource } from '../../../../UI/TokenDetails/constants/constants';
 import EarnSection from '../../../../UI/Earn/components/EarnSection';
+import { useIsFocused } from '@react-navigation/native';
 
 interface HomepageEarnSectionProps {
   sectionIndex: number;
@@ -19,13 +20,18 @@ interface HomepageEarnSectionProps {
 const HomepageEarnSection = forwardRef<
   SectionRefreshHandle,
   HomepageEarnSectionProps
->(({ sectionIndex, totalSectionsLoaded, showDividers }, ref) => (
-  <EarnSection
-    ref={ref}
-    tokenDetailsSource={TokenDetailsSource.HomeSection}
-    homeAnalytics={{ sectionIndex, totalSectionsLoaded }}
-    showDividers={showDividers}
-  />
-));
+>(({ sectionIndex, totalSectionsLoaded, showDividers }, ref) => {
+  const isFocused = useIsFocused();
+
+  return (
+    <EarnSection
+      ref={ref}
+      tokenDetailsSource={TokenDetailsSource.HomeSection}
+      homeAnalytics={{ sectionIndex, totalSectionsLoaded }}
+      showDividers={showDividers}
+      enabled={isFocused}
+    />
+  );
+});
 
 export default React.memo(HomepageEarnSection);

--- a/app/components/Views/Homepage/Sections/EarnSection/index.ts
+++ b/app/components/Views/Homepage/Sections/EarnSection/index.ts
@@ -1,2 +1,1 @@
-export { default } from './EarnSection';
 export { default as HomepageEarnSection } from './HomepageEarnSection';

--- a/app/components/Views/Homepage/Sections/EarnSection/index.ts
+++ b/app/components/Views/Homepage/Sections/EarnSection/index.ts
@@ -1,1 +1,2 @@
 export { default } from './EarnSection';
+export { default as HomepageEarnSection } from './HomepageEarnSection';

--- a/app/components/Views/TrendingView/components/ExploreEarnSection.test.tsx
+++ b/app/components/Views/TrendingView/components/ExploreEarnSection.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { useIsFocused } from '@react-navigation/native';
+import EarnSection from '../../../UI/Earn/components/EarnSection';
+import { TokenDetailsSource } from '../../../UI/TokenDetails/constants/constants';
+import { ExploreActiveTabProvider } from '../ExploreActiveTabContext';
+import ExploreEarnSection from './ExploreEarnSection';
+
+jest.mock('@react-navigation/native', () => ({
+  useIsFocused: jest.fn(),
+}));
+jest.mock('../../../UI/Earn/components/EarnSection', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}));
+
+const mockUseIsFocused = useIsFocused as jest.MockedFunction<
+  typeof useIsFocused
+>;
+const mockEarnSection = EarnSection as jest.MockedFunction<typeof EarnSection>;
+
+const refresh = { trigger: 0, silentRefresh: true };
+
+describe('ExploreEarnSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseIsFocused.mockReturnValue(true);
+  });
+
+  it('enables Earn for its active Explore tab', () => {
+    render(
+      <ExploreActiveTabProvider activeTab="Now">
+        <ExploreEarnSection tabName="Now" refresh={refresh} />
+      </ExploreActiveTabProvider>,
+    );
+
+    expect(mockEarnSection).toHaveBeenCalledWith(
+      {
+        enabled: true,
+        refresh,
+        tokenDetailsSource: TokenDetailsSource.ExploreEarn,
+      },
+      undefined,
+    );
+  });
+
+  it('disables Earn when another Explore tab is active', () => {
+    render(
+      <ExploreActiveTabProvider activeTab="Crypto">
+        <ExploreEarnSection tabName="Now" refresh={refresh} />
+      </ExploreActiveTabProvider>,
+    );
+
+    expect(mockEarnSection).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+      undefined,
+    );
+  });
+
+  it('disables Earn when Explore screen is unfocused', () => {
+    mockUseIsFocused.mockReturnValue(false);
+
+    render(
+      <ExploreActiveTabProvider activeTab="Now">
+        <ExploreEarnSection tabName="Now" refresh={refresh} />
+      </ExploreActiveTabProvider>,
+    );
+
+    expect(mockEarnSection).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+      undefined,
+    );
+  });
+});

--- a/app/components/Views/TrendingView/components/ExploreEarnSection.tsx
+++ b/app/components/Views/TrendingView/components/ExploreEarnSection.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useIsFocused } from '@react-navigation/native';
+import EarnSection from '../../../UI/Earn/components/EarnSection';
+import { TokenDetailsSource } from '../../../UI/TokenDetails/constants/constants';
+import { useExploreActiveTab } from '../ExploreActiveTabContext';
+import type { ExploreTabName } from '../search/analytics';
+import type { RefreshConfig } from '../hooks/useExploreRefresh';
+
+interface ExploreEarnSectionProps {
+  tabName: Extract<ExploreTabName, 'Now' | 'Crypto'>;
+  refresh: RefreshConfig;
+}
+
+const ExploreEarnSection = ({ tabName, refresh }: ExploreEarnSectionProps) => {
+  const activeTab = useExploreActiveTab();
+  const isFocused = useIsFocused();
+
+  return (
+    <EarnSection
+      enabled={isFocused && activeTab === tabName}
+      refresh={refresh}
+      tokenDetailsSource={TokenDetailsSource.ExploreEarn}
+    />
+  );
+};
+
+export default React.memo(ExploreEarnSection);

--- a/app/components/Views/TrendingView/hooks/useFeedRefresh.test.ts
+++ b/app/components/Views/TrendingView/hooks/useFeedRefresh.test.ts
@@ -1,0 +1,90 @@
+import { renderHook } from '@testing-library/react-native';
+import type { RefreshConfig } from './useExploreRefresh';
+import { useFeedRefresh } from './useFeedRefresh';
+
+const createRefresh = (trigger: number): RefreshConfig => ({
+  trigger,
+  silentRefresh: true,
+});
+
+describe('useFeedRefresh', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('skips the initial refresh trigger', () => {
+    const refetch = jest.fn(() => Promise.resolve());
+
+    renderHook(() => useFeedRefresh(createRefresh(0), refetch));
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it('refetches for a nonzero trigger when enabled', () => {
+    const refetch = jest.fn(() => Promise.resolve());
+
+    renderHook(() => useFeedRefresh(createRefresh(1), refetch));
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches when the trigger increments', () => {
+    const refetch = jest.fn(() => Promise.resolve());
+    const { rerender } = renderHook(
+      ({ refresh }) => useFeedRefresh(refresh, refetch),
+      {
+        initialProps: { refresh: createRefresh(0) },
+      },
+    );
+
+    rerender({ refresh: createRefresh(1) });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not replay a consumed trigger when becoming enabled', () => {
+    const refetch = jest.fn(() => Promise.resolve());
+    const refresh = createRefresh(1);
+    const { rerender } = renderHook(
+      ({ enabled }) => useFeedRefresh(refresh, refetch, enabled),
+      {
+        initialProps: { enabled: false },
+      },
+    );
+
+    rerender({ enabled: true });
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it('ignores a new refresh object when its trigger is unchanged', () => {
+    const refetch = jest.fn(() => Promise.resolve());
+    const { rerender } = renderHook(
+      ({ refresh }) => useFeedRefresh(refresh, refetch),
+      {
+        initialProps: { refresh: createRefresh(1) },
+      },
+    );
+
+    rerender({ refresh: createRefresh(1) });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches when a new trigger arrives after becoming enabled', () => {
+    const refetch = jest.fn(() => Promise.resolve());
+    const { rerender } = renderHook(
+      ({ enabled, refresh }) => useFeedRefresh(refresh, refetch, enabled),
+      {
+        initialProps: {
+          enabled: false,
+          refresh: createRefresh(1),
+        },
+      },
+    );
+
+    rerender({ enabled: true, refresh: createRefresh(2) });
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/Views/TrendingView/hooks/useFeedRefresh.ts
+++ b/app/components/Views/TrendingView/hooks/useFeedRefresh.ts
@@ -1,16 +1,31 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import type { RefreshConfig } from './useExploreRefresh';
 
 /**
  * Wires a feed's `refetch` to the page's `refresh.trigger`. Skips trigger 0
  * (initial mount) since the underlying hook already fetches on first mount.
+ * Disabled consumers still observe triggers so enabling them does not replay
+ * an already-consumed refresh.
  */
 export const useFeedRefresh = (
   refresh: RefreshConfig | undefined,
   refetch: (() => Promise<void> | void) | undefined,
+  enabled = true,
 ): void => {
+  const lastTriggerRef = useRef(0);
+
   useEffect(() => {
-    if (!refresh || refresh.trigger === 0 || !refetch) return;
+    const trigger = refresh?.trigger;
+    if (trigger === undefined || trigger === 0) return;
+
+    if (!enabled) {
+      lastTriggerRef.current = trigger;
+      return;
+    }
+
+    if (trigger === lastTriggerRef.current || !refetch) return;
+
+    lastTriggerRef.current = trigger;
     refetch();
-  }, [refresh, refetch]);
+  }, [enabled, refresh?.trigger, refetch]);
 };

--- a/app/components/Views/TrendingView/tabs/CryptoTab.test.tsx
+++ b/app/components/Views/TrendingView/tabs/CryptoTab.test.tsx
@@ -162,7 +162,7 @@ describe('CryptoTab — Earn section', () => {
 
     expect(screen.getByTestId('explore-section-earn')).toBeOnTheScreen();
     expect(mockEarnSection).toHaveBeenCalledWith({
-      refreshTrigger: 0,
+      refresh: { trigger: 0, silentRefresh: true },
       tokenDetailsSource: TokenDetailsSource.ExploreEarn,
     });
   });
@@ -187,7 +187,7 @@ describe('CryptoTab — Earn section', () => {
     );
 
     expect(mockEarnSection).toHaveBeenCalledWith({
-      refreshTrigger: 1,
+      refresh: { trigger: 1, silentRefresh: true },
       tokenDetailsSource: TokenDetailsSource.ExploreEarn,
     });
   });

--- a/app/components/Views/TrendingView/tabs/CryptoTab.test.tsx
+++ b/app/components/Views/TrendingView/tabs/CryptoTab.test.tsx
@@ -8,10 +8,12 @@ import { TokenDetailsSource } from '../../../UI/TokenDetails/constants/constants
 import { useTokensFeed } from '../feeds/tokens/useTokensFeed';
 import { usePredictionsFeed } from '../feeds/predictions/usePredictionsFeed';
 import { usePerpsFeed } from '../feeds/perps/usePerpsFeed';
+import { ExploreActiveTabProvider } from '../ExploreActiveTabContext';
 import CryptoTab from './CryptoTab';
 
 const mockNavigate = jest.fn();
 const mockEarnSection = jest.fn((_props: Record<string, unknown>) => null);
+const mockUseIsFocused = jest.fn(() => true);
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
 const mockUseNavigation = useNavigation as jest.MockedFunction<
   typeof useNavigation
@@ -22,6 +24,7 @@ const mockUsePerpsFeed = jest.mocked(usePerpsFeed);
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
+  useIsFocused: () => mockUseIsFocused(),
 }));
 
 jest.mock('react-redux', () => ({
@@ -104,6 +107,7 @@ const arrangeMocks = ({
   earnSectionEnabled?: boolean;
 } = {}) => {
   jest.clearAllMocks();
+  mockUseIsFocused.mockReturnValue(true);
 
   mockUseNavigation.mockReturnValue({
     navigate: mockNavigate,
@@ -162,6 +166,7 @@ describe('CryptoTab — Earn section', () => {
 
     expect(screen.getByTestId('explore-section-earn')).toBeOnTheScreen();
     expect(mockEarnSection).toHaveBeenCalledWith({
+      enabled: false,
       refresh: { trigger: 0, silentRefresh: true },
       tokenDetailsSource: TokenDetailsSource.ExploreEarn,
     });
@@ -187,9 +192,39 @@ describe('CryptoTab — Earn section', () => {
     );
 
     expect(mockEarnSection).toHaveBeenCalledWith({
+      enabled: false,
       refresh: { trigger: 1, silentRefresh: true },
       tokenDetailsSource: TokenDetailsSource.ExploreEarn,
     });
+  });
+
+  it('enables Earn when Crypto is the active Explore tab', () => {
+    arrangeMocks({ earnSectionEnabled: true });
+
+    render(
+      <ExploreActiveTabProvider activeTab="Crypto">
+        <CryptoTab {...defaultTabProps} />
+      </ExploreActiveTabProvider>,
+    );
+
+    expect(mockEarnSection).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true }),
+    );
+  });
+
+  it('disables Earn when Explore screen is unfocused', () => {
+    arrangeMocks({ earnSectionEnabled: true });
+    mockUseIsFocused.mockReturnValue(false);
+
+    render(
+      <ExploreActiveTabProvider activeTab="Crypto">
+        <CryptoTab {...defaultTabProps} />
+      </ExploreActiveTabProvider>,
+    );
+
+    expect(mockEarnSection).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
   });
 });
 

--- a/app/components/Views/TrendingView/tabs/CryptoTab.test.tsx
+++ b/app/components/Views/TrendingView/tabs/CryptoTab.test.tsx
@@ -1,0 +1,207 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
+import { selectPerpsEnabledFlag } from '../../../UI/Perps';
+import { selectExploreEarnSectionEnabledFlag } from '../../../UI/Earn/selectors/featureFlags';
+import { TokenDetailsSource } from '../../../UI/TokenDetails/constants/constants';
+import { useTokensFeed } from '../feeds/tokens/useTokensFeed';
+import { usePredictionsFeed } from '../feeds/predictions/usePredictionsFeed';
+import { usePerpsFeed } from '../feeds/perps/usePerpsFeed';
+import CryptoTab from './CryptoTab';
+
+const mockNavigate = jest.fn();
+const mockEarnSection = jest.fn((_props: Record<string, unknown>) => null);
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+const mockUseNavigation = useNavigation as jest.MockedFunction<
+  typeof useNavigation
+>;
+const mockUseTokensFeed = jest.mocked(useTokensFeed);
+const mockUsePredictionsFeed = jest.mocked(usePredictionsFeed);
+const mockUsePerpsFeed = jest.mocked(usePerpsFeed);
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: jest.fn(),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../../UI/Perps', () => ({
+  selectPerpsEnabledFlag: jest.fn(),
+}));
+
+jest.mock('../../../UI/Earn/selectors/featureFlags', () => ({
+  selectExploreEarnSectionEnabledFlag: jest.fn(),
+}));
+
+jest.mock('../../../UI/Earn/components/EarnSection', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => mockEarnSection(props),
+}));
+
+jest.mock('../feeds/tokens/useTokensFeed', () => ({
+  useTokensFeed: jest.fn(),
+}));
+
+jest.mock('../feeds/predictions/usePredictionsFeed', () => ({
+  usePredictionsFeed: jest.fn(),
+}));
+
+jest.mock('../feeds/perps/usePerpsFeed', () => ({
+  usePerpsFeed: jest.fn(),
+}));
+
+jest.mock('../feeds/perps/PerpsSectionProvider', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock('../components/SectionHeader', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../components/TileCarousel', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../../../UI/RobinhoodBanner', () => ({
+  RobinhoodBanner: () => null,
+  RobinhoodBannerSurface: { ExploreCrypto: 'explore_crypto' },
+  useRobinhoodBanner: () => ({
+    dismiss: jest.fn(),
+    handlePress: jest.fn(),
+    shouldShow: false,
+  }),
+}));
+
+jest.mock('../../../UI/Trending/contexts', () => ({
+  useTrendingQuickBuySheet: () => ({
+    openQuickBuy: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../../hooks/useABTest', () => ({
+  useABTest: () => ({
+    variant: { showQuickTradeButton: false },
+  }),
+}));
+
+const defaultTabProps = {
+  refresh: { trigger: 0, silentRefresh: true },
+  refreshing: false,
+  onRefresh: jest.fn(),
+};
+
+const arrangeMocks = ({
+  perpsEnabled = false,
+  earnSectionEnabled = false,
+}: {
+  perpsEnabled?: boolean;
+  earnSectionEnabled?: boolean;
+} = {}) => {
+  jest.clearAllMocks();
+
+  mockUseNavigation.mockReturnValue({
+    navigate: mockNavigate,
+  } as never);
+
+  mockUseSelector.mockImplementation((selector) => {
+    if (selector === selectPerpsEnabledFlag) return perpsEnabled;
+    if (selector === selectExploreEarnSectionEnabledFlag) {
+      return earnSectionEnabled;
+    }
+    return undefined;
+  });
+
+  mockUseTokensFeed.mockReturnValue({
+    data: [],
+    isLoading: false,
+    refetch: jest.fn(),
+  } as never);
+  mockUsePredictionsFeed.mockReturnValue({
+    data: [],
+    isLoading: false,
+    refetch: jest.fn(),
+  } as never);
+  mockUsePerpsFeed.mockReturnValue({
+    data: [{ market: { symbol: 'BTC' } }],
+    isLoading: false,
+    refetch: jest.fn(),
+    defaultSortOptionId: 'priceChange',
+  } as never);
+};
+
+const getSectionOrder = (tree: ReturnType<typeof render>['root']): string[] => {
+  const sectionIds = new Set([
+    'explore-section-crypto_perps',
+    'explore-section-earn',
+  ]);
+
+  const walk = (node: typeof tree): string[] => {
+    const testID = node.props?.testID;
+    const ownSection = sectionIds.has(testID) ? [testID] : [];
+    const childSections = node.children.flatMap((child) =>
+      typeof child === 'string' ? [] : walk(child),
+    );
+
+    return [...ownSection, ...childSections];
+  };
+
+  return [...new Set(walk(tree))];
+};
+
+describe('CryptoTab — Earn section', () => {
+  it('renders Earn when the feature flag is enabled', () => {
+    arrangeMocks({ earnSectionEnabled: true });
+
+    render(<CryptoTab {...defaultTabProps} />);
+
+    expect(screen.getByTestId('explore-section-earn')).toBeOnTheScreen();
+    expect(mockEarnSection).toHaveBeenCalledWith({
+      refreshTrigger: 0,
+      tokenDetailsSource: TokenDetailsSource.ExploreEarn,
+    });
+  });
+
+  it('does not render Earn when the feature flag is disabled', () => {
+    arrangeMocks();
+
+    render(<CryptoTab {...defaultTabProps} />);
+
+    expect(screen.queryByTestId('explore-section-earn')).not.toBeOnTheScreen();
+    expect(mockEarnSection).not.toHaveBeenCalled();
+  });
+
+  it('forwards the Explore refresh trigger to Earn', () => {
+    arrangeMocks({ earnSectionEnabled: true });
+
+    render(
+      <CryptoTab
+        {...defaultTabProps}
+        refresh={{ trigger: 1, silentRefresh: true }}
+      />,
+    );
+
+    expect(mockEarnSection).toHaveBeenCalledWith({
+      refreshTrigger: 1,
+      tokenDetailsSource: TokenDetailsSource.ExploreEarn,
+    });
+  });
+});
+
+describe('CryptoTab — section ordering', () => {
+  it('renders Earn immediately after Perps when both sections are enabled', () => {
+    arrangeMocks({ perpsEnabled: true, earnSectionEnabled: true });
+
+    const { root } = render(<CryptoTab {...defaultTabProps} />);
+
+    expect(getSectionOrder(root)).toEqual([
+      'explore-section-crypto_perps',
+      'explore-section-earn',
+    ]);
+  });
+});

--- a/app/components/Views/TrendingView/tabs/CryptoTab.tsx
+++ b/app/components/Views/TrendingView/tabs/CryptoTab.tsx
@@ -11,7 +11,7 @@ import Routes from '../../../../constants/navigation/Routes';
 import { strings } from '../../../../../locales/i18n';
 import { TokenDetailsSource } from '../../../UI/TokenDetails/constants/constants';
 import { selectExploreEarnSectionEnabledFlag } from '../../../UI/Earn/selectors/featureFlags';
-import EarnSection from '../../../UI/Earn/components/EarnSection';
+import ExploreEarnSection from '../components/ExploreEarnSection';
 import { useTokensFeed } from '../feeds/tokens/useTokensFeed';
 import { getCaipChainIdFromAssetId } from '../../../UI/Trending/components/TrendingTokenRowItem/utils';
 import { TokenRowItem } from '../feeds/tokens/TokenRowItem';
@@ -225,12 +225,7 @@ const CryptoTabContent: React.FC<TabProps> = ({
     if (isEarnSectionEnabled) {
       items.push({
         key: 'earn',
-        content: (
-          <EarnSection
-            refresh={refresh}
-            tokenDetailsSource={TokenDetailsSource.ExploreEarn}
-          />
-        ),
+        content: <ExploreEarnSection tabName="Crypto" refresh={refresh} />,
       });
     }
 

--- a/app/components/Views/TrendingView/tabs/CryptoTab.tsx
+++ b/app/components/Views/TrendingView/tabs/CryptoTab.tsx
@@ -10,6 +10,8 @@ import { selectPerpsEnabledFlag } from '../../../UI/Perps';
 import Routes from '../../../../constants/navigation/Routes';
 import { strings } from '../../../../../locales/i18n';
 import { TokenDetailsSource } from '../../../UI/TokenDetails/constants/constants';
+import { selectExploreEarnSectionEnabledFlag } from '../../../UI/Earn/selectors/featureFlags';
+import EarnSection from '../../../UI/Earn/components/EarnSection';
 import { useTokensFeed } from '../feeds/tokens/useTokensFeed';
 import { getCaipChainIdFromAssetId } from '../../../UI/Trending/components/TrendingTokenRowItem/utils';
 import { TokenRowItem } from '../feeds/tokens/TokenRowItem';
@@ -116,6 +118,7 @@ const CryptoTabContent: React.FC<TabProps> = ({
   const perpsNavigation =
     useNavigation<NavigationProp<PerpsNavigationParamList>>();
   const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
+  const isEarnSectionEnabled = useSelector(selectExploreEarnSectionEnabledFlag);
   const { openQuickBuy } = useTrendingQuickBuySheet();
 
   const { variant: quickBuyVariant } = useABTest(
@@ -219,6 +222,18 @@ const CryptoTabContent: React.FC<TabProps> = ({
       });
     }
 
+    if (isEarnSectionEnabled) {
+      items.push({
+        key: 'earn',
+        content: (
+          <EarnSection
+            refreshTrigger={refresh.trigger}
+            tokenDetailsSource={TokenDetailsSource.ExploreEarn}
+          />
+        ),
+      });
+    }
+
     if (showPredictions) {
       items.push({
         key: 'predictions',
@@ -242,6 +257,7 @@ const CryptoTabContent: React.FC<TabProps> = ({
   }, [
     showTokens,
     showCryptoPerps,
+    isEarnSectionEnabled,
     showPredictions,
     navigation,
     tokens.data,

--- a/app/components/Views/TrendingView/tabs/CryptoTab.tsx
+++ b/app/components/Views/TrendingView/tabs/CryptoTab.tsx
@@ -227,7 +227,7 @@ const CryptoTabContent: React.FC<TabProps> = ({
         key: 'earn',
         content: (
           <EarnSection
-            refreshTrigger={refresh.trigger}
+            refresh={refresh}
             tokenDetailsSource={TokenDetailsSource.ExploreEarn}
           />
         ),

--- a/app/components/Views/TrendingView/tabs/NowTab.test.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.test.tsx
@@ -135,6 +135,7 @@ const mockEarnSection = jest.fn(
     refresh?: { trigger: number; silentRefresh: boolean };
     showDividers?: boolean;
     tokenDetailsSource?: string;
+    enabled?: boolean;
   }) =>
     React.createElement('View', {
       testID: 'explore-earn-section',
@@ -149,6 +150,7 @@ jest.mock('../../../UI/Earn/components/EarnSection', () => ({
     refresh?: { trigger: number; silentRefresh: boolean };
     showDividers?: boolean;
     tokenDetailsSource?: string;
+    enabled?: boolean;
   }) => mockEarnSection(props),
 }));
 
@@ -710,6 +712,7 @@ describe('NowTab — Earn section', () => {
 
     expect(screen.getByTestId('explore-earn-section')).toBeOnTheScreen();
     expect(mockEarnSection).toHaveBeenCalledWith({
+      enabled: true,
       refresh: { trigger: 0, silentRefresh: true },
       tokenDetailsSource: TokenDetailsSource.ExploreEarn,
     });
@@ -727,9 +730,37 @@ describe('NowTab — Earn section', () => {
     });
 
     expect(mockEarnSection).toHaveBeenCalledWith({
+      enabled: true,
       refresh: { trigger: 1, silentRefresh: true },
       tokenDetailsSource: TokenDetailsSource.ExploreEarn,
     });
+  });
+
+  it('disables Earn when another Explore tab is active', () => {
+    const mocks = arrangeMocks();
+    mocks.useSelector.mockImplementation(
+      createMockSelectorImpl({ earnSectionEnabled: true }),
+    );
+
+    renderNowTab(defaultTabProps, { activeTab: 'Crypto' });
+
+    expect(mockEarnSection).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it('disables Earn when Explore screen is unfocused', () => {
+    const mocks = arrangeMocks();
+    mocks.useSelector.mockImplementation(
+      createMockSelectorImpl({ earnSectionEnabled: true }),
+    );
+    mockUseIsFocused.mockReturnValue(false);
+
+    renderNowTab();
+
+    expect(mockEarnSection).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
   });
 
   it('does not render Earn section when disabled', () => {

--- a/app/components/Views/TrendingView/tabs/NowTab.test.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.test.tsx
@@ -711,7 +711,7 @@ describe('NowTab — Earn section', () => {
     expect(screen.getByTestId('explore-earn-section')).toBeOnTheScreen();
     expect(mockEarnSection).toHaveBeenCalledWith({
       refreshTrigger: 0,
-      tokenDetailsSource: TokenDetailsSource.Trending,
+      tokenDetailsSource: TokenDetailsSource.ExploreEarn,
     });
   });
 
@@ -728,7 +728,7 @@ describe('NowTab — Earn section', () => {
 
     expect(mockEarnSection).toHaveBeenCalledWith({
       refreshTrigger: 1,
-      tokenDetailsSource: TokenDetailsSource.Trending,
+      tokenDetailsSource: TokenDetailsSource.ExploreEarn,
     });
   });
 

--- a/app/components/Views/TrendingView/tabs/NowTab.test.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.test.tsx
@@ -130,7 +130,12 @@ jest.mock('../feeds/perps/PerpsSectionProvider', () => {
 });
 
 const mockEarnSection = jest.fn(
-  (props: { homeAnalytics?: unknown; showDividers?: boolean }) =>
+  (props: {
+    homeAnalytics?: unknown;
+    refreshTrigger?: number;
+    showDividers?: boolean;
+    tokenDetailsSource?: string;
+  }) =>
     React.createElement('View', {
       testID: 'explore-earn-section',
       accessibilityLabel: JSON.stringify(props),
@@ -139,8 +144,12 @@ const mockEarnSection = jest.fn(
 
 jest.mock('../../../UI/Earn/components/EarnSection', () => ({
   __esModule: true,
-  default: (props: { homeAnalytics?: unknown; showDividers?: boolean }) =>
-    mockEarnSection(props),
+  default: (props: {
+    homeAnalytics?: unknown;
+    refreshTrigger?: number;
+    showDividers?: boolean;
+    tokenDetailsSource?: string;
+  }) => mockEarnSection(props),
 }));
 
 const mockWhatsHappeningRefresh = jest.fn();
@@ -212,6 +221,7 @@ import { selectPerpsEnabledFlag } from '../../../UI/Perps';
 import { selectPredictEnabledFlag } from '../../../UI/Predict';
 import { selectWhatsHappeningEnabled } from '../../../../selectors/featureFlagController/whatsHappening';
 import { selectExploreEarnSectionEnabledFlag } from '../../../UI/Earn/selectors/featureFlags';
+import { TokenDetailsSource } from '../../../UI/TokenDetails/constants/constants';
 import WhatsHappeningSection from '../../../UI/WhatsHappening';
 import NowTab from './NowTab';
 import { ExploreActiveTabProvider } from '../ExploreActiveTabContext';
@@ -699,7 +709,27 @@ describe('NowTab — Earn section', () => {
     renderNowTab();
 
     expect(screen.getByTestId('explore-earn-section')).toBeOnTheScreen();
-    expect(mockEarnSection).toHaveBeenCalledWith({});
+    expect(mockEarnSection).toHaveBeenCalledWith({
+      refreshTrigger: 0,
+      tokenDetailsSource: TokenDetailsSource.Trending,
+    });
+  });
+
+  it('forwards Explore refresh trigger to Earn section', () => {
+    const mocks = arrangeMocks();
+    mocks.useSelector.mockImplementation(
+      createMockSelectorImpl({ earnSectionEnabled: true }),
+    );
+
+    renderNowTab({
+      ...defaultTabProps,
+      refresh: { trigger: 1, silentRefresh: true },
+    });
+
+    expect(mockEarnSection).toHaveBeenCalledWith({
+      refreshTrigger: 1,
+      tokenDetailsSource: TokenDetailsSource.Trending,
+    });
   });
 
   it('does not render Earn section when disabled', () => {

--- a/app/components/Views/TrendingView/tabs/NowTab.test.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.test.tsx
@@ -129,6 +129,20 @@ jest.mock('../feeds/perps/PerpsSectionProvider', () => {
     createElement(View, null, children);
 });
 
+const mockEarnSection = jest.fn(
+  (props: { homeAnalytics?: unknown; showDividers?: boolean }) =>
+    React.createElement('View', {
+      testID: 'explore-earn-section',
+      accessibilityLabel: JSON.stringify(props),
+    }),
+);
+
+jest.mock('../../../UI/Earn/components/EarnSection', () => ({
+  __esModule: true,
+  default: (props: { homeAnalytics?: unknown; showDividers?: boolean }) =>
+    mockEarnSection(props),
+}));
+
 const mockWhatsHappeningRefresh = jest.fn();
 const mockUseWhatsHappening = jest.fn(() => ({
   items: [] as { id: string }[],
@@ -197,6 +211,7 @@ import { useSelector } from 'react-redux';
 import { selectPerpsEnabledFlag } from '../../../UI/Perps';
 import { selectPredictEnabledFlag } from '../../../UI/Predict';
 import { selectWhatsHappeningEnabled } from '../../../../selectors/featureFlagController/whatsHappening';
+import { selectExploreEarnSectionEnabledFlag } from '../../../UI/Earn/selectors/featureFlags';
 import WhatsHappeningSection from '../../../UI/WhatsHappening';
 import NowTab from './NowTab';
 import { ExploreActiveTabProvider } from '../ExploreActiveTabContext';
@@ -233,15 +248,19 @@ const createMockSelectorImpl =
     perpsEnabled = false,
     predictEnabled = false,
     whatsHappeningEnabled = false,
+    earnSectionEnabled = false,
   }: {
     perpsEnabled?: boolean;
     predictEnabled?: boolean;
     whatsHappeningEnabled?: boolean;
+    earnSectionEnabled?: boolean;
   }) =>
   (selector: unknown) => {
     if (selector === selectPerpsEnabledFlag) return perpsEnabled;
     if (selector === selectPredictEnabledFlag) return predictEnabled;
     if (selector === selectWhatsHappeningEnabled) return whatsHappeningEnabled;
+    if (selector === selectExploreEarnSectionEnabledFlag)
+      return earnSectionEnabled;
     return undefined;
   };
 
@@ -667,6 +686,32 @@ describe('NowTab — Crypto Movers', () => {
 
     expect(screen.getByTestId('section-pill-eip155:1/erc20:0x17')).toBeTruthy();
     expect(screen.queryByTestId('section-pill-eip155:1/erc20:0x18')).toBeNull();
+  });
+});
+
+describe('NowTab — Earn section', () => {
+  it('renders Earn section without Homepage analytics metadata when enabled', () => {
+    const mocks = arrangeMocks();
+    mocks.useSelector.mockImplementation(
+      createMockSelectorImpl({ earnSectionEnabled: true }),
+    );
+
+    renderNowTab();
+
+    expect(screen.getByTestId('explore-earn-section')).toBeOnTheScreen();
+    expect(mockEarnSection).toHaveBeenCalledWith({});
+  });
+
+  it('does not render Earn section when disabled', () => {
+    const mocks = arrangeMocks();
+    mocks.useSelector.mockImplementation(
+      createMockSelectorImpl({ earnSectionEnabled: false }),
+    );
+
+    renderNowTab();
+
+    expect(mockEarnSection).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('explore-earn-section')).toBeNull();
   });
 });
 

--- a/app/components/Views/TrendingView/tabs/NowTab.test.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.test.tsx
@@ -132,7 +132,7 @@ jest.mock('../feeds/perps/PerpsSectionProvider', () => {
 const mockEarnSection = jest.fn(
   (props: {
     homeAnalytics?: unknown;
-    refreshTrigger?: number;
+    refresh?: { trigger: number; silentRefresh: boolean };
     showDividers?: boolean;
     tokenDetailsSource?: string;
   }) =>
@@ -146,7 +146,7 @@ jest.mock('../../../UI/Earn/components/EarnSection', () => ({
   __esModule: true,
   default: (props: {
     homeAnalytics?: unknown;
-    refreshTrigger?: number;
+    refresh?: { trigger: number; silentRefresh: boolean };
     showDividers?: boolean;
     tokenDetailsSource?: string;
   }) => mockEarnSection(props),
@@ -710,7 +710,7 @@ describe('NowTab — Earn section', () => {
 
     expect(screen.getByTestId('explore-earn-section')).toBeOnTheScreen();
     expect(mockEarnSection).toHaveBeenCalledWith({
-      refreshTrigger: 0,
+      refresh: { trigger: 0, silentRefresh: true },
       tokenDetailsSource: TokenDetailsSource.ExploreEarn,
     });
   });
@@ -727,7 +727,7 @@ describe('NowTab — Earn section', () => {
     });
 
     expect(mockEarnSection).toHaveBeenCalledWith({
-      refreshTrigger: 1,
+      refresh: { trigger: 1, silentRefresh: true },
       tokenDetailsSource: TokenDetailsSource.ExploreEarn,
     });
   });

--- a/app/components/Views/TrendingView/tabs/NowTab.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.tsx
@@ -371,7 +371,12 @@ const NowTabContent: React.FC<TabProps> = ({
     if (isEarnSectionEnabled) {
       items.push({
         key: 'earn',
-        content: <EarnSection />,
+        content: (
+          <EarnSection
+            refreshTrigger={refresh.trigger}
+            tokenDetailsSource={TokenDetailsSource.ExploreEarn}
+          />
+        ),
       });
     }
 

--- a/app/components/Views/TrendingView/tabs/NowTab.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.tsx
@@ -62,7 +62,7 @@ import {
 } from '../../../UI/WhatsHappening/hooks';
 import { selectWhatsHappeningEnabled } from '../../../../selectors/featureFlagController/whatsHappening';
 import { selectExploreEarnSectionEnabledFlag } from '../../../UI/Earn/selectors/featureFlags';
-import EarnSection from '../../../UI/Earn/components/EarnSection';
+import ExploreEarnSection from '../components/ExploreEarnSection';
 
 interface PerpsBlockProps {
   refresh: TabProps['refresh'];
@@ -371,12 +371,7 @@ const NowTabContent: React.FC<TabProps> = ({
     if (isEarnSectionEnabled) {
       items.push({
         key: 'earn',
-        content: (
-          <EarnSection
-            refresh={refresh}
-            tokenDetailsSource={TokenDetailsSource.ExploreEarn}
-          />
-        ),
+        content: <ExploreEarnSection tabName="Now" refresh={refresh} />,
       });
     }
 

--- a/app/components/Views/TrendingView/tabs/NowTab.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.tsx
@@ -61,6 +61,8 @@ import {
   useWhatsHappening,
 } from '../../../UI/WhatsHappening/hooks';
 import { selectWhatsHappeningEnabled } from '../../../../selectors/featureFlagController/whatsHappening';
+import { selectExploreEarnSectionEnabledFlag } from '../../../UI/Earn/selectors/featureFlags';
+import EarnSection from '../../../UI/Earn/components/EarnSection';
 
 interface PerpsBlockProps {
   refresh: TabProps['refresh'];
@@ -222,6 +224,7 @@ const NowTabContent: React.FC<TabProps> = ({
   const isPerpsEnabled = useSelector(selectPerpsEnabledFlag);
   const isPredictEnabled = useSelector(selectPredictEnabledFlag);
   const isWhatsHappeningEnabled = useSelector(selectWhatsHappeningEnabled);
+  const isEarnSectionEnabled = useSelector(selectExploreEarnSectionEnabledFlag);
 
   const whatsHappening = useWhatsHappening();
   const refreshWhatsHappening = whatsHappening.refresh;
@@ -365,6 +368,13 @@ const NowTabContent: React.FC<TabProps> = ({
       });
     }
 
+    if (isEarnSectionEnabled) {
+      items.push({
+        key: 'earn',
+        content: <EarnSection />,
+      });
+    }
+
     if (showWhatsHappening) {
       items.push({
         key: 'wh',
@@ -412,6 +422,7 @@ const NowTabContent: React.FC<TabProps> = ({
     showPredictions,
     showCryptoMovers,
     showPerps,
+    isEarnSectionEnabled,
     showStocks,
     whatsHappening,
     displayedPredictions,

--- a/app/components/Views/TrendingView/tabs/NowTab.tsx
+++ b/app/components/Views/TrendingView/tabs/NowTab.tsx
@@ -373,7 +373,7 @@ const NowTabContent: React.FC<TabProps> = ({
         key: 'earn',
         content: (
           <EarnSection
-            refreshTrigger={refresh.trigger}
+            refresh={refresh}
             tokenDetailsSource={TokenDetailsSource.ExploreEarn}
           />
         ),

--- a/tests/feature-flags/feature-flag-registry.ts
+++ b/tests/feature-flags/feature-flag-registry.ts
@@ -3421,6 +3421,17 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  earnExploreSectionEnabled: {
+    name: 'earnExploreSectionEnabled',
+    type: FeatureFlagType.Remote,
+    inProd: false,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '0.0.0',
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
   earnMoneyTokenListItemCtaEnabled: {
     name: 'earnMoneyTokenListItemCtaEnabled',
     type: FeatureFlagType.Remote,


### PR DESCRIPTION
### Blocked by https://github.com/MetaMask/metamask-mobile/pull/35037

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Adds Earn section to Explore's "Now" and "Crypto" tabs.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Added Earn section to Explore so users can discover earning opportunities.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1258: [Feature] Explore – Implement Earn section with Money account module](https://consensyssoftware.atlassian.net/browse/MUSD-1258)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Earn section in Explore

  Scenario: user discovers earning opportunities
    Given the Earn section feature flag is enabled
    When user opens the Explore page's "Now" or "Crypto" tabs
    Then user sees the Earn section with available asset opportunities and Money account information

  Scenario: user opens an earning strategy
    Given the Earn section contains an available asset
    When user taps the asset
    Then user sees the strategy selection flow for that asset
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — Earn section didn't exist on Explore page.

### **After**

<img width="487" height="1009" alt="image" src="https://github.com/user-attachments/assets/c09e56b1-2901-46e1-b579-ae9a49dfaf29" />

<img width="487" height="1009" alt="image" src="https://github.com/user-attachments/assets/af4bd956-058e-4fbb-9170-8ce0c4d034a5" />

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the shared Earn section used on Wallet Home and adds gated Explore data-fetch/refresh paths across Earn and Money hooks, though behavior is behind a flag and inactive tabs skip work.
> 
> **Overview**
> Introduces a version-gated **`MM_EXPLORE_EARN_SECTION_ENABLED`** / `earnExploreSectionEnabled` flag and surfaces the shared **Earn** carousel on Explore **Now** and **Crypto** when it is on.
> 
> **`EarnSection`** is refactored for reuse: callers pass `tokenDetailsSource`, optional Homepage analytics, Explore pull-to-refresh (`useFeedRefresh`), and an **`enabled`** switch so catalogue/Money fetches run only when the screen and tab are active. **Homepage** uses a thin **`HomepageEarnSection`** wrapper (dividers + `TokenDetailsSource.HomeSection`); Explore uses **`ExploreEarnSection`**. Homepage view/performance telemetry stays off for Explore; asset taps attribute **`TokenDetailsSource.ExploreEarn`**.
> 
> Earn data hooks gain **`enabled`** plumbing and tighter loading behavior (e.g. no full-section spinner on background lending refresh). Explore refresh coalesces duplicate triggers and concurrent **`EarnSection`** instances; failed refreshes are logged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b954b10f267581450e24e0b225aeabcce17178eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->