### PR TITLE
revert: identify automated RC OTA updates by commit in app info

### DIFF
--- a/app/components/Views/Settings/AppInformation/EnvironmentInfo.tsx
+++ b/app/components/Views/Settings/AppInformation/EnvironmentInfo.tsx
@@ -8,7 +8,7 @@ import {
   updateId,
   checkAutomatically,
 } from 'expo-updates';
-import { OTA_RC_AUTO_COMMIT, OTA_VERSION } from '../../../../constants/ota';
+import { OTA_VERSION } from '../../../../constants/ota';
 import {
   getFeatureFlagAppDistribution,
   getFeatureFlagAppEnvironment,
@@ -69,11 +69,6 @@ export const EnvironmentInfo = ({
             {`OTA Update status: ${otaUpdateMessage}`}
           </Text>
           <Text style={styles.branchInfo}>{`OTA Version: ${OTA_VERSION}`}</Text>
-          {OTA_RC_AUTO_COMMIT ? (
-            <Text style={styles.branchInfo}>
-              {`Auto RC OTA commit: ${OTA_RC_AUTO_COMMIT}`}
-            </Text>
-          ) : null}
         </>
       ) : null}
       {preinstalledSnaps.map((snap) => (

--- a/app/components/Views/Settings/AppInformation/index.test.tsx
+++ b/app/components/Views/Settings/AppInformation/index.test.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { waitFor, fireEvent } from '@testing-library/react-native';
 import { Image, InteractionManager, TouchableOpacity } from 'react-native';
-// Namespace import so jest.replaceProperty can override a value on the same expo-updates
-// module instance the components read from.
-// eslint-disable-next-line import-x/no-namespace
-import * as ExpoUpdates from 'expo-updates';
 import renderWithProvider, {
   DeepPartial,
   renderScreen,
@@ -48,12 +44,8 @@ jest.mock(
   }),
 );
 
-let mockOtaRcAutoCommit = '';
 jest.mock('../../../../constants/ota', () => ({
   OTA_VERSION: 'v0',
-  get OTA_RC_AUTO_COMMIT() {
-    return mockOtaRcAutoCommit;
-  },
 }));
 
 const MOCK_STATE = {
@@ -81,7 +73,6 @@ const MOCK_STATE = {
 describe('AppInformation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockOtaRcAutoCommit = '';
     jest
       .spyOn(InteractionManager, 'runAfterInteractions')
       .mockImplementation((task) => {
@@ -607,99 +598,6 @@ describe('AppInformation', () => {
         expect(getByText(/OTA Update runtime version: 1.0.0/)).toBeTruthy();
         expect(getByText(/Check Automatically: NEVER/)).toBeTruthy();
         expect(getByText(/OTA Update status:/)).toBeTruthy();
-      });
-    });
-
-    it('displays the Auto RC OTA commit after long-pressing the fox icon when CI set one', async () => {
-      mockOtaRcAutoCommit = 'a1b2c3d';
-
-      const { getByText, UNSAFE_getAllByType } = renderScreen(
-        AppInformation,
-        { name: 'AppInformation' },
-        { state: MOCK_STATE },
-      );
-
-      const foxTouchable = UNSAFE_getAllByType(TouchableOpacity).find(
-        (item) => item.props.onLongPress !== undefined,
-      );
-      if (foxTouchable) {
-        fireEvent(foxTouchable, 'longPress');
-      }
-
-      await waitFor(() => {
-        expect(getByText('Auto RC OTA commit: a1b2c3d')).toBeOnTheScreen();
-      });
-    });
-
-    it('omits the Auto RC OTA commit line when CI did not set one', async () => {
-      const { getByText, queryByText, UNSAFE_getAllByType } = renderScreen(
-        AppInformation,
-        { name: 'AppInformation' },
-        { state: MOCK_STATE },
-      );
-
-      const foxTouchable = UNSAFE_getAllByType(TouchableOpacity).find(
-        (item) => item.props.onLongPress !== undefined,
-      );
-      if (foxTouchable) {
-        fireEvent(foxTouchable, 'longPress');
-      }
-
-      await waitFor(() => {
-        expect(getByText('OTA Version: v0')).toBeOnTheScreen();
-      });
-      expect(queryByText(/Auto RC OTA commit:/)).not.toBeOnTheScreen();
-    });
-  });
-
-  describe('Version Display', () => {
-    // The version line only shows an OTA identity when the app is running a downloaded
-    // update rather than the bundle embedded in the binary. restoreAllMocks puts the
-    // shared expo-updates mock back afterwards.
-    const runningAnUpdate = () => {
-      jest.replaceProperty(ExpoUpdates, 'isEmbeddedLaunch', false);
-    };
-
-    it('identifies an Auto RC OTA update by its commit', async () => {
-      runningAnUpdate();
-      mockOtaRcAutoCommit = 'a1b2c3d';
-
-      const { getByText } = renderScreen(
-        AppInformation,
-        { name: 'AppInformation' },
-        { state: MOCK_STATE },
-      );
-
-      await waitFor(() => {
-        expect(getByText('MetaMask ota a1b2c3d (1000)')).toBeOnTheScreen();
-      });
-    });
-
-    it('falls back to OTA_VERSION for updates published outside the Auto RC path', async () => {
-      runningAnUpdate();
-
-      const { getByText } = renderScreen(
-        AppInformation,
-        { name: 'AppInformation' },
-        { state: MOCK_STATE },
-      );
-
-      await waitFor(() => {
-        expect(getByText('MetaMask ota v0 (1000)')).toBeOnTheScreen();
-      });
-    });
-
-    it('shows the native version when running the embedded bundle, even with a commit set', async () => {
-      mockOtaRcAutoCommit = 'a1b2c3d';
-
-      const { getByText } = renderScreen(
-        AppInformation,
-        { name: 'AppInformation' },
-        { state: MOCK_STATE },
-      );
-
-      await waitFor(() => {
-        expect(getByText('MetaMask v7.0.0 (1000)')).toBeOnTheScreen();
       });
     });
   });

--- a/app/components/Views/Settings/AppInformation/index.tsx
+++ b/app/components/Views/Settings/AppInformation/index.tsx
@@ -13,7 +13,7 @@ import {
   isEnabled as isOTAUpdatesEnabled,
 } from 'expo-updates';
 import { connect } from 'react-redux';
-import { OTA_RC_AUTO_COMMIT, OTA_VERSION } from '../../../../constants/ota';
+import { OTA_VERSION } from '../../../../constants/ota';
 import { strings } from '../../../../../locales/i18n';
 import AppConstants from '../../../../core/AppConstants';
 import { useTheme } from '../../../../util/theme';
@@ -123,13 +123,10 @@ const AppInformation = ({ navigation, preinstalledSnaps }: Props) => {
   /**
    * Returns the version string to display (native app version or OTA version).
    * When OTA is disabled we're always on embedded code; native isEmbeddedLaunch can be false in that case.
-   * Automated RC OTAs don't bump OTA_VERSION, so they identify themselves by commit instead.
    */
   const getVersionDisplay = () => {
     const appInfo = `${appName} v${appVersion} (${buildNumber})`;
-    const appInfoOta = `${appName} ota ${
-      OTA_RC_AUTO_COMMIT || OTA_VERSION
-    } (${buildNumber})`;
+    const appInfoOta = `${appName} ota ${OTA_VERSION} (${buildNumber})`;
     const isRunningEmbedded = isEmbeddedLaunch || !isOTAUpdatesEnabled;
     return __DEV__ || isRunningEmbedded ? appInfo : appInfoOta;
   };

--- a/app/constants/ota.ts
+++ b/app/constants/ota.ts
@@ -13,17 +13,6 @@ import otaConfig from '../../ota.config.js';
  * Kept here (not only in ota.config.js) so changes there do not alter the Expo fingerprint and break CI.
  */
 export const OTA_VERSION: string = 'vX.XX.X';
-
-/**
- * Short commit SHA the running automated release-candidate OTA update was published from.
- *
- * The automated RC path publishes on every JS-only push to a `release/*` branch, so it never
- * bumps `OTA_VERSION` and the commit is the only thing that identifies which update a tester is
- * on. Set by CI at publish time and inlined into the bundle by babel's
- * `transform-inline-environment-variables`; empty for native builds and every other OTA flow.
- */
-export const OTA_RC_AUTO_COMMIT: string = process.env.OTA_RC_AUTO_COMMIT || '';
-
 export const RUNTIME_VERSION = otaConfig.RUNTIME_VERSION;
 export const PROJECT_ID = otaConfig.PROJECT_ID;
 export const UPDATE_URL = otaConfig.UPDATE_URL;


### PR DESCRIPTION
## What

Reverts #34955.

This is a direct revert of commit 9c84a57063b45b7c43e758690b9db1c5a51bda01, restoring `app/constants/ota.ts`, `AppInformation/index.tsx`, `AppInformation/EnvironmentInfo.tsx`, and `AppInformation/index.test.tsx` to their state before that PR.

## Why

Reverting PR #34955 per request.

## Testing

`yarn jest app/components/Views/Settings/AppInformation` — 23 passed, 23 total.

`yarn eslint` on the reverted files — clean.

Made with [Cursor](https://cursor.com)