### PR TITLE
fix(activity): label BRIDGE_OUT transactions as bridges

### DIFF
--- a/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
@@ -1593,7 +1593,7 @@ describe('ActivityListItemRow — row content', () => {
     );
   });
 
-  it('renders source-only API bridge rows as sends when bridge history is unavailable', () => {
+  it('renders source-only API bridge rows as bridges when bridge history is unavailable', () => {
     const item = makeItem({
       type: 'bridge',
       status: 'success',
@@ -1609,7 +1609,7 @@ describe('ActivityListItemRow — row content', () => {
     );
 
     expect(getByTestId('activity-title-0xabc').props.children).toBe(
-      'Sent USDC',
+      'Bridged USDC',
     );
     expect(queryByTestId('activity-subtitle-0xabc')).toBeNull();
     expect(getByTestId('activity-primary-amount-0xabc').props.children).toBe(

--- a/app/components/UI/ActivityListItemRow/useActivityListItemRowContent.ts
+++ b/app/components/UI/ActivityListItemRow/useActivityListItemRowContent.ts
@@ -613,34 +613,25 @@ function resolveCoreContent(
         bridgeQuoteTokens.sourceToken ?? item.data.sourceToken;
       const destinationToken =
         bridgeQuoteTokens.destinationToken ?? item.data.destinationToken;
-      const sourceSymbol = sourceToken?.symbol;
-      const destinationSymbol = destinationToken?.symbol;
-      const isSourceOnlyApiBridge =
-        !bridgeHistoryItem && sourceToken && !destinationToken;
+      // The API only reports the source token for the outgoing leg, so fall
+      // back to it when the destination token is unknown rather than labelling
+      // the row a send.
+      const symbol = destinationToken?.symbol ?? sourceToken?.symbol;
       const subtitle =
         bridgeRouteSubtitle(bridgeHistoryItem) ??
         tokenPairSubtitle(sourceToken, destinationToken);
 
       return {
         title: statusTitle(item, {
-          success: isSourceOnlyApiBridge
-            ? withOptionalSymbol(strings('transactions.sent'), sourceSymbol)
-            : withOptionalSymbol(
-                strings('transactions.activity_bridged'),
-                destinationSymbol ?? sourceSymbol,
-              ),
-          pending: isSourceOnlyApiBridge
-            ? withOptionalSymbol(
-                strings('transactions.activity_sending'),
-                sourceSymbol,
-              )
-            : withOptionalSymbol(
-                strings('transactions.activity_bridging'),
-                destinationSymbol ?? sourceSymbol,
-              ),
-          failed: isSourceOnlyApiBridge
-            ? strings('transactions.activity_send_failed')
-            : strings('transactions.activity_bridge_failed'),
+          success: withOptionalSymbol(
+            strings('transactions.activity_bridged'),
+            symbol,
+          ),
+          pending: withOptionalSymbol(
+            strings('transactions.activity_bridging'),
+            symbol,
+          ),
+          failed: strings('transactions.activity_bridge_failed'),
         }),
         subtitle,
         ...bridgeAmountTokens(sourceToken, destinationToken),

--- a/app/components/Views/ActivityList/helpers/transformations.test.ts
+++ b/app/components/Views/ActivityList/helpers/transformations.test.ts
@@ -276,6 +276,37 @@ describe('ActivityList transformations', () => {
   });
 
   describe('selectApiEvmTransactions', () => {
+    it('classifies BRIDGE_OUT transactions as bridges', () => {
+      const bridgeOut = buildTransaction({
+        hash: '0xbridge-out',
+        transactionCategory: 'BRIDGE_OUT',
+        valueTransfers: [
+          {
+            amount: '420300',
+            contractAddress: '0x5555555555555555555555555555555555555555',
+            decimal: 6,
+            from: address,
+            symbol: 'MUSD',
+            to: otherAddress,
+            transferType: 'ERC20',
+          },
+        ],
+      } as Partial<V1TransactionByHashResponse>);
+
+      const result = selectApiEvmTransactions({ address })(
+        buildData([bridgeOut]),
+      );
+
+      const [item] = result.pages[0].data;
+      expect(item.type).toBe('bridge');
+      expect(item.data).toMatchObject({
+        sourceToken: { symbol: 'MUSD', direction: 'out' },
+      });
+      expect(item.raw).toMatchObject({
+        data: { transactionCategory: 'BRIDGE_OUT' },
+      });
+    });
+
     it('filters incoming ERC-20 transfers when the account only appears in valueTransfers', () => {
       const incomingTokenTransfer = buildTransaction({
         hash: '0xincoming-token',

--- a/app/components/Views/ActivityList/helpers/transformations.ts
+++ b/app/components/Views/ActivityList/helpers/transformations.ts
@@ -141,6 +141,19 @@ export function shouldSkipTransaction(
   );
 }
 
+// The Accounts API labels the outgoing leg of a bridge `BRIDGE_OUT`, but the
+// shared mapper only recognises `BRIDGE_WITHDRAW` as an outgoing bridge, so a
+// `BRIDGE_OUT` transaction falls through to `contractInteraction` and the row
+// ends up rendering as a send. Aliasing the category keeps the bridge
+// classification (and its source token and fees) without forking the mapper.
+function withBridgeCategoryAlias(
+  transaction: V1TransactionByHashResponse,
+): V1TransactionByHashResponse {
+  return transaction.transactionCategory === 'BRIDGE_OUT'
+    ? { ...transaction, transactionCategory: 'BRIDGE_WITHDRAW' }
+    : transaction;
+}
+
 function transformApiTransactions(
   address: string,
   transactions: V1TransactionByHashResponse[],
@@ -154,7 +167,10 @@ function transformApiTransactions(
       continue;
     }
     items.push({
-      ...mapApiTransaction({ subjectAddress, transaction: tx }),
+      ...mapApiTransaction({
+        subjectAddress,
+        transaction: withBridgeCategoryAlias(tx),
+      }),
       raw: { type: 'apiEvmTransaction' as const, data: tx },
     } as ActivityListItem);
   }

--- a/app/util/activity-adapters/activity-list-helpers.test.ts
+++ b/app/util/activity-adapters/activity-list-helpers.test.ts
@@ -183,6 +183,27 @@ describe('activity list helpers', () => {
       expect(preferLocalOrApiActivityItem(local, api)).toBe(local);
     });
 
+    it('does not let a local send beat an API bridge', () => {
+      const local = makeItem({
+        type: 'send',
+        data: {
+          from: '0xfrom',
+          to: '0xto',
+          token: { amount: '1', direction: 'out', symbol: 'MUSD' },
+        },
+      });
+      const api = makeItem({
+        type: 'bridge',
+        data: {
+          from: '0xfrom',
+          sourceToken: { amount: '1', direction: 'out', symbol: 'MUSD' },
+        },
+      });
+
+      expect(shouldPreferLocalActivityItem(local, api)).toBe(false);
+      expect(preferLocalOrApiActivityItem(local, api)).toBe(api);
+    });
+
     it('does not let a gas-token local contractInteraction beat an API send', () => {
       const local = makeItem({
         type: 'contractInteraction',

--- a/app/util/activity-adapters/activity-list-helpers.ts
+++ b/app/util/activity-adapters/activity-list-helpers.ts
@@ -70,6 +70,16 @@ export function shouldPreferLocalActivityItem(
   localItem: ActivityListItem,
   apiItem: ActivityListItem,
 ): boolean {
+  // The local mapper can only label a bridge when `TransactionMeta.type` is
+  // `bridge`, and otherwise degrades it to a plain transfer, so the API's
+  // bridge classification is the better one.
+  if (
+    apiItem.type === 'bridge' &&
+    (localItem.type === 'send' || localItem.type === 'receive')
+  ) {
+    return false;
+  }
+
   const localOutCategorizesApi =
     apiItem.type !== localItem.type &&
     localItem.type !== 'contractInteraction' &&


### PR DESCRIPTION
## **Description**

Bridge transactions showed up in mobile's activity list as "Sent MUSD" / "Sent ETH" while the extension labelled the exact same transactions "Bridged MUSD" / "Bridged ETH".

The Accounts API labels the outgoing leg of a bridge `transactionCategory: 'BRIDGE_OUT'`. The extension reads that category directly in its title hook (`ui/components/multichain/activity-v2/hooks.ts`), but mobile relies on the shared `@metamask/client-utils` API mapper, which only knows `BRIDGE_WITHDRAW`. A `BRIDGE_OUT` transaction therefore fell past every branch and became `contractInteraction`; the local copy of the same transaction then out-categorized that API copy in dedup, so the local `send` row is what rendered.

Three changes, all needed for the row to actually flip:

1. Alias `BRIDGE_OUT` to `BRIDGE_WITHDRAW` before calling the shared mapper, so the existing bridge branch runs and keeps the source token and fees. The raw API payload is left untouched.
2. Let an API `bridge` win over a local `send`/`receive` in dedup — the local mapper can only label a bridge when `TransactionMeta.type` is `bridge` and otherwise degrades it to a plain transfer.
3. Stop downgrading a bridge row's title to "Sent" when only the source token is known. `BRIDGE_OUT` never carries a destination token, and the extension shows "Bridged" in that case too.

The real fix belongs server-side (the extension's own code carries a `// This should be server-side` comment next to its `BRIDGE_OUT` handling); second-best would be upstream in `@metamask/client-utils` so both clients share it.

## **Changelog**

CHANGELOG entry: Fixed bridge transactions being labelled as sends in the activity list

## **Related issues**

Fixes:

## **Manual testing steps**

```gherkin
Feature: Bridge transactions in the activity list

  Scenario: user views a completed bridge
    Given the user has bridged a token and the transaction has been indexed

    When user opens the activity list
    Then the row reads "Bridged {symbol}" instead of "Sent {symbol}"
    And the row matches what the extension shows for the same transaction
```

## **Screenshots/Recordings**

### **Before**

Mobile: `Sent MUSD` / `Sent ETH` (extension: `Bridged MUSD` / `Bridged ETH`)

### **After**

Mobile: `Bridged MUSD` / `Bridged ETH`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

Made with [Cursor](https://cursor.com)