### PR TITLE
fix(devtools): stabilize concurrent network inspection

### DIFF
--- a/.yarn/patches/react-native-npm-0.83.6-106e10c49d.patch
+++ b/.yarn/patches/react-native-npm-0.83.6-106e10c49d.patch
@@ -1,3 +1,20 @@
+diff --git a/ReactCommon/jsinspector-modern/InspectorInterfaces.cpp b/ReactCommon/jsinspector-modern/InspectorInterfaces.cpp
+index ab5a973f12c7e26631bdf2a4705a43f3f458600c..e20c4bf818838ed0d62f91aa600bf27c34df5ac3 100644
+--- a/ReactCommon/jsinspector-modern/InspectorInterfaces.cpp
++++ b/ReactCommon/jsinspector-modern/InspectorInterfaces.cpp
+@@ -146,5 +146,9 @@ int InspectorImpl::addPage(
+-  for (const auto& listenerWeak : listeners_) {
+-    if (auto listener = listenerWeak.lock()) {
+-      listener->unstable_onHostTargetAdded();
++  // Legacy Hermes runtimes also register pages, but only Fusebox pages
++  // represent React Native hosts.
++  if (capabilities.prefersFuseboxFrontend) {
++    for (const auto& listenerWeak : listeners_) {
++      if (auto listener = listenerWeak.lock()) {
++        listener->unstable_onHostTargetAdded();
++      }
+     }
+   }
 diff --git a/scripts/cocoapods/autolinking.rb b/scripts/cocoapods/autolinking.rb
 index d8e9c7cec2f57c124cc2b2fc52b69de8940d3eb5..b297501dfc3f8d22bc87f22e86ad6e3e9d0fc5d4 100644
 --- a/scripts/cocoapods/autolinking.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed React Native DevTools Network and Performance inspection being disabled by legacy Hermes runtimes miscounted as additional React Native hosts.
+
 ## [8.7.0]
 
 ### Added

--- a/yarn.lock
+++ b/yarn.lock
@@ -41228,7 +41228,7 @@ __metadata:
 
 "react-native@patch:react-native@npm%3A0.83.6#~/.yarn/patches/react-native-npm-0.83.6-106e10c49d.patch":
   version: 0.83.6
-  resolution: "react-native@patch:react-native@npm%3A0.83.6#~/.yarn/patches/react-native-npm-0.83.6-106e10c49d.patch::version=0.83.6&hash=4643c8"
+  resolution: "react-native@patch:react-native@npm%3A0.83.6#~/.yarn/patches/react-native-npm-0.83.6-106e10c49d.patch::version=0.83.6&hash=715175"
   dependencies:
     "@jest/create-cache-key-function": "npm:^29.7.0"
     "@react-native/assets-registry": "npm:0.83.6"
@@ -41273,7 +41273,7 @@ __metadata:
       optional: true
   bin:
     react-native: cli.js
-  checksum: 10/cbbfa9c834201ebd15bb60a382b608a8a31ef84a35278a1e3d1471441c761e05656ef881562b8ed3d2a7060d8c80c613bc31e4d0499615b01985895dade25b07
+  checksum: 10/8c0e4e572b30ffb0e40c005acbb5c12bc82e455cf72bbd06b7dcba3547bf0a81e88ee6f8dbd1615bc177066357c6e87daa88fd4d5f40e6ba132f018d912e4b88
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

React Native 0.83.6 can count legacy Hermes debugger pages as additional React Native hosts. Standalone network inspection may still work, especially after refreshing DevTools, but `ReactNativeApplication.systemStateChanged` can report `isSingleHost: false` when an automated agent is debugging through CDP while a human monitors React Native DevTools. That makes CDP `Network.enable` unavailable or intermittent during side-by-side validation.

This backports the missing `prefersFuseboxFrontend` guard from [facebook/react-native#54784](https://github.com/facebook/react-native/pull/54784) into the existing 0.83.6 Yarn patch. Genuine React Native hosts are still counted; legacy Hermes pages are not. No application code or Perps behavior changes.

This PR is not required for the Perps performance changes, normal app behavior, or every standalone DevTools session. It makes concurrent agent debugging and human React Native DevTools monitoring reliable. Without the patch, either client may still work alone, but simultaneous comparison can fail or lose Mobile network visibility. Extension is unaffected.

React Native 0.83.10 includes the upstream correction. This narrow patch can be removed when Mobile upgrades beyond 0.83.6.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed React Native DevTools Network and Performance inspection being disabled by legacy Hermes runtimes miscounted as additional React Native hosts.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://github.com/react-native-community/discussions-and-proposals/discussions/954

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: React Native network inspection

  Scenario: Human DevTools and an automated CDP client observe the same requests
    Given a development build containing this patch is running
    And React Native DevTools Network recording is active
    And an automated CDP Network observer is active for api.hyperliquid.xyz/info

    When the selected wallet changes from dev2 to dev1 on the Perps page

    Then React Native DevTools records the Hyperliquid requests
    And the automated observer completes without drops, gaps, or reconnects
    And CDP Network.enable succeeds
```

Validated on iOS mmdev-2. The isolated window produced 21 matching POST requests: 5 `candleSnapshot` and 4 each of `clearinghouseState`, `frontendOpenOrders`, `spotClearinghouseState`, and `userAbstraction`.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — the failure is a native CDP error: `Network domain is unavailable when multiple React Native hosts are registered.`

### **After**

N/A — validation is captured as deterministic CDP request counts in the manual testing section.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Considered and deferred: the shared C++ fix was proven on iOS first; Android parity is not required to establish the RN 0.83 host-counting correction.
- [x] I've tested with a power user scenario
  - Validated with the existing multi-account dev fixture and a dev2 → dev1 account switch.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - Not applicable: this changes the development inspector's host classification only.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
