### PR TITLE
test(predict-next): strengthen football preview coverage

### DIFF
--- a/app/components/UI/PredictNext/AGENTS.md
+++ b/app/components/UI/PredictNext/AGENTS.md
@@ -45,6 +45,16 @@ Proposed ADRs and examples in these docs are working direction, not accepted con
 - For placement and imports, follow `docs/module-structure.md`: organize product UI by owning feature/domain, import across modules through deliberate `index.ts` APIs, and keep private implementation under the owner's `internal/` directory.
 - Work one behavior at a time: red → green → refactor.
 
+## Testing locations and boundaries
+
+PredictNext test support also lives outside this directory:
+
+- `tests/component-view/renderers/predictNext.ts` owns the shared screen renderer and registered routes.
+- `tests/component-view/fixtures/predictNext.ts` owns reusable Event fixtures, Feed messenger setup, and card assertions.
+- `tests/integration/harnesses/predict-next.ts` owns the controller-to-service integration harness.
+
+Keep screen loading, error, empty, cached-data, and navigation journeys in colocated `*.view.test.tsx` files. Reuse the shared component-view fixture instead of recreating Event builders or Feed messenger setup. Keep Feed contracts, pagination, retry, and circuit-breaker behavior in the integration harness; do not add a separate rendered-Home integration harness.
+
 ## Agent readiness
 
 `Selected for Development` is reserved for work that has explicit acceptance criteria, verification instructions, relevant context, and no unresolved product, design, or architecture questions.

--- a/app/components/UI/PredictNext/navigation/feedScreens.test.ts
+++ b/app/components/UI/PredictNext/navigation/feedScreens.test.ts
@@ -1,0 +1,47 @@
+import {
+  FEED_SCREENS,
+  NFL_FEED_SCREEN_ID,
+  getFeedScreen,
+  getFeedScreenTab,
+} from './feedScreens';
+
+describe('feedScreens', () => {
+  describe('getFeedScreen', () => {
+    it('returns the matching Feed Screen definition', () => {
+      const result = getFeedScreen(NFL_FEED_SCREEN_ID);
+
+      expect(result).toBe(FEED_SCREENS[NFL_FEED_SCREEN_ID]);
+    });
+
+    it('returns undefined for an unknown Feed Screen ID', () => {
+      const result = getFeedScreen('missing-feed-screen');
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('getFeedScreenTab', () => {
+    const definition = {
+      title: 'Sports',
+      tabs: [
+        { id: 'games', label: 'Games', feedId: 'nfl-games' },
+        { id: 'props', label: 'Props', feedId: 'nfl-props' },
+      ],
+    } as const;
+
+    it('returns the selected tab', () => {
+      const result = getFeedScreenTab(definition, 'props');
+
+      expect(result).toBe(definition.tabs[1]);
+    });
+
+    it.each([undefined, 'missing-tab'])(
+      'returns the first tab when the selected tab is %s',
+      (selectedTabId) => {
+        const result = getFeedScreenTab(definition, selectedTabId);
+
+        expect(result).toBe(definition.tabs[0]);
+      },
+    );
+  });
+});

--- a/app/components/UI/PredictNext/navigation/feedScreens.test.ts
+++ b/app/components/UI/PredictNext/navigation/feedScreens.test.ts
@@ -1,3 +1,4 @@
+import type { PredictFeedId } from '../types';
 import {
   FEED_SCREENS,
   NFL_FEED_SCREEN_ID,
@@ -24,8 +25,16 @@ describe('feedScreens', () => {
     const definition = {
       title: 'Sports',
       tabs: [
-        { id: 'games', label: 'Games', feedId: 'nfl-games' },
-        { id: 'props', label: 'Props', feedId: 'nfl-props' },
+        {
+          id: 'games',
+          label: 'Games',
+          feedId: 'nfl-games' as PredictFeedId,
+        },
+        {
+          id: 'props',
+          label: 'Props',
+          feedId: 'nfl-props' as PredictFeedId,
+        },
       ],
     } as const;
 

--- a/app/components/UI/PredictNext/views/PredictHome/PredictHome.view.test.tsx
+++ b/app/components/UI/PredictNext/views/PredictHome/PredictHome.view.test.tsx
@@ -1,233 +1,58 @@
 import '../../../../../../tests/component-view/mocks';
 import { renderPredictNext } from '../../../../../../tests/component-view/renderers/predictNext';
 import Engine from '../../../../../core/Engine';
-import { fireEvent, waitFor, within } from '@testing-library/react-native';
+import { act, fireEvent, waitFor, within } from '@testing-library/react-native';
+import { focusManager } from '@tanstack/react-query';
 import { PredictHomeTestIds } from './PredictHome.testIds';
 import { PredictEventDetailTestIds } from '../PredictEventDetail/PredictEventDetail.testIds';
 import { PredictFeedScreenTestIds } from '../PredictFeedScreen/PredictFeedScreen.testIds';
-import type {
-  PredictEntityId,
-  PredictEvent,
-  PredictFeedId,
-  PredictTimestamp,
-} from '../../types';
+import type { PredictFeedId } from '../../types';
 import { PredictEventValues } from '../../../Predict/constants/eventNames';
 import {
   NCAA_FEED_SCREEN_ID,
   NFL_FEED_SCREEN_ID,
 } from '../../navigation/feedScreens';
-
-const makeEvent = (id: string, title: string): PredictEvent => ({
-  venueId: 'kalshi' as PredictEvent['venueId'],
-  id: id as PredictEvent['id'],
-  title,
-  category: 'Sports',
-  volume: '1500000',
-  markets: [
-    {
-      id: `${id}-market` as PredictEvent['markets'][number]['id'],
-      question: title,
-      status: 'active',
-      outcomes: [
-        {
-          id: `${id}-yes` as PredictEvent['markets'][number]['outcomes'][number]['id'],
-          side: 'yes',
-          label: 'Yes',
-          askPrice:
-            '0.42' as PredictEvent['markets'][number]['outcomes'][number]['askPrice'],
-        },
-        {
-          id: `${id}-no` as PredictEvent['markets'][number]['outcomes'][number]['id'],
-          side: 'no',
-          label: 'No',
-          askPrice:
-            '0.58' as PredictEvent['markets'][number]['outcomes'][number]['askPrice'],
-        },
-      ],
-    },
-  ],
-});
-
-const makeGameEvent = (
-  id: string,
-  awayTeam: string,
-  homeTeam: string,
-  competition: string,
-  {
-    volume = '1500000',
-    score = { away: '17', home: '21' },
-  }: {
-    volume?: string;
-    score?: { away: string; home: string };
-  } = {},
-): PredictEvent => ({
-  ...makeEvent(id, `${awayTeam} vs ${homeTeam}`),
-  volume,
-  sports: {
-    sport: {
-      id: 'american-football' as PredictEntityId,
-      label: 'American football',
-    },
-    competition: {
-      id: competition.toLowerCase() as PredictEntityId,
-      label: competition,
-    },
-    game: {
-      status: 'in_progress',
-      awayTeam: { name: awayTeam, abbreviation: awayTeam.slice(0, 3) },
-      homeTeam: { name: homeTeam, abbreviation: homeTeam.slice(0, 3) },
-      score,
-      period: 'Q4',
-      clock: '12:22',
-      observedAt: '2026-08-19T12:00:00Z' as PredictTimestamp,
-    },
-  },
-  markets: [
-    {
-      ...makeEvent(id, '').markets[0],
-      id: `${id}-away-market` as PredictEntityId,
-      outcomes: [
-        {
-          ...makeEvent(id, '').markets[0].outcomes[0],
-          gameSelection: 'away',
-        },
-        makeEvent(id, '').markets[0].outcomes[1],
-      ],
-    },
-    {
-      ...makeEvent(id, '').markets[0],
-      id: `${id}-home-market` as PredictEntityId,
-      outcomes: [
-        {
-          ...makeEvent(id, '').markets[0].outcomes[0],
-          id: `${id}-home-yes` as PredictEntityId,
-          gameSelection: 'home',
-        },
-        {
-          ...makeEvent(id, '').markets[0].outcomes[1],
-          id: `${id}-home-no` as PredictEntityId,
-        },
-      ],
-    },
-  ],
-});
-
-const nflEvents = [
-  makeGameEvent('nfl-1', 'Packers', 'Steelers', 'NFL'),
-  makeGameEvent('nfl-2', 'Panthers', 'Cardinals', 'NFL', {
-    volume: '2500',
-    score: { away: '10', home: '7' },
-  }),
-];
-const ncaaEvents = [
-  makeGameEvent('ncaa-1', 'Pittsburgh', 'Miami', 'NCAAF', {
-    volume: '500',
-    score: { away: '24', home: '31' },
-  }),
-  makeGameEvent('ncaa-2', 'Georgia', 'Florida', 'NCAAF', {
-    volume: '900000',
-    score: { away: '3', home: '0' },
-  }),
-];
-
-const messengerCall = Engine.controllerMessenger.call as unknown as jest.Mock;
-
-const configureFeeds = ({
-  nfl = nflEvents,
-  ncaa = ncaaEvents,
-}: {
-  nfl?: readonly PredictEvent[] | Error;
-  ncaa?: readonly PredictEvent[] | Error;
-} = {}) => {
-  messengerCall.mockImplementation(
-    (action: string, _venueId: string, feedId: PredictFeedId) => {
-      if (action !== 'PredictMarketDataService:getFeed') {
-        return Promise.resolve(undefined);
-      }
-
-      const result = feedId === 'sports-football-nfl-games' ? nfl : ncaa;
-      if (result instanceof Error) {
-        return Promise.reject(result);
-      }
-
-      return Promise.resolve({
-        venueId: 'kalshi',
-        id: feedId,
-        title:
-          feedId === 'sports-football-nfl-games' ? 'NFL Games' : 'NCAAF Games',
-        events: result,
-      });
-    },
-  );
-};
-
-const expectGameCard = (
-  section: Parameters<typeof within>[0],
-  eventId: string,
-  {
-    away,
-    home,
-    awayScore,
-    homeScore,
-    competition,
-    volume,
-  }: {
-    away: string;
-    home: string;
-    awayScore: string;
-    homeScore: string;
-    competition: string;
-    volume: string;
-  },
-) => {
-  const card = within(section).getByTestId(
-    PredictHomeTestIds.event('kalshi', eventId),
-  );
-  const scoped = within(card);
-
-  expect(scoped.getByText(away)).toBeOnTheScreen();
-  expect(scoped.getByText(home)).toBeOnTheScreen();
-  expect(scoped.getByText(awayScore)).toBeOnTheScreen();
-  expect(scoped.getByText(homeScore)).toBeOnTheScreen();
-  expect(scoped.getByText(competition)).toBeOnTheScreen();
-  expect(scoped.getByText(volume)).toBeOnTheScreen();
-  expect(
-    scoped.getByTestId(PredictHomeTestIds.gameQuote(eventId, 'away')),
-  ).toBeOnTheScreen();
-  expect(
-    scoped.getByTestId(PredictHomeTestIds.gameQuote(eventId, 'home')),
-  ).toBeOnTheScreen();
-};
+import {
+  configurePredictNextFeeds,
+  expectPredictNextGameCard,
+  makePredictNextEvent,
+  messengerCall,
+  ncaaEvents,
+  nflEvents,
+} from '../../../../../../tests/component-view/fixtures/predictNext';
 
 describe('PredictHome', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    configureFeeds();
+    configurePredictNextFeeds();
   });
 
   it('loads the first two backend-ordered Games for both previews', async () => {
-    configureFeeds({
-      nfl: [...nflEvents, makeEvent('nfl-3', 'Hidden NFL Game')],
-      ncaa: [...ncaaEvents, makeEvent('ncaa-3', 'Hidden College Game')],
+    configurePredictNextFeeds({
+      nfl: [...nflEvents, makePredictNextEvent('nfl-3', 'Hidden NFL Game')],
+      ncaa: [
+        ...ncaaEvents,
+        makePredictNextEvent('ncaa-3', 'Hidden College Game'),
+      ],
     });
     const view = renderPredictNext();
 
-    await waitFor(() => expect(messengerCall).toHaveBeenCalledTimes(2));
-
-    expect(messengerCall).toHaveBeenCalledWith(
-      'PredictMarketDataService:getFeed',
-      'kalshi',
-      'sports-football-nfl-games',
-      { limit: 2 },
-      undefined,
-    );
-    expect(messengerCall).toHaveBeenCalledWith(
-      'PredictMarketDataService:getFeed',
-      'kalshi',
-      'sports-football-ncaa-games',
-      { limit: 2 },
-      undefined,
-    );
+    await waitFor(() => {
+      expect(messengerCall).toHaveBeenCalledWith(
+        'PredictMarketDataService:getFeed',
+        'kalshi',
+        'sports-football-nfl-games',
+        { limit: 2 },
+        undefined,
+      );
+      expect(messengerCall).toHaveBeenCalledWith(
+        'PredictMarketDataService:getFeed',
+        'kalshi',
+        'sports-football-ncaa-games',
+        { limit: 2 },
+        undefined,
+      );
+    });
 
     await view.findByTestId(PredictHomeTestIds.event('kalshi', 'nfl-1'));
     await view.findByTestId(PredictHomeTestIds.event('kalshi', 'ncaa-2'));
@@ -235,19 +60,23 @@ describe('PredictHome', () => {
     const nflSection = view.getByTestId(
       PredictHomeTestIds.section(NFL_FEED_SCREEN_ID),
     );
-    expectGameCard(nflSection, 'nfl-1', {
+    expectPredictNextGameCard(nflSection, 'nfl-1', {
       away: 'Packers',
       home: 'Steelers',
       awayScore: '17',
       homeScore: '21',
+      awayQuote: 'PAC · 41¢',
+      homeQuote: 'STE · 59¢',
       competition: 'NFL',
       volume: '$1.5M Vol',
     });
-    expectGameCard(nflSection, 'nfl-2', {
+    expectPredictNextGameCard(nflSection, 'nfl-2', {
       away: 'Panthers',
       home: 'Cardinals',
       awayScore: '10',
       homeScore: '7',
+      awayQuote: 'PAN · 36¢',
+      homeQuote: 'CAR · 64¢',
       competition: 'NFL',
       volume: '$2.5k Vol',
     });
@@ -263,19 +92,23 @@ describe('PredictHome', () => {
     const ncaaSection = view.getByTestId(
       PredictHomeTestIds.section(NCAA_FEED_SCREEN_ID),
     );
-    expectGameCard(ncaaSection, 'ncaa-1', {
+    expectPredictNextGameCard(ncaaSection, 'ncaa-1', {
       away: 'Pittsburgh',
       home: 'Miami',
       awayScore: '24',
       homeScore: '31',
+      awayQuote: 'PIT · 47¢',
+      homeQuote: 'MIA · 53¢',
       competition: 'NCAAF',
       volume: '$500 Vol',
     });
-    expectGameCard(ncaaSection, 'ncaa-2', {
+    expectPredictNextGameCard(ncaaSection, 'ncaa-2', {
       away: 'Georgia',
       home: 'Florida',
       awayScore: '3',
       homeScore: '0',
+      awayQuote: 'GEO · 55¢',
+      homeQuote: 'FLO · 45¢',
       competition: 'NCAAF',
       volume: '$900k Vol',
     });
@@ -289,40 +122,34 @@ describe('PredictHome', () => {
     ).not.toBeOnTheScreen();
   });
 
-  it('opens the NFL Feed Screen and returns without refetching previews', async () => {
-    const view = renderPredictNext();
-    await view.findByTestId(PredictHomeTestIds.event('kalshi', 'nfl-1'));
-    messengerCall.mockClear();
+  it.each([
+    { feedScreenId: NFL_FEED_SCREEN_ID, selectionLabel: 'NFL' },
+    { feedScreenId: NCAA_FEED_SCREEN_ID, selectionLabel: 'NCAAF' },
+  ])(
+    'opens the $selectionLabel Feed Screen and returns without refetching previews',
+    async ({ feedScreenId, selectionLabel }) => {
+      const view = renderPredictNext();
+      await view.findByTestId(PredictHomeTestIds.event('kalshi', 'nfl-1'));
+      messengerCall.mockClear();
 
-    fireEvent.press(
-      view.getByTestId(PredictHomeTestIds.sectionHeader(NFL_FEED_SCREEN_ID)),
-    );
+      fireEvent.press(
+        view.getByTestId(PredictHomeTestIds.sectionHeader(feedScreenId)),
+      );
 
-    expect(
-      await view.findByTestId(PredictFeedScreenTestIds.VIEW),
-    ).toBeOnTheScreen();
-    expect(view.getByText('Sports')).toBeOnTheScreen();
-    expect(view.getByText('NFL')).toBeOnTheScreen();
-    fireEvent.press(view.getByTestId(PredictFeedScreenTestIds.BACK));
-    await view.findByTestId(PredictHomeTestIds.HOME);
-    expect(messengerCall).not.toHaveBeenCalled();
-  });
+      expect(
+        await view.findByTestId(PredictFeedScreenTestIds.VIEW),
+      ).toBeOnTheScreen();
+      expect(view.getByText('Sports')).toBeOnTheScreen();
+      expect(view.getByText(selectionLabel)).toBeOnTheScreen();
 
-  it('opens the NCAAF Feed Screen', async () => {
-    const view = renderPredictNext();
+      fireEvent.press(view.getByTestId(PredictFeedScreenTestIds.BACK));
 
-    fireEvent.press(
-      await view.findByTestId(
-        PredictHomeTestIds.sectionHeader(NCAA_FEED_SCREEN_ID),
-      ),
-    );
-
-    expect(
-      await view.findByTestId(PredictFeedScreenTestIds.VIEW),
-    ).toBeOnTheScreen();
-    expect(view.getByText('Sports')).toBeOnTheScreen();
-    expect(view.getByText('NCAAF')).toBeOnTheScreen();
-  });
+      expect(
+        await view.findByTestId(PredictHomeTestIds.HOME),
+      ).toBeOnTheScreen();
+      expect(messengerCall).not.toHaveBeenCalled();
+    },
+  );
 
   it('renders a successful NCAAF preview while NFL is still loading', async () => {
     let resolveNfl: (value: unknown) => void = () => undefined;
@@ -365,7 +192,7 @@ describe('PredictHome', () => {
   });
 
   it('keeps an errored NFL preview independent from a successful NCAAF preview', async () => {
-    configureFeeds({ nfl: new Error('NFL failed') });
+    configurePredictNextFeeds({ nfl: new Error('NFL failed') });
     const view = renderPredictNext();
 
     expect(
@@ -380,7 +207,7 @@ describe('PredictHome', () => {
       view.queryByTestId(PredictHomeTestIds.sectionError(NCAA_FEED_SCREEN_ID)),
     ).not.toBeOnTheScreen();
 
-    configureFeeds();
+    configurePredictNextFeeds();
     fireEvent.press(
       view.getByTestId(PredictHomeTestIds.sectionRetry(NFL_FEED_SCREEN_ID)),
     );
@@ -389,8 +216,35 @@ describe('PredictHome', () => {
     ).toBeOnTheScreen();
   });
 
+  it('keeps cached NFL Games visible when a later refetch fails', async () => {
+    const view = renderPredictNext();
+    await view.findByTestId(PredictHomeTestIds.event('kalshi', 'nfl-1'));
+    configurePredictNextFeeds({ nfl: new Error('NFL refetch failed') });
+
+    await act(async () => {
+      focusManager.setFocused(false);
+      focusManager.setFocused(true);
+    });
+
+    await waitFor(() =>
+      expect(
+        messengerCall.mock.calls.filter(
+          ([action, , feedId]) =>
+            action === 'PredictMarketDataService:getFeed' &&
+            feedId === 'sports-football-nfl-games',
+        ),
+      ).toHaveLength(2),
+    );
+    expect(
+      view.getByTestId(PredictHomeTestIds.event('kalshi', 'nfl-1')),
+    ).toBeOnTheScreen();
+    expect(
+      view.queryByTestId(PredictHomeTestIds.sectionError(NFL_FEED_SCREEN_ID)),
+    ).not.toBeOnTheScreen();
+  });
+
   it('keeps an empty NFL preview independent from a successful NCAAF preview', async () => {
-    configureFeeds({ nfl: [] });
+    configurePredictNextFeeds({ nfl: [] });
     const view = renderPredictNext();
 
     expect(

--- a/tests/component-view/fixtures/predictNext.ts
+++ b/tests/component-view/fixtures/predictNext.ts
@@ -1,0 +1,208 @@
+import { within } from '@testing-library/react-native';
+import Engine from '../../../app/core/Engine';
+import { PredictHomeTestIds } from '../../../app/components/UI/PredictNext/views/PredictHome/PredictHome.testIds';
+import type {
+  PredictEntityId,
+  PredictEvent,
+  PredictFeedId,
+  PredictTimestamp,
+} from '../../../app/components/UI/PredictNext/types';
+
+interface GameEventOptions {
+  volume?: string;
+  score?: { away: string; home: string };
+  askPrices?: { away: string; home: string };
+}
+
+const makeEvent = (
+  id: string,
+  title: string,
+  askPrices = { away: '0.42', home: '0.58' },
+): PredictEvent => ({
+  venueId: 'kalshi' as PredictEvent['venueId'],
+  id: id as PredictEvent['id'],
+  title,
+  category: 'Sports',
+  volume: '1500000',
+  markets: [
+    {
+      id: `${id}-market` as PredictEntityId,
+      question: title,
+      status: 'active',
+      outcomes: [
+        {
+          id: `${id}-yes` as PredictEntityId,
+          side: 'yes',
+          label: 'Yes',
+          askPrice:
+            askPrices.away as PredictEvent['markets'][number]['outcomes'][number]['askPrice'],
+        },
+        {
+          id: `${id}-no` as PredictEntityId,
+          side: 'no',
+          label: 'No',
+          askPrice:
+            askPrices.home as PredictEvent['markets'][number]['outcomes'][number]['askPrice'],
+        },
+      ],
+    },
+  ],
+});
+
+export const makePredictNextEvent = makeEvent;
+
+export const makePredictNextGameEvent = (
+  id: string,
+  awayTeam: string,
+  homeTeam: string,
+  competition: string,
+  {
+    volume = '1500000',
+    score = { away: '17', home: '21' },
+    askPrices = { away: '0.42', home: '0.58' },
+  }: GameEventOptions = {},
+): PredictEvent => {
+  const event = makeEvent(id, `${awayTeam} vs ${homeTeam}`, askPrices);
+  const [awayOutcome, homeOutcome] = event.markets[0].outcomes;
+
+  return {
+    ...event,
+    volume,
+    sports: {
+      sport: {
+        id: 'american-football' as PredictEntityId,
+        label: 'American football',
+      },
+      competition: {
+        id: competition.toLowerCase() as PredictEntityId,
+        label: competition,
+      },
+      game: {
+        status: 'in_progress',
+        awayTeam: { name: awayTeam, abbreviation: awayTeam.slice(0, 3) },
+        homeTeam: { name: homeTeam, abbreviation: homeTeam.slice(0, 3) },
+        score,
+        period: 'Q4',
+        clock: '12:22',
+        observedAt: '2026-08-19T12:00:00Z' as PredictTimestamp,
+      },
+    },
+    markets: [
+      {
+        ...event.markets[0],
+        id: `${id}-away-market` as PredictEntityId,
+        outcomes: [{ ...awayOutcome, gameSelection: 'away' }, homeOutcome],
+      },
+      {
+        ...event.markets[0],
+        id: `${id}-home-market` as PredictEntityId,
+        outcomes: [
+          {
+            ...awayOutcome,
+            id: `${id}-home-yes` as PredictEntityId,
+            askPrice: askPrices.home as typeof awayOutcome.askPrice,
+            gameSelection: 'home',
+          },
+          {
+            ...homeOutcome,
+            id: `${id}-home-no` as PredictEntityId,
+          },
+        ],
+      },
+    ],
+  };
+};
+
+export const nflEvents = [
+  makePredictNextGameEvent('nfl-1', 'Packers', 'Steelers', 'NFL', {
+    askPrices: { away: '0.41', home: '0.59' },
+  }),
+  makePredictNextGameEvent('nfl-2', 'Panthers', 'Cardinals', 'NFL', {
+    volume: '2500',
+    score: { away: '10', home: '7' },
+    askPrices: { away: '0.36', home: '0.64' },
+  }),
+];
+
+export const ncaaEvents = [
+  makePredictNextGameEvent('ncaa-1', 'Pittsburgh', 'Miami', 'NCAAF', {
+    volume: '500',
+    score: { away: '24', home: '31' },
+    askPrices: { away: '0.47', home: '0.53' },
+  }),
+  makePredictNextGameEvent('ncaa-2', 'Georgia', 'Florida', 'NCAAF', {
+    volume: '900000',
+    score: { away: '3', home: '0' },
+    askPrices: { away: '0.55', home: '0.45' },
+  }),
+];
+
+export const messengerCall = Engine.controllerMessenger
+  .call as unknown as jest.Mock;
+
+export const configurePredictNextFeeds = ({
+  nfl = nflEvents,
+  ncaa = ncaaEvents,
+}: {
+  nfl?: readonly PredictEvent[] | Error;
+  ncaa?: readonly PredictEvent[] | Error;
+} = {}) => {
+  messengerCall.mockImplementation(
+    (action: string, _venueId: string, feedId: PredictFeedId) => {
+      if (action !== 'PredictMarketDataService:getFeed') {
+        return Promise.resolve(undefined);
+      }
+
+      const result = feedId === 'sports-football-nfl-games' ? nfl : ncaa;
+      if (result instanceof Error) {
+        return Promise.reject(result);
+      }
+
+      return Promise.resolve({
+        venueId: 'kalshi',
+        id: feedId,
+        title:
+          feedId === 'sports-football-nfl-games' ? 'NFL Games' : 'NCAAF Games',
+        events: result,
+      });
+    },
+  );
+};
+
+export const expectPredictNextGameCard = (
+  section: Parameters<typeof within>[0],
+  eventId: string,
+  {
+    away,
+    home,
+    awayScore,
+    homeScore,
+    awayQuote,
+    homeQuote,
+    competition,
+    volume,
+  }: {
+    away: string;
+    home: string;
+    awayScore: string;
+    homeScore: string;
+    awayQuote: string;
+    homeQuote: string;
+    competition: string;
+    volume: string;
+  },
+) => {
+  const card = within(section).getByTestId(
+    PredictHomeTestIds.event('kalshi', eventId),
+  );
+  const scoped = within(card);
+
+  expect(scoped.getByText(away)).toBeOnTheScreen();
+  expect(scoped.getByText(home)).toBeOnTheScreen();
+  expect(scoped.getByText(awayScore)).toBeOnTheScreen();
+  expect(scoped.getByText(homeScore)).toBeOnTheScreen();
+  expect(scoped.getByText(awayQuote)).toBeOnTheScreen();
+  expect(scoped.getByText(homeQuote)).toBeOnTheScreen();
+  expect(scoped.getByText(competition)).toBeOnTheScreen();
+  expect(scoped.getByText(volume)).toBeOnTheScreen();
+};


### PR DESCRIPTION
## **Description**

Follows up on review comments from #35039 by strengthening the PredictNext football preview test coverage and extracting reusable component-view fixtures for upcoming Feed Screen work.

This adds coverage for retaining cached NFL Games after a failed refetch, validates distinct quote values for every preview card, parameterizes the NFL/NCAAF Feed Screen journey, and unit-tests Feed Screen configuration lookup and tab fallback behavior.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/pull/35039

## **Manual testing steps**

N/A — test-only follow-up with no production behavior changes.

Automated verification:
- `yarn jest -c jest.config.view.js app/components/UI/PredictNext/views/PredictHome/PredictHome.view.test.tsx --runInBand --silent --coverage=false`
- `yarn jest app/components/UI/PredictNext/navigation/feedScreens.test.ts --runInBand --silent --coverage=false`
- ESLint for all changed files
- `git diff --check`

## **Screenshots/Recordings**

N/A — test-only follow-up with no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Consciously assessed as not applicable: this PR changes tests only.
- [ ] I've tested with a power user scenario
  - Consciously assessed as not applicable: this PR changes tests only.
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - Consciously assessed as not applicable: this PR changes tests only and adds no runtime operation.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation changes only; no production runtime behavior is modified.
> 
> **Overview**
> Strengthens PredictNext football **preview** component-view tests and pulls reusable setup into `tests/component-view/fixtures/predictNext.ts` (event builders, feed messenger mocks, and game-card assertions with **quote** text).
> 
> `PredictHome.view.test.tsx` now asserts per-card quote values, uses a parameterized NFL/NCAAF Feed Screen open-and-back journey, and adds a case that **cached NFL games stay on screen** when a refetch fails after a focus change (via React Query `focusManager`). New `feedScreens.test.ts` covers `getFeedScreen` lookup and `getFeedScreenTab` fallback to the first tab.
> 
> `AGENTS.md` documents where PredictNext test helpers live and that screen journeys stay in `*.view.test.tsx` while reusing the shared fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a0f5ec0e58838cdaeec9aae889ebb0d67c0ced5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->