### PR TITLE
feat(animations): add Rive animations documentation and new animations directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ General coding, UI, deeplink-handler, and PR-creation guidance now lives in the 
 - **Components**: Design system first → `component-library` second → custom last
 - **Styling**: Use `useTailwind()` hook, `Box`/`Text` components, design tokens
 - **Testing**: Mandatory for all code, AAA pattern, mock everything external
+- **Rive animations**: Use the Nitro-based `@rive-app/react-native` API and follow [`app/animations/README.md`](app/animations/README.md)
 - **Version-gated feature flags**: Use `validatedVersionGatedFeatureFlag` from `app/util/remoteFeatureFlag` in selectors — see [`docs/readme/version-gated-feature-flags.md`](docs/readme/version-gated-feature-flags.md) and [`.cursor/rules/version-gated-feature-flags.mdc`](.cursor/rules/version-gated-feature-flags.mdc)
 - **Commands**: ONLY use yarn (never npm/npx)
 
@@ -204,6 +205,7 @@ If the user asks to implement a ticket directly from Jira:
 | Documentation             | Path                                         |
 | ------------------------- | -------------------------------------------- |
 | Architecture              | `/docs/readme/architecture.md`               |
+| Animations                | `/docs/readme/animations.md`                 |
 | Environment Setup         | `/docs/readme/environment.md`                |
 | E2E Testing               | `/docs/readme/e2e-testing.md`                |
 | Debugging                 | `/docs/readme/debugging.md`                  |

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ To learn how to contribute to the MetaMask codebase, visit our [Contributor Docs
 ## Documentation
 
 - [Architecture](./docs/readme/architecture.md)
+- [Animations](./docs/readme/animations.md)
 - [BigInt number migration](./docs/bigint-migration-guide.md) (deprecated `app/util/number/index.js` burndown and ESLint allowlist)
 - [Expo Development Environment Setup](./docs/readme/expo-environment.md)
 - [Native Development Environment Setup](./docs/readme/environment.md)

--- a/app/animations/README.md
+++ b/app/animations/README.md
@@ -1,0 +1,413 @@
+# Working with Rive animations
+
+This directory contains most Rive runtime files used by MetaMask Mobile. Some
+feature-owned files are colocated with their feature, such as the Perps files in
+`app/components/UI/Perps/animations/`; follow the neighboring convention when
+adding a file.
+
+A `.riv` file is a binary runtime export. Author and inspect it in the
+[Rive Editor](https://rive.app/), then export it with **Publish** or
+**Export > For runtime**. Do not try to edit the exported file as text.
+
+## Runtime used by this repository
+
+MetaMask Mobile currently uses the legacy `rive-react-native` package. Rive's
+documentation now shows the newer `@rive-app/react-native` API first, so do not
+copy examples using `RiveView`, `useRiveFile`, `dataBind`, or `autoPlay` into
+this repository. The API used here is:
+
+- `Rive` with `source`, `dataBinding`, and `autoplay`
+- `RiveRef` or the legacy `useRive()` tuple
+- `AutoBind(true)` and `useRiveString`, `useRiveNumber`,
+  `useRiveBoolean`, and `useRiveTrigger`
+
+Check `package.json` and `yarn.lock` before relying on version-specific Rive
+features.
+
+## Tools
+
+- **Rive Editor:** author artboards, state machines, View Models, animations,
+  and runtime exports. Use the Data Binding Preview toggle and test every View
+  Model instance before exporting.
+- **iOS simulator/device and Android emulator/device:** validate the real native
+  runtimes. Jest does not parse or render the contents of a `.riv` file.
+- **Jest and React Native Testing Library:** test the React component contract,
+  callbacks, fallback UI, and calls into the mocked Rive API.
+- **Metro:** bundles local `.riv` imports. `metro.config.js` already registers
+  `riv` as an asset extension.
+
+There is no repository CLI that validates artboard, state machine, input, or
+binding names inside a `.riv` file. The Rive Editor and native runtime are the
+source of truth for those names.
+
+## Add or update a file
+
+1. In the Rive Editor, verify:
+   - Any artboard, state machine, View Model, or instance omitted from the
+     runtime props is configured as the default. Otherwise, pass its name
+     explicitly.
+   - Runtime-facing names are stable and use consistent casing.
+   - New integrations use View Model data binding. Legacy state machine inputs
+     remain supported for existing files.
+   - Layouts work at small and large phone aspect ratios.
+   - Raster assets are compressed and unused artboards/assets are removed.
+2. Export a runtime `.riv` file.
+3. Put a shared file in `app/animations/`. Use lower snake case and add a
+   version suffix when its runtime contract changes, for example
+   `account_intro_v2.riv`.
+4. Import the asset statically. No native Xcode or Gradle resource entry is
+   required:
+
+   ```tsx
+   import AccountIntroAnimation from '../../../animations/account_intro_v2.riv';
+   ```
+
+   Bundled assets are preferred over remote URLs for predictable offline,
+   startup, and OTA behavior. The import type is declared in
+   [`app/types/rive.d.ts`](../types/rive.d.ts).
+
+5. Keep all runtime-facing names together near the component, or in a small
+   `*RiveConstants.ts` file:
+
+   ```ts
+   const RIVE_ARTBOARD_NAME = 'AccountIntro';
+   const RIVE_STATE_MACHINE_NAME = 'AccountIntroState';
+   const RIVE_START_TRIGGER = 'start';
+   const RIVE_TITLE_PATH = 'content/title';
+   ```
+
+6. Implement error and accessibility fallbacks, add tests, and manually validate
+   both platforms.
+7. If Metro continues to serve an old export, restart it with
+   `yarn watch:clean`.
+
+When replacing a file without changing its filename, confirm that every
+artboard, state machine, trigger, input, binding path, and referenced asset used
+by TypeScript still exists. A typo or designer-side rename is invisible to
+Jest and is only detected by the native runtime.
+
+## Render a bundled file
+
+Use a typed ref when code needs to control playback or legacy state machine
+inputs. Fire inputs only after `onPlay`; calling the native ref before the view
+is ready can fail or be silently dropped. For delayed reveal triggers, reuse
+[`useRiveRevealTrigger`](../components/UI/Money/hooks/useRiveRevealTrigger.ts).
+
+```tsx
+import React, { useCallback, useRef, useState } from 'react';
+import { Image, StyleSheet } from 'react-native';
+import Rive, {
+  Alignment,
+  Fit,
+  type RiveRef,
+  type RNRiveError,
+} from 'rive-react-native';
+import Logger from '../../../util/Logger';
+import AccountIntroAnimation from '../../../animations/account_intro_v2.riv';
+import AccountIntroFallback from '../../../images/account_intro.png';
+
+const RIVE_STATE_MACHINE_NAME = 'AccountIntroState';
+const RIVE_START_TRIGGER = 'start';
+
+const styles = StyleSheet.create({
+  animation: { width: 240, height: 240 },
+});
+
+const AccountIntro = () => {
+  const riveRef = useRef<RiveRef>(null);
+  const [hasRiveError, setHasRiveError] = useState(false);
+
+  const handlePlay = useCallback(() => {
+    try {
+      riveRef.current?.fireState(RIVE_STATE_MACHINE_NAME, RIVE_START_TRIGGER);
+    } catch (error) {
+      Logger.error(error as Error, 'AccountIntro: Rive trigger failed');
+      setHasRiveError(true);
+    }
+  }, []);
+
+  const handleError = useCallback((riveError: RNRiveError) => {
+    Logger.error(
+      new Error(riveError.message),
+      `AccountIntro: Rive error (${riveError.type})`,
+    );
+    setHasRiveError(true);
+  }, []);
+
+  if (hasRiveError) {
+    return (
+      <Image
+        source={AccountIntroFallback}
+        style={styles.animation}
+        accessible={false}
+        testID="account-intro-fallback"
+      />
+    );
+  }
+
+  return (
+    <Rive
+      ref={riveRef}
+      source={AccountIntroAnimation}
+      stateMachineName={RIVE_STATE_MACHINE_NAME}
+      autoplay
+      fit={Fit.Contain}
+      alignment={Alignment.Center}
+      style={styles.animation}
+      onPlay={handlePlay}
+      onError={handleError}
+      testID="account-intro-animation"
+    />
+  );
+};
+```
+
+Use `Fit.Layout` with `layoutScaleFactor={PixelRatio.get()}` when the artboard
+was authored as a responsive layout. Otherwise, choose `Fit.Contain`,
+`Fit.FitWidth`, or another fit explicitly and give the Rive view deterministic
+dimensions.
+
+Existing examples:
+
+- Basic state machine and typed ref:
+  [`OnboardingAnimation`](../components/UI/OnboardingAnimation/OnboardingAnimation.tsx)
+- Responsive data-bound screen:
+  [`MoneyFirstTimeDepositView`](../components/UI/Money/Views/MoneyFirstTimeDepositView/MoneyFirstTimeDepositView.tsx)
+- High-frequency numeric data and static fallback:
+  [`MoneyCardTiltAnimation`](../components/UI/Money/components/MoneyCardTiltAnimation/MoneyCardTiltAnimation.tsx)
+- Loading timeout, first-frame fallback, and native error handling:
+  [`FoxLoader`](../components/UI/FoxLoader/FoxLoader.tsx)
+
+## Use data binding
+
+Prefer View Models and data binding for new files. In the Rive Editor, attach a
+default View Model and default instance to the artboard, then bind its
+properties. In React Native, enable auto-binding and access properties by their
+exact paths. The example omits the error fallback already shown above.
+
+```tsx
+import React, { useEffect } from 'react';
+import { PixelRatio, StyleSheet } from 'react-native';
+import Rive, {
+  AutoBind,
+  Fit,
+  useRive,
+  useRiveNumber,
+  useRiveString,
+  useRiveTrigger,
+} from 'rive-react-native';
+import AccountIntroAnimation from '../../../animations/account_intro_v2.riv';
+
+interface DataBoundAccountIntroProps {
+  title: string;
+  onComplete: () => void;
+}
+
+const DataBoundAccountIntro = ({
+  title,
+  onComplete,
+}: DataBoundAccountIntroProps) => {
+  const [setRiveRef, riveRef] = useRive();
+  const [, setTitle] = useRiveString(riveRef, 'content/title');
+  const [, setProgress] = useRiveNumber(riveRef, 'progress');
+
+  useRiveTrigger(riveRef, 'complete', onComplete);
+
+  useEffect(() => {
+    if (!riveRef) return;
+    setTitle(title);
+    setProgress(50);
+  }, [riveRef, setProgress, setTitle, title]);
+
+  return (
+    <Rive
+      ref={setRiveRef}
+      source={AccountIntroAnimation}
+      artboardName="AccountIntro"
+      stateMachineName="AccountIntroState"
+      dataBinding={AutoBind(true)}
+      fit={Fit.Layout}
+      layoutScaleFactor={PixelRatio.get()}
+      style={StyleSheet.absoluteFillObject}
+      testID="account-intro-animation"
+    />
+  );
+};
+```
+
+For high-frequency writes such as device orientation, avoid a data-binding hook
+that mirrors every value into React state. Use a `RiveRef`, check that
+`riveRef.current?.viewTag()` is not `null`, and call `setNumber` directly. See
+[`useRiveTiltWriter`](../components/UI/Money/hooks/useRiveTiltWriter.ts).
+
+If changing `artboardName` leaves bindings attached to the previous artboard,
+key the `Rive` component by artboard so React remounts the native view. Keep
+`referencedAssets` stable after mount because changing it reloads the view. The
+current runtime marks this prop as experimental, so retest it after runtime
+upgrades.
+
+## Error handling and fallbacks
+
+Treat a Rive animation as a native dependency that can fail independently of
+the surrounding React screen.
+
+- Implement `onError`. Decide which `RNRiveErrorType` values are fatal for the
+  flow and which only affect optional content.
+- Never block navigation or app startup indefinitely on `onPlay` or a state
+  transition. Add a timeout for critical flows.
+- Use a static image or normal React Native UI for essential content when
+  animation is disabled, Reduce Motion is enabled, the file fails, or a feature
+  flag is off. Decorative animations can be omitted.
+- Keep interactive controls and accessibility labels in React Native. Do not
+  rely on visual elements inside the Rive artboard as the only accessible
+  representation of content or actions.
+- For first-frame black flashes, render a matching static image or background
+  behind Rive and reveal the Rive layer after `onPlay`.
+- Wrap imperative ref calls in `try/catch`; a valid TypeScript string does not
+  prove that the name exists in the binary.
+- On Android, `fireState` with a missing input can abort in JNI before a
+  JavaScript `catch` runs. Validate every input on Android and use a safe
+  animation fallback when an exported artboard does not expose it. See the
+  documented workaround in
+  [`WalletHomeOnboardingSteps`](../components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.tsx).
+- Do not dispatch through a detached native ref. Guard `viewTag()` before
+  high-frequency imperative calls such as `setNumber` or `trigger`.
+- Add a `testID` to the Rive view and separate IDs for fallback content.
+
+For onboarding performance traces, use
+[`useRivePerformance`](../hooks/performance/useRivePerformance.ts) rather than
+introducing a second instrumentation pattern.
+
+## Unit tests
+
+[`jest.config.js`](../../jest.config.js):
+
+- Maps `rive-react-native` to the
+  [`Rive mock`](../__mocks__/rive-react-native.tsx).
+- Transforms `.riv` imports with
+  [`assetFileTransformer.js`](../util/test/assetFileTransformer.js).
+
+A component test therefore does not load the binary or native runtime.
+
+The shared mock renders a `View`, invokes `onPlay`, and exposes mocked
+imperative methods. This is enough for rendering and legacy trigger tests:
+
+```tsx
+import { render } from '@testing-library/react-native';
+import {
+  __mockRiveFireState,
+  __resetAllMocks,
+} from '../../../__mocks__/rive-react-native';
+
+beforeEach(() => {
+  __resetAllMocks();
+});
+
+it('fires the start trigger when Rive starts playing', () => {
+  render(<AccountIntro />);
+
+  expect(__mockRiveFireState).toHaveBeenCalledWith(
+    'AccountIntroState',
+    'start',
+  );
+});
+```
+
+Use a test-local `jest.mock('rive-react-native', factory)` when a component
+needs data-binding hooks or when a test must manually invoke `onPlay`,
+`onError`, or `onStateChanged`. Capture the callbacks and property paths in the
+factory, then assert the resulting application behavior. Examples:
+
+- Shared mock:
+  [`RiveOnboardingStepper.test.tsx`](../components/UI/RiveOnboardingStepper/RiveOnboardingStepper.test.tsx)
+- Data-binding hooks:
+  [`MoneyFirstTimeDepositView.test.tsx`](../components/UI/Money/Views/MoneyFirstTimeDepositView/MoneyFirstTimeDepositView.test.tsx)
+- Manually controlled runtime callbacks:
+  [`FoxLoader.test.tsx`](../components/UI/FoxLoader/FoxLoader.test.tsx)
+
+Run the focused unit test:
+
+```bash
+nvm use
+yarn jest app/path/to/Component.test.tsx --no-coverage
+```
+
+Unit tests must cover application behavior, not merely that the mocked Rive
+`View` exists. Depending on the integration, cover:
+
+- Runtime props and data-binding paths sent by the component.
+- Inputs/triggers fired in response to user or runtime events.
+- Trigger callbacks received from the Rive file.
+- `onError`, timeout, feature-flag, and Reduce Motion fallbacks.
+- Guards for an unready or detached Rive ref.
+
+Unit tests cannot verify visuals, file compatibility, fonts, asset loading,
+animation timing, or whether a runtime-facing name exists in the binary.
+
+## Manual test checklist
+
+Before merging a new or replaced `.riv` file:
+
+1. Preview every artboard, state machine, transition, View Model instance, and
+   bound value in the Rive Editor.
+2. Run the actual screen on both iOS and Android. Do not approve an asset after
+   testing only one native runtime.
+3. Check small and large devices, light and dark themes, orientation changes if
+   supported, and long localized strings.
+4. Exercise every trigger/input used by the component, including both
+   React Native-to-Rive and Rive-to-React Native communication when applicable.
+5. Enable Reduce Motion, then temporarily use an invalid runtime name or shorten
+   the timeout to verify the non-Rive path remains usable. Do not commit that
+   fault injection.
+6. Background and foreground the app and navigate away during playback to catch
+   detached-ref calls and duplicate callbacks.
+7. Check startup/render time and interaction smoothness on a lower-end Android
+   device for large or continuously running files.
+8. Include the Rive source-project link when available, changed runtime
+   contract, file-size change, and tested devices in the PR description.
+
+The entry-point `import 'expo-asset'` in [`index.js`](../../index.js) is required
+for `.riv` assets delivered through EAS Updates. Keep it when changing asset or
+Metro configuration.
+
+For deterministic E2E tests, complex or nonessential Rive playback may be
+skipped when `hasTestOverrides` is enabled, but the fallback must preserve the
+same navigation and completion behavior.
+
+## Troubleshooting
+
+- **The animation is blank or `onError` reports an incorrect name:** compare
+  `artboardName`, `stateMachineName`, input names, and binding paths against the
+  exported file. Names are case-sensitive.
+- **The editor works but the app reports an unsupported runtime version:** the
+  file uses a feature newer than the native runtime bundled by
+  `rive-react-native`. Check the Rive feature support matrix before changing
+  native runtime versions.
+- **Data-bound values do not change:** verify `dataBinding={AutoBind(true)}`, the
+  default View Model/instance, the complete property path, and that `riveRef` is
+  ready.
+- **Android throws `found null reactTag`:** the native view detached before an
+  imperative write. Check `viewTag()` and stop sensors/timers during cleanup.
+- **The first frame flashes black:** keep a matching background/static image
+  visible until `onPlay`, then fade Rive in.
+- **Jest cannot import a `.riv` file:** retain the `.riv` transform in
+  [`jest.config.js`](../../jest.config.js). Do not parse the binary in a unit
+  test.
+- **An updated export does not appear:** restart Metro with
+  `yarn watch:clean`, rebuild if the runtime dependency changed, and verify that
+  the expected asset is imported.
+
+When upgrading `rive-react-native` itself, use the
+[native development setup](../../README.md#native-development), rebuild both
+platforms, and test iOS and Android separately.
+
+## References
+
+- [Rive Editor](https://rive.app/)
+- [Exporting for runtime](https://rive.app/docs/editor/exporting/exporting-for-runtime)
+- [Rive best practices](https://rive.app/docs/getting-started/best-practices)
+- [Data binding in the editor](https://rive.app/docs/editor/data-binding/overview)
+- [React Native runtime documentation](https://rive.app/docs/runtimes/react-native/react-native)
+- [React Native migration guide](https://rive.app/docs/runtimes/react-native/migration-guide)
+- [Rive runtime feature support](https://rive.app/docs/feature-support)
+- [MetaMask unit testing guidelines](../../docs/testing/unit-testing.md)

--- a/app/animations/README.md
+++ b/app/animations/README.md
@@ -9,6 +9,31 @@ A `.riv` file is a binary runtime export. Author and inspect it in the
 [Rive Editor](https://rive.app/), then export it with **Publish** or
 **Export > For runtime**. Do not try to edit the exported file as text.
 
+## At a glance
+
+> **Use `rive-react-native`, not `@rive-app/react-native`.** The repository
+> currently uses Rive's legacy React Native runtime, so examples from the latest
+> upstream documentation are not directly compatible.
+
+- Import bundled `.riv` files statically; shared assets belong in
+  `app/animations/`, while feature-owned assets should follow their neighboring
+  convention.
+- Prefer View Model data binding for new integrations. Keep runtime-facing
+  artboard, state machine, input, trigger, and binding names together in code.
+- Always provide a non-Rive fallback for essential content and handle native
+  errors, Reduce Motion, timeouts, and detached refs.
+- Jest validates the React component contract only. It cannot inspect the
+  binary, render the animation, or verify runtime-facing names.
+- Validate every changed `.riv` file in the Rive Editor and on both iOS and
+  Android before merging.
+
+Jump to [adding or updating a file](#add-or-update-a-file),
+[rendering a bundled file](#render-a-bundled-file),
+[data binding](#use-data-binding),
+[fallbacks](#error-handling-and-fallbacks),
+[unit tests](#unit-tests), or the
+[manual test checklist](#manual-test-checklist).
+
 ## Runtime used by this repository
 
 MetaMask Mobile currently uses the legacy `rive-react-native` package. Rive's

--- a/app/animations/README.md
+++ b/app/animations/README.md
@@ -11,15 +11,17 @@ A `.riv` file is a binary runtime export. Author and inspect it in the
 
 ## At a glance
 
-> **Use `rive-react-native`, not `@rive-app/react-native`.** The repository
-> currently uses Rive's legacy React Native runtime, so examples from the latest
-> upstream documentation are not directly compatible.
+> **Use `@rive-app/react-native`.** The repository uses Rive's Nitro React
+> Native runtime. The legacy `rive-react-native` component, ref, callback, and
+> data-binding APIs are not compatible.
 
 - Import bundled `.riv` files statically; shared assets belong in
   `app/animations/`, while feature-owned assets should follow their neighboring
   convention.
 - Prefer View Model data binding for new integrations. Keep runtime-facing
   artboard, state machine, input, trigger, and binding names together in code.
+- Load files with `useRiveFile`, render `RiveView`, and wait for
+  `useRive().riveViewRef` before sending imperative inputs.
 - Always provide a non-Rive fallback for essential content and handle native
   errors, Reduce Motion, timeouts, and detached refs.
 - Jest validates the React component contract only. It cannot inspect the
@@ -36,15 +38,22 @@ Jump to [adding or updating a file](#add-or-update-a-file),
 
 ## Runtime used by this repository
 
-MetaMask Mobile currently uses the legacy `rive-react-native` package. Rive's
-documentation now shows the newer `@rive-app/react-native` API first, so do not
-copy examples using `RiveView`, `useRiveFile`, `dataBind`, or `autoPlay` into
-this repository. The API used here is:
+MetaMask Mobile uses the Nitro-based `@rive-app/react-native` package. The main
+API used here is:
 
-- `Rive` with `source`, `dataBinding`, and `autoplay`
-- `RiveRef` or the legacy `useRive()` tuple
-- `AutoBind(true)` and `useRiveString`, `useRiveNumber`,
-  `useRiveBoolean`, and `useRiveTrigger`
+- `useRiveFile(asset)` to load a bundled file, then `RiveView` with `file`,
+  `autoPlay`, and optional `artboardName` / `stateMachineName`
+- `useRive()` for `riveRef`, readiness-aware `riveViewRef`, and `setHybridRef`
+  passed to `RiveView` as `hybridRef`
+- `useViewModelInstance(riveFile, { artboardName, async: true })` with
+  `RiveView`'s `dataBind` prop
+- `useRiveString`, `useRiveNumber`, `useRiveBoolean`, and `useRiveTrigger` for
+  View Model properties and events
+
+The Nitro runtime does not expose the legacy `onPlay`, `onStateChanged`,
+`animationName`, `source`, `dataBinding`, `autoplay`, `AutoBind`, `RiveRef`, or
+`fireState` APIs. Treat a non-null `riveViewRef` as the view-ready signal and
+model completion with View Model triggers or a bounded timer.
 
 Check `package.json` and `yarn.lock` before relying on version-specific Rive
 features.
@@ -113,20 +122,24 @@ Jest and is only detected by the native runtime.
 
 ## Render a bundled file
 
-Use a typed ref when code needs to control playback or legacy state machine
-inputs. Fire inputs only after `onPlay`; calling the native ref before the view
-is ready can fail or be silently dropped. For delayed reveal triggers, reuse
+Use `useRive()` when code needs to control playback or state machine inputs.
+Pass `setHybridRef` to `RiveView`, and fire inputs only after `riveViewRef`
+becomes non-null; calling the native ref before Nitro resolves
+`awaitViewReady()` can be silently dropped. For delayed View Model reveal
+triggers, reuse
 [`useRiveRevealTrigger`](../components/UI/Money/hooks/useRiveRevealTrigger.ts).
 
 ```tsx
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Image, StyleSheet } from 'react-native';
-import Rive, {
+import {
   Alignment,
   Fit,
-  type RiveRef,
-  type RNRiveError,
-} from 'rive-react-native';
+  RiveView,
+  useRive,
+  useRiveFile,
+  type RiveError,
+} from '@rive-app/react-native';
 import Logger from '../../../util/Logger';
 import AccountIntroAnimation from '../../../animations/account_intro_v2.riv';
 import AccountIntroFallback from '../../../images/account_intro.png';
@@ -139,19 +152,22 @@ const styles = StyleSheet.create({
 });
 
 const AccountIntro = () => {
-  const riveRef = useRef<RiveRef>(null);
+  const { riveFile } = useRiveFile(AccountIntroAnimation);
+  const { riveRef, riveViewRef, setHybridRef } = useRive();
   const [hasRiveError, setHasRiveError] = useState(false);
 
-  const handlePlay = useCallback(() => {
+  useEffect(() => {
+    if (!riveViewRef) return;
+
     try {
-      riveRef.current?.fireState(RIVE_STATE_MACHINE_NAME, RIVE_START_TRIGGER);
+      riveRef.current?.triggerInput(RIVE_START_TRIGGER);
     } catch (error) {
       Logger.error(error as Error, 'AccountIntro: Rive trigger failed');
       setHasRiveError(true);
     }
-  }, []);
+  }, [riveRef, riveViewRef]);
 
-  const handleError = useCallback((riveError: RNRiveError) => {
+  const handleError = useCallback((riveError: RiveError) => {
     Logger.error(
       new Error(riveError.message),
       `AccountIntro: Rive error (${riveError.type})`,
@@ -170,16 +186,17 @@ const AccountIntro = () => {
     );
   }
 
+  if (!riveFile) return null;
+
   return (
-    <Rive
-      ref={riveRef}
-      source={AccountIntroAnimation}
+    <RiveView
+      hybridRef={setHybridRef}
+      file={riveFile}
       stateMachineName={RIVE_STATE_MACHINE_NAME}
-      autoplay
+      autoPlay
       fit={Fit.Contain}
       alignment={Alignment.Center}
       style={styles.animation}
-      onPlay={handlePlay}
       onError={handleError}
       testID="account-intro-animation"
     />
@@ -187,17 +204,17 @@ const AccountIntro = () => {
 };
 ```
 
-Use `Fit.Layout` with `layoutScaleFactor={PixelRatio.get()}` when the artboard
-was authored as a responsive layout. Otherwise, choose `Fit.Contain`,
-`Fit.FitWidth`, or another fit explicitly and give the Rive view deterministic
+Use `Fit.Layout` with `layoutScaleFactor={PixelRatio.get()}` for an artboard
+authored as a responsive layout. Otherwise, choose `Fit.Contain`,
+`Fit.FitWidth`, or another fit explicitly and give `RiveView` deterministic
 dimensions.
 
 Existing examples:
 
-- Basic state machine and typed ref:
+- Basic state machine inputs and readiness:
   [`OnboardingAnimation`](../components/UI/OnboardingAnimation/OnboardingAnimation.tsx)
 - Responsive data-bound screen:
-  [`MoneyFirstTimeDepositView`](../components/UI/Money/Views/MoneyFirstTimeDepositView/MoneyFirstTimeDepositView.tsx)
+  [`MoneyOnboardingView`](../components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx)
 - High-frequency numeric data and static fallback:
   [`MoneyCardTiltAnimation`](../components/UI/Money/components/MoneyCardTiltAnimation/MoneyCardTiltAnimation.tsx)
 - Loading timeout, first-frame fallback, and native error handling:
@@ -207,20 +224,22 @@ Existing examples:
 
 Prefer View Models and data binding for new files. In the Rive Editor, attach a
 default View Model and default instance to the artboard, then bind its
-properties. In React Native, enable auto-binding and access properties by their
-exact paths. The example omits the error fallback already shown above.
+properties. In React Native, create the instance from the loaded file, pass it
+to `RiveView.dataBind`, and access properties by their exact paths. The example
+omits the error fallback already shown above.
 
 ```tsx
 import React, { useEffect } from 'react';
 import { PixelRatio, StyleSheet } from 'react-native';
-import Rive, {
-  AutoBind,
+import {
   Fit,
-  useRive,
+  RiveView,
+  useRiveFile,
   useRiveNumber,
   useRiveString,
   useRiveTrigger,
-} from 'rive-react-native';
+  useViewModelInstance,
+} from '@rive-app/react-native';
 import AccountIntroAnimation from '../../../animations/account_intro_v2.riv';
 
 interface DataBoundAccountIntroProps {
@@ -232,54 +251,59 @@ const DataBoundAccountIntro = ({
   title,
   onComplete,
 }: DataBoundAccountIntroProps) => {
-  const [setRiveRef, riveRef] = useRive();
-  const [, setTitle] = useRiveString(riveRef, 'content/title');
-  const [, setProgress] = useRiveNumber(riveRef, 'progress');
+  const { riveFile } = useRiveFile(AccountIntroAnimation);
+  const { instance } = useViewModelInstance(riveFile, {
+    artboardName: 'AccountIntro',
+    async: true,
+  });
+  const { setValue: setTitle } = useRiveString('content/title', instance);
+  const { setValue: setProgress } = useRiveNumber('progress', instance);
 
-  useRiveTrigger(riveRef, 'complete', onComplete);
+  useRiveTrigger('complete', instance, { onTrigger: onComplete });
 
   useEffect(() => {
-    if (!riveRef) return;
+    if (!instance) return;
     setTitle(title);
     setProgress(50);
-  }, [riveRef, setProgress, setTitle, title]);
+  }, [instance, setProgress, setTitle, title]);
 
-  return (
-    <Rive
-      ref={setRiveRef}
-      source={AccountIntroAnimation}
+  return riveFile && instance ? (
+    <RiveView
+      file={riveFile}
       artboardName="AccountIntro"
       stateMachineName="AccountIntroState"
-      dataBinding={AutoBind(true)}
+      dataBind={instance}
+      autoPlay
       fit={Fit.Layout}
       layoutScaleFactor={PixelRatio.get()}
-      style={StyleSheet.absoluteFillObject}
+      style={StyleSheet.absoluteFill}
       testID="account-intro-animation"
     />
-  );
+  ) : null;
 };
 ```
 
 For high-frequency writes such as device orientation, avoid a data-binding hook
-that mirrors every value into React state. Use a `RiveRef`, check that
-`riveRef.current?.viewTag()` is not `null`, and call `setNumber` directly. See
-[`useRiveTiltWriter`](../components/UI/Money/hooks/useRiveTiltWriter.ts).
+that mirrors every value into React state. Cache
+`instance.numberProperty(path)` handles and call their `set(value)` methods
+directly. See
+[`useRiveParallaxTilt`](../components/UI/Money/hooks/useRiveParallaxTilt.ts).
 
 If changing `artboardName` leaves bindings attached to the previous artboard,
-key the `Rive` component by artboard so React remounts the native view. Keep
-`referencedAssets` stable after mount because changing it reloads the view. The
-current runtime marks this prop as experimental, so retest it after runtime
-upgrades.
+key `RiveView` by artboard so React remounts the native view. Pass
+`referencedAssets` on the first `useRiveFile` render and keep the mapping
+stable; Nitro installs the asset loader at file-load time, so updating the
+mapping after the file loads does not rebind assets.
 
 ## Error handling and fallbacks
 
 Treat a Rive animation as a native dependency that can fail independently of
 the surrounding React screen.
 
-- Implement `onError`. Decide which `RNRiveErrorType` values are fatal for the
+- Implement `onError`. Decide which `RiveErrorType` values are fatal for the
   flow and which only affect optional content.
-- Never block navigation or app startup indefinitely on `onPlay` or a state
-  transition. Add a timeout for critical flows.
+- Never block navigation or app startup indefinitely on `riveViewRef`, a View
+  Model trigger, or a state transition. Add a timeout for critical flows.
 - Use a static image or normal React Native UI for essential content when
   animation is disabled, Reduce Motion is enabled, the file fails, or a feature
   flag is off. Decorative animations can be omitted.
@@ -287,16 +311,14 @@ the surrounding React screen.
   rely on visual elements inside the Rive artboard as the only accessible
   representation of content or actions.
 - For first-frame black flashes, render a matching static image or background
-  behind Rive and reveal the Rive layer after `onPlay`.
+  behind `RiveView`; after `riveViewRef` becomes non-null, allow a frame or a
+  short fade before hiding the static layer.
 - Wrap imperative ref calls in `try/catch`; a valid TypeScript string does not
   prove that the name exists in the binary.
-- On Android, `fireState` with a missing input can abort in JNI before a
-  JavaScript `catch` runs. Validate every input on Android and use a safe
-  animation fallback when an exported artboard does not expose it. See the
-  documented workaround in
-  [`WalletHomeOnboardingSteps`](../components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.tsx).
-- Do not dispatch through a detached native ref. Guard `viewTag()` before
-  high-frequency imperative calls such as `setNumber` or `trigger`.
+- Validate every state machine input and View Model property on Android and
+  iOS; incorrect runtime names may throw or arrive through `onError`.
+- Do not dispatch through a detached native view. Gate imperative work on
+  `riveViewRef`, and stop sensors, timers, and subscriptions during cleanup.
 - Add a `testID` to the Rive view and separate IDs for fallback content.
 
 For onboarding performance traces, use
@@ -307,47 +329,47 @@ introducing a second instrumentation pattern.
 
 [`jest.config.js`](../../jest.config.js):
 
-- Maps `rive-react-native` to the
-  [`Rive mock`](../__mocks__/rive-react-native.tsx).
+- Maps `@rive-app/react-native` to the
+  [`Nitro Rive mock`](../__mocks__/rive-app-react-native.tsx).
 - Transforms `.riv` imports with
   [`assetFileTransformer.js`](../util/test/assetFileTransformer.js).
 
 A component test therefore does not load the binary or native runtime.
 
-The shared mock renders a `View`, invokes `onPlay`, and exposes mocked
-imperative methods. This is enough for rendering and legacy trigger tests:
+The shared mock renders `RiveView` as a `View`, supplies stable loaded-file,
+View Model, and ready-view values, and exposes helpers for imperative methods,
+property setters, and trigger callbacks:
 
 ```tsx
 import { render } from '@testing-library/react-native';
 import {
-  __mockRiveFireState,
-  __resetAllMocks,
-} from '../../../__mocks__/rive-react-native';
+  __mockRiveTriggerInput,
+  __resetRiveMocks,
+} from '../../../__mocks__/rive-app-react-native';
 
 beforeEach(() => {
-  __resetAllMocks();
+  __resetRiveMocks();
 });
 
-it('fires the start trigger when Rive starts playing', () => {
+it('fires the start input when the Rive view is ready', () => {
   render(<AccountIntro />);
 
-  expect(__mockRiveFireState).toHaveBeenCalledWith(
-    'AccountIntroState',
-    'start',
-  );
+  expect(__mockRiveTriggerInput).toHaveBeenCalledWith('start');
 });
 ```
 
-Use a test-local `jest.mock('rive-react-native', factory)` when a component
-needs data-binding hooks or when a test must manually invoke `onPlay`,
-`onError`, or `onStateChanged`. Capture the callbacks and property paths in the
-factory, then assert the resulting application behavior. Examples:
+Use `__getLastRiveViewMethods()` for view-method assertions,
+`__getRivePropertySetter(path)` for bound-value writes, and
+`__fireRiveTrigger(path)` for Rive-to-React Native callbacks. Use a test-local
+`jest.mock('@rive-app/react-native', factory)` only when a test needs loading,
+error, or delayed-readiness behavior not represented by the shared mock.
+Examples:
 
 - Shared mock:
   [`RiveOnboardingStepper.test.tsx`](../components/UI/RiveOnboardingStepper/RiveOnboardingStepper.test.tsx)
 - Data-binding hooks:
   [`MoneyFirstTimeDepositView.test.tsx`](../components/UI/Money/Views/MoneyFirstTimeDepositView/MoneyFirstTimeDepositView.test.tsx)
-- Manually controlled runtime callbacks:
+- Loading, readiness, and error behavior:
   [`FoxLoader.test.tsx`](../components/UI/FoxLoader/FoxLoader.test.tsx)
 
 Run the focused unit test:
@@ -358,13 +380,13 @@ yarn jest app/path/to/Component.test.tsx --no-coverage
 ```
 
 Unit tests must cover application behavior, not merely that the mocked Rive
-`View` exists. Depending on the integration, cover:
+`RiveView` exists. Depending on the integration, cover:
 
 - Runtime props and data-binding paths sent by the component.
 - Inputs/triggers fired in response to user or runtime events.
 - Trigger callbacks received from the Rive file.
 - `onError`, timeout, feature-flag, and Reduce Motion fallbacks.
-- Guards for an unready or detached Rive ref.
+- Guards for an unready or detached `riveViewRef`.
 
 Unit tests cannot verify visuals, file compatibility, fonts, asset loading,
 animation timing, or whether a runtime-facing name exists in the binary.
@@ -406,15 +428,18 @@ same navigation and completion behavior.
   exported file. Names are case-sensitive.
 - **The editor works but the app reports an unsupported runtime version:** the
   file uses a feature newer than the native runtime bundled by
-  `rive-react-native`. Check the Rive feature support matrix before changing
-  native runtime versions.
-- **Data-bound values do not change:** verify `dataBinding={AutoBind(true)}`, the
-  default View Model/instance, the complete property path, and that `riveRef` is
-  ready.
-- **Android throws `found null reactTag`:** the native view detached before an
-  imperative write. Check `viewTag()` and stop sensors/timers during cleanup.
+  `@rive-app/react-native`. Check the Rive feature support matrix before
+  changing native runtime versions.
+- **Data-bound values do not change:** verify `useViewModelInstance` resolved
+  for the correct artboard, `dataBind={instance}` is set, and the complete
+  property path matches the exported View Model.
+- **An imperative input is ignored:** pass `setHybridRef` as `hybridRef` and
+  wait for `riveViewRef` before calling `riveRef.current`.
+- **Calls fail after navigation:** the native view detached. Stop sensors,
+  timers, and subscriptions during cleanup and gate new calls on `riveViewRef`.
 - **The first frame flashes black:** keep a matching background/static image
-  visible until `onPlay`, then fade Rive in.
+  visible until `riveViewRef` is non-null, then fade it out after Rive has had
+  time to composite a frame.
 - **Jest cannot import a `.riv` file:** retain the `.riv` transform in
   [`jest.config.js`](../../jest.config.js). Do not parse the binary in a unit
   test.
@@ -422,7 +447,7 @@ same navigation and completion behavior.
   `yarn watch:clean`, rebuild if the runtime dependency changed, and verify that
   the expected asset is imported.
 
-When upgrading `rive-react-native` itself, use the
+When upgrading `@rive-app/react-native`, use the
 [native development setup](../../README.md#native-development), rebuild both
 platforms, and test iOS and Android separately.
 

--- a/docs/readme/animations.md
+++ b/docs/readme/animations.md
@@ -5,7 +5,7 @@ The two out-of-the-box animation libraries available in MetaMask mobile are [Lot
 This guide provides a high-level overview of the animation libraries, including how to use them in the mobile app and how to troubleshoot common issues.
 
 - [Lottie](#lottie)
-- [Rive](#rive) (Experimental)
+- [Rive](#rive)
 
 ## Lottie
 
@@ -63,35 +63,9 @@ Rive is a design and animation application for building interactive, real-time m
 
 The app uses the Nitro-based runtime, [`@rive-app/react-native`](https://github.com/rive-app/rive-nitro-react-native) (the legacy `rive-react-native` package was replaced in the Rive Nitro migration).
 
-### Usage
+For the repository-specific workflow, API examples, data binding, testing,
+performance guidance, fallbacks, and troubleshooting, see
+[Working with Rive animations](../../app/animations/README.md).
 
-Read more on the React Native documentation for Rive [here](https://rive.app/docs/runtimes/react-native/react-native).
-
-Declarative — load a bundled `.riv` with `useRiveFile` and render a `RiveView`:
-
-```tsx
-import { RiveView, useRiveFile } from '@rive-app/react-native';
-
-function App() {
-  const { riveFile } = useRiveFile(MyAnimation); // a bundled .riv asset
-
-  return (
-    riveFile && <RiveView file={riveFile} stateMachineName="avatar" autoPlay />
-  );
-}
-```
-
-Imperative inputs: pass `useRive()`'s `setHybridRef` to `<RiveView hybridRef={...}>`, wait for `riveViewRef` to become non-null (the Nitro equivalent of the legacy `onPlay` signal), then fire inputs with `riveRef.current?.triggerInput('Start')` / `setBooleanInputValue(...)`. See `app/components/UI/FoxLoader/FoxLoader.tsx`.
-
-Data binding: for `.riv` files authored with view models, bind an instance with `useViewModelInstance(riveFile, { artboardName, async: true })`, pass it to `<RiveView dataBind={instance}>`, and use the property hooks (`useRiveString`, `useRiveNumber`, `useRiveBoolean`, `useRiveTrigger`). See `app/components/UI/Money/Views/MoneyOnboardingView/MoneyOnboardingView.tsx`.
-
-### Testing
-
-Jest maps `@rive-app/react-native` to `app/__mocks__/rive-app-react-native.tsx` (see `moduleNameMapper` in `jest.config.js`). The mock renders plain `View`s and exposes helpers (`__mockRiveTriggerInput`, `__getLastRiveViewMethods`, `__getRivePropertySetter`, `__fireRiveTrigger`, `__resetRiveMocks`) for asserting trigger/property interactions.
-
-### Troubleshooting
-
-App crashes or `onError` fires when accessing an animation, state machine, or input?
-
-- Ensure that the artboard, state machine, view-model property, or input name exists in the Rive file (`strings file.riv | grep <name>` is a quick sanity check).
-- Note the Nitro runtime has no `onStateChanged` or `animationName` prop — drive behavior through state machine inputs, view-model triggers, or timers.
+Do not copy examples for the legacy `rive-react-native` package; its component,
+refs, callbacks, and data-binding APIs are incompatible with the Nitro runtime.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Rive guidance was split across a short general animation page and implementation examples, making it easy to copy legacy `rive-react-native` patterns or miss Nitro-specific readiness, data-binding, fallback, performance, and testing requirements.

This adds a repository-specific guide for working with `@rive-app/react-native`, including file authoring and placement, imperative inputs, View Model data binding, error handling, accessibility, high-frequency updates, unit tests, native validation, and troubleshooting. It also links the guide from the main README, animation overview, and agent instructions.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: Documentation-only change; no linked issue.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or app code modifications.
> 
> **Overview**
> Adds **`app/animations/README.md`** as the canonical guide for Rive in MetaMask Mobile: Nitro **`@rive-app/react-native`** (not legacy `rive-react-native`), bundled `.riv` placement, **`useRiveFile` / `RiveView` / `useRive`**, View Model data binding, fallbacks (errors, Reduce Motion, timeouts), Jest mocks, manual QA, and troubleshooting.
> 
> **`docs/readme/animations.md`** drops duplicated Rive snippets and points Rive readers to that guide; Rive is no longer labeled experimental in the TOC.
> 
> **`AGENTS.md`** and **`README.md`** link the animations docs and tell agents/contributors to follow the new Rive README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04926a3a70fe093f99ddd9de7e92748ab07ce491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->