### PR TITLE
fix(rewards): border and balance-gated row on Money Sweepstakes overview card

### DIFF
--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
+import BigNumber from 'bignumber.js';
 import MoneyAccountSweepstakesCampaignOverview, {
   MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS,
 } from './MoneyAccountSweepstakesCampaignOverview';
@@ -9,6 +10,7 @@ import {
   type MoneyAccountSweepstakesStatsMeDto,
 } from '../../../../../../core/Engine/controllers/rewards-controller/types';
 import { createMoneyAccountSweepstakesLocalizedText } from './testUtils';
+import useMoneyAccountBalance from '../../../../Money/hooks/useMoneyAccountBalance';
 
 jest.mock('@metamask/design-system-twrnc-preset', () => {
   const tw = (..._args: unknown[]) => ({});
@@ -23,11 +25,7 @@ jest.mock('../../../utils/formatUtils', () => ({
 
 jest.mock('../../../../Money/hooks/useMoneyAccountBalance', () => ({
   __esModule: true,
-  default: jest.fn(() => ({
-    totalFiatFormatted: '$1,250.00',
-    lastKnownTotalFiatFormatted: undefined,
-    isBalanceLoading: false,
-  })),
+  default: jest.fn(),
 }));
 
 jest.mock('../../RewardsErrorBanner', () => {
@@ -53,6 +51,26 @@ jest.mock('../../RewardsErrorBanner', () => {
       ),
   };
 });
+
+const mockUseMoneyAccountBalance = jest.mocked(useMoneyAccountBalance);
+
+const mockMoneyAccountBalance = ({
+  totalFiatFormatted = '$1,250.00',
+  lastKnownTotalFiatFormatted,
+  isBalanceLoading = false,
+  tokenTotal = new BigNumber(1250),
+}: {
+  totalFiatFormatted?: string;
+  lastKnownTotalFiatFormatted?: string;
+  isBalanceLoading?: boolean;
+  tokenTotal?: BigNumber;
+} = {}) =>
+  mockUseMoneyAccountBalance.mockReturnValue({
+    totalFiatFormatted,
+    lastKnownTotalFiatFormatted,
+    isBalanceLoading,
+    tokenTotal,
+  } as ReturnType<typeof useMoneyAccountBalance>);
 
 const localizedText = createMoneyAccountSweepstakesLocalizedText();
 
@@ -84,6 +102,10 @@ const stats: MoneyAccountSweepstakesStatsMeDto = {
 };
 
 describe('MoneyAccountSweepstakesCampaignOverview', () => {
+  beforeEach(() => {
+    mockMoneyAccountBalance();
+  });
+
   it('uses qualifying deposits for the balance display and qualification shortfall', () => {
     const { getByText, queryByText } = render(
       <MoneyAccountSweepstakesCampaignOverview
@@ -181,5 +203,52 @@ describe('MoneyAccountSweepstakesCampaignOverview', () => {
     ).toBeOnTheScreen();
     expect(getByText('Balance')).toBeOnTheScreen();
     expect(getByText('$1,250.00')).toBeOnTheScreen();
+  });
+
+  it('hides the Money Account balance row when the balance is zero', () => {
+    mockMoneyAccountBalance({
+      totalFiatFormatted: '$0.00',
+      tokenTotal: new BigNumber(0),
+    });
+
+    const { queryByTestId, queryByText } = render(
+      <MoneyAccountSweepstakesCampaignOverview
+        campaign={campaign}
+        localizedText={localizedText}
+        isParticipating
+        stats={stats}
+      />,
+    );
+
+    expect(
+      queryByTestId(
+        MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.MONEY_ACCOUNT_BALANCE_ROW,
+      ),
+    ).toBeNull();
+    expect(queryByText('Balance')).toBeNull();
+    expect(queryByText('$0.00')).toBeNull();
+  });
+
+  it('keeps the Money Account balance row while the balance is still unknown', () => {
+    mockMoneyAccountBalance({
+      totalFiatFormatted: undefined,
+      isBalanceLoading: true,
+      tokenTotal: undefined,
+    });
+
+    const { getByTestId } = render(
+      <MoneyAccountSweepstakesCampaignOverview
+        campaign={campaign}
+        localizedText={localizedText}
+        isParticipating
+        stats={stats}
+      />,
+    );
+
+    expect(
+      getByTestId(
+        MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.MONEY_ACCOUNT_BALANCE_ROW,
+      ),
+    ).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.tsx
@@ -58,8 +58,12 @@ const MoneyAccountSweepstakesCampaignOverview: React.FC<
 }) => {
   const tw = useTailwind();
   const backgroundImageUrl = campaign.image?.lightModeUrl;
-  const { totalFiatFormatted, lastKnownTotalFiatFormatted, isBalanceLoading } =
-    useMoneyAccountBalance();
+  const {
+    totalFiatFormatted,
+    lastKnownTotalFiatFormatted,
+    isBalanceLoading,
+    tokenTotal,
+  } = useMoneyAccountBalance();
 
   if (isParticipating) {
     const showStatsLoading = isStatsLoading && !stats;
@@ -97,7 +101,7 @@ const MoneyAccountSweepstakesCampaignOverview: React.FC<
           }
         >
           <Box
-            twClassName="gap-3 rounded-xl bg-muted p-4"
+            twClassName="gap-3 rounded-xl border border-border-muted bg-muted p-4"
             testID={
               MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.STATS_LOADING
             }
@@ -147,6 +151,10 @@ const MoneyAccountSweepstakesCampaignOverview: React.FC<
       isBalanceLoading &&
       totalFiatFormatted === undefined &&
       lastKnownTotalFiatFormatted === undefined;
+    // An undefined tokenTotal means the balance is still unknown (loading or
+    // fetch error), so keep the row to show the skeleton / last known value.
+    const showMoneyAccountBalanceRow =
+      tokenTotal === undefined || tokenTotal.isGreaterThan(0);
 
     return (
       <Box
@@ -154,7 +162,7 @@ const MoneyAccountSweepstakesCampaignOverview: React.FC<
         testID={MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.CONTAINER}
       >
         <Box
-          twClassName="gap-3 rounded-xl bg-muted p-4"
+          twClassName="gap-3 rounded-xl border border-border-muted bg-muted p-4"
           testID={
             MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.BALANCE_HEADER
           }
@@ -210,33 +218,37 @@ const MoneyAccountSweepstakesCampaignOverview: React.FC<
               {qualificationMessage}
             </Text>
           )}
-          <Box twClassName="border-t border-border-muted" />
-          <Box
-            alignItems={BoxAlignItems.Center}
-            flexDirection={BoxFlexDirection.Row}
-            justifyContent={BoxJustifyContent.Between}
-            testID={
-              MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.MONEY_ACCOUNT_BALANCE_ROW
-            }
-          >
-            <Text
-              variant={TextVariant.BodyMd}
-              color={TextColor.TextAlternative}
-            >
-              {localizedText.balanceTitle}
-            </Text>
-            {showMoneyAccountBalanceSkeleton ? (
-              <Skeleton style={tw.style('h-5 w-20 rounded-md')} />
-            ) : (
-              <Text
-                variant={TextVariant.BodyMd}
-                fontWeight={FontWeight.Medium}
-                color={TextColor.TextDefault}
+          {showMoneyAccountBalanceRow && (
+            <>
+              <Box twClassName="border-t border-border-muted" />
+              <Box
+                alignItems={BoxAlignItems.Center}
+                flexDirection={BoxFlexDirection.Row}
+                justifyContent={BoxJustifyContent.Between}
+                testID={
+                  MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.MONEY_ACCOUNT_BALANCE_ROW
+                }
               >
-                {moneyAccountBalanceDisplay}
-              </Text>
-            )}
-          </Box>
+                <Text
+                  variant={TextVariant.BodyMd}
+                  color={TextColor.TextAlternative}
+                >
+                  {localizedText.balanceTitle}
+                </Text>
+                {showMoneyAccountBalanceSkeleton ? (
+                  <Skeleton style={tw.style('h-5 w-20 rounded-md')} />
+                ) : (
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    fontWeight={FontWeight.Medium}
+                    color={TextColor.TextDefault}
+                  >
+                    {moneyAccountBalanceDisplay}
+                  </Text>
+                )}
+              </Box>
+            </>
+          )}
           {children}
         </Box>
       </Box>


### PR DESCRIPTION
## **Description**

Addresses design feedback left in Figma on the Money Sweepstakes eligible-deposit card:

> Add a subtle border and one key-value row if the user has a Money balance greater than 0

Two changes to `MoneyAccountSweepstakesCampaignOverview`:

1. **Subtle border on the card.** The eligible-deposit card only had `bg-muted` and no outline. It now carries `border border-border-muted`, matching the border already used by the non-participating hero card in the same component. The border is applied to both the loaded card and the stats-loading skeleton card so the card outline doesn't appear/disappear between loading and loaded states.

2. **Balance row only for users with a Money balance.** The "Balance" key-value row (and the divider above it) previously rendered for every participant, including users with no Money balance at all. It is now gated on the raw numeric balance from `useMoneyAccountBalance`, using the same `tokenTotal` check already used by `MoneyOnboardingCard`. While the balance is still unknown (loading or fetch error) the row stays mounted so the existing skeleton / last-known-value behaviour is preserved; it is only hidden once we know the balance is zero.

This PR targets **#34852** rather than `main`, since #34852 is the active Money Sweepstakes campaign UX branch and supersedes the earlier #33887.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #34852

## **Manual testing steps**

1. Open the Rewards tab and navigate to the Money Sweepstakes campaign details screen while opted in.
2. With a Money Account balance greater than $0: the eligible-deposit card shows a subtle border, and the "Balance" row with the divider is visible below the qualification message.
3. With a Money Account balance of exactly $0 (or no Money Account at all): the card still shows the border, and the "Balance" row and its divider are absent.
4. While the balance is still loading: the "Balance" row is present with a skeleton value, then either resolves to the balance or disappears if the balance turns out to be zero.

## **Screenshots/Recordings**

### **Before**

N/A — not visually verified (emulator use is disabled by standing rule); described the eligible-deposit card border + conditional balance row via code inspection only.

### **After**

N/A — not visually verified (emulator use is disabled by standing rule); described the eligible-deposit card border + conditional balance row via code inspection only.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5601739439f1ea45978e0eec895e8876037ca631. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->