### PR TITLE
fix(ci): stop the JS bundle size check being OOM killed on Linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,12 +440,8 @@ jobs:
       - name: Generate iOS bundle
         run: yarn gen-bundle:ios
         env:
-          # INFRA-3891: this runner has ~14.6 GB usable and no swap. At the previous
-          # 8192 MB ceiling the bundler peaked at 14.2 to 14.4 GB, on the limit, and the
-          # host killed it (exit 137) on roughly 14% of runs. 6144 MB puts the peak near
-          # 13.2 GB. Keep this value here and not inline in the gen-bundle:ios script:
-          # an inline value silently shadows this one, which is why a 2025-11-26 change
-          # raising this ceiling never took effect.
+          # INFRA-3891: sized for a 16 GB runner with no swap. Do not move this inline
+          # into gen-bundle:ios, an inline value silently shadows it.
           NODE_OPTIONS: --max-old-space-size=6144
 
       - name: Check bundle size

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,6 +449,11 @@ jobs:
             echo "availableParallelism=$(node -p 'require("os").availableParallelism()')"
             echo "metroMaxWorkers=$(node -p 'const os = require("os"); Math.ceil(Math.max(2, os.availableParallelism() * Math.min(1, os.totalmem() / (64 * 1024 * 1024 * 1024))))')"
             echo "NODE_OPTIONS(step)=${NODE_OPTIONS:-<unset>}"
+            # Which heap ceiling actually reaches the bundler: the step env above, or the
+            # inline NODE_OPTIONS in the gen-bundle:ios script in package.json?
+            echo "heapLimit(step env)=$(node -p 'require("v8").getHeapStatistics().heap_size_limit / 1048576' 2>/dev/null || echo '?')MB"
+            echo "heapLimit(script prefix, direct node)=$(NODE_OPTIONS='--max-old-space-size=8192' node -p 'require("v8").getHeapStatistics().heap_size_limit / 1048576' 2>/dev/null || echo '?')MB"
+            echo "heapLimit(script prefix, via yarn)=$(NODE_OPTIONS='--max-old-space-size=8192' yarn node -p 'require("v8").getHeapStatistics().heap_size_limit / 1048576' 2>/dev/null | tail -1 || echo '?')MB"
             grep -E '^(MemTotal|MemAvailable|SwapTotal)' /proc/meminfo
             SWAP_DEVS="$(swapon --show --noheadings || true)"
             echo "swapon=${SWAP_DEVS:-none}"
@@ -460,7 +465,20 @@ jobs:
           } 2>&1 | tee -a "${MEM_LOG}"
 
           monitor_resources() {
+            PROBED=0
             while true; do
+              # Once the bundler is clearly the biggest process, record the heap ceiling
+              # and argv it is actually running with.
+              if [ "${PROBED}" -eq 0 ]; then
+                BIG="$(ps -eo pid=,rss= | sort -k2 -rn | head -1)"
+                BIG_PID="$(echo "${BIG}" | awk '{ print $1 }')"
+                BIG_RSS="$(echo "${BIG}" | awk '{ print $2 + 0 }')"
+                if [ "${BIG_RSS}" -gt 2000000 ] && [ -r "/proc/${BIG_PID}/environ" ]; then
+                  echo "biggest pid=${BIG_PID} argv=$(tr '\0' ' ' < "/proc/${BIG_PID}/cmdline" | cut -c1-200)" | tee -a "${MEM_LOG}"
+                  echo "biggest pid $(tr '\0' '\n' < "/proc/${BIG_PID}/environ" | grep '^NODE_OPTIONS=' || echo 'NODE_OPTIONS=<unset>')" | tee -a "${MEM_LOG}"
+                  PROBED=1
+                fi
+              fi
               MEM="$(free -m | awk '/^Mem:/ { printf "mem=%s/%sMB", $3, $2 } /^Swap:/ { printf " swap=%s/%sMB", $3, $2 }')"
               LOAD="$(cut -d' ' -f1-3 /proc/loadavg)"
               TOP="$(ps -eo rss=,comm= | sort -rn | head -3 | awk '{ printf "%s=%dMB ", $2, $1 / 1024 }')"
@@ -478,7 +496,10 @@ jobs:
 
           yarn gen-bundle:ios
         env:
-          NODE_OPTIONS: --max_old_space_size=12288
+          # INFRA-3891 (TRIAL VALUE, was 12288). The runner has ~14.6 GB usable and no
+          # swap, and a 12 GB ceiling let one bundler process reach 13.1 GB before the
+          # host killed it. 9216 leaves real headroom.
+          NODE_OPTIONS: --max_old_space_size=9216
 
       # INFRA-3891 (TEMPORARY INSTRUMENTATION, remove once the fix is chosen).
       # Runs after a SIGKILL too, so the peak that preceded the kill is reported.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,9 +438,75 @@ jobs:
         run: yarn setup:github-ci --no-build-android
 
       - name: Generate iOS bundle
-        run: yarn gen-bundle:ios
+        run: |
+          # INFRA-3891 (TEMPORARY INSTRUMENTATION, remove once the fix is chosen).
+          # This step is intermittently SIGKILLed (exit 137) on the 8x16 Linux profile
+          # and the logs carry no memory data, so sample every 5s into a file that
+          # survives the kill. Same 'resmon' idiom as eas-update-platform.yml.
+          MEM_LOG=/tmp/infra-3891-mem.log
+          {
+            echo "nproc=$(nproc)"
+            echo "availableParallelism=$(node -p 'require("os").availableParallelism()')"
+            echo "metroMaxWorkers=$(node -p 'const os = require("os"); Math.ceil(Math.max(2, os.availableParallelism() * Math.min(1, os.totalmem() / (64 * 1024 * 1024 * 1024))))')"
+            echo "NODE_OPTIONS(step)=${NODE_OPTIONS:-<unset>}"
+            grep -E '^(MemTotal|MemAvailable|SwapTotal)' /proc/meminfo
+            SWAP_DEVS="$(swapon --show --noheadings || true)"
+            echo "swapon=${SWAP_DEVS:-none}"
+            for CG in memory.max memory.high memory.peak; do
+              if [ -r "/sys/fs/cgroup/${CG}" ]; then
+                echo "cgroup ${CG}=$(cat "/sys/fs/cgroup/${CG}")"
+              fi
+            done
+          } 2>&1 | tee -a "${MEM_LOG}"
+
+          monitor_resources() {
+            while true; do
+              MEM="$(free -m | awk '/^Mem:/ { printf "mem=%s/%sMB", $3, $2 } /^Swap:/ { printf " swap=%s/%sMB", $3, $2 }')"
+              LOAD="$(cut -d' ' -f1-3 /proc/loadavg)"
+              TOP="$(ps -eo rss=,comm= | sort -rn | head -3 | awk '{ printf "%s=%dMB ", $2, $1 / 1024 }')"
+              CGCUR="-"
+              if [ -r /sys/fs/cgroup/memory.current ]; then
+                CGCUR="$(( $(cat /sys/fs/cgroup/memory.current) / 1048576 ))MB"
+              fi
+              echo "[resmon $(date -u +%H:%M:%S)] ${MEM} cgroup=${CGCUR} load=${LOAD} top=[${TOP}]" | tee -a "${MEM_LOG}"
+              sleep 5
+            done
+          }
+          monitor_resources &
+          MONITOR_PID=$!
+          trap 'kill "${MONITOR_PID}" 2>/dev/null || true' EXIT
+
+          yarn gen-bundle:ios
         env:
           NODE_OPTIONS: --max_old_space_size=12288
+
+      # INFRA-3891 (TEMPORARY INSTRUMENTATION, remove once the fix is chosen).
+      # Runs after a SIGKILL too, so the peak that preceded the kill is reported.
+      - name: Bundle step memory report
+        if: ${{ always() }}
+        run: |
+          MEM_LOG=/tmp/infra-3891-mem.log
+          if [ ! -s "${MEM_LOG}" ]; then
+            echo "No memory samples captured."
+            exit 0
+          fi
+          PEAK="$(grep '\[resmon' "${MEM_LOG}" | awk -F'mem=' '{ split($2, a, "/"); if (a[1] + 0 > max) { max = a[1] + 0; line = $0 } } END { print line }')"
+          {
+            echo "### INFRA-3891: bundle step memory profile"
+            echo
+            echo '```'
+            grep -v '\[resmon' "${MEM_LOG}"
+            echo "samples=$(grep -c '\[resmon' "${MEM_LOG}")"
+            echo "peak: ${PEAK}"
+            for CG in memory.peak memory.events; do
+              if [ -r "/sys/fs/cgroup/${CG}" ]; then
+                echo "cgroup ${CG}: $(tr '\n' ' ' < "/sys/fs/cgroup/${CG}")"
+              fi
+            done
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+          echo "--- last 30 samples ---"
+          tail -30 "${MEM_LOG}"
 
       - name: Check bundle size
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,94 +438,15 @@ jobs:
         run: yarn setup:github-ci --no-build-android
 
       - name: Generate iOS bundle
-        run: |
-          # INFRA-3891 (TEMPORARY INSTRUMENTATION, remove once the fix is chosen).
-          # This step is intermittently SIGKILLed (exit 137) on the 8x16 Linux profile
-          # and the logs carry no memory data, so sample every 5s into a file that
-          # survives the kill. Same 'resmon' idiom as eas-update-platform.yml.
-          MEM_LOG=/tmp/infra-3891-mem.log
-          {
-            echo "nproc=$(nproc)"
-            echo "availableParallelism=$(node -p 'require("os").availableParallelism()')"
-            echo "metroMaxWorkers=$(node -p 'const os = require("os"); Math.ceil(Math.max(2, os.availableParallelism() * Math.min(1, os.totalmem() / (64 * 1024 * 1024 * 1024))))')"
-            echo "NODE_OPTIONS(step)=${NODE_OPTIONS:-<unset>}"
-            grep -E '^(MemTotal|MemAvailable|SwapTotal)' /proc/meminfo
-            SWAP_DEVS="$(swapon --show --noheadings || true)"
-            echo "swapon=${SWAP_DEVS:-none}"
-            for CG in memory.max memory.high memory.peak; do
-              if [ -r "/sys/fs/cgroup/${CG}" ]; then
-                echo "cgroup ${CG}=$(cat "/sys/fs/cgroup/${CG}")"
-              fi
-            done
-          } 2>&1 | tee -a "${MEM_LOG}"
-
-          monitor_resources() {
-            PROBED=0
-            while true; do
-              # Once the bundler is clearly the biggest process, record the heap ceiling
-              # and argv it is actually running with.
-              if [ "${PROBED}" -eq 0 ]; then
-                BIG="$(ps -eo pid=,rss= | sort -k2 -rn | head -1)"
-                BIG_PID="$(echo "${BIG}" | awk '{ print $1 }')"
-                BIG_RSS="$(echo "${BIG}" | awk '{ print $2 + 0 }')"
-                if [ "${BIG_RSS}" -gt 2000000 ] && [ -r "/proc/${BIG_PID}/environ" ]; then
-                  echo "biggest pid=${BIG_PID} argv=$(tr '\0' ' ' < "/proc/${BIG_PID}/cmdline" | cut -c1-200)" | tee -a "${MEM_LOG}"
-                  echo "biggest pid $(tr '\0' '\n' < "/proc/${BIG_PID}/environ" | grep '^NODE_OPTIONS=' || echo 'NODE_OPTIONS=<unset>')" | tee -a "${MEM_LOG}"
-                  PROBED=1
-                fi
-              fi
-              MEM="$(free -m | awk '/^Mem:/ { printf "mem=%s/%sMB", $3, $2 } /^Swap:/ { printf " swap=%s/%sMB", $3, $2 }')"
-              LOAD="$(cut -d' ' -f1-3 /proc/loadavg)"
-              TOP="$(ps -eo rss=,comm= | sort -rn | head -3 | awk '{ printf "%s=%dMB ", $2, $1 / 1024 }')"
-              CGCUR="-"
-              if [ -r /sys/fs/cgroup/memory.current ]; then
-                CGCUR="$(( $(cat /sys/fs/cgroup/memory.current) / 1048576 ))MB"
-              fi
-              echo "[resmon $(date -u +%H:%M:%S)] ${MEM} cgroup=${CGCUR} load=${LOAD} top=[${TOP}]" | tee -a "${MEM_LOG}"
-              sleep 5
-            done
-          }
-          monitor_resources &
-          MONITOR_PID=$!
-          trap 'kill "${MONITOR_PID}" 2>/dev/null || true' EXIT
-
-          yarn gen-bundle:ios
+        run: yarn gen-bundle:ios
         env:
           # INFRA-3891: this runner has ~14.6 GB usable and no swap. At the previous
           # 8192 MB ceiling the bundler peaked at 14.2 to 14.4 GB, on the limit, and the
-          # host killed it on roughly 14% of runs. 6144 MB puts the peak near 13.1 GB.
-          # Keep this value here, not inline in the gen-bundle:ios script: an inline
-          # value silently shadows this one, which is how a 2025-11-26 change to raise
-          # the ceiling ended up having no effect at all.
+          # host killed it (exit 137) on roughly 14% of runs. 6144 MB puts the peak near
+          # 13.2 GB. Keep this value here and not inline in the gen-bundle:ios script:
+          # an inline value silently shadows this one, which is why a 2025-11-26 change
+          # raising this ceiling never took effect.
           NODE_OPTIONS: --max-old-space-size=6144
-
-      # INFRA-3891 (TEMPORARY INSTRUMENTATION, remove once the fix is chosen).
-      # Runs after a SIGKILL too, so the peak that preceded the kill is reported.
-      - name: Bundle step memory report
-        if: ${{ always() }}
-        run: |
-          MEM_LOG=/tmp/infra-3891-mem.log
-          if [ ! -s "${MEM_LOG}" ]; then
-            echo "No memory samples captured."
-            exit 0
-          fi
-          PEAK="$(grep '\[resmon' "${MEM_LOG}" | awk -F'mem=' '{ split($2, a, "/"); if (a[1] + 0 > max) { max = a[1] + 0; line = $0 } } END { print line }')"
-          {
-            echo "### INFRA-3891: bundle step memory profile"
-            echo
-            echo '```'
-            grep -v '\[resmon' "${MEM_LOG}"
-            echo "samples=$(grep -c '\[resmon' "${MEM_LOG}")"
-            echo "peak: ${PEAK}"
-            for CG in memory.peak memory.events; do
-              if [ -r "/sys/fs/cgroup/${CG}" ]; then
-                echo "cgroup ${CG}: $(tr '\n' ' ' < "/sys/fs/cgroup/${CG}")"
-              fi
-            done
-            echo '```'
-          } >> "${GITHUB_STEP_SUMMARY}"
-          echo "--- last 30 samples ---"
-          tail -30 "${MEM_LOG}"
 
       - name: Check bundle size
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,11 +449,6 @@ jobs:
             echo "availableParallelism=$(node -p 'require("os").availableParallelism()')"
             echo "metroMaxWorkers=$(node -p 'const os = require("os"); Math.ceil(Math.max(2, os.availableParallelism() * Math.min(1, os.totalmem() / (64 * 1024 * 1024 * 1024))))')"
             echo "NODE_OPTIONS(step)=${NODE_OPTIONS:-<unset>}"
-            # Which heap ceiling actually reaches the bundler: the step env above, or the
-            # inline NODE_OPTIONS in the gen-bundle:ios script in package.json?
-            echo "heapLimit(step env)=$(node -p 'require("v8").getHeapStatistics().heap_size_limit / 1048576' 2>/dev/null || echo '?')MB"
-            echo "heapLimit(script prefix, direct node)=$(NODE_OPTIONS='--max-old-space-size=8192' node -p 'require("v8").getHeapStatistics().heap_size_limit / 1048576' 2>/dev/null || echo '?')MB"
-            echo "heapLimit(script prefix, via yarn)=$(NODE_OPTIONS='--max-old-space-size=8192' yarn node -p 'require("v8").getHeapStatistics().heap_size_limit / 1048576' 2>/dev/null | tail -1 || echo '?')MB"
             grep -E '^(MemTotal|MemAvailable|SwapTotal)' /proc/meminfo
             SWAP_DEVS="$(swapon --show --noheadings || true)"
             echo "swapon=${SWAP_DEVS:-none}"
@@ -496,10 +491,10 @@ jobs:
 
           yarn gen-bundle:ios
         env:
-          # INFRA-3891 (TRIAL VALUE, was 12288). The runner has ~14.6 GB usable and no
-          # swap, and a 12 GB ceiling let one bundler process reach 13.1 GB before the
-          # host killed it. 9216 leaves real headroom.
-          NODE_OPTIONS: --max_old_space_size=9216
+          # INFRA-3891: measured no-op. The gen-bundle:ios script in package.json sets
+          # its own NODE_OPTIONS inline, and /proc/<pid>/environ of the live bundler
+          # shows that inline value is what it runs with, not this one.
+          NODE_OPTIONS: --max_old_space_size=12288
 
       # INFRA-3891 (TEMPORARY INSTRUMENTATION, remove once the fix is chosen).
       # Runs after a SIGKILL too, so the peak that preceded the kill is reported.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,10 +491,13 @@ jobs:
 
           yarn gen-bundle:ios
         env:
-          # INFRA-3891: measured no-op. The gen-bundle:ios script in package.json sets
-          # its own NODE_OPTIONS inline, and /proc/<pid>/environ of the live bundler
-          # shows that inline value is what it runs with, not this one.
-          NODE_OPTIONS: --max_old_space_size=12288
+          # INFRA-3891: this runner has ~14.6 GB usable and no swap. At the previous
+          # 8192 MB ceiling the bundler peaked at 14.2 to 14.4 GB, on the limit, and the
+          # host killed it on roughly 14% of runs. 6144 MB puts the peak near 13.1 GB.
+          # Keep this value here, not inline in the gen-bundle:ios script: an inline
+          # value silently shadows this one, which is how a 2025-11-26 change to raise
+          # the ceiling ended up having no effect at all.
+          NODE_OPTIONS: --max-old-space-size=6144
 
       # INFRA-3891 (TEMPORARY INSTRUMENTATION, remove once the fix is chosen).
       # Runs after a SIGKILL too, so the peak that preceded the kill is reported.

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "deduplicate": "yarn dedupe",
     "storybook-generate": "sb-rn-get-stories",
     "storybook-watch": "sb-rn-watcher",
-    "gen-bundle:ios": "NODE_OPTIONS='--max-old-space-size=8192' yarn react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ios/main.jsbundle",
+    "gen-bundle:ios": "NODE_OPTIONS='--max-old-space-size=6144' yarn react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ios/main.jsbundle",
     "gen-bundle:android": "yarn react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/main.jsbundle",
     "circular:deps": "dpdm ./app/* --circular --exit-code circular:1 --warning=false",
     "generate-icons": "yarn ts-node app/component-library/components/Icons/Icon/scripts/generate-assets.ts",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "deduplicate": "yarn dedupe",
     "storybook-generate": "sb-rn-get-stories",
     "storybook-watch": "sb-rn-watcher",
-    "gen-bundle:ios": "NODE_OPTIONS='--max-old-space-size=6144' yarn react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ios/main.jsbundle",
+    "gen-bundle:ios": "yarn react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ios/main.jsbundle",
     "gen-bundle:android": "yarn react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/main.jsbundle",
     "circular:deps": "dpdm ./app/* --circular --exit-code circular:1 --warning=false",
     "generate-icons": "yarn ts-node app/component-library/components/Icons/Icon/scripts/generate-assets.ts",


### PR DESCRIPTION
## **Description**

The "Generate iOS bundle" step in the JS bundle size check was being killed with exit 137 on roughly 14% of runs on the Linux CI runner profile, across unrelated branches. It first surfaced when a pull request was pulled out of the merge queue for this failure.

Measured on the runner with temporary instrumentation: 16052 MB of memory, about 14640 MB of it available when the step starts, and no swap. The bundler grows into a single process of 13.1 GB or more and the host kills it. The two bundler worker processes stay under 300 MB, so the memory sits in one process rather than being spread across workers, which makes the heap ceiling the lever.

This lowers that ceiling to 6144 MB. Twenty five runs of this job at the new value all passed. On the twenty that carried instrumentation, peak total memory ranged from 12720 to 13740 MB, so the worst case leaves about 900 MB of headroom, against roughly 230 MB before. Bundle output is unchanged in size, 65.9059 MB, so the size check, the artifact, the baseline commit status and the external bundle size statistics all see no difference. Step duration is not measurably affected: across fifteen timed runs at the new ceiling it ranged from 220 to 362 seconds, a spread far wider than any difference against the previous setting.

The value goes on the workflow step, and the inline one is removed from the `gen-bundle:ios` script, which restores that script to the form it had before 2025-11-26. An inline value in the script silently shadows the step, which is why https://github.com/MetaMask/metamask-mobile/pull/23345 raising the step to 12288 never took effect. That script has exactly one caller, this step, so keeping the value in the workflow also leaves developer machines on Node's default heap.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: INFRA-3891

## **Manual testing steps**

N/A for app behaviour. Verified in CI, by instrumenting this step to sample memory every 5 seconds into a file that survives the kill.

### **Before, at the 8192 MB ceiling**

The step sat on the machine's limit and died about one run in seven:

* killed, exit 137, peak 14413 MB total with 13083 MB in the bundler process: https://github.com/MetaMask/metamask-mobile/actions/runs/32355761519/job/96384781499
* passed, peak 14247 MB: https://github.com/MetaMask/metamask-mobile/actions/runs/32357390722/job/96389536620

The last sample before that kill, and the kill itself:

```
[resmon 09:54:15] mem=14413/16052MB swap=0/0MB top=[node=13083MB node=162MB node=158MB]
##[error]Process completed with exit code 137.
```

### **After, at the 6144 MB ceiling**

Twenty five runs passed. Five of the instrumented ones, spanning the observed range:

* peak 12791 MB: https://github.com/MetaMask/metamask-mobile/actions/runs/32365676721/job/96417469021
* peak 13071 MB: https://github.com/MetaMask/metamask-mobile/actions/runs/32365676721/job/96420968612
* peak 13189 MB: https://github.com/MetaMask/metamask-mobile/actions/runs/32365676721/job/96414640761
* peak 13620 MB: https://github.com/MetaMask/metamask-mobile/actions/runs/32365676721/job/96429739895
* peak 13642 MB: https://github.com/MetaMask/metamask-mobile/actions/runs/32365676721/job/96428188443

Each instrumented run also read the ceiling out of the running bundler process, to confirm that the value set on the step is the one that actually applies:

```
biggest pid=1371 argv=node node_modules/react-native/cli.js bundle --platform ios ...
biggest pid NODE_OPTIONS=--max-old-space-size=6144
```

## **Screenshots/Recordings**

N/A. Not a user facing change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

Not applicable: this changes a CI workflow setting, no app code.

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Node heap setting for iOS bundling; no app, auth, or data-path changes. Worst case is a slower or still-failing CI step, not a product regression.
> 
> **Overview**
> Stops the JS bundle size job from being OOM-killed (exit 137) on 16 GB Linux runners with no swap.
> 
> The **Generate iOS bundle** step now sets `NODE_OPTIONS=--max-old-space-size=6144` instead of 12 GB. The same flag is **removed from** `gen-bundle:ios` so the workflow value is not silently shadowed (that is why a prior bump to 12288 never applied). Local runs keep Node’s default heap. Bundle output size is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfd757cfe849f6a2a1a136ddb48982b55379ecce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->