### PR TITLE
feat(performance): BrowserStack + Sauce Labs providers (post-TestMu PoC)

### DIFF
--- a/.github/workflows/build-android-upload-to-browserstack.yml
+++ b/.github/workflows/build-android-upload-to-browserstack.yml
@@ -914,12 +914,12 @@ jobs:
       - name: Upload APKs to Sauce Labs
         id: sauce-upload
         env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+          SAUCE_USERNAME: oauth-javier.vera-857be
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         run: |
           set -euo pipefail
-          if [ -z "${SAUCE_USERNAME:-}" ] || [ -z "${SAUCE_ACCESS_KEY:-}" ]; then
-            echo "::error::SAUCE_USERNAME and SAUCE_ACCESS_KEY secrets are required"
+          if [ -z "${SAUCE_ACCESS_KEY:-}" ]; then
+            echo "::error::SAUCE_ACCESS_KEY secret is required"
             exit 1
           fi
           upload() {

--- a/.github/workflows/build-android-upload-to-browserstack.yml
+++ b/.github/workflows/build-android-upload-to-browserstack.yml
@@ -63,6 +63,11 @@ on:
           run without requiring a fingerprint, then upload them to BrowserStack
           as-is. This mode is intended for test-only changes.
         default: false
+      enable_saucelabs:
+        required: false
+        type: boolean
+        default: false
+        description: 'Upload the Android APKs to Sauce Labs'
       runner_provider:
         description: >-
           Runner provider forwarded from the caller. Leave empty to defer to the repo
@@ -89,6 +94,12 @@ on:
       without-srp-version:
         description: 'App version for without-SRP build'
         value: ${{ jobs.upload-to-browserstack.outputs.without-srp-version }}
+      with-srp-sauce-url:
+        description: 'Sauce Labs URL for with-SRP version'
+        value: ${{ jobs.upload-to-saucelabs.outputs.with-srp-sauce-url }}
+      without-srp-sauce-url:
+        description: 'Sauce Labs URL for without-SRP version'
+        value: ${{ jobs.upload-to-saucelabs.outputs.without-srp-sauce-url }}
   workflow_dispatch:
     inputs:
       description:
@@ -843,3 +854,94 @@ jobs:
             echo "❌ Both APK uploads failed. Failing step."
             exit 1
           fi
+
+  upload-to-saucelabs:
+    name: Upload APKs to Sauce Labs
+    runs-on: ubuntu-latest
+    needs:
+      [
+        check-builds-needed,
+        resolve-fingerprint-reuse,
+        build-with-srp,
+        build-without-srp,
+      ]
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.check-builds-needed.outputs.builds-needed == 'true' &&
+      inputs.enable_saucelabs == true &&
+      (
+        needs.resolve-fingerprint-reuse.outputs.found == 'true' ||
+        (
+          needs.build-with-srp.result == 'success' &&
+          needs.build-without-srp.result == 'success'
+        )
+      )
+    continue-on-error: true
+    outputs:
+      with-srp-sauce-url: ${{ steps.sauce-upload.outputs.with-srp-sauce-url }}
+      without-srp-sauce-url: ${{ steps.sauce-upload.outputs.without-srp-sauce-url }}
+
+    steps:
+      - name: Download reused with-SRP APK
+        if: needs.resolve-fingerprint-reuse.outputs.found == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: fingerprint-reuse-android-apk-${{ needs.check-builds-needed.outputs.with-srp-build-name }}
+          path: artifacts/with-srp
+
+      - name: Download reused without-SRP APK
+        if: needs.resolve-fingerprint-reuse.outputs.found == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: fingerprint-reuse-android-apk-${{ needs.check-builds-needed.outputs.without-srp-build-name }}
+          path: artifacts/without-srp
+
+      - name: Download fresh with-SRP APK
+        if: needs.resolve-fingerprint-reuse.outputs.found != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: android-apk-${{ needs.check-builds-needed.outputs.with-srp-build-name }}
+          path: artifacts/with-srp
+
+      - name: Download fresh without-SRP APK
+        if: needs.resolve-fingerprint-reuse.outputs.found != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: android-apk-${{ needs.check-builds-needed.outputs.without-srp-build-name }}
+          path: artifacts/without-srp
+
+      - name: Upload APKs to Sauce Labs
+        id: sauce-upload
+        env:
+          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SAUCE_USERNAME:-}" ] || [ -z "${SAUCE_ACCESS_KEY:-}" ]; then
+            echo "::error::SAUCE_USERNAME and SAUCE_ACCESS_KEY secrets are required"
+            exit 1
+          fi
+          upload() {
+            local apk="$1"
+            local name="$2"
+            curl -fsS -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" \
+              -X POST "https://api.eu-central-1.saucelabs.com/v1/storage/upload" \
+              -F "name=$name" -F "payload=@$apk" >/dev/null
+            echo "storage:filename=$name"
+          }
+
+          with_srp="$(find artifacts/with-srp -name '*.apk' -type f | head -1)"
+          without_srp="$(find artifacts/without-srp -name '*.apk' -type f | head -1)"
+          if [ -z "$with_srp" ] || [ -z "$without_srp" ]; then
+            echo "::error::Sauce Labs APK upload requires both APK variants"
+            exit 1
+          fi
+
+          with_name="metamask-with-srp-${{ github.run_id }}.apk"
+          without_name="metamask-without-srp-${{ github.run_id }}.apk"
+          {
+            echo "with-srp-sauce-url=$(upload "$with_srp" "$with_name")"
+            echo "without-srp-sauce-url=$(upload "$without_srp" "$without_name")"
+          } >> "$GITHUB_OUTPUT"
+

--- a/.github/workflows/performance-test-runner-saucelabs.yml
+++ b/.github/workflows/performance-test-runner-saucelabs.yml
@@ -36,8 +36,6 @@ on:
         type: string
         default: test
     secrets:
-      SAUCE_USERNAME:
-        required: false
       SAUCE_ACCESS_KEY:
         required: true
       MM_TEST_ACCOUNT_SRP:
@@ -105,7 +103,7 @@ jobs:
             exit 1
           fi
           {
-            echo "SAUCE_USERNAME=${{ secrets.SAUCE_USERNAME }}"
+            echo "SAUCE_USERNAME=oauth-javier.vera-857be"
             echo "SAUCE_ACCESS_KEY=${{ secrets.SAUCE_ACCESS_KEY }}"
             echo "SAUCE_ANDROID_APP_URL=$sauce_app_url"
             echo "SAUCE_ANDROID_ONBOARDING_APP_URL=$sauce_app_url"
@@ -136,10 +134,6 @@ jobs:
             echo "DISABLE_VIDEO_DOWNLOAD=true"
             echo "DISABLE_NETWORK_LOGS=true"
           } >> "$GITHUB_ENV"
-          if [ -z "${{ secrets.SAUCE_USERNAME }}" ]; then
-            echo "::error::SAUCE_USERNAME secret is required for Sauce Labs lanes"
-            exit 1
-          fi
 
       - name: Run Sauce Labs tests
         continue-on-error: true

--- a/.github/workflows/performance-test-runner-saucelabs.yml
+++ b/.github/workflows/performance-test-runner-saucelabs.yml
@@ -1,0 +1,173 @@
+name: Performance Test Runner — Sauce Labs (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        required: true
+        type: string
+      build_type:
+        required: true
+        type: string
+      sauce_app_url:
+        required: true
+        type: string
+      device_matrix:
+        required: false
+        type: string
+        default: '[{"name":"Google_Pixel_7_POC49","os_version":""}]'
+      device_mode:
+        required: false
+        type: string
+        default: private
+        description: 'private or cloud device allocation mode'
+      branch_name:
+        required: true
+        type: string
+      sauce_build_name:
+        required: true
+        type: string
+      grep_tags:
+        required: false
+        type: string
+        default: ''
+      sentry_target:
+        required: false
+        type: string
+        default: test
+    secrets:
+      SAUCE_USERNAME:
+        required: false
+      SAUCE_ACCESS_KEY:
+        required: true
+      MM_TEST_ACCOUNT_SRP:
+        required: true
+      TEST_SRP_1:
+        required: true
+      TEST_SRP_2:
+        required: true
+      TEST_SRP_3:
+        required: true
+      TEST_SRP_4:
+        required: true
+      E2E_PASSWORD:
+        required: true
+      MM_SENTRY_DSN_TEST:
+        required: false
+      MM_SENTRY_DSN:
+        required: false
+
+jobs:
+  run-tests:
+    name: '[Sauce Labs] Run ${{ inputs.build_type }} on ${{ inputs.platform }}'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        device: ${{ fromJson(inputs.device_matrix) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Restore node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            .yarn/install-state.gz
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: yarn --immutable
+
+      - name: Setup project
+        run: yarn setup:github-ci --node
+
+      - name: Set Sauce Labs test environment
+        run: |
+          set -euo pipefail
+          sauce_app_url="${{ inputs.sauce_app_url }}"
+          if [ -z "$sauce_app_url" ]; then
+            echo "::error::Sauce Labs app URL is required"
+            exit 1
+          fi
+          {
+            echo "SAUCE_USERNAME=${{ secrets.SAUCE_USERNAME }}"
+            echo "SAUCE_ACCESS_KEY=${{ secrets.SAUCE_ACCESS_KEY }}"
+            echo "SAUCE_ANDROID_APP_URL=$sauce_app_url"
+            echo "SAUCE_ANDROID_ONBOARDING_APP_URL=$sauce_app_url"
+            echo "SAUCE_ANDROID_CLEAN_APP_URL=$sauce_app_url"
+            echo "SAUCE_ANDROID_SEEDLESS_APP_URL=$sauce_app_url"
+            echo "SAUCE_BUILD_TYPE=${{ inputs.build_type }}"
+            if [ "${{ inputs.device_mode }}" = "cloud" ]; then
+              echo "SAUCE_DEVICE=Google Pixel.*"
+              echo "SAUCE_WORKERS=2"
+              echo "SAUCE_PRIVATE_DEVICES_ONLY=false"
+            else
+              echo "SAUCE_DEVICE=Google_Pixel_7_POC(49|05)"
+              echo "SAUCE_WORKERS=2"
+              echo "SAUCE_PRIVATE_DEVICES_ONLY=true"
+            fi
+            echo "SAUCE_BUILD_NAME=${{ inputs.sauce_build_name }}"
+            echo "TEST_PLATFORM=${{ inputs.platform }}"
+            echo "QA_APP_VERSION=sauce-${{ github.run_id }}"
+            echo "E2E_PERFORMANCE_CLOUD_PROVIDER=saucelabs"
+            echo "E2E_PERFORMANCE_SENTRY_ENVIRONMENT=github-actions-performance-e2e-saucelabs"
+            echo "E2E_PERFORMANCE_SENTRY_DSN=${{ inputs.sentry_target == 'real' && secrets.MM_SENTRY_DSN || secrets.MM_SENTRY_DSN_TEST }}"
+            echo "MM_TEST_ACCOUNT_SRP=${{ secrets.MM_TEST_ACCOUNT_SRP }}"
+            echo "TEST_SRP_1=${{ secrets.TEST_SRP_1 }}"
+            echo "TEST_SRP_2=${{ secrets.TEST_SRP_2 }}"
+            echo "TEST_SRP_3=${{ secrets.TEST_SRP_3 }}"
+            echo "TEST_SRP_4=${{ secrets.TEST_SRP_4 }}"
+            echo "E2E_PASSWORD=${{ secrets.E2E_PASSWORD }}"
+            echo "DISABLE_VIDEO_DOWNLOAD=true"
+            echo "DISABLE_NETWORK_LOGS=true"
+          } >> "$GITHUB_ENV"
+          if [ -z "${{ secrets.SAUCE_USERNAME }}" ]; then
+            echo "::error::SAUCE_USERNAME secret is required for Sauce Labs lanes"
+            exit 1
+          fi
+
+      - name: Run Sauce Labs tests
+        continue-on-error: true
+        env:
+          GREP_TAGS: ${{ inputs.grep_tags }}
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.build_type }}" = "onboarding" ]; then
+            projects=(
+              "--project=saucelabs-android-onboarding"
+              "--project=saucelabs-android-onboarding-seedless"
+            )
+          else
+            projects=("--project=saucelabs-android")
+          fi
+          if [ -n "$GREP_TAGS" ]; then
+            yarn playwright test --config=tests/playwright.saucelabs.config.ts "${projects[@]}" --grep "$GREP_TAGS"
+          else
+            yarn playwright test --config=tests/playwright.saucelabs.config.ts "${projects[@]}"
+          fi
+
+      - name: Upload Sauce Labs results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: saucelabs-${{ inputs.platform }}-${{ inputs.build_type == 'onboarding' && 'onboarding-flow' || inputs.build_type }}-test-results-${{ github.run_id }}
+          path: |
+            tests/reporters/reports
+            tests/test-reports/playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/run-performance-e2e-manual.yml
+++ b/.github/workflows/run-performance-e2e-manual.yml
@@ -28,33 +28,30 @@ on:
         description: 'BrowserStack Android Onboarding App URL (bs://...)'
         required: false
         type: string
-      browserstack_app_url_ios_onboarding:
-        description: 'BrowserStack iOS Onboarding App URL (bs://...)'
-        required: false
-        type: string
       browserstack_app_url_android_imported_wallet:
         description: 'BrowserStack Android Imported Wallet App URL (bs://...)'
         required: false
         type: string
-      browserstack_app_url_ios_imported_wallet:
-        description: 'BrowserStack iOS Imported Wallet App URL (bs://...)'
-        required: false
-        type: string
-      performance_tags:
-        description: 'JSON array of performance tags. Blank runs all; [] skips all.'
-        required: false
-        type: string
-        default: ''
       reuse_main_builds:
         description: 'For e2e only, reuse and upload the latest Android APKs from main CI'
         required: false
         type: boolean
         default: false
-      source_fingerprint:
-        description: 'Optional @expo/fingerprint hash for Android app reuse'
+      enable_browserstack:
+        description: 'Run BrowserStack performance lanes'
         required: false
-        type: string
-        default: ''
+        type: boolean
+        default: true
+      enable_saucelabs:
+        description: 'Run Sauce Labs private devices (Pixel 7 POC49/POC05, 2 workers)'
+        required: false
+        type: boolean
+        default: false
+      enable_saucelabs_cloud:
+        description: 'Run Sauce Labs cloud devices (Google Pixel.*, 2 workers)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -64,9 +61,17 @@ permissions:
   statuses: write
 
 concurrency:
-  # Manual runs are isolated by ref and variant so they do not block the
-  # scheduled cadence.
-  group: performance-e2e-trigger-${{ github.event_name == 'schedule' && github.event.schedule || github.ref }}-${{ github.event_name == 'schedule' && 'scheduled' || inputs.build_variant }}
+  # Manual runs are isolated by run id so they do not block the scheduled cadence.
+  group: >-
+    ${{
+      github.event_name == 'workflow_dispatch' &&
+      format('performance-e2e-manual-{0}', github.run_id) ||
+      format(
+        'performance-e2e-trigger-{0}-{1}',
+        github.ref,
+        github.event.schedule || 'scheduled'
+      )
+    }}
   cancel-in-progress: false
 
 jobs:
@@ -79,6 +84,9 @@ jobs:
       source_ref: main
       build_variant: e2e
       sentry_target: test
+      enable_browserstack: true
+      enable_saucelabs: false
+      enable_saucelabs_cloud: false
     secrets: inherit
 
   manual:
@@ -91,10 +99,9 @@ jobs:
       build_variant: ${{ inputs.build_variant }}
       sentry_target: ${{ inputs.sentry_target }}
       browserstack_app_url_android_onboarding: ${{ inputs.browserstack_app_url_android_onboarding }}
-      browserstack_app_url_ios_onboarding: ${{ inputs.browserstack_app_url_ios_onboarding }}
       browserstack_app_url_android_imported_wallet: ${{ inputs.browserstack_app_url_android_imported_wallet }}
-      browserstack_app_url_ios_imported_wallet: ${{ inputs.browserstack_app_url_ios_imported_wallet }}
-      performance_tags: ${{ inputs.performance_tags }}
       reuse_main_builds: ${{ inputs.build_variant == 'e2e' && inputs.reuse_main_builds }}
-      source_fingerprint: ${{ inputs.source_fingerprint }}
+      enable_browserstack: ${{ inputs.enable_browserstack }}
+      enable_saucelabs: ${{ inputs.enable_saucelabs }}
+      enable_saucelabs_cloud: ${{ inputs.enable_saucelabs_cloud }}
     secrets: inherit

--- a/.github/workflows/run-performance-e2e.yml
+++ b/.github/workflows/run-performance-e2e.yml
@@ -71,6 +71,22 @@ on:
         type: string
         default: ''
 
+      enable_browserstack:
+        description: 'Run BrowserStack performance lanes'
+        required: false
+        type: boolean
+        default: true
+      enable_saucelabs:
+        description: 'Run Sauce Labs private-device performance lanes'
+        required: false
+        type: boolean
+        default: false
+      enable_saucelabs_cloud:
+        description: 'Run Sauce Labs cloud-device performance lanes'
+        required: false
+        type: boolean
+        default: false
+
 permissions:
   contents: write
   id-token: write
@@ -271,8 +287,15 @@ jobs:
       !cancelled() &&
       needs.prepare.result == 'success' &&
       needs.prepare.outputs.run_tests == 'true' &&
-      !inputs.browserstack_app_url_android_onboarding &&
-      !inputs.browserstack_app_url_android_imported_wallet
+      (
+        inputs.enable_saucelabs == true ||
+        inputs.enable_saucelabs_cloud == true ||
+        (
+          inputs.enable_browserstack != false &&
+          !inputs.browserstack_app_url_android_onboarding &&
+          !inputs.browserstack_app_url_android_imported_wallet
+        )
+      )
     with:
       branch_name: ${{ inputs.branch_name }}
       source_ref: ${{ inputs.source_ref }}
@@ -283,6 +306,7 @@ jobs:
       # unset; passing a blank value into this boolean workflow_call input makes
       # the reusable Android build job fail to start.
       main_branch_only: ${{ inputs.reuse_main_builds == true && inputs.build_variant == 'e2e' }}
+      enable_saucelabs: ${{ inputs.enable_saucelabs == true || inputs.enable_saucelabs_cloud == true }}
     secrets: inherit
 
   # =============================================================================
@@ -295,6 +319,7 @@ jobs:
     needs: [prepare, trigger-android-dual-versions]
     if: >-
       always() && !failure() && !cancelled() &&
+      inputs.enable_browserstack != false &&
       needs.prepare.outputs.run_tests == 'true' &&
       (
         needs.trigger-android-dual-versions.result == 'skipped' ||
@@ -323,7 +348,7 @@ jobs:
     uses: ./.github/workflows/performance-test-runner.yml
     needs:
       - prepare
-    if: always() && !failure() && !cancelled() && needs.prepare.outputs.run_tests == 'true' && inputs.browserstack_app_url_ios_onboarding != ''
+    if: always() && !failure() && !cancelled() && inputs.enable_browserstack != false && needs.prepare.outputs.run_tests == 'true' && inputs.browserstack_app_url_ios_onboarding != ''
     with:
       platform: ios
       build_type: onboarding
@@ -347,6 +372,7 @@ jobs:
     needs: [prepare, trigger-android-dual-versions]
     if: >-
       always() && !cancelled() &&
+      inputs.enable_browserstack != false &&
       needs.prepare.outputs.run_tests == 'true' &&
       (
         needs.trigger-android-dual-versions.result == 'skipped' ||
@@ -374,7 +400,7 @@ jobs:
     uses: ./.github/workflows/performance-test-runner.yml
     needs:
       - prepare
-    if: always() && !cancelled() && needs.prepare.outputs.run_tests == 'true' && inputs.browserstack_app_url_ios_imported_wallet != ''
+    if: always() && !cancelled() && inputs.enable_browserstack != false && needs.prepare.outputs.run_tests == 'true' && inputs.browserstack_app_url_ios_imported_wallet != ''
     with:
       platform: ios
       build_type: imported-wallet
@@ -388,6 +414,95 @@ jobs:
       grep_tags: ${{ needs.prepare.outputs.grep_pattern }}
     secrets: inherit
 
+
+  # =============================================================================
+  # SAUCE LABS PRIVATE / CLOUD LANES
+  # =============================================================================
+
+  run-android-onboarding-tests-saucelabs:
+    name: '[Sauce Labs] Performance Test Android (Onboarding)'
+    uses: ./.github/workflows/performance-test-runner-saucelabs.yml
+    needs: [prepare, trigger-android-dual-versions]
+    if: >-
+      always() && !failure() && !cancelled() &&
+      inputs.enable_saucelabs == true &&
+      needs.prepare.outputs.run_tests == 'true' &&
+      needs.trigger-android-dual-versions.result == 'success' &&
+      needs.trigger-android-dual-versions.outputs.without-srp-sauce-url != ''
+    with:
+      platform: android
+      build_type: onboarding
+      sauce_app_url: ${{ needs.trigger-android-dual-versions.outputs.without-srp-sauce-url }}
+      device_mode: private
+      branch_name: ${{ inputs.branch_name }}
+      sauce_build_name: ${{ needs.prepare.outputs.android_build_name }}-SauceLabs
+      grep_tags: ${{ needs.prepare.outputs.grep_pattern }}
+      sentry_target: ${{ inputs.sentry_target || 'test' }}
+    secrets: inherit
+
+  run-android-onboarding-tests-saucelabs-cloud:
+    name: '[Sauce Labs Cloud] Performance Test Android (Onboarding)'
+    uses: ./.github/workflows/performance-test-runner-saucelabs.yml
+    needs: [prepare, trigger-android-dual-versions]
+    if: >-
+      always() && !failure() && !cancelled() &&
+      inputs.enable_saucelabs_cloud == true &&
+      needs.prepare.outputs.run_tests == 'true' &&
+      needs.trigger-android-dual-versions.result == 'success' &&
+      needs.trigger-android-dual-versions.outputs.without-srp-sauce-url != ''
+    with:
+      platform: android
+      build_type: onboarding
+      sauce_app_url: ${{ needs.trigger-android-dual-versions.outputs.without-srp-sauce-url }}
+      device_mode: cloud
+      branch_name: ${{ inputs.branch_name }}
+      sauce_build_name: ${{ needs.prepare.outputs.android_build_name }}-SauceLabs-Cloud
+      grep_tags: ${{ needs.prepare.outputs.grep_pattern }}
+      sentry_target: ${{ inputs.sentry_target || 'test' }}
+    secrets: inherit
+
+  run-android-imported-wallet-tests-saucelabs:
+    name: '[Sauce Labs] Performance Test Android (Imported Wallet)'
+    uses: ./.github/workflows/performance-test-runner-saucelabs.yml
+    needs: [prepare, trigger-android-dual-versions]
+    if: >-
+      always() && !cancelled() &&
+      inputs.enable_saucelabs == true &&
+      needs.prepare.outputs.run_tests == 'true' &&
+      needs.trigger-android-dual-versions.result == 'success' &&
+      needs.trigger-android-dual-versions.outputs.with-srp-sauce-url != ''
+    with:
+      platform: android
+      build_type: imported-wallet
+      sauce_app_url: ${{ needs.trigger-android-dual-versions.outputs.with-srp-sauce-url }}
+      device_mode: private
+      branch_name: ${{ inputs.branch_name }}
+      sauce_build_name: ${{ needs.prepare.outputs.android_build_name }}-SauceLabs
+      grep_tags: ${{ needs.prepare.outputs.grep_pattern }}
+      sentry_target: ${{ inputs.sentry_target || 'test' }}
+    secrets: inherit
+
+  run-android-imported-wallet-tests-saucelabs-cloud:
+    name: '[Sauce Labs Cloud] Performance Test Android (Imported Wallet)'
+    uses: ./.github/workflows/performance-test-runner-saucelabs.yml
+    needs: [prepare, trigger-android-dual-versions]
+    if: >-
+      always() && !cancelled() &&
+      inputs.enable_saucelabs_cloud == true &&
+      needs.prepare.outputs.run_tests == 'true' &&
+      needs.trigger-android-dual-versions.result == 'success' &&
+      needs.trigger-android-dual-versions.outputs.with-srp-sauce-url != ''
+    with:
+      platform: android
+      build_type: imported-wallet
+      sauce_app_url: ${{ needs.trigger-android-dual-versions.outputs.with-srp-sauce-url }}
+      device_mode: cloud
+      branch_name: ${{ inputs.branch_name }}
+      sauce_build_name: ${{ needs.prepare.outputs.android_build_name }}-SauceLabs-Cloud
+      grep_tags: ${{ needs.prepare.outputs.grep_pattern }}
+      sentry_target: ${{ inputs.sentry_target || 'test' }}
+    secrets: inherit
+
   aggregate-results:
     name: Aggregate All Test Results
     runs-on: ubuntu-latest
@@ -398,6 +513,10 @@ jobs:
         run-android-onboarding-tests,
         run-ios-imported-wallet-tests,
         run-ios-onboarding-tests,
+        run-android-onboarding-tests-saucelabs,
+        run-android-onboarding-tests-saucelabs-cloud,
+        run-android-imported-wallet-tests-saucelabs,
+        run-android-imported-wallet-tests-saucelabs-cloud,
       ]
     if: always() && needs.prepare.outputs.run_tests == 'true'
     steps:

--- a/docs/superpowers/plans/2026-08-17-saucelabs-performance-provider.md
+++ b/docs/superpowers/plans/2026-08-17-saucelabs-performance-provider.md
@@ -1,0 +1,97 @@
+# Sauce Labs Performance Provider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Sauce Labs as an optional third performance provider and produce one deduplicated comparison report for BrowserStack and Sauce Labs.
+
+**Architecture:** Create a Sauce Labs-specific WebDriver provider and reusable workflow, rather than modifying BrowserStack or TestMu capabilities. The caller workflow will expose `enable_saucelabs` and run Sauce onboarding/imported lanes independently. Sauce results will use a `saucelabs-` artifact prefix and the existing provider-aware aggregator.
+
+**Tech Stack:** GitHub Actions reusable workflows, WebdriverIO/Appium, TypeScript, Playwright performance reporters, Node.js test scripts.
+
+## Global Constraints
+
+- Sauce Labs is optional and must run only when `enable_saucelabs` is true.
+- Sauce device name is exactly `Google_Pixel_7_POC49`.
+- Sauce Android `platformVersion` is intentionally omitted.
+- BrowserStack  behavior must remain unchanged.
+- Sauce credentials must come from `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` secrets.
+- Sauce app uploads must use separate onboarding/imported APKs and never reuse the wrong APK variant.
+- Final results must be deduplicated by provider, platform, device, and scenario.
+- Tests must preserve quality-gate failures, infrastructure/test errors, and missing-metric results as distinct reasons.
+
+---
+
+### Task 1: Add Sauce Labs provider configuration
+
+**Files:**
+- Create: `tests/framework/services/providers/saucelabs/SauceLabsConfigBuilder.ts`
+- Create: `tests/framework/services/providers/saucelabs/SauceLabsConfigBuilder.test.ts`
+- Modify: `tests/framework/services/providers/index.ts`
+- Modify: provider selection/configuration code that maps `TEST_PLATFORM` and `CLOUD_PROVIDER`
+
+**Interfaces:**
+- Consumes `ProjectConfig`, `SauceLabsConfig`, `SAUCE_USERNAME`, `SAUCE_ACCESS_KEY`, `SAUCE_APP`, and `SAUCE_DEVICE_NAME`.
+- Produces a WebdriverIO config using Sauce Labs endpoint `ondemand.us-west-1.saucelabs.com/wd/hub`.
+- Capabilities must include `appium:deviceName: Google_Pixel_7_POC49`, omit `appium:platformVersion`, use Android UiAutomator2, full reset, and the same command/element settings needed by the existing performance framework.
+
+- [ ] Write failing unit tests for required credentials, exact device name, omitted platform version, and app capability.
+- [ ] Run the targeted test and verify failure before implementation.
+- [ ] Implement the minimal Sauce Labs config builder with explicit validation for missing credentials and app URL.
+- [ ] Add provider selection without changing BrowserStack selection.
+- [ ] Run the targeted test and verify it passes.
+- [ ] Commit the provider configuration as one logical commit.
+
+### Task 2: Add Sauce Labs app upload and reusable runners
+
+**Files:**
+- Create: `.github/workflows/performance-test-runner-saucelabs.yml`
+- Modify: `.github/workflows/run-performance-e2e.yml`
+- Modify: `.github/workflows/run-performance-e2e-manual.yml`
+- Create or modify: Sauce upload action/script used by the workflow
+
+**Interfaces:**
+- Manual workflow input: `enable_saucelabs` boolean, default `false`.
+- Caller workflow input: `enable_saucelabs` boolean, default `false`.
+- Reusable runner inputs: platform, build type, Sauce app URL, branch/build name, device matrix, tags, and credentials.
+- Output artifacts: `saucelabs-android-onboarding-*` and `saucelabs-android-imported-wallet-*`.
+
+- [ ] Add failing workflow/script tests for disabled Sauce lanes, missing Sauce credentials, and separate onboarding/imported app URLs.
+- [ ] Add the manual input and pass it through the manual-to-reusable workflow call.
+- [ ] Add Sauce app upload steps using onboarding `without-SRP` and imported-wallet `with-SRP` APKs.
+- [ ] Add onboarding and imported-wallet Sauce jobs gated by `enable_saucelabs`.
+- [ ] Configure the Sauce matrix with exactly `Google_Pixel_7_POC49` and no OS version.
+- [ ] Ensure Sauce jobs can run alongside BrowserStack  without changing their dependencies or concurrency groups.
+- [ ] Run workflow validation and targeted script tests.
+- [ ] Commit the workflow/upload changes as one logical commit.
+
+### Task 3: Integrate Sauce results into reporting
+
+**Files:**
+- Modify: `tests/scripts/aggregate-performance-reports.mjs`
+- Modify: `tests/scripts/aggregate-performance-reports.test.mjs`
+- Modify: `tests/scripts/generate-performance-pr-comment.mjs` if provider sections are rendered there
+
+**Interfaces:**
+- Provider detection must classify `saucelabs-` artifacts as `saucelabs`.
+- `providerResults.saucelabs` must contain one entry per unique scenario with passed, failed, mixed, attempts, failure reasons, and quality-gate violations.
+- Existing BrowserStack/TestMu summary fields remain backward compatible.
+
+- [ ] Add tests for Sauce artifact classification and deduplication.
+- [ ] Add tests for one Sauce scenario with a quality-gate failure and one with an infrastructure failure.
+- [ ] Run the aggregation tests and confirm all providers remain separate.
+- [ ] Update final HTML/provider breakdown to include Sauce Labs only when artifacts exist.
+- [ ] Commit reporting changes as one logical commit.
+
+### Task 4: Validate the three-provider workflow
+
+**Files:**
+- Modify: `docs/testing` or performance README with Sauce setup and required secrets.
+- Verify all workflow and test files from Tasks 1–3.
+
+- [ ] Run targeted TypeScript tests for the Sauce builder.
+- [ ] Run aggregation and reporting tests.
+- [ ] Run workflow syntax/actionlint validation.
+- [ ] Verify the three-provider manual dispatch graph with Sauce enabled and with Sauce disabled.
+- [ ] Confirm artifacts and final report show separate BrowserStack and Sauce Labs sections.
+- [ ] Run the repository verification commands relevant to changed files.
+- [ ] Commit documentation and final validation changes.

--- a/tests/flows/wallet.flow.ts
+++ b/tests/flows/wallet.flow.ts
@@ -957,10 +957,19 @@ export const selectAccountByDevice = async (
   deviceName: string,
 ): Promise<void> => {
   const deviceAccountMapping = PlaywrightUtilities.buildDeviceAccountMapping();
-  const accountName = deviceAccountMapping[deviceName];
+  // Sauce Labs cloud allocation may use regex device names such as "Google Pixel.*".
+  const normalizedDeviceName = deviceName.replace(/\.\*$/, '');
+  const accountName =
+    deviceAccountMapping[deviceName] ??
+    deviceAccountMapping[normalizedDeviceName];
 
-  if (!(deviceName in deviceAccountMapping)) {
-    throw new Error(`Account name not found for device: ${deviceName}`);
+  if (accountName === undefined) {
+    throw new Error(
+      `Account name not found for device: ${deviceName}` +
+        (normalizedDeviceName !== deviceName
+          ? ` (normalized: ${normalizedDeviceName})`
+          : ''),
+    );
   }
 
   if (!accountName) {

--- a/tests/framework/config/global.setup.ts
+++ b/tests/framework/config/global.setup.ts
@@ -23,6 +23,13 @@ function parseProjectNames(): string[] {
       } else {
         throw new Error('Project name is required with --project flag');
       }
+    } else if (arg.startsWith('--project=')) {
+      const projectName = arg.slice('--project='.length);
+      if (projectName) {
+        projects.push(projectName);
+      } else {
+        throw new Error('Project name is required with --project flag');
+      }
     }
   });
 

--- a/tests/framework/services/index.ts
+++ b/tests/framework/services/index.ts
@@ -11,6 +11,7 @@ export {
   type ProviderType,
   EmulatorProvider,
   BrowserStackProvider,
+  SauceLabsProvider,
 } from './providers';
 
 // Appium utilities

--- a/tests/framework/services/providers/factory.ts
+++ b/tests/framework/services/providers/factory.ts
@@ -4,10 +4,12 @@ import { EmulatorProvider } from './emulator';
 import { BrowserStackProvider } from './browserstack';
 import { ProviderName } from '../../types.ts';
 
+/* eslint-disable @typescript-eslint/no-require-imports -- Sauce Labs stays lazy-loaded */
+
 /**
  * Supported provider types
  */
-export type ProviderType = 'emulator' | 'browserstack';
+export type ProviderType = 'emulator' | 'browserstack' | 'saucelabs';
 
 /**
  * Factory function to create the appropriate service provider
@@ -18,7 +20,7 @@ export function createServiceProvider(project: ProjectConfig): ServiceProvider {
 
   if (!provider) {
     throw new Error(
-      'Device provider is not specified in the configuration. Please specify "emulator" or "browserstack".',
+      'Device provider is not specified in the configuration. Please specify "emulator", "browserstack", or "saucelabs".',
     );
   }
 
@@ -30,9 +32,15 @@ export function createServiceProvider(project: ProjectConfig): ServiceProvider {
     case ProviderName.BROWSERSTACK:
       return new BrowserStackProvider(project);
 
+    case ProviderName.SAUCELABS: {
+      const sauceLabsModule =
+        require('./saucelabs') as typeof import('./saucelabs');
+      return new sauceLabsModule.SauceLabsProvider(project);
+    }
+
     default:
       throw new Error(
-        `Unknown device provider: "${provider}". Supported providers: emulator, browserstack.`,
+        `Unknown device provider: "${provider}". Supported providers: emulator, browserstack, saucelabs.`,
       );
   }
 }

--- a/tests/framework/services/providers/index.ts
+++ b/tests/framework/services/providers/index.ts
@@ -1,3 +1,4 @@
 export { createServiceProvider, type ProviderType } from './factory.ts';
 export { EmulatorProvider } from './emulator';
 export { BrowserStackProvider } from './browserstack';
+export { SauceLabsProvider } from './saucelabs';

--- a/tests/framework/services/providers/saucelabs/SauceLabsConfigBuilder.test.ts
+++ b/tests/framework/services/providers/saucelabs/SauceLabsConfigBuilder.test.ts
@@ -1,0 +1,46 @@
+import { ProviderName, Platform } from '../../../types.ts';
+import { SauceLabsConfigBuilder } from './SauceLabsConfigBuilder.ts';
+
+describe('SauceLabsConfigBuilder', () => {
+  const originalUsername = process.env.SAUCE_USERNAME;
+  const originalAccessKey = process.env.SAUCE_ACCESS_KEY;
+
+  afterEach(() => {
+    if (originalUsername === undefined) delete process.env.SAUCE_USERNAME;
+    else process.env.SAUCE_USERNAME = originalUsername;
+    if (originalAccessKey === undefined) delete process.env.SAUCE_ACCESS_KEY;
+    else process.env.SAUCE_ACCESS_KEY = originalAccessKey;
+  });
+
+  it('builds an Android config without an OS version', () => {
+    process.env.SAUCE_USERNAME = 'user';
+    process.env.SAUCE_ACCESS_KEY = 'key';
+
+    const config = new SauceLabsConfigBuilder({
+      use: {
+        platform: Platform.ANDROID,
+        device: {
+          provider: ProviderName.SAUCELABS,
+          name: 'Google_Pixel_7_POC49',
+        },
+        app: {
+          packageName: 'io.metamask',
+          launchableActivity: 'io.metamask.MainActivity',
+          buildPath: 'storage:filename=app.apk',
+        },
+      },
+    } as never).build();
+
+    expect(config.hostname).toBe('ondemand.eu-central-1.saucelabs.com');
+    expect(config.capabilities['appium:deviceName']).toBe(
+      'Google_Pixel_7_POC49',
+    );
+    expect(config.capabilities).not.toHaveProperty('appium:platformVersion');
+    expect(config.capabilities['sauce:options']).toMatchObject({
+      app: 'storage:filename=app.apk',
+      appiumVersion: 'latest',
+      capturePerformance: true,
+      privateDevicesOnly: true,
+    });
+  });
+});

--- a/tests/framework/services/providers/saucelabs/SauceLabsConfigBuilder.ts
+++ b/tests/framework/services/providers/saucelabs/SauceLabsConfigBuilder.ts
@@ -1,0 +1,75 @@
+/* eslint-disable import-x/no-nodejs-modules */
+import path from 'path';
+import type { ProjectConfig } from '../../common/types.ts';
+import type { SauceLabsConfig } from '../../../types.ts';
+
+export class SauceLabsConfigBuilder {
+  constructor(private readonly project: ProjectConfig) {}
+
+  build() {
+    const device = this.project.use.device as SauceLabsConfig;
+    const appUrl = this.project.use.app?.buildPath;
+    // Bracket access keeps Jest/runtime environment values dynamic.
+    // eslint-disable-next-line dot-notation
+    const username = process.env[String('SAUCE_USERNAME')];
+    // eslint-disable-next-line dot-notation
+    const accessKey = process.env[String('SAUCE_ACCESS_KEY')];
+
+    if (!appUrl) {
+      throw new Error('Sauce Labs app URL (buildPath) is required');
+    }
+    if (!username || !accessKey) {
+      throw new Error(
+        'SAUCE_USERNAME and SAUCE_ACCESS_KEY environment variables are required',
+      );
+    }
+
+    const platformName = this.project.use.platform;
+    const projectName = path.basename(process.cwd());
+    const privateDevicesOnly =
+      process.env.SAUCE_PRIVATE_DEVICES_ONLY?.toLowerCase() !== 'false';
+    const sauceOptions = {
+      name: `${projectName} ${platformName} test`,
+      build: process.env.SAUCE_BUILD_NAME || `${projectName} ${platformName}`,
+      appiumVersion: 'latest',
+      deviceName: device.name,
+      platformName,
+      app: appUrl,
+      extendedDebugging: true,
+      capturePerformance: true,
+      recordVideo: true,
+      recordScreenshots: true,
+      ...(privateDevicesOnly
+        ? { privateDevicesOnly: true }
+        : { publicDevicesOnly: true }),
+      ...(device.orientation ? { orientation: device.orientation } : {}),
+    };
+
+    return {
+      protocol: 'https' as const,
+      hostname:
+        process.env.SAUCE_HOSTNAME || 'ondemand.eu-central-1.saucelabs.com',
+      port: 443,
+      path: '/wd/hub',
+      user: username,
+      key: accessKey,
+      logLevel: 'warn' as const,
+      connectionRetryTimeout: 300_000,
+      connectionRetryCount: 3,
+      capabilities: {
+        platformName,
+        'appium:app': appUrl,
+        'appium:deviceName': device.name,
+        'appium:automationName':
+          platformName === 'android' ? 'UiAutomator2' : 'XCUITest',
+        'appium:autoGrantPermissions': true,
+        'appium:autoAcceptAlerts': true,
+        'appium:fullReset': true,
+        'sauce:options': sauceOptions,
+        ...(device.otherApps && device.otherApps.length > 0
+          ? { 'appium:otherApps': device.otherApps }
+          : {}),
+      },
+    };
+  }
+}

--- a/tests/framework/services/providers/saucelabs/SauceLabsProvider.ts
+++ b/tests/framework/services/providers/saucelabs/SauceLabsProvider.ts
@@ -1,0 +1,29 @@
+import { remote, type Browser } from 'webdriverio';
+import { BaseServiceProvider } from '../../common/base/BaseServiceProvider.ts';
+import type { ProjectConfig } from '../../common/types.ts';
+import { SauceLabsConfigBuilder } from './SauceLabsConfigBuilder.ts';
+
+export class SauceLabsProvider extends BaseServiceProvider {
+  constructor(project: ProjectConfig) {
+    super(project, 'SauceLabsProvider');
+  }
+
+  async globalSetup(): Promise<void> {
+    await super.globalSetup?.();
+    this.logger.info('Sauce Labs global setup complete');
+  }
+
+  async getDriver(): Promise<Browser> {
+    const start = Date.now();
+    const browser = await remote(
+      new SauceLabsConfigBuilder(this.project).build(),
+    );
+    this.sessionCreationDurationMs = Date.now() - start;
+    this.sessionId = browser.sessionId;
+    this.logger.info(
+      `Driver created for Sauce Labs with session: ${this.sessionId} ` +
+        `(session creation took ${this.sessionCreationDurationMs}ms)`,
+    );
+    return browser;
+  }
+}

--- a/tests/framework/services/providers/saucelabs/index.ts
+++ b/tests/framework/services/providers/saucelabs/index.ts
@@ -1,0 +1,2 @@
+export { SauceLabsProvider } from './SauceLabsProvider.ts';
+export { SauceLabsConfigBuilder } from './SauceLabsConfigBuilder.ts';

--- a/tests/framework/types.ts
+++ b/tests/framework/types.ts
@@ -40,6 +40,7 @@ export enum ProviderName {
   EMULATOR = 'emulator',
   SIMULATOR = 'simulator',
   BROWSERSTACK = 'browserstack',
+  SAUCELABS = 'saucelabs',
 }
 
 export enum Platform {
@@ -82,6 +83,14 @@ export interface BrowserStackConfig {
   otherApps?: string[];
 }
 
+export interface SauceLabsConfig {
+  provider: ProviderName;
+  name: string;
+  osVersion?: string;
+  orientation?: DeviceOrientation;
+  otherApps?: string[];
+}
+
 export interface AppConfig {
   appId?: string;
   packageName?: string;
@@ -89,7 +98,10 @@ export interface AppConfig {
   buildPath?: string;
 }
 
-export type DeviceConfig = EmulatorConfig | BrowserStackConfig;
+export type DeviceConfig =
+  | EmulatorConfig
+  | BrowserStackConfig
+  | SauceLabsConfig;
 
 export interface TimeoutOptions {
   /**

--- a/tests/playwright.saucelabs.config.ts
+++ b/tests/playwright.saucelabs.config.ts
@@ -1,0 +1,73 @@
+import { Platform, ProviderName } from './framework/types';
+import { defineConfig } from './framework/config';
+
+const device = {
+  provider: ProviderName.SAUCELABS,
+  name: process.env.SAUCE_DEVICE || 'Google_Pixel_7_POC(49|05)',
+};
+
+const app = (buildPath?: string) => ({
+  packageName: 'io.metamask',
+  launchableActivity: 'io.metamask.MainActivity',
+  buildPath,
+});
+
+export default defineConfig({
+  testDir: './',
+  fullyParallel: false,
+  workers: Number.parseInt(process.env.SAUCE_WORKERS || '1', 10),
+  retries: 0,
+  timeout: 7 * 60 * 1000,
+  grep: /@Performance\b/,
+  reporter: [
+    [
+      'html',
+      { open: 'never', outputFolder: './test-reports/playwright-report' },
+    ],
+    ['./reporters/PerformanceReporter.ts'],
+    ['list'],
+  ],
+  use: { trace: 'on-first-retry' },
+  projects: [
+    {
+      name: 'saucelabs-android',
+      testMatch: '**/performance/login/**/*.spec.ts',
+      use: {
+        platform: Platform.ANDROID,
+        device,
+        app: app(process.env.SAUCE_ANDROID_APP_URL),
+      },
+    },
+    {
+      name: 'saucelabs-android-onboarding',
+      testMatch: '**/performance/onboarding/**/*.spec.ts',
+      testIgnore: '**/performance/onboarding/seedless-*.spec.ts',
+      use: {
+        platform: Platform.ANDROID,
+        device,
+        app: app(
+          process.env.SAUCE_ANDROID_ONBOARDING_APP_URL ||
+            process.env.SAUCE_ANDROID_CLEAN_APP_URL,
+        ),
+      },
+    },
+    {
+      name: 'saucelabs-android-onboarding-seedless',
+      testMatch: '**/performance/onboarding/seedless-*.spec.ts',
+      use: {
+        platform: Platform.ANDROID,
+        device,
+        app: app(
+          process.env.SAUCE_ANDROID_SEEDLESS_APP_URL ||
+            process.env.SAUCE_ANDROID_CLEAN_APP_URL,
+        ),
+      },
+    },
+  ].filter((project) => {
+    const buildType = process.env.SAUCE_BUILD_TYPE;
+    if (buildType === 'onboarding') {
+      return project.name.startsWith('saucelabs-android-onboarding');
+    }
+    return project.name === 'saucelabs-android';
+  }),
+});

--- a/tests/reporters/generators/JsonReportGenerator.test.ts
+++ b/tests/reporters/generators/JsonReportGenerator.test.ts
@@ -82,9 +82,28 @@ describe('JsonReportGenerator', () => {
     ).toBe(true);
     expect(
       paths.some(
-        (p: string) => p.includes('iPhone_14_Pro') && p.includes('16.1'),
+        (p: string) => p.includes('iPhone_14_Pro') && p.includes('16_1'),
       ),
     ).toBe(true);
+  });
+
+  it('sanitizes regex characters in device OS report filenames', () => {
+    const data = makeReportData({
+      metrics: [
+        makeMetricsEntry({
+          device: {
+            name: 'Pixel.*',
+            osVersion: '13.*|14.*',
+            provider: 'testmu',
+          },
+        }),
+      ],
+    });
+
+    const files = generator.generate(data, '/reports');
+
+    expect(files[0]).not.toMatch(/[|*]/u);
+    expect(files[0]).toContain('13___14__');
   });
 
   it('groups metrics by device key', () => {
@@ -251,6 +270,30 @@ describe('JsonReportGenerator', () => {
         apiCalls,
       });
       expect(firstArtifact.profilingData).toEqual(profilingData);
+    });
+
+    it('sanitizes device OS versions in app-profiling filenames', () => {
+      const data = makeReportData({
+        metrics: [
+          makeMetricsEntry({
+            device: {
+              name: 'Pixel.*',
+              osVersion: '13.*|14.*',
+              provider: 'testmu',
+            },
+            profilingSummary: { issues: 0 },
+          }),
+        ],
+      });
+
+      const files = generator.generate(data, '/reports');
+      const profilingFile = files.find((file) =>
+        file.includes(`${path.sep}app-profiling${path.sep}`),
+      );
+
+      expect(profilingFile).toBeDefined();
+      expect(profilingFile).not.toMatch(/[|*]/u);
+      expect(profilingFile).toContain('13___14__');
     });
 
     it('creates the app-profiling directory when missing', () => {

--- a/tests/reporters/generators/JsonReportGenerator.ts
+++ b/tests/reporters/generators/JsonReportGenerator.ts
@@ -88,11 +88,15 @@ export class JsonReportGenerator {
 
       const safeTestName = this.sanitizeFileSegment(metric.testName, 60);
       const safeDeviceName = this.sanitizeFileSegment(metric.device.name, 40);
+      const safeOsVersion = this.sanitizeFileSegment(
+        metric.device.osVersion,
+        20,
+      );
       const projectSuffix = metric.projectName
         ? `-${this.sanitizeFileSegment(metric.projectName, 40)}`
         : '';
 
-      let baseName = `app-profiling-${safeTestName}-${safeDeviceName}-${metric.device.osVersion}${projectSuffix}`;
+      let baseName = `app-profiling-${safeTestName}-${safeDeviceName}-${safeOsVersion}${projectSuffix}`;
       const collisionCount = usedFileNames.get(baseName) ?? 0;
       usedFileNames.set(baseName, collisionCount + 1);
       if (collisionCount > 0) {
@@ -158,9 +162,13 @@ export class JsonReportGenerator {
         /[^a-zA-Z0-9]/g,
         '_',
       );
+      const safeOsVersion = this.sanitizeFileSegment(
+        deviceData.device.osVersion,
+        20,
+      );
       const jsonPath = path.join(
         reportsDir,
-        `performance-metrics-${testName}-${safeDeviceName}-${deviceData.device.osVersion}.json`,
+        `performance-metrics-${testName}-${safeDeviceName}-${safeOsVersion}.json`,
       );
       fs.writeFileSync(jsonPath, JSON.stringify(deviceData.metrics, null, 2));
       logger.info(`Device-specific report saved: ${jsonPath}`);

--- a/tests/reporters/utils/DeviceInfoExtractor.ts
+++ b/tests/reporters/utils/DeviceInfoExtractor.ts
@@ -35,6 +35,14 @@ export class DeviceInfoExtractor {
       };
     }
 
+    if (process.env.SAUCE_DEVICE) {
+      return {
+        name: process.env.SAUCE_DEVICE,
+        osVersion: process.env.SAUCE_OS_VERSION || '',
+        provider: 'saucelabs',
+      };
+    }
+
     return {
       name: 'Unknown',
       osVersion: 'Unknown',

--- a/tests/scripts/aggregate-performance-reports.mjs
+++ b/tests/scripts/aggregate-performance-reports.mjs
@@ -153,7 +153,24 @@ function collectAppProfilingArtifacts(searchDirs, outputDir) {
     }
 
     const destPath = path.join(profilingOutputDir, fileName);
-    fs.copyFileSync(sourcePath, destPath);
+    try {
+      const artifact = JSON.parse(fs.readFileSync(sourcePath, 'utf8'));
+      const providerFromArtifact =
+        artifact.cloudProvider ||
+        artifact.provider ||
+        artifact.device?.provider ||
+        null;
+      const providerFromPath = getCloudProviderFromPath(
+        sourcePath.toLowerCase(),
+      );
+      artifact.cloudProvider = providerFromArtifact ?? providerFromPath;
+      fs.writeFileSync(destPath, JSON.stringify(artifact, null, 2));
+    } catch (error) {
+      console.warn(
+        `⚠️ Could not enrich app profiling artifact provider for ${sourcePath}: ${error.message}`,
+      );
+      fs.copyFileSync(sourcePath, destPath);
+    }
     copiedCount += 1;
     console.log(`📦 Collected app profiling artifact: ${destPath}`);
   }
@@ -162,6 +179,14 @@ function collectAppProfilingArtifacts(searchDirs, outputDir) {
     `✅ Collected ${copiedCount} per-scenario app profiling artifact(s) into ${profilingOutputDir}`,
   );
   return copiedCount;
+}
+
+function getCloudProviderFromPath(fullPath) {
+  if (fullPath.includes('saucelabs-')) {
+    return 'saucelabs';
+  }
+
+  return 'browserstack';
 }
 
 /**
@@ -184,6 +209,8 @@ function extractPlatformScenarioAndDevice(filePath) {
   const fullPath = filePath.toLowerCase();
   
   // Determine platform and scenario from path patterns
+  const cloudProvider = getCloudProviderFromPath(fullPath);
+
   if (fullPath.includes('android-imported-wallet-test-results')) {
     platform = 'android';
     platformKey = 'Android';
@@ -196,7 +223,10 @@ function extractPlatformScenarioAndDevice(filePath) {
     scenario = 'imported-wallet';
     scenarioKey = 'ImportedWallet';
     console.log(`✅ Detected iOS Imported Wallet test`);
-  } else if (fullPath.includes('android-onboarding-flow-test-results')) {
+  } else if (
+    fullPath.includes('android-onboarding-flow-test-results') ||
+    fullPath.includes('android-onboarding-test-results')
+  ) {
     platform = 'android';
     platformKey = 'Android';
     scenario = 'onboarding';
@@ -216,7 +246,8 @@ function extractPlatformScenarioAndDevice(filePath) {
   // Extract device info from path
   const deviceMatch = pathParts.find(part =>
     part.includes('-imported-wallet-test-results-') ||
-    part.includes('-onboarding-flow-test-results-')
+    part.includes('-onboarding-flow-test-results-') ||
+    part.includes('-onboarding-test-results-')
   );
 
   if (deviceMatch) {
@@ -226,7 +257,11 @@ function extractPlatformScenarioAndDevice(filePath) {
 
     // Pattern: android-imported-wallet-test-results-DeviceName-OSVersion (5 parts)
     // Pattern: android-onboarding-flow-test-results-DeviceName-OSVersion (5 parts)
-    const deviceInfoStart = 5;
+    // Sauce Labs prefixes artifact names with "saucelabs-".
+    let deviceInfoStart = 5;
+    if (cloudProvider === 'saucelabs') {
+      deviceInfoStart = 6;
+    }
     
     if (parts.length >= deviceInfoStart + 1) {
       const deviceInfo = parts.slice(deviceInfoStart).join('-');
@@ -252,8 +287,8 @@ function extractPlatformScenarioAndDevice(filePath) {
     console.log(`🔍 Available parts:`, pathParts);
   }
   
-  console.log(`📊 Final extraction: platform="${platformKey}", scenario="${scenarioKey}", device="${deviceKey}"`);
-  return { platform, platformKey, scenario, scenarioKey, deviceKey };
+  console.log(`📊 Final extraction: platform="${platformKey}", scenario="${scenarioKey}", device="${deviceKey}", provider="${cloudProvider}"`);
+  return { platform, platformKey, scenario, scenarioKey, deviceKey, cloudProvider };
 }
 
 
@@ -282,6 +317,7 @@ function processTestReport(testReport) {
     apiCallsError: testReport.apiCallsError ?? null,
     // Include quality gates if available
     qualityGates: testReport.qualityGates || null,
+    cloudProvider: testReport.cloudProvider || null,
   };
   
   if (testReport.testFailed) {
@@ -294,6 +330,62 @@ function processTestReport(testReport) {
   }
   
   return cleanedReport;
+}
+
+/**
+ * Build one deduplicated result set per cloud provider.
+ * Parallel provider tasks and retries can emit multiple reports for the
+ * same scenario. Keep every attempt for diagnosis, but expose one scenario
+ * result with passed, failed, or mixed status.
+ * @param {Object} testExecutions
+ * @returns {Object}
+ */
+function createProviderResults(testExecutions) {
+  const providerResults = {};
+
+  Object.values(testExecutions).forEach((execution) => {
+    const { testInfo, attempts, cloudProvider } = execution;
+    if (!providerResults[cloudProvider]) {
+      providerResults[cloudProvider] = {
+        provider: cloudProvider,
+        totalTests: 0,
+        passedTests: 0,
+        failedTests: 0,
+        mixedTests: 0,
+        passed: [],
+        failed: [],
+        mixed: [],
+      };
+    }
+
+    const status =
+      execution.hasPassed && execution.hasFailed
+        ? 'mixed'
+        : execution.hasPassed
+          ? 'passed'
+          : 'failed';
+    const scenario = {
+      ...testInfo,
+      status,
+      attempts,
+      failureAttempts: attempts.filter((attempt) => attempt.testFailed),
+    };
+
+    const result = providerResults[cloudProvider];
+    result.totalTests += 1;
+    if (status === 'passed') {
+      result.passedTests += 1;
+      result.passed.push(scenario);
+    } else if (status === 'failed') {
+      result.failedTests += 1;
+      result.failed.push(scenario);
+    } else {
+      result.mixedTests += 1;
+      result.mixed.push(scenario);
+    }
+  });
+
+  return providerResults;
 }
 
 /**
@@ -450,13 +542,18 @@ function createSummary(groupedResults) {
           profilingTestCount++;
         }
         
-        // Track test executions by unique key (testName + platform + device)
-        const uniqueKey = `${test.testName}|${platform}|${device}`;
+        // Track test executions by unique key. Provider is part of the identity
+        // so Sauce Labs and BrowserStack results remain separate.
+        const cloudProvider =
+          test.cloudProvider || test.device?.provider || 'unknown';
+        const uniqueKey = `${test.testName}|${platform}|${device}|${cloudProvider}`;
         
         if (!testExecutions[uniqueKey]) {
           testExecutions[uniqueKey] = {
             hasPassed: false,
             hasFailed: false,
+            cloudProvider,
+            attempts: [],
             testInfo: {
               testName: test.testName,
               testFilePath: test.testFilePath,
@@ -464,6 +561,7 @@ function createSummary(groupedResults) {
               platform,
               device,
               team: test.team,
+              cloudProvider,
               sessionId: test.sessionId || null,
               videoURL: test.videoURL || null,
               failureReason: test.failureReason,
@@ -472,6 +570,17 @@ function createSummary(groupedResults) {
             }
           };
         }
+
+        testExecutions[uniqueKey].attempts.push({
+          status: test.testFailed ? 'failed' : 'passed',
+          testFailed: Boolean(test.testFailed),
+          failureReason: test.failureReason ?? null,
+          qualityGates: test.qualityGates || null,
+          qualityGatesViolations: test.qualityGatesViolations || null,
+          sessionId: test.sessionId || null,
+          videoURL: test.videoURL || null,
+          totalTime: test.totalTime ?? null,
+        });
         
         // Track if this test has ever passed or failed
         if (test.testFailed) {
@@ -492,8 +601,10 @@ function createSummary(groupedResults) {
     });
   });
   
-  // Unique test count: each test counts once per device regardless of retries
+  // Unique test count: each test counts once per provider/device regardless of
+  // retries or parallel provider tasks.
   const uniqueTestCount = Object.keys(testExecutions).length;
+  const rawExecutionCount = totalTests;
 
   // Second pass: determine final test status
   // A test is only considered failed if ALL executions failed (no successful retry)
@@ -505,7 +616,7 @@ function createSummary(groupedResults) {
     'imported-wallet': { android: 0, ios: 0 },
   };
 
-  const uniqueFailedTestNames = new Set();
+  const uniqueFailedTestKeys = new Set();
 
   Object.values(testExecutions).forEach(execution => {
     // If test passed at least once, it's considered passed (successful retry)
@@ -516,9 +627,11 @@ function createSummary(groupedResults) {
     // Test failed all executions - count as 1 failure
     if (execution.hasFailed) {
       totalFailedTests++;
-      uniqueFailedTestNames.add(execution.testInfo.testName);
       
       const { testInfo } = execution;
+      uniqueFailedTestKeys.add(
+        `${testInfo.testName}|${testInfo.platform}|${testInfo.device}|${testInfo.cloudProvider}`,
+      );
       const platformKey = testInfo.platform.toLowerCase();
       const scenario = resolveScenarioFromTestFilePath(testInfo.testFilePath);
       
@@ -554,6 +667,7 @@ function createSummary(groupedResults) {
           tags: testInfo.tags,
           platform: testInfo.platform,
           device: testInfo.device,
+          cloudProvider: testInfo.cloudProvider,
           scenario,
           sessionId: testInfo.sessionId ?? null,
           recordingLink: testInfo.videoURL ?? null,
@@ -565,32 +679,40 @@ function createSummary(groupedResults) {
     }
   });
   
-  // Count tests by platform
+  // Count unique tests by platform/device for the final report. Raw execution
+  // counts remain available as `rawExecutionCount` for audit/debugging.
   const platforms = {};
   const testsByPlatform = {};
   const summaryDevices = [];
   const platformDevices = { Android: [], iOS: [] };
-  
-  Object.keys(groupedResults).forEach(platform => {
-    platforms[platform.toLowerCase()] = Object.keys(groupedResults[platform]).length;
-    testsByPlatform[platform.toLowerCase()] = 0;
-    
-    Object.keys(groupedResults[platform]).forEach(device => {
-      const testsCount = groupedResults[platform][device].length;
-      testsByPlatform[platform.toLowerCase()] += testsCount;
-      
-      summaryDevices.push({ platform, device, testCount: testsCount });
-      platformDevices[platform].push(device);
-    });
+  const uniqueDeviceCounts = new Map();
+
+  Object.values(testExecutions).forEach(({ testInfo }) => {
+    const key = `${testInfo.platform}|${testInfo.device}`;
+    uniqueDeviceCounts.set(key, (uniqueDeviceCounts.get(key) ?? 0) + 1);
   });
-  
+
+  uniqueDeviceCounts.forEach((testCount, key) => {
+    const [platform, device] = key.split('|');
+    const platformKey = platform.toLowerCase();
+    platforms[platformKey] = (platforms[platformKey] ?? 0) + 1;
+    testsByPlatform[platformKey] =
+      (testsByPlatform[platformKey] ?? 0) + testCount;
+    summaryDevices.push({ platform, device, testCount });
+    platformDevices[platform].push(device);
+  });
+
+  totalTests = uniqueTestCount;
+
   // Calculate profiling averages
   const avgCpuUsage = profilingTestCount > 0 ? (totalCpuUsage / profilingTestCount).toFixed(2) : 0;
   const avgMemoryUsage = profilingTestCount > 0 ? (totalMemoryUsage / profilingTestCount).toFixed(2) : 0;
   const profilingCoverage = totalTests > 0 ? ((totalTestsWithProfiling / totalTests) * 100).toFixed(1) : 0;
+  const providerResults = createProviderResults(testExecutions);
   
   const summary = {
     totalTests,
+    rawExecutionCount,
     uniqueTests: uniqueTestCount,
     platforms,
     testsByPlatform,
@@ -606,11 +728,12 @@ function createSummary(groupedResults) {
       avgMemoryUsage: `${avgMemoryUsage} MB`,
       profilingTestCount
     },
+    providerResults,
     // Failed tests grouped by team for Slack notifications
     // Only includes tests that failed ALL retries (if a retry passed, test is not counted as failed)
     failedTestsStats: {
       totalFailedTests,
-      uniqueFailedTests: uniqueFailedTestNames.size,
+      uniqueFailedTests: uniqueFailedTestKeys.size,
       teamsAffected: Object.keys(failedTestsByTeam).length,
       failedTestsByTeam
     },
@@ -654,6 +777,17 @@ function formatDuration(ms) {
   return `${minutes}m ${seconds}s`;
 }
 
+function formatCloudProvider(cloudProvider) {
+  switch (cloudProvider) {
+    case 'saucelabs':
+      return 'Sauce Labs';
+    case 'browserstack':
+      return 'BrowserStack';
+    default:
+      return cloudProvider || 'Unknown';
+  }
+}
+
 /**
  * Generate HTML report from aggregated results
  * @param {Object} groupedResults - Grouped test results
@@ -671,26 +805,29 @@ function generateHtmlReport(groupedResults, summary) {
     timeZoneName: 'short'
   });
 
-  // Count passed/failed tests
+  // Render one deduplicated scenario per provider. Raw attempts remain in the
+  // JSON artifacts for auditability, but must not inflate the final report.
   let passedTests = 0;
   let failedTests = 0;
-  const allTests = [];
+  let mixedTests = 0;
+  const allTests = Object.values(summary.providerResults || {}).flatMap(
+    (providerResult) => [
+      ...providerResult.passed,
+      ...providerResult.failed,
+      ...providerResult.mixed,
+    ],
+  );
 
-  Object.keys(groupedResults).forEach(platform => {
-    Object.keys(groupedResults[platform]).forEach(device => {
-      groupedResults[platform][device].forEach(test => {
-        if (test.testFailed) {
-          failedTests++;
-        } else {
-          passedTests++;
-        }
-        allTests.push({ ...test, platform, device });
-      });
-    });
+  allTests.forEach((test) => {
+    test.testFailed = test.status !== 'passed';
+    if (test.status === 'passed') passedTests++;
+    else if (test.status === 'failed') failedTests++;
+    else mixedTests++;
   });
 
-  const passRate = summary.totalTests > 0 
-    ? ((passedTests / summary.totalTests) * 100).toFixed(1) 
+  const finalTestCount = passedTests + failedTests + mixedTests;
+  const passRate = finalTestCount > 0
+    ? ((passedTests / finalTestCount) * 100).toFixed(1)
     : 0;
 
   // Generate test rows HTML
@@ -737,6 +874,7 @@ function generateHtmlReport(groupedResults, summary) {
             </div>
           </td>
           <td><span class="platform-badge platform-${test.platform.toLowerCase()}">${test.platform}</span></td>
+          <td class="provider-cell">${formatCloudProvider(test.cloudProvider)}</td>
           <td class="device-cell">${test.device}</td>
           <td class="duration-cell">${formatDuration(test.totalTime || 0)}</td>
           <td class="steps-cell">
@@ -754,31 +892,25 @@ function generateHtmlReport(groupedResults, summary) {
 
   // Generate platform breakdown
   const generatePlatformBreakdown = () => {
-    return Object.keys(groupedResults).map(platform => {
-      const devices = Object.keys(groupedResults[platform]);
-      const testCount = devices.reduce((acc, device) => 
-        acc + groupedResults[platform][device].length, 0);
-      
-      const deviceList = devices.map(device => {
-        const deviceTests = groupedResults[platform][device];
-        const passed = deviceTests.filter(t => !t.testFailed).length;
-        const failed = deviceTests.filter(t => t.testFailed).length;
-        return `
-          <div class="device-item">
-            <span class="device-name">${device}</span>
-            <div class="device-stats">
-              <span class="passed-count">${passed} ✓</span>
-              ${failed > 0 ? `<span class="failed-count">${failed} ✗</span>` : ''}
-            </div>
+    return Object.values(summary.providerResults || {}).map((providerResult) => {
+      const providerName = formatCloudProvider(providerResult.provider);
+      const testCount = providerResult.totalTests;
+      const deviceList = [`
+        <div class="device-item">
+          <span class="device-name">${providerName}</span>
+          <div class="device-stats">
+            <span class="passed-count">${providerResult.passedTests} ✓</span>
+            ${providerResult.failedTests > 0 ? `<span class="failed-count">${providerResult.failedTests} ✗</span>` : ''}
+            ${providerResult.mixedTests > 0 ? `<span class="failed-count">${providerResult.mixedTests} mixed</span>` : ''}
           </div>
-        `;
-      }).join('');
+        </div>
+      `].join('');
 
       return `
         <div class="platform-card">
           <div class="platform-header">
-            <span class="platform-icon">${platform === 'Android' ? '🤖' : '🍎'}</span>
-            <span class="platform-name">${platform}</span>
+            <span class="platform-icon">☁️</span>
+            <span class="platform-name">${providerName}</span>
             <span class="platform-test-count">${testCount} tests</span>
           </div>
           <div class="device-list">${deviceList}</div>
@@ -1439,7 +1571,7 @@ function generateHtmlReport(groupedResults, summary) {
         <div class="label">Pass Rate</div>
       </div>
       <div class="summary-card info">
-        <div class="value">${summary.totalTests}</div>
+        <div class="value">${finalTestCount}</div>
         <div class="label">Total Tests</div>
       </div>
       <div class="summary-card success">
@@ -1450,6 +1582,12 @@ function generateHtmlReport(groupedResults, summary) {
         <div class="value">${failedTests}</div>
         <div class="label">Failed</div>
       </div>
+      ${mixedTests > 0 ? `
+      <div class="summary-card warning">
+        <div class="value">${mixedTests}</div>
+        <div class="label">Mixed attempts</div>
+      </div>
+      ` : ''}
       <div class="summary-card purple">
         <div class="value">${summary.devices?.length || 0}</div>
         <div class="label">Devices</div>
@@ -1503,7 +1641,7 @@ function generateHtmlReport(groupedResults, summary) {
       <div class="tests-header">
         <h2>🧪 Test Results</h2>
         <div class="filter-tabs">
-          <button class="filter-tab active" onclick="filterTests('all')">All (${summary.totalTests})</button>
+          <button class="filter-tab active" onclick="filterTests('all')">All (${finalTestCount})</button>
           <button class="filter-tab" onclick="filterTests('passed')">Passed (${passedTests})</button>
           <button class="filter-tab" onclick="filterTests('failed')">Failed (${failedTests})</button>
         </div>
@@ -1515,6 +1653,7 @@ function generateHtmlReport(groupedResults, summary) {
             <tr>
               <th>Test Name</th>
               <th>Platform</th>
+              <th>Provider</th>
               <th>Device</th>
               <th>Duration</th>
               <th>Steps</th>
@@ -1633,6 +1772,7 @@ function aggregateReports() {
         let platformKey = 'Unknown';
         let scenarioKey = 'Unknown';
         let deviceKey = 'Unknown Device';
+        let cloudProvider = 'unknown';
         
         // First try to extract from file path (for artifact folder structure)
         const pathExtraction = extractPlatformScenarioAndDevice(filePath);
@@ -1641,10 +1781,15 @@ function aggregateReports() {
           platformKey = pathExtraction.platformKey;
           scenarioKey = pathExtraction.scenarioKey;
           deviceKey = pathExtraction.deviceKey;
+          cloudProvider = pathExtraction.cloudProvider;
         } else {
           // Fallback: extract from JSON content and filename
           if (Array.isArray(reportData) && reportData.length > 0) {
             const firstReport = reportData[0];
+            cloudProvider =
+              firstReport.cloudProvider ||
+              firstReport.device?.provider ||
+              'unknown';
             
             if (firstReport.device) {
               // Determine platform from device name
@@ -1675,7 +1820,9 @@ function aggregateReports() {
           }
         }
         
-        console.log(`📊 Final values: platformKey="${platformKey}", scenarioKey="${scenarioKey}", deviceKey="${deviceKey}"`);
+        console.log(
+          `📊 Final values: platformKey="${platformKey}", scenarioKey="${scenarioKey}", deviceKey="${deviceKey}", provider="${cloudProvider}"`,
+        );
         
         // Initialize structure if it doesn't exist
         console.log(`🔧 Creating keys: platformKey="${platformKey}", deviceKey="${deviceKey}"`);
@@ -1689,13 +1836,18 @@ function aggregateReports() {
         }
         
         // Process the report data
+        const processReportWithContext = (testReport) => ({
+          ...processTestReport(testReport),
+          cloudProvider,
+        });
+
         if (Array.isArray(reportData)) {
           reportData.forEach(testReport => {
-            const cleanedReport = processTestReport(testReport);
+            const cleanedReport = processReportWithContext(testReport);
             groupedResults[platformKey][deviceKey].push(cleanedReport);
           });
         } else {
-          const cleanedReport = processTestReport(reportData);
+          const cleanedReport = processReportWithContext(reportData);
           groupedResults[platformKey][deviceKey].push(cleanedReport);
         }
       } catch (error) {
@@ -1747,6 +1899,7 @@ export {
   collectAppProfilingArtifacts,
   extractPlatformScenarioAndDevice,
   processTestReport,
+  createProviderResults,
   generateHtmlReport,
   formatDuration,
 };

--- a/tests/scripts/aggregate-performance-reports.test.mjs
+++ b/tests/scripts/aggregate-performance-reports.test.mjs
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  aggregateReports,
+  extractPlatformScenarioAndDevice,
+} from './aggregate-performance-reports.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const makeReport = (testName, provider, overrides = {}) => [
+  {
+    testName,
+    testFilePath: 'tests/performance/onboarding/import-wallet.spec.ts',
+    tags: ['@Performance'],
+    steps: [],
+    total: 1000,
+    testFailed: Boolean(overrides.testFailed),
+    failureReason: overrides.failureReason,
+    qualityGates: overrides.qualityGates || { passed: true, violations: [] },
+    sessionId: overrides.sessionId || `${provider}-session`,
+    device: {
+      name: 'Google Pixel 7 Pro',
+      osVersion: '13',
+      provider,
+    },
+    cloudProvider: provider,
+  },
+];
+
+const writeJson = (filePath, data) => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+};
+
+test('extractPlatformScenarioAndDevice classifies Sauce Labs and BrowserStack artifacts separately', () => {
+  assert.deepEqual(
+    extractPlatformScenarioAndDevice(
+      [
+        'test-results',
+        'saucelabs-android-onboarding-flow-test-results-Google_Pixel_7_POC49',
+        'tests',
+        'reporters',
+        'reports',
+        'performance-metrics-Create_wallet-Google_Pixel_7_POC49-.json',
+      ].join('/'),
+    ),
+    {
+      platform: 'android',
+      platformKey: 'Android',
+      scenario: 'onboarding',
+      scenarioKey: 'Onboarding',
+      deviceKey: 'Google_Pixel_7_POC49',
+      cloudProvider: 'saucelabs',
+    },
+  );
+
+  assert.deepEqual(
+    extractPlatformScenarioAndDevice(
+      [
+        'test-results',
+        'android-imported-wallet-test-results-Google Pixel 7 Pro-13',
+        'tests',
+        'reporters',
+        'reports',
+        'performance-metrics-Import_wallet-Google_Pixel_7_Pro-13.json',
+      ].join('/'),
+    ),
+    {
+      platform: 'android',
+      platformKey: 'Android',
+      scenario: 'imported-wallet',
+      scenarioKey: 'ImportedWallet',
+      deviceKey: 'Google Pixel 7 Pro+13',
+      cloudProvider: 'browserstack',
+    },
+  );
+});
+
+test('aggregateReports keeps Sauce Labs and BrowserStack results in separate provider buckets', () => {
+  const originalCwd = process.cwd();
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perf-agg-'));
+
+  try {
+    process.chdir(tempDir);
+
+    writeJson(
+      path.join(
+        'test-results',
+        'saucelabs-android-imported-wallet-test-results-Google_Pixel_7_POC49',
+        'tests',
+        'reporters',
+        'reports',
+        'performance-metrics-Import_wallet-sauce.json',
+      ),
+      makeReport('Import wallet', 'saucelabs', {
+        testFailed: true,
+        failureReason: 'quality_gate',
+        qualityGates: {
+          passed: false,
+          violations: [{ metric: 'total', actual: 90000, threshold: 60000 }],
+        },
+      }),
+    );
+
+    writeJson(
+      path.join(
+        'test-results',
+        'android-imported-wallet-test-results-Google Pixel 7 Pro-13',
+        'tests',
+        'reporters',
+        'reports',
+        'performance-metrics-Import_wallet-bs.json',
+      ),
+      makeReport('Import wallet', 'browserstack'),
+    );
+
+    aggregateReports();
+
+    const summary = JSON.parse(
+      fs.readFileSync(
+        path.join('tests', 'aggregated-reports', 'summary.json'),
+        'utf8',
+      ),
+    );
+
+    assert.deepEqual(Object.keys(summary.providerResults).sort(), [
+      'browserstack',
+      'saucelabs',
+    ]);
+    assert.equal(summary.providerResults.saucelabs.failedTests, 1);
+    assert.equal(summary.providerResults.browserstack.passedTests, 1);
+  } finally {
+    process.chdir(originalCwd);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('workflow still downloads all *-test-results-* artifacts including Sauce Labs', () => {
+  const workflow = fs.readFileSync(
+    path.join(
+      __dirname,
+      '..',
+      '..',
+      '.github',
+      'workflows',
+      'run-performance-e2e.yml',
+    ),
+    'utf8',
+  );
+  assert.match(workflow, /pattern:\s+['"]?\*-test-results-\*['"]?/);
+  assert.match(workflow, /performance-test-runner-saucelabs\.yml/);
+});

--- a/tests/scripts/generate-performance-pr-comment.mjs
+++ b/tests/scripts/generate-performance-pr-comment.mjs
@@ -129,25 +129,70 @@ async function main() {
     return device ? formatDevice(String(device)) : fallbackPlatform;
   }
 
+  function getCloudProviderKey(test) {
+    const cloudProvider =
+      test?.cloudProvider ||
+      (typeof test?.device === 'object' ? test.device?.provider : null);
+
+    return cloudProvider ? String(cloudProvider).toLowerCase() : 'unknown';
+  }
+
+  function formatCloudProvider(cloudProvider) {
+    const providerKey = getCloudProviderKey({ cloudProvider });
+
+    switch (providerKey) {
+      case 'saucelabs':
+        return 'Sauce Labs';
+      case 'browserstack':
+        return 'BrowserStack';
+      default:
+        return providerKey === 'unknown'
+          ? 'Unknown'
+          : String(cloudProvider ?? providerKey);
+    }
+  }
+
+  function getProviderAwareTestKey(platform, device, testName, cloudProvider) {
+    return `${platform}|${device}|${getCloudProviderKey({ cloudProvider })}|${testName}`;
+  }
+
+  function getLegacyTestKey(platform, device, testName) {
+    return `${platform}|${device}|${testName}`;
+  }
+
   function getFailedTestKeys() {
     const failedTests = Object.values(failedByTeam).flatMap(
       (teamData) => teamData.tests ?? [],
     );
     const bySessionId = new Map();
-    const byTestIdentity = new Map();
+    const byProviderTestIdentity = new Map();
+    const byLegacyTestIdentity = new Map();
 
     for (const test of failedTests) {
       if (test.sessionId) {
         bySessionId.set(test.sessionId, test);
       }
 
-      byTestIdentity.set(
-        `${test.platform}|${getDeviceKey(test.device)}|${test.testName}`,
-        test,
-      );
+      const providerKey = getCloudProviderKey(test);
+      if (providerKey === 'unknown') {
+        byLegacyTestIdentity.set(
+          getLegacyTestKey(test.platform, getDeviceKey(test.device), test.testName),
+          test,
+        );
+      } else {
+        byProviderTestIdentity.set(
+          getProviderAwareTestKey(
+            test.platform,
+            getDeviceKey(test.device),
+            test.testName,
+            providerKey,
+          ),
+          test,
+        );
+      }
     }
 
-    return { bySessionId, byTestIdentity };
+    return { bySessionId, byProviderTestIdentity, byLegacyTestIdentity };
   }
 
   function getAllTestRuns() {
@@ -162,8 +207,16 @@ async function main() {
         (tests ?? []).map((test) => {
           const failedTest =
             failedTestKeys.bySessionId.get(test.sessionId) ??
-            failedTestKeys.byTestIdentity.get(
-              `${platform}|${deviceKey}|${test.testName}`,
+            failedTestKeys.byProviderTestIdentity.get(
+              getProviderAwareTestKey(
+                platform,
+                deviceKey,
+                test.testName,
+                getCloudProviderKey(test),
+              ),
+            ) ??
+            failedTestKeys.byLegacyTestIdentity.get(
+              getLegacyTestKey(platform, deviceKey, test.testName),
             );
           const qualityGatesFailed = test.qualityGates?.passed === false;
           const failed = Boolean(failedTest) || qualityGatesFailed;
@@ -178,6 +231,8 @@ async function main() {
             testName: test.testName,
             platform,
             device: getDeviceLabel(test.device ?? deviceKey, platform),
+            cloudProvider: getCloudProviderKey(test),
+            provider: formatCloudProvider(getCloudProviderKey(test)),
             duration,
             reason: failed
               ? formatReason(
@@ -212,18 +267,18 @@ async function main() {
     for (const teamData of Object.values(failedByTeam)) {
       for (const test of teamData.tests ?? []) {
         const device = parseDeviceKey(test.device);
-        const key = `${test.platform}|${getDeviceKey(test.device)}|${test.testName}`;
+        const key = getProviderAwareTestKey(
+          test.platform,
+          getDeviceKey(test.device),
+          test.testName,
+          getCloudProviderKey(test),
+        );
 
-        let currentArtifact = findMatchingArtifact(currentArtifacts, {
+        const currentArtifact = findMatchingArtifact(currentArtifacts, {
           testName: test.testName,
           device,
+          cloudProvider: getCloudProviderKey(test),
         })?.data;
-
-        if (!currentArtifact && !device.name) {
-          currentArtifact = currentArtifacts.find(
-            ({ data }) => data.testName === test.testName,
-          )?.data;
-        }
 
         try {
           const baseline = findBaselineScenario({
@@ -233,6 +288,7 @@ async function main() {
             currentRunId: runId,
             testName: test.testName,
             device: currentArtifact?.device ?? device,
+            cloudProvider: getCloudProviderKey(test),
             workRoot,
           });
 
@@ -339,15 +395,23 @@ async function main() {
         const recording = t.recordingLink
           ? `[📹 Watch](${t.recordingLink})`
           : '—';
-        const key = `${t.platform}|${getDeviceKey(t.device)}|${t.testName}`;
+        const provider = formatCloudProvider(getCloudProviderKey(t));
+        const key = getProviderAwareTestKey(
+          t.platform,
+          getDeviceKey(t.device),
+          t.testName,
+          getCloudProviderKey(t),
+        );
         const profilingSection = profilingByKey.get(key);
 
         md += `#### ${escapeMarkdownTable(t.testName)}\n\n`;
-        md += `| Platform | Device | Reason | Recording |\n`;
-        md += `|----------|--------|--------|-----------|\n`;
+        md += `| Platform | Device | Provider | Reason | Recording |\n`;
+        md += `|----------|--------|----------|--------|-----------|\n`;
         md += `| ${escapeMarkdownTable(t.platform)} | ${escapeMarkdownTable(
           device,
-        )} | ${escapeMarkdownTable(reason)} | ${recording} |\n\n`;
+        )} | ${escapeMarkdownTable(provider)} | ${escapeMarkdownTable(
+          reason,
+        )} | ${recording} |\n\n`;
 
         if (profilingSection) {
           md += `${profilingSection}\n`;
@@ -358,8 +422,8 @@ async function main() {
 
   if (passedTestRuns.length > 0) {
     md += `<details>\n<summary>✅ Passed Tests (${passedTestRuns.length})</summary>\n\n`;
-    md += `| Test | Platform | Device | Duration | Team | Recording |\n`;
-    md += `|------|----------|--------|----------|------|-----------|\n`;
+    md += `| Test | Platform | Device | Provider | Duration | Team | Recording |\n`;
+    md += `|------|----------|--------|----------|----------|------|-----------|\n`;
 
     for (const test of passedTestRuns) {
       const recording = test.recordingLink
@@ -368,9 +432,9 @@ async function main() {
 
       md += `| ${escapeMarkdownTable(test.testName)} | ${
         test.platform
-      } | ${escapeMarkdownTable(test.device)} | ${test.duration} | ${escapeMarkdownTable(
-        test.team,
-      )} | ${recording} |\n`;
+      } | ${escapeMarkdownTable(test.device)} | ${escapeMarkdownTable(
+        test.provider,
+      )} | ${test.duration} | ${escapeMarkdownTable(test.team)} | ${recording} |\n`;
     }
 
     md += `\n</details>\n\n`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

After the TestMu PoC period ended, this branch is cut from `main` with only **BrowserStack** and **Sauce Labs** as performance providers.

- Adds Sauce Labs provider, Playwright config, and reusable runner
- Manual workflow toggles:
  - `enable_browserstack` (default `true`)
  - `enable_saucelabs` (private Pixel 7 POC49/POC05, 2 workers)
  - `enable_saucelabs_cloud` (`Google Pixel.*`, 2 workers)
- Scheduled runs remain BrowserStack-only
- Reporting aggregates BrowserStack and Sauce Labs results separately
- No TestMu / HyperExecute workflows or provider code

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: MMQA performance provider comparison (post-TestMu PoC)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: performance provider selection

  Scenario: run BrowserStack only
    Given the manual performance workflow
    When enable_browserstack is true and Sauce Labs flags are false
    Then only BrowserStack lanes execute

  Scenario: run Sauce Labs private
    Given SAUCE_USERNAME and SAUCE_ACCESS_KEY secrets are configured
    When enable_saucelabs is true
    Then private device lanes upload APKs and run with 2 workers

  Scenario: run Sauce Labs cloud
    When enable_saucelabs_cloud is true
    Then cloud device lanes use Google Pixel.* allocation
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — CI workflow / provider wiring change

### **After**

N/A — CI workflow / provider wiring change

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a75116c-34e8-4488-896c-267d304e469b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a75116c-34e8-4488-896c-267d304e469b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

