### PR TITLE
fix(metamask-pay): quote validation fixes cp-8.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -388,7 +388,7 @@
     "@metamask/superstruct": "^3.2.1",
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/transaction-controller": "^69.5.2",
-    "@metamask/transaction-pay-controller": "^26.3.1",
+    "@metamask/transaction-pay-controller": "^26.4.0",
     "@metamask/tron-wallet-snap": "^1.33.1",
     "@metamask/utils": "^11.11.0",
     "@metamask/wallet": "^10.0.0",

--- a/tests/smoke-appium/confirmations/pay/perps-deposit.spec.ts
+++ b/tests/smoke-appium/confirmations/pay/perps-deposit.spec.ts
@@ -19,7 +19,6 @@ import TransactionPayConfirmation from '../../../page-objects/Confirmation/Trans
 import PayWithModal from '../../../page-objects/Confirmation/PayWithModal.js';
 import PayWithModalTokenPicker from '../../../page-objects/Confirmation/PayWithModalTokenPicker.js';
 import FooterActions from '../../../page-objects/Browser/Confirmations/FooterActions.js';
-import TabBarComponent from '../../../page-objects/wallet/TabBarComponent.js';
 import WalletActionsBottomSheet from '../../../page-objects/wallet/WalletActionsBottomSheet.js';
 
 import ActivitiesView from '../../../page-objects/Transactions/ActivitiesView.js';
@@ -89,7 +88,7 @@ appiumTest.describe(SmokeConfirmations('MM Pay - Perps deposit'), () => {
 
           await PerpsHomeView.tapBackHomeButton();
           await waitForWalletHomePlaywright(resolveE2EWaitTimeoutMs(20_000));
-          await TabBarComponent.tapActivity();
+          await WalletView.tapActivityButton();
 
           await ActivitiesView.tapTypeFilterChip();
           await ActivitiesView.tapTypeFilterOption('perps');

--- a/tests/smoke-appium/confirmations/pay/predict-deposit.spec.ts
+++ b/tests/smoke-appium/confirmations/pay/predict-deposit.spec.ts
@@ -21,6 +21,7 @@ import TabBarComponent from '../../../page-objects/wallet/TabBarComponent.js';
 import WalletActionsBottomSheet from '../../../page-objects/wallet/WalletActionsBottomSheet.js';
 import PredictMarketList from '../../../page-objects/Predict/PredictMarketList.js';
 import ActivitiesView from '../../../page-objects/Transactions/ActivitiesView.js';
+import WalletView from '../../../page-objects/wallet/WalletView.js';
 import ActivityDetails from '../../../page-objects/Transactions/ActivityDetails.js';
 import { setupRemoteFeatureFlagsMock } from '../../../api-mocking/helpers/remoteFeatureFlagsHelper.js';
 import { predictDepositFlags } from '../../../api-mocking/mock-responses/pay/feature-flag-mocks.js';

--- a/tests/smoke-appium/confirmations/pay/predict-deposit.spec.ts
+++ b/tests/smoke-appium/confirmations/pay/predict-deposit.spec.ts
@@ -83,7 +83,7 @@ appiumTest.describe(SmokeConfirmations('MM Pay - Predict deposit'), () => {
 
           await PredictMarketList.tapBackButton();
           await waitForWalletHomePlaywright(resolveE2EWaitTimeoutMs(20_000));
-          await TabBarComponent.tapActivity();
+          await WalletView.tapActivityButton();
 
           await ActivitiesView.tapTypeFilterChip();
           await ActivitiesView.tapTypeFilterOption('predictions');

--- a/yarn.lock
+++ b/yarn.lock
@@ -10670,9 +10670,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-pay-controller@npm:^26.3.1":
-  version: 26.3.1
-  resolution: "@metamask/transaction-pay-controller@npm:26.3.1"
+"@metamask/transaction-pay-controller@npm:^26.4.0":
+  version: 26.4.0
+  resolution: "@metamask/transaction-pay-controller@npm:26.4.0"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
@@ -10695,7 +10695,7 @@ __metadata:
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  checksum: 10/c1a38127ebf2152b36812714b841b1a57e4904130c56341f566373e9984d1f91137d1121266443ac352374a7a2114c4fb0b1b3ad10223a473f7b74c19f885ba7
+  checksum: 10/a47967c5d4d87fc6b9a4b67a9c08cc3879c0bf825a80146dabd4821ae3a6177026e028a35d543f8617056114d8d8130f0f94e2d4915dd72a1dd4ff6ec9832cee
   languageName: node
   linkType: hard
 
@@ -35859,7 +35859,7 @@ __metadata:
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/tooling-insight": "npm:^1.0.0"
     "@metamask/transaction-controller": "npm:^69.5.2"
-    "@metamask/transaction-pay-controller": "npm:^26.3.1"
+    "@metamask/transaction-pay-controller": "npm:^26.4.0"
     "@metamask/tron-wallet-snap": "npm:^1.33.1"
     "@metamask/utils": "npm:^11.11.0"
     "@metamask/wallet": "npm:^10.0.0"


### PR DESCRIPTION
## **Description**

Bumps `@metamask/transaction-pay-controller` from `26.3.1` to `26.4.0`, which contains quote validation fixes.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #35077

## **Manual testing steps**

N/A — dependency version bump only.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d3653cbee0a4ebeea36e990da0bb51b4aaa46d95. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->