### PR TITLE
fix(social): sort feed items chronologically across loaded pages

### DIFF
--- a/app/components/Views/SocialLeaderboard/FeedView/hooks/useTraderFeed.test.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/hooks/useTraderFeed.test.ts
@@ -220,6 +220,89 @@ describe('useTraderFeed', () => {
     expect(result.current.items[0]?.type).toBe('perps');
   });
 
+  it('sorts loaded items newest-first so same-day rows share one section header', async () => {
+    const newerSameDay = mockSpotFeedItem({
+      positionId: 'pos-newer-same-day',
+      timestamp: 1_777_000_800,
+    });
+    const olderDifferentDay = mockPerpFeedItem({
+      positionId: 'pos-older-day',
+      timestamp: 1_776_800_000,
+    });
+    const olderSameDay = mockSpotFeedItem({
+      positionId: 'pos-older-same-day',
+      timestamp: 1_777_000_100,
+    });
+    mockCall.mockResolvedValue(
+      mockFeedResponse([olderSameDay, olderDifferentDay, newerSameDay]),
+    );
+
+    const { result } = renderHook(() => useTraderFeed({ audience: 'all' }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.items).toHaveLength(3));
+
+    expect(result.current.items.map((item) => item.timestamp)).toEqual([
+      1_777_000_800_000, 1_777_000_100_000, 1_776_800_000_000,
+    ]);
+    expect(result.current.sections).toHaveLength(2);
+    expect(result.current.sections[0]?.data).toHaveLength(2);
+    expect(result.current.sections[1]?.data).toHaveLength(1);
+  });
+
+  // Mirrors a real leaderboard response: the feed splices a notable position
+  // from two days earlier into the middle of the page, and the `olderThan`
+  // cursor is the last item's timestamp — so page 2 returns events that are
+  // newer than that spliced-in row. Without a global sort the day headers read
+  // Aug 20, Aug 18, Aug 20.
+  it('keeps one section per day when a later page is newer than a spliced-in row', async () => {
+    const newest = mockSpotFeedItem({
+      positionId: 'pos-aug-20-latest',
+      timestamp: 1_787_217_322, // Aug 20 05:15 EDT
+    });
+    const splicedInOlderDay = mockPerpFeedItem({
+      positionId: 'pos-aug-18-spliced',
+      timestamp: 1_787_069_401, // Aug 18 12:10 EDT
+    });
+    const pageBoundary = mockSpotFeedItem({
+      positionId: 'pos-aug-20-boundary',
+      timestamp: 1_787_215_115, // Aug 20 04:38 EDT
+    });
+    const nextPage = mockPerpFeedItem({
+      positionId: 'pos-aug-20-next-page',
+      timestamp: 1_787_209_200, // Aug 20 03:00 EDT
+    });
+    mockCall
+      .mockResolvedValueOnce(
+        mockFeedResponse(
+          [newest, splicedInOlderDay, pageBoundary],
+          'older-cursor',
+        ),
+      )
+      .mockResolvedValueOnce(mockFeedResponse([nextPage]));
+
+    const { result } = renderHook(() => useTraderFeed({ audience: 'all' }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+
+    act(() => {
+      result.current.loadMore();
+    });
+
+    await waitFor(() => expect(result.current.items).toHaveLength(4));
+
+    expect(result.current.items.map((item) => item.timestamp)).toEqual([
+      1_787_217_322_000, 1_787_215_115_000, 1_787_209_200_000,
+      1_787_069_401_000,
+    ]);
+    expect(result.current.sections).toHaveLength(2);
+    expect(result.current.sections[0]?.data).toHaveLength(3);
+    expect(result.current.sections[1]?.data).toHaveLength(1);
+  });
+
   it('does not refetch when the type filter changes', async () => {
     mockCall.mockResolvedValue(
       mockFeedResponse([mockSpotFeedItem(), mockPerpFeedItem()]),

--- a/app/components/Views/SocialLeaderboard/FeedView/hooks/useTraderFeed.ts
+++ b/app/components/Views/SocialLeaderboard/FeedView/hooks/useTraderFeed.ts
@@ -70,6 +70,10 @@ export interface UseTraderFeedResult {
 
 const EMPTY_ITEMS: FeedItem[] = [];
 
+/** Newest event first. Stable for equal timestamps (preserves API order). */
+const byTimestampDesc = (a: FeedItem, b: FeedItem): number =>
+  b.timestamp - a.timestamp;
+
 /** Maps the UI type filter to the `FeedItem.type` discriminant. */
 const matchesTypeFilter = (
   item: FeedItem,
@@ -84,7 +88,11 @@ const matchesTypeFilter = (
   return item.type === 'perps';
 };
 
-/** Groups feed items into day sections, newest day first. */
+/**
+ * Groups a newest-first list into day sections. Consecutive items that share
+ * a local calendar day share a header — which holds only after a global
+ * timestamp sort of every loaded item.
+ */
 const groupByDay = (items: FeedItem[]): FeedSection[] => {
   const sections: FeedSection[] = [];
 
@@ -158,10 +166,15 @@ export const useTraderFeed = (
     if (!pages || pages.length === 0) {
       return EMPTY_ITEMS;
     }
+    // The feed splices notable positions in out of chronological order, while
+    // the `olderThan` cursor is only the last item's timestamp — so a later
+    // page can hold events newer than those spliced-in rows. Sort the whole
+    // loaded set to keep one header per day.
     return pages
       .flatMap((page) => page.items ?? [])
       .map(mapFeedItem)
-      .filter((item): item is FeedItem => item !== null);
+      .filter((item): item is FeedItem => item !== null)
+      .sort(byTimestampDesc);
   }, [pages]);
 
   const hasLoadedItems = loadedItems.length > 0;


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The Top traders **Feed** rendered the same calendar day under more than one header — e.g. `Aug 20 2026`, then `Aug 18 2026`, then `Aug 20 2026` again.

**Reason for the change.** `groupByDay` in `useTraderFeed` starts a new section whenever *consecutive* items fall on a different local calendar day, which is correct only if the list it receives is already newest-first. It is not. Inspecting a real 30-item leaderboard response showed that 28 items were in perfect descending order while exactly 2 were spliced in ~41 hours out of place — both high-realized-PnL closed positions from the same trader, which looks like deliberate "notable position" injection upstream rather than corrupt data.

Sorting each page in isolation cannot fix this, because the `olderThan` cursor is just the last item's timestamp:

```
olderCursor "eyJ0aW1lc3RhbXAiOjE3ODcxOTQzNzkuMjF9"  ->  {"timestamp":1787194379.21}
```

The spliced-in rows sit far below that cursor, so the *next* page legitimately returns events that are newer than rows already on screen.

**Solution.** Sort the full set of loaded items newest-first before grouping, so each calendar day renders exactly one header regardless of how the API interleaves pages. `Array.prototype.sort` is stable, so items sharing a timestamp keep their API order.

Two supporting notes:

- `timestamp` and `lastTradeAt` were verified identical on all 30 sampled items, and `floor(timestamp)` matched the newest trade in each position — so `timestamp` is the right field to sort and display on. No field change needed.
- Because the injected rows are genuinely out of order, they visibly sink down the list as more pages load. That is correct ordering, but if it proves distracting the durable fix is upstream: stop splicing them into the leaderboard feed, or sort server-side in `va-mmcx-social-api`.

Scoped to `useTraderFeed` only, and deliberately kept separate from the pull-to-refresh timestamp fix in #35073 (disjoint files, so the two can merge in either order).

<img height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-20 at 11 55 01" src="https://github.com/user-attachments/assets/d2a7522f-60e9-4b11-88b7-c9c28ebe2873" />
<img height="800" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-20 at 11 54 47" src="https://github.com/user-attachments/assets/dde9a751-725c-4c60-88f2-04b0b19b9daf" />



## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/TSA-1005 — the bug reported on that ticket (frozen relative timestamps) is closed by #35073. This PR fixes a separate ordering defect found while validating it, so it references the ticket rather than closing it.
Refs: #35073

## **Manual testing steps**

```gherkin
Feature: Top traders feed is ordered newest-first and grouped by day

  Scenario: day headers are not repeated on first load
    Given the user opens Top traders and selects the "Feed" tab
    And the "All" audience toggle is selected
    When the feed finishes loading
    Then rows are ordered newest activity first
    And each calendar day appears under exactly one date header

  Scenario: loading older pages preserves chronological order
    Given the user is viewing the Top traders "Feed" tab
    When the user scrolls to the bottom to load more activity
    Then the newly loaded rows are merged into the existing newest-first order
    And no date header is repeated further down the list

  Scenario: pull-to-refresh preserves chronological order
    Given the user is viewing the Top traders "Feed" tab
    When the user pulls down to refresh
    Then the refreshed rows are ordered newest activity first
    And each calendar day still appears under exactly one date header
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Feed rendering `Aug 20 2026` -> `Aug 18 2026` -> `Aug 20 2026`. Screenshot to be attached by the author.

### **After**

Feed rendering a single `Aug 20 2026` header with rows descending `8m`, `13m`, `13m`, `13m`. Screenshot to be attached by the author.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d76070033b8e80bc5b741766a515e9976287eb99. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->