### PR TITLE
fix(e2e): restore Activity navigation for MM Pay deposit smokes

### DIFF
--- a/tests/page-objects/wallet/TabBarComponent.ts
+++ b/tests/page-objects/wallet/TabBarComponent.ts
@@ -191,16 +191,31 @@ class TabBarComponent {
         // opened from the wallet-header clock button (`wallet-activity-button`).
         // When Money is off, that header button is hidden and the Activity tab
         // is the only entry point. Prefer whichever control is present.
-        try {
-          await Gestures.waitAndTap(this.tabBarActivityButton, {
-            timeout: 2000,
-            elemDescription: 'Tab Bar - Activity Button',
-          });
-        } catch {
-          await Gestures.waitAndTap(WalletView.activityButton, {
-            timeout: 2000,
-            elemDescription: 'Wallet Activity button',
-          });
+        //
+        // If a prior attempt already navigated but the title was not ready yet,
+        // neither entry point is on screen — skip / swallow taps and wait for
+        // the title so executeWithRetry can succeed once Activity is visible.
+        const alreadyOnActivity = await Utilities.isElementVisible(
+          ActivitiesView.title,
+          500,
+        );
+        if (!alreadyOnActivity) {
+          try {
+            await Gestures.waitAndTap(this.tabBarActivityButton, {
+              timeout: 2000,
+              elemDescription: 'Tab Bar - Activity Button',
+            });
+          } catch {
+            try {
+              await Gestures.waitAndTap(WalletView.activityButton, {
+                timeout: 2000,
+                elemDescription: 'Wallet Activity button',
+              });
+            } catch {
+              // Both entry points missing — likely already on Activity from a
+              // prior attempt; fall through to the title assertion below.
+            }
+          }
         }
         await Assertions.expectElementToBeVisible(ActivitiesView.title, {
           description: 'Activity View Title',

--- a/tests/page-objects/wallet/TabBarComponent.ts
+++ b/tests/page-objects/wallet/TabBarComponent.ts
@@ -187,7 +187,21 @@ class TabBarComponent {
   async tapActivity(): Promise<void> {
     await Utilities.executeWithRetry(
       async () => {
-        await Gestures.waitAndTap(this.tabBarActivityButton, { timeout: 2000 });
+        // Money account replaces the Activity tab with Money; Activity is then
+        // opened from the wallet-header clock button (`wallet-activity-button`).
+        // When Money is off, that header button is hidden and the Activity tab
+        // is the only entry point. Prefer whichever control is present.
+        try {
+          await Gestures.waitAndTap(this.tabBarActivityButton, {
+            timeout: 2000,
+            elemDescription: 'Tab Bar - Activity Button',
+          });
+        } catch {
+          await Gestures.waitAndTap(WalletView.activityButton, {
+            timeout: 2000,
+            elemDescription: 'Wallet Activity button',
+          });
+        }
         await Assertions.expectElementToBeVisible(ActivitiesView.title, {
           description: 'Activity View Title',
           timeout: 500,


### PR DESCRIPTION
## Summary
- Confirmations Appium smoke-1 fails on main (Android + iOS) after #34937: `TabBarComponent.tapActivity()` cannot find `tab-bar-item-Activity`.
- Root cause: pay deposit feature flags enable Money account; when Money is geo-visible, MainNavigator replaces the Activity tab with Money. Activity is only available via wallet header `wallet-activity-button`.
- Fix: `tapActivity()` tries the Activity tab, then falls back to the wallet header button, skips taps if Activity is already open, and still waits for the Activities title.

## Why this landed on main
- #34937’s first CI run *did* fail on `tab-bar-item-Activity`.
- Later green runs (including the merge CI) selected SmokeConfirmations via Smart E2E, but Appium Android/iOS were **skipped**: after #34898 Appium was still gated to Cirrus while PR builds already ran on Namespace, so the Appium `if:` stayed false. The CI status gate treats skipped E2E as pass.
- That Namespace/Cirrus skip hole is fixed in #35002 — Appium now follows the same runner provider as the builds (still can skip for normal reasons like no selected tags / build didn’t run).

## Test plan
- [ ] CI: `appium-confirmations-android-smoke-1` and `appium-confirmations-ios-smoke-1` pass
- [ ] Specifically green: MM Pay Perps deposit + MM Pay Predict deposit specs

Related main failure: https://github.com/MetaMask/metamask-mobile/actions/runs/32356252998
Refs: #34937, #34898, #35002
