### PR TITLE
feat: enhance OrderContent to handle network and token icon resolutio…

### DIFF
--- a/app/components/UI/Ramp/Views/OrderDetails/OrderContent.test.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderContent.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import { fireEvent, act, screen } from '@testing-library/react-native';
+import { fireEvent, screen, waitFor } from '@testing-library/react-native';
 import OrderContent from './OrderContent';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 import { type RampsOrder, RampsOrderStatus } from '@metamask/ramps-controller';
 import Clipboard from '@react-native-clipboard/clipboard';
 import InAppBrowser from 'react-native-inappbrowser-reborn';
+import imageIcons from '../../../../../images/image-icons';
+import { AVATARTOKEN_IMAGE_TESTID } from '../../../../../component-library/components/Avatars/Avatar/variants/AvatarToken/AvatarToken.constants';
 import { RampsOrderDetailsSelectorsIDs } from './OrderDetails.testIds';
 
 type RampsOrderWithPaymentDetails = RampsOrder & {
@@ -22,7 +24,10 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: mockNavigate, goBack: jest.fn() }),
 }));
 
+// Only `getNetworkImageSource` is stubbed: `toRampsOrderCaipChainId` resolves
+// decimal chain ids through the real `getDecimalChainId` from this module.
 jest.mock('../../../../../util/networks', () => ({
+  ...jest.requireActual('../../../../../util/networks'),
   getNetworkImageSource: jest.fn(() => ({
     uri: 'https://example.com/eth.png',
   })),
@@ -135,12 +140,10 @@ describe('OrderContent', () => {
     renderOrder(mockOrder);
     fireEvent.press(screen.getByText('View on Transak'));
 
-    await act(async () => {
-      // wait for async InAppBrowser calls
-    });
-
-    expect(InAppBrowser.open).toHaveBeenCalledWith(
-      'https://transak.com/order/abc',
+    await waitFor(() =>
+      expect(InAppBrowser.open).toHaveBeenCalledWith(
+        'https://transak.com/order/abc',
+      ),
     );
   });
 
@@ -150,13 +153,11 @@ describe('OrderContent', () => {
     renderOrder(mockOrder);
     fireEvent.press(screen.getByText('View on Transak'));
 
-    await act(async () => {
-      // wait for async calls
-    });
-
-    expect(mockNavigate).toHaveBeenCalledWith(
-      'Webview',
-      expect.objectContaining({ screen: 'SimpleWebview' }),
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith(
+        'Webview',
+        expect.objectContaining({ screen: 'SimpleWebview' }),
+      ),
     );
   });
 
@@ -361,94 +362,116 @@ describe('OrderContent', () => {
 
   describe('token icon and network badge', () => {
     // The V2 orders API is inconsistent about `network`: the declared type is
-    // `{ chainId, name }` but providers such as Sardine return a bare decimal
-    // string. The provider `iconUrl` is equally unreliable, pointing at a
-    // per-environment host that only resolves in production.
-    const usdcAssetId =
+    // `{ chainId, name }`, but providers such as Sardine send a bare decimal
+    // string and Coinbase sends an unparseable network name. The provider
+    // `iconUrl` is equally unreliable, pointing at a per-environment host that
+    // only resolves in production.
+    //
+    // Each chain-id case below puts a different chain on every resolver source
+    // (network -> cryptoCurrency.chainId -> assetId), so a test can only pass
+    // when the branch it names is the one that produced the value.
+    const OPTIMISM_CAIP = 'eip155:10';
+    const mainnetAssetId =
       'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
-    const usdcCdnUrl =
+    const mainnetCdnUrl =
       'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png';
+    const providerIconUrl =
+      'https://dev-static.cx.metamask.io/api/v1/tokenIcons/1/0xa0b8.png';
 
-    function makeUsdcOrder(overrides: Partial<RampsOrder>): RampsOrder {
-      return {
+    function renderChainOrder(network: unknown, chainId?: string) {
+      renderOrder({
         ...mockOrder,
+        network: network as RampsOrder['network'],
         cryptoCurrency: {
           symbol: 'USDC',
           decimals: 6,
-          assetId: usdcAssetId,
-          chainId: 'eip155:1',
-          iconUrl:
-            'https://dev-static.cx.metamask.io/api/v1/tokenIcons/1/0xa0b8.png',
+          assetId: mainnetAssetId,
+          chainId,
+          iconUrl: providerIconUrl,
         },
-        ...overrides,
-      };
+      });
     }
 
+    it('resolves the network badge from the network object', () => {
+      renderChainOrder({ chainId: '0x89', name: 'Polygon' }, OPTIMISM_CAIP);
+
+      expect(mockGetNetworkImageSource).toHaveBeenCalledWith({
+        chainId: 'eip155:137',
+      });
+    });
+
     it('resolves the network badge when network is a bare decimal string', () => {
-      renderOrder(
-        makeUsdcOrder({ network: '1' as unknown as RampsOrder['network'] }),
-      );
+      renderChainOrder('137', OPTIMISM_CAIP);
+
+      expect(mockGetNetworkImageSource).toHaveBeenCalledWith({
+        chainId: 'eip155:137',
+      });
+    });
+
+    it('falls back to cryptoCurrency.chainId when network is an unparseable name', () => {
+      renderChainOrder('ethereum', OPTIMISM_CAIP);
+
+      expect(mockGetNetworkImageSource).toHaveBeenCalledWith({
+        chainId: OPTIMISM_CAIP,
+      });
+    });
+
+    it('falls back to the asset id when network and chainId are missing', () => {
+      renderChainOrder(undefined, undefined);
 
       expect(mockGetNetworkImageSource).toHaveBeenCalledWith({
         chainId: 'eip155:1',
       });
     });
 
-    it('falls back to cryptoCurrency.chainId when network is missing', () => {
-      renderOrder(
-        makeUsdcOrder({
-          network: undefined as unknown as RampsOrder['network'],
-        }),
-      );
-
-      expect(mockGetNetworkImageSource).toHaveBeenCalledWith({
-        chainId: 'eip155:1',
+    it('renders no network badge when no source yields a chain id', () => {
+      renderOrder({
+        ...mockOrder,
+        network: undefined as unknown as RampsOrder['network'],
+        cryptoCurrency: { symbol: 'USDC', iconUrl: providerIconUrl },
       });
+
+      expect(mockGetNetworkImageSource).not.toHaveBeenCalled();
     });
 
-    it('prefers the bundled icon over the provider iconUrl for a known symbol', () => {
-      renderOrder(
-        makeUsdcOrder({ network: '1' as unknown as RampsOrder['network'] }),
-      );
+    it('prefers the bundled icon over the asset id CDN url for a known symbol', () => {
+      renderChainOrder('1', 'eip155:1');
 
-      // `imageIcons` carries a bundled USDC asset, so no remote url is used.
-      expect(JSON.stringify(screen.toJSON())).not.toContain(
-        'dev-static.cx.metamask.io',
+      // `imageIcons` carries a bundled USDC asset, so neither remote url is used.
+      expect(screen.getByTestId(AVATARTOKEN_IMAGE_TESTID).props.source).toBe(
+        imageIcons.USDC,
       );
     });
 
     it('renders the token icon from the asset id CDN for an unbundled symbol', () => {
-      renderOrder(
-        makeUsdcOrder({
-          network: '1' as unknown as RampsOrder['network'],
-          cryptoCurrency: {
-            symbol: 'CROSSMINTTEST',
-            decimals: 6,
-            assetId: usdcAssetId,
-            iconUrl:
-              'https://dev-static.cx.metamask.io/api/v1/tokenIcons/1/0xa0b8.png',
-          },
-        }),
-      );
+      renderOrder({
+        ...mockOrder,
+        cryptoCurrency: {
+          symbol: 'CROSSMINTTEST',
+          decimals: 6,
+          assetId: mainnetAssetId,
+          chainId: 'eip155:1',
+          iconUrl: providerIconUrl,
+        },
+      });
 
-      const tree = JSON.stringify(screen.toJSON());
-      expect(tree).toContain(usdcCdnUrl);
-      expect(tree).not.toContain('dev-static.cx.metamask.io');
+      expect(
+        screen.getByTestId(AVATARTOKEN_IMAGE_TESTID).props.source,
+      ).toStrictEqual({ uri: mainnetCdnUrl });
     });
 
     it('falls back to the provider iconUrl when the order has no asset id', () => {
-      renderOrder(
-        makeUsdcOrder({
-          cryptoCurrency: {
-            symbol: 'XYZ',
-            iconUrl: 'https://provider.example/xyz.png',
-          },
-        }),
-      );
+      renderOrder({
+        ...mockOrder,
+        cryptoCurrency: {
+          symbol: 'XYZ',
+          iconUrl: 'https://provider.example/xyz.png',
+        },
+      });
 
-      expect(JSON.stringify(screen.toJSON())).toContain(
-        'https://provider.example/xyz.png',
-      );
+      expect(
+        screen.getByTestId(AVATARTOKEN_IMAGE_TESTID).props.source,
+      ).toStrictEqual({ uri: 'https://provider.example/xyz.png' });
     });
   });
 

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderContent.test.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderContent.test.tsx
@@ -28,6 +28,10 @@ jest.mock('../../../../../util/networks', () => ({
   })),
 }));
 
+const mockGetNetworkImageSource = jest.requireMock(
+  '../../../../../util/networks',
+).getNetworkImageSource as jest.Mock;
+
 jest.mock('@react-native-clipboard/clipboard', () => ({
   setString: jest.fn(),
 }));
@@ -353,6 +357,99 @@ describe('OrderContent', () => {
       screen.getByTestId('ramps-order-details-token-amount'),
     ).toHaveTextContent('... ETH');
     expect(screen.getAllByText('...')).toHaveLength(2);
+  });
+
+  describe('token icon and network badge', () => {
+    // The V2 orders API is inconsistent about `network`: the declared type is
+    // `{ chainId, name }` but providers such as Sardine return a bare decimal
+    // string. The provider `iconUrl` is equally unreliable, pointing at a
+    // per-environment host that only resolves in production.
+    const usdcAssetId =
+      'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+    const usdcCdnUrl =
+      'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png';
+
+    function makeUsdcOrder(overrides: Partial<RampsOrder>): RampsOrder {
+      return {
+        ...mockOrder,
+        cryptoCurrency: {
+          symbol: 'USDC',
+          decimals: 6,
+          assetId: usdcAssetId,
+          chainId: 'eip155:1',
+          iconUrl:
+            'https://dev-static.cx.metamask.io/api/v1/tokenIcons/1/0xa0b8.png',
+        },
+        ...overrides,
+      };
+    }
+
+    it('resolves the network badge when network is a bare decimal string', () => {
+      renderOrder(
+        makeUsdcOrder({ network: '1' as unknown as RampsOrder['network'] }),
+      );
+
+      expect(mockGetNetworkImageSource).toHaveBeenCalledWith({
+        chainId: 'eip155:1',
+      });
+    });
+
+    it('falls back to cryptoCurrency.chainId when network is missing', () => {
+      renderOrder(
+        makeUsdcOrder({
+          network: undefined as unknown as RampsOrder['network'],
+        }),
+      );
+
+      expect(mockGetNetworkImageSource).toHaveBeenCalledWith({
+        chainId: 'eip155:1',
+      });
+    });
+
+    it('prefers the bundled icon over the provider iconUrl for a known symbol', () => {
+      renderOrder(
+        makeUsdcOrder({ network: '1' as unknown as RampsOrder['network'] }),
+      );
+
+      // `imageIcons` carries a bundled USDC asset, so no remote url is used.
+      expect(JSON.stringify(screen.toJSON())).not.toContain(
+        'dev-static.cx.metamask.io',
+      );
+    });
+
+    it('renders the token icon from the asset id CDN for an unbundled symbol', () => {
+      renderOrder(
+        makeUsdcOrder({
+          network: '1' as unknown as RampsOrder['network'],
+          cryptoCurrency: {
+            symbol: 'CROSSMINTTEST',
+            decimals: 6,
+            assetId: usdcAssetId,
+            iconUrl:
+              'https://dev-static.cx.metamask.io/api/v1/tokenIcons/1/0xa0b8.png',
+          },
+        }),
+      );
+
+      const tree = JSON.stringify(screen.toJSON());
+      expect(tree).toContain(usdcCdnUrl);
+      expect(tree).not.toContain('dev-static.cx.metamask.io');
+    });
+
+    it('falls back to the provider iconUrl when the order has no asset id', () => {
+      renderOrder(
+        makeUsdcOrder({
+          cryptoCurrency: {
+            symbol: 'XYZ',
+            iconUrl: 'https://provider.example/xyz.png',
+          },
+        }),
+      );
+
+      expect(JSON.stringify(screen.toJSON())).toContain(
+        'https://provider.example/xyz.png',
+      );
+    });
   });
 
   it('does not render info row when statusDescription is absent', () => {

--- a/app/components/UI/Ramp/Views/OrderDetails/OrderContent.tsx
+++ b/app/components/UI/Ramp/Views/OrderDetails/OrderContent.tsx
@@ -34,6 +34,8 @@ import { toDateFormat } from '../../../../../util/date';
 import { formatSubscriptNotation } from '../../../../../util/number/subscriptNotation';
 import { formatWithThreshold } from '../../../../../util/assets';
 import { getNetworkImageSource } from '../../../../../util/networks';
+import { toRampsOrderCaipChainId } from '../../../../../util/activity-adapters/adapters/ramps-order-helpers';
+import { getTokenImageSource } from '../../../ActivityListItemRow/tokenIcon';
 import Logger from '../../../../../util/Logger';
 import { hasDepositOrderField } from '../../utils/depositUtils';
 import BankDetailRow from '../../components/BankDetailRow/BankDetailRow';
@@ -80,7 +82,18 @@ const OrderContent: React.FC<OrderContentProps> = ({
 
   const providerName = order.provider?.name ?? '';
   const providerOrderLink = order.providerOrderLink;
-  const cryptoIconUrl = order.cryptoCurrency?.iconUrl;
+  // Prefer the asset-id CDN url (environment-independent, and the same source
+  // Activity details use) over the provider-supplied `iconUrl`, which points at
+  // a per-environment host that does not resolve outside production.
+  const cryptoImageSource =
+    getTokenImageSource({
+      assetId: order.cryptoCurrency?.assetId,
+      symbol: order.cryptoCurrency?.symbol,
+      direction: 'in',
+    }) ??
+    (order.cryptoCurrency?.iconUrl
+      ? { uri: order.cryptoCurrency.iconUrl }
+      : undefined);
   const fiatDecimals = order.fiatCurrency?.decimals ?? 2;
   const providerSupportUrl =
     order.provider?.links?.find((link) =>
@@ -233,19 +246,14 @@ const OrderContent: React.FC<OrderContentProps> = ({
     trackEvent,
   ]);
 
-  const normalizeChainIdForBadge = (chainId: string): string => {
-    if (!chainId || chainId.includes(':') || chainId.startsWith('0x')) {
-      return chainId;
-    }
-    const decimal = parseInt(chainId, 10);
-    return isNaN(decimal) ? chainId : `0x${decimal.toString(16)}`;
-  };
-
-  const normalizedNetworkChainId = normalizeChainIdForBadge(
-    order.network?.chainId ?? '',
-  );
-  const networkImageSource = normalizedNetworkChainId
-    ? getNetworkImageSource({ chainId: normalizedNetworkChainId })
+  // Providers disagree on the `network` shape: some send the declared
+  // `{ chainId, name }` object, others a bare decimal string ("1"). Reuse the
+  // Activity resolver, which walks network object -> network string ->
+  // cryptoCurrency.chainId -> assetId and always yields a CAIP chain id.
+  const networkChainId = toRampsOrderCaipChainId(order) ?? '';
+  const networkName = order.network?.name || networkChainId;
+  const networkImageSource = networkChainId
+    ? getNetworkImageSource({ chainId: networkChainId })
     : null;
 
   const capitalizeWords = useCallback(
@@ -335,7 +343,7 @@ const OrderContent: React.FC<OrderContentProps> = ({
           badgeElement={
             networkImageSource ? (
               <BadgeNetwork
-                name={normalizedNetworkChainId}
+                name={networkName}
                 imageSource={networkImageSource}
               />
             ) : null
@@ -343,7 +351,7 @@ const OrderContent: React.FC<OrderContentProps> = ({
         >
           <AvatarToken
             name={cryptoSymbol}
-            imageSource={cryptoIconUrl ? { uri: cryptoIconUrl } : undefined}
+            imageSource={cryptoImageSource}
             size={AvatarSize.Lg}
           />
         </BadgeWrapper>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

The Ramps order details screen often rendered a blank token avatar and no network badge, while the exact same order showed both correctly in Activity. Two independent causes were behind it, and `OrderContent` was resolving both images on its own instead of reusing the resolvers Activity already relies on.

**1. The token icon used the provider-supplied `iconUrl`.** That url points at a per-environment icon host, and outside production it does not resolve at all (`dev-static.cx.metamask.io` is NXDOMAIN), so the request failed silently and the avatar stayed empty. The screen now resolves the icon through `getTokenImageSource()` from `ActivityListItemRow/tokenIcon`, which prefers the bundled asset for known symbols and otherwise builds the environment-independent asset-id CDN url. The provider `iconUrl` is kept only as a last-resort fallback for orders that carry no `assetId`.

**2. The network badge depended on `order.network` being an object.** The V2 orders type declares `network` as `{ chainId, name }`, but providers disagree: Sardine, for instance, returns a bare decimal string such as `"1"`. In that case `order.network?.chainId` was `undefined`, the local `normalizeChainIdForBadge()` helper passed the empty value straight through, and the badge was skipped entirely. That helper is removed in favour of `toRampsOrderCaipChainId()` from `util/activity-adapters`, which walks network object → network string → `cryptoCurrency.chainId` → `assetId` and always yields a CAIP chain id. As a side effect the badge label is now the network name (falling back to the CAIP id) rather than a raw hex chain id.

Net result: order details and Activity now derive icons from the same source, so an order fetched straight from the provider callback renders identically to one read back from order history. Five tests cover the new paths: bare decimal `network`, missing `network`, bundled-icon preference, the asset-id CDN path for an unbundled symbol, and the `iconUrl` fallback when no `assetId` is present.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed missing token icons and network badges on the buy/sell order details screen.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3903

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Ramps order details icons

  Scenario: user opens order details right after returning from the provider
    Given the user completed a buy through a provider that returns `network` as a bare string (e.g. Sardine)
    And the app has just been redirected back from the provider checkout

    When the user opens the order details screen for that order
    Then the token avatar renders with the correct token icon
    And the network badge renders on top of the avatar with the correct network image

  Scenario: user opens the same order from Activity
    Given the order is already present in order history

    When the user taps the order in the Activity list
    Then the order details screen shows the same token icon and network badge as the Activity row

  Scenario: order details for a token without a bundled icon
    Given an order whose crypto currency has an `assetId` but no bundled icon

    When the user opens the order details screen
    Then the token icon loads from the asset-id CDN url instead of the provider `iconUrl`
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- TODO: attach the captured before recording — order details opened straight after the provider redirect, showing the empty token avatar and no network badge. -->


https://github.com/user-attachments/assets/5deb7502-926e-4623-a2c7-31e1215542ea



### **After**

<!-- TODO: attach the captured after recording — same order, token icon and network badge both rendering. -->


https://github.com/user-attachments/assets/eddd1731-7dc1-4df9-857a-f95eff493fd2



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6153d8abc55d21fa6f2936a0c7702f78f7ab80c7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->