### PR TITLE
fix(wallet): keep header actions visible with long account names

### DIFF
--- a/app/component-library/components/Pickers/PickerAccount/PickerAccount.styles.ts
+++ b/app/component-library/components/Pickers/PickerAccount/PickerAccount.styles.ts
@@ -27,9 +27,17 @@ const styleSheet = (params: {
       ...(style as ViewStyle),
       flexDirection: 'row',
       borderWidth: 0,
+      flexShrink: 1,
+      minWidth: 0,
+      maxWidth: '100%',
+    },
+    accountName: {
+      flexShrink: 1,
+      minWidth: 0,
     },
     dropdownIcon: {
       marginLeft: 8,
+      flexShrink: 0,
     },
     accountAddressLabel: {
       color: colors.text.alternative,

--- a/app/component-library/components/Pickers/PickerAccount/PickerAccount.test.tsx
+++ b/app/component-library/components/Pickers/PickerAccount/PickerAccount.test.tsx
@@ -48,6 +48,22 @@ describe('PickerAccount', () => {
       expect(getByText(customAccountName)).toBeOnTheScreen();
     });
 
+    it('truncates long account names to a single shrinking line', () => {
+      const longAccountName =
+        "Account Fun fun fun fun it's so fun and so long that it overflows";
+
+      const { getByTestId } = render(
+        <PickerAccount {...defaultProps} accountName={longAccountName} />,
+      );
+
+      const accountNameLabel = getByTestId(
+        WalletViewSelectorsIDs.ACCOUNT_NAME_LABEL_TEXT,
+      );
+
+      expect(accountNameLabel).toHaveProp('numberOfLines', 1);
+      expect(accountNameLabel).toHaveStyle({ flexShrink: 1, minWidth: 0 });
+    });
+
     it('should render correctly with snapshot', () => {
       const { toJSON } = render(<PickerAccount {...defaultProps} />);
       expect(toJSON()).toBeDefined();

--- a/app/component-library/components/Pickers/PickerAccount/PickerAccount.tsx
+++ b/app/component-library/components/Pickers/PickerAccount/PickerAccount.tsx
@@ -33,6 +33,7 @@ const PickerAccount = forwardRef<View, PickerAccountProps>(
           variant={TextVariant.BodyMDMedium}
           testID={WalletViewSelectorsIDs.ACCOUNT_NAME_LABEL_TEXT}
           numberOfLines={1}
+          style={styles.accountName}
         >
           {accountName}
         </DSText>

--- a/app/components/Views/Wallet/WalletView.testIds.ts
+++ b/app/components/Views/Wallet/WalletView.testIds.ts
@@ -21,6 +21,7 @@ export const WalletViewSelectorsIDs = {
   NAVBAR_NETWORK_TEXT: 'open-networks-text',
   NFT_TAB_CONTAINER: 'collectible-contracts',
   ACCOUNT_ICON: 'account-picker',
+  ACCOUNT_PICKER_CONTAINER: 'wallet-header-account-picker-container',
   ACCOUNT_NAME_LABEL_INPUT: 'account-label-text-input',
   ACCOUNT_NAME_LABEL_TEXT: 'account-label',
   TOKENS_CONTAINER: 'tokens',

--- a/app/components/Views/Wallet/components/WalletHeader/WalletHeader.test.tsx
+++ b/app/components/Views/Wallet/components/WalletHeader/WalletHeader.test.tsx
@@ -139,9 +139,9 @@ describe('WalletHeader', () => {
       <WalletHeader {...defaultProps} />,
     );
 
-    const accountPicker = getByTestId(WalletViewSelectorsIDs.ACCOUNT_ICON);
-
-    expect(accountPicker.parent).toHaveStyle({
+    expect(
+      getByTestId(WalletViewSelectorsIDs.ACCOUNT_PICKER_CONTAINER),
+    ).toHaveStyle({
       flex: 1,
       minWidth: 0,
       overflow: 'hidden',

--- a/app/components/Views/Wallet/components/WalletHeader/WalletHeader.test.tsx
+++ b/app/components/Views/Wallet/components/WalletHeader/WalletHeader.test.tsx
@@ -110,6 +110,44 @@ describe('WalletHeader', () => {
     );
   });
 
+  it('keeps header action buttons visible when the account name is very long', () => {
+    const { getByTestId } = renderWithProvider(
+      <WalletHeader
+        {...defaultProps}
+        displayName="Account Fun fun fun fun it's so fun and so long that it overflows"
+      />,
+    );
+
+    expect(getByTestId(WalletViewSelectorsIDs.ACCOUNT_ICON)).toBeOnTheScreen();
+    expect(
+      getByTestId(WalletViewSelectorsIDs.WALLET_SEARCH_BUTTON),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(WalletViewSelectorsIDs.NAVBAR_ADDRESS_COPY_BUTTON),
+    ).toBeOnTheScreen();
+    expect(getByTestId(WalletViewSelectorsIDs.CARD_BUTTON)).toBeOnTheScreen();
+    expect(
+      getByTestId(WalletViewSelectorsIDs.WALLET_HAMBURGER_MENU_BUTTON),
+    ).toBeOnTheScreen();
+    expect(
+      getByTestId(WalletViewSelectorsIDs.ACCOUNT_NAME_LABEL_TEXT),
+    ).toHaveProp('numberOfLines', 1);
+  });
+
+  it('lets the account picker shrink below its name width so action buttons stay on screen', () => {
+    const { getByTestId } = renderWithProvider(
+      <WalletHeader {...defaultProps} />,
+    );
+
+    const accountPicker = getByTestId(WalletViewSelectorsIDs.ACCOUNT_ICON);
+
+    expect(accountPicker.parent).toHaveStyle({
+      flex: 1,
+      minWidth: 0,
+      overflow: 'hidden',
+    });
+  });
+
   describe('when the Money account is visible', () => {
     it('shows the activity button and hides the card button', () => {
       const { getByTestId, queryByTestId } = renderWithProvider(

--- a/app/components/Views/Wallet/components/WalletHeader/WalletHeader.tsx
+++ b/app/components/Views/Wallet/components/WalletHeader/WalletHeader.tsx
@@ -164,7 +164,10 @@ const WalletHeader = ({
           version did. The picker wrapper must flex and allow shrinking
           below the account name's intrinsic width (`minWidth: 0`) so
           long names truncate instead of pushing action buttons off-screen. */}
-      <View style={accountPickerContainerStyle}>
+      <View
+        style={accountPickerContainerStyle}
+        testID={WalletViewSelectorsIDs.ACCOUNT_PICKER_CONTAINER}
+      >
         <PickerAccount
           accountName={displayName}
           onPress={handleAccountPickerPress}

--- a/app/components/Views/Wallet/components/WalletHeader/WalletHeader.tsx
+++ b/app/components/Views/Wallet/components/WalletHeader/WalletHeader.tsx
@@ -29,7 +29,15 @@ interface TouchAreaSlop {
   right: number;
 }
 
-const accountPickerContainerStyle: ViewStyle = { flex: 1 };
+const accountPickerContainerStyle: ViewStyle = {
+  flex: 1,
+  minWidth: 0,
+  overflow: 'hidden',
+};
+
+const headerActionsContainerStyle: ViewStyle = {
+  flexShrink: 0,
+};
 
 export interface WalletHeaderProps {
   displayName: string;
@@ -75,7 +83,13 @@ const WalletHeader = ({
     <HeaderRoot
       testID={WalletViewSelectorsIDs.WALLET_HEADER_ROOT}
       endAccessory={
-        <View style={headerActionButtonsContainerStyle} accessible={false}>
+        <View
+          style={[
+            headerActionButtonsContainerStyle,
+            headerActionsContainerStyle,
+          ]}
+          accessible={false}
+        >
           <ButtonIcon
             iconProps={{
               color: MMDSIconColor.IconDefault,
@@ -147,8 +161,9 @@ const WalletHeader = ({
       twClassName="pl-1 pr-3"
     >
       {/* `HeaderRoot` doesn't shrink `children` like the old deprecated
-          version did, so the account picker needs its own flex-1 wrapper
-          to make room for the action buttons on narrow screens. */}
+          version did. The picker wrapper must flex and allow shrinking
+          below the account name's intrinsic width (`minWidth: 0`) so
+          long names truncate instead of pushing action buttons off-screen. */}
       <View style={accountPickerContainerStyle}>
         <PickerAccount
           accountName={displayName}

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -212,10 +212,14 @@ const createStyles = ({ colors }: Theme) =>
     headerActionButtonsContainer: {
       flexDirection: 'row',
       gap: 8,
+      flexShrink: 0,
     },
     headerAccountPickerStyle: {
       marginRight: 16,
       backgroundColor: 'transparent',
+      flexShrink: 1,
+      minWidth: 0,
+      maxWidth: '100%',
     },
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

Long account names on the wallet home header were expanding the account picker past the available width and pushing the search, copy, card, and menu icons off-screen.

The design-system `HeaderRoot` lays children and `endAccessory` in a row without wrapping custom children in `flex-1` (the old local header did). The header already added a `flex: 1` wrapper, but Yoga will not shrink a flex item below its text's intrinsic width unless `minWidth` is `0`. The picker label also needed `flexShrink: 1` so `numberOfLines={1}` can truncate instead of growing the row. Action buttons now use `flexShrink: 0` so they keep their space.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed a bug that pushed wallet home header icons off-screen when the account name was very long

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: wallet home header overflow with long account names

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Wallet home header account picker

  Scenario: long account name truncates without hiding header actions
    Given the user is on the wallet home screen
    And the selected account name is very long
    When the home header is visible
    Then the account name is truncated with an ellipsis
    And the search, copy, and menu icons remain fully visible on the right
    And tapping the truncated account name still opens the account selector

  Scenario: short account name still fits naturally
    Given the user is on the wallet home screen
    And the selected account name is short (for example "Account 1")
    When the home header is visible
    Then the full account name is visible
    And the header action icons remain visible on the right
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

A long account name filled the header and clipped the nav icons off the right edge of the screen.

### **After**

Unit tests cover the shrink styles and that search/copy/card/menu remain in the tree with a long account name. Please confirm on device that the truncated name leaves the header icons fully visible.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1790d18b-d583-458c-a5cc-ae9266736ee2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1790d18b-d583-458c-a5cc-ae9266736ee2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

