### PR TITLE
fix(security-trust): reclassify IMPERSONATOR_LOW_CONFIDENCE as Info

### DIFF
--- a/app/components/UI/SecurityTrust/utils/securityUtils.test.ts
+++ b/app/components/UI/SecurityTrust/utils/securityUtils.test.ts
@@ -218,6 +218,20 @@ describe('securityUtils', () => {
         ]);
       });
 
+      it('ignores Info features such as IMPERSONATOR_LOW_CONFIDENCE when resultType is Warning', () => {
+        const features = [
+          makeFeature('IMPERSONATOR_LOW_CONFIDENCE'),
+          makeFeature('HONEYPOT'),
+        ];
+
+        const { tags, remainingCount } = getFeatureTags(features, 'Warning');
+
+        expect(tags).toEqual([
+          { label: strings('security_trust.features.negative.honeypot') },
+        ]);
+        expect(remainingCount).toBe(0);
+      });
+
       it('caps display at 3 and returns correct remainingCount', () => {
         const features = [
           makeFeature('HONEYPOT'),

--- a/app/components/UI/SecurityTrust/utils/securityUtils.ts
+++ b/app/components/UI/SecurityTrust/utils/securityUtils.ts
@@ -320,8 +320,8 @@ export const getNegativeFeatureLabels = (): Record<
     label: strings(
       'security_trust.features.negative.impersonator_low_confidence',
     ),
-    type: 'Warning',
-  }, // used to be Info, but now it's Warning
+    type: 'Info',
+  },
   IS_MINTABLE: {
     label: strings('security_trust.features.negative.is_mintable'),
     type: 'Info',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

The `IMPERSONATOR_LOW_CONFIDENCE` security signal was classified as a `Warning`-type feature in the token security trust feature map (with an inline comment noting it "used to be Info, but now it's Warning"). Blockaid classifies this signal as `Info`-level, and `Info`-level features should not be surfaced to users as warnings. This PR updates its `BlockaidFeatureType` in `app/components/UI/SecurityTrust/utils/securityUtils.ts` to `Info` and removes the now-stale comment.

Because `getFeatureTags` only surfaces `Warning`/`Spam` features for a `Warning` or `Spam` result type (and `Malicious` features for a `Malicious` result type), the signal is no longer shown as a risk tag on the Token Details security trust surfaces, and it no longer counts toward the "+N more" overflow. The label and its localized strings are unchanged — only the severity classification moves. The bridge `TokenWarningModal` reads only the feature `label` from this map, so it is unaffected.

An accompanying unit test asserts that `IMPERSONATOR_LOW_CONFIDENCE` is excluded from the tags returned for a `Warning` result type.

The equivalent change is being made in metamask-extension ([#45661](https://github.com/MetaMask/metamask-extension/pull/45661)) so both clients classify this signal consistently.

## **Changelog**

CHANGELOG entry: Fixed an issue where the low-confidence "Unconfirmed impersonator" security signal was shown as a warning on the token details page

## **Related issues**

Fixes: [ASSETS-3902](https://consensyssoftware.atlassian.net/browse/ASSETS-3902)

## **Manual testing steps**

Test token from the ticket: `0x2524592CfD16eAb328eE54636259b43a48154A8D` (CUBIT) on Ethereum Mainnet.

```gherkin
Feature: Token security trust signal classification

  Scenario: Low-confidence impersonator signal is not shown as a warning
    Given the wallet is on Ethereum Mainnet
    And the token CUBIT (0x2524592CfD16eAb328eE54636259b43a48154A8D) is available

    When user opens the CUBIT token details page
    And user views the security trust section
    Then the "Unconfirmed impersonator" tag is not listed among the risk feature tags
    And the legitimate Warning-level "Unstable price" tag is still listed
    And the overflow count ("+N more") reflects the reduced number of warning features
```

## **Screenshots/Recordings**

N/A — no visual design change. The change removes one feature tag from an existing list; layout, styling, and all other tags are unchanged.

<!--
### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76a5d6cf-8a80-4493-8f1b-dd11ff0c33de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76a5d6cf-8a80-4493-8f1b-dd11ff0c33de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[ASSETS-3902]: https://consensyssoftware.atlassian.net/browse/ASSETS-3902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ