### PR TITLE
feat: history and network filter for Limit + Recurring 

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.mockHistory.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.mockHistory.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import {
+  FontWeight,
+  Tag,
+  TagSeverity,
+  TextColor,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import OpenOrderRow from '../../../components/OpenOrderRow';
+import type { OpenOrderRowProps } from '../../../components/OpenOrderRow/OpenOrderRow.types';
+import type { OrdersTabConfig } from '../../../components/OrdersTabs';
+import type { BridgeToken } from '../../../types';
+
+const MOCK_DEST_TOKEN: BridgeToken = {
+  address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  chainId: '0x1',
+  decimals: 6,
+  symbol: 'USDC',
+  name: 'USD Coin',
+};
+
+const MOCK_LIMIT_HISTORY_VARIANTS = ['filled', 'expired'] as const;
+
+export const MOCK_LIMIT_HISTORY_ORDERS = MOCK_LIMIT_HISTORY_VARIANTS.map(
+  (variant) => ({
+    id: `mock-limit-history-${variant}`,
+    token: MOCK_DEST_TOKEN,
+    variant,
+  }),
+);
+
+type MockLimitHistoryOrder = (typeof MOCK_LIMIT_HISTORY_ORDERS)[number];
+
+function getLimitHistorySlots(
+  item: MockLimitHistoryOrder,
+): Pick<
+  OpenOrderRowProps,
+  | 'subtitle'
+  | 'primaryValue'
+  | 'secondaryValue'
+  | 'primaryColor'
+  | 'titleEndAccessory'
+> {
+  const limitPrice = strings('bridge.limit.limit_price', {
+    symbol: item.token.symbol,
+  });
+
+  switch (item.variant) {
+    case 'filled':
+      return {
+        subtitle: strings('bridge.limit.filled_at', { date: 'Mar 12' }),
+        primaryValue: `+0.325 ${item.token.symbol}`,
+        secondaryValue: '-0.1 ETH',
+        primaryColor: TextColor.SuccessDefault,
+        titleEndAccessory: (
+          <Tag severity={TagSeverity.Success}>
+            {strings('bridge.limit.filled')}
+          </Tag>
+        ),
+      };
+    case 'expired':
+      return {
+        subtitle: strings('bridge.limit.expired_after', { duration: 'X' }),
+        primaryValue: '$208.99',
+        secondaryValue: limitPrice,
+        titleEndAccessory: (
+          <Tag severity={TagSeverity.Neutral}>
+            {strings('bridge.limit.expired')}
+          </Tag>
+        ),
+      };
+  }
+}
+
+function renderLimitHistoryOrder(item: MockLimitHistoryOrder) {
+  return (
+    <OpenOrderRow
+      token={item.token}
+      title={strings('bridge.limit.pair', {
+        source: 'ETH',
+        dest: item.token.symbol,
+      })}
+      subtitleFontWeight={FontWeight.Medium}
+      {...getLimitHistorySlots(item)}
+    />
+  );
+}
+
+export const LIMIT_MOCK_HISTORY_TAB: OrdersTabConfig<MockLimitHistoryOrder> = {
+  items: MOCK_LIMIT_HISTORY_ORDERS,
+  renderItem: renderLimitHistoryOrder,
+  keyExtractor: (item) => item.id,
+  getItemChainId: (item) => item.token.chainId,
+};

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.view.test.tsx
@@ -17,7 +17,7 @@ async function openLimitTab(renderResult: ReturnType<typeof renderBridgeView>) {
 }
 
 describeForPlatforms('BridgeLimitOrderView', () => {
-  it('shows history empty copy after pressing the History tab', async () => {
+  it('shows filled and expired history rows after pressing the History tab', async () => {
     const renderResult = renderBridgeView();
 
     await openLimitTab(renderResult);
@@ -33,12 +33,7 @@ describeForPlatforms('BridgeLimitOrderView', () => {
     ).toBeOnTheScreen();
     expect(
       renderResult.getByText(
-        strings('bridge.limit.filled_at', { date: 'Mar 12' }),
-      ),
-    ).toBeOnTheScreen();
-    expect(
-      renderResult.getByText(
-        strings('bridge.limit.expired_after', { duration: 'X' }),
+        strings('bridge.limit.expiry', { timeLeft: '4d left' }),
       ),
     ).toBeOnTheScreen();
 
@@ -48,10 +43,32 @@ describeForPlatforms('BridgeLimitOrderView', () => {
 
     await waitFor(() => {
       expect(
-        renderResult.getByText(strings('bridge.orders.empty.history')),
-      ).toBeOnTheScreen();
+        renderResult.queryByText(strings('bridge.limit.not_enough_gas')),
+      ).toBeNull();
     });
-    expect(renderResult.queryAllByText(pair)).toHaveLength(0);
-    expect(renderResult.queryByText(strings('bridge.all_networks'))).toBeNull();
+    expect(
+      renderResult.queryByText(
+        strings('bridge.limit.expiry', { timeLeft: '4d left' }),
+      ),
+    ).toBeNull();
+    expect(
+      renderResult.queryByText(strings('bridge.orders.empty.history')),
+    ).toBeNull();
+    expect(
+      renderResult.getByText(strings('bridge.all_networks')),
+    ).toBeOnTheScreen();
+    expect(
+      renderResult.getByText(strings('bridge.limit.filled')),
+    ).toBeOnTheScreen();
+    expect(
+      renderResult.getByText(strings('bridge.limit.expired')),
+    ).toBeOnTheScreen();
+    expect(renderResult.getByText('+0.325 USDC')).toBeOnTheScreen();
+    expect(
+      renderResult.getByText(
+        strings('bridge.limit.limit_price', { symbol: 'USDC' }),
+      ),
+    ).toBeOnTheScreen();
+    expect(renderResult.getAllByText(pair)).toHaveLength(2);
   });
 });

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/index.tsx
@@ -27,6 +27,7 @@ import { useLatestBalance } from '../../../hooks/useLatestBalance';
 import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
 import { createStyles } from '../orderViewShell.styles';
 import { useLimitOrderSwapInputs } from './useLimitOrderSwapInputs';
+import { LIMIT_MOCK_HISTORY_TAB } from './BridgeLimitOrderView.mockHistory';
 import { LIMIT_MOCK_OPEN_ORDERS_TAB } from './BridgeLimitOrderView.mockOpenOrders';
 
 interface BridgeLimitOrderViewContentProps {
@@ -117,7 +118,7 @@ const BridgeLimitOrderViewContent = ({
           <OrdersTabs
             enabledChainIds={enabledChainIds}
             openOrders={LIMIT_MOCK_OPEN_ORDERS_TAB}
-            history={{ items: [] }}
+            history={LIMIT_MOCK_HISTORY_TAB}
           />
         </ScrollView>
 

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.mockHistory.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.mockHistory.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import {
+  FontWeight,
+  Tag,
+  TagSeverity,
+  TextColor,
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../../locales/i18n';
+import OpenOrderRow from '../../../components/OpenOrderRow';
+import type { OrdersTabConfig } from '../../../components/OrdersTabs';
+import type { BridgeToken } from '../../../types';
+
+const MOCK_DEST_TOKEN: BridgeToken = {
+  address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  chainId: '0x1',
+  decimals: 6,
+  symbol: 'USDC',
+  name: 'USD Coin',
+};
+
+const MOCK_RECURRING_HISTORY_ORDER = {
+  id: 'mock-recurring-history-filled',
+  token: MOCK_DEST_TOKEN,
+};
+
+type MockRecurringHistoryOrder = typeof MOCK_RECURRING_HISTORY_ORDER;
+
+function renderRecurringHistoryOrder(item: MockRecurringHistoryOrder) {
+  return (
+    <OpenOrderRow
+      token={item.token}
+      title={strings('bridge.tabs.recurring')}
+      subtitle={strings('bridge.recurring.pair', {
+        source: 'ETH',
+        dest: item.token.symbol,
+      })}
+      primaryValue={`+0.325 ${item.token.symbol}`}
+      secondaryValue="-0.1 ETH"
+      primaryColor={TextColor.SuccessDefault}
+      subtitleFontWeight={FontWeight.Medium}
+      titleEndAccessory={
+        <Tag severity={TagSeverity.Success}>
+          {strings('bridge.recurring.filled')}
+        </Tag>
+      }
+    />
+  );
+}
+
+export const RECURRING_MOCK_HISTORY_TAB: OrdersTabConfig<MockRecurringHistoryOrder> =
+  {
+    items: [MOCK_RECURRING_HISTORY_ORDER],
+    renderItem: renderRecurringHistoryOrder,
+    keyExtractor: (item) => item.id,
+    getItemChainId: (item) => item.token.chainId,
+  };

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
@@ -546,7 +546,7 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
     });
   });
 
-  it('shows history empty copy after pressing the History tab', async () => {
+  it('shows a filled history row after pressing the History tab', async () => {
     const renderResult = renderBridgeView();
 
     await openRecurringTab(renderResult);
@@ -555,19 +555,16 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
       source: 'ETH',
       dest: 'USDC',
     });
+    const scheduleSummary = strings('bridge.recurring.schedule_summary', {
+      interval: '1 day',
+      count: '5',
+    });
 
     expect(renderResult.getAllByText(pair)).toHaveLength(2);
     expect(
       renderResult.getByText(strings('bridge.all_networks')),
     ).toBeOnTheScreen();
-    expect(
-      renderResult.getByText(
-        strings('bridge.recurring.schedule_summary', {
-          interval: '1 day',
-          count: '5',
-        }),
-      ),
-    ).toBeOnTheScreen();
+    expect(renderResult.getByText(scheduleSummary)).toBeOnTheScreen();
     expect(
       renderResult.getByText(strings('bridge.recurring.filled')),
     ).toBeOnTheScreen();
@@ -577,11 +574,21 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
     );
 
     await waitFor(() => {
-      expect(
-        renderResult.getByText(strings('bridge.orders.empty.history')),
-      ).toBeOnTheScreen();
+      expect(renderResult.queryByText(scheduleSummary)).toBeNull();
     });
-    expect(renderResult.queryAllByText(pair)).toHaveLength(0);
-    expect(renderResult.queryByText(strings('bridge.all_networks'))).toBeNull();
+    expect(
+      renderResult.queryByText(strings('bridge.orders.empty.history')),
+    ).toBeNull();
+    expect(
+      renderResult.getByText(strings('bridge.all_networks')),
+    ).toBeOnTheScreen();
+    expect(
+      renderResult.getAllByText(strings('bridge.tabs.recurring')).length,
+    ).toBeGreaterThan(0);
+    expect(
+      renderResult.getByText(strings('bridge.recurring.filled')),
+    ).toBeOnTheScreen();
+    expect(renderResult.getByText('+0.325 USDC')).toBeOnTheScreen();
+    expect(renderResult.getAllByText(pair)).toHaveLength(1);
   });
 });

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/index.tsx
@@ -28,6 +28,7 @@ import { BridgeViewSelectorsIDs } from '../BridgeView.testIds';
 import { createStyles } from '../orderViewShell.styles';
 import { useRecurringBuyKeypad } from './useRecurringBuyKeypad';
 import { useRecurringBuySwapInputs } from './useRecurringBuySwapInputs';
+import { RECURRING_MOCK_HISTORY_TAB } from './BridgeRecurringBuyView.mockHistory';
 import { RECURRING_MOCK_OPEN_ORDERS_TAB } from './BridgeRecurringBuyView.mockOpenOrders';
 
 interface BridgeRecurringBuyViewContentProps {
@@ -133,7 +134,7 @@ const BridgeRecurringBuyViewContent = ({
           <OrdersTabs
             enabledChainIds={enabledChainIds}
             openOrders={RECURRING_MOCK_OPEN_ORDERS_TAB}
-            history={{ items: [] }}
+            history={RECURRING_MOCK_HISTORY_TAB}
           />
         </ScrollView>
 

--- a/app/components/UI/Bridge/_mocks_/bridgeReducerState.ts
+++ b/app/components/UI/Bridge/_mocks_/bridgeReducerState.ts
@@ -43,9 +43,16 @@ export const mockBridgeReducerState: BridgeState = {
   selectedQuoteRequestId: undefined,
   balanceRefreshKey: 0,
   hardwareWalletsSwaps: initialHardwareWalletsSwapsState,
+
+  // Batch Sell
   batchSellSourceTokens: [],
   batchSellSourceTokenAmounts: {},
   batchSellDestToken: undefined,
   batchSellSlippages: {},
+
+  // Recurring
   recurring: initialRecurringState,
+
+  // Orders (Limit + Recurring, Open + History)
+  ordersNetworkFilter: undefined,
 };

--- a/app/components/UI/Bridge/_mocks_/initialState.ts
+++ b/app/components/UI/Bridge/_mocks_/initialState.ts
@@ -833,5 +833,6 @@ export const initialState = {
     isSelectingToken: false,
     tokenSelectorNetworkFilter: undefined,
     recurring: initialRecurringState,
+    ordersNetworkFilter: undefined,
   },
 };

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkListModal.test.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkListModal.test.tsx
@@ -2,16 +2,22 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { useSelector, useDispatch } from 'react-redux';
 import { CaipChainId } from '@metamask/utils';
-import NetworkListModal from './NetworkListModal';
+import NetworkListModal, {
+  type NetworkListModalFilterTarget,
+} from './NetworkListModal';
 import {
   selectAllowedChainRanking,
+  selectOrdersNetworkFilter,
   selectTokenSelectorNetworkFilter,
 } from '../../../../../core/redux/slices/bridge';
 import { useABTest } from '../../../../../hooks';
 import { useChainValueOrder } from '../../hooks/useChainValueOrder';
 
 const mockOnCloseBottomSheet = jest.fn();
-let mockRouteParams: { enabledChainIds?: CaipChainId[] } = {};
+let mockRouteParams: {
+  enabledChainIds?: CaipChainId[];
+  filterTarget?: NetworkListModalFilterTarget;
+} = {};
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
@@ -79,8 +85,13 @@ jest.mock(
 jest.mock('../../../../../core/redux/slices/bridge', () => ({
   selectAllowedChainRanking: jest.fn(),
   selectTokenSelectorNetworkFilter: jest.fn(),
+  selectOrdersNetworkFilter: jest.fn(),
   setTokenSelectorNetworkFilter: jest.fn((chainId) => ({
     type: 'bridge/setTokenSelectorNetworkFilter',
+    payload: chainId,
+  })),
+  setOrdersNetworkFilter: jest.fn((chainId) => ({
+    type: 'bridge/setOrdersNetworkFilter',
     payload: chainId,
   })),
 }));
@@ -134,6 +145,7 @@ describe('NetworkListModal', () => {
     jest.mocked(useChainValueOrder).mockReturnValue(mockChainRanking);
     jest.mocked(selectAllowedChainRanking).mockReturnValue(mockChainRanking);
     jest.mocked(selectTokenSelectorNetworkFilter).mockReturnValue(undefined);
+    jest.mocked(selectOrdersNetworkFilter).mockReturnValue(undefined);
     // NetworkListModal calls useSelector(selectTokenSelectorNetworkFilter)
     // directly, and wraps selectAllowedChainRanking in an inline lambda (to
     // forward the optional enabledChainIds route param) — invoke whatever
@@ -250,6 +262,42 @@ describe('NetworkListModal', () => {
       fireEvent.press(getByTestId('network-option-all'));
 
       expect(mockOnCloseBottomSheet).toHaveBeenCalled();
+    });
+  });
+
+  describe('orders filterTarget', () => {
+    it('dispatches setOrdersNetworkFilter with undefined when "All" is pressed', () => {
+      mockRouteParams = { filterTarget: 'orders' };
+
+      const { getByTestId } = render(<NetworkListModal />);
+      fireEvent.press(getByTestId('network-option-all'));
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'bridge/setOrdersNetworkFilter',
+        payload: undefined,
+      });
+      expect(mockDispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'bridge/setTokenSelectorNetworkFilter',
+        }),
+      );
+    });
+
+    it('dispatches setOrdersNetworkFilter with chainId when a network is pressed', () => {
+      mockRouteParams = { filterTarget: 'orders' };
+
+      const { getByTestId } = render(<NetworkListModal />);
+      fireEvent.press(getByTestId('network-option-eip155:137'));
+
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'bridge/setOrdersNetworkFilter',
+        payload: 'eip155:137',
+      });
+      expect(mockDispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'bridge/setTokenSelectorNetworkFilter',
+        }),
+      );
     });
   });
 });

--- a/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkListModal.tsx
+++ b/app/components/UI/Bridge/components/BridgeTokenSelector/NetworkListModal.tsx
@@ -19,7 +19,9 @@ import { getNetworkImageSource } from '../../../../../util/networks';
 import type { RootState } from '../../../../../reducers';
 import {
   selectAllowedChainRanking,
+  selectOrdersNetworkFilter,
   selectTokenSelectorNetworkFilter,
+  setOrdersNetworkFilter,
   setTokenSelectorNetworkFilter,
 } from '../../../../../core/redux/slices/bridge';
 import { useABTest } from '../../../../../hooks';
@@ -35,25 +37,37 @@ interface ChainRankingEntry {
   name: string;
 }
 
+export type NetworkListModalFilterTarget = 'tokenSelector' | 'orders';
+
 export interface NetworkListModalParams {
   /**
    * When provided, restricts the network list to these chains instead
    * of the default allowed chainRanking.
    */
   enabledChainIds?: CaipChainId[];
+  /**
+   * Which Redux network filter this modal reads and writes.
+   * Defaults to the token selector filter.
+   */
+  filterTarget?: NetworkListModalFilterTarget;
 }
 
 interface NetworkListModalContentProps {
   chainRanking: ChainRankingEntry[];
+  filterTarget: NetworkListModalFilterTarget;
 }
 
 const NetworkListModalContent: React.FC<NetworkListModalContentProps> = ({
   chainRanking,
+  filterTarget,
 }) => {
   const dispatch = useDispatch();
   const sheetRef = useRef<BottomSheetRef>(null);
 
-  const selectedChainId = useSelector(selectTokenSelectorNetworkFilter);
+  const tokenSelectorFilter = useSelector(selectTokenSelectorNetworkFilter);
+  const ordersFilter = useSelector(selectOrdersNetworkFilter);
+  const selectedChainId =
+    filterTarget === 'orders' ? ordersFilter : tokenSelectorFilter;
 
   const handleClose = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();
@@ -61,10 +75,14 @@ const NetworkListModalContent: React.FC<NetworkListModalContentProps> = ({
 
   const handleNetworkPress = useCallback(
     (chainId?: CaipChainId) => {
-      dispatch(setTokenSelectorNetworkFilter(chainId));
+      dispatch(
+        filterTarget === 'orders'
+          ? setOrdersNetworkFilter(chainId)
+          : setTokenSelectorNetworkFilter(chainId),
+      );
       sheetRef.current?.onCloseBottomSheet();
     },
-    [dispatch],
+    [dispatch, filterTarget],
   );
 
   const isAllSelected = !selectedChainId;
@@ -121,16 +139,23 @@ const NetworkListModalContent: React.FC<NetworkListModalContentProps> = ({
 
 const NetworkValueOrderedListModal: React.FC<NetworkListModalContentProps> = ({
   chainRanking,
+  filterTarget,
 }) => {
   const orderedChainRanking = useChainValueOrder(chainRanking);
 
-  return <NetworkListModalContent chainRanking={orderedChainRanking} />;
+  return (
+    <NetworkListModalContent
+      chainRanking={orderedChainRanking}
+      filterTarget={filterTarget}
+    />
+  );
 };
 
 const NetworkListModal: React.FC = () => {
   const route =
     useRoute<RouteProp<{ params: NetworkListModalParams }, 'params'>>();
   const enabledChainIds = route.params?.enabledChainIds;
+  const filterTarget = route.params?.filterTarget ?? 'tokenSelector';
   const chainRanking: ChainRankingEntry[] = useSelector((state: RootState) =>
     selectAllowedChainRanking(state, enabledChainIds),
   );
@@ -141,10 +166,20 @@ const NetworkListModal: React.FC = () => {
   );
 
   if (variant.orderByValue) {
-    return <NetworkValueOrderedListModal chainRanking={chainRanking} />;
+    return (
+      <NetworkValueOrderedListModal
+        chainRanking={chainRanking}
+        filterTarget={filterTarget}
+      />
+    );
   }
 
-  return <NetworkListModalContent chainRanking={chainRanking} />;
+  return (
+    <NetworkListModalContent
+      chainRanking={chainRanking}
+      filterTarget={filterTarget}
+    />
+  );
 };
 
 export default NetworkListModal;

--- a/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.test.tsx
+++ b/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.test.tsx
@@ -69,8 +69,8 @@ describe('OrdersTabs', () => {
     expect(getByText(strings('bridge.orders.empty.history'))).toBeOnTheScreen();
     expect(queryByText(strings('bridge.orders.empty.open_orders'))).toBeNull();
     expect(
-      queryByTestId(OrdersTabsSelectorsIDs.NETWORK_FILTER_BUTTON),
-    ).toBeNull();
+      getByTestId(OrdersTabsSelectorsIDs.NETWORK_FILTER_BUTTON),
+    ).toHaveTextContent(strings('bridge.all_networks'));
   });
 
   it('opens the swaps network picker when the All networks filter is pressed', () => {

--- a/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.test.tsx
+++ b/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.test.tsx
@@ -83,7 +83,7 @@ describe('OrdersTabs', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.MODALS.ROOT, {
       screen: Routes.BRIDGE.MODALS.NETWORK_LIST_MODAL,
-      params: { enabledChainIds: undefined },
+      params: { enabledChainIds: undefined, filterTarget: 'orders' },
     });
   });
 
@@ -100,7 +100,7 @@ describe('OrdersTabs', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(Routes.BRIDGE.MODALS.ROOT, {
       screen: Routes.BRIDGE.MODALS.NETWORK_LIST_MODAL,
-      params: { enabledChainIds },
+      params: { enabledChainIds, filterTarget: 'orders' },
     });
   });
 
@@ -150,7 +150,7 @@ describe('OrdersTabs', () => {
         ...initialState,
         bridge: {
           ...initialState.bridge,
-          tokenSelectorNetworkFilter: formatChainIdToCaip('0xa'),
+          ordersNetworkFilter: formatChainIdToCaip('0xa'),
         },
       },
     );
@@ -169,7 +169,7 @@ describe('OrdersTabs', () => {
         ...initialState,
         bridge: {
           ...initialState.bridge,
-          tokenSelectorNetworkFilter: formatChainIdToCaip('0xa'),
+          ordersNetworkFilter: formatChainIdToCaip('0xa'),
         },
       },
     );

--- a/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.tsx
+++ b/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.tsx
@@ -211,17 +211,15 @@ function OrdersTabs<TOpen, THistory>({
         testID={OrdersTabsSelectorsIDs.TABS_BAR}
       />
       <Box twClassName="mx-4 flex-1 gap-4 py-4">
+        <OrdersNetworkFilter enabledChainIds={enabledChainIds} />
         {selectedTab === OrdersTabKey.OpenOrders ? (
-          <>
-            <OrdersNetworkFilter enabledChainIds={enabledChainIds} />
-            <OrdersTabPanel
-              items={openOrders.items}
-              renderItem={openOrders.renderItem}
-              keyExtractor={openOrders.keyExtractor}
-              getItemChainId={openOrders.getItemChainId}
-              emptyDescription={strings('bridge.orders.empty.open_orders')}
-            />
-          </>
+          <OrdersTabPanel
+            items={openOrders.items}
+            renderItem={openOrders.renderItem}
+            keyExtractor={openOrders.keyExtractor}
+            getItemChainId={openOrders.getItemChainId}
+            emptyDescription={strings('bridge.orders.empty.open_orders')}
+          />
         ) : (
           <OrdersTabPanel
             items={history.items}

--- a/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.tsx
+++ b/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.tsx
@@ -31,7 +31,7 @@ import type { RootState } from '../../../../../reducers';
 import { getNetworkImageSource } from '../../../../../util/networks';
 import {
   selectAllowedChainRanking,
-  selectTokenSelectorNetworkFilter,
+  selectOrdersNetworkFilter,
 } from '../../../../../core/redux/slices/bridge';
 import { OrdersEmptyState } from './OrdersEmptyState';
 import { OrdersTabsSelectorsIDs } from './OrdersTabs.testIds';
@@ -63,7 +63,7 @@ function OrdersNetworkFilter({
   enabledChainIds?: CaipChainId[];
 }) {
   const navigation = useNavigation<AppNavigationProp>();
-  const selectedChainId = useSelector(selectTokenSelectorNetworkFilter);
+  const selectedChainId = useSelector(selectOrdersNetworkFilter);
   const chainRanking = useSelector((state: RootState) =>
     selectAllowedChainRanking(state, enabledChainIds),
   );
@@ -76,7 +76,7 @@ function OrdersNetworkFilter({
   const handlePress = useCallback(() => {
     navigation.navigate(Routes.BRIDGE.MODALS.ROOT, {
       screen: Routes.BRIDGE.MODALS.NETWORK_LIST_MODAL,
-      params: { enabledChainIds },
+      params: { enabledChainIds, filterTarget: 'orders' },
     });
   }, [enabledChainIds, navigation]);
 
@@ -128,7 +128,7 @@ function OrdersTabPanel<T>({
   emptyDescription: string;
 }) {
   const tw = useTailwind();
-  const selectedChainId = useSelector(selectTokenSelectorNetworkFilter);
+  const selectedChainId = useSelector(selectOrdersNetworkFilter);
 
   const filteredItems = useMemo(
     () =>

--- a/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.types.ts
+++ b/app/components/UI/Bridge/components/OrdersTabs/OrdersTabs.types.ts
@@ -21,7 +21,7 @@ export interface OrdersTabsProps<TOpen, THistory> {
   history: OrdersTabConfig<THistory>;
   initialTab?: OrdersTabKey;
   /**
-   * Restricts the Open orders network picker to these chains.
+   * Restricts the orders network picker to these chains.
    * Omit to show the default allowed ranking.
    */
   enabledChainIds?: CaipChainId[];

--- a/app/core/redux/slices/bridge/index.test.ts
+++ b/app/core/redux/slices/bridge/index.test.ts
@@ -19,6 +19,8 @@ import reducer, {
   selectAllowedChainRanking,
   setTokenSelectorNetworkFilter,
   selectTokenSelectorNetworkFilter,
+  setOrdersNetworkFilter,
+  selectOrdersNetworkFilter,
   setVisiblePillChainIds,
   selectVisiblePillChainIds,
   setSelectedQuoteRequestId,
@@ -152,6 +154,7 @@ describe('bridge slice', () => {
           everyUnit: 'hour',
           repeatCount: '10',
         },
+        ordersNetworkFilter: undefined,
       });
     });
   });
@@ -1091,6 +1094,38 @@ describe('bridge slice', () => {
     });
   });
 
+  describe('setOrdersNetworkFilter', () => {
+    it('sets the network filter to a chain ID', () => {
+      const chainId = 'eip155:1';
+      const action = setOrdersNetworkFilter(chainId as CaipChainId);
+      const state = reducer(initialState, action);
+
+      expect(state.ordersNetworkFilter).toBe(chainId);
+    });
+
+    it('clears the network filter when set to undefined', () => {
+      const stateWithFilter = {
+        ...initialState,
+        ordersNetworkFilter: 'eip155:1' as CaipChainId,
+      };
+      const action = setOrdersNetworkFilter(undefined);
+      const state = reducer(stateWithFilter, action);
+
+      expect(state.ordersNetworkFilter).toBeUndefined();
+    });
+
+    it('updates the network filter from one chain to another', () => {
+      const stateWithFilter = {
+        ...initialState,
+        ordersNetworkFilter: 'eip155:1' as CaipChainId,
+      };
+      const action = setOrdersNetworkFilter('eip155:137' as CaipChainId);
+      const state = reducer(stateWithFilter, action);
+
+      expect(state.ordersNetworkFilter).toBe('eip155:137');
+    });
+  });
+
   describe('selectBatchSellQuotes', () => {
     it('uses the BridgeController quote request count', () => {
       const mockState = cloneDeep(mockRootState);
@@ -1201,6 +1236,33 @@ describe('bridge slice', () => {
       };
 
       const result = selectTokenSelectorNetworkFilter(
+        mockState as unknown as RootState,
+      );
+
+      expect(result).toBe('eip155:10');
+    });
+  });
+
+  describe('selectOrdersNetworkFilter', () => {
+    it('returns undefined when no filter is set', () => {
+      const mockState = cloneDeep(mockRootState);
+      (mockState as any).bridge = { ...initialState };
+
+      const result = selectOrdersNetworkFilter(
+        mockState as unknown as RootState,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    it('returns the set chain ID', () => {
+      const mockState = cloneDeep(mockRootState);
+      (mockState as any).bridge = {
+        ...initialState,
+        ordersNetworkFilter: 'eip155:10',
+      };
+
+      const result = selectOrdersNetworkFilter(
         mockState as unknown as RootState,
       );
 

--- a/app/core/redux/slices/bridge/index.ts
+++ b/app/core/redux/slices/bridge/index.ts
@@ -115,13 +115,20 @@ export interface BridgeState {
   selectedQuoteRequestId: string | undefined;
   balanceRefreshKey: number;
   hardwareWalletsSwaps: HardwareWalletsSwapsState;
+
+  // Batch Sell
   batchSellSourceTokens: BridgeToken[];
   batchSellSourceTokenAmounts: Partial<
     Record<CaipAssetType, string | undefined>
   >;
   batchSellDestToken: BridgeToken | undefined;
   batchSellSlippages: Partial<Record<CaipAssetType, string | undefined>>;
+
+  // Recurring
   recurring: RecurringState;
+
+  // Orders (Limit + Recurring, Open + History)
+  ordersNetworkFilter: CaipChainId | undefined;
 }
 
 export const initialState: BridgeState = {
@@ -154,7 +161,12 @@ export const initialState: BridgeState = {
   batchSellSourceTokenAmounts: {},
   batchSellDestToken: undefined,
   batchSellSlippages: {},
+
+  // Recurring
   recurring: initialRecurringState,
+
+  // Orders (Limit + Recurring, Open + History)
+  ordersNetworkFilter: undefined,
 };
 
 const name = 'bridge';
@@ -322,6 +334,12 @@ const slice = createSlice({
       action: PayloadAction<CaipChainId | undefined>,
     ) => {
       state.tokenSelectorNetworkFilter = action.payload;
+    },
+    setOrdersNetworkFilter: (
+      state,
+      action: PayloadAction<CaipChainId | undefined>,
+    ) => {
+      state.ordersNetworkFilter = action.payload;
     },
     setVisiblePillChainIds: (
       state,
@@ -1030,6 +1048,11 @@ export const selectTokenSelectorNetworkFilter = createSelector(
   (bridgeState) => bridgeState.tokenSelectorNetworkFilter,
 );
 
+export const selectOrdersNetworkFilter = createSelector(
+  selectBridgeState,
+  (bridgeState) => bridgeState.ordersNetworkFilter,
+);
+
 export const selectVisiblePillChainIds = createSelector(
   selectBridgeState,
   (bridgeState) => bridgeState.visiblePillChainIds,
@@ -1136,6 +1159,7 @@ export const {
   setIsGasIncluded7702Supported,
   setAbTestContext,
   setTokenSelectorNetworkFilter,
+  setOrdersNetworkFilter,
   setVisiblePillChainIds,
   setSelectedQuoteRequestId,
   updateHardwareWalletsSwaps,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Limit and Recurring Open orders were reusing the token selector network filter in Redux, so picking a network on orders also changed the source/dest token picker (and vice versa). History also had no rows and no network button.

This PR adds `state.bridge.ordersNetworkFilter`, shared by Limit and Recurring Open and History lists, and teaches `NetworkListModal` which field to write via `filterTarget: 'tokenSelector' | 'orders'`. The token selector still defaults to its own field. History now shows the same All networks button and dummy USDC-on-mainnet rows (Limit: filled + expired; Recurring: one filled). The filter persists across those four lists and is cleared by `resetBridgeState` when leaving Swaps.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added Limit and Recurring order history lists and a dedicated network filter for orders

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: SWAPS-4913

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Limit and Recurring orders network filter and history

  Background:
    Given I am logged into MetaMask Mobile
    And Limit and Recurring swaps are available

  Scenario: Limit History shows dummy filled and expired rows
    Given I am on Unified Swaps
    And I open the Limit tab

    When user taps History
    Then I should see the All networks filter
    And I should see an ETH → USDC filled row with +0.325 USDC
    And I should see an ETH → USDC expired row with USDC limit price
    And I should not see Open orders-only copy such as Not enough gas

  Scenario: Recurring History shows a dummy filled row
    Given I am on Unified Swaps
    And I open the Recurring tab

    When user taps History
    Then I should see the All networks filter
    And I should see a Recurring filled row with ETH → USDC and +0.325 USDC
    And I should not see the open-order schedule summary

  Scenario: orders network filter is independent of the token selector
    Given I am on Limit Open orders
    And I select Optimism on the All networks filter

    When user opens the source token picker
    Then the token selector should not stay filtered to Optimism

    When user returns to Limit or Recurring History
    Then the orders filter should still be Optimism until I leave Swaps
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A

### **After**

<!-- [screenshots/recordings] -->



https://github.com/user-attachments/assets/82b785e1-ef24-4a7f-8ebd-387e61b1b0f3


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared bridge Redux and the network picker used by token selection, so a wrong filterTarget could leak filters between orders and the token selector. History is still mock data, not live orders.
> 
> **Overview**
> Stops Limit and Recurring order lists from sharing `tokenSelectorNetworkFilter` with the token picker. Adds `ordersNetworkFilter` in the bridge slice and a `filterTarget` on `NetworkListModal` so the All networks control writes the orders field only.
> 
> The network filter now stays visible on History as well as Open orders, and persists across Limit/Recurring until `resetBridgeState`. History is no longer empty: Limit shows mock filled and expired ETH→USDC rows; Recurring shows one mock filled row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5b6938fe698af52a8e474704607778f82cf284e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->