### PR TITLE
fix(predict): resolve real medium font face for market row titles

### DIFF
--- a/app/components/UI/Predict/components/PredictMarketRowItem/PredictMarketRowItem.tsx
+++ b/app/components/UI/Predict/components/PredictMarketRowItem/PredictMarketRowItem.tsx
@@ -7,6 +7,7 @@ import { PredictEventValues } from '../../constants/eventNames';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
+  FontWeight,
   Icon,
   IconColor,
   IconName,
@@ -118,8 +119,8 @@ const PredictMarketRowItem = ({
       <View style={tw.style('flex-1 pl-4')}>
         <Text
           variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
           color={TextColor.TextDefault}
-          style={tw.style('font-medium')}
           numberOfLines={1}
           ellipsizeMode="tail"
         >

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictDiscovery/BtcLiveRow.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictDiscovery/BtcLiveRow.tsx
@@ -12,6 +12,7 @@ import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import {
   Box,
   BoxFlexDirection,
+  FontWeight,
   Icon,
   IconColor,
   IconName,
@@ -49,6 +50,7 @@ interface BtcLiveValuesHandle {
 const BtcCurrentPrice = memo(({ value }: { value: number | undefined }) => (
   <Text
     variant={TextVariant.BodyMd}
+    fontWeight={FontWeight.Medium}
     color={TextColor.TextDefault}
     numberOfLines={1}
   >

--- a/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictDiscovery/HomepagePredictDiscoveryLivePill.tsx
+++ b/app/components/Views/Homepage/Sections/Predictions/components/HomepagePredictDiscovery/HomepagePredictDiscoveryLivePill.tsx
@@ -6,11 +6,11 @@ import {
   BoxBackgroundColor,
   BoxFlexDirection,
   BoxJustifyContent,
+  FontWeight,
   Text,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react-native';
-import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { strings } from '../../../../../../../../locales/i18n';
 
 interface HomepagePredictDiscoveryLivePillProps {
@@ -29,7 +29,6 @@ const formatLivePillValue = (value: string): string =>
 const HomepagePredictDiscoveryLivePill = ({
   value,
 }: HomepagePredictDiscoveryLivePillProps) => {
-  const tw = useTailwind();
   const displayValue = value ? formatLivePillValue(value) : undefined;
 
   return (
@@ -50,16 +49,19 @@ const HomepagePredictDiscoveryLivePill = ({
       </Box>
       <Text
         variant={TextVariant.BodyXs}
+        fontWeight={FontWeight.Medium}
         color={TextColor.TextDefault}
-        style={tw.style('ml-2 font-medium')}
+        twClassName="ml-2"
       >
         {strings('predict.homepage_discovery.btc_live')}
       </Text>
       {displayValue ? (
         <Text
           variant={TextVariant.BodyXs}
+          fontWeight={FontWeight.Medium}
           color={TextColor.SuccessDefault}
-          style={[tw.style('ml-2 font-medium'), styles.countdown]}
+          twClassName="ml-2"
+          style={styles.countdown}
         >
           {displayValue}
         </Text>


### PR DESCRIPTION
## **Description**

Market row titles in the Predictions homepage section rendered in a visibly different typeface than the BTC live row directly above them.

The cause is how the weight was applied. `Text` from `@metamask/design-system-react-native` derives a concrete font *family* from the variant's weight — `BodyMd` maps to `Regular`, which resolves to a family whose name already encodes its weight — and then applies the caller's `style` prop last. `PredictMarketRowItem` kept `variant={TextVariant.BodyMd}` but layered `style={tw.style('font-medium')}` on top, producing `fontFamily: <regular face>` together with `fontWeight: '500'`. iOS has to reconcile those two conflicting instructions and substitutes a synthesized face, so the title did not simply render heavier — it rendered as a different font.

This passes the design system's `fontWeight` prop instead, so `Text` resolves the real medium family. The BTC row and the live pill are aligned to the same `BodyMd` + `FontWeight.Medium` pairing so every title in the section shares one face and weight, and the pill's spacing moves from a `style` override to the idiomatic `twClassName` prop.

Scoped to the Predictions discovery section. The same `style={tw.style('font-medium')}` pattern exists in roughly 25 other components and is left alone here to keep this reviewable; it is worth a follow-up sweep.

## **Changelog**

CHANGELOG entry: Fixed prediction market titles rendering in an inconsistent font weight on the wallet home screen

## **Related issues**

Fixes: N/A — visual inconsistency found while verifying the Predictions homepage section locally.

## **Manual testing steps**

```gherkin
Feature: Predictions homepage section typography

  Scenario: user views the Predictions section on the wallet home screen
    Given the Predict feature flag is enabled
    And the "coreMCU747AbtestPredictPositionsEmptyState" flag is set to "treatment"
    And the wallet has no open prediction positions
    And Polygon RPC is reachable so the positions query resolves

    When user scrolls to the Predictions section on the Home tab
    Then the "BTC Price" title, the "Live" pill, and both championship titles all render in the same medium face
    And no title renders in a synthesized or mismatched weight
```

## **Screenshots/Recordings**

### **Before**

Championship titles render in a heavier, synthesized face while the BTC title stays regular.

<img width="600" alt="Before - mismatched title weights" src="https://raw.githubusercontent.com/ragkandala/metamask-mobile/1f400ed90f0c7e033736cff9b5d45847b527521d/predict-font-weight/before.png" />

### **After**

All titles resolve the real medium face and match.

<img width="600" alt="After - consistent medium title weights" src="https://raw.githubusercontent.com/ragkandala/metamask-mobile/1f400ed90f0c7e033736cff9b5d45847b527521d/predict-font-weight/after.png" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

Notes on the checklist above: no new tests were added because this changes only how an existing style is expressed — the 118 existing tests across `PredictMarketRowItem` and the Predictions section pass unchanged, and none of them assert on font family. No JSDoc was needed as no new APIs were introduced.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

Performance boxes are unchecked deliberately: this was verified on the iOS Simulator only, so Android and power-user scenarios have not been exercised. No tracing is relevant — the change swaps one style declaration for an equivalent prop and adds no new operations.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)