### PR TITLE
fix(whats-happening): keep last-known related asset prices

### DIFF
--- a/app/components/UI/WhatsHappening/WhatsHappening.testIds.ts
+++ b/app/components/UI/WhatsHappening/WhatsHappening.testIds.ts
@@ -2,4 +2,5 @@ export const WhatsHappeningSelectorsIDs = {
   CAROUSEL: 'whats-happening-carousel',
   SECTION_TITLE: 'whats-happening-section-title',
   AI_GENERATED_LABEL: 'whats-happening-ai-disclaimer-button',
+  ASSET_PRICE_SKELETON: 'whats-happening-asset-price-skeleton',
 } as const;

--- a/app/components/Views/WhatsHappeningDetailView/components/AssetRow.test.tsx
+++ b/app/components/Views/WhatsHappeningDetailView/components/AssetRow.test.tsx
@@ -3,6 +3,7 @@ import { screen, fireEvent } from '@testing-library/react-native';
 import { TextColor } from '@metamask/design-system-react-native';
 import type { RelatedAsset } from '@metamask/ai-controllers';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
+import { WhatsHappeningSelectorsIDs } from '../../../UI/WhatsHappening/WhatsHappening.testIds';
 import AssetRow from './AssetRow';
 import { getRelatedAssetImageSource } from '../utils/getRelatedAssetImageSource';
 
@@ -149,6 +150,44 @@ describe('AssetRow', () => {
       />,
     );
     expect(screen.queryByText('$')).toBeNull();
+  });
+
+  it('renders a price skeleton when isPriceLoading is true', () => {
+    renderWithProvider(
+      <AssetRow
+        asset={btcAsset}
+        actionLabel="Trade"
+        accessibilityLabel="Trade BTC"
+        onAction={onAction}
+        isPriceLoading
+      />,
+    );
+
+    expect(
+      screen.getByTestId(WhatsHappeningSelectorsIDs.ASSET_PRICE_SKELETON),
+    ).toBeOnTheScreen();
+  });
+
+  it('renders the price line instead of the skeleton when secondaryLine is provided', () => {
+    renderWithProvider(
+      <AssetRow
+        asset={btcAsset}
+        actionLabel="Trade"
+        accessibilityLabel="Trade BTC"
+        onAction={onAction}
+        isPriceLoading={false}
+        secondaryLine={{
+          priceText: '$95,000.00',
+          changeText: '+2.50%',
+          changeColor: TextColor.SuccessDefault,
+        }}
+      />,
+    );
+
+    expect(screen.getByText('$95,000.00')).toBeOnTheScreen();
+    expect(
+      screen.queryByTestId(WhatsHappeningSelectorsIDs.ASSET_PRICE_SKELETON),
+    ).toBeNull();
   });
 
   describe('image routing via RelatedAssetAvatar', () => {

--- a/app/components/Views/WhatsHappeningDetailView/components/AssetRow.tsx
+++ b/app/components/Views/WhatsHappeningDetailView/components/AssetRow.tsx
@@ -13,6 +13,8 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import type { RelatedAsset } from '@metamask/ai-controllers';
+import { Skeleton } from '../../../../component-library/components-temp/Skeleton';
+import { WhatsHappeningSelectorsIDs } from '../../../UI/WhatsHappening/WhatsHappening.testIds';
 import { getRelatedAssetImageSource } from '../utils/getRelatedAssetImageSource';
 import RelatedAssetAvatar from './RelatedAssetAvatar';
 
@@ -29,6 +31,8 @@ interface AssetRowProps {
   onAction?: () => void;
   /** When provided, renders price + 24h change below the asset name. */
   secondaryLine?: AssetRowSecondaryLine;
+  /** Two-line layout with a price-line skeleton until the first quote. */
+  isPriceLoading?: boolean;
 }
 
 /**
@@ -41,11 +45,19 @@ const AssetRow: React.FC<AssetRowProps> = ({
   accessibilityLabel,
   onAction,
   secondaryLine,
+  isPriceLoading = false,
 }) => {
   const image = useMemo(() => getRelatedAssetImageSource(asset), [asset]);
   const title = asset.name || asset.symbol;
 
-  const description = secondaryLine ? (
+  const description = isPriceLoading ? (
+    <Skeleton
+      height={16}
+      width={96}
+      twClassName="rounded"
+      testID={WhatsHappeningSelectorsIDs.ASSET_PRICE_SKELETON}
+    />
+  ) : secondaryLine ? (
     <Box flexDirection={BoxFlexDirection.Row} alignItems={BoxAlignItems.Center}>
       <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
         {secondaryLine.priceText}
@@ -78,7 +90,9 @@ const AssetRow: React.FC<AssetRowProps> = ({
   return (
     <ListItem
       variant={
-        secondaryLine ? ListItemVariant.TwoLines : ListItemVariant.OneLine
+        secondaryLine || isPriceLoading
+          ? ListItemVariant.TwoLines
+          : ListItemVariant.OneLine
       }
       avatar={<RelatedAssetAvatar name={title} image={image} />}
       title={title}

--- a/app/components/Views/WhatsHappeningDetailView/components/PerpsRow.test.tsx
+++ b/app/components/Views/WhatsHappeningDetailView/components/PerpsRow.test.tsx
@@ -6,6 +6,7 @@ import Routes from '../../../../constants/navigation/Routes';
 import type { RelatedAsset } from '@metamask/ai-controllers';
 import type { WhatsHappeningItem } from '../../../UI/WhatsHappening/types';
 import { MetaMetricsEvents } from '../../../../core/Analytics/MetaMetrics.events';
+import { WhatsHappeningSelectorsIDs } from '../../../UI/WhatsHappening/WhatsHappening.testIds';
 import type { PerpsPriceEntry } from '../hooks/useWhatsHappeningAssetPrices';
 
 const mockNavigate = jest.fn();
@@ -232,9 +233,12 @@ describe('PerpsRow', () => {
     );
     expect(screen.getByText('$172.50')).toBeOnTheScreen();
     expect(screen.getByText('+3.45%')).toBeOnTheScreen();
+    expect(
+      screen.queryByTestId(WhatsHappeningSelectorsIDs.ASSET_PRICE_SKELETON),
+    ).toBeNull();
   });
 
-  it('shows no price text when no price entry is available', () => {
+  it('shows a price skeleton when no finite price is available', () => {
     renderWithProvider(
       <PerpsRow
         asset={perpsOnlyAsset}
@@ -244,6 +248,10 @@ describe('PerpsRow', () => {
         perpsPriceBySymbol={emptyPriceMap}
       />,
     );
-    expect(screen.queryByText('$')).toBeNull();
+
+    expect(
+      screen.getByTestId(WhatsHappeningSelectorsIDs.ASSET_PRICE_SKELETON),
+    ).toBeOnTheScreen();
+    expect(screen.queryByText('—')).toBeNull();
   });
 });

--- a/app/components/Views/WhatsHappeningDetailView/components/PerpsRow.tsx
+++ b/app/components/Views/WhatsHappeningDetailView/components/PerpsRow.tsx
@@ -40,14 +40,25 @@ const PerpsRow: React.FC<PerpsRowProps> = ({
   const { handleTrade } = useTradeNavigation(asset);
   const { trackEvent, createEventBuilder } = useAnalytics();
 
-  // Perps prices are always quoted in USD
+  const perpsMarketSymbol = asset.hlPerpsMarket?.[0];
+  const priceEntry = perpsMarketSymbol
+    ? perpsPriceBySymbol[perpsMarketSymbol]
+    : undefined;
+  const hasFinitePrice =
+    priceEntry?.price !== undefined && Number.isFinite(priceEntry.price);
+
+  // Perps prices are always quoted in USD. Wait for a finite quote before
+  // formatting so partial live ticks never render the empty "—" state.
   const secondaryLine = useMemo(() => {
-    const symbol = asset.hlPerpsMarket?.[0];
-    if (!symbol) return undefined;
-    const entry = perpsPriceBySymbol[symbol];
-    if (!entry) return undefined;
-    return formatAssetPrice(entry.price, entry.percentChange24h, 'USD');
-  }, [asset.hlPerpsMarket, perpsPriceBySymbol]);
+    if (!hasFinitePrice || !priceEntry) {
+      return undefined;
+    }
+    return formatAssetPrice(
+      priceEntry.price,
+      priceEntry.percentChange24h,
+      'USD',
+    );
+  }, [hasFinitePrice, priceEntry]);
 
   const handleTradeWithTracking = useCallback(() => {
     const perpsMarket = asset.hlPerpsMarket?.[0];
@@ -77,8 +88,6 @@ const PerpsRow: React.FC<PerpsRowProps> = ({
     createEventBuilder,
   ]);
 
-  const perpsMarketSymbol = asset.hlPerpsMarket?.[0];
-
   return (
     <AssetRow
       asset={asset}
@@ -90,6 +99,7 @@ const PerpsRow: React.FC<PerpsRowProps> = ({
       }
       onAction={perpsMarketSymbol ? handleTradeWithTracking : undefined}
       secondaryLine={secondaryLine}
+      isPriceLoading={Boolean(perpsMarketSymbol) && !hasFinitePrice}
     />
   );
 };

--- a/app/components/Views/WhatsHappeningDetailView/hooks/useWhatsHappeningAssetPrices.test.ts
+++ b/app/components/Views/WhatsHappeningDetailView/hooks/useWhatsHappeningAssetPrices.test.ts
@@ -196,4 +196,82 @@ describe('useWhatsHappeningAssetPrices', () => {
       });
     });
   });
+
+  describe('last-known prices across partial ticks', () => {
+    const ethAsset: RelatedAsset = {
+      sourceAssetId: 'eth',
+      symbol: 'ETH',
+      name: 'Ethereum',
+      hlPerpsMarket: ['ETH'],
+    };
+
+    it('keeps the previous finite price when a later tick omits the symbol', () => {
+      mockUsePerpsLivePrices.mockReturnValue({
+        BTC: { price: '95000', percentChange24h: '2.5' },
+        ETH: { price: '3000', percentChange24h: '1.1' },
+      });
+
+      const { result, rerender } = renderHook(() =>
+        useWhatsHappeningAssetPrices([btcPerpsAsset, ethAsset]),
+      );
+
+      expect(result.current.perpsPriceBySymbol.BTC).toEqual({
+        price: 95000,
+        percentChange24h: 2.5,
+      });
+
+      mockUsePerpsLivePrices.mockReturnValue({
+        ETH: { price: '3100', percentChange24h: '1.4' },
+      });
+      rerender(() => useWhatsHappeningAssetPrices([btcPerpsAsset, ethAsset]));
+
+      expect(result.current.perpsPriceBySymbol.BTC).toEqual({
+        price: 95000,
+        percentChange24h: 2.5,
+      });
+      expect(result.current.perpsPriceBySymbol.ETH).toEqual({
+        price: 3100,
+        percentChange24h: 1.4,
+      });
+    });
+
+    it('leaves price undefined until the first finite quote for a symbol', () => {
+      mockUsePerpsLivePrices.mockReturnValue({
+        ETH: { price: '3000', percentChange24h: '1.1' },
+      });
+
+      const { result } = renderHook(() =>
+        useWhatsHappeningAssetPrices([btcPerpsAsset, ethAsset]),
+      );
+
+      expect(result.current.perpsPriceBySymbol.BTC).toEqual({
+        price: undefined,
+        percentChange24h: undefined,
+      });
+      expect(result.current.perpsPriceBySymbol.ETH.price).toBe(3000);
+    });
+
+    it('drops last-known prices for symbols no longer in the asset list', () => {
+      mockUsePerpsLivePrices.mockReturnValue({
+        BTC: { price: '95000', percentChange24h: '2.5' },
+        ETH: { price: '3000', percentChange24h: '1.1' },
+      });
+
+      const { result, rerender } = renderHook(
+        ({ assets }: { assets: RelatedAsset[] }) =>
+          useWhatsHappeningAssetPrices(assets),
+        { initialProps: { assets: [btcPerpsAsset, ethAsset] } },
+      );
+
+      expect(result.current.perpsPriceBySymbol.BTC?.price).toBe(95000);
+
+      mockUsePerpsLivePrices.mockReturnValue({
+        ETH: { price: '3000', percentChange24h: '1.1' },
+      });
+      rerender({ assets: [ethAsset] });
+
+      expect(result.current.perpsPriceBySymbol.BTC).toBeUndefined();
+      expect(result.current.perpsPriceBySymbol.ETH.price).toBe(3000);
+    });
+  });
 });

--- a/app/components/Views/WhatsHappeningDetailView/hooks/useWhatsHappeningAssetPrices.ts
+++ b/app/components/Views/WhatsHappeningDetailView/hooks/useWhatsHappeningAssetPrices.ts
@@ -1,6 +1,7 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useIsFocused } from '@react-navigation/native';
 import type { RelatedAsset } from '@metamask/ai-controllers';
+import type { PriceUpdate } from '@metamask/perps-controller';
 import { usePerpsLivePrices } from '../../../UI/Perps/hooks/stream';
 
 export interface PerpsPriceEntry {
@@ -15,10 +16,44 @@ export interface UseWhatsHappeningAssetPricesResult {
 
 const NO_SYMBOLS: string[] = [];
 
+const EMPTY_PRICE_ENTRY: PerpsPriceEntry = {
+  price: undefined,
+  percentChange24h: undefined,
+};
+
+function parseLivePriceEntry(
+  liveEntry: PriceUpdate | undefined,
+): PerpsPriceEntry {
+  if (!liveEntry) {
+    return EMPTY_PRICE_ENTRY;
+  }
+
+  const rawPrice = parseFloat(liveEntry.price);
+  const rawChange = liveEntry.percentChange24h
+    ? parseFloat(liveEntry.percentChange24h)
+    : undefined;
+
+  return {
+    price: Number.isNaN(rawPrice) ? undefined : rawPrice,
+    percentChange24h:
+      rawChange !== undefined && Number.isNaN(rawChange)
+        ? undefined
+        : rawChange,
+  };
+}
+
+function hasFinitePrice(entry: PerpsPriceEntry): boolean {
+  return entry.price !== undefined && Number.isFinite(entry.price);
+}
+
 /**
  * Returns live price data for every perps market referenced by the given
  * related assets. Prices come from the WebSocket stream via
  * `usePerpsLivePrices` and are throttled to 3 s to limit re-renders.
+ *
+ * `usePerpsLivePrices` replaces its map on every tick, and ticks are often
+ * partial (only symbols that changed). This hook keeps last-known finite
+ * prices so omitted symbols do not flash empty.
  *
  * Assets without an `hlPerpsMarket` entry are ignored.
  */
@@ -44,26 +79,25 @@ export function useWhatsHappeningAssetPrices(
     throttleMs: 3000,
   });
 
+  const lastKnownBySymbolRef = useRef<Record<string, PerpsPriceEntry>>({});
+
   const perpsPriceBySymbol = useMemo<Record<string, PerpsPriceEntry>>(() => {
     const map: Record<string, PerpsPriceEntry> = {};
+    const nextKnown: Record<string, PerpsPriceEntry> = {};
+
     for (const symbol of perpsSymbols) {
-      const liveEntry = livePerpsPrices[symbol];
-      if (!liveEntry) {
-        map[symbol] = { price: undefined, percentChange24h: undefined };
-        continue;
+      const parsed = parseLivePriceEntry(livePerpsPrices[symbol]);
+      const resolved = hasFinitePrice(parsed)
+        ? parsed
+        : (lastKnownBySymbolRef.current[symbol] ?? parsed);
+      map[symbol] = resolved;
+      if (hasFinitePrice(resolved)) {
+        nextKnown[symbol] = resolved;
       }
-      const rawPrice = parseFloat(liveEntry.price);
-      const rawChange = liveEntry.percentChange24h
-        ? parseFloat(liveEntry.percentChange24h)
-        : undefined;
-      map[symbol] = {
-        price: isNaN(rawPrice) ? undefined : rawPrice,
-        percentChange24h:
-          rawChange !== undefined && isNaN(rawChange) ? undefined : rawChange,
-      };
     }
+
+    lastKnownBySymbolRef.current = nextKnown;
     return map;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [perpsSymbols, livePerpsPrices]);
 
   return { perpsPriceBySymbol };


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Related Assets on the What's Happening detail card were flashing between a live price and an empty `—`. Each expanded card subscribes to several perps symbols through one `usePerpsLivePrices` call. That hook replaces its entire map on every tick, and ticks are often partial (only symbols that changed), so omitted symbols became `undefined` and rendered as a dash.

This keeps last-known finite prices in `useWhatsHappeningAssetPrices` (What's Happening only — no Perps stream changes). Rows that have never received a quote show a small skeleton instead of `—`. After the first quote, the row keeps that price until a newer tick for that symbol arrives.


https://github.com/user-attachments/assets/7e0da352-a3ea-446a-bd68-ac0bc33855e0

<img height="810" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-20 at 18 12 26" src="https://github.com/user-attachments/assets/4bd10acd-28e8-436b-a591-97dce3b14981" />


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed What's Happening related asset prices flickering between a live quote and an empty dash

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TSA-1024

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: What's Happening related asset prices

  Background:
    Given I am logged into MetaMask Mobile
    And What's Happening is enabled
    And perps markets are available

  Scenario: related assets do not flash an empty dash after the first quote
    Given I open the What's Happening detail view from the homepage
    And the visible card lists multiple related assets

    When live prices start arriving for some assets before others
    Then assets without a first quote show a skeleton under the name
    And assets with a quote show price and 24h change
    And a quoted asset does not flip back to "—" while other assets update

  Scenario: Trade remains available while prices load
    Given I am on a What's Happening expanded card with related assets

    When a related asset still shows the price skeleton
    Then the Trade button is still visible
    And tapping Trade still opens the perps market
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of this change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only price display and local last-known caching in What's Happening; no auth, trading, or stream-protocol changes.
> 
> **Overview**
> Fixes related-asset prices on the What's Happening detail card flickering between a live quote and an empty dash when partial perps ticks omit symbols.
> 
> `useWhatsHappeningAssetPrices` now keeps last-known **finite** prices across ticks and drops entries when a symbol leaves the asset list. `PerpsRow` only formats a price after a finite quote; until then `AssetRow` uses a two-line **skeleton** instead of `—`. Trade remains available while prices load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35ae499fcbc74153ad124a209144b1cf742b32d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->