### PR TITLE
chore(ci): remove Cirrus runner fallback

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,9 +26,8 @@ When you're done with your project / bugfix / feature and ready to submit a PR, 
 
 ### Runner provider switch
 
-Which runner fleet a job lands on is controlled by four repository-level Actions variables. They exist so the fleet can be moved or rolled back by editing variables, with no code change, no revert and no redeploy.
+Which runner fleet a job lands on is controlled by three repository-level Actions variables and, where supported, an explicit workflow input. Namespace is the default for migrated jobs.
 
-- `NAMESPACE_RUNNER_PROVIDER` — fallback when the job's platform variable is unset. It does not override `NAMESPACE_RUNNER_LINUX` / `_ANDROID` / `_IOS`.
 - `NAMESPACE_RUNNER_IOS` — iOS and macOS jobs only.
 - `NAMESPACE_RUNNER_ANDROID` — Android build and e2e jobs only.
 - `NAMESPACE_RUNNER_LINUX` — everything else (lint, unit, integration, upload and summary jobs).
@@ -36,30 +35,25 @@ Which runner fleet a job lands on is controlled by four repository-level Actions
 Accepted values:
 
 - `namespace` — Namespace runners (`namespace-profile-*`).
-- `current` — the routing that predates the Namespace migration. This is not one label: it resolves per job to Cirrus for native builds and e2e, and to `ubuntu-latest` or `macos-latest` for the lighter jobs.
+- `bitrise` — Bitrise Build Hub runners, only for workflows that explicitly support the Bitrise provider.
 
 Resolution order, highest priority first:
 
 1. The `runner_provider` workflow input, when it is set to something other than `inherit`. This is a per-run override.
 2. The platform variable for the job (`NAMESPACE_RUNNER_IOS`, `_ANDROID` or `_LINUX`).
-3. `NAMESPACE_RUNNER_PROVIDER`.
-4. `current`.
+3. `namespace` (the safe default when no supported provider is selected).
 
-Push-, schedule- and `merge_group`-triggered workflows have no dispatch inputs, so the variables are the only way to steer them. That is why the input default is empty rather than a concrete provider.
+Push-, schedule- and `merge_group`-triggered workflows have no dispatch inputs, so the platform variables are the way to steer them. When a platform variable is unset, the workflow defaults to Namespace.
 
-The production build chain (`build.yml`, `setup-node-modules.yml`, `upload-to-testflight.yml` and their callers) and PR CI (`ci.yml` plus the Android/iOS e2e build workflows) are on the switch. BrowserStack native builds go through `build.yml` and follow the fleet. OTA (`eas-update-platform.yml`) and iOS BrowserStack upload follow `NAMESPACE_RUNNER_LINUX` (`ci-linux` vs `ubuntu-latest`). Android BrowserStack upload/repack follows `NAMESPACE_RUNNER_ANDROID` (`metamask-android-build`, which has JDK and `/opt/android-sdk`) and keeps Cirrus / `ubuntu-latest` only for `current` rollback. Do not put that job on `ci-linux`.
+The production build chain (`build.yml`, `setup-node-modules.yml`, `upload-to-testflight.yml` and their callers) and PR CI (`ci.yml` plus the Android/iOS e2e build workflows) use Namespace. BrowserStack native builds go through `build.yml` and follow the platform fleet. OTA (`eas-update-platform.yml`) and iOS BrowserStack upload follow `NAMESPACE_RUNNER_LINUX` (`ci-linux` vs `ubuntu-latest`). Android BrowserStack upload/repack follows `NAMESPACE_RUNNER_ANDROID` (`metamask-android-build`, which has JDK and `/opt/android-sdk`). Bitrise routing remains explicit and separate. Do not put that job on `ci-linux`.
 
-The scheduled arm64 E2E APK build (`build-android-arm64-scheduled.yml`) previously stayed on Cirrus for artifact-store parity, but now uses `inherit`. When resolved to Namespace, it dual-uploads the release APK to both GitHub Actions and Namespace artifact stores; on a `current` rollback it uploads to GitHub only. That keeps the local-repro `gh run download` path working while the build itself runs on Namespace. Appium jobs and fixture validation already follow the same resolution chain as the PR build jobs (converted in #35002).
+The scheduled arm64 E2E APK build (`build-android-arm64-scheduled.yml`) uses `inherit`. It dual-uploads the release APK to both GitHub Actions and Namespace artifact stores so the local-repro `gh run download` path continues to work while the build runs on Namespace. Appium jobs and fixture validation follow the same resolution chain as the PR build jobs (converted in #35002).
 
 A few short GitHub-hosted jobs stay on `ubuntu-latest` on purpose and do not follow `NAMESPACE_RUNNER_LINUX`: `get-requirements.yml`, `native-build-fingerprint`, `prepare-e2e-timings`, `ios-tests-ready`, and `cleanup-ci-js-deps`.
 
-#### Rolling back
+#### Provider overrides
 
-- Everything back to the pre-migration routing: set `NAMESPACE_RUNNER_LINUX`, `NAMESPACE_RUNNER_ANDROID`, and `NAMESPACE_RUNNER_IOS` to `current` (or clear them). `NAMESPACE_RUNNER_PROVIDER=current` alone does nothing while those platform vars stay `namespace`.
-- Android only, leaving iOS and Linux on Namespace: set `NAMESPACE_RUNNER_ANDROID=current`.
-- iOS only: set `NAMESPACE_RUNNER_IOS=current`.
-- Generic Linux CI jobs back to `ubuntu-latest`: set `NAMESPACE_RUNNER_LINUX=current`.
-- A single run, without touching any variable: dispatch the workflow with `runner_provider=current`.
+The legacy runner rollback path has been retired. Namespace is the supported provider for migrated jobs. Bitrise may be selected explicitly only in workflows that document Bitrise support.
 
 In-flight runs are unaffected; the next run picks up the new value.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Which runner fleet a job lands on is controlled by three repository-level Action
 Accepted values:
 
 - `namespace` — Namespace runners (`namespace-profile-*`).
-- `bitrise` — Bitrise Build Hub runners, only for workflows that explicitly support the Bitrise provider.
+- Any other value (including an unset platform variable with no dispatch override) falls through to GitHub-hosted runners (`ubuntu-latest` on Linux, `macos-15` on macOS).
 
 Resolution order, highest priority first:
 
@@ -45,7 +45,7 @@ Resolution order, highest priority first:
 
 Push-, schedule- and `merge_group`-triggered workflows have no dispatch inputs, so the platform variables are the way to steer them. When a platform variable is unset, the workflow defaults to Namespace.
 
-The production build chain (`build.yml`, `setup-node-modules.yml`, `upload-to-testflight.yml` and their callers) and PR CI (`ci.yml` plus the Android/iOS e2e build workflows) use Namespace. BrowserStack native builds go through `build.yml` and follow the platform fleet. OTA (`eas-update-platform.yml`) and iOS BrowserStack upload follow `NAMESPACE_RUNNER_LINUX` (`ci-linux` vs `ubuntu-latest`). Android BrowserStack upload/repack follows `NAMESPACE_RUNNER_ANDROID` (`metamask-android-build`, which has JDK and `/opt/android-sdk`). Bitrise routing remains explicit and separate. Do not put that job on `ci-linux`.
+The production build chain (`build.yml`, `setup-node-modules.yml`, `upload-to-testflight.yml` and their callers) and PR CI (`ci.yml` plus the Android/iOS e2e build workflows) use Namespace. BrowserStack native builds go through `build.yml` and follow the platform fleet. OTA (`eas-update-platform.yml`) and iOS BrowserStack upload follow `NAMESPACE_RUNNER_LINUX` (`ci-linux` vs `ubuntu-latest`). Android BrowserStack upload/repack follows `NAMESPACE_RUNNER_ANDROID` (`metamask-android-build`, which has JDK and `/opt/android-sdk`). Do not put that job on `ci-linux`.
 
 The scheduled arm64 E2E APK build (`build-android-arm64-scheduled.yml`) uses `inherit`. It dual-uploads the release APK to both GitHub Actions and Namespace artifact stores so the local-repro `gh run download` path continues to work while the build runs on Namespace. Appium jobs and fixture validation follow the same resolution chain as the PR build jobs (converted in #35002).
 
@@ -53,7 +53,7 @@ A few short GitHub-hosted jobs stay on `ubuntu-latest` on purpose and do not fol
 
 #### Provider overrides
 
-The legacy runner rollback path has been retired. Namespace is the supported provider for migrated jobs. Bitrise may be selected explicitly only in workflows that document Bitrise support.
+The legacy Cirrus/`current` rollback path has been retired. Namespace is the supported provider for migrated jobs. Non-Namespace resolution routes to GitHub-hosted runners.
 
 In-flight runs are unaffected; the next run picks up the new value.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,8 +34,8 @@ Which runner fleet a job lands on is controlled by three repository-level Action
 
 Accepted values:
 
-- `namespace` — Namespace runners (`namespace-profile-*`).
-- Any other value (including an unset platform variable with no dispatch override) falls through to GitHub-hosted runners (`ubuntu-latest` on Linux, `macos-15` on macOS).
+- `namespace` — Namespace runners (`namespace-profile-*`). Default when a platform variable is unset.
+- Any other explicit value routes to GitHub-hosted runners (`ubuntu-latest` on Linux, `macos-15` on macOS).
 
 Resolution order, highest priority first:
 

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -9,12 +9,6 @@ self-hosted-runner:
     - "gha-mm-scale-set-ubuntu-22.04-amd64-small"
     - "gha-mm-scale-set-ubuntu-22.04-amd64-med"
     - "macos-15"
-    - "ghcr.io/cirruslabs/macos-runner:tahoe"
-    - "ghcr.io/cirruslabs/macos-runner:tahoe-xl"
-    - "ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md"
-    - "ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg"
-    - "ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-xl"
-    - "low-priority"
     # Namespace runner profile labels (INFRA-3592). Format: namespace-profile-<profile-name>.
     - "namespace-profile-metamask-ci-linux"
     - "namespace-profile-metamask-android-build"

--- a/.github/actions/download-e2e-artifact/action.yml
+++ b/.github/actions/download-e2e-artifact/action.yml
@@ -1,5 +1,5 @@
 # Download from the artifact store that matches the selected runner provider.
-# Namespace runners read Namespace storage; current runners read GitHub storage.
+# Namespace runners read Namespace storage; GitHub-hosted runners read GitHub storage.
 name: 'Download E2E artifact'
 description: >
   Download an artifact from Namespace storage when runner-provider contains

--- a/.github/actions/dual-upload-e2e-artifact/dual-upload-e2e-artifact.test.ts
+++ b/.github/actions/dual-upload-e2e-artifact/dual-upload-e2e-artifact.test.ts
@@ -158,9 +158,9 @@ describe('dual-upload-e2e-artifact', () => {
     );
   });
 
-  it('still requires GitHub on current even when skip-github is set', () => {
+  it('still requires GitHub on non-Namespace runners even when skip-github is set', () => {
     const result = runScript({
-      RUNNER_PROVIDER: 'current',
+      RUNNER_PROVIDER: 'ubuntu-latest',
       SKIP_GITHUB: 'true',
       GH_1: 'success',
     });
@@ -195,9 +195,9 @@ describe('dual-upload-e2e-artifact', () => {
     );
   });
 
-  it('requires only GitHub for the current provider', () => {
+  it('requires only GitHub for a GitHub-hosted runner provider', () => {
     const result = runScript({
-      RUNNER_PROVIDER: 'current',
+      RUNNER_PROVIDER: 'ubuntu-latest',
       GH_1: 'success',
     });
 
@@ -205,9 +205,9 @@ describe('dual-upload-e2e-artifact', () => {
     expect(result.stdout).toContain('Uploaded to GitHub store');
   });
 
-  it('fails the current provider when GitHub upload fails', () => {
+  it('fails GitHub-hosted upload when GitHub upload fails', () => {
     const result = runScript({
-      RUNNER_PROVIDER: 'current',
+      RUNNER_PROVIDER: 'ubuntu-latest',
       GH_1: 'failure',
     });
 

--- a/.github/actions/setup-ci-js-deps/action.yml
+++ b/.github/actions/setup-ci-js-deps/action.yml
@@ -10,7 +10,7 @@ inputs:
   runner_provider:
     description: 'Runner provider (`namespace` or any GitHub-hosted value).'
     required: false
-    default: 'current'
+    default: 'namespace'
 
 runs:
   using: 'composite'

--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: false
     default: '3.2.9'
   xcode-version:
-    description: 'Xcode version to select (e.g., 26.3). Uses xcodes CLI on Cirrus Labs runners, falls back to xcode-select on GitHub-hosted runners.'
+    description: 'Xcode version to select (e.g., 26.3). Uses the xcodes CLI via `sudo xcodes select`.'
     required: false
     default: '26.3'
   jdk-version:
@@ -88,9 +88,9 @@ inputs:
     required: false
     default: 'qa'
   runner_provider:
-    description: 'Runner provider forwarded from the caller workflow chain. When set to "namespace", toolchain-install steps short-circuit if the pinned version is already on the image. Default "current" preserves byte-identical behaviour on existing GitHub-hosted / Cirrus runners.'
+    description: 'Runner provider forwarded from the caller workflow chain. When set to "namespace", toolchain-install steps short-circuit if the pinned version is already on the image. Defaults to "namespace".'
     required: false
-    default: 'current'
+    default: 'namespace'
   js-retry-timeout-minutes:
     description: >-
       Per-attempt timeout (minutes) for Corepack and yarn install retry steps.

--- a/.github/workflows/build-and-upload-to-testflight.yml
+++ b/.github/workflows/build-and-upload-to-testflight.yml
@@ -68,7 +68,6 @@ on:
         options:
           - inherit
           - namespace
-          - current
         default: inherit
 
 permissions:

--- a/.github/workflows/build-android-arm64-scheduled.yml
+++ b/.github/workflows/build-android-arm64-scheduled.yml
@@ -58,9 +58,8 @@ jobs:
       build_type: main
       metamask_environment: e2e
       include_arm64: true
-      # Follows standard resolution (NAMESPACE_RUNNER_ANDROID -> NAMESPACE_RUNNER_PROVIDER).
-      # When resolved to namespace, build-android-e2e.yml dual-uploads the arm64 release APK
-      # to Namespace and GitHub stores so gh run download keeps working. On current rollback,
-      # only the GitHub store receives the APK (sufficient for local repro).
+      # Follows standard resolution through NAMESPACE_RUNNER_ANDROID, defaulting to Namespace.
+      # build-android-e2e.yml dual-uploads the arm64 release APK to Namespace and GitHub
+      # stores so gh run download keeps working.
       runner_provider: inherit
     secrets: inherit

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -56,27 +56,26 @@ on:
 jobs:
   build-android-apks:
     name: Build Android E2E APKs
-    # The current arm uses the 48 GB Cirrus runner with lower priority outside releases.
+    # Namespace is the supported runner for Android E2E builds. GitHub-hosted labels are
+    # retained only as a defensive fallback for explicitly overridden provider values.
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-         vars.NAMESPACE_RUNNER_ANDROID || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+         vars.NAMESPACE_RUNNER_ANDROID || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-android-build' ||
-        (startsWith(github.base_ref, 'release/') &&
-         fromJSON('["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg"]') ||
-         fromJSON('["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg", "low-priority"]'))
+        'ubuntu-latest'
       }}
     timeout-minutes: 40
     env:
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
           inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-          vars.NAMESPACE_RUNNER_ANDROID || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+          vars.NAMESPACE_RUNNER_ANDROID || 'namespace'
         }}
       GRADLE_USER_HOME: >-
         ${{
           (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-           vars.NAMESPACE_RUNNER_ANDROID || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+           vars.NAMESPACE_RUNNER_ANDROID || 'namespace') == 'namespace' &&
           '/home/runner/_work/.gradle' || '/home/admin/_work/.gradle'
         }}
       CACHE_GENERATION: v1 # Increment this to bust the cache (v1, v2, v3, etc.)
@@ -228,7 +227,7 @@ jobs:
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' && steps.force-builds.outputs.force != 'true' && steps.find-reusable-build.outputs.found != 'true' && inputs.include_arm64 == false && inputs.reuse-main-builds-only != true }}
         id: apk-cache-restore
         # This action automatically updates the cache at the end of the workflow
-        uses: cirruslabs/cache@bba69c6578b863ad0398ad40567bd2ef70290fe0 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ${{ steps.determine-target-paths.outputs.apk-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}.apk
@@ -239,7 +238,7 @@ jobs:
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' && steps.force-builds.outputs.force != 'true' && steps.find-reusable-build.outputs.found != 'true' && inputs.include_arm64 == false && (inputs.reuse-main-builds-only == true || (steps.apk-cache-restore.outputs.cache-hit != 'true' && github.ref_name != 'main')) }}
         id: apk-cache-restore-main
         # This will only restore the cache, not update it
-        uses: cirruslabs/cache/restore@bba69c6578b863ad0398ad40567bd2ef70290fe0 # v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ${{ steps.determine-target-paths.outputs.apk-target-path }}/${{ steps.determine-target-paths.outputs.artifact_name }}.apk
@@ -431,7 +430,7 @@ jobs:
       #
       # Deliberately placed *before* the Gradle cache restores rather than directly
       # before the build, which is where the iOS equivalent sits. "Restore Gradle
-      # dependencies from branch cache" below is `cirruslabs/cache` (not `/restore`),
+      # dependencies from branch cache" below is `actions/cache` (not `/restore`),
       # so it saves at post-job whenever its key missed. Today a miss is always
       # followed by a compile, so what it saves is populated; if a late reuse could
       # skip the compile after that step had run, the post-job save would write a
@@ -570,12 +569,12 @@ jobs:
 
       # Skipped on Namespace runners because the Namespace cache action above
       # already handles `${GRADLE_USER_HOME}/caches` and `wrapper` — running
-      # cirruslabs/cache on top of it would be redundant work and a redundant
+      # actions/cache on top of it would be redundant work and a redundant
       # save at end of run.
       - name: Restore Gradle dependencies from branch cache
         id: gradle-cache-restore
         # This action automatically updates the cache at the end of the workflow
-        uses: cirruslabs/cache@bba69c6578b863ad0398ad40567bd2ef70290fe0 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' && steps.gate.outputs.needs-native-build == 'true' && !(steps.download-late-apk.outcome == 'success' && steps.download-late-test-apk.outcome == 'success') }}
         env:
           GRADLE_CACHE_VERSION: 1
@@ -590,7 +589,7 @@ jobs:
 
       - name: Restore Gradle dependencies from main cache
         # This will only restore the cache, not update it
-        uses: cirruslabs/cache/restore@bba69c6578b863ad0398ad40567bd2ef70290fe0 # v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' && steps.gate.outputs.needs-native-build == 'true' && steps.gradle-cache-restore.outputs.cache-hit != 'true' && github.ref_name != 'main' && !(steps.download-late-apk.outcome == 'success' && steps.download-late-test-apk.outcome == 'success') }}
         env:
           GRADLE_CACHE_VERSION: 1
@@ -704,8 +703,8 @@ jobs:
           IGNORE_BOXLOGS_DEVELOPMENT: true
           GITHUB_CI: 'true'
           CI: 'true'
-          NODE_OPTIONS: '--max-old-space-size=8192'
-          METRO_MAX_WORKERS: '6'
+          NODE_OPTIONS: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' && '--max-old-space-size=8192' || '--max-old-space-size=4096' }}
+          METRO_MAX_WORKERS: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' && '6' || '4' }}
           RAMP_INTERNAL_BUILD: 'true'
           SEEDLESS_ONBOARDING_ENABLED: 'true'
           MM_NOTIFICATIONS_UI_ENABLED: 'true'

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -348,7 +348,7 @@ jobs:
               echo "Test-only PR: reusing main branch Android artifacts from GitHub Actions (no repack)."
             elif [[ "${{ steps.apk-cache-restore-main.outputs.cache-hit }}" == "true" ]]; then
               echo "needs-native-build=false" >> "$GITHUB_OUTPUT"
-              echo "Test-only PR: reusing main branch Android artifacts from Cirrus APK cache (no repack)."
+              echo "Test-only PR: reusing main branch Android artifacts from Namespace APK cache (no repack)."
             else
               echo "::warning::Test-only PR could not reuse main Android builds yet (GitHub artifacts or main APK cache). Falling back to fresh native build."
               echo "needs-native-build=true" >> "$GITHUB_OUTPUT"
@@ -516,7 +516,7 @@ jobs:
       # there because `actions/download-artifact` merges into its destination and the
       # iOS payload is a `.app` *directory* bundle, so a stale one would blend with
       # the donor's. An APK is a single file that the extraction overwrites whole.
-      # Nothing on this path should have written these files either: the Cirrus APK
+      # Nothing on this path should have written these files either: the Namespace APK
       # caches above only restore when the first lookup found nothing, and a hit
       # there forces `needs-native-build=false`, which this step cannot be reached
       # under. Kept as cheap insurance against a partial restore — if the download
@@ -801,7 +801,7 @@ jobs:
           # `needs-native-build=true`, because it was computed before the re-check.
           # A late reuse is mutually exclusive with every other branch below — it
           # requires a non-Namespace runner and a `true` gate, so no Namespace hit,
-          # no early GitHub reuse and no Cirrus hit can coexist with it.
+          # no early GitHub reuse and no Namespace cache hit can coexist with it.
           decision="Fresh native build"
           if [[ "${LATE_APK_DOWNLOAD_OUTCOME:-}" == "success" && "${LATE_TEST_APK_DOWNLOAD_OUTCOME:-}" == "success" ]]; then
             decision="GitHub artifact reuse (late — donor appeared during setup)"
@@ -810,7 +810,7 @@ jobs:
           elif [[ "${REUSABLE_FOUND:-}" == "true" && "${METADATA_VALID:-}" == "true" && "${APK_DOWNLOAD_OUTCOME:-}" == "success" && "${TEST_APK_DOWNLOAD_OUTCOME:-}" == "success" ]]; then
             decision="GitHub artifact reuse"
           elif [[ "${BRANCH_CACHE_HIT:-}" == "true" || "${MAIN_CACHE_HIT:-}" == "true" ]]; then
-            decision="Cirrus APK cache"
+            decision="Namespace APK cache"
           elif [[ "${NEEDS_NATIVE_BUILD:-}" == "false" ]]; then
             decision="reuse/cache hit"
           fi

--- a/.github/workflows/build-android-e2e.yml
+++ b/.github/workflows/build-android-e2e.yml
@@ -72,12 +72,10 @@ jobs:
           inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
           vars.NAMESPACE_RUNNER_ANDROID || 'namespace'
         }}
-      GRADLE_USER_HOME: >-
-        ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-           vars.NAMESPACE_RUNNER_ANDROID || 'namespace') == 'namespace' &&
-          '/home/runner/_work/.gradle' || '/home/admin/_work/.gradle'
-        }}
+      # Namespace and GitHub-hosted runners use the standard runner home.
+      # Cannot reference RESOLVED_RUNNER_PROVIDER: env entries in the same block are
+      # not visible to each other.
+      GRADLE_USER_HOME: /home/runner/_work/.gradle
       CACHE_GENERATION: v1 # Increment this to bust the cache (v1, v2, v3, etc.)
       YARN_ENABLE_GLOBAL_CACHE: 'true' # Enable Yarn global cache for faster installs
       E2E_BUILD_METADATA_ARTIFACT: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-android-build-metadata

--- a/.github/workflows/build-android-internal-distribution.yml
+++ b/.github/workflows/build-android-internal-distribution.yml
@@ -28,7 +28,6 @@ on:
         options:
           - inherit
           - namespace
-          - current
         default: inherit
 
 permissions:
@@ -53,7 +52,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-         vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+         vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     outputs:

--- a/.github/workflows/build-android-upload-to-browserstack.yml
+++ b/.github/workflows/build-android-upload-to-browserstack.yml
@@ -101,7 +101,6 @@ on:
         type: choice
         options:
           - inherit
-          - current
           - namespace
         default: inherit
 
@@ -463,23 +462,20 @@ jobs:
     name: Upload APKs to BrowserStack
     # Namespace uses metamask-android-build (JDK + /opt/android-sdk). ci-linux
     # does not have that image; setup-e2e-env skips JDK when provider=namespace.
-    # current keeps today's split: Cirrus lg for fingerprint-repack, ubuntu-latest
-    # for as-is/fresh upload.
+    # GitHub-hosted labels are retained only as a defensive fallback for explicitly
+    # overridden provider values.
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-         vars.NAMESPACE_RUNNER_ANDROID || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+         vars.NAMESPACE_RUNNER_ANDROID || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-android-build' ||
-        (needs.resolve-fingerprint-reuse.outputs.found == 'true' &&
-         inputs.main_branch_only != true &&
-         fromJSON('["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg"]') ||
-         fromJSON('["ubuntu-latest"]'))
+        'ubuntu-latest'
       }}
     env:
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
           inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-          vars.NAMESPACE_RUNNER_ANDROID || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+          vars.NAMESPACE_RUNNER_ANDROID || 'namespace'
         }}
     # Only the JS-repack path needs build-e2e/rc/exp secrets (ADDITIONAL_SRP_1, etc.).
     # Fresh/as-is upload only needs repo-level BrowserStack credentials.
@@ -597,8 +593,8 @@ jobs:
           CI: 'true'
           GITHUB_CI: 'true'
           PLATFORM: android
-          NODE_OPTIONS: '--max-old-space-size=8192'
-          METRO_MAX_WORKERS: '6'
+          NODE_OPTIONS: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' && '--max-old-space-size=8192' || '--max-old-space-size=4096' }}
+          METRO_MAX_WORKERS: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' && '6' || '4' }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -62,7 +62,6 @@ on:
         options:
           - inherit
           - namespace
-          - current
         default: inherit
 
 permissions:

--- a/.github/workflows/build-ios-e2e.yml
+++ b/.github/workflows/build-ios-e2e.yml
@@ -47,11 +47,13 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-         vars.NAMESPACE_RUNNER_IOS || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+         vars.NAMESPACE_RUNNER_IOS || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ios-build' ||
-        (startsWith(github.base_ref, 'release/') &&
-         fromJSON('["ghcr.io/cirruslabs/macos-runner:tahoe-xl"]') ||
-         fromJSON('["ghcr.io/cirruslabs/macos-runner:tahoe-xl", "low-priority"]'))
+        inputs.runner_provider == 'bitrise' &&
+        (vars.BITRISE_BUILD_MACHINE_TYPE != '' &&
+         fromJSON(format('["bitrise_pool_name:bitrise-metamask-ios-build","{0}"]', vars.BITRISE_BUILD_MACHINE_TYPE)) ||
+         'bitrise_pool_name:bitrise-metamask-ios-build') ||
+        'macos-15'
       }}
     outputs:
       artifacts-url: ${{ steps.set-artifacts-url.outputs.artifacts-url }}
@@ -61,7 +63,7 @@ jobs:
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
           inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-          vars.NAMESPACE_RUNNER_IOS || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+          vars.NAMESPACE_RUNNER_IOS || 'namespace'
         }}
       IOS_APP_CACHE_VERSION: 2
       XCODE_CACHE_VERSION: 1
@@ -235,7 +237,7 @@ jobs:
         id: ios-app-cache-restore
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' && steps.force-builds.outputs.force != 'true' && steps.find-reusable-build.outputs.found != 'true' && inputs.source-fingerprint != '' && inputs.reuse-main-builds-only != true }}
         # This action automatically updates the cache at the end of the workflow
-        uses: cirruslabs/cache@bba69c6578b863ad0398ad40567bd2ef70290fe0 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
@@ -245,7 +247,7 @@ jobs:
         id: ios-app-cache-restore-main
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' && steps.force-builds.outputs.force != 'true' && steps.find-reusable-build.outputs.found != 'true' && inputs.source-fingerprint != '' && (inputs.reuse-main-builds-only == true || (steps.ios-app-cache-restore.outputs.cache-hit != 'true' && github.ref_name != 'main')) }}
         # This will only restore the cache, not update it
-        uses: cirruslabs/cache/restore@bba69c6578b863ad0398ad40567bd2ef70290fe0 # v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
@@ -297,7 +299,7 @@ jobs:
         id: xcode-restore-cache
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' && steps.gate.outputs.needs-native-build == 'true' }}
         # This action automatically updates the cache at the end of the workflow
-        uses: cirruslabs/cache@bba69c6578b863ad0398ad40567bd2ef70290fe0 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/Library/Developer/Xcode/DerivedData
@@ -307,7 +309,7 @@ jobs:
       - name: Restore Xcode derived data from main cache
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' && steps.gate.outputs.needs-native-build == 'true' && steps.xcode-restore-cache.outputs.cache-hit != 'true' && github.ref_name != 'main' }}
         id: xcode-restore-cache-main
-        uses: cirruslabs/cache/restore@bba69c6578b863ad0398ad40567bd2ef70290fe0 # v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/Library/Developer/Xcode/DerivedData
@@ -867,7 +869,7 @@ jobs:
           echo "Upload Status Summary:"
           echo "- APP (Simulator): namespace=${{ steps.upload-app-namespace.outcome }} github=${{ steps.upload-app.outcome }}"
           echo "- Build metadata: namespace=${{ steps.upload-metadata-namespace.outcome }} github=${{ steps.upload-metadata.outcome }}"
-          echo "- Source Map: namespace=${{ steps.upload-sourcemap-namespace.outcome }} current=${{ steps.upload-sourcemap.outcome }}"
+          echo "- Source Map: namespace=${{ steps.upload-sourcemap-namespace.outcome }} github=${{ steps.upload-sourcemap.outcome }}"
 
         env:
           GITHUB_REPOSITORY: '${{ github.repository }}'

--- a/.github/workflows/build-ios-e2e.yml
+++ b/.github/workflows/build-ios-e2e.yml
@@ -49,10 +49,6 @@ jobs:
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
          vars.NAMESPACE_RUNNER_IOS || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ios-build' ||
-        inputs.runner_provider == 'bitrise' &&
-        (vars.BITRISE_BUILD_MACHINE_TYPE != '' &&
-         fromJSON(format('["bitrise_pool_name:bitrise-metamask-ios-build","{0}"]', vars.BITRISE_BUILD_MACHINE_TYPE)) ||
-         'bitrise_pool_name:bitrise-metamask-ios-build') ||
         'macos-15'
       }}
     outputs:

--- a/.github/workflows/build-ios-e2e.yml
+++ b/.github/workflows/build-ios-e2e.yml
@@ -224,7 +224,7 @@ jobs:
           echo "Source branch: ${{ steps.find-reusable-build.outputs.source-branch }}"
         shell: bash
 
-      # Fingerprint-keyed iOS app cache — parity with Android's Cirrus APK cache. This
+      # Fingerprint-keyed iOS app cache — parity with Android's Namespace APK cache. This
       # catches the cases GitHub artifact discovery misses (donor run cancelled before
       # upload, artifact past its 7-day retention, or outside the search window): once a
       # native build with this fingerprint has completed on this branch (or on main), the
@@ -233,7 +233,7 @@ jobs:
       # The key carries build_type and metamask_environment because those are what
       # distinguish one compiled .app from another (they're the same fields the GitHub
       # artifact is named after), on top of the fingerprint itself.
-      - name: Restore iOS app matching fingerprint from branch cache (Cirrus)
+      - name: Restore iOS app matching fingerprint from branch cache (Namespace)
         id: ios-app-cache-restore
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' && steps.force-builds.outputs.force != 'true' && steps.find-reusable-build.outputs.found != 'true' && inputs.source-fingerprint != '' && inputs.reuse-main-builds-only != true }}
         # This action automatically updates the cache at the end of the workflow
@@ -243,7 +243,7 @@ jobs:
             ios/build/Build/Products/Release-iphonesimulator/MetaMask.app
           key: ios-app-${{ github.ref_name }}-${{ inputs.build_type }}-${{ inputs.metamask_environment }}-v${{ env.IOS_APP_CACHE_VERSION }}-${{ inputs.source-fingerprint }}
 
-      - name: Restore iOS app matching fingerprint from main cache (Cirrus)
+      - name: Restore iOS app matching fingerprint from main cache (Namespace)
         id: ios-app-cache-restore-main
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' && steps.force-builds.outputs.force != 'true' && steps.find-reusable-build.outputs.found != 'true' && inputs.source-fingerprint != '' && (inputs.reuse-main-builds-only == true || (steps.ios-app-cache-restore.outputs.cache-hit != 'true' && github.ref_name != 'main')) }}
         # This will only restore the cache, not update it
@@ -266,7 +266,7 @@ jobs:
               echo "Test-only PR: reusing main branch iOS artifacts from GitHub Actions (no repack)."
             elif [[ "${{ steps.ios-app-cache-restore-main.outputs.cache-hit }}" == "true" ]]; then
               echo "needs-native-build=false" >> "$GITHUB_OUTPUT"
-              echo "Test-only PR: reusing main branch iOS app from Cirrus cache (no repack)."
+              echo "Test-only PR: reusing main branch iOS app from Namespace cache (no repack)."
             else
               echo "::warning::Test-only PR could not reuse main iOS builds yet (GitHub artifacts or main app cache). Falling back to fresh native build."
               echo "needs-native-build=true" >> "$GITHUB_OUTPUT"
@@ -279,7 +279,7 @@ jobs:
           elif [[ "${{ steps.ios-app-cache-restore.outputs.cache-hit }}" == "true" \
              || "${{ steps.ios-app-cache-restore-main.outputs.cache-hit }}" == "true" ]]; then
             echo "needs-native-build=false" >> "$GITHUB_OUTPUT"
-            echo "iOS app cache hit (Cirrus); heavy native setup will be skipped."
+            echo "iOS app cache hit (Namespace); heavy native setup will be skipped."
           else
             if [[ "${{ steps.find-reusable-build.outputs.found }}" == "true" && "${{ steps.validate-reusable-metadata.outputs.valid }}" != "true" ]]; then
               echo "::warning::Reusable run was found but metadata validation failed; falling back to fresh native build."
@@ -684,7 +684,7 @@ jobs:
           elif [[ "${REUSABLE_FOUND:-}" == "true" && "${METADATA_VALID:-}" == "true" && "${APP_DOWNLOAD_OUTCOME:-}" == "success" ]]; then
             decision="GitHub artifact reuse"
           elif [[ "${BRANCH_CACHE_HIT:-}" == "true" || "${MAIN_CACHE_HIT:-}" == "true" ]]; then
-            decision="Cirrus iOS app cache"
+            decision="Namespace iOS app cache"
           elif [[ "${NEEDS_NATIVE_BUILD:-}" == "false" ]]; then
             # Remaining gate branch that skips the native build: the test-only
             # (`reuse-main-builds-only`) path, which reuses main's artifacts on a
@@ -847,7 +847,7 @@ jobs:
           if-no-files-found: error
         continue-on-error: true
 
-      - name: Upload iOS Source Map (current)
+      - name: Upload iOS Source Map (GitHub)
         id: upload-sourcemap
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-ios-upload-to-browserstack.yml
+++ b/.github/workflows/build-ios-upload-to-browserstack.yml
@@ -72,7 +72,6 @@ on:
         type: choice
         options:
           - inherit
-          - current
           - namespace
         default: inherit
 
@@ -126,7 +125,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-         vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+         vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     needs: [check-builds-needed, trigger-ios-with-srp-build, trigger-ios-without-srp-build]

--- a/.github/workflows/build-rc-repack.yml
+++ b/.github/workflows/build-rc-repack.yml
@@ -79,9 +79,9 @@ jobs:
     runs-on: >-
       ${{
         ((inputs.platform == 'ios' && vars.NAMESPACE_RUNNER_IOS || vars.NAMESPACE_RUNNER_ANDROID) ||
-         vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+         'namespace') == 'namespace' &&
         (inputs.platform == 'ios' && 'namespace-profile-metamask-ios-build' || 'namespace-profile-metamask-android-build') ||
-        (inputs.platform == 'ios' && 'ghcr.io/cirruslabs/macos-runner:tahoe-xl' || 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg')
+        (inputs.platform == 'ios' && 'macos-15' || 'ubuntu-latest')
       }}
     # github_environment of main-rc in builds.yml; see the build_name input.
     environment: build-rc
@@ -89,7 +89,7 @@ jobs:
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
           (inputs.platform == 'ios' && vars.NAMESPACE_RUNNER_IOS || vars.NAMESPACE_RUNNER_ANDROID) ||
-          vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+          'namespace'
         }}
       ARTIFACT_NAME: ${{ inputs.platform == 'ios' && format('ios-ipa-{0}', inputs.build_name) || format('android-apk-{0}', inputs.build_name) }}
     outputs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,6 @@ on:
         options:
           - inherit
           - namespace
-          - current
         default: inherit
 
 permissions:
@@ -119,7 +118,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-         vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+         vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
@@ -128,7 +127,7 @@ jobs:
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
           inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-          vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+          vars.NAMESPACE_RUNNER_LINUX || 'namespace'
         }}
     outputs:
       github_environment: ${{ steps.config.outputs.github_environment }}
@@ -226,15 +225,15 @@ jobs:
     strategy:
       matrix:
         platform: ${{ inputs.platform == 'both' && fromJSON('["android", "ios"]') || fromJSON(format('["{0}"]', inputs.platform)) }}
-    # Namespace: per-platform build profiles. Cirrus fallback: lg (large) runner for the
-    # 8GB Gradle heap on Android, macOS Tahoe for iOS (has Xcode 26.x).
+    # Namespace: per-platform build profiles. GitHub-hosted labels are retained only as
+    # a defensive fallback for explicitly overridden provider values.
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
          (matrix.platform == 'ios' && vars.NAMESPACE_RUNNER_IOS || matrix.platform != 'ios' && vars.NAMESPACE_RUNNER_ANDROID) ||
-         vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+         'namespace') == 'namespace' &&
         (matrix.platform == 'ios' && 'namespace-profile-metamask-ios-build' || 'namespace-profile-metamask-android-build') ||
-        (matrix.platform == 'ios' && 'ghcr.io/cirruslabs/macos-runner:tahoe-xl' || 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg')
+        (matrix.platform == 'ios' && 'macos-15' || 'ubuntu-latest')
       }}
     environment: ${{ needs.prepare.outputs.github_environment }}
     env:
@@ -244,18 +243,12 @@ jobs:
         ${{
           inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
           (matrix.platform == 'ios' && vars.NAMESPACE_RUNNER_IOS || matrix.platform != 'ios' && vars.NAMESPACE_RUNNER_ANDROID) ||
-          vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+          'namespace'
         }}
-      # Namespace runners use the standard runner home; Cirrus images run as `admin`.
+      # Namespace and GitHub-hosted runners use the standard runner home.
       # Cannot reference RESOLVED_RUNNER_PROVIDER: env entries in the same block are
       # not visible to each other.
-      GRADLE_USER_HOME: >-
-        ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-           (matrix.platform == 'ios' && vars.NAMESPACE_RUNNER_IOS || matrix.platform != 'ios' && vars.NAMESPACE_RUNNER_ANDROID) ||
-           vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-          '/home/runner/_work/.gradle' || '/home/admin/_work/.gradle'
-        }}
+      GRADLE_USER_HOME: /home/runner/_work/.gradle
       # Must match setup-node-modules.yml's CACHE_GENERATION; the two compose the same cache key.
       CACHE_GENERATION: v2
     steps:
@@ -467,7 +460,7 @@ jobs:
           ALL_SECRETS: ${{ toJSON(secrets) }}
         run: node scripts/set-secrets-from-config.js
 
-      # Android only: minimal env (SDK is pre-installed on Cirrus runner)
+      # Android only: minimal env (SDK is pre-installed on the Namespace runner)
       - name: Set Android environment variables
         if: matrix.platform == 'android'
         run: |
@@ -490,7 +483,7 @@ jobs:
       - name: Restore Gradle dependencies from branch cache (Android)
         if: matrix.platform == 'android'
         id: gradle-cache-restore
-        uses: cirruslabs/cache@bba69c6578b863ad0398ad40567bd2ef70290fe0 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/_work/.gradle/caches
@@ -499,7 +492,7 @@ jobs:
 
       - name: Restore Gradle dependencies from main cache (Android)
         if: matrix.platform == 'android' && steps.gradle-cache-restore.outputs.cache-hit != 'true' && github.ref_name != 'main'
-        uses: cirruslabs/cache/restore@bba69c6578b863ad0398ad40567bd2ef70290fe0 # v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/_work/.gradle/caches
@@ -740,7 +733,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-         vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+         vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
@@ -749,7 +742,7 @@ jobs:
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
           inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-          vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+          vars.NAMESPACE_RUNNER_LINUX || 'namespace'
         }}
     outputs:
       checkout_ref: ${{ steps.meta.outputs.checkout_ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     # macos/ios-build concurrency.
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
@@ -83,7 +83,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     if: ${{ needs.get_requirements.outputs.skip_everything != 'true' }}
     needs:
@@ -199,7 +199,7 @@ jobs:
     name: Dedupe
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
@@ -207,7 +207,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     if: ${{ needs.get_requirements.outputs.skip_everything != 'true' }}
     needs:
@@ -258,7 +258,7 @@ jobs:
     name: Run `@lavamoat/git-safe-dependencies`
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
@@ -266,7 +266,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     if: ${{ needs.get_requirements.outputs.skip_everything != 'true' }}
     needs:
@@ -310,7 +310,7 @@ jobs:
     name: Run `${{ matrix.scripts }}`
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         matrix.profile || 'ubuntu-latest'
       }}
     env:
@@ -318,7 +318,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     if: ${{ needs.get_requirements.outputs.skip_everything != 'true' }}
     needs:
@@ -396,7 +396,7 @@ jobs:
     name: Dependency audit (advisory)
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     outputs:
@@ -406,7 +406,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     if: ${{ needs.get_requirements.outputs.skip_everything != 'true' }}
     needs:
@@ -463,7 +463,7 @@ jobs:
     name: JS bundle size check
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
       }}
     env:
@@ -471,7 +471,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     if: ${{ needs.get_requirements.outputs.skip_everything != 'true' }}
     needs:
@@ -715,7 +715,7 @@ jobs:
           name: ios-bundle
           path: ios/main.jsbundle
           retention-days: 7
-      - name: Upload iOS bundle (current)
+      - name: Upload iOS bundle (GitHub)
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
         uses: actions/upload-artifact@v4
         with:
@@ -727,7 +727,7 @@ jobs:
     name: Ship JS bundle size check
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
@@ -735,7 +735,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     needs: [js-bundle-size-check]
     if: ${{ github.ref == 'refs/heads/main' }}
@@ -763,7 +763,7 @@ jobs:
         with:
           name: ios-bundle
           path: ios
-      - name: Download iOS bundle (current)
+      - name: Download iOS bundle (GitHub)
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
         uses: actions/download-artifact@v4
         with:
@@ -798,7 +798,7 @@ jobs:
     name: Check workflows
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
@@ -806,7 +806,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     if: ${{ needs.get_requirements.outputs.skip_everything != 'true' }}
     needs:
@@ -839,7 +839,7 @@ jobs:
     name: Prepare CI JS dependencies
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
@@ -847,7 +847,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     if: ${{ needs.get_requirements.outputs.skip_everything != 'true' }}
     needs:
@@ -883,7 +883,7 @@ jobs:
     name: Unit tests (${{ matrix.shard }})
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
       }}
     env:
@@ -891,7 +891,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     if: ${{ !cancelled() && needs.get_requirements.result == 'success' && needs.get_requirements.outputs.skip_everything != 'true' }}
     needs:
@@ -954,7 +954,7 @@ jobs:
           path: ./tests/coverage/jest-results.json
           if-no-files-found: error
           retention-days: 7
-      - name: Upload coverage unit shard (current)
+      - name: Upload coverage unit shard (GitHub)
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
         uses: actions/upload-artifact@v4
         with:
@@ -977,7 +977,7 @@ jobs:
   merge-unit-and-component-view-tests:
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
@@ -985,7 +985,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     needs:
       - prepare-ci-js-deps
@@ -1022,7 +1022,7 @@ jobs:
         with:
           pattern: coverage-*
           path: tests/coverage/
-      - name: Download coverage shards (current)
+      - name: Download coverage shards (GitHub)
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
         uses: actions/download-artifact@v4
         with:
@@ -1106,7 +1106,7 @@ jobs:
           path: ./tests/merged-coverage/lcov.info
           if-no-files-found: error
           retention-days: 7
-      - name: Upload lcov.info (current)
+      - name: Upload lcov.info (GitHub)
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
         uses: actions/upload-artifact@v4
         with:
@@ -1122,7 +1122,7 @@ jobs:
           path: ./cv-test-stats.json
           if-no-files-found: error
           retention-days: 7
-      - name: Upload cv-test-stats (current)
+      - name: Upload cv-test-stats (GitHub)
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
         uses: actions/upload-artifact@v4
         with:
@@ -1138,7 +1138,7 @@ jobs:
           path: ./integration-test-stats.json
           if-no-files-found: error
           retention-days: 7
-      - name: Upload integration-test-stats (current)
+      - name: Upload integration-test-stats (GitHub)
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
         uses: actions/upload-artifact@v4
         with:
@@ -1154,7 +1154,7 @@ jobs:
           path: ./unit-test-stats.json
           if-no-files-found: error
           retention-days: 7
-      - name: Upload unit-test-stats (current)
+      - name: Upload unit-test-stats (GitHub)
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
         uses: actions/upload-artifact@v4
         with:
@@ -1172,7 +1172,7 @@ jobs:
           path: ./tests/coverage-cv-lcov/
           if-no-files-found: error
           retention-days: 7
-      - name: Upload cv-test-coverage-html (current)
+      - name: Upload cv-test-coverage-html (GitHub)
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
         uses: actions/upload-artifact@v4
         with:
@@ -1206,7 +1206,7 @@ jobs:
           path: ./tests/coverage-integration-lcov/
           if-no-files-found: error
           retention-days: 7
-      - name: Upload integration-test-coverage-html (current)
+      - name: Upload integration-test-coverage-html (GitHub)
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' && steps.aggregate-coverage.outputs.has_integration_coverage == 'true' }}
         uses: actions/upload-artifact@v4
         with:
@@ -1261,7 +1261,7 @@ jobs:
     name: Component view tests (${{ matrix.shard }})
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
       }}
     env:
@@ -1269,7 +1269,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     if: ${{ !cancelled() && needs.get_requirements.result == 'success' && needs.get_requirements.outputs.skip_everything != 'true' }}
     needs:
@@ -1331,7 +1331,7 @@ jobs:
           path: ./tests/coverage/jest-results.json
           if-no-files-found: error
           retention-days: 7
-      - name: Upload coverage CV shard (current)
+      - name: Upload coverage CV shard (GitHub)
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
         uses: actions/upload-artifact@v4
         with:
@@ -1351,7 +1351,7 @@ jobs:
     name: Integration tests (${{ matrix.shard }})
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         matrix.profile || 'ubuntu-latest'
       }}
     env:
@@ -1359,7 +1359,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     if: ${{ !cancelled() && needs.get_requirements.result == 'success' && needs.get_requirements.outputs.skip_everything != 'true' }}
     needs:
@@ -1432,7 +1432,7 @@ jobs:
           path: ./tests/coverage/jest-results.json
           if-no-files-found: error
           retention-days: 7
-      - name: Upload coverage integration shard (current)
+      - name: Upload coverage integration shard (GitHub)
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
         uses: actions/upload-artifact@v4
         with:
@@ -1445,7 +1445,7 @@ jobs:
     name: 'Smart E2E Selection'
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
@@ -1453,7 +1453,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     if: ${{ needs.get_requirements.outputs.run_smart_e2e_selection == 'true' }}
     needs:
@@ -1565,7 +1565,7 @@ jobs:
       runner_provider: >-
         ${{
           inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-          vars.NAMESPACE_RUNNER_ANDROID || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+          vars.NAMESPACE_RUNNER_ANDROID || 'namespace'
         }}
       reuse-main-builds-only: ${{ needs.get_requirements.outputs.native_build_needed == 'false' }}
     secrets: inherit
@@ -1652,7 +1652,7 @@ jobs:
       runner_provider: >-
         ${{
           inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-          vars.NAMESPACE_RUNNER_IOS || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+          vars.NAMESPACE_RUNNER_IOS || 'namespace'
         }}
       reuse-main-builds-only: ${{ needs.get_requirements.outputs.native_build_needed == 'false' }}
     secrets: inherit
@@ -1697,7 +1697,7 @@ jobs:
       runner_provider: >-
         ${{
           inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-          vars.NAMESPACE_RUNNER_ANDROID || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+          vars.NAMESPACE_RUNNER_ANDROID || 'namespace'
         }}
       selected_tags: >-
         ${{
@@ -1758,7 +1758,7 @@ jobs:
       runner_provider: >-
         ${{
           inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-          vars.NAMESPACE_RUNNER_IOS || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+          vars.NAMESPACE_RUNNER_IOS || 'namespace'
         }}
       selected_tags: >-
         ${{
@@ -1810,7 +1810,7 @@ jobs:
       runner_provider: >-
         ${{
           inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-          vars.NAMESPACE_RUNNER_ANDROID || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+          vars.NAMESPACE_RUNNER_ANDROID || 'namespace'
         }}
     secrets: inherit
 
@@ -1818,7 +1818,7 @@ jobs:
     name: 'Report Fixture Validation'
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
@@ -1826,7 +1826,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     if: ${{ !cancelled() && needs.validate-e2e-fixtures.result != 'skipped' }}
     needs: [validate-e2e-fixtures]
@@ -1862,7 +1862,7 @@ jobs:
     name: SonarCloud analysis
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
       }}
     env:
@@ -1870,7 +1870,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     needs: merge-unit-and-component-view-tests
     # Run when merged coverage is ready even if optional integration shards failed upstream.
@@ -1902,7 +1902,7 @@ jobs:
         with:
           name: lcov.info
           path: coverage/
-      - name: Download lcov.info (current)
+      - name: Download lcov.info (GitHub)
         if: ${{ env.RESOLVED_RUNNER_PROVIDER != 'namespace' }}
         uses: actions/download-artifact@v4
         with:
@@ -1941,7 +1941,7 @@ jobs:
     name: SonarCloud quality gate status
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
@@ -1949,7 +1949,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     needs: sonar-cloud
     if: ${{ always() && !cancelled() && needs.sonar-cloud.result == 'success' && github.event_name != 'merge_group' && !github.event.pull_request.head.repo.fork }}
@@ -2080,7 +2080,7 @@ jobs:
     if: ${{ always() && !cancelled() }}
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
@@ -2088,7 +2088,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     needs:
       - get_requirements
@@ -2134,7 +2134,7 @@ jobs:
     name: Log merge group failure
     runs-on: >-
       ${{
-        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+        (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
@@ -2142,7 +2142,7 @@ jobs:
       # directly, or a provider set through the repo variables would be ignored.
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
-          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current')
+          (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || 'namespace')
         }}
     # Only run this job if the merge group event fails, skip on forks
     if: ${{ github.event_name == 'merge_group' && failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ on:
         type: choice
         options:
           - inherit
-          - current
           - namespace
         default: inherit
       pr_number:
@@ -1693,7 +1692,7 @@ jobs:
       build_type: 'main'
       metamask_environment: 'e2e'
       # Mirrors build-android-apks' resolution chain so this consumer always matches
-      # the builder's artifact store (GitHub on current, Namespace store on namespace).
+      # the builder's artifact store (GitHub-hosted fallback, Namespace store on namespace).
       runner_provider: >-
         ${{
           inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
@@ -1754,7 +1753,7 @@ jobs:
       build_type: 'main'
       metamask_environment: 'e2e'
       # Mirrors build-ios-apps' resolution chain so this consumer always matches
-      # the builder's artifact store (GitHub on current, Namespace store on namespace).
+      # the builder's artifact store (GitHub-hosted fallback, Namespace store on namespace).
       runner_provider: >-
         ${{
           inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
@@ -1806,7 +1805,7 @@ jobs:
       cache-android-golden-snapshot: false
       android-emulator-boot-mode: cold
       # Mirrors build-android-apps' resolution chain so this consumer always matches
-      # the builder's artifact store (GitHub on current, Namespace store on namespace).
+      # the builder's artifact store (GitHub-hosted fallback, Namespace store on namespace).
       runner_provider: >-
         ${{
           inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||

--- a/.github/workflows/eas-update-platform.yml
+++ b/.github/workflows/eas-update-platform.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-         vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+         vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
       }}
     environment: ${{ inputs.github_environment }}
@@ -57,7 +57,7 @@ jobs:
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
           inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-          vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+          vars.NAMESPACE_RUNNER_LINUX || 'namespace'
         }}
       # OTA-specific vars only — build config + secrets come from builds.yml via steps below
       TARGET_COMMIT_HASH: ${{ inputs.commit_sha }}

--- a/.github/workflows/expo-dev-build.yml
+++ b/.github/workflows/expo-dev-build.yml
@@ -40,7 +40,6 @@ on:
         options:
           - inherit
           - namespace
-          - current
         default: inherit
       force_build:
         description: Force a fresh build even if the fingerprint is unchanged

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -19,7 +19,6 @@ on:
         options:
           - inherit
           - namespace
-          - current
         default: inherit
 
 permissions:

--- a/.github/workflows/prime-appium-e2e-android-emulator.yml
+++ b/.github/workflows/prime-appium-e2e-android-emulator.yml
@@ -14,7 +14,7 @@ on:
   workflow_call:
     inputs:
       runner_provider:
-        description: 'Runner provider (namespace or current)'
+        description: 'Runner provider (namespace or GitHub-hosted fallback)'
         required: false
         type: string
         default: 'namespace'
@@ -35,7 +35,7 @@ jobs:
       ${{
         inputs.runner_provider == 'namespace' &&
         'namespace-profile-metamask-android-e2e' ||
-        fromJSON('["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg"]')
+        'ubuntu-latest'
       }}
     env:
       ANDROID_AVD_NAME: appium_smoke_avd

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -51,7 +51,7 @@ on:
         type: string
         default: 'e2e'
       runner_provider:
-        description: 'Runner provider (namespace or current)'
+        description: 'Runner provider (namespace)'
         required: false
         type: string
         default: 'namespace'
@@ -115,11 +115,7 @@ jobs:
         inputs.runner_provider == 'namespace' &&
         (inputs.platform == 'ios' && 'namespace-profile-metamask-ios-e2e' ||
          'namespace-profile-metamask-android-e2e') ||
-        (inputs.platform == 'ios' &&
-          fromJSON('["ghcr.io/cirruslabs/macos-runner:tahoe"]')) ||
-        (startsWith(github.base_ref, 'release/') &&
-          fromJSON('["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg"]') ||
-          fromJSON('["ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg", "low-priority"]'))
+        (inputs.platform == 'ios' && 'macos-15' || 'ubuntu-latest')
       }}
     env:
       ANDROID_AVD_NAME: appium_smoke_avd
@@ -322,7 +318,7 @@ jobs:
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release.apk
           path: ${{ steps.android-artifacts.outputs.apk-target-path }}
-      - name: Download Android build artifacts (GitHub — build may be on Cirrus)
+      - name: Download Android build artifacts (GitHub fallback)
         if: >-
           ${{
             inputs.platform == 'android' &&
@@ -334,7 +330,7 @@ jobs:
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-release.apk
           path: ${{ steps.android-artifacts.outputs.apk-target-path }}
-      - name: Download Android build artifacts (current)
+      - name: Download Android build artifacts (GitHub)
         if: ${{ inputs.platform == 'android' && inputs.runner_provider != 'namespace' && steps.select-specs.outputs.spec_count != '0' }}
         uses: actions/download-artifact@v4
         with:
@@ -362,7 +358,7 @@ jobs:
           }}
         shell: bash
         run: rm -rf "artifacts/${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app"
-      - name: Download iOS build artifacts (GitHub — build may be on Cirrus)
+      - name: Download iOS build artifacts (GitHub fallback)
         if: >-
           ${{
             inputs.platform == 'ios' &&
@@ -374,7 +370,7 @@ jobs:
         with:
           name: ${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app
           path: artifacts/${{ inputs.build_type }}-${{ inputs.metamask_environment }}-MetaMask.app
-      - name: Download iOS build artifacts (current)
+      - name: Download iOS build artifacts (GitHub)
         if: ${{ inputs.platform == 'ios' && inputs.runner_provider != 'namespace' && steps.select-specs.outputs.spec_count != '0' }}
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -51,7 +51,7 @@ on:
         type: string
         default: 'e2e'
       runner_provider:
-        description: 'Runner provider (namespace)'
+        description: 'Runner provider (namespace or GitHub-hosted fallback)'
         required: false
         type: string
         default: 'namespace'

--- a/.github/workflows/run-appium-smoke-tests-android.yml
+++ b/.github/workflows/run-appium-smoke-tests-android.yml
@@ -19,7 +19,7 @@ on:
         type: string
         default: 'e2e'
       runner_provider:
-        description: 'Runner provider (namespace or current)'
+        description: 'Runner provider (namespace)'
         required: false
         type: string
         default: 'namespace'
@@ -56,7 +56,7 @@ on:
         type: string
         default: 'e2e'
       runner_provider:
-        description: 'Runner provider (namespace or current)'
+        description: 'Runner provider (namespace)'
         required: false
         type: string
         default: 'namespace'

--- a/.github/workflows/run-appium-smoke-tests-android.yml
+++ b/.github/workflows/run-appium-smoke-tests-android.yml
@@ -19,7 +19,7 @@ on:
         type: string
         default: 'e2e'
       runner_provider:
-        description: 'Runner provider (namespace)'
+        description: 'Runner provider (namespace or GitHub-hosted fallback)'
         required: false
         type: string
         default: 'namespace'
@@ -56,7 +56,7 @@ on:
         type: string
         default: 'e2e'
       runner_provider:
-        description: 'Runner provider (namespace)'
+        description: 'Runner provider (namespace or GitHub-hosted fallback)'
         required: false
         type: string
         default: 'namespace'

--- a/.github/workflows/run-appium-smoke-tests-ios.yml
+++ b/.github/workflows/run-appium-smoke-tests-ios.yml
@@ -20,7 +20,7 @@ on:
         type: string
         default: 'e2e'
       runner_provider:
-        description: 'Runner provider (namespace)'
+        description: 'Runner provider (namespace or GitHub-hosted fallback)'
         required: false
         type: string
         default: 'namespace'

--- a/.github/workflows/run-appium-smoke-tests-ios.yml
+++ b/.github/workflows/run-appium-smoke-tests-ios.yml
@@ -20,7 +20,7 @@ on:
         type: string
         default: 'e2e'
       runner_provider:
-        description: 'Runner provider (namespace or current)'
+        description: 'Runner provider (namespace)'
         required: false
         type: string
         default: 'namespace'
@@ -63,7 +63,7 @@ jobs:
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
-      runner_provider: ${{ inputs.runner_provider || 'current' }}
+      runner_provider: ${{ inputs.runner_provider || 'namespace' }}
       changed_spec_files: ${{ inputs.changed_spec_files }}
     secrets: inherit
 
@@ -89,7 +89,7 @@ jobs:
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
-      runner_provider: ${{ inputs.runner_provider || 'current' }}
+      runner_provider: ${{ inputs.runner_provider || 'namespace' }}
       changed_spec_files: ${{ inputs.changed_spec_files }}
     secrets: inherit
 
@@ -114,7 +114,7 @@ jobs:
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
-      runner_provider: ${{ inputs.runner_provider || 'current' }}
+      runner_provider: ${{ inputs.runner_provider || 'namespace' }}
       changed_spec_files: ${{ inputs.changed_spec_files }}
     secrets: inherit
 
@@ -139,7 +139,7 @@ jobs:
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
-      runner_provider: ${{ inputs.runner_provider || 'current' }}
+      runner_provider: ${{ inputs.runner_provider || 'namespace' }}
       changed_spec_files: ${{ inputs.changed_spec_files }}
     secrets: inherit
 
@@ -166,7 +166,7 @@ jobs:
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
-      runner_provider: ${{ inputs.runner_provider || 'current' }}
+      runner_provider: ${{ inputs.runner_provider || 'namespace' }}
       changed_spec_files: ${{ inputs.changed_spec_files }}
     secrets: inherit
 
@@ -190,7 +190,7 @@ jobs:
       total_splits: 2
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
-      runner_provider: ${{ inputs.runner_provider || 'current' }}
+      runner_provider: ${{ inputs.runner_provider || 'namespace' }}
       changed_spec_files: ${{ inputs.changed_spec_files }}
     secrets: inherit
 
@@ -215,7 +215,7 @@ jobs:
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
-      runner_provider: ${{ inputs.runner_provider || 'current' }}
+      runner_provider: ${{ inputs.runner_provider || 'namespace' }}
       changed_spec_files: ${{ inputs.changed_spec_files }}
     secrets: inherit
 
@@ -240,7 +240,7 @@ jobs:
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
-      runner_provider: ${{ inputs.runner_provider || 'current' }}
+      runner_provider: ${{ inputs.runner_provider || 'namespace' }}
       changed_spec_files: ${{ inputs.changed_spec_files }}
     secrets: inherit
 
@@ -265,7 +265,7 @@ jobs:
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
-      runner_provider: ${{ inputs.runner_provider || 'current' }}
+      runner_provider: ${{ inputs.runner_provider || 'namespace' }}
       changed_spec_files: ${{ inputs.changed_spec_files }}
     secrets: inherit
 
@@ -290,7 +290,7 @@ jobs:
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
-      runner_provider: ${{ inputs.runner_provider || 'current' }}
+      runner_provider: ${{ inputs.runner_provider || 'namespace' }}
       changed_spec_files: ${{ inputs.changed_spec_files }}
     secrets: inherit
 
@@ -315,7 +315,7 @@ jobs:
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
-      runner_provider: ${{ inputs.runner_provider || 'current' }}
+      runner_provider: ${{ inputs.runner_provider || 'namespace' }}
       changed_spec_files: ${{ inputs.changed_spec_files }}
     secrets: inherit
 
@@ -340,7 +340,7 @@ jobs:
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
-      runner_provider: ${{ inputs.runner_provider || 'current' }}
+      runner_provider: ${{ inputs.runner_provider || 'namespace' }}
       changed_spec_files: ${{ inputs.changed_spec_files }}
     secrets: inherit
 
@@ -365,7 +365,7 @@ jobs:
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
-      runner_provider: ${{ inputs.runner_provider || 'current' }}
+      runner_provider: ${{ inputs.runner_provider || 'namespace' }}
       changed_spec_files: ${{ inputs.changed_spec_files }}
     secrets: inherit
 
@@ -390,6 +390,6 @@ jobs:
       test-timeout-minutes: 25
       build_type: ${{ inputs.build_type || 'main' }}
       metamask_environment: ${{ inputs.metamask_environment || 'e2e' }}
-      runner_provider: ${{ inputs.runner_provider || 'current' }}
+      runner_provider: ${{ inputs.runner_provider || 'namespace' }}
       changed_spec_files: ${{ inputs.changed_spec_files }}
     secrets: inherit

--- a/.github/workflows/run-e2e-api-specs.yml
+++ b/.github/workflows/run-e2e-api-specs.yml
@@ -22,7 +22,6 @@ on:
         required: false
         type: choice
         options:
-          - current
           - namespace
         default: namespace
       ios_build_run_id:
@@ -43,9 +42,9 @@ jobs:
       contents: read
     runs-on: >-
       ${{
-        (inputs.runner_provider || 'current') == 'namespace' &&
+        (inputs.runner_provider || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ios-e2e' ||
-        fromJSON('["ghcr.io/cirruslabs/macos-runner:tahoe"]')
+        'macos-15'
       }}
 
     env:
@@ -62,11 +61,11 @@ jobs:
 
     steps:
       - name: Checkout (Namespace)
-        if: ${{ (inputs.runner_provider || 'current') == 'namespace' }}
+        if: ${{ (inputs.runner_provider || 'namespace') == 'namespace' }}
         uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
 
       - name: Checkout
-        if: ${{ (inputs.runner_provider || 'current') != 'namespace' }}
+        if: ${{ (inputs.runner_provider || 'namespace') != 'namespace' }}
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref || github.ref }}
@@ -81,7 +80,7 @@ jobs:
           install-foundry: 'true'
           skip-pod-install: 'true'
           install-applesimutils: 'false'
-          runner_provider: ${{ inputs.runner_provider || 'current' }}
+          runner_provider: ${{ inputs.runner_provider || 'namespace' }}
 
       - name: Cache ffmpeg (Homebrew)
         uses: actions/cache@v4
@@ -313,7 +312,7 @@ jobs:
           MM_INFURA_PROJECT_ID: ${{ secrets.MM_INFURA_PROJECT_ID }}
 
       - name: Upload Playwright HTML report (Namespace)
-        if: ${{ always() && (inputs.runner_provider || 'current') == 'namespace' }}
+        if: ${{ always() && (inputs.runner_provider || 'namespace') == 'namespace' }}
         uses: namespace-actions/upload-artifact@f6ccaacc655aec41b93af180d1d7eef21af862d2 # v1.0.3
         with:
           name: api-specs-report
@@ -321,8 +320,8 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-      - name: Upload Playwright HTML report (current)
-        if: ${{ always() && (inputs.runner_provider || 'current') != 'namespace' }}
+      - name: Upload Playwright HTML report (GitHub)
+        if: ${{ always() && (inputs.runner_provider || 'namespace') != 'namespace' }}
         uses: actions/upload-artifact@v4
         with:
           name: api-specs-report

--- a/.github/workflows/runway-production-builds.yml
+++ b/.github/workflows/runway-production-builds.yml
@@ -29,7 +29,6 @@ on:
         options:
           - inherit
           - namespace
-          - current
         default: inherit
 
 permissions:

--- a/.github/workflows/runway-rc-builds.yml
+++ b/.github/workflows/runway-rc-builds.yml
@@ -29,7 +29,6 @@ on:
         options:
           - inherit
           - namespace
-          - current
         default: inherit
 
 permissions:

--- a/.github/workflows/setup-node-modules.yml
+++ b/.github/workflows/setup-node-modules.yml
@@ -100,11 +100,10 @@ jobs:
          (inputs.platform == 'ios' && vars.NAMESPACE_RUNNER_IOS ||
           inputs.platform == 'android' && vars.NAMESPACE_RUNNER_ANDROID ||
           inputs.platform != 'ios' && inputs.platform != 'android' && vars.NAMESPACE_RUNNER_LINUX) ||
-         vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+         'namespace') == 'namespace' &&
         (inputs.platform == 'ios' && 'namespace-profile-metamask-ios-build' ||
          (inputs.platform == 'android' && 'namespace-profile-metamask-android-build' || 'namespace-profile-metamask-ci-linux')) ||
-        (inputs.platform == 'ios' && 'ghcr.io/cirruslabs/macos-runner:tahoe-xl' ||
-         (inputs.platform == 'android' && 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg' || 'ubuntu-latest'))
+        (inputs.platform == 'ios' && 'macos-15' || 'ubuntu-latest')
       }}
     permissions:
       contents: read
@@ -118,7 +117,7 @@ jobs:
           (inputs.platform == 'ios' && vars.NAMESPACE_RUNNER_IOS ||
            inputs.platform == 'android' && vars.NAMESPACE_RUNNER_ANDROID ||
            inputs.platform != 'ios' && inputs.platform != 'android' && vars.NAMESPACE_RUNNER_LINUX) ||
-          vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+          'namespace'
         }}
       # Must match build.yml's CACHE_GENERATION; the two compose the same cache key.
       CACHE_GENERATION: v2

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -178,7 +178,7 @@ jobs:
 
   update-fixtures:
     name: Export & update fixtures
-    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-android-e2e' || (startsWith(github.base_ref, 'release/') && fromJSON('["ghcr.io/cirruslabs/macos-runner:tahoe"]') || fromJSON('["ghcr.io/cirruslabs/macos-runner:tahoe", "low-priority"]')) }}
+    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-android-e2e' || 'macos-15' }}
     timeout-minutes: 45
     permissions:
       actions: write

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -27,7 +27,6 @@ on:
         required: false
         type: choice
         options:
-          - current
           - namespace
         default: namespace
 

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -177,7 +177,7 @@ jobs:
 
   update-fixtures:
     name: Export & update fixtures
-    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-android-e2e' || 'macos-15' }}
+    runs-on: ${{ inputs.runner_provider == 'namespace' && 'namespace-profile-metamask-android-e2e' || 'ubuntu-latest' }}
     timeout-minutes: 45
     permissions:
       actions: write

--- a/.github/workflows/upload-to-testflight.yml
+++ b/.github/workflows/upload-to-testflight.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-         vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
+         vars.NAMESPACE_RUNNER_LINUX || 'namespace') == 'namespace' &&
         'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     steps:
@@ -81,12 +81,13 @@ jobs:
   upload-ios-testflight:
     name: Upload iOS to TestFlight
     needs: [testflight-upload-summary]
-    # iOS/macOS only ever runs on Namespace or Cirrus; there is no GitHub-hosted macOS arm.
+    # iOS/macOS uses the Namespace build profile. macOS is retained only as a defensive
+    # fallback for explicitly overridden provider values.
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-         vars.NAMESPACE_RUNNER_IOS || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ios-build' || 'ghcr.io/cirruslabs/macos-runner:tahoe-xl'
+         vars.NAMESPACE_RUNNER_IOS || 'namespace') == 'namespace' &&
+        'namespace-profile-metamask-ios-build' || 'macos-15'
       }}
     env:
       # Effective provider for this job. Steps must test this, never inputs.runner_provider
@@ -94,7 +95,7 @@ jobs:
       RESOLVED_RUNNER_PROVIDER: >-
         ${{
           inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
-          vars.NAMESPACE_RUNNER_IOS || vars.NAMESPACE_RUNNER_PROVIDER || 'current'
+          vars.NAMESPACE_RUNNER_IOS || 'namespace'
         }}
     steps:
       - name: Checkout repository (Namespace)


### PR DESCRIPTION
## **Description**

This cleanup removes deprecated Cirrus runner labels, Cirrus cache actions, and the `current` runner-provider fallback from the GitHub Actions configuration after the Namespace migration. Migrated workflows now default to Namespace, with GitHub-hosted fallback labels retained where needed. Bitrise routing and cleanup remain explicitly out of scope.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [MCWP-802](https://consensyssoftware.atlassian.net/browse/MCWP-802)

## **Manual testing steps**

```gherkin
Feature: Cirrus CI cleanup

  Scenario: validate migrated workflow configuration
    Given the changed GitHub Actions workflows and runner configuration
    When actionlint is run against each changed workflow
    Then the changed workflow syntax and expressions pass validation
    And no Cirrus labels, cache actions, or current-provider fallbacks remain
```

Static validation performed:
- `actionlint` passes for all changed workflows when excluding the pre-existing `if: false` warning in `run-e2e-api-specs.yml`.
- `git diff --check` passes.
- The available local Prettier binary reports existing warnings in three changed YAML files; no unrelated formatter rewrite was included.

## **Screenshots/Recordings**

### **Before**

N/A, CI configuration and documentation only.

### **After**

N/A, CI configuration and documentation only.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

N/A, this is a CI configuration and documentation cleanup.

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance Guide for Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MCWP-802]: https://consensyssoftware.atlassian.net/browse/MCWP-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide CI/workflow changes affect where builds and E2E run and how caches and artifacts behave; mis-routing could break PR gates or release pipelines until validated on Namespace.
> 
> **Overview**
> **Retires the Cirrus/`current` CI runner path** so migrated GitHub Actions workflows treat **Namespace as the default** and only fall back to **GitHub-hosted** labels (`ubuntu-latest` / `macos-15`) when provider resolution is not Namespace.
> 
> Resolution is simplified across **PR CI, production builds, E2E/Appium, BrowserStack, TestFlight, and OTA**: `NAMESPACE_RUNNER_PROVIDER` and the `current` workflow input are removed; unset platform vars and composite-action defaults now resolve to **`namespace`** instead of Cirrus. **Cirrus runner labels** are dropped from **actionlint**; **Gradle/APK/Xcode caches** on non-Namespace paths use **`actions/cache`** instead of **`cirruslabs/cache`**. Docs in **CONTRIBUTING** describe the new three-variable model and note that legacy Cirrus rollback is gone.
> 
> Supporting tweaks include a fixed **`GRADLE_USER_HOME`**, provider-aware **Metro/Node heap** on Android repack jobs, renamed artifact steps (**GitHub** vs **current**), and **dual-upload** tests updated for GitHub-hosted provider values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cae7b67d68b7f98ccc77f89581b04d43da3f8f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->