### PR TITLE
feat: (1st commit) recurring input amounts

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeLimitOrderView/BridgeLimitOrderView.view.test.tsx
@@ -71,4 +71,17 @@ describeForPlatforms('BridgeLimitOrderView', () => {
     ).toBeOnTheScreen();
     expect(renderResult.getAllByText(pair)).toHaveLength(2);
   });
+
+  it('keeps the dest amount input and does not show Recurring You get copy', async () => {
+    const renderResult = renderBridgeView();
+
+    await openLimitTab(renderResult);
+
+    expect(
+      renderResult.getByTestId(BridgeViewSelectorsIDs.LIMIT_DEST_TOKEN_INPUT),
+    ).toBeOnTheScreen();
+    expect(
+      renderResult.queryByText(strings('bridge.recurring.you_get')),
+    ).not.toBeOnTheScreen();
+  });
 });

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/BridgeRecurringBuyView.view.test.tsx
@@ -544,6 +544,38 @@ describeForPlatforms('BridgeRecurringBuyView', () => {
         ),
       ).toHaveDisplayValue('1');
     });
+
+    it('shows You get on dest and does not fill a dest amount after source amount is entered', async () => {
+      const renderResult = renderBridgeView();
+
+      await openRecurringTab(renderResult);
+      await openAmountKeypad(renderResult);
+      fireEvent.press(renderResult.getByTestId('keypad-key-2'));
+
+      await waitFor(() => {
+        expect(
+          renderResult.getByTestId(
+            BridgeViewSelectorsIDs.RECURRING_SOURCE_TOKEN_INPUT,
+          ),
+        ).toHaveDisplayValue('2');
+      });
+      expect(
+        renderResult.getByTestId(BridgeViewSelectorsIDs.RECURRING_DEST_YOU_GET),
+      ).toBeOnTheScreen();
+      expect(
+        renderResult.getByText(strings('bridge.recurring.you_get')),
+      ).toBeOnTheScreen();
+      expect(
+        renderResult.queryByTestId(
+          BridgeViewSelectorsIDs.RECURRING_DEST_TOKEN_INPUT,
+        ),
+      ).not.toBeOnTheScreen();
+      expect(
+        renderResult.getByTestId(
+          BridgeViewSelectorsIDs.RECURRING_DEST_TOKEN_AREA,
+        ),
+      ).toBeOnTheScreen();
+    });
   });
 
   it('shows a filled history row after pressing the History tab', async () => {

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/index.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeRecurringBuyView/index.tsx
@@ -112,6 +112,10 @@ const BridgeRecurringBuyViewContent = ({
             sourceAmountTypeToggleTestID={
               BridgeViewSelectorsIDs.RECURRING_SOURCE_AMOUNT_TYPE_TOGGLE
             }
+            hideDestAmount
+            destAmountReplacementLabelTestID={
+              BridgeViewSelectorsIDs.RECURRING_DEST_YOU_GET
+            }
           />
 
           <SwapsBanners

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.testIds.ts
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.testIds.ts
@@ -33,6 +33,7 @@ export const BridgeViewSelectorsIDs = {
     'recurring-source-token-area-amount-type-toggle',
   RECURRING_DEST_TOKEN_AREA: 'recurring-dest-token-area',
   RECURRING_DEST_TOKEN_INPUT: 'recurring-dest-token-area-input',
+  RECURRING_DEST_YOU_GET: 'recurring-dest-you-get',
 } as const;
 
 export type BridgeViewSelectorsIDsType = typeof BridgeViewSelectorsIDs;

--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx
@@ -557,7 +557,7 @@ describeForPlatforms('BridgeView', () => {
       bridgeControllerState.quotes = [quoteWithTrade];
     }
 
-    const { getByTestId, getByText } = renderComponentViewScreen(
+    const { getByTestId, getByText, queryByText } = renderComponentViewScreen(
       BridgeView as unknown as React.ComponentType,
       { name: Routes.BRIDGE.BRIDGE_VIEW },
       { state },
@@ -569,6 +569,9 @@ describeForPlatforms('BridgeView', () => {
       ).toBe('$1.00');
     });
     expect(getByText('1 USDC')).toBeOnTheScreen();
+    expect(
+      queryByText(strings('bridge.recurring.you_get')),
+    ).not.toBeOnTheScreen();
   });
 
   it('resets source cursor to the end when input is focused again', async () => {

--- a/app/components/UI/Bridge/components/SwapsInputs/SwapsInputs.styles.ts
+++ b/app/components/UI/Bridge/components/SwapsInputs/SwapsInputs.styles.ts
@@ -17,5 +17,8 @@ export const createStyles = (params: { theme: Theme }) => {
       paddingHorizontal: 12,
       paddingVertical: 24,
     },
+    compactDestTokenCard: {
+      paddingVertical: 12,
+    },
   });
 };

--- a/app/components/UI/Bridge/components/SwapsInputs/SwapsInputs.tsx
+++ b/app/components/UI/Bridge/components/SwapsInputs/SwapsInputs.tsx
@@ -35,10 +35,6 @@ interface SwapsInputsProps {
   sourceTokenAreaTestID: string;
   destTokenAreaTestID: string;
   sourceAmountTypeToggleTestID: string;
-  /**
-   * Recurring dest only. Limit must leave this unset so dest still shows
-   * the quoted amount, loading skeleton, and fiat.
-   */
   hideDestAmount?: boolean;
   destAmountReplacementLabelTestID?: string;
 }

--- a/app/components/UI/Bridge/components/SwapsInputs/SwapsInputs.tsx
+++ b/app/components/UI/Bridge/components/SwapsInputs/SwapsInputs.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box } from '@metamask/design-system-react-native';
 import type { CaipChainId } from '@metamask/utils';
+import { strings } from '../../../../../../locales/i18n';
 import { useStyles } from '../../../../../component-library/hooks';
 import { getNetworkImageSource } from '../../../../../util/networks';
 import {
@@ -34,6 +35,12 @@ interface SwapsInputsProps {
   sourceTokenAreaTestID: string;
   destTokenAreaTestID: string;
   sourceAmountTypeToggleTestID: string;
+  /**
+   * Recurring dest only. Limit must leave this unset so dest still shows
+   * the quoted amount, loading skeleton, and fiat.
+   */
+  hideDestAmount?: boolean;
+  destAmountReplacementLabelTestID?: string;
 }
 
 export const SwapsInputs = ({
@@ -55,6 +62,8 @@ export const SwapsInputs = ({
   sourceTokenAreaTestID,
   destTokenAreaTestID,
   sourceAmountTypeToggleTestID,
+  hideDestAmount = false,
+  destAmountReplacementLabelTestID,
 }: SwapsInputsProps) => {
   const { styles } = useStyles(createStyles);
 
@@ -97,9 +106,14 @@ export const SwapsInputs = ({
           />
         </Box>
         <FLipQuoteButton onPress={onFlipPress} disabled={isFlipDisabled} />
-        <Box style={styles.tokenCard}>
+        <Box
+          style={[
+            styles.tokenCard,
+            hideDestAmount ? styles.compactDestTokenCard : undefined,
+          ]}
+        >
           <TokenInputArea
-            amount={destTokenAmount}
+            amount={hideDestAmount ? undefined : destTokenAmount}
             token={destToken}
             networkImageSource={
               destToken
@@ -110,8 +124,17 @@ export const SwapsInputs = ({
             tokenType={TokenInputAreaType.Destination}
             onInputPress={onDestInputPress}
             onTokenPress={onDestTokenPress}
-            isLoading={!destTokenAmount && isDestAmountLoading}
-            showFiatAmountAsPrimary={sourceAmountInput.isFiatMode}
+            isLoading={
+              hideDestAmount ? false : !destTokenAmount && isDestAmountLoading
+            }
+            showFiatAmountAsPrimary={
+              hideDestAmount ? false : sourceAmountInput.isFiatMode
+            }
+            hideAmount={hideDestAmount}
+            amountReplacementLabel={
+              hideDestAmount ? strings('bridge.recurring.you_get') : undefined
+            }
+            amountReplacementLabelTestID={destAmountReplacementLabelTestID}
             enabledChainIds={enabledChainIds}
             excludeRwaTokens
             hideFiatValueWhenUnpriced

--- a/app/components/UI/Bridge/components/TokenInputArea/TokenInputArea.test.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/TokenInputArea.test.tsx
@@ -1419,4 +1419,57 @@ describe('TokenInputArea', () => {
       expect(mockOnInputPress).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('hideAmount', () => {
+    const destToken: BridgeToken = {
+      address: '0x1234567890123456789012345678901234567890',
+      symbol: 'TEST',
+      decimals: 18,
+      chainId: '0x1' as `0x${string}`,
+    };
+
+    it('renders the amount label and hides the dest amount, fiat, and subtitle', () => {
+      mockUseDisplayCurrencyValue.mockReturnValue('$100.00');
+
+      const { getByTestId, queryByTestId, queryByText } = renderScreen(
+        () => (
+          <TokenInputArea
+            testID="token-input"
+            tokenType={TokenInputAreaType.Destination}
+            token={destToken}
+            amount="1.5"
+            hideAmount
+            amountReplacementLabel="You get"
+            amountReplacementLabelTestID="token-input-you-get"
+          />
+        ),
+        { name: 'TokenInputArea' },
+        { state: initialState },
+      );
+
+      expect(getByTestId('token-input-you-get')).toHaveTextContent('You get');
+      expect(queryByTestId('token-input-input')).toBeNull();
+      expect(queryByText('$100.00')).toBeNull();
+      expect(queryByText('1.5')).toBeNull();
+      expect(getByTestId('token-button')).toHaveTextContent('TEST');
+    });
+
+    it('renders the dest amount input when hideAmount is not set', () => {
+      const { getByTestId, queryByTestId } = renderScreen(
+        () => (
+          <TokenInputArea
+            testID="token-input"
+            tokenType={TokenInputAreaType.Destination}
+            token={destToken}
+            amount="1.5"
+          />
+        ),
+        { name: 'TokenInputArea' },
+        { state: initialState },
+      );
+
+      expect(getByTestId('token-input-input').props.value).toBe('1.5');
+      expect(queryByTestId('token-input-you-get')).toBeNull();
+    });
+  });
 });

--- a/app/components/UI/Bridge/components/TokenInputArea/index.tsx
+++ b/app/components/UI/Bridge/components/TokenInputArea/index.tsx
@@ -22,6 +22,7 @@ import { colors as importedColors } from '../../../../../styles/common';
 import { Box } from '../../../Box/Box';
 import Text, {
   TextColor,
+  TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
 import Icon, {
   IconColor,
@@ -206,6 +207,20 @@ interface TokenInputAreaProps {
    * rather than the "$0.00" such a token would otherwise be priced at.
    */
   hideFiatValueWhenUnpriced?: boolean;
+  /**
+   * When true, the amount input, loading skeleton, fiat row, and subtitle
+   * are omitted. Used by Recurring dest to show a static label instead of
+   * the quoted dest amount. Limit and Market must leave this unset.
+   */
+  hideAmount?: boolean;
+  /**
+   * Label rendered in place of the amount when `hideAmount` is true.
+   */
+  amountReplacementLabel?: string;
+  /**
+   * Test ID for the `amountReplacementLabel` text.
+   */
+  amountReplacementLabelTestID?: string;
 }
 
 export const TokenInputArea = forwardRef<
@@ -242,6 +257,9 @@ export const TokenInputArea = forwardRef<
       enabledChainIds,
       excludeRwaTokens,
       hideFiatValueWhenUnpriced = false,
+      hideAmount = false,
+      amountReplacementLabel,
+      amountReplacementLabelTestID,
     },
     ref,
   ) => {
@@ -415,8 +433,19 @@ export const TokenInputArea = forwardRef<
       <Box style={style}>
         <Box style={styles.content} gap={2}>
           <Box style={styles.row}>
-            <Box style={styles.amountContainer} onLayout={onContainerLayout}>
-              {isLoading ? (
+            <Box
+              style={styles.amountContainer}
+              onLayout={hideAmount ? undefined : onContainerLayout}
+            >
+              {hideAmount ? (
+                <Text
+                  variant={TextVariant.BodySMMedium}
+                  color={TextColor.Alternative}
+                  testID={amountReplacementLabelTestID}
+                >
+                  {amountReplacementLabel}
+                </Text>
+              ) : isLoading ? (
                 <Skeleton width="50%" height="80%" style={styles.input} />
               ) : (
                 <Box style={styles.amountInputWrapper}>
@@ -488,73 +517,75 @@ export const TokenInputArea = forwardRef<
               </Button>
             )}
           </Box>
-          <Box style={styles.row}>
-            {isLoading ? (
-              <Skeleton width={80} height={24} />
-            ) : (
-              <>
-                <Box style={styles.currencyContainer}>
-                  <TouchableOpacity
-                    style={styles.secondaryValueContainer}
-                    onPress={onAmountTypeTogglePress}
-                    disabled={!onAmountTypeTogglePress}
-                    testID={
-                      onAmountTypeTogglePress
-                        ? amountTypeToggleTestID
-                        : undefined
+          {hideAmount ? null : (
+            <Box style={styles.row}>
+              {isLoading ? (
+                <Skeleton width={80} height={24} />
+              ) : (
+                <>
+                  <Box style={styles.currencyContainer}>
+                    <TouchableOpacity
+                      style={styles.secondaryValueContainer}
+                      onPress={onAmountTypeTogglePress}
+                      disabled={!onAmountTypeTogglePress}
+                      testID={
+                        onAmountTypeTogglePress
+                          ? amountTypeToggleTestID
+                          : undefined
+                      }
+                    >
+                      {shouldShowSecondaryAmount ? (
+                        <Text color={TextColor.Alternative}>
+                          {secondaryAmountDisplayValue}
+                        </Text>
+                      ) : null}
+                      {onAmountTypeTogglePress ? (
+                        <Icon
+                          name={IconName.SwapVertical}
+                          size={IconSize.Sm}
+                          color={IconColor.Alternative}
+                        />
+                      ) : null}
+                    </TouchableOpacity>
+                  </Box>
+                  <Box
+                    flexDirection={
+                      tokenType === TokenInputAreaType.Source &&
+                      onMaxPress &&
+                      shouldShowMaxButton
+                        ? FlexDirection.Row
+                        : FlexDirection.Column
                     }
+                    gap={4}
+                    style={styles.hidden}
                   >
-                    {shouldShowSecondaryAmount ? (
-                      <Text color={TextColor.Alternative}>
-                        {secondaryAmountDisplayValue}
-                      </Text>
-                    ) : null}
-                    {onAmountTypeTogglePress ? (
-                      <Icon
-                        name={IconName.SwapVertical}
-                        size={IconSize.Sm}
-                        color={IconColor.Alternative}
-                      />
-                    ) : null}
-                  </TouchableOpacity>
-                </Box>
-                <Box
-                  flexDirection={
-                    tokenType === TokenInputAreaType.Source &&
-                    onMaxPress &&
-                    shouldShowMaxButton
-                      ? FlexDirection.Row
-                      : FlexDirection.Column
-                  }
-                  gap={4}
-                  style={styles.hidden}
-                >
-                  <Text
-                    color={
-                      isInsufficientBalance &&
-                      tokenType === TokenInputAreaType.Source
-                        ? TextColor.Error
-                        : TextColor.Alternative
-                    }
-                  >
-                    {subtitle}
-                  </Text>
-                  {tokenType === TokenInputAreaType.Source &&
-                    tokenBalance &&
-                    onMaxPress &&
-                    shouldShowMaxButton && (
-                      <OldButton
-                        variant={OldButtonVariants.Link}
-                        label={strings('bridge.max')}
-                        onPress={onMaxPress}
-                        disabled={!subtitle}
-                        testID="token-input-area-max-button"
-                      />
-                    )}
-                </Box>
-              </>
-            )}
-          </Box>
+                    <Text
+                      color={
+                        isInsufficientBalance &&
+                        tokenType === TokenInputAreaType.Source
+                          ? TextColor.Error
+                          : TextColor.Alternative
+                      }
+                    >
+                      {subtitle}
+                    </Text>
+                    {tokenType === TokenInputAreaType.Source &&
+                      tokenBalance &&
+                      onMaxPress &&
+                      shouldShowMaxButton && (
+                        <OldButton
+                          variant={OldButtonVariants.Link}
+                          label={strings('bridge.max')}
+                          onPress={onMaxPress}
+                          disabled={!subtitle}
+                          testID="token-input-area-max-button"
+                        />
+                      )}
+                  </Box>
+                </>
+              )}
+            </Box>
+          )}
         </Box>
       </Box>
     );

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -8523,6 +8523,7 @@
       "expired_after": "Expired after {{duration}}"
     },
     "recurring": {
+      "you_get": "You get",
       "every": "Every",
       "repeat": "Repeat",
       "times": "times",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Recurring dest was reusing the Limit/Market amount row, so a quoted received amount (and dest fiat/address) showed under the dest token even though Recurring should not display that yet. Quotes still need to be fetched for later work (flip, banners, price range).

This PR adds opt-in dest presentation on the shared input components: Recurring dest shows a static "You get" label plus the dest token picker, with a shorter dest card. Limit leaves the new flags unset so dest amount, loading skeleton, and fiat stay unchanged. Market does not use `SwapsInputs` and is not passed `hideAmount`. Quote requests on Recurring are unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Hid the quoted destination amount on Recurring swaps and showed a You get label instead

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: SWAPS-4910

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Recurring dest You get label

  Background:
    Given I am logged into MetaMask Mobile
    And Limit and Recurring swaps are available

  Scenario: Recurring dest shows You get instead of a received amount
    Given I am on Unified Swaps
    And I open the Recurring tab

    When I enter a source amount
    Then I should see "You get" on the destination row
    And I should see the destination token picker
    And I should not see a destination received amount, dest fiat, or dest amount skeleton

  Scenario: Recurring still fetches a quote in the background
    Given I am on the Recurring tab
    And I have valid source and dest tokens

    When I enter a source amount
    Then quote fetching should still run
    And flip, quote error banners, and other quote-backed UI should still have quote data available

  Scenario: Limit dest amount is unchanged
    Given I am on Unified Swaps
    And I open the Limit tab

    Then I should see the destination amount input
    And I should not see Recurring "You get" copy

  Scenario: Market dest amount is unchanged
    Given I am on Unified Swaps
    And I am on the Market tab

    Then I should see the destination amount input
    And I should not see Recurring "You get" copy
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — no screenshots were captured for this change.

### **After**

<!-- [screenshots/recordings] -->
<img width="598" height="1144" alt="Screenshot 2026-08-20 at 3 53 08 PM" src="https://github.com/user-attachments/assets/37707c1c-315e-452d-ba71-c9067ce8243c" />



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only presentation change on Recurring dest; quote logic and Limit/Market amount inputs are left as-is.
> 
> **Overview**
> Recurring dest no longer shows a quoted received amount, dest fiat, or loading skeleton. It now shows a static **You get** label plus the dest token picker on a more compact card.
> 
> `TokenInputArea` and `SwapsInputs` gain opt-in `hideAmount` / `hideDestAmount` so Limit and Market dest inputs stay unchanged. Quote fetching on Recurring is not altered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5aa2dbc36dff1d0ea7f094021fa2de2479e14c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->