### PR TITLE
fix(rewards): shrink Money Account balance row text on sweepstakes overview

### DIFF
--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.tsx
@@ -220,7 +220,7 @@ const MoneyAccountSweepstakesCampaignOverview: React.FC<
             }
           >
             <Text
-              variant={TextVariant.BodyMd}
+              variant={TextVariant.BodySm}
               color={TextColor.TextAlternative}
             >
               {localizedText.balanceTitle}
@@ -229,7 +229,7 @@ const MoneyAccountSweepstakesCampaignOverview: React.FC<
               <Skeleton style={tw.style('h-5 w-20 rounded-md')} />
             ) : (
               <Text
-                variant={TextVariant.BodyMd}
+                variant={TextVariant.BodySm}
                 fontWeight={FontWeight.Medium}
                 color={TextColor.TextDefault}
               >


### PR DESCRIPTION
## **Description**

The Money Account balance row on the Money Account Sweepstakes overview screen (the "Existing Money balance" label and its `$0.00` value) rendered one size larger than intended. This shrinks both the label and value text by one step (`BodyMd` -> `BodySm`) to match the intended layout.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: Improve hierarchy in top campaign card.

## **Manual testing steps**

```gherkin
Feature: Money Account Sweepstakes overview

  Scenario: user views the Money Account balance row
    Given the user has opted into the Money Account Sweepstakes campaign

    When user views the campaign overview screen
    Then the "Existing Money balance" label and its dollar value render at the smaller BodySm text size
```

## **Screenshots/Recordings**

### **Before**

<img width="442" height="326" alt="image" src="https://github.com/user-attachments/assets/e68eda2f-1efd-4e5c-879f-614485e79218" />

### **After**

<img width="426" height="331" alt="image" src="https://github.com/user-attachments/assets/e200a47e-5d94-4424-b6b5-2f66f6129940" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)