### PR TITLE
fix(perps): show trigger prices in order history

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -687,6 +687,8 @@ export const PerpsTransactionSelectorsIDs = {
 
   // Common buttons
   BLOCK_EXPLORER_BUTTON: 'block-explorer-button',
+  LIMIT_PRICE_ROW: 'perps-order-transaction-limit-price-row',
+  TRIGGER_PRICE_ROW: 'perps-order-transaction-trigger-price-row',
 };
 
 export const PerpsChartGridLinesSelectorsIDs = {

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
+import type { OrdinaryOrderType } from '@metamask/perps-controller';
 import Routes from '../../../../../constants/navigation/Routes';
 import PerpsOrderTransactionView from './PerpsOrderTransactionView';
 import {
@@ -23,11 +24,81 @@ const mockTransaction = {
     text: 'Filled',
     statusType: 'filled' as const,
     type: 'limit',
+    orderType: 'limit',
     size: '3000',
     limitPrice: 2000,
     filled: '100%',
   },
 };
+
+const orderTypeCases = [
+  {
+    orderType: 'market',
+    executionType: 'market',
+    detailedOrderType: 'Market',
+    limitPrice: undefined,
+    triggerPrice: undefined,
+  },
+  {
+    orderType: 'limit',
+    executionType: 'limit',
+    detailedOrderType: 'Limit',
+    limitPrice: 2000,
+    triggerPrice: undefined,
+  },
+  {
+    orderType: 'stop_market',
+    executionType: 'market',
+    detailedOrderType: 'Stop Market',
+    limitPrice: undefined,
+    triggerPrice: 2100,
+  },
+  {
+    orderType: 'stop_limit',
+    executionType: 'limit',
+    detailedOrderType: 'Stop Limit',
+    limitPrice: 2050,
+    triggerPrice: 2100,
+  },
+  {
+    orderType: 'take_profit_market',
+    executionType: 'market',
+    detailedOrderType: 'Take Profit Market',
+    limitPrice: undefined,
+    triggerPrice: 2200,
+  },
+  {
+    orderType: 'take_profit_limit',
+    executionType: 'limit',
+    detailedOrderType: 'Take Profit Limit',
+    limitPrice: 2150,
+    triggerPrice: 2200,
+  },
+] as const satisfies readonly {
+  orderType: OrdinaryOrderType;
+  executionType: 'market' | 'limit';
+  detailedOrderType: string;
+  limitPrice?: number;
+  triggerPrice?: number;
+}[];
+
+const createOrderTransaction = (
+  orderType: OrdinaryOrderType,
+  executionType: 'market' | 'limit',
+  detailedOrderType: string,
+  limitPrice?: number,
+  triggerPrice?: number,
+) => ({
+  ...mockTransaction,
+  order: {
+    ...mockTransaction.order,
+    type: executionType,
+    orderType,
+    detailedOrderType,
+    limitPrice,
+    triggerPrice,
+  },
+});
 
 const mockUseNavigation = jest.fn();
 const mockUseRoute = jest.fn();
@@ -305,6 +376,108 @@ describe('PerpsOrderTransactionView', () => {
     mockUseRoute.mockReturnValue({
       params: { transaction: marketOrderTransaction },
     });
+
+    render(<PerpsOrderTransactionView />);
+
+    expect(mockUsePerpsRecordedOrderFees).toHaveBeenCalledWith(
+      'order-123',
+      'ETH',
+      1640995200000,
+    );
+  });
+
+  it.each(orderTypeCases)(
+    'renders the trigger price row for $orderType orders',
+    ({
+      orderType,
+      executionType,
+      detailedOrderType,
+      limitPrice,
+      triggerPrice,
+    }) => {
+      mockUseRoute.mockReturnValue({
+        params: {
+          transaction: createOrderTransaction(
+            orderType,
+            executionType,
+            detailedOrderType,
+            limitPrice,
+            triggerPrice,
+          ),
+        },
+      });
+
+      const { queryByTestId } = render(<PerpsOrderTransactionView />);
+      const triggerPriceRow = queryByTestId(
+        PerpsTransactionSelectorsIDs.TRIGGER_PRICE_ROW,
+      );
+
+      if (triggerPrice === undefined) {
+        expect(triggerPriceRow).not.toBeOnTheScreen();
+      } else {
+        expect(triggerPriceRow).toBeOnTheScreen();
+      }
+    },
+  );
+
+  it.each(orderTypeCases)(
+    'renders the limit price row for $orderType orders',
+    ({
+      orderType,
+      executionType,
+      detailedOrderType,
+      limitPrice,
+      triggerPrice,
+    }) => {
+      mockUseRoute.mockReturnValue({
+        params: {
+          transaction: createOrderTransaction(
+            orderType,
+            executionType,
+            detailedOrderType,
+            limitPrice,
+            triggerPrice,
+          ),
+        },
+      });
+
+      const { queryByTestId } = render(<PerpsOrderTransactionView />);
+      const limitPriceRow = queryByTestId(
+        PerpsTransactionSelectorsIDs.LIMIT_PRICE_ROW,
+      );
+
+      if (limitPrice === undefined) {
+        expect(limitPriceRow).not.toBeOnTheScreen();
+      } else {
+        expect(limitPriceRow).toBeOnTheScreen();
+      }
+    },
+  );
+
+  it('omits the trigger price row when a trigger order has no trigger price', () => {
+    const transaction = createOrderTransaction(
+      'stop_market',
+      'market',
+      'Stop Market',
+    );
+    mockUseRoute.mockReturnValue({ params: { transaction } });
+
+    const { queryByTestId } = render(<PerpsOrderTransactionView />);
+
+    expect(
+      queryByTestId(PerpsTransactionSelectorsIDs.TRIGGER_PRICE_ROW),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('uses recorded fills for triggered order fees', () => {
+    const transaction = createOrderTransaction(
+      'stop_market',
+      'market',
+      'Stop Market',
+      undefined,
+      2100,
+    );
+    mockUseRoute.mockReturnValue({ params: { transaction } });
 
     render(<PerpsOrderTransactionView />);
 

--- a/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.tsx
+++ b/app/components/UI/Perps/Views/PerpsTransactionsView/PerpsOrderTransactionView.tsx
@@ -30,11 +30,23 @@ import {
   formatTransactionDate,
   PRICE_RANGES_UNIVERSAL,
 } from '../../utils/formatUtils';
+import {
+  getOrderPriceRowVisibility,
+  getValidPerpsPrice,
+  resolvePerpsTransactionOrderType,
+} from '../../utils/orderUtils';
 import { styleSheet } from './PerpsOrderTransactionView.styles';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { trackBlockExplorerLinkClicked } from '../../../../../util/analytics/externalLinkTracking';
 import { PerpsConnectionProvider } from '../../providers/PerpsConnectionProvider';
 import { PerpsStreamProvider } from '../../providers/PerpsStreamManager';
+
+interface PerpsOrderDetailRow {
+  key: string;
+  label: string;
+  value: string | number | undefined;
+  testID?: string;
+}
 
 const PerpsOrderTransactionViewContent: React.FC = () => {
   const { styles } = useStyles(styleSheet, {});
@@ -97,24 +109,55 @@ const PerpsOrderTransactionViewContent: React.FC = () => {
     });
   };
 
+  const order = transaction.order;
+  const orderType = order ? resolvePerpsTransactionOrderType(order) : undefined;
+  const { showTriggerPrice, showLimitPrice } =
+    getOrderPriceRowVisibility(orderType);
+
+  const priceRows: PerpsOrderDetailRow[] = [];
+  if (order && showTriggerPrice) {
+    const triggerPrice = getValidPerpsPrice(order.triggerPrice);
+    if (triggerPrice !== null) {
+      priceRows.push({
+        key: 'trigger-price',
+        label: strings('perps.order.trigger_price'),
+        value: formatPerpsFiat(triggerPrice, {
+          ranges: PRICE_RANGES_UNIVERSAL,
+        }),
+        testID: PerpsTransactionSelectorsIDs.TRIGGER_PRICE_ROW,
+      });
+    }
+  }
+
+  if (order && showLimitPrice) {
+    const limitPrice = getValidPerpsPrice(order.limitPrice);
+    if (limitPrice !== null) {
+      priceRows.push({
+        key: 'limit-price',
+        label: strings('perps.transactions.order.limit_price'),
+        value: formatPerpsFiat(limitPrice, {
+          ranges: PRICE_RANGES_UNIVERSAL,
+        }),
+        testID: PerpsTransactionSelectorsIDs.LIMIT_PRICE_ROW,
+      });
+    }
+  }
+
   // Main detail rows based on design
-  const mainDetailRows = [
+  const mainDetailRows: PerpsOrderDetailRow[] = [
     {
+      key: 'date',
       label: strings('perps.transactions.order.date'),
       value: formatTransactionDate(transaction.timestamp),
     },
-    // Add order-specific fields when available from transaction data
     {
+      key: 'size',
       label: strings('perps.transactions.order.size'),
       value: formatPerpsFiat(transaction.order?.size ?? 0),
     },
+    ...priceRows,
     {
-      label: strings('perps.transactions.order.limit_price'),
-      value: formatPerpsFiat(transaction.order?.limitPrice ?? 0, {
-        ranges: PRICE_RANGES_UNIVERSAL,
-      }),
-    },
-    {
+      key: 'filled',
       label: strings('perps.transactions.order.filled'),
       value: transaction.order?.filled,
     },
@@ -157,7 +200,8 @@ const PerpsOrderTransactionViewContent: React.FC = () => {
           <View style={styles.detailsContainer}>
             {mainDetailRows.map((detail, index) => (
               <View
-                key={index}
+                key={detail.key}
+                testID={detail.testID}
                 style={[
                   styles.detailRow,
                   index === mainDetailRows.length - 1 && styles.detailRowLast,

--- a/app/components/UI/Perps/types/transactionHistory.ts
+++ b/app/components/UI/Perps/types/transactionHistory.ts
@@ -1,4 +1,5 @@
 import { RouteProp } from '@react-navigation/native';
+import type { OrderType } from '@metamask/perps-controller';
 import type { PerpsNavigationParamList } from './navigation';
 
 export enum PerpsOrderTransactionStatus {
@@ -72,9 +73,13 @@ export interface PerpsTransaction {
     orderId?: string;
     text: PerpsOrderTransactionStatus;
     statusType: PerpsOrderTransactionStatusType;
+    /** Legacy execution type retained for activity adapter compatibility. */
     type: 'limit' | 'market';
+    /** Normalized order placement type, including trigger variants. */
+    orderType?: OrderType;
     size: string;
-    limitPrice: string;
+    limitPrice?: string;
+    triggerPrice?: string;
     filled: string;
     side?: 'buy' | 'sell';
     reduceOnly?: boolean;

--- a/app/components/UI/Perps/utils/orderUtils.test.ts
+++ b/app/components/UI/Perps/utils/orderUtils.test.ts
@@ -48,14 +48,23 @@ describe('orderUtils', () => {
       },
     );
 
-    it('resolves a legacy stop-market transaction from its detailed order type', () => {
-      const result = resolvePerpsTransactionOrderType({
-        type: 'market',
-        detailedOrderType: 'Stop Market',
-      });
+    it.each([
+      ['stop_market', 'market', 'Stop Market'],
+      ['stop_limit', 'limit', 'Stop Limit'],
+      ['take_profit_market', 'market', 'Take Profit Market'],
+      ['take_profit_limit', 'limit', 'Take Profit Limit'],
+    ] as const)(
+      'resolves legacy %s from its detailed order type',
+      (orderType, executionType, detailedOrderType) => {
+        const result = resolvePerpsTransactionOrderType({
+          type: executionType,
+          orderType: executionType,
+          detailedOrderType,
+        });
 
-      expect(result).toBe('stop_market');
-    });
+        expect(result).toBe(orderType);
+      },
+    );
 
     it('keeps a normalized order type when transaction data provides one', () => {
       const result = resolvePerpsTransactionOrderType({

--- a/app/components/UI/Perps/utils/orderUtils.test.ts
+++ b/app/components/UI/Perps/utils/orderUtils.test.ts
@@ -16,6 +16,9 @@ import {
   willFlipPosition,
   determineMakerStatus,
   isPriceOutsideDeviationBand,
+  getOrderPriceRowVisibility,
+  getValidPerpsPrice,
+  resolvePerpsTransactionOrderType,
 } from './orderUtils';
 import { Order, OrderParams } from '@metamask/perps-controller';
 import { Position } from '../hooks';
@@ -28,6 +31,52 @@ jest.mock('../../../../core/SDKConnect/utils/DevLogger', () => ({
 }));
 
 describe('orderUtils', () => {
+  describe('transaction order price rows', () => {
+    it.each([
+      ['market', false, false],
+      ['limit', false, true],
+      ['stop_market', true, false],
+      ['stop_limit', true, true],
+      ['take_profit_market', true, false],
+      ['take_profit_limit', true, true],
+    ] as const)(
+      'maps %s to trigger-price=%s and limit-price=%s',
+      (orderType, showTriggerPrice, showLimitPrice) => {
+        const result = getOrderPriceRowVisibility(orderType);
+
+        expect(result).toEqual({ showTriggerPrice, showLimitPrice });
+      },
+    );
+
+    it('resolves a legacy stop-market transaction from its detailed order type', () => {
+      const result = resolvePerpsTransactionOrderType({
+        type: 'market',
+        detailedOrderType: 'Stop Market',
+      });
+
+      expect(result).toBe('stop_market');
+    });
+
+    it('keeps a normalized order type when transaction data provides one', () => {
+      const result = resolvePerpsTransactionOrderType({
+        type: 'market',
+        orderType: 'take_profit_limit',
+        detailedOrderType: 'Take Profit Market',
+      });
+
+      expect(result).toBe('take_profit_limit');
+    });
+
+    it.each([undefined, null, '', '0', 'not-a-price'] as const)(
+      'returns null for a missing or invalid price value %s',
+      (price) => {
+        const result = getValidPerpsPrice(price);
+
+        expect(result).toBeNull();
+      },
+    );
+  });
+
   describe('formatOrderLabel', () => {
     it('should format opening long market order', () => {
       const order: Order = {

--- a/app/components/UI/Perps/utils/orderUtils.ts
+++ b/app/components/UI/Perps/utils/orderUtils.ts
@@ -2,6 +2,7 @@ import { capitalize } from 'lodash';
 import {
   isLimitExecutionOrderType,
   isTPSLOrder,
+  isTriggerOrderType,
   type OrderParams,
   type Order,
   type OrderDirection,
@@ -27,21 +28,30 @@ const TRIGGER_CONDITION_PRICE_ABOVE = 'perps.order_details.price_above';
 const TRIGGER_CONDITION_PRICE_BELOW = 'perps.order_details.price_below';
 
 /**
- * Parses the trigger price from an order, returning null when absent or invalid.
- * Use this instead of inline `parseFloat(order.triggerPrice ?? '')` + validity checks.
+ * Parses a Perps price, returning null when absent or invalid.
+ *
+ * @param price - Price value from a controller order or transaction.
+ * @returns The positive numeric price, or null when unavailable.
  */
-export const getValidTriggerPrice = (order: Order): number | null => {
-  const parsed = parseFloat(order.triggerPrice ?? '');
+export const getValidPerpsPrice = (
+  price: string | number | null | undefined,
+): number | null => {
+  const parsed = typeof price === 'number' ? price : parseFloat(price ?? '');
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
 };
 
 /**
+ * Parses the trigger price from an order, returning null when absent or invalid.
+ * Use this instead of inline `parseFloat(order.triggerPrice ?? '')` + validity checks.
+ */
+export const getValidTriggerPrice = (order: Order): number | null =>
+  getValidPerpsPrice(order.triggerPrice);
+
+/**
  * Parses the execution/limit price from an order, returning null when absent or invalid.
  */
-export const getValidOrderPrice = (order: Order): number | null => {
-  const parsed = parseFloat(order.price ?? '');
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
-};
+export const getValidOrderPrice = (order: Order): number | null =>
+  getValidPerpsPrice(order.price);
 
 /**
  * Whether an order price is outside HyperLiquid's allowed band relative to a
@@ -90,6 +100,59 @@ type OrderPriceLabelKey =
  */
 export const isTriggerOrder = (order: Order): boolean =>
   Boolean(order.isTrigger || isTPSLOrder(order.detailedOrderType));
+
+export interface PerpsTransactionOrderLike {
+  type: 'limit' | 'market';
+  orderType?: OrderType;
+  detailedOrderType?: string;
+}
+
+/**
+ * Resolves the normalized order type for transaction-history data.
+ *
+ * @param order - Transaction order data, including legacy fields.
+ * @returns The normalized order type used by detail-row policies.
+ */
+export const resolvePerpsTransactionOrderType = (
+  order: PerpsTransactionOrderLike,
+): OrderType => {
+  if (order.orderType) {
+    return order.orderType;
+  }
+
+  const detailedOrderType = order.detailedOrderType?.toLowerCase() ?? '';
+
+  if (detailedOrderType.includes('take profit')) {
+    return detailedOrderType.includes('limit')
+      ? 'take_profit_limit'
+      : 'take_profit_market';
+  }
+
+  if (detailedOrderType.includes('stop')) {
+    return detailedOrderType.includes('limit') ? 'stop_limit' : 'stop_market';
+  }
+
+  return order.type;
+};
+
+export interface PerpsOrderPriceRowVisibility {
+  showTriggerPrice: boolean;
+  showLimitPrice: boolean;
+}
+
+/**
+ * Resolves which price rows belong in an order detail view.
+ *
+ * @param orderType - Normalized placement type for the order.
+ * @returns Visibility flags for trigger and limit price rows.
+ */
+export const getOrderPriceRowVisibility = (
+  orderType: OrderType | undefined,
+): PerpsOrderPriceRowVisibility => ({
+  showTriggerPrice: orderType !== undefined && isTriggerOrderType(orderType),
+  showLimitPrice:
+    orderType !== undefined && isLimitExecutionOrderType(orderType),
+});
 
 /**
  * Resolves the execution price shown for an open order.

--- a/app/components/UI/Perps/utils/orderUtils.ts
+++ b/app/components/UI/Perps/utils/orderUtils.ts
@@ -116,7 +116,9 @@ export interface PerpsTransactionOrderLike {
 export const resolvePerpsTransactionOrderType = (
   order: PerpsTransactionOrderLike,
 ): OrderType => {
-  if (order.orderType) {
+  // A normalized trigger type is authoritative. Ordinary market/limit values
+  // are legacy execution types and must not mask a detailed trigger label.
+  if (order.orderType && isTriggerOrderType(order.orderType)) {
     return order.orderType;
   }
 
@@ -132,7 +134,7 @@ export const resolvePerpsTransactionOrderType = (
     return detailedOrderType.includes('limit') ? 'stop_limit' : 'stop_market';
   }
 
-  return order.type;
+  return order.orderType ?? order.type;
 };
 
 export interface PerpsOrderPriceRowVisibility {

--- a/app/components/UI/Perps/utils/transactionTransforms.test.ts
+++ b/app/components/UI/Perps/utils/transactionTransforms.test.ts
@@ -1088,6 +1088,48 @@ describe('transactionTransforms', () => {
       triggerPrice?: string;
     }[];
 
+    const legacyTriggerOrderCases = [
+      {
+        orderType: 'stop_market',
+        executionType: 'market',
+        detailedOrderType: 'Stop Market',
+        price: '50500',
+        triggerPrice: '50000',
+        limitPrice: undefined,
+      },
+      {
+        orderType: 'stop_limit',
+        executionType: 'limit',
+        detailedOrderType: 'Stop Limit',
+        price: '49500',
+        triggerPrice: '50000',
+        limitPrice: '49500',
+      },
+      {
+        orderType: 'take_profit_market',
+        executionType: 'market',
+        detailedOrderType: 'Take Profit Market',
+        price: '50500',
+        triggerPrice: '51000',
+        limitPrice: undefined,
+      },
+      {
+        orderType: 'take_profit_limit',
+        executionType: 'limit',
+        detailedOrderType: 'Take Profit Limit',
+        price: '51500',
+        triggerPrice: '51000',
+        limitPrice: '51500',
+      },
+    ] as const satisfies readonly {
+      orderType: TriggerOrderType;
+      executionType: 'market' | 'limit';
+      detailedOrderType: string;
+      price: string;
+      triggerPrice: string;
+      limitPrice: string | undefined;
+    }[];
+
     it.each(orderTypeCases)(
       'preserves $orderType price fields in transaction history',
       ({
@@ -1125,6 +1167,40 @@ describe('transactionTransforms', () => {
               ? undefined
               : price,
         });
+      },
+    );
+
+    it.each(legacyTriggerOrderCases)(
+      'recovers $orderType from legacy order metadata',
+      ({
+        orderType,
+        executionType,
+        detailedOrderType,
+        price,
+        triggerPrice,
+        limitPrice,
+      }) => {
+        const sourceOrder = {
+          ...mockOrder,
+          orderType: executionType,
+          isTrigger: true,
+          detailedOrderType,
+          price,
+          triggerPrice,
+        };
+
+        const result = transformOrdersToTransactions([sourceOrder]);
+
+        expect(result[0]?.order).toEqual(
+          expect.objectContaining({
+            orderType,
+            type: executionType,
+            isTrigger: true,
+            detailedOrderType,
+            triggerPrice,
+            limitPrice,
+          }),
+        );
       },
     );
 

--- a/app/components/UI/Perps/utils/transactionTransforms.test.ts
+++ b/app/components/UI/Perps/utils/transactionTransforms.test.ts
@@ -13,7 +13,11 @@ import {
 } from './transactionTransforms';
 import { getTokenTransferData } from '../../../Views/confirmations/utils/transaction-pay';
 import { parseStandardTokenTransactionData } from '../../../Views/confirmations/utils/transaction';
-import { OrderFill } from '@metamask/perps-controller';
+import {
+  OrderFill,
+  type OrdinaryOrderType,
+  type TriggerOrderType,
+} from '@metamask/perps-controller';
 import { FillType } from '../components/PerpsTransactionItem/PerpsTransactionItem';
 import {
   PerpsOrderTransactionStatus,
@@ -1026,11 +1030,109 @@ describe('transactionTransforms', () => {
       timestamp: 1640995200000,
     };
 
+    const orderTypeCases = [
+      {
+        orderType: 'market',
+        executionType: 'market',
+        detailedOrderType: 'Market',
+        price: '50000',
+        triggerOrderType: undefined,
+        triggerPrice: undefined,
+      },
+      {
+        orderType: 'limit',
+        executionType: 'limit',
+        detailedOrderType: 'Limit',
+        price: '50000',
+        triggerOrderType: undefined,
+        triggerPrice: undefined,
+      },
+      {
+        orderType: 'stop_market',
+        executionType: 'market',
+        detailedOrderType: 'Stop Market',
+        price: '50500',
+        triggerOrderType: 'stop_market',
+        triggerPrice: '50000',
+      },
+      {
+        orderType: 'stop_limit',
+        executionType: 'limit',
+        detailedOrderType: 'Stop Limit',
+        price: '49500',
+        triggerOrderType: 'stop_limit',
+        triggerPrice: '50000',
+      },
+      {
+        orderType: 'take_profit_market',
+        executionType: 'market',
+        detailedOrderType: 'Take Profit Market',
+        price: '50500',
+        triggerOrderType: 'take_profit_market',
+        triggerPrice: '51000',
+      },
+      {
+        orderType: 'take_profit_limit',
+        executionType: 'limit',
+        detailedOrderType: 'Take Profit Limit',
+        price: '51500',
+        triggerOrderType: 'take_profit_limit',
+        triggerPrice: '51000',
+      },
+    ] as const satisfies readonly {
+      orderType: OrdinaryOrderType;
+      executionType: 'market' | 'limit';
+      detailedOrderType: string;
+      price: string;
+      triggerOrderType?: TriggerOrderType;
+      triggerPrice?: string;
+    }[];
+
+    it.each(orderTypeCases)(
+      'preserves $orderType price fields in transaction history',
+      ({
+        orderType,
+        executionType,
+        detailedOrderType,
+        price,
+        triggerOrderType,
+        triggerPrice,
+      }) => {
+        const sourceOrder = {
+          ...mockOrder,
+          orderType: executionType,
+          triggerOrderType,
+          detailedOrderType,
+          price,
+          triggerPrice,
+        };
+
+        const result = transformOrdersToTransactions([sourceOrder]);
+        const transformedOrder = result[0].order;
+
+        expect(transformedOrder).toMatchObject({
+          orderType,
+          type: executionType,
+          detailedOrderType,
+          triggerPrice:
+            orderType === 'market' || orderType === 'limit'
+              ? undefined
+              : triggerPrice,
+          limitPrice:
+            orderType === 'market' ||
+            orderType === 'stop_market' ||
+            orderType === 'take_profit_market'
+              ? undefined
+              : price,
+        });
+      },
+    );
+
     it('transforms filled order correctly (defaults to 100% without fill data)', () => {
       const result = transformOrdersToTransactions([mockOrder]);
 
       expect(result).toHaveLength(1);
-      expect(result[0]).toEqual({
+      expect(result[0]).toMatchObject({
         id: 'order1-1640995200000',
         type: 'order',
         category: 'limit_order',
@@ -1043,6 +1145,7 @@ describe('transactionTransforms', () => {
           text: PerpsOrderTransactionStatus.Filled,
           statusType: PerpsOrderTransactionStatusType.Filled,
           type: 'limit',
+          orderType: 'limit',
           size: '50000',
           limitPrice: '50000',
           filled: '100%', // Filled status without fill data defaults to 100%

--- a/app/components/UI/Perps/utils/transactionTransforms.ts
+++ b/app/components/UI/Perps/utils/transactionTransforms.ts
@@ -20,7 +20,11 @@ import {
   PerpsOrderTransactionStatusType,
   PerpsTransaction,
 } from '../types/transactionHistory';
-import { formatOrderLabel, getValidPerpsPrice } from './orderUtils';
+import {
+  formatOrderLabel,
+  getValidPerpsPrice,
+  resolvePerpsTransactionOrderType,
+} from './orderUtils';
 import { getTokenTransferData } from '../../../Views/confirmations/utils/transaction-pay';
 import { parseStandardTokenTransactionData } from '../../../Views/confirmations/utils/transaction';
 import { calcTokenAmount } from '../../../../util/transactions';
@@ -472,7 +476,14 @@ export function transformOrdersToTransactions(
     const title = formatOrderLabel(order);
     const subtitle = `${originalSize || '0'} ${getPerpsDisplaySymbol(symbol)}`;
 
-    const normalizedOrderType: OrderType = triggerOrderType ?? orderType;
+    const executionType = isLimitExecutionOrderType(orderType)
+      ? 'limit'
+      : 'market';
+    const normalizedOrderType: OrderType = resolvePerpsTransactionOrderType({
+      type: executionType,
+      orderType: triggerOrderType ?? orderType,
+      detailedOrderType,
+    });
     const isLimitExecution = isLimitExecutionOrderType(normalizedOrderType);
     const isTriggerType = isTriggerOrderType(normalizedOrderType);
     const limitPrice =

--- a/app/components/UI/Perps/utils/transactionTransforms.ts
+++ b/app/components/UI/Perps/utils/transactionTransforms.ts
@@ -10,6 +10,9 @@ import {
   OrderFill,
   UserHistoryItem,
   getPerpsDisplaySymbol,
+  isLimitExecutionOrderType,
+  isTriggerOrderType,
+  type OrderType,
 } from '@metamask/perps-controller';
 import {
   FillType,
@@ -17,7 +20,7 @@ import {
   PerpsOrderTransactionStatusType,
   PerpsTransaction,
 } from '../types/transactionHistory';
-import { formatOrderLabel } from './orderUtils';
+import { formatOrderLabel, getValidPerpsPrice } from './orderUtils';
 import { getTokenTransferData } from '../../../Views/confirmations/utils/transaction-pay';
 import { parseStandardTokenTransactionData } from '../../../Views/confirmations/utils/transaction';
 import { calcTokenAmount } from '../../../../util/transactions';
@@ -453,8 +456,10 @@ export function transformOrdersToTransactions(
       timestamp,
       side,
       reduceOnly,
-      isTrigger,
+      isTrigger: sourceIsTrigger,
       detailedOrderType,
+      triggerOrderType,
+      triggerPrice: sourceTriggerPrice,
     } = order;
 
     const isCancelled = status === 'canceled';
@@ -467,7 +472,17 @@ export function transformOrdersToTransactions(
     const title = formatOrderLabel(order);
     const subtitle = `${originalSize || '0'} ${getPerpsDisplaySymbol(symbol)}`;
 
-    const orderTypeSlug = orderType.toLowerCase().split(' ').join('_');
+    const normalizedOrderType: OrderType = triggerOrderType ?? orderType;
+    const isLimitExecution = isLimitExecutionOrderType(normalizedOrderType);
+    const isTriggerType = isTriggerOrderType(normalizedOrderType);
+    const limitPrice =
+      isLimitExecution && getValidPerpsPrice(price) !== null
+        ? price
+        : undefined;
+    const triggerPrice =
+      isTriggerType && getValidPerpsPrice(sourceTriggerPrice) !== null
+        ? sourceTriggerPrice
+        : undefined;
 
     let orderStatusType: PerpsOrderTransactionStatusType =
       PerpsOrderTransactionStatusType.Pending;
@@ -549,13 +564,15 @@ export function transformOrdersToTransactions(
         orderId,
         text: statusText,
         statusType: orderStatusType,
-        type: orderTypeSlug.includes('limit') ? 'limit' : 'market',
+        type: isLimitExecution ? 'limit' : 'market',
+        orderType: normalizedOrderType,
         size: BigNumber(originalSize).multipliedBy(price).toString(),
-        limitPrice: price,
+        limitPrice,
+        triggerPrice,
         filled: `${filledPercent}%`,
         side,
         reduceOnly,
-        isTrigger,
+        isTrigger: sourceIsTrigger || isTriggerType,
         detailedOrderType,
       },
     };

--- a/app/components/Views/ActivityDetails/ActivityDetails.perps.view.test.tsx
+++ b/app/components/Views/ActivityDetails/ActivityDetails.perps.view.test.tsx
@@ -69,6 +69,7 @@ const {
   FEES_ROW,
   PNL_ROW,
   LIMIT_PRICE_ROW,
+  TRIGGER_PRICE_ROW,
   FILLED_ROW,
   TOTAL_FEE_ROW,
   RATE_ROW,
@@ -724,16 +725,35 @@ describeForPlatforms('ActivityDetails — Perps orders', () => {
       within(sizeRow).getByText(getPerpsPriceValue(order?.size) ?? ''),
     ).toBeOnTheScreen();
 
-    const limitPriceRow = getByTestId(LIMIT_PRICE_ROW);
-    expect(limitPriceRow).toHaveTextContent(
-      strings('perps.transactions.order.limit_price'),
-      { exact: false },
-    );
-    expect(
-      within(limitPriceRow).getByText(
-        getPerpsPriceValue(order?.limitPrice) ?? '',
-      ),
-    ).toBeOnTheScreen();
+    if (order?.triggerPrice) {
+      const triggerPriceRow = getByTestId(TRIGGER_PRICE_ROW);
+      expect(triggerPriceRow).toHaveTextContent(
+        strings('perps.order.trigger_price'),
+        { exact: false },
+      );
+      expect(
+        within(triggerPriceRow).getByText(
+          getPerpsPriceValue(order.triggerPrice) ?? '',
+        ),
+      ).toBeOnTheScreen();
+    } else {
+      expect(queryByTestId(TRIGGER_PRICE_ROW)).not.toBeOnTheScreen();
+    }
+
+    if (order?.limitPrice) {
+      const limitPriceRow = getByTestId(LIMIT_PRICE_ROW);
+      expect(limitPriceRow).toHaveTextContent(
+        strings('perps.transactions.order.limit_price'),
+        { exact: false },
+      );
+      expect(
+        within(limitPriceRow).getByText(
+          getPerpsPriceValue(order.limitPrice) ?? '',
+        ),
+      ).toBeOnTheScreen();
+    } else {
+      expect(queryByTestId(LIMIT_PRICE_ROW)).not.toBeOnTheScreen();
+    }
 
     expect(getByTestId(FILLED_ROW)).toHaveTextContent(filled, {
       exact: false,

--- a/app/components/Views/ActivityDetails/ActivityDetails.testIds.ts
+++ b/app/components/Views/ActivityDetails/ActivityDetails.testIds.ts
@@ -26,6 +26,7 @@ export const ActivityDetailsSelectorsIDs = {
   FEES_ROW: 'activity-details-fees-row',
   PNL_ROW: 'activity-details-pnl-row',
   LIMIT_PRICE_ROW: 'activity-details-limit-price-row',
+  TRIGGER_PRICE_ROW: 'activity-details-trigger-price-row',
   FILLED_ROW: 'activity-details-filled-row',
   TOTAL_FEE_ROW: 'activity-details-total-fee-row',
   RATE_ROW: 'activity-details-rate-row',

--- a/app/components/Views/ActivityDetails/templates/PerpsDetails.test.tsx
+++ b/app/components/Views/ActivityDetails/templates/PerpsDetails.test.tsx
@@ -276,6 +276,35 @@ describe('PerpsDetails', () => {
     ).toBeOnTheScreen();
   });
 
+  it('renders a trigger price row for a legacy stop-market transaction', () => {
+    const transaction: PerpsTransaction = {
+      ...baseTransaction,
+      type: 'order',
+      category: 'limit_order',
+      title: 'Stop market order',
+      order: {
+        orderId: 'legacy-stop-market-order',
+        text: PerpsOrderTransactionStatus.Filled,
+        statusType: PerpsOrderTransactionStatusType.Filled,
+        type: 'market',
+        orderType: 'market',
+        size: '10',
+        triggerPrice: '99000',
+        filled: '100%',
+        isTrigger: true,
+        detailedOrderType: 'Stop Market',
+      },
+    };
+
+    const { getByTestId } = renderWithProvider(
+      <PerpsDetails item={perpsItem('marketShort', transaction)} />,
+    );
+
+    expect(
+      getByTestId(ActivityDetailsSelectorsIDs.TRIGGER_PRICE_ROW),
+    ).toBeOnTheScreen();
+  });
+
   it('renders trade rows and trade-again CTA', () => {
     const transaction: PerpsTransaction = {
       ...baseTransaction,

--- a/app/components/Views/ActivityDetails/templates/PerpsDetails.test.tsx
+++ b/app/components/Views/ActivityDetails/templates/PerpsDetails.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
 import type { TransactionMeta } from '@metamask/transaction-controller';
+import type { OrdinaryOrderType } from '@metamask/perps-controller';
 import { backgroundState } from '../../../../util/test/initial-root-state';
 import type { ActivityListItem } from '../../../../util/activity-adapters';
 import {
@@ -73,6 +74,73 @@ const baseTransaction: Pick<
   timestamp: 1_765_361_640_000,
   asset: 'BTC',
 };
+
+const orderRowCases = [
+  {
+    orderType: 'market',
+    executionType: 'market',
+    limitPrice: undefined,
+    triggerPrice: undefined,
+  },
+  {
+    orderType: 'limit',
+    executionType: 'limit',
+    limitPrice: '98023',
+    triggerPrice: undefined,
+  },
+  {
+    orderType: 'stop_market',
+    executionType: 'market',
+    limitPrice: undefined,
+    triggerPrice: '99000',
+  },
+  {
+    orderType: 'stop_limit',
+    executionType: 'limit',
+    limitPrice: '98023',
+    triggerPrice: '99000',
+  },
+  {
+    orderType: 'take_profit_market',
+    executionType: 'market',
+    limitPrice: undefined,
+    triggerPrice: '101000',
+  },
+  {
+    orderType: 'take_profit_limit',
+    executionType: 'limit',
+    limitPrice: '102000',
+    triggerPrice: '101000',
+  },
+] as const satisfies readonly {
+  orderType: OrdinaryOrderType;
+  executionType: 'market' | 'limit';
+  limitPrice?: string;
+  triggerPrice?: string;
+}[];
+
+const createOrderTransaction = ({
+  orderType,
+  executionType,
+  limitPrice,
+  triggerPrice,
+}: (typeof orderRowCases)[number]): PerpsTransaction => ({
+  ...baseTransaction,
+  type: 'order',
+  category: 'limit_order',
+  title: `${orderType} order`,
+  order: {
+    orderId: `${orderType}-order`,
+    text: PerpsOrderTransactionStatus.Filled,
+    statusType: PerpsOrderTransactionStatusType.Filled,
+    type: executionType,
+    orderType,
+    size: '10',
+    limitPrice,
+    triggerPrice,
+    filled: '100%',
+  },
+});
 
 /**
  * @param type - Activity kind the row maps to.
@@ -175,6 +243,37 @@ function localPerpsFundsItem(
 describe('PerpsDetails', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it.each(orderRowCases)('renders the $orderType price rows', (orderCase) => {
+    const transaction = createOrderTransaction(orderCase);
+
+    const { getByTestId, queryByTestId } = renderWithProvider(
+      <PerpsDetails item={perpsItem('marketShort', transaction)} />,
+    );
+
+    const triggerPriceRow = queryByTestId(
+      ActivityDetailsSelectorsIDs.TRIGGER_PRICE_ROW,
+    );
+    const limitPriceRow = queryByTestId(
+      ActivityDetailsSelectorsIDs.LIMIT_PRICE_ROW,
+    );
+
+    if (orderCase.triggerPrice) {
+      expect(triggerPriceRow).toBeOnTheScreen();
+    } else {
+      expect(triggerPriceRow).not.toBeOnTheScreen();
+    }
+
+    if (orderCase.limitPrice) {
+      expect(limitPriceRow).toBeOnTheScreen();
+    } else {
+      expect(limitPriceRow).not.toBeOnTheScreen();
+    }
+
+    expect(
+      getByTestId(ActivityDetailsSelectorsIDs.FILLED_ROW),
+    ).toBeOnTheScreen();
   });
 
   it('renders trade rows and trade-again CTA', () => {

--- a/app/components/Views/ActivityDetails/templates/PerpsDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/PerpsDetails.tsx
@@ -229,7 +229,8 @@ function OrderDetails({
     getOrderPriceRowVisibility(orderType);
   const priceRows: React.ReactElement[] = [];
 
-  if (order && showTriggerPrice && getValidPerpsPrice(order.triggerPrice)) {
+  const validTriggerPrice = getValidPerpsPrice(order?.triggerPrice);
+  if (order && showTriggerPrice && validTriggerPrice !== null) {
     priceRows.push(
       <ActivityDetailRow
         key="trigger-price"
@@ -240,7 +241,8 @@ function OrderDetails({
     );
   }
 
-  if (order && showLimitPrice && getValidPerpsPrice(order.limitPrice)) {
+  const validLimitPrice = getValidPerpsPrice(order?.limitPrice);
+  if (order && showLimitPrice && validLimitPrice !== null) {
     priceRows.push(
       <ActivityDetailRow
         key="limit-price"

--- a/app/components/Views/ActivityDetails/templates/PerpsDetails.tsx
+++ b/app/components/Views/ActivityDetails/templates/PerpsDetails.tsx
@@ -52,6 +52,11 @@ import {
 } from '../components/ActivityDetailsPerps.utils';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { usePerpsRecordedOrderFees } from '../../../UI/Perps/hooks';
+import {
+  getOrderPriceRowVisibility,
+  getValidPerpsPrice,
+  resolvePerpsTransactionOrderType,
+} from '../../../UI/Perps/utils/orderUtils';
 import { resolvePerpsOrderStatusLabel } from '../../../UI/ActivityListItemRow/titleLabels';
 import { PerpsConnectionProvider } from '../../../UI/Perps/providers/PerpsConnectionProvider';
 import { PerpsStreamProvider } from '../../../UI/Perps/providers/PerpsStreamManager';
@@ -219,6 +224,32 @@ function OrderDetails({
     isFeeLoading || hasFeeError || totalFee === undefined
       ? '—'
       : formatPerpsOrderFee(totalFee);
+  const orderType = order ? resolvePerpsTransactionOrderType(order) : undefined;
+  const { showTriggerPrice, showLimitPrice } =
+    getOrderPriceRowVisibility(orderType);
+  const priceRows: React.ReactElement[] = [];
+
+  if (order && showTriggerPrice && getValidPerpsPrice(order.triggerPrice)) {
+    priceRows.push(
+      <ActivityDetailRow
+        key="trigger-price"
+        label={strings('perps.order.trigger_price')}
+        value={getPerpsPriceValue(order.triggerPrice)}
+        testID={ActivityDetailsSelectorsIDs.TRIGGER_PRICE_ROW}
+      />,
+    );
+  }
+
+  if (order && showLimitPrice && getValidPerpsPrice(order.limitPrice)) {
+    priceRows.push(
+      <ActivityDetailRow
+        key="limit-price"
+        label={strings('perps.transactions.order.limit_price')}
+        value={getPerpsPriceValue(order.limitPrice)}
+        testID={ActivityDetailsSelectorsIDs.LIMIT_PRICE_ROW}
+      />,
+    );
+  }
 
   return (
     <ActivityDetailsTemplateFrame
@@ -240,11 +271,7 @@ function OrderDetails({
             value={order?.size ? getPerpsPriceValue(order.size) : undefined}
             testID={ActivityDetailsSelectorsIDs.SIZE_ROW}
           />
-          <ActivityDetailRow
-            label={strings('perps.transactions.order.limit_price')}
-            value={getPerpsPriceValue(order?.limitPrice)}
-            testID={ActivityDetailsSelectorsIDs.LIMIT_PRICE_ROW}
-          />
+          {priceRows}
           <ActivityDetailRow
             label={strings('perps.transactions.order.filled')}
             value={order?.filled}

--- a/tests/component-view/presets/activity.ts
+++ b/tests/component-view/presets/activity.ts
@@ -19,6 +19,7 @@ import type {
   Order,
   OrderFill,
   UserHistoryItem,
+  OrdinaryOrderType,
 } from '@metamask/perps-controller';
 import {
   FillType,
@@ -1988,7 +1989,10 @@ const ACTIVITY_CV_PERPS_ORDER_SPECS: Record<
   {
     id: string;
     title: string;
-    orderType: 'market' | 'limit';
+    orderType: OrdinaryOrderType;
+    executionType: 'market' | 'limit';
+    limitPrice?: string;
+    triggerPrice?: string;
     filled: string;
     statusText: PerpsOrderTransactionStatus;
     statusType: PerpsOrderTransactionStatusType;
@@ -2001,6 +2005,8 @@ const ACTIVITY_CV_PERPS_ORDER_SPECS: Record<
     id: 'activity-cv-perps-order-market-close-short',
     title: 'Market close short',
     orderType: 'market',
+    executionType: 'market',
+    limitPrice: undefined,
     filled: '100%',
     statusText: PerpsOrderTransactionStatus.Filled,
     statusType: PerpsOrderTransactionStatusType.Filled,
@@ -2009,7 +2015,9 @@ const ACTIVITY_CV_PERPS_ORDER_SPECS: Record<
   stopMarketCloseShort: {
     id: 'activity-cv-perps-order-stop-market-close-short',
     title: 'Stop market close short',
-    orderType: 'market',
+    orderType: 'stop_market',
+    executionType: 'market',
+    triggerPrice: ACTIVITY_CV_PERPS_TRADE_PRICE,
     filled: '100%',
     statusText: PerpsOrderTransactionStatus.Filled,
     statusType: PerpsOrderTransactionStatusType.Filled,
@@ -2019,7 +2027,10 @@ const ACTIVITY_CV_PERPS_ORDER_SPECS: Record<
   takeProfitCanceled: {
     id: 'activity-cv-perps-order-tp-canceled',
     title: 'Take profit limit close short',
-    orderType: 'limit',
+    orderType: 'take_profit_limit',
+    executionType: 'limit',
+    limitPrice: ACTIVITY_CV_PERPS_TRADE_PRICE,
+    triggerPrice: '91000',
     filled: '0%',
     statusText: PerpsOrderTransactionStatus.Canceled,
     statusType: PerpsOrderTransactionStatusType.Canceled,
@@ -2029,7 +2040,10 @@ const ACTIVITY_CV_PERPS_ORDER_SPECS: Record<
   takeProfitFilled: {
     id: 'activity-cv-perps-order-tp-filled',
     title: 'Take profit limit close short',
-    orderType: 'limit',
+    orderType: 'take_profit_limit',
+    executionType: 'limit',
+    limitPrice: ACTIVITY_CV_PERPS_TRADE_PRICE,
+    triggerPrice: '91000',
     filled: '100%',
     statusText: PerpsOrderTransactionStatus.Filled,
     statusType: PerpsOrderTransactionStatusType.Filled,
@@ -2055,9 +2069,11 @@ export const buildActivityCvPerpsOrderTransaction = (
       orderId: spec.id,
       text: spec.statusText,
       statusType: spec.statusType,
-      type: spec.orderType,
+      type: spec.executionType,
+      orderType: spec.orderType,
       size: '9.2113',
-      limitPrice: ACTIVITY_CV_PERPS_TRADE_PRICE,
+      limitPrice: spec.limitPrice,
+      triggerPrice: spec.triggerPrice,
       filled: spec.filled,
       side: 'buy',
       reduceOnly: spec.reduceOnly,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Preserve normalized trigger order types and separate trigger/limit prices so Hyperliquid stop and take profit orders display accurate history details. Keep recorded fill fee lookup and omit missing prices instead of rendering zero dollars.

## Summary

Perps order history always rendered a limit price row, causing stop-market and take profit market orders to display fabricated `$0` values and preventing stop-limit orders from showing distinct trigger and limit prices.

This change:

- Preserves normalized order types and separate `triggerPrice`/`limitPrice` values through transaction history.
- Applies the correct row matrix:
  - Market: no price row
  - Limit: limit price
  - Stop/Take Profit Market: trigger price
  - Stop/Take Profit Limit: trigger price followed by limit price
- Omits missing or invalid prices instead of displaying `$0`.
- Updates both the primary order-history view and the legacy ActivityDetails surface.
- Reuses the existing `perps.order.trigger_price` translation.
- Adds full-matrix transform, utility, view, and component-view coverage.

## Jira alignment and implementation decisions

The Jira requirements referenced `usePerpsOrderFees`, but the existing implementation uses `usePerpsRecordedOrderFees`, which sums fees from actual historical fills. The recorded fill path was retained because it reflects the fee actually paid and does not require an order type fallback. A regression assertion confirms triggered orders continue using this path.

The Jira requirements also assume order type and price data are directly available for rendering. In the existing code, `order.type` only supports legacy `market`/`limit` values, while trigger details were represented indirectly through `detailedOrderType` and `isTrigger`; `limitPrice` was also rendered unconditionally. The transaction contract was therefore extended additively with a normalized order type and separate trigger price while retaining the legacy `type` field for existing consumers.

The position transaction view remains out of scope.

## Validation

- Targeted Jest suites: 292 tests passed.
- Perps component-view suite: 28 tests passed.
- TypeScript validation passed.
- Changed-file ESLint and Prettier checks passed.
- Full lint remains blocked by an existing `react-native-i18n` parser error.
- Full unit testing was stopped after stalling.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Perps order history to display trigger prices for stop-loss and take-profit orders, including separate trigger and limit prices for trigger-limit orders.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3721

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps order history trigger prices

  Background:
    Given I am logged into MetaMask Mobile
    And Perps is enabled
    And my account has historical Hyperliquid orders

  Scenario: user views market and limit order prices
    Given I am on the Perps order history screen
    When user opens a market order
    Then no trigger-price or limit-price row is displayed

    When user opens a limit order
    Then the limit-price row is displayed
    And no trigger-price row is displayed

  Scenario: user views trigger-market order prices
    Given I am on the Perps order history screen
    And I have a Stop Market or Take Profit Market order
    When user opens the order
    Then the trigger-price row is displayed with the correct formatted value
    And no limit-price row is displayed

  Scenario: user views trigger-limit order prices
    Given I am on the Perps order history screen
    And I have a Stop Limit or Take Profit Limit order with distinct trigger and limit prices
    When user opens the order
    Then the trigger-price row is displayed first
    And the limit-price row is displayed second
    And both rows show their correct formatted values

  Scenario: user views an order with an unavailable price
    Given a historical trigger order has a missing or invalid trigger price
    When user opens the order
    Then the invalid trigger-price row is omitted
    And no `$0` price is displayed

  Scenario: user views fees for a triggered order
    Given I have a triggered order with recorded execution fees
    When user opens the order details
    Then the total fee row displays the recorded execution fee
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-26 at 22 29 05" src="https://github.com/user-attachments/assets/6a0364e4-82f2-4abe-b841-04887bd1e132" />

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-26 at 22 31 01" src="https://github.com/user-attachments/assets/db9fd474-1a07-488d-8b5b-19f537cad129" />


## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and additive transaction-shape changes in Perps order history only, with broad test coverage and no auth or payment logic touched.
> 
> **Overview**
> Fixes Perps **order history** so stop and take-profit orders show the right price fields instead of always rendering a limit price (often as **$0**).
> 
> **Data pipeline:** `transformOrdersToTransactions` now stores a normalized `orderType` plus optional `triggerPrice` and `limitPrice` (only when they apply to that type). Legacy rows still resolve trigger types from `detailedOrderType` via `resolvePerpsTransactionOrderType`. Shared helpers (`getValidPerpsPrice`, `getOrderPriceRowVisibility`) decide which rows to show and skip missing/invalid values.
> 
> **UI:** `PerpsOrderTransactionView` and Activity `PerpsDetails` build detail rows from that matrix—market: none; limit: limit only; stop/TP market: trigger only; stop/TP limit: trigger then limit. Test IDs and parameterized tests cover the full order-type matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64bade425a518d17e2f39816911e25bad0b5710f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->