### PR TITLE
fix(settings): keep device auth toggle on after password modal

### DIFF
--- a/app/components/Views/Settings/SecuritySettings/Sections/DeviceSecurityToggle.test.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/DeviceSecurityToggle.test.tsx
@@ -311,6 +311,45 @@ describe('DeviceSecurityToggle', () => {
       });
     });
 
+    it('keeps toggle on after password entry until capabilities refresh', async () => {
+      jest.useFakeTimers();
+      let onPasswordSet: ((password: string) => Promise<void>) | undefined;
+      mockUpdateAuthPreference
+        .mockRejectedValueOnce(
+          new Error(ReauthenticateErrorType.PASSWORD_NOT_SET_WITH_BIOMETRICS),
+        )
+        .mockResolvedValueOnce(undefined);
+      mockNavigate.mockImplementation(
+        (
+          _: string,
+          params?: { onPasswordSet?: (p: string) => Promise<void> },
+        ) => {
+          if (params?.onPasswordSet) onPasswordSet = params.onPasswordSet;
+        },
+      );
+
+      const { getByTestId } = renderComponent();
+      const toggle = await waitFor(() =>
+        getByTestId(SecurityPrivacyViewSelectorsIDs.DEVICE_SECURITY_TOGGLE),
+      );
+      fireEvent(toggle, 'onValueChange', true);
+
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalled());
+      await act(async () => {
+        if (onPasswordSet) await onPasswordSet('test-password');
+      });
+
+      expect(
+        getByTestId(SecurityPrivacyViewSelectorsIDs.DEVICE_SECURITY_TOGGLE)
+          .props.value,
+      ).toBe(true);
+
+      act(() => {
+        jest.runAllTimers();
+      });
+      jest.useRealTimers();
+    });
+
     it('clears optimistic state when user cancels password entry', async () => {
       let onCancel: (() => void) | undefined;
       mockUpdateAuthPreference.mockRejectedValueOnce(

--- a/app/components/Views/Settings/SecuritySettings/Sections/DeviceSecurityToggle.tsx
+++ b/app/components/Views/Settings/SecuritySettings/Sections/DeviceSecurityToggle.tsx
@@ -114,13 +114,18 @@ const DeviceSecurityToggle = ({
                   authType,
                   password: enteredPassword,
                 });
+                // Keep optimistic ON until capabilities refresh so the toggle
+                // does not flash off after the password modal closes.
+                setTimeout(() => {
+                  setOptimisticValue(null);
+                }, 100);
               } catch (updateError) {
                 Logger.error(
                   updateError as Error,
                   'Failed to update auth preference after password entry',
                 );
+                setOptimisticValue(null);
               }
-              setOptimisticValue(null);
             },
             onCancel: () => {
               setOptimisticValue(null);


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

Enabling Device Authentication that requires the password modal left the toggle OFF after the modal closed. `onPasswordSet` always cleared the optimistic value before `useAuthCapabilities` refreshed. The success path now keeps the optimistic ON state for the same 100ms window as the non-password path; failures still revert immediately.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: Fixed the Device Authentication toggle staying off after entering the wallet password

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: #24030
Refs: MCWP-805

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Device Authentication toggle after password

  Scenario: enable PIN / passcode from Security settings
    Given the wallet is imported and Device Authentication is off
    When the user turns on Device Authentication
    And the user enters the wallet password
    Then the password modal closes
    And the Device Authentication toggle is ON without leaving the screen

  Scenario: cancel password entry
    Given the user has started enabling Device Authentication
    When the user cancels the password modal
    Then the toggle stays OFF
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — see GitHub issue #24030

### **After**

N/A — unit test covers optimistic ON after password success

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)