### PR TITLE
refactor(stake): migrate staking confirmation to MMDS (MUSD-1293)

### DIFF
--- a/app/components/UI/Stake/components/StakingConfirmation/AccountCard/AccountCard.tsx
+++ b/app/components/UI/Stake/components/StakingConfirmation/AccountCard/AccountCard.tsx
@@ -7,7 +7,6 @@ import {
   Card,
   KeyValueRow,
   Text,
-  TextColor,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import { selectSelectedInternalAccountByScope } from '../../../../../../selectors/multichainAccounts/accounts';
@@ -21,12 +20,10 @@ import ContractTag from '../ContractTag/ContractTag';
 import useVaultMetadata from '../../../hooks/useVaultMetadata';
 import { EVM_SCOPE } from '../../../../Earn/constants/networks';
 import { selectAvatarAccountType } from '../../../../../../selectors/settings';
-
-const KEY_VALUE_ROW_CLASSNAME = 'h-auto px-0 overflow-hidden';
-
-const KEY_VALUE_ROW_KEY_TEXT_PROPS = {
-  color: TextColor.TextDefault,
-};
+import {
+  KEY_VALUE_ROW_CLASSNAME,
+  KEY_VALUE_ROW_KEY_TEXT_PROPS,
+} from '../keyValueRow';
 
 const AccountCard = ({
   contractName,

--- a/app/components/UI/Stake/components/StakingConfirmation/AccountCard/AccountCard.tsx
+++ b/app/components/UI/Stake/components/StakingConfirmation/AccountCard/AccountCard.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
+import {
+  AvatarNetwork,
+  AvatarNetworkSize,
+  Card,
+  KeyValueRow,
+  Text,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../locales/i18n';
-import KeyValueRow from '../../../../../../component-library/components-temp/KeyValueRow';
-import Avatar, {
-  AvatarVariant,
-  AvatarSize,
-} from '../../../../../../component-library/components/Avatars/Avatar';
-import Text from '../../../../../../component-library/components/Texts/Text';
 import { selectSelectedInternalAccountByScope } from '../../../../../../selectors/multichainAccounts/accounts';
 import { useStyles } from '../../../../../hooks/useStyles';
-import Card from '../../../../../../component-library/components/Cards/Card';
 import styleSheet from './AccountCard.styles';
 import images from '../../../../../../images/image-icons';
 import AccountTag from '../AccountTag/AccountTag';
@@ -20,6 +21,12 @@ import ContractTag from '../ContractTag/ContractTag';
 import useVaultMetadata from '../../../hooks/useVaultMetadata';
 import { EVM_SCOPE } from '../../../../Earn/constants/networks';
 import { selectAvatarAccountType } from '../../../../../../selectors/settings';
+
+const KEY_VALUE_ROW_CLASSNAME = 'h-auto px-0 overflow-hidden';
+
+const KEY_VALUE_ROW_KEY_TEXT_PROPS = {
+  color: TextColor.TextDefault,
+};
 
 const AccountCard = ({
   contractName,
@@ -41,51 +48,53 @@ const AccountCard = ({
 
   return (
     <View>
-      <Card testID="account-card" style={styles.cardGroupTop} disabled>
+      <Card accessible testID="account-card" style={styles.cardGroupTop}>
         {selectedAccount && (
           <KeyValueRow
-            field={{ label: { text: primaryLabel } }}
-            value={{
-              label: (
-                <AccountTag
-                  accountAddress={selectedAccount?.address}
-                  accountName={selectedAccount.metadata.name}
-                  avatarAccountType={avatarAccountType}
-                />
-              ),
-            }}
+            twClassName={KEY_VALUE_ROW_CLASSNAME}
+            keyLabel={primaryLabel}
+            keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
+            value={
+              <AccountTag
+                accountAddress={selectedAccount?.address}
+                accountName={selectedAccount.metadata.name}
+                avatarAccountType={avatarAccountType}
+              />
+            }
           />
         )}
         <KeyValueRow
-          field={{
-            label: { text: secondaryLabel },
-          }}
-          value={{
-            label: (
-              <ContractTag
-                contractAddress={vaultMetadata?.vaultAddress ?? contractName}
-                contractName={contractName}
-                avatarAccountType={avatarAccountType}
-              />
-            ),
-          }}
+          twClassName={KEY_VALUE_ROW_CLASSNAME}
+          keyLabel={secondaryLabel}
+          keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
+          value={
+            <ContractTag
+              contractAddress={vaultMetadata?.vaultAddress ?? contractName}
+              contractName={contractName}
+              avatarAccountType={avatarAccountType}
+            />
+          }
         />
       </Card>
-      <Card style={styles.cardGroupBottom} disabled>
+      <Card accessible style={styles.cardGroupBottom}>
         <KeyValueRow
-          field={{ label: { text: strings('asset_details.network') } }}
-          value={{
-            label: (
-              <View style={styles.networkKeyValueRow}>
-                <Avatar
-                  variant={AvatarVariant.Network}
-                  imageSource={images.ETHEREUM}
-                  size={AvatarSize.Xs}
-                />
-                <Text>{networkName}</Text>
-              </View>
-            ),
-          }}
+          twClassName={KEY_VALUE_ROW_CLASSNAME}
+          keyLabel={strings('asset_details.network')}
+          keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
+          value={
+            <View style={styles.networkKeyValueRow}>
+              <AvatarNetwork
+                twClassName="rounded bg-default"
+                src={
+                  images.ETHEREUM as React.ComponentProps<
+                    typeof AvatarNetwork
+                  >['src']
+                }
+                size={AvatarNetworkSize.Xs}
+              />
+              <Text>{networkName}</Text>
+            </View>
+          }
         />
       </Card>
     </View>

--- a/app/components/UI/Stake/components/StakingConfirmation/AccountTag/AccountTag.tsx
+++ b/app/components/UI/Stake/components/StakingConfirmation/AccountTag/AccountTag.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import TagBase, {
-  TagShape,
+import {
+  AvatarAccount,
+  AvatarAccountSize,
+  Tag,
   TagSeverity,
-} from '../../../../../../component-library/base-components/TagBase';
-import Avatar, {
-  AvatarVariant,
-  AvatarSize,
-  AvatarAccountType,
-} from '../../../../../../component-library/components/Avatars/Avatar';
+  Text,
+  TextColor,
+} from '@metamask/design-system-react-native';
+import { AvatarAccountType } from '../../../../../../component-library/components/Avatars/Avatar';
+import { getAvatarAccountVariant } from '../../../../../../component-library/components-temp/MultichainAccounts/avatarAccountVariant';
 import { AccountTagProps } from './AccountTag.types';
 
 const AccountTag = ({
@@ -15,20 +16,20 @@ const AccountTag = ({
   accountName,
   avatarAccountType = AvatarAccountType.Maskicon,
 }: AccountTagProps) => (
-  <TagBase
+  <Tag
+    twClassName="rounded-full px-2 py-0.5"
     startAccessory={
-      <Avatar
-        variant={AvatarVariant.Account}
-        size={AvatarSize.Xs}
-        accountAddress={accountAddress}
-        type={avatarAccountType}
+      <AvatarAccount
+        twClassName="rounded bg-default"
+        size={AvatarAccountSize.Xs}
+        address={accountAddress}
+        variant={getAvatarAccountVariant(avatarAccountType)}
       />
     }
-    shape={TagShape.Pill}
     severity={TagSeverity.Info}
   >
-    {accountName ?? accountAddress}
-  </TagBase>
+    <Text color={TextColor.InfoDefault}>{accountName ?? accountAddress}</Text>
+  </Tag>
 );
 
 export default AccountTag;

--- a/app/components/UI/Stake/components/StakingConfirmation/ConfirmationFooter/FooterButtonGroup/FooterButtonGroup.tsx
+++ b/app/components/UI/Stake/components/StakingConfirmation/ConfirmationFooter/FooterButtonGroup/FooterButtonGroup.tsx
@@ -5,15 +5,15 @@ import { formatEther } from 'ethers/lib/utils';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../../../core/NavigationService/types';
 import { strings } from '../../../../../../../../locales/i18n';
-import Button, {
-  ButtonVariants,
-  ButtonWidthTypes,
+import {
+  Button,
   ButtonSize,
-} from '../../../../../../../component-library/components/Buttons/Button';
-import Text, {
-  TextVariant,
+  ButtonVariant,
+  FontWeight,
+  Text,
   TextColor,
-} from '../../../../../../../component-library/components/Texts/Text';
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../../hooks/useStyles';
 import styleSheet from './FooterButtonGroup.styles';
 import { selectSelectedInternalAccountByScope } from '../../../../../../../selectors/multichainAccounts/accounts';
@@ -226,34 +226,40 @@ const FooterButtonGroup = ({ valueWei, action }: FooterButtonGroupProps) => {
   return (
     <View style={styles.footerContainer}>
       <Button
-        label={
-          <Text variant={TextVariant.BodyMDMedium} color={TextColor.Primary}>
-            {strings('stake.cancel')}
-          </Text>
-        }
         testID="cancel-button"
         style={styles.button}
-        variant={ButtonVariants.Secondary}
-        width={ButtonWidthTypes.Full}
+        variant={ButtonVariant.Secondary}
+        isFullWidth
         size={ButtonSize.Lg}
         onPress={handleCancelPress}
-        disabled={didSubmitTransaction}
-      />
+        isDisabled={didSubmitTransaction}
+      >
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.PrimaryDefault}
+        >
+          {strings('stake.cancel')}
+        </Text>
+      </Button>
       <Button
-        label={
-          <Text variant={TextVariant.BodyMDMedium} color={TextColor.Inverse}>
-            {strings('stake.continue')}
-          </Text>
-        }
         testID="continue-button"
         style={styles.button}
-        variant={ButtonVariants.Primary}
-        width={ButtonWidthTypes.Full}
+        variant={ButtonVariant.Primary}
+        isFullWidth
         size={ButtonSize.Lg}
         onPress={handleConfirmation}
-        disabled={didSubmitTransaction}
-        loading={didSubmitTransaction}
-      />
+        isDisabled={didSubmitTransaction}
+        isLoading={didSubmitTransaction}
+      >
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.PrimaryInverse}
+        >
+          {strings('stake.continue')}
+        </Text>
+      </Button>
     </View>
   );
 };

--- a/app/components/UI/Stake/components/StakingConfirmation/ConfirmationFooter/LegalLinks/LegalLinks.tsx
+++ b/app/components/UI/Stake/components/StakingConfirmation/ConfirmationFooter/LegalLinks/LegalLinks.tsx
@@ -3,10 +3,12 @@ import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../../../core/NavigationService/types';
 import { View, TouchableOpacity } from 'react-native';
 import { strings } from '../../../../../../../../locales/i18n';
-import Text, {
-  TextVariant,
+import {
+  FontWeight,
+  Text,
   TextColor,
-} from '../../../../../../../component-library/components/Texts/Text';
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import AppConstants from '../../../../../../../core/AppConstants';
 import { useStyles } from '../../../../../../hooks/useStyles';
 import styleSheet from './LegalLinks.styles';
@@ -31,7 +33,11 @@ const FooterLegalLinks = () => {
         }
         style={styles.legalLink}
       >
-        <Text variant={TextVariant.BodyMDMedium} color={TextColor.Primary}>
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.PrimaryDefault}
+        >
           {strings('stake.terms_of_service')}
         </Text>
       </TouchableOpacity>
@@ -42,7 +48,11 @@ const FooterLegalLinks = () => {
         }
         style={styles.legalLink}
       >
-        <Text variant={TextVariant.BodyMDMedium} color={TextColor.Primary}>
+        <Text
+          variant={TextVariant.BodyMd}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.PrimaryDefault}
+        >
           {strings('stake.risk_disclosure')}
         </Text>
       </TouchableOpacity>

--- a/app/components/UI/Stake/components/StakingConfirmation/ContractTag/ContractTag.tsx
+++ b/app/components/UI/Stake/components/StakingConfirmation/ContractTag/ContractTag.tsx
@@ -1,16 +1,16 @@
 import React, { useMemo } from 'react';
-import { ImageSourcePropType } from 'react-native';
-import TagBase, {
+import {
+  AvatarAccount,
+  AvatarAccountSize,
+  AvatarNetwork,
+  AvatarNetworkSize,
+  Tag,
   TagSeverity,
-  TagShape,
-} from '../../../../../../component-library/base-components/TagBase';
-import Text from '../../../../../../component-library/components/Texts/Text';
+  Text,
+} from '@metamask/design-system-react-native';
 import { ContractTagProps } from './ContractTag.types';
-import Avatar, {
-  AvatarVariant,
-  AvatarSize,
-  AvatarAccountType,
-} from '../../../../../../component-library/components/Avatars/Avatar';
+import { AvatarAccountType } from '../../../../../../component-library/components/Avatars/Avatar';
+import { getAvatarAccountVariant } from '../../../../../../component-library/components-temp/MultichainAccounts/avatarAccountVariant';
 import imageIcons from '../../../../../../images/image-icons';
 import { CHAIN_ID_TO_AAVE_V3_POOL_CONTRACT_ADDRESS } from '../../../../Earn/utils/tempLending';
 
@@ -31,29 +31,33 @@ const ContractTag = ({
   );
 
   return (
-    <TagBase
+    <Tag
+      twClassName="rounded-full px-2 py-0.5 bg-alternative"
       startAccessory={
         aaveAddresses.has(contractAddress.toLowerCase()) ? (
-          <Avatar
-            variant={AvatarVariant.Network}
-            size={AvatarSize.Xs}
+          <AvatarNetwork
+            twClassName="rounded bg-default"
+            size={AvatarNetworkSize.Xs}
             name={contractName}
-            imageSource={imageIcons.AAVE as ImageSourcePropType}
+            src={
+              imageIcons.AAVE as React.ComponentProps<
+                typeof AvatarNetwork
+              >['src']
+            }
           />
         ) : (
-          <Avatar
-            variant={AvatarVariant.Account}
-            size={AvatarSize.Xs}
-            accountAddress={contractAddress}
-            type={avatarAccountType}
+          <AvatarAccount
+            twClassName="rounded bg-default"
+            size={AvatarAccountSize.Xs}
+            address={contractAddress}
+            variant={getAvatarAccountVariant(avatarAccountType)}
           />
         )
       }
-      shape={TagShape.Pill}
       severity={TagSeverity.Neutral}
     >
       <Text>{contractName}</Text>
-    </TagBase>
+    </Tag>
   );
 };
 

--- a/app/components/UI/Stake/components/StakingConfirmation/RewardsCard/RewardsCard.tsx
+++ b/app/components/UI/Stake/components/StakingConfirmation/RewardsCard/RewardsCard.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { View } from 'react-native';
 import {
-  ButtonIconSize,
   Card,
   FontWeight,
-  IconName,
   KeyValueRow,
   Text,
   TextColor,
@@ -13,19 +11,12 @@ import { strings } from '../../../../../../../locales/i18n';
 import { useStyles } from '../../../../../hooks/useStyles';
 import styleSheet from './RewardsCard.styles';
 import { RewardsCardProps } from './RewardsCard.types';
-import { createTooltipOpenedEvent } from '../../../utils/metaMetrics/tooltipMetaMetricsUtils';
-import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
-import useTooltipModal from '../../../../../hooks/useTooltipModal';
-
-const KEY_VALUE_ROW_CLASSNAME = 'h-auto px-0 overflow-hidden';
-
-const KEY_VALUE_ROW_KEY_TEXT_PROPS = {
-  color: TextColor.TextDefault,
-};
-
-const KEY_VALUE_ROW_VALUE_TEXT_PROPS = {
-  fontWeight: FontWeight.Regular,
-};
+import {
+  KEY_VALUE_ROW_CLASSNAME,
+  KEY_VALUE_ROW_KEY_TEXT_PROPS,
+  KEY_VALUE_ROW_VALUE_TEXT_PROPS,
+  useKeyValueRowTooltip,
+} from '../keyValueRow';
 
 const RewardsCard = ({
   rewardRate,
@@ -33,8 +24,7 @@ const RewardsCard = ({
   rewardsFiat,
 }: RewardsCardProps) => {
   const { styles } = useStyles(styleSheet, {});
-  const { trackEvent } = useAnalytics();
-  const { openTooltipModal } = useTooltipModal();
+  const tooltipProps = useKeyValueRowTooltip();
 
   return (
     <Card accessible style={styles.card}>
@@ -42,21 +32,12 @@ const RewardsCard = ({
         twClassName={KEY_VALUE_ROW_CLASSNAME}
         keyLabel={strings('tooltip_modal.reward_rate.title')}
         keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
-        keyEndButtonIconProps={{
-          size: ButtonIconSize.Xs,
-          iconName: IconName.Question,
-          accessibilityRole: 'button',
-          accessibilityLabel: `${strings(
-            'tooltip_modal.reward_rate.title',
-          )} tooltip`,
-          onPress: () => {
-            openTooltipModal(
-              strings('tooltip_modal.reward_rate.title'),
-              strings('tooltip_modal.reward_rate.tooltip'),
-            );
-            trackEvent(createTooltipOpenedEvent('Rewards Card', 'Reward Rate'));
-          },
-        }}
+        keyEndButtonIconProps={tooltipProps(
+          strings('tooltip_modal.reward_rate.title'),
+          strings('tooltip_modal.reward_rate.tooltip'),
+          'Rewards Card',
+          'Reward Rate',
+        )}
         value={rewardRate}
         valueTextProps={{
           color: TextColor.SuccessDefault,
@@ -78,23 +59,12 @@ const RewardsCard = ({
         twClassName={KEY_VALUE_ROW_CLASSNAME}
         keyLabel={strings('tooltip_modal.reward_frequency.title')}
         keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
-        keyEndButtonIconProps={{
-          size: ButtonIconSize.Xs,
-          iconName: IconName.Question,
-          accessibilityRole: 'button',
-          accessibilityLabel: `${strings(
-            'tooltip_modal.reward_frequency.title',
-          )} tooltip`,
-          onPress: () => {
-            openTooltipModal(
-              strings('tooltip_modal.reward_frequency.title'),
-              strings('tooltip_modal.reward_frequency.tooltip'),
-            );
-            trackEvent(
-              createTooltipOpenedEvent('Rewards Card', 'Reward Frequency'),
-            );
-          },
-        }}
+        keyEndButtonIconProps={tooltipProps(
+          strings('tooltip_modal.reward_frequency.title'),
+          strings('tooltip_modal.reward_frequency.tooltip'),
+          'Rewards Card',
+          'Reward Frequency',
+        )}
         value={strings('stake.12_hours')}
         valueTextProps={KEY_VALUE_ROW_VALUE_TEXT_PROPS}
       />

--- a/app/components/UI/Stake/components/StakingConfirmation/RewardsCard/RewardsCard.tsx
+++ b/app/components/UI/Stake/components/StakingConfirmation/RewardsCard/RewardsCard.tsx
@@ -1,17 +1,31 @@
 import React from 'react';
 import { View } from 'react-native';
-import { strings } from '../../../../../../../locales/i18n';
-import KeyValueRow from '../../../../../../component-library/components-temp/KeyValueRow';
-import Text, {
+import {
+  ButtonIconSize,
+  Card,
+  FontWeight,
+  IconName,
+  KeyValueRow,
+  Text,
   TextColor,
-  TextVariant,
-} from '../../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../../locales/i18n';
 import { useStyles } from '../../../../../hooks/useStyles';
-import Card from '../../../../../../component-library/components/Cards/Card';
 import styleSheet from './RewardsCard.styles';
 import { RewardsCardProps } from './RewardsCard.types';
 import { createTooltipOpenedEvent } from '../../../utils/metaMetrics/tooltipMetaMetricsUtils';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
+import useTooltipModal from '../../../../../hooks/useTooltipModal';
+
+const KEY_VALUE_ROW_CLASSNAME = 'h-auto px-0 overflow-hidden';
+
+const KEY_VALUE_ROW_KEY_TEXT_PROPS = {
+  color: TextColor.TextDefault,
+};
+
+const KEY_VALUE_ROW_VALUE_TEXT_PROPS = {
+  fontWeight: FontWeight.Regular,
+};
 
 const RewardsCard = ({
   rewardRate,
@@ -20,58 +34,69 @@ const RewardsCard = ({
 }: RewardsCardProps) => {
   const { styles } = useStyles(styleSheet, {});
   const { trackEvent } = useAnalytics();
+  const { openTooltipModal } = useTooltipModal();
 
   return (
-    <Card style={styles.card} disabled>
+    <Card accessible style={styles.card}>
       <KeyValueRow
-        field={{
-          label: { text: strings('tooltip_modal.reward_rate.title') },
-          tooltip: {
-            title: strings('tooltip_modal.reward_rate.title'),
-            content: strings('tooltip_modal.reward_rate.tooltip'),
-            onPress: () =>
-              trackEvent(
-                createTooltipOpenedEvent('Rewards Card', 'Reward Rate'),
-              ),
+        twClassName={KEY_VALUE_ROW_CLASSNAME}
+        keyLabel={strings('tooltip_modal.reward_rate.title')}
+        keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
+        keyEndButtonIconProps={{
+          size: ButtonIconSize.Xs,
+          iconName: IconName.Question,
+          accessibilityRole: 'button',
+          accessibilityLabel: `${strings(
+            'tooltip_modal.reward_rate.title',
+          )} tooltip`,
+          onPress: () => {
+            openTooltipModal(
+              strings('tooltip_modal.reward_rate.title'),
+              strings('tooltip_modal.reward_rate.tooltip'),
+            );
+            trackEvent(createTooltipOpenedEvent('Rewards Card', 'Reward Rate'));
           },
         }}
-        value={{
-          label: {
-            text: rewardRate,
-            color: TextColor.Success,
-            variant: TextVariant.BodyMD,
-          },
+        value={rewardRate}
+        valueTextProps={{
+          color: TextColor.SuccessDefault,
+          fontWeight: FontWeight.Regular,
         }}
       />
       <KeyValueRow
-        field={{ label: { text: strings('stake.estimated_annual_rewards') } }}
-        value={{
-          label: (
-            <View style={styles.estAnnualRewardValue}>
-              <Text color={TextColor.Alternative}>{rewardsFiat}</Text>
-              <Text>{rewardsEth}</Text>
-            </View>
-          ),
-        }}
+        twClassName={KEY_VALUE_ROW_CLASSNAME}
+        keyLabel={strings('stake.estimated_annual_rewards')}
+        keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
+        value={
+          <View style={styles.estAnnualRewardValue}>
+            <Text color={TextColor.TextAlternative}>{rewardsFiat}</Text>
+            <Text>{rewardsEth}</Text>
+          </View>
+        }
       />
       <KeyValueRow
-        field={{
-          label: { text: strings('tooltip_modal.reward_frequency.title') },
-          tooltip: {
-            title: strings('tooltip_modal.reward_frequency.title'),
-            content: strings('tooltip_modal.reward_frequency.tooltip'),
-            onPress: () =>
-              trackEvent(
-                createTooltipOpenedEvent('Rewards Card', 'Reward Frequency'),
-              ),
+        twClassName={KEY_VALUE_ROW_CLASSNAME}
+        keyLabel={strings('tooltip_modal.reward_frequency.title')}
+        keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
+        keyEndButtonIconProps={{
+          size: ButtonIconSize.Xs,
+          iconName: IconName.Question,
+          accessibilityRole: 'button',
+          accessibilityLabel: `${strings(
+            'tooltip_modal.reward_frequency.title',
+          )} tooltip`,
+          onPress: () => {
+            openTooltipModal(
+              strings('tooltip_modal.reward_frequency.title'),
+              strings('tooltip_modal.reward_frequency.tooltip'),
+            );
+            trackEvent(
+              createTooltipOpenedEvent('Rewards Card', 'Reward Frequency'),
+            );
           },
         }}
-        value={{
-          label: {
-            text: strings('stake.12_hours'),
-            variant: TextVariant.BodyMD,
-          },
-        }}
+        value={strings('stake.12_hours')}
+        valueTextProps={KEY_VALUE_ROW_VALUE_TEXT_PROPS}
       />
     </Card>
   );

--- a/app/components/UI/Stake/components/StakingConfirmation/TokenValueStack/TokenValueStack.tsx
+++ b/app/components/UI/Stake/components/StakingConfirmation/TokenValueStack/TokenValueStack.tsx
@@ -1,17 +1,13 @@
 import React from 'react';
 import { View } from 'react-native';
-import { useSelector } from 'react-redux';
-import Badge, {
-  BadgeVariant,
-} from '../../../../../../component-library/components/Badges/Badge';
-import BadgeWrapper, {
-  BadgePosition,
-} from '../../../../../../component-library/components/Badges/BadgeWrapper';
-import Text, {
-  TextVariant,
+import {
+  BadgeNetwork,
+  BadgeWrapper,
+  BadgeWrapperPosition,
+  Text,
   TextColor,
-} from '../../../../../../component-library/components/Texts/Text';
-import { selectEvmNetworkName } from '../../../../../../selectors/networkInfos';
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../hooks/useStyles';
 import NetworkMainAssetLogo from '../../../../NetworkMainAssetLogo';
 import styleSheet from './TokenValueStack.styles';
@@ -27,28 +23,29 @@ const TokenValueStack = ({
 }: TokenValueStackProps) => {
   const { styles } = useStyles(styleSheet, {});
 
-  const networkName = useSelector(selectEvmNetworkName);
-
   return (
     <View style={[styles.tokenValueStackContainer, style]}>
       <BadgeWrapper
         style={styles.badgeWrapper}
-        badgePosition={BadgePosition.BottomRight}
-        badgeElement={
-          <Badge
-            variant={BadgeVariant.Network}
-            imageSource={images.ETHEREUM}
-            name={networkName}
+        position={BadgeWrapperPosition.BottomRight}
+        badge={
+          <BadgeNetwork
+            twClassName="h-6 w-6 rounded-md bg-default"
+            src={
+              images.ETHEREUM as React.ComponentProps<
+                typeof BadgeNetwork
+              >['src']
+            }
           />
         }
       >
         <NetworkMainAssetLogo style={styles.ethLogo} />
       </BadgeWrapper>
       <View style={styles.balancesContainer}>
-        <Text variant={TextVariant.HeadingLG}>
+        <Text variant={TextVariant.HeadingLg}>
           {renderFromWei(amountWei)} {tokenSymbol}
         </Text>
-        <Text color={TextColor.Alternative}>{amountFiat}</Text>
+        <Text color={TextColor.TextAlternative}>{amountFiat}</Text>
       </View>
     </View>
   );

--- a/app/components/UI/Stake/components/StakingConfirmation/UnstakeTimeCard/UnstakeTimeCard.tsx
+++ b/app/components/UI/Stake/components/StakingConfirmation/UnstakeTimeCard/UnstakeTimeCard.tsx
@@ -1,41 +1,61 @@
 import React from 'react';
-import KeyValueRow from '../../../../../../component-library/components-temp/KeyValueRow';
-import Card from '../../../../../../component-library/components/Cards/Card';
+import {
+  ButtonIconSize,
+  Card,
+  FontWeight,
+  IconName,
+  KeyValueRow,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../hooks/useStyles';
 import styleSheet from './UnstakeTimeCard.styles';
-import { TextVariant } from '../../../../../../component-library/components/Texts/Text';
 import { strings } from '../../../../../../../locales/i18n';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
+import useTooltipModal from '../../../../../hooks/useTooltipModal';
 import { createTooltipOpenedEvent } from '../../../utils/metaMetrics/tooltipMetaMetricsUtils';
+
+const KEY_VALUE_ROW_CLASSNAME = 'h-auto px-0 overflow-hidden';
+
+const KEY_VALUE_ROW_KEY_TEXT_PROPS = {
+  color: TextColor.TextDefault,
+};
+
+const KEY_VALUE_ROW_VALUE_TEXT_PROPS = {
+  fontWeight: FontWeight.Regular,
+};
 
 const UnstakingTimeCard = () => {
   const { styles } = useStyles(styleSheet, {});
 
   const { trackEvent } = useAnalytics();
 
+  const { openTooltipModal } = useTooltipModal();
+
   return (
-    <Card style={styles.card} disabled>
+    <Card accessible style={styles.card}>
       <KeyValueRow
-        field={{
-          label: { text: strings('tooltip_modal.unstaking_time.title') },
-          tooltip: {
-            title: strings('tooltip_modal.unstaking_time.title'),
-            content: strings('tooltip_modal.unstaking_time.tooltip'),
-            onPress: () =>
-              trackEvent(
-                createTooltipOpenedEvent(
-                  'Unstaking Time Card',
-                  'Unstaking Time',
-                ),
-              ),
+        twClassName={KEY_VALUE_ROW_CLASSNAME}
+        keyLabel={strings('tooltip_modal.unstaking_time.title')}
+        keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
+        keyEndButtonIconProps={{
+          size: ButtonIconSize.Xs,
+          iconName: IconName.Question,
+          accessibilityRole: 'button',
+          accessibilityLabel: `${strings(
+            'tooltip_modal.unstaking_time.title',
+          )} tooltip`,
+          onPress: () => {
+            openTooltipModal(
+              strings('tooltip_modal.unstaking_time.title'),
+              strings('tooltip_modal.unstaking_time.tooltip'),
+            );
+            trackEvent(
+              createTooltipOpenedEvent('Unstaking Time Card', 'Unstaking Time'),
+            );
           },
         }}
-        value={{
-          label: {
-            text: strings('stake.estimated_unstaking_time'),
-            variant: TextVariant.BodyMD,
-          },
-        }}
+        value={strings('stake.estimated_unstaking_time')}
+        valueTextProps={KEY_VALUE_ROW_VALUE_TEXT_PROPS}
       />
     </Card>
   );

--- a/app/components/UI/Stake/components/StakingConfirmation/UnstakeTimeCard/UnstakeTimeCard.tsx
+++ b/app/components/UI/Stake/components/StakingConfirmation/UnstakeTimeCard/UnstakeTimeCard.tsx
@@ -1,35 +1,19 @@
 import React from 'react';
-import {
-  ButtonIconSize,
-  Card,
-  FontWeight,
-  IconName,
-  KeyValueRow,
-  TextColor,
-} from '@metamask/design-system-react-native';
+import { Card, KeyValueRow } from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../hooks/useStyles';
 import styleSheet from './UnstakeTimeCard.styles';
 import { strings } from '../../../../../../../locales/i18n';
-import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
-import useTooltipModal from '../../../../../hooks/useTooltipModal';
-import { createTooltipOpenedEvent } from '../../../utils/metaMetrics/tooltipMetaMetricsUtils';
-
-const KEY_VALUE_ROW_CLASSNAME = 'h-auto px-0 overflow-hidden';
-
-const KEY_VALUE_ROW_KEY_TEXT_PROPS = {
-  color: TextColor.TextDefault,
-};
-
-const KEY_VALUE_ROW_VALUE_TEXT_PROPS = {
-  fontWeight: FontWeight.Regular,
-};
+import {
+  KEY_VALUE_ROW_CLASSNAME,
+  KEY_VALUE_ROW_KEY_TEXT_PROPS,
+  KEY_VALUE_ROW_VALUE_TEXT_PROPS,
+  useKeyValueRowTooltip,
+} from '../keyValueRow';
 
 const UnstakingTimeCard = () => {
   const { styles } = useStyles(styleSheet, {});
 
-  const { trackEvent } = useAnalytics();
-
-  const { openTooltipModal } = useTooltipModal();
+  const tooltipProps = useKeyValueRowTooltip();
 
   return (
     <Card accessible style={styles.card}>
@@ -37,23 +21,12 @@ const UnstakingTimeCard = () => {
         twClassName={KEY_VALUE_ROW_CLASSNAME}
         keyLabel={strings('tooltip_modal.unstaking_time.title')}
         keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
-        keyEndButtonIconProps={{
-          size: ButtonIconSize.Xs,
-          iconName: IconName.Question,
-          accessibilityRole: 'button',
-          accessibilityLabel: `${strings(
-            'tooltip_modal.unstaking_time.title',
-          )} tooltip`,
-          onPress: () => {
-            openTooltipModal(
-              strings('tooltip_modal.unstaking_time.title'),
-              strings('tooltip_modal.unstaking_time.tooltip'),
-            );
-            trackEvent(
-              createTooltipOpenedEvent('Unstaking Time Card', 'Unstaking Time'),
-            );
-          },
-        }}
+        keyEndButtonIconProps={tooltipProps(
+          strings('tooltip_modal.unstaking_time.title'),
+          strings('tooltip_modal.unstaking_time.tooltip'),
+          'Unstaking Time Card',
+          'Unstaking Time',
+        )}
         value={strings('stake.estimated_unstaking_time')}
         valueTextProps={KEY_VALUE_ROW_VALUE_TEXT_PROPS}
       />

--- a/app/components/UI/Stake/components/StakingConfirmation/keyValueRow.ts
+++ b/app/components/UI/Stake/components/StakingConfirmation/keyValueRow.ts
@@ -1,0 +1,56 @@
+import { useCallback } from 'react';
+import {
+  ButtonIconSize,
+  FontWeight,
+  IconName,
+  TextColor,
+} from '@metamask/design-system-react-native';
+import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
+import useTooltipModal from '../../../../hooks/useTooltipModal';
+import { createTooltipOpenedEvent } from '../../utils/metaMetrics/tooltipMetaMetricsUtils';
+
+/**
+ * The design system row hard-codes horizontal padding, a fixed height and no
+ * overflow. The confirmation cards supply their own padding and size to their
+ * content, so each row opts back out.
+ */
+export const KEY_VALUE_ROW_CLASSNAME = 'h-auto px-0 overflow-hidden';
+
+export const KEY_VALUE_ROW_KEY_TEXT_PROPS = {
+  color: TextColor.TextDefault,
+};
+
+export const KEY_VALUE_ROW_VALUE_TEXT_PROPS = {
+  fontWeight: FontWeight.Regular,
+};
+
+/**
+ * Builds the `keyEndButtonIconProps` for a row whose label carries a tooltip,
+ * opening the tooltip modal and reporting it to analytics.
+ *
+ * The design system row exposes the button rather than a tooltip, so the
+ * wiring lives here to keep it identical across the confirmation cards.
+ */
+export const useKeyValueRowTooltip = () => {
+  const { openTooltipModal } = useTooltipModal();
+  const { trackEvent } = useAnalytics();
+
+  return useCallback(
+    (
+      title: string,
+      content: string,
+      location: string,
+      tooltipName: string,
+    ) => ({
+      size: ButtonIconSize.Xs,
+      iconName: IconName.Question,
+      accessibilityRole: 'button' as const,
+      accessibilityLabel: `${title} tooltip`,
+      onPress: () => {
+        openTooltipModal(title, content);
+        trackEvent(createTooltipOpenedEvent(location, tooltipName));
+      },
+    }),
+    [openTooltipModal, trackEvent],
+  );
+};


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Part of the MMDS migration tracked by MUSD-1293. This PR migrates the **staking confirmation screen** — 31 legacy `app/component-library` instances across 8 files — and drives legacy `Card` to **zero repo-wide**.

The swaps are surgical: the legacy component and its props are replaced, and the surrounding `useStyles`/`StyleSheet`/`View` scaffolding is deliberately left alone.

**MMDS components are not drop-in replacements**, so each swap carries the props needed to keep the screen pixel-identical. Every value below was derived by reading both implementations, not assumed:

| Component | MMDS default | Legacy | Compensation |
| --- | --- | --- | --- |
| `KeyValueRow` | `px-4`, fixed 40px row, no `overflow` | unpadded, content-height, `overflow: hidden` | `h-auto px-0 overflow-hidden` |
| `KeyValueRow` key | `TextAlternative` | `Default` | `keyTextProps` |
| `KeyValueRow` value | `FontWeight.Medium` | caller's variant (regular) | `valueTextProps` |
| `Tag` | `rounded-md`, `pl/pr-1.5`, no vertical padding | pill, 8px/2px | `rounded-full px-2 py-0.5` |
| `Tag` (Neutral) | `BackgroundMuted` | `background.alternative` | `bg-alternative` |
| `AvatarBase` | `bg-alternative`, 2px radius | `background.default`, 4px | `rounded bg-default` |
| `BadgeNetwork` | pinned 18px, 2px radius | 24px (half of its 48px anchor), 6px | `h-6 w-6 rounded-md` |
| `Card` | plain `View` unless `onPress` | always `TouchableOpacity` | `accessible` |

Two of those deserve calling out, because they are silent failures rather than visible ones:

1. **`KeyValueRow` row height.** Left uncompensated this grows the cards by ~104px. `h-auto` cancels it — verified by rendering: baseline resolves to `height: 40, paddingLeft: 16`, with the override `height: "auto", paddingLeft: 0`.
2. **`Card` accessibility.** The legacy `Card` was always a `TouchableOpacity`, whose `accessible` defaults true, so VoiceOver read each card as one grouped element. MMDS renders a plain `View` without `onPress`, which would announce every `Text`, avatar and tag separately. `accessible` restores grouping without inventing a fake interaction.

**Tooltips** move from the legacy `KeyValueRow`'s encapsulated handling to `keyEndButtonIconProps` wired to `useTooltipModal`. The rendered button is faithful — `ButtonIconSize.Xs` (20px box / 16px glyph, identical on both sides), `IconName.Question`, `IconColor.IconAlternative`, `accessibilityRole="button"`, `` accessibilityLabel={`${title} tooltip`} `` — and matches the MMDS `KeyValueRow` call sites already shipping in Perps since July.

### Accepted residuals

Not compensable through the components' public props, and judged not worth hand-rolling:

- Badge drop shadow: legacy applied `theme.shadows.size.xs`; no tailwind class maps to the MM shadow tokens.
- `Tag` inner gap 4px → 2px: MMDS hard-codes it on an inner `BoxRow` the `twClassName` does not reach.
- `KeyValueRow` key/value gap 0 → 16px, and the 50/50 column split becoming `shrink-0` key / `flex-1` value.
- `ButtonIcon` and `Button` gain a Reanimated 0.97 press scale; the legacy buttons used `activeOpacity={1}`.
- Disabled footer buttons now dim: legacy passed `disabled` (a `TouchableOpacity` prop) so MMDS's `opacity-50` never fired; `isDisabled` now does.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1293](https://consensyssoftware.atlassian.net/browse/MUSD-1293)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: MMDS migration of the staking confirmation screen

  Scenario: user reviews a staking deposit
    Given the user has an account with ETH on mainnet
    When user starts a pooled staking deposit and reaches the confirmation screen
    Then the account card shows the account tag, the contract tag and the network row
    And each row's label sits flush with the card padding, not indented
    And the card height matches the current production build

  Scenario: user opens a tooltip
    Given the staking confirmation screen is open
    When user taps the question icon next to "Reward rate"
    Then the reward-rate tooltip sheet opens with its title and content

  Scenario: user reviews an unstake
    Given the user has a staked balance
    When user starts an unstake and reaches the confirmation screen
    Then the unstaking-time card renders with its tooltip

  Scenario: user submits from the confirmation footer
    Given the staking confirmation screen is open
    When user taps Confirm
    Then the button shows its loading state and the Cancel button is disabled

  Scenario: screen reader reads the cards
    Given VoiceOver or TalkBack is enabled
    When user swipes through the confirmation screen
    Then each card is announced as a single grouped element
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — this PR is a component-library swap compensated to pixel parity; no visual change is intended. The residuals listed in the description are the only expected differences.

### **After**

<!-- [screenshots/recordings] -->

N/A — see above.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-1293]: https://consensyssoftware.atlassian.net/browse/MUSD-1293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only component swap on the staking confirmation screen; staking submit logic is unchanged. Residual visual/a11y differences (button dimming, press scale, card grouping) are the main review surface.
> 
> **Overview**
> Migrates the staking confirmation screen from legacy `component-library` primitives to `@metamask/design-system-react-native`, with Tailwind/prop overrides so layout stays close to the current UI.
> 
> Adds a shared `keyValueRow` helper that undoes MMDS `KeyValueRow` defaults (`h-auto px-0 overflow-hidden`, key/value text props) and wires tooltips through `keyEndButtonIconProps` + `useTooltipModal` (same analytics as before). Cards use `accessible` so screen readers still group each card.
> 
> Tags, avatars, badges, and footer buttons/legal text swap to MMDS equivalents (`Tag`, `AvatarAccount`/`AvatarNetwork`, `BadgeNetwork`, `Button`). Disabled footer buttons now use `isDisabled`/`isLoading`, so they dim instead of only blocking presses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3f32e4b054f1f54a002a3052264894a621aa181. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->