### PR TITLE
refactor(earn): migrate lending confirmations to MMDS (MUSD-1293)

### DIFF
--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/ConfirmationFooter/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/ConfirmationFooter/index.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
 import { useStyles } from '../../../../../../../component-library/hooks';
 import { Linking, View } from 'react-native';
-import Text, {
-  TextVariant,
-} from '../../../../../../../component-library/components/Texts/Text';
-import BottomSheetFooter, {
-  ButtonsAlignment,
-} from '../../../../../../../component-library/components/BottomSheets/BottomSheetFooter';
 import {
+  BottomSheetFooter,
   ButtonSize,
-  ButtonVariants,
-} from '../../../../../../../component-library/components/Buttons/Button';
+  ButtonsAlignment,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../../locales/i18n';
 import AppConstants from '../../../../../../../core/AppConstants';
 import ProgressStepper, { ProgressStep } from '../ProgressStepper';
@@ -52,24 +49,21 @@ export const ConfirmationFooter = ({
     hasProgressBar: Boolean(progressBar),
   });
 
-  const buttons = [
-    {
-      variant: ButtonVariants.Secondary,
-      label: buttonSecondary?.text ?? strings('confirm.cancel'),
-      isDisabled: Boolean(buttonSecondary?.disabled),
-      size: ButtonSize.Lg,
-      onPress: onCancel,
-      testID: CONFIRMATION_FOOTER_BUTTON_TEST_IDS.CANCEL_BUTTON,
-    },
-    {
-      variant: ButtonVariants.Primary,
-      isDisabled: Boolean(buttonPrimary?.disabled),
-      label: buttonPrimary?.text ?? strings('confirm.confirm'),
-      size: ButtonSize.Lg,
-      onPress: onConfirm,
-      testID: CONFIRMATION_FOOTER_BUTTON_TEST_IDS.CONFIRM_BUTTON,
-    },
-  ];
+  const secondaryButtonProps = {
+    children: buttonSecondary?.text ?? strings('confirm.cancel'),
+    isDisabled: Boolean(buttonSecondary?.disabled),
+    size: ButtonSize.Lg,
+    onPress: onCancel,
+    testID: CONFIRMATION_FOOTER_BUTTON_TEST_IDS.CANCEL_BUTTON,
+  };
+
+  const primaryButtonProps = {
+    isDisabled: Boolean(buttonPrimary?.disabled),
+    children: buttonPrimary?.text ?? strings('confirm.confirm'),
+    size: ButtonSize.Lg,
+    onPress: onConfirm,
+    testID: CONFIRMATION_FOOTER_BUTTON_TEST_IDS.CONFIRM_BUTTON,
+  };
 
   return (
     <View style={styles.footerContainer} testID={CONFIRMATION_FOOTER_TEST_ID}>
@@ -85,16 +79,18 @@ export const ConfirmationFooter = ({
       )}
       <BottomSheetFooter
         buttonsAlignment={ButtonsAlignment.Horizontal}
-        buttonPropsArray={buttons}
+        secondaryButtonProps={secondaryButtonProps}
+        primaryButtonProps={primaryButtonProps}
+        twClassName="py-3"
         style={styles.footerButtonsContainer}
       />
       <View style={styles.bottomTextContainer}>
         <View style={styles.bottomTextContainerLine}>
-          <Text variant={TextVariant.BodySM}>
+          <Text variant={TextVariant.BodySm}>
             {strings('confirm.staking_footer.part1')}
           </Text>
           <Text
-            variant={TextVariant.BodySM}
+            variant={TextVariant.BodySm}
             style={styles.linkText}
             onPress={() => Linking.openURL(AppConstants.URLS.TERMS_OF_USE)}
             testID={CONFIRMATION_FOOTER_LINK_TEST_IDS.TERMS_OF_USE_BUTTON}
@@ -103,12 +99,12 @@ export const ConfirmationFooter = ({
           </Text>
         </View>
         <View style={styles.bottomTextContainerLine}>
-          <Text variant={TextVariant.BodySM}>
+          <Text variant={TextVariant.BodySm}>
             {strings('confirm.staking_footer.part2')}
             {'\n'}
           </Text>
           <Text
-            variant={TextVariant.BodySM}
+            variant={TextVariant.BodySm}
             style={styles.linkText}
             onPress={() =>
               Linking.openURL(AppConstants.URLS.EARN_RISK_DISCLOSURE)
@@ -117,7 +113,7 @@ export const ConfirmationFooter = ({
           >
             {strings('confirm.staking_footer.risk_disclosure')}
           </Text>
-          <Text variant={TextVariant.BodySM}>
+          <Text variant={TextVariant.BodySm}>
             {strings('confirm.staking_footer.part3')}
           </Text>
         </View>

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/DepositInfoSection/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/DepositInfoSection/index.tsx
@@ -2,34 +2,27 @@ import React from 'react';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
 import {
-  ButtonIconSize,
   FontWeight,
-  IconName,
   KeyValueRow,
   Text,
   TextColor,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../../locales/i18n';
 import { useStyles } from '../../../../../../hooks/useStyles';
-import useTooltipModal from '../../../../../../hooks/useTooltipModal';
 import InfoSection from '../../../../../../Views/confirmations/components/UI/info-row/info-section';
 import ContractTag from '../../../../../Stake/components/StakingConfirmation/ContractTag/ContractTag';
 import { TokenI } from '../../../../../Tokens/types';
 import useEarnToken from '../../../../hooks/useEarnToken';
 import styleSheet from './DepositInfoSection.styles';
 import { selectAvatarAccountType } from '../../../../../../../selectors/settings';
+import {
+  KEY_VALUE_ROW_CLASSNAME,
+  KEY_VALUE_ROW_KEY_TEXT_PROPS,
+  KEY_VALUE_ROW_VALUE_TEXT_PROPS,
+  useKeyValueRowTooltip,
+} from '../../../../utils/keyValueRow';
 
 export const DEPOSIT_DETAILS_SECTION_TEST_ID = 'depositDetailsSection';
-
-const KEY_VALUE_ROW_CLASSNAME = 'h-auto px-0 overflow-hidden';
-
-const KEY_VALUE_ROW_KEY_TEXT_PROPS = {
-  color: TextColor.TextDefault,
-};
-
-const KEY_VALUE_ROW_VALUE_TEXT_PROPS = {
-  fontWeight: FontWeight.Regular,
-};
 
 export interface DepositInfoSectionProps {
   token: TokenI;
@@ -50,7 +43,7 @@ const DepositInfoSection = ({
 
   const avatarAccountType = useSelector(selectAvatarAccountType);
 
-  const { openTooltipModal } = useTooltipModal();
+  const tooltipProps = useKeyValueRowTooltip();
 
   const { earnToken, getEstimatedAnnualRewardsForAmount } = useEarnToken(token);
 
@@ -69,20 +62,13 @@ const DepositInfoSection = ({
           twClassName={KEY_VALUE_ROW_CLASSNAME}
           keyLabel={strings('earn.apr')}
           keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
-          keyEndButtonIconProps={{
-            size: ButtonIconSize.Xs,
-            iconName: IconName.Question,
-            accessibilityRole: 'button',
-            accessibilityLabel: `${strings('earn.apr')} tooltip`,
-            onPress: () =>
-              openTooltipModal(
-                strings('earn.apr'),
-                <View style={styles.aprTooltipContentContainer}>
-                  <Text>{strings('earn.tooltip_content.apr.part_one')}</Text>
-                  <Text>{strings('earn.tooltip_content.apr.part_two')}</Text>
-                </View>,
-              ),
-          }}
+          keyEndButtonIconProps={tooltipProps(
+            strings('earn.apr'),
+            <View style={styles.aprTooltipContentContainer}>
+              <Text>{strings('earn.tooltip_content.apr.part_one')}</Text>
+              <Text>{strings('earn.tooltip_content.apr.part_two')}</Text>
+            </View>,
+          )}
           value={`${earnToken?.experience?.apr}%`}
           valueTextProps={{
             fontWeight: FontWeight.Regular,
@@ -116,17 +102,10 @@ const DepositInfoSection = ({
           twClassName={KEY_VALUE_ROW_CLASSNAME}
           keyLabel={strings('stake.reward_frequency')}
           keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
-          keyEndButtonIconProps={{
-            size: ButtonIconSize.Xs,
-            iconName: IconName.Question,
-            accessibilityRole: 'button',
-            accessibilityLabel: `${strings('stake.reward_frequency')} tooltip`,
-            onPress: () =>
-              openTooltipModal(
-                strings('stake.reward_frequency'),
-                strings('earn.tooltip_content.reward_frequency'),
-              ),
-          }}
+          keyEndButtonIconProps={tooltipProps(
+            strings('stake.reward_frequency'),
+            strings('earn.tooltip_content.reward_frequency'),
+          )}
           value={strings('earn.every_minute')}
           valueTextProps={KEY_VALUE_ROW_VALUE_TEXT_PROPS}
         />
@@ -134,17 +113,10 @@ const DepositInfoSection = ({
           twClassName={KEY_VALUE_ROW_CLASSNAME}
           keyLabel={strings('stake.withdrawal_time')}
           keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
-          keyEndButtonIconProps={{
-            size: ButtonIconSize.Xs,
-            iconName: IconName.Question,
-            accessibilityRole: 'button',
-            accessibilityLabel: `${strings('stake.withdrawal_time')} tooltip`,
-            onPress: () =>
-              openTooltipModal(
-                strings('stake.withdrawal_time'),
-                strings('earn.tooltip_content.withdrawal_time'),
-              ),
-          }}
+          keyEndButtonIconProps={tooltipProps(
+            strings('stake.withdrawal_time'),
+            strings('earn.tooltip_content.withdrawal_time'),
+          )}
           value={strings('earn.immediate')}
           valueTextProps={KEY_VALUE_ROW_VALUE_TEXT_PROPS}
         />
@@ -152,17 +124,10 @@ const DepositInfoSection = ({
           twClassName={KEY_VALUE_ROW_CLASSNAME}
           keyLabel={strings('earn.protocol')}
           keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
-          keyEndButtonIconProps={{
-            size: ButtonIconSize.Xs,
-            iconName: IconName.Question,
-            accessibilityRole: 'button',
-            accessibilityLabel: `${strings('earn.protocol')} tooltip`,
-            onPress: () =>
-              openTooltipModal(
-                strings('earn.protocol'),
-                strings('earn.tooltip_content.protocol'),
-              ),
-          }}
+          keyEndButtonIconProps={tooltipProps(
+            strings('earn.protocol'),
+            strings('earn.tooltip_content.protocol'),
+          )}
           value={
             <ContractTag
               contractAddress={lendingContractAddress}

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/DepositInfoSection/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/DepositInfoSection/index.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
-import { strings } from '../../../../../../../../locales/i18n';
-import KeyValueRow from '../../../../../../../component-library/components-temp/KeyValueRow';
-import Text, {
+import {
+  ButtonIconSize,
+  FontWeight,
+  IconName,
+  KeyValueRow,
+  Text,
   TextColor,
-  TextVariant,
-} from '../../../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
+import { strings } from '../../../../../../../../locales/i18n';
 import { useStyles } from '../../../../../../hooks/useStyles';
+import useTooltipModal from '../../../../../../hooks/useTooltipModal';
 import InfoSection from '../../../../../../Views/confirmations/components/UI/info-row/info-section';
 import ContractTag from '../../../../../Stake/components/StakingConfirmation/ContractTag/ContractTag';
 import { TokenI } from '../../../../../Tokens/types';
@@ -16,6 +20,16 @@ import styleSheet from './DepositInfoSection.styles';
 import { selectAvatarAccountType } from '../../../../../../../selectors/settings';
 
 export const DEPOSIT_DETAILS_SECTION_TEST_ID = 'depositDetailsSection';
+
+const KEY_VALUE_ROW_CLASSNAME = 'h-auto px-0 overflow-hidden';
+
+const KEY_VALUE_ROW_KEY_TEXT_PROPS = {
+  color: TextColor.TextDefault,
+};
+
+const KEY_VALUE_ROW_VALUE_TEXT_PROPS = {
+  fontWeight: FontWeight.Regular,
+};
 
 export interface DepositInfoSectionProps {
   token: TokenI;
@@ -36,6 +50,8 @@ const DepositInfoSection = ({
 
   const avatarAccountType = useSelector(selectAvatarAccountType);
 
+  const { openTooltipModal } = useTooltipModal();
+
   const { earnToken, getEstimatedAnnualRewardsForAmount } = useEarnToken(token);
 
   if (!earnToken) return null;
@@ -50,109 +66,110 @@ const DepositInfoSection = ({
     <InfoSection testID={DEPOSIT_DETAILS_SECTION_TEST_ID}>
       <View style={styles.infoSectionContent}>
         <KeyValueRow
-          field={{
-            label: {
-              text: strings('earn.apr'),
-              variant: TextVariant.BodyMDMedium,
-            },
-            tooltip: {
-              title: strings('earn.apr'),
-              content: (
+          twClassName={KEY_VALUE_ROW_CLASSNAME}
+          keyLabel={strings('earn.apr')}
+          keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
+          keyEndButtonIconProps={{
+            size: ButtonIconSize.Xs,
+            iconName: IconName.Question,
+            accessibilityRole: 'button',
+            accessibilityLabel: `${strings('earn.apr')} tooltip`,
+            onPress: () =>
+              openTooltipModal(
+                strings('earn.apr'),
                 <View style={styles.aprTooltipContentContainer}>
                   <Text>{strings('earn.tooltip_content.apr.part_one')}</Text>
                   <Text>{strings('earn.tooltip_content.apr.part_two')}</Text>
-                </View>
+                </View>,
               ),
-            },
           }}
-          value={{
-            label: {
-              text: `${earnToken?.experience?.apr}%`,
-              variant: TextVariant.BodyMD,
-              color: TextColor.Success,
-            },
+          value={`${earnToken?.experience?.apr}%`}
+          valueTextProps={{
+            fontWeight: FontWeight.Regular,
+            color: TextColor.SuccessDefault,
           }}
         />
         <KeyValueRow
-          field={{
-            label: {
-              text: strings('stake.estimated_annual_reward'),
-            },
-          }}
-          value={{
-            label: (
-              <View style={styles.estAnnualReward}>
-                <Text numberOfLines={1}>
-                  {
-                    estimatedAnnualRewardsForAmount?.estimatedAnnualRewardsFormatted
-                  }
-                </Text>
-                <Text
-                  color={TextColor.Alternative}
-                  numberOfLines={1}
-                  ellipsizeMode="head"
-                >
-                  {
-                    estimatedAnnualRewardsForAmount?.estimatedAnnualRewardsTokenFormatted
-                  }
-                </Text>
-              </View>
-            ),
-          }}
+          twClassName={KEY_VALUE_ROW_CLASSNAME}
+          keyLabel={strings('stake.estimated_annual_reward')}
+          keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
+          value={
+            <View style={styles.estAnnualReward}>
+              <Text numberOfLines={1}>
+                {
+                  estimatedAnnualRewardsForAmount?.estimatedAnnualRewardsFormatted
+                }
+              </Text>
+              <Text
+                color={TextColor.TextAlternative}
+                numberOfLines={1}
+                ellipsizeMode="head"
+              >
+                {
+                  estimatedAnnualRewardsForAmount?.estimatedAnnualRewardsTokenFormatted
+                }
+              </Text>
+            </View>
+          }
         />
         <KeyValueRow
-          field={{
-            label: {
-              text: strings('stake.reward_frequency'),
-            },
-            tooltip: {
-              title: strings('stake.reward_frequency'),
-              content: strings('earn.tooltip_content.reward_frequency'),
-            },
+          twClassName={KEY_VALUE_ROW_CLASSNAME}
+          keyLabel={strings('stake.reward_frequency')}
+          keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
+          keyEndButtonIconProps={{
+            size: ButtonIconSize.Xs,
+            iconName: IconName.Question,
+            accessibilityRole: 'button',
+            accessibilityLabel: `${strings('stake.reward_frequency')} tooltip`,
+            onPress: () =>
+              openTooltipModal(
+                strings('stake.reward_frequency'),
+                strings('earn.tooltip_content.reward_frequency'),
+              ),
           }}
-          value={{
-            label: {
-              text: strings('earn.every_minute'),
-              variant: TextVariant.BodyMD,
-            },
-          }}
+          value={strings('earn.every_minute')}
+          valueTextProps={KEY_VALUE_ROW_VALUE_TEXT_PROPS}
         />
         <KeyValueRow
-          field={{
-            label: {
-              text: strings('stake.withdrawal_time'),
-            },
-            tooltip: {
-              title: strings('stake.withdrawal_time'),
-              content: strings('earn.tooltip_content.withdrawal_time'),
-            },
+          twClassName={KEY_VALUE_ROW_CLASSNAME}
+          keyLabel={strings('stake.withdrawal_time')}
+          keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
+          keyEndButtonIconProps={{
+            size: ButtonIconSize.Xs,
+            iconName: IconName.Question,
+            accessibilityRole: 'button',
+            accessibilityLabel: `${strings('stake.withdrawal_time')} tooltip`,
+            onPress: () =>
+              openTooltipModal(
+                strings('stake.withdrawal_time'),
+                strings('earn.tooltip_content.withdrawal_time'),
+              ),
           }}
-          value={{
-            label: {
-              text: strings('earn.immediate'),
-              variant: TextVariant.BodyMD,
-            },
-          }}
+          value={strings('earn.immediate')}
+          valueTextProps={KEY_VALUE_ROW_VALUE_TEXT_PROPS}
         />
         <KeyValueRow
-          field={{
-            label: {
-              text: strings('earn.protocol'),
-            },
-            tooltip: {
-              title: strings('earn.protocol'),
-              content: strings('earn.tooltip_content.protocol'),
-            },
+          twClassName={KEY_VALUE_ROW_CLASSNAME}
+          keyLabel={strings('earn.protocol')}
+          keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
+          keyEndButtonIconProps={{
+            size: ButtonIconSize.Xs,
+            iconName: IconName.Question,
+            accessibilityRole: 'button',
+            accessibilityLabel: `${strings('earn.protocol')} tooltip`,
+            onPress: () =>
+              openTooltipModal(
+                strings('earn.protocol'),
+                strings('earn.tooltip_content.protocol'),
+              ),
           }}
-          value={{
-            label: (
-              <ContractTag
-                contractAddress={lendingContractAddress}
-                contractName={lendingProtocol}
-                avatarAccountType={avatarAccountType}
-              />
-            ),
-          }}
+          value={
+            <ContractTag
+              contractAddress={lendingContractAddress}
+              contractName={lendingProtocol}
+              avatarAccountType={avatarAccountType}
+            />
+          }
         />
       </View>
     </InfoSection>

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/DepositReceiveSection/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/DepositReceiveSection/index.tsx
@@ -3,19 +3,19 @@ import styleSheet from './DepositReceiveSection.styles';
 import { useStyles } from '../../../../../../hooks/useStyles';
 import InfoSection from '../../../../../../Views/confirmations/components/UI/info-row/info-section';
 import { View } from 'react-native';
-import Text, {
-  TextVariant,
-  TextColor,
-} from '../../../../../../../component-library/components/Texts/Text';
-import ButtonIcon from '../../../../../../../component-library/components/Buttons/ButtonIcon';
-import { TooltipSizes } from '../../../../../../../component-library/components-temp/KeyValueRow';
 import {
+  AvatarToken,
+  AvatarTokenSize,
+  ButtonIcon,
+  ButtonIconSize,
+  FontWeight,
   IconColor,
   IconName,
-} from '../../../../../../../component-library/components/Icons/Icon';
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import useTooltipModal from '../../../../../../hooks/useTooltipModal';
-import AvatarToken from '../../../../../../../component-library/components/Avatars/Avatar/variants/AvatarToken';
-import { AvatarSize } from '../../../../../../../component-library/components/Avatars/Avatar';
 import { TokenI } from '../../../../../Tokens/types';
 import { strings } from '../../../../../../../../locales/i18n';
 
@@ -42,13 +42,13 @@ const DepositReceiveSection = ({
     <InfoSection testID={DEPOSIT_RECEIVE_SECTION_TEST_ID}>
       <View style={styles.infoSectionContent}>
         <View style={styles.receiveRow}>
-          <Text variant={TextVariant.BodyMDMedium}>
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
             {strings('earn.receive')}
           </Text>
           <ButtonIcon
             style={styles.infoIcon}
-            size={TooltipSizes.Xs}
-            iconColor={IconColor.Alternative}
+            size={ButtonIconSize.Xs}
+            iconProps={{ color: IconColor.IconAlternative }}
             iconName={IconName.Info}
             accessibilityRole={strings('earn.button')}
             accessibilityLabel={strings('earn.receive_tooltip')}
@@ -64,18 +64,20 @@ const DepositReceiveSection = ({
           <View style={styles.receiptTokenRowLeft}>
             <AvatarToken
               name={token.symbol}
-              imageSource={{
+              src={{
                 uri: token.image,
               }}
-              size={AvatarSize.Xs}
+              size={AvatarTokenSize.Xs}
+              twClassName="bg-default"
               style={styles.receiveTokenIcon}
-              isIpfsGatewayCheckBypassed
             />
-            <Text variant={TextVariant.BodyMD}>{receiptTokenName}</Text>
+            <Text variant={TextVariant.BodyMd}>{receiptTokenName}</Text>
           </View>
           <View style={styles.receiptTokenRowRight}>
             <Text>{receiptTokenAmount}</Text>
-            <Text color={TextColor.Alternative}>{receiptTokenAmountFiat}</Text>
+            <Text color={TextColor.TextAlternative}>
+              {receiptTokenAmountFiat}
+            </Text>
           </View>
         </View>
       </View>

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/Erc20TokenHero/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/Erc20TokenHero/index.tsx
@@ -3,22 +3,24 @@ import { TokenI } from '../../../../../Tokens/types';
 import { useStyles } from '../../../../../../hooks/useStyles';
 import styleSheet from './Erc20TokenHero.styles';
 import { View } from 'react-native';
-import BadgeWrapper, {
-  BadgePosition,
-} from '../../../../../../../component-library/components/Badges/BadgeWrapper';
-import Badge, {
-  BadgeVariant,
-} from '../../../../../../../component-library/components/Badges/Badge';
 import NetworkAssetLogo from '../../../../../NetworkAssetLogo';
-import { AvatarTokenSize } from '@metamask/design-system-react-native';
+import {
+  AvatarTokenSize,
+  BadgeNetwork,
+  BadgeWrapper,
+  BadgeWrapperPosition,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react-native';
 import AssetLogo from '../../../../../Assets/components/AssetLogo/AssetLogo';
 import { renderFromTokenMinimalUnit } from '../../../../../../../util/number';
-import Text, {
-  TextVariant,
-} from '../../../../../../../component-library/components/Texts/Text';
 import { getNetworkImageSource } from '../../../../../../../util/networks';
 import useFiatFormatter from '../../../../../SimulationDetails/FiatDisplay/useFiatFormatter';
 import BigNumber from 'bignumber.js';
+
+const NATIVE_TOKEN_BADGE_CLASSNAME = 'h-3 w-3 rounded-[3px] bg-default';
+
+const ERC20_TOKEN_BADGE_CLASSNAME = 'h-6 w-6 rounded-md bg-default';
 
 const TokenAvatar = ({ token }: { token: TokenI }) => {
   const { styles } = useStyles(styleSheet, {});
@@ -47,12 +49,16 @@ const NetworkAndTokenImage = ({ token }: { token: TokenI }) => {
   return (
     <View style={styles.networkAndTokenContainer}>
       <BadgeWrapper
-        badgePosition={BadgePosition.BottomRight}
-        badgeElement={
-          <Badge
-            variant={BadgeVariant.Network}
+        position={BadgeWrapperPosition.BottomRight}
+        badge={
+          <BadgeNetwork
+            twClassName={
+              token.isNative
+                ? NATIVE_TOKEN_BADGE_CLASSNAME
+                : ERC20_TOKEN_BADGE_CLASSNAME
+            }
             // @ts-expect-error The utils/network file is still JS and this function expects a networkType that should be optional
-            imageSource={getNetworkImageSource({ chainId: token?.chainId })}
+            src={getNetworkImageSource({ chainId: token?.chainId })}
           />
         }
       >
@@ -85,12 +91,12 @@ const Erc20TokenHero = ({
     <View style={styles.container}>
       <NetworkAndTokenImage token={token} />
       <View style={styles.assetAmountContainer}>
-        <Text style={styles.assetAmountText} variant={TextVariant.HeadingLG}>
+        <Text style={styles.assetAmountText} variant={TextVariant.HeadingLg}>
           {displayTokenAmount} {token.symbol}
         </Text>
         <Text
           style={styles.assetFiatConversionText}
-          variant={TextVariant.BodyMD}
+          variant={TextVariant.BodyMd}
         >
           {fiatFormatter(new BigNumber(fiatValue))}
         </Text>

--- a/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/ProgressStepper/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingDepositConfirmationView/components/ProgressStepper/index.tsx
@@ -1,19 +1,17 @@
 import React, { useMemo, useCallback } from 'react';
 import { ColorValue, Dimensions, View } from 'react-native';
 import Svg, { Line } from 'react-native-svg';
-import Avatar, {
-  AvatarVariant,
-  AvatarSize,
-} from '../../../../../../../component-library/components/Avatars/Avatar';
-import AvatarBase from '../../../../../../../component-library/components/Avatars/Avatar/foundation/AvatarBase';
 import {
+  AvatarBase,
+  AvatarBaseSize,
+  AvatarIcon,
+  AvatarIconSize,
   IconColor,
   IconName,
-} from '../../../../../../../component-library/components/Icons/Icon';
-import Text, {
+  Text,
   TextColor,
   TextVariant,
-} from '../../../../../../../component-library/components/Texts/Text';
+} from '@metamask/design-system-react-native';
 import { useStyles } from '../../../../../../hooks/useStyles';
 import Loader from '../../../../../../../component-library/components-temp/Loader';
 import styleSheet from './ProgressStepper.styles';
@@ -78,12 +76,11 @@ const ProgressStepper = ({
     (index: number, isLoading: boolean) => {
       if (isCompletedStep(index) && !isActiveStep(index) && !isLoading) {
         return (
-          <Avatar
-            variant={AvatarVariant.Icon}
-            name={IconName.Check}
-            iconColor={IconColor.Inverse}
-            size={AvatarSize.Sm}
-            backgroundColor={theme.colors.primary.default}
+          <AvatarIcon
+            iconName={IconName.Check}
+            iconProps={{ color: IconColor.PrimaryInverse }}
+            size={AvatarIconSize.Sm}
+            twClassName="bg-primary-default"
             testID={PROGRESS_STEPPER_TEST_IDS.STEP_ICON.COMPLETED}
           />
         );
@@ -93,7 +90,7 @@ const ProgressStepper = ({
         return (
           <AvatarBase
             style={styles.completeStep}
-            size={AvatarSize.Sm}
+            size={AvatarBaseSize.Sm}
             testID={PROGRESS_STEPPER_TEST_IDS.STEP_ICON.LOADING}
           >
             <View>
@@ -108,13 +105,15 @@ const ProgressStepper = ({
           style={
             isCompletedStep(index) ? styles.completeStep : styles.incompleteStep
           }
-          size={AvatarSize.Sm}
+          size={AvatarBaseSize.Sm}
         >
           <Text
             color={
-              isCompletedStep(index) ? TextColor.Inverse : TextColor.Primary
+              isCompletedStep(index)
+                ? TextColor.PrimaryInverse
+                : TextColor.PrimaryDefault
             }
-            variant={TextVariant.BodySM}
+            variant={TextVariant.BodySm}
             testID={PROGRESS_STEPPER_TEST_IDS.STEP_ICON.PENDING}
           >
             {index + 1}
@@ -127,7 +126,6 @@ const ProgressStepper = ({
       isCompletedStep,
       styles.completeStep,
       styles.incompleteStep,
-      theme.colors.primary.default,
       theme.colors.primary.inverse,
     ],
   );
@@ -163,15 +161,15 @@ const ProgressStepper = ({
             {getStepIcon(index, isLoading)}
             <Text
               style={styles.stepLabelContainer}
-              variant={TextVariant.BodySM}
-              color={TextColor.Primary}
+              variant={TextVariant.BodySm}
+              color={TextColor.PrimaryDefault}
             >
               {label.split(' ').map((word, wordIndex) => (
                 <>
                   <Text
                     key={`${word}-${wordIndex}`}
-                    variant={TextVariant.BodySM}
-                    color={TextColor.Primary}
+                    variant={TextVariant.BodySm}
+                    color={TextColor.PrimaryDefault}
                   >
                     {word}
                   </Text>

--- a/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx
@@ -33,7 +33,12 @@ import { getNetworkImageSource } from '../../../../../util/networks';
 import { renderFromTokenMinimalUnit } from '../../../../../util/number';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { useStyles } from '../../../../hooks/useStyles';
-import useTooltipModal from '../../../../hooks/useTooltipModal';
+import {
+  KEY_VALUE_ROW_CLASSNAME,
+  KEY_VALUE_ROW_KEY_TEXT_PROPS,
+  KEY_VALUE_ROW_VALUE_TEXT_PROPS,
+  useKeyValueRowTooltip,
+} from '../../utils/keyValueRow';
 import InfoRowDivider from '../../../../Views/confirmations/components/UI/info-row-divider';
 import InfoSection from '../../../../Views/confirmations/components/UI/info-row/info-section';
 import AccountTag from '../../../Stake/components/StakingConfirmation/AccountTag/AccountTag';
@@ -55,16 +60,6 @@ import useEndTraceOnMount from '../../../../hooks/useEndTraceOnMount';
 import { EVM_SCOPE } from '../../constants/networks';
 import { selectAvatarAccountType } from '../../../../../selectors/settings';
 import { selectSelectedAccountGroup } from '../../../../../selectors/multichainAccounts/accountTreeController';
-
-const KEY_VALUE_ROW_CLASSNAME = 'h-auto px-0 overflow-hidden';
-
-const KEY_VALUE_ROW_KEY_TEXT_PROPS = {
-  color: TextColor.TextDefault,
-};
-
-const KEY_VALUE_ROW_VALUE_TEXT_PROPS = {
-  fontWeight: FontWeight.Regular,
-};
 
 interface EarnWithdrawalConfirmationViewRouteParams {
   token: TokenI | EarnTokenDetails;
@@ -120,7 +115,7 @@ const EarnLendingWithdrawalConfirmationView = () => {
 
   const avatarAccountType = useSelector(selectAvatarAccountType);
 
-  const { openTooltipModal } = useTooltipModal();
+  const tooltipProps = useKeyValueRowTooltip();
 
   useEndTraceOnMount(TraceName.EarnWithdrawReviewScreen);
 
@@ -493,19 +488,10 @@ const EarnLendingWithdrawalConfirmationView = () => {
                 twClassName={KEY_VALUE_ROW_CLASSNAME}
                 keyLabel={strings('earn.withdrawal_time')}
                 keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
-                keyEndButtonIconProps={{
-                  size: ButtonIconSize.Xs,
-                  iconName: IconName.Question,
-                  accessibilityRole: 'button',
-                  accessibilityLabel: `${strings(
-                    'earn.withdrawal_time',
-                  )} tooltip`,
-                  onPress: () =>
-                    openTooltipModal(
-                      strings('earn.withdrawal_time'),
-                      strings('earn.tooltip_content.withdrawal_time'),
-                    ),
-                }}
+                keyEndButtonIconProps={tooltipProps(
+                  strings('earn.withdrawal_time'),
+                  strings('earn.tooltip_content.withdrawal_time'),
+                )}
                 value={strings('earn.immediate')}
                 valueTextProps={KEY_VALUE_ROW_VALUE_TEXT_PROPS}
               />
@@ -532,17 +518,10 @@ const EarnLendingWithdrawalConfirmationView = () => {
                 twClassName={KEY_VALUE_ROW_CLASSNAME}
                 keyLabel={strings('earn.protocol')}
                 keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
-                keyEndButtonIconProps={{
-                  size: ButtonIconSize.Xs,
-                  iconName: IconName.Question,
-                  accessibilityRole: 'button',
-                  accessibilityLabel: `${strings('earn.protocol')} tooltip`,
-                  onPress: () =>
-                    openTooltipModal(
-                      strings('earn.protocol'),
-                      strings('earn.tooltip_content.protocol'),
-                    ),
-                }}
+                keyEndButtonIconProps={tooltipProps(
+                  strings('earn.protocol'),
+                  strings('earn.tooltip_content.protocol'),
+                )}
                 value={
                   <ContractTag
                     contractAddress={lendingContractAddress}

--- a/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx
+++ b/app/components/UI/Earn/Views/EarnLendingWithdrawalConfirmationView/index.tsx
@@ -11,16 +11,17 @@ import { capitalize } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { View } from 'react-native';
 import { useSelector } from 'react-redux';
-import { HeaderStandard } from '@metamask/design-system-react-native';
+import {
+  BadgeNetwork,
+  ButtonIconSize,
+  FontWeight,
+  HeaderStandard,
+  IconName,
+  KeyValueRow,
+  Text,
+  TextColor,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
-import KeyValueRow from '../../../../../component-library/components-temp/KeyValueRow';
-import { AvatarSize } from '../../../../../component-library/components/Avatars/Avatar';
-import Badge, {
-  BadgeVariant,
-} from '../../../../../component-library/components/Badges/Badge';
-import Text, {
-  TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
 import { navigateToActivityAfterConfirmation } from '../../../../../util/navigation/navigateToActivityAfterConfirmation';
 import {
   IMetaMetricsEvent,
@@ -32,6 +33,7 @@ import { getNetworkImageSource } from '../../../../../util/networks';
 import { renderFromTokenMinimalUnit } from '../../../../../util/number';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { useStyles } from '../../../../hooks/useStyles';
+import useTooltipModal from '../../../../hooks/useTooltipModal';
 import InfoRowDivider from '../../../../Views/confirmations/components/UI/info-row-divider';
 import InfoSection from '../../../../Views/confirmations/components/UI/info-row/info-section';
 import AccountTag from '../../../Stake/components/StakingConfirmation/AccountTag/AccountTag';
@@ -53,6 +55,16 @@ import useEndTraceOnMount from '../../../../hooks/useEndTraceOnMount';
 import { EVM_SCOPE } from '../../constants/networks';
 import { selectAvatarAccountType } from '../../../../../selectors/settings';
 import { selectSelectedAccountGroup } from '../../../../../selectors/multichainAccounts/accountTreeController';
+
+const KEY_VALUE_ROW_CLASSNAME = 'h-auto px-0 overflow-hidden';
+
+const KEY_VALUE_ROW_KEY_TEXT_PROPS = {
+  color: TextColor.TextDefault,
+};
+
+const KEY_VALUE_ROW_VALUE_TEXT_PROPS = {
+  fontWeight: FontWeight.Regular,
+};
 
 interface EarnWithdrawalConfirmationViewRouteParams {
   token: TokenI | EarnTokenDetails;
@@ -107,6 +119,8 @@ const EarnLendingWithdrawalConfirmationView = () => {
   const activeAccountGroup = useSelector(selectSelectedAccountGroup);
 
   const avatarAccountType = useSelector(selectAvatarAccountType);
+
+  const { openTooltipModal } = useTooltipModal();
 
   useEndTraceOnMount(TraceName.EarnWithdrawReviewScreen);
 
@@ -476,93 +490,86 @@ const EarnLendingWithdrawalConfirmationView = () => {
           <InfoSection>
             <View style={styles.infoSectionContainer}>
               <KeyValueRow
-                field={{
-                  label: {
-                    text: strings('earn.withdrawal_time'),
-                    variant: TextVariant.BodyMDMedium,
-                  },
-                  tooltip: {
-                    title: strings('earn.withdrawal_time'),
-                    content: strings('earn.tooltip_content.withdrawal_time'),
-                  },
+                twClassName={KEY_VALUE_ROW_CLASSNAME}
+                keyLabel={strings('earn.withdrawal_time')}
+                keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
+                keyEndButtonIconProps={{
+                  size: ButtonIconSize.Xs,
+                  iconName: IconName.Question,
+                  accessibilityRole: 'button',
+                  accessibilityLabel: `${strings(
+                    'earn.withdrawal_time',
+                  )} tooltip`,
+                  onPress: () =>
+                    openTooltipModal(
+                      strings('earn.withdrawal_time'),
+                      strings('earn.tooltip_content.withdrawal_time'),
+                    ),
                 }}
-                value={{
-                  label: {
-                    text: strings('earn.immediate'),
-                    variant: TextVariant.BodyMD,
-                  },
-                }}
+                value={strings('earn.immediate')}
+                valueTextProps={KEY_VALUE_ROW_VALUE_TEXT_PROPS}
               />
             </View>
           </InfoSection>
           <InfoSection>
             <View style={styles.infoSectionContainer}>
               <KeyValueRow
-                field={{
-                  label: {
-                    text: strings('earn.withdrawing_to'),
-                    variant: TextVariant.BodyMDMedium,
-                  },
-                }}
-                value={{
-                  label: (
-                    <AccountTag
-                      accountAddress={selectedAccount?.address}
-                      accountName={
-                        activeAccountGroup?.metadata?.name ||
-                        selectedAccount.metadata.name
-                      }
-                      avatarAccountType={avatarAccountType}
-                    />
-                  ),
-                }}
+                twClassName={KEY_VALUE_ROW_CLASSNAME}
+                keyLabel={strings('earn.withdrawing_to')}
+                keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
+                value={
+                  <AccountTag
+                    accountAddress={selectedAccount?.address}
+                    accountName={
+                      activeAccountGroup?.metadata?.name ||
+                      selectedAccount.metadata.name
+                    }
+                    avatarAccountType={avatarAccountType}
+                  />
+                }
               />
               <KeyValueRow
-                field={{
-                  label: {
-                    text: strings('earn.protocol'),
-                    variant: TextVariant.BodyMDMedium,
-                  },
-                  tooltip: {
-                    title: strings('earn.protocol'),
-                    content: strings('earn.tooltip_content.protocol'),
-                  },
+                twClassName={KEY_VALUE_ROW_CLASSNAME}
+                keyLabel={strings('earn.protocol')}
+                keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
+                keyEndButtonIconProps={{
+                  size: ButtonIconSize.Xs,
+                  iconName: IconName.Question,
+                  accessibilityRole: 'button',
+                  accessibilityLabel: `${strings('earn.protocol')} tooltip`,
+                  onPress: () =>
+                    openTooltipModal(
+                      strings('earn.protocol'),
+                      strings('earn.tooltip_content.protocol'),
+                    ),
                 }}
-                value={{
-                  label: (
-                    <ContractTag
-                      contractAddress={lendingContractAddress}
-                      contractName={capitalize(lendingProtocol)}
-                      avatarAccountType={avatarAccountType}
-                    />
-                  ),
-                }}
+                value={
+                  <ContractTag
+                    contractAddress={lendingContractAddress}
+                    contractName={capitalize(lendingProtocol)}
+                    avatarAccountType={avatarAccountType}
+                  />
+                }
               />
             </View>
             <InfoRowDivider />
             <View style={styles.infoSectionContainer}>
               <KeyValueRow
-                field={{
-                  label: {
-                    text: strings('earn.network'),
-                    variant: TextVariant.BodyMDMedium,
-                  },
-                }}
-                value={{
-                  label: (
-                    <View style={styles.networkRowRight}>
-                      <Badge
-                        variant={BadgeVariant.Network}
-                        size={AvatarSize.Xs}
-                        isScaled={false}
-                        imageSource={getNetworkImageSource({
+                twClassName={KEY_VALUE_ROW_CLASSNAME}
+                keyLabel={strings('earn.network')}
+                keyTextProps={KEY_VALUE_ROW_KEY_TEXT_PROPS}
+                value={
+                  <View style={styles.networkRowRight}>
+                    <BadgeNetwork
+                      src={
+                        getNetworkImageSource({
                           chainId: token?.chainId,
-                        })}
-                      />
-                      <Text>{networkConfig?.name}</Text>
-                    </View>
-                  ),
-                }}
+                        }) as React.ComponentProps<typeof BadgeNetwork>['src']
+                      }
+                    />
+                    <Text>{networkConfig?.name}</Text>
+                  </View>
+                }
               />
             </View>
           </InfoSection>

--- a/app/components/UI/Earn/modals/LendingMaxWithdrawalModal/LendingMaxWithdrawalModal.test.tsx
+++ b/app/components/UI/Earn/modals/LendingMaxWithdrawalModal/LendingMaxWithdrawalModal.test.tsx
@@ -2,29 +2,26 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import LendingMaxWithdrawalModal from './index';
 
-// Mock the BottomSheet component
-jest.mock(
-  '../../../../../component-library/components/BottomSheets/BottomSheet',
-  () => {
-    const MockBottomSheet = ({
-      children,
-      ref,
-    }: {
-      children: React.ReactNode;
-      ref: { current: { onCloseBottomSheet: () => void } | null };
-    }) => {
-      if (ref) {
-        ref.current = {
-          onCloseBottomSheet: jest.fn(),
-        };
-      }
-      return <>{children}</>;
-    };
-    return MockBottomSheet;
-  },
-);
+const mockGoBack = jest.fn();
+const mockIsFocused = jest.fn(() => true);
+
+jest.mock('@react-navigation/native', () => {
+  const actualReactNavigation = jest.requireActual('@react-navigation/native');
+  return {
+    ...actualReactNavigation,
+    useNavigation: () => ({
+      goBack: mockGoBack,
+      isFocused: mockIsFocused,
+    }),
+  };
+});
 
 describe('LendingMaxWithdrawalModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsFocused.mockReturnValue(true);
+  });
+
   it('should render correctly', () => {
     const { getByText } = render(<LendingMaxWithdrawalModal />);
 
@@ -33,15 +30,21 @@ describe('LendingMaxWithdrawalModal', () => {
     ).toBeOnTheScreen();
   });
 
-  it('should handle close action', () => {
-    const { getByText } = render(<LendingMaxWithdrawalModal />);
+  it('navigates back when the close button is pressed', () => {
+    const { getByTestId } = render(<LendingMaxWithdrawalModal />);
 
-    // Find and click the close button
-    const closeButton = getByText("Why can't I withdraw my full balance?");
-    fireEvent.press(closeButton);
+    fireEvent.press(getByTestId('button-icon'));
 
-    // The close functionality is handled by the BottomSheet component
-    // which is mocked, so we just verify the component renders without errors
-    expect(closeButton).toBeOnTheScreen();
+    expect(mockGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not navigate back when the screen is not focused', () => {
+    mockIsFocused.mockReturnValue(false);
+
+    const { getByTestId } = render(<LendingMaxWithdrawalModal />);
+
+    fireEvent.press(getByTestId('button-icon'));
+
+    expect(mockGoBack).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Earn/modals/LendingMaxWithdrawalModal/index.tsx
+++ b/app/components/UI/Earn/modals/LendingMaxWithdrawalModal/index.tsx
@@ -1,18 +1,24 @@
-import React, { useRef } from 'react';
-import Text, {
+import React, { useCallback, useRef } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import {
+  BottomSheet,
+  BottomSheetHeader,
+  ButtonIconSize,
+  FontWeight,
+  Text,
   TextVariant,
-} from '../../../../../component-library/components/Texts/Text';
+  type BottomSheetRef,
+} from '@metamask/design-system-react-native';
+import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import { useStyles } from '../../../../hooks/useStyles';
 import styleSheet from './LendingMaxWithdrawalModal.styles';
-import BottomSheet, {
-  BottomSheetRef,
-} from '../../../../../component-library/components/BottomSheets/BottomSheet';
-import BottomSheetHeader from '../../../../../component-library/components/BottomSheets/BottomSheetHeader';
 import { View } from 'react-native';
 import { strings } from '../../../../../../locales/i18n';
 
 const LendingMaxWithdrawalModal = () => {
   const { styles } = useStyles(styleSheet, {});
+
+  const navigation = useNavigation<AppNavigationProp>();
 
   const sheetRef = useRef<BottomSheetRef>(null);
 
@@ -20,11 +26,21 @@ const LendingMaxWithdrawalModal = () => {
     sheetRef.current?.onCloseBottomSheet();
   };
 
+  const handleGoBack = useCallback(() => {
+    if (navigation.isFocused()) {
+      navigation.goBack();
+    }
+  }, [navigation]);
+
   return (
-    <BottomSheet ref={sheetRef}>
+    <BottomSheet ref={sheetRef} goBack={handleGoBack}>
       <View>
-        <BottomSheetHeader onClose={handleClose}>
-          <Text variant={TextVariant.HeadingSM}>
+        <BottomSheetHeader
+          onClose={handleClose}
+          closeButtonProps={{ size: ButtonIconSize.Lg }}
+          twClassName="min-h-14 h-auto px-4"
+        >
+          <Text variant={TextVariant.HeadingSm}>
             {strings(
               'earn.tooltip_content.lending_risk_aware_withdrawal_tooltip.why_cant_i_withdraw_full_balance',
             )}
@@ -35,7 +51,10 @@ const LendingMaxWithdrawalModal = () => {
             'earn.tooltip_content.lending_risk_aware_withdrawal_tooltip.your_withdrawal_amount_may_be_limited_by',
           )}:`}</Text>
           <Text>
-            <Text variant={TextVariant.BodyMDMedium}>{`• ${strings(
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+            >{`• ${strings(
               'earn.tooltip_content.lending_risk_aware_withdrawal_tooltip.pool_liquidity',
             )}:`}</Text>{' '}
             {`${strings(
@@ -43,7 +62,10 @@ const LendingMaxWithdrawalModal = () => {
             )}`}
           </Text>
           <Text>
-            <Text variant={TextVariant.BodyMDMedium}>{`• ${strings(
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+            >{`• ${strings(
               'earn.tooltip_content.lending_risk_aware_withdrawal_tooltip.existing_borrow_positions',
             )}:`}</Text>{' '}
             {`${strings(

--- a/app/components/UI/Earn/utils/keyValueRow.ts
+++ b/app/components/UI/Earn/utils/keyValueRow.ts
@@ -1,0 +1,44 @@
+import { ReactNode, useCallback } from 'react';
+import {
+  ButtonIconSize,
+  FontWeight,
+  IconName,
+  TextColor,
+} from '@metamask/design-system-react-native';
+import useTooltipModal from '../../../hooks/useTooltipModal';
+
+/**
+ * The design system row hard-codes horizontal padding, a fixed height and no
+ * overflow. The confirmation sections supply their own padding and size to
+ * their content, so each row opts back out.
+ */
+export const KEY_VALUE_ROW_CLASSNAME = 'h-auto px-0 overflow-hidden';
+
+export const KEY_VALUE_ROW_KEY_TEXT_PROPS = {
+  color: TextColor.TextDefault,
+};
+
+export const KEY_VALUE_ROW_VALUE_TEXT_PROPS = {
+  fontWeight: FontWeight.Regular,
+};
+
+/**
+ * Builds the `keyEndButtonIconProps` for a row whose label carries a tooltip.
+ *
+ * The design system row exposes the button rather than a tooltip, so the
+ * wiring lives here to keep it identical across the confirmation screens.
+ */
+export const useKeyValueRowTooltip = () => {
+  const { openTooltipModal } = useTooltipModal();
+
+  return useCallback(
+    (title: string, content: string | ReactNode) => ({
+      size: ButtonIconSize.Xs,
+      iconName: IconName.Question,
+      accessibilityRole: 'button' as const,
+      accessibilityLabel: `${title} tooltip`,
+      onPress: () => openTooltipModal(title, content),
+    }),
+    [openTooltipModal],
+  );
+};


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Part of the MMDS migration tracked by MUSD-1293. This PR migrates the **lending deposit and withdrawal confirmation screens** plus the max-withdrawal modal — 60 legacy `app/component-library` instances across 8 files.

The swaps are surgical: the legacy component and its props are replaced, and the surrounding `useStyles`/`StyleSheet`/`View` scaffolding is deliberately left alone.

**MMDS components are not drop-in replacements**, so each swap carries the props needed to keep the screens pixel-identical. Every value below was derived by reading both implementations, not assumed:

| Component | MMDS default | Legacy | Compensation |
| --- | --- | --- | --- |
| `KeyValueRow` | `px-4`, fixed 40px row, no `overflow` | unpadded, content-height, `overflow: hidden` | `h-auto px-0 overflow-hidden` |
| `KeyValueRow` key | `TextAlternative` | `Default` | `keyTextProps` |
| `KeyValueRow` value | `FontWeight.Medium` | caller's variant (regular) | `valueTextProps` |
| `BottomSheetFooter` | `py-0` | `paddingVertical: 12` | `py-3` |
| `BottomSheetHeader` | fixed `h-14`, `px-2`, 32px close | grows with content, 16px padding, 40px close | `min-h-14 h-auto px-4`, `closeButtonProps` |
| `AvatarBase` | `bg-alternative` | `background.default` | `bg-default` |
| `BadgeNetwork` | pinned 18px, 2px radius | half of anchor — 24px/6px (ERC-20) or 12px/3px (native) | per-path size + radius |

Three of these are silent failures rather than visible ones, and are the reason this PR exists in the shape it does:

1. **`BottomSheetFooter` hard-codes `py-0`.** Yoga resolves edge-specific `paddingTop`/`paddingBottom` above `paddingVertical`, so the footer's existing `paddingVertical: 12` would have been **silently zeroed** — no error, no failing test. `py-3` restores it.
2. **`KeyValueRow` drops the legacy root's `overflow: hidden`.** A ReactNode value bypasses the row's string-text handling, so it receives no truncation; without the clip a long value escapes the card entirely rather than being cut off.
3. **`KeyValueRow` row height.** Left uncompensated the sections grow substantially. `h-auto` cancels it — verified by rendering: baseline resolves to `height: 40, paddingLeft: 16`, with the override `height: "auto", paddingLeft: 0`.

**Deferred code made fail-loud.** The withdrawal view carries a commented-out `STAKE-1044` block ("Add back in v1.1") that uses legacy `TextVariant` values. Those values are not MMDS class names — `TextVariant.BodyMDMedium` is `'sBodyMDMedium'`, and MMDS resolves `text-${variant}`, which matches nothing — so pairing them would render **completely unstyled with no type error**. The legacy import is therefore removed rather than retained, so restoring that block fails to compile instead of shipping a silent styling bug.

**Navigation.** MMDS `BottomSheet` replaces legacy's implicit `shouldNavigateBack` with an explicit `goBack`, and drops legacy's `navigation.isFocused()` guard. The guard is restored, so the sheet cannot pop the wrong route when something is stacked above it.

### Accepted residuals

Not compensable through the components' public props, and judged not worth hand-rolling:

- Badge drop shadow: legacy applied `theme.shadows.size.xs`; no tailwind class maps to the MM shadow tokens.
- Badge border width: legacy scaled its stroke (~1.5px / ~0.75px); MMDS uses a flat 1px. Colour matches.
- `KeyValueRow` key/value gap 0 → 16px, key↔tooltip gap 0 → 4px, and the 50/50 column split becoming `shrink-0` key / `flex-1` value.
- MMDS `BottomSheet`'s Android hardware-back handler returns `true` unconditionally where legacy deferred when unfocused.
- Sheet border colour `border.alternative` → `border-muted` (1px hairline).
- `Loader` in `ProgressStepper` is **not** migrated — it has no MMDS equivalent (`Spinner` is a different component, not a rename).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: [MUSD-1293](https://consensyssoftware.atlassian.net/browse/MUSD-1293)

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: MMDS migration of the lending confirmation screens

  Scenario: user reviews a lending deposit
    Given the user holds a lendable ERC-20 such as USDC
    When user starts a lending deposit and reaches the confirmation screen
    Then the hero shows the token with its network badge at the current size
    And the deposit info rows sit flush with the section padding, not indented
    And the footer keeps its vertical padding above and below the buttons

  Scenario: user reviews a native-token lending deposit
    Given the user holds a lendable native token
    When user reaches the deposit confirmation screen
    Then the hero network badge renders smaller than on the ERC-20 path, as today

  Scenario: user opens a deposit tooltip
    Given the deposit confirmation screen is open
    When user taps a question icon in the deposit details section
    Then the matching tooltip sheet opens with its title and content

  Scenario: user reviews a lending withdrawal
    Given the user has a lending position
    When user starts a withdrawal and reaches the confirmation screen
    Then the withdrawal time, destination, protocol and network rows render
    And the network row shows the network badge beside the network name

  Scenario: user opens and dismisses the max-withdrawal modal
    Given the withdrawal input screen is open
    When user taps the max-withdrawal info affordance
    Then the modal opens with its full title visible and not clipped
    And tapping the close button dismisses the modal and returns to the input screen
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — this PR is a component-library swap compensated to pixel parity; no visual change is intended. The residuals listed in the description are the only expected differences.

### **After**

<!-- [screenshots/recordings] -->

N/A — see above.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-1293]: https://consensyssoftware.atlassian.net/browse/MUSD-1293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only component migration with no changes to transaction or auth logic. Residual visual diffs and BottomSheet back-navigation are the main review points.
> 
> **Overview**
> Migrates lending deposit/withdrawal confirmation screens and the max-withdrawal modal from the legacy component library to `@metamask/design-system-react-native`, with prop/class overrides so layout stays close to the current look.
> 
> Adds shared `keyValueRow` helpers (`KEY_VALUE_ROW_CLASSNAME`, text props, `useKeyValueRowTooltip`) so MMDS `KeyValueRow` drops default padding/height, keeps overflow clipping, and wires tooltips through `keyEndButtonIconProps`. Footer, header, badges, and avatars get similar compensations (`py-3` on `BottomSheetFooter`, native vs ERC-20 badge sizes, `goBack` + `isFocused` on the max-withdrawal sheet).
> 
> Tests now assert close navigates back only when the modal is focused. Transaction/confirm logic is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8216430d413f9b7d512ff5f95d3cfd1e59bf4b5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->