### PR TITLE
feat: add Sentry performance spans for notification list and Braze banner

### DIFF
--- a/app/components/UI/BrazeBanner/useBrazeBanner.test.ts
+++ b/app/components/UI/BrazeBanner/useBrazeBanner.test.ts
@@ -63,6 +63,28 @@ jest.mock('../../../core/Braze', () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Mock: trace
+// ---------------------------------------------------------------------------
+jest.mock('../../../util/trace', () => ({
+  trace: jest.fn(),
+  endTrace: jest.fn(),
+  TraceName: {
+    BrazeBannerTimeToContent: 'Braze Banner Time To Content',
+  },
+  TraceOperation: {
+    BrazeBannerPerformance: 'braze_banner.performance',
+  },
+}));
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'test-braze-trace-id'),
+}));
+
+const { trace: mockTrace, endTrace: mockEndTrace } = jest.requireMock(
+  '../../../util/trace',
+);
+
+// ---------------------------------------------------------------------------
 // Mock: react-redux
 // ---------------------------------------------------------------------------
 const mockDispatch = jest.fn();
@@ -697,6 +719,146 @@ describe('useBrazeBanner', () => {
     it('returns null deeplink when no banner is loaded', () => {
       const { result } = renderHook(() => useBrazeBanner(TEST_PLACEMENT_ID));
       expect(result.current.deeplink).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Performance trace
+  // ---------------------------------------------------------------------------
+  describe('performance trace', () => {
+    it('starts the time-to-content span on mount with the placement tag', () => {
+      renderHook(() => useBrazeBanner(TEST_PLACEMENT_ID));
+
+      expect(mockTrace).toHaveBeenCalledTimes(1);
+      expect(mockTrace).toHaveBeenCalledWith({
+        name: 'Braze Banner Time To Content',
+        op: 'braze_banner.performance',
+        id: 'test-braze-trace-id',
+        tags: { placement_id: TEST_PLACEMENT_ID },
+      });
+      expect(mockEndTrace).not.toHaveBeenCalled();
+    });
+
+    it('ends with success and source event when a banner event is accepted', () => {
+      renderHook(() => useBrazeBanner(TEST_PLACEMENT_ID));
+
+      fireBannerEvent([makeBanner({ bannerName: 'campaign-abc' })]);
+
+      expect(mockEndTrace).toHaveBeenCalledTimes(1);
+      expect(mockEndTrace).toHaveBeenCalledWith({
+        name: 'Braze Banner Time To Content',
+        id: 'test-braze-trace-id',
+        data: {
+          success: true,
+          source: 'event',
+          placement_id: TEST_PLACEMENT_ID,
+          banner_name: 'campaign-abc',
+        },
+      });
+    });
+
+    it('omits banner_name when the accepted banner has none', () => {
+      renderHook(() => useBrazeBanner(TEST_PLACEMENT_ID));
+
+      fireBannerEvent([makeBanner()]);
+
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: {
+            success: true,
+            source: 'event',
+            placement_id: TEST_PLACEMENT_ID,
+          },
+        }),
+      );
+    });
+
+    it('ends with source warm-cache when the probe resolves a banner', async () => {
+      mockGetBannerForPlacement.mockResolvedValue(makeBanner());
+
+      const { result } = renderHook(() => useBrazeBanner(TEST_PLACEMENT_ID));
+      await waitFor(() => expect(result.current.status).toBe('visible'));
+
+      expect(mockEndTrace).toHaveBeenCalledTimes(1);
+      expect(mockEndTrace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            success: true,
+            source: 'warm-cache',
+          }),
+        }),
+      );
+    });
+
+    it('ends with reason empty when a control banner settles the placement', async () => {
+      mockGetBannerForPlacement.mockResolvedValue({
+        ...makeBanner(),
+        isControl: true,
+      });
+
+      const { result } = renderHook(() => useBrazeBanner(TEST_PLACEMENT_ID));
+      await waitFor(() => expect(result.current.status).toBe('empty'));
+
+      expect(mockEndTrace).toHaveBeenCalledTimes(1);
+      expect(mockEndTrace).toHaveBeenCalledWith({
+        name: 'Braze Banner Time To Content',
+        id: 'test-braze-trace-id',
+        data: {
+          success: false,
+          reason: 'empty',
+          source: 'warm-cache',
+          placement_id: TEST_PLACEMENT_ID,
+        },
+      });
+    });
+
+    it('ends with reason timeout when no banner arrives in the window', () => {
+      renderHook(() => useBrazeBanner(TEST_PLACEMENT_ID));
+
+      act(() => {
+        jest.advanceTimersByTime(SKELETON_TIMEOUT_MS);
+      });
+
+      expect(mockEndTrace).toHaveBeenCalledTimes(1);
+      expect(mockEndTrace).toHaveBeenCalledWith({
+        name: 'Braze Banner Time To Content',
+        id: 'test-braze-trace-id',
+        data: {
+          success: false,
+          reason: 'timeout',
+          placement_id: TEST_PLACEMENT_ID,
+        },
+      });
+    });
+
+    it('ends with reason unmounted when the hook unmounts before settling', () => {
+      const { unmount } = renderHook(() => useBrazeBanner(TEST_PLACEMENT_ID));
+      unmount();
+
+      expect(mockEndTrace).toHaveBeenCalledTimes(1);
+      expect(mockEndTrace).toHaveBeenCalledWith({
+        name: 'Braze Banner Time To Content',
+        id: 'test-braze-trace-id',
+        data: {
+          success: false,
+          reason: 'unmounted',
+          placement_id: TEST_PLACEMENT_ID,
+        },
+      });
+    });
+
+    it('does not end again after the span already settled', () => {
+      const { unmount } = renderHook(() => useBrazeBanner(TEST_PLACEMENT_ID));
+
+      fireBannerEvent([makeBanner()]);
+      expect(mockEndTrace).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        jest.advanceTimersByTime(SKELETON_TIMEOUT_MS);
+      });
+      unmount();
+
+      expect(mockEndTrace).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/components/UI/BrazeBanner/useBrazeBanner.test.ts
+++ b/app/components/UI/BrazeBanner/useBrazeBanner.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@testing-library/react-native';
 import { AppState, type AppStateStatus } from 'react-native';
 import Braze from '@braze/react-native-sdk';
+import { endTrace, trace } from '../../../util/trace';
 import { useBrazeBanner } from './useBrazeBanner';
 
 const TEST_PLACEMENT_ID = 'placement-1';
@@ -80,9 +81,8 @@ jest.mock('uuid', () => ({
   v4: jest.fn(() => 'test-braze-trace-id'),
 }));
 
-const { trace: mockTrace, endTrace: mockEndTrace } = jest.requireMock(
-  '../../../util/trace',
-);
+const mockTrace = jest.mocked(trace);
+const mockEndTrace = jest.mocked(endTrace);
 
 // ---------------------------------------------------------------------------
 // Mock: react-redux

--- a/app/components/UI/BrazeBanner/useBrazeBanner.ts
+++ b/app/components/UI/BrazeBanner/useBrazeBanner.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AppState } from 'react-native';
 import Braze, { Banner } from '@braze/react-native-sdk';
 import { useDispatch, useSelector } from 'react-redux';
+import { v4 as uuidv4 } from 'uuid';
 import {
   dismissBrazeBanner,
   getBannerForPlacement,
@@ -11,6 +12,12 @@ import { setLastDismissedBrazeBanner } from '../../../reducers/banners';
 import { selectLastDismissedBrazeBanner } from '../../../selectors/banner';
 import Logger from '../../../util/Logger';
 import { isProduction } from '../../../util/environment';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../util/trace';
 import { SKELETON_TIMEOUT_MS } from './BrazeBanner.constants';
 import {
   getRawStringOrImageProp,
@@ -113,6 +120,9 @@ export function useBrazeBanner(placementId: string): UseBrazeBannerResult {
   const noResponseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+
+  const brazeTraceIdRef = useRef(uuidv4());
+  const brazeTraceEndedRef = useRef(false);
 
   const clearNoResponseTimeout = useCallback(() => {
     if (noResponseTimeoutRef.current) {
@@ -219,6 +229,26 @@ export function useBrazeBanner(placementId: string): UseBrazeBannerResult {
 
       setBanner(candidate);
       setStatus('visible');
+
+      if (!brazeTraceEndedRef.current) {
+        brazeTraceEndedRef.current = true;
+        const candidateBannerName = getRawStringProp(
+          candidate,
+          PROP_BANNER_NAME,
+        );
+        endTrace({
+          name: TraceName.BrazeBannerTimeToContent,
+          id: brazeTraceIdRef.current,
+          data: {
+            success: true,
+            source,
+            placement_id: placementId,
+            ...(candidateBannerName
+              ? { banner_name: candidateBannerName }
+              : {}),
+          },
+        });
+      }
     },
     [placementId, clearNoResponseTimeout],
   );
@@ -229,6 +259,15 @@ export function useBrazeBanner(placementId: string): UseBrazeBannerResult {
     if (lastDismissedBrazeBannerRef.current !== null) {
       dispatch(setLastDismissedBrazeBanner(null));
     }
+
+    brazeTraceIdRef.current = uuidv4();
+    brazeTraceEndedRef.current = false;
+    trace({
+      name: TraceName.BrazeBannerTimeToContent,
+      op: TraceOperation.BrazeBannerPerformance,
+      id: brazeTraceIdRef.current,
+      tags: { placement_id: placementId },
+    });
 
     // Warm-cache probe: if the SDK already has a banner cached for this
     // placement (e.g. returning user), show it immediately without waiting for
@@ -281,6 +320,19 @@ export function useBrazeBanner(placementId: string): UseBrazeBannerResult {
       if (!dismissedRef.current) {
         initialBannerWindowOpenRef.current = false;
         setStatus((prev) => (prev === 'loading' ? 'empty' : prev));
+
+        if (!brazeTraceEndedRef.current) {
+          brazeTraceEndedRef.current = true;
+          endTrace({
+            name: TraceName.BrazeBannerTimeToContent,
+            id: brazeTraceIdRef.current,
+            data: {
+              success: false,
+              reason: 'timeout',
+              placement_id: placementId,
+            },
+          });
+        }
       }
     }, SKELETON_TIMEOUT_MS);
 
@@ -288,6 +340,19 @@ export function useBrazeBanner(placementId: string): UseBrazeBannerResult {
       subscription.remove();
       appStateSubscription.remove();
       clearNoResponseTimeout();
+
+      if (!brazeTraceEndedRef.current) {
+        brazeTraceEndedRef.current = true;
+        endTrace({
+          name: TraceName.BrazeBannerTimeToContent,
+          id: brazeTraceIdRef.current,
+          data: {
+            success: false,
+            reason: 'unmounted',
+            placement_id: placementId,
+          },
+        });
+      }
     };
   }, [placementId, dispatch, handleBanner, clearNoResponseTimeout]);
 

--- a/app/components/UI/BrazeBanner/useBrazeBanner.ts
+++ b/app/components/UI/BrazeBanner/useBrazeBanner.ts
@@ -121,7 +121,7 @@ export function useBrazeBanner(placementId: string): UseBrazeBannerResult {
     null,
   );
 
-  const brazeTraceIdRef = useRef(uuidv4());
+  const brazeTraceIdRef = useRef<string>('');
   const brazeTraceEndedRef = useRef(false);
 
   const clearNoResponseTimeout = useCallback(() => {

--- a/app/components/UI/BrazeBanner/useBrazeBanner.ts
+++ b/app/components/UI/BrazeBanner/useBrazeBanner.ts
@@ -17,6 +17,7 @@ import {
   trace,
   TraceName,
   TraceOperation,
+  type TraceValue,
 } from '../../../util/trace';
 import { SKELETON_TIMEOUT_MS } from './BrazeBanner.constants';
 import {
@@ -123,7 +124,7 @@ export function useBrazeBanner(placementId: string): UseBrazeBannerResult {
 
   const brazeTraceIdRef = useRef<string>('');
   const brazeTraceEndedRef = useRef(false);
-  const endBrazeTrace = useCallback((data: Record<string, unknown>) => {
+  const endBrazeTrace = useCallback((data: Record<string, TraceValue>) => {
     if (brazeTraceEndedRef.current) return;
     brazeTraceEndedRef.current = true;
     endTrace({
@@ -179,6 +180,14 @@ export function useBrazeBanner(placementId: string): UseBrazeBannerResult {
         currentBannerTrackingIdRef.current = null;
         setBanner(null);
         setStatus('empty');
+        // Content determination is finished: no banner will be shown. Settle
+        // the span now instead of letting it run until unmount.
+        endBrazeTrace({
+          success: false,
+          reason: 'empty',
+          source,
+          placement_id: placementId,
+        });
         return;
       }
 

--- a/app/components/UI/BrazeBanner/useBrazeBanner.ts
+++ b/app/components/UI/BrazeBanner/useBrazeBanner.ts
@@ -122,14 +122,14 @@ export function useBrazeBanner(placementId: string): UseBrazeBannerResult {
     null,
   );
 
-  const brazeTraceIdRef = useRef<string>('');
-  const brazeTraceEndedRef = useRef(false);
+  const brazeTraceIdRef = useRef<string | null>(null);
   const endBrazeTrace = useCallback((data: Record<string, TraceValue>) => {
-    if (brazeTraceEndedRef.current) return;
-    brazeTraceEndedRef.current = true;
+    const id = brazeTraceIdRef.current;
+    if (id === null) return;
+    brazeTraceIdRef.current = null;
     endTrace({
       name: TraceName.BrazeBannerTimeToContent,
-      id: brazeTraceIdRef.current,
+      id,
       data,
     });
   }, []);
@@ -266,12 +266,12 @@ export function useBrazeBanner(placementId: string): UseBrazeBannerResult {
       dispatch(setLastDismissedBrazeBanner(null));
     }
 
-    brazeTraceIdRef.current = uuidv4();
-    brazeTraceEndedRef.current = false;
+    const traceId = uuidv4();
+    brazeTraceIdRef.current = traceId;
     trace({
       name: TraceName.BrazeBannerTimeToContent,
       op: TraceOperation.BrazeBannerPerformance,
-      id: brazeTraceIdRef.current,
+      id: traceId,
       tags: { placement_id: placementId },
     });
 

--- a/app/components/UI/BrazeBanner/useBrazeBanner.ts
+++ b/app/components/UI/BrazeBanner/useBrazeBanner.ts
@@ -123,6 +123,15 @@ export function useBrazeBanner(placementId: string): UseBrazeBannerResult {
 
   const brazeTraceIdRef = useRef<string>('');
   const brazeTraceEndedRef = useRef(false);
+  const endBrazeTrace = useCallback((data: Record<string, unknown>) => {
+    if (brazeTraceEndedRef.current) return;
+    brazeTraceEndedRef.current = true;
+    endTrace({
+      name: TraceName.BrazeBannerTimeToContent,
+      id: brazeTraceIdRef.current,
+      data,
+    });
+  }, []);
 
   const clearNoResponseTimeout = useCallback(() => {
     if (noResponseTimeoutRef.current) {
@@ -230,27 +239,15 @@ export function useBrazeBanner(placementId: string): UseBrazeBannerResult {
       setBanner(candidate);
       setStatus('visible');
 
-      if (!brazeTraceEndedRef.current) {
-        brazeTraceEndedRef.current = true;
-        const candidateBannerName = getRawStringProp(
-          candidate,
-          PROP_BANNER_NAME,
-        );
-        endTrace({
-          name: TraceName.BrazeBannerTimeToContent,
-          id: brazeTraceIdRef.current,
-          data: {
-            success: true,
-            source,
-            placement_id: placementId,
-            ...(candidateBannerName
-              ? { banner_name: candidateBannerName }
-              : {}),
-          },
-        });
-      }
+      const candidateBannerName = getRawStringProp(candidate, PROP_BANNER_NAME);
+      endBrazeTrace({
+        success: true,
+        source,
+        placement_id: placementId,
+        ...(candidateBannerName ? { banner_name: candidateBannerName } : {}),
+      });
     },
-    [placementId, clearNoResponseTimeout],
+    [placementId, clearNoResponseTimeout, endBrazeTrace],
   );
 
   useEffect(() => {
@@ -321,18 +318,11 @@ export function useBrazeBanner(placementId: string): UseBrazeBannerResult {
         initialBannerWindowOpenRef.current = false;
         setStatus((prev) => (prev === 'loading' ? 'empty' : prev));
 
-        if (!brazeTraceEndedRef.current) {
-          brazeTraceEndedRef.current = true;
-          endTrace({
-            name: TraceName.BrazeBannerTimeToContent,
-            id: brazeTraceIdRef.current,
-            data: {
-              success: false,
-              reason: 'timeout',
-              placement_id: placementId,
-            },
-          });
-        }
+        endBrazeTrace({
+          success: false,
+          reason: 'timeout',
+          placement_id: placementId,
+        });
       }
     }, SKELETON_TIMEOUT_MS);
 
@@ -341,20 +331,19 @@ export function useBrazeBanner(placementId: string): UseBrazeBannerResult {
       appStateSubscription.remove();
       clearNoResponseTimeout();
 
-      if (!brazeTraceEndedRef.current) {
-        brazeTraceEndedRef.current = true;
-        endTrace({
-          name: TraceName.BrazeBannerTimeToContent,
-          id: brazeTraceIdRef.current,
-          data: {
-            success: false,
-            reason: 'unmounted',
-            placement_id: placementId,
-          },
-        });
-      }
+      endBrazeTrace({
+        success: false,
+        reason: 'unmounted',
+        placement_id: placementId,
+      });
     };
-  }, [placementId, dispatch, handleBanner, clearNoResponseTimeout]);
+  }, [
+    placementId,
+    dispatch,
+    handleBanner,
+    clearNoResponseTimeout,
+    endBrazeTrace,
+  ]);
 
   const bannerName = banner ? getRawStringProp(banner, PROP_BANNER_NAME) : null;
   const deeplink = banner ? getRawStringProp(banner, PROP_DEEPLINK) : null;

--- a/app/components/Views/Notifications/index.test.tsx
+++ b/app/components/Views/Notifications/index.test.tsx
@@ -24,6 +24,7 @@ import Routes from '../../../constants/navigation/Routes';
 import { strings } from '../../../../locales/i18n';
 import { NotificationsViewSelectorsIDs } from './NotificationsView.testIds';
 import { NotificationMenuViewSelectorsIDs } from './NotificationMenuView.testIds';
+import { useNotificationListPerformance } from '../../../util/notifications/hooks/useNotificationListPerformance';
 
 const navigationMock = {
   navigate: jest.fn(),
@@ -39,6 +40,13 @@ jest.mock('@react-navigation/native', () => ({
 jest.mock('../../hooks/useAnalytics/useAnalytics', () => ({
   useAnalytics: jest.fn(),
 }));
+
+jest.mock(
+  '../../../util/notifications/hooks/useNotificationListPerformance',
+  () => ({
+    useNotificationListPerformance: jest.fn(),
+  }),
+);
 
 const mockMetrics = {
   trackEvent: jest.fn(),
@@ -140,6 +148,29 @@ describe('NotificationsView - content', () => {
     expect(
       getByTestId(NotificationsViewSelectorsIDs.NO_NOTIFICATIONS_CONTAINER),
     ).toBeOnTheScreen();
+  });
+
+  it('reports the deduplicated notification count for performance tracing', () => {
+    const notification = processNotification(createMockNotificationEthSent());
+    const state: DeepPartial<RootState> = {
+      engine: {
+        backgroundState: {
+          ...backgroundState,
+          NotificationServicesController: {
+            isNotificationServicesEnabled: true,
+            metamaskNotificationsList: [notification, notification],
+          },
+        },
+      },
+    };
+
+    renderWithProvider(<NotificationsView navigation={navigationMock} />, {
+      state,
+    });
+
+    expect(jest.mocked(useNotificationListPerformance)).toHaveBeenCalledWith(
+      expect.objectContaining({ notificationCount: 1 }),
+    );
   });
 
   it('shows enable prompt and opens settings when notifications are disabled', () => {

--- a/app/components/Views/Notifications/index.tsx
+++ b/app/components/Views/Notifications/index.tsx
@@ -30,6 +30,7 @@ import {
   useListNotifications,
   useMarkNotificationAsRead,
 } from '../../../util/notifications/hooks/useNotifications';
+import { useNotificationListPerformance } from '../../../util/notifications/hooks/useNotificationListPerformance';
 import { NavigationProp, ParamListBase } from '@react-navigation/native';
 import NotificationsService from '../../../util/notifications/services/NotificationService';
 import { MetaMetricsEvents } from '../../../core/Analytics';
@@ -91,6 +92,12 @@ const NotificationsView = ({
     selectIsMetamaskNotificationsEnabled,
   );
   const notifications = useSelector(getNotificationsList);
+
+  useNotificationListPerformance({
+    isLoading,
+    notificationCount: notifications.length,
+    enabled: isNotificationEnabled,
+  });
 
   const { handleMarkAllAsRead, loading } = useMarkAsReadCallback({
     notifications,

--- a/app/components/Views/Notifications/index.tsx
+++ b/app/components/Views/Notifications/index.tsx
@@ -92,18 +92,17 @@ const NotificationsView = ({
     selectIsMetamaskNotificationsEnabled,
   );
   const notifications = useSelector(getNotificationsList);
+  const { allNotifications } = useNotificationFilters({ notifications });
 
   useNotificationListPerformance({
     isLoading,
-    notificationCount: notifications.length,
+    notificationCount: allNotifications.length,
     enabled: isNotificationEnabled,
   });
 
   const { handleMarkAllAsRead, loading } = useMarkAsReadCallback({
     notifications,
   });
-
-  const { allNotifications } = useNotificationFilters({ notifications });
 
   const unreadCount = useMemo(
     () => allNotifications.filter((n) => !n.isRead).length,

--- a/app/util/notifications/hooks/useNotificationListPerformance.test.ts
+++ b/app/util/notifications/hooks/useNotificationListPerformance.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react-native';
-import { TraceName, TraceOperation } from '../../trace';
+import { endTrace, trace, TraceName, TraceOperation } from '../../trace';
 import { useNotificationListPerformance } from './useNotificationListPerformance';
 
 jest.mock('../../trace', () => ({
@@ -17,8 +17,8 @@ jest.mock('uuid', () => ({
   v4: jest.fn(() => 'test-trace-id'),
 }));
 
-const { trace: mockTrace, endTrace: mockEndTrace } =
-  jest.requireMock('../../trace');
+const mockTrace = jest.mocked(trace);
+const mockEndTrace = jest.mocked(endTrace);
 
 describe('useNotificationListPerformance', () => {
   beforeEach(() => {
@@ -54,6 +54,28 @@ describe('useNotificationListPerformance', () => {
 
     expect(mockTrace).not.toHaveBeenCalled();
     expect(mockEndTrace).not.toHaveBeenCalled();
+  });
+
+  it('reports warm data when tracing is re-enabled after loading finishes', () => {
+    const { rerender } = renderHook(
+      ({ enabled, isLoading }: { enabled: boolean; isLoading: boolean }) =>
+        useNotificationListPerformance({
+          enabled,
+          isLoading,
+          notificationCount: 2,
+        }),
+      { initialProps: { enabled: true, isLoading: true } },
+    );
+    rerender({ enabled: false, isLoading: false });
+    mockEndTrace.mockClear();
+
+    rerender({ enabled: true, isLoading: false });
+
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ source: 'warm' }),
+      }),
+    );
   });
 
   it('ends with source warm when data is already loaded on mount', () => {

--- a/app/util/notifications/hooks/useNotificationListPerformance.test.ts
+++ b/app/util/notifications/hooks/useNotificationListPerformance.test.ts
@@ -1,0 +1,168 @@
+import { renderHook } from '@testing-library/react-native';
+import { TraceName, TraceOperation } from '../../trace';
+import { useNotificationListPerformance } from './useNotificationListPerformance';
+
+jest.mock('../../trace', () => ({
+  trace: jest.fn(),
+  endTrace: jest.fn(),
+  TraceName: {
+    NotificationListTimeToContent: 'Notification List Time To Content',
+  },
+  TraceOperation: {
+    NotificationPerformance: 'notification.performance',
+  },
+}));
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'test-trace-id'),
+}));
+
+const { trace: mockTrace, endTrace: mockEndTrace } =
+  jest.requireMock('../../trace');
+
+describe('useNotificationListPerformance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('starts the trace on mount without ending it while loading', () => {
+    renderHook(() =>
+      useNotificationListPerformance({
+        isLoading: true,
+        notificationCount: 0,
+      }),
+    );
+
+    expect(mockTrace).toHaveBeenCalledTimes(1);
+    expect(mockTrace).toHaveBeenCalledWith({
+      name: TraceName.NotificationListTimeToContent,
+      op: TraceOperation.NotificationPerformance,
+      id: 'test-trace-id',
+    });
+    expect(mockEndTrace).not.toHaveBeenCalled();
+  });
+
+  it('does not trace when disabled', () => {
+    const { unmount } = renderHook(() =>
+      useNotificationListPerformance({
+        isLoading: false,
+        notificationCount: 3,
+        enabled: false,
+      }),
+    );
+    unmount();
+
+    expect(mockTrace).not.toHaveBeenCalled();
+    expect(mockEndTrace).not.toHaveBeenCalled();
+  });
+
+  it('ends with source warm when data is already loaded on mount', () => {
+    renderHook(() =>
+      useNotificationListPerformance({
+        isLoading: false,
+        notificationCount: 5,
+      }),
+    );
+
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: TraceName.NotificationListTimeToContent,
+      id: 'test-trace-id',
+      data: {
+        success: true,
+        source: 'warm',
+        notification_count: 5,
+        content_state: 'filled',
+      },
+    });
+  });
+
+  it('ends with source cold when loading resolves after mount', () => {
+    const { rerender } = renderHook(
+      ({
+        isLoading,
+        notificationCount,
+      }: {
+        isLoading: boolean;
+        notificationCount: number;
+      }) => useNotificationListPerformance({ isLoading, notificationCount }),
+      { initialProps: { isLoading: true, notificationCount: 0 } },
+    );
+
+    expect(mockEndTrace).not.toHaveBeenCalled();
+
+    rerender({ isLoading: false, notificationCount: 2 });
+
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: TraceName.NotificationListTimeToContent,
+      id: 'test-trace-id',
+      data: {
+        success: true,
+        source: 'cold',
+        notification_count: 2,
+        content_state: 'filled',
+      },
+    });
+  });
+
+  it('reports content_state empty when the loaded list has no notifications', () => {
+    renderHook(() =>
+      useNotificationListPerformance({
+        isLoading: false,
+        notificationCount: 0,
+      }),
+    );
+
+    expect(mockEndTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          content_state: 'empty',
+          notification_count: 0,
+        }),
+      }),
+    );
+  });
+
+  it('ends with reason unmounted when loading never resolves', () => {
+    const { rerender, unmount } = renderHook(
+      ({
+        isLoading,
+        notificationCount,
+      }: {
+        isLoading: boolean;
+        notificationCount: number;
+      }) => useNotificationListPerformance({ isLoading, notificationCount }),
+      { initialProps: { isLoading: true, notificationCount: 0 } },
+    );
+
+    // Count updates while still loading; cleanup must read the latest value,
+    // not the one captured when the effect mounted.
+    rerender({ isLoading: true, notificationCount: 4 });
+    unmount();
+
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: TraceName.NotificationListTimeToContent,
+      id: 'test-trace-id',
+      data: {
+        success: false,
+        reason: 'unmounted',
+        notification_count: 4,
+      },
+    });
+  });
+
+  it('does not end again on unmount after the trace already completed', () => {
+    const { unmount } = renderHook(() =>
+      useNotificationListPerformance({
+        isLoading: false,
+        notificationCount: 1,
+      }),
+    );
+
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/util/notifications/hooks/useNotificationListPerformance.ts
+++ b/app/util/notifications/hooks/useNotificationListPerformance.ts
@@ -1,0 +1,89 @@
+import { useEffect, useRef } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { endTrace, trace, TraceName, TraceOperation } from '../../trace';
+
+interface UseNotificationListPerformanceConfig {
+  isLoading: boolean;
+  notificationCount: number;
+  enabled?: boolean;
+}
+
+/**
+ * Measures time to notification list content via Sentry traces.
+ *
+ * Captured metric:
+ * - **Time to Content** — mount until `isLoading` becomes `false` (list renders).
+ *
+ * - `source: 'warm'` when `isLoading` stays `false` from mount (data in Redux).
+ * - `source: 'cold'` when `isLoading` goes `true → false` at any point (API fetch needed).
+ */
+export function useNotificationListPerformance({
+  isLoading,
+  notificationCount,
+  enabled = true,
+}: UseNotificationListPerformanceConfig) {
+  const ttcTraceId = useRef(uuidv4());
+  const ttcStarted = useRef(false);
+  const ttcEnded = useRef(false);
+  const prevIsLoading = useRef<boolean | undefined>(undefined);
+  const sawFetchRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    ttcTraceId.current = uuidv4();
+    ttcEnded.current = false;
+    sawFetchRef.current = false;
+
+    trace({
+      name: TraceName.NotificationListTimeToContent,
+      op: TraceOperation.NotificationPerformance,
+      id: ttcTraceId.current,
+    });
+    ttcStarted.current = true;
+
+    return () => {
+      if (ttcStarted.current && !ttcEnded.current) {
+        endTrace({
+          name: TraceName.NotificationListTimeToContent,
+          id: ttcTraceId.current,
+          data: {
+            success: false,
+            reason: 'unmounted',
+            notification_count: notificationCount,
+          },
+        });
+        ttcStarted.current = false;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const wasLoading = prevIsLoading.current;
+    prevIsLoading.current = isLoading;
+
+    if (wasLoading === true && !isLoading) {
+      sawFetchRef.current = true;
+    }
+
+    if (!isLoading && ttcStarted.current && !ttcEnded.current) {
+      const source =
+        sawFetchRef.current || wasLoading === true ? 'cold' : 'warm';
+
+      endTrace({
+        name: TraceName.NotificationListTimeToContent,
+        id: ttcTraceId.current,
+        data: {
+          success: true,
+          source,
+          notification_count: notificationCount,
+          content_state: notificationCount > 0 ? 'filled' : 'empty',
+        },
+      });
+      ttcEnded.current = true;
+    }
+  }, [enabled, isLoading, notificationCount]);
+}

--- a/app/util/notifications/hooks/useNotificationListPerformance.ts
+++ b/app/util/notifications/hooks/useNotificationListPerformance.ts
@@ -8,25 +8,19 @@ interface UseNotificationListPerformanceConfig {
   enabled?: boolean;
 }
 
-/**
- * Measures time to notification list content via Sentry traces.
- *
- * Captured metric:
- * - **Time to Content** — mount until `isLoading` becomes `false` (list renders).
- *
- * - `source: 'warm'` when `isLoading` stays `false` from mount (data in Redux).
- * - `source: 'cold'` when `isLoading` goes `true → false` at any point (API fetch needed).
- */
+/** Time-to-content trace for the notification list. `source: warm` = data in Redux on mount; `source: cold` = API fetch needed. */
 export function useNotificationListPerformance({
   isLoading,
   notificationCount,
   enabled = true,
 }: UseNotificationListPerformanceConfig) {
-  const ttcTraceId = useRef(uuidv4());
+  const ttcTraceId = useRef('');
   const ttcStarted = useRef(false);
   const ttcEnded = useRef(false);
   const prevIsLoading = useRef<boolean | undefined>(undefined);
   const sawFetchRef = useRef(false);
+  const latestCountRef = useRef(notificationCount);
+  latestCountRef.current = notificationCount;
 
   useEffect(() => {
     if (!enabled) return;
@@ -50,13 +44,12 @@ export function useNotificationListPerformance({
           data: {
             success: false,
             reason: 'unmounted',
-            notification_count: notificationCount,
+            notification_count: latestCountRef.current,
           },
         });
         ttcStarted.current = false;
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled]);
 
   useEffect(() => {

--- a/app/util/notifications/hooks/useNotificationListPerformance.ts
+++ b/app/util/notifications/hooks/useNotificationListPerformance.ts
@@ -23,6 +23,7 @@ export function useNotificationListPerformance({
   useEffect(() => {
     if (!enabled) return;
 
+    prevIsLoading.current = undefined;
     ttcTraceId.current = uuidv4();
     trace({
       name: TraceName.NotificationListTimeToContent,

--- a/app/util/notifications/hooks/useNotificationListPerformance.ts
+++ b/app/util/notifications/hooks/useNotificationListPerformance.ts
@@ -14,11 +14,9 @@ export function useNotificationListPerformance({
   notificationCount,
   enabled = true,
 }: UseNotificationListPerformanceConfig) {
-  const ttcTraceId = useRef('');
-  const ttcStarted = useRef(false);
-  const ttcEnded = useRef(false);
+  // Non-null = trace active; cleared on end to serve as the "active" sentinel.
+  const ttcTraceId = useRef<string | null>(null);
   const prevIsLoading = useRef<boolean | undefined>(undefined);
-  const sawFetchRef = useRef(false);
   const latestCountRef = useRef(notificationCount);
   latestCountRef.current = notificationCount;
 
@@ -26,29 +24,24 @@ export function useNotificationListPerformance({
     if (!enabled) return;
 
     ttcTraceId.current = uuidv4();
-    ttcEnded.current = false;
-    sawFetchRef.current = false;
-
     trace({
       name: TraceName.NotificationListTimeToContent,
       op: TraceOperation.NotificationPerformance,
       id: ttcTraceId.current,
     });
-    ttcStarted.current = true;
 
     return () => {
-      if (ttcStarted.current && !ttcEnded.current) {
-        endTrace({
-          name: TraceName.NotificationListTimeToContent,
-          id: ttcTraceId.current,
-          data: {
-            success: false,
-            reason: 'unmounted',
-            notification_count: latestCountRef.current,
-          },
-        });
-        ttcStarted.current = false;
-      }
+      if (!ttcTraceId.current) return;
+      endTrace({
+        name: TraceName.NotificationListTimeToContent,
+        id: ttcTraceId.current,
+        data: {
+          success: false,
+          reason: 'unmounted',
+          notification_count: latestCountRef.current,
+        },
+      });
+      ttcTraceId.current = null;
     };
   }, [enabled]);
 
@@ -58,25 +51,19 @@ export function useNotificationListPerformance({
     const wasLoading = prevIsLoading.current;
     prevIsLoading.current = isLoading;
 
-    if (wasLoading === true && !isLoading) {
-      sawFetchRef.current = true;
-    }
-
-    if (!isLoading && ttcStarted.current && !ttcEnded.current) {
-      const source =
-        sawFetchRef.current || wasLoading === true ? 'cold' : 'warm';
-
+    if (!isLoading && ttcTraceId.current) {
+      const id = ttcTraceId.current;
+      ttcTraceId.current = null;
       endTrace({
         name: TraceName.NotificationListTimeToContent,
-        id: ttcTraceId.current,
+        id,
         data: {
           success: true,
-          source,
+          source: wasLoading === true ? 'cold' : 'warm',
           notification_count: notificationCount,
           content_state: notificationCount > 0 ? 'filled' : 'empty',
         },
       });
-      ttcEnded.current = true;
     }
   }, [enabled, isLoading, notificationCount]);
 }

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -300,6 +300,9 @@ export enum TraceName {
   // Rewards
   /** Tap Rewards tab → onboarding content or enrolled dashboard shell. */
   RewardsTabTimeToContent = 'Rewards Tab Time To Content',
+  // Notifications & Braze Performance
+  NotificationListTimeToContent = 'Notification List Time To Content',
+  BrazeBannerTimeToContent = 'Braze Banner Time To Content',
 }
 
 export enum TraceOperation {
@@ -374,6 +377,9 @@ export enum TraceOperation {
   MoneyAccountDataFetch = 'money.account.data_fetch',
   // Rewards
   RewardsPerformance = 'rewards.performance',
+  // Notifications & Braze Performance
+  NotificationPerformance = 'notification.performance',
+  BrazeBannerPerformance = 'braze_banner.performance',
   RampOperation = 'ramp.operation',
   /** Token overview OHLCV WebView: initial load or asset/currency change */
   TokenOverviewAdvancedChart = 'token_overview.advanced_chart',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

Stacked on `feat/deeplink-perf-processed-navigated`. Adds Sentry performance spans for two user-perceived flows in the notifications and Braze surface.

**Notification List Time To Content** (`useNotificationListPerformance`):
- New hook mounted in `NotificationsView`; starts a UUID-keyed span on mount and ends it on the first `isLoading → false` transition.
- Tags `source: warm` (data already in Redux on mount) vs `source: cold` (API fetch needed), plus `notification_count` and `content_state: filled | empty`.
- Cleanup path records `reason: unmounted` if loading never resolved.

**Braze Banner Time To Content** (`useBrazeBanner`):
- Starts a UUID-keyed span on effect mount; ends on banner accepted (`success: true`, `source`, optional `banner_name`), empty determination for a control-group or mismatched-placement banner (`reason: empty`), SDK timeout (`reason: timeout`), or unmount (`reason: unmounted`).
- `endBrazeTrace` helper with an idempotent `brazeTraceEndedRef` guard prevents double-end across the four settlement paths.

Also fixes a stale-closure bug in the cleanup of `useNotificationListPerformance` (notification count was captured at effect-mount time; now read via a ref updated every render).

**Reading the notification `source` tag honestly:** `cold` only appears when the fetch is still in flight at mount. In practice the startup fetch usually completes before the user reaches the Notifications screen, so real-world spans skew heavily `warm`; treat `cold` as a rare lower-bound signal, not a first-class segment.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: no GitHub issue — Sentry instrumentation only, stacked on #35010
Refs: #34486

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

UI is unchanged — verify via Sentry performance dashboard or local debug logs.

```gherkin
Feature: Notification list performance trace

  Scenario: user opens Notifications with cached data (warm path)
    Given notifications are enabled and data is already in Redux
    When user navigates to the Notifications screen
    Then Sentry shows a "Notification List Time To Content" span
    And the span has success: true, source: warm, and a notification_count tag

  Scenario: user opens Notifications requiring a fetch (cold path)
    Given notifications are enabled and no cached data exists
    When user navigates to the Notifications screen
    Then the span has success: true and source: cold

  Scenario: user leaves Notifications before load completes
    Given the notification list is still loading
    When user navigates away
    Then the span has success: false and reason: unmounted

Feature: Braze banner performance trace

  Scenario: a banner is served within the timeout window
    Given an active Braze campaign targets the home placement
    When user opens the home screen
    Then Sentry shows a "Braze Banner Time To Content" span with success: true
    And the span includes banner_name and source (warm-cache or event)

  Scenario: no banner arrives within SKELETON_TIMEOUT_MS
    Given no Braze banner is available for the placement
    When the skeleton timeout fires
    Then the span has success: false and reason: timeout
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — no user-visible UI changes. Spans are observable in the Sentry performance dashboard.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes around existing load paths; no auth, payments, or user-visible behavior changes.
> 
> **Overview**
> Adds **Sentry performance instrumentation** for two flows without changing UI: the notification list and Braze home banners.
> 
> **Notification list:** New `useNotificationListPerformance` hook is wired into `NotificationsView`. It opens a UUID-keyed **Notification List Time To Content** span when notifications are enabled, closes it on the first `isLoading → false` with `source: warm | cold`, `notification_count`, and `content_state: filled | empty`, or on unmount with `reason: unmounted`. The view passes the **deduplicated** filtered list length. Unmount cleanup reads the latest count via a ref.
> 
> **Braze banner:** `useBrazeBanner` now traces **Braze Banner Time To Content** from mount (tagged with `placement_id`) through settlement: banner accepted (`success: true`, `source: event | warm-cache`, optional `banner_name`), control/mismatch empty (`reason: empty`), skeleton timeout (`reason: timeout`), or unmount (`reason: unmounted`). An idempotent `endBrazeTrace` helper avoids double-ending.
> 
> `TraceName` / `TraceOperation` in `trace.ts` gain the new span names and ops. Unit tests cover both hooks and the notifications view integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6bcdf30c71b2903687c82851e35c2add5ac61dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

