### PR TITLE
feat(perps): add button to Cancel All open orders

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -312,6 +312,14 @@ export const PerpsCloseAllPositionsViewSelectorsIDs = {
   CLOSE_ALL_BUTTON: 'perps-close-all-positions-close-all-button',
 } as const;
 
+export const PerpsCancelAllOrdersViewSelectorsIDs = {
+  SHEET: 'perps-cancel-all-orders-sheet',
+  TITLE: 'perps-cancel-all-orders-title',
+  DESCRIPTION: 'perps-cancel-all-orders-description',
+  KEEP_BUTTON: 'perps-cancel-all-orders-keep-button',
+  CANCEL_ALL_BUTTON: 'perps-cancel-all-orders-cancel-all-button',
+} as const;
+
 export const PerpsPositionDetailsViewSelectorsIDs = {
   CANDLESTICK_CHART: 'candlestick-chart',
   TRADINGVIEW_CHART: 'tradingview-chart',
@@ -522,6 +530,8 @@ export const PerpsProMarketViewSelectorsIDs = {
   POSITION_EDIT_MARGIN: 'perps-pro-market-position-edit-margin',
   POSITION_ROW: 'perps-pro-market-position-row',
   ORDERS_LIST: 'perps-pro-market-orders-list',
+  ORDERS_SUMMARY: 'perps-pro-market-orders-summary',
+  ORDERS_CANCEL_ALL: 'perps-pro-market-orders-cancel-all',
   ORDER_CANCEL: 'perps-pro-market-order-cancel',
   ORDER_EDIT: 'perps-pro-market-order-edit',
   ORDER_PRICE_EDIT: 'perps-pro-market-order-price-edit',

--- a/app/components/UI/Perps/Views/PerpsActiveTraderFlow.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsActiveTraderFlow.view.test.tsx
@@ -396,7 +396,11 @@ describe('Active Trader Flow', () => {
     });
     expect(await screen.findByText(CANCEL_ALL_TITLE)).toBeOnTheScreen();
     expect(
-      screen.getByText(strings('perps.cancel_all_modal.description')),
+      screen.getByText(
+        strings('perps.cancel_all_modal.description', {
+          count: multipleOrders.length,
+        }),
+      ),
     ).toBeOnTheScreen();
     expect(
       screen.getByText(strings('perps.cancel_all_modal.keep_orders')),

--- a/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.tsx
+++ b/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.tsx
@@ -36,7 +36,7 @@ interface PerpsCancelAllOrdersViewProps {
   onClose?: () => void;
   /** When provided, only these orders are described and cancelled. */
   orders?: Order[];
-  /** Drops "all" from the copy, which would misdescribe a filtered subset. */
+  /** Scopes cancellation to `orders` instead of the whole book. */
   isFiltered?: boolean;
 }
 
@@ -159,27 +159,22 @@ const PerpsCancelAllOrdersView: React.FC<PerpsCancelAllOrdersViewProps> = ({
 
   const primaryButtonProps = useMemo(
     () => ({
-      children: isFiltered
-        ? strings('perps.cancel_all_modal.cancel_count', { count: orderCount })
-        : strings('perps.cancel_all_modal.confirm'),
+      children: strings('perps.cancel_all_modal.confirm'),
       onPress: handleCancelAll,
       size: ButtonSize.Lg,
-      isDanger: true,
       isLoading: isCanceling,
       isDisabled: isCanceling,
       testID: PerpsCancelAllOrdersViewSelectorsIDs.CANCEL_ALL_BUTTON,
     }),
-    [handleCancelAll, isCanceling, isFiltered, orderCount],
+    [handleCancelAll, isCanceling],
   );
 
-  const title = isFiltered
-    ? strings('perps.cancel_all_modal.title_filtered')
-    : strings('perps.cancel_all_modal.title');
-  const description = isFiltered
-    ? strings('perps.cancel_all_modal.description_filtered', {
-        count: orderCount,
-      })
-    : strings('perps.cancel_all_modal.description');
+  // One title and one count-based body in both states: the count already names
+  // the scope, so the copy does not branch on the filter.
+  const title = strings('perps.cancel_all_modal.title');
+  const description = strings('perps.cancel_all_modal.description', {
+    count: orderCount,
+  });
 
   return (
     <BottomSheet

--- a/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.tsx
+++ b/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.tsx
@@ -23,7 +23,9 @@ import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
   type CancelOrdersResult,
+  type Order,
 } from '@metamask/perps-controller';
+import { PerpsCancelAllOrdersViewSelectorsIDs } from '../../Perps.testIds';
 import {
   resolveCancelAllErrorMessage,
   resolveCancelAllSuccessFeedback,
@@ -32,23 +34,33 @@ import {
 interface PerpsCancelAllOrdersViewProps {
   sheetRef?: React.RefObject<BottomSheetRef | null>;
   onClose?: () => void;
+  /** When provided, only these orders are described and cancelled. */
+  orders?: Order[];
+  /** Drops "all" from the copy, which would misdescribe a filtered subset. */
+  isFiltered?: boolean;
 }
 
 const PerpsCancelAllOrdersView: React.FC<PerpsCancelAllOrdersViewProps> = ({
   sheetRef: externalSheetRef,
   onClose: onExternalClose,
+  orders: propOrders,
+  isFiltered = false,
 }) => {
   const navigation = useNavigation<AppNavigationProp>();
   const internalSheetRef = useRef<BottomSheetRef>(null);
   const sheetRef = externalSheetRef || internalSheetRef;
   const { showToast, PerpsToastOptions } = usePerpsToasts();
 
-  const { orders } = usePerpsLiveOrders({
+  // The live stream is the fallback for call sites that do not scope the sheet
+  // themselves (the Lite home screen); a Pro panel passes its filtered list in.
+  const { orders: liveOrders } = usePerpsLiveOrders({
     throttleMs: 1000,
     hideTpSl: true,
   });
+  const orders = propOrders ?? liveOrders;
 
-  const hasOrders = Boolean(orders?.length);
+  const orderCount = orders?.length ?? 0;
+  const hasOrders = orderCount > 0;
 
   usePerpsEventTracking({
     eventName: MetaMetricsEvents.PERPS_SCREEN_VIEWED,
@@ -56,7 +68,7 @@ const PerpsCancelAllOrdersView: React.FC<PerpsCancelAllOrdersViewProps> = ({
     properties: {
       [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
         PERPS_EVENT_VALUE.SCREEN_TYPE.CANCEL_ALL_ORDERS,
-      [PERPS_EVENT_PROPERTY.OPEN_POSITION]: orders?.length || 0,
+      [PERPS_EVENT_PROPERTY.OPEN_POSITION]: orderCount,
       [PERPS_EVENT_PROPERTY.SOURCE]:
         PERPS_EVENT_VALUE.SOURCE.CANCEL_ALL_ORDERS_BUTTON,
     },
@@ -115,6 +127,7 @@ const PerpsCancelAllOrdersView: React.FC<PerpsCancelAllOrdersViewProps> = ({
       onSuccess: handleSuccess,
       onError: handleError,
       navigateBackOnSuccess: !externalSheetRef,
+      isFiltered,
     });
 
   const handleClose = useCallback(() => {
@@ -139,40 +152,57 @@ const PerpsCancelAllOrdersView: React.FC<PerpsCancelAllOrdersViewProps> = ({
       onPress: handleKeepButtonPress,
       size: ButtonSize.Lg,
       isDisabled: isCanceling,
+      testID: PerpsCancelAllOrdersViewSelectorsIDs.KEEP_BUTTON,
     }),
     [handleKeepButtonPress, isCanceling],
   );
 
   const primaryButtonProps = useMemo(
     () => ({
-      children: strings('perps.cancel_all_modal.confirm'),
+      children: isFiltered
+        ? strings('perps.cancel_all_modal.cancel_count', { count: orderCount })
+        : strings('perps.cancel_all_modal.confirm'),
       onPress: handleCancelAll,
       size: ButtonSize.Lg,
       isDanger: true,
       isLoading: isCanceling,
       isDisabled: isCanceling,
+      testID: PerpsCancelAllOrdersViewSelectorsIDs.CANCEL_ALL_BUTTON,
     }),
-    [handleCancelAll, isCanceling],
+    [handleCancelAll, isCanceling, isFiltered, orderCount],
   );
+
+  const title = isFiltered
+    ? strings('perps.cancel_all_modal.title_filtered')
+    : strings('perps.cancel_all_modal.title');
+  const description = isFiltered
+    ? strings('perps.cancel_all_modal.description_filtered', {
+        count: orderCount,
+      })
+    : strings('perps.cancel_all_modal.description');
 
   return (
     <BottomSheet
       ref={sheetRef}
       goBack={!externalSheetRef ? () => navigation.goBack() : undefined}
       onClose={externalSheetRef ? onExternalClose : undefined}
+      testID={PerpsCancelAllOrdersViewSelectorsIDs.SHEET}
     >
       <BottomSheetHeader
         onClose={handleClose}
         closeButtonProps={{ testID: 'header-close' }}
+        testID={PerpsCancelAllOrdersViewSelectorsIDs.TITLE}
       >
-        {strings('perps.cancel_all_modal.title')}
+        {title}
       </BottomSheetHeader>
 
       <Box paddingHorizontal={4}>
-        <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
-          {hasOrders
-            ? strings('perps.cancel_all_modal.description')
-            : strings('perps.order.no_orders')}
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          testID={PerpsCancelAllOrdersViewSelectorsIDs.DESCRIPTION}
+        >
+          {hasOrders ? description : strings('perps.order.no_orders')}
         </Text>
       </Box>
 

--- a/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.view.test.tsx
@@ -7,7 +7,7 @@
 import '../../../../../../tests/component-view/mocks';
 
 import React, { useRef } from 'react';
-import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react-native';
 import type { BottomSheetRef } from '@metamask/design-system-react-native';
 import type { Order } from '@metamask/perps-controller';
 import Engine from '../../../../../core/Engine';
@@ -394,11 +394,15 @@ describe('PerpsCancelAllOrdersView', () => {
       screen.queryByText(strings('perps.cancel_all_modal.description')),
     ).not.toBeOnTheScreen();
 
-    fireEvent.press(
-      screen.getByTestId(
-        PerpsCancelAllOrdersViewSelectorsIDs.CANCEL_ALL_BUTTON,
-      ),
-    );
+    // Cancelling is async and toggles isCanceling on both sides of the await,
+    // so let those updates settle before asserting and tearing down.
+    await act(async () => {
+      fireEvent.press(
+        screen.getByTestId(
+          PerpsCancelAllOrdersViewSelectorsIDs.CANCEL_ALL_BUTTON,
+        ),
+      );
+    });
 
     await waitFor(() => {
       expect(cancelOrders).toHaveBeenCalledWith({

--- a/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.view.test.tsx
@@ -19,6 +19,7 @@ import {
   renderPerpsCancelAllOrdersView,
   renderPerpsView,
 } from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
+import { PerpsCancelAllOrdersViewSelectorsIDs } from '../../Perps.testIds';
 import PerpsCancelAllOrdersView from './PerpsCancelAllOrdersView';
 
 const orders: Order[] = [
@@ -347,5 +348,120 @@ describe('PerpsCancelAllOrdersView', () => {
       ).toBeEnabled();
     });
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('names the filtered scope and cancels only the passed orders', async () => {
+    const cancelOrders = Engine.context.PerpsController
+      .cancelOrders as jest.Mock;
+    cancelOrders.mockResolvedValue({
+      success: true,
+      successCount: 1,
+      failureCount: 0,
+      results: [],
+    });
+    const ethOnly = [orders[0]];
+
+    const FilteredCancelAll = () => {
+      const sheetRef = useRef<BottomSheetRef | null>(null);
+      return (
+        <PerpsCancelAllOrdersView
+          sheetRef={sheetRef}
+          onClose={jest.fn()}
+          orders={ethOnly}
+          isFiltered
+        />
+      );
+    };
+
+    renderPerpsView(
+      FilteredCancelAll as unknown as React.ComponentType,
+      Routes.PERPS.MODALS.CANCEL_ALL_ORDERS,
+      { streamOverrides: { orders } },
+    );
+
+    expect(
+      await screen.findByText(strings('perps.cancel_all_modal.title_filtered')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(
+        strings('perps.cancel_all_modal.description_filtered', { count: 1 }),
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      screen.queryByText(strings('perps.cancel_all_modal.title')),
+    ).not.toBeOnTheScreen();
+    expect(
+      screen.queryByText(strings('perps.cancel_all_modal.description')),
+    ).not.toBeOnTheScreen();
+
+    fireEvent.press(
+      screen.getByTestId(
+        PerpsCancelAllOrdersViewSelectorsIDs.CANCEL_ALL_BUTTON,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(cancelOrders).toHaveBeenCalledWith({
+        orderIds: [orders[0].orderId],
+      });
+    });
+  });
+
+  it('counts the filtered orders on the confirm button', async () => {
+    const FilteredCancelAll = () => {
+      const sheetRef = useRef<BottomSheetRef | null>(null);
+      return (
+        <PerpsCancelAllOrdersView
+          sheetRef={sheetRef}
+          onClose={jest.fn()}
+          orders={orders}
+          isFiltered
+        />
+      );
+    };
+
+    renderPerpsView(
+      FilteredCancelAll as unknown as React.ComponentType,
+      Routes.PERPS.MODALS.CANCEL_ALL_ORDERS,
+      { streamOverrides: { orders } },
+    );
+
+    expect(
+      await screen.findByText(
+        strings('perps.cancel_all_modal.cancel_count', { count: 2 }),
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      screen.queryByText(strings('perps.cancel_all_modal.confirm')),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('describes the whole book when no filter is applied', async () => {
+    const UnfilteredCancelAll = () => {
+      const sheetRef = useRef<BottomSheetRef | null>(null);
+      return (
+        <PerpsCancelAllOrdersView
+          sheetRef={sheetRef}
+          onClose={jest.fn()}
+          orders={orders}
+        />
+      );
+    };
+
+    renderPerpsView(
+      UnfilteredCancelAll as unknown as React.ComponentType,
+      Routes.PERPS.MODALS.CANCEL_ALL_ORDERS,
+      { streamOverrides: { orders } },
+    );
+
+    expect(
+      await screen.findByText(strings('perps.cancel_all_modal.title')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(strings('perps.cancel_all_modal.description')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(strings('perps.cancel_all_modal.confirm')),
+    ).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.view.test.tsx
@@ -350,34 +350,28 @@ describe('PerpsCancelAllOrdersView', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it('names the filtered scope and cancels only the passed orders', async () => {
-    const cancelOrders = Engine.context.PerpsController
-      .cancelOrders as jest.Mock;
-    cancelOrders.mockResolvedValue({
-      success: true,
-      successCount: 1,
-      failureCount: 0,
-      results: [],
-    });
-    const ethOnly = [orders[0]];
-
+  const renderFilteredCancelAll = (filtered: Order[]) => {
     const FilteredCancelAll = () => {
       const sheetRef = useRef<BottomSheetRef | null>(null);
       return (
         <PerpsCancelAllOrdersView
           sheetRef={sheetRef}
           onClose={jest.fn()}
-          orders={ethOnly}
+          orders={filtered}
           isFiltered
         />
       );
     };
 
-    renderPerpsView(
+    return renderPerpsView(
       FilteredCancelAll as unknown as React.ComponentType,
       Routes.PERPS.MODALS.CANCEL_ALL_ORDERS,
       { streamOverrides: { orders } },
     );
+  };
+
+  it('names the filtered scope in the confirmation copy', async () => {
+    renderFilteredCancelAll([orders[0]]);
 
     expect(
       await screen.findByText(strings('perps.cancel_all_modal.title_filtered')),
@@ -393,11 +387,29 @@ describe('PerpsCancelAllOrdersView', () => {
     expect(
       screen.queryByText(strings('perps.cancel_all_modal.description')),
     ).not.toBeOnTheScreen();
+  });
 
-    // Cancelling is async and toggles isCanceling on both sides of the await,
-    // so let those updates settle before asserting and tearing down.
+  it('cancels only the passed orders when filtered', async () => {
+    const cancelOrders = Engine.context.PerpsController
+      .cancelOrders as jest.Mock;
+    cancelOrders.mockResolvedValue({
+      success: true,
+      successCount: 1,
+      failureCount: 0,
+      results: [],
+    });
+
+    renderFilteredCancelAll([orders[0]]);
+
+    await screen.findByTestId(
+      PerpsCancelAllOrdersViewSelectorsIDs.CANCEL_ALL_BUTTON,
+    );
+
+    // Cancelling is async and toggles isCanceling on both sides of the await.
+    // Await the press itself, not just the act() wrapper, so the handler and its
+    // final loading-state update are joined to the test boundary.
     await act(async () => {
-      fireEvent.press(
+      await fireEvent.press(
         screen.getByTestId(
           PerpsCancelAllOrdersViewSelectorsIDs.CANCEL_ALL_BUTTON,
         ),

--- a/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView.view.test.tsx
@@ -57,7 +57,9 @@ describe('PerpsCancelAllOrdersView', () => {
       await screen.findByText(strings('perps.cancel_all_modal.title')),
     ).toBeOnTheScreen();
     expect(
-      screen.getByText(strings('perps.cancel_all_modal.description')),
+      screen.getByText(
+        strings('perps.cancel_all_modal.description', { count: 2 }),
+      ),
     ).toBeOnTheScreen();
 
     fireEvent.press(
@@ -131,7 +133,9 @@ describe('PerpsCancelAllOrdersView', () => {
     );
 
     expect(
-      screen.getByText(strings('perps.cancel_all_modal.description')),
+      screen.getByText(
+        strings('perps.cancel_all_modal.description', { count: 2 }),
+      ),
     ).toBeOnTheScreen();
     expect(
       screen.getByText(strings('perps.cancel_all_modal.confirm')),
@@ -370,22 +374,21 @@ describe('PerpsCancelAllOrdersView', () => {
     );
   };
 
-  it('names the filtered scope in the confirmation copy', async () => {
+  it('counts only the passed orders in the confirmation copy', async () => {
     renderFilteredCancelAll([orders[0]]);
 
     expect(
-      await screen.findByText(strings('perps.cancel_all_modal.title_filtered')),
+      await screen.findByText(strings('perps.cancel_all_modal.title')),
     ).toBeOnTheScreen();
     expect(
       screen.getByText(
-        strings('perps.cancel_all_modal.description_filtered', { count: 1 }),
+        strings('perps.cancel_all_modal.description', { count: 1 }),
       ),
     ).toBeOnTheScreen();
     expect(
-      screen.queryByText(strings('perps.cancel_all_modal.title')),
-    ).not.toBeOnTheScreen();
-    expect(
-      screen.queryByText(strings('perps.cancel_all_modal.description')),
+      screen.queryByText(
+        strings('perps.cancel_all_modal.description', { count: 2 }),
+      ),
     ).not.toBeOnTheScreen();
   });
 
@@ -423,7 +426,7 @@ describe('PerpsCancelAllOrdersView', () => {
     });
   });
 
-  it('counts the filtered orders on the confirm button', async () => {
+  it('keeps the confirm label fixed while the body carries the count', async () => {
     const FilteredCancelAll = () => {
       const sheetRef = useRef<BottomSheetRef | null>(null);
       return (
@@ -443,13 +446,13 @@ describe('PerpsCancelAllOrdersView', () => {
     );
 
     expect(
-      await screen.findByText(
-        strings('perps.cancel_all_modal.cancel_count', { count: 2 }),
-      ),
+      await screen.findByText(strings('perps.cancel_all_modal.confirm')),
     ).toBeOnTheScreen();
     expect(
-      screen.queryByText(strings('perps.cancel_all_modal.confirm')),
-    ).not.toBeOnTheScreen();
+      screen.getByText(
+        strings('perps.cancel_all_modal.description', { count: 2 }),
+      ),
+    ).toBeOnTheScreen();
   });
 
   it('describes the whole book when no filter is applied', async () => {
@@ -474,7 +477,9 @@ describe('PerpsCancelAllOrdersView', () => {
       await screen.findByText(strings('perps.cancel_all_modal.title')),
     ).toBeOnTheScreen();
     expect(
-      screen.getByText(strings('perps.cancel_all_modal.description')),
+      screen.getByText(
+        strings('perps.cancel_all_modal.description', { count: 2 }),
+      ),
     ).toBeOnTheScreen();
     expect(
       screen.getByText(strings('perps.cancel_all_modal.confirm')),

--- a/app/components/UI/Perps/Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView.view.test.tsx
@@ -4,14 +4,19 @@
  */
 import '../../../../../../tests/component-view/mocks';
 
+import React, { useRef } from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react-native';
+import type { BottomSheetRef } from '@metamask/design-system-react-native';
 import type { Position } from '@metamask/perps-controller';
 import Engine from '../../../../../core/Engine';
 import { strings } from '../../../../../../locales/i18n';
+import Routes from '../../../../../constants/navigation/Routes';
 import {
   defaultPositionForViews,
   renderPerpsCloseAllPositionsView,
+  renderPerpsView,
 } from '../../../../../../tests/component-view/renderers/perpsViewRenderer';
+import PerpsCloseAllPositionsView from './PerpsCloseAllPositionsView';
 
 const positions: Position[] = [
   defaultPositionForViews,
@@ -103,5 +108,44 @@ describe('PerpsCloseAllPositionsView', () => {
       ),
     ).not.toBeOnTheScreen();
     expect(closePositions).not.toHaveBeenCalled();
+  });
+
+  it('names the filtered scope and counts only the passed positions', async () => {
+    const ethOnly = [positions[0]];
+
+    const FilteredCloseAll = () => {
+      const sheetRef = useRef<BottomSheetRef | null>(null);
+      return (
+        <PerpsCloseAllPositionsView
+          sheetRef={sheetRef}
+          onClose={jest.fn()}
+          positions={ethOnly}
+          isFiltered
+        />
+      );
+    };
+
+    renderPerpsView(
+      FilteredCloseAll as unknown as React.ComponentType,
+      Routes.PERPS.MODALS.CLOSE_ALL_POSITIONS,
+      { streamOverrides: { positions } },
+    );
+
+    expect(
+      await screen.findByText(strings('perps.close_all_modal.title_filtered')),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(
+        strings('perps.close_all_modal.description', { count: 1 }),
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      screen.queryByText(strings('perps.close_all_modal.title')),
+    ).not.toBeOnTheScreen();
+    expect(
+      screen.getByText(
+        strings('perps.close_all_modal.close_count', { count: 1 }),
+      ),
+    ).toBeOnTheScreen();
   });
 });

--- a/app/components/UI/Perps/Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView.view.test.tsx
@@ -110,38 +110,45 @@ describe('PerpsCloseAllPositionsView', () => {
     expect(closePositions).not.toHaveBeenCalled();
   });
 
-  it('names the filtered scope and counts only the passed positions', async () => {
-    const ethOnly = [positions[0]];
-
+  const renderFilteredCloseAll = (filtered: Position[]) => {
     const FilteredCloseAll = () => {
       const sheetRef = useRef<BottomSheetRef | null>(null);
       return (
         <PerpsCloseAllPositionsView
           sheetRef={sheetRef}
           onClose={jest.fn()}
-          positions={ethOnly}
+          positions={filtered}
           isFiltered
         />
       );
     };
 
-    renderPerpsView(
+    return renderPerpsView(
       FilteredCloseAll as unknown as React.ComponentType,
       Routes.PERPS.MODALS.CLOSE_ALL_POSITIONS,
       { streamOverrides: { positions } },
     );
+  };
+
+  it('names the filtered scope in the sheet title', async () => {
+    renderFilteredCloseAll([positions[0]]);
 
     expect(
       await screen.findByText(strings('perps.close_all_modal.title_filtered')),
     ).toBeOnTheScreen();
     expect(
-      screen.getByText(
+      screen.queryByText(strings('perps.close_all_modal.title')),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('counts only the passed positions', async () => {
+    renderFilteredCloseAll([positions[0]]);
+
+    expect(
+      await screen.findByText(
         strings('perps.close_all_modal.description', { count: 1 }),
       ),
     ).toBeOnTheScreen();
-    expect(
-      screen.queryByText(strings('perps.close_all_modal.title')),
-    ).not.toBeOnTheScreen();
     expect(
       screen.getByText(
         strings('perps.close_all_modal.close_count', { count: 1 }),

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrdersSummary.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrdersSummary.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import React from 'react';
+import { strings } from '../../../../../../../locales/i18n';
+import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
+import PerpsProOrdersSummary from './PerpsProOrdersSummary';
+
+describe('PerpsProOrdersSummary', () => {
+  it('renders the open order count and an unscoped cancel control', () => {
+    render(<PerpsProOrdersSummary orderCount={3} />);
+
+    expect(
+      screen.getByText(
+        strings('perps.pro_positions_panel.open_orders', { count: 3 }),
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByText(strings('perps.pro_positions_panel.cancel_all')),
+    ).toBeOnTheScreen();
+  });
+
+  it('counts the listed orders on the cancel control when filtered', () => {
+    render(<PerpsProOrdersSummary orderCount={2} isFiltered />);
+
+    expect(
+      screen.getByText(
+        strings('perps.pro_positions_panel.cancel_count', { count: 2 }),
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      screen.queryByText(strings('perps.pro_positions_panel.cancel_all')),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('invokes the cancel-all callback when the control is pressed', () => {
+    const onCancelAll = jest.fn();
+
+    render(<PerpsProOrdersSummary orderCount={1} onCancelAll={onCancelAll} />);
+
+    fireEvent.press(
+      screen.getByTestId(PerpsProMarketViewSelectorsIDs.ORDERS_CANCEL_ALL),
+    );
+
+    expect(onCancelAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrdersSummary.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrdersSummary.test.tsx
@@ -23,17 +23,22 @@ describe('PerpsProOrdersSummary', () => {
     ).toBeOnTheScreen();
   });
 
-  it('counts the listed orders on the cancel control when filtered', () => {
-    render(<PerpsProOrdersSummary orderCount={2} isFiltered />);
+  it('narrows the count to the orders left after filtering', () => {
+    render(<PerpsProOrdersSummary orderCount={2} />);
 
     expect(
       screen.getByText(
-        strings('perps.pro_positions_panel.cancel_count', { count: 2 }),
+        strings('perps.pro_positions_panel.open_orders', { count: 2 }),
       ),
     ).toBeOnTheScreen();
+  });
+
+  it('keeps the cancel label unchanged when the list is filtered', () => {
+    render(<PerpsProOrdersSummary orderCount={2} />);
+
     expect(
-      screen.queryByText(strings('perps.pro_positions_panel.cancel_all')),
-    ).not.toBeOnTheScreen();
+      screen.getByText(strings('perps.pro_positions_panel.cancel_all')),
+    ).toBeOnTheScreen();
   });
 
   it('invokes the cancel-all callback when the control is pressed', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrdersSummary.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrdersSummary.test.tsx
@@ -5,7 +5,7 @@ import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
 import PerpsProOrdersSummary from './PerpsProOrdersSummary';
 
 describe('PerpsProOrdersSummary', () => {
-  it('renders the open order count and an unscoped cancel control', () => {
+  it('renders the open order count', () => {
     render(<PerpsProOrdersSummary orderCount={3} />);
 
     expect(
@@ -13,6 +13,11 @@ describe('PerpsProOrdersSummary', () => {
         strings('perps.pro_positions_panel.open_orders', { count: 3 }),
       ),
     ).toBeOnTheScreen();
+  });
+
+  it('labels the cancel control for the whole book when unfiltered', () => {
+    render(<PerpsProOrdersSummary orderCount={3} />);
+
     expect(
       screen.getByText(strings('perps.pro_positions_panel.cancel_all')),
     ).toBeOnTheScreen();

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrdersSummary.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrdersSummary.tsx
@@ -1,0 +1,76 @@
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import React from 'react';
+import { strings } from '../../../../../../../locales/i18n';
+import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
+
+interface PerpsProOrdersSummaryProps {
+  orderCount: number;
+  isFiltered?: boolean;
+  onCancelAll?: () => void;
+}
+
+/**
+ * Aggregate summary for the Pro orders list, hosting Cancel all.
+ *
+ * Mirrors PerpsProUnrealizedPnl's placement and treatment on the Positions tab
+ * so both tabs offer their bulk action in the same spot. Orders have no
+ * aggregate P&L to show, so the left side carries the open-order count.
+ */
+const PerpsProOrdersSummary = ({
+  orderCount,
+  isFiltered = false,
+  onCancelAll,
+}: PerpsProOrdersSummaryProps) => (
+  <Box twClassName="px-2 py-3">
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Between}
+      twClassName="gap-4 rounded-xl bg-muted px-4 py-3"
+      testID={PerpsProMarketViewSelectorsIDs.ORDERS_SUMMARY}
+    >
+      <Box twClassName="flex-1">
+        <Text
+          variant={TextVariant.BodyXs}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextAlternative}
+        >
+          {strings('perps.pro_positions_panel.orders')}
+        </Text>
+        <Text variant={TextVariant.HeadingSm} color={TextColor.TextDefault}>
+          {strings('perps.pro_positions_panel.open_orders', {
+            count: orderCount,
+          })}
+        </Text>
+      </Box>
+      <Button
+        variant={ButtonVariant.Secondary}
+        size={ButtonSize.Sm}
+        isDanger
+        twClassName="self-center border-muted bg-transparent"
+        onPress={onCancelAll}
+        testID={PerpsProMarketViewSelectorsIDs.ORDERS_CANCEL_ALL}
+      >
+        {isFiltered
+          ? strings('perps.pro_positions_panel.cancel_count', {
+              count: orderCount,
+            })
+          : strings('perps.pro_positions_panel.cancel_all')}
+      </Button>
+    </Box>
+  </Box>
+);
+
+export default React.memo(PerpsProOrdersSummary);

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrdersSummary.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrdersSummary.tsx
@@ -6,7 +6,6 @@ import {
   Button,
   ButtonSize,
   ButtonVariant,
-  FontWeight,
   Text,
   TextColor,
   TextVariant,
@@ -17,20 +16,18 @@ import { PerpsProMarketViewSelectorsIDs } from '../../../Perps.testIds';
 
 interface PerpsProOrdersSummaryProps {
   orderCount: number;
-  isFiltered?: boolean;
   onCancelAll?: () => void;
 }
 
 /**
  * Aggregate summary for the Pro orders list, hosting Cancel all.
  *
- * Mirrors PerpsProUnrealizedPnl's placement and treatment on the Positions tab
- * so both tabs offer their bulk action in the same spot. Orders have no
- * aggregate P&L to show, so the left side carries the open-order count.
+ * The count reflects the orders currently listed, so it already narrows when a
+ * filter is applied — the button label stays `Cancel all` in both states and
+ * the scope is read from this count rather than repeated in the label.
  */
 const PerpsProOrdersSummary = ({
   orderCount,
-  isFiltered = false,
   onCancelAll,
 }: PerpsProOrdersSummaryProps) => (
   <Box twClassName="px-2 py-3">
@@ -42,13 +39,6 @@ const PerpsProOrdersSummary = ({
       testID={PerpsProMarketViewSelectorsIDs.ORDERS_SUMMARY}
     >
       <Box twClassName="flex-1">
-        <Text
-          variant={TextVariant.BodyXs}
-          fontWeight={FontWeight.Medium}
-          color={TextColor.TextAlternative}
-        >
-          {strings('perps.pro_positions_panel.orders')}
-        </Text>
         <Text variant={TextVariant.HeadingSm} color={TextColor.TextDefault}>
           {strings('perps.pro_positions_panel.open_orders', {
             count: orderCount,
@@ -59,15 +49,10 @@ const PerpsProOrdersSummary = ({
         variant={ButtonVariant.Secondary}
         size={ButtonSize.Sm}
         isDanger
-        twClassName="self-center border-muted bg-transparent"
         onPress={onCancelAll}
         testID={PerpsProMarketViewSelectorsIDs.ORDERS_CANCEL_ALL}
       >
-        {isFiltered
-          ? strings('perps.pro_positions_panel.cancel_count', {
-              count: orderCount,
-            })
-          : strings('perps.pro_positions_panel.cancel_all')}
+        {strings('perps.pro_positions_panel.cancel_all')}
       </Button>
     </Box>
   </Box>

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.test.tsx
@@ -930,7 +930,7 @@ describe('PerpsProPositionsPanel', () => {
     ).toBeOnTheScreen();
   });
 
-  it('counts only the listed orders on the bulk cancel when ticker-only is enabled', () => {
+  it('narrows the summary count when ticker-only is enabled', () => {
     mockUsePerpsLiveOrders.mockReturnValue({
       orders: [
         makeOrder({ orderId: 'btc-1', symbol: 'BTC' }),
@@ -952,11 +952,13 @@ describe('PerpsProPositionsPanel', () => {
 
     expect(
       screen.getByText(
-        strings('perps.pro_positions_panel.cancel_count', { count: 1 }),
+        strings('perps.pro_positions_panel.open_orders', { count: 1 }),
       ),
     ).toBeOnTheScreen();
     expect(
-      screen.queryByText(strings('perps.pro_positions_panel.cancel_all')),
+      screen.queryByText(
+        strings('perps.pro_positions_panel.open_orders', { count: 2 }),
+      ),
     ).not.toBeOnTheScreen();
   });
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.test.tsx
@@ -6,6 +6,7 @@ import type {
 } from '@metamask/perps-controller';
 import { PERPS_EVENT_VALUE } from '@metamask/perps-controller/constants';
 import React from 'react';
+import { strings } from '../../../../../../../locales/i18n';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
 import {
@@ -177,6 +178,7 @@ describe('PerpsProPositionsPanel', () => {
   const handleSharePosition = jest.fn();
   const handleCancelOrder = jest.fn();
   const handleCloseAllPress = jest.fn();
+  const handleCancelAllPress = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -198,6 +200,7 @@ describe('PerpsProPositionsPanel', () => {
       handleEditOrderPrice: jest.fn(),
       handleEditOrderSize: jest.fn(),
       handleCloseAllPress,
+      handleCancelAllPress,
       cancelingOrderId: null,
       editingOrderId: null,
       isOrderCancelable: () => true,
@@ -879,5 +882,125 @@ describe('PerpsProPositionsPanel', () => {
 
     expect(screen.getByText('No long positions.')).toBeOnTheScreen();
     expect(screen.queryByText('No open SOL positions.')).toBeNull();
+  });
+
+  it('wires the bulk cancel handler on the orders tab', () => {
+    mockUsePerpsLiveOrders.mockReturnValue({
+      orders: [makeOrder({ orderId: 'sol-1', symbol: 'SOL' })],
+      isInitialLoading: false,
+    } as ReturnType<typeof usePerpsLiveOrders>);
+
+    renderPanel('SOL');
+
+    fireEvent.press(
+      screen.getByTestId(
+        PerpsProMarketViewSelectorsIDs.POSITIONS_PANEL_TAB_ORDERS,
+      ),
+    );
+    fireEvent.press(
+      screen.getByTestId(PerpsProMarketViewSelectorsIDs.ORDERS_CANCEL_ALL),
+    );
+
+    expect(handleCancelAllPress).toHaveBeenCalled();
+  });
+
+  it('labels the bulk cancel for the whole book when no order filter is applied', () => {
+    mockUsePerpsLiveOrders.mockReturnValue({
+      orders: [
+        makeOrder({ orderId: 'btc-1', symbol: 'BTC' }),
+        makeOrder({ orderId: 'sol-1', symbol: 'SOL' }),
+      ],
+      isInitialLoading: false,
+    } as ReturnType<typeof usePerpsLiveOrders>);
+
+    renderPanel('SOL');
+
+    fireEvent.press(
+      screen.getByTestId(
+        PerpsProMarketViewSelectorsIDs.POSITIONS_PANEL_TAB_ORDERS,
+      ),
+    );
+
+    expect(
+      screen.getByText(strings('perps.pro_positions_panel.cancel_all')),
+    ).toBeOnTheScreen();
+  });
+
+  it('counts only the listed orders on the bulk cancel when ticker-only is enabled', () => {
+    mockUsePerpsLiveOrders.mockReturnValue({
+      orders: [
+        makeOrder({ orderId: 'btc-1', symbol: 'BTC' }),
+        makeOrder({ orderId: 'sol-1', symbol: 'SOL' }),
+      ],
+      isInitialLoading: false,
+    } as ReturnType<typeof usePerpsLiveOrders>);
+
+    renderPanel('SOL');
+
+    fireEvent.press(
+      screen.getByTestId(
+        PerpsProMarketViewSelectorsIDs.POSITIONS_PANEL_TAB_ORDERS,
+      ),
+    );
+    fireEvent.press(
+      screen.getByTestId(PerpsProMarketViewSelectorsIDs.POSITIONS_TICKER_ONLY),
+    );
+
+    expect(
+      screen.getByText(
+        strings('perps.pro_positions_panel.cancel_count', { count: 1 }),
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      screen.queryByText(strings('perps.pro_positions_panel.cancel_all')),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('passes the ticker-filtered orders and filtered flag to the action sheets', () => {
+    const renderActionSheets = jest.fn(() => null);
+    mockUsePerpsProPositionsPanelActions.mockReturnValue({
+      handleClosePosition,
+      handleReversePosition,
+      handleSharePosition,
+      handleEditPositionTpSl: jest.fn(),
+      handleEditPositionMargin: jest.fn(),
+      handleCancelOrder,
+      handleEditOrderPrice: jest.fn(),
+      handleEditOrderSize: jest.fn(),
+      handleCloseAllPress,
+      handleCancelAllPress,
+      cancelingOrderId: null,
+      editingOrderId: null,
+      isOrderCancelable: () => true,
+      isOrderEditable: () => true,
+      isOrderSizeEditable: () => true,
+      isPositionMarginEditable: () => true,
+      renderActionSheets,
+    });
+    mockUsePerpsLiveOrders.mockReturnValue({
+      orders: [
+        makeOrder({ orderId: 'btc-1', symbol: 'BTC' }),
+        makeOrder({ orderId: 'sol-1', symbol: 'SOL' }),
+      ],
+      isInitialLoading: false,
+    } as ReturnType<typeof usePerpsLiveOrders>);
+
+    renderPanel('SOL');
+
+    fireEvent.press(
+      screen.getByTestId(
+        PerpsProMarketViewSelectorsIDs.POSITIONS_PANEL_TAB_ORDERS,
+      ),
+    );
+    fireEvent.press(
+      screen.getByTestId(PerpsProMarketViewSelectorsIDs.POSITIONS_TICKER_ONLY),
+    );
+
+    const lastCall =
+      renderActionSheets.mock.calls[renderActionSheets.mock.calls.length - 1];
+    expect(lastCall[2]).toEqual([
+      expect.objectContaining({ orderId: 'sol-1', symbol: 'SOL' }),
+    ]);
+    expect(lastCall[3]).toBe(true);
   });
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.test.tsx
@@ -956,7 +956,7 @@ describe('PerpsProPositionsPanel', () => {
     ).not.toBeOnTheScreen();
   });
 
-  it('passes the ticker-filtered orders and filtered flag to the action sheets', () => {
+  it('passes the ticker-filtered orders to the action sheets', () => {
     const renderActionSheets = jest.fn(() => null);
     mockUsePerpsProPositionsPanelActions.mockReturnValue({
       handleClosePosition,
@@ -1001,6 +1001,50 @@ describe('PerpsProPositionsPanel', () => {
     expect(lastCall[2]).toEqual([
       expect.objectContaining({ orderId: 'sol-1', symbol: 'SOL' }),
     ]);
+  });
+
+  it('flags the orders as filtered for the action sheets', () => {
+    const renderActionSheets = jest.fn(() => null);
+    mockUsePerpsProPositionsPanelActions.mockReturnValue({
+      handleClosePosition,
+      handleReversePosition,
+      handleSharePosition,
+      handleEditPositionTpSl: jest.fn(),
+      handleEditPositionMargin: jest.fn(),
+      handleCancelOrder,
+      handleEditOrderPrice: jest.fn(),
+      handleEditOrderSize: jest.fn(),
+      handleCloseAllPress,
+      handleCancelAllPress,
+      cancelingOrderId: null,
+      editingOrderId: null,
+      isOrderCancelable: () => true,
+      isOrderEditable: () => true,
+      isOrderSizeEditable: () => true,
+      isPositionMarginEditable: () => true,
+      renderActionSheets,
+    });
+    mockUsePerpsLiveOrders.mockReturnValue({
+      orders: [
+        makeOrder({ orderId: 'btc-1', symbol: 'BTC' }),
+        makeOrder({ orderId: 'sol-1', symbol: 'SOL' }),
+      ],
+      isInitialLoading: false,
+    } as ReturnType<typeof usePerpsLiveOrders>);
+
+    renderPanel('SOL');
+
+    fireEvent.press(
+      screen.getByTestId(
+        PerpsProMarketViewSelectorsIDs.POSITIONS_PANEL_TAB_ORDERS,
+      ),
+    );
+    fireEvent.press(
+      screen.getByTestId(PerpsProMarketViewSelectorsIDs.POSITIONS_TICKER_ONLY),
+    );
+
+    const lastCall =
+      renderActionSheets.mock.calls[renderActionSheets.mock.calls.length - 1];
     expect(lastCall[3]).toBe(true);
   });
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.test.tsx
@@ -13,7 +13,10 @@ import {
   usePerpsLiveOrders,
   usePerpsLivePositions,
 } from '../../../hooks/stream';
-import { usePerpsProPositionsPanelActions } from '../../../hooks/usePerpsProPositionsPanelActions';
+import {
+  usePerpsProPositionsPanelActions,
+  type UsePerpsProPositionsPanelActionsReturn,
+} from '../../../hooks/usePerpsProPositionsPanelActions';
 import { usePerpsMarkets } from '../../../hooks/usePerpsMarkets';
 import {
   getPerpsProOrderRowSelector,
@@ -620,6 +623,7 @@ describe('PerpsProPositionsPanel', () => {
       handleEditOrderPrice: jest.fn(),
       handleEditOrderSize: jest.fn(),
       handleCloseAllPress,
+      handleCancelAllPress,
       cancelingOrderId: 'btc-1',
       editingOrderId: null,
       isOrderCancelable: () => true,
@@ -957,7 +961,11 @@ describe('PerpsProPositionsPanel', () => {
   });
 
   it('passes the ticker-filtered orders to the action sheets', () => {
-    const renderActionSheets = jest.fn(() => null);
+    const renderActionSheets: UsePerpsProPositionsPanelActionsReturn['renderActionSheets'] =
+      jest.fn(() => null);
+    const renderActionSheetsMock = renderActionSheets as jest.MockedFunction<
+      typeof renderActionSheets
+    >;
     mockUsePerpsProPositionsPanelActions.mockReturnValue({
       handleClosePosition,
       handleReversePosition,
@@ -997,14 +1005,20 @@ describe('PerpsProPositionsPanel', () => {
     );
 
     const lastCall =
-      renderActionSheets.mock.calls[renderActionSheets.mock.calls.length - 1];
+      renderActionSheetsMock.mock.calls[
+        renderActionSheetsMock.mock.calls.length - 1
+      ];
     expect(lastCall[2]).toEqual([
       expect.objectContaining({ orderId: 'sol-1', symbol: 'SOL' }),
     ]);
   });
 
   it('flags the orders as filtered for the action sheets', () => {
-    const renderActionSheets = jest.fn(() => null);
+    const renderActionSheets: UsePerpsProPositionsPanelActionsReturn['renderActionSheets'] =
+      jest.fn(() => null);
+    const renderActionSheetsMock = renderActionSheets as jest.MockedFunction<
+      typeof renderActionSheets
+    >;
     mockUsePerpsProPositionsPanelActions.mockReturnValue({
       handleClosePosition,
       handleReversePosition,
@@ -1044,7 +1058,9 @@ describe('PerpsProPositionsPanel', () => {
     );
 
     const lastCall =
-      renderActionSheets.mock.calls[renderActionSheets.mock.calls.length - 1];
+      renderActionSheetsMock.mock.calls[
+        renderActionSheetsMock.mock.calls.length - 1
+      ];
     expect(lastCall[3]).toBe(true);
   });
 });

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.tsx
@@ -38,6 +38,7 @@ import { calculatePositionAggregateTotals } from '../../../utils/pnlCalculations
 import PerpsProOrderCard from './PerpsProOrderCard';
 import PerpsProOrdersEmptyState from './PerpsProOrdersEmptyState';
 import PerpsProOrdersSortSheet from './PerpsProOrdersSortSheet';
+import PerpsProOrdersSummary from './PerpsProOrdersSummary';
 import PerpsProPositionCard from './PerpsProPositionCard';
 import PerpsProPositionsEmptyState from './PerpsProPositionsEmptyState';
 import PerpsProPositionsSideFilterSheet from './PerpsProPositionsSideFilterSheet';
@@ -125,6 +126,7 @@ const PerpsProPositionsPanel = ({
     handleEditOrderPrice,
     handleEditOrderSize,
     handleCloseAllPress,
+    handleCancelAllPress,
     cancelingOrderId,
     editingOrderId,
     isOrderCancelable,
@@ -209,6 +211,9 @@ const PerpsProPositionsPanel = ({
     () => filterProOrdersBySide(visibleOrders, ordersSideFilter),
     [ordersSideFilter, visibleOrders],
   );
+
+  const areOrdersFiltered =
+    isTickerOnly || ordersSideFilter !== DEFAULT_PRO_ORDER_SIDE_FILTER;
 
   const sortedVisiblePositions = useMemo(
     () =>
@@ -338,6 +343,11 @@ const PerpsProPositionsPanel = ({
     if (sortedVisibleOrders.length > 0) {
       return (
         <Box testID={PerpsProMarketViewSelectorsIDs.ORDERS_LIST}>
+          <PerpsProOrdersSummary
+            orderCount={sideFilteredOrders.length}
+            isFiltered={areOrdersFiltered}
+            onCancelAll={handleCancelAllPress}
+          />
           {sortedVisibleOrders.map((order, index) => (
             <PerpsProOrderCard
               key={order.orderId}
@@ -464,7 +474,12 @@ const PerpsProPositionsPanel = ({
       {activeIndex === ORDERS_TAB_INDEX
         ? renderOrdersTab()
         : renderPositionsTab()}
-      {renderActionSheets(sideFilteredPositions, isPositionsFiltered)}
+      {renderActionSheets(
+        sideFilteredPositions,
+        isPositionsFiltered,
+        sideFilteredOrders,
+        areOrdersFiltered,
+      )}
       {activeIndex === ORDERS_TAB_INDEX ? (
         <PerpsProOrdersSortSheet
           isVisible={isSortSheetOpen}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanel.tsx
@@ -345,7 +345,6 @@ const PerpsProPositionsPanel = ({
         <Box testID={PerpsProMarketViewSelectorsIDs.ORDERS_LIST}>
           <PerpsProOrdersSummary
             orderCount={sideFilteredOrders.length}
-            isFiltered={areOrdersFiltered}
             onCancelAll={handleCancelAllPress}
           />
           {sortedVisibleOrders.map((order, index) => (

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanelActions.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanelActions.test.tsx
@@ -132,6 +132,25 @@ jest.mock(
 );
 
 jest.mock(
+  '../../../Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView',
+  () => {
+    const { View } = jest.requireActual('react-native');
+    return function PerpsCancelAllOrdersView(props: {
+      orders?: { orderId: string }[];
+      isFiltered?: boolean;
+    }) {
+      return (
+        <View
+          testID="perps-cancel-all-orders-view"
+          orderIds={(props.orders ?? []).map((order) => order.orderId)}
+          isFiltered={props.isFiltered}
+        />
+      );
+    };
+  },
+);
+
+jest.mock(
   '../../../components/PerpsFlipPositionConfirmSheet/PerpsFlipPositionConfirmSheet',
   () => {
     const { View } = jest.requireActual('react-native');
@@ -238,17 +257,21 @@ const order: Order = {
 
 const ActionHarness = ({
   onReady,
+  renderSheetArgs,
 }: {
   onReady: (
     actions: ReturnType<typeof usePerpsProPositionsPanelActions>,
   ) => void;
+  renderSheetArgs?: Parameters<
+    ReturnType<typeof usePerpsProPositionsPanelActions>['renderActionSheets']
+  >;
 }) => {
   const actions = usePerpsProPositionsPanelActions();
   React.useEffect(() => {
     onReady(actions);
   }, [actions, onReady]);
 
-  return <>{actions.renderActionSheets()}</>;
+  return <>{actions.renderActionSheets(...(renderSheetArgs ?? []))}</>;
 };
 
 describe('usePerpsProPositionsPanelActions', () => {
@@ -502,6 +525,40 @@ describe('usePerpsProPositionsPanelActions', () => {
         screen.getByTestId('perps-close-all-positions-view'),
       ).toBeOnTheScreen();
     });
+  });
+
+  it('renders cancel-all sheet scoped to the passed orders when handler is invoked', async () => {
+    let actions:
+      | ReturnType<typeof usePerpsProPositionsPanelActions>
+      | undefined;
+    const filteredOrders = [
+      { orderId: 'eth-1', symbol: 'ETH' },
+    ] as unknown as Parameters<
+      ReturnType<typeof usePerpsProPositionsPanelActions>['renderActionSheets']
+    >[2];
+
+    render(
+      <ActionHarness
+        onReady={(readyActions) => {
+          actions = readyActions;
+        }}
+        renderSheetArgs={[undefined, undefined, filteredOrders, true]}
+      />,
+    );
+
+    await act(async () => {
+      actions?.handleCancelAllPress();
+    });
+
+    expect(mockGate).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('perps-cancel-all-orders-view'),
+      ).toBeOnTheScreen();
+    });
+    const sheet = screen.getByTestId('perps-cancel-all-orders-view');
+    expect(sheet.props.orderIds).toEqual(['eth-1']);
+    expect(sheet.props.isFiltered).toBe(true);
   });
 });
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanelActions.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProPositionsPanelActions.test.tsx
@@ -531,11 +531,9 @@ describe('usePerpsProPositionsPanelActions', () => {
     let actions:
       | ReturnType<typeof usePerpsProPositionsPanelActions>
       | undefined;
-    const filteredOrders = [
-      { orderId: 'eth-1', symbol: 'ETH' },
-    ] as unknown as Parameters<
-      ReturnType<typeof usePerpsProPositionsPanelActions>['renderActionSheets']
-    >[2];
+    const filteredOrders: Order[] = [
+      { ...order, orderId: 'eth-1', symbol: 'ETH' },
+    ];
 
     render(
       <ActionHarness

--- a/app/components/UI/Perps/hooks/usePerpsCancelAllOrders.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsCancelAllOrders.test.ts
@@ -399,4 +399,93 @@ describe('usePerpsCancelAllOrders', () => {
       expect(result.current.error).toBeNull();
     });
   });
+  it('cancels only the passed orders when the view is filtered', async () => {
+    // Arrange
+    const orders = [
+      createMockOrder({ orderId: 'eth-1', symbol: 'ETH' }),
+      createMockOrder({ orderId: 'eth-2', symbol: 'ETH' }),
+    ];
+    (
+      Engine.context.PerpsController.cancelOrders as jest.Mock
+    ).mockResolvedValue({
+      success: true,
+      successCount: 2,
+      failureCount: 0,
+      results: [],
+    });
+    const { result } = renderHook(() =>
+      usePerpsCancelAllOrders(orders, { isFiltered: true }),
+    );
+
+    // Act
+    await act(async () => {
+      await result.current.handleCancelAll();
+    });
+
+    // Assert
+    expect(Engine.context.PerpsController.cancelOrders).toHaveBeenCalledWith({
+      orderIds: ['eth-1', 'eth-2'],
+    });
+    expect(
+      Engine.context.PerpsController.cancelOrders,
+    ).not.toHaveBeenCalledWith({ cancelAll: true });
+  });
+
+  it('cancels the whole book when the view is not filtered', async () => {
+    // Arrange
+    const orders = [
+      createMockOrder({ orderId: 'eth-1', symbol: 'ETH' }),
+      createMockOrder({ orderId: 'btc-1', symbol: 'BTC' }),
+    ];
+    (
+      Engine.context.PerpsController.cancelOrders as jest.Mock
+    ).mockResolvedValue({
+      success: true,
+      successCount: 2,
+      failureCount: 0,
+      results: [],
+    });
+    const { result } = renderHook(() =>
+      usePerpsCancelAllOrders(orders, { isFiltered: false }),
+    );
+
+    // Act
+    await act(async () => {
+      await result.current.handleCancelAll();
+    });
+
+    // Assert
+    expect(Engine.context.PerpsController.cancelOrders).toHaveBeenCalledWith({
+      cancelAll: true,
+    });
+  });
+
+  it('scopes by order id rather than symbol so a side filter cannot over-cancel', async () => {
+    // Arrange - one market holding both a long and a short order, only the long listed
+    const orders = [createMockOrder({ orderId: 'eth-long', symbol: 'ETH' })];
+    (
+      Engine.context.PerpsController.cancelOrders as jest.Mock
+    ).mockResolvedValue({
+      success: true,
+      successCount: 1,
+      failureCount: 0,
+      results: [],
+    });
+    const { result } = renderHook(() =>
+      usePerpsCancelAllOrders(orders, { isFiltered: true }),
+    );
+
+    // Act
+    await act(async () => {
+      await result.current.handleCancelAll();
+    });
+
+    // Assert
+    expect(Engine.context.PerpsController.cancelOrders).toHaveBeenCalledWith({
+      orderIds: ['eth-long'],
+    });
+    const [params] = (Engine.context.PerpsController.cancelOrders as jest.Mock)
+      .mock.calls[0];
+    expect(params.symbols).toBeUndefined();
+  });
 });

--- a/app/components/UI/Perps/hooks/usePerpsCancelAllOrders.ts
+++ b/app/components/UI/Perps/hooks/usePerpsCancelAllOrders.ts
@@ -18,6 +18,11 @@ export interface UsePerpsCancelAllOrdersOptions {
   onError?: (error: Error) => void;
   /** Whether to navigate back on success (default: true) */
   navigateBackOnSuccess?: boolean;
+  /**
+   * Restricts cancellation to exactly the passed orders. Without it the whole
+   * book is cancelled provider-side, which would over-cancel a filtered view.
+   */
+  isFiltered?: boolean;
 }
 
 export interface UsePerpsCancelAllOrdersReturn {
@@ -56,7 +61,12 @@ export const usePerpsCancelAllOrders = (
   const [isCanceling, setIsCanceling] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
-  const { onSuccess, onError, navigateBackOnSuccess = true } = options || {};
+  const {
+    onSuccess,
+    onError,
+    navigateBackOnSuccess = true,
+    isFiltered = false,
+  } = options || {};
 
   const orderCount = orders?.length || 0;
 
@@ -71,12 +81,18 @@ export const usePerpsCancelAllOrders = (
 
     DevLogger.log('[usePerpsCancelAllOrders] Starting cancel all orders', {
       orderCount: orders.length,
+      isFiltered,
     });
 
     try {
-      const result = await Engine.context.PerpsController.cancelOrders({
-        cancelAll: true,
-      });
+      // A filtered view must cancel exactly what it lists. Scope by orderId
+      // rather than symbol: a single market can hold both a long and a short
+      // order, and the side filter can select only one of them.
+      const result = await Engine.context.PerpsController.cancelOrders(
+        isFiltered
+          ? { orderIds: orders.map((order) => order.orderId) }
+          : { cancelAll: true },
+      );
 
       DevLogger.log('[usePerpsCancelAllOrders] Cancel result', {
         success: result.success,
@@ -123,6 +139,7 @@ export const usePerpsCancelAllOrders = (
     }
   }, [
     orders,
+    isFiltered,
     onSuccess,
     onError,
     navigateBackOnSuccess,

--- a/app/components/UI/Perps/hooks/usePerpsProPositionsPanelActions.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsProPositionsPanelActions.tsx
@@ -25,6 +25,7 @@ import {
   getValidTriggerPrice,
   isSyntheticOrderCancelable,
 } from '../utils/orderUtils';
+import PerpsCancelAllOrdersView from '../Views/PerpsCancelAllOrdersView/PerpsCancelAllOrdersView';
 import PerpsCloseAllPositionsView from '../Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView';
 import PerpsSelectAdjustMarginActionView from '../Views/PerpsSelectAdjustMarginActionView/PerpsSelectAdjustMarginActionView';
 import { usePerpsEventTracking } from './usePerpsEventTracking';
@@ -59,6 +60,7 @@ export interface UsePerpsProPositionsPanelActionsReturn {
   handleEditOrderPrice: (order: Order) => void;
   handleEditOrderSize: (order: Order) => void;
   handleCloseAllPress: () => void;
+  handleCancelAllPress: () => void;
   cancelingOrderId: string | null;
   editingOrderId: string | null;
   isOrderCancelable: (order: Order) => boolean;
@@ -67,6 +69,8 @@ export interface UsePerpsProPositionsPanelActionsReturn {
   renderActionSheets: (
     filteredPositions?: Position[],
     isFiltered?: boolean,
+    filteredOrders?: Order[],
+    areOrdersFiltered?: boolean,
   ) => React.ReactNode;
 }
 
@@ -86,6 +90,7 @@ export const usePerpsProPositionsPanelActions =
     const { showToast, PerpsToastOptions } = usePerpsToasts();
 
     const [showCloseAllSheet, setShowCloseAllSheet] = useState(false);
+    const [showCancelAllSheet, setShowCancelAllSheet] = useState(false);
     const [reversePosition, setReversePosition] = useState<Position | null>(
       null,
     );
@@ -97,6 +102,7 @@ export const usePerpsProPositionsPanelActions =
     );
 
     const closeAllSheetRef = useRef<BottomSheetRef>(null);
+    const cancelAllSheetRef = useRef<BottomSheetRef>(null);
     const reversePositionSheetRef = useRef<BottomSheetRef>(null);
     const adjustMarginSheetRef = useRef<BottomSheetRef>(null);
 
@@ -146,6 +152,10 @@ export const usePerpsProPositionsPanelActions =
       setShowCloseAllSheet(false);
     }, []);
 
+    const handleCancelAllSheetClose = useCallback(() => {
+      setShowCancelAllSheet(false);
+    }, []);
+
     const handleReverseSheetClose = useCallback(() => {
       setReversePosition(null);
     }, []);
@@ -159,6 +169,12 @@ export const usePerpsProPositionsPanelActions =
         closeAllSheetRef.current?.onOpenBottomSheet();
       }
     }, [showCloseAllSheet]);
+
+    useEffect(() => {
+      if (showCancelAllSheet) {
+        cancelAllSheetRef.current?.onOpenBottomSheet();
+      }
+    }, [showCancelAllSheet]);
 
     useEffect(() => {
       if (reversePosition) {
@@ -345,8 +361,20 @@ export const usePerpsProPositionsPanelActions =
       );
     }, [runGatedEligibleAction]);
 
+    const handleCancelAllPress = useCallback(() => {
+      runGatedEligibleAction(
+        PERPS_EVENT_VALUE.SOURCE.CANCEL_ALL_ORDERS_BUTTON,
+        () => setShowCancelAllSheet(true),
+      );
+    }, [runGatedEligibleAction]);
+
     const renderActionSheets = useCallback(
-      (filteredPositions?: Position[], isFiltered?: boolean) => (
+      (
+        filteredPositions?: Position[],
+        isFiltered?: boolean,
+        filteredOrders?: Order[],
+        areOrdersFiltered?: boolean,
+      ) => (
         <>
           {showCloseAllSheet && (
             <PerpsProModalPortal onRequestClose={handleCloseAllSheetClose}>
@@ -355,6 +383,17 @@ export const usePerpsProPositionsPanelActions =
                 onClose={handleCloseAllSheetClose}
                 positions={filteredPositions}
                 isFiltered={isFiltered}
+              />
+            </PerpsProModalPortal>
+          )}
+
+          {showCancelAllSheet && (
+            <PerpsProModalPortal onRequestClose={handleCancelAllSheetClose}>
+              <PerpsCancelAllOrdersView
+                sheetRef={cancelAllSheetRef}
+                onClose={handleCancelAllSheetClose}
+                orders={filteredOrders}
+                isFiltered={areOrdersFiltered}
               />
             </PerpsProModalPortal>
           )}
@@ -398,11 +437,13 @@ export const usePerpsProPositionsPanelActions =
         adjustMarginPosition,
         closeGeoBlockModal,
         handleAdjustMarginSheetClose,
+        handleCancelAllSheetClose,
         handleCloseAllSheetClose,
         handleReverseSheetClose,
         isGeoBlockVisible,
         renderOrderEditSheets,
         reversePosition,
+        showCancelAllSheet,
         showCloseAllSheet,
       ],
     );
@@ -417,6 +458,7 @@ export const usePerpsProPositionsPanelActions =
       handleEditOrderPrice,
       handleEditOrderSize,
       handleCloseAllPress,
+      handleCancelAllPress,
       cancelingOrderId,
       editingOrderId,
       isOrderCancelable,

--- a/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
@@ -3564,6 +3564,50 @@ describe('PerpsStreamManager', () => {
       unsubscribe();
     });
 
+    it('flushes the cancelled-order snapshot to a throttled subscriber without waiting out the throttle', async () => {
+      // Regression: the Pro orders panel subscribes with throttleMs: 1000. A
+      // resume flush delivered as a normal 'fresh' update would sit in
+      // pendingUpdate behind that timer, leaving cancelled orders on screen for
+      // up to a second after the venue already reported an empty book.
+      const callback = jest.fn();
+      const unsubscribe = testStreamManager.orders.subscribe({
+        callback,
+        throttleMs: 1000,
+      });
+
+      await waitFor(() => expect(mockOrdersSubscribe).toHaveBeenCalled());
+
+      // First fresh update is delivered immediately, then throttling applies.
+      act(() => {
+        orderCallback?.([SAMPLE_ORDER]);
+      });
+      await waitFor(() => expect(callback).toHaveBeenCalledTimes(1));
+      callback.mockClear();
+
+      act(() => {
+        testStreamManager.orders.pause();
+      });
+      act(() => {
+        orderCallback?.([]);
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(callback).not.toHaveBeenCalled();
+
+      act(() => {
+        testStreamManager.orders.resume();
+      });
+
+      // Delivered synchronously by resume, NOT parked behind the 1000ms throttle
+      // timer. Asserted without waitFor on purpose: waitFor polls on real timers
+      // and would simply outlast the throttle window, passing either way.
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith([]);
+
+      unsubscribe();
+    });
+
     it('does not re-deliver on resume when nothing was suppressed', async () => {
       const callback = jest.fn();
       const unsubscribe = testStreamManager.orders.subscribe({

--- a/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.test.tsx
@@ -3305,10 +3305,18 @@ describe('PerpsStreamManager', () => {
 
       expect(callback).not.toHaveBeenCalled();
 
-      // Resume channel
+      // Resume channel — the update suppressed while paused is flushed now, so
+      // subscribers never keep rendering data the venue has already replaced.
       act(() => {
         testStreamManager.orders.resume();
       });
+
+      await waitFor(() => {
+        expect(callback).toHaveBeenCalledWith([
+          expect.objectContaining({ orderId: '2', symbol: 'ETH' }),
+        ]);
+      });
+      callback.mockClear();
 
       // Send another update (should be received)
       act(() => {
@@ -3428,10 +3436,18 @@ describe('PerpsStreamManager', () => {
       });
       expect(callback).not.toHaveBeenCalled();
 
-      // Caller B releases — count drops to 0, emission resumes
+      // Caller B releases — count drops to 0, emission resumes and the last
+      // update suppressed during the pause is flushed to subscribers.
       act(() => {
         testStreamManager.orders.resume();
       }); // caller B: controller
+      await waitFor(() => {
+        expect(callback).toHaveBeenCalledWith(
+          expect.arrayContaining([expect.objectContaining({ orderId: '3' })]),
+        );
+      });
+      callback.mockClear();
+
       act(() => {
         orderCallback?.([{ ...SAMPLE_ORDER, orderId: '4' }]);
       });
@@ -3497,6 +3513,84 @@ describe('PerpsStreamManager', () => {
           ]),
         );
       });
+
+      unsubscribe();
+    });
+
+    it('flushes the cancelled-order snapshot that arrived while paused', async () => {
+      // Regression: a bulk cancel pauses the orders channel, the venue pushes the
+      // now-empty book while paused, and resume() used to only decrement the
+      // counter. Subscribers kept rendering cancelled orders until an unrelated
+      // later tick or a reload — stale state a trader could act on.
+      const callback = jest.fn();
+      const unsubscribe = testStreamManager.orders.subscribe({
+        callback,
+        throttleMs: 0,
+      });
+
+      await waitFor(() => expect(mockOrdersSubscribe).toHaveBeenCalled());
+
+      act(() => {
+        orderCallback?.([SAMPLE_ORDER]);
+      });
+      await waitFor(() => expect(callback).toHaveBeenCalledTimes(1));
+      callback.mockClear();
+
+      // Controller pauses the channel for the duration of the bulk cancel.
+      act(() => {
+        testStreamManager.orders.pause();
+      });
+
+      // The venue confirms every order is gone while emission is paused.
+      act(() => {
+        orderCallback?.([]);
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(callback).not.toHaveBeenCalled();
+
+      // Controller's finally block releases the pause.
+      act(() => {
+        testStreamManager.orders.resume();
+      });
+
+      // The empty book must reach subscribers without another venue tick.
+      await waitFor(() => {
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith([]);
+      });
+
+      unsubscribe();
+    });
+
+    it('does not re-deliver on resume when nothing was suppressed', async () => {
+      const callback = jest.fn();
+      const unsubscribe = testStreamManager.orders.subscribe({
+        callback,
+        throttleMs: 0,
+      });
+
+      await waitFor(() => expect(mockOrdersSubscribe).toHaveBeenCalled());
+
+      act(() => {
+        orderCallback?.([SAMPLE_ORDER]);
+      });
+      await waitFor(() => expect(callback).toHaveBeenCalledTimes(1));
+      callback.mockClear();
+
+      // A pause window with no venue update in it leaves nothing to flush.
+      act(() => {
+        testStreamManager.orders.pause();
+      });
+      act(() => {
+        testStreamManager.orders.resume();
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(callback).not.toHaveBeenCalled();
 
       unsubscribe();
     });

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -127,6 +127,9 @@ abstract class StreamChannel<T> {
   // than to when the caller happened to look.
   protected lastDeliveredAt: number | null = null;
   protected deliveryRevision = 0;
+  // Set when a delivery is dropped because the channel is paused, so resume()
+  // knows the cache holds data the subscribers never saw.
+  protected hasSuppressedDelivery = false;
   // Retry counter for deferred connect() calls
   protected connectRetryCount = 0;
   // Timer handle for deferConnect so it can be cancelled on disconnect
@@ -140,6 +143,7 @@ abstract class StreamChannel<T> {
     this.deliveryRevision += 1;
     // Block emission while any pause is held (WebSocket continues receiving updates)
     if (this.pauseCount > 0) {
+      this.hasSuppressedDelivery = true;
       return;
     }
 
@@ -189,6 +193,7 @@ abstract class StreamChannel<T> {
     this.deliveryRevision += 1;
     // Block emission while any pause is held (WebSocket continues receiving updates)
     if (this.pauseCount > 0) {
+      this.hasSuppressedDelivery = true;
       return;
     }
 
@@ -542,9 +547,35 @@ abstract class StreamChannel<T> {
    * Resume emission of updates to subscribers.
    * Each pause() call must be matched by exactly one resume(). Emission
    * resumes only when all callers have released their pause.
+   *
+   * Updates that arrived while paused were cached but never delivered, so the
+   * last one is flushed here. Without it a batch operation that settles during
+   * the pause — cancelling every order, closing every position — leaves the UI
+   * rendering rows the venue has already removed until some later unrelated
+   * tick, which is stale state the user can act on.
    */
   public resume(): void {
-    this.pauseCount = Math.max(0, this.pauseCount - 1);
+    if (this.pauseCount === 0) {
+      // Unmatched resume — nothing was held, so there is nothing to flush.
+      return;
+    }
+
+    this.pauseCount -= 1;
+    if (this.pauseCount > 0) {
+      return;
+    }
+
+    if (!this.hasSuppressedDelivery) {
+      return;
+    }
+    this.hasSuppressedDelivery = false;
+
+    const latest = this.getCachedData();
+    if (latest === null || latest === undefined) {
+      return;
+    }
+
+    this.notifySubscribers(latest);
   }
 
   protected getCachedData(): T | null {

--- a/app/components/UI/Perps/providers/PerpsStreamManager.tsx
+++ b/app/components/UI/Perps/providers/PerpsStreamManager.tsx
@@ -576,6 +576,11 @@ abstract class StreamChannel<T> {
     }
 
     this.notifySubscribers(latest);
+    // Throttled subscribers would otherwise park this in pendingUpdate behind a
+    // timer — the Pro orders panel throttles at 1000ms, so a cancelled order
+    // could stay on screen for up to a second after the book is already empty.
+    // The batch operation has finished; there is nothing left to throttle.
+    this.flushThrottledDeliveries();
   }
 
   protected getCachedData(): T | null {

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1548,6 +1548,12 @@
     "pro_positions_panel": {
       "order_history": "Order history",
       "close_count": "Close ({{count}})",
+      "cancel_all": "Cancel all",
+      "cancel_count": "Cancel ({{count}})",
+      "open_orders": {
+        "one": "{{count}} open order",
+        "other": "{{count}} open orders"
+      },
       "positions": "Positions",
       "positions_with_count": "Positions ({{count}})",
       "orders": "Orders",
@@ -2433,7 +2439,13 @@
     },
     "cancel_all_modal": {
       "title": "Cancel all orders",
+      "title_filtered": "Cancel orders",
       "description": "We'll cancel all your open orders.",
+      "description_filtered": {
+        "one": "We'll cancel your open order.",
+        "other": "We'll cancel your {{count}} open orders."
+      },
+      "cancel_count": "Cancel ({{count}})",
       "keep_orders": "Keep orders",
       "confirm": "Confirm",
       "canceling": "Canceling...",

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1549,10 +1549,9 @@
       "order_history": "Order history",
       "close_count": "Close ({{count}})",
       "cancel_all": "Cancel all",
-      "cancel_count": "Cancel ({{count}})",
       "open_orders": {
-        "one": "{{count}} open order",
-        "other": "{{count}} open orders"
+        "one": "{{count}} order",
+        "other": "{{count}} orders"
       },
       "positions": "Positions",
       "positions_with_count": "Positions ({{count}})",
@@ -2438,16 +2437,13 @@
       "error_message": "Failed to close {{count}} position(s)"
     },
     "cancel_all_modal": {
-      "title": "Cancel all orders",
-      "title_filtered": "Cancel orders",
-      "description": "We'll cancel all your open orders.",
-      "description_filtered": {
-        "one": "We'll cancel your open order.",
-        "other": "We'll cancel your {{count}} open orders."
+      "title": "Cancel orders",
+      "description": {
+        "one": "We'll cancel {{count}} pending order. Any unfilled orders will be removed immediately.",
+        "other": "We'll cancel {{count}} pending orders. Any unfilled orders will be removed immediately."
       },
-      "cancel_count": "Cancel ({{count}})",
       "keep_orders": "Keep orders",
-      "confirm": "Confirm",
+      "confirm": "Cancel all",
       "canceling": "Canceling...",
       "success_title": "Orders canceled",
       "success_message": "Successfully canceled {{count}} order(s)",


### PR DESCRIPTION
## **Description**

The Pro-mode Orders tab had no bulk-cancel control, so clearing several resting orders meant cancelling them one at a time. This adds a `Cancel all` action to the Orders tab that respects the tab's active filters.

The confirmation sheet and the underlying Engine call are now scope-aware. When the list is filtered, the sheet says `Cancel orders` and counts only the listed orders, and cancellation is scoped by `orderIds` so orders in other markets survive. Unfiltered, both the copy and the provider-side `cancelAll` behaviour are unchanged.

Scoping is by order id rather than by symbol on purpose: one market can hold both a long and a short order, so a symbol-scoped cancel would over-cancel whenever the side filter is active without the ticker filter.

Validating this surfaced a second, pre-existing defect that the feature makes easy to hit,
fixed here as well: `StreamChannel.resume()` in `PerpsStreamManager` dropped the venue
update that arrived while a batch operation held the channel paused. After cancelling every
order the list kept rendering orders the venue had already removed, until an unrelated tick
or a reload. It affects every batch path that pauses a channel, close-all positions
included. See **Stream fix** below.

The ticket's second gap — the filtered Close All positions sheet claiming it closes everything — was already fixed in #34941. No code change was needed there; this PR adds the regression test that was missing.

## **Changelog**

CHANGELOG entry: Added a Cancel all button to the Pro mode Orders tab that cancels only the orders currently listed when a filter is applied, and fixed cancelled orders continuing to show in the list until the app was reloaded

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3701

## **Manual testing steps**

```gherkin
Feature: Cancel all open orders from the Pro mode Orders tab

  Scenario: user cancels every open order with no filter applied
    Given the wallet is unlocked with a funded perps balance
    And the user has open limit orders in the ETH and BTC markets
    And the user is on a Pro mode market screen with the Orders tab selected
    Then the summary reads "2 orders"
    When user taps "Cancel all"
    Then the sheet is titled "Cancel orders"
    And the sheet reads "We'll cancel 2 pending orders. Any unfilled orders will be removed immediately."
    When user confirms
    Then every open order is cancelled

  Scenario: user cancels only the filtered market's orders
    Given the wallet is unlocked with a funded perps balance
    And the user has open limit orders in the ETH and BTC markets
    And the user is on the ETH Pro mode market screen with the Orders tab selected
    When user enables the "ETH only" filter
    Then the summary narrows to "1 order"
    And the bulk action still reads "Cancel all"
    When user taps it
    Then the sheet is titled "Cancel orders"
    And the sheet reads "We'll cancel 1 pending order. Any unfilled orders will be removed immediately."
    When user confirms
    Then the ETH order is cancelled
    And the BTC order is still open

  Scenario: user sees the right count when closing filtered positions
    Given the user has open positions in two markets on a Pro mode market screen
    When user filters the Positions tab to one market
    And user taps the close control
    Then the sheet is titled "Close positions"
    And it describes only the single filtered position
```

## **Screenshots/Recordings**

<table>
<tr><td colspan="2"><strong>Recipe visual evidence</strong><br/>Screenshots are grouped for quick reviewer comparison.</td></tr>
<tr>
<td align="center" width="50%"><strong>ETH only checked: summary narrows to 1 order, action still reads Cancel all</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/TAT-3701-feat-add-cancel-all-orders-button/after-ac1-orders-tab-cancel-count-visible.png" alt="ETH only checked: summary narrows to 1 order, action still reads Cancel all" width="400" /></td>
<td align="center" width="50%"><strong>No filter: summary reads 2 orders, action reads Cancel all</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/TAT-3701-feat-add-cancel-all-orders-button/after-ac2-orders-tab-cancel-all-visible.png" alt="No filter: summary reads 2 orders, action reads Cancel all" width="400" /></td>
</tr>
<tr>
<td align="center" width="50%"><strong>Confirmation over the filtered market: We'll cancel 1 pending order</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/TAT-3701-feat-add-cancel-all-orders-button/after-ac3-confirmation-filtered.png" alt="Confirmation over the filtered market: We'll cancel 1 pending order" width="400" /></td>
<td align="center" width="50%"><strong>Confirmation over the whole book: We'll cancel 2 pending orders</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/TAT-3701-feat-add-cancel-all-orders-button/after-ac3-confirmation-unfiltered.png" alt="Confirmation over the whole book: We'll cancel 2 pending orders" width="400" /></td>
</tr>
</table>

### **Before**

Not captured. The Orders tab had no bulk-cancel control at all before this change, so a
"before" shot would just be an ordinary order list. The recipe encodes that absence as a
gate instead: `ac2-await-cancel-all-button` waits on `perps-pro-market-orders-cancel-all`,
a testID that does not exist on pre-change code, so the recipe fails without this PR.

### **After**

**Scope is carried by the count, not the label** — `2 orders` with no filter, `1 order`
with `ETH only` checked and the BTC row gone. The action reads `Cancel all` in both.

| | File |
| --- | --- |
| Unfiltered: `2 orders` + `Cancel all` | `after-ac2-orders-tab-cancel-all-visible.png` |
| Filtered: `1 order` + `Cancel all`, BTC row gone | `after-ac1-orders-tab-cancel-count-visible.png` |

**Confirmation names the scope by count** — same title, different count.

| | File |
| --- | --- |
| Whole book: *We'll cancel 2 pending orders…* | `after-ac3-confirmation-unfiltered.png` |
| Filtered: *We'll cancel 1 pending order…* | `after-ac3-confirmation-filtered.png` |

`after.mp4` records the full 42/42 passing run with the panel scrolled into frame. Note the
run HUD overlays the sheet footer in these captures, so the `Keep orders` / `Cancel all`
buttons are partly obscured; the sheet's title and body — the AC3 claim — are fully legible.

Two AC wordings were superseded by the design (the `Cancel (n)` label and AC3's
filtered-vs-all copy). Both were confirmed before implementing and a note is filed on the
ticket. Functional scope is unchanged: a filtered cancel still touches only the listed
market's orders.

## **Stream fix**

`app/components/UI/Perps/providers/PerpsStreamManager.tsx`

Batch operations pause a stream channel via the controller's `withStreamPause` so in-flight
WebSocket ticks cannot re-render stale data mid-operation. The venue's confirming update
lands inside that window: `this.cache.set('orders', orders)` runs, then `notifySubscribers`
returns early because `pauseCount > 0` and the delivery is dropped. `resume()` only
decremented the counter, so subscribers never saw the update that says the orders are gone.

The fresh data was already sitting in the cache — it just never reached anyone. `resume()`
now tracks whether a delivery was suppressed and flushes the cached snapshot on the
outermost release. An unmatched `resume()` remains a no-op, and a pause window with no
update in it delivers nothing.

Proof:

- **On device** — `artifacts/recipe-stale-row.json`, 14/14 pass: after cancelling both
  orders, `perps-pro-market-orders-cancel-all` and `perps-pro-market-orders-list` both go
  absent with no reload, and `before-bulk-cancel-two-orders.png` /
  `after-bulk-cancel-list-cleared.png` show the list going from two orders to
  "Your open orders will appear here."
- **Mutation-checked unit test** — "flushes the cancelled-order snapshot that arrived while
  paused" fails on the old `resume()` (0 deliveries) and passes on the fix.
- **No fallout** — 7166 tests across 335 Perps suites pass, including the positions,
  prices, and fills channels that share this base class.

Two existing pause/resume tests were updated: both asserted the old behavior by clearing
the mock and expecting only the post-resume tick. They now also assert the flush.

## **Validation Recipe**

<details><summary>recipe.json (42 steps — seeds orders in two markets, scrolls the panel into view, then proves the scoped bulk cancel and the confirmation copy in both scopes)</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "TAT-3701 Pro-mode Cancel All open orders",
  "description": "Proves the Pro Orders tab exposes a scope-aware bulk cancel: with the ticker filter on it cancels only that market's orders and names the filtered scope, with no filter it cancels every open order and says so, and the Positions tab's filtered Close All still counts only the filtered subset.",
  "workflow": {
    "entry": "reach-perps",
    "nodes": {
      "confirm-two-open": {
        "action": "metamask.perps.assert_orders",
        "mode": "matching",
        "markets": [
          "ETH",
          "BTC"
        ],
        "state": "open",
        "intent": "Confirm both markets really hold an open order before any cancelling is attempted",
        "next": "await-pro-panel"
      },
      "await-pro-panel": {
        "action": "ui.wait_for",
        "test_id": "perps-pro-market-positions-panel",
        "expected": "present",
        "timeout_ms": 20000,
        "intent": "The advanced view's positions and orders section is on screen for the trader",
        "next": "open-orders-tab"
      },
      "open-orders-tab": {
        "action": "ui.press",
        "test_id": "perps-pro-market-positions-panel-tab-orders",
        "settle": true,
        "intent": "Move the trader to the list of their open orders",
        "next": "await-orders-list"
      },
      "await-orders-list": {
        "action": "ui.wait_for",
        "test_id": "perps-pro-market-orders-list",
        "expected": "present",
        "timeout_ms": 15000,
        "intent": "The trader's open orders are listed on screen",
        "next": "scroll-to-orders-1"
      },
      "ac2-await-cancel-all-button": {
        "action": "ui.wait_for",
        "test_id": "perps-pro-market-orders-cancel-all",
        "expected": "present",
        "timeout_ms": 15000,
        "intent": "AC2: the orders list offers the trader a bulk cancel, which it did not before this change",
        "next": "ac2-await-unfiltered-label"
      },
      "ac2-await-unfiltered-label": {
        "action": "ui.wait_for",
        "text": "2 orders",
        "expected": "present",
        "timeout_ms": 10000,
        "intent": "AC2: before any filter the summary counts the trader\u2019s whole order book",
        "next": "ac2-await-fixed-label"
      },
      "ac1-filter-to-eth": {
        "action": "ui.press",
        "test_id": "perps-pro-market-positions-ticker-only",
        "settle": true,
        "intent": "AC1: narrow the orders list to the market the trader is looking at",
        "next": "ac1-await-scoped-button-label"
      },
      "ac1-await-scoped-button-label": {
        "action": "ui.wait_for",
        "text": "1 order",
        "expected": "present",
        "timeout_ms": 10000,
        "intent": "AC1: once filtered, the summary counts only the single order still listed instead of the whole book",
        "next": "ac1-await-label-unchanged"
      },
      "ac1-open-confirmation": {
        "action": "ui.press",
        "test_id": "perps-pro-market-orders-cancel-all",
        "settle": true,
        "intent": "AC1: the trader asks to cancel what the filtered list shows",
        "next": "ac3-await-filtered-title"
      },
      "ac3-await-filtered-title": {
        "action": "ui.wait_for",
        "text": "Cancel orders",
        "expected": "present",
        "timeout_ms": 15000,
        "intent": "AC3: the confirmation drops the word all, which would misdescribe a filtered subset",
        "next": "ac3-await-filtered-description"
      },
      "ac3-await-filtered-description": {
        "action": "ui.wait_for",
        "text": "We'll cancel 1 pending order. Any unfilled orders will be removed immediately.",
        "expected": "present",
        "timeout_ms": 10000,
        "intent": "AC3: the filtered confirmation counts exactly the one order the trader will lose",
        "next": "ac3-capture-filtered-sheet"
      },
      "ac1-confirm-cancel": {
        "action": "ui.press",
        "test_id": "perps-cancel-all-orders-cancel-all-button",
        "settle": true,
        "intent": "AC1: the trader confirms cancelling the filtered market's order",
        "next": "ac1-settle"
      },
      "ac1-settle": {
        "action": "wait",
        "duration_ms": 6000,
        "intent": "Allow the cancellation to reach the exchange and the order book to refresh",
        "next": "ac1-assert-eth-gone"
      },
      "ac1-assert-eth-gone": {
        "action": "metamask.perps.assert_orders",
        "market": "ETH",
        "state": "none",
        "timeout_ms": 30000,
        "intent": "AC1: the filtered market's order is genuinely gone from the exchange",
        "next": "ac1-assert-btc-survived"
      },
      "ac1-assert-btc-survived": {
        "action": "metamask.perps.assert_orders",
        "market": "BTC",
        "state": "open",
        "timeout_ms": 30000,
        "intent": "AC1: the market that was filtered out kept its order, so the cancel did not over-reach",
        "next": "ac2-clear-filter"
      },
      "ac2-clear-filter": {
        "action": "ui.press",
        "test_id": "perps-pro-market-positions-ticker-only",
        "settle": true,
        "intent": "AC2: the trader widens the list back to every market",
        "next": "scroll-after-clear"
      },
      "ac2-open-confirmation": {
        "action": "ui.press",
        "test_id": "perps-pro-market-orders-cancel-all",
        "settle": true,
        "intent": "AC2: the trader asks to cancel everything they have open",
        "next": "ac2-await-remaining-count"
      },
      "ac3-await-unfiltered-title": {
        "action": "ui.wait_for",
        "text": "Cancel orders",
        "expected": "present",
        "timeout_ms": 15000,
        "intent": "AC3: the confirmation names the action the trader is about to take",
        "next": "ac3-await-unfiltered-description"
      },
      "ac3-await-unfiltered-description": {
        "action": "ui.wait_for",
        "text": "We'll cancel 2 pending orders. Any unfilled orders will be removed immediately.",
        "expected": "present",
        "timeout_ms": 10000,
        "intent": "AC3: the unfiltered confirmation counts every open order, not a subset",
        "next": "ac3-capture-unfiltered-sheet"
      },
      "ac2-confirm-cancel": {
        "action": "ui.press",
        "test_id": "perps-cancel-all-orders-cancel-all-button",
        "settle": true,
        "intent": "AC2: the trader confirms cancelling every open order",
        "next": "ac2-settle"
      },
      "ac2-settle": {
        "action": "wait",
        "duration_ms": 6000,
        "intent": "Allow the bulk cancellation to reach the exchange and the order book to refresh",
        "next": "ac2-assert-book-empty"
      },
      "ac2-assert-book-empty": {
        "action": "metamask.perps.assert_orders",
        "mode": "all",
        "state": "none",
        "timeout_ms": 30000,
        "intent": "AC2: no open order survives anywhere, including the market that was spared a moment ago",
        "next": "teardown"
      },
      "teardown": {
        "action": "metamask.perps.teardown_state",
        "network": "testnet",
        "positions": {
          "state": "none",
          "mode": "all"
        },
        "orders": {
          "state": "none",
          "mode": "all"
        },
        "timeout_ms": 240000,
        "intent": "Return the account to an empty book so the next run starts from the same place",
        "next": "done"
      },
      "done": {
        "action": "end",
        "status": "pass"
      },
      "reach-perps": {
        "action": "metamask.perps.start_state",
        "network": "testnet",
        "page": "market",
        "market": "ETH",
        "intent": "Put the trader on a funded testnet Perps account looking at a market",
        "next": "restart-app"
      },
      "seed-eth-order": {
        "action": "metamask.perps.ensure_orders",
        "market": "ETH",
        "side": "long",
        "state": "open",
        "notional": 12,
        "leverage": 2,
        "timeout_ms": 180000,
        "intent": "Give the trader a resting ETH order, the one a market filter will keep",
        "next": "seed-btc-order"
      },
      "seed-btc-order": {
        "action": "metamask.perps.ensure_orders",
        "market": "BTC",
        "side": "long",
        "state": "open",
        "notional": 12,
        "leverage": 2,
        "timeout_ms": 180000,
        "intent": "Give the trader a resting BTC order, the one a market filter must spare",
        "next": "confirm-two-open"
      },
      "restart-app": {
        "action": "app.lifecycle",
        "event": "restart",
        "platform": "ios",
        "timeout_ms": 180000,
        "intent": "Start the trader from a freshly opened app so no leftover filter is applied",
        "next": "unlock-after-restart"
      },
      "reopen-pro-market": {
        "action": "ui.navigate",
        "page": "perps-market",
        "market": "ETH",
        "mode": "pro",
        "timeout_ms": 90000,
        "intent": "Return the trader to the advanced trading view after the restart",
        "next": "seed-eth-order"
      },
      "unlock-after-restart": {
        "action": "metamask.wallet.ensure_unlocked",
        "unlock_timeout_ms": 120000,
        "intent": "Let the trader back into their wallet after the restart",
        "next": "reopen-pro-market"
      },
      "scroll-to-orders-1": {
        "action": "ui.swipe",
        "target": {
          "x": 200,
          "y": 650
        },
        "direction": "up",
        "distance": 600,
        "duration_ms": 500,
        "settle": true,
        "intent": "Drag the market screen up so the trader's orders section comes into view",
        "next": "scroll-to-orders-2"
      },
      "scroll-to-orders-2": {
        "action": "ui.swipe",
        "target": {
          "x": 200,
          "y": 650
        },
        "direction": "up",
        "distance": 600,
        "duration_ms": 500,
        "settle": true,
        "intent": "Continue dragging until the orders list and its bulk action are on screen",
        "next": "ac2-await-cancel-all-button"
      },
      "ac2-capture-unfiltered": {
        "action": "ui.screenshot",
        "path": "screenshots/after-ac2-orders-tab-cancel-all-visible.png",
        "label": "AC2: Orders tab shows a Cancel all control covering every open order",
        "intent": "The trader can see a bulk cancel offered over their whole order book",
        "next": "ac1-filter-to-eth"
      },
      "ac1-capture-scoped": {
        "action": "ui.screenshot",
        "path": "screenshots/after-ac1-orders-tab-cancel-count-visible.png",
        "label": "AC1: with the ETH only filter on, the bulk action counts just the listed order",
        "intent": "The trader can see the bulk action counting only the orders the filter left listed",
        "next": "ac1-open-confirmation"
      },
      "ac3-capture-filtered-sheet": {
        "action": "ui.screenshot",
        "path": "screenshots/after-ac3-confirmation-filtered.png",
        "label": "AC3: filtered confirmation reads Cancel orders and names the single order",
        "intent": "The trader reads a confirmation naming the filtered scope before losing the order",
        "next": "ac1-confirm-cancel"
      },
      "ac3-capture-unfiltered-sheet": {
        "action": "ui.screenshot",
        "path": "screenshots/after-ac3-confirmation-unfiltered.png",
        "label": "AC3: unfiltered confirmation reads Cancel all orders and describes the whole book",
        "intent": "The trader reads a confirmation covering every open order before losing them",
        "next": "ac3-dismiss-unfiltered"
      },
      "scroll-after-clear": {
        "action": "ui.swipe",
        "target": {
          "x": 200,
          "y": 650
        },
        "direction": "up",
        "distance": 600,
        "duration_ms": 500,
        "settle": true,
        "intent": "Keep the orders section in view after the list widens back to every market",
        "next": "ac2-open-confirmation"
      },
      "ac2-await-fixed-label": {
        "action": "ui.wait_for",
        "text": "Cancel all",
        "expected": "present",
        "timeout_ms": 10000,
        "intent": "AC2: the bulk action is offered as Cancel all over the whole book",
        "next": "ac3-open-unfiltered-confirmation"
      },
      "ac1-await-label-unchanged": {
        "action": "ui.wait_for",
        "text": "Cancel all",
        "expected": "present",
        "timeout_ms": 10000,
        "intent": "AC1: the bulk action keeps the same label once filtered; the count above it carries the scope",
        "next": "ac1-capture-scoped"
      },
      "ac3-open-unfiltered-confirmation": {
        "action": "ui.press",
        "test_id": "perps-pro-market-orders-cancel-all",
        "settle": true,
        "intent": "AC3: the trader opens the confirmation with their whole order book listed",
        "next": "ac3-await-unfiltered-title"
      },
      "ac3-dismiss-unfiltered": {
        "action": "ui.press",
        "test_id": "perps-cancel-all-orders-keep-button",
        "settle": true,
        "intent": "The trader backs out, keeping every order so the filtered case can be shown next",
        "next": "ac2-capture-unfiltered"
      },
      "ac2-await-remaining-count": {
        "action": "ui.wait_for",
        "text": "We'll cancel 1 pending order. Any unfilled orders will be removed immediately.",
        "expected": "present",
        "timeout_ms": 15000,
        "intent": "AC2: with the filter cleared the confirmation counts the order AC1 deliberately spared",
        "next": "ac2-confirm-cancel"
      }
    }
  }
}
```
</details>

## **Validation Logs**

Command:

```bash
mm-harness run temp/tasks/feat/tat-3701-0820-233718/artifacts/recipe.json \
  --adapter mobile \
  --record-video=full-run \
  --artifacts-dir temp/tasks/feat/tat-3701-0820-233718/artifacts/recipe-run \
  --target /Users/deeeed/dev/metamask/metamask-mobile-3 \
  --slot macpro-mm-3 --json
```

<details><summary>Full output (42/42 passed)</summary>

```
status: pass
passed: 42 / 42
failed: 0
durationMs: 95750

Node sequence (execution order, all passed):
   1. reach-perps
   2. restart-app
   3. unlock-after-restart
   4. reopen-pro-market
   5. seed-eth-order
   6. seed-btc-order
   7. confirm-two-open
   8. await-pro-panel
   9. open-orders-tab
  10. await-orders-list
  11. scroll-to-orders-1
  12. scroll-to-orders-2
  13. ac2-await-cancel-all-button
  14. ac2-await-unfiltered-label
  15. ac2-await-fixed-label
  16. ac3-open-unfiltered-confirmation
  17. ac3-await-unfiltered-title
  18. ac3-await-unfiltered-description
  19. ac3-capture-unfiltered-sheet
  20. ac3-dismiss-unfiltered
  21. ac2-capture-unfiltered
  22. ac1-filter-to-eth
  23. ac1-await-scoped-button-label
  24. ac1-await-label-unchanged
  25. ac1-capture-scoped
  26. ac1-open-confirmation
  27. ac3-await-filtered-title
  28. ac3-await-filtered-description
  29. ac3-capture-filtered-sheet
  30. ac1-confirm-cancel
  31. ac1-settle
  32. ac1-assert-eth-gone
  33. ac1-assert-btc-survived
  34. ac2-clear-filter
  35. scroll-after-clear
  36. ac2-open-confirmation
  37. ac2-await-remaining-count
  38. ac2-confirm-cancel
  39. ac2-settle
  40. ac2-assert-book-empty
  41. teardown
  42. done
```
</details>

### Acceptance criteria status

| AC | Status | Proof |
| --- | --- | --- |
| Filtered Orders tab → Cancel All cancels only market X's orders | PASS | `ac1-assert-eth-gone` (ETH → none) **and** `ac1-assert-btc-survived` (BTC still open); screenshot `after-ac1-orders-tab-cancel-count-visible.png` |
| No filter → Cancel All cancels all open orders | PASS | `ac2-assert-book-empty` (`mode=all`, `state=none`); screenshot `after-ac2-orders-tab-cancel-all-visible.png` |
| Confirmation copy names the scope | PASS | Four verbatim `ui.wait_for` assertions covering both directions; screenshots `after-ac3-confirmation-filtered.png` and `after-ac3-confirmation-unfiltered.png` |
| Filtered Close All positions sheet shows the right count | PASS | Component view test; already correct in the tree since #34941, regression test added here |

The recipe fails on pre-change code: `ac2-await-cancel-all-button` waits on `perps-pro-market-orders-cancel-all`, which does not exist before this change.

AC4 has no runtime recipe node because seeding its precondition is rejected by this testnet for every harness action that opens a position (`Price too far from oracle`). It is covered by a component view test instead. Details in `artifacts/recipe-coverage.md`.

### Unit and view tests

```
335 suites, 7168 tests passed  (full Perps unit sweep, no regressions)
 17 suites,  108 tests passed  (full Perps component-view sweep)
141 tests passed               (PerpsStreamManager, incl. the pause/resume flush guard)
```

Coverage on changed files: 91.66% statements, 87.75% branches. `PerpsProOrdersSummary.tsx` (new) at 100%.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

Not applicable to this change, and not performed. It adds one button and a bottom-sheet copy branch to an existing list — no new data fetching, no hot-path work, and no new render loop. Validation ran on iOS only.

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

