### PR TITLE
fix(perps): fix CTA cutoff on Perps Lite for Android devices

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -265,6 +265,8 @@ export const PerpsHomeViewSelectorsIDs = {
   SEARCH_INPUT: 'perps-home-search',
   HOME_HEADING: 'perps-home-heading',
   SCROLL_CONTENT: 'scroll-content',
+  FIXED_FOOTER: 'perps-home-fixed-footer',
+  BOTTOM_SPACER: 'perps-home-bottom-spacer',
   WITHDRAW_BUTTON: 'perps-home-withdraw-button',
   ADD_FUNDS_BUTTON: 'perps-home-add-funds-button',
   POSITIONS_PNL_VALUE: 'perps-home-positions-pnl-value',

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { act, render, fireEvent, waitFor } from '@testing-library/react-native';
+import { StyleSheet, type StyleProp, type ViewStyle } from 'react-native';
 import PerpsHomeView from './PerpsHomeView';
 import { PERPS_EVENT_VALUE, PerpsMode } from '@metamask/perps-controller';
+import {
+  FIXED_BOTTOM_CONTAINER_BASE_HEIGHT,
+  FIXED_BOTTOM_CONTAINER_PADDING,
+} from '../../constants/perpsUIConfig';
 import {
   selectPerpsFeedbackEnabledFlag,
   selectPerpsProductsEnabledFlag,
@@ -534,6 +539,27 @@ const mockScrollTracking = () => ({
 const mockUsePerpsLiveAccount = jest.requireMock('../../hooks/stream')
   .usePerpsLiveAccount as jest.Mock;
 
+const mockUseBottomSafeAreaInset = jest.requireMock('../../hooks')
+  .useBottomSafeAreaInset as jest.Mock;
+
+// Stand-in for a real Android gesture navigation bar (24dp), so a regression that
+// drops the inset from a layout calculation changes the asserted value.
+const NAVIGATION_BAR_INSET = 24;
+
+const fundedAccount = {
+  account: {
+    totalBalance: '100',
+    spendableBalance: '100',
+    withdrawableBalance: '100',
+    unrealizedPnl: '0',
+    returnOnEquity: '0',
+  },
+  isInitialLoading: false,
+};
+
+const flattenStyle = (node: { props: { style: unknown } }) =>
+  StyleSheet.flatten(node.props.style as StyleProp<ViewStyle>);
+
 describe('PerpsHomeView', () => {
   const mockDefaultData = {
     positions: [],
@@ -557,6 +583,8 @@ describe('PerpsHomeView', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // clearAllMocks drops the factory implementation; restore the default inset.
+    mockUseBottomSafeAreaInset.mockReturnValue(0);
     mockHasCompletedPerpsModeSelection.mockResolvedValue(false);
     mockNavigateBack.mockClear();
     mockNavigateToWallet.mockClear();
@@ -1276,6 +1304,59 @@ describe('PerpsHomeView', () => {
       expect(
         getByTestId(PerpsHomeViewSelectorsIDs.ADD_FUNDS_BUTTON),
       ).toBeTruthy();
+    });
+
+    it('adds the system navigation bar inset to the fixed footer padding', () => {
+      mockUseBottomSafeAreaInset.mockReturnValue(NAVIGATION_BAR_INSET);
+      mockUsePerpsLiveAccount.mockReturnValue(fundedAccount);
+
+      const { getByTestId } = render(<PerpsHomeView />);
+
+      expect(
+        flattenStyle(getByTestId(PerpsHomeViewSelectorsIDs.FIXED_FOOTER)),
+      ).toEqual(
+        expect.objectContaining({
+          paddingBottom: FIXED_BOTTOM_CONTAINER_PADDING + NAVIGATION_BAR_INSET,
+        }),
+      );
+    });
+
+    it('reserves scroll space for the navigation bar inset below the fixed footer', () => {
+      mockUseBottomSafeAreaInset.mockReturnValue(NAVIGATION_BAR_INSET);
+      mockUsePerpsLiveAccount.mockReturnValue(fundedAccount);
+
+      const { getByTestId } = render(<PerpsHomeView />);
+
+      expect(
+        flattenStyle(getByTestId(PerpsHomeViewSelectorsIDs.BOTTOM_SPACER)),
+      ).toEqual(
+        expect.objectContaining({
+          height:
+            FIXED_BOTTOM_CONTAINER_BASE_HEIGHT +
+            NAVIGATION_BAR_INSET +
+            FIXED_BOTTOM_CONTAINER_PADDING,
+        }),
+      );
+    });
+  });
+
+  describe('scroll content bottom padding', () => {
+    it('adds the system navigation bar inset when no fixed footer is rendered', () => {
+      mockUseBottomSafeAreaInset.mockReturnValue(NAVIGATION_BAR_INSET);
+      mockUsePerpsLiveAccount.mockReturnValue(fundedAccount);
+
+      const { getByTestId } = render(<PerpsHomeView />);
+
+      const contentContainerStyle = StyleSheet.flatten(
+        getByTestId(PerpsHomeViewSelectorsIDs.SCROLL_CONTENT).props
+          .contentContainerStyle as StyleProp<ViewStyle>,
+      );
+
+      expect(contentContainerStyle).toEqual(
+        expect.objectContaining({
+          paddingBottom: FIXED_BOTTOM_CONTAINER_PADDING + NAVIGATION_BAR_INSET,
+        }),
+      );
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
@@ -557,6 +557,14 @@ const fundedAccount = {
   isInitialLoading: false,
 };
 
+// Children such as PerpsCompetitionBanner resolve storage in an async effect
+// after the first render; flush it so assertions run on a settled tree.
+const settleAsyncChildren = async () => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
 const flattenStyle = (node: { props: { style: unknown } }) =>
   StyleSheet.flatten(node.props.style as StyleProp<ViewStyle>);
 
@@ -583,7 +591,8 @@ describe('PerpsHomeView', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // clearAllMocks drops the factory implementation; restore the default inset.
+    // Pin the default inset so a mockReturnValue set by one test cannot leak
+    // into later ones (clearAllMocks resets call state, not return values).
     mockUseBottomSafeAreaInset.mockReturnValue(0);
     mockHasCompletedPerpsModeSelection.mockResolvedValue(false);
     mockNavigateBack.mockClear();
@@ -1306,11 +1315,12 @@ describe('PerpsHomeView', () => {
       ).toBeTruthy();
     });
 
-    it('adds the system navigation bar inset to the fixed footer padding', () => {
+    it('adds the system navigation bar inset to the fixed footer padding', async () => {
       mockUseBottomSafeAreaInset.mockReturnValue(NAVIGATION_BAR_INSET);
       mockUsePerpsLiveAccount.mockReturnValue(fundedAccount);
 
       const { getByTestId } = render(<PerpsHomeView />);
+      await settleAsyncChildren();
 
       expect(
         flattenStyle(getByTestId(PerpsHomeViewSelectorsIDs.FIXED_FOOTER)),
@@ -1321,11 +1331,12 @@ describe('PerpsHomeView', () => {
       );
     });
 
-    it('reserves scroll space for the navigation bar inset below the fixed footer', () => {
+    it('reserves scroll space for the navigation bar inset below the fixed footer', async () => {
       mockUseBottomSafeAreaInset.mockReturnValue(NAVIGATION_BAR_INSET);
       mockUsePerpsLiveAccount.mockReturnValue(fundedAccount);
 
       const { getByTestId } = render(<PerpsHomeView />);
+      await settleAsyncChildren();
 
       expect(
         flattenStyle(getByTestId(PerpsHomeViewSelectorsIDs.BOTTOM_SPACER)),
@@ -1341,11 +1352,12 @@ describe('PerpsHomeView', () => {
   });
 
   describe('scroll content bottom padding', () => {
-    it('adds the system navigation bar inset when no fixed footer is rendered', () => {
+    it('adds the system navigation bar inset when no fixed footer is rendered', async () => {
       mockUseBottomSafeAreaInset.mockReturnValue(NAVIGATION_BAR_INSET);
       mockUsePerpsLiveAccount.mockReturnValue(fundedAccount);
 
       const { getByTestId } = render(<PerpsHomeView />);
+      await settleAsyncChildren();
 
       const contentContainerStyle = StyleSheet.flatten(
         getByTestId(PerpsHomeViewSelectorsIDs.SCROLL_CONTENT).props

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
@@ -137,6 +137,7 @@ const mockCloseEligibilityModal = jest.fn();
 const mockSetPerpsMode = jest.fn();
 const mockUsePerpsHomeSectionTracking = jest.fn();
 jest.mock('../../hooks', () => ({
+  useBottomSafeAreaInset: jest.fn(() => 0),
   usePerpsHomeData: jest.fn(),
   usePerpsMeasurement: jest.fn(),
   usePerpsNavigation: jest.fn(() => ({

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.test.tsx
@@ -565,7 +565,7 @@ const settleAsyncChildren = async () => {
   });
 };
 
-const flattenStyle = (node: { props: { style: unknown } }) =>
+const flattenStyle = (node: { props: Record<string, unknown> }) =>
   StyleSheet.flatten(node.props.style as StyleProp<ViewStyle>);
 
 describe('PerpsHomeView', () => {

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -7,7 +7,6 @@ import React, {
 } from 'react';
 import { View, Modal, NativeScrollEvent } from 'react-native';
 import { useSelector } from 'react-redux';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   useNavigation,
   useRoute,
@@ -47,6 +46,7 @@ import {
 } from '../../utils/formatUtils';
 import Routes from '../../../../../constants/navigation/Routes';
 import {
+  useBottomSafeAreaInset,
   usePerpsHomeData,
   usePerpsNavigation,
   usePerpsMeasurement,
@@ -138,7 +138,7 @@ import {
 
 const PerpsHomeView = () => {
   const { styles } = useStyles(styleSheet, {});
-  const insets = useSafeAreaInsets();
+  const bottomSafeAreaInset = useBottomSafeAreaInset();
   const navigation = useNavigation<AppNavigationProp>();
   const route =
     useRoute<RouteProp<PerpsNavigationParamList, 'PerpsMarketListView'>>();
@@ -1001,8 +1001,8 @@ const PerpsHomeView = () => {
   }, []);
 
   // Calculate actual footer dimensions
-  // Footer: paddingTop(16) + button(48) + paddingBottom(16 + insets.bottom)
-  const footerHeight = 80 + insets.bottom;
+  // Footer: paddingTop(16) + button(48) + paddingBottom(16 + bottomSafeAreaInset)
+  const footerHeight = 80 + bottomSafeAreaInset;
 
   const showsFixedFooter =
     !isBalanceEmpty &&
@@ -1020,8 +1020,8 @@ const PerpsHomeView = () => {
 
   // Add safe area inset to footer for Android navigation bar
   const fixedFooterStyle = useMemo(
-    () => [styles.fixedFooter, { paddingBottom: 16 + insets.bottom }],
-    [styles.fixedFooter, insets.bottom],
+    () => [styles.fixedFooter, { paddingBottom: 16 + bottomSafeAreaInset }],
+    [styles.fixedFooter, bottomSafeAreaInset],
   );
 
   const scrollContentContainerStyle = useMemo(
@@ -1029,9 +1029,9 @@ const PerpsHomeView = () => {
       styles.scrollViewContent,
       showsFixedFooter
         ? { paddingBottom: 0 }
-        : { paddingBottom: 16 + insets.bottom },
+        : { paddingBottom: 16 + bottomSafeAreaInset },
     ],
-    [styles.scrollViewContent, showsFixedFooter, insets.bottom],
+    [styles.scrollViewContent, showsFixedFooter, bottomSafeAreaInset],
   );
 
   const titleEndAccessory = useMemo(() => {

--- a/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
+++ b/app/components/UI/Perps/Views/PerpsHomeView/PerpsHomeView.tsx
@@ -111,6 +111,10 @@ import { TraceName } from '../../../../../util/trace';
 import { buildPerpsCufStartTags } from '../../utils/perpsCufTrace';
 import { PERPS_CUF_TAG, PERPS_CUF_VARIANT } from '../../constants/perpsCufTags';
 import {
+  FIXED_BOTTOM_CONTAINER_BASE_HEIGHT,
+  FIXED_BOTTOM_CONTAINER_PADDING,
+} from '../../constants/perpsUIConfig';
+import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
   type PerpsMarketData,
@@ -1000,9 +1004,9 @@ const PerpsHomeView = () => {
     setShowCancelAllSheet(false);
   }, []);
 
-  // Calculate actual footer dimensions
-  // Footer: paddingTop(16) + button(48) + paddingBottom(16 + bottomSafeAreaInset)
-  const footerHeight = 80 + bottomSafeAreaInset;
+  // Calculate actual footer dimensions: the base footer geometry plus the
+  // system navigation-bar inset added to its bottom padding at runtime.
+  const footerHeight = FIXED_BOTTOM_CONTAINER_BASE_HEIGHT + bottomSafeAreaInset;
 
   const showsFixedFooter =
     !isBalanceEmpty &&
@@ -1013,14 +1017,21 @@ const PerpsHomeView = () => {
   const bottomSpacerStyle = useMemo(
     () => ({
       // Reserve space for the fixed footer only when it is rendered.
-      height: showsFixedFooter ? footerHeight + 16 : 16,
+      height: showsFixedFooter
+        ? footerHeight + FIXED_BOTTOM_CONTAINER_PADDING
+        : FIXED_BOTTOM_CONTAINER_PADDING,
     }),
     [showsFixedFooter, footerHeight],
   );
 
   // Add safe area inset to footer for Android navigation bar
   const fixedFooterStyle = useMemo(
-    () => [styles.fixedFooter, { paddingBottom: 16 + bottomSafeAreaInset }],
+    () => [
+      styles.fixedFooter,
+      {
+        paddingBottom: FIXED_BOTTOM_CONTAINER_PADDING + bottomSafeAreaInset,
+      },
+    ],
     [styles.fixedFooter, bottomSafeAreaInset],
   );
 
@@ -1029,7 +1040,9 @@ const PerpsHomeView = () => {
       styles.scrollViewContent,
       showsFixedFooter
         ? { paddingBottom: 0 }
-        : { paddingBottom: 16 + bottomSafeAreaInset },
+        : {
+            paddingBottom: FIXED_BOTTOM_CONTAINER_PADDING + bottomSafeAreaInset,
+          },
     ],
     [styles.scrollViewContent, showsFixedFooter, bottomSafeAreaInset],
   );
@@ -1187,7 +1200,10 @@ const PerpsHomeView = () => {
         <PerpsHomeSectionList sections={homeSections} />
 
         {/* Bottom spacing for tab bar */}
-        <View style={bottomSpacerStyle} />
+        <View
+          style={bottomSpacerStyle}
+          testID={PerpsHomeViewSelectorsIDs.BOTTOM_SPACER}
+        />
       </Reanimated.ScrollView>
 
       {/* Close All Positions Bottom Sheet */}
@@ -1208,7 +1224,10 @@ const PerpsHomeView = () => {
 
       {/* Fixed Footer with Action Buttons - Only show when balance is not empty and no sheets are open */}
       {showsFixedFooter && (
-        <View style={fixedFooterStyle}>
+        <View
+          style={fixedFooterStyle}
+          testID={PerpsHomeViewSelectorsIDs.FIXED_FOOTER}
+        >
           <View style={styles.footerButtonsContainer} accessible={false}>
             <Button
               variant={ButtonVariant.Secondary}

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.styles.ts
@@ -1,6 +1,12 @@
 import { StyleSheet } from 'react-native';
 import type { Colors } from '../../../../../util/theme/models';
 
+/**
+ * Visual padding kept between the fixed CTA and the bottom of its container.
+ * The system navigation-bar inset is added to this at runtime.
+ */
+export const FIXED_BOTTOM_CONTAINER_PADDING = 16;
+
 const createStyles = (colors: Colors) =>
   StyleSheet.create({
     container: {

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.styles.ts
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.styles.ts
@@ -1,12 +1,6 @@
 import { StyleSheet } from 'react-native';
 import type { Colors } from '../../../../../util/theme/models';
 
-/**
- * Visual padding kept between the fixed CTA and the bottom of its container.
- * The system navigation-bar inset is added to this at runtime.
- */
-export const FIXED_BOTTOM_CONTAINER_PADDING = 16;
-
 const createStyles = (colors: Colors) =>
   StyleSheet.create({
     container: {

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.test.tsx
@@ -185,6 +185,7 @@ jest.mock('../../hooks/usePerpsNetworkManagement', () => ({
 
 // Mock the hooks module - these will be overridden in beforeEach
 jest.mock('../../hooks', () => ({
+  useBottomSafeAreaInset: jest.fn(() => 0),
   usePerpsLiveAccount: jest.fn(),
   usePerpsTrading: jest.fn(),
   usePerpsNetwork: jest.fn(),

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -275,15 +275,6 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
     [styles.fixedBottomContainer, insets.bottom],
   );
 
-  DevLogger.log(
-    '[TAT-3822] BUG_MARKER: perps lite CTA bottom inset — ' +
-      JSON.stringify({
-        insetsBottom: insets.bottom,
-        appliedPaddingBottom: insets.bottom + 16,
-        scrollReserve: 120,
-      }),
-  );
-
   // Deferred loading: Load non-critical data after UI renders
   const [isDataReady, setIsDataReady] = useState(false);
   useEffect(() => {

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -14,10 +14,7 @@ import React, {
   useState,
 } from 'react';
 import { ScrollView, TouchableOpacity, View } from 'react-native';
-import {
-  SafeAreaView,
-  useSafeAreaInsets,
-} from 'react-native-safe-area-context';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { PerpsOrderViewSelectorsIDs } from '../../Perps.testIds';
 import {
   Box,
@@ -104,6 +101,7 @@ import {
   usePerpsOrderContext,
 } from '../../contexts/PerpsOrderContext';
 import {
+  useBottomSafeAreaInset,
   useHasExistingPosition,
   useMinimumOrderAmount,
   usePerpsLiquidationPrice,
@@ -165,7 +163,9 @@ import {
   buildPerpsOrderParams,
   buildPerpsOrderTrackingData,
 } from '../../utils/orderParams';
-import createStyles from './PerpsOrderView.styles';
+import createStyles, {
+  FIXED_BOTTOM_CONTAINER_PADDING,
+} from './PerpsOrderView.styles';
 import { PerpsPayRow } from './PerpsPayRow';
 import { useUpdateTokenAmount } from '../../../../Views/confirmations/hooks/transactions/useUpdateTokenAmount';
 import { useConfirmActions } from '../../../../Views/confirmations/hooks/useConfirmActions';
@@ -242,7 +242,7 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
     route.params?.chartLibrary ?? getPerpsChartLibrary(isAdvancedChartEnabled);
   const fromTokenDetails = route.params?.fromTokenDetails ?? false;
   const { colors } = useTheme();
-  const insets = useSafeAreaInsets();
+  const bottomSafeAreaInset = useBottomSafeAreaInset();
 
   useAddToken({
     chainId: CHAIN_IDS.ARBITRUM,
@@ -266,13 +266,14 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
 
   const styles = createStyles(colors);
 
-  // Dynamic bottom padding for fixed container: safe area inset + 16px visual padding
+  // Dynamic bottom padding for fixed container: system navigation-bar inset plus
+  // the visual padding, so the CTA is never drawn under the navigation bar.
   const fixedBottomContainerStyle = useMemo(
     () => ({
       ...styles.fixedBottomContainer,
-      paddingBottom: insets.bottom + 16,
+      paddingBottom: bottomSafeAreaInset + FIXED_BOTTOM_CONTAINER_PADDING,
     }),
-    [styles.fixedBottomContainer, insets.bottom],
+    [styles.fixedBottomContainer, bottomSafeAreaInset],
   );
 
   // Deferred loading: Load non-critical data after UI renders

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -96,6 +96,7 @@ import {
 } from '@metamask/perps-controller/constants';
 import { PERPS_ANALYTICS_PREVIOUS_LEVERAGE } from '../../constants/perpsAnalytics';
 import { bpsToPercent } from '../../constants/slippageConfig';
+import { FIXED_BOTTOM_CONTAINER_PADDING } from '../../constants/perpsUIConfig';
 import {
   PerpsOrderProvider,
   usePerpsOrderContext,
@@ -163,9 +164,7 @@ import {
   buildPerpsOrderParams,
   buildPerpsOrderTrackingData,
 } from '../../utils/orderParams';
-import createStyles, {
-  FIXED_BOTTOM_CONTAINER_PADDING,
-} from './PerpsOrderView.styles';
+import createStyles from './PerpsOrderView.styles';
 import { PerpsPayRow } from './PerpsPayRow';
 import { useUpdateTokenAmount } from '../../../../Views/confirmations/hooks/transactions/useUpdateTokenAmount';
 import { useConfirmActions } from '../../../../Views/confirmations/hooks/useConfirmActions';

--- a/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
+++ b/app/components/UI/Perps/Views/PerpsOrderView/PerpsOrderView.tsx
@@ -275,6 +275,15 @@ const PerpsOrderViewContentBase: React.FC<PerpsOrderViewContentProps> = ({
     [styles.fixedBottomContainer, insets.bottom],
   );
 
+  DevLogger.log(
+    '[TAT-3822] BUG_MARKER: perps lite CTA bottom inset — ' +
+      JSON.stringify({
+        insetsBottom: insets.bottom,
+        appliedPaddingBottom: insets.bottom + 16,
+        scrollReserve: 120,
+      }),
+  );
+
   // Deferred loading: Load non-critical data after UI renders
   const [isDataReady, setIsDataReady] = useState(false);
   useEffect(() => {

--- a/app/components/UI/Perps/constants/perpsUIConfig.ts
+++ b/app/components/UI/Perps/constants/perpsUIConfig.ts
@@ -29,3 +29,19 @@ export const ORDER_BOOK_SPREAD = {
 
 // Withdrawal constants (HyperLiquid-specific UI progress timing)
 export const HYPERLIQUID_WITHDRAWAL_PROGRESS_INTERVAL_MS = 30000; // 30 seconds progress update interval
+
+// Fixed bottom CTA container geometry (density-independent pixels).
+// Screens that pin a CTA container to the bottom of the window add the system
+// navigation-bar inset to FIXED_BOTTOM_CONTAINER_PADDING at runtime, so the
+// visual gap survives above the navigation bar instead of being consumed by it.
+export const FIXED_BOTTOM_CONTAINER_PADDING = 16;
+
+// Height of a footer button in a fixed bottom CTA container.
+export const FIXED_BOTTOM_CONTAINER_BUTTON_HEIGHT = 48;
+
+// Footer height excluding the navigation-bar inset:
+// paddingTop + button + paddingBottom.
+export const FIXED_BOTTOM_CONTAINER_BASE_HEIGHT =
+  FIXED_BOTTOM_CONTAINER_PADDING +
+  FIXED_BOTTOM_CONTAINER_BUTTON_HEIGHT +
+  FIXED_BOTTOM_CONTAINER_PADDING;

--- a/app/components/UI/Perps/hooks/index.ts
+++ b/app/components/UI/Perps/hooks/index.ts
@@ -1,4 +1,5 @@
 // Core hooks (direct controller access)
+export { useBottomSafeAreaInset } from './useBottomSafeAreaInset';
 export { usePerpsCategories } from './usePerpsCategories';
 export { useHasNewMarkets } from './useHasNewMarkets';
 export { usePerpsMarkets } from './usePerpsMarkets';

--- a/app/components/UI/Perps/hooks/useBottomSafeAreaInset.test.ts
+++ b/app/components/UI/Perps/hooks/useBottomSafeAreaInset.test.ts
@@ -1,0 +1,93 @@
+import { renderHook } from '@testing-library/react-native';
+import { useWindowDimensions } from 'react-native';
+import {
+  useSafeAreaFrame,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
+import { useBottomSafeAreaInset } from './useBottomSafeAreaInset';
+
+jest.mock('react-native/Libraries/Utilities/useWindowDimensions');
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaFrame: jest.fn(),
+  useSafeAreaInsets: jest.fn(),
+}));
+
+const mockUseWindowDimensions = jest.mocked(useWindowDimensions);
+const mockUseSafeAreaFrame = jest.mocked(useSafeAreaFrame);
+const mockUseSafeAreaInsets = jest.mocked(useSafeAreaInsets);
+
+const WINDOW_HEIGHT = 914;
+const WINDOW_WIDTH = 411;
+
+const arrangeInsets = ({
+  insetBottom,
+  frameHeight,
+}: {
+  insetBottom: number;
+  frameHeight: number;
+}) => {
+  mockUseSafeAreaInsets.mockReturnValue({
+    top: 24,
+    bottom: insetBottom,
+    left: 0,
+    right: 0,
+  });
+  mockUseSafeAreaFrame.mockReturnValue({
+    x: 0,
+    y: 0,
+    width: WINDOW_WIDTH,
+    height: frameHeight,
+  });
+  mockUseWindowDimensions.mockReturnValue({
+    width: WINDOW_WIDTH,
+    height: WINDOW_HEIGHT,
+    scale: 2.625,
+    fontScale: 1,
+  });
+};
+
+describe('useBottomSafeAreaInset', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the reported inset when the platform provides one', () => {
+    arrangeInsets({ insetBottom: 34, frameHeight: WINDOW_HEIGHT - 34 });
+
+    const { result } = renderHook(() => useBottomSafeAreaInset());
+
+    expect(result.current).toBe(34);
+  });
+
+  it('derives the gesture navigation bar inset when the reported inset is zero', () => {
+    arrangeInsets({ insetBottom: 0, frameHeight: WINDOW_HEIGHT - 24 });
+
+    const { result } = renderHook(() => useBottomSafeAreaInset());
+
+    expect(result.current).toBe(24);
+  });
+
+  it('derives the three-button navigation bar inset when the reported inset is zero', () => {
+    arrangeInsets({ insetBottom: 0, frameHeight: WINDOW_HEIGHT - 48 });
+
+    const { result } = renderHook(() => useBottomSafeAreaInset());
+
+    expect(result.current).toBe(48);
+  });
+
+  it('returns zero when there is no navigation bar to clear', () => {
+    arrangeInsets({ insetBottom: 0, frameHeight: WINDOW_HEIGHT });
+
+    const { result } = renderHook(() => useBottomSafeAreaInset());
+
+    expect(result.current).toBe(0);
+  });
+
+  it('returns zero when the frame is taller than the window', () => {
+    arrangeInsets({ insetBottom: 0, frameHeight: WINDOW_HEIGHT + 10 });
+
+    const { result } = renderHook(() => useBottomSafeAreaInset());
+
+    expect(result.current).toBe(0);
+  });
+});

--- a/app/components/UI/Perps/hooks/useBottomSafeAreaInset.test.ts
+++ b/app/components/UI/Perps/hooks/useBottomSafeAreaInset.test.ts
@@ -22,9 +22,11 @@ const WINDOW_WIDTH = 411;
 const arrangeInsets = ({
   insetBottom,
   frameHeight,
+  frameY = 0,
 }: {
   insetBottom: number;
   frameHeight: number;
+  frameY?: number;
 }) => {
   mockUseSafeAreaInsets.mockReturnValue({
     top: 24,
@@ -34,7 +36,7 @@ const arrangeInsets = ({
   });
   mockUseSafeAreaFrame.mockReturnValue({
     x: 0,
-    y: 0,
+    y: frameY,
     width: WINDOW_WIDTH,
     height: frameHeight,
   });
@@ -69,6 +71,18 @@ describe('useBottomSafeAreaInset', () => {
 
   it('derives the three-button navigation bar inset when the reported inset is zero', () => {
     arrangeInsets({ insetBottom: 0, frameHeight: WINDOW_HEIGHT - 48 });
+
+    const { result } = renderHook(() => useBottomSafeAreaInset());
+
+    expect(result.current).toBe(48);
+  });
+
+  it('accounts for a frame offset from the top of the window', () => {
+    arrangeInsets({
+      insetBottom: 0,
+      frameY: 24,
+      frameHeight: WINDOW_HEIGHT - 24 - 48,
+    });
 
     const { result } = renderHook(() => useBottomSafeAreaInset());
 

--- a/app/components/UI/Perps/hooks/useBottomSafeAreaInset.ts
+++ b/app/components/UI/Perps/hooks/useBottomSafeAreaInset.ts
@@ -1,0 +1,30 @@
+import { useWindowDimensions } from 'react-native';
+import {
+  useSafeAreaFrame,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
+
+/**
+ * Returns the bottom safe-area inset in density-independent pixels.
+ *
+ * On Android `useSafeAreaInsets().bottom` reports 0 even when a system
+ * navigation bar (gesture pill or three-button bar) is occupying the bottom of
+ * the screen, so screens that pin content to `bottom: 0` end up drawing their
+ * padding underneath it. The safe-area frame does account for the navigation
+ * bar, so the gap between the frame and the window is used as the fallback.
+ *
+ * @returns The bottom inset to reserve for the system navigation bar.
+ */
+export const useBottomSafeAreaInset = (): number => {
+  const insets = useSafeAreaInsets();
+  const frame = useSafeAreaFrame();
+  const windowDimensions = useWindowDimensions();
+
+  if (insets.bottom > 0) {
+    return insets.bottom;
+  }
+
+  const frameDerivedInset = windowDimensions.height - (frame.y + frame.height);
+
+  return frameDerivedInset > 0 ? frameDerivedInset : 0;
+};


### PR DESCRIPTION
## **Description**

On Android, `useSafeAreaInsets().bottom` reports `0` on the Perps Lite order screen even when the
system navigation bar is occupying the bottom of the display. The fixed CTA container is
`position: absolute; bottom: 0`, so its `paddingBottom: insets.bottom + 16` collapsed to a bare
`16dp` and the intended visual gap landed on top of the navigation bar instead of above it. On
devices with a taller bottom inset the button itself is drawn into that region and appears cut off.
iOS is unaffected because `insets.bottom` is non-zero there.

This adds a `useBottomSafeAreaInset` hook that falls back to the safe-area frame
(`window.height - (frame.y + frame.height)`) when the reported inset is `0`, and uses it for the
order screen's CTA padding. The `16` visual padding is extracted to a named
`FIXED_BOTTOM_CONTAINER_PADDING` constant.

The same formula was also in use on the Perps Lite home screen (`PerpsHomeView`), whose fixed
Withdraw / Add funds footer is structurally identical (`position: absolute; bottom: 0`). All three
of its inset call sites — the footer padding, the scroll reserve that must match the footer height,
and the no-footer scroll padding — now use the hook, so the scrollable content clears the navigation
bar as well as the footer.

The shared footer geometry (`16` visual padding, `48` button height, and the derived `80` base
height) is named in `constants/perpsUIConfig.ts` so the spacer reserve and the rendered footer stay
in sync, and both Lite screens consume one definition rather than duplicating the literals.

Measured on a physical Pixel 6a (Android 17, gesture navigation): the gap between the CTA and the
navigation bar goes from **42px to 105px**, and the resolved bottom spacing from **16dp to 40dp**.

## **Changelog**

CHANGELOG entry: Fixed the Perps Lite order screen call-to-action being cut off by the system navigation bar on Android

## **Related issues**

Fixes: [TAT-3822](https://consensyssoftware.atlassian.net/browse/TAT-3822)

## **Manual testing steps**

```gherkin
Feature: Perps Lite order screen call-to-action placement on Android

  Scenario: user opens the Perps Lite order screen on an Android device
    Given an Android device using gesture navigation
    And the wallet is unlocked

    When user opens a Perps market in Lite mode and taps Long or Short
    Then the place order button is fully visible above the system navigation bar
    And a visible gap separates the button from the navigation bar

  Scenario: user scrolls the Perps Lite home screen on an Android device
    Given an Android device using gesture navigation
    And the wallet is unlocked

    When user opens Perps in Lite mode and scrolls to the bottom of the home screen
    Then the last row of content is fully visible above the system navigation bar
    And the Withdraw and Add funds footer is not clipped by the navigation bar
```

## **Screenshots/Recordings**

Perps Lite order screen on a physical Pixel 6a with gesture navigation: the place-order CTA now clears the system navigation bar (gap 42px -> 105px).

<table>
<tr><td colspan="2"><strong>Perps Lite place-order CTA vs the Android navigation bar</strong></td></tr>
<tr>
</tr>
</table>

**Video**
<table>
</table>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

Validated on a physical Pixel 6a (Android 17, gesture navigation). Coverage: 2/2 ACs PROVEN.

<details>
<summary>recipe.json</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "Perps Lite place-order CTA clears the Android navigation bar",
  "description": "Opens the Perps Lite order screen on Android and proves the place-order CTA is fully visible above the system navigation bar with at least the intended 16px visual gap, and that the applied bottom spacing is derived from the real navigation-bar inset rather than collapsing to a hardcoded constant.",
  "workflow": {
    "entry": "setup-status",
    "nodes": {
      "setup-status": {
        "action": "app.status",
        "intent": "Confirm the mobile bridge is reachable before proving anything",
        "next": "setup-unlock"
      },
      "setup-unlock": {
        "action": "metamask.wallet.ensure_unlocked",
        "intent": "Make the wallet usable so the Perps screens can be reached",
        "next": "setup-navigate-market"
      },
      "setup-navigate-market": {
        "action": "ui.navigate",
        "intent": "Open the BTC market in the Lite experience where the bug is reported",
        "page": "perps-market",
        "market": "BTC",
        "mode": "lite",
        "timeout_ms": 60000,
        "next": "setup-wait-short-cta"
      },
      "setup-wait-short-cta": {
        "action": "ui.wait_for",
        "intent": "Confirm the BTC market screen has finished loading for the trader",
        "test_id": "perps-market-details-short-button",
        "timeout_ms": 90000,
        "next": "setup-open-order-screen"
      },
      "setup-open-order-screen": {
        "action": "ui.press",
        "intent": "Open the Perps Lite order screen that shows the cut-off CTA",
        "test_id": "perps-market-details-short-button",
        "settle": true,
        "next": "ac1-wait-place-order-cta",
        "timeout_ms": 60000
      },
      "ac1-wait-place-order-cta": {
        "action": "ui.wait_for",
        "intent": "Confirm the trader has reached the order screen that shows the buy button",
        "test_id": "perps-order-view-place-order-button",
        "timeout_ms": 60000,
        "next": "ac1-measure-cta-clearance"
      },
      "ac1-measure-cta-clearance": {
        "action": "command",
        "intent": "Record how much space separates the CTA from the system navigation bar",
        "timeout_ms": 60000,
        "next": "ac1-assert-cta-clears-nav-bar"
      },
      "ac1-assert-cta-clears-nav-bar": {
        "action": "assert_json",
        "intent": "Confirm the CTA is not overlapped by the system navigation bar",
        "assert": {
          "path": "$.ctaClearsNavBar",
          "operator": "eq",
          "value": true
        },
        "next": "ac1-assert-cta-gap-is-visible"
      },
      "ac1-assert-cta-gap-is-visible": {
        "action": "assert_json",
        "intent": "Confirm the visual gap above the navigation bar is preserved rather than consumed by it",
        "assert": {
          "path": "$.clearancePx",
          "operator": "gt",
          "value": 63
        },
        "next": "ac1-screenshot-cta-above-nav-bar"
      },
      "ac1-screenshot-cta-above-nav-bar": {
        "action": "ui.screenshot",
        "intent": "Show the trader can see the entire buy button sitting clear of the navigation bar",
        "label": "AC1: place-order CTA fully visible above the Android navigation bar",
        "next": "ac2-assert-inset-derived-padding"
      },
      "ac2-assert-inset-derived-padding": {
        "action": "command",
        "intent": "Confirm the CTA bottom spacing is computed from the measured navigation-bar inset instead of a hardcoded constant",
        "timeout_ms": 120000,
        "next": "ac2-index-artifacts"
      },
      "ac2-index-artifacts": {
        "action": "index_artifacts",
        "intent": "Register the measurement and derivation evidence for review",
        "next": "done",
        "artifacts": [
          {
            "type": "report",
            "category": "validation",
            "label": "AC1: CTA vs navigation-bar measurement"
          },
          {
            "type": "log",
            "category": "validation",
            "label": "AC2: inset-derived padding test output"
          }
        ]
      },
      "done": {
        "action": "end",
        "status": "pass"
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
flowchart TD
    setup_status["setup-status<br/>(app.status)"]
    setup_unlock["setup-unlock<br/>(metamask.wallet.ensure_unlocked)"]
    setup_navigate_market["setup-navigate-market<br/>(ui.navigate)"]
    setup_wait_short_cta["setup-wait-short-cta<br/>(ui.wait_for)"]
    setup_open_order_screen["setup-open-order-screen<br/>(ui.press)"]
    ac1_wait_place_order_cta["ac1-wait-place-order-cta<br/>(ui.wait_for)"]
    ac1_measure_cta_clearance["ac1-measure-cta-clearance<br/>(command)"]
    ac1_assert_cta_clears_nav_bar["ac1-assert-cta-clears-nav-bar<br/>(assert_json)"]
    ac1_assert_cta_gap_is_visible["ac1-assert-cta-gap-is-visible<br/>(assert_json)"]
    ac1_screenshot_cta_above_nav_bar["ac1-screenshot-cta-above-nav-bar<br/>(ui.screenshot)"]
    ac2_assert_inset_derived_padding["ac2-assert-inset-derived-padding<br/>(command)"]
    ac2_index_artifacts["ac2-index-artifacts<br/>(index_artifacts)"]
    done["done<br/>(end)"]
    setup_status --> setup_unlock
    setup_unlock --> setup_navigate_market
    setup_navigate_market --> setup_wait_short_cta
    setup_wait_short_cta --> setup_open_order_screen
    setup_open_order_screen --> ac1_wait_place_order_cta
    ac1_wait_place_order_cta --> ac1_measure_cta_clearance
    ac1_measure_cta_clearance --> ac1_assert_cta_clears_nav_bar
    ac1_assert_cta_clears_nav_bar --> ac1_assert_cta_gap_is_visible
    ac1_assert_cta_gap_is_visible --> ac1_screenshot_cta_above_nav_bar
    ac1_screenshot_cta_above_nav_bar --> ac2_assert_inset_derived_padding
    ac2_assert_inset_derived_padding --> ac2_index_artifacts
    ac2_index_artifacts --> done
```

</details>

Perps Lite order screen on a physical Pixel 6a with gesture navigation: the place-order CTA now clears the system navigation bar (gap 42px -> 105px).

<table>
<tr><td colspan="2"><strong>Perps Lite place-order CTA vs the Android navigation bar</strong></td></tr>
<tr>
<td align="center" valign="top" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35151/before-evidence-ac1-cta-above-nav-bar.png?sha=8a657bcaaa0f3542" alt="before" width="320" /></td>
<td align="center" valign="top" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35151/after-ac1-cta-above-nav-bar.png?sha=5e30813b73ef24df" alt="after" width="320" /></td>
</tr>
</table>


[TAT-3822]: https://consensyssoftware.atlassian.net/browse/TAT-3822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only change for Perps Lite bottom padding. No auth, trading, or data-path changes; risk is limited to incorrect inset on some Android layouts.
> 
> **Overview**
> Stops Perps Lite fixed CTAs from sitting under the Android system navigation bar when `useSafeAreaInsets().bottom` reports `0`.
> 
> Adds `useBottomSafeAreaInset`, which uses the reported inset when present and otherwise derives it from the gap between the window and the safe-area frame. `PerpsOrderView` and `PerpsHomeView` apply that inset to footer padding, scroll reserve, and no-footer content padding.
> 
> Shared footer geometry (`16` padding, `48` button height, `80` base height) is named in `perpsUIConfig` so spacer and footer stay in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cdbf38de83905b8e81fa42ea85c1689c817608b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

