### PR TITLE
feat(rewards): show when Money Account campaign stats were last updated

### DIFF
--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.test.tsx
@@ -19,6 +19,10 @@ jest.mock('@metamask/design-system-twrnc-preset', () => {
 jest.mock('../../../utils/formatUtils', () => ({
   formatUsd: (value: number | null) =>
     value == null ? '—' : `$${value.toFixed(2)}`,
+  // Stubbed to a fixed shape so the assertions don't depend on the test
+  // machine's locale or timezone.
+  formatRewardsTimeOnly: (date: Date) =>
+    `T-${date.toISOString().slice(11, 16)}`,
 }));
 
 jest.mock('../../../../Money/hooks/useMoneyAccountBalance', () => ({
@@ -182,4 +186,46 @@ describe('MoneyAccountSweepstakesCampaignOverview', () => {
     expect(getByText('Balance')).toBeOnTheScreen();
     expect(getByText('$1,250.00')).toBeOnTheScreen();
   });
+
+  it('renders the last-checked row from the backend ingest watermark', () => {
+    const { getByTestId, getByText } = render(
+      <MoneyAccountSweepstakesCampaignOverview
+        campaign={campaign}
+        localizedText={localizedText}
+        isParticipating
+        stats={{ ...stats, dataAsOf: '2026-08-24T09:15:00.000Z' }}
+      />,
+    );
+
+    expect(
+      getByTestId(
+        MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.LAST_CHECKED_ROW,
+      ),
+    ).toBeOnTheScreen();
+    expect(getByText('T-09:15')).toBeOnTheScreen();
+  });
+
+  it.each([
+    ['the field is absent (older backend build)', undefined],
+    ['the ingest has never run', null],
+    ['the timestamp is unparseable', 'not-a-date'],
+  ])(
+    'hides the last-checked row rather than showing a bogus date when %s',
+    (_case, dataAsOf) => {
+      const { queryByTestId } = render(
+        <MoneyAccountSweepstakesCampaignOverview
+          campaign={campaign}
+          localizedText={localizedText}
+          isParticipating
+          stats={{ ...stats, dataAsOf }}
+        />,
+      );
+
+      expect(
+        queryByTestId(
+          MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.LAST_CHECKED_ROW,
+        ),
+      ).toBeNull();
+    },
+  );
 });

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.tsx
@@ -17,7 +17,7 @@ import type {
   MoneyAccountSweepstakesLocalizedTextDto,
   MoneyAccountSweepstakesStatsMeDto,
 } from '../../../../../../core/Engine/controllers/rewards-controller/types';
-import { formatUsd } from '../../../utils/formatUtils';
+import { formatRewardsTimeOnly, formatUsd } from '../../../utils/formatUtils';
 import { AMOUNT_PLACEHOLDER, ENTRIES_COUNT_PLACEHOLDER } from './constants';
 import RewardsErrorBanner from '../../RewardsErrorBanner';
 import { strings } from '../../../../../../../locales/i18n';
@@ -31,6 +31,7 @@ export const MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS = {
   STATS_ERROR: 'money-account-sweepstakes-stats-error',
   MONEY_ACCOUNT_BALANCE_ROW:
     'money-account-sweepstakes-money-account-balance-row',
+  LAST_CHECKED_ROW: 'money-account-sweepstakes-last-checked-row',
 } as const;
 
 interface MoneyAccountSweepstakesCampaignOverviewProps {
@@ -148,6 +149,20 @@ const MoneyAccountSweepstakesCampaignOverview: React.FC<
       totalFiatFormatted === undefined &&
       lastKnownTotalFiatFormatted === undefined;
 
+    // How stale the deposit figures are, straight from the backend's ingest
+    // watermark. Absent on older backend builds and null where the ingest has
+    // never run, and a malformed value would make Intl throw — in all three
+    // cases the row is hidden rather than showing a misleading date.
+    const lastCheckedAt = (() => {
+      if (!stats?.dataAsOf) {
+        return null;
+      }
+      const parsed = new Date(stats.dataAsOf);
+      return Number.isNaN(parsed.getTime())
+        ? null
+        : formatRewardsTimeOnly(parsed);
+    })();
+
     return (
       <Box
         twClassName="px-4 pb-5 pt-4"
@@ -237,6 +252,30 @@ const MoneyAccountSweepstakesCampaignOverview: React.FC<
               </Text>
             )}
           </Box>
+          {lastCheckedAt !== null && (
+            <Box
+              alignItems={BoxAlignItems.Center}
+              flexDirection={BoxFlexDirection.Row}
+              justifyContent={BoxJustifyContent.Between}
+              testID={
+                MONEY_ACCOUNT_SWEEPSTAKES_CAMPAIGN_OVERVIEW_TEST_IDS.LAST_CHECKED_ROW
+              }
+            >
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+              >
+                {strings('rewards.campaign_details.last_checked_at')}
+              </Text>
+              <Text
+                variant={TextVariant.BodyMd}
+                fontWeight={FontWeight.Medium}
+                color={TextColor.TextDefault}
+              >
+                {lastCheckedAt}
+              </Text>
+            </Box>
+          )}
           {children}
         </Box>
       </Box>

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -5829,6 +5829,7 @@ export class RewardsController extends BaseController<
         qualifyingThresholdUsd: 0,
         todayStatus: 'not_yet_qualified',
         daysRemaining: 0,
+        dataAsOf: null,
       };
     }
 
@@ -5852,6 +5853,7 @@ export class RewardsController extends BaseController<
             qualifyingThresholdUsd: cached.qualifyingThresholdUsd,
             todayStatus: cached.todayStatus,
             daysRemaining: cached.daysRemaining,
+            dataAsOf: cached.dataAsOf,
           },
           lastFetched: cached.lastFetched,
         };

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -1576,6 +1576,15 @@ export interface MoneyAccountSweepstakesStatsMeDto {
   qualifyingThresholdUsd: number;
   todayStatus: MoneyAccountSweepstakesTodayStatus;
   daysRemaining: number;
+  /**
+   * ISO timestamp of when the backend's on-chain ingest last ran — how fresh
+   * the deposit/balance figures above are, NOT when the response was built.
+   *
+   * Optional because older backend builds omit it entirely, and null when that
+   * environment's ingest has never run. Either way there is no freshness to
+   * report, so callers must hide the label rather than render a fallback date.
+   */
+  dataAsOf?: string | null;
 }
 
 export interface MoneyAccountSweepstakesPrizePoolDto {
@@ -1656,6 +1665,7 @@ export type MoneyAccountSweepstakesStatsMeState = {
   qualifyingThresholdUsd: number;
   todayStatus: MoneyAccountSweepstakesTodayStatus;
   daysRemaining: number;
+  dataAsOf?: string | null;
   lastFetched: number;
 };
 

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -10229,6 +10229,7 @@
       "stats_error_title": "Unable to load stats",
       "stats_error_description": "We had a problem loading your stats. Please try again.",
       "retry": "Retry",
+      "last_checked_at": "Last checked at",
       "ondo": {
         "entries_closed_title": "Entries closed",
         "entries_closed_description": "You missed the opt-in window. Check back for more campaigns in the future."


### PR DESCRIPTION
## **Description**

Adds a "Last checked at" row to the Money Account Sweepstakes campaign details card, showing when the figures on it were last refreshed on the backend.

The card shows a qualifying-deposit figure with nothing to say how current it is, and "why isn't my deposit showing up yet" is the obvious question that invites. The answer is how far behind the backend's on-chain ingest is, which is now returned as `dataAsOf` on `stats/me` (backend PR consensys-vertical-apps/va-mmcx-rewards#762). The new row sits directly below the existing balance row and reuses that row's exact label/value styling.

Notably this is **not** a client-side timestamp taken at fetch time. That would have read "checked 2 seconds ago" while the ingest sat an hour behind — confidently wrong on precisely the screen where someone is asking why their deposit is missing. The value is the server's own ingest watermark, so it reflects real data freshness rather than the age of the HTTP response.

The field is consumed as optional, so this can ship ahead of the backend deploy: the row hides itself when `dataAsOf` is absent (older backend build), `null` (that environment's ingest has never run) or unparseable, rather than rendering a placeholder or an invalid date.

Worth flagging for review: adding a field to a cached `RewardsController` endpoint takes three coordinated edits, not one — the DTO interface, the hand-maintained `MoneyAccountSweepstakesStatsMeState` mirror, and the `readCache` mapping that rebuilds the payload field by field (plus the feature-disabled default). Doing only the first would have worked on the initial network call and then silently dropped the field on every cache hit.

The label is a `locales/languages/en.json` string rather than a Contentful `localizedText` key. The card's other labels are Contentful, but every existing freshness label in Rewards (VIP, Ondo, Perps, Predict) lives in `en.json`, and a new `localizedText` key would need a backend key-set change plus a Contentful entry edit.

Scoped deliberately to the display change only — no refresh/caching behaviour is touched in this PR.

## **Changelog**

CHANGELOG entry: Added a "Last checked at" row to the Money Account campaign details card showing when the stats were last updated.

## **Related issues**

Refs: N/A

Depends on: consensys-vertical-apps/va-mmcx-rewards#762 (adds `dataAsOf` to `stats/me`). Safe to merge before that lands — the row simply stays hidden until the field is served.

## **Manual testing steps**

1. Opt in to the Money Account Sweepstakes campaign and open **Rewards → Campaigns → Money Account Sweepstakes**.
2. Confirm the card renders as before: eligible-deposit figure, entries line, qualification message, and the "Balance" row.
3. Against a backend that serves `dataAsOf`, confirm a "Last checked at" row appears directly below the "Balance" row, right-aligned, showing a time of day.
4. Confirm the time shown corresponds to the backend's last ingest run, not to when you opened the screen — reopening the screen should not advance it.
5. Against a backend that does not serve the field (or an environment whose ingest has never run), confirm the row is absent entirely — no empty row, no "Invalid Date".
6. Confirm the loading skeletons and the stats error banner + retry still behave as before.

## **Screenshots/Recordings**

Live captures were not taken: per standing project policy this change was verified without booting a simulator or emulator. The visual change is described below and is covered by unit tests asserting the row's presence, its formatted value, and its absence in each of the three degraded cases. Happy to attach device screenshots before merge if preferred.

### **Before**

Card ends with the "Balance" row: label left, amount right-aligned, then the CTA. No indication anywhere on the screen of how current the figures are.

### **After**

A second row is added immediately below the "Balance" row, matching it exactly: `BodyMd` / `TextAlternative` label "Last checked at" on the left, `BodyMd` / `Medium` / `TextDefault` time value right-aligned (e.g. "9:15 AM"). When `dataAsOf` is absent, null or unparseable the row is not rendered at all, so the card looks identical to Before.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and cache-field plumbing for an optional timestamp; no auth, payments, or data-write changes. Hidden-by-default if the backend does not send the field.
> 
> **Overview**
> Adds a **Last checked at** row under the Money Account Sweepstakes balance, using the backend ingest watermark (`dataAsOf`) rather than client fetch time so the time reflects how fresh deposit figures actually are.
> 
> The field is optional on the stats DTO and cache state. The row is hidden when `dataAsOf` is missing, `null`, or unparseable so older backends and never-run ingest do not show a bogus date. Cache read/write and the feature-disabled default now pass `dataAsOf` through so it is not dropped on cache hits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ffae89b7556cdce4011a7a7e919d84f6f990488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->