### PR TITLE
perf(network): stabilize network connect list data

### DIFF
--- a/app/components/Views/NetworkConnect/NetworkConnectMultiSelector/NetworkConnectMultiSelector.test.tsx
+++ b/app/components/Views/NetworkConnect/NetworkConnectMultiSelector/NetworkConnectMultiSelector.test.tsx
@@ -11,6 +11,7 @@ import {
   selectEvmChainId,
 } from '../../../../selectors/networkController';
 import { CaipChainId } from '@metamask/utils';
+import { getNetworkImageSource } from '../../../../util/networks';
 
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
@@ -24,6 +25,10 @@ jest.mock('@react-navigation/native', () => ({
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useSelector: jest.fn(),
+}));
+
+jest.mock('../../../../util/networks', () => ({
+  getNetworkImageSource: jest.fn(() => ({ uri: 'network-image' })),
 }));
 
 const mockNetworkConfigurations = {
@@ -85,6 +90,18 @@ describe('NetworkConnectMultiSelector', () => {
         ConnectedAccountsSelectorsIDs.SELECT_ALL_NETWORKS_BUTTON,
       )[0],
     ).toBeOnTheScreen();
+  });
+
+  it('reuses derived networks when network configurations are unchanged', () => {
+    const { rerender } = renderWithProvider(
+      <NetworkConnectMultiSelector {...defaultProps} />,
+    );
+    const initialCallCount = (getNetworkImageSource as jest.Mock).mock.calls
+      .length;
+
+    rerender(<NetworkConnectMultiSelector {...defaultProps} />);
+
+    expect(getNetworkImageSource).toHaveBeenCalledTimes(initialCallCount);
   });
 
   it('disables the select all button when loading', () => {

--- a/app/components/Views/NetworkConnect/NetworkConnectMultiSelector/NetworkConnectMultiSelector.tsx
+++ b/app/components/Views/NetworkConnect/NetworkConnectMultiSelector/NetworkConnectMultiSelector.tsx
@@ -1,5 +1,5 @@
 // Third party dependencies.
-import React, { useCallback, useState, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
@@ -57,19 +57,23 @@ const NetworkConnectMultiSelector = ({
     onSubmit(selectedChainIds);
   }, [onSubmit, selectedChainIds]);
   // TODO: [SOLANA]  When we support non evm networks, refactor this
-  const networks = Object.entries(networkConfigurations).map(
-    ([key, network]: [
-      string,
-      EvmAndMultichainNetworkConfigurationsWithCaipChainId,
-    ]) => ({
-      id: key,
-      name: network.name,
-      isSelected: false,
-      imageSource: getNetworkImageSource({
-        chainId: network.caipChainId,
-      }),
-      caipChainId: network.caipChainId,
-    }),
+  const networks = useMemo(
+    () =>
+      Object.entries(networkConfigurations).map(
+        ([key, network]: [
+          string,
+          EvmAndMultichainNetworkConfigurationsWithCaipChainId,
+        ]) => ({
+          id: key,
+          name: network.name,
+          isSelected: false,
+          imageSource: getNetworkImageSource({
+            chainId: network.caipChainId,
+          }),
+          caipChainId: network.caipChainId,
+        }),
+      ),
+    [networkConfigurations],
   );
 
   const onSelectNetwork = useCallback(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
`NetworkConnectMultiSelector` rebuilt its network array and every row object on each render, even when the selected network configurations had not changed. This produced unstable list data and repeated network image-source derivation during unrelated state or parent updates.

This change memoizes the derived network array using `networkConfigurations` as its dependency. A regression test rerenders the component with the same configurations and verifies that network image sources are not recalculated.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: TMCU-1325

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Network connection multi-selector

  Scenario: user updates connected networks
    Given I am editing the networks connected to a dapp
    And multiple networks are available

    When user selects and deselects networks
    Then each network should display the expected selection state
    And submitting should update the dapp network permissions
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small memoization-only change in a UI selector with a regression test; no permission or network-selection logic is altered.
> 
> **Overview**
> Stops `NetworkConnectMultiSelector` from rebuilding its network list (and re-deriving image sources) on every render.
> 
> The derived `networks` array is now `useMemo`’d on `networkConfigurations`, so list identity stays stable when configs are unchanged. A test rerenders with the same configs and asserts `getNetworkImageSource` is not called again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8dfe2fcd7281e2eb05e502e50af2a1971ea65d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->