### PR TITLE
test(bridge): wait for debounced quote request in BridgeView CV test

### DIFF
--- a/app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx
+++ b/app/components/UI/Bridge/Views/BridgeView/BridgeView.view.test.tsx
@@ -72,6 +72,10 @@ describeForPlatforms('BridgeView', () => {
     Date.now = () => new Date().getTime();
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('renders input areas and hides confirm button without tokens or amount', () => {
     const { getByTestId, queryByTestId } = renderBridgeView({
       overrides: {
@@ -702,10 +706,8 @@ describeForPlatforms('BridgeView', () => {
           expect.anything(),
         );
       },
-      { timeout: 1000 },
+      { timeout: 5000 },
     );
-
-    updateQuoteSpy.mockRestore();
   });
 
   it('uses token input without resetting persisted fiat mode when price data is unavailable', async () => {


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`BridgeView [ios] › keeps quote requests based on token amount after fiat input` failed in CI with `updateQuoteSpy` called 0 times, then passed on retry. Quote requests are lodash-debounced at 300ms and the market-view effect cancels pending calls when deps change. `{ timeout: 1000 }` is too tight on a loaded runner.

This wait now uses `{ timeout: 5000 }` (same ceiling as other async CV waits in this file). Spies are restored in `afterEach` instead of only at the end of this test. The timeout is a poll ceiling, not a sleep.

Related CV flakes from the same CI window (`WatchlistFullScreenView` nested `findBy` / `ActivityDetails` fiat `$0.00`) were already fixed in #35032.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #35088

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — component-view test only. Locally: 10/10 targeted runs of `keeps quote requests based on token amount after fiat input`, plus 5/5 full `BridgeView.view.test.tsx` runs with `--randomize`.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

Not applicable — test-only change, no runtime code touched.

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)