### PR TITLE
feat: add ListHeaderComponent to AccountsList for improved UI rendering

### DIFF
--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react-native';
+import { Text } from 'react-native';
 import {
   AccountsList,
   type AccountProps,
@@ -76,6 +77,7 @@ const ACCOUNT_3_TEST_ID = {
 type RenderAccountsListOverrides = Partial<{
   accountProps: AccountProps;
   notificationAccountListProps: NotificationAccountListProps;
+  ListHeaderComponent: React.ReactElement;
 }>;
 
 interface RenderAccountsListMocks {
@@ -236,6 +238,7 @@ describe('AccountList', () => {
           overrides.notificationAccountListProps ??
           mocks.notificationAccountListProps
         }
+        ListHeaderComponent={overrides.ListHeaderComponent}
       />,
       { state: initialRootState },
     );
@@ -373,16 +376,18 @@ describe('AccountList', () => {
     });
   });
 
-  it('renders nothing when there are no notification wallet groups', () => {
+  it('renders the list header when there are no notification wallet groups', () => {
     const mocks = arrangeMocks();
 
-    const { queryByTestId } = renderAccountsList(mocks, {
+    const { getByText, queryByTestId } = renderAccountsList(mocks, {
       accountProps: {
         accountAvatarType: AvatarAccountType.JazzIcon,
         accountWalletGroups: [],
       },
+      ListHeaderComponent: <Text>Wallet activity settings</Text>,
     });
 
+    expect(getByText('Wallet activity settings')).toBeOnTheScreen();
     expect(queryByTestId(ACCOUNT_1_TEST_ID.item)).not.toBeOnTheScreen();
   });
 

--- a/app/components/Views/Settings/NotificationsSettings/AccountsList.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/AccountsList.tsx
@@ -20,6 +20,7 @@ export type NotificationAccountListProps = ReturnType<
 interface AccountsListProps {
   accountProps: AccountProps;
   notificationAccountListProps: NotificationAccountListProps;
+  ListHeaderComponent?: React.ReactElement;
   /** When true, disables all account switches. */
   disabled?: boolean;
 }
@@ -27,6 +28,7 @@ interface AccountsListProps {
 export const AccountsList = ({
   accountProps,
   notificationAccountListProps,
+  ListHeaderComponent,
   disabled = false,
 }: AccountsListProps) => {
   const theme = useTheme();
@@ -83,29 +85,31 @@ export const AccountsList = ({
     [accountWalletGroups],
   );
 
-  if (accountWalletGroups.length === 0) {
-    return null;
-  }
-
   return (
-    <View>
-      <SectionList
-        sections={sections}
-        keyExtractor={(item) => item.id}
-        stickySectionHeadersEnabled={false}
-        renderSectionHeader={({ section }) => (
+    <SectionList
+      testID={NotificationSettingsViewSelectorsIDs.WALLET_ACTIVITY_LIST}
+      style={styles.walletActivityList}
+      contentContainerStyle={styles.walletActivityListContent}
+      sections={sections}
+      keyExtractor={(item) => item.id}
+      stickySectionHeadersEnabled={false}
+      ListHeaderComponent={ListHeaderComponent}
+      renderSectionHeader={({ section }) => (
+        <View style={disabled ? styles.disabledContent : undefined}>
           <AccountListHeader
             title={section.title}
             containerStyle={styles.accountHeader}
           />
-        )}
-        renderItem={({ item }) => {
-          const evmAddress = getEvmAddress(item.accounts);
-          if (!evmAddress) {
-            return null;
-          }
+        </View>
+      )}
+      renderItem={({ item }) => {
+        const evmAddress = getEvmAddress(item.accounts);
+        if (!evmAddress) {
+          return null;
+        }
 
-          return (
+        return (
+          <View style={disabled ? styles.disabledContent : undefined}>
             <NotificationOptionToggle
               key={item.id}
               item={item}
@@ -123,9 +127,9 @@ export const AccountsList = ({
                 evmAddress,
               )}
             />
-          );
-        }}
-      />
-    </View>
+          </View>
+        );
+      }}
+    />
   );
 };

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.test.tsx
@@ -80,7 +80,11 @@ jest.mock('../../../../util/notifications/hooks/useSessionProfileId', () => ({
 
 jest.mock('./SocialAINotificationPreferencesContent', () => () => null);
 jest.mock('./AccountsList', () => ({
-  AccountsList: () => null,
+  AccountsList: ({
+    ListHeaderComponent,
+  }: {
+    ListHeaderComponent?: React.ReactElement;
+  }) => ListHeaderComponent ?? null,
 }));
 jest.mock('./AccountsList.hooks', () => ({
   useWalletActivityAccountSelection: () => ({

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.tsx
@@ -5,7 +5,6 @@ import {
   StackActions,
 } from '@react-navigation/native';
 import React, { useEffect } from 'react';
-import { ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useSelector } from 'react-redux';
 import { useTheme } from '../../../../util/theme';
@@ -57,16 +56,11 @@ const NotificationSettingsSection = ({
         title={strings('app_settings.notifications_title')}
         onBack={() => navigation.goBack()}
       />
-      <ScrollView
-        style={styles.container}
-        contentContainerStyle={styles.contentContainer}
-      >
-        <NotificationSettingsSectionContent
-          type={type}
-          title={title}
-          description={description}
-        />
-      </ScrollView>
+      <NotificationSettingsSectionContent
+        type={type}
+        title={title}
+        description={description}
+      />
     </SafeAreaView>
   );
 };

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSectionContent.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSectionContent.test.tsx
@@ -15,6 +15,32 @@ import Logger from '../../../../util/Logger';
 
 jest.mock('./hooks/useNotificationStoragePreferences');
 jest.mock('../../../hooks/useAnalytics/useAnalytics');
+jest.mock('./AccountsList', () => {
+  const MockView = jest.requireActual('react-native').View;
+
+  return {
+    AccountsList: ({
+      ListHeaderComponent,
+    }: {
+      ListHeaderComponent?: React.ReactElement;
+    }) => (
+      <>
+        {ListHeaderComponent}
+        <MockView testID="notification-settings-wallet-activity-list" />
+      </>
+    ),
+  };
+});
+jest.mock('./AccountsList.hooks', () => ({
+  useWalletActivityAccountSelection: () => ({
+    accountProps: {},
+    notificationAccountListProps: {},
+    hasEnabledAccount: true,
+    hasNotificationAccounts: true,
+    isUpdatingAllAccounts: false,
+    toggleAllAccounts: jest.fn(),
+  }),
+}));
 
 const PUSH_TOGGLE =
   NotificationSettingsViewSelectorsIDs.PUSH_NOTIFICATIONS_TOGGLE;
@@ -119,6 +145,41 @@ describe('NotificationSettingsSectionContent', () => {
 
     expect(screen.getByTestId(PUSH_TOGGLE)).toHaveProp('disabled', undefined);
     expect(screen.getByTestId(IN_APP_TOGGLE)).toHaveProp('disabled', undefined);
+  });
+
+  it('uses the section ScrollView for static sections', () => {
+    renderContent();
+
+    expect(
+      screen.getByTestId(
+        NotificationSettingsViewSelectorsIDs.SECTION_SCROLL_VIEW,
+      ),
+    ).toBeOnTheScreen();
+    expect(
+      screen.queryByTestId(
+        NotificationSettingsViewSelectorsIDs.WALLET_ACTIVITY_LIST,
+      ),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('uses the wallet activity list as the only section scroller', () => {
+    renderContent({
+      type: 'walletActivity',
+      title: 'Wallet activity',
+      description: 'Buy, sells, transfers, and swaps',
+    });
+
+    expect(
+      screen.queryByTestId(
+        NotificationSettingsViewSelectorsIDs.SECTION_SCROLL_VIEW,
+      ),
+    ).not.toBeOnTheScreen();
+    expect(
+      screen.getByTestId(
+        NotificationSettingsViewSelectorsIDs.WALLET_ACTIVITY_LIST,
+      ),
+    ).toBeOnTheScreen();
+    expect(screen.getByText('Wallet activity')).toBeOnTheScreen();
   });
 
   it('disables both channel toggles when disabled is true', () => {

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSectionContent.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSectionContent.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback } from 'react';
-import { Switch, TouchableOpacity, View } from 'react-native';
+import React, { useCallback, useMemo } from 'react';
+import { ScrollView, Switch, TouchableOpacity, View } from 'react-native';
 import { useTheme } from '../../../../util/theme';
 import { useStyles } from '../../../../component-library/hooks';
 import styleSheet from './NotificationsSettings.styles';
@@ -32,6 +32,20 @@ interface SectionContentProps {
   disabled?: boolean;
 }
 
+interface ListSectionContentProps extends SectionContentProps {
+  ListHeaderComponent: React.ReactElement;
+}
+
+type SectionDefinition =
+  | {
+      layout: 'scroll';
+      Content?: React.ComponentType<SectionContentProps>;
+    }
+  | {
+      layout: 'list';
+      Content: React.ComponentType<ListSectionContentProps>;
+    };
+
 const SETTINGS_TYPE_BY_SECTION: Record<NotificationPreferenceSection, string> =
   {
     walletActivity: 'wallet_activity',
@@ -45,7 +59,8 @@ const SETTINGS_TYPE_BY_SECTION: Record<NotificationPreferenceSection, string> =
 const WalletActivitySectionContent = ({
   styles,
   disabled = false,
-}: SectionContentProps) => {
+  ListHeaderComponent,
+}: ListSectionContentProps) => {
   const { trackEvent, createEventBuilder } = useAnalytics();
   const { updatePreferencesSection } = useNotificationStoragePreferences();
   const {
@@ -89,56 +104,79 @@ const WalletActivitySectionContent = ({
     createEventBuilder,
   ]);
 
-  return (
-    <View style={disabled ? styles.disabledContent : undefined}>
-      <View style={styles.line} />
-      <View style={styles.setting}>
-        <View style={styles.walletActivityHeader}>
-          <Text
-            color={TextColor.TextDefault}
-            variant={TextVariant.HeadingMd}
-            fontWeight={FontWeight.Medium}
-          >
-            {strings('app_settings.notifications_opts.select_accounts_title')}
-          </Text>
-          {hasNotificationAccounts ? (
-            <TouchableOpacity
-              onPress={handleToggleAllAccounts}
-              disabled={disabled || isUpdatingAllAccounts}
-              accessibilityRole="button"
-              style={styles.selectAllButton}
-              testID={
-                NotificationSettingsViewSelectorsIDs.ACCOUNT_NOTIFICATIONS_SELECT_ALL
-              }
-            >
+  const accountsListHeader = useMemo(
+    () => (
+      <View>
+        {ListHeaderComponent}
+        <View style={disabled ? styles.disabledContent : undefined}>
+          <View style={styles.line} />
+          <View style={styles.setting}>
+            <View style={styles.walletActivityHeader}>
               <Text
-                color={
-                  disabled || isUpdatingAllAccounts
-                    ? TextColor.TextMuted
-                    : TextColor.PrimaryDefault
-                }
-                variant={TextVariant.BodyMd}
+                color={TextColor.TextDefault}
+                variant={TextVariant.HeadingMd}
                 fontWeight={FontWeight.Medium}
               >
                 {strings(
-                  hasEnabledAccount
-                    ? 'app_settings.notifications_opts.deselect_all'
-                    : 'app_settings.notifications_opts.select_all',
+                  'app_settings.notifications_opts.select_accounts_title',
                 )}
               </Text>
-            </TouchableOpacity>
-          ) : null}
+              {hasNotificationAccounts ? (
+                <TouchableOpacity
+                  onPress={handleToggleAllAccounts}
+                  disabled={disabled || isUpdatingAllAccounts}
+                  accessibilityRole="button"
+                  style={styles.selectAllButton}
+                  testID={
+                    NotificationSettingsViewSelectorsIDs.ACCOUNT_NOTIFICATIONS_SELECT_ALL
+                  }
+                >
+                  <Text
+                    color={
+                      disabled || isUpdatingAllAccounts
+                        ? TextColor.TextMuted
+                        : TextColor.PrimaryDefault
+                    }
+                    variant={TextVariant.BodyMd}
+                    fontWeight={FontWeight.Medium}
+                  >
+                    {strings(
+                      hasEnabledAccount
+                        ? 'app_settings.notifications_opts.deselect_all'
+                        : 'app_settings.notifications_opts.select_all',
+                    )}
+                  </Text>
+                </TouchableOpacity>
+              ) : null}
+            </View>
+            <Text
+              color={TextColor.TextAlternative}
+              variant={TextVariant.BodyMd}
+            >
+              {strings('app_settings.notifications_opts.select_accounts_desc')}
+            </Text>
+          </View>
         </View>
-        <Text color={TextColor.TextAlternative} variant={TextVariant.BodyMd}>
-          {strings('app_settings.notifications_opts.select_accounts_desc')}
-        </Text>
       </View>
-      <AccountsList
-        accountProps={accountProps}
-        notificationAccountListProps={notificationAccountListProps}
-        disabled={disabled}
-      />
-    </View>
+    ),
+    [
+      ListHeaderComponent,
+      disabled,
+      handleToggleAllAccounts,
+      hasEnabledAccount,
+      hasNotificationAccounts,
+      isUpdatingAllAccounts,
+      styles,
+    ],
+  );
+
+  return (
+    <AccountsList
+      accountProps={accountProps}
+      notificationAccountListProps={notificationAccountListProps}
+      disabled={disabled}
+      ListHeaderComponent={accountsListHeader}
+    />
   );
 };
 
@@ -171,15 +209,25 @@ const MarketingSectionContent = ({
   </View>
 );
 
-const SECTION_CONTENT_BY_TYPE: Partial<
-  Record<
-    NotificationPreferenceSection,
-    React.ComponentType<SectionContentProps>
-  >
+const SECTION_DEFINITIONS: Record<
+  NotificationPreferenceSection,
+  SectionDefinition
 > = {
-  walletActivity: WalletActivitySectionContent,
-  socialAI: SocialAISectionContent,
-  marketing: MarketingSectionContent,
+  walletActivity: {
+    layout: 'list',
+    Content: WalletActivitySectionContent,
+  },
+  socialAI: {
+    layout: 'scroll',
+    Content: SocialAISectionContent,
+  },
+  marketing: {
+    layout: 'scroll',
+    Content: MarketingSectionContent,
+  },
+  perps: { layout: 'scroll' },
+  agenticCli: { layout: 'scroll' },
+  priceAlerts: { layout: 'scroll' },
 };
 
 export interface NotificationSettingsSectionContentProps {
@@ -201,7 +249,7 @@ export const NotificationSettingsSectionContent = ({
   const { preferences, updateSectionChannel } =
     useNotificationStoragePreferences();
   const sectionPrefs = preferences?.[type];
-  const SectionContent = SECTION_CONTENT_BY_TYPE[type];
+  const sectionDefinition = SECTION_DEFINITIONS[type];
 
   const trackChannelUpdate = useCallback(
     (channel: NotificationChannel, enabled: boolean) => {
@@ -278,79 +326,115 @@ export const NotificationSettingsSectionContent = ({
   const isSectionContentDisabled =
     Boolean(disabled) || (!push.value && !inApp.value);
 
+  const listHeader = useMemo(
+    () => (
+      <View>
+        {title ? (
+          <View style={styles.setting}>
+            <Text color={TextColor.TextDefault} variant={TextVariant.HeadingLg}>
+              {title}
+            </Text>
+            {description ? (
+              <Text
+                color={TextColor.TextAlternative}
+                variant={TextVariant.BodyMd}
+              >
+                {description}
+              </Text>
+            ) : null}
+          </View>
+        ) : null}
+
+        <View style={styles.switchElement}>
+          <Text
+            color={disabled ? TextColor.TextMuted : TextColor.TextDefault}
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+          >
+            {strings('app_settings.notifications_opts.push_recommended')}
+          </Text>
+          <Switch
+            value={push.value}
+            onValueChange={push.onValueChange}
+            disabled={disabled}
+            trackColor={{
+              true: theme.colors.primary.default,
+              false: theme.colors.border.muted,
+            }}
+            thumbColor={theme.brandColors.white}
+            style={styles.switch}
+            ios_backgroundColor={theme.colors.border.muted}
+            testID={
+              NotificationSettingsViewSelectorsIDs.PUSH_NOTIFICATIONS_TOGGLE
+            }
+          />
+        </View>
+
+        <View style={styles.switchElement}>
+          <Text
+            color={disabled ? TextColor.TextMuted : TextColor.TextDefault}
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+          >
+            {strings('app_settings.notifications_opts.in_app')}
+          </Text>
+          <Switch
+            value={inApp.value}
+            onValueChange={inApp.onValueChange}
+            disabled={disabled}
+            trackColor={{
+              true: theme.colors.primary.default,
+              false: theme.colors.border.muted,
+            }}
+            thumbColor={theme.brandColors.white}
+            style={styles.switch}
+            ios_backgroundColor={theme.colors.border.muted}
+            testID={
+              NotificationSettingsViewSelectorsIDs.FEATURE_ANNOUNCEMENTS_TOGGLE
+            }
+          />
+        </View>
+      </View>
+    ),
+    [
+      description,
+      disabled,
+      inApp.onValueChange,
+      inApp.value,
+      push.onValueChange,
+      push.value,
+      styles,
+      theme,
+      title,
+    ],
+  );
+
   if (!sectionPrefs) return null;
 
+  if (sectionDefinition.layout === 'list') {
+    const ListContent = sectionDefinition.Content;
+
+    return (
+      <ListContent
+        styles={styles}
+        disabled={isSectionContentDisabled}
+        ListHeaderComponent={listHeader}
+      />
+    );
+  }
+
+  const SectionContent = sectionDefinition.Content;
+
   return (
-    <>
-      {title ? (
-        <View style={styles.setting}>
-          <Text color={TextColor.TextDefault} variant={TextVariant.HeadingLg}>
-            {title}
-          </Text>
-          {description ? (
-            <Text
-              color={TextColor.TextAlternative}
-              variant={TextVariant.BodyMd}
-            >
-              {description}
-            </Text>
-          ) : null}
-        </View>
-      ) : null}
-
-      <View style={styles.switchElement}>
-        <Text
-          color={disabled ? TextColor.TextMuted : TextColor.TextDefault}
-          variant={TextVariant.BodyMd}
-          fontWeight={FontWeight.Medium}
-        >
-          {strings('app_settings.notifications_opts.push_recommended')}
-        </Text>
-        <Switch
-          value={push.value}
-          onValueChange={push.onValueChange}
-          disabled={disabled}
-          trackColor={{
-            true: theme.colors.primary.default,
-            false: theme.colors.border.muted,
-          }}
-          thumbColor={theme.brandColors.white}
-          style={styles.switch}
-          ios_backgroundColor={theme.colors.border.muted}
-          testID={
-            NotificationSettingsViewSelectorsIDs.PUSH_NOTIFICATIONS_TOGGLE
-          }
-        />
-      </View>
-
-      <View style={styles.switchElement}>
-        <Text
-          color={disabled ? TextColor.TextMuted : TextColor.TextDefault}
-          variant={TextVariant.BodyMd}
-          fontWeight={FontWeight.Medium}
-        >
-          {strings('app_settings.notifications_opts.in_app')}
-        </Text>
-        <Switch
-          value={inApp.value}
-          onValueChange={inApp.onValueChange}
-          disabled={disabled}
-          trackColor={{
-            true: theme.colors.primary.default,
-            false: theme.colors.border.muted,
-          }}
-          thumbColor={theme.brandColors.white}
-          style={styles.switch}
-          ios_backgroundColor={theme.colors.border.muted}
-          testID={
-            NotificationSettingsViewSelectorsIDs.FEATURE_ANNOUNCEMENTS_TOGGLE
-          }
-        />
-      </View>
-
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.contentContainer}
+      testID={NotificationSettingsViewSelectorsIDs.SECTION_SCROLL_VIEW}
+    >
+      {listHeader}
       {SectionContent ? (
         <SectionContent styles={styles} disabled={isSectionContentDisabled} />
       ) : null}
-    </>
+    </ScrollView>
   );
 };

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsView.testIds.ts
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsView.testIds.ts
@@ -12,6 +12,8 @@ export const NotificationSettingsViewSelectorsIDs = {
     'notification-settings-feature-announcements-toggle',
   FEATURE_ANNOUNCEMENT_SEPARATOR:
     'notification-settings-feature-announcements-separator',
+  SECTION_SCROLL_VIEW: 'notification-settings-section-scroll-view',
+  WALLET_ACTIVITY_LIST: 'notification-settings-wallet-activity-list',
   PERPS_NOTIFICATIONS_TOGGLE:
     'notification-settings-perps-notifications-toggle',
   ACCOUNT_NOTIFICATIONS_SELECT_ALL:

--- a/app/components/Views/Settings/NotificationsSettings/NotificationsSettings.styles.ts
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationsSettings.styles.ts
@@ -18,6 +18,15 @@ const styleSheet = (params: { theme: Theme }) =>
     contentContainer: {
       flexGrow: 1,
     },
+    walletActivityList: {
+      flex: 1,
+      backgroundColor: params.theme.colors.background.default,
+    },
+    walletActivityListContent: {
+      flexGrow: 1,
+      paddingHorizontal: 16,
+      paddingBottom: 48,
+    },
     line: {
       borderTopWidth: 1,
       borderTopColor: params.theme.colors.border.muted,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Removes the same-orientation `ScrollView`/`SectionList` nesting from Wallet Activity notification settings. The account `SectionList` is now the screen content's sole vertical scroller, with the section title, channel toggles, and account controls rendered through `ListHeaderComponent`. This restores list windowing for users with many wallets or accounts and avoids React Native's nested virtualized-list warning.

The notification section content now owns its scrolling strategy through a typed section-definition registry. Static sections continue to use a `ScrollView`, while list-backed sections can provide their own virtualized renderer without adding feature-specific branches to the screen shell. The list header is memoized, empty account lists retain the notification controls, and tests cover both layout strategies.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1323

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Wallet Activity notification account list

  Scenario: User manages notifications with many accounts
    Given MetaMask notifications are enabled
    And the wallet contains multiple notification-eligible EVM accounts across multiple wallets

    When the user opens Settings > Notifications > Wallet Activity
    Then the notification title, description, channel toggles, and account controls are displayed
    And all eligible accounts are grouped by wallet
    And the screen scrolls as one continuous list
    And no nested VirtualizedList warning is logged

    When the user changes an account notification toggle
    Then the toggle updates and the account notification preference is persisted

  Scenario: User has no notification-eligible accounts
    Given MetaMask notifications are enabled
    And the wallet contains no notification-eligible EVM accounts

    When the user opens Settings > Notifications > Wallet Activity
    Then the notification title, description, and channel toggles remain displayed
    And no account rows are displayed
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI-only layout change in notification settings, but it rewires scrolling and empty-list rendering for Wallet Activity, so scroll/header regressions are possible.
> 
> **Overview**
> Stops Wallet Activity notification settings from nesting a `SectionList` inside a `ScrollView`. The account list is now the only vertical scroller, with title, channel toggles, and select-all controls passed through `ListHeaderComponent`. That restores list windowing for large account sets and avoids React Native’s nested virtualized-list warning.
> 
> Section content now picks a layout via a typed registry: list-backed sections render their own virtualized list, static sections keep a `ScrollView`. Empty account lists still show the header controls instead of returning nothing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 606fc58049a1f7acb1b564da4a5b266bd24e772b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->