### PR TITLE
feat(swaps): categorize bridge performance traces

### DIFF
--- a/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
+++ b/app/components/UI/Bridge/hooks/useBridgeQuoteRequest/useBridgeQuoteRequest.test.ts
@@ -14,7 +14,12 @@ import * as bridgeSelectors from '../../../../../selectors/bridge';
 import useIsInsufficientBalance from '../useInsufficientBalance';
 import { useLatestBalance } from '../useLatestBalance';
 import { useInsufficientNativeReserveError } from '../useInsufficientNativeReserveError';
-import { endTrace, trace, TraceName } from '../../../../../util/trace';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../../../util/trace';
 
 jest.mock('react-redux', () => ({
   useSelector: (selector: (state: unknown) => unknown) => selector({}),
@@ -172,6 +177,7 @@ describe('useBridgeQuoteRequest', () => {
 
     expect(mockTrace).toHaveBeenCalledWith({
       name: TraceName.SwapQuoteFetch,
+      op: TraceOperation.BridgeDataFetch,
       data: expect.objectContaining({
         isRefresh: false,
         request_id: expect.any(String),
@@ -197,6 +203,7 @@ describe('useBridgeQuoteRequest', () => {
 
     expect(mockTrace).toHaveBeenCalledWith({
       name: TraceName.SwapQuoteFetch,
+      op: TraceOperation.BridgeDataFetch,
       data: expect.objectContaining({
         isRefresh: true,
         request_id: expect.any(String),

--- a/app/components/UI/Bridge/hooks/useLatestBalance/index.ts
+++ b/app/components/UI/Bridge/hooks/useLatestBalance/index.ts
@@ -14,7 +14,12 @@ import {
   isNativeAddress,
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
-import { endTrace, trace, TraceName } from '../../../../../util/trace';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../../../util/trace';
 import { useNonEvmTokensWithBalance } from '../useNonEvmTokensWithBalance';
 import { isEthAddress } from '../../../../../util/address';
 
@@ -131,6 +136,7 @@ export const useLatestBalance = (token: {
       try {
         trace({
           name: TraceName.BridgeBalancesUpdated,
+          op: TraceOperation.BridgeDataFetch,
           id: traceId,
           data: {
             srcChainId: chainId,

--- a/app/components/UI/Bridge/hooks/useLatestBalance/useLatestBalance.test.tsx
+++ b/app/components/UI/Bridge/hooks/useLatestBalance/useLatestBalance.test.tsx
@@ -12,7 +12,12 @@ import { act, waitFor } from '@testing-library/react-native';
 import { Hex, type CaipAssetId, type CaipChainId } from '@metamask/utils';
 import { SolScope } from '@metamask/keyring-api';
 import { cloneDeep } from 'lodash';
-import { endTrace, trace, TraceName } from '../../../../../util/trace';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../../../util/trace';
 
 // Mock dependencies
 jest.mock('../../../../../util/notifications/methods/common', () => ({
@@ -76,6 +81,7 @@ describe('useLatestBalance', () => {
     const traceId = mockTrace.mock.calls[0][0].id;
     expect(mockTrace).toHaveBeenCalledWith({
       name: TraceName.BridgeBalancesUpdated,
+      op: TraceOperation.BridgeDataFetch,
       id: expect.any(String),
       data: {
         srcChainId: '0x1',

--- a/app/components/UI/Bridge/hooks/useSearchTokens.test.ts
+++ b/app/components/UI/Bridge/hooks/useSearchTokens.test.ts
@@ -7,7 +7,12 @@ import {
   MOCK_CHAIN_IDS,
 } from '../testUtils/fixtures';
 import { PopularToken } from '../types';
-import { endTrace, trace, TraceName } from '../../../../util/trace';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../../util/trace';
 
 global.fetch = jest.fn();
 
@@ -90,6 +95,7 @@ describe('useSearchTokens', () => {
       );
       expect(mockTrace).toHaveBeenCalledWith({
         name: TraceName.SwapTokenSearch,
+        op: TraceOperation.BridgeDataFetch,
         id: expect.any(String),
         data: {
           chain_scope: 'single_chain',

--- a/app/components/UI/Bridge/hooks/useSearchTokens.ts
+++ b/app/components/UI/Bridge/hooks/useSearchTokens.ts
@@ -6,7 +6,12 @@ import { BridgeClientId, getClientHeaders } from '@metamask/bridge-controller';
 import { BRIDGE_API_BASE_URL } from '../../../../constants/bridge';
 import Engine from '../../../../core/Engine';
 import { getBaseSemVerVersion } from '../../../../util/version';
-import { endTrace, trace, TraceName } from '../../../../util/trace';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../../util/trace';
 import type { IncludeAsset, PopularToken } from '../types';
 
 const MIN_SEARCH_LENGTH = 3;
@@ -150,6 +155,7 @@ export const useSearchTokens = ({
           traceId = uuidv4();
           trace({
             name: TraceName.SwapTokenSearch,
+            op: TraceOperation.BridgeDataFetch,
             id: traceId,
             data: {
               chain_scope:

--- a/app/components/UI/Bridge/utils/swapBridgePageLoadTrace.ts
+++ b/app/components/UI/Bridge/utils/swapBridgePageLoadTrace.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { formatChainIdToCaip } from '@metamask/bridge-controller';
-import { trace, TraceName } from '../../../../util/trace';
+import { trace, TraceName, TraceOperation } from '../../../../util/trace';
 import type { BridgeToken, BridgeViewMode } from '../types';
 
 export interface SwapBridgePageLoadTraceRoute {
@@ -26,6 +26,7 @@ export const startSwapBridgePageLoadTrace = <
 
   trace({
     name: TraceName.SwapViewLoaded,
+    op: TraceOperation.BridgeScreenPerformance,
     id,
     data: {
       entry_point: route.sourcePage,

--- a/app/components/UI/Bridge/utils/swapQuoteFetchTrace.test.ts
+++ b/app/components/UI/Bridge/utils/swapQuoteFetchTrace.test.ts
@@ -1,5 +1,10 @@
 import { v4 as uuidv4 } from 'uuid';
-import { endTrace, trace, TraceName } from '../../../../util/trace';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../../util/trace';
 import { swapQuoteFetchTrace } from './swapQuoteFetchTrace';
 import type { BridgeToken } from '../types';
 
@@ -40,6 +45,7 @@ describe('swapQuoteFetchTrace', () => {
     expect(traceId).toBe('quote-trace-id');
     expect(mockTrace).toHaveBeenCalledWith({
       name: TraceName.SwapQuoteFetch,
+      op: TraceOperation.BridgeDataFetch,
       id: 'quote-trace-id',
       data: {
         request_id: 'quote-trace-id',

--- a/app/components/UI/Bridge/utils/swapQuoteFetchTrace.ts
+++ b/app/components/UI/Bridge/utils/swapQuoteFetchTrace.ts
@@ -1,6 +1,11 @@
 import { v4 as uuidv4 } from 'uuid';
 import { formatChainIdToCaip } from '@metamask/bridge-controller';
-import { endTrace, trace, TraceName } from '../../../../util/trace';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../../util/trace';
 import type { BridgeToken } from '../types';
 
 export type SwapQuoteFetchTraceResult =
@@ -57,6 +62,7 @@ export const swapQuoteFetchTrace = {
     }
     trace({
       name: TraceName.SwapQuoteFetch,
+      op: TraceOperation.BridgeDataFetch,
       id,
       data: {
         request_id: id,

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -321,6 +321,9 @@ export enum TraceOperation {
   OnboardingScreenPerformance = 'onboarding.screen.performance',
   OnboardingRivePerformance = 'onboarding.rive.performance',
   OnboardingNavigationPerformance = 'onboarding.navigation.performance',
+  // Swap/Bridge
+  BridgeScreenPerformance = 'bridge.screen.performance',
+  BridgeDataFetch = 'bridge.data_fetch',
   // Accounts
   AccountCreate = 'account.create',
   AccountDiscover = 'account.discover',

--- a/docs/swaps/swaps-sentry-reference.md
+++ b/docs/swaps/swaps-sentry-reference.md
@@ -1,0 +1,25 @@
+# Swaps/Bridge Sentry reference
+
+## Trace operation classification
+
+The `TraceOperation` value is a coarse grouping key for Sentry performance
+dashboards. It should classify the kind of work being measured rather than
+repeat the trace name.
+
+| Trace name                | Operation                   | Use for                                            |
+| ------------------------- | --------------------------- | -------------------------------------------------- |
+| `Swap View Loaded`        | `bridge.screen.performance` | Unified swap/bridge screen mount-to-visible timing |
+| `Swap Quote Fetch`        | `bridge.data_fetch`         | Quote request latency                              |
+| `Swap Token Search`       | `bridge.data_fetch`         | Token search request latency                       |
+| `Bridge Balances Updated` | `bridge.data_fetch`         | Balance refresh latency                            |
+
+Use `bridge.screen.performance` for shared unified-view screen or view
+mount-to-visible timing. Use `bridge.data_fetch` for shared unified-view API or
+data-fetch latency, such as quote, token search, and balance requests.
+
+Do not create a new operation for every trace name. For a future trace, first
+decide whether it measures screen readiness or data fetching. A hybrid
+interaction such as submit-to-confirmation should use its own operation (for
+example, `bridge.execution`), and transaction-type-specific traces should use
+their own `swap.*` or `bridge.*` operation rather than one of these shared
+values.


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.
Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This follow-up to [#35094](https://github.com/MetaMask/metamask-mobile/pull/35094)
implements SWAPS-4936 by adding coarse Sentry operation categories to the
existing unified swaps/bridge performance spans.

- Added `bridge.screen.performance` to the existing `Swap View Loaded` trace.
- Added `bridge.data_fetch` to the existing quote fetch, token search, and
  balance refresh traces.
- Preserved existing trace names, lifecycles, payloads, and identifiers; no
  duplicate traces were introduced.
- Documented the classification rule in
  `docs/swaps/swaps-sentry-reference.md`.

Validation:

- Updated existing focused assertions to cover the new `op` metadata.
- Focused Jest assertions passed; the local Jest process later hit the Node
  heap limit during teardown.
- `yarn lint:tsc` remains blocked by the pre-existing missing
  `app/util/termsOfUse/termsOfUseContent` module.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: [SWAPS-4936](https://consensyssoftware.atlassian.net/browse/SWAPS-4936)
Follow-up to [#35094](https://github.com/MetaMask/metamask-mobile/pull/35094).

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — this is a telemetry and documentation change with no user-facing
behavior or UI changes. Existing focused Jest assertions cover the added trace
operation metadata.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

N/A — no UI changes.

### **After**

<!-- [screenshots/recordings] -->

N/A — no UI changes.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android (not applicable: no UI or native behavior changed)
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario (not applicable: no user-facing behavior changed)
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->


[SWAPS-4936]: https://consensyssoftware.atlassian.net/browse/SWAPS-4936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ