### PR TITLE
docs(swaps): document swap and bridge Sentry traces

### DIFF
--- a/docs/swaps/swaps-sentry-reference.md
+++ b/docs/swaps/swaps-sentry-reference.md
@@ -1,25 +1,96 @@
 # Swaps/Bridge Sentry reference
 
-## Trace operation classification
+## Scope and measurement model
 
-The `TraceOperation` value is a coarse grouping key for Sentry performance
-dashboards. It should classify the kind of work being measured rather than
-repeat the trace name.
+The unified swap/bridge view uses four manual Sentry spans. Each span's primary
+measurement is its duration: the elapsed time between the `startTime` passed to
+`trace()` and the `timestamp` passed to `endTrace()`, in milliseconds. The
+`data` fields listed below are span attributes for context, not separate
+measurements. These traces do not emit additional `setMeasurement` values.
 
-| Trace name                | Operation                   | Use for                                            |
-| ------------------------- | --------------------------- | -------------------------------------------------- |
-| `Swap View Loaded`        | `bridge.screen.performance` | Unified swap/bridge screen mount-to-visible timing |
-| `Swap Quote Fetch`        | `bridge.data_fetch`         | Quote request latency                              |
-| `Swap Token Search`       | `bridge.data_fetch`         | Token search request latency                       |
-| `Bridge Balances Updated` | `bridge.data_fetch`         | Balance refresh latency                            |
+`TraceOperation` is a coarse grouping key for performance dashboards. It
+classifies the work being measured rather than repeating the trace name.
 
-Use `bridge.screen.performance` for shared unified-view screen or view
-mount-to-visible timing. Use `bridge.data_fetch` for shared unified-view API or
-data-fetch latency, such as quote, token search, and balance requests.
+## Complete trace catalog
 
-Do not create a new operation for every trace name. For a future trace, first
-decide whether it measures screen readiness or data fetching. A hybrid
-interaction such as submit-to-confirmation should use its own operation (for
-example, `bridge.execution`), and transaction-type-specific traces should use
-their own `swap.*` or `bridge.*` operation rather than one of these shared
-values.
+| TraceName (Sentry transaction name)                           | TraceOperation              | Panel title          | Emission locations                                                                                                                                                                                                                                                                                                                                       | What it measures                                                                                                                                                                                                                                                                                                                                    |
+| ------------------------------------------------------------- | --------------------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TraceName.SwapViewLoaded` (`Swap View Loaded`)               | `bridge.screen.performance` | **Page Load**        | Start: `app/components/UI/Bridge/utils/swapBridgePageLoadTrace.ts:27`; finish: `app/components/UI/Bridge/hooks/useSwapBridgePageLoadTrace/index.ts:38` (ready) or `:61` (unmount)                                                                                                                                                                        | Unified swap/bridge view start → source and destination tokens plus the latest source balance are available. A prefilled amount also waits for the quote surface. Ends with `result: success` or `result: cancelled`.                                                                                                                               |
+| `TraceName.SwapQuoteFetch` (`Swap Quote Fetch`)               | `bridge.data_fetch`         | **Quote Fetch**      | Start: `app/components/UI/Bridge/utils/swapQuoteFetchTrace.ts:63`; finish helper: `app/components/UI/Bridge/utils/swapQuoteFetchTrace.ts:33`; result handling: `app/components/UI/Bridge/hooks/useBridgeQuoteEvents/index.ts:105-127` and cancellation/error handling: `app/components/UI/Bridge/hooks/useBridgeQuoteRequest/index.ts:139-152, :187-212` | Quote request commit → first usable quote, no quotes, error, or cancellation. The trace starts before the 300 ms debounce, so the duration includes that user-perceived wait. Start attributes: `request_id`, `isRefresh`, `swap_type`, `src_chain_id`, `dest_chain_id`; end attribute: `result` (`success`, `no_quotes`, `error`, or `cancelled`). |
+| `TraceName.SwapTokenSearch` (`Swap Token Search`)             | `bridge.data_fetch`         | **Token Search**     | Start: `app/components/UI/Bridge/hooks/useSearchTokens.ts:156`; finish: `app/components/UI/Bridge/hooks/useSearchTokens.ts:222`                                                                                                                                                                                                                          | Initial, non-pagination `/getTokens/search` request start → response parsing and result state update. Pagination requests are not separately traced. Start attributes: `chain_scope`, `query_length_bucket`; end attributes: `result` and `result_count_bucket`.                                                                                    |
+| `TraceName.BridgeBalancesUpdated` (`Bridge Balances Updated`) | `bridge.data_fetch`         | **Balances Updated** | Start: `app/components/UI/Bridge/hooks/useLatestBalance/index.ts:137`; finish: `app/components/UI/Bridge/hooks/useLatestBalance/index.ts:164`                                                                                                                                                                                                            | EVM source-token balance refresh, including native `getBalance` or ERC-20 `balanceOf`, through the fetch result and state update. Non-EVM balances use controller data and do not emit this span. Attributes: `srcChainId`, `isNative`, and ending `result` (`success` or `error`).                                                                 |
+
+The page-load span is started by the navigation flow at
+`app/components/UI/Bridge/hooks/useSwapBridgeNavigation/index.ts:357` and by
+the “Bridge again” flow at
+`app/components/UI/Bridge/components/TransactionDetails/TransactionDetails.tsx:495`.
+
+## Panel naming
+
+Dashboard panels should use the generic UI interaction, not the raw
+`TraceName` string:
+
+| Panel title          | Backed by               |
+| -------------------- | ----------------------- |
+| **Page Load**        | `SwapViewLoaded`        |
+| **Quote Fetch**      | `SwapQuoteFetch`        |
+| **Token Search**     | `SwapTokenSearch`       |
+| **Balances Updated** | `BridgeBalancesUpdated` |
+
+Reserve a `Swap` or `Bridge` prefix in a panel title for a trace that is
+genuinely transaction-type-specific, such as a future cross-chain-only
+destination-polling trace. Do not use those prefixes for shared interactions
+in the unified swap/bridge view.
+
+## Operation naming
+
+- Use `bridge.screen.performance` for screen or view mount-to-visible timing.
+- Use `bridge.data_fetch` for API-call or other data-fetch latency.
+- For a new trace, first ask whether it measures a screen load or a data fetch;
+  do not create a bespoke operation for every trace name.
+- Do not force a genuinely hybrid flow into either shared operation. For
+  example, submit-to-confirmation may use `bridge.execution`.
+- For transaction-type-specific operations, keep the prefixes distinct:
+  `swap.*` for swap-only work and `bridge.*` for bridge-only work. Shared
+  unified-view work stays under the `bridge.*` operations above regardless of
+  whether the user is swapping or bridging.
+
+## Legacy TraceName inconsistency
+
+The four existing names are grandfathered and must not be renamed:
+
+- `SwapViewLoaded`, `SwapQuoteFetch`, and `SwapTokenSearch` use the legacy
+  `Swap` prefix.
+- `BridgeBalancesUpdated` uses the legacy `Bridge` prefix.
+
+All four are shared unified-view spans; the `Bridge` prefix does not make
+`BridgeBalancesUpdated` bridge-only. This inconsistency is deliberate legacy
+continuity. `TraceName` is the literal transaction name stored by Sentry,
+whereas `op` is the grouping field. Renaming a `TraceName` would split the
+historical data under the old string. The panel-title convention decouples the
+viewer-facing name from that raw value. New trace names should follow the
+conventions in this document; these four remain unchanged.
+
+## Example Sentry queries
+
+```text
+# All shared data-fetch spans
+op:bridge.data_fetch
+
+# All shared screen-load spans
+op:bridge.screen.performance
+
+# One exact trace
+transaction:"Swap Quote Fetch"
+
+# Combine an operation with an exact trace
+op:bridge.data_fetch transaction:"Swap Token Search"
+
+# The legacy Bridge-prefixed trace
+transaction:"Bridge Balances Updated"
+```
+
+The source of truth for the names and operations is
+`app/util/trace.ts`. When adding a trace, preserve an already-emitted
+`TraceName`, select the operation from the screen/data-fetch/hybrid rule above,
+and choose a generic panel title unless the trace is transaction-type-specific.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This docs-only follow-up to [PR #35172](https://github.com/MetaMask/metamask-mobile/pull/35172) documents the swap/bridge Sentry instrumentation so future dashboard and trace work follows the established conventions.

- Catalogs all four existing swap/bridge traces, their operations, emission locations, measurements, and lifecycle outcomes.
- Defines generic panel naming and screen/data-fetch operation rules.
- Documents the grandfathered `TraceName` prefix inconsistency and provides example Sentry queries.

No runtime instrumentation, trace names, or tests were changed.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: SWAPS-4937
Refs: #35172

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — documentation-only change; no runtime behavior changed.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Expands the swap/bridge Sentry reference from a short operation table into a full catalog of the four unified-view traces (`SwapViewLoaded`, `SwapQuoteFetch`, `SwapTokenSearch`, `BridgeBalancesUpdated`).
> 
> Documents duration-only measurement, emission sites, attributes, generic dashboard panel titles, operation-naming rules, the grandfathered `Swap`/`Bridge` `TraceName` prefix mismatch, and example Sentry queries. No runtime instrumentation is changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ed7448dd4741da201d5b4795b35b1801481dd4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->