### PR TITLE
fix(rewards): handle the not_scored Money Sweepstakes day status instead of a $0 shortfall

### DIFF
--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.test.tsx
@@ -104,6 +104,33 @@ describe('MoneyAccountSweepstakesCampaignOverview', () => {
     expect(getByText('$1,250.00')).toBeOnTheScreen();
   });
 
+  it('shows no qualification message on an unscored day, even with the threshold already covered', () => {
+    // Off the campaign's scored set the backend reports `not_scored` and there
+    // is no verdict for today. qualifyingDepositsUsd still reports real
+    // progress, so deriving a shortfall from it produced "Add $0.00 today".
+    const { getByText, queryByText } = render(
+      <MoneyAccountSweepstakesCampaignOverview
+        campaign={campaign}
+        localizedText={localizedText}
+        isParticipating
+        stats={{
+          ...stats,
+          qualifyingDepositsUsd: 150,
+          qualifyingThresholdUsd: 100,
+          todayStatus: 'not_scored',
+        }}
+      />,
+    );
+
+    expect(getByText('$150.00')).toBeOnTheScreen();
+    expect(queryByText(/Add \$0/)).toBeNull();
+    expect(queryByText(/to earn today's entry/)).toBeNull();
+    // Neither a promise nor a warning: no Qualified pill, no forfeit copy.
+    expect(queryByText('Qualified')).toBeNull();
+    expect(queryByText(localizedText.onTrackDescription)).toBeNull();
+    expect(queryByText(localizedText.lostTodayDescription)).toBeNull();
+  });
+
   it('renders stats skeletons while participating stats are loading with no data', () => {
     const { getByTestId, queryByText } = render(
       <MoneyAccountSweepstakesCampaignOverview

--- a/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/MoneyAccountSweepstakes/MoneyAccountSweepstakesCampaignOverview.tsx
@@ -136,6 +136,13 @@ const MoneyAccountSweepstakesCampaignOverview: React.FC<
           );
         case 'lost_today':
           return localizedText.lostTodayDescription;
+        // No day-close verdict exists off the scored set, so there is nothing
+        // truthful to promise or warn about. Deliberately silent rather than
+        // reusing the shortfall copy: `qualifyingDepositsUsd` may already
+        // cover the threshold, which rendered as "Add $0 today to earn
+        // today's entry". The figure and entry count above still show.
+        case 'not_scored':
+          return null;
         default:
           return null;
       }

--- a/app/core/Engine/controllers/rewards-controller/RewardsController.ts
+++ b/app/core/Engine/controllers/rewards-controller/RewardsController.ts
@@ -5827,7 +5827,10 @@ export class RewardsController extends BaseController<
         yieldEarnedUsd: 0,
         qualifyingDepositsUsd: 0,
         qualifyingThresholdUsd: 0,
-        todayStatus: 'not_yet_qualified',
+        // No campaign is being scored when rewards is off. `not_yet_qualified`
+        // here paired with a zero threshold, which a shortfall-deriving caller
+        // renders as "add $0".
+        todayStatus: 'not_scored',
         daysRemaining: 0,
       };
     }

--- a/app/core/Engine/controllers/rewards-controller/types.ts
+++ b/app/core/Engine/controllers/rewards-controller/types.ts
@@ -1566,7 +1566,12 @@ export type PredictThePitchPrizePoolState = {
 export type MoneyAccountSweepstakesTodayStatus =
   | 'on_track'
   | 'not_yet_qualified'
-  | 'lost_today';
+  | 'lost_today'
+  // Today is outside the campaign's scored set, so day close writes no entry
+  // either way and no verdict exists. `qualifyingDepositsUsd` still reports
+  // real progress, so a shortfall must NOT be derived from it here — the
+  // participant may already be over the threshold.
+  | 'not_scored';
 
 export interface MoneyAccountSweepstakesStatsMeDto {
   entryCount: number;


### PR DESCRIPTION
## **Description**

The Money Sweepstakes overview card derives its daily shortfall client-side:

```ts
const remainingBalance = Math.max(0, stats.qualifyingThresholdUsd - stats.qualifyingDepositsUsd);
// ...
case 'not_yet_qualified':
  return localizedText.shortfallDescription.replace(AMOUNT_PLACEHOLDER, formatUsd(remainingBalance));
```

Off a campaign's scored set (`start_date <= utc_midnight <= end_date`) the backend had no way to say "today isn't scored", so `todayStatus` fell back to its `not_yet_qualified` default while `qualifyingDepositsUsd` kept reporting real progress. A participant already **over** the threshold therefore hit the shortfall branch, the subtraction clamped to zero, and the card read:

> **"Add US$0 today to earn today's entry."**

Reported from a DEV build against "[DEV] Money Account x Week 1", where the compressed test window (RWDS-1487) means no day is ever scored, so the card stayed in that state and entries stayed at `0 / 7`.

Backend counterpart adds a fourth `todayStatus` value, `not_scored`: consensys-vertical-apps/va-mmcx-rewards#764.

This PR handles it. `not_scored` renders **no** qualification message — no `Qualified` pill, no forfeit warning, no shortfall prompt — because off the scored set there is no day-close verdict to promise or warn about. The qualifying figure, entry count and Add funds CTA are unchanged.

No new `localizedText` key is introduced. The neutral state is the absence of a message, which avoids adding a string to Contentful while content review and translations (RWDS-1495) are in flight.

Also corrects the rewards-disabled stub in `RewardsController`, which paired `not_yet_qualified` with a zero threshold — the same "add $0" shape.

Note the existing `default:` branch already returned `null`, so builds without this change degrade to the same neutral rendering rather than the bad prompt once the backend ships.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: RWDS-1488, RWDS-1487

## **Manual testing steps**

1. Point the app at an environment serving a Money Account Sweepstakes campaign whose window is outside the current UTC day (before `start_date` or after `end_date`).
2. Opt in and deposit enough to meet the campaign's `minBalanceUsd`.
3. Open the campaign details screen.
4. Before: the card reads "Add US$0 today to earn today's entry." After: no qualification line, and no `Qualified` pill; the qualifying deposit figure and `0 / 7 entries · this week` still render.
5. On a campaign whose window *does* cover today, confirm the three existing states still render as before: `Qualified` pill + on-track copy, the shortfall prompt with a real non-zero amount, and the amber forfeit copy after dipping below the threshold.

## **Screenshots/Recordings**

### **Before**

Reported from a DEV build; the qualification line under the entry count read "Add US$0 today to earn today's entry." while the eligible deposit figure was already above the campaign threshold.

### **After**

That line is absent. No other element on the card changes.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy and a disabled-feature stub only; no auth, scoring, or deposit logic changes. Existing scored-day states are unchanged.
> 
> **Overview**
> Fixes a misleading **“Add $0 today to earn today’s entry”** line on the Money Account Sweepstakes overview when today is outside the campaign’s scored window.
> 
> Adds `not_scored` to `MoneyAccountSweepstakesTodayStatus`. The overview renders **no** qualification message (no Qualified pill, shortfall prompt, or forfeit copy) for that status, while still showing deposits and entry count. The rewards-disabled stats stub now returns `not_scored` instead of `not_yet_qualified` with a zero threshold, which produced the same $0 shortfall. A unit test covers the over-threshold unscored case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cc421ee8181fedbcd7f7ed3c34c8ab525b250da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->