### PR TITLE
ci: allowlist new Namespace runner profile labels

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -20,6 +20,10 @@ self-hosted-runner:
     - "namespace-profile-metamask-android-build"
     - "namespace-profile-metamask-ios-build"
     - "namespace-profile-metamask-ios-e2e"
+    # MCWP-813
+    - "namespace-profile-metamask-ci-linux-small"
+    - "namespace-profile-metamask-ci-linux-large"
+    - "namespace-profile-metamask-android-e2e"
     # Bitrise Build Hub (INFRA-3679). bitrise_pool_name:<role-label> — value matches Build Hub runner label.
     - "bitrise_pool_name:bitrise-metamask-ios-build"
     - "bitrise_pool_name:bitrise-metamask-ios-e2e"


### PR DESCRIPTION
## **Description**

Adds the three new Namespace runner profile labels to the `self-hosted-runner.labels` allowlist in `.github/actionlint.yaml`, which currently permits only the four original `namespace-profile-*` labels.

| label | shape | ticket |
|---|---|---|
| `namespace-profile-metamask-ci-linux-small` | 4 vCPU / 8 GB | MCWP-811, MCWP-813 |
| `namespace-profile-metamask-ci-linux-large` | 16 vCPU / 32 GB | MCWP-812, MCWP-813 |
| `namespace-profile-metamask-android-e2e` | 16 vCPU / 32 GB | MCWP-813 |

All three profiles already exist in Namespace. The two `ci-linux` profiles are stock `ubuntu-24.04` and share `ci-linux`'s cache volume, differing from it only in machine shape; `android-e2e` carries the `android-build` image so Appium and the Android build job can be sized independently.

**No workflow references these labels yet**, so this is a no-op for current runs — `actionlint` cannot reject a label that nothing uses. It is a prerequisite: the right-sizing changes that follow cannot land while `actionlint` rejects the labels.

`namespace-profile-metamask-ci-linux` is untouched, as are all existing `runs-on` expressions.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: MCWP-813
Refs: MCWP-811
Refs: MCWP-812

## **Manual testing steps**

N/A for app behaviour — this changes a CI lint config only, with no app code and no workflow behaviour change.

Verified with `actionlint` locally. Because `-config-file` is independent of the workflow files, the same workflows were linted against the old and new configs to isolate this change:

```
$ actionlint -config-file <origin/main config>   # 19 errors
$ actionlint -config-file .github/actionlint.yaml # 19 errors
$ diff → identical
```

Identical error sets, so this change neither introduces nor resolves any lint finding — the expected result for adding unused allowlist entries. The 19 pre-existing findings (17 `[action]` for old action pins, 2 `[if-cond]`) are surfaced only by the locally installed actionlint 1.7.12; CI pins 1.7.1, where `Check workflows` is currently green.

## **Screenshots/Recordings**

N/A. Not a user facing change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

Not applicable: this changes a CI lint configuration, no app code.

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI lint config only; no workflow, app, or security changes. Existing runs-on labels are untouched.
> 
> **Overview**
> Allowlists three new Namespace self-hosted runner labels in `actionlint.yaml` so later right-sizing PRs can use them without lint failures.
> 
> Adds `namespace-profile-metamask-ci-linux-small`, `namespace-profile-metamask-ci-linux-large`, and `namespace-profile-metamask-android-e2e`. No workflows reference these labels yet, so current CI behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6000c3da8ab7ec2bd6dd4ba5414fabe5ec4dd326. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->