### PR TITLE
chore(assets-controller): delegate AccountActivityService:transactionUpdated for v15

### DIFF
--- a/app/core/Engine/messengers/assets-controller/assets-controller-messenger.test.ts
+++ b/app/core/Engine/messengers/assets-controller/assets-controller-messenger.test.ts
@@ -38,6 +38,7 @@ const ASSETS_CONTROLLER_DELEGATED_EVENTS = [
   'TransactionController:unapprovedTransactionAdded',
   'AccountActivityService:balanceUpdated',
   'AccountActivityService:statusChanged',
+  'AccountActivityService:transactionUpdated',
   'RemoteFeatureFlagController:stateChange',
 ] as const;
 
@@ -159,6 +160,21 @@ describe('getAssetsControllerMessenger', () => {
       expect.objectContaining({
         events: expect.arrayContaining([
           'AccountActivityService:statusChanged',
+        ]),
+      }),
+    );
+  });
+
+  it('delegates AccountActivityService transactionUpdated event', () => {
+    const rootMessenger = getRootMessenger();
+    const delegateSpy = jest.spyOn(rootMessenger, 'delegate');
+
+    getAssetsControllerMessenger(rootMessenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        events: expect.arrayContaining([
+          'AccountActivityService:transactionUpdated',
         ]),
       }),
     );

--- a/app/core/Engine/messengers/assets-controller/assets-controller-messenger.ts
+++ b/app/core/Engine/messengers/assets-controller/assets-controller-messenger.ts
@@ -38,6 +38,9 @@ const ASSETS_CONTROLLER_DELEGATED_EVENTS = [
   // Real-time post-tx balances (AccountActivityService WS path)
   'AccountActivityService:balanceUpdated',
   'AccountActivityService:statusChanged',
+  // Correlates a confirmed tx with its WS push to skip a redundant Accounts
+  // API call (see AssetsController#waitForWsTransactionUpdate)
+  'AccountActivityService:transactionUpdated',
   // AccountsApiDataSource: re-evaluate Accounts API vs RPC when remote flags change
   'RemoteFeatureFlagController:stateChange',
 ] as const;


### PR DESCRIPTION
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`@metamask/assets-controller` v15 adds a breaking change: it now listens for `AccountActivityService:transactionUpdated` to skip redundant Accounts API balance refetches after a transaction is confirmed when the WebSocket already delivered the update.

Mobile uses a scoped `AssetsController` messenger with an explicit delegation list, so this event must be delegated or `AssetsController` will never receive it and will always fall back to the API call.

This PR adds that delegation (and a test). The `@metamask/assets-controller` package bump to v15 will follow once it is published — see MetaMask/core#9940.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3910

Refs: MetaMask/core#9940

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A — messenger wiring only. End-to-end verification depends on bumping `@metamask/assets-controller` to v15 once published; after that, confirm a transaction on a WS-active chain does not trigger a redundant Accounts API balance refetch when the WebSocket already updated balances.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.