### PR TITLE
ci: right-size Linux CI jobs onto the 4x8 Namespace profile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
          vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
       # Effective provider for this job. Steps must test this, never inputs.runner_provider
@@ -741,7 +741,7 @@ jobs:
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
          vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
       # Effective provider for this job. Steps must test this, never inputs.runner_provider

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
       # Effective provider for this job. Steps must test this, never inputs.runner_provider
@@ -201,7 +201,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
       # Effective provider for this job. Steps must test this, never inputs.runner_provider
@@ -260,7 +260,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
       # Effective provider for this job. Steps must test this, never inputs.runner_provider
@@ -312,7 +312,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        matrix.profile || 'ubuntu-latest'
       }}
     env:
       # Effective provider for this job. Steps must test this, never inputs.runner_provider
@@ -325,16 +325,30 @@ jobs:
     needs:
       - get_requirements
     strategy:
+      # `include` with no base axis yields exactly these combinations, and `name`
+      # already interpolates a matrix value, so the rendered job names stay
+      # `Run <script>` and the required status checks keep reporting (MCWP-813).
+      # `profile` is consumed by `runs-on` above. Shape follows peak RAM.
       matrix:
-        scripts:
-          - lint
-          - lint:tsc
-          - lint:changelog
-          - format:check
-          - audit:ci
-          - test:depcheck
-          - test:tgz-check
-          - constraints
+        include:
+          # Stay on 8x16: peak RAM above the 8 GB line.
+          - scripts: lint # 12.3 GB peak
+            profile: namespace-profile-metamask-ci-linux
+          - scripts: lint:tsc # 8.9 GB peak
+            profile: namespace-profile-metamask-ci-linux
+          # Right-sized to 4x8: worst observed peak <= 5.6 GB.
+          - scripts: lint:changelog
+            profile: namespace-profile-metamask-ci-linux-small
+          - scripts: format:check
+            profile: namespace-profile-metamask-ci-linux-small
+          - scripts: audit:ci
+            profile: namespace-profile-metamask-ci-linux-small
+          - scripts: test:depcheck
+            profile: namespace-profile-metamask-ci-linux-small
+          - scripts: test:tgz-check
+            profile: namespace-profile-metamask-ci-linux-small
+          - scripts: constraints
+            profile: namespace-profile-metamask-ci-linux-small
     steps:
       - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
         if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
@@ -378,6 +392,10 @@ jobs:
           fi
 
   js-bundle-size-check:
+    # Stays on 8x16 (MCWP-813). It is the thinnest margin on the profile — 14.3 GB
+    # peak of 16 post-#35071, ~11% headroom — but the heap fix took it from a 13.6%
+    # to a 2.3% failure rate, so the cheap remedy is already applied. Revisit with
+    # MCWP-812 if failures recur; `ci-linux-large` exists for that.
     name: JS bundle size check
     runs-on: >-
       ${{
@@ -646,7 +664,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
       # Effective provider for this job. Steps must test this, never inputs.runner_provider
@@ -719,7 +737,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
       # Effective provider for this job. Steps must test this, never inputs.runner_provider
@@ -751,7 +769,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
       # Effective provider for this job. Steps must test this, never inputs.runner_provider
@@ -872,7 +890,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
       # Effective provider for this job. Steps must test this, never inputs.runner_provider
@@ -1231,11 +1249,16 @@ jobs:
   # Integration tests are optional for the PR gate — they feed coverage into
   # merge → Sonar but are not listed in check-all-jobs-pass needs.
   integration-tests:
-    name: Integration tests
+    # Renders exactly as GitHub's own matrix suffix did for `name: Integration tests`
+    # with a single `shard` axis, so the `Integration tests (1)` / `(2)` required
+    # checks keep reporting. Spelling it out is load-bearing: the auto-suffix joins
+    # *every* matrix value, so adding `profile` below would otherwise rename these
+    # checks to `Integration tests (1, namespace-profile-...)` (MCWP-813).
+    name: Integration tests (${{ matrix.shard }})
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        matrix.profile || 'ubuntu-latest'
       }}
     env:
       # Effective provider for this job. Steps must test this, never inputs.runner_provider
@@ -1250,7 +1273,18 @@ jobs:
       - prepare-ci-js-deps
     strategy:
       matrix:
-        shard: [1, 2]
+        include:
+          # Shard 1 peaks at 9.3 GB — above the 8 GB line, so it keeps 8x16.
+          - shard: 1
+            profile: namespace-profile-metamask-ci-linux
+            heap_mb: 12288
+          # Shard 2 peaks at 5.3 GB. On the 4x8 shape the heap ceiling has to come
+          # down with it: 12288 would let V8 grow past physical RAM before it
+          # self-limits, and RAM overrun is a hard exit-137. 6144 sits above the
+          # observed peak, and the profile carries 8 GB of swap as a backstop.
+          - shard: 2
+            profile: namespace-profile-metamask-ci-linux-small
+            heap_mb: 6144
     steps:
       - uses: namespacelabs/nscloud-checkout-action@938f5d2d403d6224d9a0c0dc559b1dae09c2ede4 # v8.1.1
         if: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' }}
@@ -1280,7 +1314,7 @@ jobs:
             --json \
             --outputFile=tests/results/integration-test-results-${{ matrix.shard }}.json
         env:
-          NODE_OPTIONS: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' && '--max-old-space-size=12288' || '--max-old-space-size=20480' }}
+          NODE_OPTIONS: ${{ env.RESOLVED_RUNNER_PROVIDER == 'namespace' && format('--max-old-space-size={0}', matrix.heap_mb) || '--max-old-space-size=20480' }}
       - name: Rename coverage report and extract test count for this shard
         shell: bash
         run: |
@@ -1310,7 +1344,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
       # Effective provider for this job. Steps must test this, never inputs.runner_provider
@@ -1648,7 +1682,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
       # Effective provider for this job. Steps must test this, never inputs.runner_provider
@@ -1772,7 +1806,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
       # Effective provider for this job. Steps must test this, never inputs.runner_provider
@@ -1911,7 +1945,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
       # Effective provider for this job. Steps must test this, never inputs.runner_provider
@@ -1965,7 +1999,7 @@ jobs:
     runs-on: >-
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider || vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     env:
       # Effective provider for this job. Steps must test this, never inputs.runner_provider

--- a/.github/workflows/upload-to-testflight.yml
+++ b/.github/workflows/upload-to-testflight.yml
@@ -59,7 +59,7 @@ jobs:
       ${{
         (inputs.runner_provider != '' && inputs.runner_provider != 'inherit' && inputs.runner_provider ||
          vars.NAMESPACE_RUNNER_LINUX || vars.NAMESPACE_RUNNER_PROVIDER || 'current') == 'namespace' &&
-        'namespace-profile-metamask-ci-linux' || 'ubuntu-latest'
+        'namespace-profile-metamask-ci-linux-small' || 'ubuntu-latest'
       }}
     steps:
       - name: Display TestFlight upload summary


### PR DESCRIPTION
## **Description**

Moves the over-provisioned Linux CI cohort from `namespace-profile-metamask-ci-linux` (8 vCPU / 16 GB) to `namespace-profile-metamask-ci-linux-small` (4 vCPU / 8 GB, 8 GB swap). Shapes follow measured peak RAM from `nsc instance report`. The ~79% of profile time that genuinely needs 16 GB is untouched.

**15 jobs move to 4x8.** 12 standalone in `ci.yml` (`check-diff`, `dedupe`, `git-safe-dependencies`, `ship-js-bundle-size-check`, `check-workflows`, `prepare-ci-js-deps`, `merge-unit-and-component-view-tests`, `smart-e2e-selection`, `report-fixture-validation`, `sonar-cloud-quality-gate-status`, `check-all-jobs-pass`, `log-merge-group-failure`), plus `prepare` and `emit-build-metadata` in `build.yml` and `testflight-upload-summary` in `upload-to-testflight.yml`.

**Two matrices restructured** to `include`-only with a `profile` key that `runs-on` reads, so shape can vary per entry:

| matrix | stays 8x16 | moves to 4x8 |
|---|---|---|
| `scripts` | `lint` (12.3 GB), `lint:tsc` (8.9 GB) | `lint:changelog`, `format:check`, `audit:ci`, `test:depcheck`, `test:tgz-check`, `constraints` |
| `integration-tests` | shard 1 (9.3 GB) | shard 2 (5.3 GB) |

Untouched on 8x16: `unit-tests` ×10, `component-view-tests` ×3, `sonar-cloud`, `js-bundle-size-check`.

### Two things reviewers should look at closely

**Required check names are preserved.** `integration-tests` needed an explicit `name: Integration tests (${{ matrix.shard }})`. GitHub only auto-appends matrix values when `name` interpolates none, and that suffix joins *every* matrix value — so adding `profile` would have renamed the checks to `Integration tests (1, namespace-profile-...)` and blocked branch protection. `scripts` already interpolated `matrix.scripts`, so it was immune.

**Integration shard 2's heap ceiling drops 12288 → 6144 MB** alongside its shape, and is now per-shard rather than per-job. A 12 GB ceiling on an 8 GB machine lets V8 grow past physical RAM before it self-limits, and RAM overrun is a hard exit-137, not a slowdown. 6144 sits above the 5.3 GB observed peak; the profile carries 8 GB of swap as a backstop.

Every edit keeps the `RESOLVED_RUNNER_PROVIDER` resolution chain and the `ubuntu-latest` fallback intact, so `NAMESPACE_RUNNER_LINUX=current` still evacuates the whole fleet.

### Scope deliberately not covered

MCWP-813's long tail includes four more sites with **no measured baseline** in the sampling window, three of them release-path: `eas-update-platform.yml` `push-update` (OTA runs a JS bundle — the heaviest memory consumer in the repo), `build-ios-upload-to-browserstack.yml` `download-and-upload-to-browserstack`, `build-android-internal-distribution.yml` `publish-apk`, and the six `update-e2e-fixtures.yml` helper jobs. Together ~570 inst-min (2.8% of the cohort). Left on 8x16 until a targeted `nsc instance report --jobname` gives them baselines, since the AC requires post-change evidence of peak RAM < 8 GB per moved job.

Records the MCWP-813 decision for `JS bundle size check`: **stays on 8x16** (14.3 GB peak of 16, ~11% headroom, but #35071 already took it from a 13.6% to a 2.3% failure rate; revisit with MCWP-812, `ci-linux-large` exists for it).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: MCWP-811
Refs: MCWP-813

## **Manual testing steps**

N/A for app behaviour — CI runner shapes only, no app code. `NAMESPACE_RUNNER_LINUX=namespace`, so this PR's own CI run exercises the new profiles directly.

**1. Required check names did not drift** (the main risk). Baseline is pre-change merge_group run `32729922012`:

```bash
gh run view 32729922012 --json jobs -q '.jobs[].name' | sort -u > /tmp/before.txt
gh run view <THIS_PR_CI_RUN> --json jobs -q '.jobs[].name' | sort -u > /tmp/after.txt
diff <(grep -E '^(Run `|Integration tests)' /tmp/before.txt) \
     <(grep -E '^(Run `|Integration tests)' /tmp/after.txt)   # must be empty
```

Watch for `Integration tests (1, namespace-profile-...)` — that would mean the explicit `name:` did not take.

**2. Jobs landed on the intended shape.** The runner prints this in `Set up job`:

```bash
gh run view --job <JOB_ID> --log | grep -E 'Machine Type|Tag:|User Bundled Cache'
```

- moved jobs → `Machine Type: 4x8`, `Tag: namespace-profile-metamask-ci-linux-small`
- `Run \`lint\``, `Integration tests (1)`, `Unit tests (N)`, `SonarCloud analysis`, `JS bundle size check` → `Machine Type: 8x16`, `Tag: namespace-profile-metamask-ci-linux`

**3. Cache sharing works.** On a 4x8 runner the cache line must still name `ci-linux`, confirming the shared `volume_tag`:

```
User Bundled Cache: github-namespace-profile-metamask-ci-linux-MetaMask-metamask-mobile with 30GB.
```

`nsc volume list` should still show 4 profile volumes. A new `...-ci-linux-small-...` volume means sharing failed and the cohort is running cold, which would invalidate step 5.

**4. No OOM, headroom intact.**

```bash
nsc instance report --start <T0> --end <T1> --repository MetaMask/metamask-mobile \
  --profile namespace-profile-metamask-ci-linux-small --out -
```

Expect `resources_cpu == 4`, `resources_ram_gb == 8`, zero exit-137, peak RAM < 8 GB.

> ⚠️ `resources_ram_gb_actual_max_percent` is a **fraction of the allocation**, not an absolute. The allocation halved, so identical memory use now reports double the percentage — `format:check`'s worst run was 5.4 GB = 0.34 on 16 GB and will read **0.68** on 8 GB. Multiply by `resources_ram_gb` before comparing against MCWP-813's tables.

**5. Wall clock within +25% of baseline** (MCWP-813 AC). Baselines: `format:check` 110s, `test:depcheck` 82s, `Integration tests (2)` 82s, `Check diff` 69s, `Dedupe` 45s, `lint:changelog` 45s, `audit:ci` 43s, `test:tgz-check` 43s, `constraints` 42s, `Check all jobs pass` 15s. One PR run is a sample of one — take p50 over ≥1 day post-merge.

**6. Rollback path intact** (AC in both tickets):

```bash
gh workflow run ci.yml --ref ci/right-size-linux-ci-jobs -f runner_provider=current
```

Every job must report `ubuntu-latest` and no `namespace-profile-*`.

### Verified locally

- `actionlint -config-file .github/actionlint.yaml`: 19 findings on `main`, 19 on this branch, `comm -13` shows zero new. All 19 are pre-existing (17 deprecated action pins, 2 `if: false`) and surface only under locally-installed 1.7.12; CI pins 1.7.1 where `Check workflows` is green.
- All three workflows parse; matrix expansion dumped and checked — 8 `scripts` entries and 2 `integration-tests` entries resolve to the intended profiles and heap values.
- All 10 matrix-derived job names cross-checked against the names actually recorded in `nsc instance report`, not just against the YAML.

**Not verifiable pre-merge:** `check-all-jobs-pass` is itself now on 4x8 and is the final merge-queue gate, so its latency matters more than its cost — worth watching the first few merge-queue passes.

## **Screenshots/Recordings**

N/A. Not a user facing change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

Not applicable: this changes CI runner shapes, no app code.

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only but changes runner sizing and integration shard heap limits; OOM or slower jobs could fail merge gates if baselines were wrong, though check names and rollback via `runner_provider=current` are preserved.
> 
> **Overview**
> **Right-sizes Namespace Linux CI** by moving jobs whose measured peak RAM stays under 8 GB from `namespace-profile-metamask-ci-linux` (8 vCPU / 16 GB) to `namespace-profile-metamask-ci-linux-small` (4 vCPU / 8 GB). Heavy jobs—unit tests, component-view tests, SonarCloud, and **JS bundle size check**—remain on 8x16.
> 
> Across `ci.yml`, `build.yml`, and `upload-to-testflight.yml`, lightweight standalone jobs (e.g. check-diff, dedupe, prepare-ci-js-deps, check-all-jobs-pass) now use the small profile when `RESOLVED_RUNNER_PROVIDER` is Namespace; the `ubuntu-latest` fallback is unchanged.
> 
> The **`scripts`** matrix uses `include` with a per-entry **`profile`**: only `lint` and `lint:tsc` keep 8x16; changelog, format, audit, depcheck, tgz-check, and constraints move to 4x8.
> 
> **`integration-tests`** keeps required check names via explicit `name: Integration tests (${{ matrix.shard }})`. Shard 1 stays on 8x16 with a 12 GB heap; shard 2 moves to 4x8 with **`NODE_OPTIONS` heap 6144 MB** (was 12288) so V8 does not overshoot physical RAM on the smaller shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b2cbb78ddc55235553fd39fa5161dbd1b29d5e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->