### PR TITLE
fix(onboarding): keep checklist completion durable when exit animations are interrupted

### DIFF
--- a/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.test.tsx
+++ b/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.test.tsx
@@ -629,6 +629,121 @@ describe('WalletHomeOnboardingSteps', () => {
     });
   });
 
+  describe('interrupted exit animations (TMCU-1248)', () => {
+    /** Reanimated reports `finished: false` when a re-render retargets the bar mid-fill. */
+    function cancelProgressFillToFull() {
+      const actual = jest.requireActual(
+        './walletHomeOnboardingProgressAnimation',
+      ).animateWalletHomeOnboardingProgressRatio;
+      animateProgressRatioSpy.mockImplementation(
+        (progressRatio, target, options) => {
+          if (target === 1) {
+            options?.onComplete?.(false);
+            return;
+          }
+          actual(progressRatio, target, options);
+        },
+      );
+    }
+
+    it('completes the flow when the last-step progress fill is cancelled', async () => {
+      cancelProgressFillToFull();
+      const { getByTestId, store } = renderSteps({
+        walletHomeOnboardingSteps: { suppressedReason: null, stepIndex: 2 },
+      });
+
+      fireEvent.press(
+        getByTestId(WalletHomeOnboardingStepsSelectors.SKIP_BUTTON),
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(
+          WALLET_HOME_ONBOARDING_CHECKLIST_COMPLETE_TRANSITION_MS + 100,
+        );
+      });
+
+      await waitFor(() => {
+        expect(store.getState().onboarding.walletHomeOnboardingSteps).toEqual(
+          expect.objectContaining({ suppressedReason: 'flow_completed' }),
+        );
+      });
+    });
+
+    it('runs the coordinated flow exit when the last-step progress fill is cancelled', async () => {
+      cancelProgressFillToFull();
+      const onCoordinatedFlowExit = jest.fn().mockResolvedValue(undefined);
+      const { getByTestId } = renderWithProvider(
+        <WalletHomeOnboardingSteps
+          testID="steps-root"
+          onCoordinatedFlowExit={onCoordinatedFlowExit}
+        />,
+        {
+          state: {
+            onboarding: {
+              ...baseOnboarding,
+              walletHomeOnboardingSteps: {
+                suppressedReason: null,
+                stepIndex: 2,
+              },
+            },
+            engine: { backgroundState },
+          },
+        },
+      );
+
+      fireEvent.press(
+        getByTestId(WalletHomeOnboardingStepsSelectors.SKIP_BUTTON),
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(
+          WALLET_HOME_ONBOARDING_CHECKLIST_COMPLETE_TRANSITION_MS + 100,
+        );
+      });
+
+      await waitFor(() => {
+        expect(onCoordinatedFlowExit).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('commits the skipped step when the checklist unmounts mid-transition', async () => {
+      const { getByTestId, store, unmount } = renderSteps({
+        walletHomeOnboardingSteps: { suppressedReason: null, stepIndex: 1 },
+      });
+
+      fireEvent.press(
+        getByTestId(WalletHomeOnboardingStepsSelectors.SKIP_BUTTON),
+      );
+
+      // Unmount during the outro hold — before the slide-out would have committed.
+      unmount();
+
+      await waitFor(() => {
+        expect(store.getState().onboarding.walletHomeOnboardingSteps).toEqual(
+          expect.objectContaining({ stepIndex: 2 }),
+        );
+      });
+    });
+
+    it('completes the flow when the checklist unmounts mid-completion', async () => {
+      const { getByTestId, store, unmount } = renderSteps({
+        walletHomeOnboardingSteps: { suppressedReason: null, stepIndex: 2 },
+      });
+
+      fireEvent.press(
+        getByTestId(WalletHomeOnboardingStepsSelectors.SKIP_BUTTON),
+      );
+
+      unmount();
+
+      await waitFor(() => {
+        expect(store.getState().onboarding.walletHomeOnboardingSteps).toEqual(
+          expect.objectContaining({ suppressedReason: 'flow_completed' }),
+        );
+      });
+    });
+  });
+
   it('clamps persisted stepIndex when it is out of range', () => {
     const { store } = renderSteps({
       walletHomeOnboardingSteps: { suppressedReason: null, stepIndex: 99 },
@@ -644,6 +759,22 @@ describe('WalletHomeOnboardingSteps', () => {
       <WalletHomeOnboardingSteps testID="steps-root" isAwaitingBalance />,
       {
         state: {
+          onboarding: baseOnboarding,
+          engine: { backgroundState },
+        },
+      },
+    );
+
+    expect(getByTestId('steps-root-hero-awaiting-balance')).toBeOnTheScreen();
+    expect(getByTestId('steps-root-hero-fund')).toBeOnTheScreen();
+    expect(getByTestId(primaryTestId)).toBeDisabled();
+  });
+
+  it('does not rewind to the fund shell when balance re-resolves on a later step', () => {
+    const { getByTestId, queryByTestId } = renderWithProvider(
+      <WalletHomeOnboardingSteps testID="steps-root" isAwaitingBalance />,
+      {
+        state: {
           onboarding: {
             ...baseOnboarding,
             walletHomeOnboardingSteps: {
@@ -656,9 +787,10 @@ describe('WalletHomeOnboardingSteps', () => {
       },
     );
 
-    expect(getByTestId('steps-root-hero-awaiting-balance')).toBeOnTheScreen();
-    expect(getByTestId('steps-root-hero-fund')).toBeOnTheScreen();
-    expect(getByTestId(primaryTestId)).toBeDisabled();
+    expect(queryByTestId('steps-root-hero-awaiting-balance')).toBeNull();
+    expect(queryByTestId('steps-root-hero-fund')).toBeNull();
+    expect(getByTestId('steps-root-hero-notifications')).toBeOnTheScreen();
+    expect(getByTestId(primaryTestId)).toBeEnabled();
   });
 
   it('renders fund hero and progress for step 0', () => {

--- a/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.tsx
+++ b/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.tsx
@@ -86,8 +86,9 @@ const SLIDE_DISTANCE = Dimensions.get('window').width;
 export interface WalletHomeOnboardingStepsProps {
   testID?: string;
   /**
-   * When true, show the first-step shell with a loading hero and disabled primary until
+   * When true, show the fund-step shell with a loading hero and disabled primary until
    * aggregated balance / empty-state is resolved (in-flow users reopening the app).
+   * Only honoured on the fund step — see {@link isAwaitingBalanceShell}.
    */
   isAwaitingBalance?: boolean;
   /**
@@ -144,22 +145,26 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
     useWalletHomeOnboardingVisibleSteps();
   const totalSteps = visibleSteps.length;
 
+  const [isStepTransitioning, setIsStepTransitioning] = useState(false);
+
+  const isAwaitingBalanceShell =
+    isAwaitingBalance && stepIndex === 0 && !isStepTransitioning;
+
   useWalletHomeOnboardingChecklistHomeViewed({
-    isAwaitingBalance,
+    isAwaitingBalance: isAwaitingBalanceShell,
     stepIndex,
     isFocused,
     steps: visibleSteps,
   });
-  const displayStepIndex = isAwaitingBalance ? 0 : stepIndex;
   /** Capped index for progress + hero; matches visible steps bounds before Redux clamps persisted step. */
   const visualStepIndexForProgress = walletHomeOnboardingCappedVisualStepIndex(
-    displayStepIndex,
+    stepIndex,
     totalSteps,
   );
 
   const isStepIndexBeyondVisibleSteps =
     walletHomeOnboardingShouldHoldRenderForDroppedStep({
-      displayStepIndex,
+      displayStepIndex: stepIndex,
       stepCount: totalSteps,
       includeNotificationsStep,
     });
@@ -177,6 +182,9 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
     ((finished: boolean) => void) | null
   >(null);
   const advanceLockRef = useRef(false);
+  const pendingAdvanceCommitRef = useRef<(() => void | Promise<void>) | null>(
+    null,
+  );
   const outroHoldTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
@@ -216,13 +224,11 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
     setSkipIntroAfterDeferredNavReturn(false);
   }, [stepIndex]);
 
-  const [isStepTransitioning, setIsStepTransitioning] = useState(false);
   /** True after returning from swap/onramp/settings until the resume hold ends and advance starts. */
   const [isAwaitingDeferredNavResumeHold, setIsAwaitingDeferredNavResumeHold] =
     useState(false);
   const stepIndexRef = useRef(stepIndex);
   const isLastStepRef = useRef(stepIndex >= totalSteps - 1);
-  /** Kept in sync with `stepIndex` + `isAwaitingBalance` so Primary commit matches `goNextOrComplete` ref reads. */
   const currentStepKindRef = useRef<WalletHomeOnboardingStepKind>(
     visibleSteps[visualStepIndexForProgress].kind,
   );
@@ -230,19 +236,23 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
     canAdvanceFundStepAfterBalanceRef.current = canAdvanceFundStepAfterBalance;
     stepIndexRef.current = stepIndex;
     isLastStepRef.current = stepIndex >= totalSteps - 1;
-    const displayIdx = isAwaitingBalance ? 0 : stepIndex;
-    const cappedVisual = walletHomeOnboardingCappedVisualStepIndex(
-      displayIdx,
-      totalSteps,
-    );
-    currentStepKindRef.current = visibleSteps[cappedVisual].kind;
+    currentStepKindRef.current = visibleSteps[visualStepIndexForProgress].kind;
   }, [
     canAdvanceFundStepAfterBalance,
-    isAwaitingBalance,
     stepIndex,
     totalSteps,
     visibleSteps,
+    visualStepIndexForProgress,
   ]);
+
+  const runPendingAdvanceCommit = useCallback((): Promise<void> => {
+    const commit = pendingAdvanceCommitRef.current;
+    pendingAdvanceCommitRef.current = null;
+    if (!commit) {
+      return Promise.resolve();
+    }
+    return Promise.resolve(commit()).catch(() => undefined);
+  }, []);
 
   useEffect(
     () => () => {
@@ -258,8 +268,10 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
         clearTimeout(fundBalanceAutoAdvanceTimerRef.current);
         fundBalanceAutoAdvanceTimerRef.current = null;
       }
+      // Clearing the outro hold above would otherwise strand the advance mid-transition.
+      runPendingAdvanceCommit();
     },
-    [],
+    [runPendingAdvanceCommit],
   );
 
   useEffect(() => {
@@ -330,7 +342,7 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
     if (
       !skipIntroAfterDeferredNavReturn ||
       hasTestOverrides ||
-      isAwaitingBalance
+      isAwaitingBalanceShell
     ) {
       return;
     }
@@ -364,7 +376,7 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
     return () => {
       clearTimeout(timeoutId);
     };
-  }, [isAwaitingBalance, skipIntroAfterDeferredNavReturn]);
+  }, [isAwaitingBalanceShell, skipIntroAfterDeferredNavReturn]);
 
   const currentStep = visibleSteps[visualStepIndexForProgress];
 
@@ -394,7 +406,7 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
   }, []);
 
   const goNextOrComplete = useCallback(() => {
-    if (isAwaitingBalance) {
+    if (isAwaitingBalanceShell) {
       return;
     }
     if (advanceLockRef.current) {
@@ -415,6 +427,18 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
 
     advanceLockRef.current = true;
     setIsStepTransitioning(true);
+    pendingAdvanceCommitRef.current = fromIsLast
+      ? () => {
+          if (onCoordinatedFlowExit) {
+            return onCoordinatedFlowExit();
+          }
+          dispatch(suppressWalletHomeOnboardingSteps('flow_completed'));
+          return undefined;
+        }
+      : () => {
+          dispatch(setWalletHomeOnboardingStepsStep(fromIndex + 1));
+          return undefined;
+        };
 
     const runSlideOutThenCommit = () => {
       if (fromIsLast) {
@@ -429,12 +453,8 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
           }).start(({ finished }) => {
             if (!finished) {
               checklistFadeOpacity.setValue(1);
-              finishAdvance();
-              return;
             }
-            onCoordinatedFlowExit()
-              .then(() => finishAdvance())
-              .catch(() => finishAdvance());
+            runPendingAdvanceCommit().then(finishAdvance);
           });
           return;
         }
@@ -450,10 +470,8 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
         }).start(({ finished }) => {
           if (!finished) {
             slideY.setValue(0);
-            finishAdvance();
-            return;
           }
-          dispatch(suppressWalletHomeOnboardingSteps('flow_completed'));
+          runPendingAdvanceCommit();
           finishAdvance();
         });
         return;
@@ -467,10 +485,11 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
       }).start(({ finished }) => {
         if (!finished) {
           slideX.setValue(0);
+          runPendingAdvanceCommit();
           finishAdvance();
           return;
         }
-        dispatch(setWalletHomeOnboardingStepsStep(fromIndex + 1));
+        runPendingAdvanceCommit();
         slideX.setValue(SLIDE_DISTANCE);
         requestAnimationFrame(() => {
           Animated.timing(slideX, {
@@ -515,11 +534,8 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
     };
 
     if (fromIsLast) {
-      onProgressFillCompleteRef.current = (finished) => {
-        if (!finished) {
-          finishAdvance();
-          return;
-        }
+      onProgressFillCompleteRef.current = () => {
+        onProgressFillCompleteRef.current = null;
         scheduleOutroHoldThenSlide();
       };
       animateWalletHomeOnboardingProgressRatio(progressRatio, 1, {
@@ -534,9 +550,10 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
     dispatch,
     finishAdvance,
     handleProgressFillComplete,
-    isAwaitingBalance,
+    isAwaitingBalanceShell,
     onCoordinatedFlowExit,
     progressRatio,
+    runPendingAdvanceCommit,
     slideX,
     slideY,
     checklistFadeOpacity,
@@ -613,6 +630,10 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
       : WALLET_HOME_ONBOARDING_POST_NAV_RESUME_HOLD_MS;
     resumeHoldAfterReturnTimerRef.current = setTimeout(() => {
       resumeHoldAfterReturnTimerRef.current = null;
+      if (isAwaitingBalanceShell) {
+        setIsAwaitingDeferredNavResumeHold(false);
+        return;
+      }
       deferAdvanceUntilReturnRef.current = false;
       deferFromFundStepRef.current = false;
       sawBlurWhileDeferredRef.current = false;
@@ -627,7 +648,12 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
       }
       setIsAwaitingDeferredNavResumeHold(false);
     };
-  }, [canAdvanceFundStepAfterBalance, goNextOrComplete, isFocused]);
+  }, [
+    canAdvanceFundStepAfterBalance,
+    goNextOrComplete,
+    isAwaitingBalanceShell,
+    isFocused,
+  ]);
 
   /**
    * Fund step: user received funds (or already had positive aggregate) without an active
@@ -760,7 +786,7 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
           justifyContent={BoxJustifyContent.Center}
           twClassName="relative z-10 flex-1 w-full min-h-0 self-stretch"
         >
-          {isAwaitingBalance ? (
+          {isAwaitingBalanceShell ? (
             <ActivityIndicator
               size="large"
               accessibilityLabel={strings(
@@ -820,7 +846,7 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
             isFullWidth
             isDisabled={
               isStepTransitioning ||
-              isAwaitingBalance ||
+              isAwaitingBalanceShell ||
               isAwaitingDeferredNavResumeHold
             }
             testID={primaryTestID}
@@ -841,7 +867,7 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
               twClassName="min-w-0 flex-1"
               isDisabled={
                 isStepTransitioning ||
-                isAwaitingBalance ||
+                isAwaitingBalanceShell ||
                 isAwaitingDeferredNavResumeHold
               }
               testID={WalletHomeOnboardingStepsSelectors.SKIP_BUTTON}
@@ -854,7 +880,7 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
               twClassName="min-w-0 flex-1"
               isDisabled={
                 isStepTransitioning ||
-                isAwaitingBalance ||
+                isAwaitingBalanceShell ||
                 isAwaitingDeferredNavResumeHold
               }
               testID={primaryTestID}


### PR DESCRIPTION
## **Description**

The wallet home checklist could stay on screen after the user skipped the last step. Completion was dispatched only at the very end of a ~1.6s animation chain, so any interruption dropped it silently and persisted `suppressedReason: null`. The checklist then came back and only cleared if the user relaunched the app and skipped everything again.

**What changed**

- **Scoped the balance-loading shell to the fund step** (and to non-transitioning renders). It previously applied at *every* step, so a balance re-resolve mid-advance rewound the tile to step 1, retargeted the progress bar and cancelled the in-flight fill.
- **Made the completion durable.** The owed state change is recorded when the user acts (`pendingAdvanceCommitRef`) and runs exactly once from every terminal path — interrupted fade, interrupted slide, cancelled progress fill, and unmount.
- **Stopped the deferred-return hold from dropping the advance** when the balance shell happens to be up as the timer fires.

**Why it was intermittent**

`isAwaitingBalance` derives from a `hasBalanceFetched` latch that resets whenever the group balance re-resolves, and `skipInitialBalanceWait` is stripped from persisted state. So this only hit users who had **reopened the app**, and a trade (balance churn) was a reliable trigger — matching the report.

| Ticket | Event | Trigger point | Schema change |
| ------ | ----- | ------------- | ------------- |
| [TMCU-1248](https://consensyssoftware.atlassian.net/browse/TMCU-1248) | None (bug fix, no analytics change) | Skip/Primary on the last checklist step; step advance after returning from swaps/on-ramp/settings | None |

<details>
<summary>More info: the two failure paths in detail</summary>

**1. Balance shell rewound the tile mid-advance**

`displayStepIndex = isAwaitingBalance ? 0 : stepIndex` applied at any step. `isAwaitingBalance` comes from `AccountGroupBalance` (`isLoading && !skipInitialBalanceWait`), and `hasBalanceFetched` resets to `false` whenever `groupBalance.groupId` changes — including to `null` (`useAccountGroupBalanceFetchState`). A flip during the completion window rewrote the visible step to 0, which retargeted the progress bar, which called `cancelAnimation`, which fired the fill callback with `finished: false`.

**2. Every `finished: false` branch abandoned the user's action**

The old code reset the transform and called `finishAdvance()` without dispatching — treating an interrupted *animation* as a cancelled *action*. Unmount cleared the outro-hold timer the same way, with nothing committed. Net effect: `advanceLockRef` released, buttons re-enabled, `suppressedReason` still `null`, and that null persisted.

The completion chain is progress fill (420ms) → outro hold (920ms) → fade (280ms) ≈ 1.6s, and the terminal dispatch sat at the end of all of it.
</details>

## **Changelog**

CHANGELOG entry: Fixed a bug where the wallet home get-started checklist could stay on screen after the user skipped all steps

## **Related issues**

Fixes: [TMCU-1248](https://consensyssoftware.atlassian.net/browse/TMCU-1248)

## **Manual testing steps**

```gherkin
Feature: Wallet home onboarding checklist completion

  Scenario: user skips the last step after reopening the app
    Given a freshly onboarded wallet showing the get-started checklist
    And the app has been force-quit and reopened (so the balance shell path is active)

    When user skips through to the last step
    And user taps Skip on the last step
    Then the checklist runs its outro and disappears
    And it does not return after the balance finishes loading
    And it does not return after force-quitting and reopening the app

  Scenario: user completes the trade step then finishes the checklist
    Given a reopened app showing the checklist on the trade step
    When user taps Trade, completes a swap, and returns to the wallet home
    Then the checklist advances to the next step
    And skipping the remaining steps removes the checklist permanently

  Scenario: balance re-resolves while the user is past the fund step
    Given the checklist is on the trade or notifications step
    When the aggregated balance re-resolves (e.g. after a trade)
    Then the checklist stays on the current step
    And it does not flash back to the "Fund your wallet" loading shell
```

## **Screenshots/Recordings**

### **Before**

Screenshots: TODO (author) — checklist still present after skipping the last step.

### **After**

Screenshots: TODO (author) — checklist runs outro and disappears; does not reappear after relaunch.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - N/A — no new operations; this removes work rather than adding it.

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

### Test evidence

New regression cases in `WalletHomeOnboardingSteps.test.tsx`. I confirmed all 5 fail against the unmodified component and pass with the fix:

- completes the flow when the last-step progress fill is cancelled
- runs the coordinated flow exit when the last-step progress fill is cancelled — **this is the production path and had no coverage at all before**
- commits the skipped step when the checklist unmounts mid-transition
- completes the flow when the checklist unmounts mid-completion
- does not rewind to the fund shell when balance re-resolves on a later step

<details>
<summary>More info: test output</summary>

```
$ yarn jest app/components/UI/WalletHomeOnboardingSteps app/components/UI/Assets/components/Balance
Test Suites: 21 passed, 21 total
Tests:       157 passed, 157 total
```

Against the unmodified component, the 5 new/changed cases fail:

```
Tests:       5 failed, 32 passed, 37 total
```

`yarn lint` and `yarn tsc --noEmit` clean on the changed files.

Not caused by this change: `app/components/Views/Wallet/index.test.tsx` fails to load on a clean tree too (unrelated Perps import chain, 0 tests collected).
</details>

### Validation against the extension

Not applicable — the wallet home onboarding checklist is mobile-only and has no extension counterpart.


[TMCU-1248]: https://consensyssoftware.atlassian.net/browse/TMCU-1248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ