### PR TITLE
fix: restore safe-area shim alias to stop headers jumping on mount

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -184,6 +184,20 @@ module.exports = function (baseConfig) {
               'node:buffer': '@craftzdog/react-native-buffer',
             },
             resolveRequest: (context, moduleName, platform) => {
+              // Swaps in a SafeAreaView that applies the top inset via
+              // useSafeAreaInsets; the native inset recalculates on mount and
+              // visibly drops headers a frame late. Bare specifier only —
+              // subpaths (jest/mock, and the shim's own `src/` imports) must
+              // still resolve to node_modules.
+              if (moduleName === 'react-native-safe-area-context') {
+                return {
+                  type: 'sourceFile',
+                  filePath: path.resolve(
+                    __dirname,
+                    'app/shims/react-native-safe-area-context.tsx',
+                  ),
+                };
+              }
               // reflect-metadata's only job is to add metadata APIs
               // (Reflect.defineMetadata etc.) to the global Reflect object.
               // getPolyfills above already runs it once at bundle startup,

--- a/metro.config.js
+++ b/metro.config.js
@@ -184,11 +184,8 @@ module.exports = function (baseConfig) {
               'node:buffer': '@craftzdog/react-native-buffer',
             },
             resolveRequest: (context, moduleName, platform) => {
-              // Swaps in a SafeAreaView that applies the top inset via
-              // useSafeAreaInsets; the native inset recalculates on mount and
-              // visibly drops headers a frame late. Bare specifier only —
-              // subpaths (jest/mock, and the shim's own `src/` imports) must
-              // still resolve to node_modules.
+              // Bare package only: subpaths (e.g. jest/mock) must resolve to node_modules.
+              // Jest does not remap this package — mapping breaks jest/mock's requireActual().
               if (moduleName === 'react-native-safe-area-context') {
                 return {
                   type: 'sourceFile',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Wallet headers (and any other screen that takes its top inset from `SafeAreaView`) render flush with the status bar for a frame, then drop into place. That jump is the native `SafeAreaView` recalculating top padding on mount.

We already had a fix for this: Metro remaps the bare `react-native-safe-area-context` import to `app/shims/react-native-safe-area-context.tsx`, whose `SafeAreaView` applies the top inset from `useSafeAreaInsets` instead of native padding (original [PR](https://github.com/MetaMask/metamask-mobile/pull/28622)). The RN 0.81.5 upgrade removed that alias.

This PR restores the Metro alias. Subpaths (`jest/mock`, and the shim's own `src/` imports) still resolve to `node_modules`.

Unit tests cannot cover this: Jest does not use the Metro resolver. Confirm on a device that Wallet, Rewards, and Money headers no longer jump after launch.


## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where screen headers would briefly jump down after opening the app

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://github.com/MetaMask/metamask-mobile/pull/28622

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Wallet header position on mount
  
Scenario: Wallet header stays put after the screen appears
    Given the user is unlocked into the app
    And the Wallet tab is the first screen shown
    When the Wallet screen finishes rendering
    Then the header sits below the status bar on the first painted frame
    And the header does not drop down a moment later
 
Scenario: Other tabs that use SafeAreaView top inset also stay put
    Given the user is unlocked into the app
    When the user opens Rewards
    Then the Rewards header does not jump down on mount
    When the user opens Money
    Then the Money header does not jump down on mount
 
Scenario: Explore and Activity still look aligned
    Given the user is unlocked into the app
    When the user switches between Wallet, Explore, and Activity
    Then the header top edges line up across those tabs
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

|BEFORE|AFTER|
|---|---|
|<img width="220" height="450" alt="before" src="https://github.com/user-attachments/assets/a4e60072-5a13-4cd9-b766-913981f9769d" />|<img width="220" height="450" alt="After" src="https://github.com/user-attachments/assets/bbc7c425-b196-4590-8320-9e6130fbadab" />|

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bundler alias for a layout shim with no changes to auth, networking, or persisted data; manual device check is the main validation path since Jest does not use Metro resolution.
> 
> **Overview**
> **Restores Metro remapping** so bare imports of `react-native-safe-area-context` resolve to `app/shims/react-native-safe-area-context.tsx` instead of the package in `node_modules`. That shim’s `SafeAreaView` applies the top inset from `useSafeAreaInsets` rather than native padding, which stops headers (Wallet, Rewards, Money, etc.) from sitting under the status bar for a frame and then jumping down on mount.
> 
> The alias was dropped during the RN 0.81.5 upgrade while the shim and its tests remained; tests still pass because they import the shim by relative path, so production bundles silently reverted to the native component.
> 
> The new resolver rule applies **only** to the bare package name—subpaths such as `jest/mock` still resolve through `node_modules` so Jest’s `requireActual()` keeps working.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73a5c170ba3638af3f4c4af5b1425549d97d10b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->