### PR TITLE
fix(perps): remove one of the 2 Activity entry points in pro mode

### DIFF
--- a/app/components/UI/Perps/Perps.testIds.ts
+++ b/app/components/UI/Perps/Perps.testIds.ts
@@ -575,6 +575,7 @@ export const PerpsProOrderFormSelectorsIDs = {
   KEYBOARD_CLOSE: 'perps-pro-order-form-keyboard-close',
   AVAILABLE_BALANCE: 'perps-pro-order-form-available-balance',
   ADD_FUNDS_BUTTON: 'perps-pro-order-form-add-funds',
+  REDUCE_ONLY_CONTAINER: 'perps-pro-order-form-reduce-only-container',
   REDUCE_ONLY: 'perps-pro-order-form-reduce-only',
   TPSL: 'perps-pro-order-form-tpsl',
   NOTICE: 'perps-pro-order-form-notice',

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -526,26 +526,36 @@ describe('PerpsProOrderForm', () => {
       expect(playSelection).toHaveBeenCalledTimes(1);
     });
 
-    it('exposes Reduce only with checked checkbox semantics', () => {
+    it('exposes Reduce only with selected button semantics', () => {
       renderForm({ reduceOnly: true });
 
       expect(screen.getByTestId(ids.REDUCE_ONLY)).toHaveProp(
         'accessibilityRole',
-        'checkbox',
+        'button',
       );
       expect(screen.getByTestId(ids.REDUCE_ONLY)).toHaveProp(
         'accessibilityState',
-        expect.objectContaining({ checked: true }),
+        expect.objectContaining({ selected: true }),
       );
     });
 
-    it('calls onReduceOnlyChange with the next checked value', () => {
+    it('selects Reduce only when the inactive filter is pressed', () => {
       const onReduceOnlyChange = jest.fn();
       renderForm({ onReduceOnlyChange });
 
       fireEvent.press(screen.getByTestId(ids.REDUCE_ONLY));
 
       expect(onReduceOnlyChange).toHaveBeenCalledWith(true);
+      expect(playSelection).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears Reduce only when the active filter is pressed', () => {
+      const onReduceOnlyChange = jest.fn();
+      renderForm({ onReduceOnlyChange, reduceOnly: true });
+
+      fireEvent.press(screen.getByTestId(ids.REDUCE_ONLY));
+
+      expect(onReduceOnlyChange).toHaveBeenCalledWith(false);
       expect(playSelection).toHaveBeenCalledTimes(1);
     });
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -597,7 +597,10 @@ const PerpsProOrderForm = ({
             availableBalance={availableBalance}
             onAddFundsPress={onAddFundsPress}
           />
-          <Box twClassName="h-12 justify-center rounded-xl bg-muted px-3">
+          <Box
+            twClassName="h-12 justify-center rounded-xl bg-muted px-3"
+            testID={ids.REDUCE_ONLY_CONTAINER}
+          >
             <Checkbox
               label={strings('perps.order.reduce_only')}
               labelProps={{

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -6,11 +6,11 @@ import {
   BoxFlexDirection,
   ButtonBase,
   ButtonBaseSize,
+  ButtonFilter,
   ButtonIcon,
   ButtonIconSize,
   ButtonSemantic,
   ButtonSemanticSeverity,
-  Checkbox,
   FilterButton,
   FontWeight,
   HelpText,
@@ -433,6 +433,10 @@ const PerpsProOrderForm = ({
     [onReduceOnlyChange, playSelection],
   );
 
+  const handleReduceOnlyPress = useCallback(() => {
+    handleReduceOnlyChange(!reduceOnly);
+  }, [handleReduceOnlyChange, reduceOnly]);
+
   const handleExpandOrderBook = useCallback(() => {
     if (!onExpandOrderBook) {
       return;
@@ -597,22 +601,16 @@ const PerpsProOrderForm = ({
             availableBalance={availableBalance}
             onAddFundsPress={onAddFundsPress}
           />
-          <Box
-            twClassName="h-12 justify-center rounded-xl bg-muted px-3"
-            testID={ids.REDUCE_ONLY_CONTAINER}
-          >
-            <Checkbox
-              label={strings('perps.order.reduce_only')}
-              labelProps={{
-                variant: TextVariant.BodySm,
-                fontWeight: FontWeight.Medium,
-                style: { marginLeft: 0, flex: 1 },
-              }}
-              isSelected={reduceOnly}
-              onChange={handleReduceOnlyChange}
+          <Box testID={ids.REDUCE_ONLY_CONTAINER} twClassName="items-start">
+            <ButtonFilter
+              isActive={reduceOnly}
+              accessibilityState={{ selected: reduceOnly }}
+              onPress={handleReduceOnlyPress}
+              size={ButtonBaseSize.Sm}
               testID={ids.REDUCE_ONLY}
-              twClassName="w-full flex-row-reverse justify-between"
-            />
+            >
+              {strings('perps.order.reduce_only')}
+            </ButtonFilter>
           </Box>
           {showsTpSl ? (
             <TPSLRow

--- a/app/components/UI/Perps/components/PerpsBalanceBottomSheet/PerpsBalanceBottomSheet.test.tsx
+++ b/app/components/UI/Perps/components/PerpsBalanceBottomSheet/PerpsBalanceBottomSheet.test.tsx
@@ -23,14 +23,6 @@ jest.mock('../../hooks/usePerpsHomeActions', () => ({
   })),
 }));
 
-const mockNavigateToActivity = jest.fn();
-
-jest.mock('../../hooks/usePerpsNavigation', () => ({
-  usePerpsNavigation: jest.fn(() => ({
-    navigateToActivity: mockNavigateToActivity,
-  })),
-}));
-
 let mockPerpsAccount: {
   totalBalance: string;
   spendableBalance: string;
@@ -144,16 +136,12 @@ describe('PerpsBalanceBottomSheet', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('closes the sheet and navigates to activity when the history button is pressed', () => {
-    const onClose = jest.fn();
-    const { getByTestId } = renderSheet({ onClose });
+  it('does not render the history button', () => {
+    const { queryByTestId } = renderSheet();
 
-    fireEvent.press(
-      getByTestId(PerpsBalanceBottomSheetSelectorsIDs.HISTORY_BUTTON),
-    );
-
-    expect(onClose).toHaveBeenCalledTimes(1);
-    expect(mockNavigateToActivity).toHaveBeenCalledTimes(1);
+    expect(
+      queryByTestId(PerpsBalanceBottomSheetSelectorsIDs.HISTORY_BUTTON),
+    ).not.toBeOnTheScreen();
   });
 
   it('closes the sheet and invokes handleWithdraw when the withdraw button is pressed', () => {

--- a/app/components/UI/Perps/components/PerpsBalanceBottomSheet/PerpsBalanceBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsBalanceBottomSheet/PerpsBalanceBottomSheet.tsx
@@ -26,7 +26,6 @@ import { strings } from '../../../../../../locales/i18n';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
 import { usePerpsLiveAccount } from '../../hooks/stream';
 import { usePerpsHomeActions } from '../../hooks/usePerpsHomeActions';
-import { usePerpsNavigation } from '../../hooks/usePerpsNavigation';
 import {
   formatPercentage,
   formatPerpsBalance,
@@ -41,8 +40,8 @@ import ModalSafeAreaProvider from '../../../../../component-library/components-t
  * Perps account balance bottom sheet.
  *
  * Shows total balance, available balance, and unrealized P&L, with quick
- * access to Withdraw / Add funds and Perps activity history. Opened from the
- * wallet icon in the Pro market header without leaving the market screen.
+ * access to Withdraw / Add funds. Opened from the wallet icon in the Pro
+ * market header without leaving the market screen.
  */
 const PerpsBalanceBottomSheet: React.FC<PerpsBalanceBottomSheetProps> = ({
   isVisible,
@@ -52,7 +51,6 @@ const PerpsBalanceBottomSheet: React.FC<PerpsBalanceBottomSheetProps> = ({
   const bottomSheetRef = useRef<BottomSheetRef>(null);
   const privacyMode = useSelector(selectPrivacyMode);
   const { account: perpsAccount } = usePerpsLiveAccount({ throttleMs: 1000 });
-  const { navigateToActivity } = usePerpsNavigation();
 
   const {
     handleAddFunds,
@@ -81,15 +79,9 @@ const PerpsBalanceBottomSheet: React.FC<PerpsBalanceBottomSheetProps> = ({
     bottomSheetRef.current?.onCloseBottomSheet();
   }, []);
 
-  const handleHistoryPress = useCallback(() => {
-    bottomSheetRef.current?.onCloseBottomSheet(() => {
-      navigateToActivity();
-    });
-  }, [navigateToActivity]);
-
   // Withdraw always navigates away (to the withdraw screen or into a
-  // confirmation flow), so close the sheet first — same as History above —
-  // instead of leaving it mounted underneath the next screen.
+  // confirmation flow), so close the sheet first instead of leaving it
+  // mounted underneath the next screen.
   const handleWithdrawPress = useCallback(() => {
     bottomSheetRef.current?.onCloseBottomSheet(() => {
       handleWithdraw();
@@ -189,19 +181,7 @@ const PerpsBalanceBottomSheet: React.FC<PerpsBalanceBottomSheetProps> = ({
               bottomLabelWrapperProps={{ twClassName: 'w-full' }}
             />
 
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-            >
-              <ButtonIcon
-                size={ButtonIconSize.Md}
-                iconName={IconName.Activity}
-                onPress={handleHistoryPress}
-                accessibilityLabel={strings(
-                  'perps.balance_bottom_sheet.history_button',
-                )}
-                testID={PerpsBalanceBottomSheetSelectorsIDs.HISTORY_BUTTON}
-              />
+            <Box alignItems={BoxAlignItems.Center}>
               <ButtonIcon
                 size={ButtonIconSize.Md}
                 iconName={IconName.Close}

--- a/app/components/UI/Perps/components/PerpsBalanceBottomSheet/PerpsBalanceBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsBalanceBottomSheet/PerpsBalanceBottomSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { Modal, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import {
@@ -36,7 +36,6 @@ import PerpsBottomSheetTooltip from '../PerpsBottomSheetTooltip';
 import { PerpsBalanceBottomSheetSelectorsIDs } from '../../Perps.testIds';
 import { PerpsBalanceBottomSheetProps } from './PerpsBalanceBottomSheet.types';
 import ModalSafeAreaProvider from '../../../../../component-library/components-temp/ModalSafeAreaProvider';
-import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 
 /**
  * Perps account balance bottom sheet.
@@ -69,14 +68,6 @@ const PerpsBalanceBottomSheet: React.FC<PerpsBalanceBottomSheetProps> = ({
   const spendableBalance = perpsAccount?.spendableBalance || '0';
   const unrealizedPnl = parseFloat(perpsAccount?.unrealizedPnl || '0');
   const roe = parseFloat(perpsAccount?.returnOnEquity || '0');
-
-  useEffect(() => {
-    if (isVisible) {
-      DevLogger.log(
-        '[PR-TAT-3778] BUG_MARKER: Activity entry point is visible in the Perps balance bottom sheet',
-      );
-    }
-  }, [isVisible]);
 
   const pnlColor = privacyMode
     ? TextColor.TextDefault

--- a/app/components/UI/Perps/components/PerpsBalanceBottomSheet/PerpsBalanceBottomSheet.tsx
+++ b/app/components/UI/Perps/components/PerpsBalanceBottomSheet/PerpsBalanceBottomSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { Modal, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import {
@@ -36,6 +36,7 @@ import PerpsBottomSheetTooltip from '../PerpsBottomSheetTooltip';
 import { PerpsBalanceBottomSheetSelectorsIDs } from '../../Perps.testIds';
 import { PerpsBalanceBottomSheetProps } from './PerpsBalanceBottomSheet.types';
 import ModalSafeAreaProvider from '../../../../../component-library/components-temp/ModalSafeAreaProvider';
+import DevLogger from '../../../../../core/SDKConnect/utils/DevLogger';
 
 /**
  * Perps account balance bottom sheet.
@@ -68,6 +69,14 @@ const PerpsBalanceBottomSheet: React.FC<PerpsBalanceBottomSheetProps> = ({
   const spendableBalance = perpsAccount?.spendableBalance || '0';
   const unrealizedPnl = parseFloat(perpsAccount?.unrealizedPnl || '0');
   const roe = parseFloat(perpsAccount?.returnOnEquity || '0');
+
+  useEffect(() => {
+    if (isVisible) {
+      DevLogger.log(
+        '[PR-TAT-3778] BUG_MARKER: Activity entry point is visible in the Perps balance bottom sheet',
+      );
+    }
+  }, [isVisible]);
 
   const pnlColor = privacyMode
     ? TextColor.TextDefault


### PR DESCRIPTION
## **Description**

Removed the duplicate Activity entry point from the Perps balance bottom sheet while retaining Activity beside Positions and Orders in the Pro market panel. The Reduce only control now uses the compact filter-button treatment, leaving the balance-sheet close target uncrowded.

## **Changelog**

CHANGELOG entry: Removed the duplicate Perps Activity button and made the Reduce only control more compact

## **Related issues**

Fixes: [TAT-3778](https://consensyssoftware.atlassian.net/browse/TAT-3778)

## **Manual testing steps**

```gherkin
Feature: Perps Pro activity entry points and order controls

  Scenario: user opens the Perps Pro market and balance sheet
    Given the user has opened the BTC market in the Pro trading layout
    When the user views the order form, Positions and Orders panel, and balance sheet
    Then Reduce only is shown as a compact filter control
    And Activity remains available beside Positions and Orders
    And the balance sheet has no duplicate Activity entry
    And the balance-sheet close target is uncrowded
```

## **Screenshots/Recordings**

Pro mode keeps one Activity entry beside Positions and Orders, removes the duplicate balance-sheet action, and uses a compact Reduce-only filter.

<table>
<tr><td colspan="2"><strong>Balance sheet: duplicate Activity removed and close target uncrowded</strong></td></tr>
<tr>
<td align="center" valign="top" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35222/before-evidence-ac1-balance-sheet-duplicate-activity.png?sha=6c67adf2327e9de2" alt="before" width="320" /></td>
<td align="center" valign="top" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35222/after-ac1-balance-sheet-no-activity.png?sha=045426ae3a2c7281" alt="after" width="320" /></td>
</tr>
<tr><td colspan="2"><strong>Reduce only: oversized checkbox replaced by compact filter button</strong></td></tr>
<tr>
<td align="center" valign="top" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35222/before-evidence-ac4-reduce-only-checkbox.png?sha=cdf2ade3f3af7c0d" alt="before" width="320" /></td>
<td align="center" valign="top" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35222/after-ac4-reduce-only-filter.png?sha=389c2754855a8188" alt="after" width="320" /></td>
</tr>
</table>

<table>
<tr><td align="center" valign="top" width="50%"><strong>Activity remains beside Positions and Orders</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35222/after-ac2-positions-activity.png?sha=10f4e26f5953eddc" alt="Activity remains beside Positions and Orders" width="320" /></td><td></td></tr>
</table>

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>Final deterministic validation recipe</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "TAT-3778 Perps Pro Activity entry points and controls",
  "description": "Proves the balance sheet has no duplicate Activity button, the positions panel retains Activity, the close target has room, and Reduce only uses the compact filter control.",
  "workflow": {
    "entry": "setup-unlock-wallet",
    "nodes": {
      "setup-unlock-wallet": {
        "action": "metamask.wallet.ensure_unlocked",
        "target_timeout_ms": 45000,
        "unlock_timeout_ms": 45000,
        "intent": "Ensure the prepared wallet is unlocked",
        "next": "setup-open-pro-markets"
      },
      "setup-open-pro-markets": {
        "action": "ui.navigate",
        "page": "perps-market",
        "mode": "pro",
        "market": "BTC",
        "intent": "Open BTC market details in the advanced Pro trading layout",
        "next": "ac4-assert-reduce-only-visible"
      },
      "ac4-assert-reduce-only-visible": {
        "action": "ui.wait_for",
        "test_id": "perps-pro-order-form-reduce-only-container",
        "expected": "visible",
        "intent": "Confirm the replacement Reduce only filter control is visible",
        "next": "ac4-screenshot-reduce-only"
      },
      "ac4-screenshot-reduce-only": {
        "action": "ui.screenshot",
        "path": "evidence-ac4-reduce-only-filter.png",
        "label": "Compact Reduce only filter control in the Pro order form",
        "intent": "Show reviewers that Reduce only no longer occupies an oversized checkbox row",
        "next": "ac2-scroll-activity-entry"
      },
      "ac2-scroll-activity-entry": {
        "action": "ui.scroll",
        "scroll_into_view": true,
        "test_id": "perps-pro-market-positions-history",
        "intent": "Bring the lower positions and orders controls into the viewport",
        "next": "ac2-scroll-panel-up"
      },
      "ac2-scroll-panel-up": {
        "action": "ui.scroll",
        "delta_y": 180,
        "intent": "Position the Positions and Orders header clearly above the evidence overlay",
        "next": "ac2-assert-activity-entry-visible"
      },
      "ac2-assert-activity-entry-visible": {
        "action": "ui.wait_for",
        "test_id": "perps-pro-market-positions-history",
        "expected": "visible",
        "intent": "Confirm Activity remains next to the positions and orders list",
        "next": "ac2-screenshot-activity-entry"
      },
      "ac2-screenshot-activity-entry": {
        "action": "ui.screenshot",
        "path": "evidence-ac2-positions-activity.png",
        "label": "Activity entry next to Positions and Orders",
        "intent": "Show reviewers the single retained Activity entry beside Positions and Orders",
        "next": "setup-scroll-wallet-button"
      },
      "setup-scroll-wallet-button": {
        "action": "ui.scroll",
        "scroll_into_view": true,
        "test_id": "perps-pro-market-header-wallet-button",
        "intent": "Return to the Pro market header wallet button",
        "next": "setup-open-balance-sheet"
      },
      "setup-open-balance-sheet": {
        "action": "ui.press",
        "test_id": "perps-pro-market-header-wallet-button",
        "intent": "Open the wallet and Perps balance bottom sheet",
        "next": "ac1-assert-history-absent"
      },
      "ac1-assert-history-absent": {
        "action": "ui.wait_for",
        "test_id": "perps-balance-bottom-sheet-history-button",
        "expected": "absent",
        "intent": "Confirm the duplicate Activity button is absent from the balance sheet",
        "next": "ac1-assert-balance-sheet-visible"
      },
      "ac1-assert-balance-sheet-visible": {
        "action": "ui.wait_for",
        "test_id": "perps-balance-bottom-sheet-close-button",
        "expected": "visible",
        "intent": "Confirm the balance sheet remains visibly open after removing Activity",
        "next": "ac1-screenshot-balance-sheet"
      },
      "ac1-screenshot-balance-sheet": {
        "action": "ui.screenshot",
        "path": "evidence-ac1-balance-sheet-no-activity.png",
        "label": "Perps balance sheet without duplicate Activity entry",
        "intent": "Show reviewers that the balance sheet contains account actions but no duplicate Activity control",
        "next": "ac3-assert-close-target-visible"
      },
      "ac3-assert-close-target-visible": {
        "action": "ui.wait_for",
        "test_id": "perps-balance-bottom-sheet-close-button",
        "expected": "visible",
        "intent": "Confirm the close target is visible with no adjacent Activity target crowding it",
        "next": "ac3-screenshot-close-target"
      },
      "ac3-screenshot-close-target": {
        "action": "ui.screenshot",
        "path": "evidence-ac3-close-target-spacing.png",
        "label": "Uncrowded balance-sheet close target",
        "intent": "Show reviewers the close target with clear space around it",
        "next": "teardown-close-balance-sheet"
      },
      "teardown-close-balance-sheet": {
        "action": "ui.press",
        "test_id": "perps-balance-bottom-sheet-close-button",
        "intent": "Leave the Pro market ready for a clean subsequent replay",
        "next": "done"
      },
      "done": {
        "action": "end",
        "status": "pass"
      }
    }
  }
}
```
</details>

Recipe coverage: 4/4 acceptance criteria proven. See the packaged `recipe-coverage.md` artifact.

## **Recipe Workflow**

<details>
<summary>Validation workflow</summary>

```mermaid
flowchart TD
  setup_unlock_wallet["Ensure wallet is unlocked"] --> setup_open_pro_markets["Open BTC Pro market"]
  setup_open_pro_markets --> ac4_wait["AC4: Reduce only filter visible"]
  ac4_wait --> ac4_shot["Capture compact Reduce only control"]
  ac4_shot --> ac2_scroll["Scroll Positions panel into view"]
  ac2_scroll --> ac2_adjust["Adjust evidence framing"]
  ac2_adjust --> ac2_wait["AC2: Activity entry visible"]
  ac2_wait --> ac2_shot["Capture Activity beside Positions and Orders"]
  ac2_shot --> header_scroll["Return to wallet button"]
  header_scroll --> open_sheet["Open balance sheet"]
  open_sheet --> ac1_absent["AC1: Duplicate Activity absent"]
  ac1_absent --> sheet_visible["Balance sheet remains visible"]
  sheet_visible --> ac1_shot["Capture balance sheet without Activity"]
  ac1_shot --> ac3_wait["AC3: Close target visible"]
  ac3_wait --> ac3_shot["Capture uncrowded close target"]
  ac3_shot --> teardown["Close balance sheet"]
  teardown --> done(["Pass"])
```
</details>

[TAT-3778]: https://consensyssoftware.atlassian.net/browse/TAT-3778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Perps Pro UI and navigation cleanup with no changes to order submission, balances, or auth; regression risk is mostly visual and accessibility around Reduce only toggling.
> 
> **Overview**
> Removes the **Activity** icon from the Pro **Perps balance bottom sheet** so Pro mode keeps a single Activity entry beside Positions and Orders; the sheet header now shows only **Close** next to balance details, with withdraw/add funds unchanged.
> 
> In the Pro **order form**, **Reduce only** is no longer a full-width muted-row **Checkbox**; it is a compact **`ButtonFilter`** that toggles on press (same `onReduceOnlyChange` behavior) with **button** / **selected** accessibility instead of checkbox semantics. A **`REDUCE_ONLY_CONTAINER`** test id was added for automation.
> 
> Tests were updated to match the new controls and to assert the history button is absent from the balance sheet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ea2982c1e6ded24773f2f81357e094240a972a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->