### PR TITLE
fix(perps): bug: Slippage edit button missing pressed state in Perps Pro Mode

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -704,6 +704,18 @@ describe('PerpsProOrderForm', () => {
       ).toBeOnTheScreen();
     });
 
+    it('names the slippage edit affordance and keeps it reachable at the minimum tap size', () => {
+      renderForm({
+        summary: { ...slippageSummary, onSlippagePress: jest.fn() },
+      });
+
+      const editButton = screen.getByTestId(ids.SUMMARY_SLIPPAGE_BUTTON);
+
+      expect(editButton).toHaveProp('accessibilityRole', 'button');
+      expect(editButton).toHaveProp('accessibilityLabel', 'Set slippage');
+      expect(editButton).toHaveProp('hitSlop', 12);
+    });
+
     it('applies a pressed background to the slippage edit affordance while held', () => {
       renderForm({
         summary: { ...slippageSummary, onSlippagePress: jest.fn() },

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react-native';
+import {
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '@testing-library/react-native';
 import { IconName } from '@metamask/design-system-react-native';
-import { Keyboard, type View } from 'react-native';
+import { Keyboard, StyleSheet, type View } from 'react-native';
 import {
   PerpsProMarketViewSelectorsIDs,
   PerpsProOrderFormSelectorsIDs,
@@ -667,6 +672,61 @@ describe('PerpsProOrderForm', () => {
       });
 
       expect(screen.getByTestId(testID)).toBeDisabled();
+    });
+  });
+
+  describe('slippage edit control', () => {
+    const slippageSummary = {
+      margin: '--',
+      liquidationPrice: '--',
+      slippage: '0.50% / 1%',
+    };
+
+    const backgroundOf = (testID: string) =>
+      StyleSheet.flatten(screen.getByTestId(testID).props.style)
+        ?.backgroundColor;
+
+    it('renders the slippage edit affordance as an icon-only button', () => {
+      renderForm({
+        summary: { ...slippageSummary, onSlippagePress: jest.fn() },
+      });
+
+      const editButton = screen.getByTestId(ids.SUMMARY_SLIPPAGE_BUTTON);
+
+      expect(editButton).toBeOnTheScreen();
+      expect(
+        within(editButton).queryByText(slippageSummary.slippage),
+      ).not.toBeOnTheScreen();
+      expect(
+        within(screen.getByTestId(ids.SUMMARY_SLIPPAGE)).getByText(
+          slippageSummary.slippage,
+        ),
+      ).toBeOnTheScreen();
+    });
+
+    it('applies a pressed background to the slippage edit affordance while held', () => {
+      renderForm({
+        summary: { ...slippageSummary, onSlippagePress: jest.fn() },
+      });
+      const restingBackground = backgroundOf(ids.SUMMARY_SLIPPAGE_BUTTON);
+
+      fireEvent(screen.getByTestId(ids.SUMMARY_SLIPPAGE_BUTTON), 'pressIn');
+
+      expect(backgroundOf(ids.SUMMARY_SLIPPAGE_BUTTON)).not.toBe(
+        restingBackground,
+      );
+    });
+
+    it('restores the resting background once the slippage edit affordance is released', () => {
+      renderForm({
+        summary: { ...slippageSummary, onSlippagePress: jest.fn() },
+      });
+      const restingBackground = backgroundOf(ids.SUMMARY_SLIPPAGE_BUTTON);
+      fireEvent(screen.getByTestId(ids.SUMMARY_SLIPPAGE_BUTTON), 'pressIn');
+
+      fireEvent(screen.getByTestId(ids.SUMMARY_SLIPPAGE_BUTTON), 'pressOut');
+
+      expect(backgroundOf(ids.SUMMARY_SLIPPAGE_BUTTON)).toBe(restingBackground);
     });
   });
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -19,6 +19,7 @@ import {
   playImpact,
   playSelection,
 } from '../../../../../../../util/haptics';
+import { strings } from '../../../../../../../../locales/i18n';
 
 jest.mock('../../../../components/PerpsSlider', () => 'PerpsSlider');
 jest.mock('../../../../components/PerpsFeesDisplay', () => 'PerpsFeesDisplay');
@@ -712,7 +713,10 @@ describe('PerpsProOrderForm', () => {
       const editButton = screen.getByTestId(ids.SUMMARY_SLIPPAGE_BUTTON);
 
       expect(editButton).toHaveProp('accessibilityRole', 'button');
-      expect(editButton).toHaveProp('accessibilityLabel', 'Set slippage');
+      expect(editButton).toHaveProp(
+        'accessibilityLabel',
+        strings('perps.slippage.config_title'),
+      );
       expect(editButton).toHaveProp('hitSlop', 12);
     });
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -38,6 +38,7 @@ import {
 } from 'react-native';
 import { strings } from '../../../../../../../../locales/i18n';
 import { useHaptics } from '../../../../../../../util/haptics';
+import DevLogger from '../../../../../../../core/SDKConnect/utils/DevLogger';
 import {
   PerpsProMarketViewSelectorsIDs,
   PerpsProOrderFormSelectorsIDs,
@@ -405,6 +406,10 @@ const PerpsProOrderForm = ({
   }, [onLeveragePress, playSelection]);
 
   const handleSlippagePress = useCallback(() => {
+    DevLogger.log(
+      '[TAT-3779] BUG_MARKER: slippage edit affordance received a press; handler present=' +
+        String(Boolean(summaryOnSlippagePress)),
+    );
     if (!summaryOnSlippagePress) {
       return;
     }

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -229,37 +229,6 @@ const summaryRowClassName = 'h-5 px-0';
 const summaryFeesRowClassName = 'min-h-6 h-auto px-0';
 const summaryRowStyle = { paddingHorizontal: 0 } as const;
 
-interface SlippageValueProps {
-  value: string;
-  onPress?: () => void;
-}
-
-const SlippageValue = ({ value, onPress }: SlippageValueProps) => (
-  <Pressable
-    accessibilityRole="button"
-    accessibilityState={{ disabled: !onPress }}
-    disabled={!onPress}
-    onPress={onPress}
-    testID={ids.SUMMARY_SLIPPAGE_BUTTON}
-  >
-    <Box twClassName="min-w-0 flex-1 flex-row items-center justify-end gap-1">
-      <Text
-        variant={TextVariant.BodyXs}
-        fontWeight={FontWeight.Medium}
-        numberOfLines={1}
-        ellipsizeMode="tail"
-      >
-        {value}
-      </Text>
-      <Icon
-        name={IconName.Edit}
-        size={IconSize.Sm}
-        color={IconColor.IconDefault}
-      />
-    </Box>
-  </Pressable>
-);
-
 const OrderSummary = ({
   margin,
   liquidationPrice,
@@ -292,7 +261,12 @@ const OrderSummary = ({
     {slippage !== undefined ? (
       <KeyValueRow
         keyLabel={strings('perps.slippage.slippage')}
-        value={<SlippageValue value={slippage} onPress={onSlippagePress} />}
+        value={slippage}
+        valueEndButtonIconProps={buttonIcon(
+          IconName.Edit,
+          ids.SUMMARY_SLIPPAGE_BUTTON,
+          onSlippagePress,
+        )}
         keyTextProps={summaryKeyTextProps}
         valueTextProps={summaryValueTextProps}
         twClassName={summaryRowClassName}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -38,7 +38,6 @@ import {
 } from 'react-native';
 import { strings } from '../../../../../../../../locales/i18n';
 import { useHaptics } from '../../../../../../../util/haptics';
-import DevLogger from '../../../../../../../core/SDKConnect/utils/DevLogger';
 import {
   PerpsProMarketViewSelectorsIDs,
   PerpsProOrderFormSelectorsIDs,
@@ -406,10 +405,6 @@ const PerpsProOrderForm = ({
   }, [onLeveragePress, playSelection]);
 
   const handleSlippagePress = useCallback(() => {
-    DevLogger.log(
-      '[TAT-3779] BUG_MARKER: slippage edit affordance received a press; handler present=' +
-        String(Boolean(summaryOnSlippagePress)),
-    );
     if (!summaryOnSlippagePress) {
       return;
     }

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -228,6 +228,7 @@ const Notices = ({ notices }: { notices: PerpsProOrderNotice[] }) =>
 const summaryRowClassName = 'h-5 px-0';
 const summaryFeesRowClassName = 'min-h-6 h-auto px-0';
 const summaryRowStyle = { paddingHorizontal: 0 } as const;
+const SLIPPAGE_EDIT_HIT_SLOP = 12;
 
 const OrderSummary = ({
   margin,
@@ -262,11 +263,18 @@ const OrderSummary = ({
       <KeyValueRow
         keyLabel={strings('perps.slippage.slippage')}
         value={slippage}
-        valueEndButtonIconProps={buttonIcon(
-          IconName.Edit,
-          ids.SUMMARY_SLIPPAGE_BUTTON,
-          onSlippagePress,
-        )}
+        valueEndButtonIconProps={{
+          ...buttonIcon(
+            IconName.Edit,
+            ids.SUMMARY_SLIPPAGE_BUTTON,
+            onSlippagePress,
+          ),
+          accessibilityRole: 'button',
+          accessibilityLabel: strings('perps.slippage.config_title'),
+          // ButtonIconSize.Xs renders a 20pt box; 12pt of slop on each side
+          // brings the tap target back to the 44pt minimum.
+          hitSlop: SLIPPAGE_EDIT_HIT_SLOP,
+        }}
         keyTextProps={summaryKeyTextProps}
         valueTextProps={summaryValueTextProps}
         twClassName={summaryRowClassName}


### PR DESCRIPTION
## **Description**

The slippage edit control in the Perps Pro order summary was a hand-rolled `Pressable` wrapping the
value text plus a bare `Icon`, so tapping it gave the trader no feedback that the tap registered. It
now goes through `KeyValueRow`'s `valueEndButtonIconProps` using the file's existing `buttonIcon()`
helper, which renders the design-system `ButtonIcon` and brings its pressed state with it. This is
the same wiring the sibling fees row and Lite mode's slippage row already use, so the fix removes
the one place in this summary that bypassed the design system rather than adding new styling.

The conversion would otherwise have cost two things the old `Pressable` provided, so both are
carried over explicitly on the same props object: an `accessibilityRole`/`accessibilityLabel` (a
bare `ButtonIcon` renders neither, which would have left an unlabeled, role-less button), and a
`hitSlop` of 12 — `ButtonIconSize.Xs` is a 20pt box, so the slop restores the 44pt minimum tap
target that the previously 118pt-wide affordance had.

## **Changelog**

CHANGELOG entry: Fixed the missing pressed state on the Slippage edit button in Perps Pro mode

## **Related issues**

Fixes: [TAT-3779](https://consensyssoftware.atlassian.net/browse/TAT-3779)

## **Manual testing steps**

```gherkin
Feature: Slippage edit button pressed state in Perps Pro mode

  Scenario: trader taps the slippage edit button
    Given the trader is on a Perps market screen in Pro mode
    And the order type is Market so the Slippage row is shown

    When the trader presses and holds the edit icon on the Slippage row
    Then the icon button shows a pressed background while held
    And releasing it opens the Set slippage sheet

  Scenario: screen reader user reaches the slippage edit button
    Given VoiceOver or TalkBack is on
    And the trader is on a Perps market screen in Pro mode

    When the trader focuses the edit icon on the Slippage row
    Then it is announced as "Set slippage" with the button role
```

## **Screenshots/Recordings**

The pressed state itself cannot be screenshotted (it only exists while the control is held), so it is proven by the unit tests the recipe runs. The screenshot shows the edit button still opens Set slippage.

<table>
<tr><td colspan="2"><strong>Tapping the slippage edit button still opens Set slippage</strong></td></tr>
<tr>
<td align="center" valign="top" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35223/before-evidence-ac3-slippage-settings.png?sha=afd75a5827a3f781" alt="before" width="320" /></td>
<td align="center" valign="top" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-farm-artifacts/main/fixes/35223/after-ac3-slippage-settings.png?sha=45c9dd55c17dd1fe" alt="after" width="320" /></td>
</tr>
</table>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

None of the three apply: this is a render-time swap of one control for its design-system equivalent,
with no new work in a hot path, no data volume dimension, and no operation worth a Sentry trace. It
was validated on iOS; the changed code is shared React Native with no platform branch.

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

Every node passed on the fixed code. A pressed state only exists while the control is held, so no
screenshot can capture it — AC1 and AC2 are proven by unit tests the recipe runs and asserts on
inside its own trace, and AC3's screenshot proves the tap still reaches Set slippage. Coverage audit:
under the recipe HUD banner, which otherwise swallows taps on it.

<details>
<summary>recipe.json</summary>

```json
{
  "$schema": "https://farmslot.io/schemas/recipe-v1.schema.json",
  "title": "Perps Pro slippage edit button is a ButtonIcon with a pressed state",
  "workflow": {
    "entry": "setup-status",
    "nodes": {
      "setup-status": {
        "action": "app.status",
        "intent": "Confirm the mobile bridge is reachable",
        "next": "setup-run-form-tests"
      },
      "setup-run-form-tests": {
        "action": "command",
        "intent": "Exercise the Pro order form's slippage affordance in isolation",
        "cmd": "yarn jest app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx --no-coverage --verbose",
        "allow_failure": true,
        "timeout_ms": 900000,
        "next": "gate-form-tests-passed"
      },
      "gate-form-tests-passed": {
        "action": "assert_exit_code",
        "intent": "Refuse to claim anything about the slippage affordance from a red suite",
        "node": "setup-run-form-tests",
        "expected": 0,
        "next": "ac1-assert-icon-only-button"
      },
      "ac1-assert-icon-only-button": {
        "action": "assert_output",
        "intent": "AC1: the slippage edit control is the design-system icon button, not a hand-rolled pressable wrapping the whole value",
        "node": "setup-run-form-tests",
        "stream": "stderr",
        "contains": "renders the slippage edit affordance as an icon-only button",
        "next": "ac2-assert-pressed-state"
      },
      "ac2-assert-pressed-state": {
        "action": "assert_output",
        "intent": "AC2: holding the slippage edit control visibly changes it, so the trader can tell the tap registered",
        "node": "setup-run-form-tests",
        "stream": "stderr",
        "contains": "applies a pressed background to the slippage edit affordance while held",
        "next": "setup-unlock"
      },
      "setup-unlock": {
        "action": "metamask.wallet.ensure_unlocked",
        "intent": "Make the fixture wallet usable before driving the trading screen",
        "next": "setup-navigate-market"
      },
      "setup-navigate-market": {
        "action": "ui.navigate",
        "intent": "Open the ETH market screen where a trader places an order",
        "page": "perps-market",
        "market": "ETH",
        "timeout_ms": 45000,
        "next": "gate-slippage-affordance-present"
      },
      "gate-slippage-affordance-present": {
        "action": "ui.wait_for",
        "intent": "Confirm the trader has reached the Pro order form and its cost summary",
        "test_id": "perps-pro-order-form-summary-slippage-button",
        "expected": "present",
        "timeout_ms": 30000,
        "next": "ac3-open-slippage-settings"
      },
      "ac3-open-slippage-settings": {
        "action": "ui.press",
        "intent": "Have the trader tap the slippage edit control",
        "test_id": "perps-pro-order-form-summary-slippage-button",
        "timeout_ms": 20000,
        "next": "ac3-assert-slippage-settings-open"
      },
      "ac3-assert-slippage-settings-open": {
        "action": "ui.wait_for",
        "intent": "AC3: the tap still takes the trader somewhere they can change slippage",
        "test_id": "perps-slippage-config-set",
        "expected": "present",
        "timeout_ms": 15000,
        "next": "ac3-screenshot-slippage-settings"
      },
      "ac3-screenshot-slippage-settings": {
        "action": "ui.screenshot",
        "intent": "Show a reviewer the slippage settings the trader landed on after the tap",
        "label": "AC3: tapping the slippage edit button opens Set slippage",
        "next": "teardown-close-slippage-settings"
      },
      "teardown-close-slippage-settings": {
        "action": "ui.press",
        "intent": "Leave the trading screen the way it was found",
        "test_id": "perps-slippage-config-set",
        "timeout_ms": 15000,
        "next": "teardown-done"
      },
      "teardown-done": { "action": "end", "status": "pass" }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
flowchart TD
  setup_status["setup-status<br/>app.status"]
  setup_run_form_tests["setup-run-form-tests<br/>command"]
  gate_form_tests_passed["gate-form-tests-passed<br/>assert_exit_code"]
  ac1_assert_icon_only_button["ac1-assert-icon-only-button<br/>assert_output"]
  ac2_assert_pressed_state["ac2-assert-pressed-state<br/>assert_output"]
  setup_unlock["setup-unlock<br/>metamask.wallet.ensure_unlocked"]
  setup_navigate_market["setup-navigate-market<br/>ui.navigate"]
  gate_slippage_affordance_present["gate-slippage-affordance-present<br/>ui.wait_for"]
  ac3_open_slippage_settings["ac3-open-slippage-settings<br/>ui.press"]
  ac3_assert_slippage_settings_open["ac3-assert-slippage-settings-open<br/>ui.wait_for"]
  ac3_screenshot_slippage_settings["ac3-screenshot-slippage-settings<br/>ui.screenshot"]
  teardown_close_slippage_settings["teardown-close-slippage-settings<br/>ui.press"]
  teardown_done["teardown-done<br/>end"]
  setup_status --> setup_run_form_tests
  setup_run_form_tests --> gate_form_tests_passed
  gate_form_tests_passed --> ac1_assert_icon_only_button
  ac1_assert_icon_only_button --> ac2_assert_pressed_state
  ac2_assert_pressed_state --> setup_unlock
  setup_unlock --> setup_navigate_market
  setup_navigate_market --> gate_slippage_affordance_present
  gate_slippage_affordance_present --> ac3_open_slippage_settings
  ac3_open_slippage_settings --> ac3_assert_slippage_settings_open
  ac3_assert_slippage_settings_open --> ac3_screenshot_slippage_settings
  ac3_screenshot_slippage_settings --> teardown_close_slippage_settings
  teardown_close_slippage_settings --> teardown_done
```

</details>

[TAT-3779]: https://consensyssoftware.atlassian.net/browse/TAT-3779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only control swap in the Perps Pro order form with no auth, payment, or data-path changes; behavior and navigation are covered by existing and new unit tests.
> 
> **Overview**
> The Perps Pro order summary **slippage row** no longer uses a custom `Pressable` that wrapped the value text and edit icon with no pressed feedback. It now matches the **fees row** and Lite mode: the slippage value stays plain text on `KeyValueRow`, and the edit action is a design-system **`ButtonIcon`** via `valueEndButtonIconProps` and the existing `buttonIcon()` helper.
> 
> **Accessibility and tap target** are preserved on that icon: `accessibilityRole`/`accessibilityLabel` (`perps.slippage.config_title`) and **`hitSlop: 12`** so the ~20pt `ButtonIconSize.Xs` control still meets the 44pt minimum. Opening Set slippage on tap is unchanged.
> 
> **Tests** add a `slippage edit control` block that asserts icon-only layout, a11y props, and pressed/resting background on `pressIn`/`pressOut`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57197297e04e6b9fd9219842ee5febf19f31f068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->