### PR TITLE
fix: avoid duplicate words in SRP validation

### DIFF
--- a/app/components/Views/ManualBackupStep2/index.js
+++ b/app/components/Views/ManualBackupStep2/index.js
@@ -26,7 +26,10 @@ import SecureContentView from '../../UI/SecureContentView';
 import { strings } from '../../../../locales/i18n';
 import { seedphraseBackedUp } from '../../../actions/user';
 import { saveOnboardingEvent as saveEvent } from '../../../actions/onboarding';
-import { compareMnemonics } from '../../../util/mnemonic';
+import {
+  compareMnemonics,
+  pickUniqueMissingWordSlots,
+} from '../../../util/mnemonic';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import { ManualBackUpStepsSelectorsIDs } from '../ManualBackupStep1/ManualBackUpSteps.testIds';
@@ -52,7 +55,7 @@ const ManualBackupStep2 = ({
   const settingsBackup = route?.params?.settingsBackup;
 
   const tw = useTailwind();
-  const { width: innerWidth, height: windowHeight } = useWindowDimensions();
+  const { width: innerWidth } = useWindowDimensions();
 
   const [gridWords, setGridWords] = useState([]);
   const [emptySlots, setEmptySlots] = useState([]);
@@ -136,20 +139,12 @@ const ManualBackupStep2 = ({
   };
 
   const generateMissingWords = useCallback(() => {
-    const rows = [0, 1, 2, 3];
-    const sortGridRows = rows.sort(() => 0.5 - Math.random());
-    const selectRandomSlots = sortGridRows.slice(0, 3);
-    const emptySlotsIndexes = selectRandomSlots.map((row) => {
-      const col = Math.floor(Math.random() * 3);
-      return row * 3 + col;
-    });
-
+    const emptySlotsIndexes = pickUniqueMissingWordSlots(words);
     const tempGrid = [...words];
-    const removed = [];
-
-    emptySlotsIndexes.forEach((i) => {
-      removed.push(tempGrid[i]);
+    const removed = emptySlotsIndexes.map((i) => {
+      const word = tempGrid[i];
       tempGrid[i] = '';
+      return word;
     });
 
     setGridWords(tempGrid);
@@ -450,7 +445,6 @@ const ManualBackupStep2 = ({
           <Box
             justifyContent={BoxJustifyContent.SpaceBetween}
             twClassName="flex-1 gap-y-4"
-            style={{ height: windowHeight - 290 }}
             testID={ManualBackUpStepsSelectorsIDs.PROTECT_CONTAINER}
           >
             <Text variant={TextVariant.DisplayMd} color={TextColor.TextDefault}>

--- a/app/components/Views/ManualBackupStep2/index.test.tsx
+++ b/app/components/Views/ManualBackupStep2/index.test.tsx
@@ -239,9 +239,11 @@ describe('ManualBackupStep2', () => {
       Platform.OS = 'android';
       const { wrapper, mockNavigation } = setupTest();
 
-      const gridItem = wrapper.getByTestId(
-        `${ManualBackUpStepsSelectorsIDs.GRID_ITEM}-0`,
-      );
+      // Filled cells use grid-item-N; empty confirmation slots use grid-item-empty-N.
+      // Which indexes are empty depends on shuffle, so pick any filled cell.
+      const gridItem = wrapper.getAllByTestId(
+        new RegExp(`^${ManualBackUpStepsSelectorsIDs.GRID_ITEM}-\\d+$`),
+      )[0];
       fireEvent.press(gridItem);
 
       expect(gridItem).toHaveStyle({ backgroundColor: expect.any(String) });

--- a/app/components/Views/ManualBackupStep2/index.test.tsx
+++ b/app/components/Views/ManualBackupStep2/index.test.tsx
@@ -830,4 +830,53 @@ describe('ManualBackupStep2', () => {
       expect(mockNavigationDispatch).toHaveBeenCalled();
     });
   });
+
+  describe('with duplicate BIP-39 words in the seed phrase', () => {
+    it('always shows three uniquely labeled missing-word options', () => {
+      // Restore real Math.random so selection exercises retries / uniqueness.
+      global.Math = Math;
+
+      const wordsWithDuplicate = [
+        'abstract',
+        'accident',
+        'abstract',
+        'announce',
+        'artefact',
+        'attitude',
+        'bachelor',
+        'broccoli',
+        'business',
+        'category',
+        'champion',
+        'cinnamon',
+      ];
+
+      const navProps = createMockNavigationProps();
+      (useNavigation as jest.Mock).mockReturnValue(navProps);
+
+      const { getByTestId } = renderWithProvider(
+        <Provider store={store}>
+          <ManualBackupStep2
+            route={{
+              params: {
+                ...defaultRouteParams,
+                words: wordsWithDuplicate,
+              },
+            }}
+            navigation={navProps}
+          />
+        </Provider>,
+      );
+
+      const labels = [0, 1, 2].map(
+        (index) =>
+          getByTestId(
+            `${ManualBackUpStepsSelectorsIDs.WORD_ITEM_MISSING}-${index}`,
+          ).props.children,
+      );
+
+      expect(labels).toHaveLength(3);
+      expect(new Set(labels).size).toBe(3);
+    });
+  });
 });

--- a/app/util/mnemonic/index.test.ts
+++ b/app/util/mnemonic/index.test.ts
@@ -4,6 +4,7 @@ import {
   uint8ArrayToMnemonic,
   convertEnglishWordlistIndicesToCodepoints,
   convertMnemonicToWordlistIndices,
+  pickUniqueMissingWordSlots,
 } from '.';
 
 const mockSRPArrayOne = [
@@ -41,6 +42,78 @@ describe('mnemonic::shuffle', () => {
     expect(mockSRPArrayOne.join('')).not.toEqual(
       shuffle(mockSRPArrayOne).join(''),
     );
+  });
+
+  it('shuffles number arrays without mutating the input', () => {
+    const input = [0, 1, 2, 3];
+    const result = shuffle(input);
+    expect(input).toEqual([0, 1, 2, 3]);
+    expect(result).toHaveLength(4);
+    expect([...result].sort()).toEqual([0, 1, 2, 3]);
+  });
+});
+
+describe('mnemonic::pickUniqueMissingWordSlots', () => {
+  it('returns unique words for a phrase that contains duplicates', () => {
+    // Valid BIP-39 pattern: same word can appear more than once.
+    const wordsWithDuplicate = [
+      'apple',
+      'banana',
+      'apple',
+      'cherry',
+      'date',
+      'elder',
+      'fig',
+      'grape',
+      'honey',
+      'iris',
+      'jade',
+      'kiwi',
+    ];
+
+    for (let i = 0; i < 30; i++) {
+      const slots = pickUniqueMissingWordSlots(wordsWithDuplicate);
+      const removed = slots.map((index) => wordsWithDuplicate[index]);
+      expect(slots).toHaveLength(3);
+      expect(new Set(removed).size).toBe(3);
+      slots.forEach((index) => {
+        expect(index).toBeGreaterThanOrEqual(0);
+        expect(index).toBeLessThan(wordsWithDuplicate.length);
+      });
+    }
+  });
+
+  it('falls back when repeated random row/column picks keep selecting the same word', () => {
+    // With Math.random always 0, the row/column sampler always hits indexes
+    // 3, 6, and 9 — set those to the same word so attempts collide.
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+    const wordsWithCollisionPath = [
+      'w0',
+      'w1',
+      'w2',
+      'same',
+      'w4',
+      'w5',
+      'same',
+      'w7',
+      'w8',
+      'same',
+      'w10',
+      'w11',
+    ];
+
+    try {
+      const slots = pickUniqueMissingWordSlots(wordsWithCollisionPath);
+      const removed = slots.map((index) => wordsWithCollisionPath[index]);
+      expect(slots).toHaveLength(3);
+      expect(new Set(removed).size).toBe(3);
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(pickUniqueMissingWordSlots([])).toEqual([]);
   });
 });
 

--- a/app/util/mnemonic/index.test.ts
+++ b/app/util/mnemonic/index.test.ts
@@ -84,21 +84,21 @@ describe('mnemonic::pickUniqueMissingWordSlots', () => {
   });
 
   it('falls back when repeated random row/column picks keep selecting the same word', () => {
-    // With Math.random always 0, the row/column sampler always hits indexes
-    // 3, 6, and 9 — set those to the same word so attempts collide.
+    // With Math.random always 0, Fisher–Yates always yields rows [1,2,3] and
+    // column 1 → indexes 4, 7, and 10. Set those to the same word so attempts collide.
     const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
     const wordsWithCollisionPath = [
       'w0',
       'w1',
       'w2',
+      'w3',
       'same',
-      'w4',
       'w5',
+      'w6',
       'same',
-      'w7',
       'w8',
+      'w9',
       'same',
-      'w10',
       'w11',
     ];
 

--- a/app/util/mnemonic/index.ts
+++ b/app/util/mnemonic/index.ts
@@ -49,7 +49,9 @@ export const pickUniqueMissingWordSlots = (
       Array.from({ length: SRP_GRID_ROW_COUNT }, (_, row) => row),
     ).slice(0, count);
     const emptySlotsIndexes = selectedRows.map((row) => {
-      const col = Math.floor(Math.random() * SRP_GRID_COLUMN_COUNT);
+      const col = shuffle(
+        Array.from({ length: SRP_GRID_COLUMN_COUNT }, (_, i) => i),
+      )[0];
       return row * SRP_GRID_COLUMN_COUNT + col;
     });
     const removedWords = emptySlotsIndexes.map((index) => words[index]);

--- a/app/util/mnemonic/index.ts
+++ b/app/util/mnemonic/index.ts
@@ -1,14 +1,12 @@
 /**
- * Method to shuffles an array of string.
+ * Fisher–Yates shuffle (does not mutate the input).
  *
- * The previous method was replaced according to the following tutorial.
- * https://javascript.info/array-methods#shuffle-an-array
+ * @see https://javascript.info/array-methods#shuffle-an-array
  *
- * @param array - Array of string.
- * @returns Array of string.
+ * @param array - Array to shuffle.
+ * @returns A new shuffled array.
  */
-
-export const shuffle = (array: string[]): string[] => {
+export const shuffle = <T>(array: T[]): T[] => {
   const shuffledArray = [...array];
   for (let i = array.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
@@ -17,6 +15,66 @@ export const shuffle = (array: string[]): string[] => {
     [shuffledArray[i], shuffledArray[j]] = [shuffledArray[j], shuffledArray[i]];
   }
   return shuffledArray;
+};
+
+const SRP_GRID_ROW_COUNT = 4;
+const SRP_GRID_COLUMN_COUNT = 3;
+const DEFAULT_MISSING_WORD_COUNT = 3;
+const UNIQUE_MISSING_WORD_MAX_ATTEMPTS = 50;
+
+/**
+ * Picks grid indexes whose seed words will be removed for SRP confirmation.
+ *
+ * BIP-39 allows the same word more than once in a phrase. The confirmation UI
+ * must still show distinct button labels, so selected words are required to be
+ * unique. Retries the existing row/column sampling until they are; falls back
+ * to a unique-word scan if random attempts keep colliding.
+ *
+ * @param words - Full seed phrase as an ordered word list (typically 12).
+ * @param missingCount - Number of words to remove (default 3).
+ * @returns Indexes into `words` for the empty confirmation slots.
+ */
+export const pickUniqueMissingWordSlots = (
+  words: string[],
+  missingCount: number = DEFAULT_MISSING_WORD_COUNT,
+): number[] => {
+  if (!words.length || missingCount <= 0) {
+    return [];
+  }
+
+  const count = Math.min(missingCount, words.length);
+
+  for (let attempt = 0; attempt < UNIQUE_MISSING_WORD_MAX_ATTEMPTS; attempt++) {
+    const selectedRows = shuffle(
+      Array.from({ length: SRP_GRID_ROW_COUNT }, (_, row) => row),
+    ).slice(0, count);
+    const emptySlotsIndexes = selectedRows.map((row) => {
+      const col = Math.floor(Math.random() * SRP_GRID_COLUMN_COUNT);
+      return row * SRP_GRID_COLUMN_COUNT + col;
+    });
+    const removedWords = emptySlotsIndexes.map((index) => words[index]);
+    if (new Set(removedWords).size === removedWords.length) {
+      return emptySlotsIndexes;
+    }
+  }
+
+  const selected: number[] = [];
+  const usedWords = new Set<string>();
+  for (const index of shuffle(
+    Array.from({ length: words.length }, (_, i) => i),
+  )) {
+    const word = words[index];
+    if (usedWords.has(word)) {
+      continue;
+    }
+    usedWords.add(word);
+    selected.push(index);
+    if (selected.length === count) {
+      return selected;
+    }
+  }
+
+  return Array.from({ length: count }, (_, i) => i);
 };
 
 /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
Fixes a rare SRP confirmation bug where users saw only **2 unique word options** for a **3-of-12** check, blocking wallet setup.

**Root cause:** BIP-39 allows the same word more than once in a seed phrase. `generateMissingWords` in Manual Backup Step 2 randomly picked 3 slots without requiring unique word labels, so duplicate picks looked like only 2 buttons (~1 in 500 creations).

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Secret Recovery Phrase confirmation sometimes showing only two word options

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TO-969

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: SRP validation word options

 Scenario: user confirms Secret Recovery Phrase with three distinct options
    Given MetaMask Mobile is creating a new wallet
    And the user reaches Manual Backup Step 2 (confirm 3 of 12 words)
    When the missing-word options are shown
    Then exactly 3 word buttons are visible
    And all 3 button labels are unique
    And the user can place all 3 words and continue successfully
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/148b9bdb-78c4-4a56-97a1-c496dd2bae32


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches onboarding SRP confirmation logic; incorrect slot selection could still block wallet setup, though behavior is covered by new tests and scope is limited to missing-word generation.
> 
> **Overview**
> Fixes **Manual Backup Step 2** so the three missing-word choices always have **distinct labels**, even when the seed phrase repeats a BIP-39 word (which could leave users with only two usable buttons and block onboarding).
> 
> Slot selection moves out of the screen into **`pickUniqueMissingWordSlots`** in `app/util/mnemonic`: it keeps the same row/column random picks but **retries** until the three removed words are unique, with a **deterministic fallback** if random picks keep colliding. **`shuffle`** is generalized to a non-mutating Fisher–Yates helper used by that logic.
> 
> The backup step layout drops a fixed **`windowHeight`-based height** on the protect container. **Unit and component tests** cover duplicate phrases, collision fallback, and the UI guarantee of three unique labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f890af971fb31ec335786e6f1ac03a6c19dd2f2d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->