### PR TITLE
fix(subscriptions): reset stack after cancel membership Done

### DIFF
--- a/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.test.tsx
+++ b/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.test.tsx
@@ -4,11 +4,12 @@ import { render, fireEvent } from '@testing-library/react-native';
 import CancelMembership from './CancelMembership';
 import { CancelMembershipTestIds } from './CancelMembership.testIds';
 import Routes from '../../../../../constants/navigation/Routes';
+import { POST_CANCELLATION_PRO_HUB_SOURCE } from './CancelMembership.utils';
 
 // ─── Navigation ───────────────────────────────────────────────────────────────
 
 const mockGoBack = jest.fn();
-const mockNavigate = jest.fn();
+const mockDispatch = jest.fn();
 const mockSetOptions = jest.fn();
 const mockAddListener = jest.fn().mockReturnValue(jest.fn());
 
@@ -18,12 +19,50 @@ jest.mock('@react-navigation/native', () => {
     ...actual,
     useNavigation: () => ({
       goBack: mockGoBack,
-      navigate: mockNavigate,
+      dispatch: mockDispatch,
       setOptions: mockSetOptions,
       addListener: mockAddListener,
     }),
   };
 });
+
+const mockProFlowState = {
+  key: 'stack',
+  index: 3,
+  routeNames: ['Home', 'ProHub', 'ProHubMembership', 'ProHubCancelMembership'],
+  routes: [
+    { key: 'home', name: 'Home' },
+    { key: 'hub', name: Routes.PRO_HUB.ROOT },
+    { key: 'membership', name: Routes.PRO_HUB.MEMBERSHIP },
+    { key: 'cancel', name: Routes.PRO_HUB.CANCEL_MEMBERSHIP },
+  ],
+  type: 'stack',
+  stale: false,
+};
+
+const expectPostCancellationReset = () => {
+  expect(mockDispatch).toHaveBeenCalledTimes(1);
+  const stackReducer = mockDispatch.mock.calls[0][0] as (
+    state: typeof mockProFlowState,
+  ) => unknown;
+
+  expect(typeof stackReducer).toBe('function');
+  expect(stackReducer(mockProFlowState)).toEqual(
+    expect.objectContaining({
+      type: 'RESET',
+      payload: expect.objectContaining({
+        index: 1,
+        routes: [
+          { key: 'home', name: 'Home' },
+          {
+            name: Routes.PRO_HUB.ROOT,
+            params: { source: POST_CANCELLATION_PRO_HUB_SOURCE },
+          },
+        ],
+      }),
+    }),
+  );
+};
 
 // ─── Tailwind ─────────────────────────────────────────────────────────────────
 
@@ -89,18 +128,16 @@ describe('CancelMembership', () => {
     ).toBeOnTheScreen();
     expect(queryByTestId(CancelMembershipTestIds.TITLE)).not.toBeOnTheScreen();
     expect(mockGoBack).not.toHaveBeenCalled();
-    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 
-  it('navigates back to the existing ProHub root when done is pressed on the success step', () => {
+  it('resets the stack to Pro Hub on top of the origin screen when done is pressed on the success step', () => {
     const { getByTestId } = renderScreen();
 
     fireEvent.press(getByTestId(CancelMembershipTestIds.CANCEL_BUTTON));
     fireEvent.press(getByTestId(CancelMembershipTestIds.SUCCESS_DONE_BUTTON));
 
-    expect(mockNavigate).toHaveBeenCalledWith(Routes.PRO_HUB.ROOT, {
-      source: 'pro_subscription_cancellation_success',
-    });
+    expectPostCancellationReset();
   });
 
   // ── Gesture / navigation interception ─────────────────────────────────────
@@ -117,7 +154,7 @@ describe('CancelMembership', () => {
       );
     });
 
-    it('beforeRemove handler prevents default and calls navigate to ProHub root', () => {
+    it('beforeRemove handler prevents default and resets to Pro Hub on top of the origin screen', () => {
       let beforeRemoveHandler:
         | ((e: { preventDefault: () => void }) => void)
         | undefined;
@@ -142,9 +179,7 @@ describe('CancelMembership', () => {
       beforeRemoveHandler?.({ preventDefault: mockPreventDefault });
 
       expect(mockPreventDefault).toHaveBeenCalledTimes(1);
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.PRO_HUB.ROOT, {
-        source: 'pro_subscription_cancellation_success',
-      });
+      expectPostCancellationReset();
     });
   });
 
@@ -171,7 +206,7 @@ describe('CancelMembership', () => {
       );
     });
 
-    it('behaves like pressing Done (navigates to ProHub root) instead of popping the screen', () => {
+    it('behaves like pressing Done (resets to Pro Hub on top of the origin screen) instead of popping the screen', () => {
       let backPressHandler: (() => boolean) | undefined;
       jest
         .spyOn(BackHandler, 'addEventListener')
@@ -188,9 +223,7 @@ describe('CancelMembership', () => {
 
       expect(handled).toBe(true);
       expect(mockGoBack).not.toHaveBeenCalled();
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.PRO_HUB.ROOT, {
-        source: 'pro_subscription_cancellation_success',
-      });
+      expectPostCancellationReset();
     });
 
     it('removes the BackHandler listener on unmount so it cannot leak into other screens', () => {

--- a/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.tsx
+++ b/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { BackHandler } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useNavigation } from '@react-navigation/native';
+import { CommonActions, useNavigation } from '@react-navigation/native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import Routes from '../../../../../constants/navigation/Routes';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
 import { CancelMembershipTestIds } from './CancelMembership.testIds';
+import { buildPostCancellationResetState } from './CancelMembership.utils';
 import CancelSurveyStep from './components/CancelSurveyStep';
 import CancelSuccessStep from './components/CancelSuccessStep';
 
@@ -37,9 +37,12 @@ const CancelMembership = () => {
   const handleDone = useCallback(() => {
     if (isNavigatingRef.current) return;
     isNavigatingRef.current = true;
-    navigation.navigate(Routes.PRO_HUB.ROOT, {
-      source: 'pro_subscription_cancellation_success',
-    });
+    // Reset instead of navigate: navigate() pushes another Pro Hub on top of
+    // this success step, so Header back would return here. Reset keeps Pro Hub
+    // on top of the screen that started the flow (Money, Wallet, etc.).
+    navigation.dispatch((state) =>
+      CommonActions.reset(buildPostCancellationResetState(state)),
+    );
   }, [navigation]);
 
   // Once the membership is cancelled (success step), disable iOS swipe-back

--- a/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.utils.test.ts
+++ b/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.utils.test.ts
@@ -79,7 +79,6 @@ describe('buildPostCancellationResetState', () => {
       'Home',
       Routes.PRO_HUB.ROOT,
       Routes.PRO_HUB.EARNED,
-      Routes.PRO_HUB.SAVED,
       Routes.PRO_HUB.CANCEL_MEMBERSHIP,
     ]);
 
@@ -89,7 +88,6 @@ describe('buildPostCancellationResetState', () => {
       nextState.routes?.some(
         (route) =>
           route.name === Routes.PRO_HUB.EARNED ||
-          route.name === Routes.PRO_HUB.SAVED ||
           route.name === Routes.PRO_HUB.CANCEL_MEMBERSHIP,
       ),
     ).toBe(false);

--- a/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.utils.test.ts
+++ b/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.utils.test.ts
@@ -1,0 +1,97 @@
+import type { NavigationState } from '@react-navigation/native';
+import Routes from '../../../../../constants/navigation/Routes';
+import {
+  POST_CANCELLATION_PRO_HUB_SOURCE,
+  buildPostCancellationResetState,
+} from './CancelMembership.utils';
+
+const createStackState = (routeNames: string[]): NavigationState => ({
+  key: 'stack',
+  index: routeNames.length - 1,
+  routeNames,
+  routes: routeNames.map((name, i) => ({
+    key: `${name}-${i}`,
+    name,
+  })),
+  type: 'stack',
+  stale: false,
+});
+
+describe('buildPostCancellationResetState', () => {
+  it('puts Pro Hub on top of the origin screen and drops cancel and membership', () => {
+    const state = createStackState([
+      'Home',
+      Routes.PRO_HUB.ROOT,
+      Routes.PRO_HUB.MEMBERSHIP,
+      Routes.PRO_HUB.CANCEL_MEMBERSHIP,
+    ]);
+
+    const nextState = buildPostCancellationResetState(state);
+
+    expect(nextState.index).toBe(1);
+    expect(nextState.routes).toEqual([
+      { key: 'Home-0', name: 'Home' },
+      {
+        name: Routes.PRO_HUB.ROOT,
+        params: { source: POST_CANCELLATION_PRO_HUB_SOURCE },
+      },
+    ]);
+  });
+
+  it('preserves whichever screen started the flow under Pro Hub', () => {
+    const state = createStackState([
+      'Money',
+      Routes.PRO_SUBSCRIPTION.ROOT,
+      Routes.PRO_HUB.ROOT,
+      Routes.PRO_HUB.CANCEL_MEMBERSHIP,
+    ]);
+
+    const nextState = buildPostCancellationResetState(state);
+
+    expect(nextState.routes).toEqual([
+      { key: 'Money-0', name: 'Money' },
+      {
+        name: Routes.PRO_HUB.ROOT,
+        params: { source: POST_CANCELLATION_PRO_HUB_SOURCE },
+      },
+    ]);
+  });
+
+  it('drops the Join Pro benefits modal so back from Pro Hub does not open it', () => {
+    const state = createStackState([
+      'Home',
+      Routes.PRO_SUBSCRIPTION.ROOT,
+      Routes.PRO_HUB.ROOT,
+      Routes.PRO_HUB.CANCEL_MEMBERSHIP,
+    ]);
+
+    const nextState = buildPostCancellationResetState(state);
+
+    expect(
+      nextState.routes?.some(
+        (route) => route.name === Routes.PRO_SUBSCRIPTION.ROOT,
+      ),
+    ).toBe(false);
+  });
+
+  it('drops Earned and Saved screens so they are not under Pro Hub after cancel', () => {
+    const state = createStackState([
+      'Home',
+      Routes.PRO_HUB.ROOT,
+      Routes.PRO_HUB.EARNED,
+      Routes.PRO_HUB.SAVED,
+      Routes.PRO_HUB.CANCEL_MEMBERSHIP,
+    ]);
+
+    const nextState = buildPostCancellationResetState(state);
+
+    expect(
+      nextState.routes?.some(
+        (route) =>
+          route.name === Routes.PRO_HUB.EARNED ||
+          route.name === Routes.PRO_HUB.SAVED ||
+          route.name === Routes.PRO_HUB.CANCEL_MEMBERSHIP,
+      ),
+    ).toBe(false);
+  });
+});

--- a/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.utils.test.ts
+++ b/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.utils.test.ts
@@ -92,4 +92,52 @@ describe('buildPostCancellationResetState', () => {
       ),
     ).toBe(false);
   });
+
+  it('keeps nested HomeNav tab state so back from Pro Hub returns to Money', () => {
+    const homeNavNestedState = {
+      index: 0,
+      routes: [
+        {
+          name: Routes.MAIN_FLOW,
+          state: {
+            index: 1,
+            routes: [
+              { name: Routes.WALLET.HOME },
+              { name: Routes.MONEY.HOME },
+            ],
+          },
+        },
+      ],
+    };
+    const homeNavParams = { screen: Routes.MONEY.HOME };
+    const state: NavigationState = {
+      ...createStackState([
+        Routes.ONBOARDING.HOME_NAV,
+        Routes.PRO_HUB.ROOT,
+        Routes.PRO_HUB.CANCEL_MEMBERSHIP,
+      ]),
+      routes: [
+        {
+          key: `${Routes.ONBOARDING.HOME_NAV}-0`,
+          name: Routes.ONBOARDING.HOME_NAV,
+          params: homeNavParams,
+          state: homeNavNestedState,
+        },
+        { key: 'ProHub-1', name: Routes.PRO_HUB.ROOT },
+        {
+          key: 'ProHubCancelMembership-2',
+          name: Routes.PRO_HUB.CANCEL_MEMBERSHIP,
+        },
+      ],
+    };
+
+    const nextState = buildPostCancellationResetState(state);
+
+    expect(nextState.routes?.[0]).toEqual({
+      key: `${Routes.ONBOARDING.HOME_NAV}-0`,
+      name: Routes.ONBOARDING.HOME_NAV,
+      params: homeNavParams,
+      state: homeNavNestedState,
+    });
+  });
 });

--- a/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.utils.test.ts
+++ b/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.utils.test.ts
@@ -101,10 +101,7 @@ describe('buildPostCancellationResetState', () => {
           name: Routes.MAIN_FLOW,
           state: {
             index: 1,
-            routes: [
-              { name: Routes.WALLET.HOME },
-              { name: Routes.MONEY.HOME },
-            ],
+            routes: [{ name: Routes.WALLET.HOME }, { name: Routes.MONEY.HOME }],
           },
         },
       ],

--- a/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.utils.ts
+++ b/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.utils.ts
@@ -18,13 +18,26 @@ const PRO_FLOW_ROUTE_NAMES = new Set<string>([
  * Pro Hub is on top. Every Pro / Join Pro screen is removed so Header back
  * returns to whatever screen started the flow (Money, Wallet, etc.) — not the
  * success step, Membership, or the Join Pro benefits modal.
+ *
+ * Preserved routes keep nested `state` and `params`. HomeNav is a tab
+ * navigator; dropping its nested state would remount it on the initial Wallet
+ * tab instead of the Money (or other) tab that started the flow.
  */
 export const buildPostCancellationResetState = (
   state: NavigationState,
 ): PartialState<NavigationState> => {
   const preservedRoutes = state.routes
     .filter((route) => !PRO_FLOW_ROUTE_NAMES.has(route.name))
-    .map(({ key, name }) => ({ key, name }));
+    .map(({ key, name, params, state: nestedState }) => ({
+      key,
+      name,
+      ...(params !== undefined ? { params } : {}),
+      // NavigationState uses `stale: false`; PartialState uses `stale?: true`.
+      // Reset accepts the live nested tree at runtime (needed to restore HomeNav).
+      ...(nestedState !== undefined
+        ? { state: nestedState as PartialState<NavigationState> }
+        : {}),
+    }));
 
   const routes = [
     ...preservedRoutes,

--- a/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.utils.ts
+++ b/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.utils.ts
@@ -1,0 +1,43 @@
+import type { NavigationState, PartialState } from '@react-navigation/native';
+import Routes from '../../../../../constants/navigation/Routes';
+
+export const POST_CANCELLATION_PRO_HUB_SOURCE =
+  'pro_subscription_cancellation_success' as const;
+
+const PRO_FLOW_ROUTE_NAMES = new Set<string>([
+  Routes.PRO_SUBSCRIPTION.ROOT,
+  Routes.PRO_HUB.ROOT,
+  Routes.PRO_HUB.MEMBERSHIP,
+  Routes.PRO_HUB.EARNED,
+  Routes.PRO_HUB.SAVED,
+  Routes.PRO_HUB.CANCEL_MEMBERSHIP,
+]);
+
+/**
+ * Builds the stack shown after the user taps Done on cancel-membership success.
+ *
+ * Pro Hub is on top. Every Pro / Join Pro screen is removed so Header back
+ * returns to whatever screen started the flow (Money, Wallet, etc.) — not the
+ * success step, Membership, or the Join Pro benefits modal.
+ */
+export const buildPostCancellationResetState = (
+  state: NavigationState,
+): PartialState<NavigationState> => {
+  const preservedRoutes = state.routes.filter(
+    (route) => !PRO_FLOW_ROUTE_NAMES.has(route.name),
+  );
+
+  const routes = [
+    ...preservedRoutes,
+    {
+      name: Routes.PRO_HUB.ROOT,
+      params: { source: POST_CANCELLATION_PRO_HUB_SOURCE },
+    },
+  ];
+
+  return {
+    ...state,
+    index: routes.length - 1,
+    routes,
+  };
+};

--- a/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.utils.ts
+++ b/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.utils.ts
@@ -9,7 +9,6 @@ const PRO_FLOW_ROUTE_NAMES = new Set<string>([
   Routes.PRO_HUB.ROOT,
   Routes.PRO_HUB.MEMBERSHIP,
   Routes.PRO_HUB.EARNED,
-  Routes.PRO_HUB.SAVED,
   Routes.PRO_HUB.CANCEL_MEMBERSHIP,
 ]);
 
@@ -23,9 +22,9 @@ const PRO_FLOW_ROUTE_NAMES = new Set<string>([
 export const buildPostCancellationResetState = (
   state: NavigationState,
 ): PartialState<NavigationState> => {
-  const preservedRoutes = state.routes.filter(
-    (route) => !PRO_FLOW_ROUTE_NAMES.has(route.name),
-  );
+  const preservedRoutes = state.routes
+    .filter((route) => !PRO_FLOW_ROUTE_NAMES.has(route.name))
+    .map(({ key, name }) => ({ key, name }));
 
   const routes = [
     ...preservedRoutes,
@@ -36,7 +35,6 @@ export const buildPostCancellationResetState = (
   ];
 
   return {
-    ...state,
     index: routes.length - 1,
     routes,
   };


### PR DESCRIPTION
## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Tapping **Done** on cancel-membership success used `navigate(ProHub)`, which pushed another Pro Hub onto the stack. Header back then returned to the success step. A later reset that inserted Join Pro under Pro Hub opened the benefits modal instead.

Done now resets the stack: all Pro / Join Pro routes are removed, a fresh Pro Hub is placed on top, and the screen that started the flow (Money, Wallet, etc.) is preserved underneath.

JIRA : https://consensyssoftware.atlassian.net/browse/SUB-1018

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Pro Hub back navigation after canceling a membership

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Cancel membership Done navigation

  Background:
    Given I am logged into MetaMask Mobile
    And I have an active Pro membership

  Scenario: Done lands on Pro Hub and back returns to the origin screen
    Given I opened Join Pro from the Money header
    And I completed subscribe and reached Pro Hub
    And I opened Membership and completed cancel through the success step

    When user taps Done
    Then I should see Pro Hub
    And I should not see the Join Pro benefits modal
    And I should not see the cancel success step

    When user taps the Pro Hub header back arrow
    Then I should return to the Money page
    And I should not see the cancel success step
    And I should not see the Join Pro benefits modal

  Scenario: Origin is not hardcoded to Money
    Given I started the Pro flow from a screen other than Money

    When user completes cancel and taps Done
    Then I should see Pro Hub

    When user taps the Pro Hub header back arrow
    Then I should return to the screen that started the flow
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — navigation stack fix; no visual change to the success step UI.

### **After**


https://github.com/user-attachments/assets/4f5a9a6b-5d33-489f-95de-b008d428e395



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

Made with [Cursor](https://cursor.com)