### PR TITLE
fix(ci): dual-upload Appium Playwright JSON reports for health report

### DIFF
--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -397,8 +397,12 @@ jobs:
           path: tests/test-reports/playwright-json/playwright-report.json
           if-no-files-found: ignore
           retention-days: 7
-      - name: Upload Playwright JSON report (current)
-        if: ${{ always() && inputs.runner_provider != 'namespace' }}
+      # Always upload to the GitHub Actions store as well (dual-upload on Namespace).
+      # The scheduled Playwright test health report and qa-stats collectors only see
+      # GitHub artifacts; Namespace-only uploads made those consumers go empty after
+      # Appium moved onto the runner-provider switch (#35002).
+      - name: Upload Playwright JSON report (GitHub)
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: playwright-json-report-${{ inputs.test-suite-name }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

After Appium moved onto the Namespace runner-provider switch (#35002), `playwright-json-report-*` artifacts were uploaded only to the Namespace artifact store. The scheduled Playwright test health report (`flaky-test-report.yml` → github-tools `playwright-test-health-report`) only lists/downloads via the GitHub Actions artifact API, so every lookback window returned `No matching artifacts found` and Slack stopped posting (from ~2026-08-20).

This dual-uploads the Playwright JSON reports: keep the Namespace upload for in-fleet consumers, and always also upload to the GitHub Actions store (same pattern as the scheduled arm64 APK dual-upload / fixture-validation GitHub-only landing).

`qa-stats` e2e collectors that read the same `playwright-json-report-*` names benefit as well.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: #35002

## **Manual testing steps**

```gherkin
Feature: Playwright JSON dual-upload for health report

  Scenario: Namespace Appium job lands JSON report in GitHub artifact store
    Given CI Appium smoke runs with runner_provider=namespace
    When the job uploads playwright-json-report-*
    Then the artifact is present in the GitHub Actions run artifact list
    And the scheduled Flaky test report finds matching artifacts instead of exiting empty
```

## **Screenshots/Recordings**

N/A — CI workflow change only.

## **Pre-merge author checklist**

- [x] I’ve followed [MetaMask coding guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [x] I’ve documented my changes if not already documented in the code itself (CI comment explaining dual-upload)
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not mandatory for a draft PR.

## **Pre-merge reviewer checklist**

- [ ] Manual testing (if warranted by the PR's complexity and/or testing instructions)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] PR has been approved by a code owner (required if CODEOWNERS exists)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b1c60ba-8460-433c-8f03-bb25e7b125a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b1c60ba-8460-433c-8f03-bb25e7b125a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

