### PR TITLE
refactor: update WalletHomeOnboardingSteps to remove loading indicator

### DIFF
--- a/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.test.tsx
+++ b/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.test.tsx
@@ -577,8 +577,8 @@ describe('WalletHomeOnboardingSteps', () => {
     ).toBe(2);
   });
 
-  it('shows first-step shell with awaiting hero and disabled primary when isAwaitingBalance', () => {
-    const { getByTestId } = renderWithProvider(
+  it('shows first-step shell without a loading indicator when isAwaitingBalance', () => {
+    const { getByTestId, queryByTestId } = renderWithProvider(
       <WalletHomeOnboardingSteps testID="steps-root" isAwaitingBalance />,
       {
         state: {
@@ -594,8 +594,10 @@ describe('WalletHomeOnboardingSteps', () => {
       },
     );
 
-    expect(getByTestId('steps-root-hero-awaiting-balance')).toBeOnTheScreen();
     expect(getByTestId('steps-root-hero-fund')).toBeOnTheScreen();
+    expect(
+      queryByTestId('steps-root-hero-awaiting-balance'),
+    ).not.toBeOnTheScreen();
     expect(getByTestId(primaryTestId)).toBeDisabled();
   });
 

--- a/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.tsx
+++ b/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.tsx
@@ -7,13 +7,7 @@ import React, {
   useState,
 } from 'react';
 import { useFocusEffect, useIsFocused } from '@react-navigation/native';
-import {
-  Animated,
-  Dimensions,
-  Easing,
-  Image,
-  View,
-} from 'react-native';
+import { Animated, Dimensions, Easing, Image, View } from 'react-native';
 import {
   Alignment,
   Fit,
@@ -764,9 +758,7 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
           justifyContent={BoxJustifyContent.Center}
           twClassName="relative z-10 flex-1 w-full min-h-0 self-stretch"
         >
-          {!isAwaitingBalance &&
-          !hasTestOverrides &&
-          checklistRiveFile ? (
+          {!isAwaitingBalance && !hasTestOverrides && checklistRiveFile ? (
             <RiveView
               key={`wallet-home-checklist-rive-${currentStep.kind}`}
               hybridRef={setChecklistHybridRef}

--- a/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.tsx
+++ b/app/components/UI/WalletHomeOnboardingSteps/WalletHomeOnboardingSteps.tsx
@@ -8,7 +8,6 @@ import React, {
 } from 'react';
 import { useFocusEffect, useIsFocused } from '@react-navigation/native';
 import {
-  ActivityIndicator,
   Animated,
   Dimensions,
   Easing,
@@ -90,7 +89,7 @@ const SLIDE_DISTANCE = Dimensions.get('window').width;
 export interface WalletHomeOnboardingStepsProps {
   testID?: string;
   /**
-   * When true, show the first-step shell with a loading hero and disabled primary until
+   * When true, show the first-step shell with an empty hero and disabled primary until
    * aggregated balance / empty-state is resolved (in-flow users reopening the app).
    */
   isAwaitingBalance?: boolean;
@@ -765,15 +764,9 @@ const WalletHomeOnboardingSteps: React.FC<WalletHomeOnboardingStepsProps> = ({
           justifyContent={BoxJustifyContent.Center}
           twClassName="relative z-10 flex-1 w-full min-h-0 self-stretch"
         >
-          {isAwaitingBalance ? (
-            <ActivityIndicator
-              size="large"
-              accessibilityLabel={strings(
-                'wallet.home_onboarding_steps.balance_loading_a11y',
-              )}
-              testID={`${testID}-hero-awaiting-balance`}
-            />
-          ) : !hasTestOverrides && checklistRiveFile ? (
+          {!isAwaitingBalance &&
+          !hasTestOverrides &&
+          checklistRiveFile ? (
             <RiveView
               key={`wallet-home-checklist-rive-${currentStep.kind}`}
               hybridRef={setChecklistHybridRef}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The wallet home onboarding checklist could briefly show a loading spinner in the hero before its Rive animation appeared. This removes the interim spinner so the static hero remains visible while balance state resolves, then displays the animation when ready. The primary action remains disabled during the wait.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Removed the loading spinner shown before the wallet onboarding checklist animation

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: TMCU-912

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Wallet home onboarding checklist loading state

  Scenario: checklist waits for balance resolution without a spinner
    Given I am eligible for the wallet home onboarding checklist
    And the wallet balance state has not finished resolving

    When the onboarding checklist appears on the Wallet home screen
    Then the fund-step hero should appear without a loading spinner
    And the primary action should remain disabled

    When the wallet balance state finishes resolving
    Then the fund-step animation should appear
    And the primary action should become enabled
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to an onboarding loading state with no auth, data, or payment logic touched; regression risk is limited to wallet home checklist presentation timing.
> 
> **Overview**
> While **`isAwaitingBalance`** is true, the wallet home onboarding checklist no longer shows a hero **`ActivityIndicator`**; users see the **fund-step static hero** (PNG) with **no Rive** until balance state resolves. The **primary button stays disabled** during that wait, matching prior behavior.
> 
> Docs and tests were updated: the prop comment now describes an **empty hero** instead of a loading hero, and the test asserts the awaiting-balance spinner test ID is **absent** while the fund hero remains on screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7aa17f7eb6e9ef084e35899c0212ac7669f519c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->