### PR TITLE
feat(swaps): add popular token fetch performance tracing

### DIFF
--- a/app/components/UI/Bridge/hooks/useFetchPopularTokens.test.ts
+++ b/app/components/UI/Bridge/hooks/useFetchPopularTokens.test.ts
@@ -5,6 +5,12 @@ import { renderHookWithProvider } from '../../../../util/test/renderWithProvider
 import { initialState } from '../_mocks_/initialState';
 import { popularTokensCache } from '../utils/cacheUtils';
 import type { IncludeAsset } from '../types';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../../util/trace';
 
 let globalFetchSpy: jest.SpyInstance;
 
@@ -16,6 +22,15 @@ jest.mock('../../../../core/Engine', () => ({
     },
   },
 }));
+
+jest.mock('../../../../util/trace', () => ({
+  ...jest.requireActual('../../../../util/trace'),
+  trace: jest.fn(),
+  endTrace: jest.fn(),
+}));
+
+const mockTrace = trace as jest.MockedFunction<typeof trace>;
+const mockEndTrace = endTrace as jest.MockedFunction<typeof endTrace>;
 
 const mockPopularTokens = [
   createMockPopularToken({ symbol: 'TEST', name: 'Test Token' }),
@@ -32,7 +47,7 @@ const mockIncludeAsset: IncludeAsset = {
 describe('useFetchPopularTokens', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
-    mockGetBearerToken.mockClear();
+    jest.clearAllMocks();
     mockGetBearerToken.mockResolvedValue('mock-bearer-token');
     globalFetchSpy = jest.spyOn(global, 'fetch');
     popularTokensCache.clear();
@@ -79,6 +94,23 @@ describe('useFetchPopularTokens', () => {
       }),
     );
     expect(popularTokensCache.size).toBe(1);
+    expect(mockTrace).toHaveBeenCalledWith({
+      name: TraceName.SwapPopularTokensFetch,
+      op: TraceOperation.BridgeDataFetch,
+      id: expect.any(String),
+      data: {
+        chain_scope: 'single_chain',
+        chain_ids: MOCK_CHAIN_IDS.ethereum,
+      },
+      startTime: expect.any(Number),
+    });
+    const traceId = mockTrace.mock.calls[0][0].id;
+    expect(mockEndTrace).toHaveBeenCalledWith({
+      name: TraceName.SwapPopularTokensFetch,
+      id: traceId,
+      timestamp: expect.any(Number),
+      data: { result: 'success' },
+    });
   });
 
   it('defaults includeAssets to an empty array when omitted', async () => {
@@ -115,12 +147,17 @@ describe('useFetchPopularTokens', () => {
     });
 
     await result.current({ chainIds: [MOCK_CHAIN_IDS.ethereum] });
+    expect(mockTrace).toHaveBeenCalledTimes(1);
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
+
     const cachedTokens = await result.current({
       chainIds: [MOCK_CHAIN_IDS.ethereum],
     });
 
     expect(cachedTokens).toStrictEqual(mockPopularTokens);
     expect(globalFetchSpy).toHaveBeenCalledTimes(1);
+    expect(mockTrace).toHaveBeenCalledTimes(1);
+    expect(mockEndTrace).toHaveBeenCalledTimes(1);
   });
 
   describe('bearer token retrieval on mount', () => {
@@ -161,6 +198,7 @@ describe('useFetchPopularTokens', () => {
     const noCacheUndefinedResultCases = [
       {
         description: 'does not cache when the API returns an empty array',
+        traceResult: 'success' as const,
         setupFetchMock: () => {
           globalFetchSpy.mockResolvedValueOnce({
             ok: true,
@@ -171,6 +209,7 @@ describe('useFetchPopularTokens', () => {
       {
         description:
           'does not cache when the API returns a malformed top-level payload',
+        traceResult: 'error' as const,
         setupFetchMock: () => {
           globalFetchSpy.mockResolvedValueOnce({
             ok: true,
@@ -179,7 +218,20 @@ describe('useFetchPopularTokens', () => {
         },
       },
       {
+        description: 'returns undefined when JSON parsing fails',
+        traceResult: 'error' as const,
+        setupFetchMock: () => {
+          globalFetchSpy.mockResolvedValueOnce({
+            ok: true,
+            json: async () => {
+              throw new Error('invalid JSON');
+            },
+          });
+        },
+      },
+      {
         description: 'returns undefined when the response is not ok',
+        traceResult: 'error' as const,
         setupFetchMock: () => {
           globalFetchSpy.mockResolvedValueOnce({
             ok: false,
@@ -191,6 +243,7 @@ describe('useFetchPopularTokens', () => {
       {
         description:
           'returns undefined on AbortError without writing to the cache',
+        traceResult: 'cancelled' as const,
         setupFetchMock: () => {
           const abortError = new Error('aborted');
           abortError.name = 'AbortError';
@@ -201,7 +254,7 @@ describe('useFetchPopularTokens', () => {
 
     it.each(noCacheUndefinedResultCases)(
       '$description',
-      async ({ setupFetchMock }) => {
+      async ({ setupFetchMock, traceResult }) => {
         setupFetchMock();
 
         const { result } = renderHookWithProvider(
@@ -217,6 +270,13 @@ describe('useFetchPopularTokens', () => {
 
         expect(tokens).toBeUndefined();
         expect(popularTokensCache.size).toBe(0);
+        expect(mockTrace).toHaveBeenCalledTimes(1);
+        expect(mockEndTrace).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: TraceName.SwapPopularTokensFetch,
+            data: { result: traceResult },
+          }),
+        );
       },
     );
   });

--- a/app/components/UI/Bridge/hooks/useFetchPopularTokens.ts
+++ b/app/components/UI/Bridge/hooks/useFetchPopularTokens.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { v4 as uuidv4 } from 'uuid';
 import type { CaipChainId } from '@metamask/utils';
 import { BridgeClientId, getClientHeaders } from '@metamask/bridge-controller';
 
@@ -7,6 +8,12 @@ import { BRIDGE_API_BASE_URL } from '../../../../constants/bridge';
 import Engine from '../../../../core/Engine';
 import { selectBasicFunctionalityEnabled } from '../../../../selectors/settings';
 import { getBaseSemVerVersion } from '../../../../util/version';
+import {
+  endTrace,
+  trace,
+  TraceName,
+  TraceOperation,
+} from '../../../../util/trace';
 import type { IncludeAsset, PopularToken } from '../types';
 import {
   cleanupExpiredEntries,
@@ -21,6 +28,8 @@ export interface FetchPopularTokensParams {
   includeAssets?: IncludeAsset[];
   signal?: AbortSignal;
 }
+
+type PopularTokensTraceResult = 'success' | 'cancelled' | 'error';
 
 /**
  * Lightweight fetcher hook for the Bridge `/getTokens/popular` endpoint.
@@ -62,7 +71,21 @@ export const useFetchPopularTokens = () => {
         return cachedEntry.data;
       }
 
+      const traceId = uuidv4();
+      let traceResult: PopularTokensTraceResult = 'success';
+
       try {
+        trace({
+          name: TraceName.SwapPopularTokensFetch,
+          op: TraceOperation.BridgeDataFetch,
+          id: traceId,
+          data: {
+            chain_scope: chainIds.length > 1 ? 'multi_chain' : 'single_chain',
+            chain_ids: chainIds.join(','),
+          },
+          startTime: Date.now(),
+        });
+
         const response = await fetch(
           `${BRIDGE_API_BASE_URL}/getTokens/popular`,
           {
@@ -81,34 +104,48 @@ export const useFetchPopularTokens = () => {
         );
 
         if (response.ok === false) {
+          traceResult = 'error';
           console.error(
             `Failed to fetch popular tokens with status ${response.status}`,
           );
           return undefined;
         }
 
-        const popularAssetsResponse: PopularToken[] = await response.json();
-        const isValidTopLevelPayload = Array.isArray(popularAssetsResponse);
+        const popularAssetsResponse: unknown = await response.json();
+        if (!Array.isArray(popularAssetsResponse)) {
+          traceResult = 'error';
+          return undefined;
+        }
 
-        if (isValidTopLevelPayload && popularAssetsResponse.length > 0) {
+        const popularTokens = popularAssetsResponse as PopularToken[];
+        if (popularAssetsResponse.length > 0) {
           // Cache only valid top-level API payloads so malformed responses do
           // not suppress retries for the full cache TTL.
           setPopularTokensCache({
             includeAssets,
             chainIds,
-            popularTokens: popularAssetsResponse,
+            popularTokens,
           });
-          return popularAssetsResponse;
+          return popularTokens;
         }
 
         return undefined;
       } catch (error) {
         // Ignore abort errors - request was intentionally cancelled
         if (error instanceof Error && error.name === 'AbortError') {
+          traceResult = 'cancelled';
           return undefined;
         }
+        traceResult = 'error';
         console.error('Error fetching popular tokens:', error);
         return undefined;
+      } finally {
+        endTrace({
+          name: TraceName.SwapPopularTokensFetch,
+          id: traceId,
+          timestamp: Date.now(),
+          data: { result: traceResult },
+        });
       }
     },
     [bearerToken],

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -121,6 +121,7 @@ export enum TraceName {
   BridgeBalancesUpdated = 'Bridge Balances Updated',
   SwapQuoteFetch = 'Swap Quote Fetch',
   SwapTokenSearch = 'Swap Token Search',
+  SwapPopularTokensFetch = 'Swap Popular Tokens Fetch',
   Card = 'Card',
   // Earn
   EarnDepositScreen = 'Earn Deposit Screen',


### PR DESCRIPTION
## **Description**

Add Sentry performance instrumentation for uncached requests to the Bridge `/getTokens/popular` endpoint. Each request records its chain scope and the exact requested chain IDs, then closes with an explicit `success`, `cancelled`, or `error` result. Cache hits do not create a fetch trace.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/SWAPS-4982

## **Manual testing steps**

```gherkin
Feature: Popular token fetch performance telemetry

  Scenario: Record popular token fetch telemetry
    Given a development build with Sentry enabled
    When the user opens the Swaps or Bridge token selector
    And popular tokens are fetched for all, favorite, or a single chain
    Then the popular tokens load as before
    And Sentry records a `Swap Popular Tokens Fetch` span
    And the span includes the exact fetched chain IDs and a result
```

Validation completed:
- Pre-commit Prettier and ESLint hooks passed.
- The focused Jest suite reported 12 passing tests; the local runner hung after reporting success and was aborted.

## **Screenshots/Recordings**

### **Before**

N/A — telemetry-only change; no UI changes.

### **After**

N/A — telemetry-only change; no UI changes.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Native Android validation was attempted but blocked by the local Sentry upload configuration.
- [ ] I've tested with a power user scenario
  - Not run; this is a telemetry-only change.
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - The new popular-token fetch span uses `bridge.data_fetch`.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only instrumentation on an existing fetch hook; behavior change is limited to stricter handling of malformed API payloads (still returns undefined).
> 
> **Overview**
> Adds **Sentry performance spans** for uncached Bridge `/getTokens/popular` requests via a new `SwapPopularTokensFetch` trace (operation `bridge.data_fetch`). Each network fetch starts a span with **chain scope** (`single_chain` / `multi_chain`) and the requested **chain IDs**, then closes with **`success`**, **`cancelled`**, or **`error`**; **cache hits do not emit traces**.
> 
> `useFetchPopularTokens` also **tightens response handling**: non-array JSON is treated as failure (traced as error) instead of relying on a combined validity check. Tests mock `trace` / `endTrace` and cover success, cache reuse, and failure paths including JSON parse errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6561b35093c7d140815ca0e4c55a7feac2f30443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->