### PR TITLE
style: update ActivityListItemRow styles and add tests for pending spinner layout

### DIFF
--- a/app/components/UI/ActivityListItemRow/ActivityListItemRow.styles.ts
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRow.styles.ts
@@ -65,6 +65,8 @@ export const createStyles = (
       lineHeight: 18,
       marginTop: 0,
       color: colors.text.default,
+      flexShrink: 1,
+      minWidth: 0,
     } as TextStyle,
     listItemTitleFailed: {
       color: colors.error.default,
@@ -81,7 +83,7 @@ export const createStyles = (
     } as TextStyle,
     listItemAmounts: {
       alignItems: 'flex-end',
-      flexShrink: 1,
+      flexShrink: 0,
       maxWidth: '45%',
       minWidth: 0,
     },
@@ -113,11 +115,14 @@ export const createStyles = (
     titleRow: {
       flexDirection: 'row',
       alignItems: 'center',
+      flexShrink: 1,
+      minWidth: 0,
     },
     titleSpinner: {
       height: 18,
       justifyContent: 'center',
       marginLeft: 6,
+      flexShrink: 0,
       transform: [{ translateY: -2 }],
     },
     statusRow: {

--- a/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
@@ -2444,8 +2444,11 @@ describe('ActivityListItemRow — pending rows', () => {
     );
 
     const title = getByTestId(`activity-title-${item.hash}`);
-    const spinner = getByTestId(`activity-pending-spinner-${item.hash}`);
+    const spinnerContainer = getByTestId(
+      `activity-pending-spinner-container-${item.hash}`,
+    );
     const amount = getByTestId(`activity-primary-amount-${item.hash}`);
+    const amountColumn = getByTestId(`activity-amount-column-${item.hash}`);
 
     expect(title).toHaveTextContent('Unstaking Ethereum');
     expect(amount).toHaveTextContent('+0.0007901 ETH');
@@ -2460,12 +2463,12 @@ describe('ActivityListItemRow — pending rows', () => {
       minWidth: 0,
     });
     expect(
-      ReactNativeStyleSheet.flatten(spinner.parent?.props.style),
+      ReactNativeStyleSheet.flatten(spinnerContainer.props.style),
     ).toMatchObject({
       flexShrink: 0,
     });
     expect(
-      ReactNativeStyleSheet.flatten(amount.parent?.props.style),
+      ReactNativeStyleSheet.flatten(amountColumn.props.style),
     ).toMatchObject({
       flexShrink: 0,
     });

--- a/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRow.test.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
 import type { ReactTestInstance } from 'react-test-renderer';
+import { StyleSheet as ReactNativeStyleSheet } from 'react-native';
 import {
   TransactionStatus,
   TransactionType,
@@ -2419,6 +2420,55 @@ describe('ActivityListItemRow — pending rows', () => {
     expect(getByTestId('activity-subtitle-0xabc').props.children).toBe(
       'To: 0x1234...',
     );
+  });
+
+  it('keeps the pending spinner inside the title column when an amount is present', () => {
+    const item: ActivityListItem = {
+      type: 'unstake',
+      chainId: 'eip155:1',
+      status: 'pending',
+      timestamp: 1_787_646_540_000,
+      hash: '0xactivitypendingunstakelayout',
+      isEarliestNonce: true,
+      data: {
+        token: {
+          direction: 'in',
+          symbol: 'ETH',
+          decimals: 18,
+          amount: '790100000000000',
+        },
+      },
+    };
+    const { getByTestId } = render(
+      <ActivityListItemRow item={item} index={0} {...pendingHandlers()} />,
+    );
+
+    const title = getByTestId(`activity-title-${item.hash}`);
+    const spinner = getByTestId(`activity-pending-spinner-${item.hash}`);
+    const amount = getByTestId(`activity-primary-amount-${item.hash}`);
+
+    expect(title).toHaveTextContent('Unstaking Ethereum');
+    expect(amount).toHaveTextContent('+0.0007901 ETH');
+    expect(ReactNativeStyleSheet.flatten(title.props.style)).toMatchObject({
+      flexShrink: 1,
+      minWidth: 0,
+    });
+    expect(
+      ReactNativeStyleSheet.flatten(title.parent?.props.style),
+    ).toMatchObject({
+      flexShrink: 1,
+      minWidth: 0,
+    });
+    expect(
+      ReactNativeStyleSheet.flatten(spinner.parent?.props.style),
+    ).toMatchObject({
+      flexShrink: 0,
+    });
+    expect(
+      ReactNativeStyleSheet.flatten(amount.parent?.props.style),
+    ).toMatchObject({
+      flexShrink: 0,
+    });
   });
 
   it('renders queued rows with an hourglass prefix and no title spinner', () => {

--- a/app/components/UI/ActivityListItemRow/ActivityListItemRowLayout.tsx
+++ b/app/components/UI/ActivityListItemRow/ActivityListItemRowLayout.tsx
@@ -144,7 +144,10 @@ export function ActivityListItemRowLayout({
   ) : undefined;
   const amountColumn =
     primaryAmountNode || secondaryAmountNode ? (
-      <View style={styles.listItemAmounts}>
+      <View
+        style={styles.listItemAmounts}
+        testID={`activity-amount-column-${testIdSuffix}`}
+      >
         {primaryAmountNode}
         {secondaryAmountNode}
       </View>

--- a/app/components/UI/ActivityListItemRow/PendingActivityListItemRow.tsx
+++ b/app/components/UI/ActivityListItemRow/PendingActivityListItemRow.tsx
@@ -68,7 +68,10 @@ export function PendingActivityListItemRow({
       : subtitleAccountParts;
 
   const titleAccessory = isQueued ? undefined : (
-    <View style={styles.titleSpinner}>
+    <View
+      style={styles.titleSpinner}
+      testID={`activity-pending-spinner-container-${testIdSuffix}`}
+    >
       <PendingSpinner testID={`activity-pending-spinner-${testIdSuffix}`} />
     </View>
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes pending Activity rows where a long title and spinner overlap the amount.
The title column can now shrink while the spinner and amount retain their
required widths, keeping all three elements inside their respective columns.
A regression test covers the pending unstake layout with a visible amount.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed pending Activity row spinners overlapping transaction amounts

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1220

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Pending Activity row layout

  Scenario: View a pending transaction with a long title and an amount
    Given the wallet has a pending unstake transaction with an amount
    And the Activity screen is open

    When the pending transaction row is rendered
    Then the spinner remains next to the transaction title
    And the spinner does not overlap the transaction amount
    And the full amount remains visible in the right column
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/651cec0f-44d5-4842-8bc6-74b07df3204e" /><!-- [screenshots/recordings] -->

### **After**
<img width="380" height="377" alt="Screenshot 2026-08-25 at 12 24 45" src="https://github.com/user-attachments/assets/3f1f323b-fcd1-4169-9716-3552b8f58330" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped flexbox styling and test-only testIDs on Activity list rows; no transaction or data logic changes.
> 
> **Overview**
> Fixes **pending Activity list rows** where a long title plus the pending spinner could overlap the right-hand amount column.
> 
> **Layout:** The title column (`listItemTitle`, `titleRow`) can shrink with `flexShrink: 1` and `minWidth: 0` so text ellipsizes. The **amount column** and **spinner** use `flexShrink: 0` so they keep their width; the amount column no longer shrinks (`listItemAmounts` went from `flexShrink: 1` to `0`).
> 
> **Tests:** Adds `testID`s on the amount column and spinner wrapper, plus a regression test for a pending unstake row with an amount that asserts the expected flex styles on title, spinner, and amount nodes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab2f45dce339d9684c08a05b7305be399ba26cf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->