### PR TITLE
perf: virtualize Social AI followed traders list

### DIFF
--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSection.test.tsx
@@ -78,7 +78,12 @@ jest.mock('../../../../util/notifications/hooks/useSessionProfileId', () => ({
   }),
 }));
 
-jest.mock('./SocialAINotificationPreferencesContent', () => () => null);
+jest.mock(
+  './SocialAINotificationPreferencesContent',
+  () =>
+    ({ ListHeaderComponent }: { ListHeaderComponent?: React.ReactElement }) =>
+      ListHeaderComponent ?? null,
+);
 jest.mock('./AccountsList', () => ({
   AccountsList: ({
     ListHeaderComponent,

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSectionContent.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSectionContent.test.tsx
@@ -41,6 +41,20 @@ jest.mock('./AccountsList.hooks', () => ({
     toggleAllAccounts: jest.fn(),
   }),
 }));
+jest.mock('./SocialAINotificationPreferencesContent', () => {
+  const MockView = jest.requireActual('react-native').View;
+
+  return ({
+    ListHeaderComponent,
+  }: {
+    ListHeaderComponent?: React.ReactElement;
+  }) => (
+    <>
+      {ListHeaderComponent}
+      <MockView testID="notification-preferences-view-traders-list" />
+    </>
+  );
+});
 
 const PUSH_TOGGLE =
   NotificationSettingsViewSelectorsIDs.PUSH_NOTIFICATIONS_TOGGLE;
@@ -180,6 +194,24 @@ describe('NotificationSettingsSectionContent', () => {
       ),
     ).toBeOnTheScreen();
     expect(screen.getByText('Wallet activity')).toBeOnTheScreen();
+  });
+
+  it('uses the Social AI trader list as the only section scroller', () => {
+    renderContent({
+      type: 'socialAI',
+      title: 'Social AI',
+      description: 'Trading signals',
+    });
+
+    expect(
+      screen.queryByTestId(
+        NotificationSettingsViewSelectorsIDs.SECTION_SCROLL_VIEW,
+      ),
+    ).not.toBeOnTheScreen();
+    expect(
+      screen.getByTestId('notification-preferences-view-traders-list'),
+    ).toBeOnTheScreen();
+    expect(screen.getByText('Social AI')).toBeOnTheScreen();
   });
 
   it('disables both channel toggles when disabled is true', () => {

--- a/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSectionContent.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/NotificationSettingsSectionContent.tsx
@@ -183,15 +183,19 @@ const WalletActivitySectionContent = ({
 const SocialAISectionContent = ({
   styles,
   disabled = false,
-}: SectionContentProps) => (
-  <>
-    <View style={styles.line} />
-    <SocialAINotificationPreferencesContent
-      showPushToggle={false}
-      withHorizontalPadding={false}
-      disabled={disabled}
-    />
-  </>
+  ListHeaderComponent,
+}: ListSectionContentProps) => (
+  <SocialAINotificationPreferencesContent
+    showPushToggle={false}
+    withHorizontalPadding={false}
+    disabled={disabled}
+    ListHeaderComponent={
+      <>
+        {ListHeaderComponent}
+        <View style={styles.line} />
+      </>
+    }
+  />
 );
 
 const MarketingSectionContent = ({
@@ -218,7 +222,7 @@ const SECTION_DEFINITIONS: Record<
     Content: WalletActivitySectionContent,
   },
   socialAI: {
-    layout: 'scroll',
+    layout: 'list',
     Content: SocialAISectionContent,
   },
   marketing: {

--- a/app/components/Views/Settings/NotificationsSettings/SocialAINotificationPreferencesContent.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/SocialAINotificationPreferencesContent.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog */
 import { AvatarAccount } from '@metamask/design-system-react-native';
+import { FlashList } from '@shopify/flash-list';
 import { fireEvent, screen } from '@testing-library/react-native';
 import { Image } from 'expo-image';
 import React from 'react';
@@ -33,6 +34,10 @@ jest.mock('@react-navigation/native', () => {
     useNavigation: () => ({ navigate: mockNavigate }),
   };
 });
+
+jest.mock('@shopify/flash-list', () => ({
+  FlashList: jest.requireActual('react-native').FlatList,
+}));
 
 jest.mock('../../../../selectors/currencyRateController', () => ({
   selectCurrentCurrency: () => 'USD',
@@ -212,6 +217,26 @@ describe('SocialAINotificationPreferencesContent', () => {
         NotificationPreferencesSelectorsIDs.TRADER_TOGGLE('trader-2'),
       ).props.value,
     ).toBe(false);
+  });
+
+  it('renders followed traders in a FlashList with stable trader keys', () => {
+    mockUseFollowedTraders.mockReturnValue(
+      makeFollowedTradersResult({ traders: followedTraders }),
+    );
+
+    const { UNSAFE_getByType } = renderComponent();
+    const traderList = UNSAFE_getByType(FlashList);
+
+    expect(
+      screen.getByTestId(NotificationPreferencesSelectorsIDs.TRADERS_LIST),
+    ).toBeOnTheScreen();
+    expect(traderList.props.data).toBe(followedTraders);
+    expect(traderList.props.keyExtractor(followedTraders[0], 0)).toBe(
+      'trader-1',
+    );
+    expect(traderList.props.keyExtractor(followedTraders[0], 1)).toBe(
+      'trader-1',
+    );
   });
 
   it('renders the Maskicon fallback for traders without a profile image', () => {

--- a/app/components/Views/Settings/NotificationsSettings/SocialAINotificationPreferencesContent.test.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/SocialAINotificationPreferencesContent.test.tsx
@@ -239,6 +239,28 @@ describe('SocialAINotificationPreferencesContent', () => {
     );
   });
 
+  it('passes external trader row state to FlashList extraData', () => {
+    mockUseFollowedTraders.mockReturnValue(
+      makeFollowedTradersResult({ traders: followedTraders }),
+    );
+    mockUseNotificationPreferences.mockReturnValue(
+      makeNotificationPreferencesResult({
+        preferences: makePreferences({
+          pushNotificationsEnabled: false,
+          inAppNotificationsEnabled: false,
+          mutedTraderProfileIds: ['trader-1'],
+        }),
+      }),
+    );
+
+    const { UNSAFE_getByType } = renderComponent();
+
+    expect(UNSAFE_getByType(FlashList).props.extraData).toEqual({
+      mutedTraderProfileIds: ['trader-1'],
+      tradingSignalsChannelsDisabled: true,
+    });
+  });
+
   it('renders the Maskicon fallback for traders without a profile image', () => {
     mockUseFollowedTraders.mockReturnValue(
       makeFollowedTradersResult({ traders: followedTraders }),

--- a/app/components/Views/Settings/NotificationsSettings/SocialAINotificationPreferencesContent.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/SocialAINotificationPreferencesContent.tsx
@@ -232,6 +232,13 @@ const SocialAINotificationPreferencesContent = ({
   const separatorStyle = tw.style(
     `h-px bg-muted${withHorizontalPadding ? ' mx-4' : ''}`,
   );
+  const traderRowState = useMemo(
+    () => ({
+      mutedTraderProfileIds: preferences.mutedTraderProfileIds,
+      tradingSignalsChannelsDisabled,
+    }),
+    [preferences.mutedTraderProfileIds, tradingSignalsChannelsDisabled],
+  );
 
   const renderTrader: ListRenderItem<FollowedTrader> = useCallback(
     ({ item: trader }) => (
@@ -402,6 +409,7 @@ const SocialAINotificationPreferencesContent = ({
   return (
     <FlashList
       data={followedTraders}
+      extraData={traderRowState}
       renderItem={renderTrader}
       keyExtractor={getTraderKey}
       getItemType={getTraderItemType}

--- a/app/components/Views/Settings/NotificationsSettings/SocialAINotificationPreferencesContent.tsx
+++ b/app/components/Views/Settings/NotificationsSettings/SocialAINotificationPreferencesContent.tsx
@@ -11,7 +11,8 @@ import {
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useNavigation, type NavigationProp } from '@react-navigation/native';
-import React, { useCallback } from 'react';
+import { FlashList, type ListRenderItem } from '@shopify/flash-list';
+import React, { memo, useCallback, useMemo } from 'react';
 import { Switch, TouchableOpacity, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../../locales/i18n';
@@ -37,12 +38,15 @@ import {
   DEFAULT_TX_AMOUNT_LIMIT,
   useFollowedTraders,
   useNotificationPreferences,
+  type FollowedTrader,
   type TxAmountThreshold,
 } from '../../SocialLeaderboard/NotificationPreferences/hooks';
 import { areTradingSignalsChannelsDisabled } from '../../SocialLeaderboard/NotificationPreferences/hooks/tradingSignalsChannels';
 import { NotificationPreferencesSelectorsIDs } from '../../SocialLeaderboard/NotificationPreferences/NotificationPreferences.testIds';
 
 const AVATAR_SIZE = 40;
+const getTraderKey = (trader: FollowedTrader) => trader.id;
+const getTraderItemType = () => 'trader';
 
 interface TraderNotificationRowProps {
   traderId: string;
@@ -56,73 +60,76 @@ interface TraderNotificationRowProps {
   onPress: (traderId: string, username: string) => void;
 }
 
-const TraderNotificationRow: React.FC<TraderNotificationRowProps> = ({
-  traderId,
-  username,
-  address,
-  avatarUri,
-  isEnabled,
-  isDisabled,
-  withHorizontalPadding,
-  onToggle,
-  onPress,
-}) => {
-  const tw = useTailwind();
-  const { colors, brandColors } = useTheme();
+const TraderNotificationRow: React.FC<TraderNotificationRowProps> = memo(
+  ({
+    traderId,
+    username,
+    address,
+    avatarUri,
+    isEnabled,
+    isDisabled,
+    withHorizontalPadding,
+    onToggle,
+    onPress,
+  }) => {
+    const tw = useTailwind();
+    const { colors, brandColors } = useTheme();
 
-  return (
-    <Box
-      flexDirection={BoxFlexDirection.Row}
-      alignItems={BoxAlignItems.Center}
-      justifyContent={BoxJustifyContent.Between}
-      twClassName={`${withHorizontalPadding ? 'px-4' : ''} py-3${
-        isDisabled ? ' opacity-50' : ''
-      }`}
-      testID={NotificationPreferencesSelectorsIDs.TRADER_ROW(traderId)}
-    >
-      <TouchableOpacity
-        onPress={() => onPress(traderId, username)}
-        accessibilityRole="button"
-        style={tw.style('flex-row items-center gap-3 flex-1 min-w-0 mr-3')}
-        testID={NotificationPreferencesSelectorsIDs.TRADER_PRESS(traderId)}
+    return (
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Between}
+        twClassName={`${withHorizontalPadding ? 'px-4' : ''} py-3${
+          isDisabled ? ' opacity-50' : ''
+        }`}
+        testID={NotificationPreferencesSelectorsIDs.TRADER_ROW(traderId)}
       >
-        <TraderAvatar
-          imageUrl={avatarUri}
-          address={address}
-          size={AVATAR_SIZE}
-          recyclingKey={traderId}
-        />
-
-        <Text
-          variant={TextVariant.BodyMd}
-          fontWeight={FontWeight.Medium}
-          color={TextColor.TextDefault}
-          numberOfLines={1}
-          twClassName="flex-1"
+        <TouchableOpacity
+          onPress={() => onPress(traderId, username)}
+          accessibilityRole="button"
+          style={tw.style('flex-row items-center gap-3 flex-1 min-w-0 mr-3')}
+          testID={NotificationPreferencesSelectorsIDs.TRADER_PRESS(traderId)}
         >
-          {username}
-        </Text>
-      </TouchableOpacity>
+          <TraderAvatar
+            imageUrl={avatarUri}
+            address={address}
+            size={AVATAR_SIZE}
+            recyclingKey={traderId}
+          />
 
-      <Switch
-        value={isEnabled}
-        onValueChange={() => onToggle(traderId)}
-        disabled={isDisabled}
-        trackColor={{
-          true: colors.primary.default,
-          false: colors.border.muted,
-        }}
-        thumbColor={brandColors.white}
-        ios_backgroundColor={colors.border.muted}
-        testID={NotificationPreferencesSelectorsIDs.TRADER_TOGGLE(traderId)}
-      />
-    </Box>
-  );
-};
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextDefault}
+            numberOfLines={1}
+            twClassName="flex-1"
+          >
+            {username}
+          </Text>
+        </TouchableOpacity>
+
+        <Switch
+          value={isEnabled}
+          onValueChange={() => onToggle(traderId)}
+          disabled={isDisabled}
+          trackColor={{
+            true: colors.primary.default,
+            false: colors.border.muted,
+          }}
+          thumbColor={brandColors.white}
+          ios_backgroundColor={colors.border.muted}
+          testID={NotificationPreferencesSelectorsIDs.TRADER_TOGGLE(traderId)}
+        />
+      </Box>
+    );
+  },
+);
 
 export interface SocialAINotificationPreferencesContentProps {
   showPushToggle?: boolean;
   withHorizontalPadding?: boolean;
+  ListHeaderComponent?: React.ReactElement;
   /**
    * Forces the dependent Trading Signals UI (thresholds, traders) into the
    * disabled/greyed-out look — same as when both channels are off. Used by
@@ -134,6 +141,7 @@ export interface SocialAINotificationPreferencesContentProps {
 const SocialAINotificationPreferencesContent = ({
   showPushToggle = true,
   withHorizontalPadding = true,
+  ListHeaderComponent,
   disabled = false,
 }: SocialAINotificationPreferencesContentProps) => {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
@@ -225,141 +233,187 @@ const SocialAINotificationPreferencesContent = ({
     `h-px bg-muted${withHorizontalPadding ? ' mx-4' : ''}`,
   );
 
-  return (
-    <>
-      {showPreferencesSkeleton ? (
-        <PreferencesSkeleton />
-      ) : (
-        <>
-          {showPushToggle ? (
-            <>
-              <Box
-                flexDirection={BoxFlexDirection.Row}
-                alignItems={BoxAlignItems.Center}
-                justifyContent={BoxJustifyContent.Between}
-                twClassName={`${horizontalPaddingClassName} py-4`}
-              >
-                <Text
-                  variant={TextVariant.BodyMd}
-                  color={TextColor.TextDefault}
+  const renderTrader: ListRenderItem<FollowedTrader> = useCallback(
+    ({ item: trader }) => (
+      <TraderNotificationRow
+        traderId={trader.id}
+        username={trader.username}
+        address={trader.address}
+        avatarUri={trader.avatarUri}
+        isEnabled={isTraderNotificationEnabled(trader.id)}
+        isDisabled={tradingSignalsChannelsDisabled}
+        withHorizontalPadding={withHorizontalPadding}
+        onToggle={handleToggleTrader}
+        onPress={handleTraderPress}
+      />
+    ),
+    [
+      handleToggleTrader,
+      handleTraderPress,
+      isTraderNotificationEnabled,
+      tradingSignalsChannelsDisabled,
+      withHorizontalPadding,
+    ],
+  );
+
+  const listHeader = useMemo(
+    () => (
+      <>
+        {ListHeaderComponent}
+
+        {showPreferencesSkeleton ? (
+          <PreferencesSkeleton />
+        ) : (
+          <>
+            {showPushToggle ? (
+              <>
+                <Box
+                  flexDirection={BoxFlexDirection.Row}
+                  alignItems={BoxAlignItems.Center}
+                  justifyContent={BoxJustifyContent.Between}
+                  twClassName={`${horizontalPaddingClassName} py-4`}
                 >
-                  {strings(
-                    'social_leaderboard.notification_preferences.allow_push_notifications',
-                  )}
-                </Text>
-                <Switch
-                  value={Boolean(preferences.pushNotificationsEnabled)}
-                  onValueChange={handleSetEnabled}
-                  trackColor={{
-                    true: colors.primary.default,
-                    false: colors.border.muted,
-                  }}
-                  thumbColor={brandColors.white}
-                  ios_backgroundColor={colors.border.muted}
-                  testID={NotificationPreferencesSelectorsIDs.GLOBAL_TOGGLE}
-                />
-              </Box>
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    color={TextColor.TextDefault}
+                  >
+                    {strings(
+                      'social_leaderboard.notification_preferences.allow_push_notifications',
+                    )}
+                  </Text>
+                  <Switch
+                    value={Boolean(preferences.pushNotificationsEnabled)}
+                    onValueChange={handleSetEnabled}
+                    trackColor={{
+                      true: colors.primary.default,
+                      false: colors.border.muted,
+                    }}
+                    thumbColor={brandColors.white}
+                    ios_backgroundColor={colors.border.muted}
+                    testID={NotificationPreferencesSelectorsIDs.GLOBAL_TOGGLE}
+                  />
+                </Box>
 
-              <View style={separatorStyle} />
-            </>
-          ) : null}
+                <View style={separatorStyle} />
+              </>
+            ) : null}
 
-          <ThresholdRadioList
-            selected={
-              (preferences.txAmountLimit ??
-                DEFAULT_TX_AMOUNT_LIMIT) as TxAmountThreshold
-            }
-            onChange={handleSetTxAmountLimit}
-            isDisabled={tradingSignalsChannelsDisabled}
-            currency={currentCurrency}
-            labelText={strings(
-              'social_leaderboard.notification_preferences.trades_over_label',
-            )}
-            withHorizontalPadding={withHorizontalPadding}
-            testIDForAmount={
-              NotificationPreferencesSelectorsIDs.THRESHOLD_OPTION
-            }
-          />
-        </>
-      )}
+            <ThresholdRadioList
+              selected={
+                (preferences.txAmountLimit ??
+                  DEFAULT_TX_AMOUNT_LIMIT) as TxAmountThreshold
+              }
+              onChange={handleSetTxAmountLimit}
+              isDisabled={tradingSignalsChannelsDisabled}
+              currency={currentCurrency}
+              labelText={strings(
+                'social_leaderboard.notification_preferences.trades_over_label',
+              )}
+              withHorizontalPadding={withHorizontalPadding}
+              testIDForAmount={
+                NotificationPreferencesSelectorsIDs.THRESHOLD_OPTION
+              }
+            />
+          </>
+        )}
 
-      <Box
-        twClassName={`${horizontalPaddingClassName} pt-5 pb-2`}
-        testID={NotificationPreferencesSelectorsIDs.TRADERS_SECTION}
-      >
-        <Text
-          variant={TextVariant.BodyMd}
-          fontWeight={FontWeight.Medium}
-          color={
-            tradingSignalsChannelsDisabled
-              ? TextColor.TextMuted
-              : TextColor.TextDefault
-          }
-        >
-          {strings(
-            'social_leaderboard.notification_preferences.traders_you_follow',
-          )}
-        </Text>
-        <Text
-          variant={TextVariant.BodySm}
-          color={
-            tradingSignalsChannelsDisabled
-              ? TextColor.TextMuted
-              : TextColor.TextAlternative
-          }
-          twClassName="mt-0.5"
-        >
-          {strings(
-            'social_leaderboard.notification_preferences.traders_you_follow_desc',
-          )}
-        </Text>
-      </Box>
-
-      {showFollowedError ? (
-        <Box testID={NotificationPreferencesSelectorsIDs.TRADERS_ERROR}>
-          <ErrorState
-            title={strings(
-              'social_leaderboard.notification_preferences.error_loading_followed',
-            )}
-            onRetry={refreshFollowed}
-          />
-        </Box>
-      ) : showFollowedLoading ? (
-        <View testID={NotificationPreferencesSelectorsIDs.TRADERS_LOADING}>
-          <TradersFollowedSkeleton />
-        </View>
-      ) : showFollowedEmpty ? (
         <Box
-          twClassName={`${horizontalPaddingClassName} py-6`}
-          testID={NotificationPreferencesSelectorsIDs.TRADERS_EMPTY}
+          twClassName={`${horizontalPaddingClassName} pt-5 pb-2`}
+          testID={NotificationPreferencesSelectorsIDs.TRADERS_SECTION}
         >
           <Text
             variant={TextVariant.BodyMd}
-            color={TextColor.TextAlternative}
-            twClassName="text-center"
+            fontWeight={FontWeight.Medium}
+            color={
+              tradingSignalsChannelsDisabled
+                ? TextColor.TextMuted
+                : TextColor.TextDefault
+            }
           >
             {strings(
-              'social_leaderboard.notification_preferences.traders_you_follow_empty',
+              'social_leaderboard.notification_preferences.traders_you_follow',
+            )}
+          </Text>
+          <Text
+            variant={TextVariant.BodySm}
+            color={
+              tradingSignalsChannelsDisabled
+                ? TextColor.TextMuted
+                : TextColor.TextAlternative
+            }
+            twClassName="mt-0.5"
+          >
+            {strings(
+              'social_leaderboard.notification_preferences.traders_you_follow_desc',
             )}
           </Text>
         </Box>
-      ) : (
-        followedTraders.map((trader) => (
-          <TraderNotificationRow
-            key={trader.id}
-            traderId={trader.id}
-            username={trader.username}
-            address={trader.address}
-            avatarUri={trader.avatarUri}
-            isEnabled={isTraderNotificationEnabled(trader.id)}
-            isDisabled={tradingSignalsChannelsDisabled}
-            withHorizontalPadding={withHorizontalPadding}
-            onToggle={handleToggleTrader}
-            onPress={handleTraderPress}
-          />
-        ))
+      </>
+    ),
+    [
+      ListHeaderComponent,
+      brandColors.white,
+      colors.border.muted,
+      colors.primary.default,
+      currentCurrency,
+      handleSetEnabled,
+      handleSetTxAmountLimit,
+      horizontalPaddingClassName,
+      preferences.pushNotificationsEnabled,
+      preferences.txAmountLimit,
+      separatorStyle,
+      showPreferencesSkeleton,
+      showPushToggle,
+      tradingSignalsChannelsDisabled,
+      withHorizontalPadding,
+    ],
+  );
+
+  const listEmpty = showFollowedError ? (
+    <Box testID={NotificationPreferencesSelectorsIDs.TRADERS_ERROR}>
+      <ErrorState
+        title={strings(
+          'social_leaderboard.notification_preferences.error_loading_followed',
+        )}
+        onRetry={refreshFollowed}
+      />
+    </Box>
+  ) : showFollowedLoading ? (
+    <View testID={NotificationPreferencesSelectorsIDs.TRADERS_LOADING}>
+      <TradersFollowedSkeleton />
+    </View>
+  ) : showFollowedEmpty ? (
+    <Box
+      twClassName={`${horizontalPaddingClassName} py-6`}
+      testID={NotificationPreferencesSelectorsIDs.TRADERS_EMPTY}
+    >
+      <Text
+        variant={TextVariant.BodyMd}
+        color={TextColor.TextAlternative}
+        twClassName="text-center"
+      >
+        {strings(
+          'social_leaderboard.notification_preferences.traders_you_follow_empty',
+        )}
+      </Text>
+    </Box>
+  ) : null;
+
+  return (
+    <FlashList
+      data={followedTraders}
+      renderItem={renderTrader}
+      keyExtractor={getTraderKey}
+      getItemType={getTraderItemType}
+      ListHeaderComponent={listHeader}
+      ListEmptyComponent={listEmpty}
+      style={tw.style('flex-1')}
+      contentContainerStyle={tw.style(
+        `${withHorizontalPadding ? '' : 'px-4 '}pb-12`,
       )}
-    </>
+      showsVerticalScrollIndicator={false}
+      testID={NotificationPreferencesSelectorsIDs.TRADERS_LIST}
+    />
   );
 };
 

--- a/app/components/Views/SocialLeaderboard/NotificationPreferences/NotificationPreferences.testIds.ts
+++ b/app/components/Views/SocialLeaderboard/NotificationPreferences/NotificationPreferences.testIds.ts
@@ -9,6 +9,7 @@ export const NotificationPreferencesSelectorsIDs = {
   TRADERS_EMPTY: 'notification-preferences-view-traders-empty',
   TRADERS_ERROR: 'notification-preferences-view-traders-error',
   TRADERS_LOADING: 'notification-preferences-view-traders-loading',
+  TRADERS_LIST: 'notification-preferences-view-traders-list',
   TRADER_TOGGLE: (traderId: string) =>
     `notification-preferences-view-trader-toggle-${traderId}`,
   TRADER_ROW: (traderId: string) =>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Virtualizes the user-growable followed-traders list in Social AI notification
preferences. The Social AI section now uses one `FlashList` as its only vertical
scroller, with the section title, channel toggles, threshold controls, and
trader heading rendered in `ListHeaderComponent`.

Trader rows use stable IDs and memoization so only visible rows mount and rows
can be recycled as the user scrolls. Loading, error, empty, disabled, toggle,
and profile-navigation behavior remain unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1324

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Virtualized Social AI followed-traders notification list

  Scenario: user scrolls a long followed-traders list
    Given MetaMask notifications and Social AI are enabled
    And the user follows enough traders to overflow the screen
    When the user opens Settings > Notifications > Social AI
    And scrolls through the followed-traders list
    Then the entire Social AI section scrolls as one continuous list
    And trader rows render as they enter the viewport
    And the header controls remain accessible at the top of the list

  Scenario: user toggles a recycled trader row
    Given the user is viewing a long followed-traders list
    When the user toggles notifications for a trader
    And scrolls the trader off-screen and back into view
    Then the trader retains the updated notification state
    And the full list does not visibly remount
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/performance refactor in notification settings with behavior preserved and added unit tests; no auth, persistence, or API contract changes.
> 
> **Overview**
> **Virtualizes** the Social AI followed-traders list and makes it the **only vertical scroller** for that notification section.
> 
> `SocialAINotificationPreferencesContent` now renders traders in a **`FlashList`** instead of mapping every row. Threshold controls, optional push toggle, and the “traders you follow” heading sit in **`ListHeaderComponent`**; loading, error, and empty states use **`ListEmptyComponent`**. Rows are **`memo`**’d, keyed by trader id, and **`extraData`** carries mute/channel-disabled state so recycled rows stay in sync.
> 
> In **`NotificationSettingsSectionContent`**, the Social AI section switches from **`scroll`** to **`list`** layout (like wallet activity). Section chrome (title, channel toggles, divider) is passed into the Social AI content via **`ListHeaderComponent`** so the outer section scroll view is no longer used.
> 
> Tests and **`TRADERS_LIST`** test id cover FlashList wiring and the single-scroller behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b089dae5f313287611916f0a437014e65ba080a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->