### PR TITLE
fix(subscriptions): restore HomeNav when cancel stack has no origin

### DIFF
--- a/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.test.tsx
+++ b/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.test.tsx
@@ -11,7 +11,7 @@ import { POST_CANCELLATION_PRO_HUB_SOURCE } from './CancelMembership.utils';
 const mockGoBack = jest.fn();
 const mockDispatch = jest.fn();
 const mockSetOptions = jest.fn();
-const mockAddListener = jest.fn().mockReturnValue(jest.fn());
+const mockAddListener = jest.fn();
 
 jest.mock('@react-navigation/native', () => {
   const actual = jest.requireActual('@react-navigation/native');
@@ -80,7 +80,8 @@ const renderScreen = () => render(<CancelMembership />);
 
 describe('CancelMembership', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
+    mockAddListener.mockReturnValue(jest.fn());
   });
 
   afterEach(() => {

--- a/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.utils.test.ts
+++ b/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.utils.test.ts
@@ -137,4 +137,22 @@ describe('buildPostCancellationResetState', () => {
       state: homeNavNestedState,
     });
   });
+
+  it('inserts HomeNav under Pro Hub when the stack has no non-Pro origin screen', () => {
+    const state = createStackState([
+      Routes.PRO_HUB.ROOT,
+      Routes.PRO_HUB.CANCEL_MEMBERSHIP,
+    ]);
+
+    const nextState = buildPostCancellationResetState(state);
+
+    expect(nextState.index).toBe(1);
+    expect(nextState.routes).toEqual([
+      { name: Routes.ONBOARDING.HOME_NAV },
+      {
+        name: Routes.PRO_HUB.ROOT,
+        params: { source: POST_CANCELLATION_PRO_HUB_SOURCE },
+      },
+    ]);
+  });
 });

--- a/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.utils.ts
+++ b/app/components/Views/ProHub/screens/CancelMembership/CancelMembership.utils.ts
@@ -22,6 +22,9 @@ const PRO_FLOW_ROUTE_NAMES = new Set<string>([
  * Preserved routes keep nested `state` and `params`. HomeNav is a tab
  * navigator; dropping its nested state would remount it on the initial Wallet
  * tab instead of the Money (or other) tab that started the flow.
+ *
+ * If every route is a Pro / Join Pro screen, HomeNav is inserted so Header
+ * back from Pro Hub has a destination instead of a single-screen dead end.
  */
 export const buildPostCancellationResetState = (
   state: NavigationState,
@@ -39,8 +42,16 @@ export const buildPostCancellationResetState = (
         : {}),
     }));
 
+  // A Pro-only stack (deep link, prior reset) would leave Pro Hub with
+  // nothing underneath. HomeNav is the app's safe root so Header back
+  // is never a dead end.
+  const originRoutes =
+    preservedRoutes.length > 0
+      ? preservedRoutes
+      : [{ name: Routes.ONBOARDING.HOME_NAV }];
+
   const routes = [
-    ...preservedRoutes,
+    ...originRoutes,
     {
       name: Routes.PRO_HUB.ROOT,
       params: { source: POST_CANCELLATION_PRO_HUB_SOURCE },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Follow-up to #35229. That PR landed the post-cancel stack reset, but the review-comment guard that inserts `HomeNav` under Pro Hub was committed after the squash merge and never made it onto `main`.

If every route in the stack is a Pro / Join Pro screen (deep link or a prior reset), `preservedRoutes` is empty and Done would reset to a single Pro Hub screen with nowhere for Header back to go. This PR inserts `Routes.ONBOARDING.HOME_NAV` as the origin in that case.

Also resets `mockAddListener` in `beforeEach` (`jest.resetAllMocks()` plus a fresh `mockReturnValue`) so the `beforeRemove` mock implementation cannot leak between tests.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Pro Hub back navigation getting stuck after cancel membership when no origin screen is on the stack

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: #35229

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Cancel membership Done navigation fallback

  Background:
    Given I am logged into MetaMask Mobile
    And I have an active Pro membership

  Scenario: Done still lands on Pro Hub when the flow started from Money
    Given I opened Pro Hub from the Money tab
    And I completed cancel membership to the success step

    When user taps Done
    Then I should see Pro Hub
    When user taps Header back
    Then I should return to the Money tab

  Scenario: Done does not leave a dead-end Pro Hub stack
    Given I reached cancel membership success with only Pro screens on the stack

    When user taps Done
    Then I should see Pro Hub
    When user taps Header back
    Then I should land on Home (Wallet) instead of staying on Pro Hub
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — navigation-stack guard only; no UI change.

### **After**

N/A — navigation-stack guard only; no UI change.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)