### PR TITLE
refactor(networks): optimize network filtering logic in CustomNetwork component

### DIFF
--- a/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.tsx
+++ b/app/components/Views/Settings/NetworksSettings/NetworkSettings/CustomNetworkView/CustomNetwork.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import NetworkModals from '../../../../../UI/NetworkModal';
 import { View, TouchableOpacity } from 'react-native';
 import { useSelector } from 'react-redux';
@@ -78,15 +78,11 @@ const CustomNetwork = ({
     selectAdditionalNetworksBlacklistFeatureFlag,
   );
 
-  // Apply blacklist filter to the network list
-  const baseNetworkList = customNetworksList ?? PopularList;
-  const filteredNetworkList = getFilteredPopularNetworks(
-    blacklistedChainIds,
-    baseNetworkList,
-  );
-
-  const supportedNetworkList = filteredNetworkList.map(
-    (networkConfiguration: Network) => {
+  const filteredPopularList = useMemo(() => {
+    const supportedNetworkList = getFilteredPopularNetworks(
+      blacklistedChainIds,
+      customNetworksList ?? PopularList,
+    ).map((networkConfiguration: Network) => {
       const isAdded = Object.values(networkConfigurations).some(
         (
           savedNetwork: NetworkConfiguration | MultichainNetworkConfiguration,
@@ -108,16 +104,22 @@ const CustomNetwork = ({
         ...networkConfiguration,
         isAdded,
       };
-    },
-  );
+    });
+
+    return showAddedNetworks
+      ? supportedNetworkList
+      : supportedNetworkList.filter((network) => !network.isAdded);
+  }, [
+    blacklistedChainIds,
+    customNetworksList,
+    networkConfigurations,
+    showAddedNetworks,
+  ]);
 
   const { colors } = useTheme();
   const { styles } = useStyles(styleSheet, {});
   const networkSettingsStyles = createStyles();
   const customNetworkStyles = createCustomNetworkStyles({ colors });
-  const filteredPopularList = showAddedNetworks
-    ? supportedNetworkList
-    : supportedNetworkList.filter((n) => !n.isAdded);
 
   const handleNetworkPress = useCallback(
     async (networkConfiguration: Network & { isAdded: boolean }) => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`CustomNetwork` rebuilt its filtered and annotated network list on every component render, including modal-state renders where the network inputs had not changed. This repeatedly allocated network rows and reran the nested configured-network lookup.

This change memoizes the complete derivation using the network configurations, blacklist, optional custom list, and added-network visibility as dependencies. Existing list filtering and rendering behavior remains unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: TMCU-1330

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Additional network list derivation

  Background:
    Given I am logged into MetaMask Mobile
    And I have at least one popular network that has not been added

  Scenario: user opens and closes the popular network modal
    Given I am viewing the additional networks list

    When user selects an available popular network
    Then the network confirmation modal should open
    And the selected network details should be correct

    When user closes the network confirmation modal
    Then the additional networks list should remain unchanged
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Render-time memoization only; no changes to filtering rules, network add flow, or data handling.
> 
> **Overview**
> **CustomNetwork** no longer rebuilds the blacklist-filtered popular network list and `isAdded` annotations on every render (including when only the network confirmation modal opens or closes).
> 
> That full pipeline—`getFilteredPopularNetworks`, the per-row configured-network lookup, and optional hiding of already-added networks—is now wrapped in **`useMemo`** with dependencies on blacklist flags, the custom list override, Redux network configurations, and `showAddedNetworks`. List content and UI behavior stay the same; redundant allocations and nested lookups are avoided when unrelated state updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a6ab8897552a85346eaf064e76c9781d2729caa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->