### PR TITLE
fix(perps): align wallet ListItem with Pro Mode design

### DIFF
--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.test.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.test.tsx
@@ -220,13 +220,17 @@ describe('PerpsCard', () => {
   describe('Rendering', () => {
     it('renders position card with correct content', () => {
       // Arrange & Act
-      const { getByText } = render(
+      const { getByText, queryByText } = render(
         <PerpsCard position={mockPosition} testID="test-position-card" />,
       );
 
-      // Assert
-      expect(getByText('ETH 3x long')).toBeDefined();
-      expect(getByText('1.5 ETH')).toBeDefined();
+      // Assert — Pro-mode layout: symbol + badge, size/balance in subtitle, PnL split
+      expect(getByText('ETH')).toBeOnTheScreen();
+      expect(getByText('3x Long')).toBeOnTheScreen();
+      expect(getByText(/1\.5 ETH • \$4,350/)).toBeOnTheScreen();
+      expect(getByText('+$150.00')).toBeOnTheScreen();
+      expect(queryByText('ETH 3x long')).toBeNull();
+      expect(queryByText(/\+\$150\.00 \(/)).toBeNull();
     });
 
     it('renders order card with correct content', () => {
@@ -266,7 +270,8 @@ describe('PerpsCard', () => {
       );
 
       // Assert
-      expect(getByText('+$100.50 (+5.0%)')).toBeDefined();
+      expect(getByText('+$100.50')).toBeOnTheScreen();
+      expect(getByText('+5.0%')).toBeOnTheScreen();
     });
 
     it('displays correct PnL color for negative position', () => {
@@ -283,7 +288,8 @@ describe('PerpsCard', () => {
       );
 
       // Assert
-      expect(getByText('-$50.25 (-2.5%)')).toBeDefined();
+      expect(getByText('-$50.25')).toBeOnTheScreen();
+      expect(getByText('-2.5%')).toBeOnTheScreen();
     });
 
     it('displays short position correctly', () => {
@@ -299,8 +305,9 @@ describe('PerpsCard', () => {
       );
 
       // Assert
-      expect(getByText('ETH 3x short')).toBeDefined();
-      expect(getByText('1.5 ETH')).toBeDefined();
+      expect(getByText('ETH')).toBeOnTheScreen();
+      expect(getByText('3x Short')).toBeOnTheScreen();
+      expect(getByText(/1\.5 ETH/)).toBeOnTheScreen();
     });
 
     it('displays order side correctly', () => {
@@ -453,7 +460,8 @@ describe('PerpsCard', () => {
       );
 
       // Assert - actual values visible, no hiding dots
-      expect(getByText('+$100.50 (+5.0%)')).toBeOnTheScreen();
+      expect(getByText('+$100.50')).toBeOnTheScreen();
+      expect(getByText('+5.0%')).toBeOnTheScreen();
       expect(queryByText(DOTS_SHORT)).toBeNull();
     });
 
@@ -482,9 +490,10 @@ describe('PerpsCard', () => {
         <PerpsCard position={mockPosition} testID="test-card" />,
       );
 
-      // Assert - title stays visible; size is treated as sensitive
-      expect(getByText('ETH 3x long')).toBeOnTheScreen();
-      expect(queryByText('1.5 ETH')).toBeNull();
+      // Assert - title and leverage badge stay visible; size/balance is treated as sensitive
+      expect(getByText('ETH')).toBeOnTheScreen();
+      expect(getByText('3x Long')).toBeOnTheScreen();
+      expect(queryByText(/1\.5 ETH/)).toBeNull();
     });
   });
 });

--- a/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
+++ b/app/components/UI/Perps/components/PerpsCard/PerpsCard.tsx
@@ -9,6 +9,8 @@ import {
   ListItemVariant,
   SensitiveText,
   SensitiveTextLength,
+  Tag,
+  TagSeverity,
   Text,
   TextColor,
   TextVariant,
@@ -45,6 +47,8 @@ import { MetaMetricsEvents } from '../../../../../core/Analytics/MetaMetrics.eve
 
 interface PositionListDisplay {
   title: string;
+  badgeText: string;
+  badgeSeverity: TagSeverity;
   description: string;
   valueText: string;
   subvalueText: string;
@@ -63,21 +67,25 @@ const getPositionListDisplay = (position: Position): PositionListDisplay => {
   const isLong = parseFloat(position.size) > 0;
   const displaySymbol = getPerpsDisplaySymbol(position.symbol);
   const absoluteSize = Math.abs(parseFloat(position.size));
-  const directionLower = isLong
-    ? strings('perps.market.long_lowercase')
-    : strings('perps.market.short_lowercase');
+  const directionLabel = isLong
+    ? strings('perps.market.long')
+    : strings('perps.market.short');
+  const positionValueDisplay = formatPerpsFiat(position.positionValue, {
+    ranges: PRICE_RANGES_MINIMAL_VIEW,
+  });
 
   const pnlValue = parseFloat(position.unrealizedPnl);
   const roeValue = parseFloat(position.returnOnEquity) * 100;
 
   return {
-    // Match main: leverage lives in the title string (e.g. "ETH 3x long")
-    title: `${displaySymbol} ${position.leverage.value}x ${directionLower}`,
-    description: `${formatPositionSize(absoluteSize.toString())} ${displaySymbol}`,
-    valueText: formatPerpsFiat(position.positionValue, {
-      ranges: PRICE_RANGES_MINIMAL_VIEW,
-    }),
-    subvalueText: `${formatPnl(pnlValue)} (${formatPercentage(roeValue, 1)})`,
+    title: displaySymbol,
+    badgeText: `${position.leverage.value}x ${directionLabel}`,
+    badgeSeverity: isLong ? TagSeverity.Success : TagSeverity.Danger,
+    description: `${formatPositionSize(
+      absoluteSize.toString(),
+    )} ${displaySymbol} • ${positionValueDisplay}`,
+    valueText: formatPnl(pnlValue),
+    subvalueText: formatPercentage(roeValue, 1),
     subvalueColor:
       pnlValue >= 0 ? TextColor.SuccessDefault : TextColor.ErrorDefault,
   };
@@ -180,6 +188,11 @@ const PerpsCardContent: React.FC<PerpsCardContentProps> = ({
   }
 
   const title = positionDisplay?.title ?? orderDisplay?.title ?? '';
+  const titleEndAccessory = positionDisplay ? (
+    <Tag severity={positionDisplay.badgeSeverity} twClassName="self-center">
+      {positionDisplay.badgeText}
+    </Tag>
+  ) : undefined;
   const descriptionNode = (
     <SensitiveText
       variant={TextVariant.BodySm}
@@ -191,11 +204,15 @@ const PerpsCardContent: React.FC<PerpsCardContentProps> = ({
       {positionDisplay?.description ?? orderDisplay?.description ?? ''}
     </SensitiveText>
   );
+  const valueColor =
+    privacyMode || !position
+      ? TextColor.TextDefault
+      : (positionDisplay?.subvalueColor ?? TextColor.TextDefault);
   const valueNode = (
     <SensitiveText
       variant={TextVariant.BodyMd}
       fontWeight={FontWeight.Medium}
-      color={TextColor.TextDefault}
+      color={valueColor}
       isHidden={privacyMode}
       length={SensitiveTextLength.Short}
     >
@@ -236,6 +253,17 @@ const PerpsCardContent: React.FC<PerpsCardContentProps> = ({
         symbol ? <PerpsTokenLogo symbol={symbol} size={iconSize} /> : undefined
       }
       title={title}
+      titleProps={
+        titleEndAccessory
+          ? {
+              numberOfLines: 1,
+              // flexShrink lets the title yield space to the leverage badge.
+              // eslint-disable-next-line react-native/no-inline-styles
+              style: { flexShrink: 1 },
+            }
+          : undefined
+      }
+      titleEndAccessory={titleEndAccessory}
       description={descriptionNode}
       value={valueNode}
       subvalue={subvalueNode}

--- a/tests/page-objects/Perps/PerpsView.ts
+++ b/tests/page-objects/Perps/PerpsView.ts
@@ -143,13 +143,10 @@ class PerpsView {
   }
 
   private getPositionPrimaryLine(
-    symbol: string,
+    _symbol: string,
     direction: 'long' | 'short',
   ): EncapsulatedElementType {
-    const escapedSymbol = symbol.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return Matchers.getElementByText(
-      new RegExp(`${escapedSymbol} \\d+x ${direction}`),
-    );
+    return Matchers.getElementByText(new RegExp(`\\d+x ${direction}`, 'i'));
   }
 
   // Orders section on the Perps main tab
@@ -260,7 +257,7 @@ class PerpsView {
   }
 
   /**
-   * After fill: order label gone and position row matches `{symbol} {n}x {direction}` (PerpsCard).
+   * After fill: order label gone and position row matches symbol + `{n}x {direction}` badge (PerpsCard).
    */
   async expectPositionRowAfterLimitOrderFilled(
     options: PerpsPortfolioLimitFlowExpectOptions,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Perps position rows in Wallet (and Perps home) showed the same data as Pro Mode but used a different ListItem layout: leverage and direction were part of the title, balance sat on the right, and PnL amount/percentage were combined in the subvalue.

This updates `PerpsCard` so Wallet matches Pro Mode: symbol as the title with a `Nx Long/Short` tag, size and balance in the subtitle, and PnL amount/percentage split across value and subvalue.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Aligned the Perps position list item in Wallet with the Pro Mode design

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:
Refs: TAT-3776

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps position ListItem consistency

  Background:
    Given I am logged into MetaMask Mobile
    And I have at least one open Perps position

  Scenario: user compares Wallet and Pro Mode position rows
    Given I am on the Wallet home screen
    And the Perps section shows my open position

    When I view the position ListItem
    Then the title is the asset symbol only
    And leverage and direction appear in a badge (for example "3x Long")
    And size and balance appear in the subtitle
    And PnL amount is the right-side value
    And PnL percentage is the right-side subvalue

    When I open the same position in Perps Pro Mode
    Then the ListItem layout matches Wallet (title, badge, subtitle, value, subvalue)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A — device screenshots were not captured; layout is covered by PerpsCard unit tests.

### **After**

N/A — device screenshots were not captured; layout is covered by PerpsCard unit tests.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
