### PR TITLE
feat(top-traders): enhance TopTradersSection with visibility handling and query optimizations

### DIFF
--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.test.tsx
@@ -9,6 +9,7 @@ import { SectionRefreshHandle } from '../../types';
 const mockRefetch = jest.fn().mockResolvedValue(undefined);
 const mockNavigate = jest.fn();
 const mockPlayErrorNotification = jest.fn(() => Promise.resolve());
+let mockHasFetched = true;
 
 jest.mock('../../../../../util/haptics', () => ({
   playErrorNotification: () => mockPlayErrorNotification(),
@@ -74,7 +75,10 @@ const mockUseTopTraders = jest.fn((_options?: unknown) => ({
 }));
 
 jest.mock('./hooks', () => ({
-  useTopTraders: (args: unknown) => mockUseTopTraders(args),
+  useTopTraders: (args: unknown) => ({
+    hasFetched: mockHasFetched,
+    ...mockUseTopTraders(args),
+  }),
   usePrefetchTraderProfiles: jest.fn(),
 }));
 
@@ -124,6 +128,17 @@ jest.mock('../../hooks/useSectionViewportVisible', () => ({
   __esModule: true,
   default: jest.fn(() => ({ isVisible: true, onLayout: jest.fn() })),
 }));
+
+jest.mock('../../hooks/useSectionPerformance', () => ({
+  useSectionPerformance: jest.fn(),
+}));
+
+const mockUseSectionViewportVisible = jest.requireMock(
+  '../../hooks/useSectionViewportVisible',
+).default as jest.Mock;
+const mockUseSectionPerformance = jest.requireMock(
+  '../../hooks/useSectionPerformance',
+).useSectionPerformance as jest.Mock;
 
 let mockNotificationPreferences = {
   ...DEFAULT_SOCIAL_AI_PREFERENCES,
@@ -200,6 +215,11 @@ describe('TopTradersSection', () => {
     jest.clearAllMocks();
     mockSelectSocialLeaderboardEnabled.mockImplementation(() => true);
     mockSelectSocialLeaderboardPerpsEnabled.mockImplementation(() => true);
+    mockHasFetched = true;
+    mockUseSectionViewportVisible.mockReturnValue({
+      isVisible: true,
+      onLayout: jest.fn(),
+    });
     mockNotificationPreferences = {
       ...DEFAULT_SOCIAL_AI_PREFERENCES,
       mutedTraderProfileIds: [
@@ -227,6 +247,148 @@ describe('TopTradersSection', () => {
         timeframe: '7d',
         limit: 50,
       }),
+    );
+  });
+
+  it('defers the leaderboard query while the section is offscreen', () => {
+    mockUseSectionViewportVisible.mockReturnValue({
+      isVisible: false,
+      onLayout: jest.fn(),
+    });
+
+    renderWithProvider(<TopTradersSection {...defaultProps} />);
+
+    expect(mockUseTopTraders).toHaveBeenLastCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it('keeps a measurable skeleton mounted before the first query', () => {
+    mockUseSectionViewportVisible.mockReturnValue({
+      isVisible: false,
+      onLayout: jest.fn(),
+    });
+    mockUseTopTraders.mockReturnValue({
+      traders: [],
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refresh: mockRefetch,
+      toggleFollow: jest.fn(),
+    });
+    mockHasFetched = false;
+
+    renderWithProvider(<TopTradersSection {...defaultProps} />);
+
+    expect(
+      screen.getByTestId('homepage-top-traders-section-root'),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId('homepage-top-traders-carousel'),
+    ).toBeOnTheScreen();
+  });
+
+  it('registers the idle placeholder as a rendered section for Home Viewed analytics', () => {
+    mockUseSectionViewportVisible.mockReturnValue({
+      isVisible: false,
+      onLayout: jest.fn(),
+    });
+    mockHasFetched = false;
+    mockUseTopTraders.mockReturnValue({
+      traders: [],
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refresh: mockRefetch,
+      toggleFollow: jest.fn(),
+    });
+    const mockUseHomeViewedEvent = jest.requireMock(
+      '../../hooks/useHomeViewedEvent',
+    ).default as jest.Mock;
+
+    renderWithProvider(<TopTradersSection {...defaultProps} />);
+
+    expect(
+      mockUseHomeViewedEvent.mock.calls.at(-1)?.[0].sectionRef,
+    ).not.toBeNull();
+  });
+
+  it('keeps a cached empty result measurable until this section requests data', () => {
+    mockUseSectionViewportVisible.mockReturnValue({
+      isVisible: false,
+      onLayout: jest.fn(),
+    });
+    mockUseTopTraders.mockReturnValue({
+      traders: [],
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refresh: mockRefetch,
+      toggleFollow: jest.fn(),
+    });
+
+    renderWithProvider(<TopTradersSection {...defaultProps} />);
+
+    expect(
+      screen.getByTestId('homepage-top-traders-section-root'),
+    ).toBeOnTheScreen();
+    expect(
+      screen.getByTestId('homepage-top-traders-carousel'),
+    ).toBeOnTheScreen();
+    expect(mockUseTopTraders).toHaveBeenLastCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it('does not count disabled-query idle time as data-fetch latency', () => {
+    mockUseSectionViewportVisible.mockReturnValue({
+      isVisible: false,
+      onLayout: jest.fn(),
+    });
+    mockHasFetched = false;
+    mockUseTopTraders.mockReturnValue({
+      traders: [],
+      isLoading: true,
+      isFetching: false,
+      error: null,
+      refresh: mockRefetch,
+      toggleFollow: jest.fn(),
+    });
+
+    renderWithProvider(<TopTradersSection {...defaultProps} />);
+
+    expect(mockUseSectionPerformance).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        isLoading: false,
+      }),
+    );
+  });
+
+  it('keeps the query enabled after the section first enters the viewport', () => {
+    let isVisible = false;
+    mockUseSectionViewportVisible.mockImplementation(() => ({
+      isVisible,
+      onLayout: jest.fn(),
+    }));
+
+    const { rerender } = renderWithProvider(
+      <TopTradersSection {...defaultProps} />,
+    );
+    expect(mockUseTopTraders).toHaveBeenLastCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+
+    isVisible = true;
+    rerender(<TopTradersSection {...defaultProps} />);
+    expect(mockUseTopTraders).toHaveBeenLastCalledWith(
+      expect.objectContaining({ enabled: true }),
+    );
+
+    isVisible = false;
+    rerender(<TopTradersSection {...defaultProps} />);
+    expect(mockUseTopTraders).toHaveBeenLastCalledWith(
+      expect.objectContaining({ enabled: true }),
     );
   });
 
@@ -560,6 +722,19 @@ describe('TopTradersSection', () => {
 
     expect(ref.current).not.toBeNull();
     await expect(ref.current?.refresh()).resolves.toBeUndefined();
+  });
+
+  it('preserves explicit Homepage refresh while the section is offscreen', async () => {
+    mockUseSectionViewportVisible.mockReturnValue({
+      isVisible: false,
+      onLayout: jest.fn(),
+    });
+    const ref = createRef<SectionRefreshHandle>();
+    renderWithProvider(<TopTradersSection ref={ref} {...defaultProps} />);
+
+    await expect(ref.current?.refresh()).resolves.toBeUndefined();
+
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
   });
 
   it('invokes onLayout from useHomeViewedEvent when the section root lays out', () => {

--- a/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
+++ b/app/components/Views/Homepage/Sections/TopTraders/TopTradersSection.tsx
@@ -8,6 +8,7 @@ import { useNavigation } from '@react-navigation/native';
 import React, {
   forwardRef,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -85,10 +86,29 @@ const TopTradersSection = forwardRef<
   const title = strings('homepage.sections.top_traders');
   const [visibleTraderIds, setVisibleTraderIds] = useState<string[]>([]);
 
+  // Keep an idle placeholder measurable before the first request. Do not feed
+  // query loading back into this hook: doing so would hide visibility as soon
+  // as the visibility-gated request starts.
+  const { isVisible: isSectionVisible, onLayout: sectionVisibleOnLayout } =
+    useSectionViewportVisible(sectionViewRef, { isLoading: false });
+  const [hasEverBeenVisible, setHasEverBeenVisible] =
+    useState(isSectionVisible);
+
+  useEffect(() => {
+    if (isSectionVisible && !hasEverBeenVisible) {
+      setHasEverBeenVisible(true);
+    }
+  }, [hasEverBeenVisible, isSectionVisible]);
+
+  // Keep the query warm after its first reveal. A continuous visibility gate
+  // would re-enable this stale query and refetch whenever the user scrolls back.
+  const hasRequestedTraders = isSectionVisible || hasEverBeenVisible;
+
   const {
     traders: allTraders,
     isLoading,
     isFetching,
+    hasFetched,
     error,
     refresh,
     toggleFollow,
@@ -97,7 +117,7 @@ const TopTradersSection = forwardRef<
     chains: SPOT_CHAINS,
     sort: DEFAULT_LEADERBOARD_SORT,
     timeframe: DEFAULT_TIMEFRAME,
-    enabled: isEnabled,
+    enabled: isEnabled && hasRequestedTraders,
   });
 
   // Mirrors the leaderboard's landing state (Tokens / 7D / P&L): the API only
@@ -124,10 +144,24 @@ const TopTradersSection = forwardRef<
   const hasTraders = traders.length > 0;
   const hasError = Boolean(error);
   const showError = hasError && !isFetching && !hasTraders;
-  const willRender = isEnabled && (isInFlight || hasError || hasTraders);
+  const showSkeletons =
+    !hasTraders && (!hasRequestedTraders || !hasFetched || isInFlight);
+  const showViewMore = hasTraders;
+  // A cached empty result must not remove the viewport target before this
+  // instance has requested data; otherwise it can never become visible and
+  // revalidate the stale query.
+  const isEmpty =
+    hasRequestedTraders &&
+    hasFetched &&
+    !isInFlight &&
+    !hasError &&
+    !hasTraders;
+  // The idle skeleton is a real, measurable root. Keep it registered with
+  // viewport analytics so it is not mistaken for a non-rendered empty section.
+  const sectionMountsVisibleRoot = isEnabled && !isEmpty;
 
   const { onLayout: homeViewedOnLayout } = useHomeViewedEvent({
-    sectionRef: willRender ? sectionViewRef : null,
+    sectionRef: sectionMountsVisibleRoot ? sectionViewRef : null,
     isLoading,
     sectionName: HomeSectionNames.TOP_TRADERS,
     sectionIndex,
@@ -135,9 +169,6 @@ const TopTradersSection = forwardRef<
     isEmpty: traders.length === 0,
     itemCount: traders.length,
   });
-
-  const { isVisible: isSectionVisible, onLayout: sectionVisibleOnLayout } =
-    useSectionViewportVisible(sectionViewRef, { isLoading });
 
   usePrefetchTraderProfiles(visibleTraderIds, {
     enabled: isEnabled && hasTraders,
@@ -157,16 +188,14 @@ const TopTradersSection = forwardRef<
     // sections. Without this, a fetch error with no cached traders would be
     // reported as `content_state: 'empty'`.
     isEmpty: !isLoading && !hasError && !hasTraders,
-    isLoading,
+    // React Query v4 reports isLoading=true for an uncached disabled query.
+    // Require active fetching so offscreen dwell is not counted as fetch time.
+    isLoading: isLoading && isFetching,
     // Disable telemetry once we render the error UI so the in-flight TTC and
     // data-fetch spans get closed via the hook's cleanup instead of remaining
     // open until the user navigates away.
     enabled: isEnabled && !showError,
   });
-
-  const showSkeletons = isInFlight && !hasTraders;
-  const showViewMore = hasTraders;
-  const isEmpty = !isInFlight && !hasError && !hasTraders;
 
   const carouselData = useMemo((): TopTradersCarouselItem[] => {
     const items: TopTradersCarouselItem[] = traders.map((trader) => ({

--- a/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.test.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.test.ts
@@ -85,6 +85,7 @@ const makeQueryResult = (
     data: undefined,
     isLoading: false,
     isFetching: false,
+    isFetched: false,
     error: null,
     refetch: mockRefetch,
     ...overrides,
@@ -241,6 +242,12 @@ describe('useTopTraders', () => {
       mockUseQuery.mockReturnValue(makeQueryResult({ isLoading: true }));
       const { result } = renderHook(() => useTopTraders());
       expect(result.current.isLoading).toBe(true);
+    });
+
+    it('exposes whether the query has fetched', () => {
+      mockUseQuery.mockReturnValue(makeQueryResult({ isFetched: true }));
+      const { result } = renderHook(() => useTopTraders());
+      expect(result.current.hasFetched).toBe(true);
     });
 
     it('returns the error message for an Error object', () => {

--- a/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.ts
+++ b/app/components/Views/Homepage/Sections/TopTraders/hooks/useTopTraders.ts
@@ -21,6 +21,7 @@ export interface UseTopTradersResult {
   traders: TopTrader[];
   isLoading: boolean;
   isFetching: boolean;
+  hasFetched: boolean;
   error: string | null;
   refresh: () => Promise<void>;
   toggleFollow: (
@@ -72,7 +73,7 @@ export const useTopTraders = (
   // AppState → focusManager, and react-data-query uses staleTime: 0, so a
   // foreground/reconnect can otherwise run queryFn before React commits
   // enabled:false after background auto-lock. Unlock flips enabled true and fetches.
-  const { data, isLoading, isFetching, error, refetch } =
+  const { data, isLoading, isFetching, isFetched, error, refetch } =
     useQuery<LeaderboardResponse>({
       queryKey,
       enabled: (options?.enabled ?? true) && isUnlocked,
@@ -153,11 +154,12 @@ export const useTopTraders = (
       traders,
       isLoading,
       isFetching,
+      hasFetched: isFetched,
       error: formatSocialQueryErrorMessage(error),
       refresh,
       toggleFollow,
     }),
-    [traders, isLoading, isFetching, error, refresh, toggleFollow],
+    [traders, isLoading, isFetching, isFetched, error, refresh, toggleFollow],
   );
 };
 

--- a/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
+++ b/app/components/Views/SocialLeaderboard/TopTradersView/TopTradersView.test.tsx
@@ -204,6 +204,7 @@ const buildResult = (
   traders: fixtureTraders,
   isLoading: false,
   isFetching: true,
+  hasFetched: false,
   error: null,
   refresh: mockRefresh as () => Promise<void>,
   toggleFollow: mockToggleFollow,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Defers the Homepage Top Traders leaderboard request until the section enters
the viewport. Before the first request, the section keeps its existing skeleton
mounted so viewport visibility can be measured without changing the layout.

After the section has first been visible, the leaderboard query stays enabled.
This keeps its data warm and avoids re-enabling a stale query every time the
user scrolls away and back. Query fetch state is now exposed separately so a
disabled, not-yet-fetched query is not mistaken for a confirmed empty result.
The idle placeholder remains registered with Homepage viewport analytics so it
is not reported as an immediately viewed empty section. Existing mount-based
time-to-content telemetry retains its original semantics, while data-fetch
latency starts only when the deferred query is actively fetching.

The Homepage fetch limit remains 50 because the API ranks by its 30-day
figures, while the Homepage re-ranks that candidate set by the displayed 7-day
metric before selecting 10 traders. Reducing the limit would change ranking
quality.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1329

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Lazy-load the Homepage Top Traders section

  Scenario: leaderboard request is deferred while Top Traders is offscreen
    Given the Social Leaderboard feature is enabled
    When the user opens the Wallet Homepage and remains on the initial viewport
    Then no Top Traders leaderboard request is made
    And a layout-stable Top Traders placeholder remains mounted offscreen

  Scenario: leaderboard loads when Top Traders approaches the viewport
    Given the user is on the Wallet Homepage
    When the user scrolls until Top Traders enters the viewport
    Then the Top Traders leaderboard request is made
    And the skeleton is replaced by trader cards
    And visible trader profiles are prefetched

  Scenario: loaded leaderboard remains warm after scrolling away
    Given Top Traders has loaded
    When the user scrolls away from Top Traders and back
    Then the loaded trader cards remain available
    And viewport re-entry does not re-enable a disabled stale query
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Homepage Top Traders lazy-loading, rendering, and telemetry; behavior is covered by new unit tests with no auth or payment changes.
> 
> **Overview**
> **Defers the Homepage Top Traders leaderboard request** until the section enters the viewport, while keeping a layout-stable skeleton mounted so visibility can still be measured.
> 
> The `useTopTraders` query is gated with `enabled: isEnabled && hasRequestedTraders`, where `hasRequestedTraders` flips on after the section has been visible once and **stays true** if the user scrolls away—avoiding disable/re-enable cycles that would refetch stale cache. `useTopTraders` now exposes **`hasFetched`** so a disabled or uncached query is not treated as a confirmed empty section.
> 
> Skeleton, empty, and Home Viewed registration logic were updated so the idle placeholder remains a measurable root (including when a cached empty result exists before this instance has requested data). **Section performance telemetry** reports fetch latency only when `isLoading && isFetching`, so React Query’s disabled-query loading state is not counted as offscreen dwell time.
> 
> Tests cover deferred queries, sticky enablement after first visibility, analytics refs, performance hook args, and pull-to-refresh via section ref while offscreen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed38775af63b6fdd5d4ff0458d27b93b1825a554. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->