### PR TITLE
fix(confirmations): show Relay exact-input deposit output

### DIFF
--- a/app/components/Views/confirmations/components/rows/total-row/total-row.test.tsx
+++ b/app/components/Views/confirmations/components/rows/total-row/total-row.test.tsx
@@ -76,6 +76,19 @@ describe('TotalRow', () => {
       expect(getByText(TOTAL_FIAT_MOCK)).toBeDefined();
     });
 
+    it('renders the total amount for an explicitly output-based quote', () => {
+      useTransactionPayTotalsMock.mockReturnValue({
+        isInputBased: false,
+        total: { usd: '123.456' },
+        targetAmount: { usd: '99.38', fiat: '99.38' },
+      } as unknown as TransactionPayTotals);
+
+      const { getByTestId, getByText } = render();
+
+      expect(getByTestId('total-row')).toBeOnTheScreen();
+      expect(getByText(TOTAL_FIAT_MOCK)).toBeDefined();
+    });
+
     it('renders skeleton when quotes are loading', () => {
       useIsTransactionPayLoadingMock.mockReturnValue(true);
 
@@ -109,6 +122,20 @@ describe('TotalRow', () => {
         isWithdraw: true,
         canSelectWithdrawToken: true,
       });
+
+      const { getByTestId, getByText, queryByTestId } = render();
+
+      expect(getByTestId('receive-row')).toBeOnTheScreen();
+      expect(getByText(RECEIVE_FIAT_MOCK)).toBeOnTheScreen();
+      expect(queryByTestId('total-row')).toBeNull();
+    });
+
+    it('renders the receive row for input-based quotes', () => {
+      useTransactionPayTotalsMock.mockReturnValue({
+        isInputBased: true,
+        total: { usd: '100', fiat: '100' },
+        targetAmount: { usd: '99.38', fiat: '99.38' },
+      } as unknown as TransactionPayTotals);
 
       const { getByTestId, getByText, queryByTestId } = render();
 

--- a/app/components/Views/confirmations/components/rows/total-row/total-row.tsx
+++ b/app/components/Views/confirmations/components/rows/total-row/total-row.tsx
@@ -25,18 +25,21 @@ import {
  * Row component that owns the bottom line of the totals section.
  *
  * For withdrawal flows (when the feature flag allows selecting a withdraw
- * token) and for exact-output flows when Max is selected, the "You receive" row
- * is shown so the user can see they receive less than they put in. Otherwise the
- * total cost row is shown.
+ * token), input-based quotes, and non-withdraw flows when Max is selected, the
+ * "You receive" row is shown so the user can see the authoritative destination
+ * amount. Otherwise the total cost row is shown.
  */
 export function TotalRow() {
   const { canSelectWithdrawToken } = useTransactionPayWithdraw();
   const isMaxAmount = useTransactionPayIsMaxAmount();
+  const totals = useTransactionPayTotals();
   const transactionMetadata = useTransactionMetadataRequest();
   const isWithdraw = isTransactionPayWithdraw(transactionMetadata);
 
   const showReceiveRow =
-    canSelectWithdrawToken || (Boolean(isMaxAmount) && !isWithdraw);
+    canSelectWithdrawToken ||
+    totals?.isInputBased === true ||
+    (Boolean(isMaxAmount) && !isWithdraw);
 
   if (showReceiveRow) {
     return <ReceiveRow />;
@@ -87,7 +90,7 @@ function TotalFeesRow() {
 }
 
 /**
- * Displays "You'll receive" for withdrawal and Max exact-output flows.
+ * Displays "You'll receive" for withdrawal, input-based, and Max flows.
  *
  * The net received amount is the target amount computed by the Transaction Pay
  * controller (after all provider, network, and MetaMask fees), so this row

--- a/package.json
+++ b/package.json
@@ -402,7 +402,7 @@
     "@metamask/superstruct": "^3.2.1",
     "@metamask/swappable-obj-proxy": "^2.1.0",
     "@metamask/transaction-controller": "^69.6.0",
-    "@metamask/transaction-pay-controller": "^27.0.0",
+    "@metamask/transaction-pay-controller": "^27.1.0",
     "@metamask/tron-wallet-snap": "^3.2.0",
     "@metamask/utils": "^11.11.0",
     "@metamask/wallet": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9872,7 +9872,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ramps-controller@npm:^20.0.0, @metamask/ramps-controller@npm:^20.2.0":
+"@metamask/ramps-controller@npm:^20.2.0":
   version: 20.2.0
   resolution: "@metamask/ramps-controller@npm:20.2.0"
   dependencies:
@@ -10134,7 +10134,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/sentinel-api-service@npm:^1.0.0, @metamask/sentinel-api-service@npm:^1.0.1":
+"@metamask/sentinel-api-service@npm:^1.0.1":
   version: 1.0.1
   resolution: "@metamask/sentinel-api-service@npm:1.0.1"
   dependencies:
@@ -10683,9 +10683,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-pay-controller@npm:^27.0.0":
-  version: 27.0.0
-  resolution: "@metamask/transaction-pay-controller@npm:27.0.0"
+"@metamask/transaction-pay-controller@npm:^27.1.0":
+  version: 27.1.0
+  resolution: "@metamask/transaction-pay-controller@npm:27.1.0"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
@@ -10699,16 +10699,16 @@ __metadata:
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^36.0.0"
-    "@metamask/ramps-controller": "npm:^20.0.0"
-    "@metamask/remote-feature-flag-controller": "npm:^6.0.0"
-    "@metamask/sentinel-api-service": "npm:^1.0.0"
+    "@metamask/ramps-controller": "npm:^20.2.0"
+    "@metamask/remote-feature-flag-controller": "npm:^6.1.0"
+    "@metamask/sentinel-api-service": "npm:^1.0.1"
     "@metamask/transaction-controller": "npm:^69.6.1"
     "@metamask/utils": "npm:^11.11.0"
     bignumber.js: "npm:^9.1.2"
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  checksum: 10/fadb35bd7a1e291e70c72fab700c97b0c89c7546db082752322c77306cd8e3f6f0e07c1c7b14bfaf1fd2f8a1aaa5fc6521cb4ef95c5c0ff97520a21132f42527
+  checksum: 10/4c15879987aa924f89ed9b24ef0ca7ebf0d9bb3c4f2f496fe371924ea3c260b0ab816bea5c393b55119030dda973e31d3e78ebf8a2b1ca453f5b1e8d87591b89
   languageName: node
   linkType: hard
 
@@ -35902,7 +35902,7 @@ __metadata:
     "@metamask/test-dapp-solana": "npm:^0.3.0"
     "@metamask/tooling-insight": "npm:^1.0.1"
     "@metamask/transaction-controller": "npm:^69.6.0"
-    "@metamask/transaction-pay-controller": "npm:^27.0.0"
+    "@metamask/transaction-pay-controller": "npm:^27.1.0"
     "@metamask/tron-wallet-snap": "npm:^3.2.0"
     "@metamask/utils": "npm:^11.11.0"
     "@metamask/wallet": "npm:^11.0.0"


### PR DESCRIPTION
## **Description**

Integrates the exact-input Relay deposit semantics published in `@metamask/transaction-pay-controller@27.1.0`.

- Updates `@metamask/transaction-pay-controller` from `^27.0.0` to `^27.1.0`.
- Reads the controller-owned `TransactionPayTotals.isInputBased` flag.
- Shows **You receive** with the controller's authoritative `targetAmount` when totals are explicitly input-based.
- Preserves the existing presentation for output-based or legacy totals, including the current Max and withdrawal behavior.
- Treats only `isInputBased === true` as input-based, so mixed aggregates and quotes without the flag retain their existing behavior.

The rebase incorporates the newer MetaMask Pay balance/totals architecture from `main`: `TotalRow` remains the sole owner of the bottom totals line, Max inputs remain stable, and receive amounts come directly from `totals.targetAmount`.

This consumes the behavior added by [MetaMask/core#9954](https://github.com/MetaMask/core/pull/9954), which uses exact-input Relay quotes when no transaction is embedded while preserving exact-output behavior for embedded transactions and `perpsDepositAndOrder`.

## **Changelog**

CHANGELOG entry: Updated input-based confirmations to show the authoritative destination amount while preserving the entered source amount

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1782

## **Manual testing steps**

```gherkin
Feature: Controller-owned input-based confirmation totals

  Scenario: Review an input-based Relay deposit
    Given the Pay Controller returns totals with isInputBased set to true
    When the user reviews the confirmation
    Then the confirmation displays You receive
    And it uses totals.targetAmount as the destination amount

  Scenario: Review an output-based or mixed quote
    Given totals.isInputBased is false or unavailable
    When the user reviews a non-Max deposit confirmation
    Then the existing Total row is displayed

  Scenario: Review an existing Max or withdrawal flow
    Given the confirmation would already display You receive
    When the controller returns updated totals
    Then the existing Max and withdrawal presentation is preserved
```

## **Screenshots/Recordings**

N/A — no visual design change; this changes which existing totals row is selected.

### **Before**

N/A

### **After**

N/A

## **Validation**

- Three focused Jest suites passed three consecutive times: 91 tests per run.
- `yarn lint:tsc`
- Focused ESLint and Prettier checks for `TotalRow` and its tests
- `yarn install --immutable`
- `git diff --check origin/main...HEAD`

The flaky-test detector suggestions were audited against the rebased branch: there is no empty `waitFor`, relevant mocks are reset in `beforeEach`, and `updatePendingAmount` is synchronous and already invoked inside `act`.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - Not applicable: this change adds no asynchronous operations or performance-sensitive behavior.

For performance guidelines, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized confirmation UI branching on a new controller flag; money amounts still come from existing totals hooks with strict `=== true` for input-based cases.
> 
> **Overview**
> Bumps `@metamask/transaction-pay-controller` to **27.1.0** so confirmations can use controller-owned `TransactionPayTotals.isInputBased`.
> 
> **`TotalRow`** now chooses the bottom totals line using that flag: when `isInputBased === true`, it shows **You receive** with `totals.targetAmount` (same as withdraw / Max-on-deposit flows). Output-based quotes (`isInputBased === false`) and totals without the flag still show the **Total** row. Max and withdrawal behavior is unchanged.
> 
> Tests cover explicit input-based and output-based totals mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77f3bb6b77aa9df912517aea36a903d4ef5ba1c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->