### PR TITLE
feat(money): add VBA Verify identity screen

### DIFF
--- a/app/components/Nav/Main/MainNavigator.js
+++ b/app/components/Nav/Main/MainNavigator.js
@@ -82,6 +82,7 @@ import TokenListRoutes from '../../UI/Ramp/routes';
 
 import V2BankDetails from '../../UI/Ramp/Views/NativeFlow/BankDetails';
 import GetPixKey from '../../UI/Ramp/Views/VirtualBankAccount/GetPixKey';
+import VbaVerifyIdentity from '../../UI/Ramp/Views/VirtualBankAccount/VerifyIdentity';
 
 import { colors as importedColors } from '../../../styles/common';
 import OrderDetails from '../../UI/Ramp/Aggregator/Views/OrderDetails';
@@ -1220,6 +1221,11 @@ const MainNavigator = () => {
       <NativeStack.Screen
         name={Routes.RAMP.GET_PIX_KEY}
         component={GetPixKey}
+        options={{ headerShown: false, ...slideFromRightNativeOptions }}
+      />
+      <NativeStack.Screen
+        name={Routes.RAMP.VBA_VERIFY_IDENTITY}
+        component={VbaVerifyIdentity}
         options={{ headerShown: false, ...slideFromRightNativeOptions }}
       />
       <NativeStack.Screen

--- a/app/components/Nav/Main/MainNavigator.test.js
+++ b/app/components/Nav/Main/MainNavigator.test.js
@@ -40,6 +40,7 @@ describe('MainNavigator Route Constants', () => {
     expect(Routes.RAMP.TOKEN_SELECTION).toBeDefined();
     expect(Routes.RAMP.ORDER_DETAILS).toBeDefined();
     expect(Routes.RAMP.GET_PIX_KEY).toBeDefined();
+    expect(Routes.RAMP.VBA_VERIFY_IDENTITY).toBeDefined();
   });
 
   it('has deposit routes defined', () => {

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/GetPixKey.test.tsx
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/GetPixKey.test.tsx
@@ -62,15 +62,14 @@ describe('GetPixKey', () => {
     expect(mockGoBack).toHaveBeenCalled();
   });
 
-  it('enables agree and continue once disclaimers load, without navigating yet', () => {
+  it('navigates to the verify identity screen when agree and continue is pressed after disclaimers load', () => {
     const { getByTestId } = renderWithProvider(<GetPixKey />);
 
     const button = getByTestId(GetPixKeySelectorsIDs.AGREE_AND_CONTINUE_BUTTON);
     expect(button).toBeEnabled();
 
-    // The Verify identity screen lands in a follow-up PR.
     fireEvent.press(button);
-    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('RampVbaVerifyIdentity');
   });
 
   it('shows a skeleton loader instead of any disclaimer links while the fetch is in flight, and disables the CTA', () => {

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/GetPixKey.tsx
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/GetPixKey.tsx
@@ -24,6 +24,7 @@ import { Skeleton } from '../../../../../component-library/components-temp/Skele
 import TagBase from '../../../../../component-library/base-components/TagBase';
 import { TagShape } from '../../../../../component-library/base-components/TagBase/TagBase.types';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
+import Routes from '../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../locales/i18n';
 import { PIX_BRAND_COLOR, VBA_KYC_COUNTRY_CODE } from './constants';
 import { GetPixKeySelectorsIDs } from './GetPixKey.testIds';
@@ -68,8 +69,8 @@ const GetPixKey = () => {
   const handleBack = useCallback(() => navigation.goBack(), [navigation]);
 
   const handleAgreeAndContinue = useCallback(() => {
-    // TODO: navigate to the Verify identity screen (follow-up PR).
-  }, []);
+    navigation.navigate(Routes.RAMP.VBA_VERIFY_IDENTITY);
+  }, [navigation]);
 
   return (
     <SafeAreaView

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/VerifyIdentity.test.tsx
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/VerifyIdentity.test.tsx
@@ -71,25 +71,27 @@ describe('VbaVerifyIdentity', () => {
     ).toBeOnTheScreen();
   });
 
-  it('keeps the data and privacy sub-topics collapsed by default, and shows their titles once opened', () => {
-    const { getByText, queryByText, getByTestId } = renderWithProvider(
-      <VbaVerifyIdentity />,
-    );
+  it('keeps the data and privacy sub-topics collapsed by default', () => {
+    const { queryByText } = renderWithProvider(<VbaVerifyIdentity />);
 
     expect(queryByText('What we collect')).not.toBeOnTheScreen();
     expect(queryByText('How we store data')).not.toBeOnTheScreen();
     expect(queryByText('How to delete')).not.toBeOnTheScreen();
+  });
+
+  it('shows sub-topic titles but keeps their body copy folded once data and privacy opens', () => {
+    const { getByText, queryByText, getByTestId } = renderWithProvider(
+      <VbaVerifyIdentity />,
+    );
 
     fireEvent.press(
       getByTestId(VbaVerifyIdentitySelectorsIDs.DATA_AND_PRIVACY_TOGGLE),
     );
 
-    // Sub-topic titles are visible once "Data and privacy" opens, but each
-    // sub-topic's own body copy stays folded until it's individually
-    // expanded.
     expect(getByText('What we collect')).toBeOnTheScreen();
     expect(getByText('How we store data')).toBeOnTheScreen();
     expect(getByText('How to delete')).toBeOnTheScreen();
+    // Each sub-topic's body copy stays folded until individually expanded.
     expect(
       queryByText(
         'We collect personal information as part of identity verification, including legal full name, address, and more.',

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/VerifyIdentity.test.tsx
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/VerifyIdentity.test.tsx
@@ -27,6 +27,7 @@ jest.mock('@react-navigation/native', () => ({
 describe('VbaVerifyIdentity', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   it('renders the title, steps, and continue button', () => {

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/VerifyIdentity.test.tsx
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/VerifyIdentity.test.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { Linking } from 'react-native';
+import { fireEvent } from '@testing-library/react-native';
+import renderWithProvider from '../../../../../util/test/renderWithProvider';
+import VbaVerifyIdentity from './VerifyIdentity';
+import { VbaVerifyIdentitySelectorsIDs } from './VerifyIdentity.testIds';
+import {
+  IDOS_PRIVACY_POLICY_URL,
+  IDOS_TERMS_URL,
+  METAMASK_PRIVACY_POLICY_URL,
+  METAMASK_TERMS_URL,
+  SUMSUB_PRIVACY_POLICY_URL,
+  SUMSUB_TERMS_URL,
+} from './constants';
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    goBack: mockGoBack,
+  }),
+}));
+
+describe('VbaVerifyIdentity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the title, steps, and continue button', () => {
+    const { getByText, getByTestId } = renderWithProvider(
+      <VbaVerifyIdentity />,
+    );
+
+    expect(getByText('Verify your identity')).toBeOnTheScreen();
+    expect(getByText('Upload ID document')).toBeOnTheScreen();
+    expect(getByText('Take a selfie')).toBeOnTheScreen();
+    expect(getByText('Confirm personal details')).toBeOnTheScreen();
+    expect(
+      getByTestId(VbaVerifyIdentitySelectorsIDs.CONTINUE_BUTTON),
+    ).toBeOnTheScreen();
+  });
+
+  it('navigates back when the header back button is pressed', () => {
+    const { getByTestId } = renderWithProvider(<VbaVerifyIdentity />);
+
+    fireEvent.press(getByTestId(VbaVerifyIdentitySelectorsIDs.BACK_BUTTON));
+
+    expect(mockGoBack).toHaveBeenCalled();
+  });
+
+  it('shows the legal links regardless of the data and privacy toggle state', () => {
+    const { getByTestId, queryByTestId } = renderWithProvider(
+      <VbaVerifyIdentity />,
+    );
+
+    expect(
+      getByTestId(VbaVerifyIdentitySelectorsIDs.METAMASK_PRIVACY_POLICY_LINK),
+    ).toBeOnTheScreen();
+
+    fireEvent.press(
+      getByTestId(VbaVerifyIdentitySelectorsIDs.DATA_AND_PRIVACY_TOGGLE),
+    );
+
+    // Legal links are their own always-visible section, unaffected by the
+    // "Data and privacy" toggle above them.
+    expect(
+      queryByTestId(VbaVerifyIdentitySelectorsIDs.METAMASK_PRIVACY_POLICY_LINK),
+    ).toBeOnTheScreen();
+  });
+
+  it('keeps the data and privacy sub-topics collapsed by default, and shows their titles once opened', () => {
+    const { getByText, queryByText, getByTestId } = renderWithProvider(
+      <VbaVerifyIdentity />,
+    );
+
+    expect(queryByText('What we collect')).not.toBeOnTheScreen();
+    expect(queryByText('How we store data')).not.toBeOnTheScreen();
+    expect(queryByText('How to delete')).not.toBeOnTheScreen();
+
+    fireEvent.press(
+      getByTestId(VbaVerifyIdentitySelectorsIDs.DATA_AND_PRIVACY_TOGGLE),
+    );
+
+    // Sub-topic titles are visible once "Data and privacy" opens, but each
+    // sub-topic's own body copy stays folded until it's individually
+    // expanded.
+    expect(getByText('What we collect')).toBeOnTheScreen();
+    expect(getByText('How we store data')).toBeOnTheScreen();
+    expect(getByText('How to delete')).toBeOnTheScreen();
+    expect(
+      queryByText(
+        'We collect personal information as part of identity verification, including legal full name, address, and more.',
+      ),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('expands an individual sub-topic without affecting the others', () => {
+    const { getByTestId, getByText, queryByText } = renderWithProvider(
+      <VbaVerifyIdentity />,
+    );
+
+    fireEvent.press(
+      getByTestId(VbaVerifyIdentitySelectorsIDs.DATA_AND_PRIVACY_TOGGLE),
+    );
+    fireEvent.press(
+      getByTestId(VbaVerifyIdentitySelectorsIDs.WHAT_WE_COLLECT_TOGGLE),
+    );
+
+    expect(
+      getByText(
+        'We collect personal information as part of identity verification, including legal full name, address, and more.',
+      ),
+    ).toBeOnTheScreen();
+    expect(getByText('How we store data')).toBeOnTheScreen();
+    expect(
+      queryByText(
+        'You can delete your data anytime by going to Settings > Manage data.',
+      ),
+    ).not.toBeOnTheScreen();
+  });
+
+  it('opens each legal link with the expected URL', () => {
+    const spy = jest.spyOn(Linking, 'openURL');
+    const { getByTestId } = renderWithProvider(<VbaVerifyIdentity />);
+
+    fireEvent.press(
+      getByTestId(VbaVerifyIdentitySelectorsIDs.METAMASK_PRIVACY_POLICY_LINK),
+    );
+    expect(spy).toHaveBeenCalledWith(METAMASK_PRIVACY_POLICY_URL);
+
+    fireEvent.press(
+      getByTestId(VbaVerifyIdentitySelectorsIDs.METAMASK_TERMS_LINK),
+    );
+    expect(spy).toHaveBeenCalledWith(METAMASK_TERMS_URL);
+
+    fireEvent.press(
+      getByTestId(VbaVerifyIdentitySelectorsIDs.IDOS_PRIVACY_POLICY_LINK),
+    );
+    expect(spy).toHaveBeenCalledWith(IDOS_PRIVACY_POLICY_URL);
+
+    fireEvent.press(getByTestId(VbaVerifyIdentitySelectorsIDs.IDOS_TERMS_LINK));
+    expect(spy).toHaveBeenCalledWith(IDOS_TERMS_URL);
+
+    fireEvent.press(
+      getByTestId(VbaVerifyIdentitySelectorsIDs.SUMSUB_PRIVACY_POLICY_LINK),
+    );
+    expect(spy).toHaveBeenCalledWith(SUMSUB_PRIVACY_POLICY_URL);
+
+    fireEvent.press(
+      getByTestId(VbaVerifyIdentitySelectorsIDs.SUMSUB_TERMS_LINK),
+    );
+    expect(spy).toHaveBeenCalledWith(SUMSUB_TERMS_URL);
+  });
+});

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/VerifyIdentity.testIds.ts
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/VerifyIdentity.testIds.ts
@@ -1,0 +1,16 @@
+export const VbaVerifyIdentitySelectorsIDs = {
+  CONTAINER: 'vba-verify-identity-container',
+  BACK_BUTTON: 'vba-verify-identity-back-button',
+  CONTINUE_BUTTON: 'vba-verify-identity-continue-button',
+  DATA_AND_PRIVACY_TOGGLE: 'vba-verify-identity-data-and-privacy-toggle',
+  WHAT_WE_COLLECT_TOGGLE: 'vba-verify-identity-what-we-collect-toggle',
+  HOW_WE_STORE_DATA_TOGGLE: 'vba-verify-identity-how-we-store-data-toggle',
+  HOW_TO_DELETE_TOGGLE: 'vba-verify-identity-how-to-delete-toggle',
+  METAMASK_PRIVACY_POLICY_LINK:
+    'vba-verify-identity-metamask-privacy-policy-link',
+  METAMASK_TERMS_LINK: 'vba-verify-identity-metamask-terms-link',
+  IDOS_PRIVACY_POLICY_LINK: 'vba-verify-identity-idos-privacy-policy-link',
+  IDOS_TERMS_LINK: 'vba-verify-identity-idos-terms-link',
+  SUMSUB_PRIVACY_POLICY_LINK: 'vba-verify-identity-sumsub-privacy-policy-link',
+  SUMSUB_TERMS_LINK: 'vba-verify-identity-sumsub-terms-link',
+};

--- a/app/components/UI/Ramp/Views/VirtualBankAccount/VerifyIdentity.tsx
+++ b/app/components/UI/Ramp/Views/VirtualBankAccount/VerifyIdentity.tsx
@@ -1,0 +1,336 @@
+import React, { useCallback, useState } from 'react';
+import { Linking, Pressable, ScrollView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  FontWeight,
+  HeaderStandard,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react-native';
+import { useTailwind } from '@metamask/design-system-twrnc-preset';
+import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
+import { strings } from '../../../../../../locales/i18n';
+import {
+  IDOS_PRIVACY_POLICY_URL,
+  IDOS_TERMS_URL,
+  METAMASK_PRIVACY_POLICY_URL,
+  METAMASK_TERMS_URL,
+  SUMSUB_PRIVACY_POLICY_URL,
+  SUMSUB_TERMS_URL,
+} from './constants';
+import { VbaVerifyIdentitySelectorsIDs } from './VerifyIdentity.testIds';
+import LegalLink from './components/LegalLink';
+
+const CHEVRON_ANIMATION_DURATION = 200;
+
+const StepRow = ({
+  icon,
+  children,
+}: {
+  icon: IconName;
+  children: React.ReactNode;
+}) => (
+  <Box
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Center}
+    twClassName="gap-3"
+  >
+    <Icon name={icon} size={IconSize.Md} color={IconColor.IconDefault} />
+    <Text variant={TextVariant.BodyMd}>{children}</Text>
+  </Box>
+);
+
+// Collapsible row for the "Data and privacy" sub-topics; each manages its
+// own expand state since rows don't affect each other.
+const AccordionRow = ({
+  title,
+  defaultExpanded = false,
+  testID,
+  children,
+}: {
+  title: string;
+  defaultExpanded?: boolean;
+  testID: string;
+  children: React.ReactNode;
+}) => {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+  const chevronRotation = useSharedValue(defaultExpanded ? 180 : 0);
+
+  const animatedChevronStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${chevronRotation.value}deg` }],
+  }));
+
+  const toggle = useCallback(() => {
+    setIsExpanded((prev) => {
+      chevronRotation.value = withTiming(prev ? 0 : 180, {
+        duration: CHEVRON_ANIMATION_DURATION,
+        easing: Easing.out(Easing.ease),
+      });
+      return !prev;
+    });
+  }, [chevronRotation]);
+
+  return (
+    <Box>
+      <Pressable onPress={toggle} testID={testID}>
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Between}
+          twClassName="py-2"
+        >
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+            {title}
+          </Text>
+          <Animated.View style={animatedChevronStyle}>
+            <Icon
+              name={IconName.ArrowDown}
+              size={IconSize.Md}
+              color={IconColor.IconDefault}
+            />
+          </Animated.View>
+        </Box>
+      </Pressable>
+      {isExpanded ? (
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          twClassName="pb-3"
+        >
+          {children}
+        </Text>
+      ) : null}
+      <Box twClassName="h-px bg-border-muted" />
+    </Box>
+  );
+};
+
+const VbaVerifyIdentity = () => {
+  const navigation = useNavigation<AppNavigationProp>();
+  const tw = useTailwind();
+  const [isDataAndPrivacyExpanded, setIsDataAndPrivacyExpanded] =
+    useState(false);
+  const chevronRotation = useSharedValue(0);
+
+  const animatedChevronStyle = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${chevronRotation.value}deg` }],
+  }));
+
+  const handleBack = useCallback(() => navigation.goBack(), [navigation]);
+
+  const handleContinue = useCallback(() => {
+    // The next screen in the VBA KYC flow isn't built yet.
+  }, []);
+
+  const toggleDataAndPrivacy = useCallback(() => {
+    setIsDataAndPrivacyExpanded((prev) => {
+      chevronRotation.value = withTiming(prev ? 0 : 180, {
+        duration: CHEVRON_ANIMATION_DURATION,
+        easing: Easing.out(Easing.ease),
+      });
+      return !prev;
+    });
+  }, [chevronRotation]);
+
+  const openMetaMaskPrivacyPolicy = useCallback(
+    () => Linking.openURL(METAMASK_PRIVACY_POLICY_URL),
+    [],
+  );
+  const openMetaMaskTerms = useCallback(
+    () => Linking.openURL(METAMASK_TERMS_URL),
+    [],
+  );
+  const openIdosPrivacyPolicy = useCallback(
+    () => Linking.openURL(IDOS_PRIVACY_POLICY_URL),
+    [],
+  );
+  const openIdosTerms = useCallback(() => Linking.openURL(IDOS_TERMS_URL), []);
+  const openSumsubPrivacyPolicy = useCallback(
+    () => Linking.openURL(SUMSUB_PRIVACY_POLICY_URL),
+    [],
+  );
+  const openSumsubTerms = useCallback(
+    () => Linking.openURL(SUMSUB_TERMS_URL),
+    [],
+  );
+
+  return (
+    <SafeAreaView
+      edges={['right', 'bottom', 'left']}
+      style={tw.style('flex-1 bg-default')}
+    >
+      <HeaderStandard
+        onBack={handleBack}
+        backButtonProps={{ testID: VbaVerifyIdentitySelectorsIDs.BACK_BUTTON }}
+        includesTopInset
+      />
+      <ScrollView
+        contentContainerStyle={tw.style('flex-grow px-4 pb-4')}
+        testID={VbaVerifyIdentitySelectorsIDs.CONTAINER}
+      >
+        <Text variant={TextVariant.HeadingLg} twClassName="mt-2">
+          {strings('virtual_bank_account.verify_identity.title')}
+        </Text>
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          twClassName="mt-2"
+        >
+          {strings('virtual_bank_account.verify_identity.description')}
+        </Text>
+
+        <Box twClassName="mt-4 p-4 gap-4 rounded-xl bg-muted">
+          <StepRow icon={IconName.Card}>
+            {strings('virtual_bank_account.verify_identity.step_upload_id')}
+          </StepRow>
+          <StepRow icon={IconName.Camera}>
+            {strings('virtual_bank_account.verify_identity.step_take_selfie')}
+          </StepRow>
+          <StepRow icon={IconName.UserCheck}>
+            {strings(
+              'virtual_bank_account.verify_identity.step_confirm_details',
+            )}
+          </StepRow>
+        </Box>
+
+        <Pressable
+          onPress={toggleDataAndPrivacy}
+          testID={VbaVerifyIdentitySelectorsIDs.DATA_AND_PRIVACY_TOGGLE}
+        >
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Between}
+            twClassName="mt-6 py-2"
+          >
+            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+              {strings(
+                'virtual_bank_account.verify_identity.data_and_privacy_title',
+              )}
+            </Text>
+            <Animated.View style={animatedChevronStyle}>
+              <Icon
+                name={IconName.ArrowDown}
+                size={IconSize.Md}
+                color={IconColor.IconDefault}
+              />
+            </Animated.View>
+          </Box>
+        </Pressable>
+
+        {isDataAndPrivacyExpanded ? (
+          <Box>
+            <AccordionRow
+              title={strings(
+                'virtual_bank_account.verify_identity.what_we_collect_title',
+              )}
+              testID={VbaVerifyIdentitySelectorsIDs.WHAT_WE_COLLECT_TOGGLE}
+            >
+              {strings(
+                'virtual_bank_account.verify_identity.what_we_collect_description',
+              )}
+            </AccordionRow>
+            <AccordionRow
+              title={strings(
+                'virtual_bank_account.verify_identity.how_we_store_data_title',
+              )}
+              testID={VbaVerifyIdentitySelectorsIDs.HOW_WE_STORE_DATA_TOGGLE}
+            >
+              {strings(
+                'virtual_bank_account.verify_identity.how_we_store_data_description',
+              )}
+            </AccordionRow>
+            <AccordionRow
+              title={strings(
+                'virtual_bank_account.verify_identity.how_to_delete_title',
+              )}
+              testID={VbaVerifyIdentitySelectorsIDs.HOW_TO_DELETE_TOGGLE}
+            >
+              {strings(
+                'virtual_bank_account.verify_identity.how_to_delete_description',
+              )}
+            </AccordionRow>
+          </Box>
+        ) : null}
+
+        <Box twClassName="mt-4 gap-1">
+          <LegalLink
+            onPress={openMetaMaskPrivacyPolicy}
+            testID={VbaVerifyIdentitySelectorsIDs.METAMASK_PRIVACY_POLICY_LINK}
+          >
+            {strings(
+              'virtual_bank_account.verify_identity.metamask_privacy_policy',
+            )}
+          </LegalLink>
+          <LegalLink
+            onPress={openMetaMaskTerms}
+            testID={VbaVerifyIdentitySelectorsIDs.METAMASK_TERMS_LINK}
+          >
+            {strings('virtual_bank_account.verify_identity.metamask_terms')}
+          </LegalLink>
+          <LegalLink
+            onPress={openIdosPrivacyPolicy}
+            testID={VbaVerifyIdentitySelectorsIDs.IDOS_PRIVACY_POLICY_LINK}
+          >
+            {strings(
+              'virtual_bank_account.verify_identity.idos_privacy_policy',
+            )}
+          </LegalLink>
+          <LegalLink
+            onPress={openIdosTerms}
+            testID={VbaVerifyIdentitySelectorsIDs.IDOS_TERMS_LINK}
+          >
+            {strings('virtual_bank_account.verify_identity.idos_terms')}
+          </LegalLink>
+          <LegalLink
+            onPress={openSumsubPrivacyPolicy}
+            testID={VbaVerifyIdentitySelectorsIDs.SUMSUB_PRIVACY_POLICY_LINK}
+          >
+            {strings(
+              'virtual_bank_account.verify_identity.sumsub_privacy_policy',
+            )}
+          </LegalLink>
+          <LegalLink
+            onPress={openSumsubTerms}
+            testID={VbaVerifyIdentitySelectorsIDs.SUMSUB_TERMS_LINK}
+          >
+            {strings('virtual_bank_account.verify_identity.sumsub_terms')}
+          </LegalLink>
+        </Box>
+      </ScrollView>
+
+      <Box twClassName="p-4">
+        <Button
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          isFullWidth
+          onPress={handleContinue}
+          testID={VbaVerifyIdentitySelectorsIDs.CONTINUE_BUTTON}
+        >
+          {strings('virtual_bank_account.verify_identity.button')}
+        </Button>
+      </Box>
+    </SafeAreaView>
+  );
+};
+
+export default VbaVerifyIdentity;

--- a/app/constants/navigation/Routes.ts
+++ b/app/constants/navigation/Routes.ts
@@ -40,6 +40,7 @@ const Routes = {
     ENTER_ADDRESS: 'RampEnterAddress',
     // Virtual Bank Account (Brazil neobank MVP) flow — Iron KYC, not Transak.
     GET_PIX_KEY: 'RampGetPixKey',
+    VBA_VERIFY_IDENTITY: 'RampVbaVerifyIdentity',
     MODALS: {
       ID: 'RampModals',
       TOKEN_SELECTOR: 'RampTokenSelectorModal',

--- a/app/core/NavigationService/types.ts
+++ b/app/core/NavigationService/types.ts
@@ -557,6 +557,7 @@ export type RootStackParamList = {
 
   // Virtual Bank Account (Brazil neobank MVP) flow — Iron KYC, not Transak.
   RampGetPixKey: undefined;
+  RampVbaVerifyIdentity: undefined;
 
   // Deposit routes
   Deposit: DepositNavigationParams | undefined;

--- a/locales/languages/en.json
+++ b/locales/languages/en.json
@@ -1113,6 +1113,27 @@
       "agreement_text": "By continuing, you agree to the terms and conditions above.",
       "powered_by_moonpay": "Powered by MoonPay.",
       "button": "Agree and continue"
+    },
+    "verify_identity": {
+      "title": "Verify your identity",
+      "description": "Verification is quick and only needs to be done once. To verify, you'll need to:",
+      "step_upload_id": "Upload ID document",
+      "step_take_selfie": "Take a selfie",
+      "step_confirm_details": "Confirm personal details",
+      "data_and_privacy_title": "Data and privacy",
+      "what_we_collect_title": "What we collect",
+      "what_we_collect_description": "We collect personal information as part of identity verification, including legal full name, address, and more.",
+      "how_we_store_data_title": "How we store data",
+      "how_we_store_data_description": "Verification info is securely stored on MetaMask-managed servers. It's encrypted with your Secret Recovery Phrase entropy and we can't access the data. Your consent will be required for future use with another provider.",
+      "how_to_delete_title": "How to delete",
+      "how_to_delete_description": "You can delete your data anytime by going to Settings > Manage data.",
+      "metamask_privacy_policy": "MetaMask Privacy Policy",
+      "metamask_terms": "MetaMask T&C",
+      "idos_privacy_policy": "idOS Privacy Policy",
+      "idos_terms": "idOS T&C",
+      "sumsub_privacy_policy": "Sumsub Privacy Policy",
+      "sumsub_terms": "Sumsub T&C",
+      "button": "Continue"
     }
   },
   "social_leaderboard": {


### PR DESCRIPTION
## **Description**

Stacked on top of #34703 (Get Pix Key screen). Adds the second screen of the VBA (Brazil neobank) Iron KYC flow: **Verify your identity**. Split out of #34703 to keep each PR under the max-lines limit.

- `VerifyIdentity`: KYC step list (upload ID, take a selfie, confirm personal details), a collapsible "Data and privacy" section with three sub-accordions (what we collect / how we store data / how to delete), and always-visible legal links (MetaMask, idOS, Sumsub) sourced from `AppConstants` and verified-live partner URLs.
- Wires the "Agree and continue" CTA on `GetPixKey` (a documented no-op in #34703) to navigate here.
- The "Continue" button on `VerifyIdentity` is a no-op since the next screen in the flow (identity verification) isn't built yet.

Still gated behind the `money-movement-brazil-neobank` flag from the base of the stack (#34698).

## **Changelog**

CHANGELOG entry: Added the Verify identity screen to the virtual bank account KYC flow, behind the Brazil neobank feature flag

## **Related issues**

https://consensyssoftware.atlassian.net/browse/TRAM-3876

## **Manual testing steps**

```gherkin
Feature: VBA Verify identity screen

  Scenario: user reaches the Verify identity screen
    Given the money-movement-brazil-neobank feature flag is enabled
    And the user is on the "Get your Pix Key" screen with disclaimers loaded

    When user taps "Agree and continue"
    Then the "Verify your identity" screen is shown

    When user taps "Data and privacy"
    Then the three sub-topics expand and collapse independently
    And the legal links (MetaMask, idOS, Sumsub) open in the browser
```

## **Screenshots/Recordings**

### **Before**

N/A, new screen with no prior UI.

### **After**

https://github.com/user-attachments/assets/0f25ed1f-1f06-418e-a437-54188068d93a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

