### PR TITLE
fix: user rejection being intepreted as failed for hw flow 

### DIFF
--- a/app/components/UI/HardwareWallet/Swaps/HardwareWalletsSwaps.test.tsx
+++ b/app/components/UI/HardwareWallet/Swaps/HardwareWalletsSwaps.test.tsx
@@ -113,6 +113,7 @@ jest.mock('../../../../core/HardwareWallet/helpers', () => ({
   getDeviceIdForAddress: jest.fn().mockResolvedValue('ledger-device-id'),
   // Re-export anything else the component tree might import from helpers
   getHardwareWalletTypeForAddress: jest.fn().mockReturnValue('ledger'),
+  getHardwareWalletTypeName: jest.fn().mockReturnValue('Ledger'),
 }));
 
 jest.mock('../../../../core/Ledger/Ledger', () => ({

--- a/app/components/UI/HardwareWallet/Swaps/useHardwareWalletSubmit.test.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHardwareWalletSubmit.test.ts
@@ -1,0 +1,231 @@
+import { renderHook, act } from '@testing-library/react-native';
+import type { Dispatch, AnyAction } from 'redux';
+import { type TransactionMeta } from '@metamask/transaction-controller';
+import { updateHardwareWalletsSwaps } from '../../../../core/redux/slices/bridge';
+import {
+  HardwareWalletsSwapsEventType,
+  HardwareWalletsSwapsStatus,
+  initialHardwareWalletsSwapsState,
+} from './HardwareWalletsSwaps.state';
+import { useHardwareWalletSubmit } from './useHardwareWalletSubmit';
+
+const mockAcceptPendingApproval = jest.fn();
+const mockSubmitBridgeTx = jest.fn();
+const mockShowHardwareWalletError = jest.fn();
+const mockDispatch = jest.fn((action: unknown) => action);
+
+jest.mock('../../../../core/Engine', () => ({
+  __esModule: true,
+  default: {
+    acceptPendingApproval: (...args: unknown[]) =>
+      mockAcceptPendingApproval(...args),
+    controllerMessenger: {
+      call: jest.fn(),
+      subscribe: jest.fn(),
+      unsubscribe: jest.fn(),
+    },
+    context: {},
+  },
+}));
+
+jest.mock('../../../../core/HardwareWallet', () => ({
+  useHardwareWallet: () => ({
+    showHardwareWalletError: mockShowHardwareWalletError,
+  }),
+}));
+
+jest.mock('../../../../core/HardwareWallet/helpers', () => ({
+  getDeviceIdForAddress: jest.fn().mockResolvedValue('device-1'),
+  getHardwareWalletTypeName: jest.fn(() => 'Ledger'),
+}));
+
+jest.mock('../../../Views/confirmations/hooks/useApprovalRequest', () => ({
+  __esModule: true,
+  default: () => ({
+    approvalRequest: {
+      id: 'approval-1',
+      requestData: { from: '0xabc' },
+    },
+  }),
+}));
+
+jest.mock('../../../../util/bridge/hooks/useSubmitBridgeTx', () => ({
+  __esModule: true,
+  default: () => ({ submitBridgeTx: mockSubmitBridgeTx }),
+}));
+
+jest.mock('../../Bridge/utils/postTradeNotifications', () => ({
+  withPostTradeNotificationSuppression: jest.fn(async (fn) => fn()),
+  showPostTradeNotificationSurface: jest.fn(),
+  hidePostTradeNotificationSurface: jest.fn(),
+}));
+
+jest.mock('../../../../core/redux/slices/bridge', () => ({
+  updateHardwareWalletsSwaps: jest.fn((event) => event),
+}));
+
+const preparedTxMeta = {
+  id: 'tx-1',
+  txParams: { from: '0xfrom' },
+} as unknown as TransactionMeta;
+
+/** Renders the hook exactly as production wires it: send via approval accept, bridge via submitBridgeTx. */
+function renderSubmitHook(isSendFlow: boolean) {
+  return renderHook(() =>
+    useHardwareWalletSubmit({
+      isSendFlow,
+      walletAddress: '0xfrom',
+      dispatch: mockDispatch as unknown as Dispatch<AnyAction>,
+      progressRef: {
+        current: {
+          ...initialHardwareWalletsSwapsState,
+          status: HardwareWalletsSwapsStatus.Waiting,
+        },
+      },
+      submissionGenerationRef: { current: 0 },
+      preparedTxMeta,
+      approvalRequestId: 'approval-1',
+      submissionParams: { quoteResponse: {} } as never,
+      ensureDeviceReady: jest.fn().mockResolvedValue(true),
+      setPendingOperationAddress: jest.fn(),
+    }),
+  );
+}
+
+describe('useHardwareWalletSubmit (unified device-rejection handling)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('send flow: dispatches Rejected (inline state, NO error sheet) for a raw TransportStatusError 0x6985', async () => {
+    const deviceRejection = Object.assign(
+      new Error('Ledger device: Action cancelled by user (0x6985)'),
+      { name: 'TransportStatusError', statusCode: 27013 },
+    );
+    mockAcceptPendingApproval.mockRejectedValue(deviceRejection);
+
+    const { result } = renderSubmitHook(true);
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    // Inline-only UX: the rejection is surfaced by the Rejected state on the
+    // progress screen; the error sheet must NOT be shown.
+    expect(mockShowHardwareWalletError).not.toHaveBeenCalled();
+
+    // The flow state must be Rejected, not the generic TransactionFailed.
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: HardwareWalletsSwapsEventType.Rejected,
+    });
+    expect(mockDispatch).not.toHaveBeenCalledWith({
+      type: HardwareWalletsSwapsEventType.TransactionFailed,
+    });
+  });
+
+  it('send flow: detects user cancellation from the error message alone', async () => {
+    mockAcceptPendingApproval.mockRejectedValue(
+      new Error('Ledger device: Action cancelled by user'),
+    );
+
+    const { result } = renderSubmitHook(true);
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(mockShowHardwareWalletError).not.toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: HardwareWalletsSwapsEventType.Rejected,
+    });
+    expect(mockDispatch).not.toHaveBeenCalledWith({
+      type: HardwareWalletsSwapsEventType.TransactionFailed,
+    });
+  });
+
+  it("send flow: internal 'Batch cancelled' abort signal is NOT a device rejection", async () => {
+    mockAcceptPendingApproval.mockRejectedValue(new Error('Batch cancelled'));
+
+    const { result } = renderSubmitHook(true);
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(mockShowHardwareWalletError).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalledWith({
+      type: HardwareWalletsSwapsEventType.Rejected,
+    });
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: HardwareWalletsSwapsEventType.TransactionFailed,
+    });
+  });
+
+  it('send flow: non-cancellation errors keep the generic TransactionFailed handling', async () => {
+    mockAcceptPendingApproval.mockRejectedValue(
+      new Error('Some transport blowup'),
+    );
+
+    const { result } = renderSubmitHook(true);
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(mockShowHardwareWalletError).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalledWith({
+      type: HardwareWalletsSwapsEventType.Rejected,
+    });
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: HardwareWalletsSwapsEventType.TransactionFailed,
+    });
+  });
+
+  it('bridge flow: non-cancellation submitBridgeTx errors dispatch TransactionFailed without a sheet', async () => {
+    // Bridge submitFn rejections are broadcast/publish errors; plain ones
+    // must stay on the generic failure path.
+    mockSubmitBridgeTx.mockRejectedValue(new Error('Broadcast failed'));
+
+    const { result } = renderSubmitHook(false);
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(mockSubmitBridgeTx).toHaveBeenCalledTimes(1);
+    expect(mockShowHardwareWalletError).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalledWith({
+      type: HardwareWalletsSwapsEventType.Rejected,
+    });
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: HardwareWalletsSwapsEventType.TransactionFailed,
+    });
+  });
+
+  it('bridge flow: IF a cancellation-shaped error reaches the unified path, it gets Rejected inline, no sheet (unified behavior)', async () => {
+    // Bridge signing errors normally never reach runSubmit's catch (the
+    // batch tracker consumes them), but if a device-rejection-shaped error
+    // ever rejects submitBridgeTx, the unified branch handles it like send.
+    mockSubmitBridgeTx.mockRejectedValue(
+      Object.assign(
+        new Error('Ledger device: Action cancelled by user (0x6985)'),
+        { name: 'TransportStatusError', statusCode: 27013 },
+      ),
+    );
+
+    const { result } = renderSubmitHook(false);
+
+    await act(async () => {
+      await result.current.submit();
+    });
+
+    expect(mockSubmitBridgeTx).toHaveBeenCalledTimes(1);
+    expect(mockShowHardwareWalletError).not.toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: HardwareWalletsSwapsEventType.Rejected,
+    });
+    expect(mockDispatch).not.toHaveBeenCalledWith({
+      type: HardwareWalletsSwapsEventType.TransactionFailed,
+    });
+  });
+});

--- a/app/components/UI/HardwareWallet/Swaps/useHardwareWalletSubmit.test.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHardwareWalletSubmit.test.ts
@@ -1,11 +1,13 @@
-import { renderHook, act } from '@testing-library/react-native';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
 import type { Dispatch, AnyAction } from 'redux';
 import { type TransactionMeta } from '@metamask/transaction-controller';
 import { updateHardwareWalletsSwaps } from '../../../../core/redux/slices/bridge';
 import {
   HardwareWalletsSwapsEventType,
   HardwareWalletsSwapsStatus,
-  initialHardwareWalletsSwapsState,
+  HardwareWalletsSwapsStepKind,
+  HardwareWalletsSwapsStepStatus,
+  type HardwareWalletsSwapsState,
 } from './HardwareWalletsSwaps.state';
 import { useHardwareWalletSubmit } from './useHardwareWalletSubmit';
 
@@ -69,19 +71,41 @@ const preparedTxMeta = {
   txParams: { from: '0xfrom' },
 } as unknown as TransactionMeta;
 
+const waitingProgressState: HardwareWalletsSwapsState = {
+  status: HardwareWalletsSwapsStatus.Waiting,
+  currentStep: 0,
+  totalSteps: 1,
+  steps: [
+    {
+      kind: HardwareWalletsSwapsStepKind.Transaction,
+      status: HardwareWalletsSwapsStepStatus.Waiting,
+    },
+  ],
+  disconnectedStep: null,
+};
+
+const submittedProgressState: HardwareWalletsSwapsState = {
+  status: HardwareWalletsSwapsStatus.Submitted,
+  currentStep: 1,
+  totalSteps: 1,
+  steps: [
+    {
+      kind: HardwareWalletsSwapsStepKind.Transaction,
+      status: HardwareWalletsSwapsStepStatus.Signed,
+    },
+  ],
+  disconnectedStep: null,
+};
+
 /** Renders the hook exactly as production wires it: send via approval accept, bridge via submitBridgeTx. */
 function renderSubmitHook(isSendFlow: boolean) {
-  return renderHook(() =>
+  const progressRef = { current: waitingProgressState };
+  const hook = renderHook(() =>
     useHardwareWalletSubmit({
       isSendFlow,
       walletAddress: '0xfrom',
       dispatch: mockDispatch as unknown as Dispatch<AnyAction>,
-      progressRef: {
-        current: {
-          ...initialHardwareWalletsSwapsState,
-          status: HardwareWalletsSwapsStatus.Waiting,
-        },
-      },
+      progressRef,
       submissionGenerationRef: { current: 0 },
       preparedTxMeta,
       approvalRequestId: 'approval-1',
@@ -90,6 +114,8 @@ function renderSubmitHook(isSendFlow: boolean) {
       setPendingOperationAddress: jest.fn(),
     }),
   );
+
+  return { ...hook, progressRef };
 }
 
 describe('useHardwareWalletSubmit (unified device-rejection handling)', () => {
@@ -194,6 +220,40 @@ describe('useHardwareWalletSubmit (unified device-rejection handling)', () => {
 
     expect(mockSubmitBridgeTx).toHaveBeenCalledTimes(1);
     expect(mockShowHardwareWalletError).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalledWith({
+      type: HardwareWalletsSwapsEventType.Rejected,
+    });
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: HardwareWalletsSwapsEventType.TransactionFailed,
+    });
+  });
+
+  it('bridge flow: dispatches TransactionFailed for rejection-shaped broadcast errors after signing', async () => {
+    let rejectBroadcast!: (reason?: unknown) => void;
+    mockSubmitBridgeTx.mockImplementation(
+      () =>
+        new Promise<never>((_, reject) => {
+          rejectBroadcast = reject;
+        }),
+    );
+
+    const { result, progressRef } = renderSubmitHook(false);
+    let submitPromise!: Promise<void>;
+
+    act(() => {
+      submitPromise = result.current.submit();
+    });
+    await waitFor(() => {
+      expect(mockSubmitBridgeTx).toHaveBeenCalledTimes(1);
+    });
+    progressRef.current = submittedProgressState;
+
+    await act(async () => {
+      rejectBroadcast(new Error('Broadcast rejected by provider'));
+      await submitPromise;
+    });
+
+    expect(mockSubmitBridgeTx).toHaveBeenCalledTimes(1);
     expect(mockDispatch).not.toHaveBeenCalledWith({
       type: HardwareWalletsSwapsEventType.Rejected,
     });

--- a/app/components/UI/HardwareWallet/Swaps/useHardwareWalletSubmit.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHardwareWalletSubmit.ts
@@ -25,6 +25,7 @@ import useSubmitBridgeTx from '../../../../util/bridge/hooks/useSubmitBridgeTx';
 import { withPostTradeNotificationSuppression } from '../../Bridge/utils/postTradeNotifications';
 import {
   HardwareWalletsSwapsEventType,
+  HardwareWalletsSwapsStatus,
   type HardwareWalletsSwapsState,
 } from './HardwareWalletsSwaps.state';
 import type { SubmissionParams } from './HardwareWalletsSwaps';
@@ -186,16 +187,12 @@ export function useHardwareWalletSubmit({
         if (submissionGenerationRef.current !== submissionGenerationAtStart) {
           return undefined;
         }
-        // Device rejections are treated uniformly for both flows and are
-        // surfaced INLINE via the Rejected state (rejected_title + Try
-        // Again/Cancel on the progress screen) — no error sheet. Bridge
-        // signing errors never reach this catch — the batch tracker's
-        // executeHardwareWalletOperation consumes them without rethrowing —
-        // so submitFn rejections here are approval (send) or broadcast
-        // (bridge) failures. Known internal abort signals whose messages
-        // merely look like cancellations are excluded so they fall through
-        // to the generic failure path.
+        // Rejected is only accepted while the progress state is Waiting. Once
+        // all signing steps have completed (Submitted), submitFn can reject
+        // because publishing failed; its error message may contain a broad
+        // cancellation pattern but must reach TransactionFailed.
         if (
+          progressRef.current.status === HardwareWalletsSwapsStatus.Waiting &&
           isDeviceUserRejection(error, {
             excludedMessages: INTERNAL_ABORT_MESSAGES,
           })
@@ -216,7 +213,7 @@ export function useHardwareWalletSubmit({
         return undefined;
       }
     },
-    [dispatch, submissionGenerationRef],
+    [dispatch],
   );
 
   // ── Send flow ──────────────────────────────────────────────────────

--- a/app/components/UI/HardwareWallet/Swaps/useHardwareWalletSubmit.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHardwareWalletSubmit.ts
@@ -213,6 +213,7 @@ export function useHardwareWalletSubmit({
         return undefined;
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps - refs do not need to be included in the dependency array
     [dispatch],
   );
 

--- a/app/components/UI/HardwareWallet/Swaps/useHardwareWalletSubmit.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHardwareWalletSubmit.ts
@@ -15,12 +15,15 @@ import type { Hex } from '@metamask/utils';
 import Engine from '../../../../core/Engine';
 import Logger from '../../../../util/Logger';
 import { getDeviceIdForAddress } from '../../../../core/HardwareWallet/helpers';
+import {
+  INTERNAL_ABORT_MESSAGES,
+  isDeviceUserRejection,
+} from '../../../../core/HardwareWallet/errors/helpers';
 import { updateHardwareWalletsSwaps } from '../../../../core/redux/slices/bridge';
 import useApprovalRequest from '../../../Views/confirmations/hooks/useApprovalRequest';
 import useSubmitBridgeTx from '../../../../util/bridge/hooks/useSubmitBridgeTx';
 import { withPostTradeNotificationSuppression } from '../../Bridge/utils/postTradeNotifications';
 import {
-  HardwareWalletsSwapsStatus,
   HardwareWalletsSwapsEventType,
   type HardwareWalletsSwapsState,
 } from './HardwareWalletsSwaps.state';
@@ -173,7 +176,7 @@ export function useHardwareWalletSubmit({
     }
   }, [submissionParams]);
 
-  // Shared stale-submission guard + TransactionFailed dispatch.
+  // Shared stale-submission guard + failure dispatch.
   const runSubmit = useCallback(
     async <Result>(submitFn: () => Promise<Result>) => {
       const submissionGenerationAtStart = submissionGenerationRef.current;
@@ -181,31 +184,39 @@ export function useHardwareWalletSubmit({
         return await submitFn();
       } catch (error) {
         if (submissionGenerationRef.current !== submissionGenerationAtStart) {
-          return;
+          return undefined;
         }
-        Logger.error(error as Error, 'HW swap submit failed');
-        const status = progressRef.current.status;
-        // Only transition to Failed from active phases:
-        // - Waiting:  HW signing step failed (device error, keyring error, etc.)
-        // - Submitted: signing succeeded but the broadcast (STX backend) failed
-        //
-        // Other statuses (Rejected, Disconnected, Cancelled, Failed, Idle) are
-        // already terminal or handled — the error is redundant and skipping it
-        // avoids overwriting state the reducer deliberately expects to be retryable.
+        // Device rejections are treated uniformly for both flows and are
+        // surfaced INLINE via the Rejected state (rejected_title + Try
+        // Again/Cancel on the progress screen) — no error sheet. Bridge
+        // signing errors never reach this catch — the batch tracker's
+        // executeHardwareWalletOperation consumes them without rethrowing —
+        // so submitFn rejections here are approval (send) or broadcast
+        // (bridge) failures. Known internal abort signals whose messages
+        // merely look like cancellations are excluded so they fall through
+        // to the generic failure path.
         if (
-          status === HardwareWalletsSwapsStatus.Waiting ||
-          status === HardwareWalletsSwapsStatus.Submitted
+          isDeviceUserRejection(error, {
+            excludedMessages: INTERNAL_ABORT_MESSAGES,
+          })
         ) {
           dispatch(
             updateHardwareWalletsSwaps({
-              type: HardwareWalletsSwapsEventType.TransactionFailed,
+              type: HardwareWalletsSwapsEventType.Rejected,
             }),
           );
+          return undefined;
         }
+        Logger.error(error as Error, 'HW swap submit failed');
+        dispatch(
+          updateHardwareWalletsSwaps({
+            type: HardwareWalletsSwapsEventType.TransactionFailed,
+          }),
+        );
         return undefined;
       }
     },
-    [dispatch, progressRef, submissionGenerationRef],
+    [dispatch, submissionGenerationRef],
   );
 
   // ── Send flow ──────────────────────────────────────────────────────

--- a/app/components/UI/HardwareWallet/Swaps/useHwBatchSignTracker.test.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHwBatchSignTracker.test.ts
@@ -129,6 +129,7 @@ interface MockTransactionMeta {
   txParams: { from: string; to?: string };
   batchId?: string;
   chainId?: string;
+  error?: { message: string; name?: string };
 }
 
 interface MockApprovalState {
@@ -475,6 +476,26 @@ describe('useHwBatchSignTracker', () => {
     fireTxEvent(txMeta({ type: txType, status }), undefined, eventKey);
 
     expect(mockUpdateSwaps).toHaveBeenCalledWith(expected);
+  });
+
+  it('dispatches Rejected when transactionFailed carries a Ledger device rejection', () => {
+    renderEnabledHook();
+
+    fireTxEvent(
+      txMeta({
+        type: TransactionType.bridgeApproval,
+        status: TransactionStatus.failed,
+        error: {
+          name: 'TransportStatusError',
+          message: 'Ledger device: Action cancelled by user (0x6985)',
+        },
+      }),
+      undefined,
+      'failed',
+    );
+
+    expect(mockUpdateSwaps).toHaveBeenCalledWith(EXPECT_REJECTED_APPROVAL);
+    expect(mockUpdateSwaps).not.toHaveBeenCalledWith(EXPECT_TX_FAILED);
   });
 
   it('ignores events from a different address', () => {
@@ -1869,6 +1890,43 @@ describe('useHwBatchSignTracker', () => {
         expect(getAllStatusHandlers()).toHaveLength(2);
       });
       broadcastTxEvent({ ...tx, status: TransactionStatus.dropped });
+    });
+
+    it('dispatches rejected (not failed) when Ledger device rejection is reported through onError', async () => {
+      const batchId = 'batch-ledger-reject-001';
+      const tx = matchingBatchTx(batchId);
+      const ledgerRejection = Object.assign(
+        new Error('Ledger device: Action cancelled by user (0x6985)'),
+        { name: 'TransportStatusError', statusCode: 27013 },
+      );
+      let didSuppressErrorSheet = false;
+      mockHwOpOnce(async ({ execute, onError, onRejected }) => {
+        await execute();
+        didSuppressErrorSheet = onError?.(ledgerRejection) ?? false;
+        const rejectionPromise = onRejected?.();
+        await waitFor(() => {
+          expect(getAllStatusHandlers()).toHaveLength(2);
+        });
+        broadcastTxEvent({ ...tx, status: TransactionStatus.dropped });
+        await rejectionPromise;
+        return false;
+      });
+
+      setMockTransactions([tx]);
+      setMockPendingApprovals({
+        [batchId]: { id: batchId, type: ApprovalType.TransactionBatch },
+      });
+      renderEnabledHook();
+
+      await act(async () => {
+        await getApprovalHandler()();
+      });
+
+      expect(didSuppressErrorSheet).toBe(true);
+      expect(mockUpdateSwaps).toHaveBeenCalledWith({
+        type: HardwareWalletsSwapsEventType.Rejected,
+      });
+      expect(mockUpdateSwaps).not.toHaveBeenCalledWith(EXPECT_TX_FAILED);
     });
 
     it('dispatches rejected when Keystone cancellation is reported through onError', async () => {

--- a/app/components/UI/HardwareWallet/Swaps/useHwBatchSignTracker.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHwBatchSignTracker.ts
@@ -11,6 +11,10 @@ import {
   executeHardwareWalletOperation,
   useHardwareWallet,
 } from '../../../../core/HardwareWallet';
+import {
+  INTERNAL_ABORT_MESSAGES,
+  isDeviceUserRejection,
+} from '../../../../core/HardwareWallet/errors/helpers';
 import { updateHardwareWalletsSwaps } from '../../../../core/redux/slices/bridge';
 import {
   HardwareWalletsSwapsStepKind,
@@ -67,6 +71,30 @@ import {
   type TrackingStrategy,
   NO_ACTION,
 } from './hw-batch-sign/tracking-strategy';
+
+/**
+ * TransactionController records a device-side reject as `failed` (approval
+ * was already accepted; signing then failed), not `rejected`. Reconstruct an
+ * Error so {@link isDeviceUserRejection} can parse the stored message/name.
+ */
+function isDeviceRejectionFromFailedTx(error?: {
+  message?: string;
+  name?: string;
+}): boolean {
+  if (!error?.message) {
+    return false;
+  }
+  if (error.message === KEYSTONE_TX_CANCELED) {
+    return true;
+  }
+  const wrapped = new Error(error.message);
+  if (error.name) {
+    wrapped.name = error.name;
+  }
+  return isDeviceUserRejection(wrapped, {
+    excludedMessages: INTERNAL_ABORT_MESSAGES,
+  });
+}
 
 /**
  * Drives hardware-wallet signing for a multi-step bridge/swap batch.
@@ -482,8 +510,16 @@ export function useHwBatchSignTracker({
                     }),
                   );
                 }
-                const isKeystoneCancel = message === KEYSTONE_TX_CANCELED;
-                if (isKeystoneCancel) {
+                // Device-side user rejections (Ledger 0x6985, Keystone cancel,
+                // message patterns) must surface INLINE as Rejected — not the
+                // generic TransactionFailed that handleApprovalRejection
+                // otherwise dispatches. Internal abort messages that merely
+                // look like cancellations are excluded so they stay Failed.
+                const isDeviceRejection =
+                  isDeviceUserRejection(error, {
+                    excludedMessages: INTERNAL_ABORT_MESSAGES,
+                  }) || message === KEYSTONE_TX_CANCELED;
+                if (isDeviceRejection) {
                   didDispatchCancellationRejection = true;
                   latestValuesRef.current.dispatch(
                     updateHardwareWalletsSwaps({
@@ -494,7 +530,7 @@ export function useHwBatchSignTracker({
 
                 return (
                   isStxSubmissionFailure ||
-                  isKeystoneCancel ||
+                  isDeviceRejection ||
                   message === BATCH_CANCELLED_ERROR
                 );
               },
@@ -783,7 +819,13 @@ export function useHwBatchSignTracker({
     };
 
     const classifyFinished: SignedEventClassifier = (meta) => {
-      if (meta.status === TransactionStatus.failed)
+      if (meta.status === TransactionStatus.failed) {
+        // Device rejects arrive as `failed` because acceptRequest already
+        // consumed the approval; signing then threw. Classify before the
+        // generic Failed path so the progress screen shows Rejected.
+        if (isDeviceRejectionFromFailedTx(meta.error)) {
+          return classifyRejected(meta);
+        }
         return {
           event: { type: HardwareWalletsSwapsEventType.TransactionFailed },
           shouldTrackAsPending: false,
@@ -791,6 +833,7 @@ export function useHwBatchSignTracker({
           shouldEnqueueApprovals: false,
           shouldTrackCancellation: false,
         };
+      }
       return classifyStatusUpdate(meta);
     };
 

--- a/app/components/UI/HardwareWallet/Swaps/useHwConnectionMonitoring.test.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHwConnectionMonitoring.test.ts
@@ -17,18 +17,18 @@ import type { HardwareWalletContextValue } from '../../../../core/HardwareWallet
 import { useHardwareWallet } from '../../../../core/HardwareWallet';
 import {
   getRecoveryActionForErrorCode,
-  isUserCancellation,
+  isDeviceUserRejection,
 } from '../../../../core/HardwareWallet/errors/helpers';
-import { RecoveryAction } from '../../../../core/HardwareWallet/errors/types';
 import { parseErrorByType } from '../../../../core/HardwareWallet/errors/parser';
+import { RecoveryAction } from '../../../../core/HardwareWallet/errors/types';
 
 jest.mock('../../../../core/HardwareWallet', () => ({
   useHardwareWallet: jest.fn(),
 }));
 
 jest.mock('../../../../core/HardwareWallet/errors/helpers', () => ({
-  isUserCancellation: jest.fn(),
   getRecoveryActionForErrorCode: jest.fn(),
+  isDeviceUserRejection: jest.fn(),
 }));
 
 jest.mock('../../../../core/HardwareWallet/errors/parser', () => ({
@@ -185,7 +185,7 @@ describe('useHwConnectionMonitoring', () => {
     (parseErrorByType as jest.Mock).mockReturnValue(
       makeParsedError(ErrorCode.Unknown),
     );
-    (isUserCancellation as jest.Mock).mockReturnValue(false);
+    (isDeviceUserRejection as jest.Mock).mockReturnValue(false);
     // Default: errors are recoverable by reconnecting (no flow dispatch).
     (getRecoveryActionForErrorCode as jest.Mock).mockReturnValue(
       RecoveryAction.RETRY,
@@ -338,7 +338,7 @@ describe('useHwConnectionMonitoring', () => {
     (parseErrorByType as jest.Mock).mockReturnValue(
       makeParsedError(ErrorCode.UserRejected),
     );
-    (isUserCancellation as jest.Mock).mockReturnValue(true);
+    (isDeviceUserRejection as jest.Mock).mockReturnValue(true);
 
     renderAndTransitionToWaiting(createErrorState(error));
 
@@ -354,7 +354,7 @@ describe('useHwConnectionMonitoring', () => {
     (parseErrorByType as jest.Mock).mockReturnValue(
       makeParsedError(ErrorCode.DeviceStateBlindSignNotSupported),
     );
-    (isUserCancellation as jest.Mock).mockReturnValue(false);
+    (isDeviceUserRejection as jest.Mock).mockReturnValue(false);
     (getRecoveryActionForErrorCode as jest.Mock).mockReturnValue(
       RecoveryAction.ACKNOWLEDGE,
     );
@@ -371,7 +371,7 @@ describe('useHwConnectionMonitoring', () => {
     (parseErrorByType as jest.Mock).mockReturnValue(
       makeParsedError(ErrorCode.DeviceStateBlindSignNotSupported),
     );
-    (isUserCancellation as jest.Mock).mockReturnValue(false);
+    (isDeviceUserRejection as jest.Mock).mockReturnValue(false);
     (getRecoveryActionForErrorCode as jest.Mock).mockReturnValue(
       RecoveryAction.ACKNOWLEDGE,
     );
@@ -386,7 +386,7 @@ describe('useHwConnectionMonitoring', () => {
     (parseErrorByType as jest.Mock).mockReturnValue(
       makeParsedError(ErrorCode.DeviceStateBlindSignNotSupported),
     );
-    (isUserCancellation as jest.Mock).mockReturnValue(false);
+    (isDeviceUserRejection as jest.Mock).mockReturnValue(false);
     (getRecoveryActionForErrorCode as jest.Mock).mockReturnValue(
       RecoveryAction.ACKNOWLEDGE,
     );
@@ -405,7 +405,7 @@ describe('useHwConnectionMonitoring', () => {
     (parseErrorByType as jest.Mock).mockReturnValue(
       makeParsedError(ErrorCode.Unknown),
     );
-    (isUserCancellation as jest.Mock).mockReturnValue(false);
+    (isDeviceUserRejection as jest.Mock).mockReturnValue(false);
 
     renderAndTransitionToWaiting(createErrorState(error));
 
@@ -576,7 +576,7 @@ describe('useHwConnectionMonitoring', () => {
     (parseErrorByType as jest.Mock).mockReturnValue(
       makeParsedError(ErrorCode.UserRejected),
     );
-    (isUserCancellation as jest.Mock).mockReturnValue(true);
+    (isDeviceUserRejection as jest.Mock).mockReturnValue(true);
 
     const { rerender } = renderAndTransitionToWaiting(createErrorState(error));
 
@@ -672,7 +672,7 @@ describe('useHwConnectionMonitoring', () => {
     (parseErrorByType as jest.Mock).mockReturnValue(
       makeParsedError(ErrorCode.Unknown),
     );
-    (isUserCancellation as jest.Mock).mockReturnValue(false);
+    (isDeviceUserRejection as jest.Mock).mockReturnValue(false);
 
     mockUseHardwareWallet.mockReturnValue(
       mockContextWith(createErrorState(error)),
@@ -767,7 +767,7 @@ describe('useHwConnectionMonitoring', () => {
     (parseErrorByType as jest.Mock).mockReturnValue(
       makeParsedError(ErrorCode.Unknown),
     );
-    (isUserCancellation as jest.Mock).mockReturnValue(false);
+    (isDeviceUserRejection as jest.Mock).mockReturnValue(false);
 
     const readyState = createReadyState();
     mockUseHardwareWallet.mockReturnValue(mockContextWith(readyState));

--- a/app/components/UI/HardwareWallet/Swaps/useHwConnectionMonitoring.ts
+++ b/app/components/UI/HardwareWallet/Swaps/useHwConnectionMonitoring.ts
@@ -4,10 +4,10 @@ import { ConnectionStatus, ErrorCode } from '@metamask/hw-wallet-sdk';
 import { useHardwareWallet } from '../../../../core/HardwareWallet';
 import {
   getRecoveryActionForErrorCode,
-  isUserCancellation,
+  isDeviceUserRejection,
 } from '../../../../core/HardwareWallet/errors/helpers';
-import { RecoveryAction } from '../../../../core/HardwareWallet/errors/types';
 import { parseErrorByType } from '../../../../core/HardwareWallet/errors/parser';
+import { RecoveryAction } from '../../../../core/HardwareWallet/errors/types';
 import { updateHardwareWalletsSwaps } from '../../../../core/redux/slices/bridge';
 import {
   HardwareWalletsSwapsStatus,
@@ -231,7 +231,7 @@ export function useHwConnectionMonitoring({
       return;
     }
 
-    if (error && isUserCancellation(error)) {
+    if (error && isDeviceUserRejection(error)) {
       handledErrorRef.current = error;
       dispatch(
         updateHardwareWalletsSwaps({

--- a/app/core/HardwareWallet/errors/helpers.test.ts
+++ b/app/core/HardwareWallet/errors/helpers.test.ts
@@ -7,6 +7,8 @@ import {
 } from '@metamask/hw-wallet-sdk';
 import {
   isUserCancellation,
+  isDeviceUserRejection,
+  INTERNAL_ABORT_MESSAGES,
   getIconForErrorCode,
   getIconColorForErrorCode,
   getTitleForErrorCode,
@@ -69,6 +71,86 @@ describe('error helpers', () => {
 
     it('returns false for null', () => {
       expect(isUserCancellation(null)).toBe(false);
+    });
+
+    it('returns false for a RAW transport rejection (by design)', () => {
+      // Raw keyring/transport errors are not HardwareWalletError instances;
+      // confirm-flow suppression depends on them returning false here.
+      const rawRejection = Object.assign(
+        new Error('Ledger device: Action cancelled by user (0x6985)'),
+        { name: 'TransportStatusError', statusCode: 27013 },
+      );
+
+      expect(isUserCancellation(rawRejection)).toBe(false);
+    });
+  });
+
+  describe('isDeviceUserRejection', () => {
+    it('returns true for a RAW TransportStatusError 0x6985 (parsed internally)', () => {
+      const rawRejection = Object.assign(
+        new Error('Ledger device: Action cancelled by user (0x6985)'),
+        { name: 'TransportStatusError', statusCode: 27013 },
+      );
+
+      expect(isDeviceUserRejection(rawRejection)).toBe(true);
+    });
+
+    it('returns true for a plain Error whose message signals cancellation', () => {
+      expect(
+        isDeviceUserRejection(
+          new Error('Ledger device: Action cancelled by user'),
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false for an exactly-matching excluded message', () => {
+      expect(
+        isDeviceUserRejection(new Error('Batch cancelled'), {
+          excludedMessages: ['Batch cancelled'],
+        }),
+      ).toBe(false);
+    });
+
+    it('returns false for the Batch cancelled internal abort via INTERNAL_ABORT_MESSAGES', () => {
+      expect(
+        isDeviceUserRejection(new Error('Batch cancelled'), {
+          excludedMessages: INTERNAL_ABORT_MESSAGES,
+        }),
+      ).toBe(false);
+    });
+
+    it('returns false for the STX no-hash internal abort via INTERNAL_ABORT_MESSAGES', () => {
+      expect(
+        isDeviceUserRejection(
+          new Error(
+            'Smart Transaction does not have a transaction hash, there was a problem',
+          ),
+          {
+            excludedMessages: INTERNAL_ABORT_MESSAGES,
+          },
+        ),
+      ).toBe(false);
+    });
+
+    it('returns true for a HardwareWalletError UserRejected instance', () => {
+      const error = new HardwareWalletError('User rejected', {
+        code: ErrorCode.UserRejected,
+        severity: Severity.Info,
+        category: Category.UserAction,
+        userMessage: 'User rejected',
+      });
+
+      expect(isDeviceUserRejection(error)).toBe(true);
+    });
+
+    it('returns false for null', () => {
+      expect(isDeviceUserRejection(null)).toBe(false);
+    });
+
+    it('returns false for non-error values', () => {
+      expect(isDeviceUserRejection('UserRejected')).toBe(false);
+      expect(isDeviceUserRejection(42)).toBe(false);
+      expect(isDeviceUserRejection(undefined)).toBe(false);
     });
   });
 

--- a/app/core/HardwareWallet/errors/helpers.ts
+++ b/app/core/HardwareWallet/errors/helpers.ts
@@ -9,10 +9,19 @@ import {
   IconColor,
 } from '../../../component-library/components/Icons/Icon';
 import { MOBILE_ERROR_EXTENSIONS } from './mappings';
+import { parseErrorByType } from './parser';
 import { RecoveryAction } from './types';
 
 /**
- * Check if an error represents a user cancellation
+ * Check if an error represents a user cancellation.
+ *
+ * Returns `true` ONLY for parsed `HardwareWalletError` instances whose code is
+ * `UserRejected` or `UserCancelled`. RAW keyring/transport errors (e.g. a
+ * Ledger `TransportStatusError` with status `0x6985`) are NOT
+ * `HardwareWalletError` instances and return `false` BY DESIGN — the
+ * confirm-flow suppression depends on raw errors being ignored here. To
+ * classify a possibly-raw error, parse it first (see
+ * {@link isDeviceUserRejection}).
  */
 export function isUserCancellation(error: unknown): boolean {
   if (HardwareWalletError.isHardwareWalletError(error)) {
@@ -22,6 +31,39 @@ export function isUserCancellation(error: unknown): boolean {
     );
   }
   return false;
+}
+
+/**
+ * Swap/bridge-internal failure messages that merely LOOK like device
+ * cancellations and must never be classified as a user rejection. Keep in
+ * sync with:
+ * - BATCH_CANCELLED_ERROR in app/components/UI/HardwareWallet/Swaps/hw-batch-sign/constants.ts
+ * - STX_NO_HASH_ERROR in app/util/smart-transactions/smart-publish-hook.ts
+ */
+export const INTERNAL_ABORT_MESSAGES: readonly string[] = [
+  'Batch cancelled',
+  'Smart Transaction does not have a transaction hash, there was a problem',
+];
+
+/**
+ * Classifies a possibly-RAW error (keyring/transport/approval rejection) as a
+ * device-side user rejection by parsing it first. Internal abort signals whose
+ * messages merely CONTAIN cancellation keywords (e.g. 'Batch cancelled') must be
+ * passed via excludedMessages (exact match) so they are not misclassified. For
+ * swap/send callers, use {@link INTERNAL_ABORT_MESSAGES} as the recommended
+ * exclusion list.
+ */
+export function isDeviceUserRejection(
+  error: unknown,
+  options?: { excludedMessages?: readonly string[] },
+): boolean {
+  if (
+    error instanceof Error &&
+    options?.excludedMessages?.includes(error.message)
+  ) {
+    return false;
+  }
+  return isUserCancellation(parseErrorByType(error));
 }
 
 /**

--- a/app/core/HardwareWallet/errors/parser.test.ts
+++ b/app/core/HardwareWallet/errors/parser.test.ts
@@ -206,6 +206,24 @@ describe('parseErrorByType', () => {
       expect(result.code).toBe(ErrorCode.DeviceDisconnected);
     });
 
+    it('parses legacy BLE "Failed to open transport" as BluetoothConnectionFailed', () => {
+      const error = new Error('Failed to open transport');
+
+      const result = parseErrorByType(error, walletType);
+
+      expect(result.code).toBe(ErrorCode.BluetoothConnectionFailed);
+    });
+
+    it('parses DMK "No cached DiscoveredDevice" as DeviceDisconnected', () => {
+      const error = new Error(
+        'No cached DiscoveredDevice for deviceId: ABC-123',
+      );
+
+      const result = parseErrorByType(error, walletType);
+
+      expect(result.code).toBe(ErrorCode.DeviceDisconnected);
+    });
+
     it('parses LockedDeviceError', () => {
       const error = new Error('Device is locked');
       error.name = 'LockedDeviceError';

--- a/app/core/HardwareWallet/errors/parser.ts
+++ b/app/core/HardwareWallet/errors/parser.ts
@@ -290,6 +290,19 @@ export const LOCAL_MESSAGE_PATTERNS: {
     patterns: ['disconnected', 'disconnect', 'connection lost'],
     code: ErrorCode.DeviceDisconnected,
   },
+  {
+    // Legacy BLE adapter: TransportBLE.open returned null — the Ledger is not
+    // currently connectable (locked, screen off, out of range, cold BLE cache
+    // after app restart).
+    patterns: ['failed to open transport'],
+    code: ErrorCode.BluetoothConnectionFailed,
+  },
+  {
+    // DMK adapter: direct connect attempted with a stored deviceId but no
+    // device-discovery session has run this app launch.
+    patterns: ['no cached discovereddevice'],
+    code: ErrorCode.DeviceDisconnected,
+  },
   { patterns: ['timeout', 'timed out'], code: ErrorCode.ConnectionTimeout },
   {
     patterns: ['locked', 'unlock'],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.



md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

Rejecting a hardware-wallet signing request (Ledger `0x6985`, Keystone cancel) showed a generic error instead of the cancel screen, because raw transport errors and `failed` transactions weren't recognized as user rejections.

This PR adds `isDeviceUserRejection()` (parses raw errors, excludes internal abort messages like "Batch cancelled") and uses it in the swap submit, batch-sign, and connection-monitoring hooks so device rejections surface the inline Rejected screen. Also maps cold-start Ledger BLE/DMK connect failures to specific error codes.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed hardware wallet swaps showing a generic error instead of the cancel screen when a user rejected the signing request on their device


## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:  https://consensyssoftware.atlassian.net/browse/MUL-2020?atlOrigin=eyJpIjoiMzMyYmQzZDFiZjZlNDVkZjgyNzdlMWY3NDk5MjdjZWMiLCJwIjoiaiJ9

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Hardware wallet swap device rejection

  Scenario: user rejects a swap signing request on a Ledger
    Given the app is unlocked with a Ledger connected via Bluetooth/USB
    And a swap/bridge has been confirmed from a Ledger account
    And the signing request is displayed on the device

    When user rejects the request on the device (0x6985)
    Then the progress screen shows the inline "Rejected" state with Try Again / Cancel
    And no generic error sheet is shown

  Scenario: user cancels signing on a Keystone
    Given the app is unlocked with a Keystone connected
    And a swap/bridge has been confirmed from a Keystone account

    When user cancels on the Keystone device
    Then the progress screen shows the inline "Rejected" state

  Scenario: internal batch abort is not treated as a user rejection
    Given a hardware wallet swap batch fails internally (e.g. "Batch cancelled" or STX no-hash error)

    When the failure surfaces
    Then the flow shows the Failed state (not Rejected)
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/0dae2e92-4b2c-4d0c-b080-b8a1099c3cea

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUL-2019]: https://consensyssoftware.atlassian.net/browse/MUL-2019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hardware-wallet swap state-machine error routing across submit, batch-sign, and connection hooks; misclassification could show wrong terminal UI, though exclusions and phase guards limit blast radius.
> 
> **Overview**
> Fixes hardware-wallet swap/bridge flows treating **device-side sign rejections** (Ledger `0x6985`, Keystone cancel, similar messages) as generic **Failed** instead of the inline **Rejected** progress state.
> 
> Introduces **`isDeviceUserRejection()`**, which parses raw transport/keyring errors and honors **`INTERNAL_ABORT_MESSAGES`** so internal signals like **"Batch cancelled"** and STX no-hash failures stay on **TransactionFailed**. **`isUserCancellation`** is unchanged for parsed `HardwareWalletError` only (confirm-flow behavior preserved).
> 
> **Submit path** (`useHardwareWalletSubmit`): while status is **Waiting**, matching rejections dispatch **Rejected** without the HW error sheet; post-sign **Submitted** failures still map to **TransactionFailed** even if the message looks like a cancel.
> 
> **Batch signing** (`useHwBatchSignTracker`): `onError` and **`failed`** transaction events reclassify device rejections to **Rejected** (including re-wrapped tx error snapshots).
> 
> **Connection monitoring** swaps to **`isDeviceUserRejection`** for the same UX. **Error parser** adds mappings for legacy BLE **"Failed to open transport"** and DMK **"No cached DiscoveredDevice"** connect failures.
> 
> Coverage is expanded in **`useHardwareWalletSubmit.test.ts`** and related HW swap tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2590997a50633efeaf60f5af9f24d9d17cbf403f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->