### PR TITLE
fix(confirmations): default pay-with to money account when EOA has no tokens (CONF-1758)

### DIFF
--- a/app/components/Views/confirmations/hooks/pay/useAutomaticMoneyAccountPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticMoneyAccountPayToken.test.ts
@@ -1,0 +1,261 @@
+import { renderHookWithProvider } from '../../../../../util/test/renderWithProvider';
+import { TransactionType } from '@metamask/transaction-controller';
+import { PaymentOverride } from '@metamask/transaction-pay-controller';
+import {
+  isHardwareAccount,
+  isQRHardwareAccount,
+} from '../../../../../util/address';
+import { selectMetaMaskPayFlags } from '../../../../../selectors/featureFlagController/confirmations';
+import { selectPrimaryMoneyAccount } from '../../../../../selectors/moneyAccountController';
+import { selectPaymentOverrideByTransactionId } from '../../../../../selectors/transactionPayController';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+import useMoneyAccountBalance from '../../../../UI/Money/hooks/useMoneyAccountBalance';
+import { applyMoneyAccountOverride } from '../../utils/transaction-pay';
+import { transactionIdMock } from '../../__mocks__/controllers/transaction-controller-mock';
+import { useAutomaticMoneyAccountPayToken } from './useAutomaticMoneyAccountPayToken';
+
+jest.mock('../transactions/useTransactionMetadataRequest');
+jest.mock('../../../../../util/address');
+jest.mock('../../../../../selectors/transactionPayController');
+jest.mock(
+  '../../../../../selectors/featureFlagController/confirmations',
+  () => ({
+    ...jest.requireActual(
+      '../../../../../selectors/featureFlagController/confirmations',
+    ),
+    selectMetaMaskPayFlags: jest.fn(),
+  }),
+);
+jest.mock('../../../../../selectors/moneyAccountController', () => ({
+  ...jest.requireActual('../../../../../selectors/moneyAccountController'),
+  selectPrimaryMoneyAccount: jest.fn(),
+}));
+jest.mock('../../../../UI/Money/hooks/useMoneyAccountBalance', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock('../../utils/transaction-pay', () => ({
+  ...jest.requireActual('../../utils/transaction-pay'),
+  applyMoneyAccountOverride: jest.fn(),
+}));
+
+const MONEY_ACCOUNT_ADDRESS_MOCK = '0xabc1111111111111111111111111111111111111';
+
+function runHook({
+  autoSelectFiatPayment = false,
+  disable = false,
+  hasFiatPaymentSelected = false,
+  hasTokenBalance = false,
+  payTokenSelected = false,
+}: {
+  autoSelectFiatPayment?: boolean;
+  disable?: boolean;
+  hasFiatPaymentSelected?: boolean;
+  hasTokenBalance?: boolean;
+  payTokenSelected?: boolean;
+} = {}) {
+  return renderHookWithProvider(
+    () =>
+      useAutomaticMoneyAccountPayToken({
+        autoSelectFiatPayment,
+        disable,
+        hasFiatPaymentSelected,
+        hasTokenBalance,
+        payTokenSelected,
+      }),
+    { state: {} },
+  );
+}
+
+describe('useAutomaticMoneyAccountPayToken', () => {
+  const useTransactionMetadataRequestMock = jest.mocked(
+    useTransactionMetadataRequest,
+  );
+  const isHardwareAccountMock = jest.mocked(isHardwareAccount);
+  const isQRHardwareAccountMock = jest.mocked(isQRHardwareAccount);
+  const selectMetaMaskPayFlagsMock = jest.mocked(selectMetaMaskPayFlags);
+  const selectPrimaryMoneyAccountMock = jest.mocked(selectPrimaryMoneyAccount);
+  const selectPaymentOverrideMock = jest.mocked(
+    selectPaymentOverrideByTransactionId,
+  );
+  const useMoneyAccountBalanceMock = jest.mocked(useMoneyAccountBalance);
+  const applyMoneyAccountOverrideMock = jest.mocked(applyMoneyAccountOverride);
+
+  function mockMoneyAccountPay({
+    balance = '7.61',
+    enabled = true,
+    isBalanceLoading = false,
+    type = TransactionType.perpsDeposit,
+  }: {
+    balance?: string;
+    enabled?: boolean;
+    isBalanceLoading?: boolean;
+    type?: TransactionType;
+  } = {}) {
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: transactionIdMock,
+      type,
+      txParams: { from: '0xdc47789de4ceff0e8fe9d15d728af7f17550c164' },
+    } as never);
+    selectPrimaryMoneyAccountMock.mockReturnValue({
+      address: MONEY_ACCOUNT_ADDRESS_MOCK,
+    } as never);
+    selectMetaMaskPayFlagsMock.mockReturnValue({
+      enableMoneyAccountTransactions: enabled
+        ? { perpsDeposit: true, predictDeposit: true }
+        : {},
+    } as never);
+    useMoneyAccountBalanceMock.mockReturnValue({
+      isBalanceLoading,
+      withdrawableFiatRaw: isBalanceLoading ? undefined : balance,
+    } as never);
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    isHardwareAccountMock.mockReturnValue(false);
+    isQRHardwareAccountMock.mockReturnValue(false);
+    selectPaymentOverrideMock.mockReturnValue(undefined);
+    selectMetaMaskPayFlagsMock.mockReturnValue({
+      enableMoneyAccountTransactions: {},
+    } as never);
+    selectPrimaryMoneyAccountMock.mockReturnValue(undefined);
+    useMoneyAccountBalanceMock.mockReturnValue({
+      isBalanceLoading: false,
+      withdrawableFiatRaw: undefined,
+    } as never);
+    useTransactionMetadataRequestMock.mockReturnValue({
+      id: transactionIdMock,
+      type: TransactionType.perpsDeposit,
+      txParams: { from: '0xdc47789de4ceff0e8fe9d15d728af7f17550c164' },
+    } as never);
+  });
+
+  it.each([
+    ['perpsDeposit', TransactionType.perpsDeposit],
+    ['predictDeposit', TransactionType.predictDeposit],
+  ])(
+    'selects money account for %s when it has a balance and the EOA has no tokens',
+    (_label, type) => {
+      mockMoneyAccountPay({ type });
+
+      const { result } = runHook();
+
+      expect(result.current.shouldSelect).toBe(true);
+      expect(applyMoneyAccountOverrideMock).toHaveBeenCalledWith(
+        transactionIdMock,
+        MONEY_ACCOUNT_ADDRESS_MOCK,
+        expect.objectContaining({ type, id: transactionIdMock }),
+      );
+    },
+  );
+
+  it('does not select money account when the EOA has token balance', () => {
+    mockMoneyAccountPay({ balance: '20' });
+
+    const { result } = runHook({ hasTokenBalance: true });
+
+    expect(result.current.shouldSelect).toBe(false);
+    expect(applyMoneyAccountOverrideMock).not.toHaveBeenCalled();
+  });
+
+  it('does not select money account when its balance is 0', () => {
+    mockMoneyAccountPay({ balance: '0' });
+
+    const { result } = runHook();
+
+    expect(result.current.shouldSelect).toBe(false);
+    expect(applyMoneyAccountOverrideMock).not.toHaveBeenCalled();
+  });
+
+  it('does not select money account when the transaction type is not enabled', () => {
+    mockMoneyAccountPay({ enabled: false });
+
+    runHook();
+
+    expect(applyMoneyAccountOverrideMock).not.toHaveBeenCalled();
+  });
+
+  it('returns pending while money account balance is loading', () => {
+    mockMoneyAccountPay({ isBalanceLoading: true });
+
+    const { result } = runHook();
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.shouldSelect).toBe(false);
+    expect(applyMoneyAccountOverrideMock).not.toHaveBeenCalled();
+  });
+
+  it('selects money account after balance loads when the EOA has no tokens', () => {
+    mockMoneyAccountPay({ isBalanceLoading: true });
+
+    const { rerender, result } = runHook();
+
+    expect(applyMoneyAccountOverrideMock).not.toHaveBeenCalled();
+
+    useMoneyAccountBalanceMock.mockReturnValue({
+      isBalanceLoading: false,
+      withdrawableFiatRaw: '7.61',
+    } as never);
+
+    rerender(undefined);
+
+    expect(result.current.shouldSelect).toBe(true);
+    expect(applyMoneyAccountOverrideMock).toHaveBeenCalledWith(
+      transactionIdMock,
+      MONEY_ACCOUNT_ADDRESS_MOCK,
+      expect.objectContaining({ type: TransactionType.perpsDeposit }),
+    );
+  });
+
+  it('does not select money account for a hardware wallet', () => {
+    mockMoneyAccountPay();
+    isHardwareAccountMock.mockReturnValue(true);
+
+    runHook();
+
+    expect(applyMoneyAccountOverrideMock).not.toHaveBeenCalled();
+  });
+
+  it('does not select money account when auto-selecting fiat payment', () => {
+    mockMoneyAccountPay();
+
+    runHook({ autoSelectFiatPayment: true });
+
+    expect(applyMoneyAccountOverrideMock).not.toHaveBeenCalled();
+  });
+
+  it('does not select money account when a pay token is already selected', () => {
+    mockMoneyAccountPay();
+
+    runHook({ payTokenSelected: true });
+
+    expect(applyMoneyAccountOverrideMock).not.toHaveBeenCalled();
+  });
+
+  it('does not select money account when a fiat payment method is selected', () => {
+    mockMoneyAccountPay();
+
+    runHook({ hasFiatPaymentSelected: true });
+
+    expect(applyMoneyAccountOverrideMock).not.toHaveBeenCalled();
+  });
+
+  it('does not select money account when payment override is already MoneyAccount', () => {
+    mockMoneyAccountPay();
+    selectPaymentOverrideMock.mockReturnValue(PaymentOverride.MoneyAccount);
+
+    runHook();
+
+    expect(applyMoneyAccountOverrideMock).not.toHaveBeenCalled();
+  });
+
+  it('does not select money account when disabled', () => {
+    mockMoneyAccountPay();
+
+    runHook({ disable: true });
+
+    expect(applyMoneyAccountOverrideMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticMoneyAccountPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticMoneyAccountPayToken.ts
@@ -1,0 +1,123 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  TransactionMeta,
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
+import { PaymentOverride } from '@metamask/transaction-pay-controller';
+import { createProjectLogger } from '@metamask/utils';
+import { RootState } from '../../../../../reducers';
+import { selectMetaMaskPayFlags } from '../../../../../selectors/featureFlagController/confirmations';
+import { selectPrimaryMoneyAccount } from '../../../../../selectors/moneyAccountController';
+import { selectPaymentOverrideByTransactionId } from '../../../../../selectors/transactionPayController';
+import {
+  isHardwareAccount,
+  isQRHardwareAccount,
+} from '../../../../../util/address';
+import useMoneyAccountBalance from '../../../../UI/Money/hooks/useMoneyAccountBalance';
+import { getTransactionType } from '../../utils/transaction';
+import { applyMoneyAccountOverride } from '../../utils/transaction-pay';
+import { useTransactionMetadataRequest } from '../transactions/useTransactionMetadataRequest';
+
+const log = createProjectLogger('transaction-pay');
+
+const MONEY_ACCOUNT_FALLBACK_DEPOSIT_TYPES: TransactionType[] = [
+  TransactionType.perpsDeposit,
+  TransactionType.predictDeposit,
+];
+
+/**
+ * Auto-selects the Money account for Perps and Predict deposits when the
+ * selected EOA has no token balance and the Money account has a positive
+ * balance. Existing token auto-select is left unchanged whenever any token
+ * balance exists.
+ */
+export function useAutomaticMoneyAccountPayToken({
+  autoSelectFiatPayment = false,
+  disable = false,
+  hasFiatPaymentSelected,
+  hasTokenBalance,
+  payTokenSelected,
+}: {
+  autoSelectFiatPayment?: boolean;
+  disable?: boolean;
+  hasFiatPaymentSelected: boolean;
+  hasTokenBalance: boolean;
+  payTokenSelected: boolean;
+}): { isPending: boolean; shouldSelect: boolean } {
+  const isUpdated = useRef<string | undefined>(undefined);
+  const transactionMetaRequest = useTransactionMetadataRequest();
+  const transactionMeta = useMemo(
+    () => transactionMetaRequest ?? ({ txParams: {} } as TransactionMeta),
+    [transactionMetaRequest],
+  );
+  const transactionId = transactionMeta.id;
+  const from = transactionMeta.txParams?.from;
+  const isHardwareWallet = isHardwareAccount(from ?? '') ?? false;
+  const isQRWallet = isQRHardwareAccount(from ?? '');
+
+  const paymentOverride = useSelector((state: RootState) =>
+    selectPaymentOverrideByTransactionId(state, transactionId ?? ''),
+  );
+  const { enableMoneyAccountTransactions } = useSelector(
+    selectMetaMaskPayFlags,
+  );
+  const moneyAccount = useSelector(selectPrimaryMoneyAccount);
+  const transactionType = getTransactionType(transactionMeta);
+
+  const canUseMoneyAccountPay =
+    !autoSelectFiatPayment &&
+    !isHardwareWallet &&
+    !isQRWallet &&
+    paymentOverride !== PaymentOverride.MoneyAccount &&
+    !hasTokenBalance &&
+    hasTransactionType(transactionMeta, MONEY_ACCOUNT_FALLBACK_DEPOSIT_TYPES) &&
+    Boolean(
+      transactionType && enableMoneyAccountTransactions[transactionType],
+    ) &&
+    Boolean(moneyAccount);
+
+  const { isBalanceLoading, withdrawableFiatRaw } = useMoneyAccountBalance({
+    enabled: canUseMoneyAccountPay,
+  });
+  const moneyAccountBalance = Number(withdrawableFiatRaw ?? 0);
+  const isPending = canUseMoneyAccountPay && isBalanceLoading;
+  const shouldSelect = canUseMoneyAccountPay && moneyAccountBalance > 0;
+
+  useEffect(() => {
+    if (
+      disable ||
+      payTokenSelected ||
+      hasFiatPaymentSelected ||
+      !transactionId ||
+      isUpdated.current === transactionId ||
+      isPending ||
+      !shouldSelect
+    ) {
+      return;
+    }
+
+    applyMoneyAccountOverride(
+      transactionId,
+      moneyAccount?.address,
+      transactionMeta,
+    );
+    isUpdated.current = transactionId;
+    log('Automatically selected money account (no token balance)', {
+      moneyAccountBalance,
+    });
+  }, [
+    disable,
+    hasFiatPaymentSelected,
+    isPending,
+    moneyAccount?.address,
+    moneyAccountBalance,
+    payTokenSelected,
+    shouldSelect,
+    transactionId,
+    transactionMeta,
+  ]);
+
+  return { isPending, shouldSelect };
+}

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.ts
@@ -41,6 +41,7 @@ import { selectLastWithdrawTokenByType } from '../../../../../selectors/transact
 import { selectPaymentOverrideByTransactionId } from '../../../../../selectors/transactionPayController';
 import { useIsFiatPaymentAvailable } from './useIsFiatPaymentAvailable';
 import { useMMPayFiatConfig } from './useMMPayFiatConfig';
+import { useAutomaticMoneyAccountPayToken } from './useAutomaticMoneyAccountPayToken';
 
 jest.mock('../transactions/useTransactionMetadataRequest');
 jest.mock('../transactions/useTransactionAccountOverride');
@@ -53,6 +54,7 @@ jest.mock('./useWithdrawTokenFilter');
 jest.mock('../../../../UI/Ramp/hooks/useRampsPaymentMethods');
 jest.mock('./useIsFiatPaymentAvailable');
 jest.mock('./useMMPayFiatConfig');
+jest.mock('./useAutomaticMoneyAccountPayToken');
 jest.mock('../../../../../selectors/transactionController', () => ({
   ...jest.requireActual('../../../../../selectors/transactionController'),
   selectLastWithdrawTokenByType: jest.fn(),
@@ -135,6 +137,9 @@ describe('useAutomaticTransactionPayToken', () => {
     selectMetaMaskPayTokensFlags,
   );
   const selectRelayFixedSpreadMock = jest.mocked(selectRelayFixedSpread);
+  const useAutomaticMoneyAccountPayTokenMock = jest.mocked(
+    useAutomaticMoneyAccountPayToken,
+  );
   const useTransactionMetadataRequestMock = jest.mocked(
     useTransactionMetadataRequest,
   );
@@ -203,6 +208,11 @@ describe('useAutomaticTransactionPayToken', () => {
     jest.mocked(useMMPayFiatConfig).mockReturnValue({
       enabledTransactionTypes: [],
       maxDelayMinutesForPaymentMethods: 10,
+    });
+
+    useAutomaticMoneyAccountPayTokenMock.mockReturnValue({
+      isPending: false,
+      shouldSelect: false,
     });
   });
 
@@ -1756,5 +1766,37 @@ describe('useAutomaticTransactionPayToken', () => {
         });
       },
     );
+  });
+
+  describe('money account fallback', () => {
+    it('does not select a token while money account auto-select is pending', () => {
+      useAutomaticMoneyAccountPayTokenMock.mockReturnValue({
+        isPending: true,
+        shouldSelect: false,
+      });
+      useTransactionPayAvailableTokensMock.mockReturnValue({
+        availableTokens: [] as AssetType[],
+        hasTokens: false,
+      });
+
+      runHook();
+
+      expect(setPayTokenMock).not.toHaveBeenCalled();
+    });
+
+    it('does not select a token when money account auto-select should run', () => {
+      useAutomaticMoneyAccountPayTokenMock.mockReturnValue({
+        isPending: false,
+        shouldSelect: true,
+      });
+      useTransactionPayAvailableTokensMock.mockReturnValue({
+        availableTokens: [] as AssetType[],
+        hasTokens: false,
+      });
+
+      runHook();
+
+      expect(setPayTokenMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/app/components/Views/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -45,6 +45,7 @@ import { MUSD_TOKEN_ADDRESS } from '../../../../UI/Earn/constants/musd';
 import { useWithdrawTokenFilter } from './useWithdrawTokenFilter';
 import { useTransactionAccountOverride } from '../transactions/useTransactionAccountOverride';
 import { useRampsPaymentMethods } from '../../../../UI/Ramp/hooks/useRampsPaymentMethods';
+import { useAutomaticMoneyAccountPayToken } from './useAutomaticMoneyAccountPayToken';
 
 export interface SetPayTokenRequest {
   address: Hex;
@@ -131,6 +132,17 @@ export function useAutomaticTransactionPayToken({
     [availableTokens, isWithdraw, withdrawTokenFilter],
   );
 
+  const {
+    isPending: isMoneyAccountPayPending,
+    shouldSelect: shouldSelectMoneyAccount,
+  } = useAutomaticMoneyAccountPayToken({
+    autoSelectFiatPayment,
+    disable,
+    hasFiatPaymentSelected,
+    hasTokenBalance: tokens.length > 0,
+    payTokenSelected: Boolean(payToken),
+  });
+
   const selectBestToken = useCallback(
     () =>
       getBestToken({
@@ -179,6 +191,14 @@ export function useAutomaticTransactionPayToken({
       !transactionId ||
       isUpdated.current === transactionId
     ) {
+      return;
+    }
+
+    // Let money-account fallback own the default when the EOA has no tokens.
+    if (isMoneyAccountPayPending || shouldSelectMoneyAccount) {
+      if (shouldSelectMoneyAccount) {
+        isUpdated.current = transactionId;
+      }
       return;
     }
 
@@ -231,11 +251,13 @@ export function useAutomaticTransactionPayToken({
     disable,
     hasFiatPaymentSelected,
     isFiatEnabled,
+    isMoneyAccountPayPending,
     maxDelayMinutesForPaymentMethods,
     payToken,
     paymentMethods,
     requiredTokens,
     setPayToken,
+    shouldSelectMoneyAccount,
     tokens,
     transactionId,
   ]);


### PR DESCRIPTION
## **Description**

If a user has no tokens on the selected EOA but does have a Money account balance, Perps and Predict Add funds left Pay with empty. Auto-select only considered tokens (then fiat), so Money account was never chosen.

This defaults Pay with to Money account for Perps and Predict deposits only when the EOA has no token balance. If the user has any token balance, existing token auto-select is unchanged even when Money account has more funds.

## **Changelog**

CHANGELOG entry: Fixed Money account not being auto-selected on Perps and Predict deposits when the EOA had no token balance

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1758

## **Manual testing steps**

```gherkin
Feature: Pay with default on Perps and Predict deposit

  Scenario: user has Money account balance and no EOA tokens
    Given the user has a Money account with a positive balance
    And the selected EOA has no tokens
    When the user opens Perps Add funds
    Then Pay with shows Money account by default
    And the user can still open the picker and change the payment method

  Scenario: user has token balance
    Given the selected EOA has at least one token with a balance
    And the user also has a Money account balance
    When the user opens Perps or Predict Add funds
    Then Pay with shows a token by default
    And Money account is available in the picker but is not auto-selected
```

## **Screenshots/Recordings**

N/A — before state captured on the ticket; after screenshots pending device verification before Ready for Review.

### **Before**

Pay with showed "Select payment method" even though Money account had a balance and was available in the picker.

### **After**

N/A — pending device capture.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default payment selection on deposit confirmations using the same override path as manual Money account selection, but scope is limited to two transaction types and many explicit guards (flags, balance, hardware, existing selections).
> 
> **Overview**
> Fixes **Pay with** staying empty on Perps and Predict add-funds when the selected EOA has no token balance but the Money account does.
> 
> A new **`useAutomaticMoneyAccountPayToken`** hook applies the existing Money account payment override for **`perpsDeposit`** and **`predictDeposit`** when the EOA has no pay tokens, the Money account has withdrawable balance &gt; 0, feature flags allow it, and the user has not already chosen fiat, a token, or hardware/QR signing. It exposes **`isPending`** while balance loads and **`shouldSelect`** when override should run.
> 
> **`useAutomaticTransactionPayToken`** now calls that hook and **skips** automatic token (and related) selection while Money account auto-select is pending or active, so the two paths do not fight each other. Token auto-select behavior is unchanged whenever the EOA has any available pay token.
> 
> Tests cover the new hook’s guard rails and integration tests assert **`setPayToken`** is not invoked when Money account fallback owns the default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d67b51f61c4b628e5fe7f9cb89940d65514ca82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->