### PR TITLE
feat(perps): add floating labels to Pro price inputs

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/PerpsProMarketView.view.test.tsx
@@ -129,6 +129,13 @@ const renderProMarketWithTwapFlag = (
 const findSizeInput = () =>
   screen.findByTestId(ids.SIZE_INPUT, {}, { timeout: TIMEOUT_MS });
 
+const findPriceInput = (testID: string) =>
+  screen.findByTestId(
+    testID,
+    { includeHiddenElements: true },
+    { timeout: TIMEOUT_MS },
+  );
+
 const openTwapOrderForm = async () => {
   const sizeInput = await findSizeInput();
   fireEvent.press(screen.getByTestId(ids.ORDER_TYPE_BUTTON));
@@ -243,7 +250,7 @@ describeForPlatforms('PerpsProMarketView input journeys', () => {
           { timeout: TIMEOUT_MS },
         ),
       );
-      const limitPriceInput = await screen.findByTestId(ids.LIMIT_PRICE_INPUT);
+      const limitPriceInput = await findPriceInput(ids.LIMIT_PRICE_INPUT);
       fireEvent.changeText(limitPriceInput, '00025');
 
       await waitFor(() => expect(limitPriceInput).toHaveProp('value', '25'));
@@ -714,7 +721,7 @@ describeForPlatforms('PerpsProMarketView input journeys', () => {
         PerpsOrderTypeBottomSheetSelectorsIDs.STOP_MARKET_OPTION,
       );
 
-      const triggerInput = await screen.findByTestId(ids.TRIGGER_PRICE_INPUT);
+      const triggerInput = await findPriceInput(ids.TRIGGER_PRICE_INPUT);
       expect(screen.queryByTestId(ids.LIMIT_PRICE_INPUT)).not.toBeOnTheScreen();
       expect(screen.queryByTestId(ids.TPSL)).not.toBeOnTheScreen();
       const placeOrderButton = screen.getByTestId(ids.PLACE_ORDER_BUTTON);
@@ -755,7 +762,7 @@ describeForPlatforms('PerpsProMarketView input journeys', () => {
         PerpsOrderTypeBottomSheetSelectorsIDs.TAKE_PROFIT_MARKET_OPTION,
       );
 
-      const triggerInput = await screen.findByTestId(ids.TRIGGER_PRICE_INPUT);
+      const triggerInput = await findPriceInput(ids.TRIGGER_PRICE_INPUT);
       fireEvent.changeText(triggerInput, '3000');
       fireEvent(triggerInput, 'blur');
 
@@ -783,7 +790,7 @@ describeForPlatforms('PerpsProMarketView input journeys', () => {
         PerpsOrderTypeBottomSheetSelectorsIDs.STOP_LIMIT_OPTION,
       );
 
-      const triggerInput = await screen.findByTestId(ids.TRIGGER_PRICE_INPUT);
+      const triggerInput = await findPriceInput(ids.TRIGGER_PRICE_INPUT);
       const placeOrderButton = screen.getByTestId(ids.PLACE_ORDER_BUTTON);
       fireEvent.changeText(triggerInput, '3000');
 
@@ -818,7 +825,7 @@ describeForPlatforms('PerpsProMarketView input journeys', () => {
         PerpsOrderTypeBottomSheetSelectorsIDs.TAKE_PROFIT_LIMIT_OPTION,
       );
 
-      const triggerInput = await screen.findByTestId(ids.TRIGGER_PRICE_INPUT);
+      const triggerInput = await findPriceInput(ids.TRIGGER_PRICE_INPUT);
       const placeOrderButton = screen.getByTestId(ids.PLACE_ORDER_BUTTON);
       fireEvent.changeText(triggerInput, '1000');
 
@@ -850,7 +857,7 @@ describeForPlatforms('PerpsProMarketView input journeys', () => {
       PerpsOrderTypeBottomSheetSelectorsIDs.STOP_MARKET_OPTION,
     );
 
-    const triggerInput = await screen.findByTestId(ids.TRIGGER_PRICE_INPUT);
+    const triggerInput = await findPriceInput(ids.TRIGGER_PRICE_INPUT);
     const placeOrderButton = screen.getByTestId(ids.PLACE_ORDER_BUTTON);
 
     await waitFor(
@@ -892,7 +899,7 @@ describeForPlatforms('PerpsProMarketView input journeys', () => {
         ),
       );
 
-      const limitInput = await screen.findByTestId(ids.LIMIT_PRICE_INPUT);
+      const limitInput = await findPriceInput(ids.LIMIT_PRICE_INPUT);
       const placeOrderButton = screen.getByTestId(ids.PLACE_ORDER_BUTTON);
       expect(
         screen.queryByTestId(ids.PRICE_CARD_MESSAGE),
@@ -922,8 +929,8 @@ describeForPlatforms('PerpsProMarketView input journeys', () => {
       PerpsOrderTypeBottomSheetSelectorsIDs.STOP_LIMIT_OPTION,
     );
 
-    const triggerInput = await screen.findByTestId(ids.TRIGGER_PRICE_INPUT);
-    const limitInput = await screen.findByTestId(ids.LIMIT_PRICE_INPUT);
+    const triggerInput = await findPriceInput(ids.TRIGGER_PRICE_INPUT);
+    const limitInput = await findPriceInput(ids.LIMIT_PRICE_INPUT);
     const placeOrderButton = screen.getByTestId(ids.PLACE_ORDER_BUTTON);
     fireEvent.changeText(triggerInput, '2600');
 
@@ -966,8 +973,8 @@ describeForPlatforms('PerpsProMarketView input journeys', () => {
         PerpsOrderTypeBottomSheetSelectorsIDs.STOP_LIMIT_OPTION,
       );
 
-      const triggerInput = await screen.findByTestId(ids.TRIGGER_PRICE_INPUT);
-      const limitInput = await screen.findByTestId(ids.LIMIT_PRICE_INPUT);
+      const triggerInput = await findPriceInput(ids.TRIGGER_PRICE_INPUT);
+      const limitInput = await findPriceInput(ids.LIMIT_PRICE_INPUT);
       fireEvent.changeText(triggerInput, '2600');
       fireEvent(triggerInput, 'blur');
       fireEvent.changeText(limitInput, '2650');
@@ -1035,8 +1042,8 @@ describeForPlatforms('PerpsProMarketView input journeys', () => {
         PerpsOrderTypeBottomSheetSelectorsIDs.STOP_LIMIT_OPTION,
       );
 
-      const triggerInput = await screen.findByTestId(ids.TRIGGER_PRICE_INPUT);
-      const limitInput = await screen.findByTestId(ids.LIMIT_PRICE_INPUT);
+      const triggerInput = await findPriceInput(ids.TRIGGER_PRICE_INPUT);
+      const limitInput = await findPriceInput(ids.LIMIT_PRICE_INPUT);
       fireEvent.changeText(triggerInput, '2600');
       fireEvent(triggerInput, 'blur');
       fireEvent.changeText(limitInput, '2650');

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.test.tsx
@@ -9,6 +9,7 @@ import PerpsProCompactInput, {
 // design system's real `forwardRef<TextInput>` contract.
 const mockInputFocus = jest.fn();
 const mockInputBlur = jest.fn();
+const mockInputUnmount = jest.fn();
 jest.mock('@metamask/design-system-react-native', () => {
   const actual = jest.requireActual('@metamask/design-system-react-native');
   const MockReact = jest.requireActual('react');
@@ -21,6 +22,12 @@ jest.mock('@metamask/design-system-react-native', () => {
           focus: mockInputFocus,
           blur: mockInputBlur,
         }));
+        MockReact.useEffect(
+          () => () => {
+            mockInputUnmount();
+          },
+          [],
+        );
         return MockReact.createElement(TextInput, props);
       },
     ),
@@ -114,6 +121,7 @@ describe('PerpsProCompactInput', () => {
           {...defaultProps}
           variant="inline"
           placeholder="0.00"
+          startAccessory={<Text>$</Text>}
         />,
       );
 
@@ -128,6 +136,7 @@ describe('PerpsProCompactInput', () => {
       expect(label.props.style).not.toEqual(inactiveLabelStyle);
       expect(input).toHaveProp('placeholder', '0.00');
       expect(mockInputFocus).toHaveBeenCalledTimes(1);
+      expect(mockInputUnmount).not.toHaveBeenCalled();
     });
 
     it('restores the full label after an empty inline field blurs', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.test.tsx
@@ -98,11 +98,12 @@ describe('PerpsProCompactInput', () => {
       expect(mockInputFocus).toHaveBeenCalledTimes(1);
     });
 
-    it('reports taps on the inline variant, which has no label to press', () => {
+    it('reports a tap that a visible inline input consumes', () => {
       const onFieldPress = jest.fn();
       render(
         <PerpsProCompactInput
           {...defaultProps}
+          value="1"
           variant="inline"
           onFieldPress={onFieldPress}
         />,
@@ -126,7 +127,9 @@ describe('PerpsProCompactInput', () => {
       );
 
       const label = screen.getByTestId(`${defaultProps.testID}-label`);
-      const input = screen.getByTestId(defaultProps.testID);
+      const input = screen.getByTestId(defaultProps.testID, {
+        includeHiddenElements: true,
+      });
       const inactiveLabelStyle = label.props.style;
 
       expect(input).toHaveProp('placeholder', '');
@@ -155,10 +158,11 @@ describe('PerpsProCompactInput', () => {
       fireEvent(screen.getByTestId(defaultProps.testID), 'blur');
 
       expect(label.props.style).toEqual(inactiveLabelStyle);
-      expect(screen.getByTestId(defaultProps.testID)).toHaveProp(
-        'placeholder',
-        '',
-      );
+      expect(
+        screen.getByTestId(defaultProps.testID, {
+          includeHiddenElements: true,
+        }),
+      ).toHaveProp('placeholder', '');
     });
 
     it('keeps the compact label after a populated inline field blurs', () => {
@@ -194,6 +198,46 @@ describe('PerpsProCompactInput', () => {
 
       expect(mockInputFocus).toHaveBeenCalledTimes(1);
       expect(onFieldPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('exposes an empty inline field as an activatable control instead of a static label', () => {
+      render(<PerpsProCompactInput {...defaultProps} variant="inline" />);
+
+      const field = screen.getByRole('button', { name: defaultProps.label });
+
+      expect(field).toHaveProp('testID', `${defaultProps.testID}-field`);
+      expect(
+        screen.getByTestId(defaultProps.testID, {
+          includeHiddenElements: true,
+        }),
+      ).toHaveProp('accessibilityElementsHidden', true);
+    });
+
+    it('focuses the hidden inline input when assistive tech activates the label', () => {
+      render(<PerpsProCompactInput {...defaultProps} variant="inline" />);
+
+      fireEvent.press(screen.getByRole('button', { name: defaultProps.label }));
+
+      expect(mockInputFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it('hands accessibility to the input after the empty inline field activates', () => {
+      render(<PerpsProCompactInput {...defaultProps} variant="inline" />);
+
+      fireEvent.press(screen.getByTestId(`${defaultProps.testID}-field`));
+
+      expect(screen.getByTestId(`${defaultProps.testID}-field`)).toHaveProp(
+        'accessible',
+        false,
+      );
+      expect(screen.getByTestId(defaultProps.testID)).toHaveProp(
+        'accessibilityElementsHidden',
+        false,
+      );
+      expect(screen.getByTestId(defaultProps.testID)).toHaveProp(
+        'accessibilityLabel',
+        defaultProps.label,
+      );
     });
 
     it('keeps the end accessory outside the press target so its own press wins', () => {

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.test.tsx
@@ -108,6 +108,61 @@ describe('PerpsProCompactInput', () => {
   });
 
   describe('inline field press target', () => {
+    it('shrinks the label and reveals the input when the row is pressed', () => {
+      render(
+        <PerpsProCompactInput
+          {...defaultProps}
+          variant="inline"
+          placeholder="0.00"
+        />,
+      );
+
+      const label = screen.getByTestId(`${defaultProps.testID}-label`);
+      const input = screen.getByTestId(defaultProps.testID);
+      const inactiveLabelStyle = label.props.style;
+
+      expect(input).toHaveProp('placeholder', '');
+
+      fireEvent.press(screen.getByTestId(`${defaultProps.testID}-field`));
+
+      expect(label.props.style).not.toEqual(inactiveLabelStyle);
+      expect(input).toHaveProp('placeholder', '0.00');
+      expect(mockInputFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it('restores the full label after an empty inline field blurs', () => {
+      render(<PerpsProCompactInput {...defaultProps} variant="inline" />);
+
+      const label = screen.getByTestId(`${defaultProps.testID}-label`);
+      const inactiveLabelStyle = label.props.style;
+
+      fireEvent.press(screen.getByTestId(`${defaultProps.testID}-field`));
+      fireEvent(screen.getByTestId(defaultProps.testID), 'blur');
+
+      expect(label.props.style).toEqual(inactiveLabelStyle);
+      expect(screen.getByTestId(defaultProps.testID)).toHaveProp(
+        'placeholder',
+        '',
+      );
+    });
+
+    it('keeps the compact label after a populated inline field blurs', () => {
+      render(
+        <PerpsProCompactInput
+          {...defaultProps}
+          value="123.45"
+          variant="inline"
+        />,
+      );
+
+      const label = screen.getByTestId(`${defaultProps.testID}-label`);
+      const compactLabelStyle = label.props.style;
+
+      fireEvent(screen.getByTestId(defaultProps.testID), 'blur');
+
+      expect(label.props.style).toEqual(compactLabelStyle);
+    });
+
     it('focuses from a tap anywhere in the row, not just the ~20px of text', () => {
       const onFieldPress = jest.fn();
       render(

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.test.tsx
@@ -19,7 +19,7 @@ jest.mock('@metamask/design-system-react-native', () => {
     Input: MockReact.forwardRef(
       (props: Record<string, unknown>, ref: React.Ref<unknown>) => {
         MockReact.useImperativeHandle(ref, () => ({
-          focus: mockInputFocus,
+          focus: () => mockInputFocus(props),
           blur: mockInputBlur,
         }));
         MockReact.useEffect(
@@ -136,6 +136,12 @@ describe('PerpsProCompactInput', () => {
       expect(label.props.style).not.toEqual(inactiveLabelStyle);
       expect(input).toHaveProp('placeholder', '0.00');
       expect(mockInputFocus).toHaveBeenCalledTimes(1);
+      expect(mockInputFocus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          placeholder: '0.00',
+          twClassName: 'flex-1 border-0 bg-transparent p-0',
+        }),
+      );
       expect(mockInputUnmount).not.toHaveBeenCalled();
     });
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
@@ -10,7 +10,7 @@ import {
   TextVariant,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   InputAccessoryView,
   Keyboard,
@@ -93,10 +93,14 @@ const PerpsProCompactInput = ({
 }: PerpsProCompactInputProps) => {
   const tw = useTailwind();
   const inputRef = useRef<TextInput>(null);
+  const [isFocused, setIsFocused] = useState(false);
+  const isInlineActive = isFocused || value.length > 0;
+  const isInputVisible = variant !== 'inline' || isInlineActive;
   const inputAccessoryViewID =
     Platform.OS === 'ios' ? getPerpsProInputAccessoryID(testID) : undefined;
   useEffect(() => {
     if (isHidden) {
+      setIsFocused(false);
       inputRef.current?.blur();
     }
   }, [isHidden]);
@@ -109,9 +113,21 @@ const PerpsProCompactInput = ({
         style: { height: 0, overflow: 'hidden' as const, opacity: 0 },
       } as const)
     : undefined;
+  const handleFocus = () => {
+    setIsFocused(true);
+    onFocus?.();
+  };
+  const handleBlur = () => {
+    setIsFocused(false);
+    onBlur?.();
+  };
+  const handleFieldPress = () => {
+    setIsFocused(true);
+    onFieldPress?.();
+  };
   const focusInput = () => {
     inputRef.current?.focus();
-    onFieldPress?.();
+    handleFieldPress();
   };
 
   const input = (
@@ -120,17 +136,21 @@ const PerpsProCompactInput = ({
       value={value}
       onChangeText={onChangeText}
       keyboardType={keyboardType}
-      onFocus={onFocus}
-      onBlur={onBlur}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
       // A tap landing here is consumed by the input, so neither the inline
       // variant's wrapping pressable nor the stacked variant's label fires.
-      onPressIn={onFieldPress}
+      onPressIn={handleFieldPress}
       inputAccessoryViewID={inputAccessoryViewID}
-      placeholder={placeholder}
+      placeholder={isInputVisible ? placeholder : ''}
       placeholderTextColor={tw.color(`text-${placeholderColor}`)}
       textVariant={TextVariant.BodySm}
       isStateStylesDisabled
-      twClassName="flex-1 border-0 bg-transparent p-0"
+      twClassName={
+        isInputVisible
+          ? 'flex-1 border-0 bg-transparent p-0'
+          : 'absolute h-1 w-1 opacity-0'
+      }
       testID={testID}
       accessibilityLabel={label}
     />
@@ -142,25 +162,36 @@ const PerpsProCompactInput = ({
         twClassName={
           isHidden
             ? undefined
-            : 'h-12 flex-row items-center border-t border-muted px-3'
+            : 'h-[54px] flex-row items-center border-t border-muted px-3 py-1'
         }
         testID={`${testID}-container`}
         {...hiddenProps}
       >
-        {/* The input's text occupies only ~20px of this 48px row, so most of
-            the row is dead space. Without a pressable filling it, taps there
-            reach the enclosing ScrollView instead, and its
-            `keyboardShouldPersistTaps="handled"` treats an unhandled tap as a
-            request to dismiss the keyboard. `endAccessory` stays outside so the
-            mid-price button keeps its own press. */}
+        {/* Keep the input area separate from the Mid action so the whole field
+            can focus without making the Mid action focus the input. */}
         <Pressable
           onPress={focusInput}
           accessible={false}
-          style={tw`h-full min-w-0 flex-1 flex-row items-center`}
+          style={tw`h-full min-w-0 flex-1 justify-center`}
           testID={`${testID}-field`}
         >
-          {startAccessory}
-          {input}
+          <Text
+            variant={isInlineActive ? TextVariant.BodyXs : TextVariant.BodySm}
+            color={TextColor.TextAlternative}
+            testID={`${testID}-label`}
+          >
+            {label}
+          </Text>
+          <Box
+            twClassName={
+              isInlineActive
+                ? 'w-full flex-row items-center'
+                : 'absolute h-0 w-0'
+            }
+          >
+            {isInlineActive ? startAccessory : null}
+            {input}
+          </Box>
         </Pressable>
         {endAccessory}
       </Box>

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
@@ -186,10 +186,18 @@ const PerpsProCompactInput = ({
             twClassName={
               isInlineActive
                 ? 'w-full flex-row items-center'
-                : 'absolute h-0 w-0'
+                : 'absolute h-0 w-0 overflow-hidden'
             }
           >
-            {isInlineActive ? startAccessory : null}
+            {/* Keep the accessory slot stable so activating the field does not
+                remount the focused native input. */}
+            <Box
+              twClassName={
+                isInlineActive ? 'shrink-0' : 'h-0 w-0 overflow-hidden'
+              }
+            >
+              {startAccessory}
+            </Box>
             {input}
           </Box>
         </Pressable>

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
@@ -94,16 +94,23 @@ const PerpsProCompactInput = ({
   const tw = useTailwind();
   const inputRef = useRef<TextInput>(null);
   const [isFocused, setIsFocused] = useState(false);
+  const [shouldFocusInput, setShouldFocusInput] = useState(false);
   const isInlineActive = isFocused || value.length > 0;
   const isInputVisible = variant !== 'inline' || isInlineActive;
   const inputAccessoryViewID =
     Platform.OS === 'ios' ? getPerpsProInputAccessoryID(testID) : undefined;
   useEffect(() => {
     if (isHidden) {
+      setShouldFocusInput(false);
       setIsFocused(false);
       inputRef.current?.blur();
+      return;
     }
-  }, [isHidden]);
+    if (shouldFocusInput) {
+      setShouldFocusInput(false);
+      inputRef.current?.focus();
+    }
+  }, [isHidden, shouldFocusInput]);
 
   const hiddenProps = isHidden
     ? ({
@@ -126,8 +133,8 @@ const PerpsProCompactInput = ({
     onFieldPress?.();
   };
   const focusInput = () => {
-    inputRef.current?.focus();
     handleFieldPress();
+    setShouldFocusInput(true);
   };
 
   const input = (

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProCompactInput.tsx
@@ -160,6 +160,8 @@ const PerpsProCompactInput = ({
       }
       testID={testID}
       accessibilityLabel={label}
+      accessibilityElementsHidden={!isInputVisible}
+      importantForAccessibility={isInputVisible ? 'yes' : 'no'}
     />
   );
 
@@ -174,17 +176,23 @@ const PerpsProCompactInput = ({
         testID={`${testID}-container`}
         {...hiddenProps}
       >
-        {/* Keep the input area separate from the Mid action so the whole field
-            can focus without making the Mid action focus the input. */}
+        {/* Empty fields hide the native input, so this pressable must stay in
+            the a11y tree as the control that focuses it. Once the input is
+            visible, drop out so VoiceOver/TalkBack can land on the TextInput
+            instead of a wrapping button. Mid stays outside either way. */}
         <Pressable
           onPress={focusInput}
-          accessible={false}
+          accessible={!isInlineActive}
+          accessibilityRole={isInlineActive ? undefined : 'button'}
+          accessibilityLabel={isInlineActive ? undefined : label}
           style={tw`h-full min-w-0 flex-1 justify-center`}
           testID={`${testID}-field`}
         >
           <Text
             variant={isInlineActive ? TextVariant.BodyXs : TextVariant.BodySm}
             color={TextColor.TextAlternative}
+            accessible={false}
+            importantForAccessibility="no"
             testID={`${testID}-label`}
           >
             {label}

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -11,6 +11,7 @@ import {
   PerpsProMarketViewSelectorsIDs,
   PerpsProOrderFormSelectorsIDs,
 } from '../../../../Perps.testIds';
+import { strings } from '../../../../../../../../locales/i18n';
 import { getPerpsProInputAccessoryID } from './PerpsProCompactInput';
 import PerpsProOrderForm from './PerpsProOrderForm';
 import type { PerpsProOrderFormProps } from './PerpsProOrderForm.types';
@@ -186,8 +187,10 @@ describe('PerpsProOrderForm', () => {
       expect(screen.getByTestId(ids.LIMIT_PRICE_INPUT)).toBeOnTheScreen();
     });
 
-    it('renders the dollar prefix for limit prices', () => {
+    it('reveals the dollar prefix after activating a limit price field', () => {
       renderForm({ orderType: 'limit' });
+
+      fireEvent.press(screen.getByTestId(`${ids.LIMIT_PRICE_INPUT}-field`));
 
       expect(screen.getByTestId(ids.LIMIT_PRICE_PREFIX)).toHaveTextContent('$');
     });
@@ -196,6 +199,80 @@ describe('PerpsProOrderForm', () => {
       renderForm({ orderType: 'market' });
 
       expect(screen.queryByTestId(ids.LIMIT_PRICE_INPUT)).not.toBeOnTheScreen();
+    });
+
+    it.each([
+      { orderType: 'market' as const, labels: [] },
+      {
+        orderType: 'limit' as const,
+        labels: [
+          {
+            inputID: ids.LIMIT_PRICE_INPUT,
+            label: strings('perps.order.limit_price'),
+          },
+        ],
+      },
+      {
+        orderType: 'stop_market' as const,
+        labels: [
+          {
+            inputID: ids.TRIGGER_PRICE_INPUT,
+            label: strings('perps.order.trigger_price'),
+          },
+        ],
+      },
+      {
+        orderType: 'take_profit_market' as const,
+        labels: [
+          {
+            inputID: ids.TRIGGER_PRICE_INPUT,
+            label: strings('perps.order.trigger_price'),
+          },
+        ],
+      },
+      {
+        orderType: 'stop_limit' as const,
+        labels: [
+          {
+            inputID: ids.TRIGGER_PRICE_INPUT,
+            label: strings('perps.order.trigger_price'),
+          },
+          {
+            inputID: ids.LIMIT_PRICE_INPUT,
+            label: strings('perps.order.limit_price'),
+          },
+        ],
+      },
+      {
+        orderType: 'take_profit_limit' as const,
+        labels: [
+          {
+            inputID: ids.TRIGGER_PRICE_INPUT,
+            label: strings('perps.order.trigger_price'),
+          },
+          {
+            inputID: ids.LIMIT_PRICE_INPUT,
+            label: strings('perps.order.limit_price'),
+          },
+        ],
+      },
+    ])('assigns the $orderType price labels', ({ orderType, labels }) => {
+      renderForm({ orderType });
+
+      const expectedLabels = new Map(
+        labels.map(({ inputID, label }) => [inputID, label]),
+      );
+      for (const inputID of [ids.TRIGGER_PRICE_INPUT, ids.LIMIT_PRICE_INPUT]) {
+        const labelTestID = `${inputID}-label`;
+        const expectedLabel = expectedLabels.get(inputID);
+        if (expectedLabel) {
+          expect(screen.getByTestId(labelTestID)).toHaveTextContent(
+            expectedLabel,
+          );
+        } else {
+          expect(screen.queryByTestId(labelTestID)).not.toBeOnTheScreen();
+        }
+      }
     });
 
     it.each([

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -20,7 +20,6 @@ import {
   playImpact,
   playSelection,
 } from '../../../../../../../util/haptics';
-import { strings } from '../../../../../../../../locales/i18n';
 
 jest.mock('../../../../components/PerpsSlider', () => 'PerpsSlider');
 jest.mock('../../../../components/PerpsFeesDisplay', () => 'PerpsFeesDisplay');

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -102,6 +102,9 @@ const createProps = (
 const renderForm = (overrides: Partial<PerpsProOrderFormProps> = {}) =>
   render(<PerpsProOrderForm {...createProps(overrides)} />);
 
+const getMountedInput = (testID: string) =>
+  screen.getByTestId(testID, { includeHiddenElements: true });
+
 describe('PerpsProOrderForm', () => {
   beforeEach(() => {
     jest.mocked(playImpact).mockClear();
@@ -126,7 +129,7 @@ describe('PerpsProOrderForm', () => {
       const onLimitPriceChange = jest.fn();
       renderForm({ orderType: 'limit', onLimitPriceChange });
 
-      fireEvent.changeText(screen.getByTestId(ids.LIMIT_PRICE_INPUT), '.123');
+      fireEvent.changeText(getMountedInput(ids.LIMIT_PRICE_INPUT), '.123');
 
       expect(onLimitPriceChange).toHaveBeenCalledWith('.123');
     });
@@ -134,7 +137,7 @@ describe('PerpsProOrderForm', () => {
     it('omits the Mid chip when onUseMidPricePress is not provided', () => {
       renderForm({ orderType: 'limit' });
 
-      expect(screen.getByTestId(ids.LIMIT_PRICE_INPUT)).toBeOnTheScreen();
+      expect(getMountedInput(ids.LIMIT_PRICE_INPUT)).toBeOnTheScreen();
       expect(screen.queryByTestId(ids.MID_PRICE_BUTTON)).not.toBeOnTheScreen();
     });
 
@@ -148,7 +151,7 @@ describe('PerpsProOrderForm', () => {
       const onLimitPriceBlur = jest.fn();
       renderForm({ orderType: 'limit', onLimitPriceBlur });
 
-      fireEvent(screen.getByTestId(ids.LIMIT_PRICE_INPUT), 'blur');
+      fireEvent(getMountedInput(ids.LIMIT_PRICE_INPUT), 'blur');
 
       expect(onLimitPriceBlur).toHaveBeenCalledTimes(1);
     });
@@ -157,7 +160,7 @@ describe('PerpsProOrderForm', () => {
       const onLimitPriceFocus = jest.fn();
       renderForm({ orderType: 'limit', onLimitPriceFocus });
 
-      fireEvent(screen.getByTestId(ids.LIMIT_PRICE_INPUT), 'focus');
+      fireEvent(getMountedInput(ids.LIMIT_PRICE_INPUT), 'focus');
 
       expect(onLimitPriceFocus).toHaveBeenCalledTimes(1);
     });
@@ -168,7 +171,7 @@ describe('PerpsProOrderForm', () => {
 
       // `pressIn` rather than `focus`: re-tapping a focused input fires no
       // focus event, which is the case this callback exists to cover.
-      fireEvent(screen.getByTestId(ids.LIMIT_PRICE_INPUT), 'pressIn');
+      fireEvent(getMountedInput(ids.LIMIT_PRICE_INPUT), 'pressIn');
 
       expect(onLimitPriceFieldPress).toHaveBeenCalledTimes(1);
     });
@@ -183,7 +186,7 @@ describe('PerpsProOrderForm', () => {
     it('renders limit price input for limit orders', () => {
       renderForm({ orderType: 'limit' });
 
-      expect(screen.getByTestId(ids.LIMIT_PRICE_INPUT)).toBeOnTheScreen();
+      expect(getMountedInput(ids.LIMIT_PRICE_INPUT)).toBeOnTheScreen();
     });
 
     it('reveals the dollar prefix after activating a limit price field', () => {
@@ -288,8 +291,8 @@ describe('PerpsProOrderForm', () => {
           onUseMidPricePress,
         });
 
-        expect(screen.getByTestId(ids.TRIGGER_PRICE_INPUT)).toBeOnTheScreen();
-        expect(screen.getByTestId(ids.LIMIT_PRICE_INPUT)).toBeOnTheScreen();
+        expect(getMountedInput(ids.TRIGGER_PRICE_INPUT)).toBeOnTheScreen();
+        expect(getMountedInput(ids.LIMIT_PRICE_INPUT)).toBeOnTheScreen();
         expect(screen.getByTestId(ids.MID_PRICE_BUTTON)).toBeOnTheScreen();
         expect(screen.getByTestId(ids.ORDER_TYPE_BUTTON)).toHaveTextContent(
           title,
@@ -306,7 +309,7 @@ describe('PerpsProOrderForm', () => {
       (orderType) => {
         renderForm({ orderType });
 
-        expect(screen.getByTestId(ids.TRIGGER_PRICE_INPUT)).toBeOnTheScreen();
+        expect(getMountedInput(ids.TRIGGER_PRICE_INPUT)).toBeOnTheScreen();
         expect(
           screen.queryByTestId(ids.LIMIT_PRICE_INPUT),
         ).not.toBeOnTheScreen();
@@ -374,7 +377,7 @@ describe('PerpsProOrderForm', () => {
       const onTriggerPriceChange = jest.fn();
       renderForm({ orderType: 'stop_market', onTriggerPriceChange });
 
-      fireEvent.changeText(screen.getByTestId(ids.TRIGGER_PRICE_INPUT), '.123');
+      fireEvent.changeText(getMountedInput(ids.TRIGGER_PRICE_INPUT), '.123');
 
       expect(onTriggerPriceChange).toHaveBeenCalledWith('.123');
     });
@@ -383,7 +386,7 @@ describe('PerpsProOrderForm', () => {
       const onTriggerPriceBlur = jest.fn();
       renderForm({ orderType: 'take_profit_market', onTriggerPriceBlur });
 
-      fireEvent(screen.getByTestId(ids.TRIGGER_PRICE_INPUT), 'blur');
+      fireEvent(getMountedInput(ids.TRIGGER_PRICE_INPUT), 'blur');
 
       expect(onTriggerPriceBlur).toHaveBeenCalledTimes(1);
     });
@@ -526,8 +529,8 @@ describe('PerpsProOrderForm', () => {
     it('connects the trigger input to its pre-mounted accessory on stop-market', () => {
       renderForm({ orderType: 'stop_market' });
 
-      expect(screen.getByTestId(ids.TRIGGER_PRICE_INPUT)).toBeOnTheScreen();
-      expect(screen.getByTestId(ids.TRIGGER_PRICE_INPUT)).toHaveProp(
+      expect(getMountedInput(ids.TRIGGER_PRICE_INPUT)).toBeOnTheScreen();
+      expect(getMountedInput(ids.TRIGGER_PRICE_INPUT)).toHaveProp(
         'inputAccessoryViewID',
         triggerAccessoryID,
       );
@@ -542,7 +545,7 @@ describe('PerpsProOrderForm', () => {
         'inputAccessoryViewID',
         sizeAccessoryID,
       );
-      expect(screen.getByTestId(ids.LIMIT_PRICE_INPUT)).toHaveProp(
+      expect(getMountedInput(ids.LIMIT_PRICE_INPUT)).toHaveProp(
         'inputAccessoryViewID',
         limitPriceAccessoryID,
       );

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -499,7 +499,7 @@ const PerpsProOrderForm = ({
           >
             <ButtonBase
               onPress={handleOrderTypeButtonPress}
-              twClassName="h-12 w-full bg-transparent px-3"
+              twClassName="h-[54px] w-full bg-transparent px-3"
               contentWrapperProps={{ twClassName: 'w-full justify-between' }}
               textProps={{ variant: TextVariant.BodySm }}
               endIconName={IconName.ArrowDown}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Perps Pro trigger and limit price inputs did not clearly identify which price users should enter. This change adds Figma aligned `Trigger price` and `Limit price` labels. Labels shrink when a field is focused or populated, revealing the cursor, currency prefix, and input value while keeping the `Mid` action independent. Label visibility remains correct for market, limit, stop/take-market, and stop/take-limit orders.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added clear trigger and limit price labels to Perps Pro order inputs

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3837

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps Pro price input labels
  Background:
    Given I have a funded Perps account
    And Perps Pro mode is active
    And market data is loaded
  Scenario: limit orders show the limit price label
    Given I select Limit
    Then I see the "Limit price" label
    And I do not see a "Trigger price" field
  Scenario: tapping a price field reveals its input
    Given I select Limit
    When I tap anywhere in the Limit price field except the Mid button
    Then the "Limit price" label becomes smaller
    And the dollar prefix and input placeholder become visible
    And the keyboard opens
  Scenario: triggered market orders show only the trigger price label
    Given I select Stop Market or Take Market
    Then I see the "Trigger price" label
    And I do not see a "Limit price" field
  Scenario: triggered limit orders show both price labels
    Given I select Stop Limit or Take Limit
    Then I see both "Trigger price" and "Limit price" labels
    When I tap the Trigger price field
    Then its label becomes smaller
    And its input content becomes visible
    When I tap the Mid button
    Then the Mid action is executed
    And the Limit price field is not focused
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/ddf8b561-0e09-4244-aec9-aac103785e1c



## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and test changes in Perps Pro order form inputs; no auth, payment, or order-validation logic changes beyond how price fields are presented and focused.
> 
> **Overview**
> Adds **Figma-aligned floating labels** (`Trigger price`, `Limit price`) to Perps Pro inline price fields in `PerpsProCompactInput`. When a field is empty, users see only the label; tapping the row **shrinks the label**, shows the **$** prefix, placeholder, and value, and focuses the input—while the **Mid** chip stays outside the press target.
> 
> The inline layout keeps the native `TextInput` mounted but visually hidden until active so **iOS keyboard accessories** still bind; focus is deferred via state so activation does not remount the input. **Accessibility** treats the empty row as a button, then exposes the real input after activation. Order-type row height is aligned to **54px** in the form and compact input.
> 
> Tests were updated to query hidden price inputs with `includeHiddenElements` and to cover label shrink/restore, a11y handoff, and order-type label wiring across market/limit/stop/take variants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33e88b3eda8a438df7043b6df6b170b705434206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->