### PR TITLE
test(perps): await async market insights entry card in CV test

### DIFF
--- a/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.view.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsMarketDetailsView/PerpsMarketDetailsView.view.test.tsx
@@ -832,13 +832,24 @@ describe('PerpsMarketDetailsView', () => {
       });
     };
 
+    // The entry card replaces a skeleton only after the AiDigestController fetch
+    // resolves, so it needs the same explicit timeout AssetOverviewContent's CV
+    // test uses for this card. The 1s default is not enough on a loaded CV shard.
+    const findInsightsEntryCard = () =>
+      screen.findByTestId(
+        MarketInsightsSelectorsIDs.ENTRY_CARD,
+        {},
+        { timeout: 15000 },
+      );
+
+    const openInsightsFromEntryCard = async () => {
+      fireEvent.press(await findInsightsEntryCard());
+    };
+
     it('opens market insights from Perps and hides Long/Short when position is open', async () => {
       renderPerpsInsightsJourney({ hasPosition: true });
 
-      const entryCard = await screen.findByTestId(
-        MarketInsightsSelectorsIDs.ENTRY_CARD,
-      );
-      fireEvent.press(entryCard);
+      await openInsightsFromEntryCard();
 
       expect(
         await screen.findByTestId(MarketInsightsSelectorsIDs.VIEW_CONTAINER),
@@ -866,9 +877,7 @@ describe('PerpsMarketDetailsView', () => {
     it('shows Long/Short in market insights when there is no position', async () => {
       renderPerpsInsightsJourney({ hasPosition: false });
 
-      fireEvent.press(
-        await screen.findByTestId(MarketInsightsSelectorsIDs.ENTRY_CARD),
-      );
+      await openInsightsFromEntryCard();
 
       expect(
         await screen.findByTestId(MarketInsightsSelectorsIDs.LONG_BUTTON),
@@ -884,19 +893,30 @@ describe('PerpsMarketDetailsView', () => {
         insightsFlagEnabled: false,
       });
 
-      await waitFor(() => {
-        expect(
-          screen.queryByTestId(MarketInsightsSelectorsIDs.ENTRY_CARD),
-        ).not.toBeOnTheScreen();
-      });
+      // Assert the absence only once the view is mounted and no skeleton is
+      // pending, otherwise the expectation passes before insights could render.
+      expect(
+        await screen.findByTestId(PerpsMarketDetailsViewSelectorsIDs.CONTAINER),
+      ).toBeOnTheScreen();
+      await waitFor(
+        () => {
+          expect(
+            screen.queryByTestId(
+              MarketInsightsSelectorsIDs.ENTRY_CARD_SKELETON,
+            ),
+          ).toBeNull();
+        },
+        { timeout: 15000 },
+      );
+      expect(
+        screen.queryByTestId(MarketInsightsSelectorsIDs.ENTRY_CARD),
+      ).toBeNull();
     });
 
     it('shows sources bottom sheet when tapping a trend item from Perps insights', async () => {
       renderPerpsInsightsJourney({ hasPosition: true });
 
-      fireEvent.press(
-        await screen.findByTestId(MarketInsightsSelectorsIDs.ENTRY_CARD),
-      );
+      await openInsightsFromEntryCard();
 
       const trendItem = await screen.findByTestId(
         `${MarketInsightsSelectorsIDs.TREND_ITEM}-0`,
@@ -913,9 +933,7 @@ describe('PerpsMarketDetailsView', () => {
       try {
         renderPerpsInsightsJourney({ hasPosition: true });
 
-        fireEvent.press(
-          await screen.findByTestId(MarketInsightsSelectorsIDs.ENTRY_CARD),
-        );
+        await openInsightsFromEntryCard();
         const thumbsUp = await screen.findByTestId(
           MarketInsightsSelectorsIDs.THUMBS_UP_BUTTON,
         );
@@ -941,9 +959,7 @@ describe('PerpsMarketDetailsView', () => {
     it('shows feedback bottom sheet on thumbs down from Perps insights', async () => {
       renderPerpsInsightsJourney({ hasPosition: true });
 
-      fireEvent.press(
-        await screen.findByTestId(MarketInsightsSelectorsIDs.ENTRY_CARD),
-      );
+      await openInsightsFromEntryCard();
       fireEvent.press(
         await screen.findByTestId(
           MarketInsightsSelectorsIDs.THUMBS_DOWN_BUTTON,


### PR DESCRIPTION
## **Description**

`PerpsMarketDetailsView.view.test.tsx` intermittently failed in the
`Component view tests` CI shards with `market-insights-entry-card` reported as
missing, most often on `tracks thumbs up interaction from Perps insights`.

**Root cause.** The entry card is gated on an async fetch, not on Redux state:

- `useMarketInsights` starts with `isLoading: true` and calls
  `Engine.context.AiDigestController.fetchMarketInsights()` inside a `useEffect`.
- `PerpsMarketDetailsView` renders `MarketInsightsEntryCardSkeleton` until
  `perpsInsightsReport` is set, and only then renders `MarketInsightsEntryCard`
  with the `market-insights-entry-card` testID.

So the card appears one or more renders after mount, once the promise resolves.
This file waited for it with Testing Library's **1s default** timeout, while
`AssetOverviewContent.view.test.tsx` — the other CV test covering the very same
card and the same `setupMarketInsightsEngineMock` fixture — already waits
**15s** for it. On a loaded CV shard (`maxWorkers: 1`, up to 20GB heap, GC
pauses) the 1s budget expired before the resolved report reached the tree, so
the card looked absent even though nothing was wrong with the component.

**Fix.** Align this file with the existing convention for this card:

- A single `findInsightsEntryCard` / `openInsightsFromEntryCard` helper waits
  with the explicit `{ timeout: 15000 }` used by `AssetOverviewContent`, and
  replaces the five duplicated lookups.
- The negative case (`feature flag disabled`) now waits for the view container
  and for the skeleton to be gone before asserting the card's absence. It
  previously asserted absence immediately, which passed before insights could
  ever have rendered — it could not have caught a regression.

No assertion was weakened, no sleep was added, no retry was enabled, and no
production code changed. The happy path is unaffected: the card still resolves
in ~150ms locally, the larger budget only absorbs shard contention.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://consensyssoftware.atlassian.net/browse/MMQA-2237

## **Manual testing steps**

```gherkin
Feature: Perps market insights entry card

  Scenario: user opens market insights from Perps market details
    Given the aiSocialMarketInsightsPerpsEnabled flag is on
    And a market insights report is available for the market

    When user opens Perps market details
    Then the insights skeleton is replaced by the entry card
    And pressing the card opens the Market Insights view
```

Validation run on this branch:

- `yarn test:view:one --testPathPattern="PerpsMarketDetailsView.view.test"` → **34/34 passed**
- The six insights tests run **10 consecutive times** → **10/10 passed, 0 failed**
- `npx eslint` on the changed file → clean
- `npx tsc --project ./tsconfig.json` → clean

## **Screenshots/Recordings**

N/A — test-only change, no UI is modified.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)