### PR TITLE
ci(appium): mount a Namespace cache volume for Appium shards

### DIFF
--- a/.github/workflows/run-appium-e2e-workflow.yml
+++ b/.github/workflows/run-appium-e2e-workflow.yml
@@ -49,7 +49,13 @@ on:
         type: string
         default: 'namespace'
       android-tag:
-        description: 'Android system image tag (default = AOSP; google_apis includes Chrome for browser dApp tests)'
+        description: >-
+          Android system image tag. Stays on `default` (AOSP): `google_apis` is
+          baked into the runner image and would skip a ~9s dl.google.com pull,
+          but it ships Play Services and a different browser engine, which
+          breaks the browser-navigation suite (ENS resolution, cross-origin
+          redirect display, history isolation, safe-browsing interstitial).
+          Switching needs those assertions audited first.
         required: false
         type: string
         default: 'default'
@@ -84,6 +90,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         if: ${{ inputs.runner_provider != 'namespace' }}
+
+      # This workflow mounted no cache volume, so every shard ran a cold
+      # `yarn install` (~51s vs 4.2s warm). `.metamask` is the foundryup
+      # download cache and lives in the workspace, so only a mount can serve it.
+      #
+      # node_modules is Android-only on purpose: nscloud-cache-action mounts
+      # paths as symlinks into the cache volume, which breaks Xcode projects
+      # that resolve $(SRCROOT) to a physical path (#34931). iOS Appium builds
+      # WebDriverAgent from node_modules, so it is exposed to that; Android
+      # runs no Xcode or Gradle and does not republish node_modules.
+      - name: Configure Namespace cache (Android)
+        if: ${{ inputs.runner_provider == 'namespace' && inputs.platform == 'android' }}
+        uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
+        with:
+          path: |
+            ~/.cache/yarn
+            .metamask
+            node_modules
+            .yarn/cache
+
+      # No `cache: cocoapods`: this job passes skip-pod-install=true, so it
+      # never runs pod install.
+      - name: Configure Namespace cache (iOS)
+        if: ${{ inputs.runner_provider == 'namespace' && inputs.platform == 'ios' }}
+        uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1
+        with:
+          path: |
+            ~/.cache/yarn
+            .metamask
+            .yarn/cache
 
       - name: Setup E2E environment (Android)
         if: ${{ inputs.platform == 'android' }}


### PR DESCRIPTION
## **Description**

`run-appium-e2e-workflow.yml` contained **zero** `nscloud-cache-action` blocks, and the `actions/cache` fallback inside `setup-e2e-env` is skipped when the provider is `namespace`. Every Appium shard therefore ran a fully cold `yarn install`:

| | Resolution | Fetch | Link | total |
|---|---|---|---|---|
| `ci-linux`, cache warm | 295ms | 801ms | 2.8s | **4.2s** |
| Appium shard, no cache | 12.9s | 13.4s | 24.3s | **51s** |

A 16× fetch-step delta, on roughly 1,000 Android and 450 iOS shards a day on 16 and 6 vCPU shapes.

`.metamask` is included because it is the `@metamask/foundryup` download cache and lives in the workspace, so no image layer can serve it — logs showed `[foundryup] binaries not in cache` and a re-fetch from `github.com/foundry-rs/foundry/releases` on every shard.

### The Android/iOS asymmetry is deliberate

`node_modules` is mounted on Android but **not** iOS. `nscloud-cache-action` mounts cached paths as symlinks into the cache volume, which breaks Xcode projects that resolve `$(SRCROOT)` to a physical path — the root cause of the iOS archive failures in #34931.

iOS Appium builds WebDriverAgent (`scripts/e2e/prepare-ios-appium-runner.mjs`), an Xcode project vendored inside `node_modules`, so it is exposed to the same class of bug. Android runs no Xcode and no Gradle (it consumes a prebuilt APK) and does not republish `node_modules` as an artifact, which was the other half of #34931. `ci.yml` already mounts `node_modules` on Linux in production under the same conditions.

Consequence: Android gets the full 51s → ~4s; iOS keeps its Link step and goes roughly 63s → ~30s. That is the price of not breaking WDA.

No `cache: cocoapods` on the iOS mount — this job passes `skip-pod-install: true`, so it never runs `pod install`.

## What was removed from this PR

An earlier revision also switched `android-tag` from `default` (AOSP) to `google_apis`, to skip a ~9s `dl.google.com` system-image pull. **That has been reverted after it regressed CI.**

Measured against concurrent runs on the same profile and the same 16x32 shape, same time window:

| | n | RAM median | RAM range | >11 GB | failures |
|---|---|---|---|---|---|
| `google_apis` | 27 | **11.70 GB** | 11.45–11.93 | 27/27 | **7 (25.9%)** |
| `default` (AOSP) | 57 | **9.06 GB** | 8.82–9.34 | 0/56 | **0 (0%)** |

Non-overlapping distributions — the `google_apis` minimum exceeds the AOSP maximum. A wider pre-change baseline (n=174) had RAM max 9.35 GB and zero runs above 11 GB.

The ~2.6 GB delta is Play Services running in the guest. The memory is not itself the failure mechanism (11.7 GB of 32 is 37%); the failures are behavioural. Every failure was at the test-execution step with all setup steps green, and the failing tests were specifically:

```
✘ browser-navigation.spec.ts › resolves and displays ENS website (vitalik.eth)
✘ browser-navigation.spec.ts › displays redirected URL after cross-origin redirect
   ❌ Assert URL bar shows the origin of the initial redirect page failed after 60 attempts
   element ("textContains(\"No history leaked\")") still not displayed
   element ("Back to safety") still not displayed
```

Downloads passed; navigation, URL-bar origin, history isolation and the safe-browsing interstitial failed — i.e. a different browser engine. `Back to safety` is a Chrome safe-browsing screen. These suites were written against AOSP's WebView.

The optimisation itself works (`System image already installed`, zero download lines), so it is worth revisiting — but as its own PR, with the browser-suite assertions audited first. The input description now records this.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: MCWP-816

## **Manual testing steps**

N/A for app behaviour — CI runner cache configuration only, no app code.

**Verified on CI** (run `32894891582`, which included the now-reverted tag change):

- `Mounted 4 cache paths.` — the mount is wired correctly and resolves to the intended paths.
- `cache_volume_hit=true` on **25 of 27** shards, inheriting the already-warm `metamask-android-build` volume.
- **iOS 29/29 green** — confirms the WebDriverAgent / `node_modules` exclusion holds.
- Local: YAML parses, both cache steps resolve correctly, `actionlint` reports 19 findings on `main` and 19 on this branch (`comm -13` shows zero new).

**Still to confirm on this revision:**

1. `[foundryup] found binaries in cache` replaces `binaries not in cache` — `.metamask` is mounted but was not yet populated on the first run, so anvil was still fetched.
2. `yarn install` Fetch step drops from ~13s toward ~1s as the volume warms.
3. Android shard failure rate returns to baseline (~3.5%) now the AOSP image is restored.
4. `Setup E2E environment (Android)` returns to the ~82s baseline — the 140s median observed previously is attributed to the Play Services boot, not to the cache mount, and that needs confirming.

Do not use the `cache_volume_hit` column in `nsc instance report` as the sole signal — it reported `false` on `ci-linux-small` even where durations proved a warm cache. Read the job-log banner.

## **Screenshots/Recordings**

N/A. Not a user facing change.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

Not applicable: CI runner cache configuration, no app code.

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only changes with an intentional Android/iOS cache split to avoid known Xcode/WebDriverAgent symlink issues; no application or auth/data-path changes.
> 
> **Overview**
> Appium E2E shards on Namespace runners previously had **no** `nscloud-cache-action`, so each shard paid a cold **`yarn install`** (~51s) and re-downloaded **foundryup** into `.metamask` because that cache only lives in the workspace.
> 
> This PR adds **platform-specific cache steps** after checkout: **Android** mounts `~/.cache/yarn`, `.metamask`, `node_modules`, and `.yarn/cache`; **iOS** mounts the same except **`node_modules`** (and skips CocoaPods because pod install is skipped). Inline comments explain that symlinked cache paths break Xcode/`$(SRCROOT)` and WebDriverAgent builds from `node_modules` (#34931).
> 
> The **`android-tag`** workflow input description is expanded to document why the default stays **AOSP** (`default`) rather than **`google_apis`**: the latter changes the browser engine and breaks `browser-navigation` assertions until those tests are audited.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b1146c395b49453b4b68db0fc5f920d721fa38a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->