### PR TITLE
fix(assets): keep Arc USDC in the token list when its native twin is absent

### DIFF
--- a/app/enablement/assets/networks-customization.test.ts
+++ b/app/enablement/assets/networks-customization.test.ts
@@ -12,6 +12,9 @@ import { ImportAsset } from '../../components/Views/AddAsset/utils/utils';
 const ARC = NETWORKS_CHAIN_ID.ARC;
 const STABLE = NETWORKS_CHAIN_ID.STABLE;
 const OTHER_TOKEN = '0x1111111111111111111111111111111111111111';
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const NATIVE_ASSET = { address: ZERO_ADDRESS, isNative: true };
+const ARC_NATIVE_ASSET_ID = 'eip155:5042/slip44:5042';
 
 describe('networks-customization', () => {
   describe('filterExcludedAssets', () => {
@@ -20,31 +23,61 @@ describe('networks-customization', () => {
         [ARC]: [
           { address: ARC_USDC_ERC20_TOKEN_ADDRESS },
           { address: OTHER_TOKEN },
-          { symbol: 'USDC' }, // native-style asset without address
+          NATIVE_ASSET,
         ],
-        [STABLE]: [{ address: STABLE_USDT0_ERC20_ADDRESS }],
+        [STABLE]: [{ address: STABLE_USDT0_ERC20_ADDRESS }, NATIVE_ASSET],
         '0x1': [{ address: ARC_USDC_ERC20_TOKEN_ADDRESS }],
       } as unknown as AccountGroupAssets;
 
       const result = filterExcludedAssets(assets);
 
-      expect(result[ARC]).toEqual([
+      expect(result[ARC]).toStrictEqual([
         { address: OTHER_TOKEN },
-        { symbol: 'USDC' },
+        NATIVE_ASSET,
       ]);
-      expect(result[STABLE]).toEqual([]);
+      expect(result[STABLE]).toStrictEqual([NATIVE_ASSET]);
       // Same address on an unrelated chain is untouched
-      expect(result['0x1']).toEqual([
+      expect(result['0x1']).toStrictEqual([
         { address: ARC_USDC_ERC20_TOKEN_ADDRESS },
+      ]);
+    });
+
+    it('keeps the excluded ERC-20 when the chain has no native asset', () => {
+      const assets = {
+        [ARC]: [
+          { address: ARC_USDC_ERC20_TOKEN_ADDRESS },
+          { address: OTHER_TOKEN },
+        ],
+      } as unknown as AccountGroupAssets;
+
+      expect(filterExcludedAssets(assets)[ARC]).toStrictEqual([
+        { address: ARC_USDC_ERC20_TOKEN_ADDRESS },
+        { address: OTHER_TOKEN },
+      ]);
+    });
+
+    it('recognises the native asset from a slip44 asset id', () => {
+      const assets = {
+        [ARC]: [
+          { address: ARC_USDC_ERC20_TOKEN_ADDRESS },
+          { assetId: ARC_NATIVE_ASSET_ID },
+        ],
+      } as unknown as AccountGroupAssets;
+
+      expect(filterExcludedAssets(assets)[ARC]).toStrictEqual([
+        { assetId: ARC_NATIVE_ASSET_ID },
       ]);
     });
 
     it('is case-insensitive on address', () => {
       const assets = {
-        [ARC]: [{ address: ARC_USDC_ERC20_TOKEN_ADDRESS.toUpperCase() }],
+        [ARC]: [
+          { address: ARC_USDC_ERC20_TOKEN_ADDRESS.toUpperCase() },
+          NATIVE_ASSET,
+        ],
       } as unknown as AccountGroupAssets;
 
-      expect(filterExcludedAssets(assets)[ARC]).toEqual([]);
+      expect(filterExcludedAssets(assets)[ARC]).toStrictEqual([NATIVE_ASSET]);
     });
   });
 

--- a/app/enablement/assets/networks-customization.ts
+++ b/app/enablement/assets/networks-customization.ts
@@ -3,7 +3,12 @@ import {
   TokenBalancesControllerState,
 } from '@metamask/assets-controllers';
 import { NETWORKS_CHAIN_ID } from '../../constants/network';
-import { Hex, isStrictHexString } from '@metamask/utils';
+import {
+  Hex,
+  isCaipAssetType,
+  isStrictHexString,
+  parseCaipAssetType,
+} from '@metamask/utils';
 import { ImportAsset } from '../../components/Views/AddAsset/utils/utils';
 import { SupportedCaipChainId } from '@metamask/multichain-network-controller';
 
@@ -57,17 +62,57 @@ function isExcludedAsset(chainId: string, address: string): boolean {
   return getExcludedAddress(chainId) === address.toLowerCase();
 }
 
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+/**
+ * Whether an asset is the native representation of its chain - the entry the
+ * excluded ERC-20 is a display duplicate of. Native assets reach this filter
+ * flagged with `isNative`, carrying the zero address, or identified only by a
+ * `slip44` CAIP-19 asset ID.
+ */
+function isNativeRepresentation(asset: {
+  isNative?: boolean;
+  address?: string;
+  assetId?: string;
+}): boolean {
+  if (asset.isNative) {
+    return true;
+  }
+
+  const parsed =
+    typeof asset.assetId === 'string' && isCaipAssetType(asset.assetId)
+      ? parseCaipAssetType(asset.assetId)
+      : undefined;
+
+  if (parsed?.assetNamespace === 'slip44') {
+    return true;
+  }
+
+  const address = asset.address ?? parsed?.assetReference;
+  return address?.toLowerCase() === ZERO_ADDRESS;
+}
+
 /**
  * Removes chain-specific ERC-20 tokens (e.g. Arc USDC at 0x3600...,
  * Stable USDT0) from the per-chain asset map so they never appear as
  * duplicates of the native token. The native token (zero address) is kept -
  * it is the source of truth for display on those chains.
+ *
+ * The ERC-20 is only removed when that native token is actually part of the
+ * chain's assets. Both identities mirror the same balance, so when the native
+ * one is missing (e.g. no `assetsInfo` metadata for `eip155:5042/slip44:5042`)
+ * the ERC-20 is the only representation left and hiding it would drop the
+ * token from the list entirely.
  */
 export function filterExcludedAssets(
   assets: AccountGroupAssets,
 ): AccountGroupAssets {
   return Object.entries(assets).reduce((acc, [chainId, chainAssets]) => {
-    if (!chainAssets || !getExcludedAddress(chainId)) {
+    if (
+      !chainAssets ||
+      !getExcludedAddress(chainId) ||
+      !chainAssets.some(isNativeRepresentation)
+    ) {
       return acc;
     }
     return {
@@ -114,6 +159,9 @@ export function filterExcludedTokenBalances(
 /**
  * Filters out excluded ERC-20s (e.g. Arc USDC at 0x3600...) for the
  * given chain - they are display duplicates of the chain's native gas token.
+ *
+ * Unconditional, unlike {@link filterExcludedAssets}: this is a catalogue of
+ * importable tokens, where the duplicate must never be offered.
  */
 export function filterExcludedImportAssets(
   tokens: ImportAsset[],

--- a/app/selectors/assets/assets-list.test.ts
+++ b/app/selectors/assets/assets-list.test.ts
@@ -2330,4 +2330,16 @@ describe('selectAssetsBySelectedAccountGroup – Arc USDC ERC-20 filter', () => 
 
     expect(run()).toStrictEqual(assets);
   });
+
+  it('keeps the Arc USDC ERC-20 when the native token is absent, so USDC is never missing', () => {
+    const assets = {
+      [ARC]: [
+        { address: ARC_ERC20, symbol: 'USDC' },
+        { address: DAI_ADDR, symbol: 'DAI' },
+      ],
+    } as unknown as AccountGroupAssets;
+    innerSelector.mockReturnValue(assets);
+
+    expect(run()[ARC]).toStrictEqual(assets[ARC]);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Port of the extension fix in [MetaMask/metamask-extension#45751](https://github.com/MetaMask/metamask-extension/pull/45751) — mobile carries the same logic and the same latent failure, even though the reports so far have only come from the extension.

On Arc the gas token **is** USDC, and the identical balance is also exposed as an ERC-20 at `0x3600000000000000000000000000000000000000`. The Accounts API returns both identities for every Arc account (verified against the address quoted in the ticket):

```
GET /v6/multiaccount/balances?accountIds=eip155:5042:0x5eec…000a7
  { type: "native", assetId: "eip155:5042/slip44:5042", decimals: 18, balance: "647.330286933672578483" }
  { type: "erc20",  assetId: "eip155:5042/erc20:0x3600…0000", decimals: 6, balance: "647.330286" }
```

To avoid listing USDC twice, `app/enablement/assets/networks-customization.ts` hid the ERC-20 twin unconditionally in favour of the native representation. But the native row is not guaranteed to exist: on the assets-unify-state path it is derived by `getAccountTrackerControllerAccountsByChainId` in `app/selectors/assets/assets-migration.ts`, which only emits a native balance for assets whose `AssetsController.assetsInfo[assetId].type === 'native'`. That metadata comes from core's `DEFAULT_TRACKED_ASSETS_BY_CHAIN` seeding, and until [MetaMask/core#9869](https://github.com/MetaMask/core/pull/9869) it was keyed on the ERC-20 id rather than `eip155:5042/slip44:5042`. When the metadata is missing, **both** USDC entries are dropped and the token vanishes from the list — while the aggregated balance, which reads `assetsBalance` directly, still counts it.

This makes the exclusion conditional: the homonym ERC-20 (Arc USDC, Stable USDT0) is only hidden when the native token it duplicates is actually present in the same per-chain asset list. Since both identities mirror the same balance, exactly one USDC entry is always shown, with the correct amount and fiat value (the price API prices both identities identically). Aggregated-balance filtering (`filterExcludedTokenBalances`, `augmentAssetControllersState`) is untouched, so the total keeps counting a single USDC and stays consistent with the list. `filterExcludedImportAssets` also stays unconditional — that is the importable-token catalogue, where the duplicate must never be offered.

## **Changelog**

CHANGELOG entry: Fixed USDC missing from the token list on the Arc network

## **Related issues**

Fixes: [ASSETS-3900](https://consensyssoftware.atlassian.net/browse/ASSETS-3900)

## **Manual testing steps**

```gherkin
Feature: Arc USDC is always visible in the token list

  Scenario: user with an Arc USDC balance opens the wallet
    Given the Arc network is enabled
    And the selected account holds a non-zero USDC balance on Arc

    When user opens the wallet token list
    Then USDC is listed exactly once with the correct balance and fiat value
    And the sum of the listed assets matches the aggregated wallet balance

  Scenario: user searches for the Arc USDC ERC-20 in Add Asset
    Given the Arc network is enabled

    When user opens Add Asset and searches for "USDC" or pastes 0x3600000000000000000000000000000000000000
    Then the ERC-20 duplicate is not offered as an importable token

  Scenario: user opens the send flow on Arc
    Given the Arc network is enabled
    And the selected account holds a non-zero USDC balance on Arc

    When user opens the send asset picker
    Then USDC appears exactly once

  Scenario: user with a Stable USDT0 balance opens the wallet
    Given the Stable network is enabled
    And the selected account holds a non-zero USDT0 balance

    When user opens the wallet token list
    Then USDT0 is listed exactly once
```

## **Screenshots/Recordings**

N/A — no visual change beyond the token row being present; the affected state requires a real Arc wallet whose `assetsInfo` is missing the native entry.

<!--
### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

Not applicable: the change is a pure predicate added to an existing per-chain filter (one `Array.some` over a single chain's assets, only for the two chains that have an excluded ERC-20), with no new render work or I/O.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33e16741-340e-4d60-bfaf-b6ab9d4b51f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33e16741-340e-4d60-bfaf-b6ab9d4b51f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[ASSETS-3900]: https://consensyssoftware.atlassian.net/browse/ASSETS-3900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ