### PR TITLE
fix(devtools): isolate local runtime artifacts

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,1 +1,3 @@
-{}
+{
+  "ignore_dirs": ["temp"]
+}

--- a/metro.config.js
+++ b/metro.config.js
@@ -57,18 +57,44 @@ const {
   wrapWithReanimatedMetroConfig,
 } = require('react-native-reanimated/metro-config');
 
-// Escapes a filesystem path for safe embedding in a RegExp so the mm CLI
-// daemon-artifact blockList entries below only match paths anchored at the
+// Escapes a filesystem path for safe embedding in a RegExp so local artifact
+// blockList entries only match paths anchored at the
 // worktree root, not the same substring appearing anywhere in node_modules.
 const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-// mm CLI (visual testing) daemon artifacts, anchored to this worktree root.
+const artifactDirectoryPattern = (relativeDir) =>
+  new RegExp(
+    `^${escapeRegExp(path.resolve(__dirname, relativeDir))}(?:[/\\\\]|$)`,
+  );
+
+const additionalArtifactDirs = (
+  process.env.METRO_ADDITIONAL_ARTIFACT_DIRS ?? ''
+)
+  .split(',')
+  .map((value) => value.trim())
+  .filter(Boolean)
+  .map((relativeDir) => {
+    if (
+      path.isAbsolute(relativeDir) ||
+      relativeDir === '.' ||
+      relativeDir.split(/[\\/]/).includes('..')
+    ) {
+      throw new Error(
+        'METRO_ADDITIONAL_ARTIFACT_DIRS accepts only checkout-relative directories without `..`.',
+      );
+    }
+    return relativeDir;
+  });
+
+// Local runtime and visual-testing artifacts, anchored to this worktree root.
 // Anchoring prevents an unrelated dependency whose path merely *contains*
-// `.mm-server` or `test-artifacts/` from being silently dropped from the bundle.
-const mmDaemonArtifactBlockList = [
+// one of these names from being silently dropped from the bundle.
+const localArtifactBlockList = [
   new RegExp(`^${escapeRegExp(path.join(__dirname, '.mm-daemon.log'))}$`),
-  new RegExp(`^${escapeRegExp(path.join(__dirname, '.mm-server'))}`),
-  new RegExp(`^${escapeRegExp(path.join(__dirname, 'test-artifacts'))}/`),
+  artifactDirectoryPattern('.mm-server'),
+  artifactDirectoryPattern('test-artifacts'),
+  artifactDirectoryPattern('temp'),
+  ...additionalArtifactDirs.map(artifactDirectoryPattern),
 ];
 
 // True when the module being resolved was requested from a file inside
@@ -142,8 +168,8 @@ module.exports = function (baseConfig) {
         mergeConfig(defaultConfig, {
           cacheVersion: `${defaultConfig.cacheVersion || '1.0'}:${metroTransformProfile}`,
           resolver: {
-            // Exclude mm CLI daemon artifacts from the file watcher so that
-            // log writes, state updates and test-artifact captures don't
+            // Exclude local runtime artifacts from the file watcher so that
+            // log writes, state updates, and artifact captures don't
             // trigger unnecessary Fast Refresh cycles during visual testing.
             blockList: [
               ...(Array.isArray(defaultConfig.resolver.blockList)
@@ -151,7 +177,7 @@ module.exports = function (baseConfig) {
                 : defaultConfig.resolver.blockList
                   ? [defaultConfig.resolver.blockList]
                   : []),
-              ...mmDaemonArtifactBlockList,
+              ...localArtifactBlockList,
             ],
             unstable_enablePackageExports: true,
             assetExts: [...assetExts.filter((ext) => ext !== 'svg'), 'riv'],

--- a/metro.config.js
+++ b/metro.config.js
@@ -77,10 +77,11 @@ const additionalArtifactDirs = (
     if (
       path.isAbsolute(relativeDir) ||
       relativeDir === '.' ||
-      relativeDir.split(/[\\/]/).includes('..')
+      relativeDir.split(/[\\/]/).includes('..') ||
+      path.resolve(__dirname, relativeDir) === __dirname
     ) {
       throw new Error(
-        'METRO_ADDITIONAL_ARTIFACT_DIRS accepts only checkout-relative directories without `..`.',
+        'METRO_ADDITIONAL_ARTIFACT_DIRS accepts only non-root checkout-relative directories without `..`.',
       );
     }
     return relativeDir;


### PR DESCRIPTION
## **Description**

Local validation tools write screenshots, traces, logs, and reports while MetaMask is running. Metro and Watchman could treat those files as source activity, trigger Fast Refresh, rotate the debugger target, or dismiss the screen being validated.

This change makes `temp` the shared artifact directory ignored by both Watchman and Metro. Optional checkout-relative directories can be excluded from Metro with `METRO_ADDITIONAL_ARTIFACT_DIRS=reports,local-output`. Watchman configuration is static JSON, so tools that need both layers of isolation should write under `temp`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/pull/34948

## **Manual testing steps**

```gherkin
Feature: Stable local validation runtime

  Scenario: A validation tool writes under temp
    Given Metro watches the checkout
    When the tool writes logs, screenshots, traces, or reports under temp
    Then Metro excludes the files from its bundle inputs
    And Watchman ignores the temp tree

  Scenario: A developer adds another Metro-only artifact directory
    Given METRO_ADDITIONAL_ARTIFACT_DIRS=reports,local-output
    When Metro loads its configuration
    Then Metro excludes both checkout-relative directories
    And rejects absolute or parent-relative paths
```

## **Screenshots/Recordings**

### **Before**

N/A. This changes DEV tooling configuration.

### **After**

N/A. This changes DEV tooling configuration.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only Metro and Watchman configuration; no production app logic, auth, or data handling changes.
> 
> **Overview**
> **Stops local validation output from disturbing the dev runtime** by treating `temp` as the shared artifact directory and tightening how Metro ignores those paths.
> 
> Watchman now **ignores the `temp` tree** via a proper `.watchmanconfig` (replacing the invalid `-{}` stub).
> 
> Metro **generalizes the mm CLI blocklist** into `localArtifactBlockList`: anchored directory patterns via `artifactDirectoryPattern`, adds **`temp`**, and supports extra checkout-relative dirs through **`METRO_ADDITIONAL_ARTIFACT_DIRS`** (comma-separated, with validation that rejects absolute paths, `..`, and the repo root). Comments and watcher wording are updated to describe local runtime artifacts rather than only the mm daemon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90e0b7b518f09ba057022f38a94fe74e8d93ba3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->