### PR TITLE
fix(predict): classify Polymarket request aborts

### DIFF
--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.test.ts
@@ -68,6 +68,10 @@ import {
 } from './utils';
 import { submitProtocolClobOrder } from './protocol/transport';
 import {
+  PolymarketRequestCancelledError,
+  PolymarketRequestTimeoutError,
+} from './fetchWithTimeout';
+import {
   buildClaimTransaction,
   planDepositWalletClaim,
 } from './preflight/claim';
@@ -729,6 +733,38 @@ describe('PolymarketProvider', () => {
       ).rejects.toThrow('Failed');
     });
 
+    it('does not report expected market request timeouts to Sentry', async () => {
+      const Logger = jest.requireMock('../../../../../util/Logger').default;
+      const timeoutError = new PolymarketRequestTimeoutError(
+        new Error('The operation was aborted'),
+      );
+      mockFetchEventsFromPolymarketApi.mockRejectedValue(timeoutError);
+
+      await expect(
+        createProvider().getMarkets({ category: 'trending' }),
+      ).rejects.toBe(timeoutError);
+
+      expect(Logger.error).not.toHaveBeenCalled();
+      expect(Logger.log).toHaveBeenCalledWith(
+        'Predict markets request ended by expected timeout/cancellation:',
+        timeoutError.message,
+        expect.any(Object),
+      );
+    });
+
+    it('reports unowned native market aborts to Sentry', async () => {
+      const Logger = jest.requireMock('../../../../../util/Logger').default;
+      const abortError = new Error('The operation was aborted');
+      abortError.name = 'AbortError';
+      mockFetchEventsFromPolymarketApi.mockRejectedValue(abortError);
+
+      await expect(
+        createProvider().getMarkets({ category: 'trending' }),
+      ).rejects.toBe(abortError);
+
+      expect(Logger.error).toHaveBeenCalledWith(abortError, expect.any(Object));
+    });
+
     it('prefers team-to-advance outcomes for World Cup carousel markets', async () => {
       const provider = createProvider();
       const moneylineOutcome = {
@@ -1017,6 +1053,42 @@ describe('PolymarketProvider', () => {
       json: jest.fn().mockResolvedValue([{}]),
     });
     signer.signTypedMessage.mockResolvedValue('0xsigned-order');
+  });
+
+  describe('eligibility request errors', () => {
+    it('does not report expected caller cancellation to Sentry', async () => {
+      const Logger = jest.requireMock('../../../../../util/Logger').default;
+      const cancellationError = new PolymarketRequestCancelledError(
+        new Error('The operation was aborted'),
+      );
+      global.fetch = jest.fn().mockRejectedValue(cancellationError);
+
+      await expect(createProvider().isEligible()).resolves.toEqual({
+        isEligible: false,
+      });
+
+      expect(Logger.error).not.toHaveBeenCalled();
+      expect(Logger.log).toHaveBeenCalledWith(
+        'Predict geoblock request ended by expected timeout/cancellation:',
+        cancellationError.message,
+        expect.any(Object),
+      );
+    });
+
+    it('reports genuine geoblock connectivity failures to Sentry', async () => {
+      const Logger = jest.requireMock('../../../../../util/Logger').default;
+      const networkError = new TypeError('Network request failed');
+      global.fetch = jest.fn().mockRejectedValue(networkError);
+
+      await expect(createProvider().isEligible()).resolves.toEqual({
+        isEligible: false,
+      });
+
+      expect(Logger.error).toHaveBeenCalledWith(
+        networkError,
+        expect.any(Object),
+      );
+    });
   });
 
   it('exposes the Polymarket provider id', () => {

--- a/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
+++ b/app/components/UI/Predict/providers/polymarket/PolymarketProvider.ts
@@ -178,7 +178,10 @@ import {
   waitForDepositWalletDeployed,
   waitForDepositWalletTransaction,
 } from './depositWallet';
-import { fetchWithTimeout } from './fetchWithTimeout';
+import {
+  fetchWithTimeout,
+  isExpectedPolymarketRequestAbort,
+} from './fetchWithTimeout';
 
 export type SignTypedMessageFn = (
   params: TypedMessageParams,
@@ -1003,13 +1006,22 @@ export class PolymarketProvider implements PredictProvider {
     } catch (error) {
       DevLogger.log('Error getting markets via Polymarket API:', error);
 
-      Logger.error(
-        error instanceof Error ? error : new Error(String(error)),
-        this.getErrorContext('getMarkets', {
-          category: params?.category,
-          hasAfterCursor: Boolean(params?.afterCursor),
-        }),
-      );
+      const errorContext = this.getErrorContext('getMarkets', {
+        category: params?.category,
+        hasAfterCursor: Boolean(params?.afterCursor),
+      });
+      if (isExpectedPolymarketRequestAbort(error)) {
+        Logger.log(
+          'Predict markets request ended by expected timeout/cancellation:',
+          error instanceof Error ? error.message : String(error),
+          errorContext,
+        );
+      } else {
+        Logger.error(
+          error instanceof Error ? error : new Error(String(error)),
+          errorContext,
+        );
+      }
 
       throw error;
     }
@@ -2538,13 +2550,22 @@ export class PolymarketProvider implements PredictProvider {
         timestamp: new Date().toISOString(),
       });
 
-      // Log to Sentry - this error is swallowed (returns false) so controller won't see it
-      Logger.error(
-        error instanceof Error ? error : new Error(String(error)),
-        this.getErrorContext('isEligible', {
-          operation: 'geoblock_check',
-        }),
-      );
+      const errorContext = this.getErrorContext('isEligible', {
+        operation: 'geoblock_check',
+      });
+      if (isExpectedPolymarketRequestAbort(error)) {
+        Logger.log(
+          'Predict geoblock request ended by expected timeout/cancellation:',
+          error instanceof Error ? error.message : String(error),
+          errorContext,
+        );
+      } else {
+        // This error is swallowed (returns false), so the controller cannot report it.
+        Logger.error(
+          error instanceof Error ? error : new Error(String(error)),
+          errorContext,
+        );
+      }
     }
     return result;
   }

--- a/app/components/UI/Predict/providers/polymarket/fetchWithTimeout.test.ts
+++ b/app/components/UI/Predict/providers/polymarket/fetchWithTimeout.test.ts
@@ -1,5 +1,7 @@
 import {
   fetchWithTimeout,
+  PolymarketRequestCancelledError,
+  PolymarketRequestTimeoutError,
   POLYMARKET_REQUEST_TIMEOUT_MS,
 } from './fetchWithTimeout';
 
@@ -16,20 +18,24 @@ describe('fetchWithTimeout', () => {
     jest.useRealTimers();
   });
 
-  it('aborts a request after the Polymarket timeout', async () => {
+  it('classifies the internal Polymarket timeout', async () => {
+    const abortError = new Error('The operation was aborted');
+    abortError.name = 'AbortError';
     mockFetch.mockImplementation(
       (_input: RequestInfo | URL, init?: RequestInit) =>
         new Promise((_resolve, reject) => {
-          init?.signal?.addEventListener('abort', () =>
-            reject(new Error('Request timeout')),
-          );
+          init?.signal?.addEventListener('abort', () => reject(abortError));
         }),
     );
 
     const request = fetchWithTimeout('https://example.com');
     jest.advanceTimersByTime(POLYMARKET_REQUEST_TIMEOUT_MS);
 
-    await expect(request).rejects.toThrow('Polymarket request timeout');
+    expect(POLYMARKET_REQUEST_TIMEOUT_MS).toBe(35_000);
+    await expect(request).rejects.toMatchObject({
+      name: PolymarketRequestTimeoutError.name,
+      cause: abortError,
+    });
   });
 
   it('passes request options and an abort signal to fetch', async () => {
@@ -49,14 +55,14 @@ describe('fetchWithTimeout', () => {
     });
   });
 
-  it('preserves caller cancellation without reporting a timeout', async () => {
+  it('classifies caller cancellation separately from timeout', async () => {
     const callerController = new AbortController();
+    const abortError = new Error('The operation was aborted');
+    abortError.name = 'AbortError';
     mockFetch.mockImplementation(
       (_input: RequestInfo | URL, init?: RequestInit) =>
         new Promise((_resolve, reject) => {
-          init?.signal?.addEventListener('abort', () =>
-            reject(new Error('Caller cancelled request')),
-          );
+          init?.signal?.addEventListener('abort', () => reject(abortError));
         }),
     );
     const request = fetchWithTimeout('https://example.com', {
@@ -65,21 +71,39 @@ describe('fetchWithTimeout', () => {
 
     callerController.abort();
 
-    await expect(request).rejects.toThrow('Caller cancelled request');
+    await expect(request).rejects.toMatchObject({
+      name: PolymarketRequestCancelledError.name,
+      cause: abortError,
+    });
   });
 
   it('passes an aborted caller signal to fetch', async () => {
     const callerController = new AbortController();
     callerController.abort();
-    mockFetch.mockRejectedValue(new Error('Caller cancelled request'));
+    const abortError = new Error('The operation was aborted');
+    abortError.name = 'AbortError';
+    mockFetch.mockRejectedValue(abortError);
 
     await expect(
       fetchWithTimeout('https://example.com', {
         signal: callerController.signal,
       }),
-    ).rejects.toThrow('Caller cancelled request');
+    ).rejects.toMatchObject({
+      name: PolymarketRequestCancelledError.name,
+      cause: abortError,
+    });
 
     const requestInit = mockFetch.mock.calls[0][1] as RequestInit;
     expect(requestInit.signal?.aborted).toBe(true);
+  });
+
+  it('preserves native fetch aborts not owned by the wrapper or caller', async () => {
+    const abortError = new Error('The operation was aborted');
+    abortError.name = 'AbortError';
+    mockFetch.mockRejectedValue(abortError);
+
+    await expect(fetchWithTimeout('https://example.com')).rejects.toBe(
+      abortError,
+    );
   });
 });

--- a/app/components/UI/Predict/providers/polymarket/fetchWithTimeout.ts
+++ b/app/components/UI/Predict/providers/polymarket/fetchWithTimeout.ts
@@ -1,4 +1,25 @@
-export const POLYMARKET_REQUEST_TIMEOUT_MS = 10_000;
+export const POLYMARKET_REQUEST_TIMEOUT_MS = 35_000;
+
+export class PolymarketRequestTimeoutError extends Error {
+  constructor(cause: unknown) {
+    super('Polymarket request timed out', { cause });
+    this.name = 'PolymarketRequestTimeoutError';
+  }
+}
+
+export class PolymarketRequestCancelledError extends Error {
+  constructor(cause: unknown) {
+    super('Polymarket request cancelled', { cause });
+    this.name = 'PolymarketRequestCancelledError';
+  }
+}
+
+export const isExpectedPolymarketRequestAbort = (error: unknown): boolean =>
+  error instanceof PolymarketRequestTimeoutError ||
+  error instanceof PolymarketRequestCancelledError ||
+  (error instanceof Error &&
+    (error.name === 'PolymarketRequestTimeoutError' ||
+      error.name === 'PolymarketRequestCancelledError'));
 
 export async function fetchWithTimeout(
   input: RequestInfo | URL,
@@ -6,18 +27,29 @@ export async function fetchWithTimeout(
 ): Promise<Response> {
   const controller = new AbortController();
   let didTimeout = false;
-  const abortFromCaller = () => controller.abort(init.signal?.reason);
+  let didCallerAbort = init.signal?.aborted ?? false;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const abortFromCaller = () => {
+    if (didTimeout) {
+      return;
+    }
+    didCallerAbort = true;
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    controller.abort(init.signal?.reason);
+  };
 
-  if (init.signal?.aborted) {
+  if (didCallerAbort) {
     abortFromCaller();
   } else {
     init.signal?.addEventListener('abort', abortFromCaller, { once: true });
+    timeout = setTimeout(() => {
+      didTimeout = true;
+      init.signal?.removeEventListener('abort', abortFromCaller);
+      controller.abort();
+    }, POLYMARKET_REQUEST_TIMEOUT_MS);
   }
-
-  const timeout = setTimeout(() => {
-    didTimeout = true;
-    controller.abort();
-  }, POLYMARKET_REQUEST_TIMEOUT_MS);
 
   try {
     return await fetch(input, {
@@ -26,11 +58,16 @@ export async function fetchWithTimeout(
     });
   } catch (error) {
     if (didTimeout) {
-      throw new Error('Polymarket request timeout', { cause: error });
+      throw new PolymarketRequestTimeoutError(error);
+    }
+    if (didCallerAbort) {
+      throw new PolymarketRequestCancelledError(error);
     }
     throw error;
   } finally {
-    clearTimeout(timeout);
+    if (timeout) {
+      clearTimeout(timeout);
+    }
     init.signal?.removeEventListener('abort', abortFromCaller);
   }
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Polymarket requests currently time out after 10 seconds, and expected timeout or caller-cancellation aborts are reported to Sentry as errors. This creates noise for request endings that the application initiated and can stop slower requests prematurely.

This change increases the Polymarket request timeout to 35 seconds and classifies wrapper timeouts and caller cancellations with dedicated error types. `getMarkets` and `isEligible` log those expected aborts without reporting them to Sentry, while unowned native aborts and genuine connectivity failures remain reportable. Unit tests cover timeout, cancellation, pre-aborted signals, native aborts, successful requests, and provider reporting behavior.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed Predict market requests that could time out too early

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: PRED-1252

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

N/A - This changes internal request timeout classification and logging without changing the UI. The behavior is covered by the focused `fetchWithTimeout` and `PolymarketProvider` unit tests.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A - No visual changes.

### **After**

N/A - No visual changes.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

N/A - This change only classifies existing request termination paths and adjusts a timeout constant; it does not change rendering or add performance-sensitive work.

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and timeout tuning for Predict Polymarket fetches; no auth or payment logic changes, with behavior locked in by unit tests.
> 
> **Overview**
> Polymarket HTTP calls now use a **35s** timeout (up from 10s), and `fetchWithTimeout` wraps abort failures in **`PolymarketRequestTimeoutError`** vs **`PolymarketRequestCancelledError`** so internal timeouts and caller-driven cancellations are distinguishable from other `AbortError`s.
> 
> **`getMarkets`** and **`isEligible`** use **`isExpectedPolymarketRequestAbort`** to log those expected endings with **`Logger.log`** instead of **`Logger.error`**, reducing Sentry noise while still reporting genuine failures (e.g. network errors) and unclassified native aborts. Errors still propagate to callers unchanged.
> 
> Unit tests cover the wrapper classification paths and provider logging behavior for markets and geoblock eligibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eafd1d3293ca56ac9f15414d18ea3a1508d6732. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->