### PR TITLE
feat(performance): support targeted trace metadata

### DIFF
--- a/app/util/trace.test.ts
+++ b/app/util/trace.test.ts
@@ -14,7 +14,9 @@ import {
   endTrace,
   trace,
   annotateTrace,
+  annotateTraceByRequest,
   getTraceContext,
+  setTraceMeasurement,
   ONBOARDING_MACHINE_TIME_ATTRIBUTE,
   TraceName,
   TraceOperation,
@@ -491,6 +493,221 @@ describe('Trace', () => {
       expect(
         getTraceContext({ name: TraceName.OnboardingJourneyOverall }),
       ).toBeUndefined();
+    });
+  });
+
+  describe('targeted trace metadata', () => {
+    it('targets the default trace when the request omits an id', () => {
+      updateCachedConsent(true);
+      const spanMock = {
+        end: jest.fn(),
+        setAttribute: jest.fn(),
+      } as unknown as Span;
+      startSpanManualMock.mockImplementationOnce((_, fn) =>
+        fn(spanMock, () => undefined),
+      );
+      trace({ name: NAME_MOCK });
+
+      setTraceMeasurement({ name: NAME_MOCK }, 'ready_ms', 10, 'millisecond');
+      annotateTraceByRequest({ name: NAME_MOCK }, { lifecycle: 'warm' });
+
+      expect(setMeasurement).toHaveBeenCalledWith(
+        'ready_ms',
+        10,
+        'millisecond',
+        spanMock,
+      );
+      expect(spanMock.setAttribute).toHaveBeenCalledWith('lifecycle', 'warm');
+      endTrace({ name: NAME_MOCK });
+    });
+
+    it('isolates measurements and attributes across overlapping trace ids', () => {
+      updateCachedConsent(true);
+      const firstSpan = {
+        end: jest.fn(),
+        setAttribute: jest.fn(),
+      } as unknown as Span;
+      const secondSpan = {
+        end: jest.fn(),
+        setAttribute: jest.fn(),
+      } as unknown as Span;
+      startSpanManualMock
+        .mockImplementationOnce((_, fn) => fn(firstSpan, () => undefined))
+        .mockImplementationOnce((_, fn) => fn(secondSpan, () => undefined));
+      trace({ name: NAME_MOCK, id: 'first' });
+      trace({ name: NAME_MOCK, id: 'second' });
+
+      setTraceMeasurement(
+        { name: NAME_MOCK, id: 'first' },
+        'ready_ms',
+        20,
+        'millisecond',
+      );
+      annotateTraceByRequest(
+        { name: NAME_MOCK, id: 'second' },
+        { lifecycle: 'cold_no_cache' },
+      );
+
+      expect(setMeasurement).toHaveBeenCalledWith(
+        'ready_ms',
+        20,
+        'millisecond',
+        firstSpan,
+      );
+      expect(secondSpan.setAttribute).toHaveBeenCalledWith(
+        'lifecycle',
+        'cold_no_cache',
+      );
+      expect(firstSpan.setAttribute).not.toHaveBeenCalled();
+      endTrace({ name: NAME_MOCK, id: 'first' });
+      endTrace({ name: NAME_MOCK, id: 'second' });
+    });
+
+    it('does not write metadata when no trace matches the request', () => {
+      updateCachedConsent(true);
+      const spanMock = {
+        end: jest.fn(),
+        setAttribute: jest.fn(),
+      } as unknown as Span;
+      startSpanManualMock.mockImplementationOnce((_, fn) =>
+        fn(spanMock, () => undefined),
+      );
+      trace({ name: NAME_MOCK, id: ID_MOCK });
+      jest.mocked(setMeasurement).mockClear();
+
+      setTraceMeasurement(
+        { name: NAME_MOCK, id: 'missing' },
+        'ready_ms',
+        30,
+        'millisecond',
+      );
+      annotateTraceByRequest(
+        { name: NAME_MOCK, id: 'missing' },
+        { lifecycle: 'warm' },
+      );
+
+      expect(setMeasurement).not.toHaveBeenCalled();
+      expect(spanMock.setAttribute).not.toHaveBeenCalled();
+      endTrace({ name: NAME_MOCK, id: ID_MOCK });
+    });
+
+    it('writes a measurement to the matching pending span', () => {
+      updateCachedConsent(true);
+
+      const spanEndMock = jest.fn();
+      const spanMock = { end: spanEndMock } as unknown as Span;
+
+      startSpanManualMock.mockImplementationOnce((_, fn) =>
+        fn(spanMock, () => {
+          // Intentionally empty
+        }),
+      );
+
+      trace({ name: NAME_MOCK, id: ID_MOCK });
+
+      setTraceMeasurement(
+        { name: NAME_MOCK, id: ID_MOCK },
+        'ready_ms',
+        123,
+        'millisecond',
+      );
+
+      expect(setMeasurement).toHaveBeenCalledWith(
+        'ready_ms',
+        123,
+        'millisecond',
+        spanMock,
+      );
+      endTrace({ name: NAME_MOCK, id: ID_MOCK });
+    });
+
+    it('replays buffered measurements and attributes when consent becomes available', async () => {
+      trace({ name: NAME_MOCK, id: ID_MOCK });
+      setTraceMeasurement(
+        { name: NAME_MOCK, id: ID_MOCK },
+        'ready_ms',
+        123,
+        'millisecond',
+      );
+      annotateTraceByRequest(
+        { name: NAME_MOCK, id: ID_MOCK },
+        { lifecycle: 'cold_no_cache' },
+      );
+
+      updateCachedConsent(true);
+      await flushBufferedTraces();
+
+      expect(setMeasurement).toHaveBeenCalledWith(
+        'ready_ms',
+        123,
+        'millisecond',
+        expect.anything(),
+      );
+      expect(startSpanManualMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: expect.objectContaining({
+            lifecycle: 'cold_no_cache',
+          }),
+        }),
+        expect.any(Function),
+      );
+      endTrace({ name: NAME_MOCK, id: ID_MOCK });
+    });
+
+    it('ignores metadata added after a buffered trace ends', async () => {
+      trace({ name: NAME_MOCK, id: ID_MOCK });
+      endTrace({ name: NAME_MOCK, id: ID_MOCK });
+
+      setTraceMeasurement(
+        { name: NAME_MOCK, id: ID_MOCK },
+        'ready_ms',
+        123,
+        'millisecond',
+      );
+      annotateTraceByRequest(
+        { name: NAME_MOCK, id: ID_MOCK },
+        { lifecycle: 'late' },
+      );
+      updateCachedConsent(true);
+      await flushBufferedTraces();
+
+      expect(setMeasurement).not.toHaveBeenCalled();
+      expect(startSpanManualMock).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          attributes: expect.objectContaining({ lifecycle: 'late' }),
+        }),
+        expect.any(Function),
+      );
+    });
+
+    it('preserves buffered onboarding account type inheritance', async () => {
+      trace({
+        name: TraceName.OnboardingJourneyOverall,
+        op: TraceOperation.OnboardingUserJourney,
+      });
+      annotateTraceByRequest(
+        { name: TraceName.OnboardingJourneyOverall },
+        { account_type: 'imported_google' },
+      );
+      trace({
+        name: TraceName.OnboardingPasswordSetupAttempt,
+        op: TraceOperation.OnboardingUserJourney,
+      });
+      endTrace({ name: TraceName.OnboardingPasswordSetupAttempt });
+      endTrace({ name: TraceName.OnboardingJourneyOverall });
+
+      updateCachedConsent(true);
+      await flushBufferedTraces();
+
+      expect(startSpanManualMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: TraceName.OnboardingPasswordSetupAttempt,
+          attributes: expect.objectContaining({
+            account_type: 'imported_google',
+          }),
+        }),
+        expect.any(Function),
+      );
     });
   });
 

--- a/app/util/trace.ts
+++ b/app/util/trace.ts
@@ -561,6 +561,11 @@ interface BufferedTrace<T = TraceRequest | EndTraceRequest> {
   type: 'start' | 'end';
   request: T;
   parentTraceName?: string; // Track parent trace name for reconnecting during flush
+  measurements?: {
+    name: string;
+    value: number;
+    unit: Parameters<typeof setMeasurement>[2];
+  }[];
 }
 
 export function trace<T>(request: TraceRequest, fn: TraceCallback<T>): T;
@@ -662,6 +667,76 @@ export function getTraceContext(
   request: Pick<TraceRequest, 'name' | 'id'>,
 ): TraceContext {
   return tracesByKey.get(getTraceKey(request))?.span;
+}
+
+function getBufferedStart(
+  request: Pick<TraceRequest, 'name' | 'id'>,
+): BufferedTrace<TraceRequest> | undefined {
+  const traceKey = getTraceKey(request);
+  for (let index = localBufferedTraces.length - 1; index >= 0; index -= 1) {
+    const bufferedTrace = localBufferedTraces[index];
+    if (getTraceKey(bufferedTrace.request) !== traceKey) {
+      continue;
+    }
+
+    return bufferedTrace.type === 'start'
+      ? (bufferedTrace as BufferedTrace<TraceRequest>)
+      : undefined;
+  }
+  return undefined;
+}
+
+/** Write a measurement to an explicit pending trace, buffering until consent. */
+export function setTraceMeasurement(
+  request: Pick<TraceRequest, 'name' | 'id'>,
+  name: string,
+  value: number,
+  unit: Parameters<typeof setMeasurement>[2],
+): void {
+  const span = getTraceContext(request);
+  if (span) {
+    setMeasurement(name, value, unit, span);
+    return;
+  }
+
+  const bufferedStart = getBufferedStart(request);
+  if (!bufferedStart) {
+    return;
+  }
+
+  const measurements = bufferedStart.measurements ?? [];
+  const existing = measurements.find(
+    (measurement) => measurement.name === name,
+  );
+  if (existing) {
+    existing.value = value;
+    existing.unit = unit;
+  } else {
+    measurements.push({ name, value, unit });
+  }
+  bufferedStart.measurements = measurements;
+}
+
+/** Attach attributes to an explicit pending trace, buffering until consent. */
+export function annotateTraceByRequest(
+  request: Pick<TraceRequest, 'name' | 'id'>,
+  attributes: Record<string, TraceValue>,
+): void {
+  const span = getTraceContext(request);
+  if (span) {
+    annotateTrace(span, attributes);
+    return;
+  }
+
+  const bufferedStart = getBufferedStart(request);
+  if (!bufferedStart) {
+    return;
+  }
+
+  bufferedStart.request.data = {
+    ...bufferedStart.request.data,
+    ...attributes,
+  };
 }
 
 /**
@@ -904,6 +979,14 @@ export async function flushBufferedTraces() {
       }) as Span;
 
       if (span) {
+        bufferedItem.measurements?.forEach((measurement) => {
+          setMeasurement(
+            measurement.name,
+            measurement.value,
+            measurement.unit,
+            span,
+          );
+        });
         activeSpans.set(traceKey, span);
       }
     } else if (bufferedItem.type === 'end') {
@@ -1098,6 +1181,7 @@ function startTrace(request: TraceRequest): TraceContext {
     pendingOnboardingMachineTimeByKey = new Map();
     onboardingAccountType = undefined;
     rememberOnboardingAccountType(request.tags);
+    rememberOnboardingAccountType(request.data);
   }
 
   if (getCachedConsent() !== true) {


### PR DESCRIPTION
## **Description**

Some performance measurements and attributes become known after a trace starts. Callers currently need the live Sentry span to add them, which does not work while traces are waiting for metrics consent.

This PR adds request-based helpers that target a pending trace by name and ID. Measurements and attributes are applied immediately to active traces or replayed when a buffered trace starts after consent. A matching buffered end closes that metadata window, so late values cannot modify a completed operation.

The API is feature-neutral. Perps is the first planned consumer, but this PR contains no Perps trace names or product code.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/pull/34948

## **Manual testing steps**

```gherkin
Feature: Target metadata to a pending performance trace

  Scenario: two traces share a name
    Given two pending traces have different IDs
    When a measurement or attribute targets one ID
    Then only that trace receives the metadata

  Scenario: metrics consent is not resolved yet
    Given a trace start is buffered
    When metadata is added before the trace ends
    Then the metadata is replayed when consent becomes available
    And metadata added after the buffered end is ignored
```

Validation:

- `yarn jest app/util/trace.test.ts --runInBand --no-watchman --coverage=false`: 59/59 passed.
- `yarn lint:tsc`: passed.
- Changed-file ESLint and formatting: passed. ESLint reports only the existing `METRICS_OPT_IN` deprecation warning.

## **Screenshots/Recordings**

### **Before**

N/A. This changes the internal tracing API.

### **After**

N/A. This changes the internal tracing API.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal tracing API only; behavior is gated on existing consent buffering and covered by new unit tests, with no product call sites in this PR.
> 
> **Overview**
> Adds **`setTraceMeasurement`** and **`annotateTraceByRequest`** so callers can attach Sentry measurements and span attributes to a pending trace by **name** and optional **id**, without holding the live span—important while traces are buffered before metrics consent.
> 
> For active traces, metadata is applied immediately; for buffered starts, measurements are stored on the buffer entry and attributes are merged into `request.data`, then **replayed** when `flushBufferedTraces` creates the span. **`getBufferedStart`** only matches an open buffered start (a buffered end closes the window), so late metadata is ignored. Overlapping traces with the same name stay isolated by id.
> 
> Onboarding journey start also reads **`account_type` from `request.data`** (not only tags), so buffered `annotateTraceByRequest` still propagates account type to child spans after flush.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e26cf0d24f05ad56e011836568d0cb8ae97b074. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->