### PR TITLE
fix(market-insights): ignore stale asset responses

### DIFF
--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.test.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react-native';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
 import { useMarketInsights } from './useMarketInsights';
 const mockFetchMarketInsights = jest.fn();
 
@@ -172,5 +172,40 @@ describe('useMarketInsights', () => {
 
     expect(result.current.report).toEqual(usdcReport);
     expect(result.current.reportAssetId).toBe('eip155:1/erc20:0x456');
+  });
+
+  it('ignores a stale request after the asset changes', async () => {
+    let resolveEth: (value: Record<string, unknown>) => void = () => undefined;
+    let resolveBtc: (value: Record<string, unknown>) => void = () => undefined;
+    const ethRequest = new Promise<Record<string, unknown>>((resolve) => {
+      resolveEth = resolve;
+    });
+    const btcRequest = new Promise<Record<string, unknown>>((resolve) => {
+      resolveBtc = resolve;
+    });
+    mockFetchMarketInsights
+      .mockReturnValueOnce(ethRequest)
+      .mockReturnValueOnce(btcRequest);
+
+    const { result, rerender } = renderHook(
+      ({ symbol }) => useMarketInsights(symbol, true),
+      { initialProps: { symbol: 'ETH' } },
+    );
+    rerender({ symbol: 'BTC' });
+
+    await act(async () => {
+      resolveEth({ asset: 'eth', generatedAt: '', headline: 'old' });
+      await ethRequest;
+    });
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.report).toBeNull();
+    expect(result.current.reportAssetId).toBeNull();
+
+    await act(async () => {
+      resolveBtc({ asset: 'btc', generatedAt: '', headline: 'current' });
+      await btcRequest;
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.reportAssetId).toBe('BTC');
   });
 });

--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MarketInsightsReport } from '@metamask/ai-controllers';
 import Engine from '../../../../core/Engine';
 import { formatRelativeTime } from '../utils/marketInsightsFormatting';
@@ -40,8 +40,10 @@ export const useMarketInsights = (
     Boolean(isEnabled && assetIdentifier),
   );
   const [error, setError] = useState<string | null>(null);
+  const requestGenerationRef = useRef(0);
 
   const fetchInsights = useCallback(async () => {
+    const requestGeneration = ++requestGenerationRef.current;
     if (!isEnabled || !assetIdentifier) {
       setReport(null);
       setReportAssetId(null);
@@ -60,19 +62,26 @@ export const useMarketInsights = (
         await Engine.context.AiDigestController.fetchMarketInsights(
           assetIdentifier,
         );
+      if (requestGeneration !== requestGenerationRef.current) return;
       setReport(data as MarketInsightsReport | null);
       setReportAssetId(data ? assetIdentifier : null);
     } catch (err) {
+      if (requestGeneration !== requestGenerationRef.current) return;
       setError(err instanceof Error ? err.message : 'Failed to fetch insights');
       setReport(null);
       setReportAssetId(null);
     } finally {
-      setIsLoading(false);
+      if (requestGeneration === requestGenerationRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [assetIdentifier, isEnabled]);
 
   useEffect(() => {
     fetchInsights();
+    return () => {
+      requestGenerationRef.current += 1;
+    };
   }, [fetchInsights]);
 
   const timeAgo = useMemo(


### PR DESCRIPTION
## **Description**

A Market Insights request can finish after the user has moved to another asset. The old hook accepts that late response, so an ETH report can briefly replace the current BTC state.

This candidate adds a request generation to the existing hook. Only the latest asset request may update report, error, or loading state. Unmount and dependency changes invalidate the previous generation.

This is the minimal alternative copied from [PR #34948](https://github.com/MetaMask/metamask-mobile/pull/34948). The broader React Query alternative is [PR #35282](https://github.com/MetaMask/metamask-mobile/pull/35282). These PRs are mutually exclusive. Merge only one.

## **Changelog**

CHANGELOG entry: Fixed Market Insights showing a report from the previously viewed asset

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/pull/34948

## **Manual testing steps**

```gherkin
Feature: Market Insights asset isolation

  Scenario: the previous asset request finishes late
    Given the ETH Market Insights request is still pending
    When the user switches to BTC
    And the ETH request finishes before the BTC request
    Then the ETH report is ignored
    And the hook remains loading until the BTC request resolves
```

Validation:

- The two changed files match PR #34948 at `13bcda69e89` byte for byte.
- Focused hook checks pass, 8/8.
- Full TypeScript, changed-file lint, formatting, and diff checks pass.

## **Screenshots/Recordings**

### **Before**

N/A. This fixes an asynchronous state race without changing the UI.

### **After**

N/A. This fixes an asynchronous state race without changing the UI.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized async state guard in one hook with matching unit tests; no auth, persistence, or API contract changes.
> 
> **Overview**
> Fixes a race where a **late Market Insights fetch** for a previous asset could briefly show the wrong report after the user switches assets (e.g. ETH response overwriting BTC).
> 
> `useMarketInsights` now tracks a **request generation** with a ref: each new fetch bumps the generation, and **only the latest generation** may update `report`, `reportAssetId`, `error`, or clear `isLoading`. Stale completions are dropped on both success and error. The effect cleanup **invalidates** the in-flight request on unmount or when `assetIdentifier` / `isEnabled` changes.
> 
> A new test drives two overlapping promises (ETH then BTC) and asserts the older ETH result is ignored while loading stays true until BTC resolves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eecb72386c6729ef4812c3574e4327ebf2310c56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->