### PR TITLE
refactor(market-insights): coordinate requests with React Query

### DIFF
--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.test.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.test.ts
@@ -1,4 +1,11 @@
-import { renderHook, waitFor } from '@testing-library/react-native';
+import React, { type PropsWithChildren } from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import {
+  onlineManager,
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query';
+import type { MarketInsightsReport } from '@metamask/ai-controllers';
 import { useMarketInsights } from './useMarketInsights';
 const mockFetchMarketInsights = jest.fn();
 
@@ -14,19 +21,37 @@ jest.mock('../../../../core/Engine', () => ({
   },
 }));
 
+let queryClient: QueryClient;
+
+const wrapper = ({ children }: PropsWithChildren) =>
+  React.createElement(QueryClientProvider, { client: queryClient }, children);
+
 describe('useMarketInsights', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2026-02-17T12:00:00.000Z'));
     jest.clearAllMocks();
+    onlineManager.setOnline(true);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+      logger: {
+        log: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      },
+    });
   });
 
   afterEach(() => {
+    queryClient.clear();
+    onlineManager.setOnline(true);
     jest.useRealTimers();
   });
 
   it('does not fetch when assetIdentifier is missing', () => {
-    const { result } = renderHook(() => useMarketInsights(undefined));
+    const { result } = renderHook(() => useMarketInsights(undefined), {
+      wrapper,
+    });
 
     expect(mockFetchMarketInsights).not.toHaveBeenCalled();
     expect(result.current.report).toBeNull();
@@ -36,8 +61,9 @@ describe('useMarketInsights', () => {
   });
 
   it('does not fetch when market insights feature is disabled', () => {
-    const { result } = renderHook(() =>
-      useMarketInsights('eip155:1/erc20:0x123', false),
+    const { result } = renderHook(
+      () => useMarketInsights('eip155:1/erc20:0x123', false),
+      { wrapper },
     );
 
     expect(mockFetchMarketInsights).not.toHaveBeenCalled();
@@ -60,8 +86,9 @@ describe('useMarketInsights', () => {
 
     mockFetchMarketInsights.mockResolvedValue(report);
 
-    const { result } = renderHook(() =>
-      useMarketInsights('eip155:1/erc20:0x123', true),
+    const { result } = renderHook(
+      () => useMarketInsights('eip155:1/erc20:0x123', true),
+      { wrapper },
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -78,8 +105,9 @@ describe('useMarketInsights', () => {
   it('returns null when controller has no insights', async () => {
     mockFetchMarketInsights.mockResolvedValue(null);
 
-    const { result } = renderHook(() =>
-      useMarketInsights('eip155:1/erc20:0x2260', true),
+    const { result } = renderHook(
+      () => useMarketInsights('eip155:1/erc20:0x2260', true),
+      { wrapper },
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -93,8 +121,9 @@ describe('useMarketInsights', () => {
   it('returns an error when fetch fails', async () => {
     mockFetchMarketInsights.mockRejectedValue(new Error('fetch failed'));
 
-    const { result } = renderHook(() =>
-      useMarketInsights('eip155:1/erc20:0x456', true),
+    const { result } = renderHook(
+      () => useMarketInsights('eip155:1/erc20:0x456', true),
+      { wrapper },
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -118,7 +147,9 @@ describe('useMarketInsights', () => {
 
     mockFetchMarketInsights.mockResolvedValue(report);
 
-    const { result } = renderHook(() => useMarketInsights('ETH', true));
+    const { result } = renderHook(() => useMarketInsights('ETH', true), {
+      wrapper,
+    });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
@@ -130,6 +161,7 @@ describe('useMarketInsights', () => {
 
   it('clears report and reportAssetId when assetIdentifier changes', async () => {
     const ethReport = {
+      digestId: 'eth-digest',
       version: '1.0',
       asset: 'eth',
       generatedAt: '2026-02-17T11:55:00.000Z',
@@ -153,7 +185,10 @@ describe('useMarketInsights', () => {
 
     const { result, rerender } = renderHook(
       ({ id }) => useMarketInsights(id, true),
-      { initialProps: { id: 'eip155:1/erc20:0x123' } },
+      {
+        initialProps: { id: 'eip155:1/erc20:0x123' },
+        wrapper,
+      },
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -172,5 +207,157 @@ describe('useMarketInsights', () => {
 
     expect(result.current.report).toEqual(usdcReport);
     expect(result.current.reportAssetId).toBe('eip155:1/erc20:0x456');
+  });
+
+  it('clears report when the feature is disabled after loading', async () => {
+    const report = {
+      version: '1.0',
+      asset: 'eth',
+      generatedAt: '2026-02-17T11:55:00.000Z',
+      headline: 'ETH advances',
+      summary: 'ETH summary',
+      trends: [],
+      sources: [],
+    };
+    mockFetchMarketInsights.mockResolvedValue(report);
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useMarketInsights('ETH', enabled),
+      { initialProps: { enabled: true }, wrapper },
+    );
+    await waitFor(() => expect(result.current.report).toEqual(report));
+
+    rerender({ enabled: false });
+
+    expect(result.current.report).toBeNull();
+    expect(result.current.reportAssetId).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('starts clean when re-enabled after loading', async () => {
+    const report = {
+      version: '1.0',
+      asset: 'eth',
+      generatedAt: '2026-02-17T11:55:00.000Z',
+      headline: 'ETH advances',
+      summary: 'ETH summary',
+      trends: [],
+      sources: [],
+    };
+    mockFetchMarketInsights.mockResolvedValueOnce(report);
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useMarketInsights('ETH', enabled),
+      { initialProps: { enabled: true }, wrapper },
+    );
+    await waitFor(() => expect(result.current.report).toEqual(report));
+    rerender({ enabled: false });
+    mockFetchMarketInsights.mockRejectedValueOnce(new Error('reload failed'));
+
+    rerender({ enabled: true });
+
+    expect(result.current.report).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.error).toBe('reload failed'));
+    expect(result.current.report).toBeNull();
+  });
+
+  it('ignores a late response from the previous assetIdentifier', async () => {
+    let resolveEth: (report: MarketInsightsReport) => void = () => undefined;
+    let resolveBtc: (report: MarketInsightsReport) => void = () => undefined;
+    const ethRequest = new Promise<MarketInsightsReport>((resolve) => {
+      resolveEth = resolve;
+    });
+    const btcRequest = new Promise<MarketInsightsReport>((resolve) => {
+      resolveBtc = resolve;
+    });
+    const ethReport = {
+      digestId: 'late-eth-digest',
+      version: '1.0',
+      asset: 'eth',
+      generatedAt: '2026-02-17T11:55:00.000Z',
+      headline: 'ETH advances',
+      summary: 'ETH summary',
+      trends: [],
+      sources: [],
+    };
+    const btcReport = {
+      digestId: 'btc-digest',
+      version: '1.0',
+      asset: 'btc',
+      generatedAt: '2026-02-17T11:56:00.000Z',
+      headline: 'BTC advances',
+      summary: 'BTC summary',
+      trends: [],
+      sources: [],
+    };
+    mockFetchMarketInsights.mockImplementation((assetIdentifier: string) =>
+      assetIdentifier === 'ETH' ? ethRequest : btcRequest,
+    );
+    const { result, rerender } = renderHook(
+      ({ id }) => useMarketInsights(id, true),
+      { initialProps: { id: 'ETH' }, wrapper },
+    );
+
+    rerender({ id: 'BTC' });
+    resolveBtc(btcReport);
+    await waitFor(() => expect(result.current.report).toEqual(btcReport));
+
+    resolveEth(ethReport);
+    await Promise.resolve();
+
+    expect(result.current.report).toEqual(btcReport);
+    expect(result.current.reportAssetId).toBe('BTC');
+  });
+
+  it('reads the controller cache while offline', async () => {
+    const report = {
+      version: '1.0',
+      asset: 'eth',
+      generatedAt: '2026-02-17T11:55:00.000Z',
+      headline: 'Cached ETH insight',
+      summary: 'Cached ETH summary',
+      trends: [],
+      sources: [],
+    };
+    mockFetchMarketInsights.mockResolvedValue(report);
+    onlineManager.setOnline(false);
+    const { result } = renderHook(() => useMarketInsights('ETH', true), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.report).toEqual(report));
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(mockFetchMarketInsights).toHaveBeenCalledWith('ETH');
+  });
+
+  it('keeps a loaded report when a background refetch fails', async () => {
+    const report = {
+      version: '1.0',
+      asset: 'eth',
+      generatedAt: '2026-02-17T11:55:00.000Z',
+      headline: 'ETH advances',
+      summary: 'ETH summary',
+      trends: [],
+      sources: [],
+    };
+    mockFetchMarketInsights.mockResolvedValueOnce(report);
+    const { result } = renderHook(() => useMarketInsights('ETH', true), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.report).toEqual(report));
+    mockFetchMarketInsights.mockRejectedValueOnce(new Error('refresh failed'));
+
+    await act(async () => {
+      await queryClient.refetchQueries({
+        queryKey: ['market-insights', 'ETH'],
+      });
+    });
+
+    expect(result.current.report).toEqual(report);
+    expect(result.current.reportAssetId).toBe('ETH');
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
   });
 });

--- a/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
+++ b/app/components/UI/MarketInsights/hooks/useMarketInsights.ts
@@ -1,7 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { MarketInsightsReport } from '@metamask/ai-controllers';
 import Engine from '../../../../core/Engine';
 import { formatRelativeTime } from '../utils/marketInsightsFormatting';
+
+const MARKET_INSIGHTS_QUERY_KEY = 'market-insights';
 
 /**
  * Result interface for the useMarketInsights hook
@@ -34,51 +37,54 @@ export const useMarketInsights = (
   assetIdentifier: string | undefined | null,
   isEnabled = false,
 ): UseMarketInsightsResult => {
-  const [report, setReport] = useState<MarketInsightsReport | null>(null);
-  const [reportAssetId, setReportAssetId] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(
-    Boolean(isEnabled && assetIdentifier),
-  );
-  const [error, setError] = useState<string | null>(null);
-
-  const fetchInsights = useCallback(async () => {
-    if (!isEnabled || !assetIdentifier) {
-      setReport(null);
-      setReportAssetId(null);
-      setError(null);
-      setIsLoading(false);
-      return;
-    }
-
-    setIsLoading(true);
-    setReport(null);
-    setReportAssetId(null);
-    setError(null);
-
-    try {
-      const data =
-        await Engine.context.AiDigestController.fetchMarketInsights(
-          assetIdentifier,
-        );
-      setReport(data as MarketInsightsReport | null);
-      setReportAssetId(data ? assetIdentifier : null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch insights');
-      setReport(null);
-      setReportAssetId(null);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [assetIdentifier, isEnabled]);
+  const queryAssetIdentifier = assetIdentifier ?? '';
+  const isQueryEnabled = isEnabled && queryAssetIdentifier.length > 0;
+  const queryClient = useQueryClient();
+  const query = useQuery<MarketInsightsReport | null, unknown>({
+    queryKey: [MARKET_INSIGHTS_QUERY_KEY, queryAssetIdentifier],
+    queryFn: () =>
+      Engine.context.AiDigestController.fetchMarketInsights(
+        queryAssetIdentifier,
+      ),
+    enabled: isQueryEnabled,
+    retry: false,
+    // The controller can satisfy this request from its persisted cache while
+    // offline. Let it decide whether a network request is necessary.
+    networkMode: 'always',
+    // AiDigestController owns the 10-minute cache and intentionally does not
+    // cache empty results. React Query only coordinates active requests here.
+    staleTime: 0,
+    cacheTime: 0,
+  });
 
   useEffect(() => {
-    fetchInsights();
-  }, [fetchInsights]);
+    if (!isQueryEnabled) {
+      queryClient.removeQueries({
+        queryKey: [MARKET_INSIGHTS_QUERY_KEY, queryAssetIdentifier],
+        exact: true,
+      });
+    }
+  }, [isQueryEnabled, queryAssetIdentifier, queryClient]);
+
+  const report = isQueryEnabled ? (query.data ?? null) : null;
+  const reportAssetId = report ? queryAssetIdentifier : null;
+  const error =
+    isQueryEnabled && !report && query.error
+      ? query.error instanceof Error
+        ? query.error.message
+        : 'Failed to fetch insights'
+      : null;
 
   const timeAgo = useMemo(
     () => (report ? formatRelativeTime(report.generatedAt) : ''),
     [report],
   );
 
-  return { report, reportAssetId, isLoading, error, timeAgo };
+  return {
+    report,
+    reportAssetId,
+    isLoading: isQueryEnabled && query.isLoading,
+    error,
+    timeAgo,
+  };
 };

--- a/app/components/UI/TokenDetails/components/AssetOverviewContent.view.test.tsx
+++ b/app/components/UI/TokenDetails/components/AssetOverviewContent.view.test.tsx
@@ -2,6 +2,7 @@ import '../../../../../tests/component-view/mocks';
 import React from 'react';
 import { Text } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { merge } from 'lodash';
 import { fireEvent, screen, waitFor } from '@testing-library/react-native';
 
@@ -80,27 +81,32 @@ function renderAssetOverviewMarketInsightsStack(
   providerValues: ProviderValues,
 ) {
   const Stack = createNativeStackNavigator();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, cacheTime: 0 } },
+  });
 
   const DefaultRouteProbe =
     (routeName: string): React.FC =>
     () => <Text testID={`route-${routeName}`}>{routeName}</Text>;
 
   return renderWithProvider(
-    <AccessRestrictedProvider>
-      <Stack.Navigator>
-        <Stack.Screen
-          name="AssetOverviewMI"
-          component={AssetOverviewContentHarness}
-        />
-        {extraRoutes.map(({ name, Component: Extra }) => (
+    <QueryClientProvider client={queryClient}>
+      <AccessRestrictedProvider>
+        <Stack.Navigator>
           <Stack.Screen
-            key={name}
-            name={name}
-            component={Extra ?? DefaultRouteProbe(name)}
+            name="AssetOverviewMI"
+            component={AssetOverviewContentHarness}
           />
-        ))}
-      </Stack.Navigator>
-    </AccessRestrictedProvider>,
+          {extraRoutes.map(({ name, Component: Extra }) => (
+            <Stack.Screen
+              key={name}
+              name={name}
+              component={Extra ?? DefaultRouteProbe(name)}
+            />
+          ))}
+        </Stack.Navigator>
+      </AccessRestrictedProvider>
+    </QueryClientProvider>,
     providerValues,
   );
 }

--- a/tests/component-view/renderers/marketInsights.tsx
+++ b/tests/component-view/renderers/marketInsights.tsx
@@ -2,6 +2,7 @@ import '../mocks';
 import React from 'react';
 import { Text } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import renderWithProvider, {
   type DeepPartial,
 } from '../../../app/util/test/renderWithProvider';
@@ -94,28 +95,33 @@ export function renderMarketInsightsViewWithNavigation(
     builder.withOverrides(overrides);
   }
   const state = builder.build();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, cacheTime: 0 } },
+  });
 
   const stackTree = (
-    <AccessRestrictedProvider>
-      <RootStack.Navigator
-        initialRouteName={Routes.MARKET_INSIGHTS.VIEW}
-        screenOptions={{ headerShown: false }}
-      >
-        <RootStack.Screen
-          name={Routes.MARKET_INSIGHTS.VIEW}
-          component={MarketInsightsView as unknown as React.ComponentType}
-          initialParams={initialParams}
-        />
-        <RootStack.Screen
-          name={Routes.BRIDGE.ROOT}
-          component={BridgeNavigator}
-        />
-        <RootStack.Screen
-          name={Routes.RAMP.TOKEN_SELECTION}
-          component={RampNavigator}
-        />
-      </RootStack.Navigator>
-    </AccessRestrictedProvider>
+    <QueryClientProvider client={queryClient}>
+      <AccessRestrictedProvider>
+        <RootStack.Navigator
+          initialRouteName={Routes.MARKET_INSIGHTS.VIEW}
+          screenOptions={{ headerShown: false }}
+        >
+          <RootStack.Screen
+            name={Routes.MARKET_INSIGHTS.VIEW}
+            component={MarketInsightsView as unknown as React.ComponentType}
+            initialParams={initialParams}
+          />
+          <RootStack.Screen
+            name={Routes.BRIDGE.ROOT}
+            component={BridgeNavigator}
+          />
+          <RootStack.Screen
+            name={Routes.RAMP.TOKEN_SELECTION}
+            component={RampNavigator}
+          />
+        </RootStack.Navigator>
+      </AccessRestrictedProvider>
+    </QueryClientProvider>
   );
 
   return renderWithProvider(stackTree, { state });


### PR DESCRIPTION
## **Description**

A Market Insights request can finish after the user has moved to another asset. The old hook accepts that late response, so an ETH report can briefly replace the current BTC state.

This candidate moves the hook's request state to React Query. Each asset has its own query key, while `AiDigestController` remains the only data cache and keeps its existing 10-minute policy. The hook API does not change.

The query also preserves existing mobile behavior: it consults the controller cache offline, clears when disabled, starts clean when re-enabled, and keeps a valid report visible if a background refresh fails.

This is the broader alternative to [PR #35281](https://github.com/MetaMask/metamask-mobile/pull/35281). The PRs are mutually exclusive. Merge only one.

Ownership note: the runtime change is in the Social AI hook. The QA renderer and Assets component-view file only add the query provider already present in the production Root.

## **Changelog**

CHANGELOG entry: Fixed Market Insights showing a report from the previously viewed asset

## **Related issues**

Refs: https://github.com/MetaMask/metamask-mobile/pull/34948

## **Manual testing steps**

```gherkin
Feature: Market Insights request coordination

  Scenario: the previous asset request finishes late
    Given the ETH Market Insights request is still pending
    When the user switches to BTC
    And the ETH request finishes after the switch
    Then the ETH report is ignored
    And only the BTC report can resolve the current view

  Scenario: a cached report is available offline
    Given AiDigestController has a fresh report
    And the device is offline
    When Market Insights opens
    Then the cached report is displayed

  Scenario: a background refresh fails
    Given a valid report is already displayed
    When a background refresh fails
    Then the valid report remains displayed
```

Validation:

- Focused hook checks pass, 12/12.
- Market Insights and Asset Overview component-view checks pass on iOS and Android, 14/14.
- Perps Market Detail component-view checks pass, 34/34.
- Full TypeScript, changed-file lint, formatting, and diff checks pass.
- Final diff review found no actionable issues.

## **Screenshots/Recordings**

### **Before**

N/A. This changes request ownership without changing the UI.

### **After**

N/A. This changes request ownership without changing the UI.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared Market Insights data loading with subtle race and offline/refetch behavior; scope is limited to one hook plus test harnesses, with no API changes for callers.
> 
> **Overview**
> Fixes Market Insights briefly showing the **wrong asset’s report** when a slower request for the previous asset finishes after the user switches assets.
> 
> **`useMarketInsights`** drops local `useState`/`useEffect` fetching in favor of **React Query** with a per-asset key (`market-insights` + identifier). `AiDigestController` still owns fetch and the 10-minute cache; React Query only coordinates in-flight work and keyed state. Query options use **`networkMode: 'always'`** so offline reads can still hit the controller cache, **`staleTime`/`cacheTime: 0`** so RQ does not duplicate caching, and **`removeQueries`** when the feature or asset query is disabled so UI clears and re-enable starts fresh.
> 
> Error surfacing is tightened so a **failed background refetch** does not replace an already-loaded report. Hook return shape is unchanged.
> 
> Tests wrap the hook in **`QueryClientProvider`** and add coverage for late responses, disable/re-enable, offline, and refetch failure. Component-view helpers for Market Insights and Asset Overview gain the same provider so tests match production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 829840eea5256a5e6222aa3d905585d2da6af53f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->