### PR TITLE
feat(perf): add BrowserStack recording links to weekly profiling risk leads

### DIFF
--- a/.cursor/automations/weekly-app-profiling-report.md
+++ b/.cursor/automations/weekly-app-profiling-report.md
@@ -61,6 +61,12 @@ Using only the collected app-profiling data, write:
    - Do not repeat every scenario or every investigation lead.
    - Group the executive summary by team.
    - Start every executive-summary bullet with the relevant Slack team tag(s).
+   - For each profiling lead (and any risk bullet that cites a peak/outlier), append the
+     BrowserStack recording URL from `peakRecordings` / lead `recordingUrl` using Slack
+     mrkdwn: `<url|Recording (peak memMax 1114.65 MB)>` or
+     `<url|Recording (peak slow frames 39.94%)>`.
+   - Prefer the peak sample for the metric you cite (memMax → `peakRecordings.memMax`,
+     slow-frame outlier → `peakRecordings.slowFrames`).
    - End with exactly 3 or fewer prioritized actions.
    - English, Slack-friendly markdown, concise.
 
@@ -109,7 +115,7 @@ Slow frames: [value] · Issues: [value] · App size: [value]
 
 *Profiling leads*
 
-[No more than 3 concise profiling-based leads.]
+[No more than 3 concise profiling-based leads, each ending with a BrowserStack recording link for the peak/outlier sample when available.]
 
 *AI insights to investigate*
 

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -728,9 +728,9 @@ Outputs:
 
 | File | Description |
 | ---- | ----------- |
-| `report.json` | Scenario averages, failing PRs, data-driven leads |
-| `slack.md` | Slack-ready markdown |
-| `ai-briefing.md` | Briefing for an AI pass (investigation insights) |
+| `report.json` | Scenario averages, peak-sample recording URLs, failing PRs, data-driven leads |
+| `slack.md` | Slack-ready markdown (leads include BrowserStack recording links for peaks) |
+| `ai-briefing.md` | Briefing for an AI pass (investigation insights + peak recordings) |
 
 Recommended automation: schedule the prompt in
 [`.cursor/automations/weekly-app-profiling-report.md`](../../.cursor/automations/weekly-app-profiling-report.md).

--- a/tests/reporters/generators/JsonReportGenerator.test.ts
+++ b/tests/reporters/generators/JsonReportGenerator.test.ts
@@ -203,6 +203,7 @@ describe('JsonReportGenerator', () => {
             testName: 'Cold Start Login',
             projectName: 'browserstack-android',
             sessionId: 'session-1',
+            videoURL: 'https://app-automate.browserstack.com/builds/b1/sessions/session-1',
             timestamp: '2026-07-22T12:00:00.000Z',
             profilingSummary,
             profilingData: profilingData as MetricsEntry['profilingData'],
@@ -212,6 +213,7 @@ describe('JsonReportGenerator', () => {
             testName: 'Warm Start Wallet',
             projectName: 'browserstack-android',
             sessionId: 'session-2',
+            videoURL: 'https://app-automate.browserstack.com/builds/b1/sessions/session-2',
             timestamp: '2026-07-22T12:01:00.000Z',
             profilingSummary,
             profilingData: profilingData as MetricsEntry['profilingData'],
@@ -221,6 +223,7 @@ describe('JsonReportGenerator', () => {
             testName: 'Send ETH',
             projectName: 'browserstack-android',
             sessionId: 'session-3',
+            videoURL: null,
             timestamp: '2026-07-22T12:02:00.000Z',
             profilingSummary,
             profilingData: profilingData as MetricsEntry['profilingData'],
@@ -247,10 +250,15 @@ describe('JsonReportGenerator', () => {
         testName: 'Cold Start Login',
         projectName: 'browserstack-android',
         sessionId: 'session-1',
+        videoURL:
+          'https://app-automate.browserstack.com/builds/b1/sessions/session-1',
         profilingSummary,
         apiCalls,
       });
       expect(firstArtifact.profilingData).toEqual(profilingData);
+
+      const thirdArtifact = JSON.parse(profilingWrites[2][1] as string);
+      expect(thirdArtifact.videoURL).toBeNull();
     });
 
     it('creates the app-profiling directory when missing', () => {

--- a/tests/reporters/generators/JsonReportGenerator.test.ts
+++ b/tests/reporters/generators/JsonReportGenerator.test.ts
@@ -203,7 +203,8 @@ describe('JsonReportGenerator', () => {
             testName: 'Cold Start Login',
             projectName: 'browserstack-android',
             sessionId: 'session-1',
-            videoURL: 'https://app-automate.browserstack.com/builds/b1/sessions/session-1',
+            videoURL:
+              'https://app-automate.browserstack.com/builds/b1/sessions/session-1',
             timestamp: '2026-07-22T12:00:00.000Z',
             profilingSummary,
             profilingData: profilingData as MetricsEntry['profilingData'],
@@ -213,7 +214,8 @@ describe('JsonReportGenerator', () => {
             testName: 'Warm Start Wallet',
             projectName: 'browserstack-android',
             sessionId: 'session-2',
-            videoURL: 'https://app-automate.browserstack.com/builds/b1/sessions/session-2',
+            videoURL:
+              'https://app-automate.browserstack.com/builds/b1/sessions/session-2',
             timestamp: '2026-07-22T12:01:00.000Z',
             profilingSummary,
             profilingData: profilingData as MetricsEntry['profilingData'],

--- a/tests/reporters/generators/JsonReportGenerator.ts
+++ b/tests/reporters/generators/JsonReportGenerator.ts
@@ -104,6 +104,7 @@ export class JsonReportGenerator {
         testName: metric.testName,
         projectName: metric.projectName ?? null,
         sessionId: metric.sessionId ?? null,
+        videoURL: metric.videoURL ?? null,
         device: metric.device,
         timestamp: metric.timestamp ?? new Date().toISOString(),
         profilingSummary: metric.profilingSummary ?? null,

--- a/tests/reporters/types.ts
+++ b/tests/reporters/types.ts
@@ -155,6 +155,8 @@ export interface AppProfilingArtifact {
   testName: string;
   projectName: string | null;
   sessionId: string | null;
+  /** BrowserStack session recording URL when enrichment succeeded. */
+  videoURL: string | null;
   device: DeviceInfo;
   timestamp: string;
   profilingSummary: ProfilingSummary | null;

--- a/tests/scripts/weekly-app-profiling-report.mjs
+++ b/tests/scripts/weekly-app-profiling-report.mjs
@@ -360,13 +360,62 @@ function downloadAggregatedReports({ repo, runId, destDir }) {
   return true;
 }
 
+function collectVideoUrlsBySession(node, out = new Map()) {
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      collectVideoUrlsBySession(item, out);
+    }
+    return out;
+  }
+  if (node && typeof node === 'object') {
+    const sessionId = node.sessionId;
+    const videoURL = node.videoURL;
+    if (
+      typeof sessionId === 'string' &&
+      sessionId &&
+      typeof videoURL === 'string' &&
+      videoURL
+    ) {
+      out.set(sessionId, videoURL);
+    }
+    for (const value of Object.values(node)) {
+      collectVideoUrlsBySession(value, out);
+    }
+  }
+  return out;
+}
+
+/**
+ * Index BrowserStack recording URLs from performance result JSONs that ship
+ * alongside app-profiling artifacts (sessionId → videoURL).
+ */
+function loadVideoUrlIndex(prAggDir) {
+  const out = new Map();
+  for (const file of [
+    'performance-results.json',
+    'aggregated-performance-report.json',
+  ]) {
+    const filePath = path.join(prAggDir, file);
+    if (!fs.existsSync(filePath)) continue;
+    try {
+      const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      collectVideoUrlsBySession(data, out);
+    } catch {
+      // Ignore malformed companion reports; app-profiling remains primary.
+    }
+  }
+  return out;
+}
+
 function collectProfilingFromArtifacts(artifactsRoot, scenarioNames) {
   const byTest = Object.fromEntries(scenarioNames.map((n) => [n, []]));
   if (!fs.existsSync(artifactsRoot)) return byTest;
 
   for (const pr of fs.readdirSync(artifactsRoot)) {
-    const dir = path.join(artifactsRoot, pr, 'agg', 'app-profiling');
+    const aggDir = path.join(artifactsRoot, pr, 'agg');
+    const dir = path.join(aggDir, 'app-profiling');
     if (!fs.existsSync(dir)) continue;
+    const videoBySession = loadVideoUrlIndex(aggDir);
     for (const file of fs.readdirSync(dir)) {
       if (!file.endsWith('.json')) continue;
       const data = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
@@ -375,8 +424,18 @@ function collectProfilingFromArtifacts(artifactsRoot, scenarioNames) {
       const s = data.profilingSummary || {};
       if (s.error || s.status === 'error') continue;
       if (s.cpu?.avg == null && s.memory?.avg == null) continue;
+      const sessionId =
+        typeof data.sessionId === 'string' && data.sessionId
+          ? data.sessionId
+          : null;
+      const videoURL =
+        (typeof data.videoURL === 'string' && data.videoURL) ||
+        (sessionId ? videoBySession.get(sessionId) : null) ||
+        null;
       byTest[name].push({
         pr: Number(pr),
+        sessionId,
+        videoURL,
         cpuAvg: s.cpu?.avg ?? null,
         cpuMax: s.cpu?.max ?? null,
         memAvg: s.memory?.avg ?? null,
@@ -393,38 +452,99 @@ function collectProfilingFromArtifacts(artifactsRoot, scenarioNames) {
   return byTest;
 }
 
+/**
+ * Pick the sample with the highest value for a metric (e.g. peak memMax).
+ * Used to attach the BrowserStack recording that best illustrates a risk.
+ */
+function pickPeakSample(samples, metricKey) {
+  let best = null;
+  for (const sample of samples || []) {
+    const raw = sample?.[metricKey];
+    if (raw == null || !Number.isFinite(raw)) continue;
+    const value = +Number(raw).toFixed(2);
+    if (!best || value > best.value) {
+      best = {
+        metric: metricKey,
+        value,
+        pr: sample.pr ?? null,
+        sessionId: sample.sessionId ?? null,
+        videoURL: sample.videoURL ?? null,
+      };
+    }
+  }
+  return best;
+}
+
+function buildPeakRecordings(samples) {
+  return {
+    memMax: pickPeakSample(samples, 'memMax'),
+    slowFrames: pickPeakSample(samples, 'slowFrames'),
+    criticalIssues: pickPeakSample(samples, 'criticalIssues'),
+    issues: pickPeakSample(samples, 'issues'),
+  };
+}
+
+function recordingLabelForLead(theme, peak) {
+  if (!peak?.videoURL) return null;
+  if (theme === 'memory') {
+    return `Recording (peak memMax ${peak.value} MB)`;
+  }
+  if (theme === 'ui-jank') {
+    return `Recording (peak slow frames ${peak.value}%)`;
+  }
+  return `Recording (peak ${peak.metric} ${peak.value})`;
+}
+
+function formatRecordingSlackLink(recordingUrl, label) {
+  if (!recordingUrl) return '';
+  const safeLabel = label || 'Recording';
+  return ` <${recordingUrl}|${safeLabel}>`;
+}
+
 function buildInvestigationLeads({ scenarioRows }) {
   const leads = [];
 
   for (const s of scenarioRows) {
     const slow = s.profiling.slowFramesPct?.avg;
     const memMax = s.profiling.memMaxMb?.avg;
+    const peaks = s.profiling.peakRecordings || {};
 
     if (slow != null && slow >= 25) {
+      const peak = peaks.slowFrames || null;
       leads.push({
         severity: 'high',
         theme: 'ui-jank',
         scenario: s.scenario,
         summary: `${s.scenario} averages ${slow}% slow frames (n=${s.profiling.samples}). Investigate list/render cost and recent merges touching this flow.`,
+        recordingUrl: peak?.videoURL ?? null,
+        recordingLabel: recordingLabelForLead('ui-jank', peak),
+        peak,
       });
     } else if (slow != null && slow >= 15) {
+      const peak = peaks.slowFrames || null;
       leads.push({
         severity: 'medium',
         theme: 'ui-jank',
         scenario: s.scenario,
         summary: `${s.scenario} shows elevated slow frames (${slow}%). Worth a trend check next week.`,
+        recordingUrl: peak?.videoURL ?? null,
+        recordingLabel: recordingLabelForLead('ui-jank', peak),
+        peak,
       });
     }
 
     if (memMax != null && memMax >= 900) {
+      const peak = peaks.memMax || null;
       leads.push({
         severity: 'high',
         theme: 'memory',
         scenario: s.scenario,
         summary: `${s.scenario} memory max avg is ${memMax} MB. Investigate retained objects / subscriptions in this flow.`,
+        recordingUrl: peak?.videoURL ?? null,
+        recordingLabel: recordingLabelForLead('memory', peak),
+        peak,
       });
     }
-
   }
 
   return leads;
@@ -542,7 +662,12 @@ function buildSlackMarkdown(report) {
           : lead.severity === 'medium'
             ? ':large_yellow_circle:'
             : ':large_green_circle:';
-      lines.push(`${icon} *[${lead.theme}]* ${lead.summary}`);
+      lines.push(
+        `${icon} *[${lead.theme}]* ${lead.summary}${formatRecordingSlackLink(
+          lead.recordingUrl,
+          lead.recordingLabel,
+        )}`,
+      );
       if (lead.examples?.length) {
         for (const ex of lead.examples) {
           lines.push(`  • <${ex.url}|#${ex.number}> ${ex.title}`);
@@ -594,6 +719,8 @@ function buildAiBriefing(report) {
   lines.push(`- Start every executive-summary bullet with the relevant team tag(s) from the scenario data.`);
   lines.push(`- Skip low-confidence scenarios (very low profiling n) unless they have extreme outliers.`);
   lines.push(`- Keep the final answer concise, in English, Slack-friendly markdown.`);
+  lines.push(`- When highlighting a risk (memory peak, slow-frame outlier, critical issues), append the matching BrowserStack recording link from \`peakRecordings\` using Slack mrkdwn: \`<url|Recording (peak …)>\`.`);
+  lines.push(`- Prefer the peak sample for the metric you cite (memMax → peakRecordings.memMax, slow frames → peakRecordings.slowFrames).`);
   lines.push(`- End with a prioritized checklist of no more than 3 bullets.`);
   lines.push('');
   lines.push(`## Window`);
@@ -628,6 +755,10 @@ function buildAiBriefing(report) {
   lines.push('');
   lines.push(`### Data details`);
   lines.push(`Use compact Slack cards for the selected scenarios. Do not use a table.`);
+  lines.push('');
+  lines.push(`### Profiling leads`);
+  lines.push(`- [Lead with metrics] <recordingUrl|Recording (peak …)>`);
+  lines.push(`- [Lead with metrics] <recordingUrl|Recording (peak …)>`);
   lines.push('');
   lines.push(`### AI insights to investigate`);
   lines.push(`1. ...`);
@@ -793,6 +924,7 @@ async function main() {
         issues: stats(samples.map((s) => s.issues)),
         criticalIssues: stats(samples.map((s) => s.criticalIssues)),
         appSizeMb: stats(samples.map((s) => s.appSizeMb)),
+        peakRecordings: buildPeakRecordings(samples),
       },
     };
   });
@@ -865,6 +997,10 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 
 export {
   buildSlackMarkdown,
+  buildInvestigationLeads,
+  buildPeakRecordings,
+  formatRecordingSlackLink,
+  pickPeakSample,
   selectFeaturedScenarios,
   selectTopLeads,
 };

--- a/tests/scripts/weekly-app-profiling-report.test.mjs
+++ b/tests/scripts/weekly-app-profiling-report.test.mjs
@@ -1,12 +1,16 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  buildInvestigationLeads,
+  buildPeakRecordings,
   buildSlackMarkdown,
+  formatRecordingSlackLink,
+  pickPeakSample,
   selectFeaturedScenarios,
   selectTopLeads,
 } from './weekly-app-profiling-report.mjs';
 
-function scenario(rank, scenario, samples, slowFrames, failRatePct) {
+function scenario(rank, scenario, samples, slowFrames, failRatePct, extras = {}) {
   return {
     rank,
     scenario,
@@ -16,10 +20,11 @@ function scenario(rank, scenario, samples, slowFrames, failRatePct) {
       samples,
       cpuAvg: { avg: 10 },
       memAvgMb: { avg: 650 },
-      memMaxMb: { avg: 800 },
+      memMaxMb: { avg: extras.memMaxAvg ?? 800 },
       slowFramesPct: { avg: slowFrames },
       issues: { avg: 2 },
       appSizeMb: { avg: 320 },
+      peakRecordings: extras.peakRecordings ?? {},
     },
   };
 }
@@ -54,7 +59,92 @@ test('limits Slack leads to three and excludes low-confidence leads', () => {
   );
 });
 
-test('Slack output uses compact sections instead of a wide table', () => {
+test('pickPeakSample selects the highest metric sample with recording', () => {
+  const peak = pickPeakSample(
+    [
+      {
+        pr: 1,
+        memMax: 900,
+        videoURL: 'https://example.com/a',
+        sessionId: 'a',
+      },
+      {
+        pr: 2,
+        memMax: 1114.65,
+        videoURL: 'https://example.com/peak',
+        sessionId: 'peak',
+      },
+      {
+        pr: 3,
+        memMax: 1000,
+        videoURL: 'https://example.com/c',
+        sessionId: 'c',
+      },
+    ],
+    'memMax',
+  );
+
+  assert.deepEqual(peak, {
+    metric: 'memMax',
+    value: 1114.65,
+    pr: 2,
+    sessionId: 'peak',
+    videoURL: 'https://example.com/peak',
+  });
+});
+
+test('buildPeakRecordings exposes memMax and slowFrames peaks', () => {
+  const peaks = buildPeakRecordings([
+    {
+      pr: 10,
+      memMax: 800,
+      slowFrames: 39.94,
+      videoURL: 'https://example.com/jank',
+      sessionId: 'jank',
+    },
+    {
+      pr: 11,
+      memMax: 1114.65,
+      slowFrames: 9.1,
+      videoURL: 'https://example.com/mem',
+      sessionId: 'mem',
+    },
+  ]);
+
+  assert.equal(peaks.memMax.videoURL, 'https://example.com/mem');
+  assert.equal(peaks.memMax.value, 1114.65);
+  assert.equal(peaks.slowFrames.videoURL, 'https://example.com/jank');
+  assert.equal(peaks.slowFrames.value, 39.94);
+});
+
+test('buildInvestigationLeads attaches peak recording for memory risks', () => {
+  const leads = buildInvestigationLeads({
+    scenarioRows: [
+      scenario(1, 'Perps open position and close it', 5, 9.4, 0, {
+        memMaxAvg: 1009.62,
+        peakRecordings: {
+          memMax: {
+            metric: 'memMax',
+            value: 1114.65,
+            pr: 42,
+            sessionId: 'peak-sess',
+            videoURL: 'https://app-automate.browserstack.com/builds/b/sessions/peak-sess',
+          },
+        },
+      }),
+    ],
+  });
+
+  assert.equal(leads.length, 1);
+  assert.equal(leads[0].theme, 'memory');
+  assert.equal(
+    leads[0].recordingUrl,
+    'https://app-automate.browserstack.com/builds/b/sessions/peak-sess',
+  );
+  assert.match(leads[0].recordingLabel, /peak memMax 1114\.65 MB/);
+});
+
+test('Slack leads include BrowserStack recording links for peaks', () => {
   const message = buildSlackMarkdown({
     meta: {
       since: '2026-08-03T00:00:00.000Z',
@@ -65,9 +155,29 @@ test('Slack output uses compact sections instead of a wide table', () => {
       artifactPrs: 3,
     },
     prSummary: { withResults: 5, allPassed: 3, withFailures: 2 },
-    scenarios: [scenario(1, 'Important flow', 4, 30, 0)],
+    scenarios: [
+      scenario(1, 'Important flow', 4, 30, 0, {
+        peakRecordings: {
+          slowFrames: {
+            metric: 'slowFrames',
+            value: 39.94,
+            pr: 7,
+            sessionId: 'sf',
+            videoURL: 'https://app-automate.browserstack.com/builds/b/sessions/sf',
+          },
+        },
+      }),
+    ],
     leads: [
-      { severity: 'high', theme: 'ui-jank', summary: 'Investigate this.' },
+      {
+        severity: 'high',
+        theme: 'ui-jank',
+        scenario: 'Important flow',
+        summary: 'Important flow averages 30% slow frames (n=4).',
+        recordingUrl:
+          'https://app-automate.browserstack.com/builds/b/sessions/sf',
+        recordingLabel: 'Recording (peak slow frames 39.94%)',
+      },
     ],
     aiInsights: '### AI insights to investigate\n1. Investigate this.',
   });
@@ -90,4 +200,17 @@ test('Slack output uses compact sections instead of a wide table', () => {
   assert.equal(message.includes('quality gate'), false);
   assert.equal(message.includes('Priority actions'), true);
   assert.equal(message.includes('Important flow'), true);
+  assert.equal(
+    message.includes(
+      '<https://app-automate.browserstack.com/builds/b/sessions/sf|Recording (peak slow frames 39.94%)>',
+    ),
+    true,
+  );
+  assert.equal(
+    formatRecordingSlackLink(
+      'https://example.com/r',
+      'Recording (peak memMax 1 MB)',
+    ),
+    ' <https://example.com/r|Recording (peak memMax 1 MB)>',
+  );
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

Weekly app-profiling Slack reports now deep-link each highlighted risk to the BrowserStack session recording that contains the peak/outlier sample (for example, peak `memMax` or peak slow frames).

This updates the collector so profiling samples resolve recording URLs from companion `performance-results.json` (and from `videoURL` on future app-profiling artifacts), attaches `peakRecordings` + `recordingUrl` on leads, and instructs the automation AI pass to keep those links next to risk bullets.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: weekly app profiling report automation

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: weekly app profiling recording links

  Scenario: collector attaches peak recording to memory lead
    Given aggregated-reports artifacts with app-profiling JSON and performance-results.json
    When the weekly report script builds investigation leads for a high memMax scenario
    Then each memory lead includes recordingUrl for the sample with the highest memMax
    And slack.md renders a Slack mrkdwn link labeled with the peak value
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

N/A — script/automation change; verified with unit tests and a real aggregated-reports artifact sample.

### **Before**

Profiling leads listed metrics only (no recording deep-link).

### **After**

Leads append `<recordingUrl|Recording (peak memMax …)>` / slow-frames equivalent when a peak sample URL is available.

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
- [ ] I've tested with a power user scenario
- [ ] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e221355-4958-41e0-af7d-4d29b06a000c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e221355-4958-41e0-af7d-4d29b06a000c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

