### PR TITLE
test: cover ImportFromSecretRecoveryPhrase toast validation paths

### DIFF
--- a/app/components/Views/ImportFromSecretRecoveryPhrase/index.test.tsx
+++ b/app/components/Views/ImportFromSecretRecoveryPhrase/index.test.tsx
@@ -34,8 +34,22 @@ import {
 import type { Span } from '@sentry/core';
 import { defaultQrSyncControllerState } from '../../../core/QrSync/QrSyncController';
 import { QrSyncSecretTypes } from '../../../core/QrSync/constants';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 
 const mockQrSyncResetState = jest.fn();
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actualDesignSystem = jest.requireActual(
+    '@metamask/design-system-react-native',
+  );
+
+  return {
+    ...actualDesignSystem,
+    toast: Object.assign(jest.fn(), {
+      dismiss: jest.fn(),
+    }),
+  };
+});
 
 jest.mock('../../../core/Engine', () => ({
   __esModule: true,
@@ -434,6 +448,86 @@ describe('ImportFromSecretRecoveryPhrase', () => {
         },
         { timeout: 3000 },
       );
+    });
+
+    it('shows length error toast when seed phrase length is not supported', async () => {
+      const { getByPlaceholderText, getByRole } = renderScreen(
+        ImportFromSecretRecoveryPhrase,
+        { name: Routes.ONBOARDING.IMPORT_FROM_SECRET_RECOVERY_PHRASE },
+        { state: initialState },
+      );
+
+      const input = getByPlaceholderText(
+        strings('import_from_seed.srp_placeholder'),
+      );
+      // Enter a valid-length phrase so Continue enables, then force the length check to fail.
+      fireEvent.changeText(
+        input,
+        'say devote wasp video cool lunch brief add fever uncover novel offer',
+      );
+
+      const continueButton = getByRole('button', { name: 'Continue' });
+
+      await waitFor(() => {
+        expect(continueButton).toBeEnabled();
+      });
+
+      const { SRP_LENGTHS } = require('./constant') as {
+        SRP_LENGTHS: number[];
+      };
+      const includesSpy = jest
+        .spyOn(SRP_LENGTHS, 'includes')
+        .mockReturnValue(false);
+
+      await act(async () => {
+        fireEvent.press(continueButton);
+      });
+
+      expect(toast).toHaveBeenCalledWith({
+        title: strings('import_from_seed.seed_phrase_length_error'),
+        severity: ToastSeverity.Danger,
+        hasNoTimeout: false,
+        showCloseButton: false,
+      });
+
+      includesSpy.mockRestore();
+    });
+
+    it('shows invalid seed phrase error when Continue is pressed with a checksum-invalid mnemonic', async () => {
+      const { getByPlaceholderText, getByTestId, getByText, getByRole } =
+        renderScreen(
+          ImportFromSecretRecoveryPhrase,
+          { name: Routes.ONBOARDING.IMPORT_FROM_SECRET_RECOVERY_PHRASE },
+          { state: initialState },
+        );
+
+      const input = getByPlaceholderText(
+        strings('import_from_seed.srp_placeholder'),
+      );
+      // 12 BIP39 words with an invalid checksum.
+      fireEvent.changeText(
+        input,
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon',
+      );
+
+      const continueButton = getByRole('button', { name: 'Continue' });
+
+      await waitFor(() => {
+        expect(continueButton).toBeEnabled();
+      });
+
+      await act(async () => {
+        fireEvent.press(continueButton);
+      });
+
+      await waitFor(() => {
+        expect(
+          getByText(strings('import_from_seed.invalid_seed_phrase')),
+        ).toBeOnTheScreen();
+      });
+      expect(
+        getByTestId(ImportFromSeedSelectorsIDs.CONTINUE_BUTTON_ID),
+      ).toBeOnTheScreen();
     });
 
     it('keeps continue enabled after entering a 24-word SRP whose first 12 words are also valid', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds unit test coverage for the uncovered `validateSeedPhrase` branches in `ImportFromSecretRecoveryPhrase` that Sonar flagged after the web3auth toast migration:

- Unsupported SRP length → design-system `toast()` with `showCloseButton: false`
- Checksum-invalid 12-word mnemonic → `invalid_seed_phrase` error

## Test plan
- [x] `yarn jest app/components/Views/ImportFromSecretRecoveryPhrase/index.test.tsx` (79/79 passing)
- [ ] Confirm Sonar new-code coverage for `ImportFromSecretRecoveryPhrase/index.tsx` clears the uncovered line
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0ae6d0c-a65b-4cd6-9758-def2ed064afa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0ae6d0c-a65b-4cd6-9758-def2ed064afa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

