### PR TITLE
fix: cp-8.8.2 update `eth-json-rpc-middleware` to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -310,7 +310,7 @@
     "@metamask/ens-resolver-snap": "^1.2.0",
     "@metamask/eth-hd-keyring": "^15.0.0",
     "@metamask/eth-json-rpc-filters": "^9.0.0",
-    "@metamask/eth-json-rpc-middleware": "^24.0.0",
+    "@metamask/eth-json-rpc-middleware": "npm:@metamask-previews/eth-json-rpc-middleware@24.0.0-preview-9a81434",
     "@metamask/eth-ledger-bridge-keyring": "^13.1.0",
     "@metamask/eth-money-keyring": "^4.0.0",
     "@metamask/eth-qr-keyring": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -310,7 +310,7 @@
     "@metamask/ens-resolver-snap": "^1.2.0",
     "@metamask/eth-hd-keyring": "^15.0.0",
     "@metamask/eth-json-rpc-filters": "^9.0.0",
-    "@metamask/eth-json-rpc-middleware": "npm:@metamask-previews/eth-json-rpc-middleware@24.0.0-preview-9a81434",
+    "@metamask/eth-json-rpc-middleware": "^24.0.1",
     "@metamask/eth-ledger-bridge-keyring": "^13.1.0",
     "@metamask/eth-money-keyring": "^4.0.0",
     "@metamask/eth-qr-keyring": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8488,24 +8488,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-json-rpc-middleware@npm:@metamask-previews/eth-json-rpc-middleware@24.0.0-preview-9a81434":
-  version: 24.0.0-preview-9a81434
-  resolution: "@metamask-previews/eth-json-rpc-middleware@npm:24.0.0-preview-9a81434"
-  dependencies:
-    "@metamask/eth-block-tracker": "npm:^15.0.1"
-    "@metamask/eth-json-rpc-provider": "npm:^6.0.1"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/json-rpc-engine": "npm:^10.5.0"
-    "@metamask/message-manager": "npm:^14.1.2"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/superstruct": "npm:^3.4.1"
-    "@metamask/utils": "npm:^11.11.0"
-    klona: "npm:^2.0.6"
-    safe-stable-stringify: "npm:^2.4.3"
-  checksum: 10/80a6bfcb26db8bc9e29d8ff5a3246cd4d11a08204d2530c841328a36bf4cfa03688769016c8a622adcc2daa72dd39b9dfcc889ad0cb5d2bf4f57f83107685adc
-  languageName: node
-  linkType: hard
-
 "@metamask/eth-json-rpc-middleware@npm:^23.1.3":
   version: 23.1.3
   resolution: "@metamask/eth-json-rpc-middleware@npm:23.1.3"
@@ -8522,6 +8504,24 @@ __metadata:
     pify: "npm:^5.0.0"
     safe-stable-stringify: "npm:^2.4.3"
   checksum: 10/aee4866afa78cb21aed9daa1211ee9a3515cb9549d9b325d5904b8769fb54790296224b58ec3555eb34a7125d2fd5180d6cba915bb1ca8dc3f04bf75e502c6b0
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-json-rpc-middleware@npm:^24.0.1":
+  version: 24.0.1
+  resolution: "@metamask/eth-json-rpc-middleware@npm:24.0.1"
+  dependencies:
+    "@metamask/eth-block-tracker": "npm:^15.0.1"
+    "@metamask/eth-json-rpc-provider": "npm:^6.0.1"
+    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/json-rpc-engine": "npm:^10.5.0"
+    "@metamask/message-manager": "npm:^14.1.2"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/superstruct": "npm:^3.4.1"
+    "@metamask/utils": "npm:^11.11.0"
+    klona: "npm:^2.0.6"
+    safe-stable-stringify: "npm:^2.4.3"
+  checksum: 10/54ebe641625c1dec7c8d2e9b46551ca9b0006b2b0f0cbdb6aa79644334222711b15cc660250710c4d5bfd0767e5a5e27a35f62dc93e63d90e35e1cf83727be28
   languageName: node
   linkType: hard
 
@@ -35709,7 +35709,7 @@ __metadata:
     "@metamask/eslint-plugin-design-tokens": "npm:^1.0.0"
     "@metamask/eth-hd-keyring": "npm:^15.0.0"
     "@metamask/eth-json-rpc-filters": "npm:^9.0.0"
-    "@metamask/eth-json-rpc-middleware": "npm:@metamask-previews/eth-json-rpc-middleware@24.0.0-preview-9a81434"
+    "@metamask/eth-json-rpc-middleware": "npm:^24.0.1"
     "@metamask/eth-ledger-bridge-keyring": "npm:^13.1.0"
     "@metamask/eth-money-keyring": "npm:^4.0.0"
     "@metamask/eth-qr-keyring": "npm:^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8488,6 +8488,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/eth-json-rpc-middleware@npm:@metamask-previews/eth-json-rpc-middleware@24.0.0-preview-9a81434":
+  version: 24.0.0-preview-9a81434
+  resolution: "@metamask-previews/eth-json-rpc-middleware@npm:24.0.0-preview-9a81434"
+  dependencies:
+    "@metamask/eth-block-tracker": "npm:^15.0.1"
+    "@metamask/eth-json-rpc-provider": "npm:^6.0.1"
+    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/json-rpc-engine": "npm:^10.5.0"
+    "@metamask/message-manager": "npm:^14.1.2"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/superstruct": "npm:^3.4.1"
+    "@metamask/utils": "npm:^11.11.0"
+    klona: "npm:^2.0.6"
+    safe-stable-stringify: "npm:^2.4.3"
+  checksum: 10/80a6bfcb26db8bc9e29d8ff5a3246cd4d11a08204d2530c841328a36bf4cfa03688769016c8a622adcc2daa72dd39b9dfcc889ad0cb5d2bf4f57f83107685adc
+  languageName: node
+  linkType: hard
+
 "@metamask/eth-json-rpc-middleware@npm:^23.1.3":
   version: 23.1.3
   resolution: "@metamask/eth-json-rpc-middleware@npm:23.1.3"
@@ -8504,24 +8522,6 @@ __metadata:
     pify: "npm:^5.0.0"
     safe-stable-stringify: "npm:^2.4.3"
   checksum: 10/aee4866afa78cb21aed9daa1211ee9a3515cb9549d9b325d5904b8769fb54790296224b58ec3555eb34a7125d2fd5180d6cba915bb1ca8dc3f04bf75e502c6b0
-  languageName: node
-  linkType: hard
-
-"@metamask/eth-json-rpc-middleware@npm:^24.0.0":
-  version: 24.0.0
-  resolution: "@metamask/eth-json-rpc-middleware@npm:24.0.0"
-  dependencies:
-    "@metamask/eth-block-tracker": "npm:^15.0.1"
-    "@metamask/eth-json-rpc-provider": "npm:^6.0.1"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/json-rpc-engine": "npm:^10.5.0"
-    "@metamask/message-manager": "npm:^14.1.2"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.11.0"
-    klona: "npm:^2.0.6"
-    safe-stable-stringify: "npm:^2.4.3"
-  checksum: 10/d78b93518b2914bdf049cbc7a3c8a6a353c1c79727b106c7eb108813528dc0f8a26ed7feef5b9e27a94239e58286af0d0fe4e4d15323ba4db13e1b64d97e5d48
   languageName: node
   linkType: hard
 
@@ -35709,7 +35709,7 @@ __metadata:
     "@metamask/eslint-plugin-design-tokens": "npm:^1.0.0"
     "@metamask/eth-hd-keyring": "npm:^15.0.0"
     "@metamask/eth-json-rpc-filters": "npm:^9.0.0"
-    "@metamask/eth-json-rpc-middleware": "npm:^24.0.0"
+    "@metamask/eth-json-rpc-middleware": "npm:@metamask-previews/eth-json-rpc-middleware@24.0.0-preview-9a81434"
     "@metamask/eth-ledger-bridge-keyring": "npm:^13.1.0"
     "@metamask/eth-money-keyring": "npm:^4.0.0"
     "@metamask/eth-qr-keyring": "npm:^2.1.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`@metamask/eth-json-rpc-middleware@24.0.0` added strict Superstruct validation of `eth_sendTransaction` / `eth_signTransaction` params. Most numeric fields accept both hex strings and numbers, but `chainId` (and the `authorizationList` `chainId` / `nonce` / `yParity` fields) were validated as string-only. As a result, requests that send a numeric `chainId` are rejected with `-32602 Invalid params` (`chainId - Expected a string, but received: <number>`), and no confirmation opens. On mobile this affects both the standard dapp path (`eth_sendTransaction`) and the WalletConnect path.

This updates `@metamask/eth-json-rpc-middleware` to a build that aligns those fields with the other quantity fields so they accept both hex strings and numbers, restoring the previous behavior.

> [!NOTE]
> This PR currently points `@metamask/eth-json-rpc-middleware` at a preview build (`npm:@metamask-previews/eth-json-rpc-middleware@24.0.0-preview-9a81434`) so the fix can be tested end-to-end. **This will be replaced with the released version before merge.**

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed transactions from dapps that send a numeric `chainId` being rejected with an "Invalid params" error instead of opening a confirmation.

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: MetaMask/metamask-extension#45763

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Numeric chainId in eth_sendTransaction

  Scenario: dapp sends a transaction with a numeric chainId
    Given a build of this branch is running on a device or simulator
    And the wallet is connected to a dapp

    When the dapp calls eth_sendTransaction with a params object whose chainId is a JSON number (e.g. 4663) rather than a hex string
    Then the transaction confirmation opens
    And the request is not rejected with "-32602 Invalid params - chainId - Expected a string, but received: 4663"

  Scenario: WalletConnect dapp sends a transaction with a numeric chainId
    Given a build of this branch is running on a device or simulator
    And the wallet is connected to a dapp over WalletConnect

    When the dapp requests eth_sendTransaction with a numeric chainId
    Then the transaction confirmation opens

  Scenario: normal transaction is unaffected
    Given a build of this branch is running on a device or simulator
    And the wallet is connected to a dapp

    When the dapp calls eth_sendTransaction with no chainId or a hex-string chainId
    Then the transaction confirmation opens as before
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches JSON-RPC transaction validation on the dapp and WalletConnect paths; scope is limited to a patch dependency with no local code edits.
> 
> **Overview**
> This PR only bumps **`@metamask/eth-json-rpc-middleware`** from **^24.0.0** to **^24.0.1** in `package.json` and refreshes `yarn.lock` (including a transitive **`@metamask/superstruct`** bump on that package). There are **no mobile app code changes**.
> 
> The intent is to pick up middleware that fixes param validation for **`eth_sendTransaction`** / **`eth_signTransaction`**: after 24.0.0, **`chainId`** (and related **`authorizationList`** quantity fields) were treated as strings-only, so dapps or WalletConnect callers sending a **numeric `chainId`** got **`-32602 Invalid params`** and never saw a confirmation. **24.0.1** aligns those fields with other quantity fields so hex strings and numbers are both accepted again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b8b74fa2e6526b7b192d0ba652331c896f82ce0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->