### PR TITLE
refactor(toast): migrate engagement toasts to the design system

### DIFF
--- a/app/components/Views/Notifications/Details/hooks/useCopyClipboard.test.ts
+++ b/app/components/Views/Notifications/Details/hooks/useCopyClipboard.test.ts
@@ -1,9 +1,7 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-import React from 'react';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import useCopyClipboard from './useCopyClipboard';
 import ClipboardManager from '../../../../../core/ClipboardManager';
-import { ToastContext } from '../../../../../component-library/components/Toast';
-import { IconName } from '../../../../../component-library/components/Icons/Icon';
 
 jest.mock('../../../../../core/ClipboardManager', () => ({
   setString: jest.fn().mockResolvedValue(undefined),
@@ -14,17 +12,15 @@ jest.mock('react-redux', () => ({
   useDispatch: () => mockDispatch,
 }));
 
-const mockShowToast = jest.fn();
-const mockToastRef = {
-  current: { showToast: mockShowToast, closeToast: jest.fn() },
-};
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
-const wrapper = ({ children }: { children: React.ReactNode }) =>
-  React.createElement(
-    ToastContext.Provider,
-    { value: { toastRef: mockToastRef } },
-    children,
-  );
+const mockToast = jest.mocked(toast);
 
 describe('useCopyClipboard', () => {
   beforeEach(() => {
@@ -37,7 +33,7 @@ describe('useCopyClipboard', () => {
   });
 
   it('copies provided value to system clipboard', async () => {
-    const { result } = renderHook(() => useCopyClipboard(), { wrapper });
+    const { result } = renderHook(() => useCopyClipboard());
     const testAddress = '0x1234567890abcdef';
 
     await act(async () => {
@@ -47,50 +43,49 @@ describe('useCopyClipboard', () => {
     expect(ClipboardManager.setString).toHaveBeenCalledWith(testAddress);
   });
 
-  it('shows toast with Icon variant after copying', async () => {
-    const { result } = renderHook(() => useCopyClipboard(), { wrapper });
+  it('shows success toast after copying', async () => {
+    const { result } = renderHook(() => useCopyClipboard());
 
     await act(async () => {
       await result.current('0x1234567890abcdef');
     });
 
-    expect(mockShowToast).toHaveBeenCalledWith(
+    expect(mockToast).toHaveBeenCalledWith(
       expect.objectContaining({
-        variant: 'Icon',
-        iconName: IconName.Confirmation,
+        severity: ToastSeverity.Success,
         hasNoTimeout: false,
       }),
     );
   });
 
   it('uses custom alert text in toast when provided', async () => {
-    const { result } = renderHook(() => useCopyClipboard(), { wrapper });
+    const { result } = renderHook(() => useCopyClipboard());
     const customMessage = 'Transaction ID copied';
 
     await act(async () => {
       await result.current('0x1234', customMessage);
     });
 
-    expect(mockShowToast).toHaveBeenCalledWith(
+    expect(mockToast).toHaveBeenCalledWith(
       expect.objectContaining({
-        labelOptions: [{ label: customMessage }],
+        title: customMessage,
       }),
     );
   });
 
   it('skips clipboard and toast when value is empty string', async () => {
-    const { result } = renderHook(() => useCopyClipboard(), { wrapper });
+    const { result } = renderHook(() => useCopyClipboard());
 
     await act(async () => {
       await result.current('');
     });
 
     expect(ClipboardManager.setString).not.toHaveBeenCalled();
-    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
   });
 
   it('dispatches protectWalletModalVisible after 2 second delay', async () => {
-    const { result } = renderHook(() => useCopyClipboard(), { wrapper });
+    const { result } = renderHook(() => useCopyClipboard());
 
     await act(async () => {
       await result.current('0x1234');

--- a/app/components/Views/Notifications/Details/hooks/useCopyClipboard.ts
+++ b/app/components/Views/Notifications/Details/hooks/useCopyClipboard.ts
@@ -1,14 +1,9 @@
-import { useCallback, useContext } from 'react';
+import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { protectWalletModalVisible } from '../../../../../actions/user';
 import ClipboardManager from '../../../../../core/ClipboardManager';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../../component-library/components/Toast';
-import { IconName } from '../../../../../component-library/components/Icons/Icon';
-import { useTheme } from '../../../../../util/theme';
 
 export const CopyClipboardAlertMessage = {
   default: (): string => strings('notifications.copied_to_clipboard'),
@@ -19,8 +14,6 @@ export const CopyClipboardAlertMessage = {
 
 function useCopyClipboard() {
   const dispatch = useDispatch();
-  const { toastRef } = useContext(ToastContext);
-  const { colors } = useTheme();
 
   const handleProtectWalletModalVisible = useCallback(
     () => dispatch(protectWalletModalVisible()),
@@ -31,18 +24,14 @@ function useCopyClipboard() {
     async (value: string, alertText?: string) => {
       if (!value) return;
       await ClipboardManager.setString(value);
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        iconColor: colors.success.default,
-        labelOptions: [
-          { label: alertText ?? CopyClipboardAlertMessage.default() },
-        ],
+      toast({
+        title: alertText ?? CopyClipboardAlertMessage.default(),
+        severity: ToastSeverity.Success,
         hasNoTimeout: false,
       });
       setTimeout(() => handleProtectWalletModalVisible(), 2000);
     },
-    [colors.success.default, toastRef, handleProtectWalletModalVisible],
+    [handleProtectWalletModalVisible],
   );
 
   return copyToClipboard;

--- a/app/components/Views/Notifications/PushNotificationOnboarding/index.test.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/index.test.tsx
@@ -1,20 +1,26 @@
 import React from 'react';
 import { fireEvent, waitFor } from '@testing-library/react-native';
 import { Platform } from 'react-native';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import renderWithProvider from '../../../../util/test/renderWithProvider';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../component-library/components/Toast';
 import PushNotificationOnboarding from '.';
 import type { PushPrePromptVariant } from '../../../../util/notifications/hooks/usePushPrePromptVariant';
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
+
+const mockToast = jest.mocked(toast);
 
 const mockMarkPrePromptShown = jest.fn().mockResolvedValue(undefined);
 const mockDismissPrePrompt = jest.fn();
 const mockRequestPushPermission = jest.fn();
 const mockEnableNotificationsInBackground = jest.fn();
 const mockEnableMarketingConsent = jest.fn();
-const mockShowToast = jest.fn();
 const mockTrackPrePromptViewed = jest.fn();
 const mockTrackPrePromptDismissed = jest.fn();
 const mockTrackPrePromptButtonClicked = jest.fn();
@@ -146,25 +152,14 @@ const renderPushNotificationOnboarding = ({
   prePromptVariant?: PushPrePromptVariant;
 } = {}) =>
   renderWithProvider(
-    <ToastContext.Provider
-      value={{
-        toastRef: {
-          current: {
-            showToast: mockShowToast,
-            closeToast: jest.fn(),
-          },
-        },
-      }}
-    >
-      <PushNotificationOnboarding
-        dismissPrePrompt={mockDismissPrePrompt}
-        isVisible={isVisible}
-        markPrePromptShown={mockMarkPrePromptShown}
-        nativeOsPermissionEnabled={nativeOsPermissionEnabled}
-        onComplete={mockOnComplete}
-        prePromptVariant={prePromptVariant}
-      />
-    </ToastContext.Provider>,
+    <PushNotificationOnboarding
+      dismissPrePrompt={mockDismissPrePrompt}
+      isVisible={isVisible}
+      markPrePromptShown={mockMarkPrePromptShown}
+      nativeOsPermissionEnabled={nativeOsPermissionEnabled}
+      onComplete={mockOnComplete}
+      prePromptVariant={prePromptVariant}
+    />,
     {
       state: {
         security: {
@@ -175,56 +170,44 @@ const renderPushNotificationOnboarding = ({
   );
 
 const expectNotificationsOnToast = () => {
-  expect(mockShowToast).toHaveBeenCalledWith(
+  expect(mockToast).toHaveBeenCalledWith(
     expect.objectContaining({
-      variant: ToastVariants.Plain,
-      labelOptions: [{ label: 'Notifications are on', isBold: true }],
-      descriptionOptions: {
-        description: "We'll send you transactions, price alerts, and updates.",
-      },
-      startAccessory: expect.any(Object),
+      title: 'Notifications are on',
+      description: "We'll send you transactions, price alerts, and updates.",
+      severity: ToastSeverity.Success,
       hasNoTimeout: false,
     }),
   );
 };
 
 const expectNotificationsOffToast = () => {
-  expect(mockShowToast).toHaveBeenCalledWith(
+  expect(mockToast).toHaveBeenCalledWith(
     expect.objectContaining({
-      variant: ToastVariants.Plain,
-      labelOptions: [{ label: 'Notifications are off', isBold: true }],
-      descriptionOptions: {
-        description: 'Turn them on anytime in Settings → Notifications.',
-      },
-      startAccessory: expect.any(Object),
+      title: 'Notifications are off',
+      description: 'Turn them on anytime in Settings → Notifications.',
+      severity: ToastSeverity.Default,
       hasNoTimeout: false,
     }),
   );
 };
 
 const expectPersonalizedAlertsOnToast = () => {
-  expect(mockShowToast).toHaveBeenCalledWith(
+  expect(mockToast).toHaveBeenCalledWith(
     expect.objectContaining({
-      variant: ToastVariants.Plain,
-      labelOptions: [{ label: 'Personalized alerts is on', isBold: true }],
-      descriptionOptions: {
-        description: 'Manage this anytime in Settings.',
-      },
-      startAccessory: expect.any(Object),
+      title: 'Personalized alerts is on',
+      description: 'Manage this anytime in Settings.',
+      severity: ToastSeverity.Success,
       hasNoTimeout: false,
     }),
   );
 };
 
 const expectPersonalizedAlertsOffToast = () => {
-  expect(mockShowToast).toHaveBeenCalledWith(
+  expect(mockToast).toHaveBeenCalledWith(
     expect.objectContaining({
-      variant: ToastVariants.Plain,
-      labelOptions: [{ label: 'Personalized alerts is off', isBold: true }],
-      descriptionOptions: {
-        description: 'Turn it on anytime in Settings.',
-      },
-      startAccessory: expect.any(Object),
+      title: 'Personalized alerts is off',
+      description: 'Turn it on anytime in Settings.',
+      severity: ToastSeverity.Default,
       hasNoTimeout: false,
     }),
   );

--- a/app/components/Views/Notifications/PushNotificationOnboarding/index.tsx
+++ b/app/components/Views/Notifications/PushNotificationOnboarding/index.tsx
@@ -1,15 +1,6 @@
-import React, { useCallback, useContext, useEffect, useRef } from 'react';
-import { StyleSheet, View } from 'react-native';
+import React, { useCallback, useEffect, useRef } from 'react';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../locales/i18n';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../component-library/components/Toast';
-import Icon, {
-  IconColor,
-  IconName,
-  IconSize,
-} from '../../../../component-library/components/Icons/Icon';
 import { useEnableMarketingConsent } from '../../../../util/notifications/hooks/useEnableMarketingConsent';
 import { usePushPermissionNotificationSetup } from '../../../../util/notifications/hooks/usePushPermissionNotificationSetup';
 import { PushPrePromptVariant } from '../../../../util/notifications/hooks/usePushPrePromptVariant';
@@ -29,13 +20,6 @@ interface PushNotificationOnboardingProps {
   prePromptVariant: PushPrePromptVariant;
 }
 
-const styles = StyleSheet.create({
-  toastAccessory: {
-    alignSelf: 'flex-start',
-    paddingTop: 4,
-  },
-});
-
 const METRICS_OPT_IN_LOCATION = 'push_pre_prompt';
 
 const PushNotificationOnboarding = ({
@@ -50,7 +34,6 @@ const PushNotificationOnboarding = ({
   const { enableNotificationsInBackground, requestPushPermission } =
     usePushPermissionNotificationSetup();
 
-  const { toastRef } = useContext(ToastContext);
   const viewedPrePromptVariant = useRef<PushPrePromptVariant>(null);
 
   // Analytics emitters for every stage of the pre-prompt → OS prompt funnel.
@@ -94,32 +77,14 @@ const PushNotificationOnboarding = ({
       title: string;
       description: string;
     }) => {
-      const iconColor = isEnabled ? IconColor.Success : IconColor.Default;
-
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Plain,
-        labelOptions: [
-          {
-            label: title,
-            isBold: true,
-          },
-        ],
-        descriptionOptions: {
-          description,
-        },
-        startAccessory: (
-          <View style={styles.toastAccessory}>
-            <Icon
-              name={isEnabled ? IconName.Confirmation : IconName.Info}
-              size={IconSize.Lg}
-              color={iconColor}
-            />
-          </View>
-        ),
+      toast({
+        title,
+        description,
+        severity: isEnabled ? ToastSeverity.Success : ToastSeverity.Default,
         hasNoTimeout: false,
       });
     },
-    [toastRef],
+    [],
   );
 
   const showPushPermissionToast = useCallback(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Notifications still showed copy-confirmation and push-onboarding feedback through the legacy `ToastContext` `showToast` API. This PR switches those call sites to the design-system `toast()` API so engagement toasts share the same toaster as the rest of the toast migration.

Copy confirmation uses `ToastSeverity.Success`. Push onboarding uses `Success` when notifications are enabled and `Default` when they are disabled. Close is handled by the design-system toaster. Shared toast infrastructure (`ToastContext`, `ToastService`, `ControllerEventToastBridge`) is unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

Refs: No tracking issue; continues the design-system toast migration for engagement flows

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Engagement design-system toasts

  Background:
    Given I am logged into MetaMask Mobile

  Scenario: user copies a notification detail
    Given I open a notification that has a copyable value

    When user taps copy
    Then a success toast appears with the copied confirmation copy
    And the toast can be dismissed with the design-system close control

  Scenario: user completes push notification onboarding
    Given I am on the push notification onboarding sheet

    When user enables notifications
    Then a success toast confirms notifications are on

    When user leaves notifications disabled
    Then a default toast confirms the disabled state
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
