### PR TITLE
refactor(toast): migrate rewards toasts to the design system

### DIFF
--- a/app/components/UI/Rewards/components/Campaigns/CampaignTile.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignTile.test.tsx
@@ -1065,10 +1065,10 @@ describe('CampaignTile', () => {
       });
 
       const toastConfig = mockShowToast.mock.calls[0][0] as {
-        closeButtonOptions: { onPress: () => void };
+        onClose: () => void;
       };
       act(() => {
-        toastConfig.closeButtonOptions.onPress();
+        toastConfig.onClose();
       });
 
       notificationsEnabled = true;

--- a/app/components/UI/Rewards/components/RewardsReferralCodeTag/RewardsReferralCodeTag.test.tsx
+++ b/app/components/UI/Rewards/components/RewardsReferralCodeTag/RewardsReferralCodeTag.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import { toast } from '@metamask/design-system-react-native';
 import RewardsReferralCodeTag from './RewardsReferralCodeTag';
 import ClipboardManager from '../../../../../core/ClipboardManager';
 import { useStyles } from '../../../../../component-library/hooks';
@@ -30,18 +31,13 @@ jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key) => key),
 }));
 
-const mockToastRef = {
-  current: {
-    showToast: jest.fn(),
-  },
-};
-
-jest.mock('react', () => ({
-  ...jest.requireActual('react'),
-  useContext: jest.fn(() => ({
-    toastRef: mockToastRef,
-  })),
-}));
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
 jest.mock('../../../../../images/rewards/vip.svg', () => 'VipIcon');
 
@@ -139,6 +135,6 @@ describe('RewardsReferralCodeTag', () => {
 
     fireEvent.press(getByText(referralCode));
 
-    expect(mockToastRef.current.showToast).toHaveBeenCalled();
+    expect(toast).toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Rewards/components/RewardsReferralCodeTag/RewardsReferralCodeTag.tsx
+++ b/app/components/UI/Rewards/components/RewardsReferralCodeTag/RewardsReferralCodeTag.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
@@ -6,13 +6,10 @@ import { useStyles } from '../../../../../component-library/hooks';
 import VipIcon from '../../../../../images/rewards/vip.svg';
 import styleSheet from './RewardsReferralCodeTag.styles';
 import ClipboardManager from '../../../../../core/ClipboardManager';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../../component-library/components/Toast';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
-import { IconName } from '../../../../../component-library/components/Icons/Icon';
 import { TouchableOpacity } from 'react-native';
+
 interface RewardsReferralCodeTagProps {
   referralCode: string;
   backgroundColor?: string;
@@ -29,21 +26,13 @@ const RewardsReferralCodeTag: React.FC<RewardsReferralCodeTagProps> = ({
     fontColor,
   });
 
-  const { toastRef } = useContext(ToastContext);
-
   const handleCopyToClipboard = () => {
     ClipboardManager.setString(referralCode);
 
-    toastRef?.current?.showToast({
-      variant: ToastVariants.Icon,
-      iconName: IconName.Copy,
+    toast({
+      title: strings('rewards.referral.referral_code_copied'),
+      severity: ToastSeverity.Success,
       hasNoTimeout: false,
-      labelOptions: [
-        {
-          label: strings('rewards.referral.referral_code_copied'),
-          isBold: true,
-        },
-      ],
     });
   };
 

--- a/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.test.ts
+++ b/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { playNotification, NotificationMoment } from '../../../../util/haptics';
 import { useCampaignOutcomeToast } from './useCampaignOutcomeToast';
 import { navigateToRewardsRoute } from '../utils';
@@ -15,26 +15,17 @@ import {
   CampaignType,
   type BaseCampaignParticipantOutcomeDto,
 } from '../../../../core/Engine/controllers/rewards-controller/types';
-const ToastVariants = { Icon: 'Icon', App: 'App', Plain: 'Plain' };
-const ButtonIconVariant = { Icon: 'Icon' };
-const IconName = { Close: 'Close', Confirmation: 'Confirmation', Star: 'Star' };
 
-jest.mock('../../../../component-library/components/Toast', () => ({
-  ToastContext: { Consumer: jest.fn(), Provider: jest.fn() },
-}));
-
-jest.mock('../../../../component-library/components/Toast/Toast.types', () => ({
-  ToastVariants: { Icon: 'Icon', App: 'App', Plain: 'Plain' },
-  ButtonIconVariant: { Icon: 'Icon' },
-}));
-
-jest.mock('../../../../component-library/components/Icons/Icon', () => ({
-  IconName: { Close: 'Close', Confirmation: 'Confirmation', Star: 'Star' },
-}));
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
-  useContext: jest.fn(),
   useCallback: jest.fn((fn) => fn),
   useMemo: jest.fn((fn) => fn()),
 }));
@@ -96,11 +87,7 @@ jest.mock('../utils', () => ({
 
 const mockDispatch = jest.fn();
 const mockNavigate = jest.fn();
-const mockShowToast = jest.fn();
-const mockCloseToast = jest.fn();
-const mockToastRef = {
-  current: { showToast: mockShowToast, closeToast: mockCloseToast },
-};
+const mockToast = jest.mocked(toast);
 
 const mockUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>;
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
@@ -176,7 +163,6 @@ describe('useCampaignOutcomeToast', () => {
     jest.clearAllMocks();
     mockUseDispatch.mockReturnValue(mockDispatch);
     mockUseNavigation.mockReturnValue({ navigate: mockNavigate } as never);
-    (useContext as jest.Mock).mockReturnValue({ toastRef: mockToastRef });
     mockUseFocusEffect.mockImplementation((cb) => {
       cb();
     });
@@ -191,13 +177,13 @@ describe('useCampaignOutcomeToast', () => {
     it('outcome is null', () => {
       setupDefaults({ outcome: null });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(mockToast).not.toHaveBeenCalled();
     });
 
     it('no campaigns match the campaignType', () => {
       setupDefaults({ campaigns: [] });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(mockToast).not.toHaveBeenCalled();
     });
 
     it('campaigns are missing from persisted state', () => {
@@ -205,7 +191,7 @@ describe('useCampaignOutcomeToast', () => {
       expect(() =>
         renderHook(() => useCampaignOutcomeToast(mockConfig)),
       ).not.toThrow();
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(mockToast).not.toHaveBeenCalled();
     });
 
     it('subscriptionId is missing', () => {
@@ -218,7 +204,7 @@ describe('useCampaignOutcomeToast', () => {
         },
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(mockToast).not.toHaveBeenCalled();
     });
 
     it('winner toast was already dismissed', () => {
@@ -232,7 +218,7 @@ describe('useCampaignOutcomeToast', () => {
         dismissed: { [key]: true },
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(mockToast).not.toHaveBeenCalled();
     });
 
     it('non_winner toast was already dismissed', () => {
@@ -246,7 +232,7 @@ describe('useCampaignOutcomeToast', () => {
         dismissed: { [key]: true },
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(mockToast).not.toHaveBeenCalled();
     });
 
     it('outcome is finalized with a verification code (neither variant)', () => {
@@ -258,7 +244,7 @@ describe('useCampaignOutcomeToast', () => {
         },
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(mockToast).not.toHaveBeenCalled();
     });
   });
 
@@ -269,12 +255,11 @@ describe('useCampaignOutcomeToast', () => {
       winnerVerificationCode: 'WINNER-XYZ',
     };
 
-    it('shows Plain variant toast with trophy startAccessory', () => {
+    it('shows a persistent toast with trophy startAccessory', () => {
       setupDefaults({ outcome: winnerOutcome });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: ToastVariants.Plain,
           hasNoTimeout: true,
           startAccessory: expect.anything(),
         }),
@@ -284,33 +269,21 @@ describe('useCampaignOutcomeToast', () => {
     it('uses consolidated winner locale keys', () => {
       setupDefaults({ outcome: winnerOutcome });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          labelOptions: [
-            {
-              label: 'rewards.campaign_outcome_toast.winner.title',
-              isBold: true,
-            },
-          ],
-          descriptionOptions: {
-            description: `rewards.campaign_outcome_toast.winner.description:${CAMPAIGN_NAME}`,
-          },
-          linkButtonOptions: expect.objectContaining({
-            label: 'rewards.campaign_outcome_toast.winner.cta',
-          }),
+          title: 'rewards.campaign_outcome_toast.winner.title',
+          description: `rewards.campaign_outcome_toast.winner.description:${CAMPAIGN_NAME}`,
+          actionButtonLabel: 'rewards.campaign_outcome_toast.winner.cta',
         }),
       );
     });
 
-    it('shows close button with correct config', () => {
+    it('passes an onClose handler', () => {
       setupDefaults({ outcome: winnerOutcome });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          closeButtonOptions: expect.objectContaining({
-            variant: ButtonIconVariant.Icon,
-            iconName: IconName.Close,
-          }),
+          onClose: expect.any(Function),
         }),
       );
     });
@@ -329,14 +302,12 @@ describe('useCampaignOutcomeToast', () => {
       winnerVerificationCode: null,
     };
 
-    it('shows Icon variant toast with Confirmation icon', () => {
+    it('shows a Success severity toast', () => {
       setupDefaults({ outcome: nonWinnerOutcome });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Confirmation,
-          backgroundColor: 'transparent',
+          severity: ToastSeverity.Success,
           hasNoTimeout: true,
         }),
       );
@@ -345,20 +316,11 @@ describe('useCampaignOutcomeToast', () => {
     it('uses consolidated non_winner locale keys', () => {
       setupDefaults({ outcome: nonWinnerOutcome });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          labelOptions: [
-            {
-              label: 'rewards.campaign_outcome_toast.non_winner.title',
-              isBold: true,
-            },
-          ],
-          descriptionOptions: {
-            description: `rewards.campaign_outcome_toast.non_winner.description:${CAMPAIGN_NAME}`,
-          },
-          linkButtonOptions: expect.objectContaining({
-            label: 'rewards.campaign_outcome_toast.non_winner.cta',
-          }),
+          title: 'rewards.campaign_outcome_toast.non_winner.title',
+          description: `rewards.campaign_outcome_toast.non_winner.description:${CAMPAIGN_NAME}`,
+          actionButtonLabel: 'rewards.campaign_outcome_toast.non_winner.cta',
         }),
       );
     });
@@ -381,16 +343,15 @@ describe('useCampaignOutcomeToast', () => {
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
-      const closeButtonOptions =
-        mockShowToast.mock.calls[0][0].closeButtonOptions;
-      closeButtonOptions.onPress();
+      const { onClose } = mockToast.mock.calls[0][0];
+      onClose();
 
       expect(mockDismissCampaignOutcomeToast).toHaveBeenCalledWith({
         campaignId: CAMPAIGN_ID,
         subscriptionId: SUBSCRIPTION_ID,
         variant: 'winner',
       });
-      expect(mockCloseToast).toHaveBeenCalled();
+      expect(mockToast.dismiss).toHaveBeenCalled();
     });
 
     it('dispatches dismissCampaignOutcomeToast with variant non_winner', () => {
@@ -403,9 +364,8 @@ describe('useCampaignOutcomeToast', () => {
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
-      const closeButtonOptions =
-        mockShowToast.mock.calls[0][0].closeButtonOptions;
-      closeButtonOptions.onPress();
+      const { onClose } = mockToast.mock.calls[0][0];
+      onClose();
 
       expect(mockDismissCampaignOutcomeToast).toHaveBeenCalledWith({
         campaignId: CAMPAIGN_ID,
@@ -426,8 +386,8 @@ describe('useCampaignOutcomeToast', () => {
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
-      const { onPress } = mockShowToast.mock.calls[0][0].linkButtonOptions;
-      onPress();
+      const { actionButtonOnPress } = mockToast.mock.calls[0][0];
+      actionButtonOnPress();
 
       expect(mockNavigateToRewardsRoute).toHaveBeenCalledWith(
         { navigate: mockNavigate },
@@ -449,8 +409,8 @@ describe('useCampaignOutcomeToast', () => {
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
-      const { onPress } = mockShowToast.mock.calls[0][0].linkButtonOptions;
-      onPress();
+      const { actionButtonOnPress } = mockToast.mock.calls[0][0];
+      actionButtonOnPress();
 
       expect(mockNavigateToRewardsRoute).toHaveBeenCalledWith(
         { navigate: mockNavigate },
@@ -482,7 +442,7 @@ describe('useCampaignOutcomeToast', () => {
 
       expect(cleanupFn).toBeDefined();
       cleanupFn?.();
-      expect(mockCloseToast).toHaveBeenCalled();
+      expect(mockToast.dismiss).toHaveBeenCalled();
     });
 
     it('does not return cleanup when variant is null', () => {
@@ -496,22 +456,6 @@ describe('useCampaignOutcomeToast', () => {
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
       expect(cleanupFn).toBeUndefined();
-    });
-  });
-
-  describe('edge cases', () => {
-    it('handles null toastRef gracefully', () => {
-      (useContext as jest.Mock).mockReturnValue({ toastRef: null });
-      setupDefaults({
-        outcome: {
-          subscriptionId: SUBSCRIPTION_ID,
-          outcomeStatus: 'pending',
-          winnerVerificationCode: 'CODE',
-        },
-      });
-      expect(() =>
-        renderHook(() => useCampaignOutcomeToast(mockConfig)),
-      ).not.toThrow();
     });
   });
 });

--- a/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.test.ts
+++ b/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.test.ts
@@ -344,7 +344,7 @@ describe('useCampaignOutcomeToast', () => {
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
       const { onClose } = mockToast.mock.calls[0][0];
-      onClose();
+      onClose?.();
 
       expect(mockDismissCampaignOutcomeToast).toHaveBeenCalledWith({
         campaignId: CAMPAIGN_ID,
@@ -365,7 +365,7 @@ describe('useCampaignOutcomeToast', () => {
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
       const { onClose } = mockToast.mock.calls[0][0];
-      onClose();
+      onClose?.();
 
       expect(mockDismissCampaignOutcomeToast).toHaveBeenCalledWith({
         campaignId: CAMPAIGN_ID,
@@ -387,7 +387,7 @@ describe('useCampaignOutcomeToast', () => {
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
       const { actionButtonOnPress } = mockToast.mock.calls[0][0];
-      actionButtonOnPress();
+      actionButtonOnPress?.({} as never);
 
       expect(mockNavigateToRewardsRoute).toHaveBeenCalledWith(
         { navigate: mockNavigate },
@@ -410,7 +410,7 @@ describe('useCampaignOutcomeToast', () => {
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
       const { actionButtonOnPress } = mockToast.mock.calls[0][0];
-      actionButtonOnPress();
+      actionButtonOnPress?.({} as never);
 
       expect(mockNavigateToRewardsRoute).toHaveBeenCalledWith(
         { navigate: mockNavigate },

--- a/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.ts
+++ b/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.ts
@@ -1,9 +1,9 @@
-import { useCallback, useContext, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../core/NavigationService/types';
 import { useDispatch, useSelector } from 'react-redux';
+import { toast } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../locales/i18n';
-import { ToastContext } from '../../../../component-library/components/Toast';
 import type {
   BaseCampaignParticipantOutcomeDto,
   CampaignType,
@@ -20,6 +20,14 @@ import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import { navigateToRewardsRoute } from '../utils';
 import useRewardsToast from './useRewardsToast';
 import type { RewardsStackParamList } from '../types/navigation';
+
+const dismissToast = () => {
+  try {
+    toast.dismiss();
+  } catch {
+    // Toaster is registered at app root; ignore if it is not mounted yet.
+  }
+};
 
 export interface CampaignOutcomeToastConfig {
   campaignType: CampaignType;
@@ -47,7 +55,6 @@ export function useCampaignOutcomeToast(
   } = config;
 
   const dispatch = useDispatch();
-  const { toastRef } = useContext(ToastContext);
   const { showToast, RewardsToastOptions } = useRewardsToast();
   const navigation = useNavigation<AppNavigationProp>();
 
@@ -105,8 +112,8 @@ export function useCampaignOutcomeToast(
         variant,
       }),
     );
-    toastRef?.current?.closeToast();
-  }, [variant, targetCampaign, subscriptionId, dispatch, toastRef]);
+    dismissToast();
+  }, [variant, targetCampaign, subscriptionId, dispatch]);
 
   const handleCta = useCallback(() => {
     if (!targetCampaign || !variant) return;
@@ -163,13 +170,12 @@ export function useCampaignOutcomeToast(
       }
 
       return () => {
-        toastRef?.current?.closeToast();
+        dismissToast();
       };
     }, [
       variant,
       isDismissed,
       targetCampaign,
-      toastRef,
       showToast,
       RewardsToastOptions,
       handleCta,

--- a/app/components/UI/Rewards/hooks/useRewardsNotificationsNudge.test.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsNotificationsNudge.test.tsx
@@ -9,7 +9,7 @@ jest.mock('react-native', () => ({
 }));
 const mockAppStateAddEventListener = AppState.addEventListener as jest.Mock;
 import { useSelector } from 'react-redux';
-import { ToastContext } from '../../../../component-library/components/Toast';
+import { toast } from '@metamask/design-system-react-native';
 import { useRewardsNotificationsNudge } from './useRewardsNotificationsNudge';
 import {
   selectIsMetamaskNotificationsEnabled,
@@ -19,15 +19,11 @@ import { isNotificationsFeatureEnabled } from '../../../../util/notifications/co
 
 const mockShowToast = jest.fn();
 const mockEnableNotifications = jest.fn();
-const mockOriginalCloseButtonPress = jest.fn();
 const mockEnableNotificationsNudge = jest.fn(
   (linkButtonOptions: { label: string; onPress: () => Promise<void> }) => ({
     variant: 'Plain',
     hasNoTimeout: true,
     linkButtonOptions,
-    closeButtonOptions: {
-      onPress: mockOriginalCloseButtonPress,
-    },
   }),
 );
 const mockLoadingToast = jest.fn((title: string, subtitle?: string) => ({
@@ -95,8 +91,15 @@ jest.mock('../../../../../locales/i18n', () => ({
   },
 }));
 
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
+
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
-const mockCloseToast = jest.fn();
 
 function mockSelectors({
   notificationsEnabled,
@@ -118,20 +121,7 @@ function renderNudgeHook(options?: {
   enabled?: boolean;
   onNotificationsEnabled?: () => void;
 }) {
-  const toastRef = {
-    current: {
-      showToast: jest.fn(),
-      closeToast: mockCloseToast,
-    },
-  };
-  const wrapper = ({ children }: { children: React.ReactNode }) =>
-    React.createElement(
-      ToastContext.Provider,
-      { value: { toastRef } },
-      children,
-    );
-
-  return renderHook(() => useRewardsNotificationsNudge(options), { wrapper });
+  return renderHook(() => useRewardsNotificationsNudge(options));
 }
 
 describe('useRewardsNotificationsNudge', () => {
@@ -179,9 +169,7 @@ describe('useRewardsNotificationsNudge', () => {
     expect(mockShowToast).toHaveBeenCalledWith(
       expect.objectContaining({
         variant: 'Plain',
-        closeButtonOptions: expect.objectContaining({
-          onPress: expect.any(Function),
-        }),
+        onClose: expect.any(Function),
       }),
     );
 
@@ -193,7 +181,7 @@ describe('useRewardsNotificationsNudge', () => {
     });
 
     expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
-    expect(mockCloseToast).toHaveBeenCalledTimes(1);
+    expect(toast.dismiss).toHaveBeenCalledTimes(1);
     expect(mockShowToast).toHaveBeenCalledTimes(2);
     expect(mockShowToast).toHaveBeenLastCalledWith(
       expect.objectContaining({ variant: 'loading' }),
@@ -237,7 +225,7 @@ describe('useRewardsNotificationsNudge', () => {
       await linkButtonOptions.onPress();
     });
 
-    expect(mockCloseToast).toHaveBeenCalledTimes(1);
+    expect(toast.dismiss).toHaveBeenCalledTimes(1);
     expect(mockShowToast).toHaveBeenLastCalledWith(
       expect.objectContaining({ variant: 'error' }),
     );
@@ -339,7 +327,7 @@ describe('useRewardsNotificationsNudge', () => {
     await waitFor(() => {
       expect(action).toHaveBeenCalledTimes(1);
     });
-    expect(mockCloseToast).toHaveBeenCalledTimes(1);
+    expect(toast.dismiss).toHaveBeenCalledTimes(1);
   });
 
   it('shows loading toast before deferred action runs via effect', async () => {
@@ -408,17 +396,16 @@ describe('useRewardsNotificationsNudge', () => {
     });
 
     const toastConfig = mockShowToast.mock.calls[0][0] as {
-      closeButtonOptions: { onPress: () => void };
+      onClose: () => void;
     };
     act(() => {
-      toastConfig.closeButtonOptions.onPress();
+      toastConfig.onClose();
     });
 
     notificationsEnabled = true;
     mockSelectors({ notificationsEnabled });
     rerender();
 
-    expect(mockOriginalCloseButtonPress).toHaveBeenCalledTimes(1);
     expect(action).not.toHaveBeenCalled();
   });
 
@@ -440,7 +427,7 @@ describe('useRewardsNotificationsNudge', () => {
 
     expect(mockGetPushPermission).toHaveBeenCalledTimes(1);
     expect(mockEnableNotifications).not.toHaveBeenCalled();
-    expect(mockCloseToast).toHaveBeenCalledTimes(1);
+    expect(toast.dismiss).toHaveBeenCalledTimes(1);
     expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
     expect(mockAppStateAddEventListener).toHaveBeenCalledWith(
       'change',
@@ -609,7 +596,7 @@ describe('useRewardsNotificationsNudge', () => {
       await linkButtonOptions.onPress();
     });
 
-    expect(mockCloseToast).toHaveBeenCalledTimes(1);
+    expect(toast.dismiss).toHaveBeenCalledTimes(1);
     expect(mockOpenSystemSettings).not.toHaveBeenCalled();
   });
 
@@ -629,7 +616,7 @@ describe('useRewardsNotificationsNudge', () => {
       await linkButtonOptions.onPress();
     });
 
-    expect(mockCloseToast).toHaveBeenCalledTimes(1);
+    expect(toast.dismiss).toHaveBeenCalledTimes(1);
   });
 
   it('closeEnableNotificationsNudge clears pending action and closes the toast', async () => {
@@ -650,7 +637,7 @@ describe('useRewardsNotificationsNudge', () => {
     mockSelectors({ notificationsEnabled });
     rerender();
 
-    expect(mockCloseToast).toHaveBeenCalledTimes(1);
+    expect(toast.dismiss).toHaveBeenCalledTimes(1);
     expect(action).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Rewards/hooks/useRewardsNotificationsNudge.ts
+++ b/app/components/UI/Rewards/hooks/useRewardsNotificationsNudge.ts
@@ -1,7 +1,7 @@
-import { useCallback, useContext, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { AppState } from 'react-native';
 import { useSelector } from 'react-redux';
-import { ToastContext } from '../../../../component-library/components/Toast';
+import { toast } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../locales/i18n';
 import {
   selectIsMetamaskNotificationsEnabled,
@@ -13,6 +13,14 @@ import NotificationService, {
   getPushPermission,
 } from '../../../../util/notifications/services/NotificationService';
 import useRewardsToast from './useRewardsToast';
+
+const dismissToast = () => {
+  try {
+    toast.dismiss();
+  } catch {
+    // Toaster is registered at app root; ignore if it is not mounted yet.
+  }
+};
 
 type NotificationsEnabledAction = () => Promise<void> | void;
 
@@ -50,7 +58,6 @@ export function useRewardsNotificationsNudge(
   const isMetaMaskPushNotificationsEnabled = useSelector(
     selectIsMetaMaskPushNotificationsEnabled,
   );
-  const { toastRef } = useContext(ToastContext);
   const { showToast, RewardsToastOptions } = useRewardsToast();
   const { enableNotifications } = useEnableNotifications({
     nudgeEnablePush: true,
@@ -78,9 +85,9 @@ export function useRewardsNotificationsNudge(
     // loading → success toast). Calling closeToast here would kill the success
     // toast that was just shown, so we skip it.
     if (!areNotificationsEnabledRef.current) {
-      toastRef?.current?.closeToast();
+      dismissToast();
     }
-  }, [toastRef]);
+  }, []);
 
   const handleTurnOnNotifications = useCallback(async () => {
     if (!enabled || notificationsEnableInFlightRef.current) {
@@ -96,7 +103,7 @@ export function useRewardsNotificationsNudge(
     try {
       const permission = await getPushPermission();
       if (permission === 'denied') {
-        toastRef?.current?.closeToast();
+        dismissToast();
         NotificationService.openSystemSettings();
         appStateSubscriptionRef.current = AppState.addEventListener(
           'change',
@@ -115,10 +122,10 @@ export function useRewardsNotificationsNudge(
             );
             try {
               await enableNotifications();
-              toastRef?.current?.closeToast();
+              dismissToast();
               onNotificationsEnabledRef.current?.();
             } catch {
-              toastRef?.current?.closeToast();
+              dismissToast();
               showToast(
                 RewardsToastOptions.error(
                   strings('rewards.notifications_nudge.enable_error'),
@@ -132,10 +139,10 @@ export function useRewardsNotificationsNudge(
         return;
       }
       await enableNotifications();
-      toastRef?.current?.closeToast();
+      dismissToast();
       onNotificationsEnabledRef.current?.();
     } catch {
-      toastRef?.current?.closeToast();
+      dismissToast();
       showToast(
         RewardsToastOptions.error(
           strings('rewards.notifications_nudge.enable_error'),
@@ -144,7 +151,7 @@ export function useRewardsNotificationsNudge(
     } finally {
       notificationsEnableInFlightRef.current = false;
     }
-  }, [enableNotifications, enabled, toastRef, showToast, RewardsToastOptions]);
+  }, [enableNotifications, enabled, showToast, RewardsToastOptions]);
 
   const showEnableNotificationsNudge = useCallback(() => {
     if (!shouldPromptToEnableNotifications) {
@@ -156,20 +163,12 @@ export function useRewardsNotificationsNudge(
       onPress: handleTurnOnNotifications,
     });
 
-    showToast(
-      nudgeConfig.closeButtonOptions
-        ? {
-            ...nudgeConfig,
-            closeButtonOptions: {
-              ...nudgeConfig.closeButtonOptions,
-              onPress: () => {
-                pendingActionRef.current = null;
-                nudgeConfig.closeButtonOptions?.onPress?.();
-              },
-            },
-          }
-        : nudgeConfig,
-    );
+    showToast({
+      ...nudgeConfig,
+      onClose: () => {
+        pendingActionRef.current = null;
+      },
+    });
     return true;
   }, [
     RewardsToastOptions,
@@ -210,7 +209,7 @@ export function useRewardsNotificationsNudge(
 
     const pendingAction = pendingActionRef.current;
     pendingActionRef.current = null;
-    toastRef?.current?.closeToast();
+    dismissToast();
     showToast(
       RewardsToastOptions.loading(
         strings('rewards.notifications_nudge.loading'),
@@ -218,20 +217,14 @@ export function useRewardsNotificationsNudge(
       ),
     );
     Promise.resolve(pendingAction()).catch(() => {
-      toastRef?.current?.closeToast();
+      dismissToast();
       showToast(
         RewardsToastOptions.error(
           strings('rewards.notifications_nudge.enable_error'),
         ),
       );
     });
-  }, [
-    areNotificationsEnabled,
-    enabled,
-    toastRef,
-    showToast,
-    RewardsToastOptions,
-  ]);
+  }, [areNotificationsEnabled, enabled, showToast, RewardsToastOptions]);
 
   useEffect(() => {
     if (!enabled) {

--- a/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
@@ -1,26 +1,14 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { render } from '@testing-library/react-native';
-import { useContext, type ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { playNotification, NotificationMoment } from '../../../../util/haptics';
-import { mockTheme } from '../../../../util/theme';
-import useRewardsToast, { RewardsToastOptions } from './useRewardsToast';
-import {
-  ToastVariants,
-  ButtonIconVariant,
-} from '../../../../component-library/components/Toast/Toast.types';
-import { IconName } from '../../../../component-library/components/Icons/Icon';
-jest.mock('react', () => ({
-  ...jest.requireActual('react'),
-  useContext: jest.fn(),
-  useCallback: jest.fn((fn) => fn),
-  useMemo: jest.fn((fn) => fn()),
-}));
+import useRewardsToast, { type RewardsToastOptions } from './useRewardsToast';
 
 jest.mock('../../../../util/haptics');
 
 jest.mock('../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
-    if (key === 'rewards.toast_dismiss') return 'Dismiss';
     if (key === 'rewards.notifications_nudge.title') return "Don't miss out";
     if (key === 'rewards.notifications_nudge.description') {
       return 'Enable notifications to stay informed on campaigns';
@@ -48,81 +36,43 @@ jest.mock('../../../../images/rewards/notification.svg', () => {
 });
 
 jest.mock('@metamask/design-system-react-native', () => {
-  const ReactActual = jest.requireActual('react');
-  const { View } = jest.requireActual('react-native');
+  const actual = jest.requireActual('@metamask/design-system-react-native');
   return {
-    Box: ({ children }: { children?: React.ReactNode }) =>
-      ReactActual.createElement(
-        View,
-        { testID: 'rewards-nudge-start-accessory-box' },
-        children,
-      ),
-    // Required by Toast.tsx module init via Toast barrel import.
-    IconColor: {
-      IconDefault: 'IconDefault',
-      OverlayInverse: 'OverlayInverse',
-      IconAlternative: 'IconAlternative',
-      IconMuted: 'IconMuted',
-      PrimaryDefault: 'PrimaryDefault',
-      PrimaryAlternative: 'PrimaryAlternative',
-      SuccessDefault: 'SuccessDefault',
-      ErrorDefault: 'ErrorDefault',
-      ErrorAlternative: 'ErrorAlternative',
-      WarningDefault: 'WarningDefault',
-      InfoDefault: 'InfoDefault',
-    },
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
   };
 });
 
-describe('useRewardsToast', () => {
-  let mockShowToast: jest.Mock;
-  let mockCloseToast: jest.Mock;
-  let mockToastRef: {
-    current: { showToast: jest.Mock; closeToast: jest.Mock };
-  };
+const mockToast = jest.mocked(toast);
 
+describe('useRewardsToast', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-
-    mockShowToast = jest.fn();
-    mockCloseToast = jest.fn();
-    mockToastRef = {
-      current: {
-        showToast: mockShowToast,
-        closeToast: mockCloseToast,
-      },
-    };
-
-    (useContext as jest.Mock).mockReturnValue({ toastRef: mockToastRef });
   });
 
-  describe('showToast function', () => {
-    it('calls toastRef showToast and triggers haptic feedback', async () => {
+  describe('showToast', () => {
+    it('calls toast excluding hapticsType and triggers haptic feedback', () => {
       const { result } = renderHook(() => useRewardsToast());
-
       const testConfig: RewardsToastOptions = {
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        hapticsType: NotificationMoment.Success,
-        labelOptions: [{ label: 'Test', isBold: true }],
-        hasNoTimeout: false,
+        ...result.current.RewardsToastOptions.success('Test'),
       };
 
-      await act(async () => {
+      act(() => {
         result.current.showToast(testConfig);
-        await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        labelOptions: [{ label: 'Test', isBold: true }],
-        hasNoTimeout: false,
-      });
+      expect(mockToast).toHaveBeenCalledTimes(1);
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: ToastSeverity.Success,
+          title: 'Test',
+        }),
+      );
+      expect(mockToast.mock.calls[0][0]).not.toHaveProperty('hapticsType');
       expect(playNotification).toHaveBeenCalledWith(NotificationMoment.Success);
     });
 
-    it('strips hapticsType from payload passed to toastRef for enableNotificationsNudge', async () => {
+    it('strips hapticsType from payload for enableNotificationsNudge', () => {
       const { result } = renderHook(() => useRewardsToast());
       const nudgeConfig =
         result.current.RewardsToastOptions.enableNotificationsNudge({
@@ -130,285 +80,129 @@ describe('useRewardsToast', () => {
           onPress: jest.fn(),
         });
 
-      await act(async () => {
+      act(() => {
         result.current.showToast(nudgeConfig);
-        await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.not.objectContaining({ hapticsType: expect.anything() }),
       );
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: ToastVariants.Plain,
           hasNoTimeout: true,
+          actionButtonLabel: 'Turn on',
         }),
       );
       expect(playNotification).toHaveBeenCalledWith(NotificationMoment.Warning);
     });
   });
 
-  describe('RewardsToastOptions configurations', () => {
-    it('returns success configuration with title only', () => {
+  describe('RewardsToastOptions', () => {
+    it('configures success toast with Success severity', () => {
       const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.success('Test Title');
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        iconColor: mockTheme.colors.success.default,
-        backgroundColor: 'transparent',
-        hapticsType: NotificationMoment.Success,
-        hasNoTimeout: false,
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Test Title', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toBeUndefined();
-      expect(config.closeButtonOptions).toMatchObject({
-        variant: ButtonIconVariant.Icon,
-        iconName: IconName.Close,
-      });
-    });
-
-    it('returns success configuration with title and subtitle', () => {
-      const { result } = renderHook(() => useRewardsToast());
       const config = result.current.RewardsToastOptions.success(
         'Test Title',
         'Test Subtitle',
       );
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        iconColor: mockTheme.colors.success.default,
-        hapticsType: NotificationMoment.Success,
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Test Title', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toEqual({
-        description: 'Test Subtitle',
-      });
+      expect(config.severity).toBe(ToastSeverity.Success);
+      expect(config.hapticsType).toBe(NotificationMoment.Success);
+      expect(config.hasNoTimeout).toBe(false);
+      expect(config.title).toBe('Test Title');
+      expect(config.description).toBe('Test Subtitle');
     });
 
-    it('returns error configuration with title only', () => {
+    it('configures error toast with Danger severity', () => {
       const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.error('Error Title');
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Danger,
-        iconColor: mockTheme.colors.error.default,
-        backgroundColor: 'transparent',
-        hapticsType: NotificationMoment.Error,
-        hasNoTimeout: false,
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Error Title', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toBeUndefined();
-      expect(config.closeButtonOptions).toMatchObject({
-        variant: ButtonIconVariant.Icon,
-        iconName: IconName.Close,
-      });
-    });
-
-    it('returns error configuration with title and subtitle', () => {
-      const { result } = renderHook(() => useRewardsToast());
       const config = result.current.RewardsToastOptions.error(
         'Error Title',
         'Error Subtitle',
       );
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Danger,
-        iconColor: mockTheme.colors.error.default,
-        hapticsType: NotificationMoment.Error,
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Error Title', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toEqual({
-        description: 'Error Subtitle',
-      });
+      expect(config.severity).toBe(ToastSeverity.Danger);
+      expect(config.hapticsType).toBe(NotificationMoment.Error);
+      expect(config.hasNoTimeout).toBe(false);
+      expect(config.title).toBe('Error Title');
+      expect(config.description).toBe('Error Subtitle');
     });
 
-    it('returns entriesClosed configuration with title only', () => {
+    it('configures warning toast as persistent Warning severity', () => {
       const { result } = renderHook(() => useRewardsToast());
-      const config =
-        result.current.RewardsToastOptions.entriesClosed('Entries closed');
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Lock,
-        iconColor: mockTheme.colors.icon.default,
-        backgroundColor: 'transparent',
-        hapticsType: NotificationMoment.Warning,
-        hasNoTimeout: false,
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Entries closed', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toBeUndefined();
-      expect(config.closeButtonOptions).toMatchObject({
-        variant: ButtonIconVariant.Icon,
-        iconName: IconName.Close,
-      });
-    });
-
-    it('returns entriesClosed configuration with title and subtitle', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.entriesClosed(
-        'Entries closed',
-        'You missed the opt-in window. Check back for more campaigns in the future.',
+      const config = result.current.RewardsToastOptions.warning(
+        'Request received',
+        'In about 7 days, your progress will be fully erased.',
       );
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Lock,
-        iconColor: mockTheme.colors.icon.default,
-        hapticsType: NotificationMoment.Warning,
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Entries closed', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toEqual({
-        description:
-          'You missed the opt-in window. Check back for more campaigns in the future.',
-      });
+      expect(config.severity).toBe(ToastSeverity.Warning);
+      expect(config.hapticsType).toBe(NotificationMoment.Warning);
+      expect(config.hasNoTimeout).toBe(true);
+      expect(config.title).toBe('Request received');
+      expect(config.description).toBe(
+        'In about 7 days, your progress will be fully erased.',
+      );
     });
 
-    it('returns loading configuration with title only', () => {
+    it('configures loading toast with a spinner and no timeout', () => {
       const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.loading('Loading...');
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Plain,
-        hasNoTimeout: true,
-        hapticsType: NotificationMoment.Warning,
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Loading...', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toBeUndefined();
-      expect(config.closeButtonOptions).toMatchObject({
-        variant: ButtonIconVariant.Icon,
-        iconName: IconName.Close,
-      });
-    });
-
-    it('returns loading configuration with title and subtitle', () => {
-      const { result } = renderHook(() => useRewardsToast());
       const config = result.current.RewardsToastOptions.loading(
         'Loading...',
         'Please wait',
       );
 
-      expect(config.labelOptions).toEqual([
-        { label: 'Loading...', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toEqual({ description: 'Please wait' });
-    });
-
-    it('calls closeToast when loading close button is pressed', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.loading('Loading...');
-
-      config.closeButtonOptions?.onPress?.();
-
-      expect(mockCloseToast).toHaveBeenCalledTimes(1);
-    });
-
-    it('renders startAccessory for loading config', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.loading('Loading...');
-
+      expect(config.hapticsType).toBe(NotificationMoment.Warning);
+      expect(config.hasNoTimeout).toBe(true);
       expect(config.startAccessory).toBeDefined();
+      expect(config.title).toBe('Loading...');
+      expect(config.description).toBe('Please wait');
     });
 
-    it('returns enableNotificationsNudge configuration with Plain variant', () => {
+    it('configures entriesClosed toast with a lock accessory', () => {
+      const { result } = renderHook(() => useRewardsToast());
+
+      const config = result.current.RewardsToastOptions.entriesClosed(
+        'Entries closed',
+        'You missed the opt-in window.',
+      );
+
+      expect(config.hapticsType).toBe(NotificationMoment.Warning);
+      expect(config.hasNoTimeout).toBe(false);
+      expect(config.startAccessory).toBeDefined();
+      expect(config.title).toBe('Entries closed');
+      expect(config.description).toBe('You missed the opt-in window.');
+    });
+
+    it('configures enableNotificationsNudge with action button', () => {
       const { result } = renderHook(() => useRewardsToast());
       const onPress = jest.fn();
+
       const config =
         result.current.RewardsToastOptions.enableNotificationsNudge({
           label: 'Turn on',
           onPress,
         });
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Plain,
-        hasNoTimeout: true,
-        hapticsType: NotificationMoment.Warning,
-        linkButtonOptions: { label: 'Turn on', onPress },
-      });
-      expect(config.labelOptions).toEqual([
-        { label: "Don't miss out", isBold: true },
-      ]);
-      expect(config.descriptionOptions).toEqual({
-        description: 'Enable notifications to stay informed on campaigns',
-      });
-      expect(config.closeButtonOptions).toMatchObject({
-        variant: ButtonIconVariant.Icon,
-        iconName: IconName.Close,
-      });
-    });
-
-    it('passes linkButtonOptions through to enableNotificationsNudge config', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const onPress = jest.fn();
-      const config =
-        result.current.RewardsToastOptions.enableNotificationsNudge({
-          label: 'Open settings',
-          onPress,
-        });
-
-      expect(config.linkButtonOptions).toEqual({
-        label: 'Open settings',
-        onPress,
-      });
-    });
-
-    it('renders startAccessory containing notification icon placeholder', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config =
-        result.current.RewardsToastOptions.enableNotificationsNudge({
-          label: 'Turn on',
-          onPress: jest.fn(),
-        });
-
+      expect(config.hasNoTimeout).toBe(true);
+      expect(config.hapticsType).toBe(NotificationMoment.Warning);
+      expect(config.title).toBe("Don't miss out");
+      expect(config.description).toBe(
+        'Enable notifications to stay informed on campaigns',
+      );
+      expect(config.actionButtonLabel).toBe('Turn on');
+      expect(config.actionButtonOnPress).toBe(onPress);
       expect(config.startAccessory).toBeDefined();
       const { getByTestId } = render(config.startAccessory as ReactElement);
       expect(getByTestId('rewards-notification-svg')).toBeDefined();
     });
 
-    it('calls closeToast when enableNotificationsNudge close button is pressed', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config =
-        result.current.RewardsToastOptions.enableNotificationsNudge({
-          label: 'Turn on',
-          onPress: jest.fn(),
-        });
-
-      config.closeButtonOptions?.onPress?.();
-
-      expect(mockCloseToast).toHaveBeenCalledTimes(1);
-    });
-
-    it('calls closeToast when close button is pressed', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.success('Test Title');
-
-      config.closeButtonOptions?.onPress?.();
-
-      expect(mockCloseToast).toHaveBeenCalledTimes(1);
-    });
-
-    it('returns outcomeWinner configuration with CTA and close handlers', () => {
+    it('configures outcomeWinner toast with CTA and close handlers', () => {
       const { result } = renderHook(() => useRewardsToast());
       const onCta = jest.fn();
       const onClose = jest.fn();
+
       const config = result.current.RewardsToastOptions.outcomeWinner({
         title: 'Winner title',
         description: 'Winner body',
@@ -417,81 +211,23 @@ describe('useRewardsToast', () => {
         onClosePress: onClose,
       });
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Plain,
-        hasNoTimeout: true,
-        hapticsType: NotificationMoment.Success,
-        descriptionOptions: { description: 'Winner body' },
-        linkButtonOptions: { label: 'Next' },
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Winner title', isBold: true },
-      ]);
+      expect(config.hasNoTimeout).toBe(true);
+      expect(config.hapticsType).toBe(NotificationMoment.Success);
+      expect(config.title).toBe('Winner title');
+      expect(config.description).toBe('Winner body');
+      expect(config.actionButtonLabel).toBe('Next');
       expect(config.startAccessory).toBeDefined();
-      config.linkButtonOptions?.onPress?.();
-      config.closeButtonOptions?.onPress?.();
+      config.actionButtonOnPress?.({} as never);
+      config.onClose?.();
       expect(onCta).toHaveBeenCalledTimes(1);
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
-    it('returns warning configuration with title only', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config =
-        result.current.RewardsToastOptions.warning('Request received');
-
-      expect(config).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Warning,
-        iconColor: mockTheme.colors.warning.default,
-        backgroundColor: 'transparent',
-        hapticsType: NotificationMoment.Warning,
-        hasNoTimeout: true,
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Request received', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toBeUndefined();
-      expect(config.closeButtonOptions).toMatchObject({
-        variant: ButtonIconVariant.Icon,
-        iconName: IconName.Close,
-      });
-    });
-
-    it('returns warning configuration with title and subtitle', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.warning(
-        'Request received',
-        'In about 7 days, your progress will be fully erased.',
-      );
-
-      expect(config).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Warning,
-        hapticsType: NotificationMoment.Warning,
-        hasNoTimeout: true,
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Request received', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toEqual({
-        description: 'In about 7 days, your progress will be fully erased.',
-      });
-    });
-
-    it('calls closeToast when warning close button is pressed', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config =
-        result.current.RewardsToastOptions.warning('Request received');
-
-      config.closeButtonOptions?.onPress?.();
-
-      expect(mockCloseToast).toHaveBeenCalledTimes(1);
-    });
-
-    it('returns outcomeNonWinner configuration with CTA and close handlers', () => {
+    it('configures outcomeNonWinner toast with Success severity', () => {
       const { result } = renderHook(() => useRewardsToast());
       const onCta = jest.fn();
       const onClose = jest.fn();
+
       const config = result.current.RewardsToastOptions.outcomeNonWinner({
         title: 'Thanks title',
         description: 'Thanks body',
@@ -500,214 +236,26 @@ describe('useRewardsToast', () => {
         onClosePress: onClose,
       });
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        iconColor: mockTheme.colors.success.default,
-        backgroundColor: 'transparent',
-        hasNoTimeout: true,
-        hapticsType: NotificationMoment.Warning,
-        descriptionOptions: { description: 'Thanks body' },
-        linkButtonOptions: { label: 'Done' },
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Thanks title', isBold: true },
-      ]);
-      config.linkButtonOptions?.onPress?.();
-      config.closeButtonOptions?.onPress?.();
+      expect(config.severity).toBe(ToastSeverity.Success);
+      expect(config.hasNoTimeout).toBe(true);
+      expect(config.hapticsType).toBe(NotificationMoment.Warning);
+      expect(config.title).toBe('Thanks title');
+      expect(config.description).toBe('Thanks body');
+      expect(config.actionButtonLabel).toBe('Done');
+      config.actionButtonOnPress?.({} as never);
+      config.onClose?.();
       expect(onCta).toHaveBeenCalledTimes(1);
       expect(onClose).toHaveBeenCalledTimes(1);
     });
-  });
 
-  describe('edge cases and error handling', () => {
-    it('handles null toastRef gracefully in showToast', async () => {
-      (useContext as jest.Mock).mockReturnValue({ toastRef: null });
+    it('omits description when subtitle is not provided', () => {
       const { result } = renderHook(() => useRewardsToast());
 
-      const testConfig: RewardsToastOptions = {
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        hapticsType: NotificationMoment.Success,
-        labelOptions: [{ label: 'Test', isBold: true }],
-        hasNoTimeout: false,
-      };
+      const success = result.current.RewardsToastOptions.success('Title');
+      const error = result.current.RewardsToastOptions.error('Error');
 
-      expect(() => {
-        act(() => {
-          result.current.showToast(testConfig);
-        });
-      }).not.toThrow();
-
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-
-      expect(playNotification).toHaveBeenCalledWith(NotificationMoment.Success);
-    });
-
-    it('handles undefined toastRef.current gracefully in showToast', async () => {
-      (useContext as jest.Mock).mockReturnValue({
-        toastRef: { current: null },
-      });
-      const { result } = renderHook(() => useRewardsToast());
-
-      const testConfig: RewardsToastOptions = {
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        hapticsType: NotificationMoment.Success,
-        labelOptions: [{ label: 'Test', isBold: true }],
-        hasNoTimeout: false,
-      };
-
-      expect(() => {
-        act(() => {
-          result.current.showToast(testConfig);
-        });
-      }).not.toThrow();
-
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-
-      expect(playNotification).toHaveBeenCalledWith(NotificationMoment.Success);
-    });
-
-    it('handles null toastRef gracefully in close button', () => {
-      (useContext as jest.Mock).mockReturnValue({ toastRef: null });
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.success('Test Title');
-
-      expect(() => {
-        config.closeButtonOptions?.onPress?.();
-      }).not.toThrow();
-    });
-
-    it('handles empty string title', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.success('');
-
-      expect(config.labelOptions).toEqual([{ label: '', isBold: true }]);
-    });
-
-    it('handles only whitespace title', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.success('   ');
-
-      expect(config.labelOptions).toEqual([{ label: '   ', isBold: true }]);
-    });
-  });
-
-  describe('memoization and dependency changes', () => {
-    it('recreates RewardsToastOptions when toastRef changes', () => {
-      const mockToastRef1 = {
-        current: { showToast: jest.fn(), closeToast: jest.fn() },
-      };
-      const mockToastRef2 = {
-        current: { showToast: jest.fn(), closeToast: jest.fn() },
-      };
-
-      (useContext as jest.Mock).mockReturnValue({ toastRef: mockToastRef1 });
-      const { result, rerender } = renderHook(() => useRewardsToast());
-
-      (useContext as jest.Mock).mockReturnValue({ toastRef: mockToastRef2 });
-      rerender();
-
-      const newConfig = result.current.RewardsToastOptions.success('Test');
-
-      newConfig.closeButtonOptions?.onPress?.();
-      expect(mockToastRef2.current.closeToast).toHaveBeenCalled();
-      expect(mockToastRef1.current.closeToast).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('default options merging', () => {
-    it('applies default options to success configuration', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.success('Test Title');
-
-      expect(config.hasNoTimeout).toBe(false);
-    });
-
-    it('applies default options to error configuration', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.error('Error Title');
-
-      expect(config.hasNoTimeout).toBe(false);
-    });
-
-    it('applies default options to entriesClosed configuration', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config =
-        result.current.RewardsToastOptions.entriesClosed('Entries closed');
-
-      expect(config.hasNoTimeout).toBe(false);
-    });
-
-    it('uses persistent toast timeout for enableNotificationsNudge', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config =
-        result.current.RewardsToastOptions.enableNotificationsNudge({
-          label: 'Turn on',
-          onPress: jest.fn(),
-        });
-
-      expect(config.hasNoTimeout).toBe(true);
-    });
-  });
-
-  describe('label and description formatting', () => {
-    it('returns bold label with title only', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.success('Test Title');
-
-      expect(config.labelOptions).toHaveLength(1);
-      expect(config.labelOptions[0]).toEqual({
-        label: 'Test Title',
-        isBold: true,
-      });
-    });
-
-    it('returns bold label and descriptionOptions with subtitle', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.success(
-        'Test Title',
-        'Test Subtitle',
-      );
-
-      expect(config.labelOptions).toHaveLength(1);
-      expect(config.labelOptions[0]).toEqual({
-        label: 'Test Title',
-        isBold: true,
-      });
-      expect(config.descriptionOptions).toEqual({
-        description: 'Test Subtitle',
-      });
-    });
-
-    it('returns undefined descriptionOptions when no subtitle for error', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.error('Error Title');
-
-      expect(config.labelOptions).toHaveLength(1);
-      expect(config.labelOptions[0]).toEqual({
-        label: 'Error Title',
-        isBold: true,
-      });
-      expect(config.descriptionOptions).toBeUndefined();
-    });
-
-    it('returns descriptionOptions for error with subtitle', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.error(
-        'Error Title',
-        'Error Subtitle',
-      );
-
-      expect(config.labelOptions).toHaveLength(1);
-      expect(config.descriptionOptions).toEqual({
-        description: 'Error Subtitle',
-      });
+      expect(success.description).toBeUndefined();
+      expect(error.description).toBeUndefined();
     });
   });
 });

--- a/app/components/UI/Rewards/hooks/useRewardsToast.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.tsx
@@ -1,15 +1,14 @@
-import React, { useCallback, useContext, useMemo } from 'react';
-import { ActivityIndicator } from 'react-native';
-import { ToastContext } from '../../../../component-library/components/Toast';
+import React, { useCallback, useMemo } from 'react';
 import {
-  ButtonIconVariant,
-  ToastDescriptionOptions,
-  ToastLabelOptions,
-  ToastLinkButtonOptions,
-  ToastOptions,
-  ToastVariants,
-} from '../../../../component-library/components/Toast/Toast.types';
-import { IconName } from '../../../../component-library/components/Icons/Icon';
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Spinner,
+  toast,
+  ToastSeverity,
+  type ToastOptions,
+} from '@metamask/design-system-react-native';
 import { useAppThemeFromContext } from '../../../../util/theme';
 import {
   playNotification,
@@ -32,6 +31,11 @@ export interface OutcomeCtaToastParams {
   onClosePress: () => void;
 }
 
+export interface RewardsToastNudgeParams {
+  label: string;
+  onPress: () => void;
+}
+
 export interface RewardsToastConfig {
   success: (title: string, subtitle?: string) => RewardsToastOptions;
   error: (title: string, subtitle?: string) => RewardsToastOptions;
@@ -39,31 +43,11 @@ export interface RewardsToastConfig {
   warning: (title: string, subtitle?: string) => RewardsToastOptions;
   entriesClosed: (title: string, subtitle?: string) => RewardsToastOptions;
   enableNotificationsNudge: (
-    linkButtonOptions: ToastLinkButtonOptions,
+    params: RewardsToastNudgeParams,
   ) => RewardsToastOptions;
   outcomeWinner: (params: OutcomeCtaToastParams) => RewardsToastOptions;
   outcomeNonWinner: (params: OutcomeCtaToastParams) => RewardsToastOptions;
 }
-
-const getRewardsToastLabels = (title: string): ToastLabelOptions => {
-  const labels: ToastLabelOptions = [
-    {
-      label: title,
-      isBold: true,
-    },
-  ];
-
-  return labels;
-};
-
-const getRewardsToastDescriptionLabels = (
-  description?: string,
-): ToastDescriptionOptions | undefined => {
-  if (!description) {
-    return undefined;
-  }
-  return { description };
-};
 
 const REWARDS_TOASTS_DEFAULT_OPTIONS: Partial<RewardsToastOptions> = {
   hasNoTimeout: false,
@@ -73,116 +57,67 @@ const useRewardsToast = (): {
   showToast: (config: RewardsToastOptions) => void;
   RewardsToastOptions: RewardsToastConfig;
 } => {
-  const { toastRef } = useContext(ToastContext);
   const theme = useAppThemeFromContext();
 
-  const showToast = useCallback(
-    (config: RewardsToastOptions) => {
-      const { hapticsType, ...toastOptions } = config;
-      toastRef?.current?.showToast(toastOptions as ToastOptions);
-      playNotification(hapticsType);
-    },
-    [toastRef],
-  );
+  const showToast = useCallback((config: RewardsToastOptions) => {
+    const { hapticsType, ...toastOptions } = config;
+    toast(toastOptions);
+    playNotification(hapticsType);
+  }, []);
 
   const RewardsToastOptions: RewardsToastConfig = useMemo(
     () => ({
       success: (title: string, subtitle?: string) => ({
         ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        iconColor: theme.colors.success.default,
-        backgroundColor: 'transparent',
+        severity: ToastSeverity.Success,
         hapticsType: NotificationMoment.Success,
-        labelOptions: getRewardsToastLabels(title),
-        descriptionOptions: getRewardsToastDescriptionLabels(subtitle),
+        title,
+        description: subtitle,
         hasNoTimeout: false,
-        closeButtonOptions: {
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-          onPress: () => {
-            toastRef?.current?.closeToast();
-          },
-        },
       }),
       error: (title: string, subtitle?: string) => ({
         ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
-        variant: ToastVariants.Icon,
-        iconName: IconName.Danger,
-        iconColor: theme.colors.error.default,
-        backgroundColor: 'transparent',
+        severity: ToastSeverity.Danger,
         hapticsType: NotificationMoment.Error,
-        labelOptions: getRewardsToastLabels(title),
-        descriptionOptions: getRewardsToastDescriptionLabels(subtitle),
+        title,
+        description: subtitle,
         hasNoTimeout: false,
-        closeButtonOptions: {
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-
-          onPress: () => {
-            toastRef?.current?.closeToast();
-          },
-        },
       }),
       loading: (title: string, subtitle?: string) => ({
         ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
-        variant: ToastVariants.Plain,
         hasNoTimeout: true,
         hapticsType: NotificationMoment.Warning,
-        startAccessory: (
-          <ActivityIndicator size="small" color={theme.colors.icon.default} />
-        ),
-        labelOptions: getRewardsToastLabels(title),
-        descriptionOptions: getRewardsToastDescriptionLabels(subtitle),
-        closeButtonOptions: {
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-          onPress: () => {
-            toastRef?.current?.closeToast();
-          },
-        },
+        startAccessory: <Spinner spinnerIconProps={{ size: IconSize.Lg }} />,
+        title,
+        description: subtitle,
       }),
       warning: (title: string, subtitle?: string) => ({
         ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
-        variant: ToastVariants.Icon,
-        iconName: IconName.Warning,
-        iconColor: theme.colors.warning.default,
-        backgroundColor: 'transparent',
+        severity: ToastSeverity.Warning,
         hapticsType: NotificationMoment.Warning,
-        labelOptions: getRewardsToastLabels(title),
-        descriptionOptions: getRewardsToastDescriptionLabels(subtitle),
+        title,
+        description: subtitle,
         hasNoTimeout: true,
-        closeButtonOptions: {
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-          onPress: () => {
-            toastRef?.current?.closeToast();
-          },
-        },
       }),
       entriesClosed: (title: string, subtitle?: string) => ({
         ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
-        variant: ToastVariants.Icon,
-        iconName: IconName.Lock,
-        iconColor: theme.colors.icon.default,
-        backgroundColor: 'transparent',
+        startAccessory: (
+          <Icon
+            name={IconName.Lock}
+            size={IconSize.Lg}
+            color={IconColor.IconDefault}
+          />
+        ),
         hapticsType: NotificationMoment.Warning,
-        labelOptions: getRewardsToastLabels(title),
-        descriptionOptions: getRewardsToastDescriptionLabels(subtitle),
+        title,
+        description: subtitle,
         hasNoTimeout: false,
-        closeButtonOptions: {
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-          onPress: () => {
-            toastRef?.current?.closeToast();
-          },
-        },
       }),
-      enableNotificationsNudge: (
-        linkButtonOptions: ToastLinkButtonOptions,
-      ) => ({
+      enableNotificationsNudge: ({
+        label,
+        onPress,
+      }: RewardsToastNudgeParams) => ({
         ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
-        variant: ToastVariants.Plain,
         hasNoTimeout: true,
         hapticsType: NotificationMoment.Warning,
         startAccessory: (
@@ -193,20 +128,10 @@ const useRewardsToast = (): {
             color={theme.colors.warning.default}
           />
         ),
-        labelOptions: getRewardsToastLabels(
-          strings('rewards.notifications_nudge.title'),
-        ),
-        descriptionOptions: getRewardsToastDescriptionLabels(
-          strings('rewards.notifications_nudge.description'),
-        ),
-        linkButtonOptions,
-        closeButtonOptions: {
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-          onPress: () => {
-            toastRef?.current?.closeToast();
-          },
-        },
+        title: strings('rewards.notifications_nudge.title'),
+        description: strings('rewards.notifications_nudge.description'),
+        actionButtonLabel: label,
+        actionButtonOnPress: onPress,
       }),
       outcomeWinner: ({
         title,
@@ -216,7 +141,6 @@ const useRewardsToast = (): {
         onClosePress,
       }: OutcomeCtaToastParams) => ({
         ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
-        variant: ToastVariants.Plain,
         hasNoTimeout: true,
         hapticsType: NotificationMoment.Success,
         startAccessory: (
@@ -227,17 +151,11 @@ const useRewardsToast = (): {
             color={theme.colors.success.default}
           />
         ),
-        labelOptions: getRewardsToastLabels(title),
-        descriptionOptions: { description },
-        linkButtonOptions: {
-          label: ctaLabel,
-          onPress: onCtaPress,
-        },
-        closeButtonOptions: {
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-          onPress: onClosePress,
-        },
+        title,
+        description,
+        actionButtonLabel: ctaLabel,
+        actionButtonOnPress: onCtaPress,
+        onClose: onClosePress,
       }),
       outcomeNonWinner: ({
         title,
@@ -246,32 +164,17 @@ const useRewardsToast = (): {
         onCtaPress,
         onClosePress,
       }: OutcomeCtaToastParams) => ({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        iconColor: theme.colors.success.default,
-        backgroundColor: 'transparent',
+        severity: ToastSeverity.Success,
         hasNoTimeout: true,
         hapticsType: NotificationMoment.Warning,
-        labelOptions: getRewardsToastLabels(title),
-        descriptionOptions: { description },
-        linkButtonOptions: {
-          label: ctaLabel,
-          onPress: onCtaPress,
-        },
-        closeButtonOptions: {
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-          onPress: onClosePress,
-        },
+        title,
+        description,
+        actionButtonLabel: ctaLabel,
+        actionButtonOnPress: onCtaPress,
+        onClose: onClosePress,
       }),
     }),
-    [
-      theme.colors.success.default,
-      theme.colors.error.default,
-      theme.colors.icon.default,
-      theme.colors.warning.default,
-      toastRef,
-    ],
+    [theme.colors.success.default, theme.colors.warning.default],
   );
 
   return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Rewards still showed referral, campaign-outcome, and notification-nudge feedback through the legacy `ToastContext` `showToast` API. This PR switches `useRewardsToast` and its callers to the design-system `toast()` API so Rewards flows share the same toaster as the rest of the toast migration.

Severity maps to `ToastSeverity` (`Success`, `Danger`, `Warning`). Loading still uses a spinner accessory. Action toasts keep their CTA via `actionButtonLabel` / `actionButtonOnPress`. Close is handled by the design-system toaster (`toast.dismiss()`). Shared toast infrastructure (`ToastContext`, `ToastService`, `ControllerEventToastBridge`) is unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

Refs: No tracking issue; continues the design-system toast migration for Rewards flows

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Rewards design-system toasts

  Background:
    Given I am logged into MetaMask Mobile
    And Rewards is available on my account

  Scenario: user copies a Rewards referral code
    Given I am on a Rewards surface that shows a referral code

    When user copies the referral code
    Then a success toast confirms the code was copied
    And the toast can be dismissed with the design-system close control

  Scenario: user sees a campaign outcome toast
    Given a Rewards campaign has a winner or non-winner outcome for me

    When the campaign outcome toast is shown
    Then the title and CTA match the outcome
    And tapping the action button runs the existing outcome action

  Scenario: user is nudged to enable Rewards notifications
    Given Rewards wants to prompt me to enable notifications

    When the nudge toast appears
    Then it shows the enable-notifications CTA
    And dismissing it does not leave a pending action behind
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
