### PR TITLE
refactor(toast): migrate mobile-core-ux toasts to the design system

### DIFF
--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -464,9 +464,7 @@ const Transactions = (props) => {
 
   const showTransactionUpdateErrorToast = (error) => {
     toast({
-      title:
-        strings('transaction_update_toast.title') ||
-        'Transaction update failed',
+      title: strings('transaction_update_toast.title'),
       description: resolveTransactionUpdateErrorMessage(error),
       severity: ToastSeverity.Danger,
       hasNoTimeout: false,

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -25,7 +25,6 @@ import { showAlert } from '../../../actions/alert';
 import ExtendedKeyringTypes from '../../../constants/keyringTypes';
 import { NO_RPC_BLOCK_EXPLORER, RPC } from '../../../constants/network';
 import Engine from '../../../core/Engine';
-import ToastService from '../../../core/ToastService/ToastService';
 import { isNonEvmChainId } from '../../../core/Multichain/utils';
 import NotificationManager from '../../../core/NotificationManager';
 import { TransactionDetailLocation } from '../../../core/Analytics/events/transactions';
@@ -86,7 +85,8 @@ import {
   executeHardwareWalletOperation,
 } from '../../../core/HardwareWallet';
 import { skipHardwareWalletErrorIfReplacementSubmitted } from '../../../core/HardwareWallet/skipHardwareWalletErrorIfReplacementSubmitted';
-import { getTransactionUpdateErrorToastOptions } from '../../../util/confirmation/transactions';
+import { resolveTransactionUpdateErrorMessage } from '../../../util/confirmation/transactions';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { LedgerReplacementTxTypes } from '../LedgerModals/LedgerTransactionModal';
 import { selectIsActivityRedesignEnabled } from '../../../selectors/featureFlagController/activityRedesign';
 import AssetDetailsActivityListItem from './AssetDetailsActivityListItem';
@@ -463,7 +463,14 @@ const Transactions = (props) => {
   );
 
   const showTransactionUpdateErrorToast = (error) => {
-    ToastService.showToast(getTransactionUpdateErrorToastOptions(error));
+    toast({
+      title:
+        strings('transaction_update_toast.title') ||
+        'Transaction update failed',
+      description: resolveTransactionUpdateErrorMessage(error),
+      severity: ToastSeverity.Danger,
+      hasNoTimeout: false,
+    });
   };
 
   const handleSpeedUpTransactionFailure = (error) => {

--- a/app/components/UI/Transactions/index.test.tsx
+++ b/app/components/UI/Transactions/index.test.tsx
@@ -378,8 +378,14 @@ describe('UnconnectedTransactions', () => {
     jest
       .spyOn(InteractionManager, 'runAfterInteractions')
       .mockImplementation((callback) => {
-        callback();
-        return { cancel: jest.fn() };
+        if (typeof callback === 'function') {
+          callback();
+        }
+        return {
+          then: jest.fn(),
+          done: jest.fn(),
+          cancel: jest.fn(),
+        };
       });
     resetNavigationMocks();
     (isHardwareAccount as jest.Mock).mockReturnValue(false);

--- a/app/components/UI/Transactions/index.test.tsx
+++ b/app/components/UI/Transactions/index.test.tsx
@@ -189,10 +189,6 @@ jest.mock('../../../core/Engine', () => ({
     },
   },
 }));
-jest.mock('../../../core/ToastService/ToastService', () => ({
-  __esModule: true,
-  default: { showToast: jest.fn() },
-}));
 jest.mock('../../../util/Logger', () => ({ error: jest.fn() }));
 jest.mock('../../../util/analytics/analytics', () => ({
   analytics: { trackEvent: jest.fn() },

--- a/app/components/UI/Transactions/index.test.tsx
+++ b/app/components/UI/Transactions/index.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { InteractionManager } from 'react-native';
 import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { UnconnectedTransactions } from '.';
 import ExtendedKeyringTypes from '../../../constants/keyringTypes';
 import { TransactionDetailLocation } from '../../../core/Analytics/events/transactions';
@@ -16,11 +18,20 @@ import {
   getBlockExplorerName,
 } from '../../../util/networks';
 import { speedUpTransaction } from '../../../util/transaction-controller';
+import { strings } from '../../../../locales/i18n';
 
 const mockGroupActivityListItems = jest.fn();
 const mockMapTransactionToActivityItem = jest.fn();
 const mockCreateQRSigningTransactionModalNavDetails = jest.fn();
 const mockExecuteHardwareWalletOperation = jest.fn();
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
 type FlashListItem = Record<string, unknown>;
 
@@ -364,6 +375,12 @@ describe('UnconnectedTransactions', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.clearAllMocks();
+    jest
+      .spyOn(InteractionManager, 'runAfterInteractions')
+      .mockImplementation((callback) => {
+        callback();
+        return { cancel: jest.fn() };
+      });
     resetNavigationMocks();
     (isHardwareAccount as jest.Mock).mockReturnValue(false);
     (isNonEvmChainId as jest.Mock).mockReturnValue(false);
@@ -383,6 +400,7 @@ describe('UnconnectedTransactions', () => {
   });
 
   afterEach(() => {
+    jest.restoreAllMocks();
     jest.clearAllTimers();
     jest.useRealTimers();
   });
@@ -797,6 +815,12 @@ describe('UnconnectedTransactions', () => {
         message: 'speedUpTransaction failed ',
         speedUpTxId: 'replacement',
       });
+      expect(toast).toHaveBeenCalledWith({
+        title: strings('transaction_update_toast.title'),
+        description: 'replacement failed',
+        severity: ToastSeverity.Danger,
+        hasNoTimeout: false,
+      });
     });
 
     it('reports failed cancellation submissions through the transaction toast', async () => {
@@ -813,6 +837,12 @@ describe('UnconnectedTransactions', () => {
       expect(Logger.error).toHaveBeenCalledWith(error, {
         cancelTxId: 'replacement',
         message: 'cancelTransaction failed ',
+      });
+      expect(toast).toHaveBeenCalledWith({
+        title: strings('transaction_update_toast.title'),
+        description: 'cancellation failed',
+        severity: ToastSeverity.Danger,
+        hasNoTimeout: false,
       });
     });
 

--- a/app/components/Views/AddressQRCode/AddressQRCode.test.tsx
+++ b/app/components/Views/AddressQRCode/AddressQRCode.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, waitFor } from '@testing-library/react-native';
 import { act } from '@testing-library/react-hooks';
 import AddressQRCode from './index';
 import renderWithProvider from '../../../util/test/renderWithProvider';
-import { ToastContext } from '../../../component-library/components/Toast';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import ClipboardManager from '../../../core/ClipboardManager';
 import { backgroundState } from '../../../util/test/initial-root-state';
 
@@ -14,16 +14,19 @@ jest.mock('../../../core/ClipboardManager', () => ({
 
 jest.mock('react-native-qrcode-svg', () => 'QRCode');
 
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
+
 const mockDispatch = jest.fn();
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useDispatch: () => mockDispatch,
 }));
-
-const mockShowToast = jest.fn();
-const mockToastRef = {
-  current: { showToast: mockShowToast, closeToast: jest.fn() },
-};
 
 const mockCloseQrModal = jest.fn();
 
@@ -54,12 +57,9 @@ const mockInitialState = {
 };
 
 const renderComponent = (state = mockInitialState) =>
-  renderWithProvider(
-    <ToastContext.Provider value={{ toastRef: mockToastRef }}>
-      <AddressQRCode closeQrModal={mockCloseQrModal} />
-    </ToastContext.Provider>,
-    { state },
-  );
+  renderWithProvider(<AddressQRCode closeQrModal={mockCloseQrModal} />, {
+    state,
+  });
 
 describe('AddressQRCode', () => {
   beforeEach(() => {
@@ -95,12 +95,11 @@ describe('AddressQRCode', () => {
     });
 
     await waitFor(() => {
-      expect(mockShowToast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          variant: 'Icon',
-          hasNoTimeout: false,
-        }),
-      );
+      expect(toast).toHaveBeenCalledWith({
+        title: expect.any(String),
+        severity: ToastSeverity.Success,
+        hasNoTimeout: false,
+      });
     });
   });
 

--- a/app/components/Views/AddressQRCode/index.js
+++ b/app/components/Views/AddressQRCode/index.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
   TouchableOpacity,
@@ -18,11 +18,7 @@ import ClipboardManager from '../../../core/ClipboardManager';
 import { useTheme } from '../../../util/theme';
 import { selectSelectedInternalAccountFormattedAddress } from '../../../selectors/accountsController';
 import { isEthAddress } from '../../../util/address';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../component-library/components/Toast';
-import { IconName } from '../../../component-library/components/Icons/Icon';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 
 const WIDTH = Dimensions.get('window').width - 88;
 
@@ -88,7 +84,6 @@ const AddressQRCode = ({ closeQrModal }) => {
   const { colors } = theme;
   const styles = useMemo(() => createStyles(theme), [theme]);
   const dispatch = useDispatch();
-  const { toastRef } = useContext(ToastContext);
 
   const selectedAddress = useSelector(
     selectSelectedInternalAccountFormattedAddress,
@@ -114,16 +109,12 @@ const AddressQRCode = ({ closeQrModal }) => {
 
   const copyAccountToClipboard = useCallback(async () => {
     await ClipboardManager.setString(selectedAddress);
-    toastRef?.current?.showToast({
-      variant: ToastVariants.Icon,
-      iconName: IconName.Confirmation,
-      iconColor: colors.success.default,
-      labelOptions: [
-        { label: strings('account_details.account_copied_to_clipboard') },
-      ],
+    toast({
+      title: strings('account_details.account_copied_to_clipboard'),
+      severity: ToastSeverity.Success,
       hasNoTimeout: false,
     });
-  }, [colors.success.default, selectedAddress, toastRef]);
+  }, [selectedAddress]);
 
   const processAddress = useCallback(() => {
     const processedAddress = `${selectedAddress.slice(0, 2)} ${selectedAddress

--- a/app/components/Views/QRAccountDisplay/QRAccountDisplay.test.tsx
+++ b/app/components/Views/QRAccountDisplay/QRAccountDisplay.test.tsx
@@ -28,6 +28,14 @@ jest.mock('../../hooks/useAnalytics/useAnalytics', () => ({
   }),
 }));
 
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
+
 const initialState = {
   engine: {
     backgroundState: {

--- a/app/components/Views/QRAccountDisplay/QRAccountDisplay.tsx
+++ b/app/components/Views/QRAccountDisplay/QRAccountDisplay.tsx
@@ -1,5 +1,5 @@
 'use strict';
-import React, { useContext } from 'react';
+import React from 'react';
 import {
   Box,
   Text,
@@ -10,17 +10,13 @@ import {
   ButtonVariant,
   ButtonSize,
   IconName,
+  toast,
+  ToastSeverity,
 } from '@metamask/design-system-react-native';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
 import { useSelector } from 'react-redux';
 import { strings } from '../../../../locales/i18n';
 import ClipboardManager from '../../../core/ClipboardManager';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../component-library/components/Toast';
-import { IconName as ComponentLibraryIconName } from '../../../component-library/components/Icons/Icon';
-import { useTheme } from '../../../util/theme';
 import { selectInternalAccounts } from '../../../selectors/accountsController';
 import { renderAccountName } from '../../../util/address';
 import { QRAccountDisplayProps } from './QRAccountDisplay.types';
@@ -44,8 +40,6 @@ const QRAccountDisplay = (props: QRAccountDisplayProps) => {
   const addr = accountAddress;
   const accounts = useSelector(selectInternalAccounts);
   const accountLabel = renderAccountName(addr, accounts);
-  const { toastRef } = useContext(ToastContext);
-  const { colors } = useTheme();
   const { trackEvent, createEventBuilder } = useAnalytics();
   const addressStart = addr.substring(0, ADDRESS_PREFIX_LENGTH);
   const addressMiddle: string = addr.substring(
@@ -57,16 +51,9 @@ const QRAccountDisplay = (props: QRAccountDisplayProps) => {
   );
 
   const showCopyNotificationToast = () => {
-    toastRef?.current?.showToast({
-      variant: ToastVariants.Icon,
-      iconName: ComponentLibraryIconName.Confirmation,
-      iconColor: colors.success.default,
-      labelOptions: [
-        {
-          label: strings(`notifications.address_copied_to_clipboard`),
-          isBold: true,
-        },
-      ],
+    toast({
+      title: strings(`notifications.address_copied_to_clipboard`),
+      severity: ToastSeverity.Success,
       hasNoTimeout: false,
     });
   };

--- a/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.test.ts
+++ b/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.test.ts
@@ -426,6 +426,7 @@ describe('useUnifiedTxActions', () => {
 
       expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
+          title: expect.any(String),
           description: 'failed',
           severity: ToastSeverity.Danger,
           hasNoTimeout: false,

--- a/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.test.ts
+++ b/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.test.ts
@@ -1,16 +1,6 @@
-import React from 'react';
-import { BoxBackgroundColor } from '@metamask/design-system-react-native';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { renderHook, act } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
-
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../component-library/components/Toast';
-import {
-  IconColor,
-  IconName,
-} from '../../../component-library/components/Icons/Icon';
 
 import {
   useUnifiedTxActions,
@@ -36,6 +26,14 @@ import {
 import ExtendedKeyringTypes from '../../../constants/keyringTypes';
 
 const mockNavigate = jest.fn();
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -138,28 +136,9 @@ import {
 import { validateTransactionActionBalance } from '../../../util/transactions';
 import { isHardwareAccount } from '../../../util/address';
 
-const mockShowToast = jest.fn();
 const SELECTED_ADDRESS = '0x29D68015EE8Eb26fD23579a1df80ff1fb0F26209';
 
-const mockToastRef = {
-  current: {
-    showToast: mockShowToast,
-    closeToast: jest.fn(),
-  },
-};
-
-function TxActionsTestWrapper({ children }: { children: React.ReactNode }) {
-  return React.createElement(
-    ToastContext.Provider,
-    { value: { toastRef: mockToastRef } },
-    children,
-  );
-}
-
-const renderUnifiedTxActions = () =>
-  renderHook(() => useUnifiedTxActions(), {
-    wrapper: TxActionsTestWrapper,
-  });
+const renderUnifiedTxActions = () => renderHook(() => useUnifiedTxActions());
 
 const SPEED_UP_GAS = {
   maxFeePerGas: '0xff',
@@ -247,7 +226,7 @@ describe('useUnifiedTxActions', () => {
         .getGasValuesForReplacement,
     );
     engineContext.TransactionController.state.transactions = [];
-    mockShowToast.mockClear();
+    jest.mocked(toast).mockClear();
 
     (createQRSigningTransactionModalNavDetails as jest.Mock).mockReturnValue([
       'QRSigningModal',
@@ -445,13 +424,10 @@ describe('useUnifiedTxActions', () => {
         } as SpeedUpCancelParams);
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: ToastVariants.Icon,
-          iconName: IconName.CircleX,
-          iconColor: IconColor.Error,
-          backgroundColor: BoxBackgroundColor.Transparent,
-          descriptionOptions: { description: 'failed' },
+          description: 'failed',
+          severity: ToastSeverity.Danger,
           hasNoTimeout: false,
         }),
       );
@@ -473,11 +449,9 @@ describe('useUnifiedTxActions', () => {
         await result.current.speedUpTransaction();
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
-          descriptionOptions: {
-            description: 'gas computation failed',
-          },
+          description: 'gas computation failed',
         }),
       );
       expect(result.current.speedUpIsOpen).toBe(false);
@@ -593,13 +567,10 @@ describe('useUnifiedTxActions', () => {
         } as SpeedUpCancelParams);
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: ToastVariants.Icon,
-          iconName: IconName.CircleX,
-          iconColor: IconColor.Error,
-          backgroundColor: BoxBackgroundColor.Transparent,
-          descriptionOptions: { description: 'nope' },
+          description: 'nope',
+          severity: ToastSeverity.Danger,
           hasNoTimeout: false,
         }),
       );
@@ -876,13 +847,10 @@ describe('useUnifiedTxActions', () => {
           });
 
           expect(mockExecuteHardwareWalletOperation).not.toHaveBeenCalled();
-          expect(mockShowToast).toHaveBeenCalledWith(
+          expect(toast).toHaveBeenCalledWith(
             expect.objectContaining({
-              variant: ToastVariants.Icon,
-              iconName: IconName.CircleX,
-              iconColor: IconColor.Error,
-              backgroundColor: BoxBackgroundColor.Transparent,
-              descriptionOptions: { description: 'gas error' },
+              description: 'gas error',
+              severity: ToastSeverity.Danger,
               hasNoTimeout: false,
             }),
           );
@@ -901,15 +869,10 @@ describe('useUnifiedTxActions', () => {
           });
 
           expect(mockExecuteHardwareWalletOperation).not.toHaveBeenCalled();
-          expect(mockShowToast).toHaveBeenCalledWith(
+          expect(toast).toHaveBeenCalledWith(
             expect.objectContaining({
-              variant: ToastVariants.Icon,
-              iconName: IconName.CircleX,
-              iconColor: IconColor.Error,
-              backgroundColor: BoxBackgroundColor.Transparent,
-              descriptionOptions: {
-                description: 'Missing transaction id for speed up',
-              },
+              description: 'Missing transaction id for speed up',
+              severity: ToastSeverity.Danger,
               hasNoTimeout: false,
             }),
           );
@@ -1099,13 +1062,10 @@ describe('useUnifiedTxActions', () => {
           });
 
           expect(mockExecuteHardwareWalletOperation).not.toHaveBeenCalled();
-          expect(mockShowToast).toHaveBeenCalledWith(
+          expect(toast).toHaveBeenCalledWith(
             expect.objectContaining({
-              variant: ToastVariants.Icon,
-              iconName: IconName.CircleX,
-              iconColor: IconColor.Error,
-              backgroundColor: BoxBackgroundColor.Transparent,
-              descriptionOptions: { description: 'cancel error' },
+              description: 'cancel error',
+              severity: ToastSeverity.Danger,
               hasNoTimeout: false,
             }),
           );
@@ -1124,15 +1084,10 @@ describe('useUnifiedTxActions', () => {
           });
 
           expect(mockExecuteHardwareWalletOperation).not.toHaveBeenCalled();
-          expect(mockShowToast).toHaveBeenCalledWith(
+          expect(toast).toHaveBeenCalledWith(
             expect.objectContaining({
-              variant: ToastVariants.Icon,
-              iconName: IconName.CircleX,
-              iconColor: IconColor.Error,
-              backgroundColor: BoxBackgroundColor.Transparent,
-              descriptionOptions: {
-                description: 'Missing transaction id for cancel',
-              },
+              description: 'Missing transaction id for cancel',
+              severity: ToastSeverity.Danger,
               hasNoTimeout: false,
             }),
           );
@@ -1330,12 +1285,10 @@ describe('useUnifiedTxActions', () => {
         await result.current.speedUpTransaction();
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: ToastVariants.Icon,
-          iconName: IconName.CircleX,
-          iconColor: IconColor.Error,
-          backgroundColor: BoxBackgroundColor.Transparent,
+          severity: ToastSeverity.Danger,
+          hasNoTimeout: false,
         }),
       );
     });
@@ -1352,12 +1305,10 @@ describe('useUnifiedTxActions', () => {
         await result.current.cancelTransaction();
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: ToastVariants.Icon,
-          iconName: IconName.CircleX,
-          iconColor: IconColor.Error,
-          backgroundColor: BoxBackgroundColor.Transparent,
+          severity: ToastSeverity.Danger,
+          hasNoTimeout: false,
         }),
       );
     });

--- a/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.ts
+++ b/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.ts
@@ -107,9 +107,7 @@ export function useUnifiedTxActions() {
   } = useHardwareWallet();
   const showTransactionUpdateErrorToast = useCallback((error: unknown) => {
     toast({
-      title:
-        strings('transaction_update_toast.title') ||
-        'Transaction update failed',
+      title: strings('transaction_update_toast.title'),
       description: resolveTransactionUpdateErrorMessage(error),
       severity: ToastSeverity.Danger,
       hasNoTimeout: false,

--- a/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.ts
+++ b/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.ts
@@ -9,15 +9,10 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import { navigateWithDetails } from '../../../util/navigation/navUtils';
-import {
-  useCallback,
-  useContext,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { ToastContext } from '../../../component-library/components/Toast';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
+import { strings } from '../../../../locales/i18n';
 import ExtendedKeyringTypes from '../../../constants/keyringTypes';
 import Engine from '../../../core/Engine';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
@@ -46,7 +41,7 @@ import {
   executeHardwareWalletOperation,
 } from '../../../core/HardwareWallet';
 import { skipHardwareWalletErrorIfReplacementSubmitted } from '../../../core/HardwareWallet/skipHardwareWalletErrorIfReplacementSubmitted';
-import { getTransactionUpdateErrorToastOptions } from '../../../util/confirmation/transactions';
+import { resolveTransactionUpdateErrorMessage } from '../../../util/confirmation/transactions';
 
 type Maybe<T> = T | null | undefined;
 
@@ -110,13 +105,16 @@ export function useUnifiedTxActions() {
     hideAwaitingConfirmation,
     showHardwareWalletError,
   } = useHardwareWallet();
-  const toastContext = useContext(ToastContext);
-  const toastRef = toastContext?.toastRef;
-  const toastRefStable = useRef(toastRef);
-  useLayoutEffect(() => {
-    toastRefStable.current = toastRef;
-  }, [toastRef]);
-
+  const showTransactionUpdateErrorToast = useCallback((error: unknown) => {
+    toast({
+      title:
+        strings('transaction_update_toast.title') ||
+        'Transaction update failed',
+      description: resolveTransactionUpdateErrorMessage(error),
+      severity: ToastSeverity.Danger,
+      hasNoTimeout: false,
+    });
+  }, []);
   const gasFeeEstimates = useSelector(selectGasFeeEstimates);
   const accounts = useSelector(selectAccounts);
   const selectedAddress = useSelector(
@@ -137,12 +135,6 @@ export function useUnifiedTxActions() {
   const isQRHardwareAccount = isHardwareAccount(selectedAddress ?? '', [
     ExtendedKeyringTypes.qr,
   ]);
-
-  const showTransactionUpdateErrorToast = useCallback((error: unknown) => {
-    toastRefStable.current?.current?.showToast(
-      getTransactionUpdateErrorToastOptions(error),
-    );
-  }, []);
 
   const closeSpeedUpCancelModal = useCallback(() => {
     setSpeedUpCancelModalState(SpeedUpCancelModalState.Closed);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Activity, address QR, and transaction-update flows still showed feedback through the legacy `ToastContext` / `ToastService` `showToast` API. This PR switches those call sites to the design-system `toast()` API so mobile-core-ux toasts share the same toaster as the rest of the toast migration.

Copy-address toasts use `ToastSeverity.Success`. Transaction update failures use `Danger` with `resolveTransactionUpdateErrorMessage` for the description. Shared toast helpers (`getTransactionUpdateErrorToastOptions`, `ToastContext`, `ToastService`, `ControllerEventToastBridge`) are unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

Refs: No tracking issue; continues the design-system toast migration for mobile-core-ux flows

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Mobile-core-ux design-system toasts

  Background:
    Given I am logged into MetaMask Mobile

  Scenario: user copies an account address from the QR screen
    Given I open the receive / address QR screen

    When user taps copy
    Then a success toast appears with the copied-address confirmation
    And the toast can be dismissed with the design-system close control

  Scenario: user fails to speed up or cancel a transaction
    Given I have a pending transaction in Activity

    When a speed-up or cancel update fails
    Then a danger toast appears with the transaction-update failed title
    And the toast description explains the failure
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
