### PR TITLE
refactor(toast): migrate money-movement toasts to the design system

### DIFF
--- a/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.test.tsx
@@ -90,7 +90,7 @@ jest.mock('@metamask/design-system-react-native', () => {
   const BottomSheet = ReactActual.forwardRef(
     (
       props: { children?: unknown; goBack?: () => void },
-      ref: ReactActual.Ref<{ onCloseBottomSheet: (cb?: () => void) => void }>,
+      ref: React.Ref<{ onCloseBottomSheet: (cb?: () => void) => void }>,
     ) => {
       ReactActual.useImperativeHandle(ref, () => ({
         onCloseBottomSheet: (cb?: () => void) => {

--- a/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.test.tsx
+++ b/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.test.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
-import {
-  IconColor,
-  IconName,
-} from '../../../../../../component-library/components/Icons/Icon';
 import SettingsModal from './SettingsModal';
 import InAppBrowser from 'react-native-inappbrowser-reborn';
 import { renderScreen } from '../../../../../../util/test/renderWithProvider';
 import { backgroundState } from '../../../../../../util/test/initial-root-state';
 import { fireEvent, waitFor, act } from '@testing-library/react-native';
 import Routes from '../../../../../../constants/navigation/Routes';
-import { ToastContext } from '../../../../../../component-library/components/Toast';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import {
   getProviderToken,
   resetProviderToken,
@@ -87,13 +83,34 @@ const mockResetProviderToken = resetProviderToken as jest.MockedFunction<
   typeof resetProviderToken
 >;
 
-const mockShowToast = jest.fn();
-const mockToastRef = {
-  current: {
-    showToast: mockShowToast,
-    closeToast: jest.fn(),
-  },
-};
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  const BottomSheet = ReactActual.forwardRef(
+    (
+      props: { children?: unknown; goBack?: () => void },
+      ref: ReactActual.Ref<{ onCloseBottomSheet: (cb?: () => void) => void }>,
+    ) => {
+      ReactActual.useImperativeHandle(ref, () => ({
+        onCloseBottomSheet: (cb?: () => void) => {
+          if (cb) {
+            cb();
+            return;
+          }
+          props.goBack?.();
+        },
+      }));
+      return ReactActual.createElement(View, null, props.children);
+    },
+  );
+  BottomSheet.displayName = 'BottomSheet';
+  return {
+    ...actual,
+    BottomSheet,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
@@ -132,27 +149,10 @@ jest.mock('../../../hooks/useRampsProviders', () => ({
   }),
 }));
 
-jest.mock('../../../../../../component-library/components/Toast', () => {
-  const actualToast = jest.requireActual(
-    '../../../../../../component-library/components/Toast',
-  );
-
-  return {
-    ...actualToast,
-    ToastVariants: {
-      Icon: 'Icon',
-    },
-  };
-});
-
 function renderWithProvider(component: React.ComponentType) {
   const WrappedComponent = () => {
     const Component = component;
-    return (
-      <ToastContext.Provider value={{ toastRef: mockToastRef }}>
-        <Component />
-      </ToastContext.Provider>
-    );
+    return <Component />;
   };
 
   return renderScreen(
@@ -286,11 +286,9 @@ describe('SettingsModal', () => {
       });
 
       expect(mockSetSelectedProvider).toHaveBeenCalledWith(null);
-      expect(mockShowToast).toHaveBeenCalledWith({
-        variant: 'Icon',
-        labelOptions: [{ label: 'Successfully logged out' }],
-        iconName: IconName.Confirmation,
-        iconColor: IconColor.Success,
+      expect(toast).toHaveBeenCalledWith({
+        title: 'Successfully logged out',
+        severity: ToastSeverity.Success,
         hasNoTimeout: false,
       });
     });
@@ -310,11 +308,9 @@ describe('SettingsModal', () => {
         expect(mockResetProviderToken).toHaveBeenCalled();
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith({
-        variant: 'Icon',
-        labelOptions: [{ label: 'Error logging out' }],
-        iconName: 'CircleX',
-        iconColor: IconColor.Error,
+      expect(toast).toHaveBeenCalledWith({
+        title: 'Error logging out',
+        severity: ToastSeverity.Danger,
         hasNoTimeout: false,
       });
     });

--- a/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.tsx
+++ b/app/components/UI/Ramp/Views/Modals/SettingsModal/SettingsModal.tsx
@@ -1,30 +1,18 @@
-import React, {
-  useCallback,
-  useRef,
-  useContext,
-  useState,
-  useEffect,
-} from 'react';
+import React, { useCallback, useRef, useState, useEffect } from 'react';
 import InAppBrowser from 'react-native-inappbrowser-reborn';
 import {
   BottomSheet,
   HeaderStandard,
   IconName,
+  toast,
+  ToastSeverity,
   type BottomSheetRef,
 } from '@metamask/design-system-react-native';
-import {
-  IconName as ComponentLibraryIconName,
-  IconColor as ComponentLibraryIconColor,
-} from '../../../../../../component-library/components/Icons/Icon';
 import { createNavigationDetails } from '../../../../../../util/navigation/navUtils';
 import Routes from '../../../../../../constants/navigation/Routes';
 import { strings } from '../../../../../../../locales/i18n';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../../core/NavigationService/types';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../../../component-library/components/Toast';
 import Logger from '../../../../../../util/Logger';
 import MenuItem from '../../../components/MenuItem';
 import { useRampsProviders } from '../../../hooks/useRampsProviders';
@@ -55,7 +43,6 @@ function SettingsModal() {
   const { trackEvent, createEventBuilder } = useAnalytics();
   const sheetRef = useRef<BottomSheetRef>(null);
   const navigation = useNavigation<AppNavigationProp>();
-  const { toastRef } = useContext(ToastContext);
   const { selectedProvider, setSelectedProvider } = useRampsProviders();
   const [isAuthenticatedWithProvider, setIsAuthenticatedWithProvider] =
     useState<boolean>(false);
@@ -161,37 +148,24 @@ function SettingsModal() {
       setSelectedProvider(null);
 
       sheetRef.current?.onCloseBottomSheet();
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        labelOptions: [
-          {
-            label: strings(
-              'fiat_on_ramp.build_quote_settings_modal.logged_out_success',
-            ),
-          },
-        ],
-        iconName: ComponentLibraryIconName.Confirmation,
-        // Toast still renders component-library Icon; use its IconColor enum, not DS tokens.
-        iconColor: ComponentLibraryIconColor.Success,
+      toast({
+        title: strings(
+          'fiat_on_ramp.build_quote_settings_modal.logged_out_success',
+        ),
+        severity: ToastSeverity.Success,
         hasNoTimeout: false,
       });
     } catch (error) {
       Logger.error(error as Error, 'Error logging out from provider:');
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        labelOptions: [
-          {
-            label: strings(
-              'fiat_on_ramp.build_quote_settings_modal.logged_out_error',
-            ),
-          },
-        ],
-        iconName: ComponentLibraryIconName.CircleX,
-        iconColor: ComponentLibraryIconColor.Error,
+      toast({
+        title: strings(
+          'fiat_on_ramp.build_quote_settings_modal.logged_out_error',
+        ),
+        severity: ToastSeverity.Danger,
         hasNoTimeout: false,
       });
     }
-  }, [setSelectedProvider, toastRef, trackEvent, createEventBuilder]);
+  }, [setSelectedProvider, trackEvent, createEventBuilder]);
 
   const handleClosePress = useCallback(() => {
     sheetRef.current?.onCloseBottomSheet();

--- a/app/components/UI/Ramp/utils/v2OrderToast.test.ts
+++ b/app/components/UI/Ramp/utils/v2OrderToast.test.ts
@@ -1,5 +1,6 @@
 import { RampsOrderStatus } from '@metamask/ramps-controller';
 import { toast, ToastSeverity } from '@metamask/design-system-react-native';
+import type { GestureResponderEvent } from 'react-native';
 import {
   buildV2OrderToastOptions,
   showV2OrderToast,
@@ -71,7 +72,7 @@ describe('v2OrderToast', () => {
       };
 
       const result = buildV2OrderToastOptions(params);
-      result?.actionButtonOnPress?.();
+      result?.actionButtonOnPress?.({} as GestureResponderEvent);
 
       expect(toast.dismiss).toHaveBeenCalled();
       expect(NavigationService.navigation.navigate).toHaveBeenCalledWith(

--- a/app/components/UI/Ramp/utils/v2OrderToast.test.ts
+++ b/app/components/UI/Ramp/utils/v2OrderToast.test.ts
@@ -1,17 +1,22 @@
 import { RampsOrderStatus } from '@metamask/ramps-controller';
-import { IconName } from '../../../../component-library/components/Icons/Icon';
-import { ToastVariants } from '../../../../component-library/components/Toast/Toast.types';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import {
   buildV2OrderToastOptions,
   showV2OrderToast,
   V2OrderToastParams,
 } from './v2OrderToast';
-import ToastService from '../../../../core/ToastService';
 import NavigationService from '../../../../core/NavigationService';
 import Routes from '../../../../constants/navigation/Routes';
 import { strings } from '../../../../../locales/i18n';
 
-jest.mock('../../../../core/ToastService');
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
+
 jest.mock('../../../../core/NavigationService', () => ({
   navigation: {
     navigate: jest.fn(),
@@ -22,8 +27,6 @@ jest.mock('../../../../../locales/i18n', () => ({
 }));
 
 describe('v2OrderToast', () => {
-  const mockToastService = ToastService as jest.Mocked<typeof ToastService>;
-
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -45,18 +48,14 @@ describe('v2OrderToast', () => {
       const result = buildV2OrderToastOptions(params);
 
       expect(result).not.toBeNull();
-      expect(result?.variant).toBe(ToastVariants.Plain);
       expect(result?.hasNoTimeout).toBe(false);
       expect(result?.startAccessory).toBeDefined();
-      expect(result?.labelOptions?.[0]?.label).toBe(
-        'Processing your purchase of ETH',
-      );
-      expect(result?.labelOptions?.[0]?.isBold).toBe(true);
-      expect(result?.descriptionOptions?.description).toBe(
+      expect(result?.title).toBe('Processing your purchase of ETH');
+      expect(result?.description).toBe(
         'This should only take a few minutes...',
       );
-      expect(result?.linkButtonOptions?.label).toBe('Track');
-      expect(result?.linkButtonOptions?.onPress).toBeDefined();
+      expect(result?.actionButtonLabel).toBe('Track');
+      expect(result?.actionButtonOnPress).toBeDefined();
     });
 
     it('navigates to order details when Track button is pressed', () => {
@@ -72,16 +71,16 @@ describe('v2OrderToast', () => {
       };
 
       const result = buildV2OrderToastOptions(params);
-      result?.linkButtonOptions?.onPress();
+      result?.actionButtonOnPress?.();
 
-      expect(mockToastService.closeToast).toHaveBeenCalled();
+      expect(toast.dismiss).toHaveBeenCalled();
       expect(NavigationService.navigation.navigate).toHaveBeenCalledWith(
         Routes.RAMP.RAMPS_ORDER_DETAILS,
         { orderId: 'test-order-id', showCloseButton: true },
       );
     });
 
-    it('returns toast options for COMPLETED state with success icon', () => {
+    it('returns toast options for COMPLETED state with success severity', () => {
       (strings as jest.Mock)
         .mockReturnValueOnce('Your purchase of 100.5 USDC was successful')
         .mockReturnValueOnce('Your USDC is now available');
@@ -96,22 +95,14 @@ describe('v2OrderToast', () => {
       const result = buildV2OrderToastOptions(params);
 
       expect(result).not.toBeNull();
-      expect(result?.variant).toBe(ToastVariants.Icon);
+      expect(result?.severity).toBe(ToastSeverity.Success);
       expect(result?.hasNoTimeout).toBe(false);
-      if (result?.variant === ToastVariants.Icon) {
-        expect(result.iconName).toBe(IconName.Confirmation);
-      }
-      expect(result?.labelOptions?.[0]?.label).toBe(
-        'Your purchase of 100.5 USDC was successful',
-      );
-      expect(result?.labelOptions?.[0]?.isBold).toBe(true);
-      expect(result?.descriptionOptions?.description).toBe(
-        'Your USDC is now available',
-      );
-      expect(result?.linkButtonOptions).toBeUndefined();
+      expect(result?.title).toBe('Your purchase of 100.5 USDC was successful');
+      expect(result?.description).toBe('Your USDC is now available');
+      expect(result?.actionButtonLabel).toBeUndefined();
     });
 
-    it('returns toast options for Failed status with error icon', () => {
+    it('returns toast options for Failed status with danger severity', () => {
       (strings as jest.Mock)
         .mockReturnValueOnce('Purchase of BTC failed')
         .mockReturnValueOnce('Please try again momentarily');
@@ -125,19 +116,13 @@ describe('v2OrderToast', () => {
       const result = buildV2OrderToastOptions(params);
 
       expect(result).not.toBeNull();
-      expect(result?.variant).toBe(ToastVariants.Icon);
+      expect(result?.severity).toBe(ToastSeverity.Danger);
       expect(result?.hasNoTimeout).toBe(false);
-      if (result?.variant === ToastVariants.Icon) {
-        expect(result.iconName).toBe(IconName.Warning);
-      }
-      expect(result?.labelOptions?.[0]?.label).toBe('Purchase of BTC failed');
-      expect(result?.labelOptions?.[0]?.isBold).toBe(true);
-      expect(result?.descriptionOptions?.description).toBe(
-        'Please try again momentarily',
-      );
+      expect(result?.title).toBe('Purchase of BTC failed');
+      expect(result?.description).toBe('Please try again momentarily');
     });
 
-    it('returns toast options for Cancelled status with warning icon', () => {
+    it('returns toast options for Cancelled status with warning severity', () => {
       (strings as jest.Mock)
         .mockReturnValueOnce('Your purchase was cancelled')
         .mockReturnValueOnce('Your purchase of DAI has been cancelled');
@@ -151,16 +136,10 @@ describe('v2OrderToast', () => {
       const result = buildV2OrderToastOptions(params);
 
       expect(result).not.toBeNull();
-      expect(result?.variant).toBe(ToastVariants.Icon);
+      expect(result?.severity).toBe(ToastSeverity.Warning);
       expect(result?.hasNoTimeout).toBe(false);
-      if (result?.variant === ToastVariants.Icon) {
-        expect(result.iconName).toBe(IconName.Warning);
-      }
-      expect(result?.labelOptions?.[0]?.label).toBe(
-        'Your purchase was cancelled',
-      );
-      expect(result?.labelOptions?.[0]?.isBold).toBe(true);
-      expect(result?.descriptionOptions?.description).toBe(
+      expect(result?.title).toBe('Your purchase was cancelled');
+      expect(result?.description).toBe(
         'Your purchase of DAI has been cancelled',
       );
     });
@@ -191,14 +170,12 @@ describe('v2OrderToast', () => {
       const result = buildV2OrderToastOptions(params);
 
       expect(result).not.toBeNull();
-      expect(result?.labelOptions?.[0]?.label).toBe(
-        'Your purchase of  ETH was successful',
-      );
+      expect(result?.title).toBe('Your purchase of  ETH was successful');
     });
   });
 
   describe('showV2OrderToast', () => {
-    it('calls ToastService.showToast with valid toast options', () => {
+    it('calls toast with valid toast options', () => {
       (strings as jest.Mock)
         .mockReturnValueOnce('Your purchase of 1.5 ETH was successful')
         .mockReturnValueOnce('Your ETH is now available');
@@ -212,15 +189,13 @@ describe('v2OrderToast', () => {
 
       showV2OrderToast(params);
 
-      expect(mockToastService.showToast).toHaveBeenCalledTimes(1);
-      const callArg = mockToastService.showToast.mock.calls[0][0];
-      expect(callArg.variant).toBe(ToastVariants.Icon);
-      if (callArg.variant === ToastVariants.Icon) {
-        expect(callArg.iconName).toBe(IconName.Confirmation);
-      }
+      expect(toast).toHaveBeenCalledTimes(1);
+      const callArg = jest.mocked(toast).mock.calls[0][0];
+      expect(callArg.severity).toBe(ToastSeverity.Success);
+      expect(callArg.title).toBe('Your purchase of 1.5 ETH was successful');
     });
 
-    it('does not call ToastService.showToast for Created status', () => {
+    it('does not call toast for Created status', () => {
       const params: V2OrderToastParams = {
         orderId: 'test-order-id',
         cryptocurrency: 'ETH',
@@ -229,7 +204,7 @@ describe('v2OrderToast', () => {
 
       showV2OrderToast(params);
 
-      expect(mockToastService.showToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/components/UI/Ramp/utils/v2OrderToast.ts
+++ b/app/components/UI/Ramp/utils/v2OrderToast.ts
@@ -1,22 +1,15 @@
 import React from 'react';
 import {
-  IconColor as DsIconColor,
   IconSize as DsIconSize,
   Spinner,
+  toast,
+  ToastSeverity,
+  type ToastOptions,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../locales/i18n';
-import {
-  IconColor,
-  IconName,
-} from '../../../../component-library/components/Icons/Icon';
-import {
-  ToastOptions,
-  ToastVariants,
-} from '../../../../component-library/components/Toast/Toast.types';
 import { RampsOrderStatus } from '@metamask/ramps-controller';
 import Routes from '../../../../constants/navigation/Routes';
 import NavigationService from '../../../../core/NavigationService';
-import ToastService from '../../../../core/ToastService';
 import { renderNumber } from '../../../../util/number/bigint';
 
 export interface V2OrderToastParams {
@@ -24,6 +17,14 @@ export interface V2OrderToastParams {
   cryptocurrency: string;
   cryptoAmount?: string | number;
   status: RampsOrderStatus;
+}
+
+function dismissToast() {
+  try {
+    toast.dismiss();
+  } catch {
+    // Toaster may be unmounted in tests
+  }
 }
 
 /**
@@ -38,34 +39,23 @@ export function buildV2OrderToastOptions(
   switch (status) {
     case RampsOrderStatus.Pending: {
       return {
-        variant: ToastVariants.Plain,
         hasNoTimeout: false,
         startAccessory: React.createElement(Spinner, {
-          color: DsIconColor.IconDefault,
           spinnerIconProps: { size: DsIconSize.Lg },
         }),
-        labelOptions: [
-          {
-            label: strings('ramps_v2.notifications.purchase_pending_title', {
-              cryptocurrency,
-            }),
-            isBold: true,
-          },
-        ],
-        descriptionOptions: {
-          description: strings(
-            'ramps_v2.notifications.purchase_pending_description',
-          ),
-        },
-        linkButtonOptions: {
-          label: strings('ramps_v2.notifications.track'),
-          onPress: () => {
-            ToastService.closeToast();
-            NavigationService.navigation.navigate(
-              Routes.RAMP.RAMPS_ORDER_DETAILS,
-              { orderId, showCloseButton: true },
-            );
-          },
+        title: strings('ramps_v2.notifications.purchase_pending_title', {
+          cryptocurrency,
+        }),
+        description: strings(
+          'ramps_v2.notifications.purchase_pending_description',
+        ),
+        actionButtonLabel: strings('ramps_v2.notifications.track'),
+        actionButtonOnPress: () => {
+          dismissToast();
+          NavigationService.navigation.navigate(
+            Routes.RAMP.RAMPS_ORDER_DETAILS,
+            { orderId, showCloseButton: true },
+          );
         },
       };
     }
@@ -75,75 +65,45 @@ export function buildV2OrderToastOptions(
         ? renderNumber(String(cryptoAmount))
         : '';
       return {
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        iconColor: IconColor.Success,
-        backgroundColor: 'transparent',
+        severity: ToastSeverity.Success,
         hasNoTimeout: false,
-        labelOptions: [
+        title: strings('ramps_v2.notifications.purchase_completed_title', {
+          amount: formattedAmount,
+          cryptocurrency,
+        }),
+        description: strings(
+          'ramps_v2.notifications.purchase_completed_description',
           {
-            label: strings('ramps_v2.notifications.purchase_completed_title', {
-              amount: formattedAmount,
-              cryptocurrency,
-            }),
-            isBold: true,
+            cryptocurrency,
           },
-        ],
-        descriptionOptions: {
-          description: strings(
-            'ramps_v2.notifications.purchase_completed_description',
-            {
-              cryptocurrency,
-            },
-          ),
-        },
+        ),
       };
     }
 
     case RampsOrderStatus.Failed: {
       return {
-        variant: ToastVariants.Icon,
-        iconName: IconName.Warning,
-        iconColor: IconColor.Error,
-        backgroundColor: 'transparent',
+        severity: ToastSeverity.Danger,
         hasNoTimeout: false,
-        labelOptions: [
-          {
-            label: strings('ramps_v2.notifications.purchase_failed_title', {
-              cryptocurrency,
-            }),
-            isBold: true,
-          },
-        ],
-        descriptionOptions: {
-          description: strings(
-            'ramps_v2.notifications.purchase_failed_description',
-          ),
-        },
+        title: strings('ramps_v2.notifications.purchase_failed_title', {
+          cryptocurrency,
+        }),
+        description: strings(
+          'ramps_v2.notifications.purchase_failed_description',
+        ),
       };
     }
 
     case RampsOrderStatus.Cancelled: {
       return {
-        variant: ToastVariants.Icon,
-        iconName: IconName.Warning,
-        iconColor: IconColor.Warning,
-        backgroundColor: 'transparent',
+        severity: ToastSeverity.Warning,
         hasNoTimeout: false,
-        labelOptions: [
+        title: strings('ramps_v2.notifications.purchase_cancelled_title'),
+        description: strings(
+          'ramps_v2.notifications.purchase_cancelled_description',
           {
-            label: strings('ramps_v2.notifications.purchase_cancelled_title'),
-            isBold: true,
+            cryptocurrency,
           },
-        ],
-        descriptionOptions: {
-          description: strings(
-            'ramps_v2.notifications.purchase_cancelled_description',
-            {
-              cryptocurrency,
-            },
-          ),
-        },
+        ),
       };
     }
 
@@ -163,6 +123,6 @@ export function buildV2OrderToastOptions(
 export function showV2OrderToast(params: V2OrderToastParams): void {
   const toastOptions = buildV2OrderToastOptions(params);
   if (toastOptions) {
-    ToastService.showToast(toastOptions);
+    toast(toastOptions);
   }
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Ramp still showed v2 order status and provider logout feedback through the legacy `ToastContext` / `ToastService` `showToast` API. This PR switches those call sites to the design-system `toast()` API so money-movement toasts share the same toaster as the rest of the toast migration.

Pending orders keep a spinner and a Track action that dismisses then navigates to order details. Completed uses `ToastSeverity.Success`, failed `Danger`, cancelled `Warning`. Logout uses `Success` or `Danger`. Shared toast infrastructure (`ToastContext`, `ToastService`, `ControllerEventToastBridge`) is unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

Refs: No tracking issue; continues the design-system toast migration for money-movement flows

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Money-movement design-system toasts

  Background:
    Given I am logged into MetaMask Mobile

  Scenario: user has a pending Ramp v2 purchase
    Given I complete a Ramp v2 buy that stays pending

    When the pending order toast appears
    Then the toast shows a spinner and a Track action
    And tapping Track dismisses the toast and opens order details

  Scenario: user completes, fails, or cancels a Ramp v2 purchase
    Given I have a Ramp v2 order that reaches a terminal status

    When the status is completed
    Then a success toast appears with the purchase confirmation
    When the status is failed
    Then a danger toast appears with the purchase failed copy
    When the status is cancelled
    Then a warning toast appears with the purchase cancelled copy

  Scenario: user logs out of a Ramp provider
    Given I am authenticated with a Ramp provider
    And I open Ramp settings

    When user logs out successfully
    Then a success toast appears with the logged-out confirmation

    When logout fails
    Then a danger toast appears with the logout error copy
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
