### PR TITLE
refactor(toast): migrate perps toasts to the design system

### DIFF
--- a/app/components/UI/Perps/Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView.tsx
+++ b/app/components/UI/Perps/Views/PerpsCloseAllPositionsView/PerpsCloseAllPositionsView.tsx
@@ -14,6 +14,7 @@ import {
   Text,
   TextColor,
   TextVariant,
+  ToastSeverity,
 } from '@metamask/design-system-react-native';
 import {
   ImpactMoment,
@@ -21,8 +22,6 @@ import {
   useHaptics,
 } from '../../../../../util/haptics';
 import { strings } from '../../../../../../locales/i18n';
-import { IconName } from '../../../../../component-library/components/Icons/Icon';
-import { ToastVariants } from '../../../../../component-library/components/Toast/Toast.types';
 import {
   usePerpsLivePositions,
   usePerpsCloseAllCalculations,
@@ -115,46 +114,30 @@ const PerpsCloseAllPositionsView: React.FC<PerpsCloseAllPositionsViewProps> = ({
   const showSuccessToast = useCallback(
     (title: string, message?: string) => {
       const toastConfig: PerpsToastOptions = {
-        variant: ToastVariants.Icon,
-        iconName: IconName.CheckBold,
-        backgroundColor: theme.colors.accent03.normal,
-        iconColor: theme.colors.accent03.dark,
+        severity: ToastSeverity.Success,
         hapticsType: NotificationMoment.Success,
         hasNoTimeout: false,
-        labelOptions: message
-          ? [
-              { label: title, isBold: true },
-              { label: '\n', isBold: false },
-              { label: message, isBold: false },
-            ]
-          : [{ label: title, isBold: true }],
-      } as PerpsToastOptions;
+        title,
+        description: message,
+      };
       showToast(toastConfig);
     },
-    [showToast, theme.colors.accent03],
+    [showToast],
   );
 
   // Toast helper for errors
   const showErrorToast = useCallback(
     (title: string, message?: string) => {
       const toastConfig: PerpsToastOptions = {
-        variant: ToastVariants.Icon,
-        iconName: IconName.Warning,
-        backgroundColor: theme.colors.accent01.light,
-        iconColor: theme.colors.accent01.dark,
+        severity: ToastSeverity.Danger,
         hapticsType: NotificationMoment.Error,
         hasNoTimeout: false,
-        labelOptions: message
-          ? [
-              { label: title, isBold: true },
-              { label: '\n', isBold: false },
-              { label: message, isBold: false },
-            ]
-          : [{ label: title, isBold: true }],
-      } as PerpsToastOptions;
+        title,
+        description: message,
+      };
       showToast(toastConfig);
     },
-    [showToast, theme.colors.accent01],
+    [showToast],
   );
 
   // Handle success callback from hook

--- a/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsWithdrawView/PerpsWithdrawView.test.tsx
@@ -176,6 +176,7 @@ jest.mock('@metamask/design-system-react-native', () => {
       testID?: string;
       onPress?: () => void;
     }) => React.createElement(TouchableOpacity, { testID, onPress }),
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
   };
 });
 

--- a/app/components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsProviderToggle.tsx
+++ b/app/components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsProviderToggle.tsx
@@ -1,15 +1,7 @@
-import {
-  IconColor,
-  IconName,
-} from '../../../../../component-library/components/Icons/Icon';
-import React, { useState, useContext, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { View, Switch, ActivityIndicator, StyleSheet } from 'react-native';
 import { strings } from '../../../../../../locales/i18n';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../../component-library/components/Toast';
 import { useStyles } from '../../../../hooks/useStyles';
 import { usePerpsNetworkConfig } from '../../hooks';
 import { selectPerpsProvider } from '../../selectors/perpsController';
@@ -18,6 +10,8 @@ import {
   Text,
   TextColor,
   TextVariant,
+  toast,
+  ToastSeverity,
 } from '@metamask/design-system-react-native';
 
 const PerpsProviderToggleStyles = () =>
@@ -42,8 +36,6 @@ const PerpsProviderToggleContent = () => {
 
   const [isLoading, setIsLoading] = useState(false);
 
-  const { toastRef } = useContext(ToastContext);
-
   const handleProviderToggle = useCallback(async () => {
     if (!currentProvider) return;
 
@@ -57,21 +49,15 @@ const PerpsProviderToggleContent = () => {
         return;
       }
 
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Warning,
-        iconColor: IconColor.Error,
-        labelOptions: [
-          {
-            label: strings('perps.errors.failed_to_switch_provider'),
-          },
-        ],
+      toast({
+        title: strings('perps.errors.failed_to_switch_provider'),
+        severity: ToastSeverity.Danger,
         hasNoTimeout: false,
       });
     } finally {
       setIsLoading(false);
     }
-  }, [currentProvider, isAggregated, switchProvider, toastRef]);
+  }, [currentProvider, isAggregated, switchProvider]);
 
   if (!currentProvider) {
     return null;

--- a/app/components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsTestnetToggle.test.tsx
+++ b/app/components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsTestnetToggle.test.tsx
@@ -32,7 +32,7 @@ describe('PerpsTestnetToggle', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockToggleTestnet.mockClear();
-    (toast as jest.Mock).mockClear();
+    (toast as unknown as jest.Mock).mockClear();
   });
 
   it('renders correctly with testnet network', () => {

--- a/app/components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsTestnetToggle.test.tsx
+++ b/app/components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsTestnetToggle.test.tsx
@@ -3,24 +3,15 @@ import { fireEvent, waitFor, act } from '@testing-library/react-native';
 import renderWithProvider from '../../../../../util/test/renderWithProvider';
 import { PerpsTestnetToggle } from './PerpsTestnetToggle';
 import { PerpsTestnetToggleSelectorsIDs } from '../../Perps.testIds';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../../component-library/components/Toast';
-import {
-  IconColor,
-  IconName,
-} from '../../../../../component-library/components/Icons/Icon';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 
-// Mock Toast Context to test toast functionality
-const mockShowToast = jest.fn();
-const mockCloseToast = jest.fn();
-const mockToastRef = {
-  current: {
-    showToast: mockShowToast,
-    closeToast: mockCloseToast,
-  },
-};
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
 // Mock Perps hooks
 const mockToggleTestnet = jest.fn();
@@ -34,26 +25,20 @@ jest.mock('../../hooks', () => ({
   usePerpsNetwork: () => mockUsePerpsNetwork(),
 }));
 
-const renderWithToastContext = (component: React.ReactElement) =>
-  renderWithProvider(
-    <ToastContext.Provider value={{ toastRef: mockToastRef }}>
-      {component}
-    </ToastContext.Provider>,
-  );
+const renderToggle = (component: React.ReactElement) =>
+  renderWithProvider(component);
 
 describe('PerpsTestnetToggle', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockToggleTestnet.mockClear();
-    mockShowToast.mockClear();
+    (toast as jest.Mock).mockClear();
   });
 
   it('renders correctly with testnet network', () => {
     mockUsePerpsNetwork.mockReturnValue('testnet');
 
-    const { getByTestId, getByText } = renderWithToastContext(
-      <PerpsTestnetToggle />,
-    );
+    const { getByTestId, getByText } = renderToggle(<PerpsTestnetToggle />);
 
     const switchElement = getByTestId(PerpsTestnetToggleSelectorsIDs.SWITCH);
     expect(switchElement.props.value).toBe(true);
@@ -65,9 +50,7 @@ describe('PerpsTestnetToggle', () => {
   it('renders correctly with mainnet network', () => {
     mockUsePerpsNetwork.mockReturnValue('mainnet');
 
-    const { getByTestId, getByText } = renderWithToastContext(
-      <PerpsTestnetToggle />,
-    );
+    const { getByTestId, getByText } = renderToggle(<PerpsTestnetToggle />);
 
     const switchElement = getByTestId(PerpsTestnetToggleSelectorsIDs.SWITCH);
     expect(switchElement.props.value).toBe(false);
@@ -83,7 +66,7 @@ describe('PerpsTestnetToggle', () => {
       isTestnet: false,
     });
 
-    const { getByTestId } = renderWithToastContext(<PerpsTestnetToggle />);
+    const { getByTestId } = renderToggle(<PerpsTestnetToggle />);
 
     const switchElement = getByTestId(PerpsTestnetToggleSelectorsIDs.SWITCH);
     expect(switchElement.props.value).toBe(true);
@@ -96,7 +79,7 @@ describe('PerpsTestnetToggle', () => {
       expect(mockToggleTestnet).toHaveBeenCalledTimes(1);
     });
 
-    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(toast).not.toHaveBeenCalled();
   });
 
   it('toggles from mainnet to testnet successfully', async () => {
@@ -106,7 +89,7 @@ describe('PerpsTestnetToggle', () => {
       isTestnet: true,
     });
 
-    const { getByTestId } = renderWithToastContext(<PerpsTestnetToggle />);
+    const { getByTestId } = renderToggle(<PerpsTestnetToggle />);
 
     const switchElement = getByTestId(PerpsTestnetToggleSelectorsIDs.SWITCH);
     expect(switchElement.props.value).toBe(false);
@@ -119,7 +102,7 @@ describe('PerpsTestnetToggle', () => {
       expect(mockToggleTestnet).toHaveBeenCalledTimes(1);
     });
 
-    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(toast).not.toHaveBeenCalled();
   });
 
   it('displays error toast when toggle fails', async () => {
@@ -128,7 +111,7 @@ describe('PerpsTestnetToggle', () => {
       success: false,
     });
 
-    const { getByTestId } = renderWithToastContext(<PerpsTestnetToggle />);
+    const { getByTestId } = renderToggle(<PerpsTestnetToggle />);
 
     const switchElement = getByTestId(PerpsTestnetToggleSelectorsIDs.SWITCH);
 
@@ -140,16 +123,10 @@ describe('PerpsTestnetToggle', () => {
       expect(mockToggleTestnet).toHaveBeenCalledTimes(1);
     });
 
-    expect(mockShowToast).toHaveBeenCalledWith(
+    expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Warning,
-        iconColor: IconColor.Error,
-        labelOptions: expect.arrayContaining([
-          expect.objectContaining({
-            label: 'Failed to toggle network',
-          }),
-        ]),
+        title: 'Failed to toggle network',
+        severity: ToastSeverity.Danger,
         hasNoTimeout: false,
       }),
     );
@@ -165,9 +142,7 @@ describe('PerpsTestnetToggle', () => {
     });
     mockToggleTestnet.mockReturnValue(togglePromise);
 
-    const { getByTestId, queryByTestId } = renderWithToastContext(
-      <PerpsTestnetToggle />,
-    );
+    const { getByTestId, queryByTestId } = renderToggle(<PerpsTestnetToggle />);
 
     const switchElement = getByTestId(PerpsTestnetToggleSelectorsIDs.SWITCH);
 
@@ -203,7 +178,7 @@ describe('PerpsTestnetToggle', () => {
       isTestnet: false,
     });
 
-    const { getByTestId } = renderWithToastContext(<PerpsTestnetToggle />);
+    const { getByTestId } = renderToggle(<PerpsTestnetToggle />);
 
     const switchElement = getByTestId(PerpsTestnetToggleSelectorsIDs.SWITCH);
     expect(switchElement.props.value).toBe(true);
@@ -223,7 +198,7 @@ describe('PerpsTestnetToggle', () => {
       success: false,
     });
 
-    const { getByTestId } = renderWithToastContext(<PerpsTestnetToggle />);
+    const { getByTestId } = renderToggle(<PerpsTestnetToggle />);
 
     const switchElement = getByTestId(PerpsTestnetToggleSelectorsIDs.SWITCH);
     expect(switchElement.props.value).toBe(true);
@@ -233,7 +208,7 @@ describe('PerpsTestnetToggle', () => {
     });
 
     await waitFor(() => {
-      expect(mockShowToast).toHaveBeenCalled();
+      expect(toast).toHaveBeenCalled();
     });
 
     // Switch should maintain original state since toggle failed
@@ -244,7 +219,7 @@ describe('PerpsTestnetToggle', () => {
     // Start with testnet
     mockUsePerpsNetwork.mockReturnValue('testnet');
 
-    const { getByTestId, getByText, rerender } = renderWithToastContext(
+    const { getByTestId, getByText, rerender } = renderToggle(
       <PerpsTestnetToggle />,
     );
 
@@ -257,11 +232,7 @@ describe('PerpsTestnetToggle', () => {
     // Simulate external network change to mainnet
     mockUsePerpsNetwork.mockReturnValue('mainnet');
 
-    rerender(
-      <ToastContext.Provider value={{ toastRef: mockToastRef }}>
-        <PerpsTestnetToggle />
-      </ToastContext.Provider>,
-    );
+    rerender(<PerpsTestnetToggle />);
 
     // Should now show mainnet
     await waitFor(() => {

--- a/app/components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsTestnetToggle.tsx
+++ b/app/components/UI/Perps/components/PerpsDeveloperOptionsSection/PerpsTestnetToggle.tsx
@@ -1,14 +1,6 @@
-import {
-  IconColor,
-  IconName,
-} from '../../../../../component-library/components/Icons/Icon';
-import React, { useState, useContext, useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 import { View, Switch, ActivityIndicator, StyleSheet } from 'react-native';
 import { strings } from '../../../../../../locales/i18n';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../../component-library/components/Toast';
 import { useStyles } from '../../../../hooks/useStyles';
 import { usePerpsNetworkConfig, usePerpsNetwork } from '../../hooks';
 import { PerpsTestnetToggleSelectorsIDs } from '../../Perps.testIds';
@@ -16,6 +8,8 @@ import {
   Text,
   TextColor,
   TextVariant,
+  toast,
+  ToastSeverity,
 } from '@metamask/design-system-react-native';
 
 const PerpsTestnetToggleStyles = () =>
@@ -40,8 +34,6 @@ export const PerpsTestnetToggle = () => {
 
   const [isLoading, setIsLoading] = useState(false);
 
-  const { toastRef } = useContext(ToastContext);
-
   const handleTestnetToggle = async () => {
     setIsLoading(true);
 
@@ -53,15 +45,9 @@ export const PerpsTestnetToggle = () => {
       return;
     }
 
-    toastRef?.current?.showToast({
-      variant: ToastVariants.Icon,
-      iconName: IconName.Warning,
-      iconColor: IconColor.Error,
-      labelOptions: [
-        {
-          label: strings('perps.errors.failed_to_toggle_network'),
-        },
-      ],
+    toast({
+      title: strings('perps.errors.failed_to_toggle_network'),
+      severity: ToastSeverity.Danger,
       hasNoTimeout: false,
     });
   };

--- a/app/components/UI/Perps/hooks/usePerpsOrderDepositTracking.test.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderDepositTracking.test.ts
@@ -4,25 +4,11 @@ import {
   TransactionType,
   type TransactionMeta,
 } from '@metamask/transaction-controller';
-import React from 'react';
 import { usePerpsOrderDepositTracking } from './usePerpsOrderDepositTracking';
-import { ToastContext } from '../../../../component-library/components/Toast';
 
 const mockShowToast = jest.fn();
-const mockCloseToast = jest.fn();
 const mockSubscribe = jest.fn();
 const mockTrack = jest.fn();
-
-const toastContextValue = {
-  toastRef: { current: { showToast: jest.fn(), closeToast: mockCloseToast } },
-};
-
-const wrapper = ({ children }: { children: React.ReactNode }) =>
-  React.createElement(
-    ToastContext.Provider,
-    { value: toastContextValue },
-    children,
-  );
 
 jest.mock('./usePerpsToasts', () => ({
   __esModule: true,
@@ -36,7 +22,8 @@ jest.mock('./usePerpsToasts', () => ({
             transactionId,
           })),
           takingLonger: {
-            closeButtonOptions: { onPress: undefined },
+            hasNoTimeout: true,
+            actionButtonOnPress: undefined,
           },
           tradeCanceled: { tradeCanceled: true },
           error: { error: true },
@@ -101,17 +88,13 @@ describe('usePerpsOrderDepositTracking', () => {
   });
 
   it('returns handleDepositConfirm function', () => {
-    const { result } = renderHook(() => usePerpsOrderDepositTracking(), {
-      wrapper,
-    });
+    const { result } = renderHook(() => usePerpsOrderDepositTracking());
 
     expect(typeof result.current.handleDepositConfirm).toBe('function');
   });
 
   it('does nothing when transaction type is not perpsDepositAndOrder', () => {
-    const { result } = renderHook(() => usePerpsOrderDepositTracking(), {
-      wrapper,
-    });
+    const { result } = renderHook(() => usePerpsOrderDepositTracking());
     const otherMeta = {
       id: 'other-id',
       type: TransactionType.simpleSend,
@@ -128,10 +111,8 @@ describe('usePerpsOrderDepositTracking', () => {
     expect(callback).not.toHaveBeenCalled();
   });
 
-  it('shows persistent progress toast with close button and subscribes to controller when type is perpsDepositAndOrder', () => {
-    const { result } = renderHook(() => usePerpsOrderDepositTracking(), {
-      wrapper,
-    });
+  it('shows persistent progress toast and subscribes to controller when type is perpsDepositAndOrder', () => {
+    const { result } = renderHook(() => usePerpsOrderDepositTracking());
 
     act(() => {
       result.current.handleDepositConfirm(perpsDepositMeta, jest.fn());
@@ -141,13 +122,7 @@ describe('usePerpsOrderDepositTracking', () => {
     const progressToastArg = mockShowToast.mock.calls[0][0];
     expect(progressToastArg).toMatchObject({
       hasNoTimeout: true,
-      closeButtonOptions: expect.objectContaining({
-        onPress: expect.any(Function),
-      }),
     });
-
-    progressToastArg.closeButtonOptions.onPress();
-    expect(mockCloseToast).toHaveBeenCalled();
 
     expect(mockSubscribe).toHaveBeenCalledWith(
       'TransactionController:transactionFailed',
@@ -160,9 +135,7 @@ describe('usePerpsOrderDepositTracking', () => {
   });
 
   it('invokes callback when transaction status becomes confirmed', () => {
-    const { result } = renderHook(() => usePerpsOrderDepositTracking(), {
-      wrapper,
-    });
+    const { result } = renderHook(() => usePerpsOrderDepositTracking());
     const handlers: {
       statusUpdated?: (payload: { transactionMeta: TransactionMeta }) => void;
     } = {};
@@ -203,9 +176,7 @@ describe('usePerpsOrderDepositTracking', () => {
   });
 
   it('does not invoke callback when transaction confirms after cancel trade requested', () => {
-    const { result } = renderHook(() => usePerpsOrderDepositTracking(), {
-      wrapper,
-    });
+    const { result } = renderHook(() => usePerpsOrderDepositTracking());
     const handlers: {
       statusUpdated?: (payload: { transactionMeta: TransactionMeta }) => void;
     } = {};
@@ -230,11 +201,11 @@ describe('usePerpsOrderDepositTracking', () => {
     jest.advanceTimersByTime(100);
 
     const takingLongerCall = mockShowToast.mock.calls[callCountBeforeAdvance];
-    const closeButtonOptions = takingLongerCall?.[0] as {
-      closeButtonOptions?: { onPress: () => void };
+    const takingLongerArg = takingLongerCall?.[0] as {
+      actionButtonOnPress?: () => void;
     };
     act(() => {
-      closeButtonOptions?.closeButtonOptions?.onPress?.();
+      takingLongerArg?.actionButtonOnPress?.();
     });
 
     expect(mockTrack).toHaveBeenCalledWith(
@@ -264,9 +235,7 @@ describe('usePerpsOrderDepositTracking', () => {
   });
 
   it('shows error toast when transaction fails with matching id', () => {
-    const { result } = renderHook(() => usePerpsOrderDepositTracking(), {
-      wrapper,
-    });
+    const { result } = renderHook(() => usePerpsOrderDepositTracking());
     const handlers: {
       failed?: (payload: { transactionMeta: TransactionMeta }) => void;
     } = {};
@@ -306,9 +275,7 @@ describe('usePerpsOrderDepositTracking', () => {
   });
 
   it('shows taking longer toast after delay', () => {
-    const { result } = renderHook(() => usePerpsOrderDepositTracking(), {
-      wrapper,
-    });
+    const { result } = renderHook(() => usePerpsOrderDepositTracking());
 
     act(() => {
       result.current.handleDepositConfirm(perpsDepositMeta, jest.fn());
@@ -329,7 +296,7 @@ describe('usePerpsOrderDepositTracking', () => {
 
     expect(mockShowToast).toHaveBeenCalled();
     expect(mockShowToast.mock.calls[0][0]).toMatchObject({
-      closeButtonOptions: expect.any(Object),
+      hasNoTimeout: true,
     });
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsOrderDepositTracking.ts
+++ b/app/components/UI/Perps/hooks/usePerpsOrderDepositTracking.ts
@@ -3,7 +3,7 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
-import { useCallback, useContext } from 'react';
+import { useCallback } from 'react';
 import Engine from '../../../../core/Engine';
 import { strings } from '../../../../../locales/i18n';
 import {
@@ -11,11 +11,8 @@ import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
 } from '@metamask/perps-controller';
-import { IconName } from '../../../../component-library/components/Icons/Icon';
-import { ToastContext } from '../../../../component-library/components/Toast';
-import { ButtonIconVariant } from '../../../../component-library/components/Toast/Toast.types';
-import usePerpsToasts from './usePerpsToasts';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
+import usePerpsToasts from './usePerpsToasts';
 import { usePerpsEventTracking } from './usePerpsEventTracking';
 
 /**
@@ -33,7 +30,6 @@ import { usePerpsEventTracking } from './usePerpsEventTracking';
 export const usePerpsOrderDepositTracking = () => {
   const { showToast, PerpsToastOptions } = usePerpsToasts();
   const { track } = usePerpsEventTracking();
-  const { toastRef } = useContext(ToastContext);
 
   const showProgressToast = useCallback(
     (transactionId: string) => {
@@ -42,21 +38,12 @@ export const usePerpsOrderDepositTracking = () => {
           0,
           transactionId,
         ),
-        labelOptions: [
-          {
-            label: strings('perps.deposit.depositing_your_funds'),
-            isBold: true,
-          },
-        ],
+        title: strings('perps.deposit.depositing_your_funds'),
+        description: undefined,
         hasNoTimeout: true,
-        closeButtonOptions: {
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-          onPress: () => toastRef?.current?.closeToast(),
-        },
       });
     },
-    [showToast, PerpsToastOptions, toastRef],
+    [showToast, PerpsToastOptions],
   );
 
   // Callback to show toast when user confirms the deposit
@@ -83,8 +70,6 @@ export const usePerpsOrderDepositTracking = () => {
         showToast(PerpsToastOptions.accountManagement.deposit.tradeCanceled);
       };
       const depositLongerTimeoutId = setTimeout(() => {
-        const baseClose = takingLongerToastOptions.closeButtonOptions;
-
         track(MetaMetricsEvents.PERPS_SCREEN_VIEWED, {
           [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
             PERPS_EVENT_VALUE.SCREEN_TYPE.CANCEL_TRADE_WITH_TOKEN_TOAST,
@@ -92,10 +77,8 @@ export const usePerpsOrderDepositTracking = () => {
 
         showToast({
           ...takingLongerToastOptions,
-          closeButtonOptions: baseClose
-            ? { ...baseClose, onPress: cancelTradeOnPress }
-            : undefined,
-        } as Parameters<typeof showToast>[0]);
+          actionButtonOnPress: cancelTradeOnPress,
+        });
       }, PERPS_CONSTANTS.DepositTakingLongerToastDelayMs);
 
       // Handle failed transactions

--- a/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
@@ -1,23 +1,9 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-import { useContext } from 'react';
 import { useNavigation } from '@react-navigation/native';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { playNotification, NotificationMoment } from '../../../../util/haptics';
 import usePerpsToasts, { PerpsToastOptions } from './usePerpsToasts';
-import {
-  ButtonIconVariant,
-  ToastVariants,
-} from '../../../../component-library/components/Toast/Toast.types';
-import {
-  IconColor,
-  IconName,
-} from '../../../../component-library/components/Icons/Icon';
-import { ButtonVariants } from '../../../../component-library/components/Buttons/Button';
 import Routes from '../../../../constants/navigation/Routes';
-import { mockTheme } from '../../../../util/theme';
-jest.mock('react', () => ({
-  ...jest.requireActual('react'),
-  useContext: jest.fn(),
-}));
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
@@ -35,29 +21,14 @@ jest.mock('../../../../util/theme', () => {
   };
 });
 
-jest.mock('@metamask/design-system-react-native', () => ({
-  IconSize: {
-    Lg: 'lg',
-    Xl: 'xl',
-  },
-  IconColor: {
-    IconDefault: 'icon-default',
-    PrimaryDefault: 'primary-default',
-  },
-  Text: 'Text',
-  TextVariant: {
-    BodyMd: 'BodyMd',
-    BodySm: 'BodySm',
-    BodySMMedium: 'BodySMMedium',
-  },
-  TextColor: {
-    TextDefault: 'TextDefault',
-  },
-  Spinner: 'Spinner',
-  FontWeight: {
-    Medium: 'medium',
-  },
-}));
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+    Spinner: 'Spinner',
+  };
+});
 
 let mockTransactionsRedesignEnabled = false;
 let mockDepositMeta: { chainId: string } | undefined;
@@ -90,12 +61,7 @@ jest.mock('../utils/translatePerpsError', () => ({
 }));
 
 describe('usePerpsToasts', () => {
-  let mockShowToast: jest.Mock;
-  let mockCloseToast: jest.Mock;
   let mockNavigate: jest.Mock;
-  let mockToastRef: {
-    current: { showToast: jest.Mock; closeToast: jest.Mock };
-  };
 
   const mockTransactionId = 'c9a6ab70-8e70-11f0-8de9-353809172f0a';
 
@@ -104,18 +70,7 @@ describe('usePerpsToasts', () => {
 
     mockTransactionsRedesignEnabled = false;
     mockDepositMeta = undefined;
-    mockShowToast = jest.fn();
-    mockCloseToast = jest.fn();
     mockNavigate = jest.fn();
-
-    mockToastRef = {
-      current: {
-        showToast: mockShowToast,
-        closeToast: mockCloseToast,
-      },
-    };
-
-    (useContext as jest.Mock).mockReturnValue({ toastRef: mockToastRef });
     (useNavigation as jest.Mock).mockReturnValue({ navigate: mockNavigate });
   });
 
@@ -124,13 +79,12 @@ describe('usePerpsToasts', () => {
   });
 
   describe('showToast function', () => {
-    it('calls toastRef showToast and triggers haptic feedback', () => {
+    it('calls toast and triggers haptic feedback', () => {
       const { result } = renderHook(() => usePerpsToasts());
       const testConfig = {
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
+        severity: ToastSeverity.Success,
         hapticsType: NotificationMoment.Success,
-        labelOptions: [{ label: 'Test', isBold: true }],
+        title: 'Test',
         hasNoTimeout: false,
       } as unknown as PerpsToastOptions;
 
@@ -138,16 +92,15 @@ describe('usePerpsToasts', () => {
         result.current.showToast(testConfig);
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        labelOptions: [{ label: 'Test', isBold: true }],
+      expect(toast).toHaveBeenCalledWith({
+        severity: ToastSeverity.Success,
+        title: 'Test',
         hasNoTimeout: false,
       });
       expect(playNotification).toHaveBeenCalledWith(NotificationMoment.Success);
     });
 
-    it('passes retryable withdrawal start failed toast options to toastRef', () => {
+    it('passes retryable withdrawal start failed toast options to toast', () => {
       const onRetry = jest.fn();
       const { result } = renderHook(() => usePerpsToasts());
       const config =
@@ -159,15 +112,11 @@ describe('usePerpsToasts', () => {
         result.current.showToast(config);
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Error,
-          iconColor: IconColor.Error,
-          linkButtonOptions: {
-            label: 'Try again',
-            onPress: onRetry,
-          },
+          severity: ToastSeverity.Danger,
+          actionButtonLabel: 'Try again',
+          actionButtonOnPress: onRetry,
         }),
       );
       expect(playNotification).toHaveBeenCalledWith(NotificationMoment.Error);
@@ -184,16 +133,12 @@ describe('usePerpsToasts', () => {
           );
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Confirmation,
+          severity: ToastSeverity.Success,
           hapticsType: NotificationMoment.Success,
           hasNoTimeout: false,
         });
-        expect(config.labelOptions).toEqual([
-          { label: 'Your Perps account was funded', isBold: true },
-          { label: '\n', isBold: false },
-          { label: '$100 available to trade', isBold: false },
-        ]);
+        expect(config.title).toBe('Your Perps account was funded');
+        expect(config.description).toBe('$100 available to trade');
       });
 
       it('returns in progress configuration with processing time', () => {
@@ -205,16 +150,11 @@ describe('usePerpsToasts', () => {
           );
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Loading,
           hapticsType: NotificationMoment.Warning,
         });
         expect(config.startAccessory).toBeTruthy();
-        expect(config.closeButtonOptions).toMatchObject({
-          label: 'Track',
-          variant: ButtonVariants.Link,
-        });
-        expect(typeof config.closeButtonOptions?.onPress).toBe('function');
+        expect(config.actionButtonLabel).toBe('Track');
+        expect(typeof config.actionButtonOnPress).toBe('function');
       });
 
       it('tracks to the redesigned details screen when the redesign is enabled', () => {
@@ -228,7 +168,7 @@ describe('usePerpsToasts', () => {
           );
 
         act(() => {
-          config.closeButtonOptions?.onPress?.();
+          config.actionButtonOnPress?.();
         });
 
         expect(mockNavigate).toHaveBeenCalledWith(Routes.ACTIVITY_DETAILS, {
@@ -251,7 +191,7 @@ describe('usePerpsToasts', () => {
           );
 
         act(() => {
-          config.closeButtonOptions?.onPress?.();
+          config.actionButtonOnPress?.();
         });
 
         expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTION_DETAILS, {
@@ -267,10 +207,7 @@ describe('usePerpsToasts', () => {
             mockTransactionId,
           );
 
-        expect(config.labelOptions).toContainEqual({
-          label: 'Funds will be available momentarily',
-          isBold: false,
-        });
+        expect(config.description).toBe('Funds will be available momentarily');
       });
 
       it('returns error configuration', () => {
@@ -279,8 +216,7 @@ describe('usePerpsToasts', () => {
           result.current.PerpsToastOptions.accountManagement.deposit.error;
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Warning,
+          severity: ToastSeverity.Danger,
           hapticsType: NotificationMoment.Error,
         });
       });
@@ -293,13 +229,9 @@ describe('usePerpsToasts', () => {
           result.current.PerpsToastOptions.accountManagement.withdrawal
             .withdrawalInProgress;
 
-        expect(config.labelOptions).toEqual([
-          { label: 'Withdrawal initiated', isBold: true },
-        ]);
+        expect(config.title).toBe('Withdrawal initiated');
         expect(config.startAccessory).toBeTruthy();
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Loading,
           hapticsType: NotificationMoment.Warning,
         });
       });
@@ -312,14 +244,10 @@ describe('usePerpsToasts', () => {
             'USDC',
           );
 
-        expect(config.labelOptions).toEqual([
-          { isBold: true, label: 'Withdrawal confirmed' },
-          { isBold: false, label: '\n' },
-          {
-            isBold: false,
-            label: "You'll receive 99.00 USDC on Arbitrum within 5 minutes",
-          },
-        ]);
+        expect(config.title).toBe('Withdrawal confirmed');
+        expect(config.description).toBe(
+          "You'll receive 99.00 USDC on Arbitrum within 5 minutes",
+        );
       });
 
       it('returns withdrawal failed configuration with custom error', () => {
@@ -329,10 +257,7 @@ describe('usePerpsToasts', () => {
             'Custom error',
           );
 
-        expect(config.labelOptions).toContainEqual({
-          label: 'Custom error',
-          isBold: false,
-        });
+        expect(config.description).toBe('Custom error');
       });
 
       it('returns withdrawal failed configuration with default error', () => {
@@ -340,10 +265,7 @@ describe('usePerpsToasts', () => {
         const config =
           result.current.PerpsToastOptions.accountManagement.withdrawal.withdrawalFailed();
 
-        expect(config.labelOptions).toContainEqual({
-          label: 'An error occurred during withdrawal',
-          isBold: false,
-        });
+        expect(config.description).toBe('An error occurred during withdrawal');
       });
 
       it('returns withdrawal start failed configuration with retry action', () => {
@@ -354,18 +276,12 @@ describe('usePerpsToasts', () => {
             onRetry,
           );
 
-        expect(config.labelOptions).toEqual([
-          { label: 'Something went wrong', isBold: true },
-          { label: '\n', isBold: false },
-          { label: 'Your withdrawal wasn’t started.', isBold: false },
-        ]);
-        expect(config.linkButtonOptions).toMatchObject({
-          label: 'Try again',
-          onPress: onRetry,
-        });
+        expect(config.title).toBe('Something went wrong');
+        expect(config.description).toBe('Your withdrawal wasn’t started.');
+        expect(config.actionButtonLabel).toBe('Try again');
+        expect(config.actionButtonOnPress).toBe(onRetry);
         expect(config).toMatchObject({
-          iconName: IconName.Error,
-          iconColor: IconColor.Error,
+          severity: ToastSeverity.Danger,
         });
       });
     });
@@ -380,15 +296,10 @@ describe('usePerpsToasts', () => {
             'ETH',
           );
 
-        expect(config.labelOptions).toEqual([
-          { label: 'Order submitted', isBold: true },
-          { label: '\n', isBold: false },
-          { label: 'Long 0.5 ETH', isBold: false },
-        ]);
+        expect(config.title).toBe('Order submitted');
+        expect(config.description).toBe('Long 0.5 ETH');
         expect(config.startAccessory).toBeTruthy();
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Loading,
           hapticsType: NotificationMoment.Warning,
         });
       });
@@ -403,12 +314,9 @@ describe('usePerpsToasts', () => {
           );
 
         expect(config).toMatchObject({
-          iconName: IconName.Confirmation,
+          severity: ToastSeverity.Success,
         });
-        expect(config.labelOptions).toContainEqual({
-          label: 'Order filled',
-          isBold: true,
-        });
+        expect(config.title).toBe('Order filled');
       });
 
       it('returns market order creation failed configuration', () => {
@@ -418,10 +326,7 @@ describe('usePerpsToasts', () => {
             'Network error',
           );
 
-        expect(config.labelOptions).toContainEqual({
-          label: 'Network error',
-          isBold: false,
-        });
+        expect(config.description).toBe('Network error');
       });
 
       it('strips hip3 prefix from asset symbol in market order submitted', () => {
@@ -433,10 +338,7 @@ describe('usePerpsToasts', () => {
             'hip3:BTC',
           );
 
-        expect(config.labelOptions).toContainEqual({
-          label: 'Long 0.5 BTC',
-          isBold: false,
-        });
+        expect(config.description).toBe('Long 0.5 BTC');
       });
 
       it('strips DEX prefix from asset symbol in market order confirmed', () => {
@@ -448,10 +350,7 @@ describe('usePerpsToasts', () => {
             'xyz:TSLA',
           );
 
-        expect(config.labelOptions).toContainEqual({
-          label: 'Short 10 TSLA',
-          isBold: false,
-        });
+        expect(config.description).toBe('Short 10 TSLA');
       });
 
       it('keeps regular asset symbols unchanged in market orders', () => {
@@ -463,10 +362,7 @@ describe('usePerpsToasts', () => {
             'SOL',
           );
 
-        expect(config.labelOptions).toContainEqual({
-          label: 'Long 2 SOL',
-          isBold: false,
-        });
+        expect(config.description).toBe('Long 2 SOL');
       });
     });
 
@@ -480,15 +376,10 @@ describe('usePerpsToasts', () => {
             'ETH',
           );
 
-        expect(config.labelOptions).toEqual([
-          { label: 'Order submitted', isBold: true },
-          { label: '\n', isBold: false },
-          { label: 'Long 0.5 ETH', isBold: false },
-        ]);
+        expect(config.title).toBe('Order submitted');
+        expect(config.description).toBe('Long 0.5 ETH');
         expect(config.startAccessory).toBeTruthy();
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Loading,
           hapticsType: NotificationMoment.Warning,
         });
       });
@@ -503,12 +394,9 @@ describe('usePerpsToasts', () => {
           );
 
         expect(config).toMatchObject({
-          iconName: IconName.Confirmation,
+          severity: ToastSeverity.Success,
         });
-        expect(config.labelOptions).toContainEqual({
-          label: 'Order placed',
-          isBold: true,
-        });
+        expect(config.title).toBe('Order placed');
       });
 
       it('returns limit order creation failed configuration', () => {
@@ -518,10 +406,7 @@ describe('usePerpsToasts', () => {
             'Network error',
           );
 
-        expect(config.labelOptions).toContainEqual({
-          label: 'Network error',
-          isBold: false,
-        });
+        expect(config.description).toBe('Network error');
       });
 
       it('strips hip3 prefix from asset symbol in limit order submitted', () => {
@@ -533,10 +418,7 @@ describe('usePerpsToasts', () => {
             'hip3:ETH',
           );
 
-        expect(config.labelOptions).toContainEqual({
-          label: 'Short 1.5 ETH',
-          isBold: false,
-        });
+        expect(config.description).toBe('Short 1.5 ETH');
       });
 
       it('strips DEX prefix from asset symbol in limit order confirmed', () => {
@@ -548,10 +430,7 @@ describe('usePerpsToasts', () => {
             'abc:AAPL',
           );
 
-        expect(config.labelOptions).toContainEqual({
-          label: 'Long 100 AAPL',
-          isBold: false,
-        });
+        expect(config.description).toBe('Long 100 AAPL');
       });
 
       it('keeps regular asset symbols unchanged in limit orders', () => {
@@ -563,10 +442,7 @@ describe('usePerpsToasts', () => {
             'BTC',
           );
 
-        expect(config.labelOptions).toContainEqual({
-          label: 'Long 5 BTC',
-          isBold: false,
-        });
+        expect(config.description).toBe('Long 5 BTC');
       });
     });
 
@@ -576,25 +452,11 @@ describe('usePerpsToasts', () => {
         const config =
           result.current.PerpsToastOptions.orderManagement.shared.submitting();
 
-        expect(config.labelOptions).toEqual([
-          { label: 'Submitting your trade', isBold: true },
-        ]);
+        expect(config.title).toBe('Submitting your trade');
         expect(config.hasNoTimeout).toBe(true);
-        expect(config.closeButtonOptions).toMatchObject({
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-        });
-        expect(config.closeButtonOptions?.onPress).toBeDefined();
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Loading,
           hapticsType: NotificationMoment.Warning,
         });
-
-        act(() => {
-          config.closeButtonOptions?.onPress?.();
-        });
-        expect(mockCloseToast).toHaveBeenCalled();
       });
 
       it('returns cancellation in progress configuration with detailed order type', () => {
@@ -607,15 +469,10 @@ describe('usePerpsToasts', () => {
             'Take Profit Limit',
           );
 
-        expect(config.labelOptions).toEqual([
-          { label: 'Cancelling take profit limit order', isBold: true },
-          { label: '\n', isBold: false },
-          { label: 'long 2.5 SOL', isBold: false },
-        ]);
+        expect(config.title).toBe('Cancelling take profit limit order');
+        expect(config.description).toBe('long 2.5 SOL');
         expect(config.startAccessory).toBeTruthy();
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Loading,
           hapticsType: NotificationMoment.Warning,
         });
       });
@@ -629,15 +486,10 @@ describe('usePerpsToasts', () => {
             'ETH',
           );
 
-        expect(config.labelOptions).toEqual([
-          { label: 'Cancelling order', isBold: true },
-          { label: '\n', isBold: false },
-          { label: 'short 1.0 ETH', isBold: false },
-        ]);
+        expect(config.title).toBe('Cancelling order');
+        expect(config.description).toBe('short 1.0 ETH');
         expect(config.startAccessory).toBeTruthy();
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Loading,
           hapticsType: NotificationMoment.Warning,
         });
       });
@@ -653,14 +505,10 @@ describe('usePerpsToasts', () => {
             'BTC',
           );
 
-        expect(config.labelOptions).toEqual([
-          { label: 'Stop market order cancelled', isBold: true },
-          { label: '\n', isBold: false },
-          { label: 'long 0.5 BTC', isBold: false },
-        ]);
+        expect(config.title).toBe('Stop market order cancelled');
+        expect(config.description).toBe('long 0.5 BTC');
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Confirmation,
+          severity: ToastSeverity.Success,
           hapticsType: NotificationMoment.Success,
         });
       });
@@ -672,17 +520,10 @@ describe('usePerpsToasts', () => {
             false,
           );
 
-        expect(config.labelOptions).toContainEqual({
-          label: 'Order cancelled',
-          isBold: true,
-        });
-        expect(config.labelOptions).toContainEqual({
-          label: 'Funds are available to trade',
-          isBold: false,
-        });
+        expect(config.title).toBe('Order cancelled');
+        expect(config.description).toBe('Funds are available to trade');
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Confirmation,
+          severity: ToastSeverity.Success,
           hapticsType: NotificationMoment.Success,
         });
       });
@@ -695,18 +536,11 @@ describe('usePerpsToasts', () => {
             'Limit Close',
           );
 
-        expect(config.labelOptions).toContainEqual({
-          label: 'Limit close order cancelled',
-          isBold: true,
-        });
+        expect(config.title).toBe('Limit close order cancelled');
         // Should not have the "funds available" message for reduce-only orders
-        expect(config.labelOptions).not.toContainEqual({
-          label: 'Funds are available to trade',
-          isBold: false,
-        });
+        expect(config.description).not.toBe('Funds are available to trade');
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Confirmation,
+          severity: ToastSeverity.Success,
           hapticsType: NotificationMoment.Success,
         });
       });
@@ -717,14 +551,10 @@ describe('usePerpsToasts', () => {
           result.current.PerpsToastOptions.orderManagement.shared
             .cancellationFailed;
 
-        expect(config.labelOptions).toEqual([
-          { label: 'Failed to cancel order', isBold: true },
-          { label: '\n', isBold: false },
-          { label: 'Order still active', isBold: false },
-        ]);
+        expect(config.title).toBe('Failed to cancel order');
+        expect(config.description).toBe('Order still active');
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Warning,
+          severity: ToastSeverity.Danger,
           hapticsType: NotificationMoment.Error,
         });
       });
@@ -736,14 +566,10 @@ describe('usePerpsToasts', () => {
             3,
           );
 
-        expect(config.labelOptions).toEqual([
-          { label: 'Orders canceled', isBold: true },
-          { label: '\n', isBold: false },
-          { label: 'Successfully canceled 3 order(s)', isBold: false },
-        ]);
+        expect(config.title).toBe('Orders canceled');
+        expect(config.description).toBe('Successfully canceled 3 order(s)');
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Confirmation,
+          severity: ToastSeverity.Success,
           hapticsType: NotificationMoment.Success,
         });
       });
@@ -756,14 +582,10 @@ describe('usePerpsToasts', () => {
             5,
           );
 
-        expect(config.labelOptions).toEqual([
-          { label: 'Orders canceled', isBold: true },
-          { label: '\n', isBold: false },
-          { label: 'Canceled 2 of 5 orders', isBold: false },
-        ]);
+        expect(config.title).toBe('Orders canceled');
+        expect(config.description).toBe('Canceled 2 of 5 orders');
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Confirmation,
+          severity: ToastSeverity.Success,
           hapticsType: NotificationMoment.Success,
         });
       });
@@ -775,14 +597,10 @@ describe('usePerpsToasts', () => {
             'Network error',
           );
 
-        expect(config.labelOptions).toEqual([
-          { label: 'Failed to cancel orders', isBold: true },
-          { label: '\n', isBold: false },
-          { label: 'Network error', isBold: false },
-        ]);
+        expect(config.title).toBe('Failed to cancel orders');
+        expect(config.description).toBe('Network error');
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Warning,
+          severity: ToastSeverity.Danger,
           hapticsType: NotificationMoment.Error,
         });
       });
@@ -792,14 +610,10 @@ describe('usePerpsToasts', () => {
         const config =
           result.current.PerpsToastOptions.orderManagement.shared.cancelAllFailed();
 
-        expect(config.labelOptions).toEqual([
-          { label: 'Failed to cancel orders', isBold: true },
-          { label: '\n', isBold: false },
-          { label: 'Unknown error', isBold: false },
-        ]);
+        expect(config.title).toBe('Failed to cancel orders');
+        expect(config.description).toBe('Unknown error');
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Warning,
+          severity: ToastSeverity.Danger,
           hapticsType: NotificationMoment.Error,
         });
       });
@@ -814,10 +628,7 @@ describe('usePerpsToasts', () => {
             'Stop Loss',
           );
 
-        expect(config.labelOptions).toContainEqual({
-          label: 'long 3 SOL',
-          isBold: false,
-        });
+        expect(config.description).toBe('long 3 SOL');
       });
 
       it('strips DEX prefix from asset symbol in cancellation success', () => {
@@ -831,10 +642,7 @@ describe('usePerpsToasts', () => {
             'xyz:TSLA',
           );
 
-        expect(config.labelOptions).toContainEqual({
-          label: 'short 50 TSLA',
-          isBold: false,
-        });
+        expect(config.description).toBe('short 50 TSLA');
       });
 
       it('keeps regular asset symbols unchanged in cancellation', () => {
@@ -846,10 +654,7 @@ describe('usePerpsToasts', () => {
             'ETH',
           );
 
-        expect(config.labelOptions).toContainEqual({
-          label: 'long 1.5 ETH',
-          isBold: false,
-        });
+        expect(config.description).toBe('long 1.5 ETH');
       });
     });
 
@@ -863,15 +668,10 @@ describe('usePerpsToasts', () => {
             'ETH',
           );
 
-        expect(config.labelOptions).toEqual([
-          { label: 'Closing position', isBold: true },
-          { label: '\n', isBold: false },
-          { label: 'long 1.5 ETH', isBold: false },
-        ]);
+        expect(config.title).toBe('Closing position');
+        expect(config.description).toBe('long 1.5 ETH');
         expect(config.startAccessory).toBeTruthy();
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Loading,
           hapticsType: NotificationMoment.Warning,
         });
       });
@@ -891,23 +691,12 @@ describe('usePerpsToasts', () => {
           );
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Confirmation,
+          severity: ToastSeverity.Success,
           hapticsType: NotificationMoment.Success,
         });
-        expect(config.labelOptions).toHaveLength(3);
-        expect(config.labelOptions?.[0]).toMatchObject({
-          label: 'Position closed',
-          isBold: true,
-        });
-        expect(config.labelOptions?.[1]).toMatchObject({
-          label: '\n',
-          isBold: false,
-        });
-        expect(config.closeButtonOptions).toMatchObject({
-          variant: ButtonVariants.Link,
-        });
-        expect(typeof config.closeButtonOptions?.onPress).toBe('function');
+        expect(config.title).toBe('Position closed');
+        expect(config.actionButtonLabel).toBeDefined();
+        expect(typeof config.actionButtonOnPress).toBe('function');
       });
 
       it('returns close full position failed configuration', () => {
@@ -917,15 +706,11 @@ describe('usePerpsToasts', () => {
             .marketClose.full.closeFullPositionFailed;
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Warning,
+          severity: ToastSeverity.Danger,
           hapticsType: NotificationMoment.Error,
         });
-        expect(config.labelOptions).toEqual([
-          { label: 'Failed to close position', isBold: true },
-          { label: '\n', isBold: false },
-          { label: 'Your position is still active', isBold: false },
-        ]);
+        expect(config.title).toBe('Failed to close position');
+        expect(config.description).toBe('Your position is still active');
       });
 
       it('returns partial position close in progress configuration', () => {
@@ -938,15 +723,10 @@ describe('usePerpsToasts', () => {
           );
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Loading,
           hapticsType: NotificationMoment.Warning,
         });
-        expect(config.labelOptions).toEqual([
-          { label: 'Partially closing position', isBold: true },
-          { label: '\n', isBold: false },
-          { label: 'short 0.5 BTC', isBold: false },
-        ]);
+        expect(config.title).toBe('Partially closing position');
+        expect(config.description).toBe('short 0.5 BTC');
         expect(config.startAccessory).toBeTruthy();
       });
 
@@ -965,23 +745,12 @@ describe('usePerpsToasts', () => {
           );
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Confirmation,
+          severity: ToastSeverity.Success,
           hapticsType: NotificationMoment.Success,
         });
-        expect(config.labelOptions).toHaveLength(3);
-        expect(config.labelOptions?.[0]).toMatchObject({
-          label: 'Position partially closed',
-          isBold: true,
-        });
-        expect(config.labelOptions?.[1]).toMatchObject({
-          label: '\n',
-          isBold: false,
-        });
-        expect(config.closeButtonOptions).toMatchObject({
-          variant: ButtonVariants.Link,
-        });
-        expect(typeof config.closeButtonOptions?.onPress).toBe('function');
+        expect(config.title).toBe('Position partially closed');
+        expect(config.actionButtonLabel).toBeDefined();
+        expect(typeof config.actionButtonOnPress).toBe('function');
       });
 
       it('returns partial position close failed configuration', () => {
@@ -991,15 +760,11 @@ describe('usePerpsToasts', () => {
             .marketClose.partial.closePartialPositionFailed;
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Warning,
+          severity: ToastSeverity.Danger,
           hapticsType: NotificationMoment.Error,
         });
-        expect(config.labelOptions).toEqual([
-          { label: 'Failed to partially close position', isBold: true },
-          { label: '\n', isBold: false },
-          { label: 'Your position is still active', isBold: false },
-        ]);
+        expect(config.title).toBe('Failed to partially close position');
+        expect(config.description).toBe('Your position is still active');
       });
 
       it('returns limit close full position submitted configuration', () => {
@@ -1014,19 +779,12 @@ describe('usePerpsToasts', () => {
         // Terminal toast (no follow-up), so it uses the success/green-tick
         // style rather than an in-progress spinner that never resolves.
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Confirmation,
+          severity: ToastSeverity.Success,
           hapticsType: NotificationMoment.Success,
         });
         expect(config.startAccessory).toBeUndefined();
-        expect(config.labelOptions).toContainEqual({
-          label: 'Placed order to close position',
-          isBold: true,
-        });
-        expect(config.labelOptions).toContainEqual({
-          label: 'long 1 ETH',
-          isBold: false,
-        });
+        expect(config.title).toBe('Placed order to close position');
+        expect(config.description).toBe('long 1 ETH');
       });
 
       it('returns limit close partial position submitted configuration', () => {
@@ -1039,18 +797,11 @@ describe('usePerpsToasts', () => {
           );
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Confirmation,
+          severity: ToastSeverity.Success,
           hapticsType: NotificationMoment.Success,
         });
-        expect(config.labelOptions).toContainEqual({
-          label: 'Partial close submitted',
-          isBold: true,
-        });
-        expect(config.labelOptions).toContainEqual({
-          label: 'long 1 ETH',
-          isBold: false,
-        });
+        expect(config.title).toBe('Partial close submitted');
+        expect(config.description).toBe('long 1 ETH');
       });
 
       it('returns limit close full position failed configuration', () => {
@@ -1060,15 +811,11 @@ describe('usePerpsToasts', () => {
             .limitClose.full.fullPositionCloseFailed;
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Warning,
+          severity: ToastSeverity.Danger,
           hapticsType: NotificationMoment.Error,
         });
-        expect(config.labelOptions).toEqual([
-          { label: 'Failed to place close order', isBold: true },
-          { label: '\n', isBold: false },
-          { label: 'Your position is still active', isBold: false },
-        ]);
+        expect(config.title).toBe('Failed to place close order');
+        expect(config.description).toBe('Your position is still active');
       });
 
       it('returns limit close partial position failed configuration', () => {
@@ -1078,15 +825,11 @@ describe('usePerpsToasts', () => {
             .limitClose.partial.partialPositionCloseFailed;
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Warning,
+          severity: ToastSeverity.Danger,
           hapticsType: NotificationMoment.Error,
         });
-        expect(config.labelOptions).toEqual([
-          { label: 'Failed to place partial close order', isBold: true },
-          { label: '\n', isBold: false },
-          { label: 'Your position is still active', isBold: false },
-        ]);
+        expect(config.title).toBe('Failed to place partial close order');
+        expect(config.description).toBe('Your position is still active');
       });
     });
 
@@ -1100,15 +843,11 @@ describe('usePerpsToasts', () => {
           );
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Confirmation,
+          severity: ToastSeverity.Success,
           hapticsType: NotificationMoment.Success,
           hasNoTimeout: false,
         });
-        expect(config.labelOptions).toHaveLength(1);
-        expect(config.labelOptions?.[0]).toMatchObject({
-          isBold: true,
-        });
+        expect(config.title).toEqual(expect.any(String));
       });
 
       it('returns remove margin success configuration', () => {
@@ -1120,15 +859,11 @@ describe('usePerpsToasts', () => {
           );
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Confirmation,
+          severity: ToastSeverity.Success,
           hapticsType: NotificationMoment.Success,
           hasNoTimeout: false,
         });
-        expect(config.labelOptions).toHaveLength(1);
-        expect(config.labelOptions?.[0]).toMatchObject({
-          isBold: true,
-        });
+        expect(config.title).toEqual(expect.any(String));
       });
 
       it('returns adjustment failed configuration with custom error', () => {
@@ -1140,19 +875,12 @@ describe('usePerpsToasts', () => {
           );
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Warning,
+          severity: ToastSeverity.Danger,
           hapticsType: NotificationMoment.Error,
           hasNoTimeout: false,
         });
-        expect(config.labelOptions).toHaveLength(3);
-        expect(config.labelOptions?.[0]).toMatchObject({
-          isBold: true,
-        });
-        expect(config.labelOptions?.[2]).toMatchObject({
-          label: customError,
-          isBold: false,
-        });
+        expect(config.title).toEqual(expect.any(String));
+        expect(config.description).toBe(customError);
       });
 
       it('returns adjustment failed configuration with default error', () => {
@@ -1161,19 +889,12 @@ describe('usePerpsToasts', () => {
           result.current.PerpsToastOptions.positionManagement.margin.adjustmentFailed();
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Warning,
+          severity: ToastSeverity.Danger,
           hapticsType: NotificationMoment.Error,
           hasNoTimeout: false,
         });
-        expect(config.labelOptions).toHaveLength(3);
-        expect(config.labelOptions?.[0]).toMatchObject({
-          isBold: true,
-        });
-        // Default error uses perps.errors.unknown key
-        expect(config.labelOptions?.[2]).toMatchObject({
-          isBold: false,
-        });
+        expect(config.title).toEqual(expect.any(String));
+        expect(config.description).toEqual(expect.any(String));
       });
     });
 
@@ -1185,14 +906,11 @@ describe('usePerpsToasts', () => {
             .updateTPSLSuccess;
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Confirmation,
+          severity: ToastSeverity.Success,
           hapticsType: NotificationMoment.Success,
           hasNoTimeout: false,
         });
-        expect(config.labelOptions).toEqual([
-          { label: 'TP/SL updated successfully', isBold: true },
-        ]);
+        expect(config.title).toBe('TP/SL updated successfully');
       });
 
       it('returns update TPSL error configuration with custom error', () => {
@@ -1204,16 +922,12 @@ describe('usePerpsToasts', () => {
           );
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Warning,
+          severity: ToastSeverity.Danger,
           hapticsType: NotificationMoment.Error,
           hasNoTimeout: false,
         });
-        expect(config.labelOptions).toEqual([
-          { label: 'Failed to update TP/SL', isBold: true },
-          { label: '\n', isBold: false },
-          { label: customError, isBold: false },
-        ]);
+        expect(config.title).toBe('Failed to update TP/SL');
+        expect(config.description).toBe(customError);
       });
 
       it('returns update TPSL error configuration with default error', () => {
@@ -1222,20 +936,14 @@ describe('usePerpsToasts', () => {
           result.current.PerpsToastOptions.positionManagement.tpsl.updateTPSLError();
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Warning,
+          severity: ToastSeverity.Danger,
           hapticsType: NotificationMoment.Error,
           hasNoTimeout: false,
         });
-        expect(config.labelOptions).toEqual([
-          { label: 'Failed to update TP/SL', isBold: true },
-          { label: '\n', isBold: false },
-          {
-            // Uses fallback message when no error provided
-            label: 'Unable to update take profit/stop loss. Please try again.',
-            isBold: false,
-          },
-        ]);
+        expect(config.title).toBe('Failed to update TP/SL');
+        expect(config.description).toBe(
+          'Unable to update take profit/stop loss. Please try again.',
+        );
       });
 
       it('returns update TPSL error configuration with undefined error', () => {
@@ -1246,20 +954,14 @@ describe('usePerpsToasts', () => {
           );
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Warning,
+          severity: ToastSeverity.Danger,
           hapticsType: NotificationMoment.Error,
           hasNoTimeout: false,
         });
-        expect(config.labelOptions).toEqual([
-          { label: 'Failed to update TP/SL', isBold: true },
-          { label: '\n', isBold: false },
-          {
-            // Uses fallback message when no error provided
-            label: 'Unable to update take profit/stop loss. Please try again.',
-            isBold: false,
-          },
-        ]);
+        expect(config.title).toBe('Failed to update TP/SL');
+        expect(config.description).toBe(
+          'Unable to update take profit/stop loss. Please try again.',
+        );
       });
     });
 
@@ -1271,11 +973,8 @@ describe('usePerpsToasts', () => {
             'Insufficient balance',
           );
 
-        expect(config.labelOptions).toEqual([
-          { label: 'Order validation failed', isBold: true },
-          { label: '\n', isBold: false },
-          { label: 'Insufficient balance', isBold: false },
-        ]);
+        expect(config.title).toBe('Order validation failed');
+        expect(config.description).toBe('Insufficient balance');
       });
     });
 
@@ -1288,21 +987,15 @@ describe('usePerpsToasts', () => {
             'DOGE',
           );
 
-        expect(config.labelOptions).toContainEqual({
-          label: 'DOGE is not a tradable asset',
-          isBold: false,
-        });
-        expect(config.closeButtonOptions).toMatchObject({
-          label: 'Go back',
-          variant: ButtonVariants.Secondary,
-        });
+        expect(config.description).toBe('DOGE is not a tradable asset');
+        expect(config.actionButtonLabel).toBe('Go back');
 
         // Test navigation handler
         act(() => {
-          config.closeButtonOptions?.onPress?.();
+          config.actionButtonOnPress?.();
         });
 
-        expect(mockCloseToast).toHaveBeenCalled();
+        expect(toast.dismiss).toHaveBeenCalled();
         expect(mockNavigate).toHaveBeenCalledWith(Routes.PERPS.ROOT);
       });
     });
@@ -1316,14 +1009,11 @@ describe('usePerpsToasts', () => {
             .shareSuccess;
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Confirmation,
+          severity: ToastSeverity.Success,
           hapticsType: NotificationMoment.Success,
           hasNoTimeout: false,
         });
-        expect(config.labelOptions).toEqual([
-          { label: 'Exported image', isBold: true },
-        ]);
+        expect(config.title).toBe('Exported image');
       });
 
       it('returns share failed configuration', () => {
@@ -1334,14 +1024,11 @@ describe('usePerpsToasts', () => {
             .shareFailed;
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Warning,
+          severity: ToastSeverity.Danger,
           hapticsType: NotificationMoment.Error,
           hasNoTimeout: false,
         });
-        expect(config.labelOptions).toEqual([
-          { label: 'Failed to export image', isBold: true },
-        ]);
+        expect(config.title).toBe('Failed to export image');
       });
     });
 
@@ -1352,14 +1039,11 @@ describe('usePerpsToasts', () => {
         const config = result.current.PerpsToastOptions.watchlist.added('BTC');
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Confirmation,
+          severity: ToastSeverity.Success,
           hapticsType: NotificationMoment.Success,
           hasNoTimeout: false,
         });
-        expect(config.labelOptions).toEqual([
-          { label: 'Added BTC to watchlist', isBold: true },
-        ]);
+        expect(config.title).toBe('Added BTC to watchlist');
       });
 
       it('returns removed configuration for the given symbol', () => {
@@ -1369,27 +1053,23 @@ describe('usePerpsToasts', () => {
           result.current.PerpsToastOptions.watchlist.removed('ETH');
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Info,
+          severity: ToastSeverity.Default,
           hapticsType: NotificationMoment.Warning,
           hasNoTimeout: false,
         });
-        expect(config.labelOptions).toEqual([
-          { label: 'Removed ETH from watchlist', isBold: true },
-        ]);
+        expect(config.title).toBe('Removed ETH from watchlist');
       });
 
       it('strips the dex prefix from HIP-3 market symbols', () => {
         const { result } = renderHook(() => usePerpsToasts());
 
         expect(
-          result.current.PerpsToastOptions.watchlist.added('somedex:BTC')
-            .labelOptions,
-        ).toEqual([{ label: 'Added BTC to watchlist', isBold: true }]);
+          result.current.PerpsToastOptions.watchlist.added('somedex:BTC').title,
+        ).toBe('Added BTC to watchlist');
         expect(
           result.current.PerpsToastOptions.watchlist.removed('somedex:ETH')
-            .labelOptions,
-        ).toEqual([{ label: 'Removed ETH from watchlist', isBold: true }]);
+            .title,
+        ).toBe('Removed ETH from watchlist');
       });
 
       it('returns add error configuration', () => {
@@ -1398,13 +1078,10 @@ describe('usePerpsToasts', () => {
         const config = result.current.PerpsToastOptions.watchlist.addError;
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Warning,
+          severity: ToastSeverity.Danger,
           hapticsType: NotificationMoment.Error,
         });
-        expect(config.labelOptions).toEqual([
-          { label: 'Failed to add market to watchlist', isBold: true },
-        ]);
+        expect(config.title).toBe('Failed to add market to watchlist');
       });
 
       it('returns limit reached configuration', () => {
@@ -1413,12 +1090,9 @@ describe('usePerpsToasts', () => {
         const config = result.current.PerpsToastOptions.watchlist.limitReached;
 
         expect(config).toMatchObject({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Info,
+          severity: ToastSeverity.Default,
         });
-        expect(config.labelOptions?.[0].label).toContain(
-          'Watchlist limit reached',
-        );
+        expect(config.title).toContain('Watchlist limit reached');
       });
     });
   });
@@ -1436,12 +1110,10 @@ describe('usePerpsToasts', () => {
 
       // Check that the configs use the correct variants and icons
       expect(successConfig).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
+        severity: ToastSeverity.Success,
       });
       expect(errorConfig).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Warning,
+        severity: ToastSeverity.Danger,
       });
     });
   });
@@ -1465,10 +1137,7 @@ describe('usePerpsToasts', () => {
       expect(successToast.hapticsType).toBe(NotificationMoment.Success);
       expect(inProgressToast.hapticsType).toBe(NotificationMoment.Warning);
       expect(inProgressToast.startAccessory).toBeTruthy();
-      expect(inProgressToast.closeButtonOptions).toMatchObject({
-        label: 'Track',
-        variant: ButtonVariants.Link,
-      });
+      expect(inProgressToast.actionButtonLabel).toBe('Track');
       expect(errorToast.hapticsType).toBe(NotificationMoment.Error);
     });
   });

--- a/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useNavigation } from '@react-navigation/native';
+import type { GestureResponderEvent } from 'react-native';
 import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { playNotification, NotificationMoment } from '../../../../util/haptics';
 import usePerpsToasts, { PerpsToastOptions } from './usePerpsToasts';
@@ -59,6 +60,8 @@ jest.mock('../utils/translatePerpsError', () => ({
     fallbackMessage: string;
   }) => error || fallbackMessage,
 }));
+
+const pressEvent = {} as GestureResponderEvent;
 
 describe('usePerpsToasts', () => {
   let mockNavigate: jest.Mock;
@@ -168,7 +171,7 @@ describe('usePerpsToasts', () => {
           );
 
         act(() => {
-          config.actionButtonOnPress?.();
+          config.actionButtonOnPress?.(pressEvent);
         });
 
         expect(mockNavigate).toHaveBeenCalledWith(Routes.ACTIVITY_DETAILS, {
@@ -191,7 +194,7 @@ describe('usePerpsToasts', () => {
           );
 
         act(() => {
-          config.actionButtonOnPress?.();
+          config.actionButtonOnPress?.(pressEvent);
         });
 
         expect(mockNavigate).toHaveBeenCalledWith(Routes.TRANSACTION_DETAILS, {
@@ -992,7 +995,7 @@ describe('usePerpsToasts', () => {
 
         // Test navigation handler
         act(() => {
-          config.actionButtonOnPress?.();
+          config.actionButtonOnPress?.(pressEvent);
         });
 
         expect(toast.dismiss).toHaveBeenCalled();

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -217,6 +217,60 @@ const getPerpsToastLabels = (
   description: secondary,
 });
 
+const getOrderPlacementSubtitle = (
+  direction: OrderDirection,
+  amount: string,
+  assetSymbol: string,
+): string =>
+  strings('perps.order.order_placement_subtitle', {
+    direction: capitalize(direction),
+    amount,
+    assetSymbol: getPerpsDisplaySymbol(assetSymbol),
+  });
+
+const createOrderPlacementToast =
+  (base: PerpsToastOptions, titleKey: string) =>
+  (
+    direction: OrderDirection,
+    amount: string,
+    assetSymbol: string,
+  ): PerpsToastOptions => ({
+    ...base,
+    ...getPerpsToastLabels(
+      strings(titleKey),
+      getOrderPlacementSubtitle(direction, amount, assetSymbol),
+    ),
+  });
+
+const createOrderFailedToast =
+  (base: PerpsToastOptions, titleKey: string, fallbackKey: string) =>
+  (error?: string): PerpsToastOptions => ({
+    ...base,
+    ...getPerpsToastLabels(
+      strings(titleKey),
+      handlePerpsError({
+        error,
+        fallbackMessage: strings(fallbackKey),
+      }),
+    ),
+  });
+
+const createOrderLifecycleToasts = (
+  bases: Record<string, PerpsToastOptions>,
+  confirmedTitleKey: string,
+) => ({
+  submitted: createOrderPlacementToast(
+    bases.inProgress,
+    'perps.order.order_submitted',
+  ),
+  confirmed: createOrderPlacementToast(bases.success, confirmedTitleKey),
+  creationFailed: createOrderFailedToast(
+    bases.error,
+    'perps.order.order_failed',
+    'perps.order.your_funds_have_been_returned_to_you',
+  ),
+});
+
 function dismissToast() {
   try {
     toast.dismiss();
@@ -468,129 +522,33 @@ const usePerpsToasts = (): {
           }),
         },
       },
-      // Intentional duplication of some options between market and limit to avoid coupling.
+      // Market and limit share factories so titles stay independent without duplicating config.
       orderManagement: {
-        market: {
-          submitted: (
-            direction: OrderDirection,
-            amount: string,
-            assetSymbol: string,
-          ) => ({
-            ...perpsBaseToastOptions.inProgress,
-            ...getPerpsToastLabels(
-              strings('perps.order.order_submitted'),
-              strings('perps.order.order_placement_subtitle', {
-                direction: capitalize(direction),
-                amount,
-                assetSymbol: getPerpsDisplaySymbol(assetSymbol),
-              }),
-            ),
-          }),
-          // Displays "Order Filled" since market orders are filled immediately or fail.
-          confirmed: (
-            direction: OrderDirection,
-            amount: string,
-            assetSymbol: string,
-          ) => ({
-            ...perpsBaseToastOptions.success,
-            ...getPerpsToastLabels(
-              strings('perps.order.order_filled'),
-              strings('perps.order.order_placement_subtitle', {
-                direction: capitalize(direction),
-                amount,
-                assetSymbol: getPerpsDisplaySymbol(assetSymbol),
-              }),
-            ),
-          }),
-          creationFailed: (error?: string) => ({
-            ...perpsBaseToastOptions.error,
-            ...getPerpsToastLabels(
-              strings('perps.order.order_failed'),
-              handlePerpsError({
-                error,
-                fallbackMessage: strings(
-                  'perps.order.your_funds_have_been_returned_to_you',
-                ),
-              }),
-            ),
-          }),
-        },
+        // Displays "Order Filled" since market orders are filled immediately or fail.
+        market: createOrderLifecycleToasts(
+          perpsBaseToastOptions,
+          'perps.order.order_filled',
+        ),
         limit: {
-          submitted: (
-            direction: OrderDirection,
-            amount: string,
-            assetSymbol: string,
-          ) => ({
-            ...perpsBaseToastOptions.inProgress,
-            ...getPerpsToastLabels(
-              strings('perps.order.order_submitted'),
-              strings('perps.order.order_placement_subtitle', {
-                direction: capitalize(direction),
-                amount,
-                assetSymbol: getPerpsDisplaySymbol(assetSymbol),
-              }),
-            ),
-          }),
           // Displays "Order Placed" since limit orders aren't typically filled immediately.
-          confirmed: (
-            direction: OrderDirection,
-            amount: string,
-            assetSymbol: string,
-          ) => ({
-            ...perpsBaseToastOptions.success,
-            ...getPerpsToastLabels(
-              strings('perps.order.order_placed'),
-              strings('perps.order.order_placement_subtitle', {
-                direction: capitalize(direction),
-                amount,
-                assetSymbol: getPerpsDisplaySymbol(assetSymbol),
-              }),
-            ),
-          }),
-          creationFailed: (error?: string) => ({
-            ...perpsBaseToastOptions.error,
-            ...getPerpsToastLabels(
-              strings('perps.order.order_failed'),
-              handlePerpsError({
-                error,
-                fallbackMessage: strings(
-                  'perps.order.your_funds_have_been_returned_to_you',
-                ),
-              }),
-            ),
-          }),
+          ...createOrderLifecycleToasts(
+            perpsBaseToastOptions,
+            'perps.order.order_placed',
+          ),
           editSubmitting: () => ({
             ...perpsBaseToastOptions.inProgress,
             hasNoTimeout: true,
             ...getPerpsToastLabels(strings('perps.order.updating_your_order')),
           }),
-          editConfirmed: (
-            direction: OrderDirection,
-            amount: string,
-            assetSymbol: string,
-          ) => ({
-            ...perpsBaseToastOptions.success,
-            ...getPerpsToastLabels(
-              strings('perps.order.order_updated'),
-              strings('perps.order.order_placement_subtitle', {
-                direction: capitalize(direction),
-                amount,
-                assetSymbol: getPerpsDisplaySymbol(assetSymbol),
-              }),
-            ),
-          }),
-          editFailed: (error?: string) => ({
-            ...perpsBaseToastOptions.error,
-            ...getPerpsToastLabels(
-              strings('perps.order.order_update_failed'),
-              handlePerpsError({
-                error,
-                fallbackMessage: strings(
-                  'perps.order.order_update_failed_subtitle',
-                ),
-              }),
-            ),
-          }),
+          editConfirmed: createOrderPlacementToast(
+            perpsBaseToastOptions.success,
+            'perps.order.order_updated',
+          ),
+          editFailed: createOrderFailedToast(
+            perpsBaseToastOptions.error,
+            'perps.order.order_update_failed',
+            'perps.order.order_update_failed_subtitle',
+          ),
         },
         // Used for both market and limit orders.
         shared: {

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -1,9 +1,9 @@
 import {
   IconSize as ReactNativeDsIconSize,
-  Text,
-  TextVariant,
   Spinner,
-  FontWeight,
+  toast,
+  ToastSeverity,
+  type ToastOptions,
 } from '@metamask/design-system-react-native';
 import { useNavigation } from '@react-navigation/native';
 import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
@@ -14,19 +14,8 @@ import {
   NotificationMoment,
   type HapticNotificationMoment,
 } from '../../../../util/haptics';
-import React, { useCallback, useContext, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { strings } from '../../../../../locales/i18n';
-import { ButtonVariants } from '../../../../component-library/components/Buttons/Button';
-import {
-  IconColor,
-  IconName,
-} from '../../../../component-library/components/Icons/Icon';
-import { ToastContext } from '../../../../component-library/components/Toast';
-import {
-  ButtonIconVariant,
-  ToastOptions,
-  ToastVariants,
-} from '../../../../component-library/components/Toast/Toast.types';
 import Routes from '../../../../constants/navigation/Routes';
 import { navigateToTransactionDetails } from '../../../../util/navigation/navigateToTransactionDetails';
 import { selectIsTransactionsRedesignEnabled } from '../../../../selectors/featureFlagController/activityRedesign';
@@ -38,7 +27,6 @@ import {
   PerpsActivityFilter,
 } from '../../../Views/ActivityScreen/types';
 import { capitalize } from '../../../../util/general';
-import { useAppThemeFromContext } from '../../../../util/theme';
 import {
   PERPS_EVENT_VALUE,
   OrderDirection,
@@ -49,13 +37,8 @@ import { formatPerpsFiat } from '../utils/formatUtils';
 import { handlePerpsError } from '../utils/translatePerpsError';
 import { formatDurationForDisplay } from '../utils/time';
 
-export type PerpsToastOptions = Omit<ToastOptions, 'labelOptions'> & {
+export type PerpsToastOptions = ToastOptions & {
   hapticsType: HapticNotificationMoment;
-  // Overwriting ToastOptions.labelOptions to also support ReactNode since this works.
-  labelOptions?: {
-    label: string | React.ReactNode;
-    isBold?: boolean;
-  }[];
 };
 
 export interface PerpsToastOptionsConfig {
@@ -227,31 +210,20 @@ export interface PerpsToastOptionsConfig {
 }
 
 const getPerpsToastLabels = (
-  primary: string | React.ReactNode,
-  secondary?: string | React.ReactNode,
-) => {
-  const labels = [
-    {
-      label: primary,
-      isBold: true,
-    },
-  ];
+  primary: string,
+  secondary?: string,
+): Pick<ToastOptions, 'title' | 'description'> => ({
+  title: primary,
+  description: secondary,
+});
 
-  if (secondary) {
-    labels.push(
-      {
-        label: '\n',
-        isBold: false,
-      },
-      {
-        label: secondary,
-        isBold: false,
-      },
-    );
+function dismissToast() {
+  try {
+    toast.dismiss();
+  } catch {
+    // Toaster may be unmounted in tests
   }
-
-  return labels;
-};
+}
 
 const PERPS_TOASTS_DEFAULT_OPTIONS: Partial<PerpsToastOptions> = {
   hasNoTimeout: false,
@@ -261,24 +233,18 @@ const usePerpsToasts = (): {
   showToast: (config: PerpsToastOptions) => void;
   PerpsToastOptions: PerpsToastOptionsConfig;
 } => {
-  const { toastRef } = useContext(ToastContext);
-  const theme = useAppThemeFromContext();
   const navigation = useNavigation<AppNavigationProp>();
 
   const perpsBaseToastOptions: Record<string, PerpsToastOptions> = useMemo(
     () => ({
       success: {
         ...(PERPS_TOASTS_DEFAULT_OPTIONS as PerpsToastOptions),
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        iconColor: IconColor.Success,
+        severity: ToastSeverity.Success,
         hapticsType: NotificationMoment.Success,
       },
       // Intentional duplication for now to avoid coupling with success options.
       inProgress: {
         ...(PERPS_TOASTS_DEFAULT_OPTIONS as PerpsToastOptions),
-        variant: ToastVariants.Icon,
-        iconName: IconName.Loading,
         hapticsType: NotificationMoment.Warning,
         startAccessory: (
           <Spinner spinnerIconProps={{ size: ReactNativeDsIconSize.Lg }} />
@@ -286,23 +252,17 @@ const usePerpsToasts = (): {
       },
       info: {
         ...(PERPS_TOASTS_DEFAULT_OPTIONS as PerpsToastOptions),
-        variant: ToastVariants.Icon,
-        iconName: IconName.Info,
-        iconColor: IconColor.Default,
+        severity: ToastSeverity.Default,
         hapticsType: NotificationMoment.Warning,
       },
       error: {
         ...(PERPS_TOASTS_DEFAULT_OPTIONS as PerpsToastOptions),
-        variant: ToastVariants.Icon,
-        iconName: IconName.Warning,
-        iconColor: IconColor.Error,
+        severity: ToastSeverity.Danger,
         hapticsType: NotificationMoment.Error,
       },
       warning: {
         ...(PERPS_TOASTS_DEFAULT_OPTIONS as PerpsToastOptions),
-        variant: ToastVariants.Icon,
-        iconName: IconName.Warning,
-        iconColor: IconColor.Warning,
+        severity: ToastSeverity.Warning,
         hapticsType: NotificationMoment.Warning,
       },
     }),
@@ -312,14 +272,14 @@ const usePerpsToasts = (): {
   const navigationHandlers = useMemo(
     () => ({
       goToPerpsTab: () => {
-        toastRef?.current?.closeToast();
+        dismissToast();
         navigation.navigate(Routes.PERPS.ROOT);
       },
       goToActivity: (
         transactionId: string,
         perpsFilter?: PerpsActivityFilter,
       ) => {
-        toastRef?.current?.closeToast();
+        dismissToast();
         const state = store.getState();
         const depositMeta = selectTransactionMetadataById(state, transactionId);
         navigateToTransactionDetails(navigation, {
@@ -334,7 +294,7 @@ const usePerpsToasts = (): {
         });
       },
       goToPnlHeroCard: (position: Position, marketPrice?: string) => {
-        toastRef?.current?.closeToast();
+        dismissToast();
         navigation.navigate(Routes.PERPS.PNL_HERO_CARD, {
           position,
           marketPrice,
@@ -342,7 +302,7 @@ const usePerpsToasts = (): {
         });
       },
     }),
-    [navigation, toastRef],
+    [navigation],
   );
 
   const perpsToastButtonOptions = useMemo(
@@ -350,35 +310,30 @@ const usePerpsToasts = (): {
       pnlHeroCardShareButton: (
         position: Position,
         marketPrice?: string,
-      ): ToastOptions['closeButtonOptions'] => ({
-        label: strings('perps.pnl_hero_card.share_button'),
-        onPress: () =>
+      ): Pick<ToastOptions, 'actionButtonLabel' | 'actionButtonOnPress'> => ({
+        actionButtonLabel: strings('perps.pnl_hero_card.share_button'),
+        actionButtonOnPress: () =>
           navigationHandlers.goToPnlHeroCard(position, marketPrice),
-        variant: ButtonVariants.Link,
       }),
       goToActivityButton: (
         transactionId: string,
-      ): ToastOptions['closeButtonOptions'] => ({
-        label: strings('perps.deposit.track'),
-        onPress: () =>
+      ): Pick<ToastOptions, 'actionButtonLabel' | 'actionButtonOnPress'> => ({
+        actionButtonLabel: strings('perps.deposit.track'),
+        actionButtonOnPress: () =>
           navigationHandlers.goToActivity(
             transactionId,
             PerpsActivityFilter.Deposits,
           ),
-        variant: ButtonVariants.Link,
       }),
     }),
     [navigationHandlers],
   );
 
-  const showToast = useCallback(
-    (config: PerpsToastOptions) => {
-      const { hapticsType, ...toastOptions } = config;
-      toastRef?.current?.showToast(toastOptions as ToastOptions);
-      playNotification(hapticsType);
-    },
-    [toastRef],
-  );
+  const showToast = useCallback((config: PerpsToastOptions) => {
+    const { hapticsType, ...toastOptions } = config;
+    toast(toastOptions);
+    playNotification(hapticsType);
+  }, []);
 
   // Centralized toast options for Perp
   const PerpsToastOptions: PerpsToastOptionsConfig = useMemo(
@@ -396,7 +351,7 @@ const usePerpsToasts = (): {
 
             return {
               ...perpsBaseToastOptions.success,
-              labelOptions: getPerpsToastLabels(
+              ...getPerpsToastLabels(
                 strings('perps.deposit.success_toast'),
                 subtext,
               ),
@@ -422,60 +377,38 @@ const usePerpsToasts = (): {
               );
             }
 
-            let closeButtonOptions;
-
-            if (processingTimeInSeconds) {
-              closeButtonOptions =
-                perpsToastButtonOptions.goToActivityButton(transactionId);
-            }
-
             return {
               ...perpsBaseToastOptions.inProgress,
-              labelOptions: getPerpsToastLabels(
+              ...getPerpsToastLabels(
                 strings('perps.deposit.in_progress'),
                 processingMessage,
               ),
-              closeButtonOptions,
+              ...(processingTimeInSeconds
+                ? perpsToastButtonOptions.goToActivityButton(transactionId)
+                : {}),
             };
           },
           takingLonger: {
             ...perpsBaseToastOptions.warning,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.deposit.deposit_taking_longer'),
             ),
             hasNoTimeout: true,
-            closeButtonOptions: {
-              label: (
-                <Text
-                  variant={TextVariant.BodySm}
-                  fontWeight={FontWeight.Medium}
-                  style={{ color: theme.colors.error.default }}
-                >
-                  {strings('perps.deposit.cancel_trade')}
-                </Text>
-              ),
-              variant: ButtonVariants.Secondary,
-              onPress: () => {
-                /* no-op */
-              },
+            actionButtonLabel: strings('perps.deposit.cancel_trade'),
+            actionButtonOnPress: () => {
+              /* no-op — callers wrap this to cancel the in-flight trade */
             },
           },
           tradeCanceled: {
             ...(PERPS_TOASTS_DEFAULT_OPTIONS as PerpsToastOptions),
-            variant: ToastVariants.Icon,
-            iconName: IconName.Warning,
-            iconColor: IconColor.Error,
+            severity: ToastSeverity.Warning,
             hapticsType: NotificationMoment.Warning,
-            labelOptions: getPerpsToastLabels(
-              strings('perps.deposit.trade_canceled'),
-            ),
-            descriptionOptions: {
-              description: strings('perps.deposit.funds_returned_to_account'),
-            },
+            ...getPerpsToastLabels(strings('perps.deposit.trade_canceled')),
+            description: strings('perps.deposit.funds_returned_to_account'),
           },
           error: {
             ...perpsBaseToastOptions.error,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.deposit.deposit_failed'),
               strings('perps.deposit.error_generic'),
             ),
@@ -484,7 +417,7 @@ const usePerpsToasts = (): {
         oneClickTrade: {
           txCreationFailed: {
             ...perpsBaseToastOptions.error,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.one_click_trade.tx_creation_failed_title'),
               strings('perps.one_click_trade.tx_creation_failed_description'),
             ),
@@ -493,13 +426,13 @@ const usePerpsToasts = (): {
         withdrawal: {
           withdrawalInProgress: {
             ...perpsBaseToastOptions.inProgress,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.withdrawal.processing_title'),
             ),
           },
           withdrawalSuccess: (amount: string, assetSymbol: string) => ({
             ...perpsBaseToastOptions.success,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.withdrawal.success_toast'),
               strings('perps.withdrawal.success_toast_description', {
                 amount: amount
@@ -512,7 +445,7 @@ const usePerpsToasts = (): {
           }),
           withdrawalFailed: (error?: string) => ({
             ...perpsBaseToastOptions.error,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.withdrawal.error'),
               handlePerpsError({
                 error,
@@ -522,16 +455,12 @@ const usePerpsToasts = (): {
           }),
           withdrawalStartFailed: (onRetry: () => void) => ({
             ...perpsBaseToastOptions.error,
-            iconName: IconName.Error,
-            iconColor: IconColor.Error,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.withdrawal.toast_error_title'),
               strings('perps.withdrawal.toast_start_error_description'),
             ),
-            linkButtonOptions: {
-              label: strings('perps.withdrawal.try_again'),
-              onPress: onRetry,
-            },
+            actionButtonLabel: strings('perps.withdrawal.try_again'),
+            actionButtonOnPress: onRetry,
           }),
         },
       },
@@ -544,7 +473,7 @@ const usePerpsToasts = (): {
             assetSymbol: string,
           ) => ({
             ...perpsBaseToastOptions.inProgress,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.order.order_submitted'),
               strings('perps.order.order_placement_subtitle', {
                 direction: capitalize(direction),
@@ -560,7 +489,7 @@ const usePerpsToasts = (): {
             assetSymbol: string,
           ) => ({
             ...perpsBaseToastOptions.success,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.order.order_filled'),
               strings('perps.order.order_placement_subtitle', {
                 direction: capitalize(direction),
@@ -571,7 +500,7 @@ const usePerpsToasts = (): {
           }),
           creationFailed: (error?: string) => ({
             ...perpsBaseToastOptions.error,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.order.order_failed'),
               handlePerpsError({
                 error,
@@ -589,7 +518,7 @@ const usePerpsToasts = (): {
             assetSymbol: string,
           ) => ({
             ...perpsBaseToastOptions.inProgress,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.order.order_submitted'),
               strings('perps.order.order_placement_subtitle', {
                 direction: capitalize(direction),
@@ -605,7 +534,7 @@ const usePerpsToasts = (): {
             assetSymbol: string,
           ) => ({
             ...perpsBaseToastOptions.success,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.order.order_placed'),
               strings('perps.order.order_placement_subtitle', {
                 direction: capitalize(direction),
@@ -616,7 +545,7 @@ const usePerpsToasts = (): {
           }),
           creationFailed: (error?: string) => ({
             ...perpsBaseToastOptions.error,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.order.order_failed'),
               handlePerpsError({
                 error,
@@ -629,9 +558,7 @@ const usePerpsToasts = (): {
           editSubmitting: () => ({
             ...perpsBaseToastOptions.inProgress,
             hasNoTimeout: true,
-            labelOptions: getPerpsToastLabels(
-              strings('perps.order.updating_your_order'),
-            ),
+            ...getPerpsToastLabels(strings('perps.order.updating_your_order')),
           }),
           editConfirmed: (
             direction: OrderDirection,
@@ -639,7 +566,7 @@ const usePerpsToasts = (): {
             assetSymbol: string,
           ) => ({
             ...perpsBaseToastOptions.success,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.order.order_updated'),
               strings('perps.order.order_placement_subtitle', {
                 direction: capitalize(direction),
@@ -650,7 +577,7 @@ const usePerpsToasts = (): {
           }),
           editFailed: (error?: string) => ({
             ...perpsBaseToastOptions.error,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.order.order_update_failed'),
               handlePerpsError({
                 error,
@@ -666,14 +593,9 @@ const usePerpsToasts = (): {
           submitting: () => ({
             ...perpsBaseToastOptions.inProgress,
             hasNoTimeout: true,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.order.submitting_your_trade'),
             ),
-            closeButtonOptions: {
-              variant: ButtonIconVariant.Icon,
-              iconName: IconName.Close,
-              onPress: () => toastRef?.current?.closeToast(),
-            },
           }),
           cancellationInProgress: (
             direction: OrderDirection,
@@ -709,7 +631,7 @@ const usePerpsToasts = (): {
 
             return {
               ...perpsBaseToastOptions.inProgress,
-              labelOptions: getPerpsToastLabels(labels[0], labels?.[1]),
+              ...getPerpsToastLabels(labels[0], labels?.[1]),
             };
           },
           cancellationSuccess: (
@@ -751,19 +673,19 @@ const usePerpsToasts = (): {
 
             return {
               ...perpsBaseToastOptions.success,
-              labelOptions: getPerpsToastLabels(labels[0], labels?.[1]),
+              ...getPerpsToastLabels(labels[0], labels?.[1]),
             };
           },
           cancellationFailed: {
             ...perpsBaseToastOptions.error,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.order.failed_to_cancel_order'),
               strings('perps.order.order_still_active'),
             ),
           },
           cancelAllSuccess: (count: number) => ({
             ...perpsBaseToastOptions.success,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.cancel_all_modal.success_title'),
               strings('perps.cancel_all_modal.success_message', { count }),
             ),
@@ -773,7 +695,7 @@ const usePerpsToasts = (): {
             totalCount: number,
           ) => ({
             ...perpsBaseToastOptions.success,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.cancel_all_modal.success_title'),
               strings('perps.cancel_all_modal.partial_success', {
                 successCount,
@@ -783,7 +705,7 @@ const usePerpsToasts = (): {
           }),
           cancelAllFailed: (error?: string) => ({
             ...perpsBaseToastOptions.error,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.cancel_all_modal.error_title'),
               error || 'Unknown error',
             ),
@@ -816,7 +738,7 @@ const usePerpsToasts = (): {
 
                 return {
                   ...perpsBaseToastOptions.inProgress,
-                  labelOptions: getPerpsToastLabels(
+                  ...getPerpsToastLabels(
                     strings('perps.close_position.closing_position'),
                     subtext,
                   ),
@@ -831,34 +753,19 @@ const usePerpsToasts = (): {
 
                 return {
                   ...perpsBaseToastOptions.success,
-                  closeButtonOptions:
-                    perpsToastButtonOptions.pnlHeroCardShareButton(
-                      position,
-                      marketPrice,
-                    ),
-                  labelOptions: getPerpsToastLabels(
+                  ...perpsToastButtonOptions.pnlHeroCardShareButton(
+                    position,
+                    marketPrice,
+                  ),
+                  ...getPerpsToastLabels(
                     strings('perps.close_position.position_closed'),
-                    <Text variant={TextVariant.BodyMd}>
-                      {strings('perps.close_position.your_pnl_is')}
-                      <Text
-                        variant={TextVariant.BodyMd}
-                        style={{
-                          color:
-                            roeValue >= 0
-                              ? theme.colors.success.default
-                              : theme.colors.error.default,
-                        }}
-                      >
-                        {' '}
-                        {`${roeValue.toFixed(2)}%`}
-                      </Text>
-                    </Text>,
+                    `${strings('perps.close_position.your_pnl_is')} ${roeValue.toFixed(2)}%`,
                   ),
                 };
               },
               closeFullPositionFailed: {
                 ...perpsBaseToastOptions.error,
-                labelOptions: getPerpsToastLabels(
+                ...getPerpsToastLabels(
                   strings('perps.close_position.failed_to_close_position'),
                   strings('perps.close_position.your_position_is_still_active'),
                 ),
@@ -887,7 +794,7 @@ const usePerpsToasts = (): {
 
                 return {
                   ...perpsBaseToastOptions.inProgress,
-                  labelOptions: getPerpsToastLabels(
+                  ...getPerpsToastLabels(
                     strings('perps.close_position.partially_closing_position'),
                     subtext,
                   ),
@@ -902,34 +809,19 @@ const usePerpsToasts = (): {
 
                 return {
                   ...perpsBaseToastOptions.success,
-                  closeButtonOptions:
-                    perpsToastButtonOptions.pnlHeroCardShareButton(
-                      position,
-                      marketPrice,
-                    ),
-                  labelOptions: getPerpsToastLabels(
+                  ...perpsToastButtonOptions.pnlHeroCardShareButton(
+                    position,
+                    marketPrice,
+                  ),
+                  ...getPerpsToastLabels(
                     strings('perps.close_position.position_partially_closed'),
-                    <Text variant={TextVariant.BodyMd}>
-                      {strings('perps.close_position.your_pnl_is')}
-                      <Text
-                        variant={TextVariant.BodyMd}
-                        style={{
-                          color:
-                            roeValue >= 0
-                              ? theme.colors.success.default
-                              : theme.colors.error.default,
-                        }}
-                      >
-                        {' '}
-                        {`${roeValue.toFixed(2)}%`}
-                      </Text>
-                    </Text>,
+                    `${strings('perps.close_position.your_pnl_is')} ${roeValue.toFixed(2)}%`,
                   ),
                 };
               },
               closePartialPositionFailed: {
                 ...perpsBaseToastOptions.error,
-                labelOptions: getPerpsToastLabels(
+                ...getPerpsToastLabels(
                   strings(
                     'perps.close_position.failed_to_partially_close_position',
                   ),
@@ -950,7 +842,7 @@ const usePerpsToasts = (): {
                 // partial close and the open limit "Order placed" toast —
                 // instead of an in-progress spinner that never resolves.
                 ...perpsBaseToastOptions.success,
-                labelOptions: getPerpsToastLabels(
+                ...getPerpsToastLabels(
                   strings('perps.close_position.position_close_order_placed'),
                   strings('perps.close_position.closing_position_subtitle', {
                     direction,
@@ -961,7 +853,7 @@ const usePerpsToasts = (): {
               }),
               fullPositionCloseFailed: {
                 ...perpsBaseToastOptions.error,
-                labelOptions: getPerpsToastLabels(
+                ...getPerpsToastLabels(
                   strings('perps.close_position.failed_to_place_close_order'),
                   strings('perps.close_position.your_position_is_still_active'),
                 ),
@@ -974,7 +866,7 @@ const usePerpsToasts = (): {
                 assetSymbol: string,
               ) => ({
                 ...perpsBaseToastOptions.success,
-                labelOptions: getPerpsToastLabels(
+                ...getPerpsToastLabels(
                   strings('perps.close_position.partial_close_submitted'),
                   strings('perps.close_position.closing_position_subtitle', {
                     direction,
@@ -985,7 +877,7 @@ const usePerpsToasts = (): {
               }),
               partialPositionCloseFailed: {
                 ...perpsBaseToastOptions.error,
-                labelOptions: getPerpsToastLabels(
+                ...getPerpsToastLabels(
                   strings(
                     'perps.close_position.failed_to_place_partial_close_order',
                   ),
@@ -994,7 +886,7 @@ const usePerpsToasts = (): {
               },
               switchToMarketOrderMissingLimitPrice: {
                 ...perpsBaseToastOptions.info,
-                labelOptions: getPerpsToastLabels(
+                ...getPerpsToastLabels(
                   strings(
                     'perps.close_position.order_type_reverted_to_market_order',
                   ),
@@ -1009,13 +901,13 @@ const usePerpsToasts = (): {
         tpsl: {
           updateTPSLSuccess: {
             ...perpsBaseToastOptions.success,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.position.tpsl.update_success'),
             ),
           },
           updateTPSLError: (error?: string) => ({
             ...perpsBaseToastOptions.error,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.position.tpsl.update_failed'),
               error || strings('perps.errors.tpslUpdateFailed'),
             ),
@@ -1024,7 +916,7 @@ const usePerpsToasts = (): {
         margin: {
           addSuccess: (assetSymbol: string, amount: string) => ({
             ...perpsBaseToastOptions.success,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.position.margin.add_success', {
                 amount,
                 asset: assetSymbol,
@@ -1033,7 +925,7 @@ const usePerpsToasts = (): {
           }),
           removeSuccess: (assetSymbol: string, amount: string) => ({
             ...perpsBaseToastOptions.success,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.position.margin.remove_success', {
                 amount,
                 asset: assetSymbol,
@@ -1042,7 +934,7 @@ const usePerpsToasts = (): {
           }),
           adjustmentFailed: (error?: string) => ({
             ...perpsBaseToastOptions.error,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.position.margin.adjustment_failed'),
               error || strings('perps.errors.marginAdjustmentFailed'),
             ),
@@ -1053,14 +945,14 @@ const usePerpsToasts = (): {
         orderForm: {
           validationError: (error: string) => ({
             ...perpsBaseToastOptions.error,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.order.validation.failed'),
               error, // Pass through directly - validation errors are already localized
             ),
           }),
           limitPriceRequired: {
             ...perpsBaseToastOptions.error,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.order.validation.please_set_a_limit_price'),
               strings(
                 'perps.order.validation.limit_price_must_be_set_before_configuring_tpsl',
@@ -1074,18 +966,15 @@ const usePerpsToasts = (): {
           error: {
             marketDataUnavailable: (assetSymbol: string) => ({
               ...perpsBaseToastOptions.error,
-              labelOptions: getPerpsToastLabels(
+              ...getPerpsToastLabels(
                 strings('perps.order.error.invalid_asset'),
                 strings('perps.order.error.asset_not_tradable', {
                   asset: getPerpsDisplaySymbol(assetSymbol),
                 }),
               ),
-              closeButtonOptions: {
-                label: strings('perps.order.error.go_back'),
-                variant: ButtonVariants.Secondary,
-                onPress: () => {
-                  navigationHandlers.goToPerpsTab();
-                },
+              actionButtonLabel: strings('perps.order.error.go_back'),
+              actionButtonOnPress: () => {
+                navigationHandlers.goToPerpsTab();
               },
             }),
           },
@@ -1095,22 +984,20 @@ const usePerpsToasts = (): {
         pnlHeroCard: {
           shareSuccess: {
             ...perpsBaseToastOptions.success,
-            labelOptions: getPerpsToastLabels(
+            ...getPerpsToastLabels(
               strings('perps.pnl_hero_card.export_success'),
             ),
           },
           shareFailed: {
             ...perpsBaseToastOptions.error,
-            labelOptions: getPerpsToastLabels(
-              strings('perps.pnl_hero_card.share_failed'),
-            ),
+            ...getPerpsToastLabels(strings('perps.pnl_hero_card.share_failed')),
           },
         },
       },
       watchlist: {
         added: (symbol: string) => ({
           ...perpsBaseToastOptions.success,
-          labelOptions: getPerpsToastLabels(
+          ...getPerpsToastLabels(
             strings('perps.watchlist.added', {
               symbol: getPerpsDisplaySymbol(symbol),
             }),
@@ -1118,7 +1005,7 @@ const usePerpsToasts = (): {
         }),
         removed: (symbol: string) => ({
           ...perpsBaseToastOptions.info,
-          labelOptions: getPerpsToastLabels(
+          ...getPerpsToastLabels(
             strings('perps.watchlist.removed', {
               symbol: getPerpsDisplaySymbol(symbol),
             }),
@@ -1126,13 +1013,11 @@ const usePerpsToasts = (): {
         }),
         addError: {
           ...perpsBaseToastOptions.error,
-          labelOptions: getPerpsToastLabels(
-            strings('perps.watchlist.add_error'),
-          ),
+          ...getPerpsToastLabels(strings('perps.watchlist.add_error')),
         },
         limitReached: {
           ...perpsBaseToastOptions.info,
-          labelOptions: getPerpsToastLabels(
+          ...getPerpsToastLabels(
             strings('perps.watchlist.limit_reached', { limit: 100 }),
           ),
         },
@@ -1146,9 +1031,6 @@ const usePerpsToasts = (): {
       perpsBaseToastOptions.success,
       perpsBaseToastOptions.warning,
       perpsToastButtonOptions,
-      theme.colors.error.default,
-      theme.colors.success.default,
-      toastRef,
     ],
   );
 

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -331,7 +331,11 @@ const usePerpsToasts = (): {
 
   const showToast = useCallback((config: PerpsToastOptions) => {
     const { hapticsType, ...toastOptions } = config;
-    toast(toastOptions);
+    try {
+      toast(toastOptions);
+    } catch {
+      // Toaster may be unmounted in tests
+    }
     playNotification(hapticsType);
   }, []);
 

--- a/app/components/UI/Perps/hooks/usePerpsToasts.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsToasts.tsx
@@ -985,15 +985,7 @@ const usePerpsToasts = (): {
         },
       },
     }),
-    [
-      navigationHandlers,
-      perpsBaseToastOptions.error,
-      perpsBaseToastOptions.inProgress,
-      perpsBaseToastOptions.info,
-      perpsBaseToastOptions.success,
-      perpsBaseToastOptions.warning,
-      perpsToastButtonOptions,
-    ],
+    [navigationHandlers, perpsBaseToastOptions, perpsToastButtonOptions],
   );
 
   return { showToast, PerpsToastOptions };

--- a/app/components/UI/Perps/hooks/usePerpsWithdrawToastRegistrations.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawToastRegistrations.test.tsx
@@ -54,7 +54,8 @@ describe('usePerpsWithdrawToastRegistrations', () => {
     expect(result.current[0].eventName).toBe(
       'TransactionController:transactionStatusUpdated',
     );
-    return result.current[0].handler;
+    const { handler } = result.current[0];
+    return (payload: unknown) => handler(payload, jest.fn());
   }
 
   it('shows pending toast when perpsWithdraw transaction is approved', () => {

--- a/app/components/UI/Perps/hooks/usePerpsWithdrawToastRegistrations.test.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawToastRegistrations.test.tsx
@@ -7,9 +7,17 @@ import {
 } from '@metamask/transaction-controller';
 import { usePerpsWithdrawToastRegistrations } from './usePerpsWithdrawToastRegistrations';
 import { strings } from '../../../../../locales/i18n';
-import { IconName } from '../../../../component-library/components/Icons/Icon';
-import { ToastVariants } from '../../../../component-library/components/Toast';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { MUSD_TOKEN_ADDRESS } from '../../Earn/constants/musd';
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+    Spinner: 'Spinner',
+  };
+});
 
 jest.mock('../../../../util/theme', () => ({
   ...jest.requireActual('../../../../util/theme'),
@@ -36,11 +44,8 @@ jest.mock('../../../../store', () => ({
 }));
 
 describe('usePerpsWithdrawToastRegistrations', () => {
-  let mockShowToast: jest.Mock;
-
   beforeEach(() => {
     jest.clearAllMocks();
-    mockShowToast = jest.fn();
   });
 
   function getHandler() {
@@ -55,28 +60,18 @@ describe('usePerpsWithdrawToastRegistrations', () => {
   it('shows pending toast when perpsWithdraw transaction is approved', () => {
     const handler = getHandler();
 
-    handler(
-      {
-        transactionMeta: {
-          id: 'tx-1',
-          type: TransactionType.perpsWithdraw,
-          status: TransactionStatus.approved,
-        } as TransactionMeta,
-      },
-      mockShowToast,
-    );
+    handler({
+      transactionMeta: {
+        id: 'tx-1',
+        type: TransactionType.perpsWithdraw,
+        status: TransactionStatus.approved,
+      } as TransactionMeta,
+    });
 
-    expect(mockShowToast).toHaveBeenCalledWith(
+    expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Loading,
+        title: strings('perps.withdrawal.toast_pending_title'),
         hasNoTimeout: false,
-        labelOptions: expect.arrayContaining([
-          expect.objectContaining({
-            label: strings('perps.withdrawal.toast_pending_title'),
-            isBold: true,
-          }),
-        ]),
       }),
     );
   });
@@ -84,21 +79,18 @@ describe('usePerpsWithdrawToastRegistrations', () => {
   it('shows pending toast when perpsWithdraw is in nestedTransactions', () => {
     const handler = getHandler();
 
-    handler(
-      {
-        transactionMeta: {
-          id: 'tx-2',
-          type: TransactionType.simpleSend,
-          nestedTransactions: [{ type: TransactionType.perpsWithdraw }],
-          status: TransactionStatus.approved,
-        } as unknown as TransactionMeta,
-      },
-      mockShowToast,
-    );
+    handler({
+      transactionMeta: {
+        id: 'tx-2',
+        type: TransactionType.simpleSend,
+        nestedTransactions: [{ type: TransactionType.perpsWithdraw }],
+        status: TransactionStatus.approved,
+      } as unknown as TransactionMeta,
+    });
 
-    expect(mockShowToast).toHaveBeenCalledWith(
+    expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
-        iconName: IconName.Loading,
+        startAccessory: expect.anything(),
       }),
     );
   });
@@ -106,27 +98,18 @@ describe('usePerpsWithdrawToastRegistrations', () => {
   it('shows success toast when perpsWithdraw transaction is confirmed', () => {
     const handler = getHandler();
 
-    handler(
-      {
-        transactionMeta: {
-          id: 'tx-3',
-          type: TransactionType.perpsWithdraw,
-          status: TransactionStatus.confirmed,
-        } as TransactionMeta,
-      },
-      mockShowToast,
-    );
+    handler({
+      transactionMeta: {
+        id: 'tx-3',
+        type: TransactionType.perpsWithdraw,
+        status: TransactionStatus.confirmed,
+      } as TransactionMeta,
+    });
 
-    expect(mockShowToast).toHaveBeenCalledWith(
+    expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        labelOptions: expect.arrayContaining([
-          expect.objectContaining({
-            label: strings('perps.withdrawal.toast_completed_title'),
-            isBold: true,
-          }),
-        ]),
+        severity: ToastSeverity.Success,
+        title: strings('perps.withdrawal.toast_completed_title'),
       }),
     );
   });
@@ -134,27 +117,18 @@ describe('usePerpsWithdrawToastRegistrations', () => {
   it('shows error toast when perpsWithdraw transaction fails', () => {
     const handler = getHandler();
 
-    handler(
-      {
-        transactionMeta: {
-          id: 'tx-4',
-          type: TransactionType.perpsWithdraw,
-          status: TransactionStatus.failed,
-        } as TransactionMeta,
-      },
-      mockShowToast,
-    );
+    handler({
+      transactionMeta: {
+        id: 'tx-4',
+        type: TransactionType.perpsWithdraw,
+        status: TransactionStatus.failed,
+      } as TransactionMeta,
+    });
 
-    expect(mockShowToast).toHaveBeenCalledWith(
+    expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Error,
-        labelOptions: expect.arrayContaining([
-          expect.objectContaining({
-            label: strings('perps.withdrawal.toast_error_title'),
-            isBold: true,
-          }),
-        ]),
+        severity: ToastSeverity.Danger,
+        title: strings('perps.withdrawal.toast_error_title'),
       }),
     );
   });
@@ -162,18 +136,15 @@ describe('usePerpsWithdrawToastRegistrations', () => {
   it('ignores non-perpsWithdraw transactions', () => {
     const handler = getHandler();
 
-    handler(
-      {
-        transactionMeta: {
-          id: 'tx-5',
-          type: TransactionType.simpleSend,
-          status: TransactionStatus.approved,
-        } as TransactionMeta,
-      },
-      mockShowToast,
-    );
+    handler({
+      transactionMeta: {
+        id: 'tx-5',
+        type: TransactionType.simpleSend,
+        status: TransactionStatus.approved,
+      } as TransactionMeta,
+    });
 
-    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(toast).not.toHaveBeenCalled();
   });
 
   it('shows success toast with post-quote token and amount', () => {
@@ -207,26 +178,17 @@ describe('usePerpsWithdrawToastRegistrations', () => {
 
     const handler = getHandler();
 
-    handler(
-      {
-        transactionMeta: {
-          id: 'tx-pq',
-          type: TransactionType.perpsWithdraw,
-          status: TransactionStatus.confirmed,
-        } as TransactionMeta,
-      },
-      mockShowToast,
-    );
+    handler({
+      transactionMeta: {
+        id: 'tx-pq',
+        type: TransactionType.perpsWithdraw,
+        status: TransactionStatus.confirmed,
+      } as TransactionMeta,
+    });
 
-    expect(mockShowToast).toHaveBeenCalledWith(
+    expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
-        iconName: IconName.Confirmation,
-        labelOptions: expect.arrayContaining([
-          expect.objectContaining({
-            label: expect.stringContaining('BNB'),
-            isBold: false,
-          }),
-        ]),
+        description: expect.stringContaining('BNB'),
       }),
     );
   });
@@ -260,22 +222,15 @@ describe('usePerpsWithdrawToastRegistrations', () => {
 
     const handler = getHandler();
 
-    handler(
-      {
-        transactionMeta: {
-          id: 'tx-ticker',
-          type: TransactionType.perpsWithdraw,
-          status: TransactionStatus.confirmed,
-        } as TransactionMeta,
-      },
-      mockShowToast,
-    );
+    handler({
+      transactionMeta: {
+        id: 'tx-ticker',
+        type: TransactionType.perpsWithdraw,
+        status: TransactionStatus.confirmed,
+      } as TransactionMeta,
+    });
 
-    expect(mockShowToast).toHaveBeenCalledWith(
-      expect.objectContaining({
-        iconName: IconName.Confirmation,
-      }),
-    );
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({}));
   });
 
   it('shows success toast with USDC fallback when no token or ticker found', () => {
@@ -301,26 +256,19 @@ describe('usePerpsWithdrawToastRegistrations', () => {
 
     const handler = getHandler();
 
-    handler(
-      {
-        transactionMeta: {
-          id: 'tx-usdc',
-          type: TransactionType.perpsWithdraw,
-          status: TransactionStatus.confirmed,
-        } as TransactionMeta,
-      },
-      mockShowToast,
-    );
+    handler({
+      transactionMeta: {
+        id: 'tx-usdc',
+        type: TransactionType.perpsWithdraw,
+        status: TransactionStatus.confirmed,
+      } as TransactionMeta,
+    });
 
-    expect(mockShowToast).toHaveBeenCalledWith(
+    expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
-        iconName: IconName.Confirmation,
-        labelOptions: expect.arrayContaining([
-          expect.objectContaining({
-            label: strings('perps.withdrawal.toast_completed_subtitle_generic'),
-            isBold: false,
-          }),
-        ]),
+        description: strings(
+          'perps.withdrawal.toast_completed_subtitle_generic',
+        ),
       }),
     );
   });
@@ -345,41 +293,35 @@ describe('usePerpsWithdrawToastRegistrations', () => {
     it('suppresses the native success toast when destination is the Money account', () => {
       const handler = getHandler();
 
-      handler(
-        {
-          transactionMeta: moneyWithdrawMeta(
-            'tx-money',
-            TransactionStatus.confirmed,
-          ),
-        },
-        mockShowToast,
-      );
+      handler({
+        transactionMeta: moneyWithdrawMeta(
+          'tx-money',
+          TransactionStatus.confirmed,
+        ),
+      });
 
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('still shows the native success toast for a non-Money withdraw (other flows unchanged)', () => {
       const handler = getHandler();
 
-      handler(
-        {
-          transactionMeta: {
-            id: 'tx-not-money',
-            type: TransactionType.perpsWithdraw,
-            status: TransactionStatus.confirmed,
-            metamaskPay: {
-              tokenAddress: MUSD_TOKEN_ADDRESS,
-              chainId: '0x1',
-              isPostQuote: true,
-              targetFiat: '25',
-            },
-          } as unknown as TransactionMeta,
-        },
-        mockShowToast,
-      );
+      handler({
+        transactionMeta: {
+          id: 'tx-not-money',
+          type: TransactionType.perpsWithdraw,
+          status: TransactionStatus.confirmed,
+          metamaskPay: {
+            tokenAddress: MUSD_TOKEN_ADDRESS,
+            chainId: '0x1',
+            isPostQuote: true,
+            targetFiat: '25',
+          },
+        } as unknown as TransactionMeta,
+      });
 
-      expect(mockShowToast).toHaveBeenCalledWith(
-        expect.objectContaining({ iconName: IconName.Confirmation }),
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({ severity: ToastSeverity.Success }),
       );
     });
   });
@@ -387,18 +329,15 @@ describe('usePerpsWithdrawToastRegistrations', () => {
   it('ignores other status changes like submitted', () => {
     const handler = getHandler();
 
-    handler(
-      {
-        transactionMeta: {
-          id: 'tx-sub',
-          type: TransactionType.perpsWithdraw,
-          status: TransactionStatus.submitted,
-        } as TransactionMeta,
-      },
-      mockShowToast,
-    );
+    handler({
+      transactionMeta: {
+        id: 'tx-sub',
+        type: TransactionType.perpsWithdraw,
+        status: TransactionStatus.submitted,
+      } as TransactionMeta,
+    });
 
-    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(toast).not.toHaveBeenCalled();
   });
 
   it('does not duplicate toasts for same transaction + status', () => {
@@ -412,9 +351,9 @@ describe('usePerpsWithdrawToastRegistrations', () => {
       } as TransactionMeta,
     };
 
-    handler(payload, mockShowToast);
-    handler(payload, mockShowToast);
+    handler(payload);
+    handler(payload);
 
-    expect(mockShowToast).toHaveBeenCalledTimes(1);
+    expect(toast).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/components/UI/Perps/hooks/usePerpsWithdrawToastRegistrations.tsx
+++ b/app/components/UI/Perps/hooks/usePerpsWithdrawToastRegistrations.tsx
@@ -1,7 +1,8 @@
 import {
-  IconColor as ReactNativeDsIconColor,
   IconSize as ReactNativeDsIconSize,
   Spinner,
+  toast,
+  ToastSeverity,
 } from '@metamask/design-system-react-native';
 import {
   TransactionMeta,
@@ -11,11 +12,7 @@ import {
 } from '@metamask/transaction-controller';
 import React, { useCallback, useMemo } from 'react';
 import { strings } from '../../../../../locales/i18n';
-import { IconName } from '../../../../component-library/components/Icons/Icon';
-import { ToastVariants } from '../../../../component-library/components/Toast';
-import type { ToastRef } from '../../../../component-library/components/Toast/Toast.types';
 import type { ToastRegistration } from '../../../Nav/App/ControllerEventToastBridge';
-import { useAppThemeFromContext } from '../../../../util/theme';
 import { resolveWithdrawTokenInfo } from '../../../Views/confirmations/utils/withdraw-token-resolution';
 import { isPerpsPredictMoneyWithdraw } from '../../Money/utils/moneyTransactionGuards';
 import { store } from '../../../../store';
@@ -37,12 +34,10 @@ function getWithdrawConfirmedDescription(transactionId: string): string {
 }
 
 export const usePerpsWithdrawToastRegistrations = (): ToastRegistration[] => {
-  const theme = useAppThemeFromContext();
-
   const processedRef = React.useRef<Set<string>>(new Set());
 
   const handleTransactionStatusUpdated = useCallback(
-    (payload: unknown, showToast: ToastRef['showToast']): void => {
+    (payload: unknown): void => {
       const { transactionMeta } = payload as {
         transactionMeta: TransactionMeta;
       };
@@ -61,26 +56,12 @@ export const usePerpsWithdrawToastRegistrations = (): ToastRegistration[] => {
       processedRef.current.add(key);
 
       if (status === TransactionStatus.approved) {
-        showToast({
-          variant: ToastVariants.Icon,
-          labelOptions: [
-            {
-              label: strings('perps.withdrawal.toast_pending_title'),
-              isBold: true,
-            },
-            { label: '\n', isBold: false },
-            {
-              label: strings('perps.withdrawal.toast_pending_subtitle'),
-              isBold: false,
-            },
-          ],
-          iconName: IconName.Loading,
+        toast({
+          title: strings('perps.withdrawal.toast_pending_title'),
+          description: strings('perps.withdrawal.toast_pending_subtitle'),
           hasNoTimeout: false,
           startAccessory: (
-            <Spinner
-              color={ReactNativeDsIconColor.IconDefault}
-              spinnerIconProps={{ size: ReactNativeDsIconSize.Lg }}
-            />
+            <Spinner spinnerIconProps={{ size: ReactNativeDsIconSize.Lg }} />
           ),
         });
         return;
@@ -91,46 +72,25 @@ export const usePerpsWithdrawToastRegistrations = (): ToastRegistration[] => {
           return;
         }
 
-        const description = getWithdrawConfirmedDescription(id);
-
-        showToast({
-          variant: ToastVariants.Icon,
-          labelOptions: [
-            {
-              label: strings('perps.withdrawal.toast_completed_title'),
-              isBold: true,
-            },
-            { label: '\n', isBold: false },
-            { label: description, isBold: false },
-          ],
-          iconName: IconName.Confirmation,
-          iconColor: theme.colors.success.default,
+        toast({
+          title: strings('perps.withdrawal.toast_completed_title'),
+          description: getWithdrawConfirmedDescription(id),
+          severity: ToastSeverity.Success,
           hasNoTimeout: false,
         });
         return;
       }
 
       if (status === TransactionStatus.failed) {
-        showToast({
-          variant: ToastVariants.Icon,
-          labelOptions: [
-            {
-              label: strings('perps.withdrawal.toast_error_title'),
-              isBold: true,
-            },
-            { label: '\n', isBold: false },
-            {
-              label: strings('perps.withdrawal.toast_error_description'),
-              isBold: false,
-            },
-          ],
-          iconName: IconName.Error,
-          iconColor: theme.colors.error.default,
+        toast({
+          title: strings('perps.withdrawal.toast_error_title'),
+          description: strings('perps.withdrawal.toast_error_description'),
+          severity: ToastSeverity.Danger,
           hasNoTimeout: false,
         });
       }
     },
-    [theme.colors.error.default, theme.colors.success.default],
+    [],
   );
 
   return useMemo(

--- a/app/components/UI/Perps/integration/componentFlow.integration.test.tsx
+++ b/app/components/UI/Perps/integration/componentFlow.integration.test.tsx
@@ -75,22 +75,14 @@ describe('Perps component flows — integration', () => {
         );
         expect(perps.mocks.showToast).toHaveBeenCalledWith(
           expect.objectContaining({
-            labelOptions: expect.arrayContaining([
-              expect.objectContaining({
-                label: expect.stringMatching(/submitted/i),
-              }),
-            ]),
+            title: expect.stringMatching(/submitted/i),
           }),
         );
         await waitFor(
           () => {
             expect(perps.mocks.showToast).toHaveBeenCalledWith(
               expect.objectContaining({
-                labelOptions: expect.arrayContaining([
-                  expect.objectContaining({
-                    label: expect.stringMatching(/filled/i),
-                  }),
-                ]),
+                title: expect.stringMatching(/filled/i),
               }),
             );
           },
@@ -153,11 +145,7 @@ describe('Perps component flows — integration', () => {
         );
         expect(perps.mocks.showToast).toHaveBeenCalledWith(
           expect.objectContaining({
-            labelOptions: expect.arrayContaining([
-              expect.objectContaining({
-                label: 'Order filled',
-              }),
-            ]),
+            title: 'Order filled',
           }),
         );
       } finally {

--- a/app/util/test/testSetup.js
+++ b/app/util/test/testSetup.js
@@ -947,6 +947,7 @@ jest.mock('@metamask/design-system-react-native', () => {
   return {
     ...actual,
     BottomSheet,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
   };
 });
 

--- a/app/util/test/testSetupView.js
+++ b/app/util/test/testSetupView.js
@@ -890,6 +890,7 @@ jest.mock('@metamask/design-system-react-native', () => {
   return {
     ...actual,
     BottomSheet,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
   };
 });
 

--- a/tests/integration/harnesses/perps/perps-component.tsx
+++ b/tests/integration/harnesses/perps/perps-component.tsx
@@ -342,7 +342,10 @@ export function buildPerpsComponentHarness(
   >;
   const closeToast = toast.dismiss as unknown as jest.Mock<void, []>;
   const toastRef: React.RefObject<ToastRef | null> = {
-    current: { showToast, closeToast },
+    current: {
+      showToast: showToast as unknown as ToastRef['showToast'],
+      closeToast,
+    },
   };
 
   const renderWithFlow = (

--- a/tests/integration/harnesses/perps/perps-component.tsx
+++ b/tests/integration/harnesses/perps/perps-component.tsx
@@ -18,7 +18,8 @@
  * MOCKED:
  *   - Shape A/B I/O boundary mocks (SDK, wallet, subscriptions, readiness)
  *   - React Native runtime modules that do not affect perps logic
- *   - Toast ref implementation, captured for assertions
+ *   - MMDS `toast()` implementation, captured for assertions
+ *   - ToastContext ref (legacy CL toasts, if any remain)
  */
 
 jest.mock('react-native-reanimated', () => {
@@ -97,6 +98,13 @@ jest.mock('../../../../app/util/trace', () => ({
   trace: jest.fn(),
   endTrace: jest.fn(),
 }));
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
 import React from 'react';
 import { View } from 'react-native';
@@ -105,6 +113,10 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ConnectionStatus } from '@metamask/hw-wallet-sdk';
 import { type PriceUpdate } from '@metamask/perps-controller';
+import {
+  toast,
+  type ToastOptions as MmdsToastOptions,
+} from '@metamask/design-system-react-native';
 
 import { buildPerpsFlowHarness, type PerpsFlowHarness } from './perps-flow';
 import type { PerpsHarnessOptions } from './perps';
@@ -121,10 +133,7 @@ import {
   PerpsStreamProvider,
   type PerpsStreamManager,
 } from '../../../../app/components/UI/Perps/providers/PerpsStreamManager';
-import type {
-  ToastOptions,
-  ToastRef,
-} from '../../../../app/component-library/components/Toast/Toast.types';
+import type { ToastRef } from '../../../../app/component-library/components/Toast/Toast.types';
 import { AccessRestrictedProvider } from '../../../../app/components/UI/Compliance';
 import Routes from '../../../../app/constants/navigation/Routes';
 import { initialStatePerps } from '../../../component-view/presets/perpsStatePreset';
@@ -132,7 +141,7 @@ import HardwareWalletContext, {
   type HardwareWalletContextValue,
 } from '../../../../app/core/HardwareWallet/contexts/HardwareWalletContext';
 
-type ToastOptionsForHarness = ToastOptions;
+type ToastOptionsForHarness = MmdsToastOptions;
 
 interface PerpsComponentRenderOptions {
   stateOverrides?: DeepPartial<RootState>;
@@ -327,8 +336,11 @@ export function buildPerpsComponentHarness(
   options: PerpsHarnessOptions = {},
 ): PerpsComponentHarness {
   const flowHarness = buildPerpsFlowHarness(options);
-  const showToast = jest.fn<void, [ToastOptionsForHarness]>();
-  const closeToast = jest.fn<void, []>();
+  const showToast = toast as unknown as jest.Mock<
+    void,
+    [ToastOptionsForHarness]
+  >;
+  const closeToast = toast.dismiss as unknown as jest.Mock<void, []>;
   const toastRef: React.RefObject<ToastRef | null> = {
     current: { showToast, closeToast },
   };
@@ -406,6 +418,8 @@ export function buildPerpsComponentHarness(
     },
     teardown: () => {
       flowHarness.harness.mocks.subscription.clearAll();
+      showToast.mockClear();
+      closeToast.mockClear();
     },
   };
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Perps still showed order, deposit, withdraw, close-all, and developer-toggle feedback through the legacy `ToastContext` `showToast` API. This PR switches those call sites to the design-system `toast()` API so Perps toasts share the same toaster as the rest of the toast migration.

`usePerpsToasts` now maps success/warning/danger/info to `ToastSeverity`, keeps spinner `startAccessory` for in-progress states, and uses `actionButtonLabel` / `actionButtonOnPress` for Track, Share, Try again, and Cancel trade. Icon-only close controls are dropped in favor of the design-system close. Shared toast infrastructure (`ToastContext`, `ToastService`, `ControllerEventToastBridge`) is unchanged.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

Refs: No tracking issue; continues the design-system toast migration for Perps flows

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps design-system toasts

  Background:
    Given I am logged into MetaMask Mobile
    And Perps is enabled for my account

  Scenario: user places a market order
    Given I am on the Perps order screen with a valid amount

    When user taps place order
    Then a submitting toast appears
    And a filled or success toast follows when the order completes
    And the toast can be dismissed with the design-system close control

  Scenario: user closes all positions
    Given I have at least one open Perps position
    And I open the close-all positions sheet

    When user confirms close all
    Then a success toast appears with the close-all confirmation

  Scenario: user fails to toggle testnet in developer options
    Given I am on Perps developer options
    And the testnet toggle will fail

    When user toggles the Hyperliquid network switch
    Then a danger toast appears with the failed-to-toggle copy
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
