### PR TITLE
feat(network): prefetch popular-token spot prices on cold start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Prefetch empty-wallet popular-token spot prices on cold start via nitro-fetch so homepage prices can resolve from cache
+
 ## [8.8.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Prefetch empty-wallet popular-token spot prices on cold start via nitro-fetch so homepage prices can resolve from cache
+- Prefetch homepage Predictions trending markets on cold start via nitro-fetch so prediction cards can resolve from cache
 
 ## [8.8.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Prefetch empty-wallet popular-token spot prices on cold start via nitro-fetch so homepage prices can resolve from cache
-- Prefetch homepage Predictions trending markets on cold start via nitro-fetch so prediction cards can resolve from cache
+- Prefetch homepage Predictions requests (trending markets and discovery event slots, covering both A/B variants) on cold start via nitro-fetch so prediction cards can resolve from cache
 
 ## [8.8.1]
 

--- a/app/core/NitroFetchSetup.test.ts
+++ b/app/core/NitroFetchSetup.test.ts
@@ -70,11 +70,12 @@ const PREDICT_TRENDING_MARKETS_URL = `${PREDICT_TRENDING_MARKETS_PREFIX}?${new U
     order: 'volume24hr',
   },
 )}`;
+const PREDICT_HOMEPAGE_SLOTS_URL = `${PREDICT_TRENDING_MARKETS_PREFIX}?limit=2&active=true&archived=false&closed=false&id=659518&id=478277`;
 
 describe('NitroFetchSetup', () => {
   describe('startup prefetch registration', () => {
-    it('registers all five startup prefetch endpoints on module load', () => {
-      expect(mockPrefetchOnAppStart).toHaveBeenCalledTimes(5);
+    it('registers all six startup prefetch endpoints on module load', () => {
+      expect(mockPrefetchOnAppStart).toHaveBeenCalledTimes(6);
       expect(mockPrefetchOnAppStart).toHaveBeenCalledWith(
         expect.stringContaining(FEATURE_FLAGS_PREFIX),
         { prefetchKey: 'feature-flags' },
@@ -102,6 +103,13 @@ describe('NitroFetchSetup', () => {
         PREDICT_TRENDING_MARKETS_URL,
         {
           prefetchKey: 'predict-trending-markets',
+          prefetchCacheTtlMs: 120_000,
+        },
+      );
+      expect(mockPrefetchOnAppStart).toHaveBeenCalledWith(
+        PREDICT_HOMEPAGE_SLOTS_URL,
+        {
+          prefetchKey: 'predict-homepage-slots',
           prefetchCacheTtlMs: 120_000,
         },
       );
@@ -326,6 +334,27 @@ describe('NitroFetchSetup', () => {
           (init as RequestInit & { prefetchCacheTtlMs?: number })
             ?.prefetchCacheTtlMs,
         ).toBe(120_000);
+      });
+
+      it('injects prefetchKey for the homepage predict discovery slots URL', async () => {
+        await global.fetch(PREDICT_HOMEPAGE_SLOTS_URL);
+
+        const [, init] = mockNitroFetch.mock.calls[0];
+        expect((init?.headers as Headers).get('prefetchKey')).toBe(
+          'predict-homepage-slots',
+        );
+        expect(
+          (init as RequestInit & { prefetchCacheTtlMs?: number })
+            ?.prefetchCacheTtlMs,
+        ).toBe(120_000);
+      });
+
+      it('does not inject prefetchKey for other limit=2 keyset requests without the slot event ids', async () => {
+        const otherUrl = `${PREDICT_TRENDING_MARKETS_PREFIX}?limit=2&active=true&archived=false&closed=false&id=111111&id=222222`;
+
+        await global.fetch(otherUrl);
+
+        expect(mockNitroFetch).toHaveBeenCalledWith(otherUrl, undefined);
       });
 
       it('does not inject prefetchKey for predict feed requests with a different page size', async () => {

--- a/app/core/NitroFetchSetup.test.ts
+++ b/app/core/NitroFetchSetup.test.ts
@@ -29,6 +29,10 @@ jest.mock('./Engine/controllers/remote-feature-flag-controller/utils', () => ({
   getFeatureFlagAppEnvironment: jest.fn(() => 'production'),
 }));
 
+jest.mock('@metamask/money-account-utils', () => ({
+  MUSD_TOKEN_ADDRESS: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+}));
+
 import './NitroFetchSetup';
 
 const mockNitroFetch = jest.mocked(nitroFetch);
@@ -36,11 +40,27 @@ const mockPrefetchOnAppStart = jest.mocked(prefetchOnAppStart);
 
 const FEATURE_FLAGS_PREFIX =
   'https://client-config.api.cx.metamask.io/v1/flags';
+const POPULAR_TOKENS_SPOT_PRICES_PREFIX =
+  'https://price.api.cx.metamask.io/v3/spot-prices';
+const MUSD_TOKEN_ADDRESS = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
+const POPULAR_TOKENS_SPOT_PRICES_URL = `${POPULAR_TOKENS_SPOT_PRICES_PREFIX}?${new URLSearchParams(
+  {
+    assetIds: [
+      `eip155:1/erc20:${MUSD_TOKEN_ADDRESS}`,
+      'eip155:1/slip44:60',
+      'bip122:000000000019d6689c085ae165831e93/slip44:0',
+      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+      'eip155:56/slip44:714',
+    ].join(','),
+    includeMarketData: 'true',
+    vsCurrency: 'usd',
+  },
+)}`;
 
 describe('NitroFetchSetup', () => {
   describe('startup prefetch registration', () => {
-    it('registers all three startup prefetch endpoints on module load', () => {
-      expect(mockPrefetchOnAppStart).toHaveBeenCalledTimes(3);
+    it('registers all four startup prefetch endpoints on module load', () => {
+      expect(mockPrefetchOnAppStart).toHaveBeenCalledTimes(4);
       expect(mockPrefetchOnAppStart).toHaveBeenCalledWith(
         expect.stringContaining(FEATURE_FLAGS_PREFIX),
         { prefetchKey: 'feature-flags' },
@@ -55,6 +75,13 @@ describe('NitroFetchSetup', () => {
         C2_DOMAIN_BLOCKLIST_URL,
         {
           prefetchKey: 'phishing-c2-blocklist',
+        },
+      );
+      expect(mockPrefetchOnAppStart).toHaveBeenCalledWith(
+        POPULAR_TOKENS_SPOT_PRICES_URL,
+        {
+          prefetchKey: 'popular-tokens-spot-prices',
+          prefetchCacheTtlMs: 120_000,
         },
       );
     });
@@ -238,6 +265,47 @@ describe('NitroFetchSetup', () => {
         expect((init?.headers as Headers).get('prefetchKey')).toBe(
           'phishing-c2-blocklist',
         );
+      });
+
+      it('injects prefetchKey for popular-tokens spot-prices URL (USD + mUSD asset)', async () => {
+        await global.fetch(POPULAR_TOKENS_SPOT_PRICES_URL);
+
+        const [, init] = mockNitroFetch.mock.calls[0];
+        expect((init?.headers as Headers).get('prefetchKey')).toBe(
+          'popular-tokens-spot-prices',
+        );
+        expect(
+          (init as RequestInit & { prefetchCacheTtlMs?: number })
+            ?.prefetchCacheTtlMs,
+        ).toBe(120_000);
+      });
+
+      it('does not inject prefetchKey for spot-prices with a non-USD currency', async () => {
+        const eurUrl = `${POPULAR_TOKENS_SPOT_PRICES_PREFIX}?${new URLSearchParams(
+          {
+            assetIds: `eip155:1/erc20:${MUSD_TOKEN_ADDRESS}`,
+            includeMarketData: 'true',
+            vsCurrency: 'eur',
+          },
+        )}`;
+
+        await global.fetch(eurUrl);
+
+        expect(mockNitroFetch).toHaveBeenCalledWith(eurUrl, undefined);
+      });
+
+      it('does not inject prefetchKey for unrelated spot-prices requests', async () => {
+        const otherUrl = `${POPULAR_TOKENS_SPOT_PRICES_PREFIX}?${new URLSearchParams(
+          {
+            assetIds: 'eip155:1/slip44:60',
+            includeMarketData: 'true',
+            vsCurrency: 'usd',
+          },
+        )}`;
+
+        await global.fetch(otherUrl);
+
+        expect(mockNitroFetch).toHaveBeenCalledWith(otherUrl, undefined);
       });
 
       it('preserves existing init options alongside injected prefetchKey', async () => {

--- a/app/core/NitroFetchSetup.test.ts
+++ b/app/core/NitroFetchSetup.test.ts
@@ -56,11 +56,25 @@ const POPULAR_TOKENS_SPOT_PRICES_URL = `${POPULAR_TOKENS_SPOT_PRICES_PREFIX}?${n
     vsCurrency: 'usd',
   },
 )}`;
+const PREDICT_TRENDING_MARKETS_PREFIX =
+  'https://gamma-api.polymarket.com/events/keyset';
+const PREDICT_TRENDING_MARKETS_URL = `${PREDICT_TRENDING_MARKETS_PREFIX}?${new URLSearchParams(
+  {
+    limit: '5',
+    active: 'true',
+    archived: 'false',
+    closed: 'false',
+    ascending: 'false',
+    liquidity_min: '10000',
+    volume_min: '10000',
+    order: 'volume24hr',
+  },
+)}`;
 
 describe('NitroFetchSetup', () => {
   describe('startup prefetch registration', () => {
-    it('registers all four startup prefetch endpoints on module load', () => {
-      expect(mockPrefetchOnAppStart).toHaveBeenCalledTimes(4);
+    it('registers all five startup prefetch endpoints on module load', () => {
+      expect(mockPrefetchOnAppStart).toHaveBeenCalledTimes(5);
       expect(mockPrefetchOnAppStart).toHaveBeenCalledWith(
         expect.stringContaining(FEATURE_FLAGS_PREFIX),
         { prefetchKey: 'feature-flags' },
@@ -81,6 +95,13 @@ describe('NitroFetchSetup', () => {
         POPULAR_TOKENS_SPOT_PRICES_URL,
         {
           prefetchKey: 'popular-tokens-spot-prices',
+          prefetchCacheTtlMs: 120_000,
+        },
+      );
+      expect(mockPrefetchOnAppStart).toHaveBeenCalledWith(
+        PREDICT_TRENDING_MARKETS_URL,
+        {
+          prefetchKey: 'predict-trending-markets',
           prefetchCacheTtlMs: 120_000,
         },
       );
@@ -292,6 +313,38 @@ describe('NitroFetchSetup', () => {
         await global.fetch(eurUrl);
 
         expect(mockNitroFetch).toHaveBeenCalledWith(eurUrl, undefined);
+      });
+
+      it('injects prefetchKey for the homepage predict trending markets URL', async () => {
+        await global.fetch(PREDICT_TRENDING_MARKETS_URL);
+
+        const [, init] = mockNitroFetch.mock.calls[0];
+        expect((init?.headers as Headers).get('prefetchKey')).toBe(
+          'predict-trending-markets',
+        );
+        expect(
+          (init as RequestInit & { prefetchCacheTtlMs?: number })
+            ?.prefetchCacheTtlMs,
+        ).toBe(120_000);
+      });
+
+      it('does not inject prefetchKey for predict feed requests with a different page size', async () => {
+        const feedUrl = `${PREDICT_TRENDING_MARKETS_PREFIX}?${new URLSearchParams(
+          {
+            limit: '20',
+            active: 'true',
+            archived: 'false',
+            closed: 'false',
+            ascending: 'false',
+            liquidity_min: '10000',
+            volume_min: '10000',
+            order: 'volume24hr',
+          },
+        )}`;
+
+        await global.fetch(feedUrl);
+
+        expect(mockNitroFetch).toHaveBeenCalledWith(feedUrl, undefined);
       });
 
       it('does not inject prefetchKey for unrelated spot-prices requests', async () => {

--- a/app/core/NitroFetchSetup.ts
+++ b/app/core/NitroFetchSetup.ts
@@ -30,10 +30,37 @@ import {
   C2_DOMAIN_BLOCKLIST_URL,
   METAMASK_STALELIST_URL,
 } from '@metamask/phishing-controller';
+import { MUSD_TOKEN_ADDRESS } from '@metamask/money-account-utils';
 import {
   getFeatureFlagAppDistribution,
   getFeatureFlagAppEnvironment,
 } from './Engine/controllers/remote-feature-flag-controller/utils';
+
+/**
+ * Must mirror POPULAR_TOKENS assetIds (same order) in
+ * app/components/Views/Homepage/Sections/Tokens/hooks/usePopularTokens.ts.
+ * Prefetch URL is USD-only; non-USD display currencies skip the cache hit and
+ * fetch normally (see urlIncludes on the popular-tokens entry).
+ */
+const POPULAR_TOKEN_ASSET_IDS = [
+  `eip155:1/erc20:${MUSD_TOKEN_ADDRESS}`,
+  'eip155:1/slip44:60',
+  'bip122:000000000019d6689c085ae165831e93/slip44:0',
+  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+  'eip155:56/slip44:714',
+] as const;
+
+/** Covers cold start → unlock → empty-wallet Tokens mount on mid-range devices. */
+const POPULAR_TOKENS_PREFETCH_TTL_MS = 120_000;
+
+interface StartupPrefetch {
+  url: string;
+  urlPrefix: string;
+  key: string;
+  /** When set, every substring must appear in the consuming URL. */
+  urlIncludes?: readonly string[];
+  prefetchCacheTtlMs?: number;
+}
 
 /**
  * Single source of truth for startup prefetches.
@@ -46,7 +73,7 @@ import {
  * Adding an entry here automatically registers it AND wires up the cache hit.
  * You cannot add one without the other.
  */
-const STARTUP_PREFETCHES = [
+const STARTUP_PREFETCHES: readonly StartupPrefetch[] = [
   {
     url:
       `https://client-config.api.cx.metamask.io/v1/flags` +
@@ -66,12 +93,42 @@ const STARTUP_PREFETCHES = [
     urlPrefix: C2_DOMAIN_BLOCKLIST_URL,
     key: 'phishing-c2-blocklist',
   },
-] as const;
+  {
+    // Empty-wallet homepage popular tokens (usePopularTokens).
+    // urlIncludes scopes the one-shot cache to that request (mUSD asset + USD)
+    // so other spot-prices callers do not consume or get a wrong currency body.
+    url: `https://price.api.cx.metamask.io/v3/spot-prices?${new URLSearchParams(
+      {
+        assetIds: POPULAR_TOKEN_ASSET_IDS.join(','),
+        includeMarketData: 'true',
+        vsCurrency: 'usd',
+      },
+    )}`,
+    urlPrefix: 'https://price.api.cx.metamask.io/v3/spot-prices',
+    urlIncludes: [MUSD_TOKEN_ADDRESS, 'vsCurrency=usd'],
+    key: 'popular-tokens-spot-prices',
+    prefetchCacheTtlMs: POPULAR_TOKENS_PREFETCH_TTL_MS,
+  },
+];
 
 function getUrl(input: RequestInfo | URL): string {
   if (typeof input === 'string') return input;
   if (input instanceof URL) return input.href;
   return (input as Request).url ?? '';
+}
+
+function matchesPrefetchEntry(url: string, entry: StartupPrefetch): boolean {
+  if (!url.startsWith(entry.urlPrefix)) {
+    return false;
+  }
+  if (
+    entry.urlIncludes?.some(
+      (needle) => !url.toLowerCase().includes(needle.toLowerCase()),
+    )
+  ) {
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -84,9 +141,7 @@ function withPrefetchKey(
 ): RequestInit | undefined {
   const url = getUrl(input);
 
-  const entry = STARTUP_PREFETCHES.find(({ urlPrefix }) =>
-    url.startsWith(urlPrefix),
-  );
+  const entry = STARTUP_PREFETCHES.find((e) => matchesPrefetchEntry(url, e));
 
   if (!entry) return init;
 
@@ -96,7 +151,14 @@ function withPrefetchKey(
     headers.set('prefetchKey', entry.key);
   }
 
-  return { ...init, headers };
+  const result: RequestInit & { prefetchCacheTtlMs?: number } = {
+    ...init,
+    headers,
+  };
+  if (entry.prefetchCacheTtlMs !== undefined) {
+    result.prefetchCacheTtlMs = entry.prefetchCacheTtlMs;
+  }
+  return result;
 }
 
 /**
@@ -142,10 +204,14 @@ function installProductionNitroFetch(): void {
   _g.Request = Request;
   _g.Response = Response;
 
-  for (const { url, key } of STARTUP_PREFETCHES) {
+  for (const entry of STARTUP_PREFETCHES) {
+    const { url, key, prefetchCacheTtlMs } = entry;
     // Non-fatal: a registration failure means the cache is cold on next launch,
     // not that the request fails — swallow so it never becomes an unhandled rejection.
-    prefetchOnAppStart(url, { prefetchKey: key }).catch(() => undefined);
+    prefetchOnAppStart(url, {
+      prefetchKey: key,
+      ...(prefetchCacheTtlMs !== undefined ? { prefetchCacheTtlMs } : {}),
+    }).catch(() => undefined);
   }
 }
 

--- a/app/core/NitroFetchSetup.ts
+++ b/app/core/NitroFetchSetup.ts
@@ -73,6 +73,19 @@ const PREDICT_TRENDING_MARKETS_URL = `https://gamma-api.polymarket.com/events/ke
   },
 )}`;
 
+/**
+ * Must mirror the homepage Predictions discovery-variant request:
+ * useHomepagePredictMarketSlots → usePredictMarketData (category 'hot',
+ * limit = HOMEPAGE_PREDICT_EVENT_SLOTS.length) with
+ * HOMEPAGE_PREDICT_EVENT_QUERY in
+ * app/components/Views/Homepage/Sections/Predictions/constants/homepagePredictMarketSlots.ts.
+ * The A/B experiment coreMCU747AbtestPredictPositionsEmptyState shows either
+ * trending markets (control) or these fixed event slots (treatment), so both
+ * URLs are registered; only one is consumed per launch.
+ */
+const PREDICT_HOMEPAGE_SLOTS_URL =
+  'https://gamma-api.polymarket.com/events/keyset?limit=2&active=true&archived=false&closed=false&id=659518&id=478277';
+
 interface StartupPrefetch {
   url: string;
   urlPrefix: string;
@@ -138,6 +151,17 @@ const STARTUP_PREFETCHES: readonly StartupPrefetch[] = [
     urlPrefix: 'https://gamma-api.polymarket.com/events/keyset',
     urlIncludes: ['limit=5&', 'order=volume24hr'],
     key: 'predict-trending-markets',
+    prefetchCacheTtlMs: HOMEPAGE_PREFETCH_TTL_MS,
+  },
+  {
+    // Homepage Predictions discovery-variant event slots
+    // (useHomepagePredictMarketSlots). urlIncludes pins the one-shot cache to
+    // the fixed slots request (limit=2, first slot event id) so Predict feed
+    // tabs fetch normally.
+    url: PREDICT_HOMEPAGE_SLOTS_URL,
+    urlPrefix: 'https://gamma-api.polymarket.com/events/keyset',
+    urlIncludes: ['limit=2&', 'id=659518'],
+    key: 'predict-homepage-slots',
     prefetchCacheTtlMs: HOMEPAGE_PREFETCH_TTL_MS,
   },
 ];

--- a/app/core/NitroFetchSetup.ts
+++ b/app/core/NitroFetchSetup.ts
@@ -50,8 +50,28 @@ const POPULAR_TOKEN_ASSET_IDS = [
   'eip155:56/slip44:714',
 ] as const;
 
-/** Covers cold start → unlock → empty-wallet Tokens mount on mid-range devices. */
-const POPULAR_TOKENS_PREFETCH_TTL_MS = 120_000;
+/** Covers cold start → unlock → homepage section mount on mid-range devices. */
+const HOMEPAGE_PREFETCH_TTL_MS = 120_000;
+
+/**
+ * Must mirror the homepage Predictions section request:
+ * usePredictMarketsForHomepage (limit 5, category 'trending') →
+ * fetchEventsFromPolymarketApi in
+ * app/components/UI/Predict/providers/polymarket/utils.ts (param order matters
+ * for an exact URL match).
+ */
+const PREDICT_TRENDING_MARKETS_URL = `https://gamma-api.polymarket.com/events/keyset?${new URLSearchParams(
+  {
+    limit: '5',
+    active: 'true',
+    archived: 'false',
+    closed: 'false',
+    ascending: 'false',
+    liquidity_min: '10000',
+    volume_min: '10000',
+    order: 'volume24hr',
+  },
+)}`;
 
 interface StartupPrefetch {
   url: string;
@@ -107,7 +127,18 @@ const STARTUP_PREFETCHES: readonly StartupPrefetch[] = [
     urlPrefix: 'https://price.api.cx.metamask.io/v3/spot-prices',
     urlIncludes: [MUSD_TOKEN_ADDRESS, 'vsCurrency=usd'],
     key: 'popular-tokens-spot-prices',
-    prefetchCacheTtlMs: POPULAR_TOKENS_PREFETCH_TTL_MS,
+    prefetchCacheTtlMs: HOMEPAGE_PREFETCH_TTL_MS,
+  },
+  {
+    // Homepage Predictions section trending markets (usePredictMarketsForHomepage).
+    // urlIncludes pins the one-shot cache to the homepage request (limit=5,
+    // volume24hr order) so Predict feed tabs (limit=20, other orders/tags)
+    // fetch normally.
+    url: PREDICT_TRENDING_MARKETS_URL,
+    urlPrefix: 'https://gamma-api.polymarket.com/events/keyset',
+    urlIncludes: ['limit=5&', 'order=volume24hr'],
+    key: 'predict-trending-markets',
+    prefetchCacheTtlMs: HOMEPAGE_PREFETCH_TTL_MS,
   },
 ];
 


### PR DESCRIPTION
Register the empty-wallet homepage spot-prices URL with nitro-fetch prefetchOnAppStart so subsequent cold starts can serve prices from FetchCache, scoped to the mUSD+USD popular-tokens request.

<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: my feature name

  Scenario: user [verb for user action]
    Given [describe expected initial app state]

    When user [verb for user action]
    Then [describe expected outcome]
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only prefetch wiring with strict URL scoping; no auth or payment logic changes, though stale homepage price/market data is possible within the 120s TTL if URLs drift from the documented mirrors.
> 
> **Overview**
> Extends **nitro-fetch** cold-start prefetching from three endpoints to six, targeting empty-wallet homepage **popular-token spot prices** (USD + fixed asset list) and **Predictions** data for both A/B paths: trending markets (`limit=5`, `volume24hr`) and fixed discovery event slots.
> 
> Prefetch entries now support optional **`urlIncludes`** matching (not just URL prefix) and a **120s** `prefetchCacheTtlMs`, so only the mirrored homepage `fetch()` calls get `prefetchKey` / cache TTL; other spot-price currencies, Predict feed tabs, and unrelated Polymarket keyset requests stay uncached. Tests cover registration and positive/negative prefetch-key injection; **CHANGELOG** documents the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 017d879ab730dcbcb5c04edab50a832651e5f6fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->