### PR TITLE
fix: show correct values in toast for money account withdrawal

### DIFF
--- a/app/components/UI/Money/hooks/useMoneyTransactionStatus.test.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionStatus.test.ts
@@ -801,7 +801,7 @@ describe('useMoneyTransactionStatus', () => {
           nestedTransactions: [
             {
               type: TransactionType.tokenMethodTransfer,
-              data: encodeTransferData(RECIPIENT_ADDRESS),
+              data: encodeTransferData(RECIPIENT_ADDRESS, BigInt(50_000_000)),
             },
           ],
         } as unknown as Partial<TransactionMeta>),
@@ -815,6 +815,32 @@ describe('useMoneyTransactionStatus', () => {
         expect.anything(),
         expect.stringMatching(/^0x1111/i),
       );
+    });
+
+    it('confirmed → success amount is the transfer amount, not the teller share amount', () => {
+      const { confirmedHandler } = renderAndGetHandlers();
+
+      confirmedHandler(
+        buildTxMeta({
+          type: TransactionType.moneyAccountWithdraw,
+          status: TransactionStatus.confirmed,
+          txParams: {
+            from: '0x0',
+            // Share amount for $2.00 at a vault rate of ~1.005 — decoding this
+            // param is the bug that showed "$1.99" for a $2.00 send.
+            data: encodeWithdrawData(BigInt(1_990_050)),
+          },
+          nestedTransactions: [
+            {
+              type: TransactionType.tokenMethodTransfer,
+              data: encodeTransferData(RECIPIENT_ADDRESS, BigInt(2_000_000)),
+            },
+          ],
+        } as unknown as Partial<TransactionMeta>),
+      );
+
+      expect(withdrawSuccessFn).toHaveBeenCalledTimes(1);
+      expect(withdrawSuccessFn.mock.calls[0][0].amountFiat).toBe('$2.00');
     });
 
     it('falls back to a shortened address when the recipient is not an internal account', () => {
@@ -976,7 +1002,7 @@ describe('useMoneyTransactionStatus', () => {
       );
     });
 
-    it('falls back to "your account" when the nested transfer tx is absent', () => {
+    it('falls back to "your account" with no amount when the nested transfer tx is absent', () => {
       const { confirmedHandler } = renderAndGetHandlers();
 
       confirmedHandler(
@@ -994,6 +1020,7 @@ describe('useMoneyTransactionStatus', () => {
       expect(withdrawSuccessFn.mock.calls[0][0].destination).toBe(
         'your account',
       );
+      expect(withdrawSuccessFn.mock.calls[0][0].amountFiat).toBeUndefined();
     });
 
     it('failed → withdraw failed toast', () => {
@@ -1555,7 +1582,13 @@ describe('useMoneyTransactionStatus', () => {
             from: '0x0',
             data: encodeWithdrawData(BigInt(50_000_000)),
           },
-        }),
+          nestedTransactions: [
+            {
+              type: TransactionType.tokenMethodTransfer,
+              data: encodeTransferData(RECIPIENT_ADDRESS, BigInt(50_000_000)),
+            },
+          ],
+        } as unknown as Partial<TransactionMeta>),
       );
 
       expect(withdrawSuccessFn).toHaveBeenCalledTimes(1);
@@ -1782,7 +1815,7 @@ describe('useMoneyTransactionStatus', () => {
       expect(depositSuccessFn.mock.calls[0][0].amountFiat).toContain('7.77');
     });
 
-    it('decodes amount from nested withdraw tx data on confirmation', () => {
+    it('decodes amount from the nested transfer tx data on withdraw confirmation', () => {
       const { confirmedHandler } = renderAndGetHandlers();
 
       confirmedHandler(
@@ -1791,7 +1824,14 @@ describe('useMoneyTransactionStatus', () => {
           nestedTransactions: [
             {
               type: TransactionType.moneyAccountWithdraw,
-              data: encodeWithdrawData(BigInt(33_330_000)) as `0x${string}`,
+              data: encodeWithdrawData(BigInt(33_100_000)) as `0x${string}`,
+            },
+            {
+              type: TransactionType.tokenMethodTransfer,
+              data: encodeTransferData(
+                RECIPIENT_ADDRESS,
+                BigInt(33_330_000),
+              ) as `0x${string}`,
             },
           ],
         }),

--- a/app/components/UI/Money/hooks/useMoneyTransactionStatus.ts
+++ b/app/components/UI/Money/hooks/useMoneyTransactionStatus.ts
@@ -45,13 +45,21 @@ const ERC20_TRANSFER_INTERFACE = new ethers.utils.Interface([
   'function transfer(address to, uint256 amount)',
 ]);
 
-function decodeErc20TransferRecipient(
+interface DecodedErc20Transfer {
+  recipient: string;
+  amount: bigint;
+}
+
+function decodeErc20Transfer(
   data: string | undefined,
-): string | undefined {
+): DecodedErc20Transfer | undefined {
   if (!data) return undefined;
   try {
-    const [to] = ERC20_TRANSFER_INTERFACE.decodeFunctionData('transfer', data);
-    return to as string;
+    const [to, amount] = ERC20_TRANSFER_INTERFACE.decodeFunctionData(
+      'transfer',
+      data,
+    );
+    return { recipient: to as string, amount: BigInt(amount.toString()) };
   } catch (error) {
     Logger.error(
       error as Error,
@@ -62,13 +70,8 @@ function decodeErc20TransferRecipient(
 }
 
 function resolveWithdrawDestination(
-  transactionMeta: TransactionMeta,
+  recipient: string | undefined,
 ): string | undefined {
-  const transferNested = nestedTxWithType(
-    transactionMeta,
-    TransactionType.tokenMethodTransfer,
-  );
-  const recipient = decodeErc20TransferRecipient(transferNested?.data);
   if (!recipient) return undefined;
   const state = store.getState();
   const account = getMemoizedInternalAccountByAddress(state, recipient);
@@ -83,27 +86,20 @@ function resolveWithdrawDestination(
   );
 }
 
-function decodeTellerAmount(
-  type: TransactionType,
+function decodeTellerDepositAmount(
   data: string | undefined,
 ): bigint | undefined {
   if (!data) return undefined;
   try {
-    if (type === TransactionType.moneyAccountDeposit) {
-      const decoded = TELLER_INTERFACE.decodeFunctionData('deposit', data);
-      return BigInt(decoded[1].toString());
-    }
-    if (type === TransactionType.moneyAccountWithdraw) {
-      const decoded = TELLER_INTERFACE.decodeFunctionData('withdraw', data);
-      return BigInt(decoded[1].toString());
-    }
+    const decoded = TELLER_INTERFACE.decodeFunctionData('deposit', data);
+    return BigInt(decoded[1].toString());
   } catch (error) {
     Logger.error(
       error as Error,
       'useMoneyTransactionStatus: failed to decode teller calldata',
     );
+    return undefined;
   }
-  return undefined;
 }
 
 export function formatMusdAmountForToast(amountWei: bigint): string {
@@ -291,28 +287,19 @@ export const useMoneyTransactionStatus = () => {
         return;
       }
 
-      const depositNested = nestedTxWithType(
-        transactionMeta,
-        TransactionType.moneyAccountDeposit,
-      );
-      const withdrawNested = nestedTxWithType(
-        transactionMeta,
-        TransactionType.moneyAccountWithdraw,
-      );
-      const nestedMatch = depositNested ?? withdrawNested;
-      const decodeType =
-        nestedMatch?.type ?? (transactionMeta.type as TransactionType);
-      const decodeData =
-        nestedMatch?.data ??
-        (transactionMeta.txParams?.data as string | undefined);
-
-      const amountBaseUnit = decodeTellerAmount(decodeType, decodeData);
-      const amountFiat =
-        amountBaseUnit !== undefined
-          ? formatMusdAmountForToast(amountBaseUnit)
-          : undefined;
-
       if (isMoneyDepositTx(transactionMeta)) {
+        const depositNested = nestedTxWithType(
+          transactionMeta,
+          TransactionType.moneyAccountDeposit,
+        );
+        const amountBaseUnit = decodeTellerDepositAmount(
+          depositNested?.data ??
+            (transactionMeta.txParams?.data as string | undefined),
+        );
+        const amountFiat =
+          amountBaseUnit !== undefined
+            ? formatMusdAmountForToast(amountBaseUnit)
+            : undefined;
         // A first deposit is confirmed by the full-page animation takeover
         // instead of a toast, so the lingering in-progress toast must be
         // closed explicitly rather than replaced by the success toast.
@@ -333,8 +320,19 @@ export const useMoneyTransactionStatus = () => {
         }
         clearMoneyAccountDepositIntent(transactionMeta.batchId);
       } else {
+        // The teller withdraw's amount param is denominated in vault shares,
+        // which is below the dollar amount whenever the share rate exceeds 1.
+        // The nested ERC-20 transfer carries the exact dollar amount the
+        // recipient receives, so that's what the toast must show.
+        const transfer = decodeErc20Transfer(
+          nestedTxWithType(transactionMeta, TransactionType.tokenMethodTransfer)
+            ?.data,
+        );
+        const amountFiat = transfer
+          ? formatMusdAmountForToast(transfer.amount)
+          : undefined;
         const destination =
-          resolveWithdrawDestination(transactionMeta) ??
+          resolveWithdrawDestination(transfer?.recipient) ??
           strings('money.toasts.withdraw_fallback_destination');
         showToast(
           MoneyToastOptions.withdraw.success({ amountFiat, destination }),


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**
This fixes a bug where the toasts shown when withdrawing from a money account would be slightly less than the real value. This was happening because the toast previously showed a value denominated in vault shares rather than dollars. Because vault shares accrue value over time they do not map to dollars 1 to 1 - and so the displayed values were wrong. Now we instead show the correct dollar value.



<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: show correct values in toast when withdrawing from money account

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes: MUSD-1243

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: money account

  Scenario: user withdraws money
    Given money in the vault

    When user withdraws musd from the money account
    Then the toast that is displayed shows the correct value
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/e894bcf9-81c1-4179-b368-785829effbd1


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/7342bd48-730b-49db-971f-b2feae09e48f



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [ ] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [ ] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [ ] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to money withdraw success toast formatting in one hook, with regression tests; no changes to transaction signing or vault logic.
> 
> **Overview**
> Withdraw success toasts were showing **slightly less than the sent dollar amount** because the hook decoded the teller `withdraw` calldata, whose amount is in **vault shares**, not mUSD received.
> 
> **Withdraw confirmation** now reads the fiat amount (and destination recipient) from the nested `tokenMethodTransfer` ERC-20 `transfer` calldata instead of the teller withdraw params. Deposits still decode amounts via `decodeTellerDepositAmount` only. If there is no nested transfer, the success toast keeps the fallback destination but leaves **`amountFiat` undefined**.
> 
> Tests were updated and extended (including a case where share decoding would show $1.99 for a $2.00 send, batched withdraws, and missing nested transfer).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62c1e17639734fa47ed0d8078061dfd23bf8779d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->