### PR TITLE
refactor(toast): migrate useRewardsToast to the design system (1/2)

### DIFF
--- a/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.test.ts
+++ b/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.test.ts
@@ -354,7 +354,7 @@ describe('useCampaignOutcomeToast', () => {
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
       const { onClose } = mockShowToast.mock.calls[0][0];
-      onClose();
+      onClose?.();
 
       expect(mockDismissCampaignOutcomeToast).toHaveBeenCalledWith({
         campaignId: CAMPAIGN_ID,
@@ -375,7 +375,7 @@ describe('useCampaignOutcomeToast', () => {
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
       const { onClose } = mockShowToast.mock.calls[0][0];
-      onClose();
+      onClose?.();
 
       expect(mockDismissCampaignOutcomeToast).toHaveBeenCalledWith({
         campaignId: CAMPAIGN_ID,
@@ -397,7 +397,7 @@ describe('useCampaignOutcomeToast', () => {
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
       const { actionButtonOnPress } = mockShowToast.mock.calls[0][0];
-      actionButtonOnPress();
+      actionButtonOnPress?.({} as never);
 
       expect(mockNavigateToRewardsRoute).toHaveBeenCalledWith(
         { navigate: mockNavigate },
@@ -420,7 +420,7 @@ describe('useCampaignOutcomeToast', () => {
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
       const { actionButtonOnPress } = mockShowToast.mock.calls[0][0];
-      actionButtonOnPress();
+      actionButtonOnPress?.({} as never);
 
       expect(mockNavigateToRewardsRoute).toHaveBeenCalledWith(
         { navigate: mockNavigate },

--- a/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.test.ts
+++ b/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { playNotification, NotificationMoment } from '../../../../util/haptics';
 import { useCampaignOutcomeToast } from './useCampaignOutcomeToast';
 import { navigateToRewardsRoute } from '../utils';
@@ -15,21 +16,16 @@ import {
   CampaignType,
   type BaseCampaignParticipantOutcomeDto,
 } from '../../../../core/Engine/controllers/rewards-controller/types';
-const ToastVariants = { Icon: 'Icon', App: 'App', Plain: 'Plain' };
-const ButtonIconVariant = { Icon: 'Icon' };
-const IconName = { Close: 'Close', Confirmation: 'Confirmation', Star: 'Star' };
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
 jest.mock('../../../../component-library/components/Toast', () => ({
   ToastContext: { Consumer: jest.fn(), Provider: jest.fn() },
-}));
-
-jest.mock('../../../../component-library/components/Toast/Toast.types', () => ({
-  ToastVariants: { Icon: 'Icon', App: 'App', Plain: 'Plain' },
-  ButtonIconVariant: { Icon: 'Icon' },
-}));
-
-jest.mock('../../../../component-library/components/Icons/Icon', () => ({
-  IconName: { Close: 'Close', Confirmation: 'Confirmation', Star: 'Star' },
 }));
 
 jest.mock('react', () => ({
@@ -96,10 +92,10 @@ jest.mock('../utils', () => ({
 
 const mockDispatch = jest.fn();
 const mockNavigate = jest.fn();
-const mockShowToast = jest.fn();
+const mockShowToast = jest.mocked(toast);
 const mockCloseToast = jest.fn();
 const mockToastRef = {
-  current: { showToast: mockShowToast, closeToast: mockCloseToast },
+  current: { showToast: jest.fn(), closeToast: mockCloseToast },
 };
 
 const mockUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>;
@@ -274,7 +270,6 @@ describe('useCampaignOutcomeToast', () => {
       renderHook(() => useCampaignOutcomeToast(mockConfig));
       expect(mockShowToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: ToastVariants.Plain,
           hasNoTimeout: true,
           startAccessory: expect.anything(),
         }),
@@ -286,18 +281,9 @@ describe('useCampaignOutcomeToast', () => {
       renderHook(() => useCampaignOutcomeToast(mockConfig));
       expect(mockShowToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          labelOptions: [
-            {
-              label: 'rewards.campaign_outcome_toast.winner.title',
-              isBold: true,
-            },
-          ],
-          descriptionOptions: {
-            description: `rewards.campaign_outcome_toast.winner.description:${CAMPAIGN_NAME}`,
-          },
-          linkButtonOptions: expect.objectContaining({
-            label: 'rewards.campaign_outcome_toast.winner.cta',
-          }),
+          title: 'rewards.campaign_outcome_toast.winner.title',
+          description: `rewards.campaign_outcome_toast.winner.description:${CAMPAIGN_NAME}`,
+          actionButtonLabel: 'rewards.campaign_outcome_toast.winner.cta',
         }),
       );
     });
@@ -307,10 +293,7 @@ describe('useCampaignOutcomeToast', () => {
       renderHook(() => useCampaignOutcomeToast(mockConfig));
       expect(mockShowToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          closeButtonOptions: expect.objectContaining({
-            variant: ButtonIconVariant.Icon,
-            iconName: IconName.Close,
-          }),
+          onClose: expect.any(Function),
         }),
       );
     });
@@ -334,9 +317,7 @@ describe('useCampaignOutcomeToast', () => {
       renderHook(() => useCampaignOutcomeToast(mockConfig));
       expect(mockShowToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: ToastVariants.Icon,
-          iconName: IconName.Confirmation,
-          backgroundColor: 'transparent',
+          severity: ToastSeverity.Success,
           hasNoTimeout: true,
         }),
       );
@@ -347,18 +328,9 @@ describe('useCampaignOutcomeToast', () => {
       renderHook(() => useCampaignOutcomeToast(mockConfig));
       expect(mockShowToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          labelOptions: [
-            {
-              label: 'rewards.campaign_outcome_toast.non_winner.title',
-              isBold: true,
-            },
-          ],
-          descriptionOptions: {
-            description: `rewards.campaign_outcome_toast.non_winner.description:${CAMPAIGN_NAME}`,
-          },
-          linkButtonOptions: expect.objectContaining({
-            label: 'rewards.campaign_outcome_toast.non_winner.cta',
-          }),
+          title: 'rewards.campaign_outcome_toast.non_winner.title',
+          description: `rewards.campaign_outcome_toast.non_winner.description:${CAMPAIGN_NAME}`,
+          actionButtonLabel: 'rewards.campaign_outcome_toast.non_winner.cta',
         }),
       );
     });
@@ -381,9 +353,8 @@ describe('useCampaignOutcomeToast', () => {
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
-      const closeButtonOptions =
-        mockShowToast.mock.calls[0][0].closeButtonOptions;
-      closeButtonOptions.onPress();
+      const { onClose } = mockShowToast.mock.calls[0][0];
+      onClose();
 
       expect(mockDismissCampaignOutcomeToast).toHaveBeenCalledWith({
         campaignId: CAMPAIGN_ID,
@@ -403,9 +374,8 @@ describe('useCampaignOutcomeToast', () => {
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
-      const closeButtonOptions =
-        mockShowToast.mock.calls[0][0].closeButtonOptions;
-      closeButtonOptions.onPress();
+      const { onClose } = mockShowToast.mock.calls[0][0];
+      onClose();
 
       expect(mockDismissCampaignOutcomeToast).toHaveBeenCalledWith({
         campaignId: CAMPAIGN_ID,
@@ -426,8 +396,8 @@ describe('useCampaignOutcomeToast', () => {
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
-      const { onPress } = mockShowToast.mock.calls[0][0].linkButtonOptions;
-      onPress();
+      const { actionButtonOnPress } = mockShowToast.mock.calls[0][0];
+      actionButtonOnPress();
 
       expect(mockNavigateToRewardsRoute).toHaveBeenCalledWith(
         { navigate: mockNavigate },
@@ -449,8 +419,8 @@ describe('useCampaignOutcomeToast', () => {
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
-      const { onPress } = mockShowToast.mock.calls[0][0].linkButtonOptions;
-      onPress();
+      const { actionButtonOnPress } = mockShowToast.mock.calls[0][0];
+      actionButtonOnPress();
 
       expect(mockNavigateToRewardsRoute).toHaveBeenCalledWith(
         { navigate: mockNavigate },

--- a/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.test.tsx
@@ -1,26 +1,14 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { render } from '@testing-library/react-native';
-import { useContext, type ReactElement } from 'react';
+import type { ReactElement } from 'react';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { playNotification, NotificationMoment } from '../../../../util/haptics';
-import { mockTheme } from '../../../../util/theme';
-import useRewardsToast, { RewardsToastOptions } from './useRewardsToast';
-import {
-  ToastVariants,
-  ButtonIconVariant,
-} from '../../../../component-library/components/Toast/Toast.types';
-import { IconName } from '../../../../component-library/components/Icons/Icon';
-jest.mock('react', () => ({
-  ...jest.requireActual('react'),
-  useContext: jest.fn(),
-  useCallback: jest.fn((fn) => fn),
-  useMemo: jest.fn((fn) => fn()),
-}));
+import useRewardsToast, { type RewardsToastOptions } from './useRewardsToast';
 
 jest.mock('../../../../util/haptics');
 
 jest.mock('../../../../../locales/i18n', () => ({
   strings: jest.fn((key: string) => {
-    if (key === 'rewards.toast_dismiss') return 'Dismiss';
     if (key === 'rewards.notifications_nudge.title') return "Don't miss out";
     if (key === 'rewards.notifications_nudge.description') {
       return 'Enable notifications to stay informed on campaigns';
@@ -48,81 +36,43 @@ jest.mock('../../../../images/rewards/notification.svg', () => {
 });
 
 jest.mock('@metamask/design-system-react-native', () => {
-  const ReactActual = jest.requireActual('react');
-  const { View } = jest.requireActual('react-native');
+  const actual = jest.requireActual('@metamask/design-system-react-native');
   return {
-    Box: ({ children }: { children?: React.ReactNode }) =>
-      ReactActual.createElement(
-        View,
-        { testID: 'rewards-nudge-start-accessory-box' },
-        children,
-      ),
-    // Required by Toast.tsx module init via Toast barrel import.
-    IconColor: {
-      IconDefault: 'IconDefault',
-      OverlayInverse: 'OverlayInverse',
-      IconAlternative: 'IconAlternative',
-      IconMuted: 'IconMuted',
-      PrimaryDefault: 'PrimaryDefault',
-      PrimaryAlternative: 'PrimaryAlternative',
-      SuccessDefault: 'SuccessDefault',
-      ErrorDefault: 'ErrorDefault',
-      ErrorAlternative: 'ErrorAlternative',
-      WarningDefault: 'WarningDefault',
-      InfoDefault: 'InfoDefault',
-    },
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
   };
 });
 
-describe('useRewardsToast', () => {
-  let mockShowToast: jest.Mock;
-  let mockCloseToast: jest.Mock;
-  let mockToastRef: {
-    current: { showToast: jest.Mock; closeToast: jest.Mock };
-  };
+const mockToast = jest.mocked(toast);
 
+describe('useRewardsToast', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-
-    mockShowToast = jest.fn();
-    mockCloseToast = jest.fn();
-    mockToastRef = {
-      current: {
-        showToast: mockShowToast,
-        closeToast: mockCloseToast,
-      },
-    };
-
-    (useContext as jest.Mock).mockReturnValue({ toastRef: mockToastRef });
   });
 
-  describe('showToast function', () => {
-    it('calls toastRef showToast and triggers haptic feedback', async () => {
+  describe('showToast', () => {
+    it('calls toast excluding hapticsType and triggers haptic feedback', () => {
       const { result } = renderHook(() => useRewardsToast());
-
       const testConfig: RewardsToastOptions = {
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        hapticsType: NotificationMoment.Success,
-        labelOptions: [{ label: 'Test', isBold: true }],
-        hasNoTimeout: false,
+        ...result.current.RewardsToastOptions.success('Test'),
       };
 
-      await act(async () => {
+      act(() => {
         result.current.showToast(testConfig);
-        await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        labelOptions: [{ label: 'Test', isBold: true }],
-        hasNoTimeout: false,
-      });
+      expect(mockToast).toHaveBeenCalledTimes(1);
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: ToastSeverity.Success,
+          title: 'Test',
+        }),
+      );
+      expect(mockToast.mock.calls[0][0]).not.toHaveProperty('hapticsType');
       expect(playNotification).toHaveBeenCalledWith(NotificationMoment.Success);
     });
 
-    it('strips hapticsType from payload passed to toastRef for enableNotificationsNudge', async () => {
+    it('strips hapticsType from payload for enableNotificationsNudge', () => {
       const { result } = renderHook(() => useRewardsToast());
       const nudgeConfig =
         result.current.RewardsToastOptions.enableNotificationsNudge({
@@ -130,285 +80,129 @@ describe('useRewardsToast', () => {
           onPress: jest.fn(),
         });
 
-      await act(async () => {
+      act(() => {
         result.current.showToast(nudgeConfig);
-        await new Promise((resolve) => setTimeout(resolve, 0));
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.not.objectContaining({ hapticsType: expect.anything() }),
       );
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: ToastVariants.Plain,
           hasNoTimeout: true,
+          actionButtonLabel: 'Turn on',
         }),
       );
       expect(playNotification).toHaveBeenCalledWith(NotificationMoment.Warning);
     });
   });
 
-  describe('RewardsToastOptions configurations', () => {
-    it('returns success configuration with title only', () => {
+  describe('RewardsToastOptions', () => {
+    it('configures success toast with Success severity', () => {
       const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.success('Test Title');
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        iconColor: mockTheme.colors.success.default,
-        backgroundColor: 'transparent',
-        hapticsType: NotificationMoment.Success,
-        hasNoTimeout: false,
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Test Title', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toBeUndefined();
-      expect(config.closeButtonOptions).toMatchObject({
-        variant: ButtonIconVariant.Icon,
-        iconName: IconName.Close,
-      });
-    });
-
-    it('returns success configuration with title and subtitle', () => {
-      const { result } = renderHook(() => useRewardsToast());
       const config = result.current.RewardsToastOptions.success(
         'Test Title',
         'Test Subtitle',
       );
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        iconColor: mockTheme.colors.success.default,
-        hapticsType: NotificationMoment.Success,
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Test Title', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toEqual({
-        description: 'Test Subtitle',
-      });
+      expect(config.severity).toBe(ToastSeverity.Success);
+      expect(config.hapticsType).toBe(NotificationMoment.Success);
+      expect(config.hasNoTimeout).toBe(false);
+      expect(config.title).toBe('Test Title');
+      expect(config.description).toBe('Test Subtitle');
     });
 
-    it('returns error configuration with title only', () => {
+    it('configures error toast with Danger severity', () => {
       const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.error('Error Title');
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Danger,
-        iconColor: mockTheme.colors.error.default,
-        backgroundColor: 'transparent',
-        hapticsType: NotificationMoment.Error,
-        hasNoTimeout: false,
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Error Title', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toBeUndefined();
-      expect(config.closeButtonOptions).toMatchObject({
-        variant: ButtonIconVariant.Icon,
-        iconName: IconName.Close,
-      });
-    });
-
-    it('returns error configuration with title and subtitle', () => {
-      const { result } = renderHook(() => useRewardsToast());
       const config = result.current.RewardsToastOptions.error(
         'Error Title',
         'Error Subtitle',
       );
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Danger,
-        iconColor: mockTheme.colors.error.default,
-        hapticsType: NotificationMoment.Error,
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Error Title', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toEqual({
-        description: 'Error Subtitle',
-      });
+      expect(config.severity).toBe(ToastSeverity.Danger);
+      expect(config.hapticsType).toBe(NotificationMoment.Error);
+      expect(config.hasNoTimeout).toBe(false);
+      expect(config.title).toBe('Error Title');
+      expect(config.description).toBe('Error Subtitle');
     });
 
-    it('returns entriesClosed configuration with title only', () => {
+    it('configures warning toast as persistent Warning severity', () => {
       const { result } = renderHook(() => useRewardsToast());
-      const config =
-        result.current.RewardsToastOptions.entriesClosed('Entries closed');
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Lock,
-        iconColor: mockTheme.colors.icon.default,
-        backgroundColor: 'transparent',
-        hapticsType: NotificationMoment.Warning,
-        hasNoTimeout: false,
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Entries closed', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toBeUndefined();
-      expect(config.closeButtonOptions).toMatchObject({
-        variant: ButtonIconVariant.Icon,
-        iconName: IconName.Close,
-      });
-    });
-
-    it('returns entriesClosed configuration with title and subtitle', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.entriesClosed(
-        'Entries closed',
-        'You missed the opt-in window. Check back for more campaigns in the future.',
+      const config = result.current.RewardsToastOptions.warning(
+        'Request received',
+        'In about 7 days, your progress will be fully erased.',
       );
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Lock,
-        iconColor: mockTheme.colors.icon.default,
-        hapticsType: NotificationMoment.Warning,
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Entries closed', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toEqual({
-        description:
-          'You missed the opt-in window. Check back for more campaigns in the future.',
-      });
+      expect(config.severity).toBe(ToastSeverity.Warning);
+      expect(config.hapticsType).toBe(NotificationMoment.Warning);
+      expect(config.hasNoTimeout).toBe(true);
+      expect(config.title).toBe('Request received');
+      expect(config.description).toBe(
+        'In about 7 days, your progress will be fully erased.',
+      );
     });
 
-    it('returns loading configuration with title only', () => {
+    it('configures loading toast with a spinner and no timeout', () => {
       const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.loading('Loading...');
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Plain,
-        hasNoTimeout: true,
-        hapticsType: NotificationMoment.Warning,
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Loading...', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toBeUndefined();
-      expect(config.closeButtonOptions).toMatchObject({
-        variant: ButtonIconVariant.Icon,
-        iconName: IconName.Close,
-      });
-    });
-
-    it('returns loading configuration with title and subtitle', () => {
-      const { result } = renderHook(() => useRewardsToast());
       const config = result.current.RewardsToastOptions.loading(
         'Loading...',
         'Please wait',
       );
 
-      expect(config.labelOptions).toEqual([
-        { label: 'Loading...', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toEqual({ description: 'Please wait' });
-    });
-
-    it('calls closeToast when loading close button is pressed', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.loading('Loading...');
-
-      config.closeButtonOptions?.onPress?.();
-
-      expect(mockCloseToast).toHaveBeenCalledTimes(1);
-    });
-
-    it('renders startAccessory for loading config', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.loading('Loading...');
-
+      expect(config.hapticsType).toBe(NotificationMoment.Warning);
+      expect(config.hasNoTimeout).toBe(true);
       expect(config.startAccessory).toBeDefined();
+      expect(config.title).toBe('Loading...');
+      expect(config.description).toBe('Please wait');
     });
 
-    it('returns enableNotificationsNudge configuration with Plain variant', () => {
+    it('configures entriesClosed toast with a lock accessory', () => {
+      const { result } = renderHook(() => useRewardsToast());
+
+      const config = result.current.RewardsToastOptions.entriesClosed(
+        'Entries closed',
+        'You missed the opt-in window.',
+      );
+
+      expect(config.hapticsType).toBe(NotificationMoment.Warning);
+      expect(config.hasNoTimeout).toBe(false);
+      expect(config.startAccessory).toBeDefined();
+      expect(config.title).toBe('Entries closed');
+      expect(config.description).toBe('You missed the opt-in window.');
+    });
+
+    it('configures enableNotificationsNudge with action button', () => {
       const { result } = renderHook(() => useRewardsToast());
       const onPress = jest.fn();
+
       const config =
         result.current.RewardsToastOptions.enableNotificationsNudge({
           label: 'Turn on',
           onPress,
         });
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Plain,
-        hasNoTimeout: true,
-        hapticsType: NotificationMoment.Warning,
-        linkButtonOptions: { label: 'Turn on', onPress },
-      });
-      expect(config.labelOptions).toEqual([
-        { label: "Don't miss out", isBold: true },
-      ]);
-      expect(config.descriptionOptions).toEqual({
-        description: 'Enable notifications to stay informed on campaigns',
-      });
-      expect(config.closeButtonOptions).toMatchObject({
-        variant: ButtonIconVariant.Icon,
-        iconName: IconName.Close,
-      });
-    });
-
-    it('passes linkButtonOptions through to enableNotificationsNudge config', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const onPress = jest.fn();
-      const config =
-        result.current.RewardsToastOptions.enableNotificationsNudge({
-          label: 'Open settings',
-          onPress,
-        });
-
-      expect(config.linkButtonOptions).toEqual({
-        label: 'Open settings',
-        onPress,
-      });
-    });
-
-    it('renders startAccessory containing notification icon placeholder', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config =
-        result.current.RewardsToastOptions.enableNotificationsNudge({
-          label: 'Turn on',
-          onPress: jest.fn(),
-        });
-
+      expect(config.hasNoTimeout).toBe(true);
+      expect(config.hapticsType).toBe(NotificationMoment.Warning);
+      expect(config.title).toBe("Don't miss out");
+      expect(config.description).toBe(
+        'Enable notifications to stay informed on campaigns',
+      );
+      expect(config.actionButtonLabel).toBe('Turn on');
+      expect(config.actionButtonOnPress).toBe(onPress);
       expect(config.startAccessory).toBeDefined();
       const { getByTestId } = render(config.startAccessory as ReactElement);
       expect(getByTestId('rewards-notification-svg')).toBeDefined();
     });
 
-    it('calls closeToast when enableNotificationsNudge close button is pressed', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config =
-        result.current.RewardsToastOptions.enableNotificationsNudge({
-          label: 'Turn on',
-          onPress: jest.fn(),
-        });
-
-      config.closeButtonOptions?.onPress?.();
-
-      expect(mockCloseToast).toHaveBeenCalledTimes(1);
-    });
-
-    it('calls closeToast when close button is pressed', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.success('Test Title');
-
-      config.closeButtonOptions?.onPress?.();
-
-      expect(mockCloseToast).toHaveBeenCalledTimes(1);
-    });
-
-    it('returns outcomeWinner configuration with CTA and close handlers', () => {
+    it('configures outcomeWinner toast with CTA and close handlers', () => {
       const { result } = renderHook(() => useRewardsToast());
       const onCta = jest.fn();
       const onClose = jest.fn();
+
       const config = result.current.RewardsToastOptions.outcomeWinner({
         title: 'Winner title',
         description: 'Winner body',
@@ -417,81 +211,23 @@ describe('useRewardsToast', () => {
         onClosePress: onClose,
       });
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Plain,
-        hasNoTimeout: true,
-        hapticsType: NotificationMoment.Success,
-        descriptionOptions: { description: 'Winner body' },
-        linkButtonOptions: { label: 'Next' },
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Winner title', isBold: true },
-      ]);
+      expect(config.hasNoTimeout).toBe(true);
+      expect(config.hapticsType).toBe(NotificationMoment.Success);
+      expect(config.title).toBe('Winner title');
+      expect(config.description).toBe('Winner body');
+      expect(config.actionButtonLabel).toBe('Next');
       expect(config.startAccessory).toBeDefined();
-      config.linkButtonOptions?.onPress?.();
-      config.closeButtonOptions?.onPress?.();
+      config.actionButtonOnPress?.({} as never);
+      config.onClose?.();
       expect(onCta).toHaveBeenCalledTimes(1);
       expect(onClose).toHaveBeenCalledTimes(1);
     });
 
-    it('returns warning configuration with title only', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config =
-        result.current.RewardsToastOptions.warning('Request received');
-
-      expect(config).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Warning,
-        iconColor: mockTheme.colors.warning.default,
-        backgroundColor: 'transparent',
-        hapticsType: NotificationMoment.Warning,
-        hasNoTimeout: true,
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Request received', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toBeUndefined();
-      expect(config.closeButtonOptions).toMatchObject({
-        variant: ButtonIconVariant.Icon,
-        iconName: IconName.Close,
-      });
-    });
-
-    it('returns warning configuration with title and subtitle', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.warning(
-        'Request received',
-        'In about 7 days, your progress will be fully erased.',
-      );
-
-      expect(config).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Warning,
-        hapticsType: NotificationMoment.Warning,
-        hasNoTimeout: true,
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Request received', isBold: true },
-      ]);
-      expect(config.descriptionOptions).toEqual({
-        description: 'In about 7 days, your progress will be fully erased.',
-      });
-    });
-
-    it('calls closeToast when warning close button is pressed', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config =
-        result.current.RewardsToastOptions.warning('Request received');
-
-      config.closeButtonOptions?.onPress?.();
-
-      expect(mockCloseToast).toHaveBeenCalledTimes(1);
-    });
-
-    it('returns outcomeNonWinner configuration with CTA and close handlers', () => {
+    it('configures outcomeNonWinner toast with Success severity', () => {
       const { result } = renderHook(() => useRewardsToast());
       const onCta = jest.fn();
       const onClose = jest.fn();
+
       const config = result.current.RewardsToastOptions.outcomeNonWinner({
         title: 'Thanks title',
         description: 'Thanks body',
@@ -500,214 +236,26 @@ describe('useRewardsToast', () => {
         onClosePress: onClose,
       });
 
-      expect(config).toMatchObject({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        iconColor: mockTheme.colors.success.default,
-        backgroundColor: 'transparent',
-        hasNoTimeout: true,
-        hapticsType: NotificationMoment.Warning,
-        descriptionOptions: { description: 'Thanks body' },
-        linkButtonOptions: { label: 'Done' },
-      });
-      expect(config.labelOptions).toEqual([
-        { label: 'Thanks title', isBold: true },
-      ]);
-      config.linkButtonOptions?.onPress?.();
-      config.closeButtonOptions?.onPress?.();
+      expect(config.severity).toBe(ToastSeverity.Success);
+      expect(config.hasNoTimeout).toBe(true);
+      expect(config.hapticsType).toBe(NotificationMoment.Warning);
+      expect(config.title).toBe('Thanks title');
+      expect(config.description).toBe('Thanks body');
+      expect(config.actionButtonLabel).toBe('Done');
+      config.actionButtonOnPress?.({} as never);
+      config.onClose?.();
       expect(onCta).toHaveBeenCalledTimes(1);
       expect(onClose).toHaveBeenCalledTimes(1);
     });
-  });
 
-  describe('edge cases and error handling', () => {
-    it('handles null toastRef gracefully in showToast', async () => {
-      (useContext as jest.Mock).mockReturnValue({ toastRef: null });
+    it('omits description when subtitle is not provided', () => {
       const { result } = renderHook(() => useRewardsToast());
 
-      const testConfig: RewardsToastOptions = {
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        hapticsType: NotificationMoment.Success,
-        labelOptions: [{ label: 'Test', isBold: true }],
-        hasNoTimeout: false,
-      };
+      const success = result.current.RewardsToastOptions.success('Title');
+      const error = result.current.RewardsToastOptions.error('Error');
 
-      expect(() => {
-        act(() => {
-          result.current.showToast(testConfig);
-        });
-      }).not.toThrow();
-
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-
-      expect(playNotification).toHaveBeenCalledWith(NotificationMoment.Success);
-    });
-
-    it('handles undefined toastRef.current gracefully in showToast', async () => {
-      (useContext as jest.Mock).mockReturnValue({
-        toastRef: { current: null },
-      });
-      const { result } = renderHook(() => useRewardsToast());
-
-      const testConfig: RewardsToastOptions = {
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        hapticsType: NotificationMoment.Success,
-        labelOptions: [{ label: 'Test', isBold: true }],
-        hasNoTimeout: false,
-      };
-
-      expect(() => {
-        act(() => {
-          result.current.showToast(testConfig);
-        });
-      }).not.toThrow();
-
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-
-      expect(playNotification).toHaveBeenCalledWith(NotificationMoment.Success);
-    });
-
-    it('handles null toastRef gracefully in close button', () => {
-      (useContext as jest.Mock).mockReturnValue({ toastRef: null });
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.success('Test Title');
-
-      expect(() => {
-        config.closeButtonOptions?.onPress?.();
-      }).not.toThrow();
-    });
-
-    it('handles empty string title', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.success('');
-
-      expect(config.labelOptions).toEqual([{ label: '', isBold: true }]);
-    });
-
-    it('handles only whitespace title', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.success('   ');
-
-      expect(config.labelOptions).toEqual([{ label: '   ', isBold: true }]);
-    });
-  });
-
-  describe('memoization and dependency changes', () => {
-    it('recreates RewardsToastOptions when toastRef changes', () => {
-      const mockToastRef1 = {
-        current: { showToast: jest.fn(), closeToast: jest.fn() },
-      };
-      const mockToastRef2 = {
-        current: { showToast: jest.fn(), closeToast: jest.fn() },
-      };
-
-      (useContext as jest.Mock).mockReturnValue({ toastRef: mockToastRef1 });
-      const { result, rerender } = renderHook(() => useRewardsToast());
-
-      (useContext as jest.Mock).mockReturnValue({ toastRef: mockToastRef2 });
-      rerender();
-
-      const newConfig = result.current.RewardsToastOptions.success('Test');
-
-      newConfig.closeButtonOptions?.onPress?.();
-      expect(mockToastRef2.current.closeToast).toHaveBeenCalled();
-      expect(mockToastRef1.current.closeToast).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('default options merging', () => {
-    it('applies default options to success configuration', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.success('Test Title');
-
-      expect(config.hasNoTimeout).toBe(false);
-    });
-
-    it('applies default options to error configuration', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.error('Error Title');
-
-      expect(config.hasNoTimeout).toBe(false);
-    });
-
-    it('applies default options to entriesClosed configuration', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config =
-        result.current.RewardsToastOptions.entriesClosed('Entries closed');
-
-      expect(config.hasNoTimeout).toBe(false);
-    });
-
-    it('uses persistent toast timeout for enableNotificationsNudge', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config =
-        result.current.RewardsToastOptions.enableNotificationsNudge({
-          label: 'Turn on',
-          onPress: jest.fn(),
-        });
-
-      expect(config.hasNoTimeout).toBe(true);
-    });
-  });
-
-  describe('label and description formatting', () => {
-    it('returns bold label with title only', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.success('Test Title');
-
-      expect(config.labelOptions).toHaveLength(1);
-      expect(config.labelOptions[0]).toEqual({
-        label: 'Test Title',
-        isBold: true,
-      });
-    });
-
-    it('returns bold label and descriptionOptions with subtitle', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.success(
-        'Test Title',
-        'Test Subtitle',
-      );
-
-      expect(config.labelOptions).toHaveLength(1);
-      expect(config.labelOptions[0]).toEqual({
-        label: 'Test Title',
-        isBold: true,
-      });
-      expect(config.descriptionOptions).toEqual({
-        description: 'Test Subtitle',
-      });
-    });
-
-    it('returns undefined descriptionOptions when no subtitle for error', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.error('Error Title');
-
-      expect(config.labelOptions).toHaveLength(1);
-      expect(config.labelOptions[0]).toEqual({
-        label: 'Error Title',
-        isBold: true,
-      });
-      expect(config.descriptionOptions).toBeUndefined();
-    });
-
-    it('returns descriptionOptions for error with subtitle', () => {
-      const { result } = renderHook(() => useRewardsToast());
-      const config = result.current.RewardsToastOptions.error(
-        'Error Title',
-        'Error Subtitle',
-      );
-
-      expect(config.labelOptions).toHaveLength(1);
-      expect(config.descriptionOptions).toEqual({
-        description: 'Error Subtitle',
-      });
+      expect(success.description).toBeUndefined();
+      expect(error.description).toBeUndefined();
     });
   });
 });

--- a/app/components/UI/Rewards/hooks/useRewardsToast.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.tsx
@@ -21,6 +21,13 @@ import RewardsTrophyIcon from '../../../../images/rewards/trophy.svg';
 
 export type RewardsToastOptions = ToastOptions & {
   hapticsType: HapticNotificationMoment;
+  /**
+   * Temporary compatibility field for callers that still wrap the legacy
+   * ToastContext close button. The follow-up call-site PR removes this.
+   */
+  closeButtonOptions?: {
+    onPress?: () => void;
+  };
 };
 
 export interface OutcomeCtaToastParams {

--- a/app/components/UI/Rewards/hooks/useRewardsToast.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.tsx
@@ -1,15 +1,14 @@
-import React, { useCallback, useContext, useMemo } from 'react';
-import { ActivityIndicator } from 'react-native';
-import { ToastContext } from '../../../../component-library/components/Toast';
+import React, { useCallback, useMemo } from 'react';
 import {
-  ButtonIconVariant,
-  ToastDescriptionOptions,
-  ToastLabelOptions,
-  ToastLinkButtonOptions,
-  ToastOptions,
-  ToastVariants,
-} from '../../../../component-library/components/Toast/Toast.types';
-import { IconName } from '../../../../component-library/components/Icons/Icon';
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Spinner,
+  toast,
+  ToastSeverity,
+  type ToastOptions,
+} from '@metamask/design-system-react-native';
 import { useAppThemeFromContext } from '../../../../util/theme';
 import {
   playNotification,
@@ -32,6 +31,11 @@ export interface OutcomeCtaToastParams {
   onClosePress: () => void;
 }
 
+export interface RewardsToastNudgeParams {
+  label: string;
+  onPress: () => void;
+}
+
 export interface RewardsToastConfig {
   success: (title: string, subtitle?: string) => RewardsToastOptions;
   error: (title: string, subtitle?: string) => RewardsToastOptions;
@@ -39,31 +43,11 @@ export interface RewardsToastConfig {
   warning: (title: string, subtitle?: string) => RewardsToastOptions;
   entriesClosed: (title: string, subtitle?: string) => RewardsToastOptions;
   enableNotificationsNudge: (
-    linkButtonOptions: ToastLinkButtonOptions,
+    params: RewardsToastNudgeParams,
   ) => RewardsToastOptions;
   outcomeWinner: (params: OutcomeCtaToastParams) => RewardsToastOptions;
   outcomeNonWinner: (params: OutcomeCtaToastParams) => RewardsToastOptions;
 }
-
-const getRewardsToastLabels = (title: string): ToastLabelOptions => {
-  const labels: ToastLabelOptions = [
-    {
-      label: title,
-      isBold: true,
-    },
-  ];
-
-  return labels;
-};
-
-const getRewardsToastDescriptionLabels = (
-  description?: string,
-): ToastDescriptionOptions | undefined => {
-  if (!description) {
-    return undefined;
-  }
-  return { description };
-};
 
 const REWARDS_TOASTS_DEFAULT_OPTIONS: Partial<RewardsToastOptions> = {
   hasNoTimeout: false,
@@ -73,116 +57,67 @@ const useRewardsToast = (): {
   showToast: (config: RewardsToastOptions) => void;
   RewardsToastOptions: RewardsToastConfig;
 } => {
-  const { toastRef } = useContext(ToastContext);
   const theme = useAppThemeFromContext();
 
-  const showToast = useCallback(
-    (config: RewardsToastOptions) => {
-      const { hapticsType, ...toastOptions } = config;
-      toastRef?.current?.showToast(toastOptions as ToastOptions);
-      playNotification(hapticsType);
-    },
-    [toastRef],
-  );
+  const showToast = useCallback((config: RewardsToastOptions) => {
+    const { hapticsType, ...toastOptions } = config;
+    toast(toastOptions);
+    playNotification(hapticsType);
+  }, []);
 
   const RewardsToastOptions: RewardsToastConfig = useMemo(
     () => ({
       success: (title: string, subtitle?: string) => ({
         ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        iconColor: theme.colors.success.default,
-        backgroundColor: 'transparent',
+        severity: ToastSeverity.Success,
         hapticsType: NotificationMoment.Success,
-        labelOptions: getRewardsToastLabels(title),
-        descriptionOptions: getRewardsToastDescriptionLabels(subtitle),
+        title,
+        description: subtitle,
         hasNoTimeout: false,
-        closeButtonOptions: {
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-          onPress: () => {
-            toastRef?.current?.closeToast();
-          },
-        },
       }),
       error: (title: string, subtitle?: string) => ({
         ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
-        variant: ToastVariants.Icon,
-        iconName: IconName.Danger,
-        iconColor: theme.colors.error.default,
-        backgroundColor: 'transparent',
+        severity: ToastSeverity.Danger,
         hapticsType: NotificationMoment.Error,
-        labelOptions: getRewardsToastLabels(title),
-        descriptionOptions: getRewardsToastDescriptionLabels(subtitle),
+        title,
+        description: subtitle,
         hasNoTimeout: false,
-        closeButtonOptions: {
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-
-          onPress: () => {
-            toastRef?.current?.closeToast();
-          },
-        },
       }),
       loading: (title: string, subtitle?: string) => ({
         ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
-        variant: ToastVariants.Plain,
         hasNoTimeout: true,
         hapticsType: NotificationMoment.Warning,
-        startAccessory: (
-          <ActivityIndicator size="small" color={theme.colors.icon.default} />
-        ),
-        labelOptions: getRewardsToastLabels(title),
-        descriptionOptions: getRewardsToastDescriptionLabels(subtitle),
-        closeButtonOptions: {
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-          onPress: () => {
-            toastRef?.current?.closeToast();
-          },
-        },
+        startAccessory: <Spinner spinnerIconProps={{ size: IconSize.Lg }} />,
+        title,
+        description: subtitle,
       }),
       warning: (title: string, subtitle?: string) => ({
         ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
-        variant: ToastVariants.Icon,
-        iconName: IconName.Warning,
-        iconColor: theme.colors.warning.default,
-        backgroundColor: 'transparent',
+        severity: ToastSeverity.Warning,
         hapticsType: NotificationMoment.Warning,
-        labelOptions: getRewardsToastLabels(title),
-        descriptionOptions: getRewardsToastDescriptionLabels(subtitle),
+        title,
+        description: subtitle,
         hasNoTimeout: true,
-        closeButtonOptions: {
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-          onPress: () => {
-            toastRef?.current?.closeToast();
-          },
-        },
       }),
       entriesClosed: (title: string, subtitle?: string) => ({
         ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
-        variant: ToastVariants.Icon,
-        iconName: IconName.Lock,
-        iconColor: theme.colors.icon.default,
-        backgroundColor: 'transparent',
+        startAccessory: (
+          <Icon
+            name={IconName.Lock}
+            size={IconSize.Lg}
+            color={IconColor.IconDefault}
+          />
+        ),
         hapticsType: NotificationMoment.Warning,
-        labelOptions: getRewardsToastLabels(title),
-        descriptionOptions: getRewardsToastDescriptionLabels(subtitle),
+        title,
+        description: subtitle,
         hasNoTimeout: false,
-        closeButtonOptions: {
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-          onPress: () => {
-            toastRef?.current?.closeToast();
-          },
-        },
       }),
-      enableNotificationsNudge: (
-        linkButtonOptions: ToastLinkButtonOptions,
-      ) => ({
+      enableNotificationsNudge: ({
+        label,
+        onPress,
+      }: RewardsToastNudgeParams) => ({
         ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
-        variant: ToastVariants.Plain,
         hasNoTimeout: true,
         hapticsType: NotificationMoment.Warning,
         startAccessory: (
@@ -193,20 +128,10 @@ const useRewardsToast = (): {
             color={theme.colors.warning.default}
           />
         ),
-        labelOptions: getRewardsToastLabels(
-          strings('rewards.notifications_nudge.title'),
-        ),
-        descriptionOptions: getRewardsToastDescriptionLabels(
-          strings('rewards.notifications_nudge.description'),
-        ),
-        linkButtonOptions,
-        closeButtonOptions: {
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-          onPress: () => {
-            toastRef?.current?.closeToast();
-          },
-        },
+        title: strings('rewards.notifications_nudge.title'),
+        description: strings('rewards.notifications_nudge.description'),
+        actionButtonLabel: label,
+        actionButtonOnPress: onPress,
       }),
       outcomeWinner: ({
         title,
@@ -216,7 +141,6 @@ const useRewardsToast = (): {
         onClosePress,
       }: OutcomeCtaToastParams) => ({
         ...(REWARDS_TOASTS_DEFAULT_OPTIONS as RewardsToastOptions),
-        variant: ToastVariants.Plain,
         hasNoTimeout: true,
         hapticsType: NotificationMoment.Success,
         startAccessory: (
@@ -227,17 +151,11 @@ const useRewardsToast = (): {
             color={theme.colors.success.default}
           />
         ),
-        labelOptions: getRewardsToastLabels(title),
-        descriptionOptions: { description },
-        linkButtonOptions: {
-          label: ctaLabel,
-          onPress: onCtaPress,
-        },
-        closeButtonOptions: {
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-          onPress: onClosePress,
-        },
+        title,
+        description,
+        actionButtonLabel: ctaLabel,
+        actionButtonOnPress: onCtaPress,
+        onClose: onClosePress,
       }),
       outcomeNonWinner: ({
         title,
@@ -246,32 +164,17 @@ const useRewardsToast = (): {
         onCtaPress,
         onClosePress,
       }: OutcomeCtaToastParams) => ({
-        variant: ToastVariants.Icon,
-        iconName: IconName.Confirmation,
-        iconColor: theme.colors.success.default,
-        backgroundColor: 'transparent',
+        severity: ToastSeverity.Success,
         hasNoTimeout: true,
         hapticsType: NotificationMoment.Warning,
-        labelOptions: getRewardsToastLabels(title),
-        descriptionOptions: { description },
-        linkButtonOptions: {
-          label: ctaLabel,
-          onPress: onCtaPress,
-        },
-        closeButtonOptions: {
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-          onPress: onClosePress,
-        },
+        title,
+        description,
+        actionButtonLabel: ctaLabel,
+        actionButtonOnPress: onCtaPress,
+        onClose: onClosePress,
       }),
     }),
-    [
-      theme.colors.success.default,
-      theme.colors.error.default,
-      theme.colors.icon.default,
-      theme.colors.warning.default,
-      toastRef,
-    ],
+    [theme.colors.success.default, theme.colors.warning.default],
   );
 
   return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

This is **PR 1/2** of the Rewards toast migration stack (958 lines). It replaces `ToastContext` inside `useRewardsToast` with the design-system `toast()` API so Rewards toast configs share the same toaster as the rest of the toast migration.

`showToast` + `RewardsToastOptions` stay the public API. Severity maps to `ToastSeverity` (`Success`, `Danger`, `Warning`). Loading still uses a spinner accessory. Action toasts keep their CTA via `actionButtonLabel` / `actionButtonOnPress`.

Campaign outcome tests now assert against `toast()` so they stay green against the new hook. A temporary `closeButtonOptions` field is kept on `RewardsToastOptions` so existing callers still typecheck. **#35304 removes that field** and remaps dismiss/onClose.

**Do not merge this without #35304.** Campaign outcome and notification-nudge still dismiss through `toastRef.closeToast()`, which will not close toasts shown by the new hook.

Supersedes the combined change in #35293 (1,192 lines; over the 1,000-line check).

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: No tracking issue; continues the design-system toast migration for Rewards flows. Stack with #35304.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Rewards toast facade

  Background:
    Given I am logged into MetaMask Mobile
    And Rewards is available on my account

  Scenario: success, error, warning, and loading toasts still appear
    Given a Rewards flow uses useRewardsToast
    When that flow shows a success, error, warning, or loading toast
    Then the toast uses the design-system toaster
    And haptic feedback still matches the toast kind
```

Full referral / campaign-outcome / notification-nudge verification is in #35304. Merging this PR alone leaves those dismiss paths on the legacy toaster.

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A — facade-only refactor; call-site screenshots are in #35304.

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0603cdc-fa70-44f1-8dc1-c978c6db6bce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0603cdc-fa70-44f1-8dc1-c978c6db6bce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

