### PR TITLE
refactor(toast): migrate remaining Rewards toast call sites (2/2)

### DIFF
--- a/app/components/UI/Rewards/components/Campaigns/CampaignTile.test.tsx
+++ b/app/components/UI/Rewards/components/Campaigns/CampaignTile.test.tsx
@@ -1065,10 +1065,10 @@ describe('CampaignTile', () => {
       });
 
       const toastConfig = mockShowToast.mock.calls[0][0] as {
-        closeButtonOptions: { onPress: () => void };
+        onClose: () => void;
       };
       act(() => {
-        toastConfig.closeButtonOptions.onPress();
+        toastConfig.onClose();
       });
 
       notificationsEnabled = true;

--- a/app/components/UI/Rewards/components/RewardsReferralCodeTag/RewardsReferralCodeTag.test.tsx
+++ b/app/components/UI/Rewards/components/RewardsReferralCodeTag/RewardsReferralCodeTag.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
+import { toast } from '@metamask/design-system-react-native';
 import RewardsReferralCodeTag from './RewardsReferralCodeTag';
 import ClipboardManager from '../../../../../core/ClipboardManager';
 import { useStyles } from '../../../../../component-library/hooks';
@@ -30,18 +31,13 @@ jest.mock('../../../../../../locales/i18n', () => ({
   strings: jest.fn((key) => key),
 }));
 
-const mockToastRef = {
-  current: {
-    showToast: jest.fn(),
-  },
-};
-
-jest.mock('react', () => ({
-  ...jest.requireActual('react'),
-  useContext: jest.fn(() => ({
-    toastRef: mockToastRef,
-  })),
-}));
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
 jest.mock('../../../../../images/rewards/vip.svg', () => 'VipIcon');
 
@@ -139,6 +135,6 @@ describe('RewardsReferralCodeTag', () => {
 
     fireEvent.press(getByText(referralCode));
 
-    expect(mockToastRef.current.showToast).toHaveBeenCalled();
+    expect(toast).toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Rewards/components/RewardsReferralCodeTag/RewardsReferralCodeTag.tsx
+++ b/app/components/UI/Rewards/components/RewardsReferralCodeTag/RewardsReferralCodeTag.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import Text, {
   TextVariant,
 } from '../../../../../component-library/components/Texts/Text';
@@ -6,13 +6,10 @@ import { useStyles } from '../../../../../component-library/hooks';
 import VipIcon from '../../../../../images/rewards/vip.svg';
 import styleSheet from './RewardsReferralCodeTag.styles';
 import ClipboardManager from '../../../../../core/ClipboardManager';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../../component-library/components/Toast';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
-import { IconName } from '../../../../../component-library/components/Icons/Icon';
 import { TouchableOpacity } from 'react-native';
+
 interface RewardsReferralCodeTagProps {
   referralCode: string;
   backgroundColor?: string;
@@ -29,21 +26,13 @@ const RewardsReferralCodeTag: React.FC<RewardsReferralCodeTagProps> = ({
     fontColor,
   });
 
-  const { toastRef } = useContext(ToastContext);
-
   const handleCopyToClipboard = () => {
     ClipboardManager.setString(referralCode);
 
-    toastRef?.current?.showToast({
-      variant: ToastVariants.Icon,
-      iconName: IconName.Copy,
+    toast({
+      title: strings('rewards.referral.referral_code_copied'),
+      severity: ToastSeverity.Success,
       hasNoTimeout: false,
-      labelOptions: [
-        {
-          label: strings('rewards.referral.referral_code_copied'),
-          isBold: true,
-        },
-      ],
     });
   };
 

--- a/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.test.ts
+++ b/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.test.ts
@@ -1,5 +1,4 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { toast, ToastSeverity } from '@metamask/design-system-react-native';
@@ -16,6 +15,7 @@ import {
   CampaignType,
   type BaseCampaignParticipantOutcomeDto,
 } from '../../../../core/Engine/controllers/rewards-controller/types';
+
 jest.mock('@metamask/design-system-react-native', () => {
   const actual = jest.requireActual('@metamask/design-system-react-native');
   return {
@@ -24,13 +24,8 @@ jest.mock('@metamask/design-system-react-native', () => {
   };
 });
 
-jest.mock('../../../../component-library/components/Toast', () => ({
-  ToastContext: { Consumer: jest.fn(), Provider: jest.fn() },
-}));
-
 jest.mock('react', () => ({
   ...jest.requireActual('react'),
-  useContext: jest.fn(),
   useCallback: jest.fn((fn) => fn),
   useMemo: jest.fn((fn) => fn()),
 }));
@@ -92,11 +87,7 @@ jest.mock('../utils', () => ({
 
 const mockDispatch = jest.fn();
 const mockNavigate = jest.fn();
-const mockShowToast = jest.mocked(toast);
-const mockCloseToast = jest.fn();
-const mockToastRef = {
-  current: { showToast: jest.fn(), closeToast: mockCloseToast },
-};
+const mockToast = jest.mocked(toast);
 
 const mockUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>;
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
@@ -172,7 +163,6 @@ describe('useCampaignOutcomeToast', () => {
     jest.clearAllMocks();
     mockUseDispatch.mockReturnValue(mockDispatch);
     mockUseNavigation.mockReturnValue({ navigate: mockNavigate } as never);
-    (useContext as jest.Mock).mockReturnValue({ toastRef: mockToastRef });
     mockUseFocusEffect.mockImplementation((cb) => {
       cb();
     });
@@ -187,13 +177,13 @@ describe('useCampaignOutcomeToast', () => {
     it('outcome is null', () => {
       setupDefaults({ outcome: null });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(mockToast).not.toHaveBeenCalled();
     });
 
     it('no campaigns match the campaignType', () => {
       setupDefaults({ campaigns: [] });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(mockToast).not.toHaveBeenCalled();
     });
 
     it('campaigns are missing from persisted state', () => {
@@ -201,7 +191,7 @@ describe('useCampaignOutcomeToast', () => {
       expect(() =>
         renderHook(() => useCampaignOutcomeToast(mockConfig)),
       ).not.toThrow();
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(mockToast).not.toHaveBeenCalled();
     });
 
     it('subscriptionId is missing', () => {
@@ -214,7 +204,7 @@ describe('useCampaignOutcomeToast', () => {
         },
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(mockToast).not.toHaveBeenCalled();
     });
 
     it('winner toast was already dismissed', () => {
@@ -228,7 +218,7 @@ describe('useCampaignOutcomeToast', () => {
         dismissed: { [key]: true },
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(mockToast).not.toHaveBeenCalled();
     });
 
     it('non_winner toast was already dismissed', () => {
@@ -242,7 +232,7 @@ describe('useCampaignOutcomeToast', () => {
         dismissed: { [key]: true },
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(mockToast).not.toHaveBeenCalled();
     });
 
     it('outcome is finalized with a verification code (neither variant)', () => {
@@ -254,7 +244,7 @@ describe('useCampaignOutcomeToast', () => {
         },
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(mockToast).not.toHaveBeenCalled();
     });
   });
 
@@ -265,10 +255,10 @@ describe('useCampaignOutcomeToast', () => {
       winnerVerificationCode: 'WINNER-XYZ',
     };
 
-    it('shows Plain variant toast with trophy startAccessory', () => {
+    it('shows a persistent toast with trophy startAccessory', () => {
       setupDefaults({ outcome: winnerOutcome });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
           hasNoTimeout: true,
           startAccessory: expect.anything(),
@@ -279,7 +269,7 @@ describe('useCampaignOutcomeToast', () => {
     it('uses consolidated winner locale keys', () => {
       setupDefaults({ outcome: winnerOutcome });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
           title: 'rewards.campaign_outcome_toast.winner.title',
           description: `rewards.campaign_outcome_toast.winner.description:${CAMPAIGN_NAME}`,
@@ -288,10 +278,10 @@ describe('useCampaignOutcomeToast', () => {
       );
     });
 
-    it('shows close button with correct config', () => {
+    it('passes an onClose handler', () => {
       setupDefaults({ outcome: winnerOutcome });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
           onClose: expect.any(Function),
         }),
@@ -312,10 +302,10 @@ describe('useCampaignOutcomeToast', () => {
       winnerVerificationCode: null,
     };
 
-    it('shows Icon variant toast with Confirmation icon', () => {
+    it('shows a Success severity toast', () => {
       setupDefaults({ outcome: nonWinnerOutcome });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
           severity: ToastSeverity.Success,
           hasNoTimeout: true,
@@ -326,7 +316,7 @@ describe('useCampaignOutcomeToast', () => {
     it('uses consolidated non_winner locale keys', () => {
       setupDefaults({ outcome: nonWinnerOutcome });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
           title: 'rewards.campaign_outcome_toast.non_winner.title',
           description: `rewards.campaign_outcome_toast.non_winner.description:${CAMPAIGN_NAME}`,
@@ -353,7 +343,7 @@ describe('useCampaignOutcomeToast', () => {
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
-      const { onClose } = mockShowToast.mock.calls[0][0];
+      const { onClose } = mockToast.mock.calls[0][0];
       onClose?.();
 
       expect(mockDismissCampaignOutcomeToast).toHaveBeenCalledWith({
@@ -361,7 +351,7 @@ describe('useCampaignOutcomeToast', () => {
         subscriptionId: SUBSCRIPTION_ID,
         variant: 'winner',
       });
-      expect(mockCloseToast).toHaveBeenCalled();
+      expect(mockToast.dismiss).toHaveBeenCalled();
     });
 
     it('dispatches dismissCampaignOutcomeToast with variant non_winner', () => {
@@ -374,7 +364,7 @@ describe('useCampaignOutcomeToast', () => {
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
-      const { onClose } = mockShowToast.mock.calls[0][0];
+      const { onClose } = mockToast.mock.calls[0][0];
       onClose?.();
 
       expect(mockDismissCampaignOutcomeToast).toHaveBeenCalledWith({
@@ -396,7 +386,7 @@ describe('useCampaignOutcomeToast', () => {
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
-      const { actionButtonOnPress } = mockShowToast.mock.calls[0][0];
+      const { actionButtonOnPress } = mockToast.mock.calls[0][0];
       actionButtonOnPress?.({} as never);
 
       expect(mockNavigateToRewardsRoute).toHaveBeenCalledWith(
@@ -419,7 +409,7 @@ describe('useCampaignOutcomeToast', () => {
       });
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
-      const { actionButtonOnPress } = mockShowToast.mock.calls[0][0];
+      const { actionButtonOnPress } = mockToast.mock.calls[0][0];
       actionButtonOnPress?.({} as never);
 
       expect(mockNavigateToRewardsRoute).toHaveBeenCalledWith(
@@ -452,7 +442,7 @@ describe('useCampaignOutcomeToast', () => {
 
       expect(cleanupFn).toBeDefined();
       cleanupFn?.();
-      expect(mockCloseToast).toHaveBeenCalled();
+      expect(mockToast.dismiss).toHaveBeenCalled();
     });
 
     it('does not return cleanup when variant is null', () => {
@@ -466,22 +456,6 @@ describe('useCampaignOutcomeToast', () => {
       renderHook(() => useCampaignOutcomeToast(mockConfig));
 
       expect(cleanupFn).toBeUndefined();
-    });
-  });
-
-  describe('edge cases', () => {
-    it('handles null toastRef gracefully', () => {
-      (useContext as jest.Mock).mockReturnValue({ toastRef: null });
-      setupDefaults({
-        outcome: {
-          subscriptionId: SUBSCRIPTION_ID,
-          outcomeStatus: 'pending',
-          winnerVerificationCode: 'CODE',
-        },
-      });
-      expect(() =>
-        renderHook(() => useCampaignOutcomeToast(mockConfig)),
-      ).not.toThrow();
     });
   });
 });

--- a/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.ts
+++ b/app/components/UI/Rewards/hooks/useCampaignOutcomeToast.ts
@@ -1,9 +1,9 @@
-import { useCallback, useContext, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../core/NavigationService/types';
 import { useDispatch, useSelector } from 'react-redux';
+import { toast } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../locales/i18n';
-import { ToastContext } from '../../../../component-library/components/Toast';
 import type {
   BaseCampaignParticipantOutcomeDto,
   CampaignType,
@@ -20,6 +20,14 @@ import { selectRewardsSubscriptionId } from '../../../../selectors/rewards';
 import { navigateToRewardsRoute } from '../utils';
 import useRewardsToast from './useRewardsToast';
 import type { RewardsStackParamList } from '../types/navigation';
+
+const dismissToast = () => {
+  try {
+    toast.dismiss();
+  } catch {
+    // Toaster is registered at app root; ignore if it is not mounted yet.
+  }
+};
 
 export interface CampaignOutcomeToastConfig {
   campaignType: CampaignType;
@@ -47,7 +55,6 @@ export function useCampaignOutcomeToast(
   } = config;
 
   const dispatch = useDispatch();
-  const { toastRef } = useContext(ToastContext);
   const { showToast, RewardsToastOptions } = useRewardsToast();
   const navigation = useNavigation<AppNavigationProp>();
 
@@ -105,8 +112,8 @@ export function useCampaignOutcomeToast(
         variant,
       }),
     );
-    toastRef?.current?.closeToast();
-  }, [variant, targetCampaign, subscriptionId, dispatch, toastRef]);
+    dismissToast();
+  }, [variant, targetCampaign, subscriptionId, dispatch]);
 
   const handleCta = useCallback(() => {
     if (!targetCampaign || !variant) return;
@@ -163,13 +170,12 @@ export function useCampaignOutcomeToast(
       }
 
       return () => {
-        toastRef?.current?.closeToast();
+        dismissToast();
       };
     }, [
       variant,
       isDismissed,
       targetCampaign,
-      toastRef,
       showToast,
       RewardsToastOptions,
       handleCta,

--- a/app/components/UI/Rewards/hooks/useRewardsNotificationsNudge.test.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsNotificationsNudge.test.tsx
@@ -9,7 +9,7 @@ jest.mock('react-native', () => ({
 }));
 const mockAppStateAddEventListener = AppState.addEventListener as jest.Mock;
 import { useSelector } from 'react-redux';
-import { ToastContext } from '../../../../component-library/components/Toast';
+import { toast } from '@metamask/design-system-react-native';
 import { useRewardsNotificationsNudge } from './useRewardsNotificationsNudge';
 import {
   selectIsMetamaskNotificationsEnabled,
@@ -19,15 +19,11 @@ import { isNotificationsFeatureEnabled } from '../../../../util/notifications/co
 
 const mockShowToast = jest.fn();
 const mockEnableNotifications = jest.fn();
-const mockOriginalCloseButtonPress = jest.fn();
 const mockEnableNotificationsNudge = jest.fn(
   (linkButtonOptions: { label: string; onPress: () => Promise<void> }) => ({
     variant: 'Plain',
     hasNoTimeout: true,
     linkButtonOptions,
-    closeButtonOptions: {
-      onPress: mockOriginalCloseButtonPress,
-    },
   }),
 );
 const mockLoadingToast = jest.fn((title: string, subtitle?: string) => ({
@@ -95,8 +91,15 @@ jest.mock('../../../../../locales/i18n', () => ({
   },
 }));
 
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
+
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
-const mockCloseToast = jest.fn();
 
 function mockSelectors({
   notificationsEnabled,
@@ -118,20 +121,7 @@ function renderNudgeHook(options?: {
   enabled?: boolean;
   onNotificationsEnabled?: () => void;
 }) {
-  const toastRef = {
-    current: {
-      showToast: jest.fn(),
-      closeToast: mockCloseToast,
-    },
-  };
-  const wrapper = ({ children }: { children: React.ReactNode }) =>
-    React.createElement(
-      ToastContext.Provider,
-      { value: { toastRef } },
-      children,
-    );
-
-  return renderHook(() => useRewardsNotificationsNudge(options), { wrapper });
+  return renderHook(() => useRewardsNotificationsNudge(options));
 }
 
 describe('useRewardsNotificationsNudge', () => {
@@ -179,9 +169,7 @@ describe('useRewardsNotificationsNudge', () => {
     expect(mockShowToast).toHaveBeenCalledWith(
       expect.objectContaining({
         variant: 'Plain',
-        closeButtonOptions: expect.objectContaining({
-          onPress: expect.any(Function),
-        }),
+        onClose: expect.any(Function),
       }),
     );
 
@@ -193,7 +181,7 @@ describe('useRewardsNotificationsNudge', () => {
     });
 
     expect(mockEnableNotifications).toHaveBeenCalledTimes(1);
-    expect(mockCloseToast).toHaveBeenCalledTimes(1);
+    expect(toast.dismiss).toHaveBeenCalledTimes(1);
     expect(mockShowToast).toHaveBeenCalledTimes(2);
     expect(mockShowToast).toHaveBeenLastCalledWith(
       expect.objectContaining({ variant: 'loading' }),
@@ -237,7 +225,7 @@ describe('useRewardsNotificationsNudge', () => {
       await linkButtonOptions.onPress();
     });
 
-    expect(mockCloseToast).toHaveBeenCalledTimes(1);
+    expect(toast.dismiss).toHaveBeenCalledTimes(1);
     expect(mockShowToast).toHaveBeenLastCalledWith(
       expect.objectContaining({ variant: 'error' }),
     );
@@ -339,7 +327,7 @@ describe('useRewardsNotificationsNudge', () => {
     await waitFor(() => {
       expect(action).toHaveBeenCalledTimes(1);
     });
-    expect(mockCloseToast).toHaveBeenCalledTimes(1);
+    expect(toast.dismiss).toHaveBeenCalledTimes(1);
   });
 
   it('shows loading toast before deferred action runs via effect', async () => {
@@ -408,17 +396,16 @@ describe('useRewardsNotificationsNudge', () => {
     });
 
     const toastConfig = mockShowToast.mock.calls[0][0] as {
-      closeButtonOptions: { onPress: () => void };
+      onClose: () => void;
     };
     act(() => {
-      toastConfig.closeButtonOptions.onPress();
+      toastConfig.onClose();
     });
 
     notificationsEnabled = true;
     mockSelectors({ notificationsEnabled });
     rerender();
 
-    expect(mockOriginalCloseButtonPress).toHaveBeenCalledTimes(1);
     expect(action).not.toHaveBeenCalled();
   });
 
@@ -440,7 +427,7 @@ describe('useRewardsNotificationsNudge', () => {
 
     expect(mockGetPushPermission).toHaveBeenCalledTimes(1);
     expect(mockEnableNotifications).not.toHaveBeenCalled();
-    expect(mockCloseToast).toHaveBeenCalledTimes(1);
+    expect(toast.dismiss).toHaveBeenCalledTimes(1);
     expect(mockOpenSystemSettings).toHaveBeenCalledTimes(1);
     expect(mockAppStateAddEventListener).toHaveBeenCalledWith(
       'change',
@@ -609,7 +596,7 @@ describe('useRewardsNotificationsNudge', () => {
       await linkButtonOptions.onPress();
     });
 
-    expect(mockCloseToast).toHaveBeenCalledTimes(1);
+    expect(toast.dismiss).toHaveBeenCalledTimes(1);
     expect(mockOpenSystemSettings).not.toHaveBeenCalled();
   });
 
@@ -629,7 +616,7 @@ describe('useRewardsNotificationsNudge', () => {
       await linkButtonOptions.onPress();
     });
 
-    expect(mockCloseToast).toHaveBeenCalledTimes(1);
+    expect(toast.dismiss).toHaveBeenCalledTimes(1);
   });
 
   it('closeEnableNotificationsNudge clears pending action and closes the toast', async () => {
@@ -650,7 +637,7 @@ describe('useRewardsNotificationsNudge', () => {
     mockSelectors({ notificationsEnabled });
     rerender();
 
-    expect(mockCloseToast).toHaveBeenCalledTimes(1);
+    expect(toast.dismiss).toHaveBeenCalledTimes(1);
     expect(action).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/Rewards/hooks/useRewardsNotificationsNudge.ts
+++ b/app/components/UI/Rewards/hooks/useRewardsNotificationsNudge.ts
@@ -1,7 +1,7 @@
-import { useCallback, useContext, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { AppState } from 'react-native';
 import { useSelector } from 'react-redux';
-import { ToastContext } from '../../../../component-library/components/Toast';
+import { toast } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../locales/i18n';
 import {
   selectIsMetamaskNotificationsEnabled,
@@ -13,6 +13,14 @@ import NotificationService, {
   getPushPermission,
 } from '../../../../util/notifications/services/NotificationService';
 import useRewardsToast from './useRewardsToast';
+
+const dismissToast = () => {
+  try {
+    toast.dismiss();
+  } catch {
+    // Toaster is registered at app root; ignore if it is not mounted yet.
+  }
+};
 
 type NotificationsEnabledAction = () => Promise<void> | void;
 
@@ -50,7 +58,6 @@ export function useRewardsNotificationsNudge(
   const isMetaMaskPushNotificationsEnabled = useSelector(
     selectIsMetaMaskPushNotificationsEnabled,
   );
-  const { toastRef } = useContext(ToastContext);
   const { showToast, RewardsToastOptions } = useRewardsToast();
   const { enableNotifications } = useEnableNotifications({
     nudgeEnablePush: true,
@@ -78,9 +85,9 @@ export function useRewardsNotificationsNudge(
     // loading → success toast). Calling closeToast here would kill the success
     // toast that was just shown, so we skip it.
     if (!areNotificationsEnabledRef.current) {
-      toastRef?.current?.closeToast();
+      dismissToast();
     }
-  }, [toastRef]);
+  }, []);
 
   const handleTurnOnNotifications = useCallback(async () => {
     if (!enabled || notificationsEnableInFlightRef.current) {
@@ -96,7 +103,7 @@ export function useRewardsNotificationsNudge(
     try {
       const permission = await getPushPermission();
       if (permission === 'denied') {
-        toastRef?.current?.closeToast();
+        dismissToast();
         NotificationService.openSystemSettings();
         appStateSubscriptionRef.current = AppState.addEventListener(
           'change',
@@ -115,10 +122,10 @@ export function useRewardsNotificationsNudge(
             );
             try {
               await enableNotifications();
-              toastRef?.current?.closeToast();
+              dismissToast();
               onNotificationsEnabledRef.current?.();
             } catch {
-              toastRef?.current?.closeToast();
+              dismissToast();
               showToast(
                 RewardsToastOptions.error(
                   strings('rewards.notifications_nudge.enable_error'),
@@ -132,10 +139,10 @@ export function useRewardsNotificationsNudge(
         return;
       }
       await enableNotifications();
-      toastRef?.current?.closeToast();
+      dismissToast();
       onNotificationsEnabledRef.current?.();
     } catch {
-      toastRef?.current?.closeToast();
+      dismissToast();
       showToast(
         RewardsToastOptions.error(
           strings('rewards.notifications_nudge.enable_error'),
@@ -144,7 +151,7 @@ export function useRewardsNotificationsNudge(
     } finally {
       notificationsEnableInFlightRef.current = false;
     }
-  }, [enableNotifications, enabled, toastRef, showToast, RewardsToastOptions]);
+  }, [enableNotifications, enabled, showToast, RewardsToastOptions]);
 
   const showEnableNotificationsNudge = useCallback(() => {
     if (!shouldPromptToEnableNotifications) {
@@ -156,20 +163,12 @@ export function useRewardsNotificationsNudge(
       onPress: handleTurnOnNotifications,
     });
 
-    showToast(
-      nudgeConfig.closeButtonOptions
-        ? {
-            ...nudgeConfig,
-            closeButtonOptions: {
-              ...nudgeConfig.closeButtonOptions,
-              onPress: () => {
-                pendingActionRef.current = null;
-                nudgeConfig.closeButtonOptions?.onPress?.();
-              },
-            },
-          }
-        : nudgeConfig,
-    );
+    showToast({
+      ...nudgeConfig,
+      onClose: () => {
+        pendingActionRef.current = null;
+      },
+    });
     return true;
   }, [
     RewardsToastOptions,
@@ -210,7 +209,7 @@ export function useRewardsNotificationsNudge(
 
     const pendingAction = pendingActionRef.current;
     pendingActionRef.current = null;
-    toastRef?.current?.closeToast();
+    dismissToast();
     showToast(
       RewardsToastOptions.loading(
         strings('rewards.notifications_nudge.loading'),
@@ -218,20 +217,14 @@ export function useRewardsNotificationsNudge(
       ),
     );
     Promise.resolve(pendingAction()).catch(() => {
-      toastRef?.current?.closeToast();
+      dismissToast();
       showToast(
         RewardsToastOptions.error(
           strings('rewards.notifications_nudge.enable_error'),
         ),
       );
     });
-  }, [
-    areNotificationsEnabled,
-    enabled,
-    toastRef,
-    showToast,
-    RewardsToastOptions,
-  ]);
+  }, [areNotificationsEnabled, enabled, showToast, RewardsToastOptions]);
 
   useEffect(() => {
     if (!enabled) {

--- a/app/components/UI/Rewards/hooks/useRewardsToast.tsx
+++ b/app/components/UI/Rewards/hooks/useRewardsToast.tsx
@@ -21,13 +21,6 @@ import RewardsTrophyIcon from '../../../../images/rewards/trophy.svg';
 
 export type RewardsToastOptions = ToastOptions & {
   hapticsType: HapticNotificationMoment;
-  /**
-   * Temporary compatibility field for callers that still wrap the legacy
-   * ToastContext close button. The follow-up call-site PR removes this.
-   */
-  closeButtonOptions?: {
-    onPress?: () => void;
-  };
 };
 
 export interface OutcomeCtaToastParams {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

<!-- mms-check: type=text required=true -->

This is **PR 2/2** of the Rewards toast migration stack (270 lines). It sits on #35303 (`useRewardsToast` → design-system `toast()`).

This PR switches the leftover Rewards surfaces that still used `ToastContext` / `toastRef.closeToast()`:

- Referral copy (`RewardsReferralCodeTag`) calls `toast()` directly
- Campaign outcome uses `toast.dismiss()` and `onClose`
- Notification nudge uses `toast.dismiss()` and `onClose`
- Removes the temporary `closeButtonOptions` compatibility field from `useRewardsToast`

After #35303 merges, retarget this PR to `main`.

Supersedes the combined change in #35293.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

CHANGELOG entry: null

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: No tracking issue; continues the design-system toast migration for Rewards flows. Depends on #35303.

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Rewards design-system toast call sites

  Background:
    Given I am logged into MetaMask Mobile
    And Rewards is available on my account
    And #35303 is included

  Scenario: user copies a Rewards referral code
    Given I am on a Rewards surface that shows a referral code
    When user copies the referral code
    Then a success toast confirms the code was copied
    And the toast can be dismissed with the design-system close control

  Scenario: user sees a campaign outcome toast
    Given a Rewards campaign has a winner or non-winner outcome for me
    When the campaign outcome toast is shown
    Then the title and CTA match the outcome
    And tapping the action button runs the existing outcome action
    And dismissing it records the outcome as dismissed

  Scenario: user is nudged to enable Rewards notifications
    Given Rewards wants to prompt me to enable notifications
    When the nudge toast appears
    Then it shows the enable-notifications CTA
    And dismissing it does not leave a pending action behind
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
- [x] I've tested with a power user scenario
- [x] I've instrumented key operations with Sentry traces for production performance metrics

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0603cdc-fa70-44f1-8dc1-c978c6db6bce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0603cdc-fa70-44f1-8dc1-c978c6db6bce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

