### PR TITLE
refactor(confirmations): migrate toasts to the design system

### DIFF
--- a/app/components/UI/QRHardware/QRSigningTransactionModal.test.tsx
+++ b/app/components/UI/QRHardware/QRSigningTransactionModal.test.tsx
@@ -11,7 +11,7 @@ import QRSigningTransactionModal, {
 import Engine from '../../../core/Engine';
 import { useParams } from '../../../util/navigation/navUtils';
 import { speedUpTransaction as speedUpTx } from '../../../util/transaction-controller';
-import ToastService from '../../../core/ToastService/ToastService';
+import { toast } from '@metamask/design-system-react-native';
 import { getTransactionUpdateErrorToastOptions } from '../../../util/confirmation/transactions';
 import {
   type QrScanRequest,
@@ -26,9 +26,13 @@ jest.mock('../../../util/transaction-controller', () => ({
   speedUpTransaction: jest.fn(),
 }));
 
-jest.mock('../../../core/ToastService/ToastService', () => ({
-  showToast: jest.fn(),
-}));
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
 jest.mock('../../../util/confirmation/transactions', () => ({
   getTransactionUpdateErrorToastOptions: jest.fn(),
@@ -74,7 +78,7 @@ jest.mock('react-native', () => {
 
 const mockUseParams = useParams as jest.Mock;
 const mockSpeedUpTx = speedUpTx as jest.Mock;
-const mockShowToast = ToastService.showToast as jest.Mock;
+const mockToast = toast as unknown as jest.Mock;
 const mockGetTransactionUpdateErrorToastOptions =
   getTransactionUpdateErrorToastOptions as jest.Mock;
 
@@ -337,7 +341,7 @@ describe('QRSigningTransactionModal', () => {
       expect(mockGetTransactionUpdateErrorToastOptions).toHaveBeenCalledWith(
         speedUpError,
       );
-      expect(mockShowToast).toHaveBeenCalledWith({
+      expect(mockToast).toHaveBeenCalledWith({
         descriptionOptions: { description: 'Error: speed up failed' },
       });
       expect(mockOnConfirmationComplete).toHaveBeenCalledWith(false);
@@ -366,7 +370,7 @@ describe('QRSigningTransactionModal', () => {
       expect(mockGetTransactionUpdateErrorToastOptions).toHaveBeenCalledWith(
         cancelError,
       );
-      expect(mockShowToast).toHaveBeenCalledWith({
+      expect(mockToast).toHaveBeenCalledWith({
         descriptionOptions: { description: 'Error: cancel failed' },
       });
       expect(mockOnConfirmationComplete).toHaveBeenCalledWith(false);
@@ -389,6 +393,6 @@ describe('QRSigningTransactionModal', () => {
       expect(mockOnConfirmationComplete).toHaveBeenCalledWith(false);
     });
 
-    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
   });
 });

--- a/app/components/UI/QRHardware/QRSigningTransactionModal.tsx
+++ b/app/components/UI/QRHardware/QRSigningTransactionModal.tsx
@@ -24,7 +24,7 @@ import {
   type GasPriceValue,
 } from '@metamask/transaction-controller';
 import { speedUpTransaction as speedUpTx } from '../../../util/transaction-controller';
-import ToastService from '../../../core/ToastService/ToastService';
+import { toast } from '@metamask/design-system-react-native';
 import { getTransactionUpdateErrorToastOptions } from '../../../util/confirmation/transactions';
 
 export const QRSignMode = {
@@ -97,9 +97,7 @@ const QRSigningTransactionModal = () => {
       } catch (error) {
         if (signMode === QRSignMode.SpeedUp || signMode === QRSignMode.Cancel) {
           InteractionManager.runAfterInteractions(() => {
-            ToastService.showToast(
-              getTransactionUpdateErrorToastOptions(error),
-            );
+            toast(getTransactionUpdateErrorToastOptions(error));
           });
         }
         onConfirmationComplete(false);

--- a/app/components/UI/Transactions/index.js
+++ b/app/components/UI/Transactions/index.js
@@ -25,7 +25,7 @@ import { showAlert } from '../../../actions/alert';
 import ExtendedKeyringTypes from '../../../constants/keyringTypes';
 import { NO_RPC_BLOCK_EXPLORER, RPC } from '../../../constants/network';
 import Engine from '../../../core/Engine';
-import ToastService from '../../../core/ToastService/ToastService';
+import { toast } from '@metamask/design-system-react-native';
 import { isNonEvmChainId } from '../../../core/Multichain/utils';
 import NotificationManager from '../../../core/NotificationManager';
 import { TransactionDetailLocation } from '../../../core/Analytics/events/transactions';
@@ -467,7 +467,7 @@ const Transactions = (props) => {
   );
 
   const showTransactionUpdateErrorToast = (error) => {
-    ToastService.showToast(getTransactionUpdateErrorToastOptions(error));
+    toast(getTransactionUpdateErrorToastOptions(error));
   };
 
   const handleSpeedUpTransactionFailure = (error) => {

--- a/app/components/UI/Transactions/index.test.tsx
+++ b/app/components/UI/Transactions/index.test.tsx
@@ -196,10 +196,13 @@ jest.mock('../../../core/Engine', () => ({
     },
   },
 }));
-jest.mock('../../../core/ToastService/ToastService', () => ({
-  __esModule: true,
-  default: { showToast: jest.fn() },
-}));
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 jest.mock('../../../util/Logger', () => ({ error: jest.fn() }));
 jest.mock('../../../util/analytics/analytics', () => ({
   analytics: { trackEvent: jest.fn() },

--- a/app/components/Views/ActivityList/useUnifiedTxActions.test.ts
+++ b/app/components/Views/ActivityList/useUnifiedTxActions.test.ts
@@ -26,12 +26,11 @@ jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
 
-jest.mock('../../../component-library/components/Toast', () => {
-  const ReactActual = jest.requireActual('react');
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
   return {
-    ToastContext: ReactActual.createContext({
-      toastRef: { current: { showToast: jest.fn() } },
-    }),
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
   };
 });
 

--- a/app/components/Views/ActivityList/useUnifiedTxActions.ts
+++ b/app/components/Views/ActivityList/useUnifiedTxActions.ts
@@ -9,9 +9,9 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import { navigateWithDetails } from '../../../util/navigation/navUtils';
-import { useCallback, useContext, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { ToastContext } from '../../../component-library/components/Toast';
+import { toast } from '@metamask/design-system-react-native';
 import ExtendedKeyringTypes from '../../../constants/keyringTypes';
 import Engine from '../../../core/Engine';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
@@ -87,9 +87,6 @@ export function useUnifiedTxActions() {
     hideAwaitingConfirmation,
     showHardwareWalletError,
   } = useHardwareWallet();
-  const toastContext = useContext(ToastContext);
-  const toastRef = toastContext?.toastRef;
-
   const gasFeeEstimates = useSelector(selectGasFeeEstimates);
   const accounts = useSelector(selectAccounts);
   const selectedAddress = useSelector(
@@ -111,14 +108,9 @@ export function useUnifiedTxActions() {
     isHardwareAccount(selectedAddress ?? '', [ExtendedKeyringTypes.qr]),
   );
 
-  const showTransactionUpdateErrorToast = useCallback(
-    (error: unknown) => {
-      toastRef?.current?.showToast(
-        getTransactionUpdateErrorToastOptions(error),
-      );
-    },
-    [toastRef],
-  );
+  const showTransactionUpdateErrorToast = useCallback((error: unknown) => {
+    toast(getTransactionUpdateErrorToastOptions(error));
+  }, []);
 
   const closeSpeedUpCancelModal = useCallback(() => {
     setSpeedUpCancelModalState(SpeedUpCancelModalState.Closed);

--- a/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.test.ts
+++ b/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.test.ts
@@ -1,16 +1,6 @@
-import React from 'react';
-import { BoxBackgroundColor } from '@metamask/design-system-react-native';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { renderHook, act } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
-
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../component-library/components/Toast';
-import {
-  IconColor,
-  IconName,
-} from '../../../component-library/components/Icons/Icon';
 
 import {
   useUnifiedTxActions,
@@ -36,6 +26,14 @@ import {
 import ExtendedKeyringTypes from '../../../constants/keyringTypes';
 
 const mockNavigate = jest.fn();
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
@@ -138,28 +136,10 @@ import {
 import { validateTransactionActionBalance } from '../../../util/transactions';
 import { isHardwareAccount } from '../../../util/address';
 
-const mockShowToast = jest.fn();
+const mockToast = toast as unknown as jest.Mock;
 const SELECTED_ADDRESS = '0x29D68015EE8Eb26fD23579a1df80ff1fb0F26209';
 
-const mockToastRef = {
-  current: {
-    showToast: mockShowToast,
-    closeToast: jest.fn(),
-  },
-};
-
-function TxActionsTestWrapper({ children }: { children: React.ReactNode }) {
-  return React.createElement(
-    ToastContext.Provider,
-    { value: { toastRef: mockToastRef } },
-    children,
-  );
-}
-
-const renderUnifiedTxActions = () =>
-  renderHook(() => useUnifiedTxActions(), {
-    wrapper: TxActionsTestWrapper,
-  });
+const renderUnifiedTxActions = () => renderHook(() => useUnifiedTxActions());
 
 const SPEED_UP_GAS = {
   maxFeePerGas: '0xff',
@@ -247,7 +227,7 @@ describe('useUnifiedTxActions', () => {
         .getGasValuesForReplacement,
     );
     engineContext.TransactionController.state.transactions = [];
-    mockShowToast.mockClear();
+    mockToast.mockClear();
 
     (createQRSigningTransactionModalNavDetails as jest.Mock).mockReturnValue([
       'QRSigningModal',
@@ -445,14 +425,12 @@ describe('useUnifiedTxActions', () => {
         } as SpeedUpCancelParams);
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: ToastVariants.Icon,
-          iconName: IconName.CircleX,
-          iconColor: IconColor.Error,
-          backgroundColor: BoxBackgroundColor.Transparent,
-          descriptionOptions: { description: 'failed' },
+          description: 'failed',
+          severity: ToastSeverity.Danger,
           hasNoTimeout: false,
+          showCloseButton: false,
         }),
       );
       expect(result.current.speedUpIsOpen).toBe(false);
@@ -473,11 +451,10 @@ describe('useUnifiedTxActions', () => {
         await result.current.speedUpTransaction();
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          descriptionOptions: {
-            description: 'gas computation failed',
-          },
+          description: 'gas computation failed',
+          severity: ToastSeverity.Danger,
         }),
       );
       expect(result.current.speedUpIsOpen).toBe(false);
@@ -593,14 +570,12 @@ describe('useUnifiedTxActions', () => {
         } as SpeedUpCancelParams);
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: ToastVariants.Icon,
-          iconName: IconName.CircleX,
-          iconColor: IconColor.Error,
-          backgroundColor: BoxBackgroundColor.Transparent,
-          descriptionOptions: { description: 'nope' },
+          description: 'nope',
+          severity: ToastSeverity.Danger,
           hasNoTimeout: false,
+          showCloseButton: false,
         }),
       );
       expect(result.current.cancelIsOpen).toBe(false);
@@ -876,14 +851,12 @@ describe('useUnifiedTxActions', () => {
           });
 
           expect(mockExecuteHardwareWalletOperation).not.toHaveBeenCalled();
-          expect(mockShowToast).toHaveBeenCalledWith(
+          expect(mockToast).toHaveBeenCalledWith(
             expect.objectContaining({
-              variant: ToastVariants.Icon,
-              iconName: IconName.CircleX,
-              iconColor: IconColor.Error,
-              backgroundColor: BoxBackgroundColor.Transparent,
-              descriptionOptions: { description: 'gas error' },
+              description: 'gas error',
+              severity: ToastSeverity.Danger,
               hasNoTimeout: false,
+              showCloseButton: false,
             }),
           );
           expect(result.current.speedUpIsOpen).toBe(false);
@@ -901,16 +874,12 @@ describe('useUnifiedTxActions', () => {
           });
 
           expect(mockExecuteHardwareWalletOperation).not.toHaveBeenCalled();
-          expect(mockShowToast).toHaveBeenCalledWith(
+          expect(mockToast).toHaveBeenCalledWith(
             expect.objectContaining({
-              variant: ToastVariants.Icon,
-              iconName: IconName.CircleX,
-              iconColor: IconColor.Error,
-              backgroundColor: BoxBackgroundColor.Transparent,
-              descriptionOptions: {
-                description: 'Missing transaction id for speed up',
-              },
+              description: 'Missing transaction id for speed up',
+              severity: ToastSeverity.Danger,
               hasNoTimeout: false,
+              showCloseButton: false,
             }),
           );
           expect(result.current.speedUpIsOpen).toBe(false);
@@ -1099,14 +1068,12 @@ describe('useUnifiedTxActions', () => {
           });
 
           expect(mockExecuteHardwareWalletOperation).not.toHaveBeenCalled();
-          expect(mockShowToast).toHaveBeenCalledWith(
+          expect(mockToast).toHaveBeenCalledWith(
             expect.objectContaining({
-              variant: ToastVariants.Icon,
-              iconName: IconName.CircleX,
-              iconColor: IconColor.Error,
-              backgroundColor: BoxBackgroundColor.Transparent,
-              descriptionOptions: { description: 'cancel error' },
+              description: 'cancel error',
+              severity: ToastSeverity.Danger,
               hasNoTimeout: false,
+              showCloseButton: false,
             }),
           );
           expect(result.current.cancelIsOpen).toBe(false);
@@ -1124,16 +1091,12 @@ describe('useUnifiedTxActions', () => {
           });
 
           expect(mockExecuteHardwareWalletOperation).not.toHaveBeenCalled();
-          expect(mockShowToast).toHaveBeenCalledWith(
+          expect(mockToast).toHaveBeenCalledWith(
             expect.objectContaining({
-              variant: ToastVariants.Icon,
-              iconName: IconName.CircleX,
-              iconColor: IconColor.Error,
-              backgroundColor: BoxBackgroundColor.Transparent,
-              descriptionOptions: {
-                description: 'Missing transaction id for cancel',
-              },
+              description: 'Missing transaction id for cancel',
+              severity: ToastSeverity.Danger,
               hasNoTimeout: false,
+              showCloseButton: false,
             }),
           );
           expect(result.current.cancelIsOpen).toBe(false);
@@ -1330,12 +1293,11 @@ describe('useUnifiedTxActions', () => {
         await result.current.speedUpTransaction();
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: ToastVariants.Icon,
-          iconName: IconName.CircleX,
-          iconColor: IconColor.Error,
-          backgroundColor: BoxBackgroundColor.Transparent,
+          severity: ToastSeverity.Danger,
+          hasNoTimeout: false,
+          showCloseButton: false,
         }),
       );
     });
@@ -1352,12 +1314,11 @@ describe('useUnifiedTxActions', () => {
         await result.current.cancelTransaction();
       });
 
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: ToastVariants.Icon,
-          iconName: IconName.CircleX,
-          iconColor: IconColor.Error,
-          backgroundColor: BoxBackgroundColor.Transparent,
+          severity: ToastSeverity.Danger,
+          hasNoTimeout: false,
+          showCloseButton: false,
         }),
       );
     });

--- a/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.ts
+++ b/app/components/Views/UnifiedTransactionsView/useUnifiedTxActions.ts
@@ -9,15 +9,9 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import { navigateWithDetails } from '../../../util/navigation/navUtils';
-import {
-  useCallback,
-  useContext,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { ToastContext } from '../../../component-library/components/Toast';
+import { toast } from '@metamask/design-system-react-native';
 import ExtendedKeyringTypes from '../../../constants/keyringTypes';
 import Engine from '../../../core/Engine';
 import { selectAccounts } from '../../../selectors/accountTrackerController';
@@ -110,13 +104,6 @@ export function useUnifiedTxActions() {
     hideAwaitingConfirmation,
     showHardwareWalletError,
   } = useHardwareWallet();
-  const toastContext = useContext(ToastContext);
-  const toastRef = toastContext?.toastRef;
-  const toastRefStable = useRef(toastRef);
-  useLayoutEffect(() => {
-    toastRefStable.current = toastRef;
-  }, [toastRef]);
-
   const gasFeeEstimates = useSelector(selectGasFeeEstimates);
   const accounts = useSelector(selectAccounts);
   const selectedAddress = useSelector(
@@ -139,9 +126,7 @@ export function useUnifiedTxActions() {
   ]);
 
   const showTransactionUpdateErrorToast = useCallback((error: unknown) => {
-    toastRefStable.current?.current?.showToast(
-      getTransactionUpdateErrorToastOptions(error),
-    );
+    toast(getTransactionUpdateErrorToastOptions(error));
   }, []);
 
   const closeSpeedUpCancelModal = useCallback(() => {

--- a/app/components/Views/confirmations/components/gas/gas-fee-token-toast/gas-fee-token-toast.test.tsx
+++ b/app/components/Views/confirmations/components/gas/gas-fee-token-toast/gas-fee-token-toast.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { toast } from '@metamask/design-system-react-native';
 import { NATIVE_TOKEN_ADDRESS } from '../../../constants/tokens';
 import { Hex } from '@metamask/utils';
 
@@ -7,10 +8,6 @@ import {
   useSelectedGasFeeToken,
 } from '../../../hooks/gas/useGasFeeToken';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../../../component-library/components/Toast';
 import { GasFeeTokenToast } from './gas-fee-token-toast';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import initialRootState, {
@@ -22,11 +19,13 @@ import { Token } from '@metamask/assets-controllers';
 import { toHex } from '@metamask/controller-utils';
 import { AccountsControllerState } from '@metamask/accounts-controller';
 
-const mockShowToast = jest.fn();
-const mockCloseToast = jest.fn();
-const mockToastRef = {
-  current: { showToast: mockShowToast, closeToast: mockCloseToast },
-};
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
 jest.mock('../../../hooks/gas/useGasFeeToken', () => ({
   useSelectedGasFeeToken: jest.fn(),
@@ -50,6 +49,8 @@ const GAS_FEE_TOKEN_MOCK: GasFeeToken = {
   tokenAddress: NATIVE_TOKEN_ADDRESS,
 };
 
+const mockToast = toast as unknown as jest.Mock;
+
 function renderToastHook(
   state: RootState = initialRootState,
   { gasFeeToken }: { gasFeeToken?: GasFeeToken } = {},
@@ -59,12 +60,7 @@ function renderToastHook(
   (useTransactionMetadataRequest as jest.Mock).mockReturnValue({
     chainId: '0x1',
   });
-  return renderWithProvider(
-    <ToastContext.Provider value={{ toastRef: mockToastRef }}>
-      <GasFeeTokenToast />
-    </ToastContext.Provider>,
-    { state },
-  );
+  return renderWithProvider(<GasFeeTokenToast />, { state });
 }
 
 describe('GasFeeTokenToast', () => {
@@ -122,68 +118,33 @@ describe('GasFeeTokenToast', () => {
 
   it('does nothing if no gasFeeToken', () => {
     renderToastHook(initialRootState, { gasFeeToken: undefined });
-    expect(mockShowToast).not.toHaveBeenCalled();
-  });
-
-  it('does nothing if no toast ref', () => {
-    (useSelectedGasFeeToken as jest.Mock).mockReturnValue(GAS_FEE_TOKEN_MOCK);
-    (useTransactionMetadataRequest as jest.Mock).mockReturnValue({
-      chainId: '0x1',
-    });
-
-    renderWithProvider(<GasFeeTokenToast />, { state: initialRootState });
-
-    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
   });
 
   it('does nothing if token has not changed (same as prevRef)', () => {
     renderToastHook(TOKENS_CONTROLLER_STATE, {
       gasFeeToken: GAS_FEE_TOKEN_MOCK,
     });
-    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
   });
 
-  it('calls showToast when token changes', () => {
+  it('calls toast when token changes', () => {
     (useSelectedGasFeeToken as jest.Mock).mockReturnValue(GAS_FEE_TOKEN_MOCK);
 
     const { rerender } = renderToastHook(TOKENS_CONTROLLER_STATE, {
       gasFeeToken: GAS_FEE_TOKEN_USDC_MOCK,
     });
-    expect(mockShowToast).toHaveBeenCalledTimes(1);
+    expect(mockToast).toHaveBeenCalledTimes(1);
 
     rerender(<GasFeeTokenToast />);
 
-    expect(mockShowToast).toHaveBeenCalledWith(
+    expect(mockToast).toHaveBeenCalledWith(
       expect.objectContaining({
-        labelOptions: [
-          {
-            label: `You're paying this network fee with ${matchingTokenSymbol}.`,
-            isBold: true,
-          },
-        ],
-        variant: ToastVariants.Network,
-        networkImageSource: { uri: matchingTokenImage },
+        title: `You're paying this network fee with ${matchingTokenSymbol}.`,
         hasNoTimeout: false,
+        startAccessory: expect.anything(),
       }),
     );
-  });
-
-  it('calls closeToast when close button is pressed', () => {
-    (useSelectedGasFeeToken as jest.Mock).mockReturnValue(GAS_FEE_TOKEN_MOCK);
-
-    renderToastHook(TOKENS_CONTROLLER_STATE, {
-      gasFeeToken: GAS_FEE_TOKEN_USDC_MOCK,
-    });
-
-    expect(mockShowToast).toHaveBeenCalledTimes(1);
-
-    const closeButtonOptions =
-      mockShowToast.mock.calls[0][0].closeButtonOptions;
-    expect(closeButtonOptions).toBeDefined();
-
-    closeButtonOptions.onPress();
-
-    expect(mockCloseToast).toHaveBeenCalledTimes(1);
   });
 
   it('uses default chainId when chainId is undefined', () => {
@@ -195,15 +156,11 @@ describe('GasFeeTokenToast', () => {
       chainId: undefined,
     });
 
-    renderWithProvider(
-      <ToastContext.Provider value={{ toastRef: mockToastRef }}>
-        <GasFeeTokenToast />
-      </ToastContext.Provider>,
-      { state: TOKENS_CONTROLLER_STATE },
-    );
+    renderWithProvider(<GasFeeTokenToast />, {
+      state: TOKENS_CONTROLLER_STATE,
+    });
 
-    // The component should still work with undefined chainId, defaulting to '0x1'
-    expect(mockShowToast).toHaveBeenCalledTimes(1);
+    expect(mockToast).toHaveBeenCalledTimes(1);
   });
 
   it('does nothing for mUSD conversion transactions', () => {
@@ -216,13 +173,10 @@ describe('GasFeeTokenToast', () => {
       type: TransactionType.musdConversion,
     });
 
-    renderWithProvider(
-      <ToastContext.Provider value={{ toastRef: mockToastRef }}>
-        <GasFeeTokenToast />
-      </ToastContext.Provider>,
-      { state: TOKENS_CONTROLLER_STATE },
-    );
+    renderWithProvider(<GasFeeTokenToast />, {
+      state: TOKENS_CONTROLLER_STATE,
+    });
 
-    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
   });
 });

--- a/app/components/Views/confirmations/components/gas/gas-fee-token-toast/gas-fee-token-toast.tsx
+++ b/app/components/Views/confirmations/components/gas/gas-fee-token-toast/gas-fee-token-toast.tsx
@@ -1,9 +1,11 @@
-import { useContext, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import {
-  ToastContext,
-  ToastVariants,
-  ButtonIconVariant,
-} from '../../../../../../component-library/components/Toast';
+  AvatarNetwork,
+  AvatarNetworkSize,
+  AvatarToken,
+  AvatarTokenSize,
+  toast,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import {
   TransactionType,
@@ -16,7 +18,6 @@ import {
   useSelectedGasFeeToken,
 } from '../../../hooks/gas/useGasFeeToken';
 import { useTransactionMetadataRequest } from '../../../hooks/transactions/useTransactionMetadataRequest';
-import { IconName } from '../../../../../../component-library/components/Icons/Icon';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { getNetworkImageSource } from '../../../../../../util/networks';
 
@@ -25,8 +26,6 @@ const IGNORED_TRANSACTION_TYPES = [TransactionType.musdConversion];
 export function GasFeeTokenToast() {
   const transactionMetadata = useTransactionMetadataRequest();
   const { chainId } = transactionMetadata || {};
-  const toastContext = useContext(ToastContext);
-  const toast = toastContext?.toastRef?.current;
   const nativeGasFeeToken = useGasFeeToken({
     tokenAddress: NATIVE_TOKEN_ADDRESS,
   });
@@ -47,35 +46,26 @@ export function GasFeeTokenToast() {
   );
 
   useEffect(() => {
-    if (!toast || !gasFeeToken || !transactionMetadata || isIgnoredType) return;
+    if (!gasFeeToken || !transactionMetadata || isIgnoredType) return;
     if (gasFeeToken.tokenAddress === prevRef.current) return;
 
     prevRef.current = gasFeeToken.tokenAddress;
 
-    toast.showToast({
-      labelOptions: [
-        {
-          label: `${strings('gas_fee_token_toast.message')}${gasFeeToken.symbol}.`,
-          isBold: true,
-        },
-      ],
-      variant: ToastVariants.Network,
+    toast({
+      title: `${strings('gas_fee_token_toast.message')}${gasFeeToken.symbol}.`,
+      startAccessory: tokenSelected?.image ? (
+        <AvatarToken
+          src={{ uri: tokenSelected.image }}
+          size={AvatarTokenSize.Md}
+        />
+      ) : (
+        <AvatarNetwork src={networkImageSource} size={AvatarNetworkSize.Md} />
+      ),
       hasNoTimeout: false,
-      networkImageSource: tokenSelected?.image
-        ? { uri: tokenSelected.image }
-        : networkImageSource,
-      closeButtonOptions: {
-        variant: ButtonIconVariant.Icon,
-        iconName: IconName.Close,
-        onPress: () => {
-          toast?.closeToast();
-        },
-      },
     });
   }, [
     gasFeeToken,
     tokenSelected,
-    toast,
     networkImageSource,
     transactionMetadata,
     isIgnoredType,

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -1,6 +1,6 @@
 import React, { act } from 'react';
 import { merge, noop } from 'lodash';
-import { ToastContext } from '../../../../../../component-library/components/Toast';
+import { toast } from '@metamask/design-system-react-native';
 import renderWithProvider from '../../../../../../util/test/renderWithProvider';
 import Engine from '../../../../../../core/Engine';
 import {
@@ -54,6 +54,84 @@ import Logger from '../../../../../../util/Logger';
 import useClearConfirmationOnBackSwipe from '../../../hooks/ui/useClearConfirmationOnBackSwipe';
 import { useAccountNoFundsAlert } from '../../../hooks/alerts/useAccountNoFundsAlert';
 import { mockTheme } from '../../../../../../util/theme';
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const React = require('react');
+  const PropTypes = require('prop-types');
+  const { View } = require('react-native');
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+
+  const BottomSheet = React.forwardRef(
+    (
+      {
+        children,
+        onClose,
+        onOpen,
+        goBack,
+        style,
+        twClassName: _twClassName,
+        testID,
+        accessibilityLabel,
+      }: {
+        children?: React.ReactNode;
+        onClose?: (hasCallback?: boolean) => void;
+        onOpen?: () => void;
+        goBack?: () => void;
+        style?: unknown;
+        twClassName?: unknown;
+        testID?: string;
+        accessibilityLabel?: string;
+      },
+      ref: React.Ref<{
+        onOpenBottomSheet: (callback?: () => void) => void;
+        onCloseBottomSheet: (callback?: () => void) => void;
+      }>,
+    ) => {
+      React.useImperativeHandle(ref, () => ({
+        onOpenBottomSheet: (callback?: () => void) => {
+          onOpen?.();
+          callback?.();
+        },
+        onCloseBottomSheet: (callback?: () => void) => {
+          const hasCallback = Boolean(callback);
+          onClose?.(hasCallback);
+          goBack?.();
+          callback?.();
+        },
+      }));
+      return React.createElement(
+        View,
+        {
+          testID: testID || 'design-system-bottom-sheet-mock',
+          style,
+          accessibilityLabel,
+        },
+        children,
+      );
+    },
+  );
+  BottomSheet.displayName = 'BottomSheet';
+  BottomSheet.propTypes = {
+    children: PropTypes.node,
+    onClose: PropTypes.func,
+    onOpen: PropTypes.func,
+    goBack: PropTypes.func,
+    style: PropTypes.oneOfType([
+      PropTypes.object,
+      PropTypes.array,
+      PropTypes.number,
+    ]),
+    twClassName: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    testID: PropTypes.string,
+    accessibilityLabel: PropTypes.string,
+  };
+
+  return {
+    ...actual,
+    BottomSheet,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
 jest.mock('../../../hooks/ui/useClearConfirmationOnBackSwipe');
 jest.mock('../../../hooks/ui/useMMPayNavigation');
@@ -220,10 +298,7 @@ function setControllerTransactions(transactions: { id: string }[]) {
   ).state = { transactions };
 }
 
-const mockShowToast = jest.fn();
-const mockToastRef = {
-  current: { showToast: mockShowToast, closeToast: jest.fn() },
-};
+const mockToast = toast as unknown as jest.Mock;
 
 interface DeferredPromise {
   promise: Promise<void>;
@@ -242,13 +317,18 @@ function createDeferredPromise(): DeferredPromise {
   return { promise, reject, resolve };
 }
 
+// CustomAmountInfo is memoized. Tests update hook mocks then rerender with the
+// same props; a changing non-visual child busts memo without remounting state.
+let customAmountInfoRenderEpoch = false;
+
 function createCustomAmountInfo(
   props: CustomAmountInfoProps & { transactionType?: TransactionType } = {},
 ) {
+  customAmountInfoRenderEpoch = !customAmountInfoRenderEpoch;
   return (
-    <ToastContext.Provider value={{ toastRef: mockToastRef } as never}>
-      <CustomAmountInfo {...props} />
-    </ToastContext.Provider>
+    <CustomAmountInfo {...props}>
+      {customAmountInfoRenderEpoch}
+    </CustomAmountInfo>
   );
 }
 
@@ -343,7 +423,7 @@ describe('CustomAmountInfo', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
-    mockShowToast.mockReset();
+    mockToast.mockReset();
     mockTransactionPayControllerState.transactionData = {};
 
     mockUseRampsUserRegion.mockReturnValue({
@@ -1067,7 +1147,7 @@ describe('CustomAmountInfo', () => {
       expect(view.getByTestId('custom-amount-input').props.onPress).toEqual(
         expect.any(Function),
       );
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
+      expect(mockToast).toHaveBeenCalledTimes(1);
     });
 
     it('unblocks non-Money review rows once quote loading starts', async () => {
@@ -1231,9 +1311,9 @@ describe('CustomAmountInfo', () => {
     // onAmountSubmit must NOT be called — keep keyboard visible for retry
     expect(mockOnAmountSubmit).not.toHaveBeenCalled();
     // Toast must be shown with the transaction-update title
-    expect(mockShowToast).toHaveBeenCalledTimes(1);
-    expect(mockShowToast).toHaveBeenCalledWith(
-      expect.objectContaining({ labelOptions: expect.any(Array) }),
+    expect(mockToast).toHaveBeenCalledTimes(1);
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: expect.any(String) }),
     );
     // Keyboard stays open: Done button and amount editing remain available.
     expect(queryByText(strings('confirm.edit_amount_done'))).toBeOnTheScreen();
@@ -1281,7 +1361,7 @@ describe('CustomAmountInfo', () => {
     });
 
     expect(updateTokenAmountMock).toHaveBeenCalledTimes(1);
-    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
     expect(mockOnAmountSubmit).not.toHaveBeenCalled();
   });
 
@@ -1322,7 +1402,7 @@ describe('CustomAmountInfo', () => {
     });
 
     expect(updateTokenAmountMock).toHaveBeenCalledTimes(1);
-    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
     expect(mockOnAmountSubmit).not.toHaveBeenCalled();
   });
 
@@ -1612,11 +1692,7 @@ describe('CustomAmountInfo', () => {
       });
 
       await act(async () => {
-        rerender(
-          <ToastContext.Provider value={{ toastRef: mockToastRef } as never}>
-            <CustomAmountInfo hasMax />
-          </ToastContext.Provider>,
-        );
+        rerender(createCustomAmountInfo({ hasMax: true }));
       });
 
       expect(updateTokenAmountMock).toHaveBeenCalledTimes(1);
@@ -1652,9 +1728,10 @@ describe('CustomAmountInfo', () => {
 
       await act(async () => {
         rerender(
-          <ToastContext.Provider value={{ toastRef: mockToastRef } as never}>
-            <CustomAmountInfo hasMax onAmountSubmit={onAmountSubmitMock} />
-          </ToastContext.Provider>,
+          createCustomAmountInfo({
+            hasMax: true,
+            onAmountSubmit: onAmountSubmitMock,
+          }),
         );
       });
 
@@ -1868,7 +1945,7 @@ describe('CustomAmountInfo', () => {
 
       // The Done handler's catch shows a toast and returns early without committing.
       expect(emittedPayloadFor('RAMPS_ORDER_PROPOSED')).toBeUndefined();
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
+      expect(mockToast).toHaveBeenCalledTimes(1);
     });
 
     // Regression guard for FIX 2 (no double emission). Renders the REAL money
@@ -2148,10 +2225,12 @@ describe('CustomAmountInfo', () => {
       fireEvent.press(getByText(strings('confirm.edit_amount_done')));
     });
 
-    const toastArg = mockShowToast.mock.calls[0][0];
-    toastArg.closeButtonOptions.onPress();
+    const toastArg = mockToast.mock.calls[0][0] as { onClose: () => void };
+    toastArg.onClose();
 
-    expect(mockToastRef.current.closeToast).toHaveBeenCalledTimes(1);
+    expect(
+      (toast as typeof toast & { dismiss: jest.Mock }).dismiss,
+    ).toHaveBeenCalledTimes(1);
   });
 
   it('opens keyboard when custom amount input is pressed', async () => {
@@ -2374,11 +2453,7 @@ describe('CustomAmountInfo', () => {
       });
 
       await act(async () => {
-        rerender(
-          <ToastContext.Provider value={{ toastRef: mockToastRef } as never}>
-            <CustomAmountInfo />
-          </ToastContext.Provider>,
-        );
+        rerender(createCustomAmountInfo());
       });
 
       expect(updateTokenAmountMock).toHaveBeenCalledTimes(1);

--- a/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/app/components/Views/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -1,11 +1,4 @@
-import React, {
-  ReactNode,
-  memo,
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-} from 'react';
+import React, { ReactNode, memo, useCallback, useEffect, useRef } from 'react';
 import { View } from 'react-native';
 import {
   TransactionType,
@@ -54,7 +47,6 @@ import { useAccountNoFundsAlert } from '../../../hooks/alerts/useAccountNoFundsA
 import EngineService from '../../../../../../core/EngineService';
 import Engine from '../../../../../../core/Engine';
 import { getAmountUpdateErrorToastOptions } from '../../../../../../util/confirmation/transactions';
-import { ToastContext } from '../../../../../../component-library/components/Toast';
 import { prefixError } from '../../../../../../util/transactions/error-prefix';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useMoneyNoFeeTokens } from '../../../hooks/pay/useMoneyNoFeeTokens';
@@ -78,6 +70,7 @@ import {
   Text,
   TextVariant,
   TextColor,
+  toast,
 } from '@metamask/design-system-react-native';
 
 const AMOUNT_UPDATE_ERROR_PREFIX = 'MetaMask Pay: Amount Update: ';
@@ -217,8 +210,6 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
     const accountOverride = useTransactionAccountOverride();
     const isWithdraw = isTransactionPayWithdraw(transactionMeta);
 
-    const { toastRef } = useContext(ToastContext);
-
     const { alertContent, alertMessage: alertMessageBase } =
       useTransactionCustomAmountAlerts({
         isInputChanged,
@@ -264,10 +255,8 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
           return;
         }
         const prefixed = prefixError(error, AMOUNT_UPDATE_ERROR_PREFIX);
-        toastRef?.current?.showToast(
-          getAmountUpdateErrorToastOptions(prefixed, () =>
-            toastRef?.current?.closeToast(),
-          ),
+        toast(
+          getAmountUpdateErrorToastOptions(prefixed, () => toast.dismiss()),
         );
         // Reopen the keyboard so the user can retry; do not advance the flow.
         setStage(CustomAmountStage.AmountInput);
@@ -287,7 +276,6 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = memo(
       onAmountSubmit,
       selectedFiatPaymentMethodId,
       setStage,
-      toastRef,
       trackAmountCommitted,
       transactionId,
       updateTokenAmount,

--- a/app/components/Views/confirmations/components/modals/mm-pay-debug-modal/mm-pay-debug-modal.tsx
+++ b/app/components/Views/confirmations/components/modals/mm-pay-debug-modal/mm-pay-debug-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState, useContext } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { Modal, ScrollView, TouchableOpacity } from 'react-native';
 import {
   BottomSheet,
@@ -13,6 +13,7 @@ import {
   Text,
   TextVariant,
   FontWeight,
+  toast,
 } from '@metamask/design-system-react-native';
 
 import {
@@ -25,8 +26,6 @@ import {
   truncateForDisplay,
 } from '../../../utils/debug/stringify-debug-value';
 import ClipboardManager from '../../../../../../core/ClipboardManager';
-import { ToastContext } from '../../../../../../component-library/components/Toast';
-import { ToastVariants } from '../../../../../../component-library/components/Toast/Toast.types';
 import { MmPayDebugModalTestIds } from './mm-pay-debug-modal.testIds';
 import { useStyles } from '../../../../../hooks/useStyles';
 import styleSheet from './mm-pay-debug-modal.styles';
@@ -36,8 +35,6 @@ export function MmPayDebugModal({ onClose }: { onClose?: () => void }) {
   const { styles } = useStyles(styleSheet, {});
   const { sections, copyAllPayload } = useMmPayDebugData();
   const quoteDebug = useMmPayQuoteDebug();
-  const { toastRef } = useContext(ToastContext);
-
   const [expandedSection, setExpandedSection] = useState<string | null>(null);
 
   const handleSheetClosed = useCallback(() => {
@@ -48,16 +45,9 @@ export function MmPayDebugModal({ onClose }: { onClose?: () => void }) {
     bottomSheetRef.current?.onCloseBottomSheet();
   }, []);
 
-  const showToast = useCallback(
-    (label: string) => {
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Plain,
-        hasNoTimeout: false,
-        labelOptions: [{ label }],
-      });
-    },
-    [toastRef],
-  );
+  const showToast = useCallback((label: string) => {
+    toast({ title: label, hasNoTimeout: false, showCloseButton: false });
+  }, []);
 
   const handleCopy = useCallback(
     async (text: string, isAll?: boolean) => {

--- a/app/util/confirmation/transactions.test.ts
+++ b/app/util/confirmation/transactions.test.ts
@@ -1,12 +1,7 @@
 import BN from 'bnjs4';
-import { BoxBackgroundColor } from '@metamask/design-system-react-native';
+import { ToastSeverity } from '@metamask/design-system-react-native';
 import { GAS_ESTIMATE_TYPES } from '@metamask/gas-fee-controller';
 import { TransactionEnvelopeType } from '@metamask/transaction-controller';
-import { ToastVariants } from '../../component-library/components/Toast';
-import {
-  IconColor,
-  IconName,
-} from '../../component-library/components/Icons/Icon';
 import { strings } from '../../../locales/i18n';
 import {
   buildTransactionParams,
@@ -167,22 +162,16 @@ describe('Confirmation Transactions Utils', () => {
   });
 
   describe('getTransactionUpdateErrorToastOptions', () => {
-    it('returns icon toast with title, styling, and description from error', () => {
-      expect(getTransactionUpdateErrorToastOptions(new Error('boom'))).toEqual(
-        expect.objectContaining({
-          variant: ToastVariants.Icon,
-          iconName: IconName.CircleX,
-          iconColor: IconColor.Error,
-          backgroundColor: BoxBackgroundColor.Transparent,
-          labelOptions: [
-            {
-              label: strings('transaction_update_toast.title'),
-              isBold: true,
-            },
-          ],
-          descriptionOptions: { description: 'boom' },
-        }),
-      );
+    it('returns danger toast with title, description, and no close button', () => {
+      expect(getTransactionUpdateErrorToastOptions(new Error('boom'))).toEqual({
+        title:
+          strings('transaction_update_toast.title') ||
+          'Transaction update failed',
+        description: 'boom',
+        severity: ToastSeverity.Danger,
+        hasNoTimeout: false,
+        showCloseButton: false,
+      });
     });
 
     it('uses friendly description for nonce too low', () => {
@@ -191,16 +180,14 @@ describe('Confirmation Transactions Utils', () => {
       );
       expect(options).toEqual(
         expect.objectContaining({
-          descriptionOptions: {
-            description: strings('transaction_update_toast.already_confirmed'),
-          },
+          description: strings('transaction_update_toast.already_confirmed'),
         }),
       );
     });
 
     it('omits description when no message is available', () => {
       expect(
-        getTransactionUpdateErrorToastOptions(undefined).descriptionOptions,
+        getTransactionUpdateErrorToastOptions(undefined).description,
       ).toBeUndefined();
     });
   });
@@ -208,22 +195,21 @@ describe('Confirmation Transactions Utils', () => {
   describe('getAmountUpdateErrorToastOptions', () => {
     const onClose = jest.fn();
 
-    it('returns a persistent toast with a close button', () => {
+    it('returns a persistent toast with a close callback', () => {
       expect(
         getAmountUpdateErrorToastOptions(new Error('boom'), onClose),
-      ).toEqual(
-        expect.objectContaining({
-          variant: ToastVariants.Icon,
-          descriptionOptions: { description: 'boom' },
-          hasNoTimeout: true,
-          closeButtonOptions: expect.objectContaining({ onPress: onClose }),
-        }),
-      );
+      ).toEqual({
+        title: strings('transaction_update_toast.amount_update_title'),
+        description: 'boom',
+        severity: ToastSeverity.Danger,
+        hasNoTimeout: true,
+        onClose,
+      });
     });
 
     it('omits description when no message is available', () => {
       expect(
-        getAmountUpdateErrorToastOptions(undefined, onClose).descriptionOptions,
+        getAmountUpdateErrorToastOptions(undefined, onClose).description,
       ).toBeUndefined();
     });
   });

--- a/app/util/confirmation/transactions.ts
+++ b/app/util/confirmation/transactions.ts
@@ -7,19 +7,13 @@ import {
   TransactionEnvelopeType,
   TransactionParams,
 } from '@metamask/transaction-controller';
-import { BoxBackgroundColor } from '@metamask/design-system-react-native';
+import {
+  ToastSeverity,
+  type ToastOptions,
+} from '@metamask/design-system-react-native';
 import { addHexPrefix, safeBNToHex } from '../number';
 import { safeToChecksumAddress } from '../address';
 import { strings } from '../../../locales/i18n';
-import { ToastVariants } from '../../component-library/components/Toast';
-import {
-  ButtonIconVariant,
-  type ToastOptions,
-} from '../../component-library/components/Toast/Toast.types';
-import {
-  IconColor,
-  IconName,
-} from '../../component-library/components/Icons/Icon';
 
 export function buildTransactionParams({
   gasDataEIP1559,
@@ -90,18 +84,11 @@ export function resolveTransactionUpdateErrorMessage(
   return raw;
 }
 
-const TRANSACTION_UPDATE_ERROR_TOAST_BASE = {
-  variant: ToastVariants.Icon,
-  iconName: IconName.CircleX,
-  iconColor: IconColor.Error,
-  backgroundColor: BoxBackgroundColor.Transparent,
-} as const;
-
 /**
  * Toast configuration for speed-up / cancel failures (legacy Transactions list and unified view).
  *
  * @param error - Thrown value from speed-up or cancel flow
- * @returns Options for the app toast `showToast` API (same shape for `ToastContext` and `ToastService`).
+ * @returns Options for the MMDS `toast()` API.
  */
 export function getTransactionUpdateErrorToastOptions(
   error: unknown,
@@ -110,10 +97,11 @@ export function getTransactionUpdateErrorToastOptions(
   const title =
     strings('transaction_update_toast.title') || 'Transaction update failed';
   return {
-    ...TRANSACTION_UPDATE_ERROR_TOAST_BASE,
-    labelOptions: [{ label: title, isBold: true }],
-    descriptionOptions: description ? { description } : undefined,
+    title,
+    ...(description !== undefined && { description }),
+    severity: ToastSeverity.Danger,
     hasNoTimeout: false,
+    showCloseButton: false,
   };
 }
 
@@ -123,7 +111,7 @@ export function getTransactionUpdateErrorToastOptions(
  *
  * @param error - Thrown value from the amount-update flow
  * @param onClose - Callback invoked when the user presses the dismiss button.
- * @returns Options for the app toast `showToast` API.
+ * @returns Options for the MMDS `toast()` API.
  */
 export function getAmountUpdateErrorToastOptions(
   error: unknown,
@@ -131,19 +119,10 @@ export function getAmountUpdateErrorToastOptions(
 ): ToastOptions {
   const description = resolveTransactionUpdateErrorMessage(error);
   return {
-    ...TRANSACTION_UPDATE_ERROR_TOAST_BASE,
-    labelOptions: [
-      {
-        label: strings('transaction_update_toast.amount_update_title'),
-        isBold: true,
-      },
-    ],
-    descriptionOptions: description ? { description } : undefined,
+    title: strings('transaction_update_toast.amount_update_title'),
+    ...(description !== undefined && { description }),
+    severity: ToastSeverity.Danger,
     hasNoTimeout: true,
-    closeButtonOptions: {
-      variant: ButtonIconVariant.Icon,
-      iconName: IconName.Close,
-      onPress: onClose,
-    },
+    onClose,
   };
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The component-library `Toast` is deprecated in favor of `toast()` from `@metamask/design-system-react-native`. Confirmation amount-update, gas-fee token, MM Pay debug copy, and transaction speed-up/cancel error flows still used `toastRef.showToast` or `ToastService.showToast`.

This PR switches those call sites to the design-system `toast()` API. `getTransactionUpdateErrorToastOptions` and `getAmountUpdateErrorToastOptions` now return MMDS toast options (`title`, `description`, `severity`) so Transactions list, unified activity, and QR hardware speed-up/cancel share the same payload. Tests mock `toast` instead of wrapping ToastContext or ToastService.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated confirmation and transaction-update toasts to the MetaMask design system

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Design system toasts for confirmations

  Background:
    Given I am logged into MetaMask Mobile

  Scenario: user changes the gas fee token on a confirmation
    Given I am on a transaction confirmation
    And a gas fee token other than the native token is available

    When user selects a different gas fee token
    Then a toast should appear from the top of the screen
    And the toast should name the selected gas token

  Scenario: user fails a speed-up or cancel
    Given I have a pending transaction in Activity
    And speed-up or cancel will fail

    When user confirms speed-up or cancel
    Then a danger toast should explain that the transaction update failed

  Scenario: user copies MM Pay debug data
    Given I open the MM Pay debug modal

    When user taps Copy or Copy All Debug Data
    Then a toast should confirm the copy or report clipboard failure
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
