### PR TITLE
refactor(card): migrate toasts to the design system

### DIFF
--- a/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.test.tsx
@@ -84,7 +84,7 @@ import type { TokenI } from '../../../Tokens/types';
 import { useCardHomeData } from '../../hooks/useCardHomeData';
 import { useOpenSwaps } from '../../hooks/useOpenSwaps';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
-import { ToastContext } from '../../../../../component-library/components/Toast';
+import { toast } from '@metamask/design-system-react-native';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { TOKEN_RATE_UNDEFINED } from '../../../Tokens/constants';
 import { selectPrivacyMode } from '../../../../../selectors/preferencesController';
@@ -118,6 +118,14 @@ import {
   StackActions,
   CommonActions,
 } from '@react-navigation/native';
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
@@ -652,15 +660,6 @@ const BAANX_CAPABILITIES = {
 const mockIsSolanaChainId = isSolanaChainId as jest.MockedFunction<
   typeof isSolanaChainId
 >;
-const mockShowToast = jest.fn();
-const mockCloseToast = jest.fn();
-const mockToastRef = {
-  current: {
-    showToast: mockShowToast,
-    closeToast: mockCloseToast,
-  },
-};
-
 jest.mock('../../../../../../locales/i18n', () => ({
   strings: (key: string, params?: Record<string, unknown>) => {
     const strings: { [key: string]: string } = {
@@ -1135,11 +1134,7 @@ function overrideCardHomeDataBalance(
   }
 }
 
-const CardHomeWithToast = () => (
-  <ToastContext.Provider value={{ toastRef: mockToastRef }}>
-    <CardHome />
-  </ToastContext.Provider>
-);
+const CardHomeWithToast = () => <CardHome />;
 
 // Helper: Render component with proper wrapper
 function render() {
@@ -1373,13 +1368,12 @@ describe('CardHome Component', () => {
         routes: [{ name: Routes.CARD.AUTHENTICATION }],
       },
     });
-    expect(mockShowToast).toHaveBeenCalledWith(
+    expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
-        labelOptions: [
-          {
-            label: strings('card.card_home.onboarding_token_revoked'),
-          },
-        ],
+        title: strings('card.card_home.onboarding_token_revoked'),
+        severity: 'warning',
+        hasNoTimeout: false,
+        showCloseButton: false,
       }),
     );
     expect(mockClearLastUnauthenticatedReason).toHaveBeenCalledTimes(1);

--- a/app/components/UI/Card/Views/CardHome/CardHome.tsx
+++ b/app/components/UI/Card/Views/CardHome/CardHome.tsx
@@ -1,6 +1,5 @@
 import React, {
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -16,6 +15,8 @@ import {
   ButtonVariant,
   ButtonSize,
   HeaderStandard,
+  toast,
+  ToastSeverity,
 } from '@metamask/design-system-react-native';
 import { useCardHeaderHandlers } from '../../hooks/useCardHeaderHandlers';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
@@ -68,10 +69,6 @@ import useCreditBalance from '../../hooks/useCreditBalance';
 import useMoneyVaultApy from '../../../Money/hooks/useMoneyVaultApy';
 import MoneyMetaMaskCard from '../../../Money/components/MoneyMetaMaskCard';
 import MoneyCardTiltAnimation from '../../../Money/components/MoneyCardTiltAnimation';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../../component-library/components/Toast';
 import SpendingLimitProgressBar from '../../components/SpendingLimitProgressBar/SpendingLimitProgressBar';
 import { AddToWalletButton } from '../../pushProvisioning/components/AddToWalletButton';
 import { CardScreenshotDeterrent } from '../../components/CardScreenshotDeterrent';
@@ -130,7 +127,6 @@ const CardHome = () => {
     useRoute<RouteProp<{ params: CardHomeRouteParams }, 'params'>>();
   const theme = useTheme();
   const tw = useTailwind();
-  const { toastRef } = useContext(ToastContext);
 
   const isSwapEnabled = useIsSwapEnabledForPriorityToken(
     data?.primaryFundingAsset?.walletAddress,
@@ -276,15 +272,11 @@ const CardHome = () => {
     }
 
     hasHandledOnboardingTokenRevocation.current = true;
-    toastRef?.current?.showToast({
-      variant: ToastVariants.Icon,
-      labelOptions: [
-        {
-          label: strings('card.card_home.onboarding_token_revoked'),
-        },
-      ],
+    toast({
+      title: strings('card.card_home.onboarding_token_revoked'),
+      severity: ToastSeverity.Warning,
       hasNoTimeout: false,
-      iconName: IconName.Warning,
+      showCloseButton: false,
     });
     navigation.dispatch(
       CommonActions.reset({
@@ -293,43 +285,33 @@ const CardHome = () => {
       }),
     );
     Engine.context.CardController.clearLastUnauthenticatedReason();
-  }, [lastUnauthenticatedReason, navigation, toastRef]);
+  }, [lastUnauthenticatedReason, navigation]);
 
   // --- Deeplink toast ---
   const hasShownDeeplinkToast = useRef(false);
   useEffect(() => {
-    if (
-      route.params?.showDeeplinkToast &&
-      !hasShownDeeplinkToast.current &&
-      toastRef?.current
-    ) {
+    if (route.params?.showDeeplinkToast && !hasShownDeeplinkToast.current) {
       hasShownDeeplinkToast.current = true;
-      toastRef.current.showToast({
-        variant: ToastVariants.Icon,
-        labelOptions: [
-          { label: strings('card.card_button_already_enabled_toast') },
-        ],
+      toast({
+        title: strings('card.card_button_already_enabled_toast'),
+        severity: ToastSeverity.Default,
         hasNoTimeout: false,
-        iconName: IconName.Info,
+        showCloseButton: false,
       });
     }
-  }, [route.params?.showDeeplinkToast, toastRef]);
+  }, [route.params?.showDeeplinkToast]);
 
   // --- Freeze error toast ---
   useEffect(() => {
-    if ((actions.freeze.error || actions.unfreeze.error) && toastRef?.current) {
-      toastRef.current.showToast({
-        variant: ToastVariants.Icon,
-        labelOptions: [
-          {
-            label: strings('card.card_home.manage_card_options.freeze_error'),
-          },
-        ],
+    if (actions.freeze.error || actions.unfreeze.error) {
+      toast({
+        title: strings('card.card_home.manage_card_options.freeze_error'),
+        severity: ToastSeverity.Warning,
         hasNoTimeout: false,
-        iconName: IconName.Warning,
+        showCloseButton: false,
       });
     }
-  }, [actions.freeze.error, actions.unfreeze.error, toastRef]);
+  }, [actions.freeze.error, actions.unfreeze.error]);
 
   // --- Derived state ---
   const hasPrimaryFiat =

--- a/app/components/UI/Card/Views/CardHome/hooks/useCardHomeActions.ts
+++ b/app/components/UI/Card/Views/CardHome/hooks/useCardHomeActions.ts
@@ -1,21 +1,16 @@
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Alert } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../../core/NavigationService/types';
 import type { NavigationDetails } from '../../../../../../util/navigation/navUtils';
 import { useSelector } from 'react-redux';
 import Engine from '../../../../../../core/Engine';
-import { useTheme } from '../../../../../../util/theme';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../locales/i18n';
 import {
   selectIsCardAuthenticated,
   selectCardActiveProviderId,
 } from '../../../../../../selectors/cardController';
-import { IconName } from '../../../../../../component-library/components/Icons/Icon';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../../../component-library/components/Toast';
 import { useAnalytics } from '../../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../../core/Analytics';
 import Routes from '../../../../../../constants/navigation/Routes';
@@ -64,8 +59,6 @@ export function useCardHomeActions({
   const isAuthenticated = useSelector(selectIsCardAuthenticated);
   const activeProviderId = useSelector(selectCardActiveProviderId);
   const { trackEvent, createEventBuilder } = useAnalytics();
-  const theme = useTheme();
-  const { toastRef } = useContext(ToastContext);
   const { reauthenticate } = useAuthentication();
 
   const { navigateToTravelPage, navigateToCardTosPage } = useNavigateToCardPage(
@@ -98,26 +91,18 @@ export function useCardHomeActions({
 
   // --- Freeze ---
 
-  const showFreezeSuccessToast = useCallback(
-    (wasFrozen: boolean) => {
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        labelOptions: [
-          {
-            label: strings(
-              wasFrozen
-                ? 'card.card_home.manage_card_options.unfreeze_success'
-                : 'card.card_home.manage_card_options.freeze_success',
-            ),
-          },
-        ],
-        iconName: IconName.Confirmation,
-        iconColor: theme.colors.success.default,
-        hasNoTimeout: false,
-      });
-    },
-    [toastRef, theme],
-  );
+  const showFreezeSuccessToast = useCallback((wasFrozen: boolean) => {
+    toast({
+      title: strings(
+        wasFrozen
+          ? 'card.card_home.manage_card_options.unfreeze_success'
+          : 'card.card_home.manage_card_options.freeze_success',
+      ),
+      severity: ToastSeverity.Success,
+      hasNoTimeout: false,
+      showCloseButton: false,
+    });
+  }, []);
 
   const handleToggleFreeze = useCallback(async () => {
     if (!isAuthenticated) {
@@ -148,7 +133,6 @@ export function useCardHomeActions({
     await withBiometricAuth({
       reauthenticate,
       navigation,
-      toastRef,
       passwordDescription: strings(
         'card.password_bottomsheet.description_unfreeze',
       ),
@@ -179,7 +163,6 @@ export function useCardHomeActions({
     trackEvent,
     createEventBuilder,
     activeProviderId,
-    toastRef,
     showFreezeSuccessToast,
   ]);
 
@@ -199,29 +182,24 @@ export function useCardHomeActions({
   const copyCardDetail = useCallback(
     (value: string) => {
       ClipboardManager.setString(value);
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        labelOptions: [
-          { label: strings('card.card_home.card_details.copied') },
-        ],
-        iconName: IconName.Copy,
-        iconColor: theme.colors.icon.default,
+      toast({
+        title: strings('card.card_home.card_details.copied'),
+        severity: ToastSeverity.Default,
         hasNoTimeout: false,
+        showCloseButton: false,
       });
     },
-    [toastRef, theme],
+    [],
   );
 
   const showCardDetailsErrorToast = useCallback(() => {
-    toastRef?.current?.showToast({
-      variant: ToastVariants.Icon,
-      labelOptions: [
-        { label: strings('card.card_home.view_card_details_error') },
-      ],
+    toast({
+      title: strings('card.card_home.view_card_details_error'),
+      severity: ToastSeverity.Warning,
       hasNoTimeout: false,
-      iconName: IconName.Warning,
+      showCloseButton: false,
     });
-  }, [toastRef]);
+  }, []);
 
   const onCardDetailsImageError = useCallback(() => {
     clearCardDetailsImageUrl();
@@ -306,7 +284,6 @@ export function useCardHomeActions({
       await withBiometricAuth({
         reauthenticate,
         navigation,
-        toastRef,
         onSuccess: () => fetchAndShowSensitiveDetails(),
       });
       return;
@@ -329,7 +306,6 @@ export function useCardHomeActions({
     await withBiometricAuth({
       reauthenticate,
       navigation,
-      toastRef,
       onSuccess: () => fetchAndShowCardDetails(),
     });
   }, [
@@ -346,7 +322,6 @@ export function useCardHomeActions({
     reauthenticate,
     fetchAndShowCardDetails,
     navigation,
-    toastRef,
     trackEvent,
     createEventBuilder,
     activeProviderId,
@@ -375,15 +350,11 @@ export function useCardHomeActions({
         }),
       );
     } catch {
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        labelOptions: [
-          {
-            label: strings('card.card_home.manage_card_options.view_pin_error'),
-          },
-        ],
+      toast({
+        title: strings('card.card_home.manage_card_options.view_pin_error'),
+        severity: ToastSeverity.Warning,
         hasNoTimeout: false,
-        iconName: IconName.Warning,
+        showCloseButton: false,
       });
     } finally {
       resetPinToken();
@@ -391,7 +362,6 @@ export function useCardHomeActions({
   }, [
     generatePinToken,
     navigation,
-    toastRef,
     resetPinToken,
     trackEvent,
     createEventBuilder,
@@ -407,7 +377,6 @@ export function useCardHomeActions({
     await withBiometricAuth({
       reauthenticate,
       navigation,
-      toastRef,
       passwordDescription: strings(
         'card.password_bottomsheet.description_view_pin',
       ),
@@ -419,7 +388,6 @@ export function useCardHomeActions({
     reauthenticate,
     fetchAndShowPin,
     navigation,
-    toastRef,
   ]);
 
   const setPinAction = useCallback(async () => {
@@ -443,7 +411,6 @@ export function useCardHomeActions({
     await withBiometricAuth({
       reauthenticate,
       navigation,
-      toastRef,
       passwordDescription: strings(
         'card.password_bottomsheet.description_set_pin',
       ),
@@ -457,7 +424,6 @@ export function useCardHomeActions({
     activeProviderId,
     reauthenticate,
     navigation,
-    toastRef,
     trackEvent,
     createEventBuilder,
   ]);

--- a/app/components/UI/Card/Views/CardHome/hooks/useCardProvisioning.ts
+++ b/app/components/UI/Card/Views/CardHome/hooks/useCardProvisioning.ts
@@ -1,11 +1,6 @@
-import { useContext, useMemo } from 'react';
-import { useTheme } from '../../../../../../util/theme';
+import { useMemo } from 'react';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../../locales/i18n';
-import { IconName } from '../../../../../../component-library/components/Icons/Icon';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../../../component-library/components/Toast';
 import {
   usePushProvisioning,
   getWalletName,
@@ -18,9 +13,6 @@ import {
 import type { CardHomeData } from '../../../../../../core/Engine/controllers/card-controller/provider-types';
 
 export function useCardProvisioning(data: CardHomeData | null | undefined) {
-  const theme = useTheme();
-  const { toastRef } = useContext(ToastContext);
-
   const cardholderName = useMemo(() => {
     if (!data?.account?.holderName) return 'Card Holder';
     const parts = data.account.holderName.split(' ');
@@ -66,33 +58,23 @@ export function useCardProvisioning(data: CardHomeData | null | undefined) {
       userAddress: userAddressForProvisioning,
       provisioningEligible: data?.account?.provisioningEligible ?? false,
       onSuccess: () => {
-        toastRef?.current?.showToast({
-          variant: ToastVariants.Icon,
-          labelOptions: [
-            {
-              label: strings('card.push_provisioning.success_message', {
-                walletName: getWalletName(),
-              }),
-            },
-          ],
-          iconName: IconName.Confirmation,
-          iconColor: theme.colors.success.default,
+        toast({
+          title: strings('card.push_provisioning.success_message', {
+            walletName: getWalletName(),
+          }),
+          severity: ToastSeverity.Success,
           hasNoTimeout: false,
+          showCloseButton: false,
         });
       },
       onError: (provisioningError: ProvisioningError) => {
-        toastRef?.current?.showToast({
-          variant: ToastVariants.Icon,
-          labelOptions: [
-            {
-              label:
-                provisioningError.message ||
-                strings('card.push_provisioning.error_unknown'),
-            },
-          ],
-          iconName: IconName.Danger,
-          iconColor: theme.colors.error.default,
+        toast({
+          title:
+            provisioningError.message ||
+            strings('card.push_provisioning.error_unknown'),
+          severity: ToastSeverity.Danger,
           hasNoTimeout: false,
+          showCloseButton: false,
         });
       },
     });

--- a/app/components/UI/Card/Views/Cashback/Cashback.test.tsx
+++ b/app/components/UI/Card/Views/Cashback/Cashback.test.tsx
@@ -1,6 +1,4 @@
 const mockGoBack = jest.fn();
-const mockShowToast = jest.fn();
-const mockCloseToast = jest.fn();
 const mockTrackEvent = jest.fn();
 const mockCreateEventBuilder = jest.fn();
 const mockNavigate = jest.fn();
@@ -14,12 +12,11 @@ jest.mock('react-native-device-info', () => ({
   getVersion: jest.fn(() => '99.0.0'),
 }));
 
-jest.mock('../../../../../component-library/components/Toast', () => {
-  const React = jest.requireActual('react');
-  const ToastContext = React.createContext({ toastRef: null });
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
   return {
-    ToastContext,
-    ToastVariants: { Icon: 'Icon' },
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
   };
 });
 
@@ -193,26 +190,15 @@ jest.mock('../../hooks/useRedeemableWallet', () => ({
 
 import React from 'react';
 import { fireEvent, screen } from '@testing-library/react-native';
+import { toast } from '@metamask/design-system-react-native';
 import { renderScreen } from '../../../../../util/test/renderWithProvider';
-import { ToastContext } from '../../../../../component-library/components/Toast';
 import Cashback from './Cashback';
 import { CashbackSelectors } from './Cashback.testIds';
 import Routes from '../../../../../constants/navigation/Routes';
 import { backgroundState } from '../../../../../util/test/initial-root-state';
 import { CASHBACK_MONEY_ACCOUNT_ORIGIN } from '../../hooks/useCardPostAuthRedirect';
 
-const mockToastRef = {
-  current: {
-    showToast: mockShowToast,
-    closeToast: mockCloseToast,
-  },
-};
-
-const CashbackWithToast = () => (
-  <ToastContext.Provider value={{ toastRef: mockToastRef }}>
-    <Cashback />
-  </ToastContext.Provider>
-);
+const CashbackWithToast = () => <Cashback />;
 
 interface RenderOverrides {
   cardHomeDataStatus?: string;
@@ -827,7 +813,7 @@ describe('Cashback Component', () => {
 
       render();
 
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('shows success toast when monitoring completes', () => {
@@ -842,11 +828,12 @@ describe('Cashback Component', () => {
 
       render();
 
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: 'Icon',
+          title: 'Withdrawal completed successfully',
+          severity: 'success',
           hasNoTimeout: false,
-          labelOptions: [{ label: 'Withdrawal completed successfully' }],
+          showCloseButton: false,
         }),
       );
     });
@@ -908,11 +895,12 @@ describe('Cashback Component', () => {
 
       render();
 
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: 'Icon',
+          title: 'Withdrawal failed. Please try again.',
+          severity: 'danger',
           hasNoTimeout: false,
-          labelOptions: [{ label: 'Withdrawal failed. Please try again.' }],
+          showCloseButton: false,
         }),
       );
     });
@@ -929,9 +917,11 @@ describe('Cashback Component', () => {
 
       render();
 
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
-          labelOptions: [{ label: 'Withdrawal failed. Please try again.' }],
+          title: 'Withdrawal failed. Please try again.',
+          severity: 'danger',
+          showCloseButton: false,
         }),
       );
     });
@@ -948,11 +938,12 @@ describe('Cashback Component', () => {
 
       render();
 
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: 'Icon',
+          title: 'Withdrawal failed. Please try again.',
+          severity: 'danger',
           hasNoTimeout: false,
-          labelOptions: [{ label: 'Withdrawal failed. Please try again.' }],
+          showCloseButton: false,
         }),
       );
     });

--- a/app/components/UI/Card/Views/RedeemWallet/RedeemWallet.tsx
+++ b/app/components/UI/Card/Views/RedeemWallet/RedeemWallet.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
@@ -13,6 +13,8 @@ import {
   HeaderStandard,
   AvatarAccount,
   AvatarBaseSize,
+  toast,
+  ToastSeverity,
 } from '@metamask/design-system-react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
@@ -24,12 +26,7 @@ import Icon, {
   IconColor,
 } from '../../../../../component-library/components/Icons/Icon';
 import { useTailwind } from '@metamask/design-system-twrnc-preset';
-import { useTheme } from '../../../../../util/theme';
 import I18n, { strings } from '../../../../../../locales/i18n';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../../component-library/components/Toast';
 import KeyValueRow from '../../../../../component-library/components-temp/KeyValueRow/KeyValueRow';
 import { getAvatarAccountVariant } from '../../../../../component-library/components-temp/MultichainAccounts/avatarAccountVariant';
 import useRedeemableWallet, {
@@ -74,8 +71,6 @@ const RedeemWallet: React.FC<RedeemWalletProps> = ({ mode }) => {
   const navigation = useNavigation<AppNavigationProp>();
   const tw = useTailwind();
   const headerHandlers = useCardHeaderHandlers('back');
-  const theme = useTheme();
-  const { toastRef } = useContext(ToastContext);
   const { trackEvent, createEventBuilder } = useAnalytics();
   const activeProviderId = useSelector(selectCardActiveProviderId);
 
@@ -211,40 +206,37 @@ const RedeemWallet: React.FC<RedeemWalletProps> = ({ mode }) => {
 
   useEffect(() => {
     if (monitoringStatus === 'success') {
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        labelOptions: [{ label: strings(config.strings.withdrawalSuccess) }],
-        iconName: IconName.Confirmation,
-        iconColor: theme.colors.success.default,
+      toast({
+        title: strings(config.strings.withdrawalSuccess),
+        severity: ToastSeverity.Success,
         hasNoTimeout: false,
+        showCloseButton: false,
       });
       navigation.goBack();
     }
-  }, [monitoringStatus, toastRef, theme, navigation, config]);
+  }, [monitoringStatus, navigation, config]);
 
   useEffect(() => {
     if (monitoringStatus === 'failed' || monitoringError) {
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        labelOptions: [{ label: strings(config.strings.withdrawalFailed) }],
-        iconName: IconName.Danger,
-        iconColor: theme.colors.error.default,
+      toast({
+        title: strings(config.strings.withdrawalFailed),
+        severity: ToastSeverity.Danger,
         hasNoTimeout: false,
+        showCloseButton: false,
       });
     }
-  }, [monitoringStatus, monitoringError, toastRef, theme, config]);
+  }, [monitoringStatus, monitoringError, config]);
 
   useEffect(() => {
     if (withdrawError) {
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        labelOptions: [{ label: strings(config.strings.withdrawalFailed) }],
-        iconName: IconName.Danger,
-        iconColor: theme.colors.error.default,
+      toast({
+        title: strings(config.strings.withdrawalFailed),
+        severity: ToastSeverity.Danger,
         hasNoTimeout: false,
+        showCloseButton: false,
       });
     }
-  }, [withdrawError, toastRef, theme, config]);
+  }, [withdrawError, config]);
 
   useEffect(
     () => () => {

--- a/app/components/UI/Card/Views/SetCardPin/ConfirmCardPin.test.tsx
+++ b/app/components/UI/Card/Views/SetCardPin/ConfirmCardPin.test.tsx
@@ -6,8 +6,7 @@ import {
   CardProviderError,
   CardProviderErrorCode,
 } from '../../../../../core/Engine/controllers/card-controller/provider-types';
-import { ToastContext } from '../../../../../component-library/components/Toast';
-import { IconName } from '../../../../../component-library/components/Icons/Icon';
+import { toast } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import { SetCardPinSelectors } from './SetCardPin.testIds';
 import { clearPinDraft, getPinDraft, setPinDraft } from './pinDraftStore';
@@ -16,8 +15,6 @@ import { PIN_ERROR_RESET_DELAY_MS } from './constants';
 const mockNavigate = jest.fn();
 const mockGoBack = jest.fn();
 const mockReset = jest.fn();
-const mockShowToast = jest.fn();
-const mockCloseToast = jest.fn();
 const mockTrackEvent = jest.fn();
 const mockCreateEventBuilder = jest.fn(() => ({
   addProperties: jest.fn().mockReturnThis(),
@@ -25,9 +22,6 @@ const mockCreateEventBuilder = jest.fn(() => ({
 }));
 const mockSetCardPin = jest.fn();
 const mockLogout = jest.fn();
-const mockToastRef = {
-  current: { showToast: mockShowToast, closeToast: mockCloseToast },
-};
 
 jest.mock('../../../../../core/Engine', () => ({
   __esModule: true,
@@ -199,6 +193,13 @@ jest.mock('@metamask/design-system-react-native', () => {
     ),
     ButtonVariant: { Primary: 'Primary' },
     ButtonSize: { Lg: 'Lg' },
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+    ToastSeverity: {
+      Success: 'success',
+      Warning: 'warning',
+      Danger: 'danger',
+      Default: 'default',
+    },
   };
 });
 
@@ -210,12 +211,7 @@ const enterPin = (pressKey: (testID: string) => void, digits: string) => {
   }
 };
 
-const renderConfirmCardPin = () =>
-  renderWithProvider(
-    <ToastContext.Provider value={{ toastRef: mockToastRef }}>
-      <ConfirmCardPin />
-    </ToastContext.Provider>,
-  );
+const renderConfirmCardPin = () => renderWithProvider(<ConfirmCardPin />);
 
 describe('ConfirmCardPin', () => {
   beforeEach(() => {
@@ -225,10 +221,6 @@ describe('ConfirmCardPin', () => {
     setPinDraft('1337');
     mockSetCardPin.mockResolvedValue(undefined);
     mockLogout.mockResolvedValue(undefined);
-    mockToastRef.current = {
-      showToast: mockShowToast,
-      closeToast: mockCloseToast,
-    };
   });
 
   afterEach(() => {
@@ -268,17 +260,12 @@ describe('ConfirmCardPin', () => {
 
     await waitFor(() => {
       expect(mockSetCardPin).toHaveBeenCalledWith('card-1', '1337');
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
-          labelOptions: [{ label: strings('card.set_pin.success_title') }],
-          descriptionOptions: {
-            description: strings('card.set_pin.success_description'),
-          },
-          iconName: IconName.Confirmation,
+          title: strings('card.set_pin.success_title'),
+          description: strings('card.set_pin.success_description'),
+          severity: 'success',
           hasNoTimeout: false,
-          closeButtonOptions: expect.objectContaining({
-            iconName: IconName.Close,
-          }),
         }),
       );
       expect(mockReset).toHaveBeenCalledWith({
@@ -286,23 +273,16 @@ describe('ConfirmCardPin', () => {
         routes: [{ name: Routes.CARD.HOME }],
       });
     });
-
-    const toastOptions = mockShowToast.mock.calls[0][0] as {
-      closeButtonOptions: { onPress: () => void };
-    };
-    toastOptions.closeButtonOptions.onPress();
-    expect(mockCloseToast).toHaveBeenCalled();
   });
 
-  it('still resets to Card Home when toast ref is unavailable', async () => {
-    mockToastRef.current = null as unknown as typeof mockToastRef.current;
+  it('still resets to Card Home after a successful pin set', async () => {
     const { getByTestId } = renderConfirmCardPin();
     enterPin((id) => fireEvent.press(getByTestId(id)), '1337');
     fireEvent.press(getByTestId(SetCardPinSelectors.SUBMIT_BUTTON));
 
     await waitFor(() => {
       expect(mockSetCardPin).toHaveBeenCalledWith('card-1', '1337');
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).toHaveBeenCalled();
       expect(mockReset).toHaveBeenCalledWith({
         index: 0,
         routes: [{ name: Routes.CARD.HOME }],
@@ -365,7 +345,7 @@ describe('ConfirmCardPin', () => {
     });
 
     await waitFor(() => {
-      expect(mockShowToast).toHaveBeenCalled();
+      expect(toast).toHaveBeenCalled();
       expect(mockReset).toHaveBeenCalledWith({
         index: 0,
         routes: [{ name: Routes.CARD.HOME }],

--- a/app/components/UI/Card/Views/SetCardPin/ConfirmCardPin.tsx
+++ b/app/components/UI/Card/Views/SetCardPin/ConfirmCardPin.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { AppState, type AppStateStatus } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../../core/NavigationService/types';
@@ -10,13 +10,7 @@ import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import Logger from '../../../../../util/Logger';
 import { CardProviderIds } from '../../../../../core/Engine/controllers/card-controller/provider-types';
-import { IconName } from '../../../../../component-library/components/Icons/Icon';
-import {
-  ButtonIconVariant,
-  ToastContext,
-  ToastVariants,
-} from '../../../../../component-library/components/Toast';
-import { useTheme } from '../../../../../util/theme';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import CardScreenshotDeterrent from '../../components/CardScreenshotDeterrent/CardScreenshotDeterrent';
 import { CardActions, CardScreens } from '../../util/metrics';
 import { SetCardPinSelectors } from './SetCardPin.testIds';
@@ -32,8 +26,6 @@ const ConfirmCardPin: React.FC = () => {
   const navigation = useNavigation<AppNavigationProp>();
   const { cardId } = useParams<{ cardId: string }>();
   const { trackEvent, createEventBuilder } = useAnalytics();
-  const { toastRef } = useContext(ToastContext);
-  const theme = useTheme();
   const [isPending, setIsPending] = React.useState(false);
   const [isTerminalForbidden, setIsTerminalForbidden] = React.useState(false);
   const submittingRef = React.useRef(false);
@@ -154,20 +146,11 @@ const ConfirmCardPin: React.FC = () => {
           })
           .build(),
       );
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        labelOptions: [{ label: strings('card.set_pin.success_title') }],
-        descriptionOptions: {
-          description: strings('card.set_pin.success_description'),
-        },
-        iconName: IconName.Confirmation,
-        iconColor: theme.colors.success.default,
+      toast({
+        title: strings('card.set_pin.success_title'),
+        description: strings('card.set_pin.success_description'),
+        severity: ToastSeverity.Success,
         hasNoTimeout: false,
-        closeButtonOptions: {
-          variant: ButtonIconVariant.Icon,
-          iconName: IconName.Close,
-          onPress: () => toastRef?.current?.closeToast(),
-        },
       });
       navigation.reset({
         index: 0,
@@ -241,8 +224,6 @@ const ConfirmCardPin: React.FC = () => {
     trackEvent,
     createEventBuilder,
     handleAuthFailure,
-    toastRef,
-    theme,
   ]);
 
   const canSubmit =

--- a/app/components/UI/Card/components/AssetSelectionBottomSheet/AssetSelectionBottomSheet.test.tsx
+++ b/app/components/UI/Card/components/AssetSelectionBottomSheet/AssetSelectionBottomSheet.test.tsx
@@ -54,9 +54,32 @@ jest.mock('../../sdk', () => ({
   }),
 }));
 
-const mockShowToast = jest.fn();
-
-jest.mock('../../../../../component-library/components/Toast');
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  const ReactActual = jest.requireActual('react');
+  const { View } = jest.requireActual('react-native');
+  const BottomSheet = ReactActual.forwardRef(
+    (
+      {
+        children,
+      }: {
+        children?: React.ReactNode;
+      },
+      ref: React.Ref<{ onCloseBottomSheet: (cb?: () => void) => void }>,
+    ) => {
+      ReactActual.useImperativeHandle(ref, () => ({
+        onCloseBottomSheet: (cb?: () => void) => cb?.(),
+      }));
+      return ReactActual.createElement(View, null, children);
+    },
+  );
+  BottomSheet.displayName = 'BottomSheet';
+  return {
+    ...actual,
+    BottomSheet,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
 const mockTrackEvent = jest.fn();
 const mockCreateEventBuilder = jest.fn();
@@ -97,9 +120,13 @@ const mockTw = Object.assign(
   },
 );
 
-jest.mock('@metamask/design-system-twrnc-preset', () => ({
-  useTailwind: () => mockTw,
-}));
+jest.mock('@metamask/design-system-twrnc-preset', () => {
+  const actual = jest.requireActual('@metamask/design-system-twrnc-preset');
+  return {
+    ...actual,
+    useTailwind: () => mockTw,
+  };
+});
 
 jest.mock('@shopify/flash-list', () =>
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -111,6 +138,7 @@ import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
 import { useSelector } from 'react-redux';
 import { CaipChainId } from '@metamask/utils';
 import { SolScope } from '@metamask/keyring-api';
+import { toast } from '@metamask/design-system-react-native';
 import AssetSelectionBottomSheet from './AssetSelectionBottomSheet';
 import {
   FundingStatus,
@@ -118,27 +146,12 @@ import {
   DelegationSettingsResponse,
 } from '../../types';
 import Routes from '../../../../../constants/navigation/Routes';
-import { ToastContext } from '../../../../../component-library/components/Toast';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { useUpdateFundingPriority } from '../../hooks/useUpdateFundingPriority';
 import { useCardHomeData } from '../../hooks/useCardHomeData';
 import { getAssetBalanceKey } from '../../util/getAssetBalanceKey';
 
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
-
-// Wrapper component to provide Toast context
-const renderWithToastContext = (component: React.ReactElement) =>
-  render(
-    <ToastContext.Provider
-      value={{
-        toastRef: {
-          current: { showToast: mockShowToast, closeToast: jest.fn() },
-        },
-      }}
-    >
-      {component}
-    </ToastContext.Provider>,
-  );
 
 // Helper function to create mock token
 const createMockToken = (
@@ -223,7 +236,7 @@ const setupComponent = (paramsOverrides: Record<string, unknown> = {}) => {
     data: { delegationSettings },
   });
 
-  return renderWithToastContext(<AssetSelectionBottomSheet />);
+  return render(<AssetSelectionBottomSheet />);
 };
 
 describe('AssetSelectionBottomSheet', () => {
@@ -747,9 +760,11 @@ describe('AssetSelectionBottomSheet', () => {
         { timeout: 3000 },
       );
 
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
-          labelOptions: [{ label: 'Spend priority updated successfully' }],
+          title: 'Spend priority updated successfully',
+          severity: 'success',
+          showCloseButton: false,
         }),
       );
     });
@@ -794,9 +809,11 @@ describe('AssetSelectionBottomSheet', () => {
 
       await waitFor(
         () => {
-          expect(mockShowToast).toHaveBeenCalledWith(
+          expect(toast).toHaveBeenCalledWith(
             expect.objectContaining({
-              labelOptions: [{ label: 'Failed to update spend priority' }],
+              title: 'Failed to update spend priority',
+              severity: 'danger',
+              showCloseButton: false,
             }),
           );
         },
@@ -827,9 +844,11 @@ describe('AssetSelectionBottomSheet', () => {
 
       await waitFor(
         () => {
-          expect(mockShowToast).toHaveBeenCalledWith(
+          expect(toast).toHaveBeenCalledWith(
             expect.objectContaining({
-              labelOptions: [{ label: 'Failed to update spend priority' }],
+              title: 'Failed to update spend priority',
+              severity: 'danger',
+              showCloseButton: false,
             }),
           );
         },

--- a/app/components/UI/Card/components/AssetSelectionBottomSheet/AssetSelectionBottomSheet.tsx
+++ b/app/components/UI/Card/components/AssetSelectionBottomSheet/AssetSelectionBottomSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { ActivityIndicator, type ScrollViewProps } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import { FlashList, type ListRenderItem } from '@shopify/flash-list';
@@ -17,14 +17,11 @@ import {
   TextColor,
   TextVariant,
   type BottomSheetRef,
+  toast,
+  ToastSeverity,
 } from '@metamask/design-system-react-native';
-import { IconName } from '../../../../../component-library/components/Icons/Icon';
 import Routes from '../../../../../constants/navigation/Routes';
 import { safeFormatChainIdToHex } from '../../util/safeFormatChainIdToHex';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../../component-library/components/Toast';
 import { useAnalytics } from '../../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { CardActions, withCardProvider } from '../../util/metrics';
@@ -71,7 +68,6 @@ const AssetSelectionBottomSheet: React.FC = () => {
 
   const theme = useTheme();
   const tw = useTailwind();
-  const { toastRef } = useContext(ToastContext);
   const { trackEvent, createEventBuilder } = useAnalytics();
   const activeProviderId = useSelector(selectCardActiveProviderId);
 
@@ -162,24 +158,22 @@ const AssetSelectionBottomSheet: React.FC = () => {
   );
 
   const showSuccessToast = useCallback(() => {
-    toastRef?.current?.showToast({
-      variant: ToastVariants.Icon,
-      labelOptions: [{ label: strings('card.asset_selection.update_success') }],
-      iconName: IconName.Confirmation,
-      iconColor: theme.colors.success.default,
+    toast({
+      title: strings('card.asset_selection.update_success'),
+      severity: ToastSeverity.Success,
       hasNoTimeout: false,
+      showCloseButton: false,
     });
-  }, [toastRef, theme]);
+  }, []);
 
   const showErrorToast = useCallback(() => {
-    toastRef?.current?.showToast({
-      variant: ToastVariants.Icon,
-      labelOptions: [{ label: strings('card.asset_selection.update_error') }],
-      iconName: IconName.Danger,
-      iconColor: theme.colors.error.default,
+    toast({
+      title: strings('card.asset_selection.update_error'),
+      severity: ToastSeverity.Danger,
       hasNoTimeout: false,
+      showCloseButton: false,
     });
-  }, [toastRef, theme]);
+  }, []);
 
   const { updateFundingPriority } = useUpdateFundingPriority({
     onSuccess: () => {

--- a/app/components/UI/Card/components/ForgotPasswordModal/ForgotPasswordModal.test.tsx
+++ b/app/components/UI/Card/components/ForgotPasswordModal/ForgotPasswordModal.test.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent, act } from '@testing-library/react-native';
 import ForgotPasswordModal from './ForgotPasswordModal';
 import { mockTheme } from '../../../../../util/theme';
 import { AppThemeKey } from '../../../../../util/theme/models';
-import { ToastContext } from '../../../../../component-library/components/Toast';
+import { toast } from '@metamask/design-system-react-native';
 import { MetaMetricsEvents } from '../../../../../core/Analytics';
 import { getCardWebBaseUrlForMetaMaskEnv } from '../../util/mapCardWebUrl';
 
@@ -36,21 +36,6 @@ jest.mock('react-redux', () => ({
 jest.mock('../../../../../selectors/cardController', () => ({
   selectCardUserLocation: jest.fn(),
 }));
-
-// Toast
-const mockShowToast = jest.fn();
-const mockCloseToast = jest.fn();
-const mockToastRef = {
-  current: { showToast: mockShowToast, closeToast: mockCloseToast },
-};
-
-jest.mock('../../../../../component-library/components/Toast', () => {
-  const ActualReact = jest.requireActual('react');
-  return {
-    ToastContext: ActualReact.createContext({ toastRef: undefined }),
-    ToastVariants: { Icon: 'Icon' },
-  };
-});
 
 // Safe area insets
 jest.mock('react-native-safe-area-context', () => ({
@@ -133,6 +118,13 @@ jest.mock('@metamask/design-system-react-native', () => {
     ButtonVariant: { Primary: 'Primary' },
     ButtonSize: { Md: 'Md' },
     TextVariant: { BodyMd: 'BodyMd' },
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+    ToastSeverity: {
+      Success: 'success',
+      Warning: 'warning',
+      Danger: 'danger',
+      Default: 'default',
+    },
   };
 });
 
@@ -193,12 +185,7 @@ jest.mock('@metamask/react-native-webview', () => {
 
 const CARD_LOGIN_URL = 'https://card.metamask.io/account/login';
 
-const renderComponent = () =>
-  render(
-    <ToastContext.Provider value={{ toastRef: mockToastRef }}>
-      <ForgotPasswordModal />
-    </ToastContext.Provider>,
-  );
+const renderComponent = () => render(<ForgotPasswordModal />);
 
 describe('ForgotPasswordModal', () => {
   beforeEach(() => {
@@ -492,7 +479,7 @@ describe('ForgotPasswordModal', () => {
       });
 
       expect(mockGoBack).not.toHaveBeenCalled();
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('does not throw on non-JSON message data', () => {
@@ -519,10 +506,13 @@ describe('ForgotPasswordModal', () => {
         });
       });
 
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledTimes(1);
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
-          labelOptions: [{ label: 'card.card_forgot_password.reset_success' }],
+          title: 'card.card_forgot_password.reset_success',
+          severity: 'success',
+          hasNoTimeout: false,
+          showCloseButton: false,
         }),
       );
     });
@@ -542,7 +532,7 @@ describe('ForgotPasswordModal', () => {
         });
       });
 
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
+      expect(toast).toHaveBeenCalledTimes(1);
     });
 
     it('does not show a toast when the user closes the WebView with the back button', () => {
@@ -551,7 +541,7 @@ describe('ForgotPasswordModal', () => {
       fireEvent.press(getByTestId('forgot-password-back-button'));
 
       expect(mockGoBack).toHaveBeenCalledTimes(1);
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('shows the success toast only once when both detection layers fire', () => {
@@ -572,7 +562,7 @@ describe('ForgotPasswordModal', () => {
         });
       });
 
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
+      expect(toast).toHaveBeenCalledTimes(1);
     });
 
     it('does not show a toast for the reset page URL', () => {
@@ -584,7 +574,7 @@ describe('ForgotPasswordModal', () => {
         });
       });
 
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
   });
 

--- a/app/components/UI/Card/components/ForgotPasswordModal/ForgotPasswordModal.tsx
+++ b/app/components/UI/Card/components/ForgotPasswordModal/ForgotPasswordModal.tsx
@@ -1,6 +1,5 @@
 import React, {
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -23,6 +22,8 @@ import {
   Text,
   TextVariant,
   HeaderStandard,
+  toast,
+  ToastSeverity,
 } from '@metamask/design-system-react-native';
 import { strings } from '../../../../../../locales/i18n';
 import AppConstants from '../../../../../core/AppConstants';
@@ -37,11 +38,6 @@ import { getCardWebBaseUrlForMetaMaskEnv } from '../../util/mapCardWebUrl';
 import { useSelector } from 'react-redux';
 import { selectCardUserLocation } from '../../../../../selectors/cardController';
 import type { CardLocation } from '../../types';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../../component-library/components/Toast';
-import { IconName } from '../../../../../component-library/components/Icons/Icon';
 
 // Single document-end injection. We intentionally do NOT use
 // `injectedJavaScriptBeforeContentLoaded`, which blanks the page on iOS WKWebView.
@@ -143,8 +139,7 @@ const ForgotPasswordModal: React.FC = () => {
     useRoute<RouteProp<ForgotPasswordModalParams, 'CardForgotPasswordModal'>>();
   const tw = useTailwind();
   const insets = useSafeAreaInsets();
-  const { themeAppearance, colors } = useTheme();
-  const { toastRef } = useContext(ToastContext);
+  const { themeAppearance } = useTheme();
   const persistedLocation = useSelector(selectCardUserLocation);
   const isUs =
     (route.params?.location ?? persistedLocation ?? 'international') === 'us';
@@ -197,17 +192,14 @@ const ForgotPasswordModal: React.FC = () => {
         )
         .build(),
     );
-    toastRef?.current?.showToast({
-      variant: ToastVariants.Icon,
-      labelOptions: [
-        { label: strings('card.card_forgot_password.reset_success') },
-      ],
-      iconName: IconName.Confirmation,
-      iconColor: colors.success.default,
+    toast({
+      title: strings('card.card_forgot_password.reset_success'),
+      severity: ToastSeverity.Success,
       hasNoTimeout: false,
+      showCloseButton: false,
     });
     navigation.goBack();
-  }, [navigation, toastRef, colors, trackEvent, createEventBuilder]);
+  }, [navigation, trackEvent, createEventBuilder]);
 
   const handleRetry = useCallback(() => {
     setStatus('loading');

--- a/app/components/UI/Card/components/WaitlistFormModal/WaitlistFormModal.test.tsx
+++ b/app/components/UI/Card/components/WaitlistFormModal/WaitlistFormModal.test.tsx
@@ -19,31 +19,6 @@ jest.mock('../../../../../util/navigation/navUtils', () => ({
   useParams: () => ({ url: 'https://share.hsforms.com/test-form' }),
 }));
 
-// Theme
-jest.mock('../../../../../util/theme', () => ({
-  useTheme: () => ({
-    colors: {
-      success: { default: 'colors.success.default' },
-    },
-  }),
-}));
-
-// Toast
-const mockShowToast = jest.fn();
-const mockCloseToast = jest.fn();
-const mockToastRef = {
-  current: { showToast: mockShowToast, closeToast: mockCloseToast },
-};
-
-jest.mock('../../../../../component-library/components/Toast', () => {
-  const ActualReact = jest.requireActual('react');
-  return {
-    ToastContext: ActualReact.createContext({ toastRef: undefined }),
-    ToastVariants: { Icon: 'Icon' },
-    ButtonIconVariant: { Icon: 'Icon' },
-  };
-});
-
 // Tailwind
 jest.mock('@metamask/design-system-twrnc-preset', () => ({
   useTailwind: () => {
@@ -93,6 +68,13 @@ jest.mock('@metamask/design-system-react-native', () => {
       Confirmation: 'Confirmation',
       Close: 'Close',
     },
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+    ToastSeverity: {
+      Success: 'success',
+      Warning: 'warning',
+      Danger: 'danger',
+      Default: 'default',
+    },
   };
 });
 
@@ -135,15 +117,9 @@ jest.mock('@metamask/react-native-webview', () => {
   };
 });
 
-// Helper: render with ToastContext provided
-import { ToastContext } from '../../../../../component-library/components/Toast';
+import { toast } from '@metamask/design-system-react-native';
 
-const renderComponent = () =>
-  render(
-    <ToastContext.Provider value={{ toastRef: mockToastRef }}>
-      <WaitlistFormModal />
-    </ToastContext.Provider>,
-  );
+const renderComponent = () => render(<WaitlistFormModal />);
 
 describe('WaitlistFormModal', () => {
   beforeEach(() => {
@@ -262,8 +238,8 @@ describe('WaitlistFormModal', () => {
         });
       });
 
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledTimes(1);
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
           hasNoTimeout: true,
         }),
@@ -295,7 +271,7 @@ describe('WaitlistFormModal', () => {
         });
       });
 
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
       expect(mockNavigate).not.toHaveBeenCalled();
     });
 

--- a/app/components/UI/Card/components/WaitlistFormModal/WaitlistFormModal.tsx
+++ b/app/components/UI/Card/components/WaitlistFormModal/WaitlistFormModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
@@ -14,17 +14,12 @@ import {
   Text,
   TextVariant,
   IconName as IconNameComponent,
+  toast,
+  ToastSeverity,
 } from '@metamask/design-system-react-native';
-import {
-  ToastContext,
-  ToastVariants,
-  ButtonIconVariant,
-} from '../../../../../component-library/components/Toast';
 import { useParams } from '../../../../../util/navigation/navUtils';
-import { useTheme } from '../../../../../util/theme';
 import { strings } from '../../../../../../locales/i18n';
 import Routes from '../../../../../constants/navigation/Routes';
-import { IconName } from '../../../../../component-library/components/Icons/Icon';
 
 export interface WaitlistFormModalParams {
   url: string;
@@ -49,8 +44,6 @@ const WaitlistFormModal: React.FC = () => {
   const { url } = useParams<WaitlistFormModalParams>();
   const navigation = useNavigation<AppNavigationProp>();
   const tw = useTailwind();
-  const { colors } = useTheme();
-  const { toastRef } = useContext(ToastContext);
   const [isLoading, setIsLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
   const [retryKey, setRetryKey] = useState(0);
@@ -84,28 +77,13 @@ const WaitlistFormModal: React.FC = () => {
       try {
         const data = JSON.parse(event.nativeEvent.data);
         if (data?.type === 'hs_form_submitted') {
-          toastRef?.current?.showToast({
-            variant: ToastVariants.Icon,
-            labelOptions: [
-              {
-                label: strings(
-                  'card.card_onboarding.waitlist_form.success_toast',
-                ),
-              },
-            ],
-            descriptionOptions: {
-              description: strings(
-                'card.card_onboarding.waitlist_form.success_toast_description',
-              ),
-            },
-            iconName: IconName.Confirmation,
-            iconColor: colors.success.default,
+          toast({
+            title: strings('card.card_onboarding.waitlist_form.success_toast'),
+            description: strings(
+              'card.card_onboarding.waitlist_form.success_toast_description',
+            ),
+            severity: ToastSeverity.Success,
             hasNoTimeout: true,
-            closeButtonOptions: {
-              variant: ButtonIconVariant.Icon,
-              iconName: IconName.Close,
-              onPress: () => toastRef?.current?.closeToast(),
-            },
           });
           navigation.navigate(Routes.WALLET.HOME as never);
         }
@@ -113,7 +91,7 @@ const WaitlistFormModal: React.FC = () => {
         // ignore non-JSON messages
       }
     },
-    [toastRef, navigation, colors],
+    [navigation],
   );
 
   return (

--- a/app/components/UI/Card/hooks/useImmersveOnboardingRouter.test.ts
+++ b/app/components/UI/Card/hooks/useImmersveOnboardingRouter.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-native';
 import { useNavigation } from '@react-navigation/native';
-import { useContext } from 'react';
+import { toast } from '@metamask/design-system-react-native';
 import { useImmersveOnboardingRouter } from './useImmersveOnboardingRouter';
 import Routes from '../../../../constants/navigation/Routes';
 import type { ImmersveNextAction } from '../util/immersvePrerequisites';
@@ -9,14 +9,13 @@ jest.mock('@react-navigation/native', () => ({
   useNavigation: jest.fn(),
 }));
 
-jest.mock('react', () => ({
-  ...jest.requireActual('react'),
-  useContext: jest.fn(),
-}));
-
-jest.mock('../../../../util/theme', () => ({
-  useTheme: () => ({ colors: { success: { default: 'mock-success' } } }),
-}));
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
 jest.mock('../../../../../locales/i18n', () => ({
   strings: (key: string) => key,
@@ -33,7 +32,6 @@ jest.mock('../../../hooks/useAnalytics/useAnalytics', () => ({
 
 const mockNavigate = jest.fn();
 const mockReset = jest.fn();
-const mockShowToast = jest.fn();
 
 const getRoute = () => {
   const { result } = renderHook(() => useImmersveOnboardingRouter());
@@ -46,9 +44,6 @@ describe('useImmersveOnboardingRouter', () => {
     (useNavigation as jest.Mock).mockReturnValue({
       navigate: mockNavigate,
       reset: mockReset,
-    });
-    (useContext as jest.Mock).mockReturnValue({
-      toastRef: { current: { showToast: mockShowToast } },
     });
   });
 
@@ -122,11 +117,12 @@ describe('useImmersveOnboardingRouter', () => {
   it('shows a toast and resets to Card Home when active', () => {
     getRoute()({ type: 'active' });
 
-    expect(mockShowToast).toHaveBeenCalledWith(
+    expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
-        labelOptions: [
-          { label: 'card.card_onboarding.sign_up.account_exists_toast' },
-        ],
+        title: 'card.card_onboarding.sign_up.account_exists_toast',
+        severity: 'success',
+        hasNoTimeout: false,
+        showCloseButton: false,
       }),
     );
     expect(mockReset).toHaveBeenCalledWith({
@@ -138,7 +134,7 @@ describe('useImmersveOnboardingRouter', () => {
   it('suppresses the toast when active but showAccountExistsToast is false', () => {
     getRoute()({ type: 'active' }, { showAccountExistsToast: false });
 
-    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(toast).not.toHaveBeenCalled();
     expect(mockReset).toHaveBeenCalledWith({
       index: 0,
       routes: [{ name: Routes.CARD.HOME }],

--- a/app/components/UI/Card/hooks/useImmersveOnboardingRouter.ts
+++ b/app/components/UI/Card/hooks/useImmersveOnboardingRouter.ts
@@ -1,14 +1,9 @@
-import { useCallback, useContext } from 'react';
+import { useCallback } from 'react';
 import { useNavigation } from '@react-navigation/native';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { navigateWithDetails } from '../../../../util/navigation/navUtils';
 import Routes from '../../../../constants/navigation/Routes';
 import { strings } from '../../../../../locales/i18n';
-import { useTheme } from '../../../../util/theme';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../component-library/components/Toast';
-import { IconName } from '../../../../component-library/components/Icons/Icon';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
 import { CardProviderIds } from '../../../../core/Engine/controllers/card-controller/provider-types';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
@@ -55,8 +50,6 @@ function destinationForAction(action: ImmersveNextAction): string {
  */
 export const useImmersveOnboardingRouter = () => {
   const navigation = useNavigation();
-  const { toastRef } = useContext(ToastContext);
-  const { colors } = useTheme();
   const { trackEvent, createEventBuilder } = useAnalytics();
 
   return useCallback(
@@ -117,18 +110,13 @@ export const useImmersveOnboardingRouter = () => {
           break;
         case 'active':
           if (showAccountExistsToast !== false) {
-            toastRef?.current?.showToast({
-              variant: ToastVariants.Icon,
-              labelOptions: [
-                {
-                  label: strings(
-                    'card.card_onboarding.sign_up.account_exists_toast',
-                  ),
-                },
-              ],
-              iconName: IconName.Confirmation,
-              iconColor: colors.success.default,
+            toast({
+              title: strings(
+                'card.card_onboarding.sign_up.account_exists_toast',
+              ),
+              severity: ToastSeverity.Success,
               hasNoTimeout: false,
+              showCloseButton: false,
             });
           }
           navigation.reset({
@@ -140,6 +128,6 @@ export const useImmersveOnboardingRouter = () => {
           break;
       }
     },
-    [navigation, toastRef, colors, trackEvent, createEventBuilder],
+    [navigation, trackEvent, createEventBuilder],
   );
 };

--- a/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.test.tsx
+++ b/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.test.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useSelector } from 'react-redux';
-import { ToastContext } from '../../../../component-library/components/Toast';
+import { toast } from '@metamask/design-system-react-native';
 import Logger from '../../../../util/Logger';
 import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
 import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlagController/moneyAccount';
@@ -125,6 +124,14 @@ jest.mock('../../../../util/theme', () => {
   return {
     ...actual,
     useTheme: jest.fn(() => actual.mockTheme),
+  };
+});
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
   };
 });
 
@@ -254,8 +261,6 @@ const applySelectorMocks = (state: ReturnType<typeof buildSelectors>) => {
 };
 
 describe('useMoneyAccountCardLinkage', () => {
-  let mockShowToast: jest.Mock;
-  let mockToastRef: { current: { showToast: jest.Mock } };
   const expectedLinkCardSheetRoute = (
     entrypoint: CardEntryPoint | string = CardEntryPoint.MONEY_LINK_CARD_SHEET,
   ) => ({
@@ -264,18 +269,10 @@ describe('useMoneyAccountCardLinkage', () => {
   });
 
   const renderLinkageHook = () =>
-    renderHook(() => useMoneyAccountCardLinkage(), {
-      wrapper: ({ children }: { children: React.ReactNode }) => (
-        <ToastContext.Provider value={{ toastRef: mockToastRef } as never}>
-          {children}
-        </ToastContext.Provider>
-      ),
-    });
+    renderHook(() => useMoneyAccountCardLinkage());
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockShowToast = jest.fn();
-    mockToastRef = { current: { showToast: mockShowToast } };
 
     mockResolveMoneyAccountCardToken.mockReturnValue(MOCK_TOKEN);
     applySelectorMocks(buildSelectors());
@@ -517,7 +514,7 @@ describe('useMoneyAccountCardLinkage', () => {
       });
 
       expect(mockNavigate).not.toHaveBeenCalled();
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('does not navigate from startLinkFlow when linkage is in progress', () => {
@@ -531,7 +528,7 @@ describe('useMoneyAccountCardLinkage', () => {
       });
 
       expect(mockNavigate).not.toHaveBeenCalled();
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
       expect(mockDispatch).not.toHaveBeenCalled();
     });
   });
@@ -549,7 +546,7 @@ describe('useMoneyAccountCardLinkage', () => {
         ...expectedLinkCardSheetRoute(),
       });
       expect(mockLinkMoneyAccountCard).not.toHaveBeenCalled();
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
       expect(result.current.status).toBe('idle');
     });
 
@@ -563,9 +560,9 @@ describe('useMoneyAccountCardLinkage', () => {
 
       expect(mockNavigate).not.toHaveBeenCalled();
       expect(mockLinkMoneyAccountCard).not.toHaveBeenCalled();
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
-      expect(mockShowToast.mock.calls[0][0]).toMatchObject({
-        labelOptions: [{ label: 'Something went wrong linking your card' }],
+      expect(toast).toHaveBeenCalledTimes(1);
+      expect(toast.mock.calls[0][0]).toMatchObject({
+        title: 'Something went wrong linking your card',
       });
     });
 
@@ -578,7 +575,7 @@ describe('useMoneyAccountCardLinkage', () => {
       });
 
       expect(mockNavigate).not.toHaveBeenCalled();
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
+      expect(toast).toHaveBeenCalledTimes(1);
     });
 
     it('fails closed when there is no primary Money account', () => {
@@ -590,7 +587,7 @@ describe('useMoneyAccountCardLinkage', () => {
       });
 
       expect(mockNavigate).not.toHaveBeenCalled();
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
+      expect(toast).toHaveBeenCalledTimes(1);
     });
 
     it('fails closed when the Money Account is already delegated (defensive guard for direct callers)', () => {
@@ -603,7 +600,7 @@ describe('useMoneyAccountCardLinkage', () => {
 
       expect(mockNavigate).not.toHaveBeenCalled();
       expect(mockLinkMoneyAccountCard).not.toHaveBeenCalled();
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
+      expect(toast).toHaveBeenCalledTimes(1);
     });
 
     it('tracks RESIDENCY_BLOCKED and fails closed when residency is blocked', () => {
@@ -615,7 +612,7 @@ describe('useMoneyAccountCardLinkage', () => {
       });
 
       expect(mockNavigate).not.toHaveBeenCalled();
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
+      expect(toast).toHaveBeenCalledTimes(1);
       expect(mockTrackEvent).toHaveBeenCalledWith(
         expect.objectContaining({ name: 'built-event' }),
       );
@@ -647,7 +644,7 @@ describe('useMoneyAccountCardLinkage', () => {
         ...expectedLinkCardSheetRoute(),
       });
       expect(mockDispatch).not.toHaveBeenCalled();
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('no-ops when the user is authenticated but not VERIFIED', () => {
@@ -659,7 +656,7 @@ describe('useMoneyAccountCardLinkage', () => {
       });
 
       expect(mockNavigate).not.toHaveBeenCalled();
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
       expect(mockDispatch).not.toHaveBeenCalled();
     });
 
@@ -672,7 +669,7 @@ describe('useMoneyAccountCardLinkage', () => {
       });
 
       expect(mockNavigate).not.toHaveBeenCalled();
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
       expect(mockDispatch).not.toHaveBeenCalled();
     });
 
@@ -686,7 +683,7 @@ describe('useMoneyAccountCardLinkage', () => {
 
       expect(mockNavigate).not.toHaveBeenCalled();
       expect(mockDispatch).not.toHaveBeenCalled();
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
+      expect(toast).toHaveBeenCalledTimes(1);
     });
 
     it('tracks RESIDENCY_BLOCKED and fails closed when residency is blocked', () => {
@@ -702,7 +699,7 @@ describe('useMoneyAccountCardLinkage', () => {
 
       expect(mockNavigate).not.toHaveBeenCalled();
       expect(mockDispatch).not.toHaveBeenCalled();
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
+      expect(toast).toHaveBeenCalledTimes(1);
       expect(mockAddProperties).toHaveBeenCalledWith(
         expect.objectContaining({
           flow: CardFlow.MONEY_ACCOUNT_LINKAGE,
@@ -722,7 +719,7 @@ describe('useMoneyAccountCardLinkage', () => {
 
       expect(mockNavigate).not.toHaveBeenCalled();
       expect(mockDispatch).not.toHaveBeenCalled();
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
+      expect(toast).toHaveBeenCalledTimes(1);
     });
 
     it('routes a not-authenticated cardholder to CardAuthentication with postAuthRedirect and sets the pending flag', () => {
@@ -747,7 +744,7 @@ describe('useMoneyAccountCardLinkage', () => {
           params: { postAuthRedirect: ORIGIN, showAuthPrompt: true },
         },
       });
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('routes an unauthenticated cardholder to CardAuthentication when base requirements are met but VEDA is not allowlisted', () => {
@@ -791,7 +788,7 @@ describe('useMoneyAccountCardLinkage', () => {
           params: { postAuthRedirect: ORIGIN, showAuthPrompt: true },
         },
       });
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('stores the origin entrypoint for the post-auth sheet resume', () => {
@@ -833,7 +830,7 @@ describe('useMoneyAccountCardLinkage', () => {
           params: { postAuthRedirect: ORIGIN },
         },
       });
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('still routes a not-authenticated cardholder to CardAuthentication when the funding token is null (token resolves after login)', () => {
@@ -857,7 +854,7 @@ describe('useMoneyAccountCardLinkage', () => {
           params: { postAuthRedirect: ORIGIN, showAuthPrompt: true },
         },
       });
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('still routes a not-authenticated non-cardholder to onboarding without arming the sheet-resume flag when the funding token is null (token resolves after login)', () => {
@@ -879,7 +876,7 @@ describe('useMoneyAccountCardLinkage', () => {
           params: { postAuthRedirect: ORIGIN },
         },
       });
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
   });
 
@@ -965,7 +962,7 @@ describe('useMoneyAccountCardLinkage', () => {
         setPendingMoneyAccountCardLink(null),
       );
       expect(mockNavigate).not.toHaveBeenCalled();
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('tracks RESIDENCY_BLOCKED, shows error toast, and clears the flag when residency is blocked after auth', () => {
@@ -981,7 +978,7 @@ describe('useMoneyAccountCardLinkage', () => {
         setPendingMoneyAccountCardLink(null),
       );
       expect(mockNavigate).not.toHaveBeenCalled();
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
+      expect(toast).toHaveBeenCalledTimes(1);
       expect(mockAddProperties).toHaveBeenCalledWith(
         expect.objectContaining({
           flow: CardFlow.MONEY_ACCOUNT_LINKAGE,
@@ -1004,7 +1001,7 @@ describe('useMoneyAccountCardLinkage', () => {
         setPendingMoneyAccountCardLink(null),
       );
       expect(mockNavigate).not.toHaveBeenCalled();
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('does nothing while the user is not yet authenticated', () => {
@@ -1034,7 +1031,7 @@ describe('useMoneyAccountCardLinkage', () => {
 
         expect(mockDispatch).not.toHaveBeenCalled();
         expect(mockNavigate).not.toHaveBeenCalled();
-        expect(mockShowToast).not.toHaveBeenCalled();
+        expect(toast).not.toHaveBeenCalled();
       },
     );
 
@@ -1054,7 +1051,7 @@ describe('useMoneyAccountCardLinkage', () => {
           setPendingMoneyAccountCardLink(null),
         );
         expect(mockNavigate).not.toHaveBeenCalled();
-        expect(mockShowToast).not.toHaveBeenCalled();
+        expect(toast).not.toHaveBeenCalled();
       },
     );
 
@@ -1100,7 +1097,7 @@ describe('useMoneyAccountCardLinkage', () => {
 
       expect(mockDispatch).not.toHaveBeenCalled();
       expect(mockNavigate).not.toHaveBeenCalled();
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('keeps the flag set when the funding token is null and card home data is still idle', () => {
@@ -1115,7 +1112,7 @@ describe('useMoneyAccountCardLinkage', () => {
 
       expect(mockDispatch).not.toHaveBeenCalled();
       expect(mockNavigate).not.toHaveBeenCalled();
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('clears the flag silently once card home data has loaded but the funding token is still unresolved', () => {
@@ -1132,7 +1129,7 @@ describe('useMoneyAccountCardLinkage', () => {
         setPendingMoneyAccountCardLink(null),
       );
       expect(mockNavigate).not.toHaveBeenCalled();
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('clears the flag silently when card home data fetch errors and the funding token cannot be resolved', () => {
@@ -1149,7 +1146,7 @@ describe('useMoneyAccountCardLinkage', () => {
         setPendingMoneyAccountCardLink(null),
       );
       expect(mockNavigate).not.toHaveBeenCalled();
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('opens the sheet on rerender once the funding token resolves after card home data succeeds', () => {
@@ -1243,10 +1240,10 @@ describe('useMoneyAccountCardLinkage', () => {
         linkPromise = result.current.confirmLinkInBackground();
       });
 
-      const pendingCall = mockShowToast.mock.calls[0]?.[0];
+      const pendingCall = toast.mock.calls[0]?.[0];
       expect(pendingCall).toMatchObject({
         hasNoTimeout: true,
-        labelOptions: [{ label: 'Linking your card' }],
+        title: 'Linking your card',
       });
       expect(pendingCall?.startAccessory).toBeDefined();
 
@@ -1255,9 +1252,9 @@ describe('useMoneyAccountCardLinkage', () => {
         await linkPromise;
       });
 
-      const successCall = mockShowToast.mock.calls[1]?.[0];
+      const successCall = toast.mock.calls[1]?.[0];
       expect(successCall).toMatchObject({
-        labelOptions: [{ label: 'Your card is ready to use' }],
+        title: 'Your card is ready to use',
         hasNoTimeout: false,
       });
     });
@@ -1322,9 +1319,9 @@ describe('useMoneyAccountCardLinkage', () => {
         is_revoke: false,
       });
 
-      const errorCall = mockShowToast.mock.calls.at(-1)?.[0];
+      const errorCall = toast.mock.calls.at(-1)?.[0];
       expect(errorCall).toMatchObject({
-        labelOptions: [{ label: 'Something went wrong linking your card' }],
+        title: 'Something went wrong linking your card',
         hasNoTimeout: false,
       });
     });
@@ -1349,14 +1346,9 @@ describe('useMoneyAccountCardLinkage', () => {
 
       expect(returned).toBe(false);
       expect(result.current.status).toBe('error');
-      expect(mockShowToast).toHaveBeenLastCalledWith(
+      expect(toast).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          labelOptions: [
-            {
-              label:
-                'This wallet is already linked to a different MetaMask Card',
-            },
-          ],
+          title: 'This wallet is already linked to a different MetaMask Card',
           hasNoTimeout: false,
         }),
       );
@@ -1389,7 +1381,7 @@ describe('useMoneyAccountCardLinkage', () => {
       });
 
       // Only the pending toast should have fired — no error toast.
-      const lastCall = mockShowToast.mock.calls.at(-1)?.[0];
+      const lastCall = toast.mock.calls.at(-1)?.[0];
       expect(lastCall).toMatchObject({ hasNoTimeout: true });
       expect(Logger.error).not.toHaveBeenCalled();
     });
@@ -1418,9 +1410,9 @@ describe('useMoneyAccountCardLinkage', () => {
         reason: CardLinkingFailureReason.PRECONDITION_FAILED,
         is_revoke: false,
       });
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
-      expect(mockShowToast.mock.calls[0][0]).toMatchObject({
-        labelOptions: [{ label: 'Something went wrong linking your card' }],
+      expect(toast).toHaveBeenCalledTimes(1);
+      expect(toast.mock.calls[0][0]).toMatchObject({
+        title: 'Something went wrong linking your card',
       });
     });
 
@@ -1464,9 +1456,9 @@ describe('useMoneyAccountCardLinkage', () => {
         reason: CardLinkingFailureReason.PRECONDITION_FAILED,
         is_revoke: true,
       });
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
-      expect(mockShowToast.mock.calls[0][0]).toMatchObject({
-        labelOptions: [{ label: 'Something went wrong unlinking your card' }],
+      expect(toast).toHaveBeenCalledTimes(1);
+      expect(toast.mock.calls[0][0]).toMatchObject({
+        title: 'Something went wrong unlinking your card',
       });
     });
 
@@ -1511,9 +1503,9 @@ describe('useMoneyAccountCardLinkage', () => {
         });
       });
 
-      expect(mockShowToast).toHaveBeenLastCalledWith(
+      expect(toast).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          labelOptions: [{ label: 'Unlinking your card' }],
+          title: 'Unlinking your card',
         }),
       );
 
@@ -1522,9 +1514,9 @@ describe('useMoneyAccountCardLinkage', () => {
         await linkPromise;
       });
 
-      expect(mockShowToast).toHaveBeenLastCalledWith(
+      expect(toast).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          labelOptions: [{ label: 'Your card was unlinked' }],
+          title: 'Your card was unlinked',
         }),
       );
     });
@@ -1543,9 +1535,9 @@ describe('useMoneyAccountCardLinkage', () => {
       });
 
       expect(returned).toBe(false);
-      expect(mockShowToast).toHaveBeenLastCalledWith(
+      expect(toast).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          labelOptions: [{ label: 'Something went wrong unlinking your card' }],
+          title: 'Something went wrong unlinking your card',
         }),
       );
     });
@@ -1571,9 +1563,9 @@ describe('useMoneyAccountCardLinkage', () => {
         });
       });
 
-      expect(mockShowToast).toHaveBeenLastCalledWith(
+      expect(toast).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          labelOptions: [{ label: 'Updating your spending limit' }],
+          title: 'Updating your spending limit',
         }),
       );
 
@@ -1582,9 +1574,9 @@ describe('useMoneyAccountCardLinkage', () => {
         await linkPromise;
       });
 
-      expect(mockShowToast).toHaveBeenLastCalledWith(
+      expect(toast).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          labelOptions: [{ label: 'Your spending limit was updated' }],
+          title: 'Your spending limit was updated',
         }),
       );
     });
@@ -1603,11 +1595,9 @@ describe('useMoneyAccountCardLinkage', () => {
       });
 
       expect(returned).toBe(false);
-      expect(mockShowToast).toHaveBeenLastCalledWith(
+      expect(toast).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          labelOptions: [
-            { label: 'Something went wrong updating your spending limit' },
-          ],
+          title: 'Something went wrong updating your spending limit',
         }),
       );
     });
@@ -1624,9 +1614,9 @@ describe('useMoneyAccountCardLinkage', () => {
         });
       });
 
-      expect(mockShowToast).toHaveBeenLastCalledWith(
+      expect(toast).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          labelOptions: [{ label: 'Your card is ready to use' }],
+          title: 'Your card is ready to use',
         }),
       );
     });
@@ -1665,7 +1655,7 @@ describe('useMoneyAccountCardLinkage', () => {
       });
 
       expect(returned).toBe(false);
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
       expect(mockLinkMoneyAccountCard).not.toHaveBeenCalled();
       expect(mockCreateEventBuilder).not.toHaveBeenCalled();
       expect(result.current.status).toBe('idle');
@@ -1693,8 +1683,8 @@ describe('useMoneyAccountCardLinkage', () => {
       // The pending toast WAS shown — we cleared the sync gate, so the
       // UI side-effect ran. But the in-progress catch branch must NOT
       // surface a success or error toast.
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
-      const onlyToast = mockShowToast.mock.calls[0]?.[0];
+      expect(toast).toHaveBeenCalledTimes(1);
+      const onlyToast = toast.mock.calls[0]?.[0];
       expect(onlyToast).toMatchObject({ hasNoTimeout: true });
       // Not an error: must not be logged or transitioned to error state.
       expect(Logger.error).not.toHaveBeenCalled();

--- a/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx
+++ b/app/components/UI/Card/hooks/useMoneyAccountCardLinkage.tsx
@@ -1,30 +1,19 @@
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigation } from '@react-navigation/native';
 import type { AppNavigationProp } from '../../../../core/NavigationService/types';
 import { useDispatch, useSelector } from 'react-redux';
 import {
-  Icon,
   IconColor,
   IconSize,
   Spinner,
+  toast,
+  ToastSeverity,
 } from '@metamask/design-system-react-native';
 import type { MoneyAccount } from '@metamask/money-account-controller';
 import Engine from '../../../../core/Engine';
 import Routes from '../../../../constants/navigation/Routes';
 import { strings } from '../../../../../locales/i18n';
 import Logger from '../../../../util/Logger';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../component-library/components/Toast';
-import { IconName } from '../../../../component-library/components/Icons/Icon';
-import { useTheme } from '../../../../util/theme';
 import { selectPrimaryMoneyAccount } from '../../../../selectors/moneyAccountController';
 import { selectMoneyAccountVaultConfig } from '../../../../selectors/featureFlagController/moneyAccount';
 import { getGasFeesSponsoredNetworkEnabled } from '../../../../selectors/featureFlagController/gasFeesSponsored';
@@ -145,8 +134,6 @@ export interface UseMoneyAccountCardLinkageReturn {
  */
 export const useMoneyAccountCardLinkage =
   (): UseMoneyAccountCardLinkageReturn => {
-    const { toastRef } = useContext(ToastContext);
-    const theme = useTheme();
     const navigation = useNavigation<AppNavigationProp>();
     const dispatch = useDispatch();
     const { trackEvent, createEventBuilder } = useAnalytics();
@@ -212,74 +199,39 @@ export const useMoneyAccountCardLinkage =
       canSubmitDelegation && !isAlreadyDelegated && !isResidencyBlocked,
     );
 
-    const showPendingToast = useCallback(
-      (action: LinkageAction) => {
-        toastRef?.current?.showToast({
-          variant: ToastVariants.Icon,
-          labelOptions: [
-            {
-              label: strings(PENDING_TITLE_BY_ACTION[action]),
-            },
-          ],
-          iconName: IconName.Loading,
-          hasNoTimeout: true,
-          startAccessory: (
-            <Spinner
-              color={IconColor.IconDefault}
-              spinnerIconProps={{ size: IconSize.Lg }}
-            />
-          ),
-        });
-      },
-      [toastRef],
-    );
+    const showPendingToast = useCallback((action: LinkageAction) => {
+      toast({
+        title: strings(PENDING_TITLE_BY_ACTION[action]),
+        hasNoTimeout: true,
+        showCloseButton: false,
+        startAccessory: (
+          <Spinner
+            color={IconColor.IconDefault}
+            spinnerIconProps={{ size: IconSize.Lg }}
+          />
+        ),
+      });
+    }, []);
 
-    const showSuccessToast = useCallback(
-      (action: LinkageAction) => {
-        toastRef?.current?.showToast({
-          variant: ToastVariants.Icon,
-          labelOptions: [
-            {
-              label: strings(SUCCESS_TITLE_BY_ACTION[action]),
-            },
-          ],
-          iconName: IconName.Confirmation,
-          iconColor: theme.colors.success.default,
-          hasNoTimeout: false,
-          startAccessory: (
-            <Icon
-              name={IconName.Confirmation}
-              color={IconColor.SuccessDefault}
-              size={IconSize.Lg}
-            />
-          ),
-        });
-      },
-      [theme.colors.success.default, toastRef],
-    );
+    const showSuccessToast = useCallback((action: LinkageAction) => {
+      toast({
+        title: strings(SUCCESS_TITLE_BY_ACTION[action]),
+        severity: ToastSeverity.Success,
+        hasNoTimeout: false,
+        showCloseButton: false,
+      });
+    }, []);
 
     const showErrorToast = useCallback(
       (action: LinkageAction = 'link', labelKey?: string) => {
-        toastRef?.current?.showToast({
-          variant: ToastVariants.Icon,
-          labelOptions: [
-            {
-              label: strings(labelKey ?? ERROR_TITLE_BY_ACTION[action]),
-            },
-          ],
-          iconName: IconName.Error,
-          iconColor: theme.colors.error.default,
+        toast({
+          title: strings(labelKey ?? ERROR_TITLE_BY_ACTION[action]),
+          severity: ToastSeverity.Danger,
           hasNoTimeout: false,
-          startAccessory: (
-            <Icon
-              name={IconName.Error}
-              color={IconColor.ErrorDefault}
-              size={IconSize.Lg}
-            />
-          ),
+          showCloseButton: false,
         });
       },
-      [theme.colors.error.default, toastRef],
+      [],
     );
 
     const trackMoneyAccountLinkingEvent = useCallback(

--- a/app/components/UI/Card/hooks/useSpendingLimit.test.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimit.test.ts
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook, act } from '@testing-library/react-hooks';
 import {
   useNavigation,
@@ -12,8 +11,8 @@ import { useCardSDK } from '../sdk';
 import { FundingStatus, CardFundingToken, CardType } from '../types';
 import { BAANX_MAX_LIMIT } from '../constants';
 import { LINEA_CAIP_CHAIN_ID } from '../util/buildTokenList';
+import { toast } from '@metamask/design-system-react-native';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
-import { ToastContext } from '../../../../component-library/components/Toast';
 import Logger from '../../../../util/Logger';
 import { createAssetSelectionModalNavigationDetails } from '../components/AssetSelectionBottomSheet';
 import Routes from '../../../../constants/navigation/Routes';
@@ -72,6 +71,14 @@ jest.mock('../../../../util/theme', () => {
   return {
     ...actual,
     useTheme: jest.fn(() => actual.mockTheme),
+  };
+});
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
   };
 });
 
@@ -280,8 +287,6 @@ describe('useSpendingLimit', () => {
   let mockCreateEventBuilder: jest.Mock;
   let mockBuild: jest.Mock;
   let mockAddProperties: jest.Mock;
-  let mockShowToast: jest.Mock;
-  let mockToastRef: { current: { showToast: jest.Mock } };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -333,18 +338,6 @@ describe('useSpendingLimit', () => {
       trackEvent: mockTrackEvent,
       createEventBuilder: mockCreateEventBuilder,
     } as never);
-
-    // Setup toast mock
-    mockShowToast = jest.fn();
-    mockToastRef = { current: { showToast: mockShowToast } };
-
-    // Mock React.useContext for ToastContext
-    jest.spyOn(React, 'useContext').mockImplementation((context) => {
-      if (context === ToastContext) {
-        return { toastRef: mockToastRef };
-      }
-      return undefined;
-    });
 
     // Setup asset selection navigation details mock
     mockCreateAssetSelectionModalNavigationDetails.mockReturnValue([
@@ -789,7 +782,7 @@ describe('useSpendingLimit', () => {
       });
 
       expect(Logger.error).toHaveBeenCalled();
-      expect(mockShowToast).toHaveBeenCalled();
+      expect(toast).toHaveBeenCalled();
     });
 
     it('shows error toast when no token is available', async () => {
@@ -805,7 +798,7 @@ describe('useSpendingLimit', () => {
         await submitPromise;
       });
 
-      expect(mockShowToast).toHaveBeenCalled();
+      expect(toast).toHaveBeenCalled();
     });
 
     it('calls submitDelegation with full limit amount', async () => {
@@ -878,7 +871,7 @@ describe('useSpendingLimit', () => {
         await submitPromise;
       });
 
-      expect(mockShowToast).toHaveBeenCalled();
+      expect(toast).toHaveBeenCalled();
     });
 
     it('navigates back for non-onboarding flow', async () => {
@@ -935,7 +928,7 @@ describe('useSpendingLimit', () => {
       expect(Logger.log).toHaveBeenCalledWith(
         'User cancelled the delegation transaction',
       );
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('shows error toast on submission failure', async () => {
@@ -950,7 +943,7 @@ describe('useSpendingLimit', () => {
       });
 
       expect(Logger.error).toHaveBeenCalled();
-      expect(mockShowToast).toHaveBeenCalled();
+      expect(toast).toHaveBeenCalled();
     });
 
     it('tracks button click event', async () => {

--- a/app/components/UI/Card/hooks/useSpendingLimit.ts
+++ b/app/components/UI/Card/hooks/useSpendingLimit.ts
@@ -3,7 +3,6 @@ import {
   useCallback,
   useMemo,
   useEffect,
-  useContext,
   useRef,
 } from 'react';
 import {
@@ -14,7 +13,6 @@ import {
 import type { AppNavigationProp } from '../../../../core/NavigationService/types';
 import { navigateWithDetails } from '../../../../util/navigation/navUtils';
 import { useSelector } from 'react-redux';
-import { useTheme } from '../../../../util/theme';
 import { selectSelectedInternalAccount } from '../../../../selectors/accountsController';
 import { selectEvmNetworkConfigurationsByChainId } from '../../../../selectors/networkController';
 import { createAccountSelectorNavDetails } from '../../../Views/AccountSelector';
@@ -50,11 +48,7 @@ import useMoneyAccountCardLinkage from './useMoneyAccountCardLinkage';
 import useMoneyAccountBalance from '../../Money/hooks/useMoneyAccountBalance';
 import useMoneyVaultApy from '../../Money/hooks/useMoneyVaultApy';
 import { useCardHomeData } from './useCardHomeData';
-import {
-  ToastContext,
-  ToastVariants,
-} from '../../../../component-library/components/Toast';
-import { IconName } from '../../../../component-library/components/Icons/Icon';
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { CaipChainId, Hex } from '@metamask/utils';
 import { useAnalytics } from '../../../hooks/useAnalytics/useAnalytics';
 import { MetaMetricsEvents } from '../../../../core/Analytics';
@@ -149,8 +143,6 @@ const useSpendingLimit = ({
   routeParams,
 }: UseSpendingLimitParams): UseSpendingLimitReturn => {
   const navigation = useNavigation<AppNavigationProp>();
-  const theme = useTheme();
-  const { toastRef } = useContext(ToastContext);
   const { trackEvent, createEventBuilder } = useAnalytics();
   const activeProviderId = useSelector(selectCardActiveProviderId);
   const { sdk } = useCardSDK();
@@ -616,33 +608,22 @@ const useSpendingLimit = ({
 
   // Toast helpers
   const showSuccessToast = useCallback(() => {
-    toastRef?.current?.showToast({
-      variant: ToastVariants.Icon,
-      labelOptions: [
-        { label: strings('card.card_spending_limit.update_success') },
-      ],
-      iconName: IconName.Confirmation,
-      iconColor: theme.colors.success.default,
+    toast({
+      title: strings('card.card_spending_limit.update_success'),
+      severity: ToastSeverity.Success,
       hasNoTimeout: false,
+      showCloseButton: false,
     });
-  }, [toastRef, theme]);
+  }, []);
 
-  const showErrorToast = useCallback(
-    (message?: string) => {
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Icon,
-        labelOptions: [
-          {
-            label: message || strings('card.card_spending_limit.update_error'),
-          },
-        ],
-        iconName: IconName.Danger,
-        iconColor: theme.colors.error.default,
-        hasNoTimeout: false,
-      });
-    },
-    [toastRef, theme],
-  );
+  const showErrorToast = useCallback((message?: string) => {
+    toast({
+      title: message || strings('card.card_spending_limit.update_error'),
+      severity: ToastSeverity.Danger,
+      hasNoTimeout: false,
+      showCloseButton: false,
+    });
+  }, []);
 
   // Navigation helpers
   const navigateToCardHome = useCallback(() => {

--- a/app/components/UI/Card/util/withBiometricAuth.test.ts
+++ b/app/components/UI/Card/util/withBiometricAuth.test.ts
@@ -1,5 +1,14 @@
+import { toast } from '@metamask/design-system-react-native';
 import { withBiometricAuth } from './withBiometricAuth';
 import { ReauthenticateErrorType } from '../../../../core/Authentication/types';
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
 jest.mock('../components/PasswordBottomSheet', () => ({
   createPasswordBottomSheetNavigationDetails: jest.fn(
@@ -19,7 +28,6 @@ function makeParams(overrides = {}) {
   return {
     reauthenticate: jest.fn(),
     navigation: { navigate: jest.fn() },
-    toastRef: { current: { showToast: jest.fn() } },
     onSuccess: jest.fn(),
     ...overrides,
   };
@@ -78,7 +86,7 @@ describe('withBiometricAuth', () => {
     await withBiometricAuth(params);
 
     expect(params.navigation.navigate).not.toHaveBeenCalled();
-    expect(params.toastRef.current.showToast).not.toHaveBeenCalled();
+    expect(toast).not.toHaveBeenCalled();
     expect(params.onSuccess).not.toHaveBeenCalled();
   });
 
@@ -90,19 +98,14 @@ describe('withBiometricAuth', () => {
 
     await withBiometricAuth(params);
 
-    expect(params.toastRef.current.showToast).toHaveBeenCalledTimes(1);
-    expect(params.toastRef.current.showToast).toHaveBeenCalledWith(
-      expect.objectContaining({ variant: expect.any(String) }),
+    expect(toast).toHaveBeenCalledTimes(1);
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'warning',
+        hasNoTimeout: false,
+        showCloseButton: false,
+      }),
     );
     expect(params.onSuccess).not.toHaveBeenCalled();
-  });
-
-  it('does not crash when toastRef is null on unknown errors', async () => {
-    const params = makeParams({ toastRef: null });
-    (params.reauthenticate as jest.Mock).mockRejectedValue(
-      new Error('Some unexpected error'),
-    );
-
-    await expect(withBiometricAuth(params)).resolves.toBeUndefined();
   });
 });

--- a/app/components/UI/Card/util/withBiometricAuth.ts
+++ b/app/components/UI/Card/util/withBiometricAuth.ts
@@ -1,7 +1,6 @@
+import { toast, ToastSeverity } from '@metamask/design-system-react-native';
 import { ReauthenticateErrorType } from '../../../../core/Authentication/types';
 import { navigateWithDetails } from '../../../../util/navigation/navUtils';
-import { IconName } from '../../../../component-library/components/Icons/Icon';
-import { ToastVariants } from '../../../../component-library/components/Toast';
 import { strings } from '../../../../../locales/i18n';
 import { createPasswordBottomSheetNavigationDetails } from '../components/PasswordBottomSheet';
 
@@ -10,8 +9,6 @@ interface BiometricAuthParams {
   reauthenticate: (...args: any[]) => Promise<any>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   navigation: { navigate: (...args: any[]) => void };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  toastRef: React.RefObject<any> | null | undefined;
   onSuccess: () => void | Promise<void>;
   passwordDescription?: string;
 }
@@ -23,7 +20,6 @@ interface BiometricAuthParams {
 export async function withBiometricAuth({
   reauthenticate,
   navigation,
-  toastRef,
   onSuccess,
   passwordDescription,
 }: BiometricAuthParams): Promise<void> {
@@ -54,13 +50,11 @@ export async function withBiometricAuth({
       return;
     }
 
-    toastRef?.current?.showToast({
-      variant: ToastVariants.Icon,
-      labelOptions: [
-        { label: strings('card.card_home.biometric_verification_required') },
-      ],
+    toast({
+      title: strings('card.card_home.biometric_verification_required'),
+      severity: ToastSeverity.Warning,
       hasNoTimeout: false,
-      iconName: IconName.Warning,
+      showCloseButton: false,
     });
   }
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The component-library `Toast` is deprecated in favor of `toast()` from `@metamask/design-system-react-native`. Card onboarding, PIN, spending limit, freeze, provisioning, redeem, and money-account linkage flows still used `toastRef.showToast`.

This PR switches those call sites to the design-system `toast()` API and maps success, warning, and error icons to `ToastSeverity`. `withBiometricAuth` no longer takes a `toastRef`; it calls `toast()` directly. Tests mock `toast` instead of wrapping ToastContext.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated MetaMask Card toasts to the MetaMask design system

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Design system toasts for MetaMask Card

  Background:
    Given I am logged into MetaMask Mobile
    And I have access to MetaMask Card

  Scenario: user freezes or unfreezes a card
    Given I am on Card Home

    When user freezes or unfreezes the card
    Then a success toast should appear from the top of the screen

  Scenario: user updates spending limit
    Given I am on the Card spending limit screen

    When user saves a new limit
    Then a success toast should confirm the update
    And a danger toast should appear if the update fails

  Scenario: user copies card details
    Given I am viewing card details

    When user copies a card detail
    Then a toast should confirm the value was copied
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
