### PR TITLE
refactor(toast): migrate leftover toasts to the design system

### DIFF
--- a/app/components/Nav/Main/index.js
+++ b/app/components/Nav/Main/index.js
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  useEffect,
-  useRef,
-  useCallback,
-  useContext,
-} from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 
 import {
   ActivityIndicator,
@@ -50,9 +44,10 @@ import ReviewModal from '../../UI/ReviewModal';
 import { useTheme } from '../../../util/theme';
 import RootRPCMethodsUI from './RootRPCMethodsUI';
 import {
-  ToastContext,
-  ToastVariants,
-} from '../../../component-library/components/Toast';
+  AvatarNetwork,
+  AvatarNetworkSize,
+  toast,
+} from '@metamask/design-system-react-native';
 import { useMinimumVersions } from '../../hooks/MinimumVersions';
 import {
   selectChainId,
@@ -206,7 +201,6 @@ const Main = (props) => {
   const isEvmSelected = useSelector(selectIsEvmNetworkSelected);
   const previousProviderConfig = useRef(undefined);
   const previousNetworkConfigurations = useRef(undefined);
-  const { toastRef } = useContext(ToastContext);
   const { networks } = useNetworksByNamespace({
     networkType: NetworkType.Popular,
   });
@@ -259,7 +253,6 @@ const Main = (props) => {
     providerConfig,
     networkName,
     networkImage,
-    toastRef,
     chainId,
     isEvmSelected,
     hasNetworkChanged,
@@ -304,28 +297,25 @@ const Main = (props) => {
         hasDeletedNetwork: Boolean(deletedNetwork),
       });
       if (shouldShowToast) {
-        toastRef?.current?.showToast({
-          variant: ToastVariants.Plain,
-          labelOptions: [
-            {
-              label: `${
-                (deletedNetwork?.name || newNetwork?.name) ??
-                strings('asset_details.network')
-              } `,
-              isBold: true,
-            },
-            {
-              label: deletedNetwork
-                ? strings('toast.network_removed')
-                : strings('toast.network_added'),
-            },
-          ],
-          networkImageSource: networkImage,
+        toast({
+          title: `${
+            (deletedNetwork?.name || newNetwork?.name) ??
+            strings('asset_details.network')
+          } ${
+            deletedNetwork
+              ? strings('toast.network_removed')
+              : strings('toast.network_added')
+          }`,
+          startAccessory: networkImage ? (
+            <AvatarNetwork src={networkImage} size={AvatarNetworkSize.Md} />
+          ) : undefined,
+          hasNoTimeout: false,
+          showCloseButton: false,
         });
       }
     }
     previousNetworkConfigurations.current = networkConfigurations;
-  }, [networkConfigurations, networkImage, toastRef]);
+  }, [networkConfigurations, networkImage]);
 
   useEffect(() => {
     if (locale.current !== I18n.locale) {

--- a/app/components/Nav/Main/utils.test.ts
+++ b/app/components/Nav/Main/utils.test.ts
@@ -1,9 +1,9 @@
 import { ImageSourcePropType } from 'react-native';
+import { toast } from '@metamask/design-system-react-native';
 import {
   handleShowNetworkActiveToast,
   shouldShowNetworkListToast,
 } from './utils';
-import { ToastVariants } from '../../../component-library/components/Toast';
 import { strings } from '../../../../locales/i18n';
 import {
   clearSuppressedNetworkAddedToast,
@@ -12,12 +12,15 @@ import {
   suppressNextNetworkAddedToast,
 } from '../../../util/networks/networkToastSuppression';
 
-describe('handleShowNetworkActiveToast', () => {
-  const mockToastRef = {
-    current: {
-      showToast: jest.fn(),
-    },
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
   };
+});
+
+describe('handleShowNetworkActiveToast', () => {
   const mockNetworkName = 'Ethereum Mainnet';
   const mockNetworkImage: ImageSourcePropType = {
     uri: 'https://example.com/eth.png',
@@ -29,119 +32,69 @@ describe('handleShowNetworkActiveToast', () => {
   });
 
   it('shows toast when not on bridge route', () => {
-    // Arrange
     const isOnBridgeRoute = false;
 
-    // Act
     handleShowNetworkActiveToast(
       isOnBridgeRoute,
-      mockToastRef,
       mockNetworkName,
       mockNetworkImage,
     );
 
-    // Assert
-    expect(mockToastRef.current.showToast).toHaveBeenCalledTimes(1);
-    expect(mockToastRef.current.showToast).toHaveBeenCalledWith({
-      variant: ToastVariants.Network,
-      labelOptions: [
-        {
-          label: `${mockNetworkName} `,
-          isBold: true,
-        },
-        { label: strings('toast.now_active') },
-      ],
-      networkImageSource: mockNetworkImage,
-    });
+    expect(toast).toHaveBeenCalledTimes(1);
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: `${mockNetworkName} ${strings('toast.now_active')}`,
+        showCloseButton: false,
+      }),
+    );
   });
 
   it('does not show toast when on bridge route', () => {
-    // Arrange
     const isOnBridgeRoute = true;
 
-    // Act
     handleShowNetworkActiveToast(
       isOnBridgeRoute,
-      mockToastRef,
       mockNetworkName,
       mockNetworkImage,
     );
 
-    // Assert
-    expect(mockToastRef.current.showToast).not.toHaveBeenCalled();
+    expect(toast).not.toHaveBeenCalled();
   });
 
-  it('handles undefined toastRef gracefully when not on bridge route', () => {
-    // Arrange
-    const isOnBridgeRoute = false;
-    const undefinedToastRef = undefined;
-
-    // Act & Assert - should not throw
-    expect(() =>
-      handleShowNetworkActiveToast(
-        isOnBridgeRoute,
-        undefinedToastRef,
-        mockNetworkName,
-        mockNetworkImage,
-      ),
-    ).not.toThrow();
-  });
-
-  it('handles toastRef with null current when not on bridge route', () => {
-    // Arrange
-    const isOnBridgeRoute = false;
-    const nullCurrentToastRef = { current: null };
-
-    // Act & Assert - should not throw
-    expect(() =>
-      handleShowNetworkActiveToast(
-        isOnBridgeRoute,
-        nullCurrentToastRef,
-        mockNetworkName,
-        mockNetworkImage,
-      ),
-    ).not.toThrow();
-  });
-
-  it('formats network name with space and bold styling', () => {
-    // Arrange
+  it('formats network name with now-active copy', () => {
     const isOnBridgeRoute = false;
     const customNetworkName = 'Polygon';
 
-    // Act
     handleShowNetworkActiveToast(
       isOnBridgeRoute,
-      mockToastRef,
       customNetworkName,
       mockNetworkImage,
     );
 
-    // Assert
-    const calledWith = mockToastRef.current.showToast.mock.calls[0][0];
-    expect(calledWith.labelOptions[0]).toEqual({
-      label: `${customNetworkName} `,
-      isBold: true,
-    });
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: `${customNetworkName} ${strings('toast.now_active')}`,
+      }),
+    );
   });
 
-  it('passes through network image source correctly', () => {
-    // Arrange
+  it('passes through network image source as start accessory', () => {
     const isOnBridgeRoute = false;
     const customNetworkImage: ImageSourcePropType = {
       uri: 'https://example.com/polygon.png',
     };
 
-    // Act
     handleShowNetworkActiveToast(
       isOnBridgeRoute,
-      mockToastRef,
       mockNetworkName,
       customNetworkImage,
     );
 
-    // Assert
-    const calledWith = mockToastRef.current.showToast.mock.calls[0][0];
-    expect(calledWith.networkImageSource).toBe(customNetworkImage);
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startAccessory: expect.anything(),
+      }),
+    );
   });
 });
 

--- a/app/components/Nav/Main/utils.ts
+++ b/app/components/Nav/Main/utils.ts
@@ -1,26 +1,26 @@
+import React from 'react';
 import { ImageSourcePropType } from 'react-native';
-import { ToastVariants } from '../../../component-library/components/Toast';
+import {
+  AvatarNetwork,
+  AvatarNetworkSize,
+  toast,
+} from '@metamask/design-system-react-native';
 import { strings } from '../../../../locales/i18n';
 import { consumeSuppressedNetworkAddedToast } from '../../../util/networks/networkToastSuppression';
 
 export const handleShowNetworkActiveToast = (
   isOnBridgeRoute: boolean,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  toastRef: React.RefObject<any> | undefined,
   networkName: string,
   networkImage: ImageSourcePropType,
 ) => {
   if (!isOnBridgeRoute) {
-    toastRef?.current?.showToast({
-      variant: ToastVariants.Network,
-      labelOptions: [
-        {
-          label: `${networkName} `,
-          isBold: true,
-        },
-        { label: strings('toast.now_active') },
-      ],
-      networkImageSource: networkImage,
+    toast({
+      title: `${networkName} ${strings('toast.now_active')}`,
+      startAccessory: React.createElement(AvatarNetwork, {
+        src: networkImage,
+        size: AvatarNetworkSize.Md,
+      }),
+      showCloseButton: false,
     });
   }
 };

--- a/app/components/Views/Browser/Browser.rendering.test.tsx
+++ b/app/components/Views/Browser/Browser.rendering.test.tsx
@@ -23,8 +23,9 @@ import {
   sortMultichainAccountsByLastSelected,
 } from '../../../core/Permissions';
 import { KeyringTypes } from '@metamask/keyring-controller';
-import { ToastContext } from '../../../component-library/components/Toast/Toast.context';
 import { parseCaipAccountId } from '@metamask/utils';
+import { toast } from '@metamask/design-system-react-native';
+import { strings } from '../../../../locales/i18n';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0020): route-isolation backlog
 import BrowserTab from '../BrowserTab/BrowserTab';
 
@@ -47,6 +48,14 @@ jest.mock('../../../core/Permissions', () => ({
   getPermittedCaipAccountIdsByHostname: jest.fn(),
   sortMultichainAccountsByLastSelected: jest.fn(),
 }));
+
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
 
 jest.mock('../BrowserTab/BrowserTab', () => ({
   __esModule: true,
@@ -413,13 +422,6 @@ describe('Browser - Rendering and Initialization', () => {
 
   it('shows active account toast when visiting a site with permitted accounts', () => {
     // 1. Mock dependencies
-    const mockShowToast = jest.fn();
-    const mockCloseToast = jest.fn();
-    const mockToastRef = {
-      current: { showToast: mockShowToast, closeToast: mockCloseToast },
-    };
-
-    // Mock required values
     const testAccountAddress = '0xabcdef123456789';
     const oldHostname = 'site1.com';
     const newHostname = 'site2.com';
@@ -484,17 +486,9 @@ describe('Browser - Rendering and Initialization', () => {
         address === testAccountAddress ? mockAccountName : 'Unknown Account';
 
       // Show toast - this is what we want to test
-      mockToastRef.current.showToast({
-        variant: 'Account',
-        labelOptions: [
-          {
-            label: `${accountName} `,
-            isBold: true,
-          },
-          { label: 'now active.' },
-        ],
-        accountAddress: address,
-        accountAvatarType: 'JazzIcon',
+      toast({
+        title: `${accountName} ${strings('toast.now_active')}`,
+        showCloseButton: false,
       });
 
       return true;
@@ -503,37 +497,22 @@ describe('Browser - Rendering and Initialization', () => {
     // Verify toast is not shown initially for site1
     const prevHostnameResult = checkIfActiveAccountChanged(oldHostname);
     expect(prevHostnameResult).toBe(false);
-    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(toast).not.toHaveBeenCalled();
 
     // Verify toast is shown when changing to site2
-    mockShowToast.mockReset();
+    (toast as jest.Mock).mockReset();
     const newHostnameResult = checkIfActiveAccountChanged(newHostname);
     expect(newHostnameResult).toBe(true);
-    expect(mockShowToast).toHaveBeenCalled();
-    expect(mockShowToast).toHaveBeenCalledWith(
+    expect(toast).toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
-        variant: 'Account',
-        accountAddress: testAccountAddress,
-        labelOptions: expect.arrayContaining([
-          expect.objectContaining({
-            isBold: true,
-            label: `${mockAccountName} `,
-          }),
-          expect.objectContaining({
-            label: 'now active.',
-          }),
-        ]),
+        title: `${mockAccountName} ${strings('toast.now_active')}`,
+        showCloseButton: false,
       }),
     );
   });
 
   describe('useEffect for active account toast', () => {
-    const mockShowToast = jest.fn();
-    const mockCloseToast = jest.fn();
-    const mockToastRef = {
-      current: { showToast: mockShowToast, closeToast: mockCloseToast },
-    };
-
     const testAccountAddress1 = '0x123';
     const testAccountAddress2 = '0x456';
     const mockAccountName1 = 'Account 1';
@@ -574,33 +553,34 @@ describe('Browser - Rendering and Initialization', () => {
       activeTab: 1,
     };
 
+    const browserTree = (
+      props: Partial<React.ComponentProps<typeof Browser>>,
+    ) => (
+      <Provider store={mockStore(mockInitialState)}>
+        <ThemeContext.Provider value={mockTheme}>
+          <IndependentNavigationContainer>
+            <Stack.Navigator>
+              <Stack.Screen name={Routes.BROWSER.VIEW}>
+                {() => <Browser {...defaultBrowserProps} {...props} />}
+              </Stack.Screen>
+            </Stack.Navigator>
+          </IndependentNavigationContainer>
+        </ThemeContext.Provider>
+      </Provider>
+    );
+
     const renderBrowserWithProps = (
       props: Partial<React.ComponentProps<typeof Browser>>,
     ) =>
-      renderWithProvider(
-        <Provider store={mockStore(mockInitialState)}>
-          <ThemeContext.Provider value={mockTheme}>
-            <ToastContext.Provider value={{ toastRef: mockToastRef }}>
-              <IndependentNavigationContainer>
-                <Stack.Navigator>
-                  <Stack.Screen name={Routes.BROWSER.VIEW}>
-                    {() => <Browser {...defaultBrowserProps} {...props} />}
-                  </Stack.Screen>
-                </Stack.Navigator>
-              </IndependentNavigationContainer>
-            </ToastContext.Provider>
-          </ThemeContext.Provider>
-        </Provider>,
-        {
-          state: {
-            ...mockInitialState,
-            browser: {
-              tabs: props.tabs || defaultBrowserProps.tabs,
-              activeTab: props.activeTab || defaultBrowserProps.activeTab,
-            },
+      renderWithProvider(browserTree(props), {
+        state: {
+          ...mockInitialState,
+          browser: {
+            tabs: props.tabs || defaultBrowserProps.tabs,
+            activeTab: props.activeTab || defaultBrowserProps.activeTab,
           },
         },
-      );
+      });
 
     beforeEach(() => {
       jest.clearAllMocks();
@@ -628,38 +608,21 @@ describe('Browser - Rendering and Initialization', () => {
         route: { params: { url: 'https://initial.com' } },
       });
 
-      expect(mockShowToast).not.toHaveBeenCalled(); // No toast on initial render for initial.com
+      expect(toast).not.toHaveBeenCalled(); // No toast on initial render for initial.com
 
       rerender(
-        <Provider store={mockStore(mockInitialState)}>
-          <ThemeContext.Provider value={mockTheme}>
-            <ToastContext.Provider value={{ toastRef: mockToastRef }}>
-              <IndependentNavigationContainer>
-                <Stack.Navigator>
-                  <Stack.Screen name={Routes.BROWSER.VIEW}>
-                    {() => (
-                      <Browser
-                        {...defaultBrowserProps}
-                        route={{ params: { url: 'https://newsite.com' } }}
-                      />
-                    )}
-                  </Stack.Screen>
-                </Stack.Navigator>
-              </IndependentNavigationContainer>
-            </ToastContext.Provider>
-          </ThemeContext.Provider>
-        </Provider>,
+        browserTree({
+          route: { params: { url: 'https://newsite.com' } },
+        }),
       );
 
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledTimes(1);
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
-          accountAddress: testAccountAddress1,
-          labelOptions: expect.arrayContaining([
-            expect.objectContaining({
-              label: `${mockEnsByAccountAddress[testAccountAddress1]} `,
-            }),
-          ]),
+          title: expect.stringContaining(
+            mockEnsByAccountAddress[testAccountAddress1],
+          ),
+          showCloseButton: false,
         }),
       );
     });
@@ -683,7 +646,7 @@ describe('Browser - Rendering and Initialization', () => {
       const { rerender } = renderBrowserWithProps({
         route: { params: { url: 'https://currentsite.com' } },
       });
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
 
       // Rerender with accounts
       (useAccounts as jest.Mock).mockReturnValue({
@@ -693,35 +656,18 @@ describe('Browser - Rendering and Initialization', () => {
       });
 
       rerender(
-        <Provider store={mockStore(mockInitialState)}>
-          <ThemeContext.Provider value={mockTheme}>
-            <ToastContext.Provider value={{ toastRef: mockToastRef }}>
-              <IndependentNavigationContainer>
-                <Stack.Navigator>
-                  <Stack.Screen name={Routes.BROWSER.VIEW}>
-                    {() => (
-                      <Browser
-                        {...defaultBrowserProps}
-                        route={{ params: { url: 'https://currentsite.com' } }}
-                      />
-                    )}
-                  </Stack.Screen>
-                </Stack.Navigator>
-              </IndependentNavigationContainer>
-            </ToastContext.Provider>
-          </ThemeContext.Provider>
-        </Provider>,
+        browserTree({
+          route: { params: { url: 'https://currentsite.com' } },
+        }),
       );
 
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
-      expect(mockShowToast).toHaveBeenCalledWith(
+      expect(toast).toHaveBeenCalledTimes(1);
+      expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
-          accountAddress: testAccountAddress1,
-          labelOptions: expect.arrayContaining([
-            expect.objectContaining({
-              label: `${mockEnsByAccountAddress[testAccountAddress1]} `,
-            }),
-          ]),
+          title: expect.stringContaining(
+            mockEnsByAccountAddress[testAccountAddress1],
+          ),
+          showCloseButton: false,
         }),
       );
     });
@@ -743,33 +689,16 @@ describe('Browser - Rendering and Initialization', () => {
         route: { params: { url: 'https://initial.com' } },
       });
       // Toast for initial.com
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
-      mockShowToast.mockClear();
+      expect(toast).toHaveBeenCalledTimes(1);
+      (toast as jest.Mock).mockClear();
 
       rerender(
-        <Provider store={mockStore(mockInitialState)}>
-          <ThemeContext.Provider value={mockTheme}>
-            <ToastContext.Provider value={{ toastRef: mockToastRef }}>
-              <IndependentNavigationContainer>
-                <Stack.Navigator>
-                  <Stack.Screen name={Routes.BROWSER.VIEW}>
-                    {() => (
-                      <Browser
-                        {...defaultBrowserProps}
-                        route={{
-                          params: { url: 'https://anothernewsite.com' },
-                        }}
-                      />
-                    )}
-                  </Stack.Screen>
-                </Stack.Navigator>
-              </IndependentNavigationContainer>
-            </ToastContext.Provider>
-          </ThemeContext.Provider>
-        </Provider>,
+        browserTree({
+          route: { params: { url: 'https://anothernewsite.com' } },
+        }),
       );
 
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('does not show toast when already on the same host with permitted accounts', () => {
@@ -784,31 +713,16 @@ describe('Browser - Rendering and Initialization', () => {
       const { rerender } = renderBrowserWithProps({
         route: { params: { url: 'https://samesite.com' } },
       });
-      expect(mockShowToast).toHaveBeenCalledTimes(1); // Initial toast
-      mockShowToast.mockClear();
+      expect(toast).toHaveBeenCalledTimes(1); // Initial toast
+      (toast as jest.Mock).mockClear();
 
       // Rerender with same URL (e.g., due to some other state change not affecting URL or accounts)
       rerender(
-        <Provider store={mockStore(mockInitialState)}>
-          <ThemeContext.Provider value={mockTheme}>
-            <ToastContext.Provider value={{ toastRef: mockToastRef }}>
-              <IndependentNavigationContainer>
-                <Stack.Navigator>
-                  <Stack.Screen name={Routes.BROWSER.VIEW}>
-                    {() => (
-                      <Browser
-                        {...defaultBrowserProps}
-                        route={{ params: { url: 'https://samesite.com' } }}
-                      />
-                    )}
-                  </Stack.Screen>
-                </Stack.Navigator>
-              </IndependentNavigationContainer>
-            </ToastContext.Provider>
-          </ThemeContext.Provider>
-        </Provider>,
+        browserTree({
+          route: { params: { url: 'https://samesite.com' } },
+        }),
       );
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('does not show toast when there are no accounts', () => {
@@ -829,7 +743,7 @@ describe('Browser - Rendering and Initialization', () => {
         route: { params: { url: 'https://anyvalidurl.com' } },
       });
 
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('does not show toast when effectiveUrl is null or undefined', () => {
@@ -849,7 +763,7 @@ describe('Browser - Rendering and Initialization', () => {
         route: { params: { url: null } }, // browserUrl will be null
         tabs: [{ id: 1, url: null, image: '', isArchived: false }], // currentUrl might become homePageUrl initially
       });
-      expect(mockShowToast).not.toHaveBeenCalled();
+      expect(toast).not.toHaveBeenCalled();
     });
 
     it('uses browserUrl from props when currentUrl is not set initially', () => {
@@ -871,16 +785,20 @@ describe('Browser - Rendering and Initialization', () => {
         // We are testing the case where currentUrl is not set via route.params.url initially and it defaults to homePageUrl
         // and then a new browserUrl prop is passed
       });
-      expect(mockShowToast).not.toHaveBeenCalled(); // homePageUrl likely won't have permitted accounts
+      expect(toast).not.toHaveBeenCalled(); // homePageUrl likely won't have permitted accounts
 
       // Simulate a new navigation where browserUrl is passed directly in route.params
       /* const { rerender } = */ renderBrowserWithProps({
         route: { params: { url: 'https://propurl.com' } },
       });
 
-      expect(mockShowToast).toHaveBeenCalledTimes(1);
-      expect(mockShowToast).toHaveBeenCalledWith(
-        expect.objectContaining({ accountAddress: testAccountAddress1 }),
+      expect(toast).toHaveBeenCalledTimes(1);
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: expect.stringContaining(
+            mockEnsByAccountAddress[testAccountAddress1],
+          ),
+        }),
       );
     });
   });

--- a/app/components/Views/Browser/index.js
+++ b/app/components/Views/Browser/index.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, {
   useCallback,
-  useContext,
   useEffect,
   useRef,
   useState,
@@ -24,9 +23,11 @@ import {
 } from '../../../actions/browser';
 import { selectAvatarAccountType } from '../../../selectors/settings';
 import {
-  ToastContext,
-  ToastVariants,
-} from '../../../component-library/components/Toast';
+  AvatarAccount,
+  AvatarAccountSize,
+  toast,
+} from '@metamask/design-system-react-native';
+import { getAvatarAccountVariant } from '../../../component-library/components-temp/MultichainAccounts/avatarAccountVariant';
 import { useAccounts } from '../../hooks/useAccounts';
 import { MetaMetricsEvents } from '../../../core/Analytics';
 import AppConstants from '../../../core/AppConstants';
@@ -75,7 +76,6 @@ export const BrowserPure = (props) => {
   const { top: topInset } = useSafeAreaInsets();
   const { styles } = useStyles(styleSheet, { topInset });
   const { trackEvent, createEventBuilder } = useAnalytics();
-  const { toastRef } = useContext(ToastContext);
   const browserUrl = props.route?.params?.url;
   const linkType = props.route?.params?.linkType;
   const prevSiteHostname = useRef(browserUrl);
@@ -246,17 +246,16 @@ export const BrowserPure = (props) => {
       });
 
       // Show active account toast
-      toastRef?.current?.showToast({
-        variant: ToastVariants.Account,
-        labelOptions: [
-          {
-            label: `${accountName} `,
-            isBold: true,
-          },
-          { label: strings('toast.now_active') },
-        ],
-        accountAddress: address,
-        accountAvatarType,
+      toast({
+        title: `${accountName} ${strings('toast.now_active')}`,
+        startAccessory: (
+          <AvatarAccount
+            address={address}
+            size={AvatarAccountSize.Md}
+            variant={getAvatarAccountVariant(accountAvatarType)}
+          />
+        ),
+        showCloseButton: false,
       });
     };
 
@@ -277,7 +276,6 @@ export const BrowserPure = (props) => {
     permittedAccountsList,
     ensByAccountAddress,
     accountAvatarType,
-    toastRef,
   ]);
 
   // componentDidMount

--- a/app/components/Views/ReturnToAppNotification/ReturnToAppNotification.tsx
+++ b/app/components/Views/ReturnToAppNotification/ReturnToAppNotification.tsx
@@ -1,10 +1,10 @@
-import React, { useContext, useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { strings } from '../../../../locales/i18n.js';
-import { ToastContext } from '../../../component-library/components/Toast/index.ts';
 import {
-  ToastRef,
-  ToastVariants,
-} from '../../../component-library/components/Toast/Toast.types.ts';
+  AvatarFavicon,
+  AvatarFaviconSize,
+  toast,
+} from '@metamask/design-system-react-native';
 import { useFavicon } from '../../hooks/useFavicon/index.ts';
 import {
   METHODS_TO_DELAY,
@@ -32,18 +32,16 @@ const getMethodLabel = (method?: string): string | undefined => {
 };
 
 // Display a toast
-const diplayToast = (
-  toastRef: ToastRef,
-  label: string,
-  faviconURI: ImageURISource,
-): void => {
+const diplayToast = (label: string, faviconURI: ImageURISource): void => {
   const isFavicon = !!faviconURI.uri;
 
-  toastRef?.showToast({
-    variant: isFavicon ? ToastVariants.App : ToastVariants.Plain,
-    labelOptions: [{ label }],
-    appIconSource: faviconURI,
+  toast({
+    title: label,
+    startAccessory: isFavicon ? (
+      <AvatarFavicon src={faviconURI} size={AvatarFaviconSize.Sm} />
+    ) : undefined,
     hasNoTimeout: false,
+    showCloseButton: false,
   });
 };
 
@@ -60,24 +58,13 @@ const ReturnToAppNotification = () => {
   const delayBetweenToast: number = 1500;
   const { method, origin, hideReturnToApp } = route.params ?? {};
   const navigation = useNavigation<AppNavigationProp>();
-  const { toastRef } = useContext(ToastContext);
   const favicon = useFavicon(origin ?? '');
   const hasExecuted = useRef<boolean>(false);
 
   useEffect(() => {
-    if (
-      toastRef &&
-      toastRef.current !== null &&
-      favicon.isLoaded &&
-      !hasExecuted.current
-    ) {
+    if (favicon.isLoaded && !hasExecuted.current) {
       hasExecuted.current = true;
       (async () => {
-        // Only for type checking
-        if (toastRef.current === null) {
-          return;
-        }
-
         // Add delay to display UI feedback before redirecting
         if (method && METHODS_TO_DELAY[method]) {
           await wait(delayAfterMethod);
@@ -86,7 +73,7 @@ const ReturnToAppNotification = () => {
         // Display specific information depending on the method
         const methodLabel = getMethodLabel(method);
         if (methodLabel !== undefined) {
-          diplayToast(toastRef.current, methodLabel, favicon.faviconURI);
+          diplayToast(methodLabel, favicon.faviconURI);
         }
 
         if (hideReturnToApp !== true) {
@@ -94,7 +81,6 @@ const ReturnToAppNotification = () => {
 
           // Ask the user to go back to the app
           diplayToast(
-            toastRef.current,
             strings('sdk_return_to_app_toast.returnToAppLabel'),
             favicon.faviconURI,
           );
@@ -104,7 +90,7 @@ const ReturnToAppNotification = () => {
       // Hide the fake modal
       navigation?.goBack();
     }
-  }, [toastRef, method, favicon, navigation, hideReturnToApp]);
+  }, [method, favicon, navigation, hideReturnToApp]);
 
   return <></>;
 };

--- a/app/components/Views/ReturnToAppNotification/index.test.tsx
+++ b/app/components/Views/ReturnToAppNotification/index.test.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { render, act } from '@testing-library/react-native';
+import { toast } from '@metamask/design-system-react-native';
 import ReturnToAppNotification from './index.tsx';
-import { ToastContext } from '../../../component-library/components/Toast/index.ts';
-import { ToastVariants } from '../../../component-library/components/Toast/Toast.types.ts';
 import { RPC_METHODS } from '../../../core/SDKConnect/SDKConnectConstants.ts';
 
 let mockRouteParams: {
@@ -39,21 +38,18 @@ jest.mock('@react-navigation/native', () => {
   };
 });
 
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
+
 const flushPromises = () => act(() => Promise.resolve());
 
 describe('ReturnToAppNotification', () => {
-  const createToastRef = () => ({
-    current: { showToast: jest.fn(), closeToast: jest.fn() },
-  });
-
-  const renderComponent = (toastRef = createToastRef()) => {
-    const utils = render(
-      <ToastContext.Provider value={{ toastRef }}>
-        <ReturnToAppNotification />
-      </ToastContext.Provider>,
-    );
-    return { ...utils, toastRef };
-  };
+  const renderComponent = () => render(<ReturnToAppNotification />);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -72,7 +68,7 @@ describe('ReturnToAppNotification', () => {
     expect(toJSON()).toBeNull();
   });
 
-  it('calls navigation.goBack when toastRef and favicon are ready', async () => {
+  it('calls navigation.goBack when favicon is ready', async () => {
     renderComponent();
     await flushPromises();
 
@@ -81,15 +77,14 @@ describe('ReturnToAppNotification', () => {
 
   it('shows return-to-app toast when hideReturnToApp is not set', async () => {
     mockRouteParams = { origin: 'https://example.com' };
-    const { toastRef } = renderComponent();
+    renderComponent();
     await flushPromises();
 
-    expect(toastRef.current.showToast).toHaveBeenCalledWith(
+    expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
-        variant: ToastVariants.App,
-        labelOptions: [{ label: 'sdk_return_to_app_toast.returnToAppLabel' }],
-        appIconSource: { uri: 'https://example.com/favicon.png' },
+        title: 'sdk_return_to_app_toast.returnToAppLabel',
         hasNoTimeout: false,
+        showCloseButton: false,
       }),
     );
   });
@@ -99,12 +94,12 @@ describe('ReturnToAppNotification', () => {
       origin: 'https://example.com',
       hideReturnToApp: true,
     };
-    const { toastRef } = renderComponent();
+    renderComponent();
     await flushPromises();
 
-    expect(toastRef.current.showToast).not.toHaveBeenCalledWith(
+    expect(toast).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        labelOptions: [{ label: 'sdk_return_to_app_toast.returnToAppLabel' }],
+        title: 'sdk_return_to_app_toast.returnToAppLabel',
       }),
     );
   });
@@ -114,15 +109,12 @@ describe('ReturnToAppNotification', () => {
       method: RPC_METHODS.WALLET_SWITCHETHEREUMCHAIN,
       origin: 'https://example.com',
     };
-    const { toastRef } = renderComponent();
+    renderComponent();
     await flushPromises();
 
-    expect(toastRef.current.showToast).toHaveBeenCalledWith(
+    expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
-        variant: ToastVariants.App,
-        labelOptions: [
-          { label: 'sdk_return_to_app_toast.networkSwitchMethodLabel' },
-        ],
+        title: 'sdk_return_to_app_toast.networkSwitchMethodLabel',
       }),
     );
   });
@@ -150,18 +142,19 @@ describe('ReturnToAppNotification', () => {
     expect(mockWait).toHaveBeenCalledTimes(1);
   });
 
-  it('uses Plain variant when favicon URI is empty', async () => {
+  it('omits start accessory when favicon URI is empty', async () => {
     mockUseFavicon.mockReturnValue({
       isLoaded: true,
       faviconURI: { uri: '' },
     });
     mockRouteParams = { origin: 'https://example.com' };
-    const { toastRef } = renderComponent();
+    renderComponent();
     await flushPromises();
 
-    expect(toastRef.current.showToast).toHaveBeenCalledWith(
+    expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
-        variant: ToastVariants.Plain,
+        title: 'sdk_return_to_app_toast.returnToAppLabel',
+        startAccessory: undefined,
       }),
     );
   });
@@ -177,48 +170,23 @@ describe('ReturnToAppNotification', () => {
     expect(mockGoBack).not.toHaveBeenCalled();
   });
 
-  it('does not execute effect when toastRef.current is null', async () => {
-    const toastRef = { current: null };
-    render(
-      <ToastContext.Provider value={{ toastRef: toastRef as never }}>
-        <ReturnToAppNotification />
-      </ToastContext.Provider>,
-    );
-    await flushPromises();
-
-    expect(mockGoBack).not.toHaveBeenCalled();
-  });
-
-  it('does not execute effect when toastRef is undefined', async () => {
-    render(
-      <ToastContext.Provider value={{ toastRef: undefined }}>
-        <ReturnToAppNotification />
-      </ToastContext.Provider>,
-    );
-    await flushPromises();
-
-    expect(mockGoBack).not.toHaveBeenCalled();
-  });
-
   it('does not show method label for non-switchEthereumChain methods', async () => {
     mockRouteParams = {
       method: RPC_METHODS.ETH_SENDTRANSACTION,
       origin: 'https://example.com',
     };
-    const { toastRef } = renderComponent();
+    renderComponent();
     await flushPromises();
 
-    expect(toastRef.current.showToast).not.toHaveBeenCalledWith(
+    expect(toast).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        labelOptions: [
-          { label: 'sdk_return_to_app_toast.networkSwitchMethodLabel' },
-        ],
+        title: 'sdk_return_to_app_toast.networkSwitchMethodLabel',
       }),
     );
 
-    expect(toastRef.current.showToast).toHaveBeenCalledWith(
+    expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
-        labelOptions: [{ label: 'sdk_return_to_app_toast.returnToAppLabel' }],
+        title: 'sdk_return_to_app_toast.returnToAppLabel',
       }),
     );
   });
@@ -228,35 +196,28 @@ describe('ReturnToAppNotification', () => {
       method: RPC_METHODS.WALLET_SWITCHETHEREUMCHAIN,
       origin: 'https://example.com',
     };
-    const { toastRef } = renderComponent();
+    renderComponent();
     await flushPromises();
 
-    expect(toastRef.current.showToast).toHaveBeenCalledTimes(2);
+    expect(toast).toHaveBeenCalledTimes(2);
 
-    expect(toastRef.current.showToast).toHaveBeenNthCalledWith(
+    expect(toast).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        labelOptions: [
-          { label: 'sdk_return_to_app_toast.networkSwitchMethodLabel' },
-        ],
+        title: 'sdk_return_to_app_toast.networkSwitchMethodLabel',
       }),
     );
 
-    expect(toastRef.current.showToast).toHaveBeenNthCalledWith(
+    expect(toast).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        labelOptions: [{ label: 'sdk_return_to_app_toast.returnToAppLabel' }],
+        title: 'sdk_return_to_app_toast.returnToAppLabel',
       }),
     );
   });
 
   it('does not execute effect more than once on re-render', async () => {
-    const toastRef = createToastRef();
-    const ui = (
-      <ToastContext.Provider value={{ toastRef }}>
-        <ReturnToAppNotification />
-      </ToastContext.Provider>
-    );
+    const ui = <ReturnToAppNotification />;
 
     const { rerender } = render(ui);
     await flushPromises();
@@ -300,13 +261,13 @@ describe('ReturnToAppNotification', () => {
 
   it('does not show method label when no method is provided', async () => {
     mockRouteParams = { origin: 'https://example.com' };
-    const { toastRef } = renderComponent();
+    renderComponent();
     await flushPromises();
 
-    expect(toastRef.current.showToast).toHaveBeenCalledTimes(1);
-    expect(toastRef.current.showToast).toHaveBeenCalledWith(
+    expect(toast).toHaveBeenCalledTimes(1);
+    expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
-        labelOptions: [{ label: 'sdk_return_to_app_toast.returnToAppLabel' }],
+        title: 'sdk_return_to_app_toast.returnToAppLabel',
       }),
     );
   });
@@ -351,10 +312,10 @@ describe('ReturnToAppNotification', () => {
       origin: 'https://example.com',
       hideReturnToApp: true,
     };
-    const { toastRef } = renderComponent();
+    renderComponent();
     await flushPromises();
 
-    expect(toastRef.current.showToast).not.toHaveBeenCalled();
+    expect(toast).not.toHaveBeenCalled();
   });
 
   it('shows only method label toast when hideReturnToApp is true and method is switchEthereumChain', async () => {
@@ -363,15 +324,13 @@ describe('ReturnToAppNotification', () => {
       origin: 'https://example.com',
       hideReturnToApp: true,
     };
-    const { toastRef } = renderComponent();
+    renderComponent();
     await flushPromises();
 
-    expect(toastRef.current.showToast).toHaveBeenCalledTimes(1);
-    expect(toastRef.current.showToast).toHaveBeenCalledWith(
+    expect(toast).toHaveBeenCalledTimes(1);
+    expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({
-        labelOptions: [
-          { label: 'sdk_return_to_app_toast.networkSwitchMethodLabel' },
-        ],
+        title: 'sdk_return_to_app_toast.networkSwitchMethodLabel',
       }),
     );
   });

--- a/app/components/Views/Wallet/index.test.tsx
+++ b/app/components/Views/Wallet/index.test.tsx
@@ -13,6 +13,14 @@ jest.mock('react-native-device-info', () => ({
   getTotalMemorySync: jest.fn(() => 4000000000),
 }));
 
+jest.mock('@metamask/design-system-react-native', () => {
+  const actual = jest.requireActual('@metamask/design-system-react-native');
+  return {
+    ...actual,
+    toast: Object.assign(jest.fn(), { dismiss: jest.fn() }),
+  };
+});
+
 // Mock components BEFORE importing the main component
 jest.mock('../AssetDetails/AssetDetailsActions', () => ({
   __esModule: true,

--- a/app/components/Views/Wallet/index.tsx
+++ b/app/components/Views/Wallet/index.tsx
@@ -2,7 +2,6 @@ import { AccountGroupId } from '@metamask/account-api';
 import type { Theme } from '@metamask/design-tokens';
 import React, {
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -44,6 +43,7 @@ import { AnalyticsEventBuilder } from '../../../util/analytics/AnalyticsEventBui
 import {
   Text as CustomText,
   TextColor,
+  toast,
 } from '@metamask/design-system-react-native';
 
 import {
@@ -59,11 +59,6 @@ import type { AppNavigationProp } from '../../../core/NavigationService/types';
 import { WalletViewSelectorsIDs } from './WalletView.testIds';
 import { BannerAlertSeverity } from '../../../component-library/components/Banners/Banner';
 import BannerAlert from '../../../component-library/components/Banners/Banner/variants/BannerAlert/BannerAlert';
-import {
-  ToastContext,
-  ToastVariants,
-  ButtonIconVariant,
-} from '../../../component-library/components/Toast';
 import ConditionalScrollView from '../../../component-library/components-temp/ConditionalScrollView';
 import { useAnalytics } from '../../../components/hooks/useAnalytics/useAnalytics';
 import Routes from '../../../constants/navigation/Routes';
@@ -353,7 +348,6 @@ const Wallet = ({
     selectPerpsGtmOnboardingModalEnabledFlag,
   );
 
-  const { toastRef } = useContext(ToastContext);
   const { trackEvent, createEventBuilder } = useAnalytics();
   const styles = useMemo(() => createStyles(theme), [theme]);
   const { colors } = theme;
@@ -643,39 +637,22 @@ const Wallet = ({
   useEffect(() => {
     if (!shouldShowNewPrivacyToast) return;
 
-    const toast = toastRef?.current;
     storePrivacyPolicyShownDate();
-    toast?.showToast({
-      variant: ToastVariants.Plain,
-      labelOptions: [
-        {
-          label: strings(`privacy_policy.toast_message`),
-          isBold: true,
-        },
-      ],
-      closeButtonOptions: {
-        variant: ButtonIconVariant.Icon,
-        iconName: IconName.Close,
-        onPress: () => {
-          storePrivacyPolicyClickedOrClosed();
-          toast?.closeToast();
-        },
-      },
-      linkButtonOptions: {
-        label: strings(`privacy_policy.toast_read_more`),
-        onPress: () => {
-          storePrivacyPolicyClickedOrClosed();
-          toast?.closeToast();
-          Linking.openURL(CONSENSYS_PRIVACY_POLICY);
-        },
-      },
+    toast({
+      title: strings('privacy_policy.toast_message'),
       hasNoTimeout: true,
+      onClose: storePrivacyPolicyClickedOrClosed,
+      actionButtonLabel: strings('privacy_policy.toast_read_more'),
+      actionButtonOnPress: () => {
+        storePrivacyPolicyClickedOrClosed();
+        toast.dismiss();
+        Linking.openURL(CONSENSYS_PRIVACY_POLICY);
+      },
     });
   }, [
     storePrivacyPolicyShownDate,
     shouldShowNewPrivacyToast,
     storePrivacyPolicyClickedOrClosed,
-    toastRef,
   ]);
 
   const isNotificationEnabled = useSelector(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The component-library `Toast` is deprecated in favor of `toast()` from `@metamask/design-system-react-native`. Remaining Nav network toasts, Browser active-account toasts, Wallet privacy-policy toasts, and SDK return-to-app toasts still used `toastRef.showToast`.

This PR switches those call sites to the design-system `toast()` API. Network toasts use `AvatarNetwork`, Browser account toasts use `AvatarAccount`, and return-to-app toasts use `AvatarFavicon` when a favicon URI is present. The privacy toast keeps a close control and a Read more action. Tests mock `toast` instead of wrapping ToastContext.

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated network, browser, wallet privacy, and SDK return-to-app toasts to the MetaMask design system

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Fixes:

## **Manual testing steps**

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Design system toasts for leftover app surfaces

  Background:
    Given I am logged into MetaMask Mobile

  Scenario: user adds or removes a network
    Given I am not on a Bridge route

    When a network is added or removed from the network list
    Then a toast should name that network
    And the toast should say the network was added or removed

  Scenario: user opens a dApp with a connected account
    Given I have an account connected to a site

    When user opens that site in the Browser
    Then a toast should say the active account is now active
    And the toast should include that account's avatar

  Scenario: user sees the privacy policy toast
    Given the privacy policy toast should be shown

    When the Wallet screen loads
    Then a toast should show the privacy policy message
    And tapping Read more should open the ConsenSys privacy policy
```

## **Screenshots/Recordings**

<!-- mms-check: type=screenshot required=true -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] I've tested on Android
  - Ideally on a mid-range device; emulator is acceptable
- [x] I've tested with a power user scenario
  - Use these [power-user SRPs](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/edit-v2/401401446401?draftShareId=9d77e1e1-4bdc-4be1-9ebb-ccd916988d93) to import wallets with many accounts and tokens
- [x] I've instrumented key operations with Sentry traces for production performance metrics
  - See [`trace()`](/app/util/trace.ts) for usage and [`addToken`](/app/components/Views/AddAsset/components/AddCustomToken/AddCustomToken.tsx#L274) for an example

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- Generated with the help of the pr-description AI skill -->
