### PR TITLE
fix(perps): restore reduce only checkbox

### DIFF
--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.test.tsx
@@ -532,36 +532,26 @@ describe('PerpsProOrderForm', () => {
       expect(playSelection).toHaveBeenCalledTimes(1);
     });
 
-    it('exposes Reduce only with selected button semantics', () => {
+    it('exposes Reduce only with checked checkbox semantics', () => {
       renderForm({ reduceOnly: true });
 
       expect(screen.getByTestId(ids.REDUCE_ONLY)).toHaveProp(
         'accessibilityRole',
-        'button',
+        'checkbox',
       );
       expect(screen.getByTestId(ids.REDUCE_ONLY)).toHaveProp(
         'accessibilityState',
-        expect.objectContaining({ selected: true }),
+        expect.objectContaining({ checked: true }),
       );
     });
 
-    it('selects Reduce only when the inactive filter is pressed', () => {
+    it('calls onReduceOnlyChange with the next checked value', () => {
       const onReduceOnlyChange = jest.fn();
       renderForm({ onReduceOnlyChange });
 
       fireEvent.press(screen.getByTestId(ids.REDUCE_ONLY));
 
       expect(onReduceOnlyChange).toHaveBeenCalledWith(true);
-      expect(playSelection).toHaveBeenCalledTimes(1);
-    });
-
-    it('clears Reduce only when the active filter is pressed', () => {
-      const onReduceOnlyChange = jest.fn();
-      renderForm({ onReduceOnlyChange, reduceOnly: true });
-
-      fireEvent.press(screen.getByTestId(ids.REDUCE_ONLY));
-
-      expect(onReduceOnlyChange).toHaveBeenCalledWith(false);
       expect(playSelection).toHaveBeenCalledTimes(1);
     });
 

--- a/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
+++ b/app/components/UI/Perps/Views/PerpsProMarketView/components/PerpsProOrderForm/PerpsProOrderForm.tsx
@@ -6,11 +6,11 @@ import {
   BoxFlexDirection,
   ButtonBase,
   ButtonBaseSize,
-  ButtonFilter,
   ButtonIcon,
   ButtonIconSize,
   ButtonSemantic,
   ButtonSemanticSeverity,
+  Checkbox,
   FilterButton,
   FontWeight,
   HelpText,
@@ -415,10 +415,6 @@ const PerpsProOrderForm = ({
     [onReduceOnlyChange, playSelection],
   );
 
-  const handleReduceOnlyPress = useCallback(() => {
-    handleReduceOnlyChange(!reduceOnly);
-  }, [handleReduceOnlyChange, reduceOnly]);
-
   const handleExpandOrderBook = useCallback(() => {
     if (!onExpandOrderBook) {
       return;
@@ -583,16 +579,22 @@ const PerpsProOrderForm = ({
             availableBalance={availableBalance}
             onAddFundsPress={onAddFundsPress}
           />
-          <Box testID={ids.REDUCE_ONLY_CONTAINER} twClassName="items-start">
-            <ButtonFilter
-              isActive={reduceOnly}
-              accessibilityState={{ selected: reduceOnly }}
-              onPress={handleReduceOnlyPress}
-              size={ButtonBaseSize.Sm}
+          <Box
+            testID={ids.REDUCE_ONLY_CONTAINER}
+            twClassName="h-12 justify-center rounded-xl bg-muted px-3"
+          >
+            <Checkbox
+              label={strings('perps.order.reduce_only')}
+              labelProps={{
+                variant: TextVariant.BodySm,
+                fontWeight: FontWeight.Medium,
+                style: { marginLeft: 0, flex: 1 },
+              }}
+              isSelected={reduceOnly}
+              onChange={handleReduceOnlyChange}
               testID={ids.REDUCE_ONLY}
-            >
-              {strings('perps.order.reduce_only')}
-            </ButtonFilter>
+              twClassName="w-full flex-row-reverse justify-between"
+            />
           </Box>
           {showsTpSl ? (
             <TPSLRow


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.

Do not mark it as "Ready for review" until this PR meets the canonical
Definition of Ready For Review in `docs/readme/ready-for-review.md`.

In short: the template must be materially complete (not just section titles
present), all status checks must be currently passing, and the only expected
follow-up commits must be reviewer-driven.
-->
<!--
mms-check directive vocabulary — read by .github/scripts/shared/pr-template-checks.ts
at module load to build the validation plan. Directives are invisible in rendered
markdown and must NOT be removed or edited without updating the validator registry.

  type=text           Section must contain non-placeholder prose.
  type=changelog      Section must have a valid CHANGELOG entry: line.
  type=issue-link     Section must have a Fixes:/Closes:/Refs: line with a value.
  type=manual-testing Section must have real testing steps or an explicit N/A.
  type=screenshot     Section must have evidence (image/URL) or an explicit N/A.
  type=checklist      Section must have all checkboxes consciously checked.
  required=true|false Whether a missing/invalid section runs the validator at all.
  blocking=true|false Whether a failure of this check fails the CI workflow.
                      Default: false — failures are shown as warnings in the sticky
                      comment but do not block the PR.

Sections without a directive are checked for structural presence only.
-->

## **Description**

<!-- recipe-evidence suggestion: edit as needed before publishing. -->
Restores the full-width Reduce only checkbox that was unintentionally replaced with a compact filter button in #35222. The balance-sheet Activity removal remains unchanged.

<!-- mms-check: type=text required=true -->

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!-- mms-check: type=changelog required=true blocking=true -->

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Restored the Reduce only checkbox in Perps Pro mode

## **Related issues**

<!-- mms-check: type=issue-link required=true -->

Refs: https://github.com/MetaMask/metamask-mobile/pull/35222

## **Manual testing steps**

<!-- recipe-evidence summary: keep reviewer-facing checks concise; full paths stay in pr-package/evidence.md. -->
Recipe evidence: `pass`
- iOS simulator `mm-3`, main Expo development build
- Final recipe: 8/8 nodes passed
- Coverage: 85% for `PerpsProOrderForm.tsx`; no new executable lines
- Focused Jest, changed-file ESLint, and Prettier passed

<!-- mms-check: type=manual-testing required=true -->

```gherkin
Feature: Perps Pro Reduce only control

  Scenario: user opens a Pro order form
    Given the user has opened a Perps market in Pro mode
    When the order form appears
    Then Reduce only is displayed as a full-width checkbox row
    And selecting it checks the checkbox
```

## **Screenshots/Recordings**

<table>
<tr><td colspan="2"><strong>Recipe visual evidence</strong><br/>Screenshots are grouped for quick reviewer comparison.</td></tr>
<tr>
<td align="center" width="50%"><strong>Before: compact Reduce only filter</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/35222-fix-restore-reduce-only-checkbox-2010/01-before-compact-reduce-only-filter.png" alt="Before: compact Reduce only filter" width="400" /></td>
<td align="center" width="50%"><strong>After: restored Reduce only checkbox</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/35222-fix-restore-reduce-only-checkbox-2010/02-after-restored-reduce-only-checkbox.png" alt="After: restored Reduce only checkbox" width="400" /></td>
</tr>
<tr>
<td align="center" width="50%"><strong>After: checked Reduce only checkbox</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-mobile-artifacts/main/evidence/35222-fix-restore-reduce-only-checkbox-2010/03-after-checked-reduce-only-checkbox.png" alt="After: checked Reduce only checkbox" width="400" /></td>
<td width="50%"></td>
</tr>
</table>

## **Pre-merge author checklist**

<!-- mms-check: type=checklist required=true -->

<!--
Every checklist item must be consciously assessed before marking this PR as
"Ready for review". A checked box means you deliberately considered that
responsibility, not that you literally performed every action listed.

Unchecked boxes are ambiguous: they are not an implicit "N/A" and they are not
a silent "skip". See `docs/readme/ready-for-review.md` for the full checklist
semantics.
-->

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Mobile Coding Standards](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-mobile/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

#### Performance checks (if applicable)

- [x] Android performance testing is N/A for this shared UI-only restoration
- [x] Power-user testing is N/A because this does not change loading or data handling
- [x] Sentry instrumentation is N/A because this does not add an operation or performance-sensitive path

For performance guidelines and tooling, see the [Performance Guide](https://consensyssoftware.atlassian.net/wiki/spaces/TL1/pages/400085549067/Performance+Guide+for+Engineers).

## **Pre-merge reviewer checklist**

<!--
Reviewer checklist items follow the same semantics as the author checklist: an
unchecked box is ambiguous, a checked box means the reviewer consciously
assessed that responsibility. See `docs/readme/ready-for-review.md`.
-->

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
